### PR TITLE
fix(terminal): restore focus after stream writes + suppress tab context menu (#136)

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -72,6 +72,9 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
   const searchMap = useRef(new Map<string, SearchAddon>())
   const logBufferRef = useRef(new Map<string, string>())
   const logSaveTimers = useRef(new Map<string, number>())
+  // Mirror activeTabId in a ref so the long-lived SSE reader closure can
+  // check the current value without forcing the whole effect to re-run.
+  const activeTabIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
     window.localStorage.setItem(PANEL_OPEN_KEY, String(isOpen))
@@ -87,6 +90,7 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
   }, [tabs])
 
   useEffect(() => {
+    activeTabIdRef.current = activeTabId
     if (activeTabId) {
       window.localStorage.setItem(ACTIVE_TAB_KEY, activeTabId)
     }
@@ -288,6 +292,13 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
               payload?.output
             if (typeof textChunk === 'string') {
               terminal.write(textChunk)
+              // Restore keyboard focus after stream writes — some browsers
+              // (Chrome, Edge) yank DOM focus back to the page after the
+              // SSE reader resolves, which leaves xterm unable to receive
+              // keystrokes until the user reloads. (#136)
+              if (tabId === activeTabIdRef.current) {
+                terminal.focus()
+              }
               const currentLog = logBufferRef.current.get(tabId) ?? ''
               const nextLog = `${currentLog}${textChunk}`
               logBufferRef.current.set(tabId, nextLog)
@@ -389,6 +400,11 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
                         : 'border-primary-200 text-primary-700',
                     )}
                     onClick={() => setActiveTabId(tab.id)}
+                    // Suppress the browser native context menu on tab
+                    // headers — we don't ship a custom one yet and the
+                    // default actions don't work on a <button> with no
+                    // editable content. (#136)
+                    onContextMenu={(event) => event.preventDefault()}
                   >
                     {tab.title}
                     {tabs.length > 1 ? (
@@ -495,6 +511,15 @@ function TerminalView({
         'h-full w-full bg-[#0b0f1a] text-primary-100',
         isActive ? 'block' : 'hidden',
       )}
+      // Clicking the container should always restore xterm focus — the
+      // textarea xterm uses for input is buried inside .xterm-helper-textarea
+      // and the click handler is the most reliable signal. (#136)
+      onClick={() => {
+        const textarea = containerRef.current?.querySelector<HTMLTextAreaElement>(
+          '.xterm-helper-textarea',
+        )
+        textarea?.focus()
+      }}
       onKeyDown={(event) => {
         if (event.key === 'c' && (event.metaKey || event.ctrlKey)) {
           document.execCommand('copy')


### PR DESCRIPTION
Closes #136.

Two related fixes for #136:

**Issue 1: Keyboard focus lost after first command**
Chrome/Edge yank DOM focus back to the document after the SSE reader resolves a chunk, so xterm stops receiving keystrokes after any output writes. Reporter diagnosed this correctly — terminal.focus() was never called after terminal.write().

Fix: call terminal.focus() after each successful terminal.write(), gated to the active tab via a ref so we don't re-run the SSE connect effect on every tab switch. Also added an onClick handler on TerminalView that focuses .xterm-helper-textarea — a manual recovery path that doesn't depend on xterm's internal handlers.

**Issue 2: Right-click on tab shows broken native context menu**
We don't ship a custom context menu and the browser default actions are useless on a button with no editable content.

Fix: onContextMenu={e => e.preventDefault()} on the tab button. If we want a real menu later (rename, close-others) we wire it here.

**Validation**
- TypeScript clean (no new errors)
- Manual: open terminal, run ls, type pwd — works (previously hung)
- Manual: right-click on tab — no menu (previously a broken native menu)