### PR TITLE
fix: client-side capability detection after SSR hydration

### DIFF
--- a/src/components/inspector/inspector-panel.tsx
+++ b/src/components/inspector/inspector-panel.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { create } from 'zustand'
 import {  useActivityStore } from './activity-store'
 import type {ActivityEvent} from './activity-store';
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -323,8 +324,8 @@ function LogsTab() {
 
 export function InspectorPanel() {
   const isOpen = useInspectorStore((s) => s.isOpen)
-  const memoryAvailable = isFeatureAvailable('memory')
-  const skillsAvailable = isFeatureAvailable('skills')
+  const memoryAvailable = useFeatureAvailable('memory')
+  const skillsAvailable = useFeatureAvailable('skills')
   const [activeTab, setActiveTab] = useState<TabId>('activity')
 
   useEffect(() => {

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -42,7 +42,8 @@ import { BrailleSpinner } from '@/components/ui/braille-spinner'
 import { ThreeDotsSpinner } from '@/components/ui/three-dots-spinner'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { applyAccentColor } from '@/lib/accent-colors'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { ProviderLogo } from '@/components/provider-logo'
 import {
   DialogClose,
@@ -148,7 +149,7 @@ const PROVIDER_CARDS: Array<{ id: string; name: string; logo: string; models: Ar
 ]
 
 function HermesContent() {
-  const configAvailable = isFeatureAvailable('config')
+  const configAvailable = useFeatureAvailable('config')
   const [activeProvider, setActiveProvider] = useState('')
   const [activeModel, setActiveModel] = useState('')
   const [availableModels, setAvailableModels] = useState<Array<string>>([])

--- a/src/hooks/use-feature-available.ts
+++ b/src/hooks/use-feature-available.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import type { EnhancedFeature } from '@/lib/feature-gates'
+
+interface GatewayStatus {
+  capabilities: Record<string, boolean>
+  hermesUrl: string
+}
+
+export function useFeatureAvailable(feature: EnhancedFeature): boolean {
+  const { data } = useQuery({
+    queryKey: ['gateway-status'],
+    queryFn: async () => {
+      const res = await fetch('/api/gateway-status')
+      if (!res.ok) return null
+      return (await res.json()) as GatewayStatus
+    },
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+
+  return data?.capabilities?.[feature] === true
+}

--- a/src/hooks/use-search-data.ts
+++ b/src/hooks/use-search-data.ts
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 // import type { ActivityEvent } from '@/types/activity-event'
 // Activity events disabled in search — SSE connection caused freezing
 // import { useActivityEvents } from '@/screens/activity/use-activity-events'
-import { isFeatureAvailable } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 
 const REQUEST_TIMEOUT_MS = 3_000
 const SESSIONS_STALE_TIME_MS = 60_000
@@ -208,8 +208,8 @@ async function fetchSkills(
 }
 
 export function useSearchData(scope: SearchQueryScope) {
-  const sessionsAvailable = isFeatureAvailable('sessions')
-  const skillsAvailable = isFeatureAvailable('skills')
+  const sessionsAvailable = useFeatureAvailable('sessions')
+  const skillsAvailable = useFeatureAvailable('skills')
 
   // Sessions
   const sessionsQuery = useQuery({

--- a/src/routes/jobs.tsx
+++ b/src/routes/jobs.tsx
@@ -1,13 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { JobsScreen } from '@/screens/jobs/jobs-screen'
 
 export const Route = createFileRoute('/jobs')({
   component: function JobsRoute() {
     usePageTitle('Jobs')
-    if (!isFeatureAvailable('jobs')) {
+    if (!useFeatureAvailable('jobs')) {
       return (
         <BackendUnavailableState
           feature="Jobs"

--- a/src/routes/memory.tsx
+++ b/src/routes/memory.tsx
@@ -1,14 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { MemoryBrowserScreen } from '@/screens/memory/memory-browser-screen'
 
 export const Route = createFileRoute('/memory')({
   ssr: false,
   component: function MemoryRoute() {
     usePageTitle('Memory')
-    if (!isFeatureAvailable('memory')) {
+    if (!useFeatureAvailable('memory')) {
       return (
         <BackendUnavailableState
           feature="Memory"

--- a/src/routes/skills.tsx
+++ b/src/routes/skills.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { SkillsScreen } from '@/screens/skills/skills-screen'
 
 export const Route = createFileRoute('/skills')({
@@ -10,7 +11,7 @@ export const Route = createFileRoute('/skills')({
 
 function SkillsRoute() {
   usePageTitle('Skills')
-  if (!isFeatureAvailable('skills')) {
+  if (!useFeatureAvailable('skills')) {
     return (
       <BackendUnavailableState
         feature="Skills"

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -15,7 +15,8 @@ import { listSessions, getConfig } from '@/server/hermes-api'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { getCapabilities } from '@/server/gateway-capabilities'
 import type { HermesSession } from '@/server/hermes-api'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -202,7 +203,7 @@ function ActivityChart({ sessions }: { sessions: HermesSession[] }) {
 // ── Model Card ───────────────────────────────────────────────────
 
 function ModelCard() {
-  const configAvailable = isFeatureAvailable('config')
+  const configAvailable = useFeatureAvailable('config')
   const configQuery = useQuery({
     queryKey: ['hermes-config'],
     queryFn: getConfig,
@@ -268,7 +269,7 @@ function ModelCard() {
 // ── Skills Widget ────────────────────────────────────────────────
 
 function SkillsWidget() {
-  const skillsAvailable = isFeatureAvailable('skills')
+  const skillsAvailable = useFeatureAvailable('skills')
   const skillsQuery = useQuery({
     queryKey: ['hermes-skills'],
     queryFn: async () => {
@@ -375,8 +376,8 @@ function SessionRow({ session, maxTokens, onClick }: {
 
 export function DashboardScreen() {
   const navigate = useNavigate()
-  const sessionsAvailable = isFeatureAvailable('sessions')
-  const skillsAvailable = isFeatureAvailable('skills')
+  const sessionsAvailable = useFeatureAvailable('sessions')
+  const skillsAvailable = useFeatureAvailable('skills')
   const sessionsQuery = useQuery({
     queryKey: chatQueryKeys.sessions,
     queryFn: () => listSessions(50, 0),

--- a/src/screens/settings/providers-screen.tsx
+++ b/src/screens/settings/providers-screen.tsx
@@ -45,7 +45,8 @@ import {
   TabsTrigger,
 } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
-import { getUnavailableReason, isFeatureAvailable } from '@/lib/feature-gates'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import {
   getProviderDisplayName,
   getProviderInfo,
@@ -1323,7 +1324,7 @@ function ProviderManagementSection(props: {
 
 export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   const queryClient = useQueryClient()
-  const configAvailable = isFeatureAvailable('config')
+  const configAvailable = useFeatureAvailable('config')
   const [activeTab, setActiveTab] = useState<SettingsTabId>('providers')
   const [search, setSearch] = useState('')
   const [draftValues, setDraftValues] = useState<Record<string, string>>({})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -459,11 +459,20 @@ const config = defineConfig(({ mode, command }) => {
             // Portable-aware health check — returns ok if any chat backend is available
             if (req.method === 'GET' && requestPath === '/api/connection-status') {
               try {
-                // Check if the configured backend has /v1/models (works for Ollama, OpenAI, etc.)
-                const modelsRes = await fetch(`${hermesApiUrl}/v1/models`, {
-                  signal: AbortSignal.timeout(3000),
-                })
-                if (modelsRes.ok) {
+                // Check for enhanced Hermes gateway first (has /api/sessions)
+                const [modelsRes, sessionsRes] = await Promise.all([
+                  fetch(`${hermesApiUrl}/v1/models`, { signal: AbortSignal.timeout(3000) }).catch(() => null),
+                  fetch(`${hermesApiUrl}/api/sessions?limit=1`, { signal: AbortSignal.timeout(3000) }).catch(() => null),
+                ])
+                const hasModels = modelsRes?.ok ?? false
+                const hasSessions = sessionsRes?.ok ?? false
+                if (hasModels && hasSessions) {
+                  res.statusCode = 200
+                  res.setHeader('content-type', 'application/json')
+                  res.end(JSON.stringify({ ok: true, mode: 'enhanced', backend: hermesApiUrl }))
+                  return
+                }
+                if (hasModels) {
                   res.statusCode = 200
                   res.setHeader('content-type', 'application/json')
                   res.end(JSON.stringify({ ok: true, mode: 'portable', backend: hermesApiUrl }))


### PR DESCRIPTION
## Summary

- Enhanced features (sessions, skills, memory, jobs) always show "unavailable" after client-side hydration because `isFeatureAvailable()` reads from a server-side module variable that resets to `false` on the client
- Created `useFeatureAvailable()` React Query hook that fetches capabilities from `/api/gateway-status` and triggers re-renders when data arrives
- Fixed vite dev server middleware to probe `/api/sessions` before defaulting to `mode: "portable"` for `/api/connection-status`

## Problem

`getCapabilities()` in `gateway-capabilities.ts` stores probed results in a module-level variable. During SSR this works fine — the server probes the gateway at startup and renders correctly. But after hydration:

1. Client-side JS re-initializes the module with all capabilities as `false`
2. The async `ensureGatewayProbed()` fires but isn't tied to React state
3. Components never re-render → features permanently show as unavailable

## Fix

Replace direct `isFeatureAvailable()` calls in route/component code with a `useFeatureAvailable()` hook backed by React Query, which reactively updates when the `/api/gateway-status` response arrives.

### Files changed
- **New:** `src/hooks/use-feature-available.ts` — reactive hook using React Query
- **Updated:** Route files (`skills.tsx`, `memory.tsx`, `jobs.tsx`), dashboard, inspector panel, settings dialog, providers screen, search data hook
- **Updated:** `vite.config.ts` — dev middleware now checks `/api/sessions` for enhanced mode detection

## Test plan
- [ ] Navigate to Skills, Memory, Jobs pages — should show content instead of "unavailable"
- [ ] Dashboard analytics section should display session stats
- [ ] Settings dialog should show config options
- [ ] Verify SSR still renders correctly (view source should show content)
- [ ] Test with gateway stopped — pages should show unavailable state

🤖 Generated with [Claude Code](https://claude.com/claude-code)