### PR TITLE
feat: embed ops console in workspace shell

### DIFF
--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -67,6 +67,13 @@ const NAV_ITEMS = [
     match: (p: string) => p.startsWith('/operations'),
   },
   {
+    id: 'ops-console',
+    label: 'Ops Console',
+    icon: Settings01Icon,
+    to: '/ops-console',
+    match: (p: string) => p.startsWith('/ops-console'),
+  },
+  {
     id: 'memory',
     label: 'Memory',
     icon: BrainIcon,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProfilesRouteImport } from './routes/profiles'
+import { Route as OpsConsoleRouteImport } from './routes/ops-console'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as JobsRouteImport } from './routes/jobs'
@@ -119,6 +120,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ProfilesRoute = ProfilesRouteImport.update({
   id: '/profiles',
   path: '/profiles',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpsConsoleRoute = OpsConsoleRouteImport.update({
+  id: '/ops-console',
+  path: '/ops-console',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OperationsRoute = OperationsRouteImport.update({
@@ -538,6 +544,7 @@ export interface FileRoutesByFullPath {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -626,6 +633,7 @@ export interface FileRoutesByTo {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/skills': typeof SkillsRoute
   '/tasks': typeof TasksRoute
@@ -714,6 +722,7 @@ export interface FileRoutesById {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -804,6 +813,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/settings'
     | '/skills'
@@ -892,6 +902,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/skills'
     | '/tasks'
@@ -979,6 +990,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/settings'
     | '/skills'
@@ -1068,6 +1080,7 @@ export interface RootRouteChildren {
   JobsRoute: typeof JobsRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
+  OpsConsoleRoute: typeof OpsConsoleRoute
   ProfilesRoute: typeof ProfilesRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
@@ -1167,6 +1180,13 @@ declare module '@tanstack/react-router' {
       path: '/profiles'
       fullPath: '/profiles'
       preLoaderRoute: typeof ProfilesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ops-console': {
+      id: '/ops-console'
+      path: '/ops-console'
+      fullPath: '/ops-console'
+      preLoaderRoute: typeof OpsConsoleRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/operations': {
@@ -1840,6 +1860,7 @@ const rootRouteChildren: RootRouteChildren = {
   JobsRoute: JobsRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
+  OpsConsoleRoute: OpsConsoleRoute,
   ProfilesRoute: ProfilesRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,

--- a/src/routes/ops-console.tsx
+++ b/src/routes/ops-console.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { OpsConsoleScreen } from '@/screens/agents/ops-console-screen'
+
+export const Route = createFileRoute('/ops-console')({
+  ssr: false,
+  component: function OpsConsoleRoute() {
+    usePageTitle('Ops Console')
+    return <OpsConsoleScreen />
+  },
+})

--- a/src/screens/agents/ops-console-screen.tsx
+++ b/src/screens/agents/ops-console-screen.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react'
+
+const EMBED_PATH = '/hci-ui/'
+
+export function OpsConsoleScreen() {
+  const [frameKey, setFrameKey] = useState(0)
+  const [lastReloadAt, setLastReloadAt] = useState<string | null>(null)
+  const iframeSrc = useMemo(() => `${EMBED_PATH}?embed=1`, [])
+
+  function reloadFrame() {
+    setFrameKey((current) => current + 1)
+    setLastReloadAt(new Date().toLocaleTimeString())
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 bg-[var(--theme-bg)] p-4 text-[var(--theme-text)] md:p-6">
+      <div className="flex flex-col gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-muted)]">
+            Unified shell
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">Ops Console</h1>
+          <p className="max-w-3xl text-sm text-[var(--theme-muted)]">
+            Hermes Control Interface embedded inside Workspace. Phase 1 keeps both apps linked. Phase 2 starts here by proxying HCI through the Workspace shell.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={reloadFrame}
+            className="inline-flex items-center justify-center rounded-xl border border-[var(--theme-border)] px-4 py-2 text-sm font-medium transition hover:bg-[var(--theme-bg-subtle)]"
+          >
+            Reload panel
+          </button>
+          <a
+            href={EMBED_PATH}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center justify-center rounded-xl bg-[var(--theme-accent)] px-4 py-2 text-sm font-semibold text-[var(--theme-accent-foreground,#111)] transition hover:opacity-90"
+          >
+            Open standalone
+          </a>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-xs text-[var(--theme-muted)]">
+        <span>Proxy target: HCI_BACKEND_URL or http://127.0.0.1:10272</span>
+        <span>{lastReloadAt ? `Reloaded ${lastReloadAt}` : 'Live embed ready'}</span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-black/10 shadow-sm">
+        <iframe
+          key={frameKey}
+          title="Hermes Control Interface"
+          src={iframeSrc}
+          className="h-full min-h-[720px] w-full border-0 bg-white"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -562,6 +562,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
+  const isOpsConsoleActive = pathname.startsWith('/ops-console')
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -810,6 +811,13 @@ function ChatSidebarComponent({
       icon: UserGroupIcon,
       label: 'Operations',
       active: isOperationsActive,
+    },
+    {
+      kind: 'link',
+      to: '/ops-console',
+      icon: Settings01Icon,
+      label: 'Ops Console',
+      active: isOpsConsoleActive,
     },
   ]
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,7 @@ async function isHermesAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const hermesApiUrl = env.HERMES_API_URL?.trim() || 'http://127.0.0.1:8642'
+  const hciBackendUrl = env.HCI_BACKEND_URL?.trim() || 'http://127.0.0.1:10272'
 
   // Hermes Agent auto-start state
   let hermesAgentChild: ChildProcess | null = null
@@ -474,6 +475,18 @@ const config = defineConfig(({ mode, command }) => {
           configure: (proxy) => {
             proxy.on('proxyRes', (_proxyRes) => {
               // Strip iframe-blocking headers so we can embed
+              delete _proxyRes.headers['x-frame-options']
+              delete _proxyRes.headers['content-security-policy']
+            })
+          },
+        },
+        '/hci-ui': {
+          target: hciBackendUrl,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/hci-ui/, ''),
+          ws: true,
+          configure: (proxy) => {
+            proxy.on('proxyRes', (_proxyRes) => {
               delete _proxyRes.headers['x-frame-options']
               delete _proxyRes.headers['content-security-policy']
             })


### PR DESCRIPTION
## Summary
- add an Ops Console route to Workspace and expose it in sidebar/mobile nav
- proxy HCI through /hci-ui so it can render inside the Workspace shell
- add an embedded ops console screen with reload and standalone-open controls

## Test Plan
- pnpm build
- verified /ops-console renders and the iframe loads Hermes Control Interface through /hci-ui in browser preview