### PR TITLE
fix(docker): use server-entry.js as container CMD (#129)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy build artefacts + runtime deps
+# Copy build artefacts + runtime deps.
+# server-entry.js is the Node HTTP server that wraps the TanStack Start fetch
+# handler exported by dist/server/server.js. Without it, `node dist/server/server.js`
+# imports the handler module, runs top-level code, and exits (code 0) because
+# nothing keeps the event loop alive — see issue #129.
 COPY --from=build --chown=workspace:workspace /app/dist ./dist
 COPY --from=build --chown=workspace:workspace /app/node_modules ./node_modules
 COPY --from=build --chown=workspace:workspace /app/package.json ./package.json
+COPY --from=build --chown=workspace:workspace /app/server-entry.js ./server-entry.js
 COPY --from=build --chown=workspace:workspace /app/skills ./skills
 
 USER workspace
@@ -48,4 +53,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD curl -fsS http://127.0.0.1:3000/ >/dev/null || exit 1
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["node", "--max-old-space-size=2048", "dist/server/server.js"]
+CMD ["node", "--max-old-space-size=2048", "server-entry.js"]


### PR DESCRIPTION
## Summary
Fixes the silent `exited (0)` crash reported in #129. The Docker image was running the wrong file.

## Root cause
The Dockerfile ran `node dist/server/server.js` directly, but `dist/server/server.js` is the TanStack Start **fetch handler module** \u2014 it exports a `fetch` function and never calls `listen()`. When Node imports it, top-level code runs, and the process exits with code 0 because nothing is keeping the event loop alive. No errors, no logs, no port binding \u2014 exactly matching the symptoms in #129.

The actual HTTP server lives at `server-entry.js` in the repo root. It creates a Node http server, serves static assets from `dist/client`, and forwards dynamic requests to the TanStack Start handler. This is the entry `scripts/start-stable.sh` already uses locally.

## Changes
- Copy `server-entry.js` into the runtime image
- Change `CMD` to `node server-entry.js`

## Verification
- `server-entry.js` binds `0.0.0.0:${PORT}` and serves the full app
- Local start via `node server-entry.js` works today (same script used by `scripts/start-stable.sh`)
- Image size impact: negligible (~12 KB file)

## Test plan
1. `docker build -t hermes-workspace:fix-129 .`
2. `docker run --rm -p 3000:3000 -e HERMES_API_URL=http://host.docker.internal:8642 hermes-workspace:fix-129`
3. `curl -fsS http://localhost:3000/` \u2014 should return the app shell
4. Container should stay running (not exit with code 0)

Closes #129