### PR TITLE
fix(chat): compact tool activity and persist local sessions

### DIFF
--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -10,7 +10,73 @@ import {
 } from '../../server/hermes-api'
 import { resolveSessionKey } from '../../server/session-utils'
 import { isAuthenticated } from '@/server/auth-middleware'
-import { getLocalSession, getLocalMessages } from '../../server/local-session-store'
+import {
+  getLocalSession,
+  getLocalMessages,
+  type LocalMessage,
+  type LocalToolCall,
+} from '../../server/local-session-store'
+
+function normalizeLocalToolCalls(value: unknown): Array<LocalToolCall> {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter(
+      (entry): entry is LocalToolCall =>
+        Boolean(entry) && typeof entry === 'object',
+    )
+    .map((entry) => ({
+      id: typeof entry.id === 'string' ? entry.id : undefined,
+      name: typeof entry.name === 'string' ? entry.name : 'tool',
+      phase: typeof entry.phase === 'string' ? entry.phase : 'complete',
+      args: entry.args,
+      preview: typeof entry.preview === 'string' ? entry.preview : undefined,
+      result: typeof entry.result === 'string' ? entry.result : undefined,
+    }))
+}
+
+function toLocalChatMessage(
+  sessionKey: string,
+  message: LocalMessage,
+  historyIndex: number,
+) {
+  const content: Array<Record<string, unknown>> = []
+  const streamToolCalls = normalizeLocalToolCalls(message.toolCalls)
+
+  if (message.role === 'assistant' && streamToolCalls.length > 0) {
+    for (const toolCall of streamToolCalls) {
+      const args =
+        toolCall.args && typeof toolCall.args === 'object' ? toolCall.args : undefined
+      content.push({
+        type: 'toolCall',
+        id: toolCall.id,
+        name: toolCall.name,
+        arguments: args as Record<string, unknown> | undefined,
+        partialJson: typeof toolCall.args === 'string' ? toolCall.args : undefined,
+      })
+    }
+  }
+
+  if (message.content) {
+    content.push({ type: 'text', text: message.content })
+  }
+
+  return {
+    id: `msg-${message.id}`,
+    role: message.role,
+    content,
+    text: message.content,
+    timestamp: message.timestamp,
+    createdAt: new Date(message.timestamp).toISOString(),
+    sessionKey,
+    __historyIndex: historyIndex,
+    ...(streamToolCalls.length > 0
+      ? {
+          streamToolCalls,
+          __streamToolCalls: streamToolCalls,
+        }
+      : {}),
+  }
+}
 
 export const Route = createFileRoute('/api/history')({
   server: {
@@ -106,13 +172,9 @@ export const Route = createFileRoute('/api/history')({
               return json({
                 sessionKey,
                 sessionId: sessionKey,
-                messages: localMessages.map((m, index) => ({
-                  id: m.id,
-                  role: m.role,
-                  content: [{ type: 'text', text: m.content }],
-                  timestamp: m.timestamp,
-                  historyIndex: index,
-                })),
+                messages: localMessages.map((message, index) =>
+                  toLocalChatMessage(sessionKey, message, index),
+                ),
               })
             }
           }

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -8,7 +8,12 @@ import {
   unregisterActiveSendRun,
 } from '../../server/send-run-tracker'
 import { getChatMode } from '../../server/gateway-capabilities'
-import { ensureLocalSession, appendLocalMessage, getLocalMessages, touchLocalSession } from '../../server/local-session-store'
+import {
+  ensureLocalSession,
+  appendLocalMessage,
+  getLocalMessages,
+  touchLocalSession,
+} from '../../server/local-session-store'
 import { getLocalProviderDef, getDiscoveredModels } from '../../server/local-provider-discovery'
 import {
   
@@ -264,6 +269,44 @@ function getToolResultPreview(data: Record<string, unknown>): string {
   }
 }
 
+type PortableToolCall = {
+  id: string
+  name: string
+  phase: string
+  args?: unknown
+  preview?: string
+  result?: string
+}
+
+function upsertPortableToolCall(
+  toolCalls: Array<PortableToolCall>,
+  nextToolCall: PortableToolCall,
+): void {
+  const existingIndex = toolCalls.findIndex(
+    (toolCall) => toolCall.id === nextToolCall.id,
+  )
+  if (existingIndex >= 0) {
+    toolCalls[existingIndex] = {
+      ...toolCalls[existingIndex],
+      ...nextToolCall,
+      args:
+        nextToolCall.args === undefined
+          ? toolCalls[existingIndex]?.args
+          : nextToolCall.args,
+      preview:
+        nextToolCall.preview === undefined
+          ? toolCalls[existingIndex]?.preview
+          : nextToolCall.preview,
+      result:
+        nextToolCall.result === undefined
+          ? toolCalls[existingIndex]?.result
+          : nextToolCall.result,
+    }
+    return
+  }
+  toolCalls.push(nextToolCall)
+}
+
 export const Route = createFileRoute('/api/send-stream')({
   server: {
     handlers: {
@@ -412,6 +455,7 @@ export const Route = createFileRoute('/api/send-stream')({
                   rawSessionKey ||
                   portableSessionKey
                 let accumulated = ''
+                const toolCalls: Array<PortableToolCall> = []
 
                 activeRunId = runId
                 registerActiveSendRun(runId)
@@ -485,10 +529,17 @@ export const Route = createFileRoute('/api/send-stream')({
                       })
                     } else if (chunk.type === 'tool') {
                       toolEventCount += 1
+                      const toolCallId = `${runId}:${chunk.name}:${toolEventCount}`
+                      upsertPortableToolCall(toolCalls, {
+                        id: toolCallId,
+                        name: chunk.name,
+                        phase: 'calling',
+                        preview: chunk.label,
+                      })
                       sendEvent('tool', {
                         phase: 'start',
                         name: chunk.name,
-                        toolCallId: `${runId}:${chunk.name}:${toolEventCount}`,
+                        toolCallId,
                         preview: chunk.label,
                         sessionKey: portableSessionKey,
                         runId,
@@ -505,11 +556,16 @@ export const Route = createFileRoute('/api/send-stream')({
                   }
 
                   // Persist assistant response to local session store
+                  const completedToolCalls = toolCalls.map((toolCall) => ({
+                    ...toolCall,
+                    phase: toolCall.phase === 'error' ? 'error' : 'complete',
+                  }))
                   appendLocalMessage(portableSessionKey, {
                     id: crypto.randomUUID(),
                     role: 'assistant',
                     content: accumulated,
                     timestamp: Date.now(),
+                    toolCalls: completedToolCalls,
                   })
                   touchLocalSession(portableSessionKey)
 

--- a/src/screens/chat/components/message-item.test.ts
+++ b/src/screens/chat/components/message-item.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildInlineToolRenderPlan } from './message-item'
+import { buildInlineToolRenderPlan, compactInlineToolRenderPlan } from './message-item'
 import type { ChatMessage } from '../types'
 
 describe('buildInlineToolRenderPlan', () => {
@@ -43,6 +43,105 @@ describe('buildInlineToolRenderPlan', () => {
         },
       },
       { kind: 'text', text: 'After tool.' },
+    ])
+  })
+})
+
+describe('compactInlineToolRenderPlan', () => {
+  it('stacks consecutive tool calls without moving surrounding text', () => {
+    const plan = compactInlineToolRenderPlan([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+
+    expect(plan).toEqual([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+  })
+
+  it('keeps separate stacks when text appears between tool calls', () => {
+    const plan = compactInlineToolRenderPlan([
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+    ])
+
+    expect(plan).toEqual([
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
     ])
   })
 })

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -158,6 +158,10 @@ export type InlineRenderPlanItem =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; section: InlineToolSection }
 
+export type CompactInlineRenderPlanItem =
+  | { kind: 'text'; text: string }
+  | { kind: 'tools'; sections: Array<InlineToolSection> }
+
 export function buildInlineToolRenderPlan(
   message: ChatMessage,
   toolSections: Array<InlineToolSection>,
@@ -198,6 +202,32 @@ export function buildInlineToolRenderPlan(
   }
 
   return plan
+}
+
+export function compactInlineToolRenderPlan(
+  plan: Array<InlineRenderPlanItem>,
+): Array<CompactInlineRenderPlanItem> {
+  const compactPlan: Array<CompactInlineRenderPlanItem> = []
+  let pendingToolSections: Array<InlineToolSection> = []
+
+  const flushTools = () => {
+    if (pendingToolSections.length === 0) return
+    compactPlan.push({ kind: 'tools', sections: pendingToolSections })
+    pendingToolSections = []
+  }
+
+  for (const item of plan) {
+    if (item.kind === 'tool') {
+      pendingToolSections.push(item.section)
+      continue
+    }
+
+    flushTools()
+    compactPlan.push(item)
+  }
+
+  flushTools()
+  return compactPlan
 }
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
@@ -1404,8 +1434,6 @@ function InlineToolSectionItem({
   const hasInputData =
     toolSection.input && Object.keys(toolSection.input).length > 0
   const hasOutputData = !!(toolSection.outputText || toolSection.errorText)
-  // Always expandable — show args, output, or at minimum the tool name/state
-  const hasExpandableContent = true
 
   return (
     <div>
@@ -1452,11 +1480,9 @@ function InlineToolSectionItem({
           {isRunning && (
             <span className="size-1.5 rounded-full animate-pulse bg-indigo-500" />
           )}
-          {hasExpandableContent && (
-            <span className="text-[8px] opacity-30 ml-0.5">
-              {open ? '▾' : '▸'}
-            </span>
-          )}
+          <span className="text-[8px] opacity-30 ml-0.5">
+            {open ? '▾' : '▸'}
+          </span>
         </div>
         {isRunning && (
           <div className="px-2.5 pb-1.5 text-[10px] text-primary-400">
@@ -1577,11 +1603,78 @@ function InlineToolSectionItem({
 function ToolCallGroup({
   toolSections,
   expandAll,
+  isStreaming,
 }: {
   toolSections: Array<InlineToolSection>
   expandAll?: boolean
   isStreaming?: boolean
 }) {
+  const [open, setOpen] = useState(Boolean(expandAll))
+  useEffect(() => {
+    if (expandAll) setOpen(true)
+  }, [expandAll])
+
+  if (toolSections.length > 1) {
+    const runningCount = toolSections.filter((section) => section.state === 'input-available' || section.state === 'input-streaming').length
+    const errorCount = toolSections.filter((section) => section.state === 'output-error').length
+    const doneCount = toolSections.length - runningCount - errorCount
+    const labels = Array.from(new Set(toolSections.map((section) => formatToolDisplayLabel(section.type, section.input))))
+    const visibleLabels = labels.slice(0, 3).join(', ')
+    const overflowLabel = labels.length > 3 ? ` +${labels.length - 3} more` : ''
+    const statusLabel =
+      runningCount > 0
+        ? `${runningCount} running`
+        : errorCount > 0
+          ? `${errorCount} failed`
+          : `${doneCount} done`
+
+    return (
+      <div className="my-3 w-full max-w-[min(100%,700px)] border-l-2 border-primary-200/60 pl-3">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-primary-600 hover:bg-primary-50/70"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="font-mono font-semibold text-ink">Tool activity</span>
+          <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] tabular-nums text-primary-600">
+            {toolSections.length} calls
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] opacity-60">
+            {visibleLabels}
+            {overflowLabel}
+          </span>
+          <span
+            className={cn(
+              'shrink-0 text-[10px] tabular-nums',
+              errorCount > 0
+                ? 'text-red-500'
+                : runningCount > 0 || isStreaming
+                  ? 'text-indigo-500'
+                  : 'text-green-600',
+            )}
+          >
+            {statusLabel}
+          </span>
+          <span className="shrink-0 text-[9px] opacity-40">
+            {open ? '▾' : '▸'}
+          </span>
+        </button>
+        {open && (
+          <div className="mt-2 flex flex-col gap-2.5">
+            {toolSections.map((toolSection, index) => (
+              <InlineToolSectionItem
+                key={toolSection.key || `${toolSection.type}-${index}`}
+                toolSection={toolSection}
+                index={index}
+                forceOpen={expandAll}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2.5 my-3 w-full max-w-[min(100%,700px)]">
       {toolSections.map((toolSection, index) => (
@@ -1694,8 +1787,8 @@ function MessageItemComponent({
   }, [])
 
   // Simulate streaming is only active while words are still being revealed
-  const totalWords = countWords(displayText)
-  const revealComplete = revealedWordCount >= totalWords && totalWords > 0
+  const displayWordCount = countWords(displayText)
+  const revealComplete = revealedWordCount >= displayWordCount && displayWordCount > 0
   const effectiveIsStreaming =
     remoteStreamingActive || (_simulateStreaming && !revealComplete)
   const assistantDisplayText = effectiveIsStreaming ? revealedText : displayText
@@ -1705,7 +1798,7 @@ function MessageItemComponent({
   )
 
   useEffect(() => {
-    const totalWords = countWords(displayText)
+    const nextTotalWords = countWords(displayText)
     const previousText = previousTextRef.current
     const previousLength = previousTextLengthRef.current
     const textGrew =
@@ -1713,7 +1806,7 @@ function MessageItemComponent({
       displayText.startsWith(previousText)
     const textChanged = displayText !== previousText
 
-    targetWordCountRef.current = totalWords
+    targetWordCountRef.current = nextTotalWords
     previousTextRef.current = displayText
     previousTextLengthRef.current = displayText.length
 
@@ -1722,12 +1815,12 @@ function MessageItemComponent({
         window.clearInterval(revealTimerRef.current)
         revealTimerRef.current = null
       }
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
     if (textChanged && !textGrew) {
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
@@ -1736,25 +1829,25 @@ function MessageItemComponent({
     }
 
     // Don't start animation if already fully revealed
-    setRevealedWordCount((currentWordCount) => {
-      if (currentWordCount >= totalWords) {
-        return currentWordCount
+    setRevealedWordCount((wordCount) => {
+      if (wordCount >= nextTotalWords) {
+        return wordCount
       }
 
       function tick() {
-        setRevealedWordCount((currentWordCount) => {
+        setRevealedWordCount((visibleWordCount) => {
           const targetWordCount = targetWordCountRef.current
-          if (currentWordCount >= targetWordCount) {
+          if (visibleWordCount >= targetWordCount) {
             if (revealTimerRef.current !== null) {
               window.clearInterval(revealTimerRef.current)
               revealTimerRef.current = null
             }
-            return currentWordCount
+            return visibleWordCount
           }
 
           const nextWordCount = Math.min(
             targetWordCount,
-            currentWordCount + WORDS_PER_TICK,
+            visibleWordCount + WORDS_PER_TICK,
           )
 
           if (
@@ -1770,7 +1863,7 @@ function MessageItemComponent({
       }
 
       revealTimerRef.current = window.setInterval(tick, TICK_INTERVAL_MS)
-      return currentWordCount
+      return wordCount
     })
   }, [displayText, effectiveIsStreaming])
 
@@ -1996,6 +2089,10 @@ function MessageItemComponent({
   const inlineRenderPlan = useMemo(
     () => buildInlineToolRenderPlan(message, finalToolSections),
     [message, finalToolSections],
+  )
+  const compactInlineRenderPlan = useMemo(
+    () => compactInlineToolRenderPlan(inlineRenderPlan),
+    [inlineRenderPlan],
   )
   const hasToolCalls = finalToolSections.length > 0
   const shouldRenderMessageBubble =
@@ -2322,11 +2419,11 @@ function MessageItemComponent({
             )}
             {!isUser && hasToolCalls && (
               <div className="flex flex-col gap-2">
-                {inlineRenderPlan.map((item, index) =>
-                  item.kind === 'tool' ? (
+                {compactInlineRenderPlan.map((item, index) =>
+                  item.kind === 'tools' ? (
                     <ToolCallGroup
-                      key={item.section.key || `tool-${index}`}
-                      toolSections={[item.section]}
+                      key={item.sections.map((section) => section.key).join(':') || `tools-${index}`}
+                      toolSections={item.sections}
                       expandAll={expandAllToolSections}
                       isStreaming={effectiveIsStreaming}
                     />
@@ -2341,11 +2438,6 @@ function MessageItemComponent({
                             'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                             effectiveIsStreaming && 'chat-streaming-content',
                           )}
-                          style={
-                            isUser
-                              ? { color: 'var(--chat-user-foreground)' }
-                              : undefined
-                          }
                         >
                           {item.text}
                         </MessageContent>
@@ -2370,11 +2462,6 @@ function MessageItemComponent({
                         'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                         effectiveIsStreaming && 'chat-streaming-content',
                       )}
-                      style={
-                        isUser
-                          ? { color: 'var(--chat-user-foreground)' }
-                          : undefined
-                      }
                     >
                       {assistantDisplayText}
                     </MessageContent>

--- a/src/server/__tests__/local-session-store.test.ts
+++ b/src/server/__tests__/local-session-store.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { existsSync, readFileSync, writeFileSync, mkdirSync } = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn().mockImplementation(() => {}),
+  mkdirSync: vi.fn().mockImplementation(() => {}),
+}))
+
+vi.mock('node:fs', () => ({
+  default: { existsSync, readFileSync, writeFileSync, mkdirSync },
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+}))
+
+const { homedir } = vi.hoisted(() => ({
+  homedir: vi.fn().mockReturnValue('/home/testuser'),
+}))
+
+vi.mock('node:os', () => ({
+  default: { homedir },
+  homedir,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.HERMES_HOME
+})
+
+async function loadMod() {
+  vi.resetModules()
+  return import('../local-session-store')
+}
+
+describe('local-session-store', () => {
+  it('writes portable sessions under HERMES_HOME immediately', async () => {
+    process.env.HERMES_HOME = '/custom/hermes'
+    const mod = await loadMod()
+
+    mod.appendLocalMessage('session-1', {
+      id: 'msg-1',
+      role: 'assistant',
+      content: 'done',
+      timestamp: 123,
+      toolCalls: [
+        {
+          id: 'tool-1',
+          name: 'shell',
+          phase: 'complete',
+          result: 'ok',
+        },
+      ],
+    })
+
+    expect(mkdirSync).toHaveBeenCalledWith('/custom/hermes/workspace', {
+      recursive: true,
+    })
+    const lastWrite = writeFileSync.mock.calls.at(-1)
+    expect(lastWrite?.[0]).toBe('/custom/hermes/workspace/local-sessions.json')
+    const parsed = JSON.parse(String(lastWrite?.[1]))
+    expect(parsed.messages['session-1'][0].toolCalls[0]).toMatchObject({
+      id: 'tool-1',
+      name: 'shell',
+      phase: 'complete',
+      result: 'ok',
+    })
+  })
+
+  it('falls back to ~/.hermes/workspace when HERMES_HOME is unset', async () => {
+    const mod = await loadMod()
+
+    mod.appendLocalMessage('session-2', {
+      id: 'msg-2',
+      role: 'user',
+      content: 'hello',
+      timestamp: 456,
+    })
+
+    const lastWrite = writeFileSync.mock.calls.at(-1)
+    expect(lastWrite?.[0]).toBe(
+      '/home/testuser/.hermes/workspace/local-sessions.json',
+    )
+  })
+})

--- a/src/server/local-session-store.ts
+++ b/src/server/local-session-store.ts
@@ -1,9 +1,22 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-const DATA_DIR = join(process.cwd(), '.runtime')
+const HERMES_HOME =
+  process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+const DATA_DIR = join(HERMES_HOME, 'workspace')
 const SESSIONS_FILE = join(DATA_DIR, 'local-sessions.json')
+const LEGACY_SESSIONS_FILE = join(process.cwd(), '.runtime', 'local-sessions.json')
 const MAX_MESSAGES_PER_SESSION = 500
+
+export type LocalToolCall = {
+  id?: string
+  name?: string
+  phase?: string
+  args?: unknown
+  preview?: string
+  result?: string
+}
 
 export type LocalSession = {
   id: string
@@ -19,7 +32,7 @@ export type LocalMessage = {
   role: string
   content: string
   timestamp: number
-  toolCalls?: unknown
+  toolCalls?: Array<LocalToolCall>
   toolCallId?: string
   toolName?: string
 }
@@ -33,8 +46,14 @@ let store: StoreData = { sessions: {}, messages: {} }
 
 function loadFromDisk(): void {
   try {
-    if (existsSync(SESSIONS_FILE)) {
-      const raw = readFileSync(SESSIONS_FILE, 'utf-8')
+    const targetFile = existsSync(SESSIONS_FILE)
+      ? SESSIONS_FILE
+      : existsSync(LEGACY_SESSIONS_FILE)
+        ? LEGACY_SESSIONS_FILE
+        : null
+
+    if (targetFile) {
+      const raw = readFileSync(targetFile, 'utf-8')
       const parsed = JSON.parse(raw) as StoreData
       if (parsed.sessions && parsed.messages) {
         store = parsed
@@ -97,7 +116,10 @@ export function updateLocalSessionTitle(
 
 export function touchLocalSession(sessionId: string): void {
   const session = store.sessions[sessionId]
-  if (session) session.updatedAt = Date.now()
+  if (session) {
+    session.updatedAt = Date.now()
+    saveToDisk()
+  }
 }
 
 export function deleteLocalSession(sessionId: string): void {
@@ -127,14 +149,5 @@ export function appendLocalMessage(
     session.messageCount = store.messages[sessionId].length
     session.updatedAt = Date.now()
   }
-  scheduleSave()
-}
-
-let saveTimer: ReturnType<typeof setTimeout> | null = null
-function scheduleSave(): void {
-  if (saveTimer) return
-  saveTimer = setTimeout(() => {
-    saveTimer = null
-    saveToDisk()
-  }, 2000)
+  saveToDisk()
 }


### PR DESCRIPTION
## Summary
- bring in the chat UI change that compacts consecutive tool activity into a cleaner assistant message presentation
- persist fallback local sessions under a writable Hermes home path instead of the container app directory
- preserve tool-call metadata when rehydrating local history so refreshed chats keep the expected tool activity UI

## Test plan
- [x] `corepack pnpm exec vitest run src/screens/chat/components/message-item.test.ts src/server/__tests__/local-session-store.test.ts`
- [x] `corepack pnpm exec tsc --noEmit`

Made with [Cursor](https://cursor.com)