### PR TITLE
feat: embed ops console in workspace shell

### DIFF
--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -67,6 +67,13 @@ const NAV_ITEMS = [
     match: (p: string) => p.startsWith('/operations'),
   },
   {
+    id: 'ops-console',
+    label: 'Ops Console',
+    icon: Settings01Icon,
+    to: '/ops-console',
+    match: (p: string) => p.startsWith('/ops-console'),
+  },
+  {
     id: 'memory',
     label: 'Memory',
     icon: BrainIcon,

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProfilesRouteImport } from './routes/profiles'
+import { Route as OpsConsoleRouteImport } from './routes/ops-console'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as JobsRouteImport } from './routes/jobs'
@@ -120,6 +121,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ProfilesRoute = ProfilesRouteImport.update({
   id: '/profiles',
   path: '/profiles',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpsConsoleRoute = OpsConsoleRouteImport.update({
+  id: '/ops-console',
+  path: '/ops-console',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OperationsRoute = OperationsRouteImport.update({
@@ -544,6 +550,7 @@ export interface FileRoutesByFullPath {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -633,6 +640,7 @@ export interface FileRoutesByTo {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/skills': typeof SkillsRoute
   '/tasks': typeof TasksRoute
@@ -722,6 +730,7 @@ export interface FileRoutesById {
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
+  '/ops-console': typeof OpsConsoleRoute
   '/profiles': typeof ProfilesRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -813,6 +822,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/settings'
     | '/skills'
@@ -902,6 +912,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/skills'
     | '/tasks'
@@ -990,6 +1001,7 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/memory'
     | '/operations'
+    | '/ops-console'
     | '/profiles'
     | '/settings'
     | '/skills'
@@ -1080,6 +1092,7 @@ export interface RootRouteChildren {
   JobsRoute: typeof JobsRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
+  OpsConsoleRoute: typeof OpsConsoleRoute
   ProfilesRoute: typeof ProfilesRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
@@ -1180,6 +1193,13 @@ declare module '@tanstack/react-router' {
       path: '/profiles'
       fullPath: '/profiles'
       preLoaderRoute: typeof ProfilesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ops-console': {
+      id: '/ops-console'
+      path: '/ops-console'
+      fullPath: '/ops-console'
+      preLoaderRoute: typeof OpsConsoleRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/operations': {
@@ -1860,6 +1880,7 @@ const rootRouteChildren: RootRouteChildren = {
   JobsRoute: JobsRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
+  OpsConsoleRoute: OpsConsoleRoute,
   ProfilesRoute: ProfilesRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,

--- a/src/routes/ops-console.tsx
+++ b/src/routes/ops-console.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { OpsConsoleScreen } from '@/screens/agents/ops-console-screen'
+
+export const Route = createFileRoute('/ops-console')({
+  ssr: false,
+  component: function OpsConsoleRoute() {
+    usePageTitle('Ops Console')
+    return <OpsConsoleScreen />
+  },
+})

--- a/src/screens/agents/ops-console-screen.tsx
+++ b/src/screens/agents/ops-console-screen.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react'
+
+const EMBED_PATH = '/hci-ui/'
+
+export function OpsConsoleScreen() {
+  const [frameKey, setFrameKey] = useState(0)
+  const [lastReloadAt, setLastReloadAt] = useState<string | null>(null)
+  const iframeSrc = useMemo(() => `${EMBED_PATH}?embed=1`, [])
+
+  function reloadFrame() {
+    setFrameKey((current) => current + 1)
+    setLastReloadAt(new Date().toLocaleTimeString())
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 bg-[var(--theme-bg)] p-4 text-[var(--theme-text)] md:p-6">
+      <div className="flex flex-col gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-muted)]">
+            Unified shell
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">Ops Console</h1>
+          <p className="max-w-3xl text-sm text-[var(--theme-muted)]">
+            Hermes Control Interface embedded inside Workspace. Phase 1 keeps both apps linked. Phase 2 starts here by proxying HCI through the Workspace shell.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={reloadFrame}
+            className="inline-flex items-center justify-center rounded-xl border border-[var(--theme-border)] px-4 py-2 text-sm font-medium transition hover:bg-[var(--theme-bg-subtle)]"
+          >
+            Reload panel
+          </button>
+          <a
+            href={EMBED_PATH}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center justify-center rounded-xl bg-[var(--theme-accent)] px-4 py-2 text-sm font-semibold text-[var(--theme-accent-foreground,#111)] transition hover:opacity-90"
+          >
+            Open standalone
+          </a>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-xs text-[var(--theme-muted)]">
+        <span>Proxy target: HCI_BACKEND_URL or http://127.0.0.1:10272</span>
+        <span>{lastReloadAt ? `Reloaded ${lastReloadAt}` : 'Live embed ready'}</span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-black/10 shadow-sm">
+        <iframe
+          key={frameKey}
+          title="Hermes Control Interface"
+          src={iframeSrc}
+          className="h-full min-h-[720px] w-full border-0 bg-white"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -563,6 +563,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
+  const isOpsConsoleActive = pathname.startsWith('/ops-console')
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -814,6 +815,13 @@ function ChatSidebarComponent({
       icon: UserGroupIcon,
       label: 'Operations',
       active: isOperationsActive,
+    },
+    {
+      kind: 'link',
+      to: '/ops-console',
+      icon: Settings01Icon,
+      label: 'Ops Console',
+      active: isOpsConsoleActive,
     },
   ]
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,7 @@ async function isHermesAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const hermesApiUrl = env.HERMES_API_URL?.trim() || 'http://127.0.0.1:8642'
+  const hciBackendUrl = env.HCI_BACKEND_URL?.trim() || 'http://127.0.0.1:10272'
 
   // Hermes Agent auto-start state
   let hermesAgentChild: ChildProcess | null = null
@@ -478,6 +479,18 @@ const config = defineConfig(({ mode, command }) => {
           configure: (proxy) => {
             proxy.on('proxyRes', (_proxyRes) => {
               // Strip iframe-blocking headers so we can embed
+              delete _proxyRes.headers['x-frame-options']
+              delete _proxyRes.headers['content-security-policy']
+            })
+          },
+        },
+        '/hci-ui': {
+          target: hciBackendUrl,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/hci-ui/, ''),
+          ws: true,
+          configure: (proxy) => {
+            proxy.on('proxyRes', (_proxyRes) => {
               delete _proxyRes.headers['x-frame-options']
               delete _proxyRes.headers['content-security-policy']
             })


### PR DESCRIPTION
## Summary
- embed the ops console in the workspace shell at /ops-console
- add a dedicated iframe route for the Hermes Control Interface at /hci-ui
- wire workspace and HCI together for cross-launching

## Validation
- pnpm build
- browser validation for /ops-console, /hci-ui, and the HCI login link