### PR TITLE
fix(#96): respect PORT env var for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ echo 'HERMES_DASHBOARD_URL=http://127.0.0.1:9119' >> .env
 # If your gateway was started with API_SERVER_KEY (auth enabled), set the same value:
 # echo 'HERMES_API_TOKEN=***' >> .env
 
-pnpm dev                            # http://localhost:3000
+pnpm dev                            # http://localhost:3000 (override with PORT=4000 pnpm dev)
 ```
 
 Requirements on the agent side:

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --port 3000",
+    "dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev",
     "build": "vite build",
     "start": "NODE_OPTIONS=\"--max-old-space-size=2048\" node .output/server/index.mjs",
-    "start:dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --port 3000",
+    "start:dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev",
     "preview": "vite preview",
     "test": "vitest run",
     "smoke:managed": "node scripts/managed-companion-smoke.mjs",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -442,8 +442,12 @@ const config = defineConfig(({ mode, command }) => {
     server: {
       // Force IPv4 — 'localhost' resolves to ::1 (IPv6) on Windows, breaking connectivity
       host: '0.0.0.0',
-      port: 3002,
-      strictPort: false, // allow fallback if 3002 is taken, but log clearly
+      // Port precedence:
+      //   1. --port CLI flag (wins, but we no longer hardcode it in package.json)
+      //   2. $PORT env var (for containers, reverse proxies, WhatsApp bridge collisions, etc. — see #96)
+      //   3. default 3000 (matches README/docs/docker-compose expectations)
+      port: process.env.PORT ? Number(process.env.PORT) : 3000,
+      strictPort: false, // allow fallback if port is taken, but log clearly
       allowedHosts: true,
       watch: {
         // Exclude generated route tree — TanStack Router's file watcher


### PR DESCRIPTION
Fixes #96 — @Maxximus007 flagged that port 3000 collides with Baileys/WhatsApp bridge, and there was no way to relocate the workspace without editing `package.json`.

## Changes
- Drop `--port 3000` from the CLI in `dev` and `start:dev`
- `vite.config.ts` now reads `process.env.PORT` (default 3000)
- Users can run: `PORT=4000 pnpm dev`
- README updated

Default stays at 3000 so existing installs, docker-compose files, and reverse-proxy rules keep working unchanged.