### PR TITLE
fix(docs): correct misleading upgrade instructions (#87)

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -17,7 +17,7 @@ export let HERMES_DASHBOARD_URL = (
 ).replace(/\/+$/, '')
 
 export const HERMES_UPGRADE_INSTRUCTIONS =
-  'For full features, install upstream Hermes Agent (`pip install hermes-agent`) and run `hermes gateway run` plus `hermes dashboard` in separate terminals.'
+  'For full features, install Hermes from source (`git clone https://github.com/NousResearch/hermes-agent && cd hermes-agent && pip install -e .`), then start the gateway on :8642 (`hermes gateway run`). For the extended APIs (Sessions, Skills, Config, Jobs) also start the dashboard on :9119 (`hermes dashboard`).'
 
 export const SESSIONS_API_UNAVAILABLE_MESSAGE = `Your Hermes backend does not support the sessions API. ${HERMES_UPGRADE_INSTRUCTIONS}`
 


### PR DESCRIPTION
Fixes part 1 of #87 (3 users +1'd — @mr-september, @TheSameCat2, @emish23).

## Problem
The `HERMES_UPGRADE_INSTRUCTIONS` banner told users to:
- `pip install hermes-agent` → **404 on PyPI**, throws `No matching distribution found`
- `hermes dashboard` → works, but only after installing from source

Users followed these instructions verbatim, hit dead ends, and correctly flagged the UI as broken.

## Fix
Accurate instructions that match upstream's README:
```
install Hermes from source:
  git clone https://github.com/NousResearch/hermes-agent
  cd hermes-agent
  pip install -e .

start both services:
  hermes gateway run      # :8642 — core chat/completions
  hermes dashboard        # :9119 — sessions/skills/config/jobs
```

The new message also tells users *why* both services matter (gateway for chat, dashboard for extended APIs), which reduces the downstream confusion we saw in #86.

## Not in this PR
The 'New Session button doesn't work' complaint in #87 is a different root cause — when dashboard isn't running in zero-fork mode, sessions can't be created. The fixed instructions here should unblock the path to getting dashboard running; the UX around that degraded state is a separate polish PR.