### PR TITLE
fix: respect chat width setting

### DIFF
--- a/src/components/prompt-kit/chat-container.tsx
+++ b/src/components/prompt-kit/chat-container.tsx
@@ -151,7 +151,7 @@ function ChatContainerContent({
     >
       <div
         className="mx-auto w-full px-3 sm:px-5 flex flex-col"
-        style={{ maxWidth: 'min(768px, 100%)' }}
+        style={{ maxWidth: 'min(var(--chat-content-max-width), 100%)' }}
       >
         <div className="flex flex-col space-y-3">{children}</div>
       </div>

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -1720,8 +1720,9 @@ function ChatComposerComponent({
   const effectiveScrollHidden = scrollHidden && !keyboardOrFocusActive
 
   const composerWrapperStyle = useMemo(() => {
+    const chatContentMaxWidth = 'min(var(--chat-content-max-width), 100%)'
     if (!isMobileViewport || embedded)
-      return { maxWidth: 'min(768px, 100%)' } as CSSProperties
+      return { maxWidth: chatContentMaxWidth } as CSSProperties
     const safeArea = 'env(safe-area-inset-bottom, 0px)'
     const tabBarH = 'var(--tabbar-h, 0px)'
     const tf = effectiveScrollHidden ? 'translateY(110%)' : 'translateY(0)'


### PR DESCRIPTION
## Summary
- Use the configured chat content width CSS variable for message container max-width
- Apply the same chat width variable to the desktop composer wrapper

## Test Plan
- corepack pnpm build

Fixes the issue where selecting Full width still left the chat body/composer constrained to 768px.