### PR TITLE
fix: add Authorization headers to all remaining gateway fetch calls

### DIFF
--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -6,7 +6,7 @@ import { execFileSync } from 'node:child_process'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import yaml from 'yaml'
-import { HERMES_API, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API, ensureGatewayProbed } from '../../server/gateway-capabilities'
 
 type CrewDefinition = {
   id: string
@@ -200,6 +200,7 @@ async function fetchAssignedTaskCounts(): Promise<Record<string, number>> {
   try {
     const res = await fetch(`${HERMES_API}/api/tasks?include_done=false`, {
       signal: AbortSignal.timeout(3_000),
+      headers: BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {},
     })
     if (!res.ok) return {}
 

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -4,11 +4,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
+
+function authHeaders(): Record<string, string> {
+  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
 
 export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
   server: {
@@ -34,7 +39,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const target = subPath
           ? `${HERMES_API}/api/jobs/${params.jobId}/${subPath}${url.search}`
           : `${HERMES_API}/api/jobs/${params.jobId}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -63,7 +68,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
           : `${HERMES_API}/api/jobs/${params.jobId}`
         const res = await fetch(target, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body: body || undefined,
         })
         return new Response(await res.text(), {
@@ -89,7 +94,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body,
         })
         return new Response(await res.text(), {
@@ -114,6 +119,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'DELETE',
+          headers: authHeaders(),
         })
         return new Response(await res.text(), {
           status: res.status,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -4,12 +4,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+function authHeaders(): Record<string, string> {
+  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
 
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
@@ -34,7 +39,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/jobs${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(res.body, {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -60,7 +65,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body,
         })
         return new Response(await res.text(), {

--- a/src/routes/api/hermes-proxy/$.ts
+++ b/src/routes/api/hermes-proxy/$.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { HERMES_API } from '../../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../../server/gateway-capabilities'
 import { isAuthenticated } from '../../../server/auth-middleware'
 
 async function proxyRequest(request: Request, splat: string) {
@@ -11,6 +11,7 @@ async function proxyRequest(request: Request, splat: string) {
   const headers = new Headers(request.headers)
   headers.delete('host')
   headers.delete('content-length')
+  if (BEARER_TOKEN) headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
 
   const init: RequestInit = {
     method: request.method,

--- a/src/routes/api/hermes-tasks-assignees.ts
+++ b/src/routes/api/hermes-tasks-assignees.ts
@@ -7,7 +7,7 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { HERMES_API } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
@@ -39,6 +39,10 @@ function getProfileNames(): string[] {
   }
 }
 
+function authHeaders(): Record<string, string> {
+  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
+
 export const Route = createFileRoute('/api/hermes-tasks-assignees')({
   server: {
     handlers: {
@@ -51,6 +55,7 @@ export const Route = createFileRoute('/api/hermes-tasks-assignees')({
         try {
           const res = await fetch(`${HERMES_API}/api/tasks/assignees`, {
             signal: AbortSignal.timeout(2000),
+            headers: authHeaders(),
           })
           if (res.ok) {
             return new Response(await res.text(), {

--- a/src/routes/api/hermes-tasks.$taskId.ts
+++ b/src/routes/api/hermes-tasks.$taskId.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { HERMES_API, ensureGatewayProbed, getCapabilities } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API, ensureGatewayProbed, getCapabilities } from '../../server/gateway-capabilities'
+
+function authHeaders(): Record<string, string> {
+  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
 
 export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
   server: {
@@ -10,7 +14,7 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
           return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
         }
         await ensureGatewayProbed()
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`)
+        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, { headers: authHeaders() })
         return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
       },
       PATCH: async ({ request, params }) => {
@@ -20,7 +24,7 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body,
         })
         return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
@@ -29,7 +33,7 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
         if (!isAuthenticated(request)) {
           return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
         }
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, { method: 'DELETE' })
+        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, { method: 'DELETE', headers: authHeaders() })
         return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
       },
       POST: async ({ request, params }) => {
@@ -41,7 +45,7 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}/${action}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body,
         })
         return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })

--- a/src/routes/api/hermes-tasks.ts
+++ b/src/routes/api/hermes-tasks.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { HERMES_API } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
+
+function authHeaders(): Record<string, string> {
+  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
 
 export const Route = createFileRoute('/api/hermes-tasks')({
   server: {
@@ -12,7 +16,7 @@ export const Route = createFileRoute('/api/hermes-tasks')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/tasks${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(res.body, { status: res.status, headers: { 'Content-Type': 'application/json' } })
       },
       POST: async ({ request }) => {
@@ -22,7 +26,7 @@ export const Route = createFileRoute('/api/hermes-tasks')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/tasks`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...authHeaders() },
           body,
         })
         return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })


### PR DESCRIPTION
## Summary

- Follows up on #52 which fixed `skills.ts` and `models.ts` — the same missing `Authorization: Bearer` header bug exists in 7 more route files
- All gateway `fetch()` calls fail with 401 when `API_SERVER_KEY` is configured because they don't include the Bearer token

### Files fixed (16 fetch calls across 7 files)
- `crew-status.ts` — `fetchAssignedTaskCounts()`
- `hermes-tasks.ts` — GET, POST `/api/tasks`
- `hermes-tasks.$taskId.ts` — GET, PATCH, DELETE, POST `/api/tasks/:id`
- `hermes-tasks-assignees.ts` — GET `/api/tasks/assignees`
- `hermes-jobs.ts` — GET, POST `/api/jobs`
- `hermes-jobs.$jobId.ts` — GET, POST, PATCH, DELETE `/api/jobs/:id`
- `hermes-proxy/$.ts` — catch-all proxy

## Root Cause

Same as #52: route handlers use direct `fetch()` to the gateway without importing `BEARER_TOKEN` from `gateway-capabilities.ts`.

## Test plan

- [x] Deploy with `HERMES_API_TOKEN` set, verify Tasks page loads
- [x] Verify task create/edit/delete/move works
- [x] Verify Jobs page loads and job CRUD works
- [x] Verify Crew Status shows task counts
- [x] Verify catch-all proxy passes auth to gateway
- [x] Deploy without `HERMES_API_TOKEN` and verify everything still works (no auth header sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)