### PR TITLE
fix: missing Authorization headers in skills and models API routes

### DIFF
--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -8,8 +8,8 @@ import {
   ensureGatewayProbed,
   getGatewayCapabilities,
 } from '../../server/hermes-api'
+import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
 
-const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
 
 // Well-known models for providers available via auth store
 const AUTH_STORE_MODELS: Record<string, Array<ModelEntry>> = {
@@ -120,7 +120,9 @@ function normalizeHermesModel(entry: unknown): ModelEntry | null {
 }
 
 async function fetchHermesModels(): Promise<Array<ModelEntry>> {
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  const headers: Record<string, string> = {}
+  if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+  const response = await fetch(`${HERMES_API}/v1/models`, { headers })
   if (!response.ok)
     throw new Error(`Hermes models request failed (${response.status})`)
   const payload = asRecord(await response.json())

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
+  HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
   getCapabilities,
@@ -38,8 +40,6 @@ type SkillSummary = {
   featuredGroup?: string
   security: SecurityRisk
 }
-
-const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
 
 const KNOWN_CATEGORIES = [
   'All',
@@ -187,7 +187,10 @@ function normalizeSkill(value: unknown): SkillSummary | null {
 }
 
 async function fetchHermesSkills(): Promise<Array<SkillSummary>> {
-  const response = await fetch(`${HERMES_API_URL}/api/skills`)
+  const headers: Record<string, string> = {}
+  if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+
+  const response = await fetch(`${HERMES_API}/api/skills`, { headers })
   if (!response.ok) {
     const body = await response.text().catch(() => '')
     throw new Error(body || `Hermes skills request failed (${response.status})`)
@@ -378,16 +381,12 @@ export const Route = createFileRoute('/api/skills')({
             }
           }
 
-          const BEARER_TOKEN =
-            (await import('../../server/gateway-capabilities')).BEARER_TOKEN
-          const HERMES_API_BASE =
-            (await import('../../server/gateway-capabilities')).HERMES_API
           const headers: Record<string, string> = {
             'Content-Type': 'application/json',
           }
           if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
 
-          const response = await fetch(`${HERMES_API_BASE}${endpoint}`, {
+          const response = await fetch(`${HERMES_API}${endpoint}`, {
             method: 'POST',
             headers,
             body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary

- `fetchHermesSkills()` in `src/routes/api/skills.ts` and `fetchHermesModels()` in `src/routes/api/models.ts` both call the Hermes gateway without an `Authorization` header, causing failures when `API_SERVER_KEY` is configured
- Skills Browser shows "0 total skills" and Profiles "Create Profile" shows "No models found"
- Both files defined their own `HERMES_API_URL` constant instead of using the shared `HERMES_API` from `gateway-capabilities.ts`

## Changes

**skills.ts:**
- Import `BEARER_TOKEN` and `HERMES_API` from `gateway-capabilities.ts` at module scope
- Remove the local `HERMES_API_URL` constant
- Add `Authorization: Bearer` header to the fetch in `fetchHermesSkills()`
- Simplify the POST handler to use the top-level imports instead of dynamic `await import()`

**models.ts:**
- Import `BEARER_TOKEN` and `HERMES_API` from `gateway-capabilities.ts`
- Remove the local `HERMES_API_URL` constant
- Add `Authorization: Bearer` header to the fetch in `fetchHermesModels()`

## Test plan

- [ ] Deploy with `HERMES_API_TOKEN` set and verify Skills Browser loads skills
- [ ] Deploy with `HERMES_API_TOKEN` set and verify Profiles page shows models
- [ ] Deploy without `HERMES_API_TOKEN` and verify both still work (no auth header sent)
- [ ] Verify skill install/uninstall/toggle (POST actions) still work with auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)