### PR TITLE
fix(chat): prevent new chat from loading previous session history

### DIFF
--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -244,6 +244,7 @@ export function useChatHistory({
   )
 
   const sessionKeyForHistory = useMemo(() => {
+    if (isNewChat) return 'new'
     const candidates = [
       normalizedForcedSessionKey,
       normalizedActiveSessionKey,
@@ -253,6 +254,7 @@ export function useChatHistory({
     return match || 'main'
   }, [
     explicitRouteSessionKey,
+    isNewChat,
     normalizedActiveSessionKey,
     normalizedForcedSessionKey,
   ])


### PR DESCRIPTION
When navigating to /chat/new, the session key resolver normalized 'new' to '' then fell back to 'main', which the server resolved to the most recent active session.

This PR adds an early return in sessionKeyForHistory to preserve 'new' when isNewChat is true, bypassing the fallback logic entirely.

Fixes #92