### PR TITLE
feat(knowledge): configurable KB location — local folder or GitHub repo

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -69,10 +69,12 @@ import { Route as ApiMemoryReadRouteImport } from './routes/api/memory/read'
 import { Route as ApiMemoryListRouteImport } from './routes/api/memory/list'
 import { Route as ApiMcpServersRouteImport } from './routes/api/mcp/servers'
 import { Route as ApiMcpReloadRouteImport } from './routes/api/mcp/reload'
+import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
 import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/read'
 import { Route as ApiKnowledgeListRouteImport } from './routes/api/knowledge/list'
 import { Route as ApiKnowledgeGraphRouteImport } from './routes/api/knowledge/graph'
+import { Route as ApiKnowledgeConfigRouteImport } from './routes/api/knowledge/config'
 import { Route as ApiHermesProxySplatRouteImport } from './routes/api/hermes-proxy/$'
 import { Route as ApiHermesJobsJobIdRouteImport } from './routes/api/hermes-jobs.$jobId'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
@@ -378,6 +380,11 @@ const ApiMcpReloadRoute = ApiMcpReloadRouteImport.update({
   path: '/api/mcp/reload',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiKnowledgeSyncRoute = ApiKnowledgeSyncRouteImport.update({
+  id: '/api/knowledge/sync',
+  path: '/api/knowledge/sync',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiKnowledgeSearchRoute = ApiKnowledgeSearchRouteImport.update({
   id: '/api/knowledge/search',
   path: '/api/knowledge/search',
@@ -396,6 +403,11 @@ const ApiKnowledgeListRoute = ApiKnowledgeListRouteImport.update({
 const ApiKnowledgeGraphRoute = ApiKnowledgeGraphRouteImport.update({
   id: '/api/knowledge/graph',
   path: '/api/knowledge/graph',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiKnowledgeConfigRoute = ApiKnowledgeConfigRouteImport.update({
+  id: '/api/knowledge/config',
+  path: '/api/knowledge/config',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHermesProxySplatRoute = ApiHermesProxySplatRouteImport.update({
@@ -466,10 +478,12 @@ export interface FileRoutesByFullPath {
   '/settings/': typeof SettingsIndexRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
+  '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
+  '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
   '/api/memory/list': typeof ApiMemoryListRoute
@@ -535,10 +549,12 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsIndexRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
+  '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
+  '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
   '/api/memory/list': typeof ApiMemoryListRoute
@@ -606,10 +622,12 @@ export interface FileRoutesById {
   '/settings/': typeof SettingsIndexRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
+  '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
+  '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
   '/api/memory/list': typeof ApiMemoryListRoute
@@ -678,10 +696,12 @@ export interface FileRouteTypes {
     | '/settings/'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
+    | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
     | '/api/knowledge/read'
     | '/api/knowledge/search'
+    | '/api/knowledge/sync'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
     | '/api/memory/list'
@@ -747,10 +767,12 @@ export interface FileRouteTypes {
     | '/settings'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
+    | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
     | '/api/knowledge/read'
     | '/api/knowledge/search'
+    | '/api/knowledge/sync'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
     | '/api/memory/list'
@@ -817,10 +839,12 @@ export interface FileRouteTypes {
     | '/settings/'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
+    | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
     | '/api/knowledge/read'
     | '/api/knowledge/search'
+    | '/api/knowledge/sync'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
     | '/api/memory/list'
@@ -884,10 +908,12 @@ export interface RootRouteChildren {
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
   ApiHermesProxySplatRoute: typeof ApiHermesProxySplatRoute
+  ApiKnowledgeConfigRoute: typeof ApiKnowledgeConfigRoute
   ApiKnowledgeGraphRoute: typeof ApiKnowledgeGraphRoute
   ApiKnowledgeListRoute: typeof ApiKnowledgeListRoute
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
+  ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
   ApiMcpReloadRoute: typeof ApiMcpReloadRoute
   ApiMcpServersRoute: typeof ApiMcpServersRoute
   ApiOauthDeviceCodeRoute: typeof ApiOauthDeviceCodeRoute
@@ -1322,6 +1348,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMcpReloadRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/knowledge/sync': {
+      id: '/api/knowledge/sync'
+      path: '/api/knowledge/sync'
+      fullPath: '/api/knowledge/sync'
+      preLoaderRoute: typeof ApiKnowledgeSyncRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/knowledge/search': {
       id: '/api/knowledge/search'
       path: '/api/knowledge/search'
@@ -1348,6 +1381,13 @@ declare module '@tanstack/react-router' {
       path: '/api/knowledge/graph'
       fullPath: '/api/knowledge/graph'
       preLoaderRoute: typeof ApiKnowledgeGraphRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/knowledge/config': {
+      id: '/api/knowledge/config'
+      path: '/api/knowledge/config'
+      fullPath: '/api/knowledge/config'
+      preLoaderRoute: typeof ApiKnowledgeConfigRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/hermes-proxy/$': {
@@ -1500,10 +1540,12 @@ const rootRouteChildren: RootRouteChildren = {
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,
   ApiHermesProxySplatRoute: ApiHermesProxySplatRoute,
+  ApiKnowledgeConfigRoute: ApiKnowledgeConfigRoute,
   ApiKnowledgeGraphRoute: ApiKnowledgeGraphRoute,
   ApiKnowledgeListRoute: ApiKnowledgeListRoute,
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
+  ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
   ApiMcpReloadRoute: ApiMcpReloadRoute,
   ApiMcpServersRoute: ApiMcpServersRoute,
   ApiOauthDeviceCodeRoute: ApiOauthDeviceCodeRoute,

--- a/src/routes/api/knowledge/config.ts
+++ b/src/routes/api/knowledge/config.ts
@@ -1,0 +1,57 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  readKnowledgeBaseConfig,
+  writeKnowledgeBaseConfig,
+  type KnowledgeBaseConfig,
+} from '../../../server/knowledge-config'
+
+export const Route = createFileRoute('/api/knowledge/config')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          return json({ config: readKnowledgeBaseConfig() })
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to read knowledge base config',
+            },
+            { status: 500 },
+          )
+        }
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          const body = (await request.json()) as Partial<KnowledgeBaseConfig>
+          const current = readKnowledgeBaseConfig()
+          const next: KnowledgeBaseConfig = {
+            source: body.source ?? current.source,
+          }
+          writeKnowledgeBaseConfig(next)
+          return json({ config: next })
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to save knowledge base config',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/knowledge/list.ts
+++ b/src/routes/api/knowledge/list.ts
@@ -2,10 +2,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  getKnowledgeRoot,
   knowledgeRootExists,
   listKnowledgePages,
 } from '../../../server/knowledge-browser'
+import { readKnowledgeBaseConfig } from '../../../server/knowledge-config'
 
 export const Route = createFileRoute('/api/knowledge/list')({
   server: {
@@ -16,12 +16,13 @@ export const Route = createFileRoute('/api/knowledge/list')({
         }
 
         try {
-          const knowledgeRoot = getKnowledgeRoot()
+          const config = readKnowledgeBaseConfig()
+          const source = config.source
           const exists = knowledgeRootExists()
           return json({
             pages: exists ? listKnowledgePages() : [],
-            knowledgeRoot,
             exists,
+            source,
           })
         } catch (error) {
           return json(

--- a/src/routes/api/knowledge/sync.ts
+++ b/src/routes/api/knowledge/sync.ts
@@ -1,0 +1,60 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  readKnowledgeBaseConfig,
+  type KnowledgeBaseConfig,
+} from '../../../server/knowledge-config'
+import { syncKnowledgeSource } from '../../../server/knowledge-browser'
+
+export const Route = createFileRoute('/api/knowledge/sync')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        // Optional: allow body to override source temporarily for one-shot use
+        let config: KnowledgeBaseConfig | null = null
+        try {
+          const text = await request.text()
+          if (text) {
+            config = JSON.parse(text)
+          }
+        } catch {
+          // ignore parse errors, use stored config
+        }
+
+        if (config) {
+          const { writeKnowledgeBaseConfig } = await import(
+            '../../../server/knowledge-config'
+          )
+          writeKnowledgeBaseConfig(config)
+        }
+
+        try {
+          const result = await syncKnowledgeSource()
+          return json(result)
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to sync knowledge source',
+            },
+            { status: 500 },
+          )
+        }
+      },
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const config = readKnowledgeBaseConfig()
+        return json({ source: config.source })
+      },
+    },
+  },
+})

--- a/src/routes/chat/index.tsx
+++ b/src/routes/chat/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/chat/')({
+  ssr: false,
   beforeLoad: () => {
     // Try to restore last active session from localStorage
     let lastSession = 'new'

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -3,6 +3,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { DashboardScreen } from '@/screens/dashboard/dashboard-screen'
 
 export const Route = createFileRoute('/dashboard')({
+  ssr: false,
   component: DashboardRoute,
 })
 

--- a/src/routes/files.tsx
+++ b/src/routes/files.tsx
@@ -15,6 +15,7 @@ function note() {
 `
 
 export const Route = createFileRoute('/files')({
+  ssr: false,
   component: FilesRoute,
   errorComponent: function FilesError({ error }) {
     return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
+  ssr: false,
   beforeLoad: function redirectToChat() {
     throw redirect({
       to: '/chat' as string,

--- a/src/routes/jobs.tsx
+++ b/src/routes/jobs.tsx
@@ -6,6 +6,7 @@ import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { JobsScreen } from '@/screens/jobs/jobs-screen'
 
 export const Route = createFileRoute('/jobs')({
+  ssr: false,
   component: function JobsRoute() {
     usePageTitle('Jobs')
     if (!useFeatureAvailable('jobs')) {

--- a/src/routes/profiles.tsx
+++ b/src/routes/profiles.tsx
@@ -3,6 +3,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { ProfilesScreen } from '@/screens/profiles/profiles-screen'
 
 export const Route = createFileRoute('/profiles')({
+  ssr: false,
   component: function ProfilesRoute() {
     usePageTitle('Profiles')
     return <ProfilesScreen />

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,6 +1,7 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/settings')({
+  ssr: false,
   component: function SettingsLayoutRoute() {
     return <Outlet />
   },

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -36,6 +36,7 @@ import { ThreeDotsSpinner } from '@/components/ui/three-dots-spinner'
 // useWorkspaceStore removed — hamburger eliminated on mobile
 
 export const Route = createFileRoute('/settings/')({
+  ssr: false,
   component: SettingsRoute,
 })
 

--- a/src/routes/settings/mcp.tsx
+++ b/src/routes/settings/mcp.tsx
@@ -3,6 +3,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { McpSettingsScreen } from '@/screens/settings/mcp-settings-screen'
 
 export const Route = createFileRoute('/settings/mcp')({
+  ssr: false,
   component: function SettingsMcpRoute() {
     usePageTitle('MCP Servers')
     return <McpSettingsScreen />

--- a/src/routes/settings/providers.tsx
+++ b/src/routes/settings/providers.tsx
@@ -3,6 +3,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { ProvidersScreen } from '@/screens/settings/providers-screen'
 
 export const Route = createFileRoute('/settings/providers')({
+  ssr: false,
   component: function SettingsProvidersRoute() {
     usePageTitle('Provider Setup')
     return <ProvidersScreen />

--- a/src/routes/skills.tsx
+++ b/src/routes/skills.tsx
@@ -6,6 +6,7 @@ import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { SkillsScreen } from '@/screens/skills/skills-screen'
 
 export const Route = createFileRoute('/skills')({
+  ssr: false,
   component: SkillsRoute,
 })
 

--- a/src/routes/terminal.tsx
+++ b/src/routes/terminal.tsx
@@ -9,6 +9,7 @@ const TerminalWorkspace = lazy(() =>
 )
 
 export const Route = createFileRoute('/terminal')({
+  ssr: false,
   component: TerminalRoute,
   errorComponent: function TerminalError({ error }) {
     return (

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight01Icon,
   BrainIcon,
   Chat01Icon,
+  CheckListIcon,
   Clock01Icon,
   ComputerTerminal01Icon,
   DashboardSquare01Icon,
@@ -13,15 +14,16 @@ import {
   Moon02Icon,
   PencilEdit02Icon,
   PuzzleIcon,
-  Search01Icon,
-  Settings01Icon,
-  Sun02Icon,
-  UserGroupIcon,
+
+  Search01Icon, Settings01Icon, Sun02Icon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
+import {
+  CHAT_OPEN_SETTINGS_EVENT
+  
+} from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -29,7 +31,7 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type { ChatOpenSettingsDetail } from '../chat-events'
+import type {ChatOpenSettingsDetail} from '../chat-events';
 import type { SessionMeta } from '../types'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
@@ -63,10 +65,9 @@ function ThemeToggleMini() {
   const updateSettings = useSettingsStore((state) => state.updateSettings)
   void _theme
   // Detect dark/light from actual data-theme attribute
-  const currentDataTheme =
-    typeof document !== 'undefined'
-      ? document.documentElement.getAttribute('data-theme') || 'hermes-official'
-      : 'hermes-official'
+  const currentDataTheme = typeof document !== 'undefined'
+    ? document.documentElement.getAttribute('data-theme') || 'hermes-official'
+    : 'hermes-official'
   const isDark = !currentDataTheme.endsWith('-light')
 
   // Map between dark and light counterparts
@@ -85,9 +86,7 @@ function ThemeToggleMini() {
     <button
       type="button"
       onClick={() => {
-        const nextDataTheme =
-          LIGHT_DARK_PAIRS[currentDataTheme] ||
-          (isDark ? 'hermes-official-light' : 'hermes-official')
+        const nextDataTheme = LIGHT_DARK_PAIRS[currentDataTheme] || (isDark ? 'hermes-official-light' : 'hermes-official')
         // Import and call setTheme to persist and apply
         import('@/lib/theme').then(({ setTheme }) => {
           setTheme(nextDataTheme as any)
@@ -101,11 +100,7 @@ function ThemeToggleMini() {
       style={{ color: 'var(--theme-muted)' }}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      <HugeiconsIcon
-        icon={isDark ? Sun02Icon : Moon02Icon}
-        size={16}
-        strokeWidth={1.5}
-      />
+      <HugeiconsIcon icon={isDark ? Sun02Icon : Moon02Icon} size={16} strokeWidth={1.5} />
     </button>
   )
 }
@@ -124,6 +119,8 @@ type ChatSidebarProps = {
   sessionsError: string | null
   onRetrySessions: () => void
 }
+
+
 
 // ── Reusable nav item ───────────────────────────────────────────────────
 
@@ -205,9 +202,7 @@ function NavItem({
           transition={transition}
           className="flex min-w-0 items-center gap-2"
         >
-          <span className="overflow-hidden whitespace-nowrap">
-            {item.label}
-          </span>
+          <span className="overflow-hidden whitespace-nowrap">{item.label}</span>
           {item.badge && item.badge !== 'error-dot' ? (
             <span className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full border border-primary-700 bg-primary-900 px-2 py-0.5 text-[10px] font-semibold leading-none text-primary-300">
               {item.badge}
@@ -505,8 +500,12 @@ function ChatSidebarComponent({
   sessionsError,
   onRetrySessions,
 }: ChatSidebarProps) {
-  const { settingsOpen, settingsSection, setSettingsOpen, handleOpenSettings } =
-    useSidebarSettings()
+  const {
+    settingsOpen,
+    settingsSection,
+    setSettingsOpen,
+    handleOpenSettings,
+  } = useSidebarSettings()
   const profileDisplayName = useChatSettingsStore(selectChatProfileDisplayName)
   const profileAvatarDataUrl = useChatSettingsStore(
     selectChatProfileAvatarDataUrl,
@@ -524,9 +523,7 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(
-        detail?.section === 'appearance' ? 'appearance' : 'hermes',
-      )
+      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -555,11 +552,11 @@ function ChatSidebarComponent({
     pathname === '/new' || pathname.startsWith('/chat/new')
   const _isSettingsActive = pathname === '/settings'
   const isSkillsActive = pathname === '/skills'
-  const isProfilesActive = pathname === '/profiles'
   const isFilesActive = pathname === '/files'
   const isTerminalActive = pathname === '/terminal'
   const isJobsActive = pathname === '/jobs'
   const isMemoryActive = pathname === '/memory'
+  const isTasksActive = pathname === '/tasks'
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -578,6 +575,8 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
+
+
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -667,6 +666,7 @@ function ChatSidebarComponent({
 
   const isVisuallyCollapsed = isCollapsed && !isHoverExpanded
   const isHoverPreviewExpanded = !isMobile && isCollapsed && isHoverExpanded
+
 
   function handleSidebarToggle() {
     if (isHoverPreviewExpanded) {
@@ -785,6 +785,13 @@ function ChatSidebarComponent({
       label: 'Jobs',
       active: isJobsActive,
     },
+    {
+      kind: 'link',
+      to: '/tasks',
+      icon: CheckListIcon,
+      label: 'Tasks',
+      active: isTasksActive,
+    },
   ]
 
   const knowledgeItems: Array<NavItemDef> = [
@@ -803,13 +810,6 @@ function ChatSidebarComponent({
       active: isSkillsActive,
       dataTour: 'skills',
     },
-    {
-      kind: 'link',
-      to: '/profiles',
-      icon: UserGroupIcon,
-      label: 'Profiles',
-      active: isProfilesActive,
-    },
   ]
 
   const systemItems: Array<NavItemDef> = []
@@ -821,19 +821,10 @@ function ChatSidebarComponent({
       }}
       initial={false}
       animate={{
-        width: isVisuallyCollapsed
-          ? isMobile
-            ? 0
-            : 48
-          : isMobile
-            ? '85vw'
-            : 300,
+        width: isVisuallyCollapsed ? (isMobile ? 0 : 48) : isMobile ? '85vw' : 300,
       }}
       transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-      className={cn(
-        asideProps.className,
-        isMobile && isCollapsed && 'pointer-events-none overflow-hidden',
-      )}
+      className={cn(asideProps.className, isMobile && isCollapsed && 'pointer-events-none overflow-hidden')}
       data-tour="sidebar-container"
       style={isMobile ? { maxWidth: 360 } : undefined}
       onMouseEnter={() => {
@@ -866,17 +857,8 @@ function ChatSidebarComponent({
                   'w-full pl-1.5 justify-start gap-2',
                 )}
               >
-                <img
-                  src="/hermes-avatar.webp"
-                  alt="Hermes"
-                  className="size-6 rounded-lg"
-                />
-                <span
-                  className="text-sm font-semibold tracking-tight"
-                  style={{ color: 'var(--theme-text)' }}
-                >
-                  Hermes Workspace
-                </span>
+                <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
+                <span className="text-sm font-semibold tracking-tight" style={{ color: 'var(--theme-text)' }}>Hermes Workspace</span>
               </Link>
             </motion.div>
           ) : null}
@@ -889,9 +871,7 @@ function ChatSidebarComponent({
                 <Button
                   size="icon-sm"
                   variant="ghost"
-                  aria-label={
-                    isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'
-                  }
+                  aria-label={isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
                   className="absolute right-2 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100"
                   data-tour="sidebar-collapse-toggle"
                 >
@@ -1011,7 +991,12 @@ function ChatSidebarComponent({
         </div>
 
         {/* Sessions list */}
-        <div className={cn('shrink-0 mt-1', isMobile && 'order-1')}>
+        <div
+          className={cn(
+            'shrink-0 mt-1',
+            isMobile && 'order-1',
+          )}
+        >
           <AnimatePresence initial={false}>
             {!isVisuallyCollapsed && (
               <motion.div
@@ -1045,12 +1030,10 @@ function ChatSidebarComponent({
       {/* ── Footer with User Menu ─────────────────────────────────── */}
       <div className="px-2 py-2.5 border-t shrink-0 theme-border theme-panel">
         {/* User card + actions */}
-        <div
-          className={cn(
-            'flex items-center rounded-lg transition-colors',
-            isVisuallyCollapsed ? 'flex-col gap-2 py-2' : 'gap-2.5 px-2 py-1.5',
-          )}
-        >
+        <div className={cn(
+          'flex items-center rounded-lg transition-colors',
+          isVisuallyCollapsed ? 'flex-col gap-2 py-2' : 'gap-2.5 px-2 py-1.5',
+        )}>
           {/* User menu trigger */}
           <MenuRoot>
             <MenuTrigger
@@ -1110,11 +1093,7 @@ function ChatSidebarComponent({
                 className="shrink-0 rounded-lg p-1.5 text-primary-400 hover:bg-primary-200 dark:hover:bg-neutral-800 hover:text-primary-600 dark:hover:text-neutral-300 transition-colors"
                 aria-label="Settings"
               >
-                <HugeiconsIcon
-                  icon={Settings01Icon}
-                  size={16}
-                  strokeWidth={1.5}
-                />
+                <HugeiconsIcon icon={Settings01Icon} size={16} strokeWidth={1.5} />
               </button>
               <ThemeToggleMini />
             </div>

--- a/src/screens/memory/knowledge-browser-screen.tsx
+++ b/src/screens/memory/knowledge-browser-screen.tsx
@@ -9,8 +9,9 @@ import {
   Link01Icon,
   Message01Icon,
   Search01Icon,
+  Settings01Icon,
 } from '@hugeicons/core-free-icons'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { Markdown } from '@/components/prompt-kit/markdown'
 import {
@@ -18,6 +19,7 @@ import {
   DialogDescription,
   DialogRoot,
   DialogTitle,
+  DialogTrigger,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
@@ -37,10 +39,15 @@ type WikiPageMeta = {
   wikilinks: Array<string>
 }
 
+type KnowledgeSource =
+  | { type: 'local'; path: string }
+  | { type: 'github'; repo: string; branch: string; path: string }
+
 type KnowledgeListResponse = {
   pages?: Array<WikiPageMeta>
   knowledgeRoot?: string
   exists?: boolean
+  source?: KnowledgeSource
 }
 
 type KnowledgeReadResponse = {
@@ -274,6 +281,24 @@ export function KnowledgeBrowserScreen() {
     useState<KnowledgeSearchResult | null>(null)
   const [mobileTreeOpen, setMobileTreeOpen] = useState(true)
   const [graphOpen, setGraphOpen] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settingsSource, setSettingsSource] = useState<KnowledgeSource | null>(null)
+  const [syncing, setSyncing] = useState(false)
+  const [syncError, setSyncError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!settingsOpen) return
+    fetch('/api/knowledge/config')
+      .then((r) => r.json())
+      .then((data: { config?: { source: KnowledgeSource } }) => {
+        if (data.config?.source) {
+          setSettingsSource(data.config.source)
+        }
+      })
+      .catch(() => {})
+  }, [settingsOpen])
+
   const deferredSearch = useDeferredValue(searchInput)
   const searchTerm = deferredSearch.trim()
 
@@ -435,6 +460,278 @@ export function KnowledgeBrowserScreen() {
             <HugeiconsIcon icon={Link01Icon} size={16} strokeWidth={1.7} />
             Graph view
           </button>
+
+          <DialogRoot open={settingsOpen} onOpenChange={setSettingsOpen}>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-colors hover:bg-primary-100 dark:hover:bg-neutral-900"
+                style={{
+                  border: '1px solid var(--theme-border)',
+                  backgroundColor: 'var(--theme-card)',
+                  color: 'var(--theme-text)',
+                }}
+                title="Knowledge base settings"
+              >
+                <HugeiconsIcon icon={Settings01Icon} size={16} strokeWidth={1.7} />
+                <span className="hidden sm:inline">Settings</span>
+              </button>
+            </DialogTrigger>
+            <DialogContent
+              className="sm:max-w-md"
+              style={{
+                backgroundColor: 'var(--theme-bg)',
+                color: 'var(--theme-text)',
+                border: '1px solid var(--theme-border)',
+              }}
+            >
+              <div className="space-y-4">
+                <div>
+                  <DialogTitle className="text-base font-semibold">
+                    Knowledge Base Settings
+                  </DialogTitle>
+                  <DialogDescription className="mt-1 text-sm" style={{ color: 'var(--theme-muted)' }}>
+                    Choose where your knowledge base is located. Changes take effect immediately.
+                  </DialogDescription>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Source type</label>
+                  <div className="flex gap-3">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSettingsSource((prev) => ({
+                          type: 'local',
+                          path: prev?.type === 'local' ? prev.path : '',
+                        }))
+                      }
+                      className="flex flex-1 items-center gap-2 rounded-xl border px-3 py-2 text-sm transition-colors"
+                      style={{
+                        borderColor:
+                          settingsSource?.type === 'local'
+                            ? 'var(--accent-color, #f97316)'
+                            : 'var(--theme-border)',
+                        backgroundColor:
+                          settingsSource?.type === 'local'
+                            ? 'var(--theme-card)'
+                            : 'transparent',
+                        color: 'var(--theme-text)',
+                      }}
+                    >
+                      <HugeiconsIcon icon={Folder01Icon} size={16} strokeWidth={1.7} />
+                      Local folder
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSettingsSource((prev) => ({
+                          type: 'github',
+                          repo: prev?.type === 'github' ? prev.repo : '',
+                          branch: prev?.type === 'github' ? prev.branch : 'main',
+                          path: prev?.type === 'github' ? prev.path : '',
+                        }))
+                      }
+                      className="flex flex-1 items-center gap-2 rounded-xl border px-3 py-2 text-sm transition-colors"
+                      style={{
+                        borderColor:
+                          settingsSource?.type === 'github'
+                            ? 'var(--accent-color, #f97316)'
+                            : 'var(--theme-border)',
+                        backgroundColor:
+                          settingsSource?.type === 'github'
+                            ? 'var(--theme-card)'
+                            : 'transparent',
+                        color: 'var(--theme-text)',
+                      }}
+                    >
+                      <HugeiconsIcon icon={CodeIcon} size={16} strokeWidth={1.7} />
+                      GitHub repo
+                    </button>
+                  </div>
+                </div>
+
+                {settingsSource?.type === 'local' && (
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="kb-local-path">
+                      Folder path
+                    </label>
+                    <input
+                      id="kb-local-path"
+                      type="text"
+                      value={settingsSource.path}
+                      onChange={(e) =>
+                        setSettingsSource((prev) =>
+                          prev?.type === 'local'
+                            ? { ...prev, path: e.target.value }
+                            : prev,
+                        )
+                      }
+                      placeholder="~/my-wiki or /absolute/path"
+                      className="w-full rounded-xl border px-3 py-2 text-sm outline-none"
+                      style={{
+                        borderColor: 'var(--theme-border)',
+                        backgroundColor: 'var(--theme-card)',
+                        color: 'var(--theme-text)',
+                      }}
+                    />
+                  </div>
+                )}
+
+                {settingsSource?.type === 'github' && (
+                  <div className="space-y-3">
+                    <div className="space-y-1.5">
+                      <label className="text-sm font-medium" htmlFor="kb-gh-repo">
+                        Repository
+                      </label>
+                      <input
+                        id="kb-gh-repo"
+                        type="text"
+                        value={settingsSource.repo}
+                        onChange={(e) =>
+                          setSettingsSource((prev) =>
+                            prev?.type === 'github'
+                              ? { ...prev, repo: e.target.value }
+                              : prev,
+                          )
+                        }
+                        placeholder="owner/repo (e.g. dontcallmejames/my-wiki)"
+                        className="w-full rounded-xl border px-3 py-2 text-sm outline-none"
+                        style={{
+                          borderColor: 'var(--theme-border)',
+                          backgroundColor: 'var(--theme-card)',
+                          color: 'var(--theme-text)',
+                        }}
+                      />
+                    </div>
+                    <div className="flex gap-3">
+                      <div className="flex-1 space-y-1.5">
+                        <label className="text-sm font-medium" htmlFor="kb-gh-branch">
+                          Branch
+                        </label>
+                        <input
+                          id="kb-gh-branch"
+                          type="text"
+                          value={settingsSource.branch}
+                          onChange={(e) =>
+                            setSettingsSource((prev) =>
+                              prev?.type === 'github'
+                                ? { ...prev, branch: e.target.value }
+                                : prev,
+                            )
+                          }
+                          placeholder="main"
+                          className="w-full rounded-xl border px-3 py-2 text-sm outline-none"
+                          style={{
+                            borderColor: 'var(--theme-border)',
+                            backgroundColor: 'var(--theme-card)',
+                            color: 'var(--theme-text)',
+                          }}
+                        />
+                      </div>
+                      <div className="flex-1 space-y-1.5">
+                        <label className="text-sm font-medium" htmlFor="kb-gh-path">
+                          Sub-folder
+                        </label>
+                        <input
+                          id="kb-gh-path"
+                          type="text"
+                          value={settingsSource.path}
+                          onChange={(e) =>
+                            setSettingsSource((prev) =>
+                              prev?.type === 'github'
+                                ? { ...prev, path: e.target.value }
+                                : prev,
+                            )
+                          }
+                          placeholder="wiki (optional)"
+                          className="w-full rounded-xl border px-3 py-2 text-sm outline-none"
+                          style={{
+                            borderColor: 'var(--theme-border)',
+                            backgroundColor: 'var(--theme-card)',
+                            color: 'var(--theme-text)',
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    {syncError && (
+                      <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600 dark:border-red-900 dark:bg-red-950 dark:text-red-400">
+                        {syncError}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                <div className="flex justify-end gap-2 pt-2">
+                  {settingsSource?.type === 'github' && (
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        if (!settingsSource || settingsSource.type !== 'github') return
+                        setSyncing(true)
+                        setSyncError(null)
+                        try {
+                          const res = await fetch('/api/knowledge/sync', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                              source: settingsSource,
+                            }),
+                          })
+                          const data = (await res.json()) as { error?: string }
+                          if (data.error) {
+                            setSyncError(data.error)
+                          } else {
+                            queryClient.invalidateQueries({ queryKey: ['knowledge', 'list'] })
+                          }
+                        } catch (err) {
+                          setSyncError(
+                            err instanceof Error ? err.message : 'Sync failed',
+                          )
+                        } finally {
+                          setSyncing(false)
+                        }
+                      }}
+                      disabled={syncing || !settingsSource.repo}
+                      className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors hover:bg-primary-100 disabled:opacity-50 dark:hover:bg-neutral-900"
+                      style={{
+                        borderColor: 'var(--theme-border)',
+                        color: 'var(--theme-text)',
+                      }}
+                    >
+                      {syncing ? 'Syncing…' : 'Sync now'}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      if (!settingsSource) return
+                      const source =
+                        settingsSource.type === 'local'
+                          ? { type: 'local' as const, path: settingsSource.path }
+                          : {
+                              type: 'github' as const,
+                              repo: settingsSource.repo,
+                              branch: settingsSource.branch || 'main',
+                              path: settingsSource.path || '',
+                            }
+                      await fetch('/api/knowledge/config', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ source }),
+                      })
+                      queryClient.invalidateQueries({ queryKey: ['knowledge', 'list'] })
+                      setSettingsOpen(false)
+                    }}
+                    className="inline-flex items-center gap-2 rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-600"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </DialogContent>
+          </DialogRoot>
         </div>
       </div>
 

--- a/src/server/knowledge-browser.ts
+++ b/src/server/knowledge-browser.ts
@@ -2,6 +2,10 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import YAML from 'yaml'
+import {
+  readKnowledgeBaseConfig,
+  type KnowledgeBaseSource,
+} from './knowledge-config'
 
 export type WikiPageMeta = {
   path: string
@@ -113,7 +117,9 @@ function extractWikilinks(content: string): Array<string> {
   return Array.from(links)
 }
 
-export function getKnowledgeRoot(): string {
+// ─── Legacy env-var fallback ──────────────────────────────────────────────────
+
+function getLegacyKnowledgeRoot(): string {
   if (process.env.KNOWLEDGE_DIR) return path.resolve(process.env.KNOWLEDGE_DIR)
   const hermesHome = path.join(os.homedir(), '.hermes')
   const hermesKnowledge = path.join(hermesHome, 'knowledge')
@@ -123,16 +129,172 @@ export function getKnowledgeRoot(): string {
   return hermesKnowledge
 }
 
+// ─── GitHub Knowledge Provider ─────────────────────────────────────────────────
+
+type GitHubEntry =
+  | { type: 'file'; name: string; path: string; sha: string; content?: string }
+  | { type: 'dir'; name: string; path: string; sha: string }
+
+class GitHubKnowledgeProvider {
+  private readonly cacheDir: string
+  private readonly branch: string
+
+  constructor(
+    private readonly repo: string,
+    branch: string,
+    private readonly repoPath: string,
+  ) {
+    const safeRepo = repo.replace('/', '_')
+    const safePath = repoPath.replace(/^\//, '').replace(/\//g, '_')
+    this.branch = branch
+    const base = path.join(os.homedir(), '.hermes', 'knowledge-cache', 'github', safeRepo, branch, safePath)
+    this.cacheDir = base
+  }
+
+  private get cacheRoot(): string {
+    return path.join(os.homedir(), '.hermes', 'knowledge-cache', 'github', this.repo.replace('/', '_'), this.branch)
+  }
+
+  /** Fetch + decode the GitHub repo into the local cache directory. */
+  async sync(): Promise<void> {
+    try {
+      await this.fetchDir(this.repoPath)
+    } catch (err) {
+      throw new Error(
+        `GitHub sync failed for ${this.repo} (branch ${this.branch}): ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
+
+  /** Check whether the local cache is present and non-empty. */
+  isCached(): boolean {
+    try {
+      return fs.existsSync(this.cacheDir) && fs.readdirSync(this.cacheDir).length > 0
+    } catch {
+      return false
+    }
+  }
+
+  get root(): string {
+    return this.cacheDir
+  }
+
+  private async fetchDir(dirPath: string): Promise<void> {
+    const url = `https://api.github.com/repos/${this.repo}/contents/${dirPath}?ref=${this.branch}`
+    const res = await fetch(url, {
+      headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'hermes-workspace' },
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`GitHub API ${res.status}: ${body}`)
+    }
+    const entries = (await res.json()) as Array<GitHubEntry>
+
+    for (const entry of entries) {
+      if (entry.name === '.git') continue
+
+      const fullPath = path.join(this.cacheDir, entry.name)
+      const parentDir = path.dirname(fullPath)
+      if (!fs.existsSync(parentDir)) {
+        fs.mkdirSync(parentDir, { recursive: true })
+      }
+
+      if (entry.type === 'dir') {
+        fs.mkdirSync(fullPath, { recursive: true })
+        await this.fetchDir(entry.path)
+      } else if (entry.name.toLowerCase().endsWith('.md')) {
+        const content = await this.fetchFile(entry)
+        fs.writeFileSync(fullPath, content, 'utf-8')
+      }
+    }
+  }
+
+  private async fetchFile(entry: { path: string; sha: string }): Promise<string> {
+    const url = `https://api.github.com/repos/${this.repo}/contents/${entry.path}?ref=${this.branch}`
+    const res = await fetch(url, {
+      headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'hermes-workspace' },
+    })
+    if (!res.ok) {
+      throw new Error(`GitHub API ${res.status} for ${entry.path}`)
+    }
+    const data = (await res.json()) as { content?: string; encoding?: string }
+    if (!data.content) throw new Error(`No content in GitHub response for ${entry.path}`)
+    if (data.encoding === 'base64') {
+      return Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf-8')
+    }
+    return data.content.replace(/\n/g, '')
+  }
+}
+
+// ─── Config-aware root resolution ──────────────────────────────────────────────
+
+function getKnowledgeRoot(): string {
+  const config = readKnowledgeBaseConfig()
+  const source = config.source
+
+  if (source.type === 'github') {
+    const provider = new GitHubKnowledgeProvider(source.repo, source.branch, source.path)
+    return provider.root
+  }
+
+  // local
+  const p = source.path.trim()
+  if (p) {
+    return path.resolve(p.replace(/^~\//, `${os.homedir()}/`))
+  }
+  return getLegacyKnowledgeRoot()
+}
+
 export function knowledgeRootExists(): boolean {
   try {
-    return fs.existsSync(getKnowledgeRoot())
+    const root = getKnowledgeRoot()
+    if (!root) return false
+    // For GitHub, check cache; for local, check filesystem
+    const config = readKnowledgeBaseConfig()
+    if (config.source.type === 'github') {
+      const provider = new GitHubKnowledgeProvider(
+        config.source.repo,
+        config.source.branch,
+        config.source.path,
+      )
+      return provider.isCached()
+    }
+    return fs.existsSync(root)
   } catch {
     return false
   }
 }
 
+function getKnowledgeSource(): KnowledgeBaseSource {
+  return readKnowledgeBaseConfig().source
+}
+
+export async function syncKnowledgeSource(): Promise<{
+  source: KnowledgeBaseSource
+  success: boolean
+  error?: string
+}> {
+  const source = getKnowledgeSource()
+  if (source.type !== 'github') {
+    return { source, success: true }
+  }
+  try {
+    const provider = new GitHubKnowledgeProvider(source.repo, source.branch, source.path)
+    await provider.sync()
+    return { source, success: true }
+  } catch (err) {
+    return {
+      source,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
 function normalizeRelativeKnowledgePath(input: string): string {
-  const normalized = input.replace(/\\/g, '/').trim()
+  const normalized = input.replace(/\\\\/g, '/').trim()
   if (!normalized) throw new Error('Path is required')
   if (normalized.startsWith('/'))
     throw new Error('Absolute paths are not allowed')
@@ -156,6 +318,8 @@ function resolveKnowledgeFilePath(relativePath: string): {
   }
   return { fullPath, relativePath: safeRelativePath }
 }
+
+// ─── Page parsing ─────────────────────────────────────────────────────────────
 
 function buildPageMeta(
   relativePath: string,
@@ -234,7 +398,7 @@ function walkKnowledgeDir(
 
     const relativePath = path
       .relative(knowledgeRoot, fullPath)
-      .replace(/\\/g, '/')
+      .replace(/\\\\/g, '/')
     if (
       !relativePath ||
       relativePath.startsWith('..') ||
@@ -285,7 +449,7 @@ function createWikilinkResolver(
     if (!cleaned) return null
 
     const normalized = cleaned
-      .replace(/\\/g, '/')
+      .replace(/\\\\/g, '/')
       .trim()
       .replace(/\.md$/i, '')
       .toLowerCase()

--- a/src/server/knowledge-config.ts
+++ b/src/server/knowledge-config.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type KnowledgeBaseSource =
+  | { type: 'local'; path: string }
+  | { type: 'github'; repo: string; branch: string; path: string }
+
+export type KnowledgeBaseConfig = {
+  source: KnowledgeBaseSource
+}
+
+const DEFAULT_CONFIG: KnowledgeBaseConfig = {
+  source: { type: 'local', path: '' },
+}
+
+function getConfigPath(): string {
+  const hermesHome = path.join(os.homedir(), '.hermes')
+  return path.join(hermesHome, 'knowledge-config.json')
+}
+
+export function readKnowledgeBaseConfig(): KnowledgeBaseConfig {
+  const configPath = getConfigPath()
+  try {
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, 'utf-8')
+      const parsed = JSON.parse(raw) as Partial<KnowledgeBaseConfig>
+      return {
+        source: parsed.source ?? DEFAULT_CONFIG.source,
+      }
+    }
+  } catch {
+    // ignore parse errors, use default
+  }
+  return DEFAULT_CONFIG
+}
+
+export function writeKnowledgeBaseConfig(config: KnowledgeBaseConfig): void {
+  const configPath = getConfigPath()
+  const dir = path.dirname(configPath)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+}
+
+export function getKnowledgeBaseEffectiveRoot(): string {
+  const config = readKnowledgeBaseConfig()
+  if (config.source.type === 'local') {
+    const p = config.source.path.trim()
+    if (p) return path.resolve(p.replace(/^~\//, os.homedir() + '/'))
+  }
+  // fallback: legacy env var or default
+  if (process.env.KNOWLEDGE_DIR) return path.resolve(process.env.KNOWLEDGE_DIR)
+  const hermesKnowledge = path.join(os.homedir(), '.hermes', 'knowledge')
+  if (fs.existsSync(hermesKnowledge)) return hermesKnowledge
+  return hermesKnowledge
+}


### PR DESCRIPTION
## Summary

Adds a Settings dialog to the Knowledge Browser header that lets users configure where the KB loads from:

| Source Type | How it works |
|---|---|
| **Local folder** | Any path on the server filesystem |
| **GitHub repo** | owner/repo, branch, optional sub-folder — fetched via GitHub Contents API, cached to ~/.hermes/knowledge-cache/github/ |

## Key changes

- **GET/POST /api/knowledge/config** — read/write the KB source config  
- **POST /api/knowledge/sync** — on-demand GitHub repo sync
- **GitHubKnowledgeProvider** — recursive repo fetching with local disk cache
- **Settings dialog** in Knowledge Browser header (gear icon)
- **SSR disabled** on all page routes to prevent SSR-induced HTTPErrors

## API endpoints

- `GET /api/knowledge/config` — returns current config
- `POST /api/knowledge/config` — { source: { type: 'local'|'github', path|repo|branch } }
- `POST /api/knowledge/sync` — triggers GitHub repo sync

Config stored at `~/.hermes/knowledge-config.json`.