### PR TITLE
fix: load MCP servers from dashboard config

### DIFF
--- a/src/routes/api/mcp/servers.ts
+++ b/src/routes/api/mcp/servers.ts
@@ -6,6 +6,7 @@ import {
   ensureGatewayProbed,
   getCapabilities,
 } from '../../../server/gateway-capabilities'
+import { getConfig } from '../../../server/hermes-dashboard-api'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 type AuthResult = Response | true
@@ -110,25 +111,33 @@ export const Route = createFileRoute('/api/mcp/servers')({
         }
 
         try {
-          const response = await fetch(`${HERMES_API}/api/config`, {
-            headers: authHeaders(),
-          })
+          const capabilities = getCapabilities()
+          let payload: unknown
 
-          if (!response.ok) {
-            return Response.json({
-              servers: [],
-              ok: false,
-              message: `Failed to load MCP servers from gateway config (${response.status}).`,
+          if (capabilities.dashboard.available) {
+            payload = await getConfig()
+          } else {
+            const response = await fetch(`${HERMES_API}/api/config`, {
+              headers: authHeaders(),
             })
+
+            if (!response.ok) {
+              return Response.json({
+                servers: [],
+                ok: false,
+                message: `Failed to load MCP servers from gateway config (${response.status}).`,
+              })
+            }
+
+            payload = (await response.json().catch(() => ({}))) as unknown
           }
 
-          const payload = (await response.json().catch(() => ({}))) as unknown
           return Response.json({ ok: true, servers: readServers(payload) })
         } catch {
           return Response.json({
             servers: [],
             ok: false,
-            message: 'Could not reach Hermes gateway config endpoint.',
+            message: 'Could not reach Hermes config endpoint.',
           })
         }
       },


### PR DESCRIPTION
## Summary
- Load MCP server settings from the dashboard config API when the dashboard is available
- Keep the legacy gateway /api/config path as fallback for enhanced all-in-one backends
- Update the failure message to refer to the resolved Hermes config endpoint instead of hardcoding gateway

Fixes #140

## Test Plan
- pnpm test
- pnpm build