### PR TITLE
Fix missing Hermes stream error fallback message

### DIFF
--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -627,7 +627,7 @@ export const Route = createFileRoute('/api/send-stream')({
                       const errorMessage =
                         readString(
                           (data.error as Record<string, unknown> | undefined)?.message,
-                        ) || 'Hermes stream error'
+                        ) || readString(data.message) || 'Hermes stream error'
                       sendEvent('error', {
                         message: errorMessage,
                         sessionKey: sessionKeyFromEvent,


### PR DESCRIPTION
## Summary
- improve Hermes stream error message fallback handling
- read `data.message` when `data.error.message` is missing
- preserve the generic fallback as the final safeguard

## Why
Some Hermes error payloads arrive with a top-level `message` field.
Without this fallback, the UI can show an unhelpful generic error
instead of the backend-provided message.

## Changes
- updated `src/routes/api/send-stream.ts`
- error message resolution order is now:
  1. `data.error.message`
  2. `data.message`
  3. `'Hermes stream error'`

## Risk
- low
- narrowly scoped to stream error formatting

## Testing
- `pnpm test`
- `pnpm build`
