### PR TITLE
fix(profiles): allow cloning from the default profile

### DIFF
--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -39,11 +39,24 @@ function getActiveProfilePath(): string {
   return path.join(getHermesRoot(), 'active_profile')
 }
 
+/**
+ * Validate a profile name that will be *written* to disk. The 'default'
+ * profile is reserved — callers must not create or mutate it via the UI.
+ */
 function validateProfileName(name: string): string {
-  const trimmed = name.trim()
-  if (!trimmed) throw new Error('Profile name is required')
+  const trimmed = validateProfileIdentifier(name)
   if (trimmed === 'default')
     throw new Error('Default profile cannot be modified here')
+  return trimmed
+}
+
+/**
+ * Validate a profile name that will only be *read* (e.g. \`cloneFrom\` source).
+ * Any existing profile name is allowed, including 'default'.
+ */
+function validateProfileIdentifier(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) throw new Error('Profile name is required')
   if (
     trimmed.includes('/') ||
     trimmed.includes('\\') ||
@@ -254,12 +267,13 @@ export function createProfile(
 
   // Clone config from source profile if specified
   if (options?.cloneFrom) {
-    const sourceName = validateProfileName(options.cloneFrom)
-    const sourceConfigPath = path.join(
-      getProfilesRoot(),
-      sourceName,
-      'config.yaml',
-    )
+    const sourceName = validateProfileIdentifier(options.cloneFrom)
+    // The 'default' profile lives at ~/.hermes, not ~/.hermes/profiles/default
+    const sourceRoot =
+      sourceName === 'default'
+        ? getHermesRoot()
+        : path.join(getProfilesRoot(), sourceName)
+    const sourceConfigPath = path.join(sourceRoot, 'config.yaml')
     if (fs.existsSync(sourceConfigPath)) {
       fs.copyFileSync(sourceConfigPath, configPath)
     } else {


### PR DESCRIPTION
User reported:

> When I try to create a new profile and select the default in 'Clone from existing' I get an error 'Default profile cannot be modified here'.

## Root cause
`validateProfileName()` in `src/server/profiles-browser.ts` blocks 'default' to protect the reserved profile. But this was used for both:

1. **Destination name** (correct \u2014 you can't overwrite 'default')
2. **Source name** on clone (wrong \u2014 cloning *from* default should work, it's the most common starting point)

## Fix
Split into two validators:
- `validateProfileName()` \u2014 rejects 'default', used for destinations
- `validateProfileIdentifier()` \u2014 allows any valid name, used for source/read-only refs

`createProfile()` now uses the identifier validator for `cloneFrom`, and correctly resolves the default profile's config path (`~/.hermes/config.yaml`, not `~/.hermes/profiles/default/config.yaml`).

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Create new profile with 'default' selected in Clone from existing \u2192 succeeds, new profile has default's model/provider config
- [ ] Attempting to create/rename a profile *to* 'default' \u2192 still blocked (expected)