### PR TITLE
fix: restore missing /api/ping status route

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ApiSessionsRouteImport } from './routes/api/sessions'
 import { Route as ApiSessionStatusRouteImport } from './routes/api/session-status'
 import { Route as ApiSendStreamRouteImport } from './routes/api/send-stream'
 import { Route as ApiSendRouteImport } from './routes/api/send'
+import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
@@ -169,6 +170,11 @@ const ApiSendRoute = ApiSendRouteImport.update({
   path: '/api/send',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiPingRoute = ApiPingRouteImport.update({
+  id: '/api/ping',
+  path: '/api/ping',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiPathsRoute = ApiPathsRouteImport.update({
   id: '/api/paths',
   path: '/api/paths',
@@ -297,6 +303,7 @@ export interface FileRoutesByFullPath {
   '/api/history': typeof ApiHistoryRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
+  '/api/ping': typeof ApiPingRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-status': typeof ApiSessionStatusRoute
@@ -342,6 +349,7 @@ export interface FileRoutesByTo {
   '/api/history': typeof ApiHistoryRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
+  '/api/ping': typeof ApiPingRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-status': typeof ApiSessionStatusRoute
@@ -389,6 +397,7 @@ export interface FileRoutesById {
   '/api/history': typeof ApiHistoryRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
+  '/api/ping': typeof ApiPingRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-status': typeof ApiSessionStatusRoute
@@ -437,6 +446,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/models'
     | '/api/paths'
+    | '/api/ping'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-status'
@@ -482,6 +492,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/models'
     | '/api/paths'
+    | '/api/ping'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-status'
@@ -528,6 +539,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/models'
     | '/api/paths'
+    | '/api/ping'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-status'
@@ -575,6 +587,7 @@ export interface RootRouteChildren {
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
+  ApiPingRoute: typeof ApiPingRoute
   ApiSendRoute: typeof ApiSendRoute
   ApiSendStreamRoute: typeof ApiSendStreamRoute
   ApiSessionStatusRoute: typeof ApiSessionStatusRoute
@@ -757,6 +770,13 @@ declare module '@tanstack/react-router' {
       path: '/api/send'
       fullPath: '/api/send'
       preLoaderRoute: typeof ApiSendRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/ping': {
+      id: '/api/ping'
+      path: '/api/ping'
+      fullPath: '/api/ping'
+      preLoaderRoute: typeof ApiPingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/paths': {
@@ -970,6 +990,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHistoryRoute: ApiHistoryRoute,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,
+  ApiPingRoute: ApiPingRoute,
   ApiSendRoute: ApiSendRoute,
   ApiSendStreamRoute: ApiSendStreamRoute,
   ApiSessionStatusRoute: ApiSessionStatusRoute,

--- a/src/routes/api/ping.ts
+++ b/src/routes/api/ping.ts
@@ -1,0 +1,55 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  HERMES_API,
+  ensureGatewayProbed,
+} from '../../server/gateway-capabilities'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+
+type PingResponse = {
+  ok: boolean
+  error?: string
+  status?: number
+  hermesUrl: string
+}
+
+export const Route = createFileRoute('/api/ping')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return Response.json(
+            {
+              ok: false,
+              error: 'Authentication required',
+              status: 401,
+              hermesUrl: HERMES_API,
+            } satisfies PingResponse,
+            { status: 401 },
+          )
+        }
+
+        const caps = await ensureGatewayProbed()
+        if (!caps.health) {
+          return Response.json(
+            {
+              ok: false,
+              error: 'Hermes unavailable',
+              status: 503,
+              hermesUrl: HERMES_API,
+            } satisfies PingResponse,
+            { status: 503 },
+          )
+        }
+
+        return Response.json(
+          {
+            ok: true,
+            status: 200,
+            hermesUrl: HERMES_API,
+          } satisfies PingResponse,
+          { status: 200 },
+        )
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a Workspace `/api/ping` compatibility route using the existing Hermes gateway probe
- preserve the response shape current chat and settings callers already expect
- restore status checks without requiring a client rewrite

## Testing
- npm run build