### PR TITLE
fix(ci): remove stale workspace-daemon COPY from Dockerfile (unblocks #88)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN corepack enable && apt-get update && apt-get install -y --no-install-recomme
 WORKDIR /app
 
 # Install deps (cache-friendly: copy only manifests first)
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./
-COPY workspace-daemon/package.json workspace-daemon/
+COPY package.json pnpm-lock.yaml* ./
 RUN pnpm install --frozen-lockfile
 
 # Copy sources and build

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "**/*.tsx",
     "eslint.config.js",
     "prettier.config.js",
-    "vite.config.js"
+    "vite.config.ts"
   ],
 
   "compilerOptions": {
@@ -27,7 +27,6 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Extracted from #91 to ship the CI unblock independently.

## What's in here (3 lines changed)
- **Dockerfile:** drop the `COPY workspace-daemon/package.json workspace-daemon/` line. That directory was deleted in 82c3f70 but the manifest copy was missed, so docker builds have been dying at that step. This is the root cause of **#88 (docker pull returns manifest unknown for latest/main/v2.0.0)** — no new images have been publishable.
- **tsconfig.json:** fix include list (`vite.config.js` → `vite.config.ts`, the actual filename) and drop redundant `baseUrl`.

## What's NOT in here
The settings-sidebar / chat-collapse / MCP theme work from #91 stays there for separate review — that's 10+ files and deserves visual verification.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] CI docker build goes green
- [ ] `docker pull outsourc-e/hermes-workspace:main` works after next publish

Fixes #88
Co-authored-by: ajojotank <ajojotank@users.noreply.github.com>