### PR TITLE
fix(jobs): handle bare array response from dashboard /api/cron/jobs

### DIFF
--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -33,8 +33,7 @@ export type JobOutput = {
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  return (await res.json()) as Array<HermesJob>
 }
 
 export async function createJob(input: {


### PR DESCRIPTION
## Summary
`fetchJobs()` in `src/lib/jobs-api.ts` does `data.jobs ?? []`, but the dashboard's `/api/cron/jobs` endpoint returns a bare array. The fallback silently returned `[]` for every response, so the workspace `/jobs` UI showed "No scheduled jobs" even when the gateway had jobs configured.

## Fix
Drop the unwrap and return the array directly with a TS cast — matches the style of `fetchSessions()` / `fetchModels()` elsewhere in the same file.

## Reproduction
- Hermes Agent v0.11.0 with several active cron jobs.
- Workspace built from `main` (hash `d274636`).
- Open `/jobs` → "No scheduled jobs / Create one to get started".
- Hit the proxy directly:

```
$ curl http://workspace:3000/api/hermes-jobs?include_disabled=true
[{"id":"a747b...","name":"Fireflies Pipeline",...}, ... 17 more ...]
```

Server returned 18 jobs; client unwrap returned `[]`.

## Test plan
- [x] `/jobs` page renders all 18 jobs after the patch
- [x] Sort/search interactions still work (HermesJob shape unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)