### PR TITLE
fix(auth): persist session tokens to ~/.hermes/workspace-sessions.json

### DIFF
--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -1,10 +1,104 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
 
 /**
- * In-memory session store.
- * For production, consider Redis or a database.
+ * Persistent session token store.
+ *
+ * Tokens are held in memory for fast lookup and persisted to a JSON file
+ * so they survive server restarts.  This is safe for single-instance
+ * deployments.  For multi-worker setups the file becomes a race-condition
+ * window — in that case replace with Redis or a database.
+ *
+ * File location: ~/.hermes/workspace-sessions.json
  */
-const validTokens = new Set<string>()
+interface SessionStore {
+  tokens: Record<string, number> // token -> expiry unix-ms
+}
+
+const STORE_FILE = join(
+  process.env.HERMES_HOME ?? join(homedir(), '.hermes'),
+  'workspace-sessions.json',
+)
+const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+function loadStore(): SessionStore {
+  try {
+    if (existsSync(STORE_FILE)) {
+      const raw = readFileSync(STORE_FILE, 'utf8')
+      const parsed = JSON.parse(raw) as SessionStore
+      // Expire any stale tokens on load
+      const now = Date.now()
+      const valid: Record<string, number> = {}
+      for (const [token, expiry] of Object.entries(parsed.tokens)) {
+        if (expiry > now) valid[token] = expiry
+      }
+      return { tokens: valid }
+    }
+  } catch {
+    // Corrupt store — start fresh
+  }
+  return { tokens: {} }
+}
+
+function saveStore(store: SessionStore): void {
+  try {
+    const dir = dirname(STORE_FILE)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+    }
+    // Write with restrictive permissions — tokens are sensitive.
+    writeFileSync(STORE_FILE, JSON.stringify(store), { encoding: 'utf8', mode: 0o600 })
+    // Enforce 0600 even if the file already existed with looser perms.
+    try {
+      chmodSync(STORE_FILE, 0o600)
+    } catch {
+      // chmod is best-effort (e.g. Windows) — ignore failures.
+    }
+  } catch {
+    // Non-fatal — tokens are still in memory.
+    console.warn(`[auth] Failed to persist session store to ${STORE_FILE}`)
+  }
+}
+
+// In-memory working copy
+const _tokens: Map<string, number> = new Map()
+
+// Hydrate from disk on module load
+const initial = loadStore()
+for (const [token, expiry] of Object.entries(initial.tokens)) {
+  _tokens.set(token, expiry)
+}
+
+/**
+ * Prune expired tokens from the store (called on every write + a periodic sweep).
+ */
+function _prune(): void {
+  const now = Date.now()
+  let changed = false
+  for (const [token, expiry] of _tokens) {
+    if (expiry <= now) {
+      _tokens.delete(token)
+      changed = true
+    }
+  }
+  if (changed) _persist()
+}
+
+function _persist(): void {
+  const store: SessionStore = { tokens: Object.fromEntries(_tokens) }
+  saveStore(store)
+}
+
+// Sweep expired tokens every 10 minutes
+setInterval(_prune, 10 * 60 * 1000)
 
 /**
  * Generate a cryptographically secure session token.
@@ -14,24 +108,33 @@ export function generateSessionToken(): string {
 }
 
 /**
- * Store a session token as valid.
+ * Store a session token as valid (30-day TTL).
  */
 export function storeSessionToken(token: string): void {
-  validTokens.add(token)
+  _tokens.set(token, Date.now() + TOKEN_TTL_MS)
+  _persist()
 }
 
 /**
- * Check if a session token is valid.
+ * Check if a session token is valid and not expired.
  */
 export function isValidSessionToken(token: string): boolean {
-  return validTokens.has(token)
+  const expiry = _tokens.get(token)
+  if (expiry === undefined) return false
+  if (expiry <= Date.now()) {
+    _tokens.delete(token)
+    _persist()
+    return false
+  }
+  return true
 }
 
 /**
  * Remove a session token (logout).
  */
 export function revokeSessionToken(token: string): void {
-  validTokens.delete(token)
+  _tokens.delete(token)
+  _persist()
 }
 
 /**


### PR DESCRIPTION
Supersedes #81 — builds on @Klng79's work with three security/portability polish commits on top. Original design (file-backed token store, 30-day TTL, 10-min prune sweep) kept as-is; this PR only hardens it.

## Changes on top of #81
- Hoist runtime `require('node:fs')` to top-level ESM import (matches rest of file)
- Use `os.homedir()` instead of `process.env.HOME ?? '/root'` — works on macOS/Windows/containers consistently
- `chmod 0600` on `workspace-sessions.json` + `mkdir 0700` on `~/.hermes` — tokens were world-readable by default
- Use `path.dirname()` instead of manual string slice

## Test plan
- [x] `pnpm tsc --noEmit` clean on the modified file
- [ ] Start workspace, log in, restart workspace — session should persist
- [ ] Verify `~/.hermes/workspace-sessions.json` mode is `-rw-------` (`stat -f '%Sp' ~/.hermes/workspace-sessions.json` → `-rw-------`)
- [ ] Delete the file, verify regeneration works

Closes #81
Co-authored-by: Klng79 <150247595+Klng79@users.noreply.github.com>