### PR TITLE
Support agent-authored artifact events in the inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Features pending cloud infrastructure:
 ### 💬 Chat
 
 - Real-time SSE streaming with tool call rendering
+- Agent-authored artifact events surfaced in the inspector
 - Multi-session management with full history
 - Markdown + syntax highlighting
 - Chronological message ordering with merge dedup

--- a/docs/agent-authored-ui-state.md
+++ b/docs/agent-authored-ui-state.md
@@ -1,0 +1,27 @@
+# Agent-authored UI state
+
+Hermes Workspace can render optional structured UI state emitted by the agent instead of relying only on heuristic panel derivation from plain chat text.
+
+## Why
+
+Some side surfaces are more trustworthy when the agent explicitly says what should be surfaced.
+
+This keeps the shell thin:
+
+- the agent decides what deserves screen space
+- the client renders it
+- heuristic fallback stays only as backup
+
+## Current scope
+
+This first slice supports agent-authored state for:
+
+- chat-side artifact events in the Inspector
+
+If no agent-authored artifact is present, existing UI behavior remains unchanged.
+
+## Notes
+
+- This is intentionally optional and backward-compatible.
+- The exact protocol shape can evolve later.
+- The shell should prefer agent-authored state when present and fall back conservatively otherwise.

--- a/src/components/inspector/inspector-panel.tsx
+++ b/src/components/inspector/inspector-panel.tsx
@@ -22,7 +22,7 @@ export const useInspectorStore = create<InspectorStore>((set) => ({
 
 // ── Tab types ─────────────────────────────────────────────────────────────────
 
-type TabId = 'activity' | 'files' | 'memory' | 'skills' | 'logs'
+type TabId = 'activity' | 'artifacts' | 'files' | 'memory' | 'skills' | 'logs'
 
 const TABS: Array<{
   id: TabId
@@ -30,6 +30,7 @@ const TABS: Array<{
   feature?: 'memory' | 'skills'
 }> = [
   { id: 'activity', label: 'Activity' },
+  { id: 'artifacts', label: 'Artifacts' },
   { id: 'files', label: 'Files' },
   { id: 'memory', label: 'Memory', feature: 'memory' },
   { id: 'skills', label: 'Skills', feature: 'skills' },
@@ -51,6 +52,39 @@ function LoadingState({ text }: { text: string }) {
       <span className="text-xs" style={{ color: 'var(--theme-muted)' }}>
         {text}
       </span>
+    </div>
+  )
+}
+
+function ArtifactsTab() {
+  const events = useActivityStore((s) => s.events)
+  const artifacts = events.filter((e) => e.type === 'artifact')
+
+  if (artifacts.length === 0) {
+    return <EmptyState text="No agent-authored artifacts yet" />
+  }
+
+  return (
+    <div className="space-y-2 p-3 overflow-auto max-h-[calc(100vh-140px)]">
+      <p className="text-xs" style={{ color: 'var(--theme-muted)' }}>
+        {artifacts.length} artifacts emitted by the agent
+      </p>
+      {artifacts.map((artifact, index) => (
+        <div
+          key={`${artifact.time}-${index}`}
+          className="rounded-lg px-3 py-2 text-xs leading-relaxed"
+          style={{
+            backgroundColor: 'var(--theme-card)',
+            border: '1px solid var(--theme-border)',
+            color: 'var(--theme-text)',
+          }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-medium">{artifact.text}</span>
+            <span style={{ color: 'var(--theme-accent)' }}>{artifact.time}</span>
+          </div>
+        </div>
+      ))}
     </div>
   )
 }
@@ -486,6 +520,7 @@ export function InspectorPanel() {
           {/* Content */}
           <div className="flex-1 overflow-auto">
             {activeTab === 'activity' && <ActivityTab />}
+            {activeTab === 'artifacts' && <ArtifactsTab />}
             {activeTab === 'files' && <FilesTab />}
             {activeTab === 'memory' && <MemoryTab />}
             {activeTab === 'skills' && <SkillsTab />}

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -689,19 +689,22 @@ export const Route = createFileRoute('/api/send-stream')({
                           ? (data.artifact as Record<string, unknown>)
                           : {}
                       const translated = {
-                        phase: 'complete',
                         name: readString(data.tool_name) || 'artifact',
-                        toolCallId: readString(data.tool_call_id) || undefined,
-                        result:
+                        title:
                           readString(artifact.title) ||
-                          readString(artifact.path) ||
-                          readString(data.path) ||
+                          readString(data.title) ||
                           'Artifact created',
+                        kind:
+                          readString(artifact.kind) ||
+                          readString(data.kind) ||
+                          'artifact',
+                        path:
+                          readString(artifact.path) || readString(data.path) || '',
                         sessionKey: sessionKeyFromEvent,
                         runId,
                       }
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
+                      sendEvent('artifact', translated)
+                      skipPublish || publishChatEvent('artifact', translated)
                       return
                     }
 

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -505,6 +505,36 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
           onTool?.(payload)
           break
         }
+        case 'artifact': {
+          markActivity()
+          const title =
+            typeof payload.title === 'string' && payload.title.trim()
+              ? payload.title.trim()
+              : 'Artifact created'
+          const kind =
+            typeof payload.kind === 'string' && payload.kind.trim()
+              ? payload.kind.trim()
+              : 'artifact'
+          const path =
+            typeof payload.path === 'string' && payload.path.trim()
+              ? payload.path.trim()
+              : ''
+          pushActivity({
+            type: 'artifact',
+            time: new Date().toLocaleTimeString(),
+            text: path ? `${title} — ${path}` : title,
+          })
+          processStoreEvent({
+            type: 'tool',
+            phase: 'complete',
+            name: `artifact:${kind}`,
+            result: path ? `${title} — ${path}` : title,
+            runId: activeRunIdRef.current ?? undefined,
+            sessionKey: activeSessionKeyRef.current,
+            transport: 'send-stream',
+          })
+          break
+        }
         case 'step': {
           const nextUsage: StepUsagePayload = {
             inputTokens:


### PR DESCRIPTION
## What this PR does
This PR adds a small first slice of support for **agent-authored structured state** inside Hermes Workspace.
Specifically, it introduces:
- a distinct `artifact` event path in the stream translator
- artifact handling in chat streaming state
- an **Artifacts** tab in the Inspector
- a short docs note describing the pattern
## Why
Today, richer agent shells often rely on heuristics to infer what should be surfaced from plain chat output.
This PR explores a thinner-shell model:
- the **agent emits artifacts**
- the **workspace renders them**
- fallback heuristics remain separate
That keeps the UI closer to the real agent state and reduces the need for the client to invent meaning from plain text.
## Scope
This is intentionally narrow.
Included:
- `artifact.created` translated into a dedicated `artifact` event
- artifact activity stored and shown in the Inspector
- lightweight docs for the pattern
Not included:
- no redesign of the UI
- no right-rail / dashboard implementation
- no agent-specific or business-specific logic
- no requirement for all agents to emit artifacts
## Notes
This PR is meant as a first, low-risk step:
- it stays backward-compatible
- it adds a concrete surface where agent-authored artifacts can be inspected
- it can later serve as the basis for richer rendering in other surfaces
## Validation
- local build passes successfully
- existing chat flow remains intact
- artifacts are now surfaced as first-class Inspector events instead of being folded into generic tool output