### PR TITLE
fix(tasks): salvage PR #54 UI improvements and complete local task API

### DIFF
--- a/src/routes/api/hermes-tasks.$taskId.ts
+++ b/src/routes/api/hermes-tasks.$taskId.ts
@@ -1,9 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, HERMES_API, ensureGatewayProbed, getCapabilities } from '../../server/gateway-capabilities'
+import { deleteTask, getTask, moveTask, updateTask } from '../../server/tasks-store'
+import type { TaskColumn } from '../../server/tasks-store'
 
-function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
 }
 
 export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
@@ -11,44 +15,71 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
     handlers: {
       GET: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
-        await ensureGatewayProbed()
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, { headers: authHeaders() })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+
+        const task = getTask(params.taskId)
+        if (!task) return jsonResponse({ error: 'Task not found' }, 404)
+        return jsonResponse({ task })
       },
+
       PATCH: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
-        const body = await request.text()
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json', ...authHeaders() },
-          body,
-        })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const task = updateTask(params.taskId, {
+            title: typeof body.title === 'string' ? body.title : undefined,
+            description: typeof body.description === 'string' ? body.description : undefined,
+            column: typeof body.column === 'string' ? body.column : undefined,
+            priority: typeof body.priority === 'string' ? body.priority : undefined,
+            assignee: body.assignee === null || typeof body.assignee === 'string' ? body.assignee : undefined,
+            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : undefined,
+            due_date: body.due_date === null || typeof body.due_date === 'string' ? body.due_date : undefined,
+            position: typeof body.position === 'number' ? body.position : undefined,
+          })
+
+          if (!task) return jsonResponse({ error: 'Task not found' }, 404)
+          return jsonResponse({ task })
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
       },
+
       DELETE: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}`, { method: 'DELETE', headers: authHeaders() })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+
+        const deleted = deleteTask(params.taskId)
+        if (!deleted) return jsonResponse({ error: 'Task not found' }, 404)
+        return jsonResponse({ ok: true })
       },
+
       POST: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
+
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || 'move'
-        const body = await request.text()
-        const res = await fetch(`${HERMES_API}/api/tasks/${params.taskId}/${action}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...authHeaders() },
-          body,
-        })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+        if (action !== 'move') {
+          return jsonResponse({ error: `Unsupported action: ${action}` }, 400)
+        }
+
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          if (typeof body.column !== 'string') {
+            return jsonResponse({ error: 'column is required' }, 400)
+          }
+          const task = moveTask(params.taskId, body.column as TaskColumn)
+          if (!task) return jsonResponse({ error: 'Task not found' }, 404)
+          return jsonResponse({ task })
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
       },
     },
   },

--- a/src/routes/api/hermes-tasks.ts
+++ b/src/routes/api/hermes-tasks.ts
@@ -1,9 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
+import { createTask, listTasks } from '../../server/tasks-store'
 
-function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
 }
 
 export const Route = createFileRoute('/api/hermes-tasks')({
@@ -11,25 +14,48 @@ export const Route = createFileRoute('/api/hermes-tasks')({
     handlers: {
       GET: async ({ request }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
+
         const url = new URL(request.url)
-        const params = url.searchParams.toString()
-        const target = `${HERMES_API}/api/tasks${params ? `?${params}` : ''}`
-        const res = await fetch(target, { headers: authHeaders() })
-        return new Response(res.body, { status: res.status, headers: { 'Content-Type': 'application/json' } })
+        const tasks = listTasks({
+          column: url.searchParams.get('column'),
+          assignee: url.searchParams.get('assignee'),
+          priority: url.searchParams.get('priority'),
+          includeDone: url.searchParams.get('include_done') === 'true',
+        })
+
+        return jsonResponse({ tasks })
       },
+
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {
-          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+          return jsonResponse({ error: 'Unauthorized' }, 401)
         }
-        const body = await request.text()
-        const res = await fetch(`${HERMES_API}/api/tasks`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...authHeaders() },
-          body,
-        })
-        return new Response(await res.text(), { status: res.status, headers: { 'Content-Type': 'application/json' } })
+
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          if (!body.title || typeof body.title !== 'string') {
+            return jsonResponse({ error: 'title is required' }, 400)
+          }
+
+          const task = createTask({
+            id: typeof body.id === 'string' ? body.id : undefined,
+            title: body.title,
+            description: typeof body.description === 'string' ? body.description : '',
+            column: typeof body.column === 'string' ? body.column : undefined,
+            priority: typeof body.priority === 'string' ? body.priority : undefined,
+            assignee: typeof body.assignee === 'string' ? body.assignee : null,
+            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+            due_date: typeof body.due_date === 'string' ? body.due_date : null,
+            position: typeof body.position === 'number' ? body.position : 0,
+            created_by: typeof body.created_by === 'string' ? body.created_by : 'user',
+          })
+
+          return jsonResponse({ task }, 201)
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
       },
     },
   },

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useSearch } from '@tanstack/react-router'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, CheckListIcon, RefreshIcon } from '@hugeicons/core-free-icons'
@@ -58,6 +58,7 @@ export function TasksScreen() {
     queryKey: [...QUERY_KEY, showDone],
     queryFn: () => fetchTasks({ include_done: showDone }),
     refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
   })
 
   // Load assignees dynamically from profiles + config
@@ -168,6 +169,7 @@ export function TasksScreen() {
   }
 
   const visibleColumns = showDone ? COLUMN_ORDER : COLUMN_ORDER.filter(c => c !== 'done')
+  const colMaxWidth = Math.floor(1200 / visibleColumns.length)
 
   return (
     <div className="min-h-full overflow-y-auto bg-surface text-ink">
@@ -238,7 +240,7 @@ export function TasksScreen() {
 
       {/* Board */}
       <div
-        className="flex flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
+        className="mx-auto flex w-full max-w-[1200px] flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
         style={{ boxShadow: 'inset 0 8px 24px rgba(0,0,0,0.2)' }}
       >
         {visibleColumns.map((col) => {
@@ -250,11 +252,12 @@ export function TasksScreen() {
             <div
               key={col}
               className={cn(
-                'flex flex-col rounded-xl border min-w-[240px] w-[280px] shrink-0',
+                'flex flex-col rounded-xl border min-w-[180px] w-full shrink-0 flex-1',
                 'bg-[var(--theme-card)] border-[var(--theme-border)]',
                 'transition-colors shadow-[0_2px_12px_rgba(0,0,0,0.25)]',
                 isDragOver && 'border-[var(--theme-accent)] bg-[var(--theme-hover)]',
               )}
+              style={{ maxWidth: colMaxWidth }}
               onDragOver={e => handleDragOver(e, col)}
               onDrop={e => handleDrop(e, col)}
               onDragLeave={() => setDragOverColumn(null)}
@@ -270,7 +273,7 @@ export function TasksScreen() {
                     {COLUMN_LABELS[col]}
                   </span>
                   <span className="text-xs text-[var(--theme-muted)]">
-                    ({tasksQuery.isLoading ? '…' : colTasks.length})
+                    ({tasksQuery.isFetching && tasksQuery.data === undefined ? '…' : colTasks.length})
                   </span>
                 </div>
                 <button
@@ -284,7 +287,22 @@ export function TasksScreen() {
 
               {/* Cards */}
               <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto">
-                {tasksQuery.isLoading ? (
+                {tasksQuery.isError ? (
+                  <motion.div
+                    key="error"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    className="flex flex-col items-center justify-center py-8 gap-2 text-red-400"
+                  >
+                    <p className="text-xs font-medium">Failed to load tasks</p>
+                    <button
+                      onClick={() => tasksQuery.refetch()}
+                      className="text-xs text-[var(--theme-accent)] hover:underline"
+                    >
+                      Retry
+                    </button>
+                  </motion.div>
+                ) : tasksQuery.isLoading ? (
                   <>
                     <SkeletonCard />
                     <SkeletonCard />

--- a/src/server/tasks-store.ts
+++ b/src/server/tasks-store.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'done'
+export type TaskPriority = 'high' | 'medium' | 'low'
+
+export type TaskRecord = {
+  id: string
+  title: string
+  description: string
+  column: TaskColumn
+  priority: TaskPriority
+  assignee: string | null
+  tags: string[]
+  due_date: string | null
+  position: number
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+type TaskFile = { tasks: TaskRecord[] }
+
+type TaskFilters = {
+  column?: string | null
+  assignee?: string | null
+  priority?: string | null
+  includeDone?: boolean
+}
+
+type CreateTaskInput = Partial<TaskRecord> & { title: string }
+type UpdateTaskInput = Partial<Omit<TaskRecord, 'id' | 'created_at' | 'created_by'>>
+
+const HERMES_HOME = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+const TASKS_FILE = path.join(HERMES_HOME, 'tasks.json')
+
+function ensureTasksFile(): void {
+  fs.mkdirSync(HERMES_HOME, { recursive: true })
+  if (!fs.existsSync(TASKS_FILE)) {
+    fs.writeFileSync(TASKS_FILE, JSON.stringify({ tasks: [] }, null, 2) + '\n', 'utf-8')
+  }
+}
+
+function readTaskFile(): TaskFile {
+  ensureTasksFile()
+  try {
+    const raw = fs.readFileSync(TASKS_FILE, 'utf-8').trim()
+    if (!raw) return { tasks: [] }
+    const parsed = JSON.parse(raw) as Partial<TaskFile>
+    return { tasks: Array.isArray(parsed.tasks) ? parsed.tasks : [] }
+  } catch {
+    return { tasks: [] }
+  }
+}
+
+function writeTaskFile(data: TaskFile): void {
+  ensureTasksFile()
+  fs.writeFileSync(TASKS_FILE, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+}
+
+function normalizeTask(task: Partial<TaskRecord> & Pick<TaskRecord, 'id' | 'title' | 'created_at' | 'updated_at' | 'created_by'>): TaskRecord {
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description ?? '',
+    column: (task.column as TaskColumn) ?? 'backlog',
+    priority: (task.priority as TaskPriority) ?? 'medium',
+    assignee: task.assignee ?? null,
+    tags: Array.isArray(task.tags) ? task.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+    due_date: task.due_date ?? null,
+    position: typeof task.position === 'number' ? task.position : 0,
+    created_by: task.created_by,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+  }
+}
+
+export function listTasks(filters: TaskFilters = {}): TaskRecord[] {
+  let tasks = readTaskFile().tasks.map(normalizeTask)
+  if (!filters.includeDone) {
+    tasks = tasks.filter((task) => task.column !== 'done')
+  }
+  if (filters.column) {
+    tasks = tasks.filter((task) => task.column === filters.column)
+  }
+  if (filters.assignee) {
+    tasks = tasks.filter((task) => task.assignee === filters.assignee)
+  }
+  if (filters.priority) {
+    tasks = tasks.filter((task) => task.priority === filters.priority)
+  }
+  return tasks.sort((a, b) => a.position - b.position || a.created_at.localeCompare(b.created_at))
+}
+
+export function getTask(taskId: string): TaskRecord | null {
+  return readTaskFile().tasks.map(normalizeTask).find((task) => task.id === taskId) ?? null
+}
+
+export function createTask(input: CreateTaskInput): TaskRecord {
+  const file = readTaskFile()
+  const now = new Date().toISOString()
+  const task = normalizeTask({
+    id: typeof input.id === 'string' && input.id ? input.id : randomUUID(),
+    title: input.title,
+    description: input.description,
+    column: input.column,
+    priority: input.priority,
+    assignee: input.assignee,
+    tags: input.tags,
+    due_date: input.due_date,
+    position: typeof input.position === 'number' ? input.position : 0,
+    created_by: typeof input.created_by === 'string' && input.created_by ? input.created_by : 'user',
+    created_at: now,
+    updated_at: now,
+  })
+  file.tasks.push(task)
+  writeTaskFile({ tasks: file.tasks.map(normalizeTask) })
+  return task
+}
+
+export function updateTask(taskId: string, updates: UpdateTaskInput): TaskRecord | null {
+  const file = readTaskFile()
+  const index = file.tasks.findIndex((task) => task.id === taskId)
+  if (index === -1) return null
+
+  const current = normalizeTask(file.tasks[index] as TaskRecord)
+  const next = normalizeTask({
+    ...current,
+    ...updates,
+    id: current.id,
+    created_by: current.created_by,
+    created_at: current.created_at,
+    updated_at: new Date().toISOString(),
+    title: typeof updates.title === 'string' ? updates.title : current.title,
+  })
+
+  file.tasks[index] = next
+  writeTaskFile({ tasks: file.tasks.map(normalizeTask) })
+  return next
+}
+
+export function moveTask(taskId: string, column: TaskColumn): TaskRecord | null {
+  return updateTask(taskId, { column })
+}
+
+export function deleteTask(taskId: string): boolean {
+  const file = readTaskFile()
+  const nextTasks = file.tasks.filter((task) => task.id !== taskId)
+  if (nextTasks.length === file.tasks.length) return false
+  writeTaskFile({ tasks: nextTasks.map((task) => normalizeTask(task as TaskRecord)) })
+  return true
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -424,12 +424,6 @@ const config = defineConfig(({ mode, command }) => {
           ws: true,
           rewrite: (path) => path.replace(/^\/ws-hermes/, ''),
         },
-        // Kanban tasks proxy: frontend /api/hermes-tasks → webapi /api/tasks
-        '/api/hermes-tasks': {
-          target: proxyTarget,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/hermes-tasks/, '/api/tasks'),
-        },
 // REST API proxy: API proxy for Hermes backend
         '/api/hermes-proxy': {
           target: proxyTarget,


### PR DESCRIPTION
## Summary\n- keep the good UI pieces from #54: dynamic Kanban column widths, explicit task error state, and anti-flicker placeholder data\n- replace the partial local task API with a complete file-backed implementation across both  and \n- preserve the existing frontend mutation contract by returning  for create/update/move\n- remove the dev proxy that previously bypassed the local task routes\n\n## Why\nPR #54 had solid product/UI improvements, but the backend portion changed the response contract and only moved half of the task API local. This follow-up keeps the contribution and finishes it cleanly so tasks actually work without a running gateway.\n\n## Test Plan\n- [x] 
> hermes-workspace@1.0.0 test /private/tmp/hermes-workspace-review
> vitest run

[hermes-agent] Already running — reusing existing process

 RUN  v3.2.4 /private/tmp/hermes-workspace-review

 ✓ src/components/onboarding/onboarding-tour.test.ts (3 tests) 2ms
 ✓ src/components/workspace-shell.test.ts (1 test) 1ms

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  20:46:56
   Duration  2.52s (transform 816ms, setup 0ms, collect 2.38s, tests 3ms, environment 0ms, prepare 103ms)\n- [x] 
> hermes-workspace@1.0.0 build /private/tmp/hermes-workspace-review
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 2494 modules transformed.
rendering chunks...
computing gzip size...
dist/client/assets/xterm-G5OQeJvU.css                          2.35 kB │ gzip:   0.72 kB
dist/client/assets/styles-BL0v0G-E.css                       156.43 kB │ gzip:  26.46 kB
dist/client/assets/index-D_Wxvt_x.js                           0.06 kB │ gzip:   0.08 kB
dist/client/assets/index-DLlBm66g.js                           0.06 kB │ gzip:   0.08 kB
dist/client/assets/settings-D3FIY6S6.js                        0.11 kB │ gzip:   0.12 kB
dist/client/assets/use-page-title-Brcv_x03.js                  0.16 kB │ gzip:   0.16 kB
dist/client/assets/providers-BDAfbXW9.js                       0.18 kB │ gzip:   0.17 kB
dist/client/assets/terminal-w1Kq6Qk_.js                        0.42 kB │ gzip:   0.28 kB
dist/client/assets/codeowners-Bp6g37R7.js                      0.55 kB │ gzip:   0.32 kB
dist/client/assets/files-C6Zx7Cx_.js                           0.63 kB │ gzip:   0.41 kB
dist/client/assets/shellsession-BADoaaVG.js                    0.71 kB │ gzip:   0.43 kB
dist/client/assets/tsv-B_m7g4N7.js                             0.74 kB │ gzip:   0.34 kB
dist/client/assets/html-derivative-BFtXZ54Q.js                 0.90 kB │ gzip:   0.50 kB
dist/client/assets/terminal-CN9sROIh.js                        0.91 kB │ gzip:   0.54 kB
dist/client/assets/_sessionKey-Cg8zXUlK.js                     0.98 kB │ gzip:   0.50 kB
dist/client/assets/git-rebase-r7XF79zn.js                      0.98 kB │ gzip:   0.44 kB
dist/client/assets/qmldir-C8lEn-DE.js                          1.00 kB │ gzip:   0.45 kB
dist/client/assets/csv-fuZLfV_i.js                             1.14 kB │ gzip:   0.37 kB
dist/client/assets/git-commit-F4YmCXRG.js                      1.23 kB │ gzip:   0.53 kB
dist/client/assets/_sessionKey-C1QUhFjL.js                     1.26 kB │ gzip:   0.67 kB
dist/client/assets/xsl-CtQFsRM5.js                             1.39 kB │ gzip:   0.52 kB
dist/client/assets/dotenv-Da5cRb03.js                          1.42 kB │ gzip:   0.53 kB
dist/client/assets/sparql-rVzFXLq3.js                          1.48 kB │ gzip:   0.82 kB
dist/client/assets/ini-BEwlwnbL.js                             1.53 kB │ gzip:   0.50 kB
dist/client/assets/fortran-fixed-form-CkoXwp7k.js              1.67 kB │ gzip:   0.69 kB
dist/client/assets/docker-BcOcwvcX.js                          1.74 kB │ gzip:   0.60 kB
dist/client/assets/hxml-Bvhsp5Yf.js                            1.74 kB │ gzip:   0.88 kB
dist/client/assets/memory-B-fL-TTd.js                          1.76 kB │ gzip:   0.75 kB
dist/client/assets/xterm-addon-fit-Cia9RSdt.js                 1.81 kB │ gzip:   0.83 kB
dist/client/assets/desktop-BmXAJ9_W.js                         1.83 kB │ gzip:   0.76 kB
dist/client/assets/_-DmBxnpc9.js                               2.11 kB │ gzip:   0.76 kB
dist/client/assets/wenyan-BV7otONQ.js                          2.16 kB │ gzip:   1.09 kB
dist/client/assets/jssm-C2t-YnRu.js                            2.24 kB │ gzip:   0.62 kB
dist/client/assets/reg-C-SQnVFl.js                             2.35 kB │ gzip:   0.70 kB
dist/client/assets/edge-BkV0erSs.js                            2.36 kB │ gzip:   0.70 kB
dist/client/assets/diff-D97Zzqfu.js                            2.57 kB │ gzip:   0.70 kB
dist/client/assets/gleam-BspZqrRM.js                           2.58 kB │ gzip:   0.82 kB
dist/client/assets/erb-B12qg9BL.js                             2.61 kB │ gzip:   0.84 kB
dist/client/assets/hy-DFXneXwc.js                              2.65 kB │ gzip:   1.18 kB
dist/client/assets/json-Cp-IABpG.js                            2.82 kB │ gzip:   0.78 kB
dist/client/assets/openscad-C4EeE6gA.js                        2.82 kB │ gzip:   1.01 kB
dist/client/assets/log-2UxHyX5q.js                             2.85 kB │ gzip:   0.90 kB
dist/client/assets/cairo-KRGpt6FW.js                           2.94 kB │ gzip:   0.81 kB
dist/client/assets/berry-uYugtg8r.js                           3.01 kB │ gzip:   0.81 kB
dist/client/assets/jsonl-DcaNXYhu.js                           3.01 kB │ gzip:   0.79 kB
dist/client/assets/jsonc-Des-eS-w.js                           3.11 kB │ gzip:   0.80 kB
dist/client/assets/logo-BtOb2qkB.js                            3.13 kB │ gzip:   1.47 kB
dist/client/assets/xterm-addon-web-links-CCHicoTf.js           3.21 kB │ gzip:   1.56 kB
dist/client/assets/po-BTJTHyun.js                              3.24 kB │ gzip:   0.91 kB
dist/client/assets/json5-C9tS-k6U.js                           3.25 kB │ gzip:   0.83 kB
dist/client/assets/mipsasm-CKIfxQSi.js                         3.26 kB │ gzip:   1.18 kB
dist/client/assets/tasl-QIJgUcNo.js                            3.29 kB │ gzip:   0.85 kB
dist/client/assets/genie-D0YGMca9.js                           3.36 kB │ gzip:   1.21 kB
dist/client/assets/rel-C3B-1QV4.js                             3.37 kB │ gzip:   1.11 kB
dist/client/assets/vala-CsfeWuGM.js                            3.37 kB │ gzip:   1.19 kB
dist/client/assets/splunk-BtCnVYZw.js                          3.44 kB │ gzip:   1.52 kB
dist/client/assets/fluent-C4IJs8-o.js                          3.61 kB │ gzip:   0.90 kB
dist/client/assets/ssh-config-_ykCGR6B.js                      3.62 kB │ gzip:   1.60 kB
dist/client/assets/jsonnet-DFQXde-d.js                         3.62 kB │ gzip:   1.05 kB
dist/client/assets/kdl-DV7GczEv.js                             3.63 kB │ gzip:   1.04 kB
dist/client/assets/glsl-DplSGwfg.js                            3.63 kB │ gzip:   1.41 kB
dist/client/assets/hurl-irOxFIW8.js                            3.65 kB │ gzip:   1.16 kB
dist/client/assets/narrat-DRg8JJMk.js                          3.67 kB │ gzip:   1.11 kB
dist/client/assets/turtle-BsS91CYL.js                          3.70 kB │ gzip:   0.98 kB
dist/client/assets/zenscript-DVFEvuxE.js                       3.91 kB │ gzip:   1.28 kB
dist/client/assets/ron-D8l8udqQ.js                             3.91 kB │ gzip:   0.98 kB
dist/client/assets/gn-n2N0HUVH.js                              4.00 kB │ gzip:   1.49 kB
dist/client/assets/pascal-D93ZcfNL.js                          4.15 kB │ gzip:   1.67 kB
dist/client/assets/tcl-dwOrl1Do.js                             4.43 kB │ gzip:   1.52 kB
dist/client/assets/nextflow-Zz6hmt5N.js                        4.51 kB │ gzip:   1.17 kB
dist/client/assets/rosmsg-BJDFO7_C.js                          4.52 kB │ gzip:   1.06 kB
dist/client/assets/http-jrhK8wxY.js                            4.55 kB │ gzip:   1.12 kB
dist/client/assets/polar-C0HS_06l.js                           4.67 kB │ gzip:   1.12 kB
dist/client/assets/sdbl-DVxCFoDh.js                            4.70 kB │ gzip:   2.01 kB
dist/client/assets/fennel-BYunw83y.js                          4.77 kB │ gzip:   1.53 kB
dist/client/assets/bibtex-CHM0blh-.js                          4.80 kB │ gzip:   0.83 kB
dist/client/assets/llvm-DjAJT7YJ.js                            5.05 kB │ gzip:   2.01 kB
dist/client/assets/wgsl-Dx-B1_4e.js                            5.14 kB │ gzip:   1.39 kB
dist/client/assets/gdresource-BOOCDP_w.js                      5.29 kB │ gzip:   1.34 kB
dist/client/assets/qml-3beO22l8.js                             5.34 kB │ gzip:   1.38 kB
dist/client/assets/zig-VOosw3JB.js                             5.34 kB │ gzip:   1.55 kB
dist/client/assets/dax-CEL-wOlO.js                             5.37 kB │ gzip:   2.23 kB
dist/client/assets/bicep-Bmn6On1c.js                           5.38 kB │ gzip:   1.15 kB
dist/client/assets/xml-sdJ4AIDG.js                             5.38 kB │ gzip:   1.21 kB
dist/client/assets/awk-DMzUqQB5.js                             5.46 kB │ gzip:   1.38 kB
dist/client/assets/coq-DkFqJrB1.js                             5.53 kB │ gzip:   1.92 kB
dist/client/assets/jinja-4LBKfQ-Z.js                           5.69 kB │ gzip:   1.40 kB
dist/client/assets/lean-BZvkOJ9d.js                            5.78 kB │ gzip:   1.92 kB
dist/client/assets/moonbit-_H4v1dQx.js                         5.90 kB │ gzip:   1.68 kB
dist/client/assets/powerquery-CEu0bR-o.js                      5.90 kB │ gzip:   1.52 kB
dist/client/assets/shaderlab-Dg9Lc6iA.js                       5.92 kB │ gzip:   2.08 kB
dist/client/assets/verilog-BQ8w6xss.js                         5.93 kB │ gzip:   1.89 kB
dist/client/assets/cypher-COkxafJQ.js                          5.96 kB │ gzip:   1.73 kB
dist/client/assets/vb-D17OF-Vu.js                              6.09 kB │ gzip:   2.34 kB
dist/client/assets/red-bN70gL4F.js                             6.26 kB │ gzip:   1.60 kB
dist/client/assets/min-dark-CafNBF8u.js                        6.29 kB │ gzip:   1.71 kB
dist/client/assets/gdshader-DkwncUOv.js                        6.33 kB │ gzip:   1.73 kB
dist/client/assets/prisma-Dd19v3D-.js                          6.33 kB │ gzip:   1.39 kB
dist/client/assets/ara-BRHolxvo.js                             6.36 kB │ gzip:   1.81 kB
dist/client/assets/clojure-P80f7IUj.js                         6.41 kB │ gzip:   1.42 kB
dist/client/assets/postcss-CXtECtnM.js                         6.42 kB │ gzip:   1.91 kB
dist/client/assets/toml-vGWfd6FD.js                            6.43 kB │ gzip:   1.28 kB
dist/client/assets/solarized-light-L9t79GZl.js                 6.48 kB │ gzip:   1.73 kB
dist/client/assets/r-Dspwwk_N.js                               6.54 kB │ gzip:   1.78 kB
dist/client/assets/proto-C7zT0LnQ.js                           6.55 kB │ gzip:   1.42 kB
dist/client/assets/smalltalk-BERRCDM3.js                       6.59 kB │ gzip:   1.62 kB
dist/client/assets/talonscript-CkByrt1z.js                     6.76 kB │ gzip:   1.49 kB
dist/client/assets/solarized-dark-DXbdFlpD.js                  6.85 kB │ gzip:   1.80 kB
dist/client/assets/riscv-BM1_JUlF.js                           6.91 kB │ gzip:   1.98 kB
dist/client/assets/min-light-CTRr51gU.js                       6.97 kB │ gzip:   1.89 kB
dist/client/assets/soy-Brmx7dQM.js                             6.98 kB │ gzip:   1.66 kB
dist/client/assets/scheme-C98Dy4si.js                          7.17 kB │ gzip:   2.05 kB
dist/client/assets/hlsl-D3lLCCz7.js                            7.26 kB │ gzip:   2.19 kB
dist/client/assets/qss-IeuSbFQv.js                             7.47 kB │ gzip:   2.58 kB
dist/client/assets/dart-CF10PKvl.js                            7.81 kB │ gzip:   1.91 kB
dist/client/assets/systemd-4A_iFExJ.js                         7.87 kB │ gzip:   2.55 kB
dist/client/assets/monokai-D4h5O-jR.js                         7.88 kB │ gzip:   1.91 kB
dist/client/assets/regexp-CDVJQ6XC.js                          7.99 kB │ gzip:   1.42 kB
dist/client/assets/haml-B8DHNrY2.js                            8.26 kB │ gzip:   1.81 kB
dist/client/assets/typst-DHCkPAjA.js                           8.39 kB │ gzip:   1.67 kB
dist/client/assets/vue-html-AaS7Mt5G.js                        8.47 kB │ gzip:   1.68 kB
dist/client/assets/plsql-ChMvpjG-.js                           8.51 kB │ gzip:   3.00 kB
dist/client/assets/horizon-BUw7H-hv.js                         8.78 kB │ gzip:   1.96 kB
dist/client/assets/kotlin-BdnUsdx6.js                          8.79 kB │ gzip:   2.13 kB
dist/client/assets/horizon-bright-Cn-bp-IR.js                  8.79 kB │ gzip:   1.97 kB
dist/client/assets/ts-tags-zn1MmPIZ.js                         8.95 kB │ gzip:   1.22 kB
dist/client/assets/make-CHLpvVh8.js                            8.96 kB │ gzip:   1.77 kB
dist/client/assets/andromeeda-C4gqWexZ.js                      9.02 kB │ gzip:   2.36 kB
dist/client/assets/sas-cz2c8ADy.js                             9.06 kB │ gzip:   3.81 kB
dist/client/assets/dark-plus-C3mMm8J8.js                       9.10 kB │ gzip:   2.10 kB
dist/client/assets/slack-dark-BthQWCQV.js                      9.12 kB │ gzip:   1.97 kB
dist/client/assets/sass-Cj5Yp3dK.js                            9.29 kB │ gzip:   2.49 kB
dist/client/assets/plastic-3e1v2bzS.js                         9.30 kB │ gzip:   1.98 kB
dist/client/assets/slack-ochin-DqwNpetd.js                     9.43 kB │ gzip:   2.10 kB
dist/client/assets/tex-idrVyKtj.js                             9.67 kB │ gzip:   3.06 kB
dist/client/assets/jison-wvAkD_A8.js                           9.69 kB │ gzip:   1.85 kB
dist/client/assets/cmake-D1j8_8rp.js                           9.86 kB │ gzip:   3.37 kB
dist/client/assets/light-plus-B7mTdjB0.js                      9.94 kB │ gzip:   2.27 kB
dist/client/assets/hcl-BWvSN4gD.js                            10.05 kB │ gzip:   1.93 kB
dist/client/assets/pkl-u5AG7uiY.js                            10.37 kB │ gzip:   1.38 kB
dist/client/assets/beancount-k_qm7-4y.js                      10.37 kB │ gzip:   1.44 kB
dist/client/assets/nextflow-groovy-BeH2EWoN.js                10.41 kB │ gzip:   2.13 kB
dist/client/assets/dream-maker-BtqSS_iP.js                    10.47 kB │ gzip:   2.25 kB
dist/client/assets/raku-DXvB9xmW.js                           10.47 kB │ gzip:   2.94 kB
dist/client/assets/yaml-Buea-lGh.js                           10.51 kB │ gzip:   2.27 kB
dist/client/assets/rst-BrH8l1NY.js                            10.67 kB │ gzip:   2.42 kB
dist/client/assets/elm-DbKCFpqz.js                            10.97 kB │ gzip:   2.12 kB
dist/client/assets/just-Cw27pwNe.js                           11.16 kB │ gzip:   2.78 kB
dist/client/assets/github-light-DAi9KRSo.js                   11.18 kB │ gzip:   2.51 kB
dist/client/assets/prolog-CbFg5uaA.js                         11.36 kB │ gzip:   3.83 kB
dist/client/assets/terraform-BETggiCN.js                      11.39 kB │ gzip:   2.51 kB
dist/client/assets/github-dark-DHJKELXO.js                    11.41 kB │ gzip:   2.55 kB
dist/client/assets/puppet-BMWR74SV.js                         11.44 kB │ gzip:   2.11 kB
dist/client/assets/laserwave-DUszq2jm.js                      11.50 kB │ gzip:   2.58 kB
dist/client/assets/memory-browser-screen-B_Swqn0a.js          11.74 kB │ gzip:   3.69 kB
dist/client/assets/gherkin-DyxjwDmM.js                        11.95 kB │ gzip:   5.05 kB
dist/client/assets/wasm-MzD3tlZU.js                           12.01 kB │ gzip:   2.19 kB
dist/client/assets/hjson-D5-asLiD.js                          12.05 kB │ gzip:   1.64 kB
dist/client/assets/handlebars-BL8al0AC.js                     12.15 kB │ gzip:   2.38 kB
dist/client/assets/apache-Pmp26Uib.js                         12.46 kB │ gzip:   3.72 kB
dist/client/assets/vesper-DU1UobuO.js                         12.69 kB │ gzip:   1.97 kB
dist/client/assets/bat-BkioyH1T.js                            12.89 kB │ gzip:   3.22 kB
dist/client/assets/fish-BvzEVeQv.js                           13.04 kB │ gzip:   1.74 kB
dist/client/assets/v-BcVCzyr7.js                              13.21 kB │ gzip:   2.74 kB
dist/client/assets/mcp-ojCXPip_.js                            13.42 kB │ gzip:   4.08 kB
dist/client/assets/vitesse-light-CVO1_9PV.js                  13.62 kB │ gzip:   3.04 kB
dist/client/assets/aurora-x-D-2ljcwZ.js                       13.66 kB │ gzip:   2.28 kB
dist/client/assets/vitesse-black-Bkuqu6BP.js                  13.68 kB │ gzip:   3.06 kB
dist/client/assets/vitesse-dark-D0r3Knsf.js                   13.76 kB │ gzip:   3.06 kB
dist/client/assets/pug-CGlum2m_.js                            13.84 kB │ gzip:   2.58 kB
dist/client/assets/luau-C-HG3fhB.js                           13.96 kB │ gzip:   3.18 kB
dist/client/assets/synthwave-84-CbfX1IO0.js                   14.04 kB │ gzip:   2.87 kB
dist/client/assets/github-light-default-D7oLnXFd.js           14.16 kB │ gzip:   3.04 kB
dist/client/assets/clarity-D53aC0YG.js                        14.28 kB │ gzip:   2.46 kB
dist/client/assets/github-light-high-contrast-BfjtVDDH.js     14.28 kB │ gzip:   3.02 kB
dist/client/assets/github-dark-dimmed-DH5Ifo-i.js             14.43 kB │ gzip:   3.13 kB
dist/client/assets/github-dark-default-Cuk6v7N8.js            14.44 kB │ gzip:   3.13 kB
dist/client/assets/github-dark-high-contrast-E3gJ1_iC.js      14.60 kB │ gzip:   3.09 kB
dist/client/assets/gnuplot-DdkO51Og.js                        14.78 kB │ gzip:   3.27 kB
dist/client/assets/rust-B1yitclQ.js                           15.07 kB │ gzip:   2.72 kB
dist/client/assets/kusto-DZf3V79B.js                          15.17 kB │ gzip:   3.92 kB
dist/client/assets/actionscript-3-CoDkCxhg.js                 15.21 kB │ gzip:   2.66 kB
dist/client/assets/nix-CwoSXNpI.js                            15.51 kB │ gzip:   2.48 kB
dist/client/assets/terminal-workspace-BXi4BAOK.js             15.53 kB │ gzip:   5.06 kB
dist/client/assets/lua-BaeVxFsk.js                            15.54 kB │ gzip:   3.16 kB
dist/client/assets/abap-BdImnpbu.js                           15.85 kB │ gzip:   5.91 kB
dist/client/assets/solidity-rGO070M0.js                       16.07 kB │ gzip:   3.11 kB
dist/client/assets/matlab-D7o27uSR.js                         16.09 kB │ gzip:   3.06 kB
dist/client/assets/cue-D82EKSYY.js                            16.20 kB │ gzip:   2.06 kB
dist/client/assets/tasks-FqjcFier.js                          16.22 kB │ gzip:   5.13 kB
dist/client/assets/elixir-CDX3lj18.js                         16.32 kB │ gzip:   2.80 kB
dist/client/assets/files-GrD_5k9b.js                          16.38 kB │ gzip:   5.91 kB
dist/client/assets/odin-BBf5iR-q.js                           16.51 kB │ gzip:   2.94 kB
dist/client/assets/bird2-DPOp833l.js                          16.97 kB │ gzip:   3.85 kB
dist/client/assets/kanagawa-wave-DWedfzmr.js                  17.12 kB │ gzip:   2.93 kB
dist/client/assets/kanagawa-lotus-CfQXZHmo.js                 17.13 kB │ gzip:   2.93 kB
dist/client/assets/kanagawa-dragon-CkXjmgJE.js                17.13 kB │ gzip:   2.95 kB
dist/client/assets/move-IF9eRakj.js                           17.51 kB │ gzip:   3.07 kB
dist/client/assets/graphql-ChdNCCLP.js                        18.00 kB │ gzip:   2.52 kB
dist/client/assets/liquid-DYVedYrR.js                         18.09 kB │ gzip:   3.16 kB
dist/client/assets/svelte-C_ipcX3V.js                         18.24 kB │ gzip:   3.14 kB
dist/client/assets/material-theme-D5KoaKCx.js                 18.62 kB │ gzip:   3.11 kB
dist/client/assets/material-theme-darker-BfHTSMKl.js          18.63 kB │ gzip:   3.11 kB
dist/client/assets/material-theme-ocean-CyktbL80.js           18.63 kB │ gzip:   3.14 kB
dist/client/assets/material-theme-lighter-B0m2ddpp.js         18.63 kB │ gzip:   3.11 kB
dist/client/assets/material-theme-palenight-Csfq5Kiy.js       18.64 kB │ gzip:   3.13 kB
dist/client/assets/gdscript-C5YyOfLZ.js                       18.99 kB │ gzip:   3.75 kB
dist/client/assets/skills-D3nRpOri.js                         19.04 kB │ gzip:   5.91 kB
dist/client/assets/groovy-gcz8RCvz.js                         19.18 kB │ gzip:   3.60 kB
dist/client/assets/mdc-BMNejdWA.js                            19.63 kB │ gzip:   6.66 kB
dist/client/assets/glimmer-js-Rg0-pVw9.js                     20.07 kB │ gzip:   2.95 kB
dist/client/assets/glimmer-ts-U6CK756n.js                     20.07 kB │ gzip:   2.94 kB
dist/client/assets/ayu-dark-DYE7WIF3.js                       20.08 kB │ gzip:   3.94 kB
dist/client/assets/ayu-mirage-32ctXXKs.js                     20.09 kB │ gzip:   3.94 kB
dist/client/assets/powershell-Dpen1YoG.js                     20.15 kB │ gzip:   4.07 kB
dist/client/assets/ayu-light-BA47KaF1.js                      20.15 kB │ gzip:   3.93 kB
dist/client/assets/viml-CJc9bBzg.js                           20.37 kB │ gzip:   6.73 kB
dist/client/assets/nushell-Cz2AlsmD.js                        20.41 kB │ gzip:   5.22 kB
dist/client/assets/snazzy-light-Bw305WKR.js                   20.77 kB │ gzip:   3.83 kB
dist/client/assets/dracula-BzJJZx-M.js                        21.07 kB │ gzip:   4.00 kB
dist/client/assets/dracula-soft-BXkSAIEj.js                   21.08 kB │ gzip:   4.04 kB
dist/client/assets/twig-DNn4PbVi.js                           21.36 kB │ gzip:   3.87 kB
dist/client/assets/wit-5i3qLPDT.js                            21.47 kB │ gzip:   2.89 kB
dist/client/assets/rose-pine-qdsjHGoJ.js                      21.74 kB │ gzip:   3.87 kB
dist/client/assets/rose-pine-moon-D4_iv3hh.js                 21.75 kB │ gzip:   3.89 kB
dist/client/assets/rose-pine-dawn-DHQR4-dF.js                 21.75 kB │ gzip:   3.89 kB
dist/client/assets/nim-CVrawwO9.js                            22.46 kB │ gzip:   3.16 kB
dist/client/assets/common-lisp-Cg-RD9OK.js                    22.58 kB │ gzip:   6.06 kB
dist/client/assets/surrealql-Bq5Q-fJD.js                      22.58 kB │ gzip:   4.32 kB
dist/client/assets/gruvbox-dark-hard-CFHQjOhq.js              22.63 kB │ gzip:   4.18 kB
dist/client/assets/gruvbox-dark-soft-CVdnzihN.js              22.63 kB │ gzip:   4.17 kB
dist/client/assets/gruvbox-light-hard-CH1njM8p.js             22.64 kB │ gzip:   4.18 kB
dist/client/assets/gruvbox-light-soft-hJgmCMqR.js             22.64 kB │ gzip:   4.18 kB
dist/client/assets/gruvbox-dark-medium-GsRaNv29.js            22.64 kB │ gzip:   4.18 kB
dist/client/assets/gruvbox-light-medium-DRw_LuNl.js           22.64 kB │ gzip:   4.18 kB
dist/client/assets/sql-BLtJtn59.js                            23.41 kB │ gzip:   7.40 kB
dist/client/assets/cadence-Bv_4Rxtq.js                        23.67 kB │ gzip:   3.67 kB
dist/client/assets/astro-CbQHKStN.js                          24.01 kB │ gzip:   7.54 kB
dist/client/assets/typespec-BGHnOYBU.js                       24.02 kB │ gzip:   2.59 kB
dist/client/assets/apl-dKokRX4l.js                            24.04 kB │ gzip:   4.20 kB
dist/client/assets/templ-P3uqSqPl.js                          24.06 kB │ gzip:   5.40 kB
dist/client/assets/vhdl-CeAyd5Ju.js                           24.26 kB │ gzip:   3.87 kB
dist/client/assets/angular-html-CU67Zn6k.js                   24.29 kB │ gzip:   4.01 kB
dist/client/assets/vue-DN_0RTcg.js                            24.48 kB │ gzip:   2.97 kB
dist/client/assets/purescript-CklMAg4u.js                     24.69 kB │ gzip:   3.25 kB
dist/client/assets/one-light-C3Wv6jpd.js                      25.30 kB │ gzip:   3.67 kB
dist/client/assets/fsharp-CXgrBDvD.js                         25.31 kB │ gzip:   4.13 kB
dist/client/assets/marko-CnJfTvn9.js                          25.48 kB │ gzip:   3.59 kB
dist/client/assets/c3-eo99z4R2.js                             25.63 kB │ gzip:   3.87 kB
dist/client/assets/knowledge-browser-screen-CBu4eBO2.js       25.64 kB │ gzip:   6.39 kB
dist/client/assets/night-owl-light-CMTm3GFP.js                25.90 kB │ gzip:   4.26 kB
dist/client/assets/system-verilog-CnnmHF94.js                 26.20 kB │ gzip:   4.85 kB
dist/client/assets/nord-Ddv68eIx.js                           26.72 kB │ gzip:   4.40 kB
dist/client/assets/codeql-DsOJ9woJ.js                         26.88 kB │ gzip:   3.79 kB
dist/client/assets/scss-OYdSNvt2.js                           27.20 kB │ gzip:   4.20 kB
dist/client/assets/java-CylS5w8V.js                           27.22 kB │ gzip:   4.26 kB
dist/client/assets/coffee-Ch7k5sss.js                         27.42 kB │ gzip:   6.35 kB
dist/client/assets/razor-Uh8Bk_45.js                          27.51 kB │ gzip:   3.57 kB
dist/client/assets/index-Mn_s3B_N.js                          28.21 kB │ gzip:   7.73 kB
dist/client/assets/jobs-jrvAduSK.js                           28.45 kB │ gzip:   5.91 kB
dist/client/assets/scala-C151Ov-r.js                          28.88 kB │ gzip:   3.94 kB
dist/client/assets/night-owl-C39BiMTA.js                      28.91 kB │ gzip:   5.16 kB
dist/client/assets/crystal-tKQVLTB8.js                        29.39 kB │ gzip:   4.44 kB
dist/client/assets/mermaid-mWjccvbQ.js                        29.51 kB │ gzip:   3.66 kB
dist/client/assets/applescript-Co6uUVPk.js                    29.57 kB │ gzip:   5.93 kB
dist/client/assets/julia-CxzCAyBv.js                          31.07 kB │ gzip:   4.33 kB
dist/client/assets/stylus-BEDo0Tqx.js                         31.07 kB │ gzip:   7.99 kB
dist/client/assets/profiles-CKqZT5EI.js                       31.77 kB │ gzip:   7.76 kB
dist/client/assets/poimandres-CS3Unz2-.js                     33.49 kB │ gzip:   5.50 kB
dist/client/assets/one-dark-pro-DVMEJ2y_.js                   33.79 kB │ gzip:   5.52 kB
dist/client/assets/bsl-BO_Y6i37.js                            33.87 kB │ gzip:   8.35 kB
dist/client/assets/haxe-CzTSHFRz.js                           35.16 kB │ gzip:   5.91 kB
dist/client/assets/nginx-BpAMiNFr.js                          35.37 kB │ gzip:   4.43 kB
dist/client/assets/houston-DnULxvSX.js                        35.42 kB │ gzip:   5.78 kB
dist/client/assets/tokyo-night-hegEt444.js                    35.67 kB │ gzip:   6.24 kB
dist/client/assets/erlang-DsQrWhSR.js                         37.48 kB │ gzip:   4.40 kB
dist/client/assets/cobol-nwyudZeR.js                          39.15 kB │ gzip:  10.87 kB
dist/client/assets/asm-D_Q5rh1f.js                            40.72 kB │ gzip:   8.21 kB
dist/client/assets/shellscript-Yzrsuije.js                    41.48 kB │ gzip:   6.09 kB
dist/client/assets/haskell-Df6bDoY_.js                        41.49 kB │ gzip:   6.44 kB
dist/client/assets/perl-C0TMdlhV.js                           43.16 kB │ gzip:   4.67 kB
dist/client/assets/d-85-TOEBH.js                              43.80 kB │ gzip:   8.47 kB
dist/client/assets/ruby-Dw2BHqvy.js                           45.95 kB │ gzip:   5.68 kB
dist/client/assets/go-CxLEBnE3.js                             46.81 kB │ gzip:   5.18 kB
dist/client/assets/apex-D8_7TLub.js                           46.99 kB │ gzip:   6.77 kB
dist/client/assets/catppuccin-mocha-D87Tk5Gz.js               47.26 kB │ gzip:   8.00 kB
dist/client/assets/catppuccin-latte-C9dUb6Cb.js               47.26 kB │ gzip:   8.00 kB
dist/client/assets/catppuccin-frappe-DFWUc33u.js              47.26 kB │ gzip:   8.02 kB
dist/client/assets/catppuccin-macchiato-DQyhUUbL.js           47.26 kB │ gzip:   8.01 kB
dist/client/assets/ada-bCR0ucgS.js                            48.08 kB │ gzip:   6.03 kB
dist/client/assets/css-DPfMkruS.js                            49.02 kB │ gzip:  11.85 kB
dist/client/assets/imba-DGztddWO.js                           49.93 kB │ gzip:   9.46 kB
dist/client/assets/everforest-dark-BgDCqdQA.js                53.75 kB │ gzip:   8.42 kB
dist/client/assets/everforest-light-C8M2exoo.js               53.75 kB │ gzip:   8.42 kB
dist/client/assets/wikitext-BhOHFoWU.js                       55.89 kB │ gzip:   4.76 kB
dist/client/assets/stata-BH5u7GGu.js                          56.99 kB │ gzip:  12.36 kB
dist/client/assets/html-GMplVEZG.js                           57.25 kB │ gzip:  11.69 kB
dist/client/assets/ballerina-BFfxhgS-.js                      58.69 kB │ gzip:   8.15 kB
dist/client/assets/markdown-Cvjx9yec.js                       59.34 kB │ gzip:   5.64 kB
dist/client/assets/ocaml-C0hk2d4L.js                          62.45 kB │ gzip:   5.02 kB
dist/client/assets/mojo-rZm6bMo-.js                           69.80 kB │ gzip:   9.27 kB
dist/client/assets/python-B6aJPvgy.js                         69.95 kB │ gzip:   9.13 kB
dist/client/assets/c-BIGW1oBm.js                              72.11 kB │ gzip:  10.51 kB
dist/client/assets/latex-CWtU0Tv5.js                          72.64 kB │ gzip:   6.72 kB
dist/client/assets/vyper-CDx5xZoG.js                          74.65 kB │ gzip:  10.74 kB
dist/client/assets/hack-CaT9iCJl.js                           80.24 kB │ gzip:  26.21 kB
dist/client/assets/swift-D82vCrfD.js                          86.69 kB │ gzip:  14.73 kB
dist/client/assets/fortran-free-form-BxgE0vQu.js              88.97 kB │ gzip:  11.27 kB
dist/client/assets/csharp-COcwbKMJ.js                         89.69 kB │ gzip:  10.69 kB
dist/client/assets/racket-BqYA7rlc.js                         92.39 kB │ gzip:  15.02 kB
dist/client/assets/less-B1dDrJ26.js                           97.63 kB │ gzip:  14.70 kB
dist/client/assets/blade-D4QpJJKB.js                         104.98 kB │ gzip:  28.20 kB
dist/client/assets/objective-c-DXmwc3jG.js                   105.41 kB │ gzip:  23.33 kB
dist/client/assets/php-Dhbhpdrm.js                           111.06 kB │ gzip:  28.52 kB
dist/client/assets/asciidoc-Ve4PFQV2.js                      131.53 kB │ gzip:   9.34 kB
dist/client/assets/mdx-Cmh6b_Ma.js                           136.11 kB │ gzip:  23.35 kB
dist/client/assets/objective-cpp-CLxacb5B.js                 171.97 kB │ gzip:  30.62 kB
dist/client/assets/javascript-wDzz0qaB.js                    174.83 kB │ gzip:  16.51 kB
dist/client/assets/tsx-COt5Ahok.js                           175.54 kB │ gzip:  16.51 kB
dist/client/assets/jsx-g9-lgVsj.js                           177.79 kB │ gzip:  16.61 kB
dist/client/assets/typescript-BPQ3VLAy.js                    181.08 kB │ gzip:  16.04 kB
dist/client/assets/angular-ts-BwZT4LLn.js                    183.82 kB │ gzip:  16.63 kB
dist/client/assets/vue-vine-CQOfvN7w.js                      190.05 kB │ gzip:  17.98 kB
dist/client/assets/wolfram-lXgVvXCa.js                       262.39 kB │ gzip:  77.14 kB
dist/client/assets/xterm-DLtHKnDE.js                         282.97 kB │ gzip:  70.40 kB
dist/client/assets/dashboard-B6ZWhJjZ.js                     352.63 kB │ gzip: 105.27 kB
dist/client/assets/wasm-CG6Dc4jp.js                          622.34 kB │ gzip: 230.29 kB
dist/client/assets/cpp-CofmeUqb.js                           626.08 kB │ gzip:  44.82 kB
dist/client/assets/emacs-lisp-C9XAeP06.js                    779.85 kB │ gzip: 196.03 kB
dist/client/assets/main-ke96Ft2v.js                        1,805.42 kB │ gzip: 554.96 kB
✓ built in 6.91s
vite v7.3.1 building ssr environment for production...
transforming...
✓ 371 modules transformed.
rendering chunks...
dist/server/assets/start-HYkvq4Ni.js                           0.06 kB
dist/server/assets/index-CeOwHEgd.js                           0.11 kB
dist/server/assets/index-Binn80vs.js                           0.11 kB
dist/server/assets/settings-DExlyVWZ.js                        0.23 kB
dist/server/assets/use-page-title-s7YWTsfq.js                  0.29 kB
dist/server/assets/terminal-COdEkdd9.js                        0.32 kB
dist/server/assets/files-BGh74Zbd.js                           0.82 kB
dist/server/assets/terminal-DEiCto8U.js                        0.95 kB
dist/server/assets/_sessionKey-7UVP78H7.js                     1.31 kB
dist/server/assets/providers-Cwki-8i3.js                       1.47 kB
dist/server/assets/memory-B6Gj5iXw.js                          3.64 kB
dist/server/assets/_sessionKey-XALaWbKK.js                     3.67 kB
dist/server/assets/_-BSa_ePx-.js                               4.17 kB
dist/server/assets/_tanstack-start-manifest_v-DKfZBFu8.js      4.21 kB
dist/server/assets/files-DvqXNLFv.js                           4.73 kB
dist/server/assets/memory-browser-screen-BuytcaAT.js          24.56 kB
dist/server/assets/dashboard-CE_jV6RC.js                      26.41 kB
dist/server/assets/mcp-BCHkA1_I.js                            26.67 kB
dist/server/assets/tasks-ygxwkO0m.js                          31.59 kB
dist/server/assets/terminal-workspace-DAWlEBZX.js             35.52 kB
dist/server/assets/skills-C6kf9lFV.js                         36.23 kB
dist/server/assets/index-CcjLm5JJ.js                          46.88 kB
dist/server/assets/knowledge-browser-screen-BoxtTnpX.js       54.10 kB
dist/server/assets/profiles-Cn_KiYtR.js                       59.27 kB
dist/server/assets/jobs-Zro10aYE.js                           59.40 kB
dist/server/server.js                                        136.42 kB
dist/server/assets/router-OqMmcI8u.js                      1,263.18 kB
✓ built in 2.43s\n\nCloses #54