### PR TITLE
feat(admin): gate Hermes Agent settings/providers behind SSO allowlist

### DIFF
--- a/src/components/admin-only-state.tsx
+++ b/src/components/admin-only-state.tsx
@@ -1,0 +1,50 @@
+import { Link } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { LockIcon } from '@hugeicons/core-free-icons'
+import { Button } from '@/components/ui/button'
+import { useCurrentUser } from '@/hooks/use-current-user'
+
+type Props = {
+  featureLabel?: string
+}
+
+export function AdminOnlyState({
+  featureLabel = 'This area',
+}: Props) {
+  const { email } = useCurrentUser()
+
+  return (
+    <div className="flex min-h-[60vh] w-full items-center justify-center p-6">
+      <div className="flex w-full max-w-md flex-col items-center gap-4 rounded-2xl border border-primary-200 bg-primary-50/80 p-8 text-center shadow-sm backdrop-blur-xl">
+        <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-primary-200 bg-primary-100/70">
+          <HugeiconsIcon icon={LockIcon} size={24} strokeWidth={1.5} />
+        </span>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-primary-900">
+            Admin only
+          </h2>
+          <p className="text-sm text-primary-600 text-pretty">
+            {featureLabel} is restricted to Hermes administrators. Ask an admin
+            to adjust the <code className="font-mono text-xs">HERMES_ADMIN_EMAILS</code>{' '}
+            allowlist if you need access.
+          </p>
+          {email ? (
+            <p className="text-xs text-primary-500">
+              Signed in as <span className="font-mono">{email}</span>
+            </p>
+          ) : null}
+        </div>
+        <div className="flex gap-2">
+          <Link to="/chat/$sessionKey" params={{ sessionKey: 'main' }}>
+            <Button size="sm">Back to chat</Button>
+          </Link>
+          <Link to="/dashboard">
+            <Button size="sm" variant="outline">
+              Dashboard
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -44,6 +44,8 @@ import { LogoLoader } from '@/components/logo-loader'
 import { BrailleSpinner } from '@/components/ui/braille-spinner'
 import { ThreeDotsSpinner } from '@/components/ui/three-dots-spinner'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
+import { AdminOnlyState } from '@/components/admin-only-state'
+import { useCurrentUser } from '@/hooks/use-current-user'
 import { applyAccentColor } from '@/lib/accent-colors'
 import { getUnavailableReason } from '@/lib/feature-gates'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
@@ -69,17 +71,29 @@ type SectionId =
   | 'notifications'
   | 'language'
 
-const SECTIONS: Array<{ id: SectionId; label: string; icon: any }> = [
-  { id: 'hermes', label: 'Model & Provider', icon: CloudIcon },
-  { id: 'agent', label: 'Agent', icon: Settings02Icon },
-  { id: 'routing', label: 'Smart Routing', icon: SparklesIcon },
-  { id: 'voice', label: 'Voice', icon: VolumeHighIcon },
-  { id: 'display', label: 'Display', icon: PaintBoardIcon },
+const SECTIONS: Array<{ id: SectionId; label: string; icon: any; adminOnly?: boolean }> = [
+  { id: 'hermes', label: 'Model & Provider', icon: CloudIcon, adminOnly: true },
+  { id: 'agent', label: 'Agent', icon: Settings02Icon, adminOnly: true },
+  { id: 'routing', label: 'Smart Routing', icon: SparklesIcon, adminOnly: true },
+  { id: 'voice', label: 'Voice', icon: VolumeHighIcon, adminOnly: true },
+  { id: 'display', label: 'Display', icon: PaintBoardIcon, adminOnly: true },
   { id: 'appearance', label: 'Theme', icon: PaintBoardIcon },
   { id: 'chat', label: 'Chat', icon: MessageMultiple01Icon },
   { id: 'notifications', label: 'Alerts', icon: Notification03Icon },
   { id: 'language', label: 'Language', icon: MessageMultiple01Icon },
 ]
+
+const ADMIN_ONLY_SECTION_IDS: ReadonlySet<SectionId> = new Set([
+  'hermes',
+  'agent',
+  'routing',
+  'voice',
+  'display',
+])
+
+function isAdminOnlyDialogSection(id: SectionId): boolean {
+  return ADMIN_ONLY_SECTION_IDS.has(id)
+}
 
 const DARK_ENTERPRISE_THEMES = new Set<ThemeId>([
   'hermes-nous',
@@ -1943,16 +1957,26 @@ export function SettingsDialog({
   onOpenChange,
   initialSection = 'hermes',
 }: SettingsDialogProps) {
-  const [active, setActive] = useState<SectionId>(initialSection)
+  const { isAdmin } = useCurrentUser()
+  const visibleSections = isAdmin
+    ? SECTIONS
+    : SECTIONS.filter((s) => !s.adminOnly)
+  const fallbackSection: SectionId = isAdmin ? 'hermes' : 'appearance'
+  const resolvedInitialSection: SectionId =
+    !isAdmin && isAdminOnlyDialogSection(initialSection)
+      ? fallbackSection
+      : initialSection
+  const [active, setActive] = useState<SectionId>(resolvedInitialSection)
   const [mobileView, setMobileView] = useState<'nav' | 'content'>('nav')
-  const ActiveContent = CONTENT_MAP[active]
+  const activeIsAdminBlocked = !isAdmin && isAdminOnlyDialogSection(active)
+  const ActiveContent = activeIsAdminBlocked ? null : CONTENT_MAP[active]
 
   useEffect(() => {
     if (open) {
-      setActive(initialSection)
+      setActive(resolvedInitialSection)
       setMobileView('nav')
     }
-  }, [initialSection, open])
+  }, [resolvedInitialSection, open])
 
   function handleSectionSelect(sectionId: SectionId) {
     setActive(sectionId)
@@ -1999,7 +2023,7 @@ export function SettingsDialog({
                 )}
               >
                 <nav className="space-y-1">
-                  {SECTIONS.map((s) => (
+                  {visibleSections.map((s) => (
                     <button
                       key={s.id}
                       type="button"
@@ -2042,7 +2066,11 @@ export function SettingsDialog({
                     Back
                   </Button>
                 </div>
-                <ActiveContent />
+                {ActiveContent ? (
+                  <ActiveContent />
+                ) : (
+                  <AdminOnlyState featureLabel="Hermes Agent configuration" />
+                )}
               </div>
             </div>
           </SettingsErrorBoundary>

--- a/src/components/settings/settings-sidebar.tsx
+++ b/src/components/settings/settings-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
+import { useCurrentUser } from '@/hooks/use-current-user'
 
 export type SettingsNavId =
   | 'connection'
@@ -14,21 +15,45 @@ export type SettingsNavId =
   | 'mcp'
   | 'language'
 
-type NavItem = { id: SettingsNavId; label: string }
+type NavItem = { id: SettingsNavId; label: string; adminOnly?: boolean }
+
+/**
+ * Sections that expose Hermes Agent provider / backend configuration. These
+ * must only be visible to users in `HERMES_ADMIN_EMAILS`.
+ */
+export const ADMIN_ONLY_SECTIONS: ReadonlyArray<SettingsNavId> = [
+  'connection',
+  'hermes',
+  'agent',
+  'routing',
+  'voice',
+  'display',
+  'mcp',
+]
 
 export const SETTINGS_NAV_ITEMS: Array<NavItem> = [
-  { id: 'connection', label: 'Connection' },
-  { id: 'hermes', label: 'Model & Provider' },
-  { id: 'agent', label: 'Agent Behavior' },
-  { id: 'routing', label: 'Smart Routing' },
-  { id: 'voice', label: 'Voice' },
-  { id: 'display', label: 'Display' },
+  { id: 'connection', label: 'Connection', adminOnly: true },
+  { id: 'hermes', label: 'Model & Provider', adminOnly: true },
+  { id: 'agent', label: 'Agent Behavior', adminOnly: true },
+  { id: 'routing', label: 'Smart Routing', adminOnly: true },
+  { id: 'voice', label: 'Voice', adminOnly: true },
+  { id: 'display', label: 'Display', adminOnly: true },
   { id: 'appearance', label: 'Appearance' },
   { id: 'chat', label: 'Chat' },
   { id: 'notifications', label: 'Notifications' },
-  { id: 'mcp', label: 'MCP Servers' },
+  { id: 'mcp', label: 'MCP Servers', adminOnly: true },
   { id: 'language', label: 'Language' },
 ]
+
+export function isAdminOnlySection(id: SettingsNavId): boolean {
+  return ADMIN_ONLY_SECTIONS.includes(id)
+}
+
+function useVisibleNavItems(): Array<NavItem> {
+  const { isAdmin } = useCurrentUser()
+  if (isAdmin) return SETTINGS_NAV_ITEMS
+  return SETTINGS_NAV_ITEMS.filter((item) => !item.adminOnly)
+}
 
 type ItemRendererArgs = {
   item: NavItem
@@ -75,6 +100,7 @@ function renderItem({
 }
 
 export function SettingsSidebar({ activeId }: { activeId: SettingsNavId }) {
+  const visible = useVisibleNavItems()
   const activeClass =
     'bg-[var(--theme-accent-subtle)] text-[var(--theme-accent)] font-semibold'
   const inactiveClass =
@@ -93,7 +119,7 @@ export function SettingsSidebar({ activeId }: { activeId: SettingsNavId }) {
           Settings
         </h1>
         <div className="flex flex-col gap-0.5">
-          {SETTINGS_NAV_ITEMS.map((item) =>
+          {visible.map((item) =>
             renderItem({
               item,
               isActive: activeId === item.id,
@@ -109,13 +135,14 @@ export function SettingsSidebar({ activeId }: { activeId: SettingsNavId }) {
 }
 
 export function SettingsMobilePills({ activeId }: { activeId: SettingsNavId }) {
+  const visible = useVisibleNavItems()
   const activeClass =
     'bg-[var(--theme-accent)] text-[var(--theme-bg)] font-semibold'
   const inactiveClass =
     'bg-primary-100 text-primary-600 hover:bg-primary-200'
   return (
     <div className="scrollbar-none flex gap-1.5 overflow-x-auto pb-2 md:hidden">
-      {SETTINGS_NAV_ITEMS.map((item) => {
+      {visible.map((item) => {
         const isActive = activeId === item.id
         const className = cn(
           'shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',

--- a/src/hooks/use-current-user.ts
+++ b/src/hooks/use-current-user.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query'
+
+export type CurrentUser = {
+  email: string | null
+  isAdmin: boolean
+  adminAllowlistConfigured: boolean
+}
+
+const DEFAULT_USER: CurrentUser = {
+  email: null,
+  isAdmin: true,
+  adminAllowlistConfigured: false,
+}
+
+async function fetchCurrentUser(): Promise<CurrentUser> {
+  try {
+    const res = await fetch('/api/me', {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) return DEFAULT_USER
+    const data = (await res.json()) as Partial<CurrentUser>
+    return {
+      email: typeof data.email === 'string' ? data.email : null,
+      isAdmin: typeof data.isAdmin === 'boolean' ? data.isAdmin : true,
+      adminAllowlistConfigured: Boolean(data.adminAllowlistConfigured),
+    }
+  } catch {
+    return DEFAULT_USER
+  }
+}
+
+export function useCurrentUser() {
+  const query = useQuery({
+    queryKey: ['current-user'],
+    queryFn: fetchCurrentUser,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  const user = query.data ?? DEFAULT_USER
+  return {
+    ...user,
+    isLoading: query.isLoading,
+    isReady: query.isFetched,
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
+import { Route as ApiMeRouteImport } from './routes/api/me'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
@@ -280,6 +281,11 @@ const ApiModelsRoute = ApiModelsRouteImport.update({
 const ApiMemoryRoute = ApiMemoryRouteImport.update({
   id: '/api/memory',
   path: '/api/memory',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMeRoute = ApiMeRouteImport.update({
+  id: '/api/me',
+  path: '/api/me',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
@@ -567,6 +573,7 @@ export interface FileRoutesByFullPath {
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/me': typeof ApiMeRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -655,6 +662,7 @@ export interface FileRoutesByTo {
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/me': typeof ApiMeRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -745,6 +753,7 @@ export interface FileRoutesById {
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/me': typeof ApiMeRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -836,6 +845,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/local-providers'
+    | '/api/me'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -924,6 +934,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/local-providers'
+    | '/api/me'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1013,6 +1024,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/local-providers'
+    | '/api/me'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1103,6 +1115,7 @@ export interface RootRouteChildren {
   ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
+  ApiMeRoute: typeof ApiMeRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
@@ -1404,6 +1417,13 @@ declare module '@tanstack/react-router' {
       path: '/api/memory'
       fullPath: '/api/memory'
       preLoaderRoute: typeof ApiMemoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/me': {
+      id: '/api/me'
+      path: '/api/me'
+      fullPath: '/api/me'
+      preLoaderRoute: typeof ApiMeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/local-providers': {
@@ -1883,6 +1903,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
+  ApiMeRoute: ApiMeRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,

--- a/src/routes/api/me.ts
+++ b/src/routes/api/me.ts
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import {
+  getCurrentUserEmail,
+  isAdminEmail,
+  isAdminAllowlistConfigured,
+} from '../../server/admin-auth'
+
+export const Route = createFileRoute('/api/me')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const email = getCurrentUserEmail(request)
+        const adminAllowlistConfigured = isAdminAllowlistConfigured()
+        const isAdmin = isAdminEmail(email)
+
+        return json({
+          email,
+          isAdmin,
+          adminAllowlistConfigured,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -24,7 +24,10 @@ import {
   SETTINGS_NAV_ITEMS,
   SettingsMobilePills,
   SettingsSidebar,
+  isAdminOnlySection,
 } from '@/components/settings/settings-sidebar'
+import { useCurrentUser } from '@/hooks/use-current-user'
+import { AdminOnlyState } from '@/components/admin-only-state'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -301,8 +304,13 @@ function SettingsRoute() {
     void fetchModels()
   }, [])
 
+  const { isAdmin, isReady } = useCurrentUser()
   const { section } = Route.useSearch()
-  const activeSection: SettingsSectionId = section ?? 'hermes'
+  const defaultSection: SettingsSectionId = isAdmin ? 'hermes' : 'appearance'
+  const requestedSection: SettingsSectionId = section ?? defaultSection
+  const adminSectionBlocked =
+    isReady && !isAdmin && isAdminOnlySection(requestedSection)
+  const activeSection: SettingsSectionId = requestedSection
 
   return (
     <div className="min-h-screen bg-surface text-primary-900">
@@ -316,23 +324,29 @@ function SettingsRoute() {
 
         {/* Content area */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
+          {adminSectionBlocked ? (
+            <AdminOnlyState featureLabel="Hermes Agent configuration" />
+          ) : null}
+
           {/* -- Connection ------------------ */}
-          {activeSection === 'connection' && <ConnectionSection />}
+          {!adminSectionBlocked && activeSection === 'connection' && (
+            <ConnectionSection />
+          )}
 
           {/* ── Hermes Agent ──────────────────────────────────── */}
-          {activeSection === 'hermes' && (
+          {!adminSectionBlocked && activeSection === 'hermes' && (
             <HermesConfigSection activeView="hermes" />
           )}
-          {activeSection === 'agent' && (
+          {!adminSectionBlocked && activeSection === 'agent' && (
             <HermesConfigSection activeView="agent" />
           )}
-          {activeSection === 'routing' && (
+          {!adminSectionBlocked && activeSection === 'routing' && (
             <HermesConfigSection activeView="routing" />
           )}
-          {activeSection === 'voice' && (
+          {!adminSectionBlocked && activeSection === 'voice' && (
             <HermesConfigSection activeView="voice" />
           )}
-          {activeSection === 'display' && (
+          {!adminSectionBlocked && activeSection === 'display' && (
             <HermesConfigSection activeView="display" />
           )}
 

--- a/src/routes/settings/mcp.tsx
+++ b/src/routes/settings/mcp.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { McpSettingsScreen } from '@/screens/settings/mcp-settings-screen'
+import { useCurrentUser } from '@/hooks/use-current-user'
+import { AdminOnlyState } from '@/components/admin-only-state'
 
 export const Route = createFileRoute('/settings/mcp')({
   ssr: false,
   component: function SettingsMcpRoute() {
     usePageTitle('MCP Servers')
+    const { isAdmin, isReady } = useCurrentUser()
+    if (!isReady) return null
+    if (!isAdmin) {
+      return <AdminOnlyState featureLabel="MCP server configuration" />
+    }
     return <McpSettingsScreen />
   },
 })

--- a/src/routes/settings/providers.tsx
+++ b/src/routes/settings/providers.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { ProvidersScreen } from '@/screens/settings/providers-screen'
+import { useCurrentUser } from '@/hooks/use-current-user'
+import { AdminOnlyState } from '@/components/admin-only-state'
 
 export const Route = createFileRoute('/settings/providers')({
   ssr: false,
   component: function SettingsProvidersRoute() {
     usePageTitle('Provider Setup')
+    const { isAdmin, isReady } = useCurrentUser()
+    if (!isReady) return null
+    if (!isAdmin) {
+      return <AdminOnlyState featureLabel="Provider setup" />
+    }
     return <ProvidersScreen />
   },
 })

--- a/src/server/admin-auth.test.ts
+++ b/src/server/admin-auth.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  getAdminEmails,
+  getCurrentUserEmail,
+  isAdminAllowlistConfigured,
+  isAdminEmail,
+  isAdminRequest,
+} from './admin-auth'
+
+const ORIGINAL_ENV = process.env.HERMES_ADMIN_EMAILS
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request('http://localhost/api/me', { headers })
+}
+
+describe('admin-auth', () => {
+  beforeEach(() => {
+    delete process.env.HERMES_ADMIN_EMAILS
+  })
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.HERMES_ADMIN_EMAILS
+    } else {
+      process.env.HERMES_ADMIN_EMAILS = ORIGINAL_ENV
+    }
+  })
+
+  it('treats everyone as admin when allowlist is unset', () => {
+    expect(isAdminAllowlistConfigured()).toBe(false)
+    expect(isAdminEmail(null)).toBe(true)
+    expect(isAdminEmail('anyone@example.com')).toBe(true)
+    expect(isAdminRequest(makeRequest({}))).toBe(true)
+  })
+
+  it('parses the allowlist case-insensitively and ignores empty entries', () => {
+    process.env.HERMES_ADMIN_EMAILS = ' Alice@Example.COM,,  bob@example.com '
+    expect(isAdminAllowlistConfigured()).toBe(true)
+    expect(getAdminEmails()).toEqual(['alice@example.com', 'bob@example.com'])
+    expect(isAdminEmail('alice@example.com')).toBe(true)
+    expect(isAdminEmail('ALICE@example.com')).toBe(true)
+    expect(isAdminEmail('bob@example.com')).toBe(true)
+    expect(isAdminEmail('carol@example.com')).toBe(false)
+    expect(isAdminEmail(null)).toBe(false)
+  })
+
+  it('reads identity from X-Forwarded-User, X-SSO-Email, X-Forwarded-Email', () => {
+    process.env.HERMES_ADMIN_EMAILS = 'admin@example.com'
+    expect(
+      getCurrentUserEmail(
+        makeRequest({ 'x-forwarded-user': 'Admin@Example.COM' }),
+      ),
+    ).toBe('admin@example.com')
+    expect(
+      getCurrentUserEmail(makeRequest({ 'x-sso-email': 'user@example.com' })),
+    ).toBe('user@example.com')
+    expect(
+      getCurrentUserEmail(
+        makeRequest({ 'x-forwarded-email': 'user@example.com' }),
+      ),
+    ).toBe('user@example.com')
+    expect(getCurrentUserEmail(makeRequest({}))).toBeNull()
+  })
+
+  it('admits admin-allowlisted requests and rejects others', () => {
+    process.env.HERMES_ADMIN_EMAILS = 'admin@example.com'
+    expect(
+      isAdminRequest(makeRequest({ 'x-sso-email': 'admin@example.com' })),
+    ).toBe(true)
+    expect(
+      isAdminRequest(makeRequest({ 'x-sso-email': 'user@example.com' })),
+    ).toBe(false)
+    expect(isAdminRequest(makeRequest({}))).toBe(false)
+  })
+})

--- a/src/server/admin-auth.ts
+++ b/src/server/admin-auth.ts
@@ -1,0 +1,62 @@
+/**
+ * Admin identity resolution based on SSO-forwarded headers.
+ *
+ * The workspace sits behind an SSO reverse proxy (Caddy at S&T Properties).
+ * The proxy forwards the authenticated user's email via identity headers.
+ * Admin access is controlled by the `HERMES_ADMIN_EMAILS` env var — a
+ * comma-separated allowlist of email addresses. Matching is case-insensitive.
+ *
+ * If `HERMES_ADMIN_EMAILS` is unset/empty, the workspace falls back to
+ * "everyone is admin" so local development and single-user deployments keep
+ * working unchanged.
+ */
+
+const IDENTITY_HEADERS = [
+  'x-forwarded-user',
+  'x-sso-email',
+  'x-forwarded-email',
+  'x-auth-request-email',
+  'x-authenticated-user',
+  'x-user-email',
+  'remote-user',
+] as const
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed) return null
+  return trimmed
+}
+
+export function getAdminEmails(): Array<string> {
+  const raw = process.env.HERMES_ADMIN_EMAILS ?? ''
+  return raw
+    .split(',')
+    .map((entry) => normalizeEmail(entry))
+    .filter((entry): entry is string => Boolean(entry))
+}
+
+export function isAdminAllowlistConfigured(): boolean {
+  return getAdminEmails().length > 0
+}
+
+export function getCurrentUserEmail(request: Request): string | null {
+  for (const header of IDENTITY_HEADERS) {
+    const value = request.headers.get(header)
+    const normalized = normalizeEmail(value)
+    if (normalized) return normalized
+  }
+  return null
+}
+
+export function isAdminEmail(email: string | null): boolean {
+  // If no allowlist is configured, treat everyone as admin — preserves
+  // the previous behavior for local/single-user installs.
+  if (!isAdminAllowlistConfigured()) return true
+  if (!email) return false
+  return getAdminEmails().includes(email.toLowerCase())
+}
+
+export function isAdminRequest(request: Request): boolean {
+  return isAdminEmail(getCurrentUserEmail(request))
+}


### PR DESCRIPTION
## Summary

- Adds `HERMES_ADMIN_EMAILS` env-driven admin gating so the workspace can sit behind S&T Properties SSO while still exposing chat to all staff and keeping Hermes Agent / provider configuration admin-only.
- New server helper (`src/server/admin-auth.ts`) reads forwarded SSO identity headers (`X-Forwarded-User`, `X-SSO-Email`, `X-Forwarded-Email`, plus a few common variants) and matches the email against a comma-separated allowlist. Case-insensitive. Empty allowlist preserves the previous "everyone is admin" behavior for local / single-user setups.
- New `/api/me` endpoint returns `{ email, isAdmin, adminAllowlistConfigured }` and is consumed by a `useCurrentUser` React-Query hook.
- Route guards on `/settings/providers` and `/settings/mcp` render a friendly `AdminOnlyState` (with a link back to chat) instead of the generic "backend unavailable" prompt.
- `SettingsSidebar`, `SettingsMobilePills`, and the `SettingsDialog` (mini quick-settings) hide admin-only sections — Connection, Model & Provider, Agent Behavior, Smart Routing, Voice, Display, MCP. Non-admins still see Appearance, Chat, Notifications, Language. Direct-URL access to an admin section (e.g. `?section=hermes`) renders `AdminOnlyState` in-place.
- Model / provider catalogue entries are untouched; only access to the settings surface changes.

## Deployment

Set the allowlist on the Hetzner deployment's env:

```
HERMES_ADMIN_EMAILS=pargov.svet@gmail.com,Tina@stproperties.org
```

Caddy already forwards SSO identity as `X-Forwarded-User` (derived from `X-SSO-Email`) — no infra change required.

## Test plan

- [x] `npm test` — 31 tests pass (including 4 new tests covering allowlist parsing and identity header extraction)
- [x] `npm run build` — production build succeeds
- [x] `npx tsc --noEmit` — no new type errors (one pre-existing error in `src/components/ui/input.tsx` is unrelated)
- [ ] Deploy and verify: non-admin sees chat + non-admin settings sections, admin-only sections and `/settings/providers` render "Admin only"; admins see the full settings surface as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)