### PR TITLE
fix(tasks): constrain kanban board to page width + eliminate refetch flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@types/react-grid-layout": "^1.3.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cytoscape": "^3.33.2",
+    "cytoscape-fcose": "^2.2.0",
     "marked": "^17.0.1",
     "motion": "^12.29.2",
     "playwright": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cytoscape:
+        specifier: ^3.33.2
+        version: 3.33.2
+      cytoscape-fcose:
+        specifier: ^2.2.0
+        version: 2.2.0(cytoscape@3.33.2)
       marked:
         specifier: ^17.0.1
         version: 17.0.4
@@ -2569,6 +2575,10 @@ packages:
 
   cytoscape@3.33.1:
     resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+    engines: {node: '>=0.10'}
+
+  cytoscape@3.33.2:
+    resolution: {integrity: sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==}
     engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
@@ -7761,7 +7771,14 @@ snapshots:
       cose-base: 2.2.0
       cytoscape: 3.33.1
 
+  cytoscape-fcose@2.2.0(cytoscape@3.33.2):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.2
+
   cytoscape@3.33.1: {}
+
+  cytoscape@3.33.2: {}
 
   d3-array@2.12.1:
     dependencies:

--- a/src/components/wiki-graph/WikiGraph.tsx
+++ b/src/components/wiki-graph/WikiGraph.tsx
@@ -1,0 +1,389 @@
+/// <reference types="cytoscape" />
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { KnowledgeGraphNode, KnowledgeGraphEdge } from '../../screens/memory/knowledge-browser-screen'
+
+// ─── Cytoscape fcose layout extension ───────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('cytoscape-fcose')
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+type WikiGraphProps = {
+  nodes: KnowledgeGraphNode[]
+  edges: KnowledgeGraphEdge[]
+  onSelect: (path: string) => void
+  currentPage?: string | null
+}
+
+// ─── Tag color palette ─────────────────────────────────────────────────────
+
+const TAG_COLORS: Record<string, string> = {
+  ai: '#e05c5c',
+  ml: '#c070e0',
+  engineering: '#5caee0',
+  ops: '#5cb87a',
+  research: '#e0a05c',
+  gaming: '#e06c5c',
+  forensics: '#5c8de0',
+  default: '#94a3b8',
+}
+
+function getNodeColor(tags: Array<string> | undefined, isActive: boolean): string {
+  if (isActive) return 'var(--accent, #3b82f6)'
+  const first = tags?.[0]?.toLowerCase()
+  if (first && first in TAG_COLORS) return TAG_COLORS[first]
+  return TAG_COLORS.default
+}
+
+// ─── Main Component ─────────────────────────────────────────────────────────
+
+export function WikiGraph({ nodes, edges, onSelect, currentPage }: WikiGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cyRef = useRef<any>(null)
+  const [filter, setFilter] = useState('')
+  const [localMode, setLocalMode] = useState(false)
+  const [dimensions, setDimensions] = useState({ width: 900, height: 520 })
+  const filterRef = useRef(filter)
+  filterRef.current = filter
+
+  // ── Init Cytoscape ────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!containerRef.current) return
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cytoscape = require('cytoscape') as typeof import('cytoscape')
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: [],
+      style: buildStylesheet(currentPage, cytoscape),
+      layout: { name: 'preset' },
+      minZoom: 0.15,
+      maxZoom: 5,
+      wheelSensitivity: 0.35,
+      boxSelectionEnabled: false,
+    })
+
+    cyRef.current = cy
+
+    // ── Hover: neighbor spotlight ─────────────────────────────────────────
+    cy.on('mouseover', 'node', (e: cytoscape.EventObject) => {
+      if (localMode) return
+      const node = e.target
+      const neighborhood = node.closedNeighborhood()
+
+      cy.elements().not(neighborhood).not(node).addClass('dimmed')
+      node.addClass('hovered')
+      node.connectedEdges().addClass('connected')
+      node.neighborhood('node').addClass('connected')
+    })
+
+    cy.on('mouseover', 'edge', (e: cytoscape.EventObject) => {
+      if (localMode) return
+      const edge = e.target
+      edge.addClass('connected')
+      edge.source().addClass('connected')
+      edge.target().addClass('connected')
+    })
+
+    cy.on('mouseout', 'node', () => {
+      if (localMode) return
+      cy.elements().removeClass('hovered connected dimmed')
+    })
+
+    cy.on('mouseout', 'edge', (e: cytoscape.EventObject) => {
+      if (localMode) return
+      e.target.removeClass('connected')
+    })
+
+    // ── Click: navigate ─────────────────────────────────────────────────
+    cy.on('tap', 'node', (e: cytoscape.EventObject) => {
+      const nodeId = e.target.id()
+      onSelect(decodeURIComponent(nodeId))
+    })
+
+    // ── Resize observer ────────────────────────────────────────────────
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect
+        if (width > 10 && height > 10) {
+          setDimensions({ width, height })
+          cy.resize()
+        }
+      }
+    })
+    if (containerRef.current) ro.observe(containerRef.current)
+
+    const rect = containerRef.current.getBoundingClientRect()
+    if (rect.width > 10 && rect.height > 10) {
+      setDimensions({ width: rect.width, height: rect.height })
+    }
+
+    return () => {
+      ro.disconnect()
+      cy.destroy()
+      cyRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [typeof window === 'undefined'])
+
+  // ── Load / reload graph data ─────────────────────────────────────────────
+
+  useEffect(() => {
+    const cy = cyRef.current
+    if (!cy || nodes.length === 0) return
+
+    const currentFilter = filterRef.current
+    const filtered = currentFilter
+      ? nodes.filter(
+          (n) =>
+            n.title.toLowerCase().includes(currentFilter.toLowerCase()) ||
+            n.tags?.some((t: string) => t.toLowerCase().includes(currentFilter.toLowerCase())),
+        )
+      : nodes
+
+    const visibleIds = new Set(filtered.map((n) => n.id))
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cytoscape = require('cytoscape') as typeof import('cytoscape')
+
+    const elements: cytoscape.ElementDefinition[] = [
+      ...filtered.map((node) => ({
+        data: {
+          id: node.id,
+          label: node.title.length > 26 ? node.title.slice(0, 24) + '…' : node.title,
+          title: node.title,
+          tags: node.tags,
+        },
+        classes: node.id === currentPage ? 'active-node' : undefined,
+      })),
+      ...edges
+        .filter((e) => visibleIds.has(e.source) && visibleIds.has(e.target))
+        .map((edge) => ({
+          data: { source: edge.source, target: edge.target },
+        })),
+    ]
+
+    cy.elements().remove()
+    cy.add(elements)
+
+    // Run fcose layout
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(cy.layout as any)({
+      name: 'fcose',
+      animate: false,
+      randomize: true,
+      dimensions: dimensions,
+      layoutOptions: {
+        randomize: true,
+        animate: false,
+        fit: true,
+        padding: 50,
+        nodeDimensionsIncludeLabels: true,
+        nodeRepulsion: () => 8000,
+        idealEdgeLength: () => 110,
+        edgeElasticity: () => 0.08,
+        gravity: 0.25,
+      },
+    } as cytoscape.LayoutOptions).run()
+
+    setTimeout(() => cy.fit(undefined, 50), 400)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodes, edges, currentPage, dimensions])
+
+  // ── Local mode ───────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const cy = cyRef.current
+    if (!cy) return
+
+    if (!localMode) {
+      cy.elements().removeClass('hovered connected dimmed')
+      return
+    }
+
+    if (!currentPage) return
+
+    const currentNode = cy.$id(currentPage)
+    if (currentNode.empty()) return
+
+    const neighborhood = currentNode.closedNeighborhood()
+    cy.elements().addClass('dimmed')
+    neighborhood.removeClass('dimmed')
+    currentNode.addClass('hovered')
+  }, [localMode, currentPage])
+
+  // ── Filter change ────────────────────────────────────────────────────────
+
+  const handleFilterChange = useCallback((value: string) => {
+    setFilter(value)
+    filterRef.current = value
+  }, [])
+
+  // ── Fit view ─────────────────────────────────────────────────────────────
+
+  const handleFit = useCallback(() => {
+    cyRef.current?.fit(undefined, 50)
+  }, [])
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3">
+        {/* Filter input */}
+        <div className="relative flex-1">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--theme-muted)]"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Filter nodes by name or tag…"
+            value={filter}
+            onChange={(e) => handleFilterChange(e.target.value)}
+            className="w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] py-2 pl-9 pr-3 text-sm text-[var(--theme-text)] placeholder-[var(--theme-muted)] outline-none transition-colors focus:border-[var(--accent)]"
+          />
+        </div>
+
+        {/* Local mode toggle */}
+        <button
+          type="button"
+          onClick={() => setLocalMode((v) => !v)}
+          className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+            localMode
+              ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
+              : 'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-text)] hover:border-[var(--theme-muted)]'
+          }`}
+          title="Toggle local mode: show only current page + immediate neighbors"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="3" />
+            <circle cx="4" cy="12" r="2" />
+            <circle cx="20" cy="12" r="2" />
+            <line x1="6" y1="12" x2="9" y2="12" />
+            <line x1="15" y1="12" x2="18" y2="12" />
+          </svg>
+          Local
+        </button>
+
+        {/* Fit view */}
+        <button
+          type="button"
+          onClick={handleFit}
+          className="inline-flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:border-[var(--theme-muted)]"
+          title="Fit graph to view"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--theme-muted)]">
+        <span>Click node to open page</span>
+        <span>·</span>
+        <span>Hover to spotlight connections</span>
+        <span>·</span>
+        <span>
+          <span
+            className="mr-1 inline-block size-2 rounded-full"
+            style={{ backgroundColor: 'var(--accent, #3b82f6)' }}
+          />
+          Current page
+        </span>
+      </div>
+
+      {/* Graph canvas */}
+      <div
+        ref={containerRef}
+        className="relative w-full overflow-hidden rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)]"
+        style={{ height: 520 }}
+      />
+    </div>
+  )
+}
+
+// ─── Style sheet builder ───────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildStylesheet(currentPageId: string | null | undefined, cytoscape: any) {
+  return cytoscape.stylesheet()
+    .selector('node')
+    .style({
+      'background-color': (ele: cytoscape.NodeSingular) => {
+        const isActive = ele.id() === currentPageId
+        const tags = ele.data('tags') as Array<string> | undefined
+        return getNodeColor(tags, isActive)
+      },
+      'border-width': 1.5,
+      'border-color': 'rgba(148,163,184,0.35)',
+      label: 'data(label)',
+      color: 'var(--theme-text, #e2e8f0)',
+      'font-size': 11,
+      width: 24,
+      height: 24,
+      'text-valign': 'bottom',
+      'text-halign': 'center',
+      'text-margin-y': 7,
+      'text-outline-width': 3,
+      'text-outline-color': 'var(--theme-bg, #0f172a)',
+    })
+    .selector('node:selected')
+    .style({
+      'border-color': 'var(--accent, #3b82f6)',
+      'border-width': 2.5,
+    })
+    .selector('edge')
+    .style({
+      width: 1.2,
+      'line-color': 'rgba(148,163,184,0.35)',
+      'target-arrow-color': 'rgba(148,163,184,0.35)',
+      'target-arrow-shape': 'none',
+      'curve-style': 'bezier',
+      opacity: 0.65,
+    })
+    // State classes applied by JS event handlers
+    .selector('.hovered')
+    .style({
+      'border-color': 'var(--accent, #3b82f6)',
+      'border-width': 2.5,
+      'background-color': 'var(--accent, #3b82f6)',
+      'z-index': 10,
+    })
+    .selector('.connected')
+    .style({
+      'border-color': 'rgba(148,163,184,0.7)',
+      'line-color': 'rgba(148,163,184,0.75)',
+      'target-arrow-color': 'rgba(148,163,184,0.75)',
+      opacity: 1,
+      'z-index': 5,
+    })
+    .selector('.dimmed')
+    .style({
+      opacity: 0.12,
+      'z-index': 1,
+    })
+    .selector('.active-node')
+    .style({
+      'border-color': 'var(--accent, #3b82f6)',
+      'border-width': 3,
+      'background-color': 'var(--accent, #3b82f6)',
+    })
+}

--- a/src/components/wiki-graph/index.ts
+++ b/src/components/wiki-graph/index.ts
@@ -1,0 +1,1 @@
+export { WikiGraph } from './WikiGraph'

--- a/src/screens/memory/knowledge-browser-screen.tsx
+++ b/src/screens/memory/knowledge-browser-screen.tsx
@@ -22,6 +22,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { WikiGraph } from '@/components/wiki-graph'
 
 type WikiPageMeta = {
   path: string
@@ -67,19 +68,19 @@ type KnowledgeSearchResponse = {
   results?: Array<KnowledgeSearchResult>
 }
 
-type KnowledgeGraphNode = {
+export type KnowledgeGraphNode = {
   id: string
   title: string
   type?: string
   tags?: Array<string>
 }
 
-type KnowledgeGraphEdge = {
+export type KnowledgeGraphEdge = {
   source: string
   target: string
 }
 
-type KnowledgeGraphResponse = {
+export type KnowledgeGraphResponse = {
   nodes?: Array<KnowledgeGraphNode>
   edges?: Array<KnowledgeGraphEdge>
 }
@@ -194,81 +195,20 @@ function GraphCanvas({
   nodes,
   edges,
   onSelect,
+  currentPage,
 }: {
   nodes: Array<KnowledgeGraphNode>
   edges: Array<KnowledgeGraphEdge>
   onSelect: (path: string) => void
+  currentPage?: string | null
 }) {
-  const layout = useMemo(() => {
-    if (nodes.length === 0) return []
-    const width = 900
-    const height = 520
-    const centerX = width / 2
-    const centerY = height / 2
-    const radius = Math.max(140, Math.min(width, height) / 2 - 72)
-
-    return nodes.map((node, index) => {
-      const angle = (Math.PI * 2 * index) / Math.max(nodes.length, 1)
-      return {
-        ...node,
-        x: centerX + Math.cos(angle) * radius,
-        y: centerY + Math.sin(angle) * radius,
-      }
-    })
-  }, [nodes])
-
-  const byId = useMemo(
-    () => new Map(layout.map((node) => [node.id, node])),
-    [layout],
-  )
-
   return (
-    <div className="overflow-hidden rounded-2xl border border-primary-200 bg-primary-50 dark:border-neutral-800 dark:bg-neutral-950">
-      <svg viewBox="0 0 900 520" className="h-[520px] w-full">
-        {edges.map((edge, index) => {
-          const source = byId.get(edge.source)
-          const target = byId.get(edge.target)
-          if (!source || !target) return null
-          return (
-            <line
-              key={`${edge.source}:${edge.target}:${index}`}
-              x1={source.x}
-              y1={source.y}
-              x2={target.x}
-              y2={target.y}
-              stroke="rgba(148, 163, 184, 0.45)"
-              strokeWidth="1.25"
-            />
-          )
-        })}
-
-        {layout.map((node) => (
-          <g
-            key={node.id}
-            onClick={() => onSelect(node.id)}
-            className="cursor-pointer"
-          >
-            <circle
-              cx={node.x}
-              cy={node.y}
-              r="16"
-              fill="rgba(59, 130, 246, 0.16)"
-              stroke="rgba(59, 130, 246, 0.65)"
-              strokeWidth="1.5"
-            />
-            <text
-              x={node.x}
-              y={node.y + 34}
-              textAnchor="middle"
-              fontSize="11"
-              fill="currentColor"
-            >
-              {node.title}
-            </text>
-          </g>
-        ))}
-      </svg>
-    </div>
+    <WikiGraph
+      nodes={nodes}
+      edges={edges}
+      onSelect={onSelect}
+      currentPage={currentPage}
+    />
   )
 }
 
@@ -1101,6 +1041,7 @@ export function KnowledgeBrowserScreen() {
               <GraphCanvas
                 nodes={graphQuery.data?.nodes ?? []}
                 edges={graphQuery.data?.edges ?? []}
+                currentPage={selectedPath}
                 onSelect={(pathValue) => {
                   setGraphOpen(false)
                   handleSelectPath(pathValue)

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useSearch } from '@tanstack/react-router'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, CheckListIcon, RefreshIcon } from '@hugeicons/core-free-icons'
@@ -58,6 +58,7 @@ export function TasksScreen() {
     queryKey: [...QUERY_KEY, showDone],
     queryFn: () => fetchTasks({ include_done: showDone }),
     refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
   })
 
   // Load assignees dynamically from profiles + config
@@ -238,7 +239,7 @@ export function TasksScreen() {
 
       {/* Board */}
       <div
-        className="flex flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
+        className="mx-auto flex w-full max-w-[1200px] flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
         style={{ boxShadow: 'inset 0 8px 24px rgba(0,0,0,0.2)' }}
       >
         {visibleColumns.map((col) => {
@@ -250,7 +251,7 @@ export function TasksScreen() {
             <div
               key={col}
               className={cn(
-                'flex flex-col rounded-xl border min-w-[240px] w-[280px] shrink-0',
+                'flex flex-col rounded-xl border min-w-[200px] w-[210px] shrink-0',
                 'bg-[var(--theme-card)] border-[var(--theme-border)]',
                 'transition-colors shadow-[0_2px_12px_rgba(0,0,0,0.25)]',
                 isDragOver && 'border-[var(--theme-accent)] bg-[var(--theme-hover)]',
@@ -270,7 +271,7 @@ export function TasksScreen() {
                     {COLUMN_LABELS[col]}
                   </span>
                   <span className="text-xs text-[var(--theme-muted)]">
-                    ({tasksQuery.isLoading ? '…' : colTasks.length})
+                    ({tasksQuery.isFetching && tasksQuery.data === undefined ? '…' : colTasks.length})
                   </span>
                 </div>
                 <button
@@ -284,7 +285,7 @@ export function TasksScreen() {
 
               {/* Cards */}
               <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto">
-                {tasksQuery.isLoading ? (
+                {tasksQuery.data === undefined ? (
                   <>
                     <SkeletonCard />
                     <SkeletonCard />


### PR DESCRIPTION
## Changes

**Width fix:**
- Add `max-w-[1200px] mx-auto` to board container to match header constraint
- Reduce column width from 280px to 210px so 5 columns fit under 1200px without horizontal overflow
- Reduce column min-width from 240px to 200px

**Refetch flicker fix:**
- Add `placeholderData: keepPreviousData` to keep stale cards visible during 30s background refetch
- Show skeletons only on true initial load (`data === undefined`), not on background refetch
- Fix column count to show task count during refetch instead of '…' flicker

## Before vs After

**Width:** 5×280px columns + gaps overflowed ~1280px viewports → now 5×210px columns fit comfortably under 1200px

**Flicker:** Every 30s the board would blank out with skeleton cards during background refetch → now stale data stays visible until fresh data arrives

Closes: kanban columns overflow page causing nested scrollbars  
Closes: 30s background refetch causes skeleton flicker