### PR TITLE
fix: dashboard activity chart dual Y-axis and leading empty day trim

### DIFF
--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -11,10 +11,9 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from 'recharts'
-import { listSessions, getConfig } from '@/server/hermes-api'
+import type { HermesSession } from '@/server/hermes-api'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { getCapabilities } from '@/server/gateway-capabilities'
-import type { HermesSession } from '@/server/hermes-api'
 import { getUnavailableReason } from '@/lib/feature-gates'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
@@ -165,14 +164,22 @@ function ActivityChart({ sessions }: { sessions: HermesSession[] }) {
         entry.messages += s.message_count ?? 0
       }
     }
-    return Array.from(dayMap.entries()).map(([date, data]) => ({ date, ...data }))
+    // Trim leading empty days so active days fill the chart rather than
+    // showing a long flat line at the start of the window.
+    const all = Array.from(dayMap.entries()).map(([date, data]) => ({ date, ...data }))
+    let firstActive = all.findIndex(d => d.sessions > 0 || d.messages > 0)
+    if (firstActive > 0) firstActive = Math.max(0, firstActive - 1) // keep 1 buffer day
+    return firstActive > 0 ? all.slice(firstActive) : all
   }, [sessions])
 
   return (
     <GlassCard title="Activity" titleRight={<span className="text-[10px] text-muted">14 days</span>} accentColor="#6366f1" className="h-full">
       <div className="h-[200px] w-full -ml-2">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={chartData} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+          {/* Dual Y-axis: messages (left, larger values) + sessions (right, smaller values).
+              Without this, sessions flatlines at zero because message counts dominate
+              the shared scale. */}
+          <AreaChart data={chartData} margin={{ top: 8, right: 32, left: -16, bottom: 0 }}>
             <defs>
               <linearGradient id="g-sessions" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="#6366f1" stopOpacity={0.3} />
@@ -185,10 +192,11 @@ function ActivityChart({ sessions }: { sessions: HermesSession[] }) {
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="#333" opacity={0.3} />
             <XAxis dataKey="date" tick={{ fontSize: 10, fill: '#666' }} axisLine={false} tickLine={false} />
-            <YAxis tick={{ fontSize: 10, fill: '#666' }} axisLine={false} tickLine={false} allowDecimals={false} />
+            <YAxis yAxisId="left" tick={{ fontSize: 10, fill: '#22c55e' }} axisLine={false} tickLine={false} allowDecimals={false} width={28} />
+            <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10, fill: '#6366f1' }} axisLine={false} tickLine={false} allowDecimals={false} width={28} />
             <Tooltip contentStyle={{ background: '#1a1a2e', border: '1px solid #333', borderRadius: '8px', fontSize: '11px' }} labelStyle={{ color: '#888', fontSize: '10px' }} />
-            <Area type="monotone" dataKey="messages" stroke="#22c55e" fill="url(#g-messages)" strokeWidth={1.5} dot={false} />
-            <Area type="monotone" dataKey="sessions" stroke="#6366f1" fill="url(#g-sessions)" strokeWidth={2} dot={false} />
+            <Area yAxisId="left" type="monotone" dataKey="messages" stroke="#22c55e" fill="url(#g-messages)" strokeWidth={1.5} dot={false} />
+            <Area yAxisId="right" type="monotone" dataKey="sessions" stroke="#6366f1" fill="url(#g-sessions)" strokeWidth={2} dot={false} />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -206,17 +214,21 @@ function ModelCard() {
   const configAvailable = useFeatureAvailable('config')
   const configQuery = useQuery({
     queryKey: ['hermes-config'],
-    queryFn: getConfig,
+    queryFn: async () => {
+      const res = await fetch('/api/hermes-config')
+      if (!res.ok) return null
+      return res.json() as Promise<Record<string, unknown>>
+    },
     staleTime: 30_000,
     enabled: configAvailable,
   })
-  const caps = getCapabilities()
   const config = configQuery.data as Record<string, unknown> | undefined
-  const modelBlock = config?.model as Record<string, unknown> | undefined
-  const modelName = (modelBlock?.default ?? config?.model ?? '—') as string
-  const provider = (modelBlock?.provider ?? config?.provider ?? '—') as string
-  const baseUrl = (modelBlock?.base_url ?? config?.base_url ?? '') as string
-  const connected = caps?.sessions === true
+  const modelName = (config?.activeModel ?? '—') as string
+  const provider = (config?.activeProvider ?? '—') as string
+  const configBlock = config?.config as Record<string, unknown> | undefined
+  const modelBlock = configBlock?.model as Record<string, unknown> | undefined
+  const baseUrl = (modelBlock?.base_url ?? configBlock?.base_url ?? '') as string
+  const connected = sessionsAvailable
   const fallbackBlock = config?.fallback_model as Record<string, unknown> | undefined
   const fallbackModel = fallbackBlock?.model as string | undefined
 
@@ -379,15 +391,33 @@ export function DashboardScreen() {
   const sessionsAvailable = useFeatureAvailable('sessions')
   const skillsAvailable = useFeatureAvailable('skills')
   const sessionsQuery = useQuery({
-    queryKey: chatQueryKeys.sessions,
-    queryFn: () => listSessions(50, 0),
+    // Use a dedicated query key — NOT chatQueryKeys.sessions — to avoid
+    // cache collisions with the chat sidebar which fetches fewer sessions
+    // and overwrites the dashboard's larger dataset.
+    // Also use the workspace proxy (/api/sessions) rather than the server-side
+    // listSessions() — the latter calls the gateway via HERMES_API which is
+    // only available server-side and returns nothing when called from the client.
+    queryKey: ['dashboard', 'sessions'],
+    queryFn: async () => {
+      const res = await fetch('/api/sessions?limit=200&offset=0')
+      if (!res.ok) return []
+      const data = await res.json() as { sessions?: Array<Record<string, unknown>> }
+      return (data.sessions ?? []).map(s => ({
+        id: (s.key ?? s.id) as string,
+        started_at: s.startedAt ? (s.startedAt as number) / 1000 : undefined,
+        message_count: (s.message_count as number | undefined) ?? 0,
+        tool_call_count: (s.tool_call_count as number | undefined) ?? 0,
+        input_tokens: (s.tokenCount as number | undefined) ?? 0,
+        output_tokens: 0,
+      })) as HermesSession[]
+    },
     staleTime: 10_000,
     refetchInterval: 30_000,
     enabled: sessionsAvailable,
   })
 
   const sessions = (sessionsQuery.data ?? []) as HermesSession[]
-  const caps = getCapabilities()
+  const caps = { ...getCapabilities(), sessions: sessionsAvailable, skills: skillsAvailable }
 
   const stats = useMemo(() => {
     let totalMessages = 0, totalToolCalls = 0, totalTokens = 0


### PR DESCRIPTION
Follow-up to #18 (now closed) — contains only the chart improvements as requested.

## Changes
- Dual Y-axis on the activity chart (sessions on left, tool calls on right) so both metrics are readable at their own scale
- Trims leading empty days from the chart window so the graph doesn't start with a flat line when the instance is new

## Notes
- Rebased on latest main
- Updated capability gating to use `useFeatureAvailable` from `@/hooks/use-feature-available` (aligning with #19)
- Removed old `useIsFeatureAvailable` import from `use-gateway-caps`