### PR TITLE
feat(chat): play sound when agent finishes responding (opt-in)

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1219,6 +1219,16 @@ function ChatContent() {
           />
         </Row>
         <Row
+          label="Sound on response complete"
+          description="Play a short sound in the browser when the agent finishes replying."
+        >
+          <Switch
+            checked={cs.soundOnChatComplete}
+            onCheckedChange={(c) => updateCS({ soundOnChatComplete: c })}
+            aria-label="Sound on response complete"
+          />
+        </Row>
+        <Row
           label="Enter key behavior"
           description={
             cs.enterBehavior === 'newline'

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -47,6 +47,12 @@ export type ChatSettings = {
    *  - true            — rail expands on hover, re-collapses on leave
    */
   sidebarHoverExpand: boolean
+  /**
+   * Play a short notification sound in the browser when the agent finishes
+   * responding in the main chat. Off by default so existing users don't get
+   * surprised by sound on next page load.
+   */
+  soundOnChatComplete: boolean
 }
 
 type ChatSettingsState = {
@@ -65,6 +71,7 @@ function defaultChatSettings(): ChatSettings {
     enterBehavior: 'send',
     chatWidth: 'comfortable',
     sidebarHoverExpand: false,
+    soundOnChatComplete: false,
   }
 }
 

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -776,6 +776,18 @@ function ChatDisplaySection() {
           />
         </SettingsRow>
         <SettingsRow
+          label="Sound on response complete"
+          description="Play a short sound in the browser when the agent finishes replying."
+        >
+          <Switch
+            checked={chatSettings.soundOnChatComplete}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ soundOnChatComplete: checked })
+            }
+            aria-label="Sound on response complete"
+          />
+        </SettingsRow>
+        <SettingsRow
           label="Enter key behavior"
           description={
             chatSettings.enterBehavior === 'newline'

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -51,6 +51,8 @@ import { useChatHistory } from './hooks/use-chat-history'
 import { useRealtimeChatHistory } from './hooks/use-realtime-chat-history'
 import { useSmoothStreamingText } from './hooks/use-smooth-streaming-text'
 import { useStreamingMessage } from './hooks/use-streaming-message'
+import { playChatComplete } from '@/lib/sounds'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { useActiveRunCheck } from './hooks/use-active-run-check'
 import { useChatMobile } from './hooks/use-chat-mobile'
 import { useChatSessions } from './hooks/use-chat-sessions'
@@ -1088,6 +1090,11 @@ export function ChatScreen({
       setSending(false)
       // Clear waitingForResponse so ThinkingBubble hides and message renders
       streamFinish()
+      // Play notification sound if the user opted in (Settings → Chat).
+      // Read directly from the store to avoid re-creating this callback on every settings change.
+      if (useChatSettingsStore.getState().settings.soundOnChatComplete) {
+        playChatComplete()
+      }
     }, [queryClient, streamFinish]),
     onError: useCallback(
       (messageText: string) => {


### PR DESCRIPTION
## Summary

The workspace already ships a complete sound notification system (`src/lib/sounds.ts` — Web Audio API synthesis, no audio assets, 7 events including `chatComplete`) plus a `useSounds` hook that auto-plays on swarm session state transitions. There's no equivalent for the **main chat**: when a regular session finishes a response, no sound plays. This patch wires `playChatComplete()` into the existing chat stream lifecycle, gated behind a new opt-in setting.

The motivation is the common case where users walk away from the tab during long generations and miss the response. Telegram / Discord users get push notifications "for free"; web users were the only ones flying blind.

## Design choices

- **Strictly opt-in.** Default is `false` so existing users hear no change unless they explicitly enable it in Settings → Chat.
- **Reuses existing primitives.** No changes to `sounds.ts` or `use-sounds.ts`. The patch only wires what's already built into the chat-screen layer.
- **Reads via `getState()` inside the callback.** I use `useChatSettingsStore.getState().settings.soundOnChatComplete` at the moment of the event rather than subscribing in the component, so the existing `useStreamingMessage` callback's deps array stays unchanged. This avoids re-creating the streaming callback every time *any* chat setting changes.
- **One sound per completed turn.** Fires from `onComplete`, alongside the existing logic that flips message status to `done` and clears `waitingForResponse`.

## Files

| File | Change |
|---|---|
| `src/hooks/use-chat-settings.ts` | Add `soundOnChatComplete: boolean` to `ChatSettings`, default `false`. |
| `src/screens/chat/chat-screen.tsx` | Import `playChatComplete`; call it in `useStreamingMessage`'s `onComplete` if the setting is on. |
| `src/components/settings-dialog/settings-dialog.tsx` | Add a Row toggle below "Show reasoning blocks". |
| `src/routes/settings/index.tsx` | Add a SettingsRow toggle below "Show reasoning blocks". |

\`\`\`
4 files changed, 36 insertions(+), 0 deletions(-)
\`\`\`

## UX notes

- Browser autoplay restrictions still apply: the first sound after a fresh tab load may be silently dropped until the user has interacted with the page (a known Web Audio quirk, not specific to this patch).
- The sound used is `playChatComplete()` from the existing palette — different from `playAgentComplete()` which fires for swarm sessions, so the two flows stay distinguishable to power users.

## Test plan

- [x] Default behavior (setting off) is byte-identical to current behavior
- [x] Toggling on in either Settings surface persists across reloads (zustand `persist` middleware was already wired for `ChatSettings`)
- [x] Sound fires exactly once per agent turn (no double-fire on retries)
- [x] No re-render storm — verified the `useStreamingMessage` callback identity is stable across setting toggles
- [x] Tested on Chrome over LAN against a Hermes gateway + dashboard on a separate host

## Open to feedback

- Happy to gate this behind a different default (`true`?), surface the toggle elsewhere (Notifications section?), or rename the setting if "Sound on response complete" doesn't match the project's UX vocabulary.
- If there's an appetite for more sound events (e.g., on first chunk, on tool call), I can split that into a follow-up.