### PR TITLE
fix: chat history lost on tab switch + mobile scroll button position

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1441,6 +1441,18 @@ export function ChatScreen({
       document.removeEventListener('visibilitychange', handleVisibility)
   }, [historyQuery])
 
+  // Re-mount catch-up: when navigating back to chat from another tab (Skills,
+  // Memory, etc.), the component re-mounts. If a response finished while we
+  // were away, the initial refetch may hit stale data. A delayed re-refetch
+  // ensures we pick up responses that were persisted shortly after the first
+  // fetch. See: https://github.com/outsourc-e/hermes-workspace/issues/43
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void historyQuery.refetch()
+    }, 2000)
+    return () => window.clearTimeout(timer)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps -- mount-only
+
   useEffect(() => {
     function handleSSEDrop() {
       void historyQuery.refetch()

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -1553,7 +1553,7 @@ function ChatMessageListComponent({
         : `calc(${bottomOffset} + ${overlayGap}px)`
     return (
       <div
-        className="pointer-events-none absolute left-1/2 z-40 -translate-x-1/2"
+        className="pointer-events-none absolute z-40 left-1/2 -translate-x-1/2 md:left-1/2 md:-translate-x-1/2 max-md:left-auto max-md:translate-x-0 max-md:right-4"
         style={{ bottom: overlayBottom }}
       >
         <ScrollToBottomButton

--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -335,6 +335,7 @@ export function useChatHistory({
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
     refetchInterval: historyRefetchInterval,
+    staleTime: 0, // Always refetch on mount — prevents stale data after tab navigation
     gcTime: 1000 * 60 * 10,
     structuralSharing: true,
     notifyOnChangeProps: ['data', 'error', 'isError'],


### PR DESCRIPTION
## Fixes

### Chat output lost when navigating tabs during streaming (#43)

**Problem:** When a user navigates away from Chat to another tab (Skills, Memory, etc.) while a response is streaming, the completed response is missing when they return. The ChatScreen unmounts, SSE closes, and local state is lost. On re-mount, the history query serves stale cached data.

**Fix:**
- Set `staleTime: 0` on the history query — ensures TanStack Query always refetches on mount instead of using cached data
- Added a delayed re-refetch (2s after mount) to catch responses that finish persisting after the initial fetch

### Scroll-to-bottom button blocks mobile screen (#39)

**Problem:** The scroll-to-bottom button was centered on screen, blocking content on mobile viewports.

**Fix:** Button stays centered on desktop, moves to bottom-right corner on mobile (`max-md:right-4`).

## Testing

1. Send a long prompt, switch to Skills tab mid-stream, wait for completion, switch back → response should be visible
2. On mobile viewport, scroll up in a long chat → scroll button should appear in bottom-right corner, not center

Fixes #43, Fixes #39