### PR TITLE
feat(api): Add model-switch endpoint for dynamic model switching

### DIFF
--- a/FEATURE-MODEL-SWITCH.md
+++ b/FEATURE-MODEL-SWITCH.md
@@ -1,0 +1,185 @@
+# Dynamic Model Switching Feature
+
+This implementation adds runtime model switching capability to Hermes Workspace, allowing users to seamlessly switch between different AI models (Copilot, Bedrock, etc.) through the UI without restarting.
+
+## What Was Added
+
+### `/src/routes/api/model-switch.ts`
+Server-side API endpoint that handles model switching requests from the UI.
+
+**Features:**
+- ✅ Session-level model switching (temporary, per-conversation)
+- ✅ Config-level switching (persists to `~/.hermes/config.yaml`)
+- ✅ Automatic provider inference from model ID
+- ✅ Graceful fallback strategy
+- ✅ Proper authentication and error handling
+
+## How It Works
+
+### 1. Client Request
+The UI (via slash commands, mode selector, or settings) sends:
+```typescript
+POST /api/model-switch
+{
+  "model": "gpt-5.4",
+  "sessionKey": "main" // optional
+}
+```
+
+### 2. Provider Inference
+The server automatically detects the provider:
+- `us.*` or `global.*` → Bedrock
+- `gpt-*`, `o1-*` → Copilot
+- `claude*` (without bedrock) → Copilot
+- `*bedrock*` → Bedrock
+- `gemini*` → Copilot
+- `nova*` → Bedrock
+
+### 3. Switching Strategy
+1. **Try session-level switch** (if `sessionKey` provided and gateway supports sessions)
+   - Calls: `POST ${HERMES_API}/api/sessions/${sessionKey}/model`
+   - Effect: Switches model for that conversation only
+   
+2. **Fallback to config update**
+   - Updates `~/.hermes/config.yaml` via dashboard API
+   - Effect: Changes default model (persists across restarts)
+
+### 4. Response
+```typescript
+{
+  "ok": true,
+  "model": "gpt-5.4",
+  "provider": "copilot"
+}
+```
+
+## Configuration Requirements
+
+### Setup Models Catalog
+Create/edit `~/.hermes/models.json`:
+```json
+[
+  {
+    "model": "gpt-5.4",
+    "provider": "copilot",
+    "name": "GPT-5.4"
+  },
+  {
+    "model": "us.anthropic.claude-sonnet-4-6",
+    "provider": "bedrock",
+    "name": "Claude Sonnet 4.6 (Bedrock)"
+  }
+]
+```
+
+### Configure Providers
+Edit `~/.hermes/config.yaml`:
+```yaml
+model:
+  provider: "copilot"
+  default: "gpt-5.4"
+  base_url: "https://api.githubcopilot.com"
+
+bedrock:
+  region: "us-east-2"
+  discovery:
+    enabled: true
+
+providers:
+  copilot:
+    base_url: "https://api.githubcopilot.com"
+  bedrock:
+    region: "us-east-2"
+```
+
+## Usage Examples
+
+### Via Slash Command
+```
+/model copilot:gpt-5.4
+/model bedrock:us.anthropic.claude-sonnet-4-6
+```
+
+### Via API
+```bash
+curl -X POST http://localhost:3000/api/model-switch \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5.4"}'
+```
+
+### Via Mode Selector
+1. Click "Mode" button in chat composer
+2. Select a mode with preferred model
+3. Confirm switch when prompted
+
+## Testing
+
+```bash
+# Start services
+hermes gateway run          # Terminal 1
+hermes dashboard            # Terminal 2
+cd ~/hermes-workspace
+pnpm dev                    # Terminal 3
+
+# Test endpoint
+curl -X POST http://localhost:3000/api/model-switch \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5.4"}'
+
+# Expected: {"ok":true,"model":"gpt-5.4","provider":"copilot"}
+```
+
+## Implementation Notes
+
+### Why This Was Needed
+- UI components (ModeSelector, slash commands, settings) already expected `/api/model-switch` endpoint
+- Client code called this endpoint but it didn't exist (404 errors)
+- This completes the feature by implementing the missing server-side handler
+
+### Design Decisions
+1. **Two-tier strategy**: Tries session-level first (temporary), falls back to config (persistent)
+2. **Provider inference**: Automatic detection reduces user friction
+3. **Error resilience**: Graceful fallbacks if gateway doesn't support session switching
+4. **Auth required**: Only authenticated users can switch models (security)
+
+### Future Enhancements
+- [ ] Model validation against available catalog before switching
+- [ ] Rate limiting to prevent abuse
+- [ ] Webhook notifications on model switch
+- [ ] Usage analytics per model/provider
+- [ ] Model recommendation based on conversation context
+
+## Architecture
+
+```
+┌─────────────────┐
+│   UI Component  │  (ModeSelector, SlashCommand, Settings)
+└────────┬────────┘
+         │ POST /api/model-switch
+         ▼
+┌─────────────────┐
+│   model-switch  │  (This file - Authentication, Provider Inference)
+│   .ts Route     │
+└────────┬────────┘
+         │
+         ├─► Try Session Switch (if sessionKey)
+         │   POST ${HERMES_API}/api/sessions/{key}/model
+         │
+         └─► Fallback: Update Config (persists)
+             PATCH ~/.hermes/config.yaml via dashboard API
+```
+
+## Contributing
+
+This implementation follows existing Hermes Workspace patterns:
+- Uses `isAuthenticated()` middleware
+- Calls `ensureGatewayProbed()` before gateway operations
+- Returns JSON responses with `{ ok: boolean, error?: string }` shape
+- Uses `BEARER_TOKEN` for gateway authentication
+- Integrates with dashboard API for config management
+
+## Related Files
+- `src/lib/gateway-api.ts` - Client-side API wrapper calling this endpoint
+- `src/components/mode-selector.tsx` - UI component using model switching
+- `src/routes/api/models.ts` - Model catalog endpoint
+- `src/screens/settings/providers-screen.tsx` - Provider management UI

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -45,6 +45,7 @@ import { Route as ApiPreviewFileRouteImport } from './routes/api/preview-file'
 import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
+import { Route as ApiModelSwitchRouteImport } from './routes/api/model-switch'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
@@ -275,6 +276,11 @@ const ApiPathsRoute = ApiPathsRouteImport.update({
 const ApiModelsRoute = ApiModelsRouteImport.update({
   id: '/api/models',
   path: '/api/models',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiModelSwitchRoute = ApiModelSwitchRouteImport.update({
+  id: '/api/model-switch',
+  path: '/api/model-switch',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiMemoryRoute = ApiMemoryRouteImport.update({
@@ -568,6 +574,7 @@ export interface FileRoutesByFullPath {
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
+  '/api/model-switch': typeof ApiModelSwitchRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
@@ -656,6 +663,7 @@ export interface FileRoutesByTo {
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
+  '/api/model-switch': typeof ApiModelSwitchRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
@@ -746,6 +754,7 @@ export interface FileRoutesById {
   '/api/history': typeof ApiHistoryRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
+  '/api/model-switch': typeof ApiModelSwitchRoute
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
@@ -837,6 +846,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/local-providers'
     | '/api/memory'
+    | '/api/model-switch'
     | '/api/models'
     | '/api/paths'
     | '/api/ping'
@@ -925,6 +935,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/local-providers'
     | '/api/memory'
+    | '/api/model-switch'
     | '/api/models'
     | '/api/paths'
     | '/api/ping'
@@ -1014,6 +1025,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/local-providers'
     | '/api/memory'
+    | '/api/model-switch'
     | '/api/models'
     | '/api/paths'
     | '/api/ping'
@@ -1104,6 +1116,7 @@ export interface RootRouteChildren {
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
+  ApiModelSwitchRoute: typeof ApiModelSwitchRoute
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
   ApiPingRoute: typeof ApiPingRoute
@@ -1397,6 +1410,13 @@ declare module '@tanstack/react-router' {
       path: '/api/models'
       fullPath: '/api/models'
       preLoaderRoute: typeof ApiModelsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/model-switch': {
+      id: '/api/model-switch'
+      path: '/api/model-switch'
+      fullPath: '/api/model-switch'
+      preLoaderRoute: typeof ApiModelSwitchRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/memory': {
@@ -1884,6 +1904,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHistoryRoute: ApiHistoryRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
+  ApiModelSwitchRoute: ApiModelSwitchRoute,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,
   ApiPingRoute: ApiPingRoute,

--- a/src/routes/api/model-switch.ts
+++ b/src/routes/api/model-switch.ts
@@ -1,0 +1,172 @@
+import { json } from '@tanstack/react-start'
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  ensureGatewayProbed,
+  getGatewayCapabilities,
+} from '../../server/hermes-api'
+import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
+import { patchHermesConfig } from '../../server/hermes-dashboard-api'
+
+type ModelSwitchRequest = {
+  model: string
+  sessionKey?: string
+}
+
+type ModelSwitchResponse = {
+  ok: boolean
+  model?: string
+  provider?: string
+  error?: string
+}
+
+function inferProvider(model: string): string {
+  if (model.startsWith('us.') || model.startsWith('global.')) {
+    return 'bedrock'
+  }
+  if (model.startsWith('gpt-') || model.startsWith('o1-')) {
+    return 'copilot'
+  }
+  if (model.includes('claude')) {
+    return model.includes('bedrock') ? 'bedrock' : 'copilot'
+  }
+  if (model.includes('gemini')) {
+    return 'copilot'
+  }
+  if (model.includes('nova')) {
+    return 'bedrock'
+  }
+  if (model.includes('/')) {
+    const prefix = model.split('/')[0]
+    if (prefix === 'anthropic' || prefix === 'openai') {
+      return 'copilot'
+    }
+  }
+  return 'unknown'
+}
+
+async function switchSessionModel(
+  sessionKey: string,
+  model: string
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (BEARER_TOKEN) {
+      headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+    }
+
+    const response = await fetch(
+      `${HERMES_API}/api/sessions/${sessionKey}/model`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ model }),
+      }
+    )
+
+    if (response.ok) {
+      return { ok: true }
+    }
+
+    return {
+      ok: false,
+      error: `Session switch failed: ${response.status} ${response.statusText}`,
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+async function updateDefaultModel(
+  model: string,
+  provider: string
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const configPatch = {
+      model: {
+        default: model,
+        provider: provider,
+      },
+    }
+
+    await patchHermesConfig(configPatch)
+    
+    return { ok: true }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+export const Route = createFileRoute('/api/model-switch')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 }
+          )
+        }
+
+        await ensureGatewayProbed()
+
+        try {
+          const body = (await request.json()) as ModelSwitchRequest
+          const { model, sessionKey } = body
+
+          if (!model || typeof model !== 'string' || model.trim().length === 0) {
+            return json(
+              { ok: false, error: 'Invalid model parameter' },
+              { status: 400 }
+            )
+          }
+
+          const trimmedModel = model.trim()
+          const provider = inferProvider(trimmedModel)
+
+          if (sessionKey && getGatewayCapabilities().sessions) {
+            const sessionResult = await switchSessionModel(sessionKey, trimmedModel)
+            if (sessionResult.ok) {
+              return json({
+                ok: true,
+                model: trimmedModel,
+                provider,
+              })
+            }
+          }
+
+          const configResult = await updateDefaultModel(trimmedModel, provider)
+          if (configResult.ok) {
+            return json({
+              ok: true,
+              model: trimmedModel,
+              provider,
+            })
+          }
+
+          return json(
+            {
+              ok: false,
+              error: 'Model switch failed: Gateway did not accept the change',
+            },
+            { status: 503 }
+          )
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          return json(
+            { ok: false, error: `Model switch failed: ${message}` },
+            { status: 500 }
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
Implements the missing `/api/model-switch` server endpoint that the UI already expects, enabling seamless runtime model switching between providers (Copilot, Bedrock, etc.) without restarting.

## Problem
The Workspace UI has model switching components (slash commands, mode selector, settings) that call `/api/model-switch`, but this endpoint doesn't exist, causing 404 errors and broken functionality.

## Solution
- Adds `src/routes/api/model-switch.ts` with POST handler
- Supports session-level switching via gateway API
- Falls back to config.yaml update for persistence
- Auto-detects provider from model ID
- Includes comprehensive documentation in `FEATURE-MODEL-SWITCH.md`

## Features
✅ **Session-level switching** - Change model for active conversation only  
✅ **Config persistence** - Updates default model (survives restart)  
✅ **Auto provider detection** - Infers Copilot/Bedrock from model ID  
✅ **Graceful fallbacks** - Works even if gateway doesn't support session switching  
✅ **Proper auth** - Requires authentication, follows existing patterns  

## Testing
```bash
# Start gateway, dashboard, and workspace
hermes gateway run          # Terminal 1
hermes dashboard            # Terminal 2
cd ~/hermes-workspace && pnpm dev  # Terminal 3

# Test via curl
curl -X POST http://localhost:3000/api/model-switch \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4"}'

# Expected: {"ok":true,"model":"gpt-5.4","provider":"copilot"}

# Test via UI
/model copilot:gpt-5.4
/model bedrock:us.anthropic.claude-sonnet-4-6
```

## How It Works
1. Client calls `POST /api/model-switch` with `{ model, sessionKey? }`
2. Server authenticates and infers provider (bedrock/copilot/etc.)
3. Tries session-level switch first (if `sessionKey` provided)
4. Falls back to updating `~/.hermes/config.yaml` default
5. Returns `{ ok: true, model, provider }`

## Usage Examples
```bash
# Via slash command
/model copilot:gpt-5.4
/model bedrock:us.anthropic.claude-sonnet-4-6

# Via Mode Selector UI
Click Mode → Select mode with preferred model → Confirm switch

# Via API directly
curl -X POST http://localhost:3000/api/model-switch \
  -H "Content-Type: application/json" \
  -d '{"model":"us.anthropic.claude-sonnet-4-6"}'
```

## Configuration
Requires `~/.hermes/models.json` and provider setup in `~/.hermes/config.yaml`. See `FEATURE-MODEL-SWITCH.md` for complete setup guide.

## Implementation Notes
- Follows existing patterns: `isAuthenticated()`, `ensureGatewayProbed()`, `BEARER_TOKEN`
- Integrates with dashboard API for config management
- Auto-generated route tree updated (`src/routeTree.gen.ts`)
- No breaking changes - pure addition

## Related Files
- `src/lib/gateway-api.ts` - Client-side wrapper calling this endpoint
- `src/components/mode-selector.tsx` - UI component using model switching
- `src/screens/chat/chat-screen.tsx` - Chat screen calling endpoint
- `src/routes/api/models.ts` - Model catalog endpoint

## Checklist
- [x] Follows existing code patterns (auth, gateway probing)
- [x] Error handling included
- [x] Works with both Copilot and Bedrock providers
- [x] Documentation added (`FEATURE-MODEL-SWITCH.md`)
- [x] Auto-generated route tree updated
- [x] Tested locally with curl and UI
- [ ] Unit tests (need guidance on workspace test patterns)

## Future Enhancements
- Model validation against available catalog
- Rate limiting
- Usage analytics per model/provider
- Model recommendation based on context

---

**Note:** This PR completes an incomplete feature. The UI components were already built and ready, just waiting for the backend implementation.