### PR TITLE
feat(sidebar): optional hover-to-expand for collapsed chat sidebar

### DIFF
--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -39,6 +39,14 @@ export type ChatSettings = {
    * the `data-chat-width` attribute on <html>.
    */
   chatWidth: ChatWidth
+  /**
+   * When the chat sidebar is collapsed to the 48px rail, should hovering
+   * the rail temporarily expand it? Follow-up to #91 — some users liked the
+   * previous hover-preview behavior.
+   *  - false (default) — rail stays 48px, icons directly clickable
+   *  - true            — rail expands on hover, re-collapses on leave
+   */
+  sidebarHoverExpand: boolean
 }
 
 type ChatSettingsState = {
@@ -56,6 +64,7 @@ function defaultChatSettings(): ChatSettings {
     avatarDataUrl: null,
     enterBehavior: 'send',
     chatWidth: 'comfortable',
+    sidebarHoverExpand: false,
   }
 }
 
@@ -126,6 +135,10 @@ export function selectEnterBehavior(state: ChatSettingsState): EnterBehavior {
 
 export function selectChatWidth(state: ChatSettingsState): ChatWidth {
   return state.settings.chatWidth
+}
+
+export function selectSidebarHoverExpand(state: ChatSettingsState): boolean {
+  return state.settings.sidebarHoverExpand
 }
 
 /**

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -815,6 +815,22 @@ function ChatDisplaySection() {
             <option value="full">Full width</option>
           </select>
         </SettingsRow>
+        <SettingsRow
+          label="Expand sidebar on hover"
+          description={
+            chatSettings.sidebarHoverExpand
+              ? 'Collapsed sidebar expands temporarily when you hover over it.'
+              : 'Collapsed sidebar stays at 48px. Click the toggle to open (default).'
+          }
+        >
+          <Switch
+            checked={chatSettings.sidebarHoverExpand}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ sidebarHoverExpand: checked })
+            }
+            aria-label="Expand sidebar on hover"
+          />
+        </SettingsRow>
       </SettingsSection>
       {/* Mobile Navigation removed — not relevant for Hermes Workspace */}
     </>

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -49,6 +49,7 @@ import { SEARCH_MODAL_EVENTS, useSearchModal } from '@/hooks/use-search-modal'
 import {
   selectChatProfileAvatarDataUrl,
   selectChatProfileDisplayName,
+  selectSidebarHoverExpand,
   useChatSettingsStore,
 } from '@/hooks/use-chat-settings'
 import { StatusDot } from '@/components/status-indicator'
@@ -608,6 +609,8 @@ function ChatSidebarComponent({
   const [deleteSessionTitle, setDeleteSessionTitle] = useState('')
   const [providersOpen, setProvidersOpen] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
+  const [isHoverExpanded, setIsHoverExpanded] = useState(false)
+  const sidebarHoverExpand = useChatSettingsStore(selectSidebarHoverExpand)
   const sidebarRef = useRef<HTMLElement | null>(null)
   const swipeStartRef = useRef<{ x: number; y: number } | null>(null)
 
@@ -662,7 +665,25 @@ function ChatSidebarComponent({
     return () => media.removeEventListener('change', update)
   }, [])
 
-  const isVisuallyCollapsed = isCollapsed
+  useEffect(() => {
+    if (isMobile || !isCollapsed || !sidebarHoverExpand) {
+      setIsHoverExpanded(false)
+    }
+  }, [isCollapsed, isMobile, sidebarHoverExpand])
+
+  const isHoverPreviewExpanded =
+    sidebarHoverExpand && !isMobile && isCollapsed && isHoverExpanded
+  const isVisuallyCollapsed = isCollapsed && !isHoverPreviewExpanded
+
+  function handleSidebarToggle() {
+    // In hover-preview mode, a click should dismiss the preview first;
+    // otherwise toggle the persistent collapsed state.
+    if (isHoverPreviewExpanded) {
+      setIsHoverExpanded(false)
+      return
+    }
+    onToggleCollapse()
+  }
 
   const asideProps = {
     className: cn(
@@ -836,6 +857,14 @@ function ChatSidebarComponent({
       className={cn(asideProps.className, isMobile && isCollapsed && 'pointer-events-none overflow-hidden')}
       data-tour="sidebar-container"
       style={isMobile ? { maxWidth: 360 } : undefined}
+      onMouseEnter={() => {
+        if (sidebarHoverExpand && !isMobile && isCollapsed) {
+          setIsHoverExpanded(true)
+        }
+      }}
+      onMouseLeave={() => {
+        if (sidebarHoverExpand && !isMobile) setIsHoverExpanded(false)
+      }}
       aria-hidden={isMobile && isCollapsed ? true : undefined}
       {...(isMobile && isCollapsed ? { inert: true } : {})}
     >
@@ -869,16 +898,16 @@ function ChatSidebarComponent({
         <TooltipProvider>
           <TooltipRoot>
             <TooltipTrigger
-              onClick={onToggleCollapse}
+              onClick={handleSidebarToggle}
               render={
                 <Button
                   size="icon-sm"
                   variant="ghost"
-                  aria-label={isCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
+                  aria-label={isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
                   className="absolute right-2 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100"
                   data-tour="sidebar-collapse-toggle"
                 >
-                  {isCollapsed ? (
+                  {isVisuallyCollapsed ? (
                     <HugeiconsIcon
                       icon={ArrowRight01Icon}
                       size={18}
@@ -895,7 +924,7 @@ function ChatSidebarComponent({
               }
             />
             <TooltipContent side="right">
-              {isCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
+              {isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
             </TooltipContent>
           </TooltipRoot>
         </TooltipProvider>


### PR DESCRIPTION
Some users liked the pre-#91 hover-to-expand behavior on the collapsed sidebar rail; others hit the bug @ajojotank fixed there (couldn't reliably uncollapse because hover flipped toggle icons and repurposed clicks).

## Fix
Make it a preference instead of picking one side.

- New `sidebarHoverExpand: boolean` in the chat-settings zustand store (persisted, **default false** \u2014 matches shipped #91 behavior)
- When **false** (default): rail stays 48px on hover, clicks always toggle the persistent state. Exactly as shipped in #91.
- When **true**: hovering the rail expands it as a preview; leaving collapses it; clicking the toggle while previewing dismisses the preview first, then the next click toggles. Exactly the pre-#91 behavior.
- Setting surfaced in `Settings \u2192 Chat Display \u2192 Expand sidebar on hover`.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Off (default): hover rail \u2192 no expand, icons directly clickable
- [ ] On: hover rail \u2192 expands; leave \u2192 collapses; click toggle while previewing \u2192 preview dismisses; click toggle again \u2192 uncollapses persistently"