### PR TITLE
fix: add clipboard fallback for insecure origins

### DIFF
--- a/src/components/connection-startup-screen.tsx
+++ b/src/components/connection-startup-screen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { AuthStatus } from '@/lib/hermes-auth'
+import { writeTextToClipboard } from '@/lib/clipboard'
 import { fetchHermesAuthStatus } from '@/lib/hermes-auth'
 
 const POLL_INTERVAL_MS = 2_000
@@ -113,7 +114,7 @@ export function ConnectionStartupScreen({ onConnected }: Props) {
 
   const handleCopy = async (text: string, idx: number) => {
     try {
-      await navigator.clipboard.writeText(text)
+      await writeTextToClipboard(text)
       setCopiedIdx(idx)
     } catch {
       /* clipboard not available */

--- a/src/components/mobile-prompt/MobileSetupModal.tsx
+++ b/src/components/mobile-prompt/MobileSetupModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Cancel01Icon, Sent02Icon, Tick01Icon } from '@hugeicons/core-free-icons';
+import { writeTextToClipboard } from '@/lib/clipboard';
 
 const STORAGE_KEY_SEEN = 'hermes-mobile-setup-seen';
 
@@ -157,7 +158,7 @@ export function MobileSetupModal({ isOpen, onClose }: MobileSetupModalProps) {
       action: (
         <button
           type="button"
-          onClick={() => networkUrl && navigator.clipboard.writeText(networkUrl.url).catch(() => {})}
+          onClick={() => networkUrl && writeTextToClipboard(networkUrl.url).catch(() => {})}
           className="group flex w-full items-center justify-between rounded-lg border border-primary-700 bg-primary-950 px-4 py-3 transition-colors hover:border-accent-500/50"
         >
           <span className="break-all font-mono text-sm text-accent-300">

--- a/src/components/prompt-kit/code-block/index.tsx
+++ b/src/components/prompt-kit/code-block/index.tsx
@@ -5,6 +5,7 @@ import { createHighlighter } from 'shiki'
 import { formatLanguageName, normalizeLanguage, resolveLanguage } from './utils'
 import type { BundledLanguage, Highlighter } from 'shiki'
 import { useResolvedTheme } from '@/hooks/use-chat-settings'
+import { writeTextToClipboard } from '@/lib/clipboard'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 
@@ -85,7 +86,7 @@ export function CodeBlock({
 
   async function handleCopy() {
     try {
-      await navigator.clipboard.writeText(content)
+      await writeTextToClipboard(content)
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1600)
     } catch {

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+export async function writeTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {
+      // Fall through to execCommand for insecure origins / limited browsers.
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Clipboard unavailable')
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+  textarea.style.top = '0'
+  textarea.style.left = '0'
+
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  textarea.setSelectionRange(0, text.length)
+
+  try {
+    const copied = document.execCommand('copy')
+    if (!copied) {
+      throw new Error('Clipboard unavailable')
+    }
+  } finally {
+    textarea.remove()
+  }
+}

--- a/src/screens/chat/components/message-actions-bar.tsx
+++ b/src/screens/chat/components/message-actions-bar.tsx
@@ -12,6 +12,7 @@ import {
   TooltipRoot,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { writeTextToClipboard } from '@/lib/clipboard'
 import { cn } from '@/lib/utils'
 
 type MessageActionsBarProps = {
@@ -37,7 +38,7 @@ export function MessageActionsBar({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text)
+      await writeTextToClipboard(text)
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1400)
     } catch {

--- a/src/screens/chat/hooks/use-chat-settings.ts
+++ b/src/screens/chat/hooks/use-chat-settings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 
+import { writeTextToClipboard } from '@/lib/clipboard'
 import { readError } from '../utils'
 import type { PathsPayload } from '../types'
 
@@ -54,7 +55,7 @@ export function useChatSettings() {
   const copySessionsDir = useCallback(() => {
     if (!paths?.sessionsDir) return
     try {
-      void navigator.clipboard.writeText(paths.sessionsDir)
+      void writeTextToClipboard(paths.sessionsDir)
     } catch {
       // ignore
     }
@@ -63,7 +64,7 @@ export function useChatSettings() {
   const copyStorePath = useCallback(() => {
     if (!paths?.storePath) return
     try {
-      void navigator.clipboard.writeText(paths.storePath)
+      void writeTextToClipboard(paths.storePath)
     } catch {
       // ignore
     }

--- a/src/screens/settings/components/provider-wizard.tsx
+++ b/src/screens/settings/components/provider-wizard.tsx
@@ -16,6 +16,7 @@ import {
   getAuthTypeLabel,
   getProviderInfo,
 } from '@/lib/provider-catalog'
+import { writeTextToClipboard } from '@/lib/clipboard'
 import { Button } from '@/components/ui/button'
 import {
   DialogContent,
@@ -217,7 +218,7 @@ export function ProviderWizard({ open, onOpenChange, editProvider }: ProviderWiz
     if (!configExample) return
 
     try {
-      await navigator.clipboard.writeText(configExample)
+      await writeTextToClipboard(configExample)
       setCopyState('copied')
     } catch {
       setCopyState('failed')


### PR DESCRIPTION
## Summary
- add a shared clipboard write helper with a legacy `execCommand` fallback
- use the helper for current copy buttons in chat, setup, and provider flows
- fix copy actions on plain HTTP, direct-IP, and Tailscale access where `navigator.clipboard` is unavailable

## Testing
- npm run build