### PR TITLE
fix: add /api/memory parent route for workspace-relative access

### DIFF
--- a/src/routes/api/memory.ts
+++ b/src/routes/api/memory.ts
@@ -1,0 +1,41 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  HERMES_API,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../server/gateway-capabilities'
+import { getMemory } from '../../server/hermes-api'
+
+export const Route = createFileRoute('/api/memory')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        await ensureGatewayProbed()
+        if (!getCapabilities().memory) {
+          return json(
+            {
+              ok: false,
+              error: `Gateway does not support /api/memory on ${HERMES_API}`,
+            },
+            { status: 503 },
+          )
+        }
+
+        try {
+          return json(await getMemory())
+        } catch (err) {
+          return json(
+            { error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds a `createFileRoute('/api/memory')` handler that proxies memory requests through the workspace server with auth
- Inspector panel already uses relative `/api/memory` paths (fixed in main), but the parent GET route was missing — requests fell through to the client router
- Rebased from PR #4 onto current main (clean single-file change)

Supersedes #4 — that PR had merge conflicts with the current route tree. This is a clean rebase with only the missing piece.

## Test plan
- [ ] Visit Inspector → Memory tab, verify it loads memory entries via `/api/memory`
- [ ] Access workspace over Tailscale/LAN, verify inspector still works (no localhost hardcoding)