### PR TITLE
fix(auth): show login screen before onboarding wizard on fresh devices

### DIFF
--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -4,12 +4,14 @@ import { getRootSurfaceState } from './-root-layout-state'
 describe('root layout surface state', () => {
   it('shows fullscreen onboarding until onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -18,9 +20,46 @@ describe('root layout surface state', () => {
 
   it('shows workspace shell and post-onboarding overlays after completion', () => {
     expect(getRootSurfaceState(true)).toEqual({
+      showLogin: false,
       showOnboarding: false,
       showWorkspaceShell: true,
       showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('shows login when auth is required and not authenticated, regardless of onboarding state', () => {
+    const unauthed = { authRequired: true, authenticated: false }
+    const expected = {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+
+    expect(getRootSurfaceState(false, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(null, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(true, unauthed)).toEqual(expected)
+  })
+
+  it('does not gate on auth when auth is not required', () => {
+    expect(
+      getRootSurfaceState(true, { authRequired: false, authenticated: false }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
+      showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('does not gate on auth when authenticated', () => {
+    expect(
+      getRootSurfaceState(false, { authRequired: true, authenticated: true }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: true,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
     })
   })
 })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -1,14 +1,31 @@
 export type RootSurfaceState = {
+  showLogin: boolean
   showOnboarding: boolean
   showWorkspaceShell: boolean
   showPostOnboardingOverlays: boolean
 }
 
+export type RootAuthStatus = {
+  authRequired: boolean
+  authenticated: boolean
+}
+
 export function getRootSurfaceState(
   onboardingComplete: boolean | null,
+  authStatus: RootAuthStatus | null = null,
 ): RootSurfaceState {
+  if (authStatus?.authRequired && !authStatus.authenticated) {
+    return {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+  }
+
   if (onboardingComplete !== true) {
     return {
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -16,6 +33,7 @@ export function getRootSurfaceState(
   }
 
   return {
+    showLogin: false,
     showOnboarding: false,
     showWorkspaceShell: true,
     showPostOnboardingOverlays: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import {
   ONBOARDING_KEY,
 } from '@/components/onboarding/hermes-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { LoginScreen } from '@/components/auth/login-screen'
+import { fetchHermesAuthStatus, type AuthStatus } from '@/lib/hermes-auth'
 import { getRootSurfaceState } from './-root-layout-state'
 
 
@@ -249,6 +251,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
   useApplyChatWidth()
 
   useEffect(() => {
@@ -297,11 +300,29 @@ function RootLayout() {
     }
   }, [])
 
-  const rootSurfaceState = getRootSurfaceState(onboardingComplete)
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    let cancelled = false
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (!cancelled) setAuthStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ authenticated: true, authRequired: false })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />
+      {rootSurfaceState.showLogin ? <LoginScreen /> : null}
       {rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>


### PR DESCRIPTION
## Summary
When `HERMES_PASSWORD` is set, a fresh device (incognito tab, new browser, mobile, etc.) lands on the onboarding wizard ("Connect Backend") instead of the password screen. Clicking through the wizard probes auth-protected endpoints, gets 401, and surfaces "HTTP 401" with no way to authenticate from the UI. Users have to know to either (a) navigate directly to a protected route like `/memory` to trigger the password form, or (b) POST `/api/auth` from devtools.

## Root cause
- `HermesOnboarding` is gated in `RootLayout` by `localStorage["hermes-onboarding-complete"]`.
- `LoginScreen` is gated inside `WorkspaceShell` by `authState.authRequired && !authState.authenticated`.
- `WorkspaceShell` only renders when onboarding is complete, so on a fresh device the login screen is unreachable.

## Fix
Move the auth gate up to `RootLayout` so login takes precedence:

1. `authRequired && !authenticated` → `<LoginScreen />`
2. `!onboardingComplete`            → `<HermesOnboarding />`
3. `onboardingComplete`             → `<WorkspaceShell>` (which still has its own `LoginScreen` guard for sessions that expire mid-use)

Auth status is fetched once at root mount via the existing `fetchHermesAuthStatus()` helper. On fetch failure (network down, etc.) it falls back to "no auth required" so loopback installs are unchanged.

## Test plan
- [x] Unit tests added in `src/routes/-root-layout-state.test.ts` cover all four state combinations (auth × onboarding)
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm test src/routes/-root-layout-state` passes (5/5)
- [x] Manual verification on a fresh browser with `HERMES_PASSWORD` set: password screen appears immediately on `/`, after login the wizard then renders normally
- [x] Loopback install (no `HERMES_PASSWORD`): no change in behavior, wizard renders as before

## Related
- Surfaces the password prompt that issue #149 mentioned but couldn't reach on fresh devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)