### PR TITLE
feat: add fleet operations audit layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,8 @@
 # Set to 1 to force the Secure attribute on session cookies even when
 # NODE_ENV is not production — useful when terminating TLS at a reverse
 # proxy. Set to 0 to force it off (only safe for localhost HTTP).
-# COOKIE_SECURE=1
+# COOKIE_SECURE=1   # use behind HTTPS / reverse proxy
+# COOKIE_SECURE=0   # required for plain HTTP on HOST=0.0.0.0 / LAN access
 
 # Trust proxy-forwarded headers (default: off)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Features pending cloud infrastructure:
 
 - `HERMES_PASSWORD` — required whenever `HOST ≠ 127.0.0.1`
 - `COOKIE_SECURE=1` — force the `Secure` cookie flag when terminating HTTPS at a proxy
+- `COOKIE_SECURE=0` — required for plain HTTP LAN access on `HOST=0.0.0.0` so the browser will actually send the auth cookie
 - `TRUST_PROXY=1` — trust `x-forwarded-for` / `x-real-ip` (only set behind a sanitizing reverse proxy)
 - `HERMES_DASHBOARD_TOKEN` — explicit bearer for dashboard API (preferred over the legacy HTML-scrape fallback)
 - `HERMES_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type Props = {
   open: boolean
@@ -34,17 +35,19 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-function formatUpdatedAt(updatedAt?: number): string {
+function formatUpdatedAt(
+  updatedAt: number | undefined,
+  use24HourTime: boolean,
+): string {
   if (typeof updatedAt !== 'number') return ''
   const value = new Date(updatedAt)
   const now = new Date()
   if (value.toDateString() === now.toDateString()) {
-    return timeFormatter.format(value)
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: !use24HourTime,
+    }).format(value)
   }
   return dayFormatter.format(value)
 }
@@ -57,6 +60,10 @@ export function MobileSessionsPanel({
   onSelectSession,
   onNewChat,
 }: Props) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+
   useEffect(() => {
     if (!open) return
     function handleKeyDown(event: KeyboardEvent) {
@@ -120,7 +127,10 @@ export function MobileSessionsPanel({
               <div className="space-y-1">
                 {sessions.map((session) => {
                   const active = session.friendlyId === activeFriendlyId
-                  const timestamp = formatUpdatedAt(session.updatedAt)
+                  const timestamp = formatUpdatedAt(
+                    session.updatedAt,
+                    use24HourTime,
+                  )
                   return (
                     <button
                       key={session.key}

--- a/src/components/mobile-tab-bar.tsx
+++ b/src/components/mobile-tab-bar.tsx
@@ -51,6 +51,13 @@ const TABS: Array<TabItem> = [
     match: (p) => p === '/dashboard',
   },
   {
+    id: 'fleet',
+    label: 'Fleet',
+    icon: DashboardSquare01Icon,
+    to: '/fleet',
+    match: (p) => p.startsWith('/fleet'),
+  },
+  {
     id: 'chat',
     label: 'Chat',
     icon: Chat01Icon,

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1229,6 +1229,16 @@ function ChatContent() {
           />
         </Row>
         <Row
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={cs.use24HourTime}
+            onCheckedChange={(c) => updateCS({ use24HourTime: c })}
+            aria-label="Use 24-hour time"
+          />
+        </Row>
+        <Row
           label="Enter key behavior"
           description={
             cs.enterBehavior === 'newline'
@@ -1971,7 +1981,7 @@ export function SettingsDialog({
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="inset-0 h-full w-full max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
+      <DialogContent className="left-0 top-0 h-[100dvh] w-screen max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
         <div className="flex h-full min-h-0 flex-col">
           <div className="flex items-center justify-between border-b border-primary-200 bg-primary-50/80 px-4 py-4 md:rounded-t-2xl md:px-5">
             <div>

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/components/usage-meter/context-alert-modal.tsx
+++ b/src/components/usage-meter/context-alert-modal.tsx
@@ -121,7 +121,7 @@ function ContextAlertModalComponent({
               )}
               <Recommendation
                 icon="🗜️"
-                text="Enable auto-compaction in Settings → Config to automatically manage context"
+                text="Auto-compaction is configured in ~/.hermes/config.yaml under the compression section"
               />
               <Recommendation
                 icon="📋"

--- a/src/components/usage-meter/usage-details-modal.tsx
+++ b/src/components/usage-meter/usage-details-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { formatModelName } from '@/lib/format-model-name'
 
 type ModelUsage = {
@@ -81,10 +82,10 @@ function formatTokens(value: number): string {
   return Math.round(value).toString()
 }
 
-function formatTimestamp(value?: number): string {
+function formatTimestamp(value: number | undefined, use24HourTime: boolean): string {
   if (!value) return '—'
   const date = new Date(value < 1_000_000_000_000 ? value * 1000 : value)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
 }
 
 function formatResetTime(iso?: string): string {
@@ -259,7 +260,7 @@ function buildCsv(usage: UsageSummary): string {
   )
   usage.sessions.forEach((session) => {
     rows.push(
-      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt)},${formatTimestamp(session.updatedAt)}`,
+      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt, use24HourTime)},${formatTimestamp(session.updatedAt, use24HourTime)}`,
     )
   })
   return rows.join('\n')
@@ -441,8 +442,8 @@ export function UsageDetailsModal({
                         {formatTokens(session.outputTokens)} out
                       </div>
                       <div className="text-xs text-primary-500">
-                        {formatTimestamp(session.startedAt)} →{' '}
-                        {formatTimestamp(session.updatedAt)}
+                        {formatTimestamp(session.startedAt, use24HourTime)} →{' '}
+                        {formatTimestamp(session.updatedAt, use24HourTime)}
                       </div>
                       <div className="font-semibold text-primary-900">
                         {formatCurrency(session.costUsd)}
@@ -473,7 +474,7 @@ export function UsageDetailsModal({
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-primary-500">
                 Auto-polls every 30s · Last updated{' '}
-                {formatTimestamp(providerUpdatedAt ?? undefined)}
+                {formatTimestamp(providerUpdatedAt ?? undefined, use24HourTime)}
               </div>
               <Button
                 size="sm"
@@ -529,7 +530,7 @@ export function UsageDetailsModal({
                         <div className="flex items-center gap-2">
                           {statusBadge(provider.status)}
                           <span className="text-[10px] text-primary-400">
-                            {formatTimestamp(provider.updatedAt)}
+                            {formatTimestamp(provider.updatedAt, use24HourTime)}
                           </span>
                         </div>
                       </div>

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,10 +11,9 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
@@ -77,8 +76,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const { settings } = useSettings()
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
+  const sidebarPinned = useWorkspaceStore((s) => s.sidebarPinned)
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
+  const toggleSidebarPinned = useWorkspaceStore((s) => s.toggleSidebarPinned)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
@@ -150,7 +151,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed && !sidebarPinned
 
   // Sessions query — shared across sidebar and chat
   const sessionsQuery = useQuery({
@@ -311,7 +312,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 creatingSession={creatingSession}
                 onCreateSession={startNewChat}
                 isCollapsed={sidebarCollapsed}
+                isPinned={sidebarPinned}
                 onToggleCollapse={toggleSidebar}
+                onTogglePinned={toggleSidebarPinned}
                 onSelectSession={handleSelectSession}
                 onActiveSessionDelete={handleActiveSessionDelete}
                 sessionsLoading={sessionsLoading}

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -99,16 +99,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   // Map pathname to tab index (mirrors TABS order in mobile-tab-bar)
   const getTabIndex = useCallback((path: string): number => {
     if (path === '/dashboard') return 0
-    if (path.startsWith('/chat') || path === '/new' || path === '/') return 1
-    if (path.startsWith('/files')) return 2
-    if (path.startsWith('/terminal')) return 3
-    if (path.startsWith('/jobs')) return 4
-    if (path.startsWith('/conductor')) return 5
-    if (path.startsWith('/operations')) return 6
-    if (path.startsWith('/memory')) return 7
-    if (path.startsWith('/skills')) return 8
-    if (path.startsWith('/profiles')) return 9
-    if (path.startsWith('/settings')) return 10
+    if (path.startsWith('/fleet')) return 1
+    if (path.startsWith('/chat') || path === '/new' || path === '/') return 2
+    if (path.startsWith('/files')) return 3
+    if (path.startsWith('/terminal')) return 4
+    if (path.startsWith('/jobs')) return 5
+    if (path.startsWith('/conductor')) return 6
+    if (path.startsWith('/operations')) return 7
+    if (path.startsWith('/memory')) return 8
+    if (path.startsWith('/skills')) return 9
+    if (path.startsWith('/profiles')) return 10
+    if (path.startsWith('/settings')) return 11
     return -1
   }, [])
 
@@ -140,7 +141,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (pathname.startsWith('/skills')) return 'Skills'
     if (pathname.startsWith('/profiles')) return 'Profiles'
     if (pathname.startsWith('/settings')) return 'Settings'
-    if (pathname.startsWith('/debug')) return 'Debug'
+    if (pathname.startsWith('/fleet')) return 'Fleet'
     if (pathname.startsWith('/activity')) return 'Activity'
     return null
   })()

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -53,6 +53,7 @@ export type ChatSettings = {
    * surprised by sound on next page load.
    */
   soundOnChatComplete: boolean
+  use24HourTime: boolean
 }
 
 type ChatSettingsState = {
@@ -72,6 +73,7 @@ function defaultChatSettings(): ChatSettings {
     chatWidth: 'comfortable',
     sidebarHoverExpand: false,
     soundOnChatComplete: false,
+    use24HourTime: false,
   }
 }
 

--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeJobsResponse } from './jobs-api'
+import type { HermesJob } from './jobs-api'
+
+const job = {
+  id: 'job-1',
+  name: 'Example job',
+  prompt: 'Run the example job',
+  schedule: {},
+  enabled: true,
+  state: 'scheduled',
+} satisfies HermesJob
+
+describe('normalizeJobsResponse', () => {
+  it('accepts dashboard cron jobs returned as a top-level array', () => {
+    expect(normalizeJobsResponse([job])).toEqual([job])
+  })
+
+  it('accepts gateway jobs returned in an object wrapper', () => {
+    expect(normalizeJobsResponse({ jobs: [job] })).toEqual([job])
+  })
+
+  it('falls back to an empty list for unexpected payloads', () => {
+    expect(normalizeJobsResponse({ jobs: null })).toEqual([])
+  })
+})

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -30,11 +30,24 @@ export type JobOutput = {
   size: number
 }
 
+export function normalizeJobsResponse(data: unknown): Array<HermesJob> {
+  if (Array.isArray(data)) return data
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'jobs' in data &&
+    Array.isArray(data.jobs)
+  ) {
+    return data.jobs as Array<HermesJob>
+  }
+  return []
+}
+
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  const data = (await res.json()) as unknown
+  return normalizeJobsResponse(data)
 }
 
 export async function createJob(input: {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,11 @@ import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as JobsRouteImport } from './routes/jobs'
+import { Route as FleetOperationsRouteImport } from './routes/fleet-operations'
+import { Route as FleetNodeRouteImport } from './routes/fleet-node'
+import { Route as FleetCronDetailRouteImport } from './routes/fleet-cron-detail'
+import { Route as FleetCronRouteImport } from './routes/fleet-cron'
+import { Route as FleetRouteImport } from './routes/fleet'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
@@ -53,6 +58,11 @@ import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
 import { Route as ApiHermesJobsRouteImport } from './routes/api/hermes-jobs'
 import { Route as ApiHermesConfigRouteImport } from './routes/api/hermes-config'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
+import { Route as ApiFleetStatusRouteImport } from './routes/api/fleet-status'
+import { Route as ApiFleetOperationsRouteImport } from './routes/api/fleet-operations'
+import { Route as ApiFleetNodeDetailRouteImport } from './routes/api/fleet-node-detail'
+import { Route as ApiFleetCronDetailRouteImport } from './routes/api/fleet-cron-detail'
+import { Route as ApiFleetCronRouteImport } from './routes/api/fleet-cron'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
@@ -135,6 +145,31 @@ const MemoryRoute = MemoryRouteImport.update({
 const JobsRoute = JobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetOperationsRoute = FleetOperationsRouteImport.update({
+  id: '/fleet-operations',
+  path: '/fleet-operations',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetNodeRoute = FleetNodeRouteImport.update({
+  id: '/fleet-node',
+  path: '/fleet-node',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetCronDetailRoute = FleetCronDetailRouteImport.update({
+  id: '/fleet-cron-detail',
+  path: '/fleet-cron-detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetCronRoute = FleetCronRouteImport.update({
+  id: '/fleet-cron',
+  path: '/fleet-cron',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetRoute = FleetRouteImport.update({
+  id: '/fleet',
+  path: '/fleet',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FilesRoute = FilesRouteImport.update({
@@ -315,6 +350,31 @@ const ApiHermesConfigRoute = ApiHermesConfigRouteImport.update({
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFleetStatusRoute = ApiFleetStatusRouteImport.update({
+  id: '/api/fleet-status',
+  path: '/api/fleet-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFleetOperationsRoute = ApiFleetOperationsRouteImport.update({
+  id: '/api/fleet-operations',
+  path: '/api/fleet-operations',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFleetNodeDetailRoute = ApiFleetNodeDetailRouteImport.update({
+  id: '/api/fleet-node-detail',
+  path: '/api/fleet-node-detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFleetCronDetailRoute = ApiFleetCronDetailRouteImport.update({
+  id: '/api/fleet-cron-detail',
+  path: '/api/fleet-cron-detail',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFleetCronRoute = ApiFleetCronRouteImport.update({
+  id: '/api/fleet-cron',
+  path: '/api/fleet-cron',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiFilesRoute = ApiFilesRouteImport.update({
@@ -541,6 +601,11 @@ export interface FileRoutesByFullPath {
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
+  '/fleet': typeof FleetRoute
+  '/fleet-cron': typeof FleetCronRoute
+  '/fleet-cron-detail': typeof FleetCronDetailRoute
+  '/fleet-node': typeof FleetNodeRoute
+  '/fleet-operations': typeof FleetOperationsRoute
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -560,6 +625,11 @@ export interface FileRoutesByFullPath {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/fleet-cron': typeof ApiFleetCronRoute
+  '/api/fleet-cron-detail': typeof ApiFleetCronDetailRoute
+  '/api/fleet-node-detail': typeof ApiFleetNodeDetailRoute
+  '/api/fleet-operations': typeof ApiFleetOperationsRoute
+  '/api/fleet-status': typeof ApiFleetStatusRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
@@ -630,6 +700,11 @@ export interface FileRoutesByTo {
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
+  '/fleet': typeof FleetRoute
+  '/fleet-cron': typeof FleetCronRoute
+  '/fleet-cron-detail': typeof FleetCronDetailRoute
+  '/fleet-node': typeof FleetNodeRoute
+  '/fleet-operations': typeof FleetOperationsRoute
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -648,6 +723,11 @@ export interface FileRoutesByTo {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/fleet-cron': typeof ApiFleetCronRoute
+  '/api/fleet-cron-detail': typeof ApiFleetCronDetailRoute
+  '/api/fleet-node-detail': typeof ApiFleetNodeDetailRoute
+  '/api/fleet-operations': typeof ApiFleetOperationsRoute
+  '/api/fleet-status': typeof ApiFleetStatusRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
@@ -719,6 +799,11 @@ export interface FileRoutesById {
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
+  '/fleet': typeof FleetRoute
+  '/fleet-cron': typeof FleetCronRoute
+  '/fleet-cron-detail': typeof FleetCronDetailRoute
+  '/fleet-node': typeof FleetNodeRoute
+  '/fleet-operations': typeof FleetOperationsRoute
   '/jobs': typeof JobsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -738,6 +823,11 @@ export interface FileRoutesById {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/fleet-cron': typeof ApiFleetCronRoute
+  '/api/fleet-cron-detail': typeof ApiFleetCronDetailRoute
+  '/api/fleet-node-detail': typeof ApiFleetNodeDetailRoute
+  '/api/fleet-operations': typeof ApiFleetOperationsRoute
+  '/api/fleet-status': typeof ApiFleetStatusRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
@@ -810,6 +900,11 @@ export interface FileRouteTypes {
     | '/conductor'
     | '/dashboard'
     | '/files'
+    | '/fleet'
+    | '/fleet-cron'
+    | '/fleet-cron-detail'
+    | '/fleet-node'
+    | '/fleet-operations'
     | '/jobs'
     | '/memory'
     | '/operations'
@@ -829,6 +924,11 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/fleet-cron'
+    | '/api/fleet-cron-detail'
+    | '/api/fleet-node-detail'
+    | '/api/fleet-operations'
+    | '/api/fleet-status'
     | '/api/gateway-status'
     | '/api/hermes-config'
     | '/api/hermes-jobs'
@@ -899,6 +999,11 @@ export interface FileRouteTypes {
     | '/conductor'
     | '/dashboard'
     | '/files'
+    | '/fleet'
+    | '/fleet-cron'
+    | '/fleet-cron-detail'
+    | '/fleet-node'
+    | '/fleet-operations'
     | '/jobs'
     | '/memory'
     | '/operations'
@@ -917,6 +1022,11 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/fleet-cron'
+    | '/api/fleet-cron-detail'
+    | '/api/fleet-node-detail'
+    | '/api/fleet-operations'
+    | '/api/fleet-status'
     | '/api/gateway-status'
     | '/api/hermes-config'
     | '/api/hermes-jobs'
@@ -987,6 +1097,11 @@ export interface FileRouteTypes {
     | '/conductor'
     | '/dashboard'
     | '/files'
+    | '/fleet'
+    | '/fleet-cron'
+    | '/fleet-cron-detail'
+    | '/fleet-node'
+    | '/fleet-operations'
     | '/jobs'
     | '/memory'
     | '/operations'
@@ -1006,6 +1121,11 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/fleet-cron'
+    | '/api/fleet-cron-detail'
+    | '/api/fleet-node-detail'
+    | '/api/fleet-operations'
+    | '/api/fleet-status'
     | '/api/gateway-status'
     | '/api/hermes-config'
     | '/api/hermes-jobs'
@@ -1077,6 +1197,11 @@ export interface RootRouteChildren {
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
   FilesRoute: typeof FilesRoute
+  FleetRoute: typeof FleetRoute
+  FleetCronRoute: typeof FleetCronRoute
+  FleetCronDetailRoute: typeof FleetCronDetailRoute
+  FleetNodeRoute: typeof FleetNodeRoute
+  FleetOperationsRoute: typeof FleetOperationsRoute
   JobsRoute: typeof JobsRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
@@ -1096,6 +1221,11 @@ export interface RootRouteChildren {
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
+  ApiFleetCronRoute: typeof ApiFleetCronRoute
+  ApiFleetCronDetailRoute: typeof ApiFleetCronDetailRoute
+  ApiFleetNodeDetailRoute: typeof ApiFleetNodeDetailRoute
+  ApiFleetOperationsRoute: typeof ApiFleetOperationsRoute
+  ApiFleetStatusRoute: typeof ApiFleetStatusRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
   ApiHermesConfigRoute: typeof ApiHermesConfigRoute
   ApiHermesJobsRoute: typeof ApiHermesJobsRouteWithChildren
@@ -1201,6 +1331,41 @@ declare module '@tanstack/react-router' {
       path: '/jobs'
       fullPath: '/jobs'
       preLoaderRoute: typeof JobsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet-operations': {
+      id: '/fleet-operations'
+      path: '/fleet-operations'
+      fullPath: '/fleet-operations'
+      preLoaderRoute: typeof FleetOperationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet-node': {
+      id: '/fleet-node'
+      path: '/fleet-node'
+      fullPath: '/fleet-node'
+      preLoaderRoute: typeof FleetNodeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet-cron-detail': {
+      id: '/fleet-cron-detail'
+      path: '/fleet-cron-detail'
+      fullPath: '/fleet-cron-detail'
+      preLoaderRoute: typeof FleetCronDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet-cron': {
+      id: '/fleet-cron'
+      path: '/fleet-cron'
+      fullPath: '/fleet-cron'
+      preLoaderRoute: typeof FleetCronRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet': {
+      id: '/fleet'
+      path: '/fleet'
+      fullPath: '/fleet'
+      preLoaderRoute: typeof FleetRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/files': {
@@ -1453,6 +1618,41 @@ declare module '@tanstack/react-router' {
       path: '/api/gateway-status'
       fullPath: '/api/gateway-status'
       preLoaderRoute: typeof ApiGatewayStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fleet-status': {
+      id: '/api/fleet-status'
+      path: '/api/fleet-status'
+      fullPath: '/api/fleet-status'
+      preLoaderRoute: typeof ApiFleetStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fleet-operations': {
+      id: '/api/fleet-operations'
+      path: '/api/fleet-operations'
+      fullPath: '/api/fleet-operations'
+      preLoaderRoute: typeof ApiFleetOperationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fleet-node-detail': {
+      id: '/api/fleet-node-detail'
+      path: '/api/fleet-node-detail'
+      fullPath: '/api/fleet-node-detail'
+      preLoaderRoute: typeof ApiFleetNodeDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fleet-cron-detail': {
+      id: '/api/fleet-cron-detail'
+      path: '/api/fleet-cron-detail'
+      fullPath: '/api/fleet-cron-detail'
+      preLoaderRoute: typeof ApiFleetCronDetailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fleet-cron': {
+      id: '/api/fleet-cron'
+      path: '/api/fleet-cron'
+      fullPath: '/api/fleet-cron'
+      preLoaderRoute: typeof ApiFleetCronRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/files': {
@@ -1857,6 +2057,11 @@ const rootRouteChildren: RootRouteChildren = {
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
   FilesRoute: FilesRoute,
+  FleetRoute: FleetRoute,
+  FleetCronRoute: FleetCronRoute,
+  FleetCronDetailRoute: FleetCronDetailRoute,
+  FleetNodeRoute: FleetNodeRoute,
+  FleetOperationsRoute: FleetOperationsRoute,
   JobsRoute: JobsRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
@@ -1876,6 +2081,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewStatusRoute: ApiCrewStatusRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
+  ApiFleetCronRoute: ApiFleetCronRoute,
+  ApiFleetCronDetailRoute: ApiFleetCronDetailRoute,
+  ApiFleetNodeDetailRoute: ApiFleetNodeDetailRoute,
+  ApiFleetOperationsRoute: ApiFleetOperationsRoute,
+  ApiFleetStatusRoute: ApiFleetStatusRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
   ApiHermesConfigRoute: ApiHermesConfigRoute,
   ApiHermesJobsRoute: ApiHermesJobsRouteWithChildren,

--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -4,12 +4,14 @@ import { getRootSurfaceState } from './-root-layout-state'
 describe('root layout surface state', () => {
   it('shows fullscreen onboarding until onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -18,9 +20,46 @@ describe('root layout surface state', () => {
 
   it('shows workspace shell and post-onboarding overlays after completion', () => {
     expect(getRootSurfaceState(true)).toEqual({
+      showLogin: false,
       showOnboarding: false,
       showWorkspaceShell: true,
       showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('shows login when auth is required and not authenticated, regardless of onboarding state', () => {
+    const unauthed = { authRequired: true, authenticated: false }
+    const expected = {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+
+    expect(getRootSurfaceState(false, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(null, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(true, unauthed)).toEqual(expected)
+  })
+
+  it('does not gate on auth when auth is not required', () => {
+    expect(
+      getRootSurfaceState(true, { authRequired: false, authenticated: false }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
+      showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('does not gate on auth when authenticated', () => {
+    expect(
+      getRootSurfaceState(false, { authRequired: true, authenticated: true }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: true,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
     })
   })
 })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -1,14 +1,31 @@
 export type RootSurfaceState = {
+  showLogin: boolean
   showOnboarding: boolean
   showWorkspaceShell: boolean
   showPostOnboardingOverlays: boolean
 }
 
+export type RootAuthStatus = {
+  authRequired: boolean
+  authenticated: boolean
+}
+
 export function getRootSurfaceState(
   onboardingComplete: boolean | null,
+  authStatus: RootAuthStatus | null = null,
 ): RootSurfaceState {
+  if (authStatus?.authRequired && !authStatus.authenticated) {
+    return {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+  }
+
   if (onboardingComplete !== true) {
     return {
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -16,6 +33,7 @@ export function getRootSurfaceState(
   }
 
   return {
+    showLogin: false,
     showOnboarding: false,
     showWorkspaceShell: true,
     showPostOnboardingOverlays: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import {
   ONBOARDING_KEY,
 } from '@/components/onboarding/hermes-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { LoginScreen } from '@/components/auth/login-screen'
+import { fetchHermesAuthStatus, type AuthStatus } from '@/lib/hermes-auth'
 import { getRootSurfaceState } from './-root-layout-state'
 
 
@@ -249,6 +251,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
   useApplyChatWidth()
 
   useEffect(() => {
@@ -297,11 +300,29 @@ function RootLayout() {
     }
   }, [])
 
-  const rootSurfaceState = getRootSurfaceState(onboardingComplete)
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    let cancelled = false
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (!cancelled) setAuthStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ authenticated: true, authRequired: false })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />
+      {rootSurfaceState.showLogin ? <LoginScreen /> : null}
       {rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>

--- a/src/routes/api/fleet-cron-detail.ts
+++ b/src/routes/api/fleet-cron-detail.ts
@@ -1,0 +1,38 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { collectFleetCronDetail } from '../../server/fleet'
+
+export const Route = createFileRoute('/api/fleet-cron-detail')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const nodeId = url.searchParams.get('nodeId')
+        const jobId = url.searchParams.get('jobId')
+
+        if (!nodeId || !jobId) {
+          return json({ error: 'Missing nodeId or jobId' }, { status: 400 })
+        }
+
+        try {
+          const detail = await collectFleetCronDetail(nodeId, jobId)
+          if (!detail) return json({ error: 'Cron job not found' }, { status: 404 })
+          return json(detail)
+        } catch (error) {
+          return json(
+            {
+              error: error instanceof Error ? error.message : 'Cron detail collection failed',
+              generatedAt: new Date().toISOString(),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/fleet-cron.ts
+++ b/src/routes/api/fleet-cron.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { collectFleetCronDashboard } from '../../server/fleet'
+
+export const Route = createFileRoute('/api/fleet-cron')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          return json(await collectFleetCronDashboard())
+        } catch (error) {
+          return json(
+            {
+              error: error instanceof Error ? error.message : 'Failed to collect fleet cron jobs',
+              generatedAt: new Date().toISOString(),
+              summary: { total: 0, active: 0, paused: 0, failedRecent: 0 },
+              jobs: [],
+            },
+            { status: 200 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/fleet-node-detail.ts
+++ b/src/routes/api/fleet-node-detail.ts
@@ -1,0 +1,39 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { collectFleetNodeDetail } from '../../server/fleet'
+
+export const Route = createFileRoute('/api/fleet-node-detail')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const nodeId = url.searchParams.get('nodeId')
+        const lines = Number(url.searchParams.get('lines') || '160')
+        if (!nodeId) {
+          return json({ error: 'Missing nodeId' }, { status: 400 })
+        }
+
+        try {
+          const detail = await collectFleetNodeDetail(nodeId, Number.isFinite(lines) ? lines : 160)
+          if (!detail) {
+            return json({ error: 'Fleet node not found' }, { status: 404 })
+          }
+          return json(detail)
+        } catch (error) {
+          return json(
+            {
+              error: error instanceof Error ? error.message : 'Failed to collect fleet node detail',
+              generatedAt: new Date().toISOString(),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/fleet-operations.ts
+++ b/src/routes/api/fleet-operations.ts
@@ -1,0 +1,33 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { executeFleetOperation, planFleetOperation, readFleetOperations } from '../../server/fleet-operations'
+
+export const Route = createFileRoute('/api/fleet-operations')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const url = new URL(request.url)
+        const limit = Number(url.searchParams.get('limit') || '100')
+        return json({ generatedAt: new Date().toISOString(), records: await readFleetOperations(limit) })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          const body = await request.json()
+          const mode = body?.mode === 'plan' ? 'plan' : 'execute'
+          const result = mode === 'plan' ? await planFleetOperation(body) : await executeFleetOperation(body)
+          const status = result.record.status === 'rejected' ? 400 : 200
+          return json(result, { status })
+        } catch (error) {
+          return json({ error: error instanceof Error ? error.message : 'Operation failed', generatedAt: new Date().toISOString() }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/fleet-status.ts
+++ b/src/routes/api/fleet-status.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { collectFleetStatus } from '../../server/fleet'
+
+export const Route = createFileRoute('/api/fleet-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          return json(await collectFleetStatus())
+        } catch (error) {
+          return json(
+            {
+              error: error instanceof Error ? error.message : 'Failed to collect fleet status',
+              generatedAt: new Date().toISOString(),
+              summary: { total: 0, healthy: 0, degraded: 0, offline: 0, unknown: 0 },
+              nodes: [],
+            },
+            { status: 200 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -1,6 +1,9 @@
 /**
- * Jobs API proxy — forwards individual job operations to Hermes FastAPI
- * or the upstream dashboard cron API.
+ * Per-job Hermes Workspace jobs proxy.
+ *
+ * Issue #162: use the same Hermes Agent profile resolution as the main jobs
+ * list route so reads, updates, triggers, and deletes all hit the same
+ * profile-scoped cron state.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -11,6 +14,10 @@ import {
   dashboardFetch,
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -39,11 +46,13 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
 
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardPath = action
-            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const res = await dashboardFetch(dashboardPath)
           return new Response(await res.text(), {
             status: res.status,
@@ -52,8 +61,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${url.search}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
@@ -72,12 +81,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
         const body = await request.text()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardAction = action === 'run' ? 'trigger' : action
           const dashboardPath = dashboardAction
-            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const method = dashboardAction ? 'POST' : 'PUT'
           const res = await dashboardFetch(dashboardPath, {
             method,
@@ -91,8 +102,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -112,14 +123,17 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ updates: body ? JSON.parse(body) : {} }),
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,
@@ -138,11 +152,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
               headers: authHeaders(),
             })

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -1,5 +1,9 @@
 /**
- * Jobs API proxy — forwards to Hermes FastAPI /api/jobs
+ * Jobs API proxy for Hermes Workspace.
+ *
+ * Issue #162: resolve the jobs profile in one place, then forward it to the
+ * Hermes dashboard / FastAPI jobs endpoints so the screen reflects the active
+ * Hermes Agent profile instead of silently drifting to another profile.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -9,9 +13,12 @@ import {
   HERMES_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
-  getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -62,11 +69,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 200, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
         const url = new URL(request.url)
-        const params = url.searchParams.toString()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs${params ? `?${params}` : ''}`)
-          : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
+          ? await dashboardFetch(`/api/cron/jobs${search}`)
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               headers: authHeaders(),
             })
         return jobsResponse(res)
@@ -88,14 +97,18 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch('/api/cron/jobs', {
+          ? await dashboardFetch(`/api/cron/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body,
             })
-          : await fetch(`${HERMES_API}/api/jobs`, {
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -17,6 +17,31 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
     handlers: {
@@ -44,10 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -48,13 +48,9 @@ export const Route = createFileRoute('/api/history')({
             })
           }
           // "main" doesn't exist in Hermes — resolve it to the user's real
-          // main chat session. We prefer (in order):
-          //   1. The most recent session with a real human-set title
-          //      (label !== id, e.g. "hows everything"). This is what users
-          //      actually mean by "main".
-          //   2. The most recent non-internal session with messages.
-          // Cron + Operations per-agent sessions are skipped so the
-          // orchestrator chat doesn't latch onto runtime junk.
+          // active chat session. Prefer the most recently active non-internal
+          // session with messages, and only fall back to a titled session when
+          // there is no better active candidate.
           if (sessionKey === 'main') {
             try {
               const sessions = await listSessions(30, 0)
@@ -66,18 +62,18 @@ export const Route = createFileRoute('/api/history')({
                 const t = (s.title ?? '').trim()
                 return t.length > 0 && t !== s.id
               }
-              const titled = sessions.find(
-                (s) => !isInternalKey(s.id) && hasRealTitle(s),
+              const active = sessions.find(
+                (s) =>
+                  !isInternalKey(s.id) &&
+                  typeof s.message_count === 'number' &&
+                  s.message_count > 0,
               )
-              const fallback = titled
+              const titled = active
                 ? null
                 : sessions.find(
-                    (s) =>
-                      !isInternalKey(s.id) &&
-                      typeof s.message_count === 'number' &&
-                      s.message_count > 0,
+                    (s) => !isInternalKey(s.id) && hasRealTitle(s),
                   )
-              const candidate = titled ?? fallback
+              const candidate = active ?? titled
               if (candidate) {
                 sessionKey = candidate.id
               } else {

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -544,10 +544,10 @@ export const Route = createFileRoute('/api/send-stream')({
               }
 
               if (SESSION_BOOTSTRAP_KEYS.has(sessionKey)) {
-                // 'main' should land in the user's existing main chat,
-                // not spin up a brand new session every time. Skip cron
-                // and Operations per-agent sessions so the orchestrator
-                // chat doesn't latch onto them.
+                // 'main' should land in the user's real active chat session,
+                // not an older titled thread. Skip cron and Operations sessions,
+                // prefer the most recently active session with messages, and
+                // only fall back to a titled session when nothing active exists.
                 let reused: string | null = null
                 if (sessionKey === 'main') {
                   try {
@@ -563,18 +563,18 @@ export const Route = createFileRoute('/api/send-stream')({
                       const t = (s.title ?? '').trim()
                       return t.length > 0 && t !== s.id
                     }
-                    const titled = recent.find(
-                      (s) => !isInternal(s.id) && hasRealTitle(s),
+                    const active = recent.find(
+                      (s) =>
+                        !isInternal(s.id) &&
+                        typeof s.message_count === 'number' &&
+                        s.message_count > 0,
                     )
-                    const fallback = titled
+                    const titled = active
                       ? null
                       : recent.find(
-                          (s) =>
-                            !isInternal(s.id) &&
-                            typeof s.message_count === 'number' &&
-                            s.message_count > 0,
+                          (s) => !isInternal(s.id) && hasRealTitle(s),
                         )
-                    const candidate = titled ?? fallback
+                    const candidate = active ?? titled
                     if (candidate) reused = candidate.id
                   } catch {
                     // fall through to createSession()

--- a/src/routes/api/terminal-input.ts
+++ b/src/routes/api/terminal-input.ts
@@ -12,7 +12,6 @@ export const Route = createFileRoute('/api/terminal-input')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        // Auth check
         if (!isAuthenticated(request)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'Unauthorized' }),
@@ -23,10 +22,6 @@ export const Route = createFileRoute('/api/terminal-input')({
         if (csrfCheck) return csrfCheck
 
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal:${ip}`, 10, 60_000)) {
-          return rateLimitResponse()
-        }
-
         const body = (await request.json().catch(() => ({}))) as Record<
           string,
           unknown
@@ -34,6 +29,14 @@ export const Route = createFileRoute('/api/terminal-input')({
         const sessionId =
           typeof body.sessionId === 'string' ? body.sessionId : ''
         const data = typeof body.data === 'string' ? body.data : ''
+
+        const rateKey = sessionId
+          ? `terminal:${ip}:${sessionId}`
+          : `terminal:${ip}`
+        if (!rateLimit(rateKey, 600, 60_000)) {
+          return rateLimitResponse()
+        }
+
         const session = getTerminalSession(sessionId)
         if (!session) {
           return new Response(JSON.stringify({ ok: false }), {

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,10 +40,13 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return new Response(
+            JSON.stringify({ ok: false, missing: true, sessionId }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
         }
         session.resize(cols, rows)
         return new Response(JSON.stringify({ ok: true }), {

--- a/src/routes/fleet-cron-detail.tsx
+++ b/src/routes/fleet-cron-detail.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { FleetCronDetailScreen } from '@/screens/fleet/fleet-cron-detail-screen'
+
+export const Route = createFileRoute('/fleet-cron-detail')({
+  component: FleetCronDetailRoute,
+})
+
+function FleetCronDetailRoute() {
+  usePageTitle('Cron Detail')
+  return <FleetCronDetailScreen />
+}

--- a/src/routes/fleet-cron.tsx
+++ b/src/routes/fleet-cron.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { FleetCronScreen } from '@/screens/fleet/fleet-cron-screen'
+
+export const Route = createFileRoute('/fleet-cron')({
+  component: FleetCronRoute,
+})
+
+function FleetCronRoute() {
+  usePageTitle('Cron Control')
+  return <FleetCronScreen />
+}

--- a/src/routes/fleet-node.tsx
+++ b/src/routes/fleet-node.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { FleetNodeScreen } from '@/screens/fleet/fleet-node-screen'
+
+export const Route = createFileRoute('/fleet-node')({
+  component: FleetNodeRoute,
+})
+
+function FleetNodeRoute() {
+  usePageTitle('Fleet Node')
+  return <FleetNodeScreen />
+}

--- a/src/routes/fleet-operations.tsx
+++ b/src/routes/fleet-operations.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { FleetOperationsScreen } from '@/screens/fleet/fleet-operations-screen'
+
+export const Route = createFileRoute('/fleet-operations')({
+  component: FleetOperationsRoute,
+})
+
+function FleetOperationsRoute() {
+  usePageTitle('Fleet Operations')
+  return <FleetOperationsScreen />
+}

--- a/src/routes/fleet.tsx
+++ b/src/routes/fleet.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { FleetScreen } from '@/screens/fleet/fleet-screen'
+
+export const Route = createFileRoute('/fleet')({
+  component: FleetRoute,
+})
+
+function FleetRoute() {
+  usePageTitle('Fleet')
+  return <FleetScreen />
+}

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -788,6 +788,18 @@ function ChatDisplaySection() {
           />
         </SettingsRow>
         <SettingsRow
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={chatSettings.use24HourTime}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ use24HourTime: checked })
+            }
+            aria-label="Use 24-hour time"
+          />
+        </SettingsRow>
+        <SettingsRow
           label="Enter key behavior"
           description={
             chatSettings.enterBehavior === 'newline'

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -575,7 +575,12 @@ export function buildDisplayEntries(
       return
     }
 
-    if (message.role === 'tool' || message.role === 'toolResult') {
+    if (
+      message.role === 'tool' ||
+      message.role === 'toolResult' ||
+      message.role === 'toolresult' ||
+      message.role === 'tool_result'
+    ) {
       const previousEntry = entries[entries.length - 1]
       if (previousEntry?.message.role === 'assistant') {
         previousEntry.attachedToolMessages.push(message)
@@ -1041,7 +1046,12 @@ function ChatMessageListComponent({
   const toolResultsByCallId = useMemo(() => {
     const map = new Map<string, ChatMessage>()
     for (const message of messages) {
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = message.toolCallId
       if (typeof toolCallId === 'string' && toolCallId.trim().length > 0) {
         map.set(toolCallId, message)
@@ -1087,7 +1097,12 @@ function ChatMessageListComponent({
         count += 1
       }
 
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = (message.toolCallId || '').trim()
       if (toolCallId.length > 0 && seenToolCallIds.has(toolCallId)) continue
       if (toolCallId.length > 0) {

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -13,19 +13,17 @@ import {
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
   PuzzleIcon,
 
   Rocket01Icon,
   Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
-import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,8 +31,9 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
+import { t } from '@/lib/i18n'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
   TooltipContent,
@@ -115,7 +114,9 @@ type ChatSidebarProps = {
   creatingSession: boolean
   onCreateSession: () => void
   isCollapsed: boolean
+  isPinned: boolean
   onToggleCollapse: () => void
+  onTogglePinned: () => void
   onSelectSession?: () => void
   onActiveSessionDelete?: () => void
   sessionsLoading: boolean
@@ -124,15 +125,11 @@ type ChatSidebarProps = {
   onRetrySessions: () => void
 }
 
-
-
 // ── Reusable nav item ───────────────────────────────────────────────────
 
 type NavItemDef = {
   kind: 'link' | 'button'
   to?: string
-  search?: Record<string, unknown>
-  hash?: string
   icon: unknown
   label: string
   active: boolean
@@ -152,7 +149,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -229,9 +226,7 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to!}
-                  search={item.search}
-                  hash={item.hash}
+                  to={item.to}
                   onClick={handleSelect}
                   className={cls}
                   data-tour={item.dataTour}
@@ -247,9 +242,7 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to!}
-        search={item.search}
-        hash={item.hash}
+        to={item.to}
         onClick={handleSelect}
         className={cls}
         data-tour={item.dataTour}
@@ -496,7 +489,9 @@ function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
   isCollapsed,
+  isPinned,
   onToggleCollapse,
+  onTogglePinned,
   onSelectSession,
   onActiveSessionDelete,
   sessionsLoading,
@@ -526,8 +521,11 @@ function ChatSidebarComponent({
 
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
-      const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      const detail = (event as CustomEvent<ChatOpenSettingsDetail | undefined>)
+        .detail
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -581,8 +579,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -886,7 +882,7 @@ function ChatSidebarComponent({
                 to="/chat"
                 className={cn(
                   buttonVariants({ variant: 'ghost', size: 'sm' }),
-                  'w-full pl-1.5 justify-start gap-2',
+                  'w-full pl-1.5 pr-20 justify-start gap-2',
                 )}
               >
                 <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
@@ -896,6 +892,36 @@ function ChatSidebarComponent({
           ) : null}
         </AnimatePresence>
         <TooltipProvider>
+          {!isVisuallyCollapsed ? (
+            <TooltipRoot>
+              <TooltipTrigger
+                onClick={onTogglePinned}
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+                    aria-pressed={isPinned}
+                    className={cn(
+                      'absolute right-9 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100',
+                      isPinned &&
+                        'bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] opacity-100',
+                    )}
+                    data-tour="sidebar-pin-toggle"
+                  >
+                    <HugeiconsIcon
+                      icon={isPinned ? PinOffIcon : PinIcon}
+                      size={18}
+                      strokeWidth={1.75}
+                    />
+                  </Button>
+                }
+              />
+              <TooltipContent side="right">
+                {isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+              </TooltipContent>
+            </TooltipRoot>
+          ) : null}
           <TooltipRoot>
             <TooltipTrigger
               onClick={handleSidebarToggle}
@@ -1202,6 +1228,7 @@ function areSidebarPropsEqual(
   if (prevProps.activeFriendlyId !== nextProps.activeFriendlyId) return false
   if (prevProps.creatingSession !== nextProps.creatingSession) return false
   if (prevProps.isCollapsed !== nextProps.isCollapsed) return false
+  if (prevProps.isPinned !== nextProps.isPinned) return false
   if (prevProps.sessionsLoading !== nextProps.sessionsLoading) return false
   if (prevProps.sessionsFetching !== nextProps.sessionsFetching) return false
   if (prevProps.sessionsError !== nextProps.sessionsError) return false

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -561,7 +561,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
-  const mainRoutes = ['/chat', '/new', '/files', '/terminal']
+  const mainRoutes = ['/chat', '/new', '/files', '/terminal', '/fleet', '/tasks', '/conductor', '/operations']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
 
@@ -753,6 +753,7 @@ function ChatSidebarComponent({
   }
 
   const isDashboardActive = pathname === '/dashboard'
+  const isFleetActive = pathname === '/fleet'
 
   const mainItems: Array<NavItemDef> = [
     {
@@ -761,6 +762,13 @@ function ChatSidebarComponent({
       icon: DashboardSquare01Icon,
       label: t('nav.dashboard'),
       active: isDashboardActive,
+    },
+    {
+      kind: 'link',
+      to: '/fleet',
+      icon: DashboardSquare01Icon,
+      label: 'Fleet',
+      active: isFleetActive,
     },
     {
       kind: 'link',

--- a/src/screens/chat/components/message-item.test.ts
+++ b/src/screens/chat/components/message-item.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildInlineToolRenderPlan } from './message-item'
+import { buildInlineToolRenderPlan, compactInlineToolRenderPlan } from './message-item'
 import type { ChatMessage } from '../types'
 
 describe('buildInlineToolRenderPlan', () => {
@@ -43,6 +43,105 @@ describe('buildInlineToolRenderPlan', () => {
         },
       },
       { kind: 'text', text: 'After tool.' },
+    ])
+  })
+})
+
+describe('compactInlineToolRenderPlan', () => {
+  it('stacks consecutive tool calls without moving surrounding text', () => {
+    const plan = compactInlineToolRenderPlan([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+
+    expect(plan).toEqual([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+  })
+
+  it('keeps separate stacks when text appears between tool calls', () => {
+    const plan = compactInlineToolRenderPlan([
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+    ])
+
+    expect(plan).toEqual([
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
     ])
   })
 })

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -232,15 +232,40 @@ export function compactInlineToolRenderPlan(
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
   if (!msg) return ''
-  // Prefer text from content blocks (exec stdout, Read output, etc.)
+  // Prefer text from structured content blocks first.
   if (Array.isArray(msg.content)) {
     const text = msg.content
-      .filter((b: any) => b?.type === 'text' && b?.text)
-      .map((b: any) => b.text as string)
+      .flatMap((block: any) => {
+        if (!block || typeof block !== 'object') return []
+        if (block.type === 'text' && typeof block.text === 'string') {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          typeof block.text === 'string'
+        ) {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          Array.isArray(block.content)
+        ) {
+          return block.content
+            .filter((part: any) => part?.type === 'text' && part?.text)
+            .map((part: any) => String(part.text))
+        }
+        return []
+      })
       .join('\n')
     if (text.trim()) return text
   }
-  // Fallback to details serialized
+  // Fallback to top-level text/body/message fields.
+  const raw = msg as Record<string, unknown>
+  for (const key of ['text', 'body', 'message']) {
+    const value = raw[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  // Then structured details.
   if (msg.details && typeof msg.details === 'object') {
     return JSON.stringify(msg.details, null, 2)
   }

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -158,6 +158,10 @@ export type InlineRenderPlanItem =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; section: InlineToolSection }
 
+export type CompactInlineRenderPlanItem =
+  | { kind: 'text'; text: string }
+  | { kind: 'tools'; sections: Array<InlineToolSection> }
+
 export function buildInlineToolRenderPlan(
   message: ChatMessage,
   toolSections: Array<InlineToolSection>,
@@ -198,6 +202,32 @@ export function buildInlineToolRenderPlan(
   }
 
   return plan
+}
+
+export function compactInlineToolRenderPlan(
+  plan: Array<InlineRenderPlanItem>,
+): Array<CompactInlineRenderPlanItem> {
+  const compactPlan: Array<CompactInlineRenderPlanItem> = []
+  let pendingToolSections: Array<InlineToolSection> = []
+
+  const flushTools = () => {
+    if (pendingToolSections.length === 0) return
+    compactPlan.push({ kind: 'tools', sections: pendingToolSections })
+    pendingToolSections = []
+  }
+
+  for (const item of plan) {
+    if (item.kind === 'tool') {
+      pendingToolSections.push(item.section)
+      continue
+    }
+
+    flushTools()
+    compactPlan.push(item)
+  }
+
+  flushTools()
+  return compactPlan
 }
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
@@ -1404,8 +1434,6 @@ function InlineToolSectionItem({
   const hasInputData =
     toolSection.input && Object.keys(toolSection.input).length > 0
   const hasOutputData = !!(toolSection.outputText || toolSection.errorText)
-  // Always expandable — show args, output, or at minimum the tool name/state
-  const hasExpandableContent = true
 
   return (
     <div>
@@ -1452,11 +1480,9 @@ function InlineToolSectionItem({
           {isRunning && (
             <span className="size-1.5 rounded-full animate-pulse bg-indigo-500" />
           )}
-          {hasExpandableContent && (
-            <span className="text-[8px] opacity-30 ml-0.5">
-              {open ? '▾' : '▸'}
-            </span>
-          )}
+          <span className="text-[8px] opacity-30 ml-0.5">
+            {open ? '▾' : '▸'}
+          </span>
         </div>
         {isRunning && (
           <div className="px-2.5 pb-1.5 text-[10px] text-primary-400">
@@ -1577,11 +1603,78 @@ function InlineToolSectionItem({
 function ToolCallGroup({
   toolSections,
   expandAll,
+  isStreaming,
 }: {
   toolSections: Array<InlineToolSection>
   expandAll?: boolean
   isStreaming?: boolean
 }) {
+  const [open, setOpen] = useState(Boolean(expandAll))
+  useEffect(() => {
+    if (expandAll) setOpen(true)
+  }, [expandAll])
+
+  if (toolSections.length > 1) {
+    const runningCount = toolSections.filter((section) => section.state === 'input-available' || section.state === 'input-streaming').length
+    const errorCount = toolSections.filter((section) => section.state === 'output-error').length
+    const doneCount = toolSections.length - runningCount - errorCount
+    const labels = Array.from(new Set(toolSections.map((section) => formatToolDisplayLabel(section.type, section.input))))
+    const visibleLabels = labels.slice(0, 3).join(', ')
+    const overflowLabel = labels.length > 3 ? ` +${labels.length - 3} more` : ''
+    const statusLabel =
+      runningCount > 0
+        ? `${runningCount} running`
+        : errorCount > 0
+          ? `${errorCount} failed`
+          : `${doneCount} done`
+
+    return (
+      <div className="my-3 w-full max-w-[min(100%,700px)] border-l-2 border-primary-200/60 pl-3">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-primary-600 hover:bg-primary-50/70"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="font-mono font-semibold text-ink">Tool activity</span>
+          <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] tabular-nums text-primary-600">
+            {toolSections.length} calls
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] opacity-60">
+            {visibleLabels}
+            {overflowLabel}
+          </span>
+          <span
+            className={cn(
+              'shrink-0 text-[10px] tabular-nums',
+              errorCount > 0
+                ? 'text-red-500'
+                : runningCount > 0 || isStreaming
+                  ? 'text-indigo-500'
+                  : 'text-green-600',
+            )}
+          >
+            {statusLabel}
+          </span>
+          <span className="shrink-0 text-[9px] opacity-40">
+            {open ? '▾' : '▸'}
+          </span>
+        </button>
+        {open && (
+          <div className="mt-2 flex flex-col gap-2.5">
+            {toolSections.map((toolSection, index) => (
+              <InlineToolSectionItem
+                key={toolSection.key || `${toolSection.type}-${index}`}
+                toolSection={toolSection}
+                index={index}
+                forceOpen={expandAll}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2.5 my-3 w-full max-w-[min(100%,700px)]">
       {toolSections.map((toolSection, index) => (
@@ -1694,8 +1787,8 @@ function MessageItemComponent({
   }, [])
 
   // Simulate streaming is only active while words are still being revealed
-  const totalWords = countWords(displayText)
-  const revealComplete = revealedWordCount >= totalWords && totalWords > 0
+  const displayWordCount = countWords(displayText)
+  const revealComplete = revealedWordCount >= displayWordCount && displayWordCount > 0
   const effectiveIsStreaming =
     remoteStreamingActive || (_simulateStreaming && !revealComplete)
   const assistantDisplayText = effectiveIsStreaming ? revealedText : displayText
@@ -1705,7 +1798,7 @@ function MessageItemComponent({
   )
 
   useEffect(() => {
-    const totalWords = countWords(displayText)
+    const nextTotalWords = countWords(displayText)
     const previousText = previousTextRef.current
     const previousLength = previousTextLengthRef.current
     const textGrew =
@@ -1713,7 +1806,7 @@ function MessageItemComponent({
       displayText.startsWith(previousText)
     const textChanged = displayText !== previousText
 
-    targetWordCountRef.current = totalWords
+    targetWordCountRef.current = nextTotalWords
     previousTextRef.current = displayText
     previousTextLengthRef.current = displayText.length
 
@@ -1722,12 +1815,12 @@ function MessageItemComponent({
         window.clearInterval(revealTimerRef.current)
         revealTimerRef.current = null
       }
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
     if (textChanged && !textGrew) {
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
@@ -1736,25 +1829,25 @@ function MessageItemComponent({
     }
 
     // Don't start animation if already fully revealed
-    setRevealedWordCount((currentWordCount) => {
-      if (currentWordCount >= totalWords) {
-        return currentWordCount
+    setRevealedWordCount((wordCount) => {
+      if (wordCount >= nextTotalWords) {
+        return wordCount
       }
 
       function tick() {
-        setRevealedWordCount((currentWordCount) => {
+        setRevealedWordCount((visibleWordCount) => {
           const targetWordCount = targetWordCountRef.current
-          if (currentWordCount >= targetWordCount) {
+          if (visibleWordCount >= targetWordCount) {
             if (revealTimerRef.current !== null) {
               window.clearInterval(revealTimerRef.current)
               revealTimerRef.current = null
             }
-            return currentWordCount
+            return visibleWordCount
           }
 
           const nextWordCount = Math.min(
             targetWordCount,
-            currentWordCount + WORDS_PER_TICK,
+            visibleWordCount + WORDS_PER_TICK,
           )
 
           if (
@@ -1770,7 +1863,7 @@ function MessageItemComponent({
       }
 
       revealTimerRef.current = window.setInterval(tick, TICK_INTERVAL_MS)
-      return currentWordCount
+      return wordCount
     })
   }, [displayText, effectiveIsStreaming])
 
@@ -1996,6 +2089,10 @@ function MessageItemComponent({
   const inlineRenderPlan = useMemo(
     () => buildInlineToolRenderPlan(message, finalToolSections),
     [message, finalToolSections],
+  )
+  const compactInlineRenderPlan = useMemo(
+    () => compactInlineToolRenderPlan(inlineRenderPlan),
+    [inlineRenderPlan],
   )
   const hasToolCalls = finalToolSections.length > 0
   const shouldRenderMessageBubble =
@@ -2322,11 +2419,11 @@ function MessageItemComponent({
             )}
             {!isUser && hasToolCalls && (
               <div className="flex flex-col gap-2">
-                {inlineRenderPlan.map((item, index) =>
-                  item.kind === 'tool' ? (
+                {compactInlineRenderPlan.map((item, index) =>
+                  item.kind === 'tools' ? (
                     <ToolCallGroup
-                      key={item.section.key || `tool-${index}`}
-                      toolSections={[item.section]}
+                      key={item.sections.map((section) => section.key).join(':') || `tools-${index}`}
+                      toolSections={item.sections}
                       expandAll={expandAllToolSections}
                       isStreaming={effectiveIsStreaming}
                     />
@@ -2341,11 +2438,6 @@ function MessageItemComponent({
                             'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                             effectiveIsStreaming && 'chat-streaming-content',
                           )}
-                          style={
-                            isUser
-                              ? { color: 'var(--chat-user-foreground)' }
-                              : undefined
-                          }
                         >
                           {item.text}
                         </MessageContent>
@@ -2370,11 +2462,6 @@ function MessageItemComponent({
                         'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                         effectiveIsStreaming && 'chat-streaming-content',
                       )}
-                      style={
-                        isUser
-                          ? { color: 'var(--chat-user-foreground)' }
-                          : undefined
-                      }
                     >
                       {assistantDisplayText}
                     </MessageContent>

--- a/src/screens/chat/components/message-timestamp.tsx
+++ b/src/screens/chat/components/message-timestamp.tsx
@@ -1,3 +1,5 @@
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
+
 type MessageTimestampProps = {
   timestamp: number
 }
@@ -10,14 +12,14 @@ function isSameDay(a: Date, b: Date): boolean {
   )
 }
 
-function formatShort(timestamp: number): string {
+function formatShort(timestamp: number, use24HourTime: boolean): string {
   const date = new Date(timestamp)
   const now = new Date()
   if (isSameDay(date, now)) {
     return new Intl.DateTimeFormat('en-US', {
       hour: 'numeric',
       minute: '2-digit',
-      hour12: true,
+      hour12: !use24HourTime,
     }).format(date)
   }
 
@@ -27,22 +29,24 @@ function formatShort(timestamp: number): string {
   }).format(date)
 }
 
-function formatFull(timestamp: number): string {
-  const value = new Intl.DateTimeFormat('en-US', {
+function formatFull(timestamp: number, use24HourTime: boolean): string {
+  return new Intl.DateTimeFormat('en-US', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
-    hour12: true,
+    hour12: !use24HourTime,
   }).format(new Date(timestamp))
-  return value
 }
 
 export function MessageTimestamp({ timestamp }: MessageTimestampProps) {
-  const shortLabel = formatShort(timestamp)
-  const fullLabel = formatFull(timestamp)
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+  const shortLabel = formatShort(timestamp, use24HourTime)
+  const fullLabel = formatFull(timestamp, use24HourTime)
 
   return (
     <span

--- a/src/screens/chat/components/sidebar/session-item.tsx
+++ b/src/screens/chat/components/sidebar/session-item.tsx
@@ -18,6 +18,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from '@/components/ui/menu'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type SessionItemProps = {
   session: SessionMeta
@@ -34,21 +35,24 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-function formatSessionTimestamp(timestamp?: number | null): string {
+function formatSessionTimestamp(
+  timestamp: number | undefined | null,
+  use24HourTime: boolean,
+): string {
   if (!timestamp) return ''
   const date = new Date(timestamp)
   const now = new Date()
   const sameDay = date.toDateString() === now.toDateString()
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: !use24HourTime,
+  })
   return (sameDay ? timeFormatter : dayFormatter).format(date)
 }
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isUuidLike(value: string): boolean {
   return UUID_PATTERN.test(value.trim())
@@ -102,6 +106,9 @@ function SessionItemComponent({
   onRename,
   onDelete,
 }: SessionItemProps) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
   const isGenerating = session.titleStatus === 'generating'
   const isError = session.titleStatus === 'error'
   const baseTitle = getSessionDisplayTitle(session, isGenerating)
@@ -117,11 +124,11 @@ function SessionItemComponent({
       return session.titleError || 'Could not generate a title'
     }
     const parts: Array<string> = []
-    const formatted = formatSessionTimestamp(updatedAt)
+    const formatted = formatSessionTimestamp(updatedAt, use24HourTime)
     if (formatted) parts.push(formatted)
     if (session.friendlyId) parts.push(getFriendlyIdLabel(session.friendlyId))
     return parts.join(' • ')
-  }, [isError, session.friendlyId, session.titleError, updatedAt])
+  }, [isError, session.friendlyId, session.titleError, updatedAt, use24HourTime])
 
   return (
     <Link

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -7,7 +7,7 @@ export type ToolCallContent = {
 }
 
 export type ToolResultContent = {
-  type: 'toolResult'
+  type: 'toolResult' | 'tool_result'
   toolCallId?: string
   toolName?: string
   content?: Array<{ type?: string; text?: string }>
@@ -27,7 +27,11 @@ export type ThinkingContent = {
   thinkingSignature?: string
 }
 
-export type MessageContent = TextContent | ToolCallContent | ThinkingContent
+export type MessageContent =
+  | TextContent
+  | ToolCallContent
+  | ToolResultContent
+  | ThinkingContent
 
 export type ChatAttachment = {
   id?: string

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -144,7 +144,10 @@ export function findToolResultForCall(
   messages: Array<ChatMessage>,
 ): ChatMessage | undefined {
   return messages.find(
-    (msg) => msg.role === 'toolResult' && msg.toolCallId === toolCallId,
+    (msg) =>
+      ['toolResult', 'toolresult', 'tool_result', 'tool'].includes(
+        String(msg.role || ''),
+      ) && msg.toolCallId === toolCallId,
   )
 }
 

--- a/src/screens/fleet/fleet-cron-detail-screen.tsx
+++ b/src/screens/fleet/fleet-cron-detail-screen.tsx
@@ -1,0 +1,137 @@
+import { useQuery } from '@tanstack/react-query'
+import type { FleetCronDetailPayload } from '@/server/fleet'
+import { cn } from '@/lib/utils'
+
+function getSearchParam(name: string) {
+  if (typeof window === 'undefined') return ''
+  return new URLSearchParams(window.location.search).get(name) || ''
+}
+
+async function fetchCronDetail(nodeId: string, jobId: string): Promise<FleetCronDetailPayload> {
+  const params = new URLSearchParams({ nodeId, jobId })
+  const res = await fetch(`/api/fleet-cron-detail?${params.toString()}`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function Badge({ children, tone = 'neutral' }: { children: React.ReactNode; tone?: 'green' | 'amber' | 'red' | 'neutral' }) {
+  const tones = {
+    green: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+    amber: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+    red: 'border-red-500/30 bg-red-500/10 text-red-300',
+    neutral: 'border-neutral-500/30 bg-neutral-500/10 text-neutral-300',
+  }
+  return <span className={cn('rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', tones[tone])}>{children}</span>
+}
+
+function Field({ label, value, mono = false }: { label: string; value?: string | null; mono?: boolean }) {
+  return (
+    <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted">{label}</div>
+      <div className={cn('mt-1 break-words text-sm text-ink', mono && 'font-mono text-xs')}>{value || '—'}</div>
+    </div>
+  )
+}
+
+function CodeBlock({ title, content }: { title: string; content?: string }) {
+  return (
+    <section className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+      <div className="mb-3 text-xs font-semibold uppercase tracking-[0.16em] text-muted">{title}</div>
+      <pre className="max-h-[460px] overflow-auto whitespace-pre-wrap rounded-xl bg-black/30 p-4 text-xs leading-relaxed text-ink">
+        {content || 'No content available.'}
+      </pre>
+    </section>
+  )
+}
+
+export function FleetCronDetailScreen() {
+  const nodeId = getSearchParam('nodeId')
+  const jobId = getSearchParam('jobId')
+  const query = useQuery({
+    queryKey: ['fleet-cron-detail', nodeId, jobId],
+    queryFn: () => fetchCronDetail(nodeId, jobId),
+    enabled: Boolean(nodeId && jobId),
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+  const data = query.data
+  const tone = data?.style.tone === 'systemish' ? 'amber' : data?.style.tone === 'human' ? 'green' : 'neutral'
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-6 py-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <a className="text-sm text-muted hover:text-ink" href="/fleet-cron">← Cron Control</a>
+            <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">Cron detail</div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink">{data?.job.name || 'Cron Job Detail'}</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted">
+              Latest run output, delivery target, prompt, and polish diagnosis. Still read-only. The sharp objects remain locked.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data ? <Badge tone={data.job.lastRunStatus === 'failed' ? 'red' : 'green'}>{data.job.lastRunStatus || data.job.status}</Badge> : null}
+            {data ? <Badge tone={tone}>{data.style.tone}</Badge> : null}
+          </div>
+        </header>
+
+        {query.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Cron detail failed: {query.error instanceof Error ? query.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        {!nodeId || !jobId ? (
+          <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-200">Missing nodeId or jobId.</div>
+        ) : null}
+
+        {query.isLoading ? (
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-muted">Collecting cron detail…</div>
+        ) : null}
+
+        {data ? (
+          <>
+            <section className="grid gap-3 md:grid-cols-4">
+              <Field label="Node" value={`${data.node.name} · ${data.node.status}`} />
+              <Field label="Schedule" value={data.job.schedule || 'manual'} mono />
+              <Field label="Next run" value={data.job.nextRun} />
+              <Field label="Delivery" value={data.job.deliveryTarget} />
+            </section>
+
+            <section className="grid gap-3 md:grid-cols-3">
+              <Field label="Model" value={data.job.model} />
+              <Field label="Provider" value={data.job.provider} />
+              <Field label="Skills" value={data.job.skills.length ? data.job.skills.join(', ') : 'none'} />
+            </section>
+
+            <section className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.16em] text-muted">Delivery polish</div>
+                  <div className="mt-1 text-sm text-ink">Score {data.style.score}</div>
+                </div>
+                <Badge tone={tone}>{data.style.tone}</Badge>
+              </div>
+              <div className="mt-3 text-sm text-muted">
+                {data.style.reasons.length ? data.style.reasons.join(' · ') : 'Looks clean from the latest output.'}
+              </div>
+              <div className="mt-4 rounded-xl bg-[var(--theme-card2)] p-4">
+                <div className="text-xs font-medium text-ink">Suggested human version</div>
+                <p className="mt-2 whitespace-pre-wrap text-sm text-muted">{data.suggestedHumanSummary}</p>
+              </div>
+            </section>
+
+            <CodeBlock title="Job prompt" content={data.job.prompt} />
+            <CodeBlock title={`Latest delivered response${data.latestOutput?.runTime ? ` · ${data.latestOutput.runTime}` : ''}`} content={data.latestOutput?.response} />
+            <CodeBlock title="Raw output artifact, redacted" content={data.latestOutput?.raw} />
+
+            <footer className="text-xs text-muted">
+              Output file: <span className="font-mono text-ink">{data.latestOutput?.path || 'none'}</span>
+              <br />Last refresh: {new Date(data.generatedAt).toLocaleString()}
+            </footer>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/fleet/fleet-cron-screen.tsx
+++ b/src/screens/fleet/fleet-cron-screen.tsx
@@ -1,0 +1,243 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import type { FleetCronDashboardJob, FleetCronDashboardPayload } from '@/server/fleet'
+import type { FleetOperationResponse } from '@/server/fleet-operations'
+import { cn } from '@/lib/utils'
+
+async function fetchFleetCron(): Promise<FleetCronDashboardPayload> {
+  const res = await fetch('/api/fleet-cron')
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function SummaryTile({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted">{label}</div>
+      <div className={cn('mt-2 text-3xl font-semibold tabular-nums', tone)}>{value}</div>
+    </div>
+  )
+}
+
+function toneClass(job: FleetCronDashboardJob) {
+  if (job.lastRunStatus === 'failed') return 'border-red-500/30 bg-red-500/10 text-red-300'
+  if (job.style.tone === 'systemish') return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+  if (job.style.tone === 'human') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  return 'border-neutral-500/30 bg-neutral-500/10 text-neutral-300'
+}
+
+function statusClass(status: string) {
+  if (status === 'active') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  if (status === 'paused') return 'border-neutral-500/30 bg-neutral-500/10 text-neutral-300'
+  return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+}
+
+function JobCard({
+  job,
+  onRunNow,
+  running,
+}: {
+  job: FleetCronDashboardJob
+  onRunNow: (job: FleetCronDashboardJob) => void
+  running: boolean
+}) {
+  const nodeDetailUrl = `/fleet-node?nodeId=${encodeURIComponent(job.nodeId)}`
+  const cronDetailUrl = `/fleet-cron-detail?nodeId=${encodeURIComponent(job.nodeId)}&jobId=${encodeURIComponent(job.id)}`
+  return (
+    <article className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="truncate text-lg font-semibold text-ink">{job.name}</h2>
+            <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', statusClass(job.status))}>{job.status}</span>
+          </div>
+          <div className="mt-1 text-xs text-muted">
+            {job.nodeName} · <span className="font-mono">{job.id}</span>
+          </div>
+        </div>
+        <span className={cn('w-fit rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', toneClass(job))}>
+          {job.lastRunStatus === 'failed' ? 'failed' : job.style.tone}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 text-xs md:grid-cols-3">
+        <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+          <div className="text-muted">Schedule</div>
+          <div className="mt-1 font-mono text-ink">{job.schedule || 'manual'}</div>
+        </div>
+        <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+          <div className="text-muted">Next run</div>
+          <div className="mt-1 truncate text-ink">{job.nextRun || '—'}</div>
+        </div>
+        <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+          <div className="text-muted">Last run</div>
+          <div className="mt-1 truncate text-ink">{job.lastRunStatus || '—'}</div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs font-medium text-ink">Delivery polish</div>
+          <div className="text-xs text-muted">score {job.style.score}</div>
+        </div>
+        <div className="mt-2 text-xs text-muted">
+          {job.style.reasons.length ? job.style.reasons.join(' · ') : 'Looks clean from available metadata.'}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href={cronDetailUrl}>
+          Cron detail
+        </a>
+        <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href={nodeDetailUrl}>
+          Node detail
+        </a>
+        <button
+          className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-100 hover:bg-amber-500/20 disabled:text-muted"
+          disabled={running}
+          onClick={() => onRunNow(job)}
+        >
+          {running ? 'Running…' : 'Run now'}
+        </button>
+        <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href="/fleet-operations">
+          Audit trail
+        </a>
+        <button className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-muted" disabled>
+          Pause/resume soon
+        </button>
+      </div>
+    </article>
+  )
+}
+
+export function FleetCronScreen() {
+  const queryClient = useQueryClient()
+  const [pendingRun, setPendingRun] = useState<FleetCronDashboardJob | null>(null)
+  const [operationResult, setOperationResult] = useState<FleetOperationResponse | null>(null)
+  const query = useQuery({
+    queryKey: ['fleet-cron'],
+    queryFn: fetchFleetCron,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+  const runNowMutation = useMutation({
+    mutationFn: async (job: FleetCronDashboardJob) => {
+      const res = await fetch('/api/fleet-operations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operation: 'cron.run_now', nodeId: job.nodeId, jobId: job.id, confirmed: true }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<FleetOperationResponse>
+    },
+    onSuccess: async (result) => {
+      setOperationResult(result)
+      setPendingRun(null)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['fleet-cron'] }),
+        queryClient.invalidateQueries({ queryKey: ['fleet-operations'] }),
+      ])
+    },
+  })
+  const data = query.data
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-6 py-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <a className="text-sm text-muted hover:text-ink" href="/fleet">← Fleet</a>
+            <span className="mx-2 text-muted">·</span>
+            <a className="text-sm text-muted hover:text-ink" href="/fleet-operations">Operations audit</a>
+            <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">Cron control</div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink">Cron Control Center</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted">
+              Schedules, run status, source nodes, delivery polish signals, and confirmation-gated execution with audit records.
+            </p>
+          </div>
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-3 text-xs text-muted">
+            <div>Registry</div>
+            <div className="mt-1 max-w-[360px] truncate font-mono text-ink">{data?.registryPath || '~/.hermes/fleet.yaml'}</div>
+          </div>
+        </header>
+
+        {query.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Cron collection failed: {query.error instanceof Error ? query.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        {runNowMutation.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Run failed: {runNowMutation.error instanceof Error ? runNowMutation.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        {operationResult ? (
+          <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            <div className="font-semibold">Operation recorded: {operationResult.record.status}</div>
+            <pre className="mt-2 whitespace-pre-wrap text-xs">{operationResult.record.resultSummary}</pre>
+            <a className="mt-3 inline-block text-xs underline" href="/fleet-operations">View audit trail</a>
+          </div>
+        ) : null}
+
+        <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <SummaryTile label="Jobs" value={data?.summary.total ?? 0} tone="text-ink" />
+          <SummaryTile label="Active" value={data?.summary.active ?? 0} tone="text-emerald-300" />
+          <SummaryTile label="Paused" value={data?.summary.paused ?? 0} tone="text-neutral-300" />
+          <SummaryTile label="Failed" value={data?.summary.failedRecent ?? 0} tone="text-red-300" />
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-2">
+          {(data?.jobs ?? []).map((job) => (
+            <JobCard
+              key={`${job.nodeId}-${job.id}`}
+              job={job}
+              running={runNowMutation.isPending && pendingRun?.nodeId === job.nodeId && pendingRun?.id === job.id}
+              onRunNow={setPendingRun}
+            />
+          ))}
+          {query.isLoading ? (
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-muted">
+              Collecting cron jobs…
+            </div>
+          ) : null}
+          {data && data.jobs.length === 0 ? (
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-muted">
+              No cron jobs reported by fleet nodes.
+            </div>
+          ) : null}
+        </section>
+
+        <footer className="text-xs text-muted">
+          Last refresh: {data ? new Date(data.generatedAt).toLocaleString() : 'not yet'}
+        </footer>
+        {pendingRun ? (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+            <div className="w-full max-w-lg rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-2xl">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-300">Confirm operation</div>
+              <h2 className="mt-2 text-xl font-semibold text-ink">Run cron now?</h2>
+              <div className="mt-4 grid gap-3 text-sm">
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3"><span className="text-muted">Node</span><br />{pendingRun.nodeName} · <span className="font-mono">{pendingRun.nodeId}</span></div>
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3"><span className="text-muted">Job</span><br />{pendingRun.name} · <span className="font-mono">{pendingRun.id}</span></div>
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3"><span className="text-muted">Side effect</span><br />Triggers this job immediately. If it sends a message, that delivery cannot be unsent.</div>
+              </div>
+              <div className="mt-5 flex justify-end gap-2">
+                <button className="rounded-lg border border-[var(--theme-border)] px-3 py-2 text-xs text-ink" onClick={() => setPendingRun(null)} disabled={runNowMutation.isPending}>
+                  Cancel
+                </button>
+                <button
+                  className="rounded-lg border border-amber-500/40 bg-amber-500/20 px-3 py-2 text-xs text-amber-100 hover:bg-amber-500/30 disabled:text-muted"
+                  disabled={runNowMutation.isPending}
+                  onClick={() => runNowMutation.mutate(pendingRun)}
+                >
+                  {runNowMutation.isPending ? 'Running…' : 'Confirm run'}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/fleet/fleet-node-screen.tsx
+++ b/src/screens/fleet/fleet-node-screen.tsx
@@ -1,0 +1,284 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { FleetNodeDetailPayload, FleetNodeStatus } from '@/server/fleet'
+import type { FleetOperationResponse } from '@/server/fleet-operations'
+import { cn } from '@/lib/utils'
+
+function getNodeIdFromLocation() {
+  if (typeof window === 'undefined') return ''
+  return new URLSearchParams(window.location.search).get('nodeId') || ''
+}
+
+function statusClass(status: FleetNodeStatus['status']) {
+  if (status === 'healthy') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  if (status === 'degraded') return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+  if (status === 'offline') return 'border-red-500/30 bg-red-500/10 text-red-300'
+  return 'border-neutral-500/30 bg-neutral-500/10 text-neutral-300'
+}
+
+async function fetchFleetNodeDetail(nodeId: string): Promise<FleetNodeDetailPayload> {
+  const res = await fetch(`/api/fleet-node-detail?nodeId=${encodeURIComponent(nodeId)}&lines=180`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function Metric({ label, value }: { label: string; value?: string | number | null }) {
+  return (
+    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted">{label}</div>
+      <div className="mt-2 break-words text-sm font-medium text-ink">{value || '—'}</div>
+    </div>
+  )
+}
+
+function CheckRow({ check }: { check: FleetNodeStatus['checks'][number] }) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-xl bg-[var(--theme-card2)] px-3 py-2">
+      <div>
+        <div className="text-sm font-medium text-ink">{check.label}</div>
+        {check.detail ? <div className="mt-1 text-xs text-muted">{check.detail}</div> : null}
+      </div>
+      <span className={cn('mt-1 size-2.5 shrink-0 rounded-full', check.ok ? 'bg-emerald-400' : 'bg-amber-400')} />
+    </div>
+  )
+}
+
+function LogBlock({ log }: { log: FleetNodeDetailPayload['logs'][number] }) {
+  return (
+    <article className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)]">
+      <div className="flex flex-col gap-1 border-b border-[var(--theme-border)] px-4 py-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="text-sm font-semibold text-ink">{log.label}</div>
+          <div className="mt-0.5 font-mono text-[11px] text-muted">{log.source}</div>
+        </div>
+        <span className={cn('w-fit rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', log.ok ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' : 'border-amber-500/30 bg-amber-500/10 text-amber-300')}>
+          {log.ok ? 'readable' : 'not ready'}
+        </span>
+      </div>
+      <pre className="max-h-[440px] overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-muted">
+        {log.content || 'No output.'}
+      </pre>
+    </article>
+  )
+}
+
+export function FleetNodeScreen() {
+  const nodeId = useMemo(getNodeIdFromLocation, [])
+  const queryClient = useQueryClient()
+  const [pendingOp, setPendingOp] = useState<{ operation: string; label: string } | null>(null)
+  const [operationResult, setOperationResult] = useState<FleetOperationResponse | null>(null)
+  const query = useQuery({
+    queryKey: ['fleet-node-detail', nodeId],
+    queryFn: () => fetchFleetNodeDetail(nodeId),
+    enabled: Boolean(nodeId),
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+
+  const opMutation = useMutation({
+    mutationFn: async ({ operation }: { operation: string }) => {
+      const res = await fetch('/api/fleet-operations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operation, nodeId, confirmed: true }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<FleetOperationResponse>
+    },
+    onSuccess: async (result) => {
+      setOperationResult(result)
+      setPendingOp(null)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['fleet-node-detail', nodeId] }),
+        queryClient.invalidateQueries({ queryKey: ['fleet-operations'] }),
+      ])
+    },
+  })
+
+  const detail = query.data
+  const node = detail?.node
+
+  const isHermesNode = node?.kind === 'hermes-local' || node?.kind === 'hermes-container'
+  const opButtons = isHermesNode
+    ? [
+        { key: 'health.check', label: 'Health check', requiresConfirm: false },
+        { key: 'gateway.restart', label: 'Restart gateway', requiresConfirm: true },
+        { key: 'agent.update', label: 'Update agent', requiresConfirm: true },
+      ]
+    : []
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-6 py-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <a className="text-sm text-muted hover:text-ink" href="/fleet">← Fleet</a>
+            <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">Fleet node</div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink">{node?.name || nodeId || 'Unknown node'}</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted">
+              Focused status, checks, redacted logs, and node-level operations.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            {node ? (
+              <span className={cn('rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em]', statusClass(node.status))}>
+                {node.status}
+              </span>
+            ) : null}
+            {opButtons.map((btn) => (
+              <button
+                key={btn.key}
+                className={cn(
+                  'rounded-lg border px-3 py-1.5 text-xs disabled:text-muted',
+                  btn.requiresConfirm
+                    ? 'border-amber-500/40 bg-amber-500/10 text-amber-100 hover:bg-amber-500/20'
+                    : 'border-[var(--theme-border)] text-ink hover:bg-[var(--theme-card2)]',
+                )}
+                disabled={opMutation.isPending}
+                onClick={() => {
+                  if (btn.requiresConfirm) {
+                    setPendingOp({ operation: btn.key, label: btn.label })
+                    setOperationResult(null)
+                  } else {
+                    opMutation.mutate({ operation: btn.key })
+                  }
+                }}
+              >
+                {opMutation.isPending && pendingOp?.operation === btn.key ? 'Running…' : btn.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {!nodeId ? (
+          <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-200">Missing nodeId.</div>
+        ) : null}
+
+        {query.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Node detail failed: {query.error instanceof Error ? query.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        {query.isLoading ? (
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-muted">
+            Collecting node detail…
+          </div>
+        ) : null}
+
+        {node ? (
+          <>
+            <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <Metric label="Kind" value={node.kind} />
+              <Metric label="Host" value={node.address || node.host} />
+              <Metric label="Container" value={node.container} />
+              <Metric label="Last seen" value={node.lastSeen ? new Date(node.lastSeen).toLocaleString() : 'never'} />
+              <Metric label="Version" value={node.version} />
+              <Metric label="Model" value={node.model} />
+              <Metric label="Provider" value={node.provider} />
+              <Metric label="Parent" value={detail?.parent?.name || node.parent} />
+            </section>
+
+            {node.cron ? (
+              <section className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="text-lg font-semibold text-ink">Cron</h2>
+                  <div className="text-sm text-muted">{node.cron.active}/{node.cron.total} active</div>
+                </div>
+                <div className="mt-3 grid gap-2">
+                  {node.cron.items.length ? node.cron.items.map((job) => (
+                    <div key={job.id} className="rounded-xl bg-[var(--theme-card2)] px-3 py-2 text-sm">
+                      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                        <div className="font-medium text-ink">{job.name}</div>
+                        <div className="font-mono text-xs text-muted">{job.id} · {job.status}</div>
+                      </div>
+                      <div className="mt-1 text-xs text-muted">{job.schedule || 'manual'} · next {job.nextRun || '—'} · last {job.lastRunStatus || '—'}</div>
+                    </div>
+                  )) : <div className="text-sm text-muted">No cron jobs reported.</div>}
+                </div>
+              </section>
+            ) : null}
+
+            <section className="grid gap-2 md:grid-cols-2">
+              {node.checks.map((check) => <CheckRow key={check.label} check={check} />)}
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-semibold text-ink">Logs</h2>
+                <div className="text-xs text-muted">Redacted before display</div>
+              </div>
+              {(detail?.logs ?? []).map((log) => <LogBlock key={`${log.label}-${log.source}`} log={log} />)}
+            </section>
+          </>
+        ) : null}
+
+        {operationResult ? (
+          <div className={cn(
+            'rounded-2xl border p-4 text-sm',
+            operationResult.record.status === 'completed'
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
+              : operationResult.record.status === 'failed'
+                ? 'border-red-500/30 bg-red-500/10 text-red-200'
+                : 'border-amber-500/30 bg-amber-500/10 text-amber-200',
+          )}>
+            <div className="font-semibold">Operation {operationResult.record.status}: {operationResult.record.operation}</div>
+            <pre className="mt-2 whitespace-pre-wrap text-xs">{operationResult.record.resultSummary}</pre>
+            <a className="mt-3 inline-block text-xs underline" href="/fleet-operations">View audit trail</a>
+          </div>
+        ) : null}
+
+        {opMutation.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Operation failed: {opMutation.error instanceof Error ? opMutation.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        <footer className="text-xs text-muted">
+          Last refresh: {detail ? new Date(detail.generatedAt).toLocaleString() : 'not yet'}
+        </footer>
+
+        {pendingOp ? (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+            <div className="w-full max-w-lg rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-2xl">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-300">Confirm operation</div>
+              <h2 className="mt-2 text-xl font-semibold text-ink">{pendingOp.label}?</h2>
+              <div className="mt-4 grid gap-3 text-sm">
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+                  <span className="text-muted">Node</span>
+                  <br />{node?.name} · <span className="font-mono">{nodeId}</span>
+                </div>
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+                  <span className="text-muted">Operation</span>
+                  <br />{pendingOp.label}
+                </div>
+                <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+                  <span className="text-muted">Side effect</span>
+                  <br />
+                  {pendingOp.operation === 'gateway.restart' && 'Restarts the gateway. Active connections will drop and reconnect.'}
+                  {pendingOp.operation === 'agent.update' && 'Pulls latest code and restarts. May break things.'}
+                </div>
+              </div>
+              <div className="mt-5 flex justify-end gap-2">
+                <button
+                  className="rounded-lg border border-[var(--theme-border)] px-3 py-2 text-xs text-ink"
+                  onClick={() => setPendingOp(null)}
+                  disabled={opMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="rounded-lg border border-amber-500/40 bg-amber-500/20 px-3 py-2 text-xs text-amber-100 hover:bg-amber-500/30 disabled:text-muted"
+                  disabled={opMutation.isPending}
+                  onClick={() => opMutation.mutate({ operation: pendingOp.operation })}
+                >
+                  {opMutation.isPending ? 'Running…' : 'Confirm'}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/fleet/fleet-operations-screen.tsx
+++ b/src/screens/fleet/fleet-operations-screen.tsx
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { FleetOperationAuditRecord, FleetOperationResponse } from '@/server/fleet-operations'
+import { cn } from '@/lib/utils'
+
+async function fetchOperations(): Promise<{ generatedAt: string; records: Array<FleetOperationAuditRecord> }> {
+  const res = await fetch('/api/fleet-operations?limit=100')
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function statusClass(status: FleetOperationAuditRecord['status']) {
+  if (status === 'completed') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  if (status === 'failed' || status === 'rejected') return 'border-red-500/30 bg-red-500/10 text-red-300'
+  if (status === 'running') return 'border-blue-500/30 bg-blue-500/10 text-blue-300'
+  return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+}
+
+export function FleetOperationsScreen() {
+  const queryClient = useQueryClient()
+  const query = useQuery({ queryKey: ['fleet-operations'], queryFn: fetchOperations, refetchInterval: 15_000 })
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/fleet-operations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'plan', operation: 'cron.run_now', nodeId: 'pierre-local', jobId: '8c886b3fed87' }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<FleetOperationResponse>
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['fleet-operations'] }),
+  })
+  const records = query.data?.records ?? []
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-6 py-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <a className="text-sm text-muted hover:text-ink" href="/fleet">← Fleet</a>
+            <div className="mt-4 text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">Operations</div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink">Fleet Operations</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted">
+              Audit trail first. Every sharp button writes a record before it does anything interesting.
+            </p>
+          </div>
+          <button
+            className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-xs text-ink hover:bg-[var(--theme-card2)] disabled:text-muted"
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            Test plan diary run
+          </button>
+        </header>
+
+        {mutation.data?.plan ? (
+          <section className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-5">
+            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-200">Planned operation</div>
+            <div className="mt-2 text-lg font-semibold text-ink">{mutation.data.plan.operation}</div>
+            <div className="mt-3 grid gap-3 text-sm md:grid-cols-2">
+              <div className="rounded-xl bg-black/20 p-3"><span className="text-muted">Node</span><br />{mutation.data.plan.nodeId}</div>
+              <div className="rounded-xl bg-black/20 p-3"><span className="text-muted">Target</span><br />{mutation.data.plan.targetId}</div>
+              <div className="rounded-xl bg-black/20 p-3"><span className="text-muted">Side effect</span><br />{mutation.data.plan.sideEffect}</div>
+              <div className="rounded-xl bg-black/20 p-3"><span className="text-muted">Rollback</span><br />{mutation.data.plan.rollback}</div>
+            </div>
+            <pre className="mt-3 overflow-auto rounded-xl bg-black/30 p-3 text-xs text-ink">{mutation.data.plan.displayCommand}</pre>
+            <div className="mt-3 text-xs text-muted">Execution buttons are wired on cron cards. This page proves the audit spine without surprise side effects.</div>
+          </section>
+        ) : null}
+
+        {query.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Operations audit failed: {query.error instanceof Error ? query.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        <section className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-ink">Recent audit records</h2>
+            <div className="text-xs text-muted">{records.length} records</div>
+          </div>
+          <div className="grid gap-3">
+            {records.map((record) => (
+              <article key={record.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="font-mono text-xs text-muted">{record.id}</div>
+                    <div className="mt-1 text-sm font-semibold text-ink">{record.operation} · {record.nodeId} · {record.targetId}</div>
+                  </div>
+                  <span className={cn('w-fit rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', statusClass(record.status))}>{record.status}</span>
+                </div>
+                <div className="mt-3 text-xs text-muted">{new Date(record.timestamp).toLocaleString()} · {record.commandClass} · actor {record.actor}</div>
+                <pre className="mt-3 whitespace-pre-wrap rounded-lg bg-black/20 p-3 text-xs text-ink">{record.resultSummary}</pre>
+              </article>
+            ))}
+            {query.isLoading ? <div className="text-sm text-muted">Collecting audit trail…</div> : null}
+            {!query.isLoading && records.length === 0 ? <div className="text-sm text-muted">No operations recorded yet.</div> : null}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/fleet/fleet-screen.tsx
+++ b/src/screens/fleet/fleet-screen.tsx
@@ -1,0 +1,186 @@
+import { useQuery } from '@tanstack/react-query'
+import type { FleetStatusPayload, FleetNodeStatus } from '@/server/fleet'
+import { cn } from '@/lib/utils'
+
+function statusClass(status: FleetNodeStatus['status']) {
+  if (status === 'healthy') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  if (status === 'degraded') return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+  if (status === 'offline') return 'border-red-500/30 bg-red-500/10 text-red-300'
+  return 'border-neutral-500/30 bg-neutral-500/10 text-neutral-300'
+}
+
+function kindLabel(kind: FleetNodeStatus['kind']) {
+  return kind.replace('-', ' ')
+}
+
+function timeLabel(value: string | null) {
+  if (!value) return 'never'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+async function fetchFleetStatus(): Promise<FleetStatusPayload> {
+  const res = await fetch('/api/fleet-status')
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function SummaryTile({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted">{label}</div>
+      <div className={cn('mt-2 text-3xl font-semibold tabular-nums', tone)}>{value}</div>
+    </div>
+  )
+}
+
+function CheckRow({ check }: { check: FleetNodeStatus['checks'][number] }) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-lg bg-[var(--theme-card2)] px-3 py-2">
+      <div>
+        <div className="text-xs font-medium text-ink">{check.label}</div>
+        {check.detail ? <div className="mt-0.5 text-[11px] text-muted line-clamp-2">{check.detail}</div> : null}
+      </div>
+      <span className={cn('mt-0.5 size-2.5 shrink-0 rounded-full', check.ok ? 'bg-emerald-400' : 'bg-amber-400')} />
+    </div>
+  )
+}
+
+function NodeCard({ node }: { node: FleetNodeStatus }) {
+  return (
+    <article className="flex min-h-[300px] flex-col rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className={cn('size-2.5 rounded-full', node.status === 'healthy' ? 'bg-emerald-400' : node.status === 'degraded' ? 'bg-amber-400' : node.status === 'offline' ? 'bg-red-400' : 'bg-neutral-400')} />
+            <h2 className="truncate text-lg font-semibold text-ink">{node.name}</h2>
+          </div>
+          <div className="mt-1 text-xs uppercase tracking-[0.14em] text-muted">{kindLabel(node.kind)}</div>
+        </div>
+        <span className={cn('rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', statusClass(node.status))}>
+          {node.status}
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 text-xs">
+        <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+          <div className="text-muted">Host</div>
+          <div className="mt-1 truncate font-medium text-ink">{node.address || node.host}</div>
+        </div>
+        <div className="rounded-xl bg-[var(--theme-card2)] p-3">
+          <div className="text-muted">Last seen</div>
+          <div className="mt-1 font-medium text-ink">{timeLabel(node.lastSeen)}</div>
+        </div>
+        {node.container ? (
+          <div className="col-span-2 rounded-xl bg-[var(--theme-card2)] p-3">
+            <div className="text-muted">Container</div>
+            <div className="mt-1 truncate font-medium text-ink">{node.container}</div>
+            {node.dockerStatus ? <div className="mt-1 text-[11px] text-muted">{node.dockerStatus}</div> : null}
+          </div>
+        ) : null}
+        {node.model || node.provider ? (
+          <div className="col-span-2 rounded-xl bg-[var(--theme-card2)] p-3">
+            <div className="text-muted">Model</div>
+            <div className="mt-1 truncate font-medium text-ink">{node.model || 'unknown'}</div>
+            <div className="mt-1 text-[11px] text-muted">{node.provider || 'provider unknown'}</div>
+          </div>
+        ) : null}
+      </div>
+
+      {node.cron ? (
+        <div className="mt-4 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-ink">Cron jobs</span>
+            <span className="text-muted">{node.cron.active}/{node.cron.total} active</span>
+          </div>
+          {node.cron.failedRecent ? (
+            <div className="mt-2 text-xs text-red-300">{node.cron.failedRecent} recent failure</div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex-1 space-y-2">
+        {node.checks.slice(0, 3).map((check) => (
+          <CheckRow key={`${node.id}-${check.label}`} check={check} />
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {node.gatewayUrl ? <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href={node.gatewayUrl}>Gateway</a> : null}
+        {node.workspaceUrl ? <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href={node.workspaceUrl}>Workspace</a> : null}
+        <a className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href={`/fleet-node?nodeId=${encodeURIComponent(node.id)}`}>
+          Detail / logs
+        </a>
+        <button className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs text-muted" disabled>
+          Operations soon
+        </button>
+      </div>
+    </article>
+  )
+}
+
+export function FleetScreen() {
+  const query = useQuery({
+    queryKey: ['fleet-status'],
+    queryFn: fetchFleetStatus,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+
+  const data = query.data
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-6 py-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">Fleet control</div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink">Hermes / OpenClaw Cockpit</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted">
+              One surface for local Hermes, Morgan VPS containers, Maya, cron, and the OpenClaw placeholder. Read-only for now. Sensible.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <a className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-1.5 text-xs text-ink hover:bg-[var(--theme-card2)]" href="/fleet-cron">
+                Cron Control Center
+              </a>
+            </div>
+          </div>
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-3 text-xs text-muted">
+            <div>Registry</div>
+            <div className="mt-1 max-w-[360px] truncate font-mono text-ink">{data?.registryPath || '~/.hermes/fleet.yaml'}</div>
+          </div>
+        </header>
+
+        {query.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Fleet collection failed: {query.error instanceof Error ? query.error.message : 'unknown error'}
+          </div>
+        ) : null}
+
+        <section className="grid grid-cols-2 gap-3 md:grid-cols-5">
+          <SummaryTile label="Total" value={data?.summary.total ?? 0} tone="text-ink" />
+          <SummaryTile label="Healthy" value={data?.summary.healthy ?? 0} tone="text-emerald-300" />
+          <SummaryTile label="Degraded" value={data?.summary.degraded ?? 0} tone="text-amber-300" />
+          <SummaryTile label="Offline" value={data?.summary.offline ?? 0} tone="text-red-300" />
+          <SummaryTile label="Unknown" value={data?.summary.unknown ?? 0} tone="text-neutral-300" />
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {(data?.nodes ?? []).map((node) => (
+            <NodeCard key={node.id} node={node} />
+          ))}
+          {query.isLoading ? (
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-muted">
+              Collecting fleet state…
+            </div>
+          ) : null}
+        </section>
+
+        <footer className="text-xs text-muted">
+          Last refresh: {data ? new Date(data.generatedAt).toLocaleString() : 'not yet'}
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/profiles/profiles-screen.tsx
+++ b/src/screens/profiles/profiles-screen.tsx
@@ -178,8 +178,9 @@ export function ProfilesScreen() {
     }
   }, [createOpen, wizardStep, allModels.length, fetchAllModels])
 
+  const profileNamePattern = /^[a-z0-9][a-z0-9_-]{0,63}$/
   const nameValid =
-    /^[A-Za-z0-9_-]+$/.test(newProfileName.trim()) &&
+    profileNamePattern.test(newProfileName.trim()) &&
     newProfileName.trim() !== 'default'
 
   function resetWizard() {
@@ -542,7 +543,7 @@ export function ProfilesScreen() {
                   />
                   {newProfileName.trim() && !nameValid ? (
                     <p className="text-xs text-red-500">
-                      Use letters, numbers, underscores, or hyphens. Cannot be
+                      Use lowercase letters, numbers, underscores, or hyphens. Cannot be
                       &quot;default&quot;.
                     </p>
                   ) : newProfileName.trim() && nameValid ? (
@@ -788,9 +789,9 @@ export function ProfilesScreen() {
                 autoFocus
               />
               {renameValue.trim() &&
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim()) && (
+                !profileNamePattern.test(renameValue.trim()) && (
                   <p className="text-xs text-red-500">
-                    Use letters, numbers, underscores, or hyphens.
+                    Use lowercase letters, numbers, underscores, or hyphens.
                   </p>
                 )}
             </div>
@@ -812,7 +813,7 @@ export function ProfilesScreen() {
               disabled={
                 !renameTarget ||
                 !renameValue.trim() ||
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim())
+                !profileNamePattern.test(renameValue.trim())
               }
             >
               Rename

--- a/src/server/fleet-operations.test.ts
+++ b/src/server/fleet-operations.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOperationPlan,
+  createAuditRecord,
+  summarizeOperationResult,
+  validateOperationRequest,
+} from './fleet-operations'
+
+describe('fleet operations', () => {
+  it('builds a safe local cron run plan without exposing secrets', () => {
+    const plan = buildOperationPlan({
+      operation: 'cron.run_now',
+      nodeId: 'pierre-local',
+      nodeKind: 'hermes-local',
+      targetId: '8c886b3fed87',
+    })
+
+    expect(plan).toMatchObject({
+      operation: 'cron.run_now',
+      scope: 'local',
+      commandClass: 'hermes cron run',
+      sideEffect: expect.stringContaining('Triggers'),
+    })
+    expect(plan.displayCommand).toBe('hermes cron run 8c886b3fed87')
+    expect(JSON.stringify(plan)).not.toMatch(/API_KEY|TOKEN|PASSWORD|SECRET/i)
+  })
+
+  it('builds a safe remote container cron run plan through docker exec', () => {
+    const plan = buildOperationPlan({
+      operation: 'cron.run_now',
+      nodeId: 'maya-round6',
+      nodeKind: 'hermes-container',
+      targetId: '7a9ab6b1356a',
+      container: 'round6-hermes',
+      parentId: 'morgan-vps',
+    })
+
+    expect(plan).toMatchObject({
+      operation: 'cron.run_now',
+      scope: 'remote-container',
+      commandClass: 'docker exec hermes cron run',
+      requiresConfirmation: true,
+    })
+    expect(plan.displayCommand).toContain('docker exec round6-hermes')
+    expect(plan.displayCommand).toContain('7a9ab6b1356a')
+  })
+
+  it('rejects unsafe operation request parameters', () => {
+    expect(validateOperationRequest({ operation: 'cron.run_now', nodeId: 'maya-round6', jobId: 'abc_123-DEF' }).ok).toBe(true)
+    expect(validateOperationRequest({ operation: 'cron.run_now', nodeId: '../maya', jobId: 'abc' }).ok).toBe(false)
+    expect(validateOperationRequest({ operation: 'cron.remove', nodeId: 'maya-round6', jobId: 'abc' }).ok).toBe(false)
+    expect(validateOperationRequest({ operation: 'cron.run_now', nodeId: 'maya-round6', jobId: 'abc; rm -rf /' }).ok).toBe(false)
+  })
+
+  it('creates audit records with redacted result summaries', () => {
+    const record = createAuditRecord({
+      operation: 'cron.run_now',
+      nodeId: 'pierre-local',
+      targetId: '8c886b3fed87',
+      actor: 'workspace',
+      status: 'completed',
+      commandClass: 'hermes cron run',
+      resultSummary: 'ok TOKEN=*** password=hunter2',
+    })
+
+    expect(record.id).toMatch(/^op_/)
+    expect(record.resultSummary).toContain('[REDACTED]')
+    expect(record.resultSummary).not.toContain('hunter2')
+    expect(record.resultSummary).not.toContain('should-not-leak')
+  })
+
+  it('summarizes command output compactly and redacts secrets', () => {
+    const summary = summarizeOperationResult('Line 1\nLine 2\nAPI_KEY=xyz', 'Done\nsecret=abc123')
+    expect(summary).toContain('Done')
+    expect(summary).not.toContain('abc123')
+    expect(summary).not.toContain('xyz')
+    expect(summary).toContain('API_KEY=[REDACTED]')
+    expect(summary).toContain('secret=[REDACTED]')
+  })
+})

--- a/src/server/fleet-operations.ts
+++ b/src/server/fleet-operations.ts
@@ -1,0 +1,538 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { collectFleetStatus, getFleetRegistryPath, redactSensitiveText, type FleetNodeStatus } from './fleet'
+
+const execFileAsync = promisify(execFile)
+const DEFAULT_TIMEOUT_MS = 20_000
+
+export type FleetOperation = 'cron.run_now' | 'gateway.restart' | 'agent.update' | 'health.check'
+export type FleetOperationStatus = 'planned' | 'running' | 'completed' | 'failed' | 'rejected'
+
+export type FleetOperationRequest = {
+  operation?: string
+  nodeId?: string
+  jobId?: string
+  actor?: string
+  confirmed?: boolean
+}
+
+export type FleetOperationPlan = {
+  operation: FleetOperation
+  nodeId: string
+  targetId: string
+  scope: 'local' | 'remote-container'
+  commandClass: string
+  displayCommand: string
+  sideEffect: string
+  rollback: string
+  requiresConfirmation: boolean
+}
+
+export type FleetOperationAuditRecord = {
+  id: string
+  timestamp: string
+  actor: string
+  operation: FleetOperation
+  nodeId: string
+  targetId: string
+  status: FleetOperationStatus
+  commandClass: string
+  resultSummary: string
+  error?: string
+}
+
+export type FleetOperationResponse = {
+  generatedAt: string
+  record: FleetOperationAuditRecord
+  plan?: FleetOperationPlan
+}
+
+function safeId(value?: string): boolean {
+  return Boolean(value && /^[a-zA-Z0-9_-]+$/.test(value))
+}
+
+function resolveExecutable(command: string): string {
+  if (command !== 'hermes') return command
+  const candidates = [
+    process.env.HERMES_CLI_PATH,
+    path.join(os.homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
+    path.join(os.homedir(), '.hermes', 'bin', 'hermes'),
+    'hermes',
+  ].filter(Boolean) as Array<string>
+  return candidates.find((candidate) => candidate === 'hermes' || existsSync(candidate)) || 'hermes'
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+export function validateOperationRequest(request: FleetOperationRequest): { ok: true } | { ok: false; error: string } {
+  if (!safeId(request.nodeId)) return { ok: false, error: 'Invalid nodeId' }
+  if (request.operation === 'cron.run_now') {
+    if (!safeId(request.jobId)) return { ok: false, error: 'Invalid jobId' }
+    return { ok: true }
+  }
+  if (['gateway.restart', 'agent.update', 'health.check'].includes(request.operation || '')) {
+    return { ok: true }
+  }
+  return { ok: false, error: 'Unsupported operation' }
+}
+
+function buildCronRunPlan(input: {
+  nodeId: string
+  nodeKind: FleetNodeStatus['kind']
+  jobId: string
+  container?: string
+  parentId?: string
+}): FleetOperationPlan {
+  if (input.nodeKind === 'hermes-local') {
+    return {
+      operation: 'cron.run_now',
+      nodeId: input.nodeId,
+      targetId: input.jobId,
+      scope: 'local',
+      commandClass: 'hermes cron run',
+      displayCommand: `hermes cron run ${input.jobId}`,
+      sideEffect: 'Triggers one scheduled Hermes cron job on the next scheduler tick.',
+      rollback: 'No rollback. If the job sends a message, delivery cannot be unsent.',
+      requiresConfirmation: true,
+    }
+  }
+
+  if (input.nodeKind === 'hermes-container' && input.container && input.parentId) {
+    return {
+      operation: 'cron.run_now',
+      nodeId: input.nodeId,
+      targetId: input.jobId,
+      scope: 'remote-container',
+      commandClass: 'docker exec hermes cron run',
+      displayCommand: `ssh ${input.parentId} -- docker exec ${input.container} hermes cron run ${input.jobId}`,
+      sideEffect: 'Triggers one scheduled Hermes cron job inside the remote container on the next scheduler tick.',
+      rollback: 'No rollback. If the job sends a message, delivery cannot be unsent.',
+      requiresConfirmation: true,
+    }
+  }
+
+  throw new Error(`Unsupported node kind for cron.run_now: ${input.nodeKind}`)
+}
+
+function buildGatewayRestartPlan(input: {
+  nodeId: string
+  nodeKind: FleetNodeStatus['kind']
+  container?: string
+  parentId?: string
+}): FleetOperationPlan {
+  if (input.nodeKind === 'hermes-local') {
+    return {
+      operation: 'gateway.restart',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'local',
+      commandClass: 'hermes gateway restart',
+      displayCommand: 'hermes gateway run --replace',
+      sideEffect: 'Restarts the Hermes gateway service. Active websocket connections will drop and reconnect.',
+      rollback: 'No rollback needed. Gateway starts from persistent state.',
+      requiresConfirmation: true,
+    }
+  }
+
+  if (input.nodeKind === 'hermes-container' && input.container && input.parentId) {
+    return {
+      operation: 'gateway.restart',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'remote-container',
+      commandClass: 'docker exec hermes gateway restart',
+      displayCommand: `ssh ${input.parentId} -- docker exec ${input.container} hermes gateway run --replace`,
+      sideEffect: 'Restarts the Hermes gateway inside the remote container. Active connections will drop.',
+      rollback: 'No rollback needed. Gateway starts from persistent state.',
+      requiresConfirmation: true,
+    }
+  }
+
+  throw new Error(`Unsupported node kind for gateway.restart: ${input.nodeKind}`)
+}
+
+function buildAgentUpdatePlan(input: {
+  nodeId: string
+  nodeKind: FleetNodeStatus['kind']
+  container?: string
+  parentId?: string
+}): FleetOperationPlan {
+  if (input.nodeKind === 'hermes-local') {
+    return {
+      operation: 'agent.update',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'local',
+      commandClass: 'hermes update',
+      displayCommand: 'hermes update',
+      sideEffect: 'Pulls latest agent code and restarts the gateway from the updated version.',
+      rollback: 'Manual git revert in ~/.hermes/hermes-agent required if update breaks.',
+      requiresConfirmation: true,
+    }
+  }
+
+  if (input.nodeKind === 'hermes-container' && input.container && input.parentId) {
+    return {
+      operation: 'agent.update',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'remote-container',
+      commandClass: 'docker exec hermes update',
+      displayCommand: `ssh ${input.parentId} -- docker exec ${input.container} hermes update`,
+      sideEffect: 'Pulls latest agent code inside the remote container. May require container rebuild for dependency changes.',
+      rollback: 'Container rebuild from previous image tag required if update breaks.',
+      requiresConfirmation: true,
+    }
+  }
+
+  throw new Error(`Unsupported node kind for agent.update: ${input.nodeKind}`)
+}
+
+function buildHealthCheckPlan(input: {
+  nodeId: string
+  nodeKind: FleetNodeStatus['kind']
+  container?: string
+  parentId?: string
+}): FleetOperationPlan {
+  if (input.nodeKind === 'hermes-local') {
+    return {
+      operation: 'health.check',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'local',
+      commandClass: 'hermes status',
+      displayCommand: 'hermes status',
+      sideEffect: 'Read-only status poll. No side effects.',
+      rollback: 'N/A',
+      requiresConfirmation: false,
+    }
+  }
+
+  if (input.nodeKind === 'hermes-container' && input.container && input.parentId) {
+    return {
+      operation: 'health.check',
+      nodeId: input.nodeId,
+      targetId: input.nodeId,
+      scope: 'remote-container',
+      commandClass: 'docker exec hermes status',
+      displayCommand: `ssh ${input.parentId} -- docker exec ${input.container} hermes status`,
+      sideEffect: 'Read-only status poll inside remote container. No side effects.',
+      rollback: 'N/A',
+      requiresConfirmation: false,
+    }
+  }
+
+  throw new Error(`Unsupported node kind for health.check: ${input.nodeKind}`)
+}
+
+export function buildOperationPlan(input: {
+  operation: FleetOperation
+  nodeId: string
+  nodeKind: FleetNodeStatus['kind']
+  targetId?: string
+  container?: string
+  parentId?: string
+}): FleetOperationPlan {
+  if (input.operation === 'cron.run_now') {
+    return buildCronRunPlan({ nodeId: input.nodeId, nodeKind: input.nodeKind, jobId: input.targetId!, container: input.container, parentId: input.parentId })
+  }
+  if (input.operation === 'gateway.restart') {
+    return buildGatewayRestartPlan({ nodeId: input.nodeId, nodeKind: input.nodeKind, container: input.container, parentId: input.parentId })
+  }
+  if (input.operation === 'agent.update') {
+    return buildAgentUpdatePlan({ nodeId: input.nodeId, nodeKind: input.nodeKind, container: input.container, parentId: input.parentId })
+  }
+  if (input.operation === 'health.check') {
+    return buildHealthCheckPlan({ nodeId: input.nodeId, nodeKind: input.nodeKind, container: input.container, parentId: input.parentId })
+  }
+  throw new Error(`Unsupported operation: ${input.operation}`)
+}
+
+function operationId(): string {
+  return `op_${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}_${Math.random().toString(16).slice(2, 8)}`
+}
+
+export function summarizeOperationResult(stdout: string, stderr: string): string {
+  const text = redactSensitiveText([stdout, stderr].filter(Boolean).join('\n').trim() || 'No command output.')
+  const lines = text.split('\n').filter(Boolean)
+  return lines.slice(Math.max(0, lines.length - 8)).join('\n').slice(0, 2_000)
+}
+
+export function createAuditRecord(input: {
+  operation: FleetOperation
+  nodeId: string
+  targetId: string
+  actor?: string
+  status: FleetOperationStatus
+  commandClass: string
+  resultSummary: string
+  error?: string
+}): FleetOperationAuditRecord {
+  return {
+    id: operationId(),
+    timestamp: new Date().toISOString(),
+    actor: input.actor || 'workspace',
+    operation: input.operation,
+    nodeId: input.nodeId,
+    targetId: input.targetId,
+    status: input.status,
+    commandClass: input.commandClass,
+    resultSummary: redactSensitiveText(input.resultSummary),
+    error: input.error ? redactSensitiveText(input.error) : undefined,
+  }
+}
+
+export function getFleetOperationsAuditPath(): string {
+  return path.join(os.homedir(), '.hermes', 'fleet', 'operations-audit.jsonl')
+}
+
+async function appendAuditRecord(record: FleetOperationAuditRecord, auditPath = getFleetOperationsAuditPath()) {
+  await mkdir(path.dirname(auditPath), { recursive: true })
+  const existing = existsSync(auditPath) ? await readFile(auditPath, 'utf8') : ''
+  await writeFile(auditPath, `${existing}${JSON.stringify(record)}\n`, 'utf8')
+}
+
+export async function readFleetOperations(limit = 100, auditPath = getFleetOperationsAuditPath()): Promise<Array<FleetOperationAuditRecord>> {
+  if (!existsSync(auditPath)) return []
+  const lines = (await readFile(auditPath, 'utf8')).split('\n').filter(Boolean)
+  return lines
+    .slice(-Math.max(1, Math.min(limit, 500)))
+    .map((line) => {
+      try {
+        return JSON.parse(line) as FleetOperationAuditRecord
+      } catch {
+        return null
+      }
+    })
+    .filter((record): record is FleetOperationAuditRecord => Boolean(record))
+    .reverse()
+}
+
+async function runCommand(command: string, args: Array<string>, timeout = DEFAULT_TIMEOUT_MS) {
+  try {
+    const { stdout, stderr } = await execFileAsync(resolveExecutable(command), args, { timeout, maxBuffer: 1024 * 256 })
+    return { ok: true, stdout: String(stdout), stderr: String(stderr) }
+  } catch (error) {
+    const err = error as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string }
+    return {
+      ok: false,
+      stdout: err.stdout ? String(err.stdout) : '',
+      stderr: err.stderr ? String(err.stderr) : err.message || 'Command failed',
+    }
+  }
+}
+
+async function executeCronRun(node: FleetNodeStatus, jobId: string) {
+  if (node.kind === 'hermes-local') {
+    return runCommand('hermes', ['cron', 'run', jobId], 20_000)
+  }
+
+  if (node.kind === 'hermes-container') {
+    const fleet = await collectFleetStatus(getFleetRegistryPath())
+    const parent = fleet.nodes.find((candidate) => candidate.id === node.parent)
+    if (!parent?.address || !parent.user || !node.container) {
+      return { ok: false, stdout: '', stderr: 'Missing parent host or container for remote cron run.' }
+    }
+    const remoteCommand = `docker exec ${shellQuote(node.container)} sh -lc ${shellQuote(`hermes cron run ${jobId}`)}`
+    return runCommand('ssh', [
+      ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+      '-o', 'BatchMode=yes',
+      '-o', 'ConnectTimeout=6',
+      `${parent.user}@${parent.address}`,
+      remoteCommand,
+    ], 25_000)
+  }
+
+  return { ok: false, stdout: '', stderr: `Unsupported node kind: ${node.kind}` }
+}
+
+async function executeGatewayRestart(node: FleetNodeStatus) {
+  if (node.kind === 'hermes-local') {
+    return runCommand('hermes', ['gateway', 'run', '--replace'], 30_000)
+  }
+
+  if (node.kind === 'hermes-container') {
+    const fleet = await collectFleetStatus(getFleetRegistryPath())
+    const parent = fleet.nodes.find((candidate) => candidate.id === node.parent)
+    if (!parent?.address || !parent.user || !node.container) {
+      return { ok: false, stdout: '', stderr: 'Missing parent host or container for remote gateway restart.' }
+    }
+    const remoteCommand = `docker exec ${shellQuote(node.container)} sh -lc ${shellQuote('hermes gateway run --replace')}`
+    return runCommand('ssh', [
+      ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+      '-o', 'BatchMode=yes',
+      '-o', 'ConnectTimeout=6',
+      `${parent.user}@${parent.address}`,
+      remoteCommand,
+    ], 35_000)
+  }
+
+  return { ok: false, stdout: '', stderr: `Unsupported node kind: ${node.kind}` }
+}
+
+async function executeAgentUpdate(node: FleetNodeStatus) {
+  if (node.kind === 'hermes-local') {
+    return runCommand('hermes', ['update'], 120_000)
+  }
+
+  if (node.kind === 'hermes-container') {
+    const fleet = await collectFleetStatus(getFleetRegistryPath())
+    const parent = fleet.nodes.find((candidate) => candidate.id === node.parent)
+    if (!parent?.address || !parent.user || !node.container) {
+      return { ok: false, stdout: '', stderr: 'Missing parent host or container for remote agent update.' }
+    }
+    const remoteCommand = `docker exec ${shellQuote(node.container)} sh -lc ${shellQuote('hermes update')}`
+    return runCommand('ssh', [
+      ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+      '-o', 'BatchMode=yes',
+      '-o', 'ConnectTimeout=6',
+      `${parent.user}@${parent.address}`,
+      remoteCommand,
+    ], 120_000)
+  }
+
+  return { ok: false, stdout: '', stderr: `Unsupported node kind: ${node.kind}` }
+}
+
+async function executeHealthCheck(node: FleetNodeStatus) {
+  if (node.kind === 'hermes-local') {
+    return runCommand('hermes', ['status'], 10_000)
+  }
+
+  if (node.kind === 'hermes-container') {
+    const fleet = await collectFleetStatus(getFleetRegistryPath())
+    const parent = fleet.nodes.find((candidate) => candidate.id === node.parent)
+    if (!parent?.address || !parent.user || !node.container) {
+      return { ok: false, stdout: '', stderr: 'Missing parent host or container for remote health check.' }
+    }
+    const remoteCommand = `docker exec ${shellQuote(node.container)} sh -lc ${shellQuote('hermes status')}`
+    return runCommand('ssh', [
+      ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+      '-o', 'BatchMode=yes',
+      '-o', 'ConnectTimeout=6',
+      `${parent.user}@${parent.address}`,
+      remoteCommand,
+    ], 15_000)
+  }
+
+  return { ok: false, stdout: '', stderr: `Unsupported node kind: ${node.kind}` }
+}
+
+async function executeOperation(node: FleetNodeStatus, operation: FleetOperation, targetId: string) {
+  if (operation === 'cron.run_now') {
+    return executeCronRun(node, targetId)
+  }
+  if (operation === 'gateway.restart') {
+    return executeGatewayRestart(node)
+  }
+  if (operation === 'agent.update') {
+    return executeAgentUpdate(node)
+  }
+  if (operation === 'health.check') {
+    return executeHealthCheck(node)
+  }
+  return { ok: false, stdout: '', stderr: `Unsupported operation: ${operation}` }
+}
+
+export async function planFleetOperation(request: FleetOperationRequest): Promise<FleetOperationResponse> {
+  const validation = validateOperationRequest(request)
+  if (!validation.ok) {
+    const err = (validation as { ok: false; error: string }).error
+    const operation = (request.operation as FleetOperation) || 'cron.run_now'
+    const targetId = request.operation === 'cron.run_now' ? (request.jobId || 'unknown') : (request.nodeId || 'unknown')
+    const record = createAuditRecord({
+      operation,
+      nodeId: request.nodeId || 'unknown',
+      targetId,
+      actor: request.actor,
+      status: 'rejected',
+      commandClass: 'validation',
+      resultSummary: err,
+      error: err,
+    })
+    return { generatedAt: new Date().toISOString(), record }
+  }
+
+  const fleet = await collectFleetStatus()
+  const node = fleet.nodes.find((candidate) => candidate.id === request.nodeId)
+  if (!node) {
+    const operation = (request.operation as FleetOperation) || 'cron.run_now'
+    const targetId = request.operation === 'cron.run_now' ? request.jobId! : request.nodeId!
+    const record = createAuditRecord({
+      operation,
+      nodeId: request.nodeId!,
+      targetId,
+      actor: request.actor,
+      status: 'rejected',
+      commandClass: 'lookup',
+      resultSummary: 'Node not found.',
+      error: 'Node not found.',
+    })
+    return { generatedAt: new Date().toISOString(), record }
+  }
+
+  const plan = buildOperationPlan({
+    operation: request.operation as FleetOperation,
+    nodeId: node.id,
+    nodeKind: node.kind,
+    ...(request.operation === 'cron.run_now' ? { targetId: request.jobId } : {}),
+    ...(node.container ? { container: node.container } : {}),
+    ...(typeof node.parent === 'string' ? { parentId: node.parent } : {}),
+  })
+  const record = createAuditRecord({
+    operation: plan.operation,
+    nodeId: node.id,
+    targetId: plan.targetId,
+    actor: request.actor,
+    status: 'planned',
+    commandClass: plan.commandClass,
+    resultSummary: `${plan.sideEffect} Confirmation required.`,
+  })
+  return { generatedAt: new Date().toISOString(), record, plan }
+}
+
+export async function executeFleetOperation(request: FleetOperationRequest): Promise<FleetOperationResponse> {
+  const planned = await planFleetOperation(request)
+  if (!planned.plan) {
+    await appendAuditRecord(planned.record)
+    return planned
+  }
+  if (!request.confirmed && planned.plan.requiresConfirmation) {
+    await appendAuditRecord(planned.record)
+    return planned
+  }
+
+  const running = createAuditRecord({
+    operation: planned.plan.operation,
+    nodeId: planned.plan.nodeId,
+    targetId: planned.plan.targetId,
+    actor: request.actor,
+    status: 'running',
+    commandClass: planned.plan.commandClass,
+    resultSummary: 'Operation accepted and execution started.',
+  })
+  await appendAuditRecord(running)
+
+  const fleet = await collectFleetStatus()
+  const node = fleet.nodes.find((candidate) => candidate.id === planned.plan!.nodeId)
+  const result = node ? await executeOperation(node, planned.plan.operation, planned.plan.targetId) : { ok: false, stdout: '', stderr: 'Node disappeared before execution.' }
+  const completed = createAuditRecord({
+    operation: planned.plan.operation,
+    nodeId: planned.plan.nodeId,
+    targetId: planned.plan.targetId,
+    actor: request.actor,
+    status: result.ok ? 'completed' : 'failed',
+    commandClass: planned.plan.commandClass,
+    resultSummary: summarizeOperationResult(result.stdout, result.stderr),
+    error: result.ok ? undefined : result.stderr || result.stdout || 'Operation failed.',
+  })
+  await appendAuditRecord(completed)
+
+  return { generatedAt: new Date().toISOString(), record: completed, plan: planned.plan }
+}

--- a/src/server/fleet.test.ts
+++ b/src/server/fleet.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFleetSummary,
+  buildCronDetailFromJob,
+  buildFleetCronDashboard,
+  classifyCronOutputStyle,
+  cronSummaryFromRawJobs,
+  inferOpenClawRuntime,
+  findFleetNode,
+  parseDockerPsLines,
+  parseHermesCronList,
+  redactSensitiveText,
+  readFleetRegistryFromText,
+} from './fleet'
+
+describe('fleet registry parsing', () => {
+  it('normalizes the fleet registry into nodes with safe defaults', () => {
+    const registry = readFleetRegistryFromText(`
+nodes:
+  - id: pierre-local
+    name: Pierre
+    kind: hermes-local
+    host: local
+    hermes_home: /Users/clawd/.hermes
+  - id: maya-round6
+    name: Maya / Round 6
+    kind: hermes-container
+    parent: morgan-vps
+    container: round6-hermes
+`)
+
+    expect(registry.nodes).toHaveLength(2)
+    expect(registry.nodes[0]).toMatchObject({
+      id: 'pierre-local',
+      status: 'unknown',
+      host: 'local',
+    })
+    expect(registry.nodes[1]).toMatchObject({
+      id: 'maya-round6',
+      parent: 'morgan-vps',
+      container: 'round6-hermes',
+    })
+  })
+})
+
+describe('fleet collectors', () => {
+  it('parses docker ps output into container states', () => {
+    const containers = parseDockerPsLines([
+      'round6-hermes|Up 4 minutes (healthy)|round6-hermes',
+      'morgan-hermes|Exited (1) 2 hours ago|config-hermes',
+    ])
+
+    expect(containers.get('round6-hermes')).toMatchObject({
+      name: 'round6-hermes',
+      healthy: true,
+      running: true,
+    })
+    expect(containers.get('morgan-hermes')).toMatchObject({
+      running: false,
+      healthy: false,
+    })
+  })
+
+  it('parses Hermes cron list output without leaking prompt content', () => {
+    const cron = parseHermesCronList(`
+  8c886b3fed87 [active]
+    Name:      Hermes Diary Update — Pierre
+    Schedule:  0 */6 * * *
+    Next run:  2026-04-29T18:00:00+02:00
+    Last run:  2026-04-29T12:01:18.904020+02:00  ok
+
+  deadbeef [paused]
+    Name:      Noisy Test
+    Last run:  2026-04-28T12:01:18.904020+02:00  failed
+`)
+
+    expect(cron.total).toBe(2)
+    expect(cron.active).toBe(1)
+    expect(cron.failedRecent).toBe(1)
+    expect(cron.items[0]).toMatchObject({
+      id: '8c886b3fed87',
+      name: 'Hermes Diary Update — Pierre',
+      status: 'active',
+      lastRunStatus: 'ok',
+    })
+  })
+
+  it('summarizes fleet health at a glance', () => {
+    const summary = buildFleetSummary([
+      { id: 'pierre', name: 'Pierre', kind: 'hermes-local', status: 'healthy', lastSeen: 'now' },
+      { id: 'maya', name: 'Maya', kind: 'hermes-container', status: 'degraded', lastSeen: 'now' },
+      { id: 'openclaw', name: 'OpenClaw', kind: 'openclaw', status: 'unknown', lastSeen: null },
+    ])
+
+    expect(summary).toEqual({
+      total: 3,
+      healthy: 1,
+      degraded: 1,
+      offline: 0,
+      unknown: 1,
+    })
+  })
+
+  it('finds fleet nodes by id without falling back to unsafe partial matches', () => {
+    const registry = readFleetRegistryFromText(`
+nodes:
+  - id: pierre-local
+    name: Pierre
+    kind: hermes-local
+  - id: pierre-local-shadow
+    name: Shadow
+    kind: hermes-local
+`)
+
+    expect(findFleetNode(registry.nodes, 'pierre-local')?.name).toBe('Pierre')
+    expect(findFleetNode(registry.nodes, 'pierre')).toBeNull()
+  })
+
+  it('redacts tokens, keys, passwords, and bearer headers from logs', () => {
+    const redacted = redactSensitiveText(`
+OPENAI_API_KEY=abc123
+ELEVENLABS_API_KEY: abcdef
+password="hunter2"
+Authorization: Bearer token-value
+normal line stays
+`)
+
+    expect(redacted).toContain('OPENAI_API_KEY=[REDACTED]')
+    expect(redacted).toContain('ELEVENLABS_API_KEY: [REDACTED]')
+    expect(redacted).toContain('password=[REDACTED]')
+    expect(redacted).toContain('Authorization: Bearer [REDACTED]')
+    expect(redacted).toContain('normal line stays')
+    expect(redacted).not.toContain('abc123')
+    expect(redacted).not.toContain('hunter2')
+    expect(redacted).not.toContain('token-value')
+  })
+
+  it('builds a unified cron dashboard from node cron summaries', () => {
+    const dashboard = buildFleetCronDashboard([
+      {
+        id: 'pierre-local',
+        name: 'Pierre',
+        kind: 'hermes-local',
+        host: 'local',
+        status: 'healthy',
+        lastSeen: 'now',
+        recentErrors: [],
+        checks: [],
+        cron: {
+          total: 2,
+          active: 1,
+          paused: 1,
+          failedRecent: 1,
+          items: [
+            { id: '8c886b3fed87', name: 'Hermes Diary Update — Pierre', status: 'active', schedule: '0 */6 * * *', lastRunStatus: 'ok' },
+            { id: 'deadbeef', name: 'Noisy Test', status: 'paused', lastRunStatus: 'failed' },
+          ],
+        },
+      },
+      {
+        id: 'maya-round6',
+        name: 'Maya',
+        kind: 'hermes-container',
+        host: 'docker',
+        status: 'healthy',
+        lastSeen: 'now',
+        recentErrors: [],
+        checks: [],
+      },
+    ])
+
+    expect(dashboard.summary).toEqual({ total: 2, active: 1, paused: 1, failedRecent: 1 })
+    expect(dashboard.jobs.find((job) => job.id === '8c886b3fed87')).toMatchObject({ nodeId: 'pierre-local', nodeName: 'Pierre' })
+  })
+
+  it('flags systemish cron output without penalizing short human summaries', () => {
+    const systemish = classifyCronOutputStyle(`
+Cronjob Response: Hermes Diary Update — Pierre
+(job_id: 8c886b3fed87)
+-------------
+📕 Hermes Diary Update — Pierre
+• job_id: 8c886b3fed87
+• Diary updated successfully.
+`)
+    const human = classifyCronOutputStyle('Diary updated.\n\n1 session added to Pierre’s diary.\nMorgan cross-reference updated too.')
+
+    expect(systemish.tone).toBe('systemish')
+    expect(systemish.score).toBeGreaterThanOrEqual(4)
+    expect(systemish.reasons).toContain('cron wrapper visible')
+    expect(human.tone).toBe('human')
+  })
+
+  it('builds a cron summary from raw container jobs.json metadata', () => {
+    const cron = cronSummaryFromRawJobs([
+      {
+        id: '7a9ab6b1356a',
+        name: 'r6-weather-oracle',
+        enabled: true,
+        schedule_display: '0 8 * * *',
+        next_run_at: '2026-04-30T08:00:00+02:00',
+        last_run_at: '2026-04-29T18:18:14+02:00',
+        last_status: 'ok',
+      },
+      {
+        id: 'paused123',
+        name: 'Paused remote job',
+        enabled: false,
+        last_status: 'failed',
+      },
+    ])
+
+    expect(cron).toMatchObject({ total: 2, active: 1, paused: 1, failedRecent: 1 })
+    expect(cron.items[0]).toMatchObject({ id: '7a9ab6b1356a', name: 'r6-weather-oracle', status: 'active' })
+  })
+
+  it('infers OpenClaw runtime state from launchctl, health, and npm version checks', () => {
+    const runtime = inferOpenClawRuntime({
+      launchctl: 'state = running\n\tpid = 98782',
+      health: '{"ok":true,"status":"live"}',
+      npm: '/usr/local/lib\n└── openclaw@2026.4.26',
+    })
+
+    expect(runtime.status).toBe('healthy')
+    expect(runtime.version).toBe('2026.4.26')
+    expect(runtime.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'LaunchAgent', ok: true }),
+      expect.objectContaining({ label: 'Gateway health', ok: true }),
+      expect.objectContaining({ label: 'OpenClaw package', ok: true }),
+    ]))
+  })
+
+  it('builds cron detail from job metadata and latest output markdown', () => {
+    const detail = buildCronDetailFromJob({
+      job: {
+        id: '8c886b3fed87',
+        name: 'Hermes Diary Update — Pierre',
+        prompt: 'Run: cd ~/"[ 03 ] CODE"/Hermes/DIARY && python3 -m diary.update_orchestrator --cross-ref',
+        skills: ['hermes-diary-system'],
+        model: { provider: 'openrouter', model: 'kimi-k2.6:cloud' },
+        schedule_display: '0 */6 * * *',
+        enabled: true,
+        last_status: 'ok',
+        deliver: 'origin',
+        origin: { platform: 'telegram', chat_id: '1854421', chat_name: 'Rodrigo Bressane' },
+      },
+      node: {
+        id: 'pierre-local',
+        name: 'Pierre',
+        kind: 'hermes-local',
+        host: 'local',
+        status: 'healthy',
+        lastSeen: 'now',
+        recentErrors: [],
+        checks: [],
+      },
+      latestOutput: `# Cron Job: Hermes Diary Update — Pierre
+
+**Job ID:** 8c886b3fed87
+
+## Prompt
+
+Run: something
+
+## Response
+
+Cronjob Response: Hermes Diary Update — Pierre
+(job_id: 8c886b3fed87)
+-------------
+📕 Hermes Diary Update — Pierre
+• job_id: 8c886b3fed87
+• Diary updated successfully.
+API_KEY=secret-value
+`,
+      outputPath: '/tmp/output.md',
+    })
+
+    expect(detail.job.id).toBe('8c886b3fed87')
+    expect(detail.job.prompt).toContain('update_orchestrator')
+    expect(detail.job.deliveryTarget).toBe('telegram:Rodrigo Bressane')
+    expect(detail.latestOutput?.response).toContain('Cronjob Response')
+    expect(detail.latestOutput?.response).not.toContain('secret-value')
+    expect(detail.style.tone).toBe('systemish')
+    expect(detail.style.reasons).toContain('job id exposed')
+    expect(detail.suggestedHumanSummary).toContain('Diary updated')
+    expect(detail.suggestedHumanSummary).not.toContain('job_id')
+  })
+})

--- a/src/server/fleet.ts
+++ b/src/server/fleet.ts
@@ -1,0 +1,945 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import YAML from 'yaml'
+
+const execFileAsync = promisify(execFile)
+const DEFAULT_TIMEOUT_MS = 8_000
+
+type RawFleetNode = {
+  id?: string
+  name?: string
+  kind?: FleetNodeKind
+  host?: string
+  address?: string
+  user?: string
+  key_path?: string
+  hermes_home?: string
+  gateway_url?: string
+  workspace_url?: string
+  parent?: string
+  container?: string
+  notes?: string
+}
+
+export type FleetNodeKind =
+  | 'hermes-local'
+  | 'hermes-container'
+  | 'host'
+  | 'openclaw'
+  | 'orchestrator'
+
+export type FleetStatus = 'healthy' | 'degraded' | 'offline' | 'unknown'
+
+export type FleetNode = {
+  id: string
+  name: string
+  kind: FleetNodeKind
+  host: string
+  address?: string
+  user?: string
+  keyPath?: string
+  hermesHome?: string
+  gatewayUrl?: string
+  workspaceUrl?: string
+  parent?: string
+  container?: string
+  notes?: string
+  status: FleetStatus
+}
+
+export type FleetCronItem = {
+  id: string
+  name: string
+  status: string
+  schedule?: string
+  nextRun?: string
+  lastRun?: string
+  lastRunStatus?: string
+}
+
+export type FleetCronSummary = {
+  total: number
+  active: number
+  paused: number
+  failedRecent: number
+  items: Array<FleetCronItem>
+}
+
+export type FleetNodeStatus = FleetNode & {
+  lastSeen: string | null
+  uptime?: string
+  version?: string
+  model?: string
+  provider?: string
+  image?: string
+  dockerStatus?: string
+  cron?: FleetCronSummary
+  recentErrors: Array<string>
+  checks: Array<{ label: string; ok: boolean; detail?: string }>
+}
+
+export type FleetSummary = Record<FleetStatus | 'total', number>
+
+export type FleetStatusPayload = {
+  generatedAt: string
+  registryPath: string
+  summary: FleetSummary
+  nodes: Array<FleetNodeStatus>
+}
+
+export type FleetLogSource = {
+  label: string
+  kind: 'file' | 'docker' | 'command' | 'note'
+  source: string
+  ok: boolean
+  content: string
+}
+
+export type FleetNodeDetailPayload = {
+  generatedAt: string
+  registryPath: string
+  node: FleetNodeStatus
+  parent?: FleetNodeStatus
+  logs: Array<FleetLogSource>
+}
+
+export type FleetCronDashboardJob = FleetCronItem & {
+  nodeId: string
+  nodeName: string
+  nodeStatus: FleetStatus
+  nodeKind: FleetNodeKind
+  outputPreview?: string
+  style: {
+    tone: 'human' | 'systemish' | 'unknown'
+    score: number
+    reasons: Array<string>
+  }
+}
+
+export type FleetCronDashboardPayload = {
+  generatedAt: string
+  registryPath: string
+  summary: Pick<FleetCronSummary, 'total' | 'active' | 'paused' | 'failedRecent'>
+  jobs: Array<FleetCronDashboardJob>
+}
+
+type RawCronJob = {
+  id: string
+  name?: string
+  prompt?: string
+  skills?: Array<string>
+  skill?: string | null
+  model?: { provider?: string; model?: string } | string | null
+  provider?: string | null
+  schedule_display?: string
+  schedule?: { display?: string; expr?: string }
+  enabled?: boolean
+  state?: string
+  next_run_at?: string
+  last_run_at?: string
+  last_status?: string
+  last_error?: string | null
+  last_delivery_error?: string | null
+  deliver?: string
+  origin?: { platform?: string; chat_id?: string; chat_name?: string; thread_id?: string | null }
+}
+
+export type FleetCronLatestOutput = {
+  path: string
+  runTime?: string
+  prompt?: string
+  response: string
+  raw: string
+}
+
+export type FleetCronDetailPayload = {
+  generatedAt: string
+  registryPath: string
+  node: Pick<FleetNodeStatus, 'id' | 'name' | 'kind' | 'status'>
+  job: FleetCronDashboardJob & {
+    prompt?: string
+    skills: Array<string>
+    model?: string
+    provider?: string
+    deliveryTarget: string
+    lastError?: string | null
+    lastDeliveryError?: string | null
+  }
+  latestOutput?: FleetCronLatestOutput
+  style: FleetCronDashboardJob['style']
+  suggestedHumanSummary: string
+}
+
+type DockerContainerState = {
+  name: string
+  status: string
+  image: string
+  running: boolean
+  healthy: boolean
+}
+
+function expandHome(value?: string): string | undefined {
+  if (!value) return value
+  if (value === '~') return os.homedir()
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2))
+  return value
+}
+
+export function readFleetRegistryFromText(text: string): { nodes: Array<FleetNode> } {
+  const parsed = YAML.parse(text) as { nodes?: Array<RawFleetNode> } | null
+  const rawNodes = Array.isArray(parsed?.nodes) ? parsed.nodes : []
+
+  return {
+    nodes: rawNodes
+      .filter((node) => node.id && node.name && node.kind)
+      .map((node) => ({
+        id: node.id!,
+        name: node.name!,
+        kind: node.kind!,
+        host: node.host || 'unknown',
+        address: node.address,
+        user: node.user,
+        keyPath: expandHome(node.key_path),
+        hermesHome: expandHome(node.hermes_home),
+        gatewayUrl: node.gateway_url,
+        workspaceUrl: node.workspace_url,
+        parent: node.parent,
+        container: node.container,
+        notes: node.notes,
+        status: 'unknown' as const,
+      })),
+  }
+}
+
+export function parseDockerPsLines(lines: Array<string>): Map<string, DockerContainerState> {
+  const containers = new Map<string, DockerContainerState>()
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const [name, status, image] = trimmed.split('|')
+    if (!name || !status) continue
+    const running = status.startsWith('Up')
+    const healthy = running && !status.includes('unhealthy') && (status.includes('(healthy)') || !status.includes('health:'))
+    containers.set(name, {
+      name,
+      status,
+      image: image || 'unknown',
+      running,
+      healthy,
+    })
+  }
+  return containers
+}
+
+export function parseHermesCronList(output: string): FleetCronSummary {
+  const items: Array<FleetCronItem> = []
+  let current: FleetCronItem | null = null
+
+  for (const rawLine of output.split('\n')) {
+    const line = rawLine.trimEnd()
+    const jobMatch = line.match(/^\s*([a-f0-9]{8,})\s+\[([^\]]+)\]/i)
+    if (jobMatch) {
+      if (current) items.push(current)
+      current = { id: jobMatch[1], status: jobMatch[2], name: jobMatch[1] }
+      continue
+    }
+    if (!current) continue
+
+    const fieldMatch = line.match(/^\s*(Name|Schedule|Next run|Last run):\s+(.*)$/)
+    if (!fieldMatch) continue
+    const [, key, value] = fieldMatch
+    if (key === 'Name') current.name = value.trim()
+    if (key === 'Schedule') current.schedule = value.trim()
+    if (key === 'Next run') current.nextRun = value.trim()
+    if (key === 'Last run') {
+      const parts = value.trim().split(/\s+/)
+      current.lastRunStatus = parts.at(-1)
+      current.lastRun = parts.slice(0, -1).join(' ') || value.trim()
+    }
+  }
+  if (current) items.push(current)
+
+  return summarizeCronItems(items)
+}
+
+function summarizeCronItems(items: Array<FleetCronItem>): FleetCronSummary {
+  return {
+    total: items.length,
+    active: items.filter((item) => item.status === 'active').length,
+    paused: items.filter((item) => item.status === 'paused').length,
+    failedRecent: items.filter((item) => item.lastRunStatus === 'failed').length,
+    items,
+  }
+}
+
+export function cronSummaryFromRawJobs(jobs: Array<RawCronJob>): FleetCronSummary {
+  return summarizeCronItems(
+    jobs.map((job) => ({
+      id: job.id,
+      name: job.name || job.id,
+      status: job.enabled === false || job.state === 'paused' ? 'paused' : 'active',
+      schedule: job.schedule_display || job.schedule?.display || job.schedule?.expr,
+      nextRun: job.next_run_at,
+      lastRun: job.last_run_at,
+      lastRunStatus: job.last_status,
+    })),
+  )
+}
+
+export function buildFleetSummary(nodes: Array<Pick<FleetNodeStatus, 'status'>>): FleetSummary {
+  return {
+    total: nodes.length,
+    healthy: nodes.filter((node) => node.status === 'healthy').length,
+    degraded: nodes.filter((node) => node.status === 'degraded').length,
+    offline: nodes.filter((node) => node.status === 'offline').length,
+    unknown: nodes.filter((node) => node.status === 'unknown').length,
+  }
+}
+
+export function classifyCronOutputStyle(output?: string | null): FleetCronDashboardJob['style'] {
+  const text = (output || '').trim()
+  if (!text) return { tone: 'unknown', score: 0, reasons: ['no output preview'] }
+
+  const checks: Array<[boolean, string]> = [
+    [/Cronjob Response:|^#\s*Cron Job:/im.test(text), 'cron wrapper visible'],
+    [/\bjob_id\b|\*\*Job ID:\*\*/i.test(text), 'job id exposed'],
+    [/^-{5,}$/m.test(text), 'separator line exposed'],
+    [/[📕📗📙]/.test(text), 'status-book emoji framing'],
+    [/^##\s*(Prompt|Response)\b|^###\s*Orchestrator Output\b/im.test(text), 'internal prompt/output sections exposed'],
+    [/•\s*(job_id|last_updated|Appended|Connected successfully)/i.test(text), 'implementation details exposed'],
+    [/The command ran successfully\. Here is the result:/i.test(text), 'tool execution narration exposed'],
+    [text.length > 900, 'too long for delivery surface'],
+  ]
+  const reasons = checks.filter(([matched]) => matched).map(([, reason]) => reason)
+  const score = reasons.length
+  return { tone: score >= 2 ? 'systemish' : 'human', score, reasons }
+}
+
+export function buildFleetCronDashboard(nodes: Array<FleetNodeStatus>): Pick<FleetCronDashboardPayload, 'summary' | 'jobs'> {
+  const jobs = nodes.flatMap((node) =>
+    (node.cron?.items || []).map((job) => ({
+      ...job,
+      nodeId: node.id,
+      nodeName: node.name,
+      nodeStatus: node.status,
+      nodeKind: node.kind,
+      style: classifyCronOutputStyle(job.name),
+    })),
+  )
+  return {
+    summary: {
+      total: jobs.length,
+      active: jobs.filter((job) => job.status === 'active').length,
+      paused: jobs.filter((job) => job.status === 'paused').length,
+      failedRecent: jobs.filter((job) => job.lastRunStatus === 'failed').length,
+    },
+    jobs: jobs.sort((a, b) => {
+      if (a.lastRunStatus === 'failed' && b.lastRunStatus !== 'failed') return -1
+      if (a.lastRunStatus !== 'failed' && b.lastRunStatus === 'failed') return 1
+      return a.name.localeCompare(b.name)
+    }),
+  }
+}
+
+function extractMarkdownSection(markdown: string, heading: string): string {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = markdown.match(new RegExp(`^## ${escaped}\\s*\\n([\\s\\S]*?)(?=^## |\\Z)`, 'm'))
+  return match?.[1]?.trim() || ''
+}
+
+function modelLabel(model: RawCronJob['model'], provider?: string | null): { model?: string; provider?: string } {
+  if (!model) return { provider: provider || undefined }
+  if (typeof model === 'string') return { model, provider: provider || undefined }
+  return { model: model.model, provider: model.provider || provider || undefined }
+}
+
+function deliveryTarget(job: RawCronJob): string {
+  if (job.origin?.platform) return `${job.origin.platform}:${job.origin.chat_name || job.origin.chat_id || 'origin'}`
+  return job.deliver || 'local'
+}
+
+export function buildCronDetailFromJob({
+  job,
+  node,
+  latestOutput,
+  outputPath,
+  registryPath = getFleetRegistryPath(),
+}: {
+  job: RawCronJob
+  node: FleetNodeStatus
+  latestOutput?: string
+  outputPath?: string
+  registryPath?: string
+}): FleetCronDetailPayload {
+  const redactedRaw = latestOutput ? redactSensitiveText(latestOutput) : ''
+  const response = latestOutput ? redactSensitiveText(extractMarkdownSection(latestOutput, 'Response') || latestOutput) : ''
+  const promptFromOutput = latestOutput ? redactSensitiveText(extractMarkdownSection(latestOutput, 'Prompt')) : undefined
+  const runTime = latestOutput?.match(/\*\*Run Time:\*\*\s+(.+)/)?.[1]?.trim()
+  const style = classifyCronOutputStyle(response || job.name)
+  const labels = modelLabel(job.model, job.provider)
+  const dashboardJob: FleetCronDashboardJob = {
+    id: job.id,
+    name: job.name || job.id,
+    status: job.enabled === false ? 'paused' : job.state === 'paused' ? 'paused' : 'active',
+    schedule: job.schedule_display || job.schedule?.display || job.schedule?.expr,
+    nextRun: job.next_run_at,
+    lastRun: job.last_run_at,
+    lastRunStatus: job.last_status,
+    nodeId: node.id,
+    nodeName: node.name,
+    nodeStatus: node.status,
+    nodeKind: node.kind,
+    outputPreview: response ? tailText(response, 8) : undefined,
+    style,
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    registryPath,
+    node: { id: node.id, name: node.name, kind: node.kind, status: node.status },
+    job: {
+      ...dashboardJob,
+      prompt: job.prompt,
+      skills: [...(job.skills || []), ...(job.skill ? [job.skill] : [])],
+      model: labels.model,
+      provider: labels.provider,
+      deliveryTarget: deliveryTarget(job),
+      lastError: job.last_error,
+      lastDeliveryError: job.last_delivery_error,
+    },
+    latestOutput: latestOutput
+      ? {
+          path: outputPath || '',
+          runTime,
+          prompt: promptFromOutput,
+          response,
+          raw: redactedRaw,
+        }
+      : undefined,
+    style,
+    suggestedHumanSummary: suggestHumanCronSummary(response || job.name),
+  }
+}
+
+function suggestHumanCronSummary(output: string): string {
+  const text = output.trim()
+  const codeBlock = text.match(/```\s*\n([\s\S]*?)\n```/)
+  const source = codeBlock?.[1]?.trim() || text
+  const lines = source
+    .split('\n')
+    .map((line) => line.replace(/^[-•*]\s*/, '').trim())
+    .filter(Boolean)
+    .filter((line) => !/^(Cronjob Response|job_id|Job ID|Run Time|Schedule|Prompt|Response|[-]{5,})/i.test(line))
+    .filter((line) => !/^\(?job_id:/i.test(line))
+  const meaningful = lines.find((line) => /diary updated|sessions?|turns?|morgan|open/i.test(line)) || lines[0]
+  if (!meaningful) return 'Done. No user-facing summary was available.'
+  return meaningful.replace(/\bjob_id\b[^\n]*/gi, '').trim()
+}
+
+export function findFleetNode<T extends { id: string }>(nodes: Array<T>, nodeId: string | null | undefined): T | null {
+  if (!nodeId) return null
+  return nodes.find((node) => node.id === nodeId) || null
+}
+
+export function redactSensitiveText(text: string): string {
+  return text
+    .replace(/\b(authorization\s*:\s*bearer)\s+[^\s]+/gi, '$1 [REDACTED]')
+    .replace(
+      /\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASS)[A-Z0-9_]*|password)\s*([:=])\s*(['"]?)[^\s'";]+\3/gi,
+      (_match, key: string, separator: string) => `${key}${separator}${separator === ':' ? ' ' : ''}[REDACTED]`,
+    )
+}
+
+function tailText(text: string, lineCount: number): string {
+  return text.split('\n').slice(-lineCount).join('\n').trimEnd()
+}
+
+function resolveExecutable(command: string): string {
+  if (command !== 'hermes') return command
+  const candidates = [
+    process.env.HERMES_CLI_PATH,
+    path.join(os.homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
+    path.join(os.homedir(), '.hermes', 'bin', 'hermes'),
+    'hermes',
+  ].filter(Boolean) as Array<string>
+  return candidates.find((candidate) => candidate === 'hermes' || existsSync(candidate)) || 'hermes'
+}
+
+async function runCommand(command: string, args: Array<string>, timeout = DEFAULT_TIMEOUT_MS) {
+  try {
+    const { stdout, stderr } = await execFileAsync(resolveExecutable(command), args, {
+      timeout,
+      maxBuffer: 1024 * 512,
+    })
+    return { ok: true, stdout: String(stdout), stderr: String(stderr) }
+  } catch (error) {
+    const err = error as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string }
+    return {
+      ok: false,
+      stdout: err.stdout ? String(err.stdout) : '',
+      stderr: err.stderr ? String(err.stderr) : err.message || 'Command failed',
+    }
+  }
+}
+
+function defaultRegistryText(): string {
+  return `nodes:
+  - id: pierre-local
+    name: Pierre / Local Hermes
+    kind: hermes-local
+    host: local
+    hermes_home: ~/.hermes
+    gateway_url: http://127.0.0.1:8642
+    workspace_url: http://127.0.0.1:8643
+
+  - id: morgan-vps
+    name: morgan-prod-01
+    kind: host
+    host: ssh
+    address: 46.225.149.254
+    user: bressane
+    key_path: ~/.ssh/id_hermes_morgan
+
+  - id: morgan-agent
+    name: Morgan
+    kind: hermes-container
+    host: docker
+    parent: morgan-vps
+    container: morgan-hermes
+    hermes_home: /workspace/.hermes
+
+  - id: maya-round6
+    name: Maya / Round 6
+    kind: hermes-container
+    host: docker
+    parent: morgan-vps
+    container: round6-hermes
+    hermes_home: /workspace/.hermes
+
+  - id: openclaw-local
+    name: OpenClaw Local
+    kind: openclaw
+    host: local
+`
+}
+
+export function getFleetRegistryPath(): string {
+  return expandHome(process.env.FLEET_REGISTRY_PATH) || path.join(os.homedir(), '.hermes', 'fleet.yaml')
+}
+
+export async function readFleetRegistry(registryPath = getFleetRegistryPath()): Promise<{ nodes: Array<FleetNode> }> {
+  if (!existsSync(registryPath)) return readFleetRegistryFromText(defaultRegistryText())
+  return readFleetRegistryFromText(await readFile(registryPath, 'utf8'))
+}
+
+async function collectLocalHermes(node: FleetNode): Promise<FleetNodeStatus> {
+  const [version, status, cron] = await Promise.all([
+    runCommand('hermes', ['--version'], 6_000),
+    runCommand('hermes', ['status', '--all'], 8_000),
+    runCommand('hermes', ['cron', 'list'], 8_000),
+  ])
+
+  const statusText = status.stdout
+  const versionLine = version.stdout.split('\n')[0]?.trim()
+  const model = statusText.match(/Model:\s+(.+)/)?.[1]?.trim()
+  const provider = statusText.match(/Provider:\s+(.+)/)?.[1]?.trim()
+  const gatewayRunning = /Gateway Service[\s\S]*Status:\s+✓ running/.test(statusText)
+  const cronSummary = parseHermesCronList(cron.stdout)
+  const ok = version.ok && status.ok
+
+  return {
+    ...node,
+    status: ok && gatewayRunning ? 'healthy' : ok ? 'degraded' : 'offline',
+    lastSeen: ok ? new Date().toISOString() : null,
+    version: versionLine,
+    model,
+    provider,
+    cron: cronSummary,
+    recentErrors: [],
+    checks: [
+      { label: 'Hermes CLI', ok: version.ok, detail: versionLine || version.stderr },
+      { label: 'Gateway', ok: gatewayRunning, detail: gatewayRunning ? 'running' : 'not confirmed' },
+      { label: 'Cron', ok: cron.ok, detail: `${cronSummary.active}/${cronSummary.total} active` },
+    ],
+  }
+}
+
+async function collectSshHost(node: FleetNode): Promise<FleetNodeStatus> {
+  if (!node.address || !node.user) {
+    return { ...node, status: 'unknown', lastSeen: null, recentErrors: ['Missing SSH address or user'], checks: [] }
+  }
+  const args = [
+    ...(node.keyPath ? ['-i', node.keyPath] : []),
+    '-o', 'BatchMode=yes',
+    '-o', 'ConnectTimeout=6',
+    `${node.user}@${node.address}`,
+    "hostname; docker ps --format '{{.Names}}|{{.Status}}|{{.Image}}'",
+  ]
+  const result = await runCommand('ssh', args, 10_000)
+  const lines = result.stdout.split('\n').filter(Boolean)
+  const hostname = lines[0]
+  const containers = parseDockerPsLines(lines.slice(1))
+  return {
+    ...node,
+    status: result.ok ? 'healthy' : 'offline',
+    lastSeen: result.ok ? new Date().toISOString() : null,
+    recentErrors: result.ok ? [] : [result.stderr],
+    checks: [
+      { label: 'SSH', ok: result.ok, detail: hostname || result.stderr },
+      { label: 'Docker containers', ok: containers.size > 0, detail: `${containers.size} visible` },
+    ],
+  }
+}
+
+function extractBetweenMarkers(text: string, start: string, end: string): string {
+  const startIndex = text.indexOf(start)
+  if (startIndex < 0) return ''
+  const contentStart = startIndex + start.length
+  const endIndex = text.indexOf(end, contentStart)
+  return text.slice(contentStart, endIndex < 0 ? undefined : endIndex).trim()
+}
+
+function parseCronJobsJson(text: string): Array<RawCronJob> {
+  if (!text.trim()) return []
+  try {
+    const parsed = JSON.parse(text) as { jobs?: Array<RawCronJob> } | Array<RawCronJob>
+    if (Array.isArray(parsed)) return parsed
+    return Array.isArray(parsed.jobs) ? parsed.jobs : []
+  } catch {
+    return []
+  }
+}
+
+async function collectDockerHermes(node: FleetNode, registryNodes: Array<FleetNode>): Promise<FleetNodeStatus> {
+  const parent = registryNodes.find((candidate) => candidate.id === node.parent)
+  if (!parent?.address || !parent.user || !node.container) {
+    return { ...node, status: 'unknown', lastSeen: null, recentErrors: ['Missing parent host or container'], checks: [] }
+  }
+
+  const sshPrefix = [
+    ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+    '-o', 'BatchMode=yes',
+    '-o', 'ConnectTimeout=6',
+    `${parent.user}@${parent.address}`,
+  ]
+  const hermesHome = node.hermesHome || '/workspace/.hermes'
+  const containerName = shellQuote(node.container)
+  const home = shellQuote(hermesHome)
+  const command = [
+    `docker ps --format '{{.Names}}|{{.Status}}|{{.Image}}' | grep '^${node.container}|' || true`,
+    `docker exec ${containerName} sh -lc 'test -d ${home} && echo HERMES_HOME_OK || true' 2>/dev/null || true`,
+    `docker exec ${containerName} sh -lc 'test -f /proc/1/environ && echo PROCESS_ENV_OK || true' 2>/dev/null || true`,
+    `echo __CRON_JSON_BEGIN__`,
+    `docker exec ${containerName} sh -lc 'cat ${home}/cron/jobs.json 2>/dev/null || true' || true`,
+    `echo __CRON_JSON_END__`,
+  ].join('; ')
+  const result = await runCommand('ssh', [...sshPrefix, command], 12_000)
+  const lines = result.stdout.split('\n')
+  const dockerLine = lines.find((line) => line.startsWith(`${node.container}|`))
+  const container = dockerLine ? parseDockerPsLines([dockerLine]).get(node.container) : null
+  const hermesHomeOk = lines.includes('HERMES_HOME_OK')
+  const processEnvOk = lines.includes('PROCESS_ENV_OK')
+  const rawJobs = parseCronJobsJson(extractBetweenMarkers(result.stdout, '__CRON_JSON_BEGIN__', '__CRON_JSON_END__'))
+  const cronSummary = cronSummaryFromRawJobs(rawJobs)
+
+  const running = Boolean(container?.running)
+  const healthy = Boolean(container?.healthy)
+  return {
+    ...node,
+    status: result.ok && healthy ? 'healthy' : result.ok && running ? 'degraded' : 'offline',
+    lastSeen: result.ok ? new Date().toISOString() : null,
+    image: container?.image,
+    dockerStatus: container?.status,
+    cron: cronSummary.total ? cronSummary : undefined,
+    recentErrors: result.ok ? [] : [result.stderr],
+    checks: [
+      { label: 'Container running', ok: running, detail: container?.status || 'not found' },
+      { label: 'Container health', ok: healthy, detail: container?.status || 'not found' },
+      { label: 'Hermes home mounted', ok: hermesHomeOk, detail: hermesHomeOk ? `${hermesHome} exists` : 'not confirmed' },
+      { label: 'Runtime environment', ok: processEnvOk, detail: processEnvOk ? '/proc/1/environ readable' : 'not confirmed' },
+      { label: 'Cron registry', ok: cronSummary.total > 0, detail: `${cronSummary.active}/${cronSummary.total} active` },
+    ],
+  }
+}
+
+export function inferOpenClawRuntime({
+  launchctl,
+  health,
+  npm,
+}: {
+  launchctl: string
+  health: string
+  npm: string
+}): Pick<FleetNodeStatus, 'status' | 'version' | 'checks'> {
+  const launchRunning = /state\s*=\s*running|job state\s*=\s*running/i.test(launchctl)
+  const pid = launchctl.match(/\bpid\s*=\s*(\d+)/i)?.[1]
+  const healthOk = /"ok"\s*:\s*true|"status"\s*:\s*"live"/i.test(health)
+  const version = npm.match(/openclaw@(\d{4}\.\d+\.\d+)/)?.[1] || launchctl.match(/OPENCLAW_SERVICE_VERSION\s*=>\s*([^\s]+)/)?.[1]
+  const packageOk = Boolean(version)
+  const status: FleetStatus = launchRunning && healthOk ? 'healthy' : launchRunning || healthOk || packageOk ? 'degraded' : 'unknown'
+
+  return {
+    status,
+    version,
+    checks: [
+      { label: 'LaunchAgent', ok: launchRunning, detail: pid ? `running, pid ${pid}` : launchRunning ? 'running' : 'not confirmed' },
+      { label: 'Gateway health', ok: healthOk, detail: healthOk ? 'http://127.0.0.1:18789/health ok' : tailText(health || 'not confirmed', 3) },
+      { label: 'OpenClaw package', ok: packageOk, detail: version ? `openclaw@${version}` : 'not confirmed' },
+    ],
+  }
+}
+
+async function collectOpenClaw(node: FleetNode): Promise<FleetNodeStatus> {
+  const [launchctl, health, npm] = await Promise.all([
+    runCommand('launchctl', ['print', `gui/${process.getuid?.() || 501}/ai.openclaw.gateway`], 6_000),
+    runCommand('curl', ['-sS', '--max-time', '3', 'http://127.0.0.1:18789/health'], 5_000),
+    runCommand('npm', ['list', '-g', 'openclaw', '--depth=0'], 8_000),
+  ])
+  const runtime = inferOpenClawRuntime({
+    launchctl: launchctl.stdout || launchctl.stderr,
+    health: health.stdout || health.stderr,
+    npm: npm.stdout || npm.stderr,
+  })
+
+  return {
+    ...node,
+    status: runtime.status,
+    lastSeen: runtime.status === 'healthy' || runtime.status === 'degraded' ? new Date().toISOString() : null,
+    version: runtime.version,
+    gatewayUrl: node.gatewayUrl || 'http://127.0.0.1:18789',
+    recentErrors: [launchctl, health, npm].filter((result) => !result.ok).map((result) => tailText(result.stderr || result.stdout, 5)),
+    checks: runtime.checks,
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+async function readLocalLog(label: string, filePath: string, lines: number): Promise<FleetLogSource> {
+  if (!existsSync(filePath)) {
+    return { label, kind: 'file', source: filePath, ok: false, content: 'Log file not found.' }
+  }
+  try {
+    const content = await readFile(filePath, 'utf8')
+    return { label, kind: 'file', source: filePath, ok: true, content: redactSensitiveText(tailText(content, lines)) }
+  } catch (error) {
+    return {
+      label,
+      kind: 'file',
+      source: filePath,
+      ok: false,
+      content: error instanceof Error ? error.message : 'Could not read log file.',
+    }
+  }
+}
+
+async function collectNodeLogs(node: FleetNodeStatus, registryNodes: Array<FleetNode>, lines: number): Promise<Array<FleetLogSource>> {
+  if (node.kind === 'hermes-local') {
+    const logRoot = path.join(os.homedir(), '.hermes', 'logs')
+    return Promise.all([
+      readLocalLog('Agent log', path.join(logRoot, 'agent.log'), lines),
+      readLocalLog('Gateway log', path.join(logRoot, 'gateway.log'), lines),
+      readLocalLog('Workspace log', path.join(logRoot, 'workspace.log'), lines),
+    ])
+  }
+
+  if (node.kind === 'hermes-container') {
+    const parent = registryNodes.find((candidate) => candidate.id === node.parent)
+    if (!parent?.address || !parent.user || !node.container) {
+      return [{ label: 'Container logs', kind: 'docker', source: node.container || 'unknown', ok: false, content: 'Missing parent host or container.' }]
+    }
+    const args = [
+      ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+      '-o', 'BatchMode=yes',
+      '-o', 'ConnectTimeout=6',
+      `${parent.user}@${parent.address}`,
+      `docker logs --tail ${Math.max(1, Math.min(lines, 500))} ${shellQuote(node.container)} 2>&1`,
+    ]
+    const result = await runCommand('ssh', args, 12_000)
+    return [{
+      label: 'Container logs',
+      kind: 'docker',
+      source: `docker logs ${node.container}`,
+      ok: result.ok,
+      content: redactSensitiveText(tailText(result.stdout || result.stderr || 'No log output.', lines)),
+    }]
+  }
+
+  if (node.kind === 'host' && node.host === 'ssh') {
+    const detail = node.recentErrors.length ? node.recentErrors.join('\n') : 'Host detail is available. Container-level logs live on the child nodes.'
+    return [{ label: 'Host note', kind: 'note', source: node.address || node.host, ok: true, content: detail }]
+  }
+
+  if (node.kind === 'openclaw') {
+    const logRoot = path.join(os.homedir(), '.openclaw', 'logs')
+    return Promise.all([
+      readLocalLog('OpenClaw gateway log', path.join(logRoot, 'gateway.log'), lines),
+      readLocalLog('OpenClaw gateway errors', path.join(logRoot, 'gateway.err.log'), lines),
+      readLocalLog('OpenClaw watchdog log', path.join(logRoot, 'watchdog.log'), lines),
+    ])
+  }
+
+  return [{ label: 'Logs', kind: 'note', source: node.kind, ok: false, content: 'No log collector configured for this node yet.' }]
+}
+
+export async function collectFleetNodeDetail(nodeId: string, lines = 160, registryPath = getFleetRegistryPath()): Promise<FleetNodeDetailPayload | null> {
+  const registry = await readFleetRegistry(registryPath)
+  const fleet = await collectFleetStatus(registryPath)
+  const node = findFleetNode(fleet.nodes, nodeId)
+  if (!node) return null
+  const parent = node.parent ? findFleetNode(fleet.nodes, node.parent) || undefined : undefined
+  const logs = await collectNodeLogs(node, registry.nodes, Math.max(20, Math.min(lines, 500)))
+  return {
+    generatedAt: new Date().toISOString(),
+    registryPath,
+    node,
+    parent,
+    logs,
+  }
+}
+
+export async function collectFleetStatus(registryPath = getFleetRegistryPath()): Promise<FleetStatusPayload> {
+  const registry = await readFleetRegistry(registryPath)
+  const statuses = await Promise.all(
+    registry.nodes.map((node) => {
+      if (node.kind === 'hermes-local') return collectLocalHermes(node)
+      if (node.kind === 'host' && node.host === 'ssh') return collectSshHost(node)
+      if (node.kind === 'hermes-container') return collectDockerHermes(node, registry.nodes)
+      if (node.kind === 'openclaw') return collectOpenClaw(node)
+      return Promise.resolve({ ...node, status: 'unknown' as const, lastSeen: null, recentErrors: [], checks: [] })
+    }),
+  )
+
+  return {
+    generatedAt: new Date().toISOString(),
+    registryPath,
+    summary: buildFleetSummary(statuses),
+    nodes: statuses,
+  }
+}
+
+export async function collectFleetCronDashboard(registryPath = getFleetRegistryPath()): Promise<FleetCronDashboardPayload> {
+  const fleet = await collectFleetStatus(registryPath)
+  const dashboard = buildFleetCronDashboard(fleet.nodes)
+  return {
+    generatedAt: new Date().toISOString(),
+    registryPath,
+    ...dashboard,
+  }
+}
+
+function cronJobsPath(): string {
+  return path.join(os.homedir(), '.hermes', 'cron', 'jobs.json')
+}
+
+async function readLocalCronJobs(): Promise<Array<RawCronJob>> {
+  try {
+    return parseCronJobsJson(await readFile(cronJobsPath(), 'utf8'))
+  } catch {
+    return []
+  }
+}
+
+async function readRemoteContainerCronDetail(
+  node: FleetNodeStatus,
+  registryNodes: Array<FleetNode>,
+  jobId: string,
+): Promise<{ jobs: Array<RawCronJob>; latest?: { path: string; content: string } }> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(jobId)) return { jobs: [] }
+  const parent = registryNodes.find((candidate) => candidate.id === node.parent)
+  if (!parent?.address || !parent.user || !node.container) return { jobs: [] }
+
+  const hermesHome = node.hermesHome || '/workspace/.hermes'
+  const sshPrefix = [
+    ...(parent.keyPath ? ['-i', parent.keyPath] : []),
+    '-o', 'BatchMode=yes',
+    '-o', 'ConnectTimeout=6',
+    `${parent.user}@${parent.address}`,
+  ]
+  const containerName = shellQuote(node.container)
+  const home = shellQuote(hermesHome)
+  const job = shellQuote(jobId)
+  const command = [
+    'echo __CRON_JSON_BEGIN__',
+    `docker exec ${containerName} sh -lc 'cat ${home}/cron/jobs.json 2>/dev/null || true' || true`,
+    'echo __CRON_JSON_END__',
+    'echo __OUTPUT_PATH_BEGIN__',
+    `docker exec ${containerName} sh -lc 'ls -t ${home}/cron/output/${job}/*.md 2>/dev/null | head -n 1' || true`,
+    'echo __OUTPUT_PATH_END__',
+    'echo __OUTPUT_CONTENT_BEGIN__',
+    `docker exec ${containerName} sh -lc 'file=$(ls -t ${home}/cron/output/${job}/*.md 2>/dev/null | head -n 1); test -n "$file" && cat "$file" || true' || true`,
+    'echo __OUTPUT_CONTENT_END__',
+  ].join('; ')
+  const result = await runCommand('ssh', [...sshPrefix, command], 12_000)
+  if (!result.ok) return { jobs: [] }
+
+  const jobs = parseCronJobsJson(extractBetweenMarkers(result.stdout, '__CRON_JSON_BEGIN__', '__CRON_JSON_END__'))
+  const outputPath = extractBetweenMarkers(result.stdout, '__OUTPUT_PATH_BEGIN__', '__OUTPUT_PATH_END__').split('\n').filter(Boolean).at(-1)
+  const content = extractBetweenMarkers(result.stdout, '__OUTPUT_CONTENT_BEGIN__', '__OUTPUT_CONTENT_END__')
+  return {
+    jobs,
+    latest: outputPath && content ? { path: `${node.container}:${outputPath}`, content } : undefined,
+  }
+}
+
+async function latestCronOutput(jobId: string): Promise<{ path: string; content: string } | undefined> {
+  const outputDir = path.join(os.homedir(), '.hermes', 'cron', 'output', jobId)
+  if (!existsSync(outputDir)) return undefined
+  try {
+    const files = await readdir(outputDir)
+    const markdownFiles = await Promise.all(
+      files
+        .filter((file) => file.endsWith('.md'))
+        .map(async (file) => {
+          const filePath = path.join(outputDir, file)
+          return { path: filePath, mtime: (await stat(filePath)).mtimeMs }
+        }),
+    )
+    const latest = markdownFiles.sort((a, b) => b.mtime - a.mtime)[0]
+    if (!latest) return undefined
+    return { path: latest.path, content: await readFile(latest.path, 'utf8') }
+  } catch {
+    return undefined
+  }
+}
+
+export async function collectFleetCronDetail(nodeId: string, jobId: string, registryPath = getFleetRegistryPath()): Promise<FleetCronDetailPayload | null> {
+  const registry = await readFleetRegistry(registryPath)
+  const fleet = await collectFleetStatus(registryPath)
+  const node = findFleetNode(fleet.nodes, nodeId)
+  if (!node) return null
+
+  if (node.kind === 'hermes-local') {
+    const jobs = await readLocalCronJobs()
+    const rawJob = jobs.find((job) => job.id === jobId)
+    if (!rawJob) return null
+    const latest = await latestCronOutput(jobId)
+    return buildCronDetailFromJob({
+      job: rawJob,
+      node,
+      latestOutput: latest?.content,
+      outputPath: latest?.path,
+      registryPath,
+    })
+  }
+
+  if (node.kind === 'hermes-container') {
+    const remote = await readRemoteContainerCronDetail(node, registry.nodes, jobId)
+    const rawJob = remote.jobs.find((job) => job.id === jobId)
+    if (!rawJob) return null
+    return buildCronDetailFromJob({
+      job: rawJob,
+      node,
+      latestOutput: remote.latest?.content,
+      outputPath: remote.latest?.path,
+      registryPath,
+    })
+  }
+
+  return null
+}

--- a/src/server/jobs-profile-resolution.test.ts
+++ b/src/server/jobs-profile-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+  sanitizeProfileName,
+} from './jobs-profile-resolution'
+
+describe('sanitizeProfileName', () => {
+  it('accepts simple profile names', () => {
+    expect(sanitizeProfileName('aurora')).toBe('aurora')
+    expect(sanitizeProfileName(' swarm6 ')).toBe('swarm6')
+  })
+
+  it('rejects empty and path-like values', () => {
+    expect(sanitizeProfileName('')).toBeNull()
+    expect(sanitizeProfileName('   ')).toBeNull()
+    expect(sanitizeProfileName('../etc')).toBeNull()
+    expect(sanitizeProfileName('a/b')).toBeNull()
+    expect(sanitizeProfileName('a\\b')).toBeNull()
+  })
+})
+
+describe('resolveJobsProfile', () => {
+  it('prefers explicit ?profile= query param', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?profile=query-one')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'query-one',
+    )
+  })
+
+  it('falls back to HERMES_PROFILE env var', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'env-one',
+    )
+  })
+
+  it('falls back to file-backed active profile when env is absent', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'file-one')).toBe('file-one')
+  })
+
+  it('ignores the default sentinel from active_profile', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'default')).toBeNull()
+  })
+})
+
+describe('buildJobsProfileSearch', () => {
+  it('adds the resolved profile while preserving other params', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?limit=10')
+    expect(buildJobsProfileSearch(url, 'aurora')).toBe(
+      '?limit=10&profile=aurora',
+    )
+  })
+
+  it('replaces any inbound profile query with the resolved profile', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', 'new')).toBe(
+      '?limit=10&profile=new',
+    )
+  })
+
+  it('drops profile from the query when no resolved profile exists', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', null)).toBe(
+      '?limit=10',
+    )
+  })
+})

--- a/src/server/jobs-profile-resolution.ts
+++ b/src/server/jobs-profile-resolution.ts
@@ -1,0 +1,55 @@
+import { getActiveProfileName } from './profiles-browser'
+
+export function sanitizeProfileName(
+  name: string | null | undefined,
+): string | null {
+  if (!name) return null
+  const trimmed = String(name).trim()
+  if (!trimmed) return null
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('..')
+  ) {
+    return null
+  }
+  return trimmed
+}
+
+export function resolveJobsProfile(
+  url: URL,
+  envProfile = process.env.HERMES_PROFILE,
+  activeProfileResolver: () => string = getActiveProfileName,
+): string | null {
+  const fromQuery = sanitizeProfileName(url.searchParams.get('profile'))
+  if (fromQuery) return fromQuery
+
+  const fromEnv = sanitizeProfileName(envProfile)
+  if (fromEnv) return fromEnv
+
+  try {
+    const fromFile = sanitizeProfileName(activeProfileResolver())
+    if (fromFile && fromFile !== 'default') return fromFile
+  } catch {
+    // ignore file-backed profile lookup failures
+  }
+
+  return null
+}
+
+export function buildJobsProfileSearch(
+  urlOrSearch: URL | string,
+  profile: string | null,
+): string {
+  const sourceSearch =
+    typeof urlOrSearch === 'string' ? urlOrSearch : urlOrSearch.search
+  const params = new URLSearchParams(
+    sourceSearch.startsWith('?') ? sourceSearch.slice(1) : sourceSearch,
+  )
+
+  params.delete('profile')
+  if (profile) params.set('profile', profile)
+
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -137,7 +137,10 @@ export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(results, workspaceRoot, path.join(workspaceRoot, 'MEMORY.md'))
+  for (const subdir of ['memory', 'memories']) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, subdir))
+  }
 
   results.sort(compareMemoryFiles)
   return results

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -3,13 +3,15 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listProfiles } from './profiles-browser'
+import { listProfiles, renameProfile } from './profiles-browser'
 
-describe('listProfiles', () => {
+describe('profiles-browser integration', () => {
   let tempHome: string
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-workspace-profiles-'))
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-'),
+    )
     vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
   })
 
@@ -24,16 +26,126 @@ describe('listProfiles', () => {
     const namedProfileRoot = path.join(profilesRoot, 'jarvis')
 
     fs.mkdirSync(namedProfileRoot, { recursive: true })
-    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'jarvis\n', 'utf-8')
-    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: default-model\n', 'utf-8')
-    fs.writeFileSync(path.join(namedProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'jarvis\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'model: default-model\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(namedProfileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
 
     const profiles = listProfiles()
     const names = profiles.map((profile) => profile.name)
 
     expect(names).toContain('default')
     expect(names).toContain('jarvis')
-    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(false)
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(true)
+    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(
+      false,
+    )
+    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(
+      true,
+    )
+  })
+
+  it('renames a profile and rewrites local/global stale references', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+    const newProfileRoot = path.join(profilesRoot, 'dr_kwon')
+
+    fs.mkdirSync(path.join(oldProfileRoot, 'skills', 'demo-skill'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(hermesRoot, 'team', 'handoffs'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'alan\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'SOUL.md'),
+      '<!-- Profile: alan (Primary: gpt-5.4) -->\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'config.yaml'),
+      'mcp:\n  command: ~/.hermes/profiles/alan/openbb-env/bin/openbb-mcp\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+      `Path: ${hermesRoot}/profiles/alan/data\n`,
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'sharedPath: ~/.hermes/profiles/alan/shared\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team-agents.md'),
+      'Agent alan owns this lane\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+      'handoff from alan with ~/.hermes/profiles/alan/path\n',
+      'utf-8',
+    )
+
+    const renamed = renameProfile('alan', 'dr_kwon')
+
+    expect(renamed.name).toBe('dr_kwon')
+    expect(fs.existsSync(oldProfileRoot)).toBe(false)
+    expect(fs.existsSync(newProfileRoot)).toBe(true)
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8'),
+    ).toBe('dr_kwon\n')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'SOUL.md'), 'utf-8'),
+    ).toContain('Profile: dr_kwon')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'config.yaml'), 'utf-8'),
+    ).toContain('~/.hermes/profiles/dr_kwon/openbb-env/bin/openbb-mcp')
+    expect(
+      fs.readFileSync(
+        path.join(newProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toContain(`${hermesRoot}/profiles/dr_kwon/data`)
+    expect(fs.readFileSync(path.join(hermesRoot, 'config.yaml'), 'utf-8')).toContain(
+      '~/.hermes/profiles/dr_kwon/shared',
+    )
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'team-agents.md'), 'utf-8'),
+    ).toContain('Agent alan owns this lane')
+    expect(
+      fs.readFileSync(
+        path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+        'utf-8',
+      ),
+    ).toContain('~/.hermes/profiles/dr_kwon/path')
+  })
+
+  it('rejects new profile names that the Hermes CLI would reject', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+
+    fs.mkdirSync(oldProfileRoot, { recursive: true })
+
+    expect(() => renameProfile('alan', 'Dr_Kwon')).toThrow(
+      /Invalid profile name/i,
+    )
   })
 })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -27,6 +28,23 @@ export type ProfileDetail = {
   skillsDir?: string
 }
 
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const TEXT_REWRITE_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.jsonl',
+  '.toml',
+  '.env',
+  '.plist',
+  '.sh',
+  '.js',
+  '.ts',
+  '.tsx',
+])
+
 function getHermesRoot(): string {
   return path.join(os.homedir(), '.hermes')
 }
@@ -45,8 +63,14 @@ function getActiveProfilePath(): string {
  */
 function validateProfileName(name: string): string {
   const trimmed = validateProfileIdentifier(name)
-  if (trimmed === 'default')
+  if (trimmed === 'default') {
     throw new Error('Default profile cannot be modified here')
+  }
+  if (!PROFILE_NAME_RE.test(trimmed)) {
+    throw new Error(
+      "Invalid profile name. Use lowercase letters, numbers, underscores, or hyphens, and start with a letter or number.",
+    )
+  }
   return trimmed
 }
 
@@ -252,7 +276,7 @@ export function readProfile(name: string): ProfileDetail {
   const profilePath =
     normalized === 'default'
       ? getHermesRoot()
-      : path.join(getProfilesRoot(), validateProfileName(normalized))
+      : path.join(getProfilesRoot(), validateProfileIdentifier(normalized))
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   const configPath = path.join(profilePath, 'config.yaml')
   const envPath = path.join(profilePath, '.env')
@@ -279,7 +303,7 @@ export function setActiveProfile(name: string): void {
     if (fs.existsSync(activePath)) fs.unlinkSync(activePath)
     return
   }
-  const normalized = validateProfileName(trimmed)
+  const normalized = validateProfileIdentifier(trimmed)
   const profilePath = path.join(getProfilesRoot(), normalized)
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   fs.mkdirSync(getHermesRoot(), { recursive: true })
@@ -405,14 +429,138 @@ export function updateProfileConfig(
   return readProfile(normalized)
 }
 
+function replaceTextReferences(
+  input: string,
+  oldName: string,
+  newName: string,
+): string {
+  const escapedOld = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const absoluteProfileOld = `${getHermesRoot()}/profiles/${oldName}`
+  const absoluteProfileNew = `${getHermesRoot()}/profiles/${newName}`
+
+  return input
+    .replaceAll(absoluteProfileOld, absoluteProfileNew)
+    .replaceAll(`~/.hermes/profiles/${oldName}`, `~/.hermes/profiles/${newName}`)
+    .replaceAll(`profiles/${oldName}/`, `profiles/${newName}/`)
+    .replaceAll(`ai.hermes.gateway-${oldName}`, `ai.hermes.gateway-${newName}`)
+    .replace(
+      new RegExp(`(<!--\\s*Profile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+    .replace(
+      new RegExp(`(\\bProfile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+}
+
+function rewriteTextFileIfPresent(
+  filePath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(filePath)) return
+  try {
+    const original = safeReadText(filePath)
+    const updated = replaceTextReferences(original, oldName, newName)
+    if (updated !== original) {
+      fs.writeFileSync(filePath, updated, 'utf-8')
+    }
+  } catch {
+    // ignore non-text or unreadable files
+  }
+}
+
+function rewriteTextFilesRecursive(
+  rootPath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(rootPath)) return
+  const stack = [rootPath]
+  while (stack.length > 0) {
+    const current = stack.pop() as string
+    let entries: Array<fs.Dirent> = []
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+        continue
+      }
+      if (!TEXT_REWRITE_EXTENSIONS.has(path.extname(entry.name))) continue
+      rewriteTextFileIfPresent(fullPath, oldName, newName)
+    }
+  }
+}
+
+function migrateLaunchAgentProfile(
+  oldName: string,
+  newName: string,
+): void {
+  if (process.platform !== 'darwin') return
+  const launchAgentsDir = path.join(os.homedir(), 'Library', 'LaunchAgents')
+  const oldPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${oldName}.plist`)
+  const newPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${newName}.plist`)
+  if (!fs.existsSync(oldPlist)) return
+
+  rewriteTextFileIfPresent(oldPlist, oldName, newName)
+  try {
+    if (fs.existsSync(newPlist)) fs.rmSync(newPlist, { force: true })
+    fs.renameSync(oldPlist, newPlist)
+  } catch {
+    return
+  }
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  if (uid == null) return
+  try {
+    execFileSync('launchctl', ['bootout', `gui/${uid}`, oldPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootout failures
+  }
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, newPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootstrap failures
+  }
+}
+
+function migrateGlobalProfileReferences(oldName: string, newName: string): void {
+  const hermesRoot = getHermesRoot()
+  const directFiles = [
+    path.join(hermesRoot, 'config.yaml'),
+    path.join(hermesRoot, 'SOUL.md'),
+    path.join(hermesRoot, 'team-agents.md'),
+    path.join(hermesRoot, 'team', 'cron.md'),
+    path.join(hermesRoot, 'team', 'day-30-runbook.md'),
+  ]
+  for (const filePath of directFiles) {
+    rewriteTextFileIfPresent(filePath, oldName, newName)
+  }
+  rewriteTextFilesRecursive(path.join(hermesRoot, 'team', 'handoffs'), oldName, newName)
+}
+
 export function renameProfile(oldName: string, newName: string): ProfileDetail {
-  const from = validateProfileName(oldName)
+  const from = validateProfileIdentifier(oldName)
   const to = validateProfileName(newName)
   const fromPath = path.join(getProfilesRoot(), from)
   const toPath = path.join(getProfilesRoot(), to)
   if (!fs.existsSync(fromPath)) throw new Error('Profile not found')
   if (fs.existsSync(toPath)) throw new Error('Target profile already exists')
+
   fs.renameSync(fromPath, toPath)
+  rewriteTextFilesRecursive(toPath, from, to)
+  migrateGlobalProfileReferences(from, to)
+  migrateLaunchAgentProfile(from, to)
+
   if (getActiveProfileName() === from) {
     fs.writeFileSync(getActiveProfilePath(), `${to}\n`, 'utf-8')
   }

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 
 type WorkspaceState = {
   sidebarCollapsed: boolean
+  sidebarPinned: boolean
   fileExplorerCollapsed: boolean
   chatFocusMode: boolean
   /** Currently active sub-page route (e.g. '/skills', '/channels') — null means chat-only */
@@ -17,6 +18,8 @@ type WorkspaceState = {
   mobileComposerFocused: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebarPinned: () => void
+  setSidebarPinned: (pinned: boolean) => void
   toggleFileExplorer: () => void
   setFileExplorerCollapsed: (collapsed: boolean) => void
   toggleChatFocusMode: () => void
@@ -34,6 +37,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      sidebarPinned: false,
       fileExplorerCollapsed: true,
       chatFocusMode: false,
       activeSubPage: null,
@@ -43,8 +47,28 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       mobileKeyboardInset: 0,
       mobileComposerFocused: false,
       toggleSidebar: () =>
-        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+        set((s) => {
+          const nextCollapsed = !s.sidebarCollapsed
+          return {
+            sidebarCollapsed: nextCollapsed,
+            sidebarPinned: nextCollapsed ? false : s.sidebarPinned,
+          }
+        }),
+      setSidebarCollapsed: (collapsed) =>
+        set((s) => ({
+          sidebarCollapsed: collapsed,
+          sidebarPinned: collapsed ? false : s.sidebarPinned,
+        })),
+      toggleSidebarPinned: () =>
+        set((s) => ({
+          sidebarPinned: !s.sidebarPinned,
+          sidebarCollapsed: s.sidebarPinned ? s.sidebarCollapsed : false,
+        })),
+      setSidebarPinned: (pinned) =>
+        set((s) => ({
+          sidebarPinned: pinned,
+          sidebarCollapsed: pinned ? false : s.sidebarCollapsed,
+        })),
       toggleFileExplorer: () =>
         set((s) => ({ fileExplorerCollapsed: !s.fileExplorerCollapsed })),
       setFileExplorerCollapsed: (collapsed) =>
@@ -65,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       name: 'hermes-workspace-v1',
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarPinned: state.sidebarPinned,
         fileExplorerCollapsed: state.fileExplorerCollapsed,
         chatPanelOpen: state.chatPanelOpen,
         chatPanelSessionKey: state.chatPanelSessionKey,


### PR DESCRIPTION
## Summary
- Add fleet status, cron, node detail, and operations routes/screens to Hermes Workspace
- Add safe operation planning and confirmed execution support for cron, gateway restart, agent update, and health check
- Store redacted append-only operation audit records in ~/.hermes/fleet/operations-audit.jsonl
- Wire Fleet navigation into desktop sidebar and mobile tabs
- Add Vitest coverage for fleet collectors and operation planning/redaction

## Test Plan
- pnpm exec vitest run src/server/fleet-operations.test.ts --reporter=basic
- pnpm test -- --reporter=basic
- pnpm build