### PR TITLE
fix(terminal): clear sessionId on PTY close/exit (#80)

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??


### PR DESCRIPTION
Closes #80.

When a backend PTY exits, the SSE stream emits exit then close. Frontend was ignoring both, so the tab kept its dead sessionId. Subsequent terminal-input and terminal-resize calls 404 in a tight loop until reload.

Fix: handle exit and close in the SSE consumer; print a dim '[session ended]' line and clear the tab's sessionId. The existing handleSendInput and resize effect already short-circuit on undefined sessionId, so the spam stops immediately.

Reporter @joaompfp's diagnosis was correct; this is exactly the patch they described.

Auto-reconnect intentionally NOT implemented; if we want a restart button later we wire it on the same handler.

TypeScript clean.