### PR TITLE
fix: capability gating broken with enhanced Hermes gateway

### DIFF
--- a/src/hooks/use-gateway-caps.ts
+++ b/src/hooks/use-gateway-caps.ts
@@ -1,0 +1,31 @@
+/**
+ * Reactive capability hook — reads from the /api/gateway-status query.
+ * Use this instead of the synchronous isFeatureAvailable() in React components.
+ * Returns null while loading (use to show a spinner), false if unavailable,
+ * true if available.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+interface GatewayStatus {
+  capabilities: Record<string, boolean>
+  hermesUrl: string
+}
+
+function useGatewayStatus() {
+  return useQuery<GatewayStatus>({
+    queryKey: ['gateway-status'],
+    queryFn: async () => {
+      const res = await fetch('/api/gateway-status')
+      if (!res.ok) throw new Error('gateway-status fetch failed')
+      return res.json()
+    },
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  })
+}
+
+export function useIsFeatureAvailable(feature: string): boolean | null {
+  const { data, isLoading } = useGatewayStatus()
+  if (isLoading || !data) return null
+  return data.capabilities[feature] === true
+}

--- a/src/routes/jobs.tsx
+++ b/src/routes/jobs.tsx
@@ -1,13 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useIsFeatureAvailable } from '@/hooks/use-gateway-caps'
 import { JobsScreen } from '@/screens/jobs/jobs-screen'
 
 export const Route = createFileRoute('/jobs')({
   component: function JobsRoute() {
     usePageTitle('Jobs')
-    if (!isFeatureAvailable('jobs')) {
+    const available = useIsFeatureAvailable('jobs')
+    if (available === null) return null
+    if (!available) {
       return (
         <BackendUnavailableState
           feature="Jobs"

--- a/src/routes/memory.tsx
+++ b/src/routes/memory.tsx
@@ -1,14 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useIsFeatureAvailable } from '@/hooks/use-gateway-caps'
 import { MemoryBrowserScreen } from '@/screens/memory/memory-browser-screen'
 
 export const Route = createFileRoute('/memory')({
   ssr: false,
   component: function MemoryRoute() {
     usePageTitle('Memory')
-    if (!isFeatureAvailable('memory')) {
+    const available = useIsFeatureAvailable('memory')
+    if (available === null) return null
+    if (!available) {
       return (
         <BackendUnavailableState
           feature="Memory"

--- a/src/routes/skills.tsx
+++ b/src/routes/skills.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useIsFeatureAvailable } from '@/hooks/use-gateway-caps'
 import { SkillsScreen } from '@/screens/skills/skills-screen'
 
 export const Route = createFileRoute('/skills')({
@@ -10,7 +11,9 @@ export const Route = createFileRoute('/skills')({
 
 function SkillsRoute() {
   usePageTitle('Skills')
-  if (!isFeatureAvailable('skills')) {
+  const available = useIsFeatureAvailable('skills')
+  if (available === null) return null
+  if (!available) {
     return (
       <BackendUnavailableState
         feature="Skills"

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -14,6 +14,7 @@ import {
 import { listSessions, getConfig } from '@/server/hermes-api'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { getCapabilities } from '@/server/gateway-capabilities'
+import { useIsFeatureAvailable } from '@/hooks/use-gateway-caps'
 import type { HermesSession } from '@/server/hermes-api'
 import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
 import { cn } from '@/lib/utils'
@@ -202,7 +203,7 @@ function ActivityChart({ sessions }: { sessions: HermesSession[] }) {
 // ── Model Card ───────────────────────────────────────────────────
 
 function ModelCard() {
-  const configAvailable = isFeatureAvailable('config')
+  const configAvailable = useIsFeatureAvailable('config') ?? false
   const configQuery = useQuery({
     queryKey: ['hermes-config'],
     queryFn: getConfig,
@@ -268,7 +269,7 @@ function ModelCard() {
 // ── Skills Widget ────────────────────────────────────────────────
 
 function SkillsWidget() {
-  const skillsAvailable = isFeatureAvailable('skills')
+  const skillsAvailable = useIsFeatureAvailable('skills') ?? false
   const skillsQuery = useQuery({
     queryKey: ['hermes-skills'],
     queryFn: async () => {
@@ -375,8 +376,8 @@ function SessionRow({ session, maxTokens, onClick }: {
 
 export function DashboardScreen() {
   const navigate = useNavigate()
-  const sessionsAvailable = isFeatureAvailable('sessions')
-  const skillsAvailable = isFeatureAvailable('skills')
+  const sessionsAvailable = useIsFeatureAvailable('sessions') ?? false
+  const skillsAvailable = useIsFeatureAvailable('skills') ?? false
   const sessionsQuery = useQuery({
     queryKey: chatQueryKeys.sessions,
     queryFn: () => listSessions(50, 0),
@@ -385,7 +386,7 @@ export function DashboardScreen() {
   })
 
   const sessions = (sessionsQuery.data ?? []) as HermesSession[]
-  const caps = getCapabilities()
+  const caps = { ...getCapabilities(), sessions: sessionsAvailable, skills: skillsAvailable }
 
   const stats = useMemo(() => {
     let totalMessages = 0, totalToolCalls = 0, totalTokens = 0

--- a/src/screens/settings/providers-screen.tsx
+++ b/src/screens/settings/providers-screen.tsx
@@ -45,7 +45,8 @@ import {
   TabsTrigger,
 } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useIsFeatureAvailable } from '@/hooks/use-gateway-caps'
 import {
   getProviderDisplayName,
   getProviderInfo,
@@ -1323,7 +1324,7 @@ function ProviderManagementSection(props: {
 
 export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   const queryClient = useQueryClient()
-  const configAvailable = isFeatureAvailable('config')
+  const configAvailable = useIsFeatureAvailable('config') ?? false
   const [activeTab, setActiveTab] = useState<SettingsTabId>('providers')
   const [search, setSearch] = useState('')
   const [draftValues, setDraftValues] = useState<Record<string, string>>({})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -456,33 +456,6 @@ const config = defineConfig(({ mode, command }) => {
               return
             }
 
-            // Portable-aware health check — returns ok if any chat backend is available
-            if (req.method === 'GET' && requestPath === '/api/connection-status') {
-              try {
-                // Check if the configured backend has /v1/models (works for Ollama, OpenAI, etc.)
-                const modelsRes = await fetch(`${hermesApiUrl}/v1/models`, {
-                  signal: AbortSignal.timeout(3000),
-                })
-                if (modelsRes.ok) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(JSON.stringify({ ok: true, mode: 'portable', backend: hermesApiUrl }))
-                  return
-                }
-                // Fall back to /health for full Hermes backends
-                const healthRes = await fetch(`${hermesApiUrl}/health`, {
-                  signal: AbortSignal.timeout(3000),
-                })
-                res.statusCode = healthRes.ok ? 200 : 502
-                res.setHeader('content-type', 'application/json')
-                res.end(JSON.stringify({ ok: healthRes.ok, mode: 'enhanced', backend: hermesApiUrl }))
-              } catch {
-                res.statusCode = 502
-                res.setHeader('content-type', 'application/json')
-                res.end(JSON.stringify({ ok: false, mode: 'disconnected', backend: hermesApiUrl }))
-              }
-              return
-            }
 
             if (
               req.method !== 'POST' ||


### PR DESCRIPTION
## Problem

When connecting a full Hermes gateway (with `--gateway`), the Jobs, Skills, Memory, and Dashboard screens all show "not available on this backend" even though the gateway is running and all APIs are responding.

Two root causes:

### 1. `isFeatureAvailable()` is synchronous but called client-side

`isFeatureAvailable()` calls `getCapabilities()` synchronously. On the client, `gateway-capabilities.ts` initialises with all capabilities defaulting to `false` — the async probe hasn't run yet. So every gated feature renders as unavailable during hydration, and since there's no re-render trigger, it stays that way.

### 2. Hardcoded `vite.config.ts` middleware shadows the real route

`vite.config.ts` had a hardcoded middleware handler for `/api/connection-status` that intercepted the request before TanStack Router and always returned `{ mode: 'portable' }` as long as `/v1/models` responded — preventing the real `connection-status` route from ever being reached.

## Fix

- Add `src/hooks/use-gateway-caps.ts` — a `useIsFeatureAvailable(feature)` hook backed by the existing `/api/gateway-status` React Query. Returns `null` while loading (renders nothing instead of flashing "unavailable"), then `true`/`false`.
- Replace all synchronous `isFeatureAvailable()` calls in route components and screens with `useIsFeatureAvailable()`.
- Remove the hardcoded `/api/connection-status` vite middleware block.

## Testing

With a Hermes gateway running (`hermes --gateway`):
- Jobs, Skills, Memory pages load correctly instead of showing the unavailable state
- Dashboard widgets load data
- Settings providers screen loads config
- Without a gateway (portable mode), pages still correctly show the unavailable state after the query resolves