### PR TITLE
fix(auth): respect theme system in login screen

### DIFF
--- a/src/components/auth/login-screen.tsx
+++ b/src/components/auth/login-screen.tsx
@@ -36,7 +36,7 @@ export function LoginScreen() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-50 to-primary-100 px-4">
       <div className="w-full max-w-md">
-        <div className="rounded-2xl bg-white px-8 py-10 shadow-xl shadow-primary-900/5 ring-1 ring-primary-900/5">
+        <div className="rounded-2xl bg-primary-100 px-8 py-10 shadow-xl shadow-primary-900/5 ring-1 ring-primary-200">
           {/* Logo */}
           <div className="mb-8 flex justify-center">
             <div className="flex items-center gap-2.5">
@@ -82,14 +82,14 @@ export function LoginScreen() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="Password"
-                className="w-full rounded-lg border border-primary-200 bg-white px-4 py-2.5 text-primary-900 placeholder-primary-400 outline-none transition-all focus:border-accent-500 focus:ring-2 focus:ring-accent-500/20"
+                className="w-full rounded-lg border border-primary-200 bg-primary-50 px-4 py-2.5 text-primary-900 placeholder-primary-400 outline-none transition-all focus:border-accent-500 focus:ring-2 focus:ring-accent-500/20"
                 disabled={loading}
                 autoFocus
               />
             </div>
 
             {error && (
-              <div className="rounded-lg bg-red-50 px-4 py-2.5 text-sm text-red-700 ring-1 ring-red-200">
+              <div className="rounded-lg bg-red-50 px-4 py-2.5 text-sm text-red-700 ring-1 ring-red-200 dark:bg-red-950/40 dark:text-red-200 dark:ring-red-800/60">
                 {error}
               </div>
             )}


### PR DESCRIPTION
## Summary

The password login screen rendered with a hardcoded white card on every theme — including the default dark `hermes-nous`. The card and the input both used `bg-white`, which sits outside the theme variable system, so they didn't follow the rest of the SPA.

## Before / after

| Theme | Before | After |
|---|---|---|
| `hermes-nous` (dark, default) | Bright white card on dark background | Dark card matches `--theme-card` |
| `hermes-nous-light` (light) | White card (works by coincidence) | Light card via `--theme-card` (slightly cleaner) |
| Any other theme | White card always | Card adapts to `--theme-card` |

(Happy to attach screenshots if helpful — just ask.)

## Why hardcoded `dark:` variants are not the right fix

The first instinct (and my first attempt) is to add `dark:bg-primary-900` etc. That doesn't work in this codebase: `src/styles.css` already remaps the entire `primary-50…primary-950` scale onto theme CSS variables (`--theme-card`, `--theme-text`, …) per `[data-theme]`. So `bg-primary-100` already adapts automatically, and `dark:bg-primary-900` actually points at `--theme-text` (the foreground color) — which is *light* in dark themes.

So the correct fix is to drop the hardcoded `bg-white` and use the theme-mapped scale that the rest of the project uses.

## Changes

- `bg-white` (card) → `bg-primary-100`  ← maps to `--theme-card`
- `bg-white` (password input) → `bg-primary-50`  ← maps to `--theme-panel`
- `ring-primary-900/5` (nearly invisible on any theme) → `ring-primary-200`  ← maps to `--theme-border`
- Error toast (`bg-red-50` / `text-red-700` / `ring-red-200`) gains a `dark:` variant — `red-*` is intentionally not theme-mapped, so this one needs the explicit override.

No new theme variables, no new tokens, no JS changes.

## Diff

\`\`\`
src/components/auth/login-screen.tsx | 6 +++---
1 file changed, 3 insertions(+), 3 deletions(-)
\`\`\`

## Test plan

- [x] Verified card background matches the rest of the SPA in `hermes-nous` (dark) and `hermes-nous-light`
- [x] Confirmed input still has visible contrast against the card in both modes
- [x] Confirmed error toast is readable on a dark theme (red-50 → red-950/40 + red-200 text)
- [x] No regressions on the other themes (`hermes-official`, `hermes-classic`, `hermes-slate`, plus their `-light` variants) — they share the same theme variable system