### PR TITLE
Fix new chat session state and installed skills listing

### DIFF
--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -38,8 +38,16 @@ export const Route = createFileRoute('/api/history')({
             friendlyId,
             defaultKey: 'main',
           })
-          // "main" doesn't exist in Hermes — resolve to latest session
-          if (sessionKey === 'main' || sessionKey === 'new') {
+          // Keep /chat/new empty until the first message creates a real session.
+          if (sessionKey === 'new') {
+            return json({
+              sessionKey: 'new',
+              sessionId: 'new',
+              messages: [],
+            })
+          }
+          // "main" doesn't exist in Hermes — resolve it to the latest session.
+          if (sessionKey === 'main') {
             try {
               const sessions = await listSessions(1, 0)
               if (sessions.length > 0) {

--- a/src/routes/api/session-status.ts
+++ b/src/routes/api/session-status.ts
@@ -40,6 +40,23 @@ export const Route = createFileRoute('/api/session-status')({
           const requestedKey = url.searchParams.get('sessionKey')?.trim() || ''
           let sessionKey = requestedKey || 'new'
 
+          if (sessionKey === 'new') {
+            return json({
+              ok: true,
+              payload: {
+                status: 'idle',
+                sessionKey: 'new',
+                sessionLabel: '',
+                model: '',
+                modelProvider: '',
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+                sessions: [],
+              },
+            })
+          }
+
           if (isSyntheticSessionKey(sessionKey)) {
             const sessions = await listSessions(1, 0)
             if (sessions.length === 0) {

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -176,8 +176,10 @@ function normalizeSkill(value: unknown): SkillSummary | null {
         ? record.fileCount
         : 0,
     sourcePath,
-    installed: Boolean(record.installed ?? false),
-    enabled: Boolean(record.enabled ?? record.installed ?? false),
+    // Hermes /api/skills returns the installed skill inventory. Older payloads
+    // omit explicit installed/enabled flags, so default to installed=true.
+    installed: Boolean(record.installed ?? true),
+    enabled: Boolean(record.enabled ?? record.installed ?? true),
     builtin: Boolean(record.builtin),
     featuredGroup: undefined,
     security: normalizeSecurity(record.security),

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -567,7 +567,9 @@ export function ChatScreen({
   } = useRealtimeChatHistory({
     sessionKey: isPortableMode
       ? 'main'
-      : resolvedSessionKey ||
+      : isNewChat
+        ? 'new'
+        : resolvedSessionKey ||
         sessionKeyForHistory ||
         activeCanonicalKey ||
         'main',
@@ -577,10 +579,11 @@ export function ChatScreen({
     enabled:
       // Always enable for new chats in portable mode (no sessions API to resolve).
       // In enhanced mode, wait for session resolution before subscribing.
-      (isNewChat ||
-        Boolean(
-          resolvedSessionKey || sessionKeyForHistory || activeCanonicalKey,
-        )) &&
+      ((isPortableMode && isNewChat) ||
+        (!isNewChat &&
+          Boolean(
+            resolvedSessionKey || sessionKeyForHistory || activeCanonicalKey,
+          ))) &&
       !isRedirecting,
     onUserMessage: useCallback(() => {
       // External message arrived (e.g. from Telegram) — show thinking indicator


### PR DESCRIPTION
## Summary
- fix installed skills detection when Hermes returns skill inventory entries without explicit `installed`/`enabled` flags
- keep `/chat/new` in an empty idle state until the first message creates a real session
- stop the new chat screen from subscribing to an existing enhanced-mode session before session creation

## Testing
- `corepack pnpm build`
- verified live on the deployed workspace against Hermes backend:
  - `/api/skills?tab=installed` returns installed skills again
  - `/api/history?sessionKey=new&friendlyId=new` returns an empty message list
  - `/api/session-status?sessionKey=new` returns an idle blank state
