### PR TITLE
feat(#101): UI-side backend URL override (Tailscale / remote setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ echo 'API_SERVER_HOST=0.0.0.0' >> ~/.hermes/.env
 
 Then restart the gateway, dashboard, and workspace. Hit the workspace from the remote device and the connection probe will use the Tailscale IP instead of localhost. Both `HERMES_API_URL` and `HERMES_DASHBOARD_URL` must be set to Tailscale/LAN-reachable URLs — setting only one will leave the other probing `127.0.0.1` and failing.
 
-**If you've already started the workspace**, stop it (Ctrl+C), edit `.env`, and start it again. The URL is read at process start; there is currently no UI-side override (planned for a future release — see #101).
+**If you've already started the workspace**, you can update both URLs from `Settings → Connection` without restarting. The values are persisted to `~/.hermes/workspace-overrides.json` and take effect immediately (gateway capabilities are reprobed on save). Editing `.env` still works for pre-start config and for CI/containers.
 
 ---
 

--- a/src/components/settings/settings-sidebar.tsx
+++ b/src/components/settings/settings-sidebar.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
 
 export type SettingsNavId =
+  | 'connection'
   | 'hermes'
   | 'agent'
   | 'routing'
@@ -16,6 +17,7 @@ export type SettingsNavId =
 type NavItem = { id: SettingsNavId; label: string }
 
 export const SETTINGS_NAV_ITEMS: Array<NavItem> = [
+  { id: 'connection', label: 'Connection' },
   { id: 'hermes', label: 'Model & Provider' },
   { id: 'agent', label: 'Agent Behavior' },
   { id: 'routing', label: 'Smart Routing' },

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -58,6 +58,7 @@ import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
 import { Route as ApiContextUsageRouteImport } from './routes/api/context-usage'
 import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection-status'
+import { Route as ApiConnectionSettingsRouteImport } from './routes/api/connection-settings'
 import { Route as ApiConductorStopRouteImport } from './routes/api/conductor-stop'
 import { Route as ApiConductorSpawnRouteImport } from './routes/api/conductor-spawn'
 import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
@@ -341,6 +342,11 @@ const ApiConnectionStatusRoute = ApiConnectionStatusRouteImport.update({
   path: '/api/connection-status',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiConnectionSettingsRoute = ApiConnectionSettingsRouteImport.update({
+  id: '/api/connection-settings',
+  path: '/api/connection-settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiConductorStopRoute = ApiConductorStopRouteImport.update({
   id: '/api/conductor-stop',
   path: '/api/conductor-stop',
@@ -548,6 +554,7 @@ export interface FileRoutesByFullPath {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/connection-settings': typeof ApiConnectionSettingsRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
@@ -635,6 +642,7 @@ export interface FileRoutesByTo {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/connection-settings': typeof ApiConnectionSettingsRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
@@ -724,6 +732,7 @@ export interface FileRoutesById {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/connection-settings': typeof ApiConnectionSettingsRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
@@ -814,6 +823,7 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/connection-settings'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
@@ -901,6 +911,7 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/connection-settings'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
@@ -989,6 +1000,7 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/connection-settings'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
@@ -1078,6 +1090,7 @@ export interface RootRouteChildren {
   ApiChatEventsRoute: typeof ApiChatEventsRoute
   ApiConductorSpawnRoute: typeof ApiConductorSpawnRoute
   ApiConductorStopRoute: typeof ApiConductorStopRoute
+  ApiConnectionSettingsRoute: typeof ApiConnectionSettingsRoute
   ApiConnectionStatusRoute: typeof ApiConnectionStatusRoute
   ApiContextUsageRoute: typeof ApiContextUsageRoute
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
@@ -1477,6 +1490,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiConnectionStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/connection-settings': {
+      id: '/api/connection-settings'
+      path: '/api/connection-settings'
+      fullPath: '/api/connection-settings'
+      preLoaderRoute: typeof ApiConnectionSettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/conductor-stop': {
       id: '/api/conductor-stop'
       path: '/api/conductor-stop'
@@ -1850,6 +1870,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiChatEventsRoute: ApiChatEventsRoute,
   ApiConductorSpawnRoute: ApiConductorSpawnRoute,
   ApiConductorStopRoute: ApiConductorStopRoute,
+  ApiConnectionSettingsRoute: ApiConnectionSettingsRoute,
   ApiConnectionStatusRoute: ApiConnectionStatusRoute,
   ApiContextUsageRoute: ApiContextUsageRoute,
   ApiCrewStatusRoute: ApiCrewStatusRoute,

--- a/src/routes/api/connection-settings.ts
+++ b/src/routes/api/connection-settings.ts
@@ -1,0 +1,83 @@
+/**
+ * Workspace connection settings — read/write the gateway + dashboard URLs the
+ * workspace uses. Writes to ~/.hermes/workspace-overrides.json and updates
+ * the in-process HERMES_API / HERMES_DASHBOARD_URL live, so users can
+ * relocate to a Tailscale/LAN address without restarting the workspace.
+ *
+ * See #101.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  ensureGatewayProbed,
+  getResolvedUrls,
+  setDashboardUrl,
+  setGatewayUrl,
+} from '../../server/gateway-capabilities'
+import { requireJsonContentType } from '../../server/rate-limit'
+
+function isValidHttpUrl(u: string): boolean {
+  try {
+    const parsed = new URL(u)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export const Route = createFileRoute('/api/connection-settings')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        return json(getResolvedUrls())
+      },
+      PUT: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            gateway?: unknown
+            dashboard?: unknown
+          }
+          if (body.gateway !== undefined) {
+            const value = typeof body.gateway === 'string' ? body.gateway : ''
+            if (value && !isValidHttpUrl(value)) {
+              return json(
+                { error: 'gateway must be a valid http(s) URL' },
+                { status: 400 },
+              )
+            }
+            setGatewayUrl(value)
+          }
+          if (body.dashboard !== undefined) {
+            const value =
+              typeof body.dashboard === 'string' ? body.dashboard : ''
+            if (value && !isValidHttpUrl(value)) {
+              return json(
+                { error: 'dashboard must be a valid http(s) URL' },
+                { status: 400 },
+              )
+            }
+            setDashboardUrl(value)
+          }
+          // Reprobe so the UI can immediately reflect the new state.
+          await ensureGatewayProbed()
+          return json({ ok: true, ...getResolvedUrls() })
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'Failed to update connection settings'
+          return json({ error: message }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -2,6 +2,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   CheckmarkCircle02Icon,
   CloudIcon,
+  Link01Icon,
   MessageMultiple01Icon,
   Mic01Icon,
   Notification03Icon,
@@ -315,6 +316,9 @@ function SettingsRoute() {
 
         {/* Content area */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
+          {/* -- Connection ------------------ */}
+          {activeSection === 'connection' && <ConnectionSection />}
+
           {/* ── Hermes Agent ──────────────────────────────────── */}
           {activeSection === 'hermes' && (
             <HermesConfigSection activeView="hermes" />
@@ -1840,5 +1844,172 @@ function HermesConfigSection({
       )}
       {sectionContent[activeView]}
     </>
+  )
+}
+
+// ── Connection Section ──────────────────────────────────────────────────
+
+type ConnectionSettings = {
+  gateway: string
+  dashboard: string
+  source: 'override' | 'env' | 'default'
+}
+
+function ConnectionSection() {
+  const [current, setCurrent] = useState<ConnectionSettings | null>(null)
+  const [gatewayInput, setGatewayInput] = useState('')
+  const [dashboardInput, setDashboardInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [isError, setIsError] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/connection-settings')
+      if (!res.ok) return
+      const data = (await res.json()) as ConnectionSettings
+      setCurrent(data)
+      setGatewayInput(data.gateway)
+      setDashboardInput(data.dashboard)
+    } catch {
+      // non-fatal
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const save = async () => {
+    setSaving(true)
+    setMessage(null)
+    setIsError(false)
+    try {
+      const res = await fetch('/api/connection-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          gateway: gatewayInput.trim(),
+          dashboard: dashboardInput.trim(),
+        }),
+      })
+      const data = (await res.json()) as ConnectionSettings & { error?: string }
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
+      setCurrent(data)
+      setMessage('Saved. Connection updated — no restart needed.')
+    } catch (err) {
+      setIsError(true)
+      setMessage(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+      setTimeout(() => setMessage(null), 6000)
+    }
+  }
+
+  const reset = async () => {
+    setGatewayInput('')
+    setDashboardInput('')
+    setSaving(true)
+    try {
+      const res = await fetch('/api/connection-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gateway: '', dashboard: '' }),
+      })
+      const data = (await res.json()) as ConnectionSettings
+      setCurrent(data)
+      setGatewayInput(data.gateway)
+      setDashboardInput(data.dashboard)
+      setMessage('Reset to env / default URLs.')
+    } catch {
+      setIsError(true)
+      setMessage('Reset failed')
+    } finally {
+      setSaving(false)
+      setTimeout(() => setMessage(null), 6000)
+    }
+  }
+
+  const inputClass =
+    'h-9 w-full rounded-lg border border-primary-200 bg-primary-50 px-3 text-sm text-primary-900 font-mono outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary-400'
+
+  const sourceLabel: Record<ConnectionSettings['source'], string> = {
+    override: 'Runtime override (saved in workspace-overrides.json)',
+    env: 'From HERMES_API_URL / HERMES_DASHBOARD_URL env vars',
+    default: 'Defaults — no override set',
+  }
+
+  return (
+    <SettingsSection
+      title="Connection"
+      description="Point the workspace at your Project Agent services. Useful for Tailscale, LAN, or remote-server setups (#101)."
+      icon={Link01Icon}
+    >
+      <div className="text-xs text-primary-600">
+        {current ? sourceLabel[current.source] : 'Loading…'}
+      </div>
+
+      <SettingsRow
+        label="Gateway URL"
+        description="Core chat + completions + health. Default http://127.0.0.1:8645."
+      >
+        <input
+          className={inputClass}
+          value={gatewayInput}
+          onChange={(e) => setGatewayInput(e.target.value)}
+          placeholder="http://100.x.y.z:8642"
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
+      </SettingsRow>
+
+      <SettingsRow
+        label="Dashboard URL"
+        description="Extended APIs — sessions, skills, config, jobs. Default http://127.0.0.1:9119."
+      >
+        <input
+          className={inputClass}
+          value={dashboardInput}
+          onChange={(e) => setDashboardInput(e.target.value)}
+          placeholder="http://100.x.y.z:9119"
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
+      </SettingsRow>
+
+      <div className="flex items-center gap-2 pt-2">
+        <Button size="sm" onClick={save} disabled={saving}>
+          {saving ? 'Saving…' : 'Save & reprobe'}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={reset}
+          disabled={saving || current?.source === 'default'}
+        >
+          Reset to defaults
+        </Button>
+        {message ? (
+          <span
+            className={cn(
+              'text-xs',
+              isError ? 'text-red-500' : 'text-emerald-600',
+            )}
+          >
+            {message}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-3 rounded-lg border border-primary-200 bg-primary-100/50 p-3 text-xs text-primary-600">
+        <strong className="font-semibold">Tailscale / remote tip:</strong>{' '}
+        Set the gateway to its Tailscale IP (e.g. <code>http://100.x.y.z:8642</code>)
+        and ensure the gateway listens on <code>0.0.0.0</code> (set{' '}
+        <code>API_SERVER_HOST=0.0.0.0</code> in the agent-side <code>.env</code>).
+        No workspace restart needed — capabilities reprobe on save.
+      </div>
+    </SettingsSection>
   )
 }

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -7,14 +7,129 @@
  *
  * Legacy enhanced-fork compatibility remains for users still running the
  * older all-in-one web API on the gateway port.
+ *
+ * Precedence for gateway/dashboard URLs:
+ *   1. Runtime override saved via setGatewayUrl() / setDashboardUrl()
+ *      (persisted to ~/.hermes/workspace-overrides.json) — set from the UI
+ *      so remote / Tailscale users can relocate without a restart (#101).
+ *   2. process.env.HERMES_API_URL / HERMES_DASHBOARD_URL at process start.
+ *   3. Default localhost (8645 / 9119).
  */
 
-export let HERMES_API = (
-  process.env.HERMES_API_URL || 'http://127.0.0.1:8645'
-).replace(/\/+$/, '')
-export let HERMES_DASHBOARD_URL = (
-  process.env.HERMES_DASHBOARD_URL || 'http://127.0.0.1:9119'
-).replace(/\/+$/, '')
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+type WorkspaceOverrides = {
+  hermesApiUrl?: string
+  hermesDashboardUrl?: string
+}
+
+function overridesPath(): string {
+  const home = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+  return path.join(home, 'workspace-overrides.json')
+}
+
+function readOverrides(): WorkspaceOverrides {
+  try {
+    const raw = fs.readFileSync(overridesPath(), 'utf-8')
+    const parsed = JSON.parse(raw) as WorkspaceOverrides
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeOverrides(next: WorkspaceOverrides): void {
+  const file = overridesPath()
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+    fs.writeFileSync(file, JSON.stringify(next, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    })
+  } catch {
+    console.warn(`[gateway] failed to persist workspace overrides to ${file}`)
+  }
+}
+
+function normalizeUrl(u: string): string {
+  return u.trim().replace(/\/+$/, '')
+}
+
+const _initialOverrides = readOverrides()
+
+export let HERMES_API = normalizeUrl(
+  _initialOverrides.hermesApiUrl ||
+    process.env.HERMES_API_URL ||
+    'http://127.0.0.1:8645',
+)
+export let HERMES_DASHBOARD_URL = normalizeUrl(
+  _initialOverrides.hermesDashboardUrl ||
+    process.env.HERMES_DASHBOARD_URL ||
+    'http://127.0.0.1:9119',
+)
+
+/**
+ * Update the gateway URL at runtime, persist it, and reset the probe cache
+ * so the next call to ensureGatewayProbed() re-detects capabilities.
+ * Returns the saved URL (normalized). Pass an empty string to clear the
+ * override and fall back to env/default.
+ */
+export function setGatewayUrl(input: string | null | undefined): string {
+  const normalized = input ? normalizeUrl(input) : ''
+  const overrides = readOverrides()
+  if (normalized) {
+    overrides.hermesApiUrl = normalized
+    HERMES_API = normalized
+  } else {
+    delete overrides.hermesApiUrl
+    HERMES_API = normalizeUrl(
+      process.env.HERMES_API_URL || 'http://127.0.0.1:8645',
+    )
+  }
+  writeOverrides(overrides)
+  // Force reprobe on the next capability check.
+  probePromise = null
+  lastProbeAt = 0
+  return HERMES_API
+}
+
+/**
+ * Same as setGatewayUrl() but for the dashboard service.
+ */
+export function setDashboardUrl(input: string | null | undefined): string {
+  const normalized = input ? normalizeUrl(input) : ''
+  const overrides = readOverrides()
+  if (normalized) {
+    overrides.hermesDashboardUrl = normalized
+    HERMES_DASHBOARD_URL = normalized
+  } else {
+    delete overrides.hermesDashboardUrl
+    HERMES_DASHBOARD_URL = normalizeUrl(
+      process.env.HERMES_DASHBOARD_URL || 'http://127.0.0.1:9119',
+    )
+  }
+  writeOverrides(overrides)
+  probePromise = null
+  lastProbeAt = 0
+  return HERMES_DASHBOARD_URL
+}
+
+/** Current resolved URLs (after any runtime override). */
+export function getResolvedUrls(): {
+  gateway: string
+  dashboard: string
+  source: 'override' | 'env' | 'default'
+} {
+  const overrides = readOverrides()
+  const source = overrides.hermesApiUrl
+    ? 'override'
+    : process.env.HERMES_API_URL
+      ? 'env'
+      : 'default'
+  return { gateway: HERMES_API, dashboard: HERMES_DASHBOARD_URL, source }
+}
 
 export const HERMES_UPGRADE_INSTRUCTIONS =
   'For full features, install Hermes from source (`git clone https://github.com/NousResearch/hermes-agent && cd hermes-agent && pip install -e .`), then start the gateway on :8642 (`hermes gateway run`). For the extended APIs (Sessions, Skills, Config, Jobs) also start the dashboard on :9119 (`hermes dashboard`).'


### PR DESCRIPTION
Closes #101.

## What this does
Adds `Settings \u2192 Connection` where users can point the workspace at a non-localhost gateway/dashboard **at runtime, no restart**. Fixes the Tailscale/LAN UX hole @diegodefieth-hash reported.

## How it works
| Layer | Change |
|---|---|
| `gateway-capabilities.ts` | Adds `setGatewayUrl()` / `setDashboardUrl()` / `getResolvedUrls()`. Updates in-process `HERMES_API` / `HERMES_DASHBOARD_URL` and persists to `~/.hermes/workspace-overrides.json` (mode 0600). Force-reprobes on change. |
| URL precedence | **override file > `HERMES_API_URL` env > `http://127.0.0.1:8645` default** \u2014 so env-based users (CI, containers) are unaffected. |
| `/api/connection-settings` | GET returns current URLs + source label; PUT accepts `{ gateway, dashboard }`, validates http(s), calls setters, reprobes. |
| `Settings \u2192 Connection` | Two inputs, Save/Reset, source label, Tailscale tip callout. |
| Sidebar nav | New `Connection` section added at the top of settings nav. |

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Open Settings \u2192 Connection, enter a Tailscale URL, Save \u2192 chat continues working against the new URL without restart
- [ ] Capabilities probe runs immediately after save (sessions/skills unlock if dashboard was unreachable before and is reachable now)
- [ ] Reset button clears override, falls back to env/default
- [ ] Overrides file: `stat -f '%Sp' ~/.hermes/workspace-overrides.json` \u2192 `-rw-------`

## Related
- #108 (docs/readme for Tailscale) mentioned this was coming \u2014 this is the proper fix on top of that docs improvement.