### PR TITLE
fix(server): don't fall back to HERMES_API_TOKEN for dashboard auth

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -222,9 +222,17 @@ export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
  * Preferred over scraping the dashboard's root HTML for an inline token
  * (the legacy path, which creates a brittle trust boundary — see #124).
  * When set, the workspace uses this directly and never parses HTML.
+ *
+ * NOTE: do NOT fall back to HERMES_API_TOKEN here. The gateway and the
+ * upstream Hermes dashboard use independent token schemes — the gateway
+ * accepts a long-lived bearer (HERMES_API_TOKEN), while the dashboard
+ * issues an ephemeral session token at boot (web_server.py:_SESSION_TOKEN).
+ * Treating them as interchangeable wedges the workspace into 401 loops on
+ * /api/sessions, /api/skills, etc. against the official dashboard. If
+ * HERMES_DASHBOARD_TOKEN isn't set, leave this empty and let
+ * fetchDashboardToken() fall through to the HTML-scrape legacy path.
  */
-const DASHBOARD_BEARER_TOKEN =
-  process.env.HERMES_DASHBOARD_TOKEN || process.env.HERMES_API_TOKEN || ''
+const DASHBOARD_BEARER_TOKEN = process.env.HERMES_DASHBOARD_TOKEN || ''
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}


### PR DESCRIPTION
## Summary

`DASHBOARD_BEARER_TOKEN` in `src/server/gateway-capabilities.ts` defaulted to `HERMES_DASHBOARD_TOKEN || HERMES_API_TOKEN`. Those two tokens are not interchangeable when running against the upstream Hermes Agent dashboard, and the OR-fallback wedges the workspace into 401 loops on every dashboard-backed endpoint after login.

## The two tokens are not the same

- **`HERMES_API_TOKEN`** — long-lived bearer for the gateway (`:8642`), set by the operator in the workspace `.env`.
- **Dashboard session token** — ephemeral, generated at boot by `hermes_cli/web_server.py`:
  ```python
  _SESSION_TOKEN = secrets.token_urlsafe(32)
  ```
  Injected into the dashboard SPA as `window.__HERMES_SESSION_TOKEN__` and rotated every restart. There is no service-to-service way to set it.

## What breaks

Setting `HERMES_API_TOKEN` is required for the gateway to authenticate workspace requests. With the OR-fallback, that same token gets reused against the dashboard, which rejects it. Result: the user logs into the workspace successfully, but every dashboard-backed call returns 500 with body like:

\`\`\`json
{\"error\":\"Hermes dashboard /api/sessions?limit=50&offset=0: 401 {\\\"detail\\\":\\\"Unauthorized\\\"}\"}
\`\`\`

Affected endpoints in the workspace include \`/api/sessions\`, \`/api/skills\`, \`/api/files\`, \`/api/connection-status\`. The chat shell renders empty / errored after auth.

## Why HTML scrape would have worked

The existing comment on the constant already says:

> Preferred over scraping the dashboard's root HTML for an inline token (the legacy path … see #124). When set, the workspace uses this directly and never parses HTML.

`fetchDashboardToken()` already implements the HTML-scrape fallback correctly — it pulls `window.__HERMES_SESSION_TOKEN__` from \`/\` and uses that against the dashboard. This works because the dashboard exposes its ephemeral token via that script tag. But the OR-fallback in \`DASHBOARD_BEARER_TOKEN\` populated the constant with the gateway token, so \`fetchDashboardToken()\` short-circuited and never tried the scrape.

## Fix

Drop the fallback to \`HERMES_API_TOKEN\`. If only \`HERMES_API_TOKEN\` is set, \`DASHBOARD_BEARER_TOKEN\` is now empty and \`fetchDashboardToken()\` falls through to the HTML-scrape path that actually works against the upstream dashboard.

## Repro

1. Run gateway + dashboard from upstream NousResearch/hermes-agent.
2. Set \`HERMES_API_TOKEN\` in workspace \`.env\` (required for gateway auth).
3. Leave \`HERMES_DASHBOARD_TOKEN\` unset.
4. Log into the workspace → \`/api/sessions\` returns 500.

After the fix the workspace successfully scrapes the ephemeral token and dashboard endpoints return 200.

## Diff

\`\`\`
src/server/gateway-capabilities.ts | 12 ++++++++++--
1 file changed, 10 insertions(+), 2 deletions(-)
\`\`\`

The new comment also documents *why* not to fall back, so the next person adding env var lookup doesn't reintroduce the OR.

## Test plan

- [x] Reproduced the 401 loop with the unfixed code against upstream Hermes dashboard
- [x] Confirmed scraped \`window.__HERMES_SESSION_TOKEN__\` returns 200 against the same dashboard
- [x] Verified workspace \`/api/sessions\`, \`/api/skills\`, \`/api/files\` return 200 after the patch
- [x] Verified gateway endpoints (\`/v1/models\`, \`/health\`) still authenticate with \`HERMES_API_TOKEN\` (not affected by this change)