### PR TITLE
feat(server): honor $HERMES_HOME env var instead of hardcoding ~/.hermes

### DIFF
--- a/src/routes/api/connection-status.ts
+++ b/src/routes/api/connection-status.ts
@@ -14,7 +14,10 @@ import {
 } from '../../server/gateway-capabilities'
 import { isAuthenticated } from '../../server/auth-middleware'
 
-const CONFIG_PATH = path.join(os.homedir(), '.hermes', 'config.yaml')
+const CONFIG_PATH = path.join(
+  process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes'),
+  'config.yaml',
+)
 
 function readActiveModel(): string {
   try {

--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -34,7 +34,7 @@ function titleCase(value: string): string {
 }
 
 function buildCrewDefinitions(): CrewDefinition[] {
-  const base = join(homedir(), '.hermes')
+  const base = process.env.HERMES_HOME ?? join(homedir(), '.hermes')
   const profilesDir = join(base, 'profiles')
   const dynamicProfiles = existsSync(profilesDir)
     ? readdirSync(profilesDir, { withFileTypes: true })
@@ -55,7 +55,7 @@ function buildCrewDefinitions(): CrewDefinition[] {
 }
 
 function getHermesHome(profilePath: string | null): string {
-  const base = join(homedir(), '.hermes')
+  const base = process.env.HERMES_HOME ?? join(homedir(), '.hermes')
   return profilePath ? join(base, 'profiles', profilePath) : base
 }
 

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -22,6 +22,7 @@ const execFileAsync = promisify(execFile)
 const WORKSPACE_ROOT = (
   process.env.HERMES_WORKSPACE_DIR ||
   process.env.HERMES_WORKSPACE_DIR ||
+  process.env.HERMES_HOME ||
   path.join(os.homedir(), '.hermes')
 ).trim()
 

--- a/src/routes/api/hermes-config.ts
+++ b/src/routes/api/hermes-config.ts
@@ -16,7 +16,7 @@ import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 type AuthResult = Response | true
 
-const HERMES_HOME = path.join(os.homedir(), '.hermes')
+const HERMES_HOME = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
 const CONFIG_PATH = path.join(HERMES_HOME, 'config.yaml')
 const ENV_PATH = path.join(HERMES_HOME, '.env')
 

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -67,7 +67,10 @@ function normalizeModel(entry: unknown): ModelEntry | null {
  * Each entry has: { id, name, provider, model, baseUrl, createdAt }
  */
 function readHermesModelsJson(): Array<ModelEntry> {
-  const modelsPath = path.join(os.homedir(), '.hermes', 'models.json')
+  const modelsPath = path.join(
+    process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes'),
+    'models.json',
+  )
   try {
     if (!fs.existsSync(modelsPath)) return []
     const raw = fs.readFileSync(modelsPath, 'utf-8')
@@ -96,7 +99,10 @@ function readHermesModelsJson(): Array<ModelEntry> {
  * Looks for "default: <model-id>" under the "model:" section.
  */
 function readHermesDefaultModel(): ModelEntry | null {
-  const configPath = path.join(os.homedir(), '.hermes', 'config.yaml')
+  const configPath = path.join(
+    process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes'),
+    'config.yaml',
+  )
   try {
     if (!fs.existsSync(configPath)) return null
     const raw = fs.readFileSync(configPath, 'utf-8')

--- a/src/routes/api/oauth.poll-token.ts
+++ b/src/routes/api/oauth.poll-token.ts
@@ -11,7 +11,8 @@ const BodySchema = z.object({
 })
 
 function saveNousTokens(accessToken: string, refreshToken?: string) {
-  const hermesDir = path.join(os.homedir(), '.hermes')
+  const hermesDir =
+    process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
   const authPath = path.join(hermesDir, 'auth.json')
 
   let existing: Record<string, unknown> = {}

--- a/src/routes/api/preview-file.ts
+++ b/src/routes/api/preview-file.ts
@@ -33,11 +33,14 @@ const MIME_BY_EXT: Record<string, string> = {
 
 function allowedPrefixes(): string[] {
   const home = os.homedir()
+  const hermesHome =
+    process.env.HERMES_HOME ?? resolvePath(home, '.hermes')
   return [
     '/tmp',
     `${home}/tmp`,
     resolvePath(home, 'dispatch'),
     resolvePath(home, 'projects'),
+    resolvePath(hermesHome, 'projects'),
     resolvePath(home, '.hermes', 'projects'),
     resolvePath(home, '.ocplatform', 'workspace', 'projects'),
   ]

--- a/src/routes/api/workspace.ts
+++ b/src/routes/api/workspace.ts
@@ -60,7 +60,7 @@ async function detectWorkspace(savedPath?: string): Promise<{
   }
 
   // Priority 3: Default Hermes workspace path
-  const defaultPath = path.join(os.homedir(), '.hermes')
+  const defaultPath = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
   const defaultValid = await isValidDirectory(defaultPath)
   if (defaultValid) {
     return {
@@ -72,12 +72,12 @@ async function detectWorkspace(savedPath?: string): Promise<{
   }
 
   // Priority 4: Hermes home directory
-  const hermesDir = path.join(os.homedir(), '.hermes')
+  const hermesDir = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
   const hermesDirValid = await isValidDirectory(hermesDir)
   if (hermesDirValid) {
     return {
       path: hermesDir,
-      folderName: '.hermes',
+      folderName: path.basename(hermesDir),
       source: 'default',
       isValid: true,
     }

--- a/src/server/hermes-agent.ts
+++ b/src/server/hermes-agent.ts
@@ -24,7 +24,10 @@ export type StartHermesAgentResult =
  * Silently returns {} if the file doesn't exist or can't be parsed.
  */
 function readHermesEnv(): Record<string, string> {
-  const envPath = join(homedir(), '.hermes', '.env')
+  const envPath = join(
+    process.env.HERMES_HOME ?? join(homedir(), '.hermes'),
+    '.env',
+  )
   try {
     const raw = readFileSync(envPath, 'utf-8')
     const result: Record<string, string> = {}

--- a/src/server/knowledge-config.ts
+++ b/src/server/knowledge-config.ts
@@ -15,7 +15,8 @@ const DEFAULT_CONFIG: KnowledgeBaseConfig = {
 }
 
 function getConfigPath(): string {
-  const hermesHome = path.join(os.homedir(), '.hermes')
+  const hermesHome =
+    process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
   return path.join(hermesHome, 'knowledge-config.json')
 }
 


### PR DESCRIPTION
## Summary

Workspace's server-side route handlers currently hardcode `path.join(os.homedir(), '.hermes')` as the Hermes home directory. The Hermes Agent itself exposes a `HERMES_HOME` environment variable that users set to relocate their home directory (e.g. running multiple installs side-by-side, or consolidating a legacy `~/.hermes` into a canonical `~/hermes`). The gateway and CLI tooling already honor it — Workspace didn't, which caused users with a non-default home to see stale/wrong data in the UI (wrong model label, empty sessions, etc.).

This PR makes every server-side path construction use the same fallback pattern that `src/server/memory-browser.ts` already uses (and that `src/routes/api/paths.ts` + `src/routes/api/hermes-tasks-assignees.ts` also had right):

```ts
process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
```

## Files touched

All source-only (no docs/UI copy changes, no package-lock changes):

| File | Sites | Notes |
|------|-------|-------|
| `src/routes/api/hermes-config.ts` | 1 | primary config reader |
| `src/routes/api/connection-status.ts` | 1 | |
| `src/routes/api/files.ts` | 1 | adds `HERMES_HOME` as a fallback after the existing `HERMES_WORKSPACE_DIR` |
| `src/routes/api/workspace.ts` | 2 | also changes `folderName: '.hermes'` to `path.basename(hermesDir)` so a custom home displays its own name |
| `src/routes/api/crew-status.ts` | 2 | `buildCrewDefinitions` + `getHermesHome` |
| `src/routes/api/preview-file.ts` | 1 | augments allow-list: keeps the legacy `~/.hermes/projects` path AND adds `$HERMES_HOME/projects` |
| `src/routes/api/oauth.poll-token.ts` | 1 | OAuth token save location |
| `src/routes/api/models.ts` | 2 | `readHermesModelsJson` + `readHermesDefaultModel` |
| `src/server/hermes-agent.ts` | 1 | `.env` reader (code-clone search paths left alone — those look for the hermes-agent install dir, not the user home) |
| `src/server/knowledge-config.ts` | 1 | |

**Deliberately NOT touched:**
- UI copy / display strings (e.g. `"Manage provider API keys stored in ~/.hermes/.env"`) — these document the default and aren't code paths.
- `src/components/terminal/terminal-workspace.tsx` — `DEFAULT_TERMINAL_CWD` is a user-facing default, orthogonal to config discovery.
- `src/server/memory-browser.ts` — already correct, used as the template.
- Test files — none needed changes.
- `package-lock.json` — unrelated to this PR.

## Verification

- `npx tsc --noEmit` produces the same 4 pre-existing repo baseline errors before and after this change. Zero new TS errors.
- Manually tested locally with `HERMES_HOME=/Users/<me>/hermes`:
  - `/api/gateway-status` reports `mode: zero-fork`, all capabilities available
  - `/api/hermes-config` returns the config from the env-specified path
  - Model label displays the correct active model instead of the stale `~/.hermes/config.yaml` value

## Motivation

Discovered while consolidating a dual-home Hermes install on macOS. The agent and gateway were writing to `~/hermes/config.yaml`, but the workspace UI kept showing a model name that was only present in the stale `~/.hermes/config.yaml`. Once I traced it, the fix was mechanical — several files just needed the same env-var fallback the repo already applies elsewhere.
