### PR TITLE
fix(#78): improve Memory Save button visibility across themes

### DIFF
--- a/src/screens/memory/memory-browser-screen.tsx
+++ b/src/screens/memory/memory-browser-screen.tsx
@@ -424,7 +424,7 @@ export function MemoryBrowserScreen() {
                       type="button"
                       disabled={isSaving}
                       onClick={handleSaveEditing}
-                      className="rounded-md bg-accent-500 px-3 py-1.5 text-xs font-semibold text-black transition-colors hover:bg-accent-400 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded-md bg-[var(--theme-accent)] px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {isSaving ? 'Saving...' : 'Save'}
                     </button>


### PR DESCRIPTION
Fixes #78 (@sean808080).

## Root cause
The Memory Save button was `bg-accent-500 text-black` \u2014 on the Classic Light / Official Light / Slate Light themes where `--theme-accent` resolves to a light amber/cream, the button's visibility is very poor against its own background, making it look like it 'disappears' while Cancel stays clearly visible next to it.

## Fix
- `bg: var(--theme-accent)` \u2014 strong color on every theme
- `text: white` \u2014 legible on all accent hues (indigo, amber, steel blue, purple)
- `shadow-sm` \u2014 clearer button affordance
- `hover: brightness-110`

No logic change. The `isEditing` state machine is already correct.

@sean808080 once this ships please try editing any memory file again \u2014 Save should now be solidly visible next to Cancel regardless of theme.