### PR TITLE
docs: Fix Docker setup instructions and add troubleshooting guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,20 @@
 # Copy this to .env and adjust as needed:
 #   cp .env.example .env
 
+# ═══════════════════════════════════════════════════════════════
+# REQUIRED for Docker Compose
+# The hermes-agent container needs an API key to function.
+# Get your key at: https://console.anthropic.com/settings/keys
+# ═══════════════════════════════════════════════════════════════
+ANTHROPIC_API_KEY=your-api-key-here
+
+# ═══════════════════════════════════════════════════════════════
+# Optional: Hermes Agent Connection
+# ═══════════════════════════════════════════════════════════════
+
 # Hermes Agent WebAPI URL (default: http://127.0.0.1:8642)
-# Change this if your Hermes Agent runs on a different host/port
+# - For Docker: Uses http://hermes-agent:8642 automatically
+# - For local dev: Set to http://127.0.0.1:8642
 # HERMES_API_URL=http://127.0.0.1:8642
 
 # Hermes Agent directory (auto-detected if sibling to workspace)

--- a/README.md
+++ b/README.md
@@ -110,23 +110,46 @@ ANTHROPIC_API_KEY=your-key-here
 
 [![Open in GitHub Codespaces](https://img.shields.io/badge/GitHub%20Codespaces-Open-181717?logo=github)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=outsourc-e/hermes-workspace)
 
+The Docker setup runs both the **Hermes Agent gateway** and **Hermes Workspace** together.
+
 ### Prerequisites
 
 - **Docker**
 - **Docker Compose**
+- **Anthropic API Key** — [Get one here](https://console.anthropic.com/settings/keys) (required for the agent gateway)
+
+### Step 1: Configure Environment
 
 ```bash
 git clone https://github.com/outsourc-e/hermes-workspace.git
 cd hermes-workspace
-cp .env.example .env   # Edit with your API key
+cp .env.example .env
+```
+
+Edit `.env` and add your API key:
+
+```env
+ANTHROPIC_API_KEY=your-key-here
+```
+
+> **Important:** The `hermes-agent` container requires `ANTHROPIC_API_KEY` to function. Without it, the gateway will fail to authenticate.
+
+### Step 2: Start the Services
+
+```bash
 docker compose up
 ```
 
-Open `http://localhost:3000`.
+This starts two services:
 
-> **Supports any provider:** Anthropic, OpenAI, OpenRouter, or local models via Ollama (no key needed). Just set the right env var in `.env` — see `.env.example` for options.
+- **hermes-agent** — The AI agent gateway (port 8642)
+- **hermes-workspace** — The web UI (port 3000)
 
-> **Ollama users:** If you get a CORS error, start Ollama with `OLLAMA_ORIGINS=* ollama serve` and use `http://127.0.0.1:11434/v1` as your base URL (not `localhost`).
+### Step 3: Access the Workspace
+
+Open `http://localhost:3000` and complete the onboarding.
+
+> **Verify:** Check the Docker logs for `[gateway] Connected to Hermes` — this confirms the workspace successfully connected to the agent.
 
 ---
 
@@ -308,6 +331,55 @@ Verify: `curl http://localhost:8642/health` should return `{"status": "ok"}`.
 ### "Using upstream NousResearch/hermes-agent"
 
 The upstream hermes-agent supports basic chat via `hermes --gateway`, but doesn't include extended endpoints (sessions, memory, skills, config) yet. The workspace will work in **portable mode** with basic chat. For full features, use our fork (`outsourc-e/hermes-agent`).
+
+### Docker: "Unauthorized" or "Connection refused" to hermes-agent
+
+If using Docker Compose and getting auth errors:
+
+1. **Check your API key is set:**
+
+   ```bash
+   cat .env | grep ANTHROPIC_API_KEY
+   # Should show: ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+2. **View the agent container logs:**
+
+   ```bash
+   docker compose logs hermes-agent
+   ```
+
+   Look for startup errors or missing API key warnings.
+
+3. **Verify the agent health endpoint:**
+
+   ```bash
+   curl http://localhost:8642/health
+   # Should return: {"status": "ok"}
+   ```
+
+4. **Restart with fresh containers:**
+
+   ```bash
+   docker compose down
+   docker compose up --build
+   ```
+
+5. **Check workspace logs for gateway status:**
+   ```bash
+   docker compose logs hermes-workspace
+   ```
+   Look for: `[gateway] http://hermes-agent:8642 mode=...` — if it shows `mode=disconnected`, the agent isn't running correctly.
+
+### Docker: "hermes webapi command not found"
+
+The `hermes webapi` command referenced in older docs doesn't exist. The correct command is:
+
+```bash
+hermes --gateway   # Starts the FastAPI gateway server
+```
+
+The Docker setup uses `hermes --gateway` automatically — no action needed if using `docker compose up`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,22 @@
+# Hermes Workspace + Agent — Docker Compose Setup
+#
+# Requirements:
+#   - Docker & Docker Compose
+#   - ANTHROPIC_API_KEY in .env file (required for the agent gateway)
+#
+# Quick Start:
+#   1. cp .env.example .env
+#   2. Add your ANTHROPIC_API_KEY to .env
+#   3. docker compose up
+#   4. Open http://localhost:3000
+#
+# Troubleshooting:
+#   - See README.md "Docker" troubleshooting section
+#   - Check logs: docker compose logs hermes-agent
+
 services:
+  # The Hermes AI Agent Gateway
+  # Provides the backend API that the workspace connects to
   hermes-agent:
     build:
       context: .
@@ -6,16 +24,19 @@ services:
     env_file:
       - .env
     environment:
+      # Pass through the API key from .env (required!)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8642/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8642/health']
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 15s
     ports:
-      - "8642:8642"
+      - '8642:8642'
 
+  # The Hermes Workspace Web UI
+  # Connects to hermes-agent at http://hermes-agent:8642
   hermes-workspace:
     build:
       context: .
@@ -26,6 +47,7 @@ services:
     env_file:
       - .env
     environment:
+      # Internal Docker network URL (not localhost!)
       HERMES_API_URL: http://hermes-agent:8642
     ports:
-      - "3000:3000"
+      - '3000:3000'


### PR DESCRIPTION
Fixes #10 - Issue connecting workspace to containerized agent

Changes:
- Clarify that ANTHROPIC_API_KEY is required for Docker setup
- Fix outdated 'hermes webapi' command reference to 'hermes --gateway'
- Add step-by-step Docker quickstart instructions
- Add Docker-specific troubleshooting section
- Update .env.example with clear API key requirement notice
- Add helpful comments to docker-compose.yml explaining services

This addresses the 'Unauthorized' errors users get when trying to autodetect the agent in Docker without proper API key configuration.