### PR TITLE
fix(types): add preview field to HermesSession (unblocks main build)

### DIFF
--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -44,6 +44,7 @@ export type HermesSession = {
   output_tokens?: number
   parent_session_id?: string | null
   last_active?: number | null
+  preview?: string | null
 }
 
 export type HermesMessage = {


### PR DESCRIPTION
Follow-up to #98. That PR added `preview` to the frontend `SessionSummary` + `SessionMeta` types and used it in `toSessionSummary()` / `normalizeSessions()`, but `HermesSession` (the server-side upstream type) was missed.

Result: `pnpm tsc --noEmit` fails on main with two TS2339 errors in `src/server/hermes-api.ts`. One-line fix.

## Verify
```
pnpm tsc --noEmit  # passes
```