### PR TITLE
fix(chat): wire approval banner to real store — tool call approvals now visible (#138)

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -71,14 +71,14 @@ import type {
   ChatComposerHelpers,
   ThinkingLevel,
 } from './components/chat-composer'
-import type { ApprovalRequest } from '@/lib/approvals-store'
+import type { ApprovalRequest } from '@/screens/gateway/lib/approvals-store'
 import type { ChatAttachment, ChatMessage, SessionMeta } from './types'
 import type { ChatRunCommandDetail } from './chat-events'
 import {
   addApproval,
   loadApprovals,
   saveApprovals,
-} from '@/lib/approvals-store'
+} from '@/screens/gateway/lib/approvals-store'
 import { stripQueuedWrapper } from '@/lib/strip-queued-wrapper'
 import { cn } from '@/lib/utils'
 import { toast } from '@/components/ui/toast'
@@ -653,7 +653,7 @@ export function ChatScreen({
       if (
         approvalId &&
         currentApprovals.some((entry) => {
-          return entry.status === 'pending' && entry.approvalId === approvalId
+          return entry.status === 'pending' && entry.gatewayApprovalId === approvalId
         })
       ) {
         setPendingApprovals(
@@ -694,8 +694,8 @@ export function ChatScreen({
         agentName,
         action,
         context,
-        source: 'hermes',
-        approvalId: approvalId || undefined,
+        source: 'agent',
+        gatewayApprovalId: approvalId || undefined,
       })
       setPendingApprovals(
         loadApprovals().filter((entry) => entry.status === 'pending'),
@@ -782,12 +782,12 @@ export function ChatScreen({
       setPendingApprovals(
         nextApprovals.filter((entry) => entry.status === 'pending'),
       )
-      if (!approval.approvalId) return
+      if (!approval.gatewayApprovalId) return
 
       const endpoint =
         status === 'approved'
-          ? `/api/approvals/${approval.approvalId}/approve`
-          : `/api/approvals/${approval.approvalId}/deny`
+          ? `/api/approvals/${approval.gatewayApprovalId}/approve`
+          : `/api/approvals/${approval.gatewayApprovalId}/deny`
       try {
         await fetch(endpoint, { method: 'POST' })
       } catch {


### PR DESCRIPTION
## Summary

- `chat-screen.tsx` was importing `addApproval` / `loadApprovals` / `saveApprovals` from `src/lib/approvals-store` — a **no-op stub** that returns `null`/`[]` and writes nothing to localStorage
- The real implementation lives at `src/screens/gateway/lib/approvals-store.ts`
- The approval banner, Approve/Deny buttons, and 2-second polling loop were **fully implemented** in `chat-screen.tsx` — they just had dead imports keeping `pendingApprovals` permanently empty
- Fixed field names to match the real `ApprovalRequest` type: `approvalId` → `gatewayApprovalId`, `source: 'hermes'` → `source: 'agent'`

## What was broken

```
onApprovalRequest fires
  → addApproval(...)        // stub: returns null, writes nothing
  → loadApprovals()         // stub: returns []
  → setPendingApprovals([]) // banner condition pendingApprovals.length > 0 = false
  → banner never renders
```

## After this fix

Approval requests from the agent SSE stream are stored in localStorage and surfaced as an amber banner with Approve / Deny buttons at the top of the chat message list.

## Test plan

- [ ] Trigger a tool call that requires approval from the agent
- [ ] Confirm the amber approval banner appears in the chat screen
- [ ] Approve / deny — confirm banner clears and agent continues/stops

Fixes #138

Worked with Interstellar Code