### PR TITLE
Fix Docker terminal runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,10 @@ RUN pnpm build
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      bash ca-certificates curl python3 tini \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
+    && groupadd -r workspace \
+    && useradd -r -m -d /home/workspace -s /bin/bash -g workspace -u 10010 workspace
 
 WORKDIR /app
 
@@ -44,6 +45,7 @@ COPY --from=build --chown=workspace:workspace /app/skills ./skills
 
 USER workspace
 ENV NODE_ENV=production \
+    HOME=/home/workspace \
     PORT=3000 \
     HOST=0.0.0.0 \
     HERMES_API_URL=http://hermes-agent:8642

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/src/components/terminal/terminal-workspace.tsx
+++ b/src/components/terminal/terminal-workspace.tsx
@@ -449,12 +449,18 @@ export function TerminalWorkspace({
           }
 
           if (eventName === 'error' && eventData) {
-            terminal.writeln('\r\n[terminal] connection error\r\n')
+            const payload = JSON.parse(eventData) as { message?: string }
+            const message =
+              typeof payload.message === 'string' && payload.message.trim()
+                ? payload.message.trim()
+                : 'connection error'
+            terminal.writeln(`\r\n[terminal] ${message}\r\n`)
           }
         }
       }
 
       // Flush any remaining buffered writes
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- set asynchronously by queueWrite while streaming
       if (flushTimer) clearTimeout(flushTimer)
       flushWrites()
 

--- a/src/routes/api/terminal-stream.ts
+++ b/src/routes/api/terminal-stream.ts
@@ -97,6 +97,8 @@ export const Route = createFileRoute('/api/terminal-stream')({
                 send('data', evt.payload)
               } else if (evt.event === 'exit') {
                 send('exit', evt.payload)
+              } else if (evt.event === 'error') {
+                send('error', evt.payload)
               }
             }
 

--- a/src/server/terminal-sessions.ts
+++ b/src/server/terminal-sessions.ts
@@ -4,6 +4,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
+import { existsSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
@@ -33,6 +34,53 @@ const __dirname_resolved =
     : dirname(fileURLToPath(import.meta.url))
 const PTY_HELPER = resolve(__dirname_resolved, 'pty-helper.py')
 
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function resolveTerminalCwd(requestedCwd: string | undefined, home: string) {
+  const expandHome = (value: string) =>
+    value.startsWith('~') ? value.replace('~', home) : value
+
+  const requested = requestedCwd ? expandHome(requestedCwd) : home
+  if (isDirectory(requested)) {
+    return {
+      cwd: requested,
+      warning: null,
+    }
+  }
+
+  const fallbacks = [home, process.cwd(), '/tmp']
+  const fallback = fallbacks.find((candidate) => isDirectory(candidate)) ?? '/'
+  return {
+    cwd: fallback,
+    warning:
+      requestedCwd && requestedCwd.trim().length > 0
+        ? `[terminal] cwd ${requestedCwd} was not available; started in ${fallback}\r\n`
+        : null,
+  }
+}
+
+function resolveTerminalShell(requestedShell: string | undefined): string {
+  if (requestedShell) {
+    if (!requestedShell.startsWith('/') || existsSync(requestedShell)) {
+      return requestedShell
+    }
+  }
+
+  if (process.platform === 'win32') return 'powershell.exe'
+
+  const fallbacks =
+    process.platform === 'darwin'
+      ? ['/bin/zsh', '/bin/bash', '/bin/sh']
+      : ['/bin/bash', '/bin/sh']
+  return fallbacks.find((candidate) => existsSync(candidate)) ?? 'sh'
+}
+
 export function createTerminalSession(params: {
   command?: Array<string>
   cwd?: string
@@ -43,18 +91,9 @@ export function createTerminalSession(params: {
   const emitter = new EventEmitter()
   const sessionId = randomUUID()
 
-  const home = process.env.HOME ?? homedir() ?? '/tmp'
-  const defaultShell =
-    process.platform === 'win32'
-      ? 'powershell.exe'
-      : process.platform === 'darwin'
-        ? '/bin/zsh'
-        : '/bin/bash'
-  const shell = params.command?.[0] ?? process.env.SHELL ?? defaultShell
-  let cwd = params.cwd ?? home
-  if (cwd.startsWith('~')) {
-    cwd = cwd.replace('~', home)
-  }
+  const home = process.env.HOME ?? homedir()
+  const shell = resolveTerminalShell(params.command?.[0] ?? process.env.SHELL)
+  const { cwd, warning: cwdWarning } = resolveTerminalCwd(params.cwd, home)
 
   const cols = params.cols ?? 80
   const rows = params.rows ?? 24
@@ -81,6 +120,13 @@ export function createTerminalSession(params: {
     } else {
       earlyBuffer.push(evt)
     }
+  }
+
+  if (cwdWarning) {
+    pushEvent({
+      event: 'data',
+      payload: { data: cwdWarning },
+    })
   }
 
   // Spawn Python PTY helper
@@ -111,6 +157,10 @@ export function createTerminalSession(params: {
   proc.stderr?.on('data', (data: Buffer) => {
     const msg = data.toString()
     if (msg.trim()) {
+      pushEvent({
+        event: 'error',
+        payload: { message: msg.trim() },
+      })
       if (import.meta.env.DEV) console.error('[pty-helper stderr]', msg)
     }
   })
@@ -129,6 +179,8 @@ export function createTerminalSession(params: {
       event: 'error',
       payload: { message: err.message },
     })
+    emitter.emit('close')
+    sessions.delete(sessionId)
   })
 
   const session: TerminalSession = {


### PR DESCRIPTION
Docker terminals can currently get into a half-connected state: the UI receives a `sessionId`, input requests can return 200, but no PTY output ever arrives.

The Docker runtime was missing the pieces the terminal backend assumes are available. Terminal sessions spawn `python3 pty-helper.py`, and the default shell is `/bin/bash`, but the production image only installed `ca-certificates`, `curl`, and `tini`. On top of that, helper spawn/stderr errors were emitted inside `terminal-sessions.ts` but dropped by `/api/terminal-stream`, which made the browser show a dead terminal instead of the actual failure.

This does a few small things together:

- install `python3` and `bash` in the production and dev workspace images
- create a real home directory for the `workspace` user and set `HOME`
- fall back to an existing cwd/shell when the requested defaults are unavailable
- forward terminal `error` events through the SSE stream
- show the actual terminal backend error in xterm instead of a generic connection message

Checks:

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/server/terminal-sessions.ts src/routes/api/terminal-stream.ts src/components/terminal/terminal-workspace.tsx`
- `pnpm build`
- production smoke: `node server-entry.js` on `127.0.0.1:4177`, then `/api/terminal-stream` + `/api/terminal-input` returned `echo terminal-ok` from the PTY stream
