### PR TITLE
fix: persist waitingForResponse across tab navigation (#43)

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -43,6 +43,7 @@ import { useChatHistory } from './hooks/use-chat-history'
 import { useRealtimeChatHistory } from './hooks/use-realtime-chat-history'
 import { useSmoothStreamingText } from './hooks/use-smooth-streaming-text'
 import { useStreamingMessage } from './hooks/use-streaming-message'
+import { useActiveRunCheck } from './hooks/use-active-run-check'
 import { useChatMobile } from './hooks/use-chat-mobile'
 import { useChatSessions } from './hooks/use-chat-sessions'
 import { useAutoSessionTitle } from './hooks/use-auto-session-title'
@@ -457,9 +458,29 @@ export function ChatScreen({
   const chatMode = useChatMode()
   const isPortableMode = chatMode === 'portable'
   const portableChatFriendlyId = isPortableMode ? 'main' : activeFriendlyId
-  const [waitingForResponse, setWaitingForResponse] = useState(
-    () => hasPendingSend() || hasPendingGeneration(),
-  )
+  // --- Issue #43 fix: lift waitingForResponse into persistent Zustand store ---
+  // The store survives component unmount, so navigating away mid-stream
+  // doesn't lose the "waiting" flag. sessionStorage backup handles reloads.
+  const storeWaiting = useChatStore((s) => s.waitingSessionKeys)
+  // resolvedSessionKey isn't available yet (defined below), so we track it via
+  // a ref that's updated once it resolves. The memo/callback read the ref.
+  const sessionKeyForWaiting = useRef<string | undefined>(undefined)
+  const waitingForResponse = useMemo(() => {
+    const key = sessionKeyForWaiting.current
+    if (!key) return hasPendingSend() || hasPendingGeneration()
+    return storeWaiting.has(key)
+  }, [storeWaiting])
+
+  const setWaitingForResponse = useCallback((waiting: boolean) => {
+    const store = useChatStore.getState()
+    const key = sessionKeyForWaiting.current
+    if (!key) return
+    if (waiting) {
+      store.setSessionWaiting(key)
+    } else {
+      store.clearSessionWaiting(key)
+    }
+  }, [])
   const [liveToolActivity, setLiveToolActivity] = useState<
     Array<{ name: string; timestamp: number }>
   >([])
@@ -549,6 +570,16 @@ export function ChatScreen({
     queryClient,
     historyRefetchInterval: sseConnectionState === 'connected' ? 30_000 : 5_000,
     portableMode: isPortableMode,
+  })
+
+  // Keep the waiting-state ref in sync with the resolved session key
+  sessionKeyForWaiting.current = resolvedSessionKey
+
+  // On remount, check if the server still has an active run for this session.
+  // If so, re-set waitingForResponse in the store so the UI shows the spinner.
+  useActiveRunCheck({
+    sessionKey: resolvedSessionKey ?? '',
+    enabled: !isNewChat && Boolean(resolvedSessionKey) && historyQuery.isSuccess,
   })
 
   // Wire SSE realtime stream for instant message delivery
@@ -846,6 +877,29 @@ export function ChatScreen({
     }, 5000)
     return () => window.clearTimeout(fallback)
   }, [waitingForResponse])
+
+  // Issue #43 polling fallback: when waiting but SSE hasn't reconnected,
+  // poll the active-run endpoint every 5s to detect completion.
+  useEffect(() => {
+    if (!waitingForResponse || !resolvedSessionKey) return
+    if (sseConnectionState === 'connected') return // SSE will deliver the event
+    const interval = window.setInterval(async () => {
+      try {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(resolvedSessionKey)}/active-run`,
+        )
+        if (!res.ok) return
+        const data = await res.json()
+        if (!data.ok || !data.run || !['accepted', 'active', 'handoff'].includes(data.run.status)) {
+          streamFinish()
+          refreshHistoryRef.current()
+        }
+      } catch {
+        // ignore network errors
+      }
+    }, 5000)
+    return () => window.clearInterval(interval)
+  }, [waitingForResponse, resolvedSessionKey, sseConnectionState, streamFinish])
 
   useAutoSessionTitle({
     friendlyId: activeFriendlyId,

--- a/src/screens/chat/hooks/use-active-run-check.ts
+++ b/src/screens/chat/hooks/use-active-run-check.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react'
+import { useChatStore } from '../../../stores/chat-store'
+
+type ActiveRunStatus =
+  | 'accepted'
+  | 'active'
+  | 'handoff'
+  | 'stalled'
+  | 'complete'
+  | 'error'
+
+type ActiveRunResponse = {
+  ok: boolean
+  run: {
+    runId: string
+    status: ActiveRunStatus
+    sessionKey: string
+    startedAt: number
+  } | null
+}
+
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
+  'accepted',
+  'active',
+  'handoff',
+])
+
+/**
+ * On mount, checks whether the server has an active run for this session.
+ * If so, marks the session as waiting in the persistent Zustand store.
+ * If the server says the run is done, clears the stale waiting state.
+ *
+ * This closes the gap where a user navigates away during streaming,
+ * the component unmounts (losing local state), and on remount the UI
+ * doesn't know a run was in progress.
+ */
+export function useActiveRunCheck({
+  sessionKey,
+  enabled,
+}: {
+  sessionKey: string
+  enabled: boolean
+}): void {
+  const hasCheckedRef = useRef(false)
+  const sessionKeyRef = useRef(sessionKey)
+  sessionKeyRef.current = sessionKey
+
+  useEffect(() => {
+    if (!enabled || !sessionKey || sessionKey === 'new') return
+    if (hasCheckedRef.current) return
+    hasCheckedRef.current = true
+
+    const controller = new AbortController()
+
+    async function check() {
+      try {
+        const response = await fetch(
+          `/api/sessions/${encodeURIComponent(sessionKey)}/active-run`,
+          { signal: controller.signal },
+        )
+        if (!response.ok) return
+
+        const data = (await response.json()) as ActiveRunResponse
+        if (!data.ok) return
+
+        const store = useChatStore.getState()
+        if (data.run && ACTIVE_STATUSES.has(data.run.status)) {
+          store.setSessionWaiting(sessionKey, data.run.runId)
+        } else if (store.isSessionWaiting(sessionKey)) {
+          // Server says run is done but we still have stale waiting state
+          store.clearSessionWaiting(sessionKey)
+        }
+      } catch {
+        // Network error or abort — ignore
+      }
+    }
+
+    void check()
+
+    return () => {
+      controller.abort()
+    }
+  }, [sessionKey, enabled])
+
+  // Reset check flag when session changes
+  useEffect(() => {
+    hasCheckedRef.current = false
+  }, [sessionKey])
+}

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -130,6 +130,19 @@ type ChatState = {
   unregisterSendStreamRun: (runId: string) => void
   /** Check if a runId is being handled by send-stream */
   isSendStreamRun: (runId: string | undefined) => boolean
+
+  /** Sessions currently waiting for a response — survives component unmount */
+  waitingSessionKeys: Set<string>
+  waitingSessionMeta: Record<
+    string,
+    { since: number; runId: string | null }
+  >
+  /** Mark a session as waiting for a response */
+  setSessionWaiting: (sessionKey: string, runId?: string | null) => void
+  /** Clear waiting state for a session */
+  clearSessionWaiting: (sessionKey: string) => void
+  /** Check if a session is waiting for a response */
+  isSessionWaiting: (sessionKey: string) => boolean
 }
 
 const createEmptyStreamingState = (): StreamingState => ({
@@ -181,6 +194,59 @@ export function restoreStreamingState(
     sessionStorage.removeItem(storageKey)
     return null
   }
+}
+
+const WAITING_TTL_MS = 120_000
+const WAITING_STORAGE_PREFIX = 'hermes_waiting_'
+
+function persistWaitingState(
+  sessionKey: string,
+  meta: { since: number; runId: string | null },
+): void {
+  if (typeof sessionStorage === 'undefined') return
+  sessionStorage.setItem(
+    `${WAITING_STORAGE_PREFIX}${sessionKey}`,
+    JSON.stringify(meta),
+  )
+}
+
+function removeWaitingState(sessionKey: string): void {
+  if (typeof sessionStorage === 'undefined') return
+  sessionStorage.removeItem(`${WAITING_STORAGE_PREFIX}${sessionKey}`)
+}
+
+function restoreWaitingSessions(): {
+  keys: Set<string>
+  meta: Record<string, { since: number; runId: string | null }>
+} {
+  const keys = new Set<string>()
+  const meta: Record<string, { since: number; runId: string | null }> = {}
+  if (typeof sessionStorage === 'undefined') return { keys, meta }
+
+  const now = Date.now()
+  for (let i = sessionStorage.length - 1; i >= 0; i--) {
+    const storageKey = sessionStorage.key(i)
+    if (!storageKey || !storageKey.startsWith(WAITING_STORAGE_PREFIX)) continue
+    const sessionKey = storageKey.slice(WAITING_STORAGE_PREFIX.length)
+    try {
+      const parsed = JSON.parse(sessionStorage.getItem(storageKey) ?? '')
+      if (
+        typeof parsed.since === 'number' &&
+        now - parsed.since < WAITING_TTL_MS
+      ) {
+        keys.add(sessionKey)
+        meta[sessionKey] = {
+          since: parsed.since,
+          runId: typeof parsed.runId === 'string' ? parsed.runId : null,
+        }
+      } else {
+        sessionStorage.removeItem(storageKey)
+      }
+    } catch {
+      sessionStorage.removeItem(storageKey)
+    }
+  }
+  return { keys, meta }
 }
 
 let realtimeMessageSequence = 0
@@ -518,6 +584,8 @@ function messageMultipartSignature(
   return `${msg.role ?? 'unknown'}:${content}:${attachments}`
 }
 
+const _restoredWaiting = restoreWaitingSessions()
+
 export const useChatStore = create<ChatState>((set, get) => ({
   connectionState: 'disconnected',
   lastError: null,
@@ -525,6 +593,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   streamingState: new Map(),
   lastEventAt: 0,
   sendStreamRunIds: new Set(),
+  waitingSessionKeys: _restoredWaiting.keys,
+  waitingSessionMeta: _restoredWaiting.meta,
 
   setConnectionState: (connectionState, error) => {
     set({ connectionState, lastError: error ?? null })
@@ -545,6 +615,30 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isSendStreamRun: (runId) => {
     if (!runId) return false
     return get().sendStreamRunIds.has(runId)
+  },
+
+  setSessionWaiting: (sessionKey, runId) => {
+    const meta = {
+      since: get().waitingSessionMeta[sessionKey]?.since ?? Date.now(),
+      runId: runId ?? null,
+    }
+    const nextKeys = new Set(get().waitingSessionKeys)
+    nextKeys.add(sessionKey)
+    const nextMeta = { ...get().waitingSessionMeta, [sessionKey]: meta }
+    persistWaitingState(sessionKey, meta)
+    set({ waitingSessionKeys: nextKeys, waitingSessionMeta: nextMeta })
+  },
+
+  clearSessionWaiting: (sessionKey) => {
+    const nextKeys = new Set(get().waitingSessionKeys)
+    nextKeys.delete(sessionKey)
+    const { [sessionKey]: _, ...nextMeta } = get().waitingSessionMeta
+    removeWaitingState(sessionKey)
+    set({ waitingSessionKeys: nextKeys, waitingSessionMeta: nextMeta })
+  },
+
+  isSessionWaiting: (sessionKey) => {
+    return get().waitingSessionKeys.has(sessionKey)
   },
 
   processEvent: (event) => {


### PR DESCRIPTION
## Summary

Fixes #43 — chat output is lost when navigating away from the chat tab during streaming.

**Root cause:** `waitingForResponse` was a local `useState` in `ChatScreen`. When the component unmounts (tab switch), this state is destroyed. On remount, the UI doesn't know a run was in progress, so it never shows the thinking indicator or reconnects to the stream.

**Fix:**
- Lifts `waitingForResponse` into the persistent Zustand `chat-store` as `waitingSessionKeys` (a `Set<string>` keyed by session)
- Backs the store with `sessionStorage` so state survives page reloads (with 120s TTL to prevent stale spinners)
- Adds `useActiveRunCheck` hook that queries `/api/sessions/:key/active-run` on remount to reconcile client state with server
- Adds a 5s polling fallback when the store says "waiting" but SSE hasn't reconnected

**Files changed:**
- `src/stores/chat-store.ts` — new `waitingSessionKeys`, `waitingSessionMeta`, and 3 actions with sessionStorage persistence
- `src/screens/chat/hooks/use-active-run-check.ts` — new hook for server-side reconciliation
- `src/screens/chat/chat-screen.tsx` — replaced `useState` with store-backed selector + wrapper

## Test plan

- [ ] Start a chat, send a message, switch to another tab while streaming — switch back and verify the thinking indicator is still shown
- [ ] Send a message, switch tabs, wait for completion, switch back — verify the response appears
- [ ] Hard-refresh the page during streaming — verify the spinner reappears (sessionStorage backup)
- [ ] Let a waiting session sit for 2+ minutes — verify the spinner auto-clears (TTL)
- [ ] Verify no regressions in normal chat flow (send, receive, stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)