### PR TITLE
feat(#90): Enter-as-newline toggle in chat settings

### DIFF
--- a/src/components/prompt-kit/prompt-input.tsx
+++ b/src/components/prompt-kit/prompt-input.tsx
@@ -14,6 +14,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import {
+  selectEnterBehavior,
+  useChatSettingsStore,
+} from '@/hooks/use-chat-settings'
 
 type PromptInputContextType = {
   isLoading: boolean
@@ -189,6 +193,7 @@ function PromptInputTextarea({
 }: PromptInputTextareaProps) {
   const { value, setValue, maxHeight, onSubmit, disabled, textareaRef } =
     usePromptInput()
+  const enterBehavior = useChatSettingsStore(selectEnterBehavior)
 
   function adjustHeight(el: HTMLTextAreaElement | null) {
     if (!el || disableAutosize) return
@@ -236,7 +241,18 @@ function PromptInputTextarea({
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) {
+      onKeyDown?.(e)
+      return
+    }
+
+    const modifierSend = e.metaKey || e.ctrlKey
+    // In 'newline' mode Enter always inserts a newline; Cmd/Ctrl+Enter sends.
+    // In 'send' mode (default) Enter sends; Shift+Enter inserts a newline.
+    const shouldSend =
+      enterBehavior === 'newline' ? modifierSend : !e.shiftKey && !modifierSend
+
+    if (shouldSend) {
       e.preventDefault()
       const form = e.currentTarget.form
       if (form) {
@@ -245,6 +261,7 @@ function PromptInputTextarea({
         onSubmit?.()
       }
     }
+    // else: let the newline happen naturally (no preventDefault)
     onKeyDown?.(e)
   }
 

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -14,6 +14,8 @@ export type LoaderStyle =
   | 'logo'
 export const DEFAULT_CHAT_DISPLAY_NAME = 'User'
 
+export type EnterBehavior = 'send' | 'newline'
+
 export type ChatSettings = {
   showToolMessages: boolean
   showReasoningBlocks: boolean
@@ -21,6 +23,12 @@ export type ChatSettings = {
   loaderStyle: LoaderStyle
   displayName: string
   avatarDataUrl: string | null
+  /**
+   * Controls how Enter behaves in the chat composer.
+   *  - 'send'    — Enter sends, Shift+Enter / Cmd+Enter inserts a newline (default)
+   *  - 'newline' — Enter inserts a newline, Cmd+Enter / Ctrl+Enter sends
+   */
+  enterBehavior: EnterBehavior
 }
 
 type ChatSettingsState = {
@@ -36,6 +44,7 @@ function defaultChatSettings(): ChatSettings {
     loaderStyle: 'dots',
     displayName: DEFAULT_CHAT_DISPLAY_NAME,
     avatarDataUrl: null,
+    enterBehavior: 'send',
   }
 }
 
@@ -98,6 +107,10 @@ export function selectChatProfileAvatarDataUrl(
   state: ChatSettingsState,
 ): string | null {
   return state.settings.avatarDataUrl
+}
+
+export function selectEnterBehavior(state: ChatSettingsState): EnterBehavior {
+  return state.settings.enterBehavior
 }
 
 export function useChatSettings() {

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -845,6 +845,24 @@ function ChatDisplaySection() {
             aria-label="Show reasoning blocks"
           />
         </SettingsRow>
+        <SettingsRow
+          label="Enter key behavior"
+          description={
+            chatSettings.enterBehavior === 'newline'
+              ? 'Enter inserts a newline. Use ⌘/Ctrl+Enter to send.'
+              : 'Enter sends the message. Use Shift+Enter for a newline.'
+          }
+        >
+          <Switch
+            checked={chatSettings.enterBehavior === 'newline'}
+            onCheckedChange={(checked) =>
+              updateChatSettings({
+                enterBehavior: checked ? 'newline' : 'send',
+              })
+            }
+            aria-label="Enter inserts newline instead of sending"
+          />
+        </SettingsRow>
       </SettingsSection>
       {/* Mobile Navigation removed — not relevant for Hermes Workspace */}
     </>


### PR DESCRIPTION
Fixes #90 (@christopherflora).

## What it does
Adds a **Enter key behavior** toggle in `Settings \u2192 Chat Display`:
- **Off (default):** Enter sends, Shift+Enter inserts newline (existing behavior)
- **On:** Enter inserts newline, \u2318/Ctrl+Enter sends

## Implementation
- Added `enterBehavior: 'send' | 'newline'` to the existing `ChatSettings` zustand store (persisted, defaulted to 'send')
- Updated `PromptInputTextarea.handleKeyDown` to branch on the setting
- Every composer (main chat, inline agent cards, operations chat, etc.) inherits from the shared component
- IME composition guard from #99 is preserved in both modes

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Toggle off: Enter sends, Shift+Enter newline \u2014 unchanged
- [ ] Toggle on: Enter inserts newline, Cmd+Enter sends
- [ ] Cmd+Enter always sends regardless of mode
- [ ] IME composition: pressing Enter to commit a candidate does NOT submit in either mode