### PR TITLE
Add oracle public-gateway start script

### DIFF
--- a/scripts/start-oracle.sh
+++ b/scripts/start-oracle.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -a
+source /home/ubuntu/.hermes/profiles/public-gateway/.env >/dev/null 2>&1
+set +a
+export HERMES_API_URL=http://127.0.0.1:8650
+export HERMES_API_TOKEN="$API_SERVER_KEY"
+export HOST=127.0.0.1
+export PORT=3000
+cd /home/ubuntu/Projects/hermes-workspace
+exec /usr/local/bin/node server-entry.js


### PR DESCRIPTION
## Summary
- add the oracle workspace launcher used by the test.zagadka.gg frontend
- point the launcher at the public-gateway Hermes API on port 8650
- load API credentials from the public-gateway profile env

## Verification
- bash -n scripts/start-oracle.sh
- live service already uses this launcher on oracle