### PR TITLE
fix: CI Docker build + settings/chat UI polish

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -211,7 +211,7 @@ export function CommandPalette({ pathname, sessions }: CommandPaletteProps) {
         keywords: 'preferences configuration',
         shortcut: 'Go',
         icon: Settings01Icon,
-        onSelect: () => void navigate({ to: '/settings' }),
+        onSelect: () => void navigate({ to: '/settings', search: {} }),
       },
     ],
     [navigate],

--- a/src/components/search/search-modal.tsx
+++ b/src/components/search/search-modal.tsx
@@ -132,7 +132,7 @@ export function SearchModal() {
         description: 'Open the settings workspace',
         onSelect: () => {
           closeModal()
-          navigate({ to: '/settings' })
+          navigate({ to: '/settings', search: {} })
         },
       },
       {

--- a/src/components/settings/settings-sidebar.tsx
+++ b/src/components/settings/settings-sidebar.tsx
@@ -1,0 +1,142 @@
+import { Link } from '@tanstack/react-router'
+import { cn } from '@/lib/utils'
+
+export type SettingsNavId =
+  | 'hermes'
+  | 'agent'
+  | 'routing'
+  | 'voice'
+  | 'display'
+  | 'appearance'
+  | 'chat'
+  | 'notifications'
+  | 'mcp'
+  | 'language'
+
+type NavItem = { id: SettingsNavId; label: string }
+
+export const SETTINGS_NAV_ITEMS: Array<NavItem> = [
+  { id: 'hermes', label: 'Model & Provider' },
+  { id: 'agent', label: 'Agent Behavior' },
+  { id: 'routing', label: 'Smart Routing' },
+  { id: 'voice', label: 'Voice' },
+  { id: 'display', label: 'Display' },
+  { id: 'appearance', label: 'Appearance' },
+  { id: 'chat', label: 'Chat' },
+  { id: 'notifications', label: 'Notifications' },
+  { id: 'mcp', label: 'MCP Servers' },
+  { id: 'language', label: 'Language' },
+]
+
+type ItemRendererArgs = {
+  item: NavItem
+  isActive: boolean
+  activeClass: string
+  inactiveClass: string
+  indicator: React.ReactNode
+}
+
+function renderItem({
+  item,
+  isActive,
+  activeClass,
+  inactiveClass,
+  indicator,
+}: ItemRendererArgs) {
+  const className = cn(
+    'relative rounded-lg px-3 py-2 text-left text-sm transition-colors',
+    isActive ? activeClass : inactiveClass,
+  )
+  const content = (
+    <>
+      {isActive ? indicator : null}
+      {item.label}
+    </>
+  )
+  if (item.id === 'mcp') {
+    return (
+      <Link key={item.id} to="/settings/mcp" className={className}>
+        {content}
+      </Link>
+    )
+  }
+  return (
+    <Link
+      key={item.id}
+      to="/settings"
+      search={{ section: item.id }}
+      className={className}
+    >
+      {content}
+    </Link>
+  )
+}
+
+export function SettingsSidebar({ activeId }: { activeId: SettingsNavId }) {
+  const activeClass =
+    'bg-[var(--theme-accent-subtle)] text-[var(--theme-accent)] font-semibold'
+  const inactiveClass =
+    'text-primary-600 hover:bg-primary-100 hover:text-primary-900'
+  const indicator = (
+    <span
+      aria-hidden
+      className="absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-full bg-[var(--theme-accent)]"
+    />
+  )
+
+  return (
+    <nav className="hidden w-48 shrink-0 md:block">
+      <div className="sticky top-8">
+        <h1 className="mb-4 px-3 text-lg font-semibold text-primary-900">
+          Settings
+        </h1>
+        <div className="flex flex-col gap-0.5">
+          {SETTINGS_NAV_ITEMS.map((item) =>
+            renderItem({
+              item,
+              isActive: activeId === item.id,
+              activeClass,
+              inactiveClass,
+              indicator,
+            }),
+          )}
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+export function SettingsMobilePills({ activeId }: { activeId: SettingsNavId }) {
+  const activeClass =
+    'bg-[var(--theme-accent)] text-[var(--theme-bg)] font-semibold'
+  const inactiveClass =
+    'bg-primary-100 text-primary-600 hover:bg-primary-200'
+  return (
+    <div className="scrollbar-none flex gap-1.5 overflow-x-auto pb-2 md:hidden">
+      {SETTINGS_NAV_ITEMS.map((item) => {
+        const isActive = activeId === item.id
+        const className = cn(
+          'shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+          isActive ? activeClass : inactiveClass,
+        )
+        if (item.id === 'mcp') {
+          return (
+            <Link key={item.id} to="/settings/mcp" className={className}>
+              {item.label}
+            </Link>
+          )
+        }
+        return (
+          <Link
+            key={item.id}
+            to="/settings"
+            search={{ section: item.id }}
+            className={className}
+          >
+            {item.label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -58,7 +58,7 @@ function TabsTab({ className, ...props }: TabsPrimitive.Tab.Props) {
   return (
     <TabsPrimitive.Tab
       className={cn(
-        '[&_svg]:-mx-0.5 relative z-10 flex h-8 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 text-sm font-medium outline-none transition-[color,background-color,box-shadow] hover:text-primary-900 focus-visible:ring-2 focus-visible:ring-primary-400 data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-primary-900 data-disabled:opacity-64 [&_svg:not([class*="size-"])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+        '[&_svg]:-mx-0.5 relative z-10 flex h-8 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 text-sm font-medium outline-none transition-[color,background-color,box-shadow] hover:text-primary-900 focus-visible:ring-2 focus-visible:ring-primary-400 data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:bg-[var(--theme-accent-subtle)] data-active:text-[var(--theme-accent)] data-active:font-semibold data-disabled:opacity-64 [&_svg:not([class*="size-"])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0',
         className,
       )}
       data-slot="tabs-tab"

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -12,12 +12,18 @@ import {
   UserIcon,
   VolumeHighIcon,
 } from '@hugeicons/core-free-icons'
-import { Link, createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
 import type * as React from 'react'
 import type { LoaderStyle } from '@/hooks/use-chat-settings'
 import type { BrailleSpinnerPreset } from '@/components/ui/braille-spinner'
 import type { ThemeId } from '@/lib/theme'
+import type { SettingsNavId } from '@/components/settings/settings-sidebar'
+import {
+  SETTINGS_NAV_ITEMS,
+  SettingsMobilePills,
+  SettingsSidebar,
+} from '@/components/settings/settings-sidebar'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -36,8 +42,21 @@ import { BrailleSpinner } from '@/components/ui/braille-spinner'
 import { ThreeDotsSpinner } from '@/components/ui/three-dots-spinner'
 // useWorkspaceStore removed — hamburger eliminated on mobile
 
+const VALID_SECTION_IDS: ReadonlyArray<SettingsNavId> = SETTINGS_NAV_ITEMS.map(
+  (item) => item.id,
+)
+
 export const Route = createFileRoute('/settings/')({
   ssr: false,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { section?: SettingsNavId } => {
+    const raw = typeof search.section === 'string' ? search.section : undefined
+    if (raw && (VALID_SECTION_IDS as ReadonlyArray<string>).includes(raw)) {
+      return { section: raw as SettingsNavId }
+    }
+    return {}
+  },
   component: SettingsRoute,
 })
 
@@ -245,36 +264,7 @@ function SettingsRow({ label, description, children }: RowProps) {
   )
 }
 
-type SettingsSectionId =
-  | 'profile'
-  | 'appearance'
-  | 'chat'
-  | 'hermes'
-  | 'agent'
-  | 'routing'
-  | 'voice'
-  | 'display'
-  | 'notifications'
-  | 'advanced'
-
-type SettingsNavItem = {
-  id: SettingsSectionId | 'mcp'
-  label: string
-  to?: '/settings/mcp'
-}
-
-const SETTINGS_NAV_ITEMS: Array<SettingsNavItem> = [
-  { id: 'hermes', label: 'Model & Provider' },
-  { id: 'agent', label: 'Agent Behavior' },
-  { id: 'routing', label: 'Smart Routing' },
-  { id: 'voice', label: 'Voice' },
-  { id: 'display', label: 'Display' },
-  { id: 'appearance', label: 'Appearance' },
-  { id: 'chat', label: 'Chat' },
-  { id: 'notifications', label: 'Notifications' },
-  { id: 'mcp', label: 'MCP Servers', to: '/settings/mcp' },
-  { id: 'language' as SettingsSectionId, label: 'Language' },
-]
+type SettingsSectionId = SettingsNavId
 
 function SettingsRoute() {
   usePageTitle('Settings')
@@ -310,8 +300,8 @@ function SettingsRoute() {
     void fetchModels()
   }, [])
 
-  const [activeSection, setActiveSection] =
-    useState<SettingsSectionId>('hermes')
+  const { section } = Route.useSearch()
+  const activeSection: SettingsSectionId = section ?? 'hermes'
 
   return (
     <div className="min-h-screen bg-surface text-primary-900">
@@ -319,74 +309,9 @@ function SettingsRoute() {
       <div className="pointer-events-none fixed inset-0 bg-gradient-to-br from-primary-100/25 via-transparent to-primary-300/20" />
 
       <main className="relative mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 pt-6 pb-24 sm:px-6 md:flex-row md:gap-6 md:pb-8 lg:pt-8">
-        {/* Sidebar nav */}
-        <nav className="hidden w-48 shrink-0 md:block">
-          <div className="sticky top-8">
-            <h1 className="mb-4 text-lg font-semibold text-primary-900 px-3">
-              Settings
-            </h1>
-            <div className="flex flex-col gap-0.5">
-              {SETTINGS_NAV_ITEMS.map((item) =>
-                item.to ? (
-                  <Link
-                    key={item.id}
-                    to={item.to}
-                    className="rounded-lg px-3 py-2 text-left text-sm text-primary-600 transition-colors hover:bg-primary-100 hover:text-primary-900"
-                  >
-                    {item.label}
-                  </Link>
-                ) : (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() =>
-                      setActiveSection(item.id as SettingsSectionId)
-                    }
-                    className={cn(
-                      'rounded-lg px-3 py-2 text-left text-sm transition-colors',
-                      activeSection === item.id
-                        ? 'bg-accent-500/10 text-accent-600 font-medium'
-                        : 'text-primary-600 hover:bg-primary-100 hover:text-primary-900',
-                    )}
-                  >
-                    {item.label}
-                  </button>
-                ),
-              )}
-            </div>
-          </div>
-        </nav>
+        <SettingsSidebar activeId={activeSection} />
 
-        {/* Mobile header — intentionally omitted; MobilePageHeader above shows "Settings" */}
-
-        {/* Mobile section pills */}
-        <div className="flex gap-1.5 overflow-x-auto pb-2 scrollbar-none md:hidden">
-          {SETTINGS_NAV_ITEMS.map((item) =>
-            item.to ? (
-              <Link
-                key={item.id}
-                to={item.to}
-                className="shrink-0 rounded-full bg-primary-100 px-3 py-1.5 text-xs font-medium text-primary-600 transition-colors"
-              >
-                {item.label}
-              </Link>
-            ) : (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setActiveSection(item.id as SettingsSectionId)}
-                className={cn(
-                  'shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
-                  activeSection === item.id
-                    ? 'bg-accent-500 text-white'
-                    : 'bg-primary-100 text-primary-600',
-                )}
-              >
-                {item.label}
-              </button>
-            ),
-          )}
-        </div>
+        <SettingsMobilePills activeId={activeSection} />
 
         {/* Content area */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
@@ -415,18 +340,19 @@ function SettingsRoute() {
                 description="Choose a workspace theme and accent color."
                 icon={PaintBoardIcon}
               >
-                <SettingsRow
-                  label="Theme"
-                  description="Choose the workspace palette. Light and dark variants are both available."
-                >
-                  <div className="w-full">
-                    <WorkspaceThemePicker />
+                <div className="space-y-2">
+                  <div>
+                    <p className="text-sm font-medium text-primary-900">
+                      Theme
+                    </p>
+                    <p className="text-xs text-primary-600 text-pretty">
+                      Choose the workspace palette. Light and dark variants are
+                      both available.
+                    </p>
                   </div>
-                </SettingsRow>
-
-                {/* Accent color removed — themes control accent */}
+                  <WorkspaceThemePicker />
+                </div>
               </SettingsSection>
-              {/* LoaderStyleSection removed — not relevant for Hermes */}
             </>
           )}
 

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -608,7 +608,6 @@ function ChatSidebarComponent({
   const [deleteSessionTitle, setDeleteSessionTitle] = useState('')
   const [providersOpen, setProvidersOpen] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
-  const [isHoverExpanded, setIsHoverExpanded] = useState(false)
   const sidebarRef = useRef<HTMLElement | null>(null)
   const swipeStartRef = useRef<{ x: number; y: number } | null>(null)
 
@@ -663,23 +662,7 @@ function ChatSidebarComponent({
     return () => media.removeEventListener('change', update)
   }, [])
 
-  useEffect(() => {
-    if (isMobile || !isCollapsed) {
-      setIsHoverExpanded(false)
-    }
-  }, [isCollapsed, isMobile])
-
-  const isVisuallyCollapsed = isCollapsed && !isHoverExpanded
-  const isHoverPreviewExpanded = !isMobile && isCollapsed && isHoverExpanded
-
-
-  function handleSidebarToggle() {
-    if (isHoverPreviewExpanded) {
-      setIsHoverExpanded(false)
-      return
-    }
-    onToggleCollapse()
-  }
+  const isVisuallyCollapsed = isCollapsed
 
   const asideProps = {
     className: cn(
@@ -853,12 +836,6 @@ function ChatSidebarComponent({
       className={cn(asideProps.className, isMobile && isCollapsed && 'pointer-events-none overflow-hidden')}
       data-tour="sidebar-container"
       style={isMobile ? { maxWidth: 360 } : undefined}
-      onMouseEnter={() => {
-        if (!isMobile && isCollapsed) setIsHoverExpanded(true)
-      }}
-      onMouseLeave={() => {
-        if (!isMobile) setIsHoverExpanded(false)
-      }}
       aria-hidden={isMobile && isCollapsed ? true : undefined}
       {...(isMobile && isCollapsed ? { inert: true } : {})}
     >
@@ -892,16 +869,16 @@ function ChatSidebarComponent({
         <TooltipProvider>
           <TooltipRoot>
             <TooltipTrigger
-              onClick={handleSidebarToggle}
+              onClick={onToggleCollapse}
               render={
                 <Button
                   size="icon-sm"
                   variant="ghost"
-                  aria-label={isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
+                  aria-label={isCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
                   className="absolute right-2 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100"
                   data-tour="sidebar-collapse-toggle"
                 >
-                  {isVisuallyCollapsed ? (
+                  {isCollapsed ? (
                     <HugeiconsIcon
                       icon={ArrowRight01Icon}
                       size={18}
@@ -918,7 +895,7 @@ function ChatSidebarComponent({
               }
             />
             <TooltipContent side="right">
-              {isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
+              {isCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
             </TooltipContent>
           </TooltipRoot>
         </TooltipProvider>

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -830,7 +830,7 @@ export function DashboardScreen() {
             label="Settings"
             icon="⚙️"
             accentColor={palette.accentSecondary}
-            onClick={() => navigate({ to: '/settings' })}
+            onClick={() => navigate({ to: '/settings', search: {} })}
           />
         </div>
       </div>

--- a/src/screens/gateway/agents-screen.tsx
+++ b/src/screens/gateway/agents-screen.tsx
@@ -1338,7 +1338,7 @@ export function AgentsScreen({ variant = 'mission-control' }: AgentsScreenProps)
               <button
                 type="button"
                 onClick={() => {
-                  void navigate({ to: '/settings' })
+                  void navigate({ to: '/settings', search: {} })
                 }}
                 className="mt-4 inline-flex min-h-11 items-center rounded-lg bg-accent-500 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-accent-600 sm:px-4 sm:py-2 sm:text-sm"
               >

--- a/src/screens/settings/mcp-settings-screen.tsx
+++ b/src/screens/settings/mcp-settings-screen.tsx
@@ -22,6 +22,10 @@ import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
 import { cn } from '@/lib/utils'
+import {
+  SettingsMobilePills,
+  SettingsSidebar,
+} from '@/components/settings/settings-sidebar'
 
 type Transport = 'stdio' | 'http'
 
@@ -520,9 +524,13 @@ export function McpSettingsScreen() {
   }
 
   return (
-    <div className="min-h-full bg-surface">
-      <main className="mx-auto w-full max-w-5xl px-4 py-6 text-primary-900 md:px-6 md:py-8">
-        <div className="space-y-5">
+    <div className="min-h-screen bg-surface text-primary-900">
+      <main className="relative mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 pt-6 pb-24 sm:px-6 md:flex-row md:gap-6 md:pb-8 lg:pt-8">
+        <SettingsSidebar activeId="mcp" />
+
+        <SettingsMobilePills activeId="mcp" />
+
+        <div className="flex-1 min-w-0 space-y-5">
           <header className="rounded-2xl border border-primary-200 bg-primary-50/80 p-5 shadow-sm">
             <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
               <div className="space-y-2">
@@ -531,7 +539,7 @@ export function McpSettingsScreen() {
                   size="sm"
                   className="-ml-2 w-fit"
                   render={
-                    <Link to="/settings">
+                    <Link to="/settings" search={{}}>
                       <HugeiconsIcon
                         icon={ArrowLeft01Icon}
                         size={16}
@@ -548,7 +556,7 @@ export function McpSettingsScreen() {
                   <p className="mt-1 text-sm text-primary-600">
                     Review configured MCP servers, draft changes locally, and
                     copy the YAML into
-                    <code className="mx-1 rounded bg-white px-1.5 py-0.5 font-mono text-xs">
+                    <code className="mx-1 rounded border border-primary-200 bg-primary-100 px-1.5 py-0.5 font-mono text-xs">
                       config.yaml
                     </code>
                     until gateway config writes land.
@@ -563,16 +571,16 @@ export function McpSettingsScreen() {
           </header>
 
           {notice ? (
-            <div className="rounded-2xl border border-primary-200 bg-white px-4 py-3 text-sm text-primary-600 shadow-sm">
+            <div className="rounded-2xl border border-primary-200 bg-primary-100 px-4 py-3 text-sm text-primary-600 shadow-sm">
               {notice}
             </div>
           ) : null}
 
           {isDirty ? (
-            <div className="rounded-2xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 shadow-sm">
+            <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 shadow-sm">
               You have unsaved changes. Copy the YAML below and paste it into
               your{' '}
-              <code className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-xs">
+              <code className="rounded bg-amber-500/20 px-1.5 py-0.5 font-mono text-xs">
                 config.yaml
               </code>
               .
@@ -615,13 +623,13 @@ export function McpSettingsScreen() {
             </div>
 
             {loading ? (
-              <div className="rounded-xl border border-primary-200 bg-white px-4 py-3 text-sm text-primary-600">
+              <div className="rounded-xl border border-primary-200 bg-primary-100 px-4 py-3 text-sm text-primary-600">
                 Loading MCP servers...
               </div>
             ) : null}
 
             {!loading && servers.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-primary-300 bg-white px-4 py-8 text-center text-sm text-primary-600">
+              <div className="rounded-xl border border-dashed border-primary-300 bg-primary-100 px-4 py-8 text-center text-sm text-primary-600">
                 No MCP servers found yet. Add one to generate a starter config
                 snippet.
               </div>
@@ -632,7 +640,7 @@ export function McpSettingsScreen() {
                 {servers.map((server) => (
                   <article
                     key={server.name}
-                    className="rounded-2xl border border-primary-200 bg-white p-4 shadow-sm"
+                    className="rounded-2xl border border-primary-200 bg-primary-100 p-4 shadow-sm"
                   >
                     <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                       <div className="min-w-0 space-y-2">
@@ -679,7 +687,7 @@ export function McpSettingsScreen() {
                           variant="outline"
                           size="sm"
                           className={cn(
-                            'text-red-600 hover:bg-red-50 hover:text-red-700',
+                            'text-red-500 hover:bg-red-500/10 hover:text-red-400',
                           )}
                           onClick={() => {
                             setServers((current) =>
@@ -715,11 +723,11 @@ export function McpSettingsScreen() {
                 </h2>
                 <p className="mt-1 text-sm text-primary-600">
                   Add this to your{' '}
-                  <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs">
+                  <code className="rounded border border-primary-200 bg-primary-100 px-1.5 py-0.5 font-mono text-xs">
                     config.yaml
                   </code>{' '}
                   under{' '}
-                  <code className="rounded bg-white px-1.5 py-0.5 font-mono text-xs">
+                  <code className="rounded border border-primary-200 bg-primary-100 px-1.5 py-0.5 font-mono text-xs">
                     mcp_servers
                   </code>
                   .
@@ -731,7 +739,7 @@ export function McpSettingsScreen() {
               </Button>
             </div>
 
-            <pre className="mt-4 overflow-x-auto rounded-2xl border border-primary-200 bg-white p-4 text-xs leading-6 text-primary-800">
+            <pre className="mt-4 overflow-x-auto rounded-2xl border border-primary-200 bg-surface p-4 text-xs leading-6 text-primary-800">
               <code>{yamlSnippet}</code>
             </pre>
           </section>


### PR DESCRIPTION
- Dockerfile: drop stale workspace-daemon COPY that broke multi-arch CI after the monorepo cleanup removed the directory.
- Chat sidebar: remove hover-to-expand behavior so the collapsed rail stays 48px and its icons are directly clickable; clicking the toggle button now always uncollapses persistently.
- Settings page: fix Appearance theme cards overlapping the label (block layout), extract a shared SettingsSidebar so the tab list also appears on /settings/mcp, add URL-driven active section via a ?section= search param, and surface a visible active-tab indicator (accent-subtle bg + accent text + left accent bar).
- MCP settings: swap hardcoded bg-white / pale amber / light-red colors for theme-aware Tailwind tokens that remap correctly in every theme.
- Tabs primitive: give data-active an accent-subtle background so the selected tab is visible across all themes (previously relied only on a sliding indicator that blended into the list background).
- Align /settings navigations in command-palette, search-modal, dashboard-screen, agents-screen, and the MCP back link with the new typed search schema.
- tsconfig: fix dangling include entry (vite.config.js -> vite.config.ts).