### PR TITLE
docs: add Ollama CORS troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Open `http://localhost:3000`.
 
 > **Supports any provider:** Anthropic, OpenAI, OpenRouter, or local models via Ollama (no key needed). Just set the right env var in `.env` — see `.env.example` for options.
 
+> **Ollama users:** If you get a CORS error, start Ollama with `OLLAMA_ORIGINS=* ollama serve` and use `http://127.0.0.1:11434/v1` as your base URL (not `localhost`).
+
 ---
 
 ## 📱 Install as App (Recommended)


### PR DESCRIPTION
Adds a note to the README about starting Ollama with `OLLAMA_ORIGINS=*` and using `127.0.0.1` instead of `localhost` to avoid CORS issues in portable mode.