### PR TITLE
fix: preserve chat history order for tied timestamps

### DIFF
--- a/src/stores/chat-store.test.ts
+++ b/src/stores/chat-store.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { useChatStore } from './chat-store'
+import type { ChatMessage } from '../screens/chat/types'
+
+function textMessage(
+  id: string,
+  role: string,
+  text: string,
+  historyIndex: number,
+): ChatMessage {
+  return {
+    id,
+    role,
+    timestamp: 1_700_000_000_000,
+    __historyIndex: historyIndex,
+    content: [{ type: 'text', text }],
+  }
+}
+
+describe('chat-store history merge ordering', () => {
+  it('preserves persisted history order when messages share a timestamp', () => {
+    const messages: Array<ChatMessage> = [
+      textMessage('m1', 'user', 'first question', 0),
+      textMessage('m2', 'assistant', 'first answer', 1),
+      textMessage('m3', 'user', 'follow-up', 2),
+    ]
+
+    const merged = useChatStore
+      .getState()
+      .mergeHistoryMessages('history-order-session', messages)
+
+    expect(merged.map((message) => message.id)).toEqual(['m1', 'm2', 'm3'])
+  })
+
+  it('accepts local-store historyIndex as a persisted order hint', () => {
+    const messages: Array<ChatMessage> = [
+      {
+        id: 'local-1',
+        role: 'user',
+        timestamp: 1_700_000_000_000,
+        historyIndex: 0,
+        content: [{ type: 'text', text: 'local question' }],
+      },
+      {
+        id: 'local-2',
+        role: 'assistant',
+        timestamp: 1_700_000_000_000,
+        historyIndex: 1,
+        content: [{ type: 'text', text: 'local answer' }],
+      },
+      {
+        id: 'local-3',
+        role: 'user',
+        timestamp: 1_700_000_000_000,
+        historyIndex: 2,
+        content: [{ type: 'text', text: 'local follow-up' }],
+      },
+    ]
+
+    const merged = useChatStore
+      .getState()
+      .mergeHistoryMessages('local-history-order-session', messages)
+
+    expect(merged.map((message) => message.id)).toEqual([
+      'local-1',
+      'local-2',
+      'local-3',
+    ])
+  })
+})

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -424,7 +424,8 @@ function getMessageHistoryIndex(
   msg: ChatMessage | null | undefined,
 ): number | undefined {
   if (!msg) return undefined
-  const value = (msg as Record<string, unknown>).__historyIndex
+  const raw = msg as Record<string, unknown>
+  const value = raw.__historyIndex ?? raw.historyIndex
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
@@ -468,10 +469,6 @@ function compareMessagesByTime(left: ChatMessage, right: ChatMessage): number {
     getMessageEventTime(right) ?? getMessageReceiveTime(right) ?? 0
   if (leftTime !== rightTime) return leftTime - rightTime
 
-  const leftRank = getMessageChronologyRank(left)
-  const rightRank = getMessageChronologyRank(right)
-  if (leftRank !== rightRank) return leftRank - rightRank
-
   const leftHistoryIndex = getMessageHistoryIndex(left)
   const rightHistoryIndex = getMessageHistoryIndex(right)
   if (
@@ -481,6 +478,10 @@ function compareMessagesByTime(left: ChatMessage, right: ChatMessage): number {
   ) {
     return leftHistoryIndex - rightHistoryIndex
   }
+
+  const leftRank = getMessageChronologyRank(left)
+  const rightRank = getMessageChronologyRank(right)
+  if (leftRank !== rightRank) return leftRank - rightRank
 
   const leftRealtimeSequence = getMessageRealtimeSequence(left)
   const rightRealtimeSequence = getMessageRealtimeSequence(right)


### PR DESCRIPTION
## Summary
- Preserve persisted history order before role-based tie-breaking when messages share the same timestamp
- Accept both __historyIndex and local-store historyIndex as ordering hints
- Add regression coverage for user → assistant → user history with identical timestamps

Fixes #143

## Test Plan
- pnpm test src/stores/chat-store.test.ts
- pnpm test
- pnpm build