### PR TITLE
feat(chat): sort sessions by last activity and use preview as fallback title

### DIFF
--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -244,6 +244,7 @@ export function useChatHistory({
   )
 
   const sessionKeyForHistory = useMemo(() => {
+    if (isNewChat) return 'new'
     const candidates = [
       normalizedForcedSessionKey,
       normalizedActiveSessionKey,
@@ -253,6 +254,7 @@ export function useChatHistory({
     return match || 'main'
   }, [
     explicitRouteSessionKey,
+    isNewChat,
     normalizedActiveSessionKey,
     normalizedForcedSessionKey,
   ])

--- a/src/screens/chat/hooks/use-chat-sessions.ts
+++ b/src/screens/chat/hooks/use-chat-sessions.ts
@@ -56,9 +56,14 @@ export function useChatSessions({
     const rawSessions = sessionsQuery.data ?? []
     const filtered = filterSessionsWithTombstones(rawSessions)
     if (!filtered.length) return filtered
-    return filtered.map((session) =>
+    const merged = filtered.map((session) =>
       mergeSessionTitle(session, storedTitles[session.friendlyId]),
     )
+    return merged.sort((a, b) => {
+      const aTs = a.updatedAt ?? 0
+      const bTs = b.updatedAt ?? 0
+      return bTs - aTs
+    })
   }, [sessionsQuery.data, storedTitles])
 
   const activeSession = useMemo(() => {

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -73,6 +73,7 @@ export type SessionSummary = {
   titleStatus?: SessionTitleStatus
   titleSource?: SessionTitleSource
   titleError?: string | null
+  preview?: string | null
 }
 
 export type SessionListResponse = {
@@ -96,6 +97,7 @@ export type SessionMeta = {
   titleStatus?: SessionTitleStatus
   titleSource?: SessionTitleSource
   titleError?: string | null
+  preview?: string | null
 }
 
 export type PathsPayload = {

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -227,7 +227,9 @@ export function normalizeSessions(
       typeof session.derivedTitle === 'string' &&
       session.derivedTitle.trim().length > 0
         ? session.derivedTitle.trim()
-        : undefined
+        : typeof session.preview === 'string' && session.preview.trim().length > 0
+          ? session.preview.trim()
+          : undefined
     const titleStatus = deriveTitleStatus(
       label,
       explicitTitle,
@@ -253,6 +255,7 @@ export function normalizeSessions(
       titleStatus,
       titleSource,
       titleError: session.titleError ?? null,
+      preview: session.preview ?? null,
     }
   })
 }

--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -300,9 +300,10 @@ export function toSessionSummary(
     kind: 'chat',
     status: session.ended_at ? 'ended' : 'idle',
     model: session.model || '',
-    label: session.title || session.id,
-    title: session.title || session.id,
-    derivedTitle: session.title || session.id,
+    label: session.title || undefined,
+    title: session.title || undefined,
+    derivedTitle: session.title || session.preview || undefined,
+    preview: session.preview || undefined,
     tokenCount: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
     totalTokens: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
     message_count: session.message_count ?? 0,
@@ -312,11 +313,13 @@ export function toSessionSummary(
     cost: 0,
     createdAt: session.started_at ? session.started_at * 1000 : Date.now(),
     startedAt: session.started_at ? session.started_at * 1000 : Date.now(),
-    updatedAt: session.ended_at
-      ? session.ended_at * 1000
-      : session.started_at
-        ? session.started_at * 1000
-        : Date.now(),
+    updatedAt: session.last_active
+      ? session.last_active * 1000
+      : session.ended_at
+        ? session.ended_at * 1000
+        : session.started_at
+          ? session.started_at * 1000
+          : Date.now(),
     usage: {
       promptTokens: session.input_tokens ?? 0,
       completionTokens: session.output_tokens ?? 0,


### PR DESCRIPTION
- Sort session list by updatedAt (descending) instead of creation order
- Use session.preview (first message snippet) as derivedTitle fallback when no explicit title is set, making sessions identifiable without manual labeling
- Fix updatedAt mapping to use last_active timestamp from gateway instead of started_at / ended_at
- Remove session ID fallback from label/title/derivedTitle fields so UI shows empty state instead of raw UUIDs

Improves discoverability of sessions and prevents the sidebar from looking like a list of unreadable IDs.