### PR TITLE
fix(tasks): dynamic column widths + direct file API (no gateway dependency)

### DIFF
--- a/src/routes/api/hermes-tasks.ts
+++ b/src/routes/api/hermes-tasks.ts
@@ -1,31 +1,220 @@
+/**
+ * Tasks API — JSON file persistence layer.
+ * Reads/writes ~/.hermes/tasks.json (simple, portable, no native modules needed in SSR).
+ */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { HERMES_API } from '../../server/gateway-capabilities'
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import os from 'node:os'
+
+const HERMES_HOME = process.env.HERMES_HOME ?? resolve(os.homedir(), '.hermes')
+const TASKS_FILE = resolve(HERMES_HOME, 'tasks.json')
+
+interface Task {
+  id: string
+  title: string
+  description: string
+  column: string
+  priority: string
+  assignee: string | null
+  tags: string[]
+  due_date: string | null
+  position: number
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+function ensureFile() {
+  const dir = HERMES_HOME
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  if (!existsSync(TASKS_FILE)) {
+    writeFileSync(TASKS_FILE, JSON.stringify({ tasks: [] }, null, 2))
+  }
+}
+
+function readTasks(): Task[] {
+  ensureFile()
+  try {
+    const raw = readFileSync(TASKS_FILE, 'utf-8')
+    if (!raw.trim()) return []
+    const data = JSON.parse(raw) as { tasks: Task[] }
+    return data.tasks ?? []
+  } catch {
+    return []
+  }
+}
+
+function writeTasks(tasks: Task[]) {
+  ensureFile()
+  writeFileSync(TASKS_FILE, JSON.stringify({ tasks }, null, 2), 'utf-8')
+}
+
+function taskToRecord(task: Task) {
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    column: task.column,
+    priority: task.priority,
+    assignee: task.assignee,
+    tags: task.tags,
+    due_date: task.due_date,
+    position: task.position,
+    created_by: task.created_by,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+  }
+}
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function errorResponse(message: string, status = 400) {
+  return jsonResponse({ error: message }, status)
+}
 
 export const Route = createFileRoute('/api/hermes-tasks')({
   server: {
     handlers: {
       GET: async ({ request }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return errorResponse('Unauthorized', 401)
         }
-        const url = new URL(request.url)
-        const params = url.searchParams.toString()
-        const target = `${HERMES_API}/api/tasks${params ? `?${params}` : ''}`
-        const res = await fetch(target)
-        return new Response(res.body, { status: res.status, headers: { 'Content-Type': 'application/json' } })
+        try {
+          const url = new URL(request.url)
+          const includeDone = url.searchParams.get('include_done') === 'true'
+          const tasks = readTasks()
+          const filtered = includeDone ? tasks : tasks.filter((t) => t.column !== 'done')
+          return jsonResponse({ tasks: filtered.map(taskToRecord) })
+        } catch (err) {
+          console.error('[tasks] GET error:', err)
+          return errorResponse('Internal error', 500)
+        }
       },
+
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return errorResponse('Unauthorized', 401)
         }
-        const body = await request.text()
-        const res = await fetch(`${HERMES_API}/api/tasks`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body,
-        })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const {
+            title,
+            description = '',
+            column = 'backlog',
+            priority = 'medium',
+            assignee = null,
+            tags = [],
+            due_date = null,
+            position = 0,
+            created_by = 'user',
+          } = body
+
+          if (!title || typeof title !== 'string') {
+            return errorResponse('title is required', 400)
+          }
+
+          const tasks = readTasks()
+          const id = (body.id as string) || crypto.randomUUID()
+          const now = new Date().toISOString()
+
+          const newTask: Task = {
+            id,
+            title,
+            description: description as string,
+            column: column as string,
+            priority: priority as string,
+            assignee: assignee as string | null,
+            tags: tags as string[],
+            due_date: due_date as string | null,
+            position: position as number,
+            created_by: created_by as string,
+            created_at: now,
+            updated_at: now,
+          }
+
+          tasks.push(newTask)
+          writeTasks(tasks)
+
+          return jsonResponse(taskToRecord(newTask), 201)
+        } catch (err) {
+          console.error('[tasks] POST error:', err)
+          return errorResponse('Internal error', 500)
+        }
+      },
+
+      PATCH: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return errorResponse('Unauthorized', 401)
+        }
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const id = body.id as string
+
+          if (!id) {
+            return errorResponse('id is required', 400)
+          }
+
+          const tasks = readTasks()
+          const idx = tasks.findIndex((t) => t.id === id)
+          if (idx === -1) {
+            return errorResponse('Task not found', 404)
+          }
+
+          const allowed = ['title', 'description', 'column', 'priority', 'assignee', 'tags', 'due_date', 'position']
+          const updated = { ...tasks[idx] }
+
+          for (const key of allowed) {
+            if (body[key] !== undefined) {
+              (updated as Record<string, unknown>)[key] = body[key]
+            }
+          }
+          updated.updated_at = new Date().toISOString()
+
+          tasks[idx] = updated
+          writeTasks(tasks)
+
+          return jsonResponse(taskToRecord(updated))
+        } catch (err) {
+          console.error('[tasks] PATCH error:', err)
+          return errorResponse('Internal error', 500)
+        }
+      },
+
+      DELETE: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return errorResponse('Unauthorized', 401)
+        }
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const id = body.id as string
+
+          if (!id) {
+            return errorResponse('id is required', 400)
+          }
+
+          const tasks = readTasks()
+          const idx = tasks.findIndex((t) => t.id === id)
+          if (idx === -1) {
+            return errorResponse('Task not found', 404)
+          }
+
+          tasks.splice(idx, 1)
+          writeTasks(tasks)
+
+          return jsonResponse({ ok: true })
+        } catch (err) {
+          console.error('[tasks] DELETE error:', err)
+          return errorResponse('Internal error', 500)
+        }
       },
     },
   },

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useSearch } from '@tanstack/react-router'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, CheckListIcon, RefreshIcon } from '@hugeicons/core-free-icons'
@@ -58,6 +58,7 @@ export function TasksScreen() {
     queryKey: [...QUERY_KEY, showDone],
     queryFn: () => fetchTasks({ include_done: showDone }),
     refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
   })
 
   // Load assignees dynamically from profiles + config
@@ -169,6 +170,10 @@ export function TasksScreen() {
 
   const visibleColumns = showDone ? COLUMN_ORDER : COLUMN_ORDER.filter(c => c !== 'done')
 
+  // 4 cols (done hidden) → each gets 1/4 of container width (max 1200px = 300px each)
+  // 5 cols (done shown) → each gets 1/5 of container width (max 1200px = 240px each)
+  const colMaxWidth = Math.floor(1200 / visibleColumns.length)
+
   return (
     <div className="min-h-full overflow-y-auto bg-surface text-ink">
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
@@ -238,7 +243,7 @@ export function TasksScreen() {
 
       {/* Board */}
       <div
-        className="flex flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
+        className="mx-auto flex w-full max-w-[1200px] flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
         style={{ boxShadow: 'inset 0 8px 24px rgba(0,0,0,0.2)' }}
       >
         {visibleColumns.map((col) => {
@@ -250,11 +255,12 @@ export function TasksScreen() {
             <div
               key={col}
               className={cn(
-                'flex flex-col rounded-xl border min-w-[240px] w-[280px] shrink-0',
+                'flex flex-col rounded-xl border min-w-[180px] w-full shrink-0 flex-1',
                 'bg-[var(--theme-card)] border-[var(--theme-border)]',
                 'transition-colors shadow-[0_2px_12px_rgba(0,0,0,0.25)]',
                 isDragOver && 'border-[var(--theme-accent)] bg-[var(--theme-hover)]',
               )}
+              style={{ maxWidth: colMaxWidth }}
               onDragOver={e => handleDragOver(e, col)}
               onDrop={e => handleDrop(e, col)}
               onDragLeave={() => setDragOverColumn(null)}
@@ -270,7 +276,7 @@ export function TasksScreen() {
                     {COLUMN_LABELS[col]}
                   </span>
                   <span className="text-xs text-[var(--theme-muted)]">
-                    ({tasksQuery.isLoading ? '…' : colTasks.length})
+                    ({tasksQuery.isFetching && tasksQuery.data === undefined ? '…' : colTasks.length})
                   </span>
                 </div>
                 <button
@@ -284,7 +290,22 @@ export function TasksScreen() {
 
               {/* Cards */}
               <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto">
-                {tasksQuery.isLoading ? (
+                {tasksQuery.isError ? (
+                  <motion.div
+                    key="error"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    className="flex flex-col items-center justify-center py-8 gap-2 text-red-400"
+                  >
+                    <p className="text-xs font-medium">Failed to load tasks</p>
+                    <button
+                      onClick={() => tasksQuery.refetch()}
+                      className="text-xs text-[var(--theme-accent)] hover:underline"
+                    >
+                      Retry
+                    </button>
+                  </motion.div>
+                ) : tasksQuery.isLoading ? (
                   <>
                     <SkeletonCard />
                     <SkeletonCard />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -424,12 +424,6 @@ const config = defineConfig(({ mode, command }) => {
           ws: true,
           rewrite: (path) => path.replace(/^\/ws-hermes/, ''),
         },
-        // Kanban tasks proxy: frontend /api/hermes-tasks → webapi /api/tasks
-        '/api/hermes-tasks': {
-          target: proxyTarget,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/hermes-tasks/, '/api/tasks'),
-        },
 // REST API proxy: API proxy for Hermes backend
         '/api/hermes-proxy': {
           target: proxyTarget,


### PR DESCRIPTION
## Changes

### Kanban UI fixes

**Column width fix (tasks-screen.tsx):**
- Calculate `colMaxWidth = Math.floor(1200 / visibleColumns.length)` dynamically
- 4 columns (done hidden) → 300px each, fills the 1200px container
- 5 columns (done shown) → 240px each, fits without overflow

**Error state fix (tasks-screen.tsx):**
- Add `isError` check — shows 'Failed to load tasks' with Retry button instead of cycling through skeleton cards indefinitely
- Keeps `keepPreviousData` for refetch, adds explicit `isLoading` for initial load

### Tasks API fix

**Direct file API (hermes-tasks.ts):**
- Replaced proxy-based API (`HERMES_API/api/tasks`) with direct `~/.hermes/tasks.json` reads/writes
- Tasks API now works without requiring the gateway to be running
- GET, POST, PATCH, DELETE all handled locally

**Proxy removal (vite.config.ts):**
- Removed the `/api/hermes-tasks` → `/api/tasks` proxy rule (no longer needed)

## Scope
- `src/screens/tasks/tasks-screen.tsx` — UI fixes (1 file)
- `src/routes/api/hermes-tasks.ts` — file-based API (new implementation)
- `vite.config.ts` — proxy cleanup
- No dependency changes, no new packages

Closes: kanban columns overflow page (4 vs 5 column layout)
Closes: infinite skeleton cycle when tasks API errors
Closes: tasks API broken without gateway running