### PR TITLE
fix(memory): scan only canonical paths in listMemoryFiles

### DIFF
--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -137,7 +137,10 @@ export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(results, workspaceRoot, path.join(workspaceRoot, 'MEMORY.md'))
+  for (const subdir of ['memory', 'memories']) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, subdir))
+  }
 
   results.sort(compareMemoryFiles)
   return results


### PR DESCRIPTION
## Summary
`listMemoryFiles()` walks the entire `HERMES_HOME` recursively, skipping only `.git` / `node_modules`. When `HERMES_HOME` is a Hermes data directory rather than a vanilla workspace home (e.g. the workspace runs in Docker with a bind mount of the agent's data dir), the walk traverses unrelated subtrees: `skills/`, `cron/output/`, `backups/`, `sessions/`, the SQLite `state.db`, etc.

With ~200 directories under that data dir, `/api/memory/list` takes >5s to respond and the client request times out (the SPA shows "MEMORY FILES (0)" forever even though `MEMORY.md` and `memories/` exist).

## Fix
`pushIfMarkdownFile()` already filters to `MEMORY.md` / `memory/` / `memories/` via `isBrowserMemoryPath()`, so descending into other subtrees is wasted work. Walk only those canonical paths directly. No behavior change for vanilla installs; large speedup for shared-home deployments.

## Test plan
- [x] `/api/memory/list` returns within 50ms with `HERMES_HOME=/opt/hermes/data` (a real Hermes data dir with 200+ subtrees)
- [x] Memory UI lists `MEMORY.md` + `memories/USER.md` correctly
- [x] Markdown files in unrelated subtrees (e.g. `skills/foo/SKILL.md`) are still excluded — they were never reachable through `isBrowserMemoryPath()` either

🤖 Generated with [Claude Code](https://claude.com/claude-code)