### PR TITLE
fix: remove orphaned workspace-daemon reference from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN corepack enable && apt-get update && apt-get install -y --no-install-recomme
 WORKDIR /app
 
 # Install deps (cache-friendly: copy only manifests first)
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./
-COPY workspace-daemon/package.json workspace-daemon/
+COPY package.json pnpm-lock.yaml* ./
 RUN pnpm install --frozen-lockfile
 
 # Copy sources and build


### PR DESCRIPTION
## Problem
Docker build fails with:
```
failed to compute cache key: "/workspace-daemon/package.json": not found
```

The Dockerfile references `workspace-daemon/package.json` but this directory does not exist in the repository.

## Fix
Removed the orphaned `COPY workspace-daemon/package.json workspace-daemon/` line from the Dockerfile build stage.

Also removed the non-existent `pnpm-workspace.yaml` from the COPY manifest glob (line already had a trailing `*` but the file doesn't exist).

## Testing
- [ ] CI passes
- [ ] Docker image builds successfully