### PR TITLE
fix: remove server-only imports from client bundles causing fatal crash

### DIFF
--- a/src/lib/feature-gates.ts
+++ b/src/lib/feature-gates.ts
@@ -1,4 +1,6 @@
-import { getCapabilities } from '../server/gateway-capabilities'
+// FIX: removed import of getCapabilities from server/gateway-capabilities — that module
+// transitively imports node:sqlite (local-db.ts) which cannot be bundled for the browser.
+// isFeatureAvailable was the only consumer and had no callers, so it is removed below.
 
 export type EnhancedFeature =
   | 'sessions'
@@ -30,11 +32,6 @@ function normalizeFeature(
   }
 
   return null
-}
-
-export function isFeatureAvailable(feature: EnhancedFeature): boolean {
-  const caps = getCapabilities()
-  return caps[feature] === true
 }
 
 export function getFeatureLabel(feature: EnhancedFeature | string): string {

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -13,7 +13,6 @@ import {
 import type { ReactNode } from 'react'
 import type { HermesSession } from '@/server/hermes-api'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
-import { getCapabilities } from '@/server/gateway-capabilities'
 import { getUnavailableReason } from '@/lib/feature-gates'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
@@ -633,12 +632,7 @@ export function DashboardScreen() {
     enabled: sessionsAvailable,
   })
 
-  const sessions = (sessionsQuery.data ?? [])
-  const caps = {
-    ...getCapabilities(),
-    sessions: sessionsAvailable,
-    skills: skillsAvailable,
-  }
+  const sessions = (sessionsQuery.data ?? []) as HermesSession[]
 
   const stats = useMemo(() => {
     let totalMessages = 0,

--- a/src/screens/settings/providers-screen.tsx
+++ b/src/screens/settings/providers-screen.tsx
@@ -25,8 +25,26 @@ import {
   getProviderInfo,
   normalizeProviderId,
 } from '@/lib/provider-catalog'
-import { getConfig, patchConfig } from '@/server/hermes-api'
 import { cn } from '@/lib/utils'
+
+// FIX: replaced direct server module imports with workspace API calls to avoid
+// bundling Node.js-only modules (node:sqlite, node:fs) into the client bundle.
+async function getConfig(): Promise<Record<string, unknown>> {
+  const res = await fetch('/api/hermes-config')
+  if (!res.ok) throw new Error(`Failed to load config: HTTP ${res.status}`)
+  const data = await res.json() as { config?: Record<string, unknown> }
+  return data.config ?? {}
+}
+
+async function patchConfig(patch: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const res = await fetch('/api/hermes-config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ config: patch }),
+  })
+  if (!res.ok) throw new Error(`Failed to save config: HTTP ${res.status}`)
+  return res.json() as Promise<Record<string, unknown>>
+}
 
 /**
  * Strip the provider prefix that hermes-agent adds internally via litellm.


### PR DESCRIPTION
## Problem

After upgrading to v1.0.0, all client-side JavaScript crashed on page load with:

```
"DatabaseSync" is not exported by "__vite-browser-external"
```

This caused all session-related functionality to break completely:
- "Loading sessions…" in sidebar never resolved
- "New Session" button froze or caused a full page reload
- Chat area stayed blank
- Clicking sessions in the sidebar did nothing

## Root Cause

Three client-side React components were importing from server-only modules that transitively pull in `node:sqlite` (via `local-db.ts` → `gateway-capabilities.ts`). Vite correctly refuses to bundle Node.js built-ins for the browser, so the entire client bundle failed to load.

Import chain:
```
routeTree.gen.ts (static imports ALL routes at startup)
  → routes/dashboard.tsx → dashboard-screen.tsx
      → @/server/gateway-capabilities  ← server-only
          → ./local-db → node:sqlite   ← browser crash

  → routes/settings/providers.tsx → providers-screen.tsx
      → @/server/hermes-api          ← server-only (imports gateway-capabilities)

  → multiple routes → @/lib/feature-gates
      → ../server/gateway-capabilities  ← server-only
```

## Fix

**`dashboard-screen.tsx`** — removed unused `getCapabilities` import and the dead `caps` variable that was built from it but never referenced anywhere.

**`providers-screen.tsx`** — replaced `getConfig` / `patchConfig` imports from `@/server/hermes-api` with inline client-safe `fetch('/api/hermes-config')` calls. The workspace already exposes this endpoint (`routes/api/hermes-config.ts`), so no new API surface was needed.

**`feature-gates.ts`** — removed `import { getCapabilities }` and the only function that used it (`isFeatureAvailable`), which had zero callers in the codebase. All other exports (`getUnavailableReason`, `createCapabilityUnavailablePayload`, `getFeatureLabel`) were untouched.

## Verification

```bash
pnpm exec vite build --mode development  # ✓ built in 2.7s, no errors
pnpm exec tsc --noEmit                   # ✓ exits 0
```

Manual testing confirmed: sessions load in sidebar, New Session navigates correctly, chat is functional, session history loads on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)