### PR TITLE
Add sidebar pin control

### DIFF
--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,10 +11,9 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
@@ -77,8 +76,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const { settings } = useSettings()
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
+  const sidebarPinned = useWorkspaceStore((s) => s.sidebarPinned)
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
+  const toggleSidebarPinned = useWorkspaceStore((s) => s.toggleSidebarPinned)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
@@ -150,7 +151,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed && !sidebarPinned
 
   // Sessions query — shared across sidebar and chat
   const sessionsQuery = useQuery({
@@ -311,7 +312,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 creatingSession={creatingSession}
                 onCreateSession={startNewChat}
                 isCollapsed={sidebarCollapsed}
+                isPinned={sidebarPinned}
                 onToggleCollapse={toggleSidebar}
+                onTogglePinned={toggleSidebarPinned}
                 onSelectSession={handleSelectSession}
                 onActiveSessionDelete={handleActiveSessionDelete}
                 sessionsLoading={sessionsLoading}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -13,19 +13,17 @@ import {
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
   PuzzleIcon,
 
   Rocket01Icon,
   Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
-import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,8 +31,9 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
+import { t } from '@/lib/i18n'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
   TooltipContent,
@@ -115,7 +114,9 @@ type ChatSidebarProps = {
   creatingSession: boolean
   onCreateSession: () => void
   isCollapsed: boolean
+  isPinned: boolean
   onToggleCollapse: () => void
+  onTogglePinned: () => void
   onSelectSession?: () => void
   onActiveSessionDelete?: () => void
   sessionsLoading: boolean
@@ -124,15 +125,11 @@ type ChatSidebarProps = {
   onRetrySessions: () => void
 }
 
-
-
 // ── Reusable nav item ───────────────────────────────────────────────────
 
 type NavItemDef = {
   kind: 'link' | 'button'
   to?: string
-  search?: Record<string, unknown>
-  hash?: string
   icon: unknown
   label: string
   active: boolean
@@ -152,7 +149,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -229,9 +226,7 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to!}
-                  search={item.search}
-                  hash={item.hash}
+                  to={item.to}
                   onClick={handleSelect}
                   className={cls}
                   data-tour={item.dataTour}
@@ -247,9 +242,7 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to!}
-        search={item.search}
-        hash={item.hash}
+        to={item.to}
         onClick={handleSelect}
         className={cls}
         data-tour={item.dataTour}
@@ -496,7 +489,9 @@ function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
   isCollapsed,
+  isPinned,
   onToggleCollapse,
+  onTogglePinned,
   onSelectSession,
   onActiveSessionDelete,
   sessionsLoading,
@@ -526,8 +521,11 @@ function ChatSidebarComponent({
 
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
-      const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      const detail = (event as CustomEvent<ChatOpenSettingsDetail | undefined>)
+        .detail
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -581,8 +579,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -886,7 +882,7 @@ function ChatSidebarComponent({
                 to="/chat"
                 className={cn(
                   buttonVariants({ variant: 'ghost', size: 'sm' }),
-                  'w-full pl-1.5 justify-start gap-2',
+                  'w-full pl-1.5 pr-20 justify-start gap-2',
                 )}
               >
                 <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
@@ -896,6 +892,36 @@ function ChatSidebarComponent({
           ) : null}
         </AnimatePresence>
         <TooltipProvider>
+          {!isVisuallyCollapsed ? (
+            <TooltipRoot>
+              <TooltipTrigger
+                onClick={onTogglePinned}
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+                    aria-pressed={isPinned}
+                    className={cn(
+                      'absolute right-9 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100',
+                      isPinned &&
+                        'bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] opacity-100',
+                    )}
+                    data-tour="sidebar-pin-toggle"
+                  >
+                    <HugeiconsIcon
+                      icon={isPinned ? PinOffIcon : PinIcon}
+                      size={18}
+                      strokeWidth={1.75}
+                    />
+                  </Button>
+                }
+              />
+              <TooltipContent side="right">
+                {isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+              </TooltipContent>
+            </TooltipRoot>
+          ) : null}
           <TooltipRoot>
             <TooltipTrigger
               onClick={handleSidebarToggle}
@@ -1202,6 +1228,7 @@ function areSidebarPropsEqual(
   if (prevProps.activeFriendlyId !== nextProps.activeFriendlyId) return false
   if (prevProps.creatingSession !== nextProps.creatingSession) return false
   if (prevProps.isCollapsed !== nextProps.isCollapsed) return false
+  if (prevProps.isPinned !== nextProps.isPinned) return false
   if (prevProps.sessionsLoading !== nextProps.sessionsLoading) return false
   if (prevProps.sessionsFetching !== nextProps.sessionsFetching) return false
   if (prevProps.sessionsError !== nextProps.sessionsError) return false

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 
 type WorkspaceState = {
   sidebarCollapsed: boolean
+  sidebarPinned: boolean
   fileExplorerCollapsed: boolean
   chatFocusMode: boolean
   /** Currently active sub-page route (e.g. '/skills', '/channels') — null means chat-only */
@@ -17,6 +18,8 @@ type WorkspaceState = {
   mobileComposerFocused: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebarPinned: () => void
+  setSidebarPinned: (pinned: boolean) => void
   toggleFileExplorer: () => void
   setFileExplorerCollapsed: (collapsed: boolean) => void
   toggleChatFocusMode: () => void
@@ -34,6 +37,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      sidebarPinned: false,
       fileExplorerCollapsed: true,
       chatFocusMode: false,
       activeSubPage: null,
@@ -43,8 +47,28 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       mobileKeyboardInset: 0,
       mobileComposerFocused: false,
       toggleSidebar: () =>
-        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+        set((s) => {
+          const nextCollapsed = !s.sidebarCollapsed
+          return {
+            sidebarCollapsed: nextCollapsed,
+            sidebarPinned: nextCollapsed ? false : s.sidebarPinned,
+          }
+        }),
+      setSidebarCollapsed: (collapsed) =>
+        set((s) => ({
+          sidebarCollapsed: collapsed,
+          sidebarPinned: collapsed ? false : s.sidebarPinned,
+        })),
+      toggleSidebarPinned: () =>
+        set((s) => ({
+          sidebarPinned: !s.sidebarPinned,
+          sidebarCollapsed: s.sidebarPinned ? s.sidebarCollapsed : false,
+        })),
+      setSidebarPinned: (pinned) =>
+        set((s) => ({
+          sidebarPinned: pinned,
+          sidebarCollapsed: pinned ? false : s.sidebarCollapsed,
+        })),
       toggleFileExplorer: () =>
         set((s) => ({ fileExplorerCollapsed: !s.fileExplorerCollapsed })),
       setFileExplorerCollapsed: (collapsed) =>
@@ -65,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       name: 'hermes-workspace-v1',
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarPinned: state.sidebarPinned,
         fileExplorerCollapsed: state.fileExplorerCollapsed,
         chatPanelOpen: state.chatPanelOpen,
         chatPanelSessionKey: state.chatPanelSessionKey,


### PR DESCRIPTION
## Summary

Adds a persistent sidebar pin control next to the existing close/open sidebar control.

- stores `sidebarPinned` in the workspace store
- opens the sidebar when the user pins it
- clears the pin when the sidebar is manually collapsed
- suppresses the desktop auto-collapse backdrop while pinned

## Screenshots

Unpinned:

![Unpinned sidebar with pin control](https://raw.githubusercontent.com/kvncrw/hermes-workspace/kc/sidebar-pin-screenshots/pr-assets/sidebar-pin/sidebar-pin-unpinned.png)

Pinned:

![Pinned sidebar with active unpin control](https://raw.githubusercontent.com/kvncrw/hermes-workspace/kc/sidebar-pin-screenshots/pr-assets/sidebar-pin/sidebar-pin-pinned.png)

## Checks

- `pnpm exec eslint src/stores/workspace-store.ts src/components/workspace-shell.tsx src/components/workspace-shell.test.ts src/screens/chat/components/chat-sidebar.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run src/components/workspace-shell.test.ts --pool forks --reporter=dot`
