### PR TITLE
fix: align telemetry fallback version with 1.0.0

### DIFF
--- a/src/lib/active-users.ts
+++ b/src/lib/active-users.ts
@@ -43,7 +43,7 @@ async function sendPing(fingerprint: string): Promise<void> {
 
   const payload = {
     id: fingerprint,
-    version: process.env.NEXT_PUBLIC_APP_VERSION ?? '3.1.0',
+    version: process.env.NEXT_PUBLIC_APP_VERSION ?? '1.0.0',
     ts: Date.now(),
     mobile: window.innerWidth < 768,
   }


### PR DESCRIPTION
## Summary
- update the active-user telemetry fallback version from 3.1.0 to 1.0.0
- keep runtime-reported version aligned with package metadata, README badge, and the existing v1.0.0 tag

## Verification
- searched repo for stale 3.1.0 source/doc references
- pnpm test
- pnpm build

## Notes
- this is the only source-level stale app version reference I found outside dependency versions in pnpm-lock.yaml