### PR TITLE
fix(settings-dialog): surface new chat options in mini dialog

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1218,6 +1218,58 @@ function ChatContent() {
             aria-label="Show reasoning blocks"
           />
         </Row>
+        <Row
+          label="Enter key behavior"
+          description={
+            cs.enterBehavior === 'newline'
+              ? 'Enter inserts a newline. Use ⌘/Ctrl+Enter to send.'
+              : 'Enter sends the message. Use Shift+Enter for a newline.'
+          }
+        >
+          <Switch
+            checked={cs.enterBehavior === 'newline'}
+            onCheckedChange={(c) =>
+              updateCS({ enterBehavior: c ? 'newline' : 'send' })
+            }
+            aria-label="Enter inserts newline instead of sending"
+          />
+        </Row>
+        <Row
+          label="Chat content width"
+          description="Max-width of the message column on wide screens."
+        >
+          <select
+            value={cs.chatWidth}
+            onChange={(e) =>
+              updateCS({
+                chatWidth: e.target.value as
+                  | 'comfortable'
+                  | 'wide'
+                  | 'full',
+              })
+            }
+            className="h-8 rounded-md border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary-400"
+            aria-label="Chat content width"
+          >
+            <option value="comfortable">Comfortable (900px)</option>
+            <option value="wide">Wide (1200px)</option>
+            <option value="full">Full width</option>
+          </select>
+        </Row>
+        <Row
+          label="Expand sidebar on hover"
+          description={
+            cs.sidebarHoverExpand
+              ? 'Collapsed sidebar expands temporarily on hover.'
+              : 'Collapsed sidebar stays at 48px until you click the toggle.'
+          }
+        >
+          <Switch
+            checked={cs.sidebarHoverExpand}
+            onCheckedChange={(c) => updateCS({ sidebarHoverExpand: c })}
+            aria-label="Expand sidebar on hover"
+          />
+        </Row>
       </div>
       {/* Loading animation removed — not relevant for Hermes */}
     </div>


### PR DESCRIPTION
The quick settings popup was missing three toggles that already exist on `/settings`:

- Enter key behavior (#90)
- Chat content width (#89)
- Expand sidebar on hover (#115)

Added all three to the dialog's Chat section using the existing `Row` primitive.

## Why
Users who default to the popup would never discover these without knowing to hunt for the full settings page. Both surfaces now show the same chat preferences.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [ ] Open mini settings \u2192 Chat section \u2192 all 5 toggles present and functional
- [ ] Changes sync with the full /settings page (same zustand store)