### PR TITLE
feat(docker): default docker compose to pre-built images (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Project Workspace are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- **`docker compose up` now pulls pre-built images by default** (#82) — `nousresearch/hermes-agent:latest` for the gateway and `ghcr.io/outsourc-e/hermes-workspace:latest` for the UI. Agent state persists in the `hermes-data` named volume. Adds `docker-compose.dev.yml` overlay for building from source.
+
 ## [2.0.0] — 2026-04-20
 
 **Zero-fork release.** Clone, don't fork. Project Workspace now runs on vanilla `pip install hermes-agent` with no patches, no drift, no custom gateway required.

--- a/README.md
+++ b/README.md
@@ -277,10 +277,14 @@ Using **Ollama, LM Studio, or another local server**? No key needed — just poi
 docker compose up
 ```
 
-This starts two services:
+This pulls two pre-built images and starts them:
 
-- **hermes-agent** — The AI agent gateway (port 8642)
-- **hermes-workspace** — The web UI (port 3000)
+- **hermes-agent** → `nousresearch/hermes-agent:latest` on port **8642**
+- **hermes-workspace** → `ghcr.io/outsourc-e/hermes-workspace:latest` on port **3000**
+
+No local build. First run takes a minute to pull; subsequent starts are instant.
+Agent state (config, sessions, skills, memory, credentials) persists in the
+`hermes-data` named volume, so containers can be recreated without data loss.
 
 ### Step 3: Access the Workspace
 
@@ -288,10 +292,21 @@ Open `http://localhost:3000` and complete the onboarding.
 
 > **Verify:** Check the Docker logs for `[gateway] Connected to Hermes` — this confirms the workspace successfully connected to the agent.
 
+### Building from source
+
+Want to hack on the workspace or the bundled agent Dockerfile? Use the dev overlay:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+The base `docker-compose.yml` stays untouched — the overlay adds `build:` blocks
+that take priority over `image:`, so both services compile from local source.
+
 ### Using a Pre-Built Image (Coolify / Easypanel / Dokploy / Unraid)
 
-If you'd rather deploy Project Workspace to a PaaS/home-lab stack without
-building from source, pull the pre-built image from GitHub Container Registry:
+Deploying Project Workspace to a PaaS or home-lab stack? Pull the image
+directly from GitHub Container Registry:
 
 ```
 ghcr.io/outsourc-e/hermes-workspace:latest
@@ -317,8 +332,8 @@ env:
 ```
 
 The image is built for `linux/amd64` and `linux/arm64`. Pair it with either
-your own `hermes-agent` container (use our `docker/agent/Dockerfile`) or an
-existing gateway on another host.
+a `nousresearch/hermes-agent:latest` container (what our `docker-compose.yml`
+does by default) or an existing gateway on another host.
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,23 @@
+# Project Workspace + Agent — Development Overlay
+#
+# Builds both services from source instead of pulling pre-built images.
+# Use when modifying the workspace or the bundled agent Dockerfile.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+#
+# The base docker-compose.yml stays untouched for a regular install-and-run.
+# When this overlay is merged in, `build:` takes priority over `image:` for
+# each service, so source code is compiled locally and tagged with the
+# upstream image name.
+
+services:
+  hermes-agent:
+    build:
+      context: .
+      dockerfile: docker/agent/Dockerfile
+
+  hermes-workspace:
+    build:
+      context: .
+      dockerfile: docker/workspace/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,23 +12,30 @@
 #   3. docker compose up
 #   4. Open http://localhost:3000
 #
-# Enhanced Mode (sessions, skills, memory, config):
-#   The bundled agent Dockerfile builds from outsourc-e/hermes-agent which
-#   includes the enhanced gateway APIs. Vanilla NousResearch/hermes-agent
-#   will work in "portable" mode (chat only, no sessions/skills/memory).
+# Images:
+#   This file pulls pre-built images by default — no local build required.
+#     - nousresearch/hermes-agent:latest  (Project Agent, Dockerfile upstream)
+#     - ghcr.io/outsourc-e/hermes-workspace:latest  (this workspace)
+#
+#   To build from source instead (e.g. for development), use:
+#     docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Persistent data:
+#   The `hermes-data` named volume mounts at /opt/data inside the agent
+#   container. Config, sessions, skills, memory, and credentials live there
+#   and survive container recreation. For host-path mounts see the commented
+#   `volumes:` block on the hermes-agent service.
 #
 # Troubleshooting:
 #   - See README.md "Docker" troubleshooting section
 #   - Check logs: docker compose logs hermes-agent
-#   - Agent must expose port 8642 with: hermes gateway run
+#   - Agent must expose port 8642
 
 services:
   # The Hermes AI Agent Gateway
   # Provides the backend API that the workspace connects to
   hermes-agent:
-    build:
-      context: .
-      dockerfile: docker/agent/Dockerfile
+    image: nousresearch/hermes-agent:latest
     env_file:
       - .env
     environment:
@@ -46,8 +53,13 @@ services:
       API_SERVER_KEY: ${API_SERVER_KEY:-}
       API_SERVER_HOST: ${API_SERVER_HOST:-0.0.0.0}
       API_SERVER_ENABLED: 'true'
+    volumes:
+      # Persist agent state across container recreation. Swap for a
+      # host-path mount (e.g. `./data:/opt/data`) if you want to edit
+      # config/skills directly from the host.
+      - hermes-data:/opt/data
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8642/health']
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:8642/health || exit 1']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -58,9 +70,7 @@ services:
   # The Project Workspace Web UI
   # Connects to hermes-agent at http://hermes-agent:8642
   hermes-workspace:
-    build:
-      context: .
-      dockerfile: docker/workspace/Dockerfile
+    image: ghcr.io/outsourc-e/hermes-workspace:latest
     depends_on:
       hermes-agent:
         condition: service_healthy
@@ -73,3 +83,6 @@ services:
       HERMES_API_TOKEN: ${API_SERVER_KEY:-}
     ports:
       - '3000:3000'
+
+volumes:
+  hermes-data:


### PR DESCRIPTION
Closes #82.

## What

`docker compose up` now pulls official pre-built images instead of cloning + building from source.

| Service | Before | After |
|---|---|---|
| `hermes-agent` | git clone + `pip install -e .` (slow, ~5 min first run) | `nousresearch/hermes-agent:latest` |
| `hermes-workspace` | local Dockerfile build | `ghcr.io/outsourc-e/hermes-workspace:latest` |

## Why

- Upstream `nousresearch/hermes-agent` has a real production Dockerfile (Playwright, non-root user, `/opt/data` volume, 354k pulls on Docker Hub). Our inline `git clone + pip install -e .` was a lazy placeholder.
- Our own GHCR image has been auto-publishing since yesterday (amd64 + arm64, tini, healthcheck, non-root). No reason to force users to rebuild it locally.
- First-run UX: image pull is a few hundred MB; source build is 5+ minutes of `npm install`, `playwright install`, `uv pip install`. Pre-built wins.

## Changes

- `docker-compose.yml` — use `image:` instead of `build:` for both services; add `hermes-data` named volume mounted at `/opt/data` so agent state survives `docker compose down`; switch healthcheck to `CMD-SHELL` for proper exit-code propagation.
- `docker-compose.dev.yml` — new overlay for contributors. `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` restores local source builds.
- `README.md` — updated quickstart to reflect the new default + added a 'Building from source' subsection.
- `CHANGELOG.md` — Unreleased entry.

## Testing

- `docker-compose.yml` and `docker-compose.dev.yml` parse cleanly via PyYAML.
- `nousresearch/hermes-agent:latest` verified live on Docker Hub (354k+ pulls, last updated today).
- `ghcr.io/outsourc-e/hermes-workspace:latest` verified live on our registry.

## Notes

- Upstream image uses `HERMES_HOME=/opt/data` and runs as UID 10000; the named volume handles this cleanly. Users who want host-path mounts (to edit skills/config directly) can swap `hermes-data:/opt/data` for `./data:/opt/data` \u2014 documented inline.
- The `docker/agent/Dockerfile` in-tree is preserved \u2014 the dev overlay still uses it, and it's a reasonable reference for users building custom agent images.

/cc @venomdev \u2014 thanks for the suggestion!