### PR TITLE
fix(server): respect HERMES_HOME env var in profiles-browser and run-store

### DIFF
--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -46,7 +46,7 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
 ])
 
 function getHermesRoot(): string {
-  return path.join(os.homedir(), '.hermes')
+  return process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
 }
 
 export function getProfilesRoot(): string {

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -33,7 +33,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(process.env.HERMES_HOME ?? homedir(), '.hermes', 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')


### PR DESCRIPTION
## Summary
`profiles-browser.ts` and `run-store.ts` hardcode `os.homedir()` to resolve the Hermes data directory, ignoring the `HERMES_HOME` environment variable. In the Docker workspace container this causes `EACCES: permission denied` errors because the workspace user's home is `/home/workspace` but the data volume is mounted at `/opt/data`.

## Root cause
- `profiles-browser.ts:getHermesRoot()` returns `path.join(os.homedir(), '.hermes')` unconditionally
- `run-store.ts:RUNS_ROOT` is derived from `homedir()` unconditionally
- All other server modules already honor `HERMES_HOME` (`tasks-store.ts`, `gateway-capabilities.ts`, `memory-browser.ts`, `auth-middleware.ts`, `gateway.ts`, `knowledge-browser.ts`, etc.)

## Fix

Both files now follow the established pattern used by the rest of the codebase:
```
// profiles-browser.ts
process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
```

```
// run-store.ts
process.env.HERMES_HOME ?? homedir()
```

No behavior change for vanilla installs where HERMES_HOME is not set — os.homedir() remains the fallback.


## Test plan
- [ ] Manual verification in Docker workspace container with HERMES_HOME=/opt/data: profile creation succeeds without EACCES
- [ ] Profile listing, creation, and activation work correctly in the UI
- [ ] Vanilla install (no HERMES_HOME set): no change in behavior, paths resolve to ~/.hermes as before