### PR TITLE
fix: normalize Hermes jobs response shape

### DIFF
--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeJobsResponse } from './jobs-api'
+import type { HermesJob } from './jobs-api'
+
+const job = {
+  id: 'job-1',
+  name: 'Example job',
+  prompt: 'Run the example job',
+  schedule: {},
+  enabled: true,
+  state: 'scheduled',
+} satisfies HermesJob
+
+describe('normalizeJobsResponse', () => {
+  it('accepts dashboard cron jobs returned as a top-level array', () => {
+    expect(normalizeJobsResponse([job])).toEqual([job])
+  })
+
+  it('accepts gateway jobs returned in an object wrapper', () => {
+    expect(normalizeJobsResponse({ jobs: [job] })).toEqual([job])
+  })
+
+  it('falls back to an empty list for unexpected payloads', () => {
+    expect(normalizeJobsResponse({ jobs: null })).toEqual([])
+  })
+})

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -30,11 +30,24 @@ export type JobOutput = {
   size: number
 }
 
+export function normalizeJobsResponse(data: unknown): Array<HermesJob> {
+  if (Array.isArray(data)) return data
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'jobs' in data &&
+    Array.isArray(data.jobs)
+  ) {
+    return data.jobs as Array<HermesJob>
+  }
+  return []
+}
+
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  const data = (await res.json()) as unknown
+  return normalizeJobsResponse(data)
 }
 
 export async function createJob(input: {

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -17,6 +17,31 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
     handlers: {
@@ -44,10 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {


### PR DESCRIPTION
## Summary
- normalize Hermes jobs API payloads so array and object response shapes are handled consistently
- harden the workspace jobs route against shape drift coming from Hermes responses
- add regression coverage for the normalized client behavior

## Test plan
- [x] `corepack pnpm exec vitest run src/lib/jobs-api.test.ts`
- [x] `corepack pnpm exec tsc --noEmit`

Made with [Cursor](https://cursor.com)