### PR TITLE
fix: nested model/provider resolution + chat profile identity (#118 leftovers)

### DIFF
--- a/src/screens/chat/components/chat-empty-state.tsx
+++ b/src/screens/chat/components/chat-empty-state.tsx
@@ -1,6 +1,13 @@
 import { HugeiconsIcon } from '@hugeicons/react'
 import { BrainIcon, CodeIcon, PuzzleIcon } from '@hugeicons/core-free-icons'
 import { motion } from 'motion/react'
+import { useEffect, useState } from 'react'
+
+type ProfileSummary = {
+  name: string
+  model?: string
+  active?: boolean
+}
 
 type SuggestionChip = {
   label: string
@@ -37,6 +44,21 @@ export function ChatEmptyState({
   onSuggestionClick,
   compact = false,
 }: ChatEmptyStateProps) {
+  const [activeProfile, setActiveProfile] = useState<ProfileSummary | null>(null)
+
+  useEffect(() => {
+    fetch('/api/profiles/list')
+      .then((res) => res.json())
+      .then((data) => {
+        const profiles = data?.profiles as Array<ProfileSummary> | undefined
+        const active = profiles?.find((p) => p.active)
+        if (active) setActiveProfile(active)
+      })
+      .catch(() => {
+        // silently ignore — profile info is cosmetic
+      })
+  }, [])
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
@@ -74,6 +96,13 @@ export function ChatEmptyState({
         >
           Begin a session
         </h2>
+
+        {activeProfile && (
+          <span className="mt-2 text-xs" style={{ color: 'var(--theme-accent)' }}>
+            {activeProfile.name}
+            {activeProfile.model ? ` · ${activeProfile.model}` : ''}
+          </span>
+        )}
 
         {!compact && (
           <>

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -163,14 +163,30 @@ export function listProfiles(): Array<ProfileSummary> {
       const sessionCount = countFilesRecursive(sessionsDir, (full) =>
         /\.(jsonl|json|sqlite|db)$/i.test(full),
       )
+      // Resolve model/provider from nested or flat config structure
+      let modelName: string | undefined
+      let providerName: string | undefined
+      if (typeof config.model === 'string') {
+        modelName = config.model
+      } else if (
+        config.model &&
+        typeof config.model === 'object' &&
+        !Array.isArray(config.model)
+      ) {
+        const m = config.model as Record<string, unknown>
+        if (typeof m.default === 'string') modelName = m.default
+        if (typeof m.provider === 'string') providerName = m.provider
+      }
+      if (!providerName && typeof config.provider === 'string') {
+        providerName = config.provider
+      }
       results.push({
         name,
         path: profilePath,
         active: name === activeProfile,
         exists: true,
-        model: typeof config.model === 'string' ? config.model : undefined,
-        provider:
-          typeof config.provider === 'string' ? config.provider : undefined,
+        model: modelName,
+        provider: providerName,
         skillCount,
         sessionCount,
         hasEnv: fs.existsSync(envPath),
@@ -187,14 +203,30 @@ export function listProfiles(): Array<ProfileSummary> {
 
   const root = getHermesRoot()
   const config = readYamlConfig(path.join(root, 'config.yaml'))
+  // Resolve model/provider for default profile too
+  let defaultModel: string | undefined
+  let defaultProvider: string | undefined
+  if (typeof config.model === 'string') {
+    defaultModel = config.model
+  } else if (
+    config.model &&
+    typeof config.model === 'object' &&
+    !Array.isArray(config.model)
+  ) {
+    const m = config.model as Record<string, unknown>
+    if (typeof m.default === 'string') defaultModel = m.default
+    if (typeof m.provider === 'string') defaultProvider = m.provider
+  }
+  if (!defaultProvider && typeof config.provider === 'string') {
+    defaultProvider = config.provider
+  }
   results.unshift({
     name: 'default',
     path: root,
     active: activeProfile === 'default',
     exists: true,
-    model: typeof config.model === 'string' ? config.model : undefined,
-    provider:
-      typeof config.provider === 'string' ? config.provider : undefined,
+    model: defaultModel,
+    provider: defaultProvider,
     skillCount: countFilesRecursive(
       path.join(root, 'skills'),
       (full) => path.basename(full) === 'SKILL.md',


### PR DESCRIPTION
## fix: nested model/provider resolution + chat profile identity

### Context
This PR contains two small UX fixes that were originally part of #118 (closed, superseded by #119). During the #119 cleanup these pieces were inadvertently dropped because they used a different approach than #119's simpler flat-config parsing.

Hermes CLI stores model config in nested format:
```yaml
model:
  default: kimi-k2.6:cloud
  provider: local-ollama
```

#119's `profiles-browser.ts` only handles the flat string form (`model: kimi-k2.6:cloud`), so profile cards show blank model/provider for users with nested configs. This PR restores nested resolution without regressing #119's fixes.

### Fixes

**1. Nested model/provider resolution in `profiles-browser.ts`**
- `listProfiles()` now resolves `model.default` and `model.provider` when `config.model` is an object
- Falls back to `config.provider` for top-level provider string
- Same logic applied to the default profile entry

**2. Chat empty state profile identity**
- `chat-empty-state.tsx` fetches `/api/profiles/list` on mount
- Displays active profile name + model below "Begin a session"
- Multi-profile users can now see which agent they're talking to without guessing

### Testing
- `pnpm test -- --run` — 44 tests pass, 0 fail
- Manually verified: `/api/profiles/list` returns correct model/provider for all profiles

### Backward compatibility
- Flat-string configs (`model: kimi-k2.6:cloud`) continue to work exactly as before
- No changes to config write path, settings UI, or provider discovery