### PR TITLE
fix(capabilities): strip trailing slashes from HERMES_API URLs

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -9,9 +9,12 @@
  * older all-in-one web API on the gateway port.
  */
 
-export let HERMES_API = process.env.HERMES_API_URL || 'http://127.0.0.1:8645'
-export let HERMES_DASHBOARD_URL =
+export let HERMES_API = (
+  process.env.HERMES_API_URL || 'http://127.0.0.1:8645'
+).replace(/\/+$/, '')
+export let HERMES_DASHBOARD_URL = (
   process.env.HERMES_DASHBOARD_URL || 'http://127.0.0.1:9119'
+).replace(/\/+$/, '')
 
 export const HERMES_UPGRADE_INSTRUCTIONS =
   'For full features, install upstream Hermes Agent (`pip install hermes-agent`) and run `hermes gateway run` plus `hermes dashboard` in separate terminals.'


### PR DESCRIPTION
## Summary
- `${HERMES_API}${path}` in `gateway-capabilities.ts` concatenates a possibly-trailing-slashed `HERMES_API` with a leading-slashed `path`, producing `//health`, `//v1/models`, etc. — which the gateway 404s, so every capability probe fails.
- Consequence: with a fully-healthy gateway, `/api/auth-check` still returns 503 `hermes_agent_unreachable` and the onboarding splash ("Let's connect your backend") sticks indefinitely.
- Trigger: any `HERMES_API_URL` that ends with `/`. Most commonly from the documented workaround for the vite auto-start self-fork race, where exact equality with the default URL (`http://127.0.0.1:8645`) forces workspace to fork its own gateway — so users append a trailing slash to break the equality.

## Fix
Normalize trailing slashes at read time on both `HERMES_API` and `HERMES_DASHBOARD_URL`:

```ts
export let HERMES_API = (
  process.env.HERMES_API_URL || 'http://127.0.0.1:8645'
).replace(/\/+$/, '')
```

Now `http://127.0.0.1:8645`, `http://127.0.0.1:8645/`, and `http://127.0.0.1:8645//` all behave the same at probe time.

## Test plan
- [x] With `HERMES_API_URL=http://127.0.0.1:8645/`, `/api/auth-check` returns 200 (`{authenticated:true, authRequired:false}`) instead of 503.
- [x] `/api/gateway-status` returns all capabilities `true`: health, chatCompletions, models, streaming, sessions, skills, memory, config, jobs, dashboard.
- [x] Onboarding splash transitions past "Let's connect your backend" once the gateway is healthy.
- [ ] Suggested: add a unit test asserting `HERMES_API` drops trailing slashes for both `/` and `//` inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)