### PR TITLE
fix: prevent IME composition Enter from submitting

### DIFF
--- a/src/components/agent-view/agent-view-panel.tsx
+++ b/src/components/agent-view/agent-view-panel.tsx
@@ -397,7 +397,7 @@ function OrchestratorCard({
                 onChange={(e) => setEditValue(e.target.value)}
                 onBlur={commitEdit}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') commitEdit()
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) commitEdit()
                   if (e.key === 'Escape') setIsEditing(false)
                 }}
                 placeholder="Agent name..."

--- a/src/components/prompt-kit/prompt-input.tsx
+++ b/src/components/prompt-kit/prompt-input.tsx
@@ -236,7 +236,7 @@ function PromptInputTextarea({
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       const form = e.currentTarget.form
       if (form) {

--- a/src/screens/agents/components/operations-agent-card.tsx
+++ b/src/screens/agents/components/operations-agent-card.tsx
@@ -143,7 +143,7 @@ export function OperationsInlineChat({
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
+              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
                 event.preventDefault()
                 void handleSend()
               }

--- a/src/screens/agents/components/operations-agent-chat.tsx
+++ b/src/screens/agents/components/operations-agent-chat.tsx
@@ -101,7 +101,7 @@ export function OperationsAgentChat({
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
-            if (event.key === 'Enter' && !event.shiftKey) {
+            if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
               event.preventDefault()
               void handleSend()
             }

--- a/src/screens/chat/components/chat-header.tsx
+++ b/src/screens/chat/components/chat-header.tsx
@@ -351,7 +351,7 @@ function ChatHeaderComponent({
                 void saveTitleEdit()
               }}
               onKeyDown={(event) => {
-                if (event.key === 'Enter') {
+                if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
                   event.preventDefault()
                   void saveTitleEdit()
                   return

--- a/src/screens/chat/components/sidebar/session-rename-dialog.tsx
+++ b/src/screens/chat/components/sidebar/session-rename-dialog.tsx
@@ -46,7 +46,7 @@ export function SessionRenameDialog({
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
                 e.preventDefault()
                 onSave(renameValue)
               }

--- a/src/screens/files/files-screen.tsx
+++ b/src/screens/files/files-screen.tsx
@@ -1349,7 +1349,7 @@ export function FilesScreen() {
               value={promptValue}
               onChange={(e) => setPromptValue(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') void handlePromptSubmit()
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) void handlePromptSubmit()
               }}
               className="w-full rounded-md border border-primary-200 dark:border-neutral-700 bg-primary-50 dark:bg-neutral-900 px-3 py-2 text-sm text-primary-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary-300"
               autoFocus

--- a/src/screens/gateway/components/config-wizards.tsx
+++ b/src/screens/gateway/components/config-wizards.tsx
@@ -887,7 +887,7 @@ export function AddTeamModal({ currentTeam, quickStartTemplates, existingIcons =
               ref={nameInputRef}
               value={teamName}
               onChange={(e) => setTeamName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter' && teamName.trim()) setStep(2) }}
+              onKeyDown={(e) => { if (e.key === 'Enter' && teamName.trim() && !e.nativeEvent.isComposing) setStep(2) }}
               placeholder="e.g. Research Squad, Dev Team..."
               className="h-11 w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-4 text-sm text-neutral-900 dark:text-white outline-none ring-accent-400 focus:ring-2 transition-colors"
             />

--- a/src/screens/gateway/components/run-console.tsx
+++ b/src/screens/gateway/components/run-console.tsx
@@ -510,7 +510,7 @@ export function RunConsole({
                 value={steerInput}
                 onChange={(e) => setSteerInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && steerInput.trim()) {
+                  if (e.key === 'Enter' && steerInput.trim() && !e.nativeEvent.isComposing) {
                     onSteerAgent(steerTarget, steerInput.trim())
                     setSteerInput('')
                     setSteerTarget(null)


### PR DESCRIPTION
  - Add `!e.nativeEvent.isComposing` guard to all Enter-to-submit
  handlers
  - Prevents IME composition (Chinese, Japanese, Korean) from
  accidentally triggering form submission

  ## Affected files
  - `src/components/prompt-kit/prompt-input.tsx`
  - `src/screens/agents/components/operations-agent-chat.tsx`
  - `src/screens/agents/components/operations-agent-card.tsx`
  - `src/screens/gateway/components/run-console.tsx`
  - `src/screens/files/files-screen.tsx`
  - `src/components/agent-view/agent-view-panel.tsx`
  - `src/screens/chat/components/chat-header.tsx`
  - `src/screens/chat/components/sidebar/session-rename-dialog.tsx`
  - `src/screens/gateway/components/config-wizards.tsx`