### PR TITLE
feat(#89): resizable chat content column

### DIFF
--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -15,6 +15,7 @@ export type LoaderStyle =
 export const DEFAULT_CHAT_DISPLAY_NAME = 'User'
 
 export type EnterBehavior = 'send' | 'newline'
+export type ChatWidth = 'comfortable' | 'wide' | 'full'
 
 export type ChatSettings = {
   showToolMessages: boolean
@@ -29,6 +30,15 @@ export type ChatSettings = {
    *  - 'newline' — Enter inserts a newline, Cmd+Enter / Ctrl+Enter sends
    */
   enterBehavior: EnterBehavior
+  /**
+   * Max-width of the chat content column (#89).
+   *  - 'comfortable' — 900px (default, keeps prior layout)
+   *  - 'wide'        — 1200px
+   *  - 'full'        — 100% of the pane (edge-to-edge)
+   * Implemented via the --chat-content-max-width CSS variable switched by
+   * the `data-chat-width` attribute on <html>.
+   */
+  chatWidth: ChatWidth
 }
 
 type ChatSettingsState = {
@@ -45,6 +55,7 @@ function defaultChatSettings(): ChatSettings {
     displayName: DEFAULT_CHAT_DISPLAY_NAME,
     avatarDataUrl: null,
     enterBehavior: 'send',
+    chatWidth: 'comfortable',
   }
 }
 
@@ -111,6 +122,22 @@ export function selectChatProfileAvatarDataUrl(
 
 export function selectEnterBehavior(state: ChatSettingsState): EnterBehavior {
   return state.settings.enterBehavior
+}
+
+export function selectChatWidth(state: ChatSettingsState): ChatWidth {
+  return state.settings.chatWidth
+}
+
+/**
+ * Hook: keep <html data-chat-width='...'> in sync with the current setting.
+ * Call once in the app root so CSS vars react to the pref.
+ */
+export function useApplyChatWidth(): void {
+  const chatWidth = useChatSettingsStore(selectChatWidth)
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.documentElement.setAttribute('data-chat-width', chatWidth)
+  }, [chatWidth])
 }
 
 export function useChatSettings() {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { Toaster } from '@/components/ui/toast'
 import { OnboardingTour } from '@/components/onboarding/onboarding-tour'
 import { KeyboardShortcutsModal } from '@/components/keyboard-shortcuts-modal'
 import { initializeSettingsAppearance } from '@/hooks/use-settings'
+import { useApplyChatWidth } from '@/hooks/use-chat-settings'
 import {
   HermesOnboarding,
   ONBOARDING_COMPLETE_EVENT,
@@ -248,6 +249,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  useApplyChatWidth()
 
   useEffect(() => {
     initializeSettingsAppearance()

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -863,6 +863,28 @@ function ChatDisplaySection() {
             aria-label="Enter inserts newline instead of sending"
           />
         </SettingsRow>
+        <SettingsRow
+          label="Chat content width"
+          description="Controls the max-width of the message column on wide screens."
+        >
+          <select
+            value={chatSettings.chatWidth}
+            onChange={(e) =>
+              updateChatSettings({
+                chatWidth: e.target.value as
+                  | 'comfortable'
+                  | 'wide'
+                  | 'full',
+              })
+            }
+            className="h-8 rounded-md border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary-400"
+            aria-label="Chat content width"
+          >
+            <option value="comfortable">Comfortable (900px)</option>
+            <option value="wide">Wide (1200px)</option>
+            <option value="full">Full width</option>
+          </select>
+        </SettingsRow>
       </SettingsSection>
       {/* Mobile Navigation removed — not relevant for Hermes Workspace */}
     </>

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -2119,7 +2119,7 @@ function MessageItemComponent({
       )}
 
       {thinking && !hasText && !hasStreamToolCalls && (
-        <div className="w-full max-w-[900px]">
+        <div className="w-full max-w-[var(--chat-content-max-width)]">
           <Collapsible defaultOpen={false}>
             <CollapsibleTrigger className="w-fit">
               <HugeiconsIcon
@@ -2161,7 +2161,7 @@ function MessageItemComponent({
         </div>
       )}
       {effectiveIsStreaming && hasLifecycleEvents && !hasToolCalls && (
-        <div className="w-full max-w-[900px] flex flex-col gap-1">
+        <div className="w-full max-w-[var(--chat-content-max-width)] flex flex-col gap-1">
           {effectiveLifecycleEvents.map((event, index) => (
             <LifecycleEventCard
               key={`${event.timestamp}-${index}-${event.text}`}
@@ -2174,7 +2174,7 @@ function MessageItemComponent({
       )}
       {/* Narration messages (tool-call activity) — compact collapsible row */}
       {!isUser && (message as any).__isNarration && hasText && (
-        <div className="w-full max-w-[900px]">
+        <div className="w-full max-w-[var(--chat-content-max-width)]">
           <details className="group/narration rounded-lg border border-primary-200/50 bg-primary-50/30 hover:bg-primary-50 dark:hover:bg-primary-800/50 transition-colors">
             <summary className="flex items-center gap-2 cursor-pointer select-none px-3 py-2 list-none [&::-webkit-details-marker]:hidden">
               <span className="size-6 flex items-center justify-center rounded-full bg-accent-500/15 shrink-0">

--- a/src/screens/chat/components/message-status.tsx
+++ b/src/screens/chat/components/message-status.tsx
@@ -20,7 +20,7 @@ export function MessageStatus({
   className,
 }: MessageStatusProps) {
   return (
-    <div className={cn('w-full max-w-[900px]', className)}>
+    <div className={cn('w-full max-w-[var(--chat-content-max-width)]', className)}>
       <Message>
         <div className="w-full rounded-xl border border-primary-200 bg-primary-50 p-4 text-primary-900">
           <div className="text-balance font-medium">{title}</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,17 @@
 
 :root {
   --tabbar-h: 0px;
+  /* Chat content max-width — controlled by Settings > Chat Display (see #89).
+   * Keep 900px default to match prior layout; 'wide' = 1200px, 'full' = 100%. */
+  --chat-content-max-width: 900px;
+}
+
+[data-chat-width='wide'] {
+  --chat-content-max-width: 1200px;
+}
+
+[data-chat-width='full'] {
+  --chat-content-max-width: 100%;
 }
 
 /* Hide scrollbars until scroll (cross-browser) */


### PR DESCRIPTION
Fixes #89 (@christopherflora).

## What it does
Adds a **Chat content width** selector in `Settings \u2192 Chat Display` with three presets:

| Option | Max-width | Use case |
|---|---|---|
| Comfortable | 900px | Default (unchanged from before) |
| Wide | 1200px | Better for code-heavy chats and wide displays |
| Full width | 100% | Edge-to-edge \u2014 maximum info density |

## Implementation
- New CSS variable `--chat-content-max-width` on `:root` and variants under `[data-chat-width='wide']` / `[data-chat-width='full']`
- Replaced the few hardcoded `max-w-[900px]` utilities in `message-item.tsx` and `message-status.tsx` with `max-w-[var(--chat-content-max-width)]`
- `chatWidth` added to the existing `ChatSettings` zustand store (persisted)
- `useApplyChatWidth()` hook syncs the setting to `<html data-chat-width='...'>` \u2014 wired once in `__root.tsx`

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Toggle setting \u2192 chat column visibly resizes without reload
- [ ] Setting persists across reloads
- [ ] Narrow screens (<900px viewport) unaffected \u2014 `max-w` only constrains on wider containers