### PR TITLE
Polish chat composer surface styling

### DIFF
--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -1689,13 +1689,13 @@ function ChatComposerComponent({
                 ? [
                     // iMessage-style: edge-to-edge, docked to bottom
                     'left-0 right-0',
-                    'bg-white/95 dark:bg-neutral-900/95 backdrop-blur-xl',
-                    'border-t border-primary-200/60 dark:border-neutral-800',
+                    'bg-surface/95 backdrop-blur-xl',
+                    'border-t border-primary-200/60',
                   ].join(' ')
                 : [
                     // scroll-hide / integrated: floating pill above tab bar
                     'left-4 right-4',
-                    'bg-white/95 dark:bg-neutral-900/95 backdrop-blur-2xl',
+                    'bg-surface/95 backdrop-blur-2xl',
                     'shadow-[0_8px_32px_rgba(0,0,0,0.15)]',
                     'rounded-[22px]',
                   ].join(' '),


### PR DESCRIPTION
## Summary
- normalize chat composer surface styling
- replace explicit light/dark background classes with `bg-surface`
- simplify top border styling in docked mode

## Why
The composer was using hard-coded theme-specific background styles.
Using shared surface tokens makes the UI more consistent and easier
to maintain.

## Changes
- updated `src/screens/chat/components/chat-composer.tsx`
- switched composer backgrounds to `bg-surface/95`
- simplified border styling for the docked composer layout

## Risk
- low to medium
- visual-only change, but should be checked in both light/dark themes

## Testing
- `pnpm test`
- `pnpm build`
