### PR TITLE
feat(integrations): bounded Honcho detection + repo-identity update gating

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,7 +47,9 @@ import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
+import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesUpdateRouteImport } from './routes/api/hermes-update'
 import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
 import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
 import { Route as ApiHermesJobsRouteImport } from './routes/api/hermes-jobs'
@@ -287,9 +289,19 @@ const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
   path: '/api/local-providers',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiIntegrationsRoute = ApiIntegrationsRouteImport.update({
+  id: '/api/integrations',
+  path: '/api/integrations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHistoryRoute = ApiHistoryRouteImport.update({
   id: '/api/history',
   path: '/api/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesUpdateRoute = ApiHermesUpdateRouteImport.update({
+  id: '/api/hermes-update',
+  path: '/api/hermes-update',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHermesTasksAssigneesRoute = ApiHermesTasksAssigneesRouteImport.update({
@@ -565,7 +577,9 @@ export interface FileRoutesByFullPath {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -653,7 +667,9 @@ export interface FileRoutesByTo {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -743,7 +759,9 @@ export interface FileRoutesById {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -834,7 +852,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -922,7 +942,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1011,7 +1033,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1101,7 +1125,9 @@ export interface RootRouteChildren {
   ApiHermesJobsRoute: typeof ApiHermesJobsRouteWithChildren
   ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
   ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
+  ApiHermesUpdateRoute: typeof ApiHermesUpdateRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
+  ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
@@ -1413,11 +1439,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiLocalProvidersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/integrations': {
+      id: '/api/integrations'
+      path: '/api/integrations'
+      fullPath: '/api/integrations'
+      preLoaderRoute: typeof ApiIntegrationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/history': {
       id: '/api/history'
       path: '/api/history'
       fullPath: '/api/history'
       preLoaderRoute: typeof ApiHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-update': {
+      id: '/api/hermes-update'
+      path: '/api/hermes-update'
+      fullPath: '/api/hermes-update'
+      preLoaderRoute: typeof ApiHermesUpdateRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/hermes-tasks-assignees': {
@@ -1881,7 +1921,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHermesJobsRoute: ApiHermesJobsRouteWithChildren,
   ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
   ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
+  ApiHermesUpdateRoute: ApiHermesUpdateRoute,
   ApiHistoryRoute: ApiHistoryRoute,
+  ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,

--- a/src/routes/api/-hermes-update.test.ts
+++ b/src/routes/api/-hermes-update.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createRemoteStatus, remoteUrlMatchesExpectedRepo } from './hermes-update'
+
+describe('hermes update repo gating', () => {
+  it('matches Claude/Hermes workspace repo aliases', () => {
+    expect(remoteUrlMatchesExpectedRepo('https://github.com/example/claude-workspace.git', ['claude-workspace', 'hermes-workspace'])).toBe(true)
+    expect(remoteUrlMatchesExpectedRepo('git@github.com:outsourc-e/hermes-workspace.git', ['claude-workspace', 'outsourc-e/hermes-workspace'])).toBe(true)
+  })
+
+  it('blocks update availability for wrong remote repos even when heads differ', () => {
+    const status = createRemoteStatus({
+      name: 'origin',
+      label: 'Hermes Workspace',
+      expectedRepo: 'hermes-workspace',
+      aliases: ['claude-workspace', 'hermes-workspace'],
+      url: 'https://github.com/example/not-workspace.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(false)
+    expect(status.updateAvailable).toBe(false)
+    expect(status.error).toContain('expected hermes-workspace')
+  })
+
+  it('allows update availability only for the expected repo with a newer remote head', () => {
+    const status = createRemoteStatus({
+      name: 'upstream',
+      label: 'Hermes Agent',
+      expectedRepo: 'hermes-agent',
+      aliases: ['claude-agent', 'hermes-agent'],
+      url: 'https://github.com/NousResearch/hermes-agent.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(true)
+    expect(status.updateAvailable).toBe(true)
+    expect(status.error).toBeNull()
+  })
+})

--- a/src/routes/api/hermes-update.ts
+++ b/src/routes/api/hermes-update.ts
@@ -1,0 +1,160 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { isAuthenticated } from '../../server/auth-middleware'
+
+type RemoteName = 'origin' | 'upstream'
+
+type RemoteStatus = {
+  name: RemoteName
+  label: string
+  url: string | null
+  expectedRepo: string
+  expectedAliases: Array<string>
+  repoMatches: boolean
+  remoteHead: string | null
+  currentHead: string | null
+  updateAvailable: boolean
+  error: string | null
+}
+
+type RemoteDefinition = {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+}
+
+export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
+  {
+    name: 'origin',
+    label: 'Hermes Workspace',
+    expectedRepo: 'hermes-workspace',
+    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
+  },
+  {
+    name: 'upstream',
+    label: 'Hermes Agent',
+    expectedRepo: 'hermes-agent',
+    aliases: ['claude-agent', 'hermes-agent', 'NousResearch/hermes-agent'],
+  },
+]
+
+function git(args: string[], timeout = 5000): string | null {
+  try {
+    return execFileSync('git', args, { cwd: process.cwd(), encoding: 'utf8', timeout }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function pkgVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as { version?: string }
+    return pkg.version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export function remoteUrlMatchesExpectedRepo(url: string | null, aliases: Array<string>): boolean {
+  if (!url) return false
+  const normalizedUrl = url
+    .toLowerCase()
+    .replace(/^git@github\.com:/, 'github.com/')
+    .replace(/^https?:\/\//, '')
+    .replace(/\.git$/, '')
+  return aliases.some((alias) => normalizedUrl.includes(alias.toLowerCase().replace(/\.git$/, '')))
+}
+
+export function createRemoteStatus(input: {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+  url: string | null
+  currentHead: string | null
+  remoteHead: string | null
+  lsRemoteFailed?: boolean
+}): RemoteStatus {
+  const repoMatches = remoteUrlMatchesExpectedRepo(input.url, input.aliases)
+  let error: string | null = null
+  if (!input.url) {
+    error = 'Remote is not configured.'
+  } else if (!repoMatches) {
+    error = `Remote URL does not match expected ${input.expectedRepo} repo.`
+  } else if (!input.remoteHead || input.lsRemoteFailed) {
+    error = 'Unable to read remote HEAD.'
+  }
+
+  return {
+    name: input.name,
+    label: input.label,
+    url: input.url,
+    expectedRepo: input.expectedRepo,
+    expectedAliases: input.aliases,
+    repoMatches,
+    remoteHead: repoMatches ? input.remoteHead : null,
+    currentHead: input.currentHead,
+    updateAvailable: Boolean(repoMatches && input.currentHead && input.remoteHead && input.currentHead !== input.remoteHead),
+    error,
+  }
+}
+
+function remoteStatus(definition: RemoteDefinition, currentHead: string | null): RemoteStatus {
+  const url = git(['remote', 'get-url', definition.name])
+  const repoMatches = remoteUrlMatchesExpectedRepo(url, definition.aliases)
+  let remoteHead: string | null = null
+  let lsRemoteFailed = false
+
+  if (url && repoMatches) {
+    const raw = git(['ls-remote', url, 'HEAD'], 8000)
+    remoteHead = raw?.split(/\s+/)[0] ?? null
+    lsRemoteFailed = !remoteHead
+  }
+
+  return createRemoteStatus({
+    name: definition.name,
+    label: definition.label,
+    expectedRepo: definition.expectedRepo,
+    aliases: definition.aliases,
+    url,
+    currentHead,
+    remoteHead,
+    lsRemoteFailed,
+  })
+}
+
+export const Route = createFileRoute('/api/hermes-update')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const currentHead = git(['rev-parse', 'HEAD'])
+        const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+        const dirty = Boolean(git(['status', '--porcelain']))
+        const remotes = UPDATE_REMOTE_DEFINITIONS.map((definition) => remoteStatus(definition, currentHead))
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          app: {
+            name: 'Hermes Workspace',
+            version: pkgVersion(),
+            branch,
+            currentHead,
+            dirty,
+          },
+          remotes,
+          updateAvailable: remotes.some((remote) => remote.updateAvailable),
+          manualConfirmRequired: true,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/integrations.ts
+++ b/src/routes/api/integrations.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { detectHonchoIntegration } from '../../server/integration-detection'
+
+export const Route = createFileRoute('/api/integrations')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          integrations: {
+            honcho: detectHonchoIntegration(),
+          },
+        })
+      },
+    },
+  },
+})

--- a/src/server/integration-detection.test.ts
+++ b/src/server/integration-detection.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { detectHonchoIntegration } from './integration-detection'
+
+const tempDirs: Array<string> = []
+
+function tempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honcho-detect-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('detectHonchoIntegration', () => {
+  it('keeps Honcho disabled when no local presence or config exists', () => {
+    const homeDir = tempHome()
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('not-detected')
+    expect(status.available).toBe(false)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects local Honcho presence without enabling unsafe use', () => {
+    const homeDir = tempHome()
+    fs.mkdirSync(path.join(homeDir, '.honcho'), { recursive: true })
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('detected-unconfigured')
+    expect(status.available).toBe(true)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects Honcho config from OpenClaw env/config without exposing secret values', () => {
+    const homeDir = tempHome()
+    const openClawHome = path.join(homeDir, '.openclaw')
+    fs.mkdirSync(openClawHome, { recursive: true })
+    fs.writeFileSync(path.join(openClawHome, '.env'), 'HONCHO_API_KEY=secret-value\n')
+    fs.writeFileSync(path.join(openClawHome, 'config.yaml'), 'honcho:\n  enabled: true\n')
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome,
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.configured).toBe(true)
+    expect(status.safeToUse).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-env' && source.configured)).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-config' && source.configured)).toBe(true)
+    expect(JSON.stringify(status)).not.toContain('secret-value')
+  })
+
+  it('detects Claude honcho.json as a configured Honcho source', () => {
+    const homeDir = tempHome()
+    const claudeHome = path.join(homeDir, '.claude')
+    fs.mkdirSync(claudeHome, { recursive: true })
+    fs.writeFileSync(path.join(claudeHome, 'honcho.json'), JSON.stringify({ appId: 'workspace', baseUrl: 'http://localhost:8787' }))
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome,
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.sources.some((source) => source.id === 'claude-honcho-json' && source.configured)).toBe(true)
+  })
+})

--- a/src/server/integration-detection.ts
+++ b/src/server/integration-detection.ts
@@ -1,0 +1,257 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import YAML from 'yaml'
+
+export type HonchoDetectionSource = {
+  id: string
+  label: string
+  path?: string
+  present: boolean
+  configured: boolean
+  details: string
+}
+
+export type HonchoIntegrationStatus = {
+  id: 'honcho'
+  label: 'Honcho memory'
+  available: boolean
+  configured: boolean
+  safeToUse: boolean
+  mode: 'ready' | 'detected-unconfigured' | 'not-detected'
+  summary: string
+  sources: Array<HonchoDetectionSource>
+  checkedAt: number
+}
+
+type DetectHonchoOptions = {
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+  openClawHome?: string
+  claudeHome?: string
+  hermesHome?: string
+  now?: number
+}
+
+const HONCHO_ENV_KEYS = [
+  'HONCHO_API_KEY',
+  'HONCHO_APP_ID',
+  'HONCHO_BASE_URL',
+  'HONCHO_URL',
+  'HONCHO_ENVIRONMENT',
+] as const
+
+const HONCHO_CONFIG_KEYS = [
+  'enabled',
+  'api_key',
+  'apiKey',
+  'app_id',
+  'appId',
+  'url',
+  'base_url',
+  'baseUrl',
+] as const
+
+function expandHome(value: string, homeDir: string): string {
+  if (value === '~') return homeDir
+  if (value.startsWith('~/')) return path.join(homeDir, value.slice(2))
+  return value
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readYaml(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = YAML.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readEnvFile(filePath: string): Record<string, string> {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const env: Record<string, string> = {}
+    for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      env[key] = value
+    }
+    return env
+  } catch {
+    return {}
+  }
+}
+
+function hasOwnTruthy(record: Record<string, unknown> | null | undefined, keys: ReadonlyArray<string>): boolean {
+  if (!record) return false
+  return keys.some((key) => {
+    const value = record[key]
+    return typeof value === 'string' ? Boolean(value.trim()) : Boolean(value)
+  })
+}
+
+function objectAt(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
+  const value = record?.[key]
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function envConfigured(env: Record<string, string | undefined>): boolean {
+  return HONCHO_ENV_KEYS.some((key) => Boolean(env[key]?.trim()))
+}
+
+function configHasHoncho(record: Record<string, unknown> | null): boolean {
+  const honchoConfig = objectAt(record, 'honcho')
+  const memoryConfig = objectAt(record, 'memory')
+  const integrationsConfig = objectAt(record, 'integrations')
+  const integrationsHoncho = objectAt(integrationsConfig, 'honcho')
+  const provider = String(memoryConfig?.provider ?? '').toLowerCase()
+
+  return (
+    hasOwnTruthy(honchoConfig, HONCHO_CONFIG_KEYS) ||
+    (provider.includes('honcho') && hasOwnTruthy(memoryConfig, ['provider', 'honcho'])) ||
+    hasOwnTruthy(integrationsHoncho, HONCHO_CONFIG_KEYS)
+  )
+}
+
+function fileSource(id: string, label: string, filePath: string, configured: boolean, details: string): HonchoDetectionSource {
+  return {
+    id,
+    label,
+    path: filePath,
+    present: fs.existsSync(filePath),
+    configured,
+    details,
+  }
+}
+
+export function detectHonchoIntegration(options: DetectHonchoOptions = {}): HonchoIntegrationStatus {
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? os.homedir()
+  const openClawHome = expandHome(options.openClawHome ?? env.OPENCLAW_HOME ?? path.join(homeDir, '.openclaw'), homeDir)
+  const claudeHome = expandHome(options.claudeHome ?? env.CLAUDE_HOME ?? path.join(homeDir, '.claude'), homeDir)
+  const hermesHome = expandHome(options.hermesHome ?? env.HERMES_HOME ?? path.join(homeDir, '.hermes'), homeDir)
+
+  const processEnvConfigured = envConfigured(env)
+
+  const openClawEnvPath = path.join(openClawHome, '.env')
+  const openClawEnvConfigured = envConfigured(readEnvFile(openClawEnvPath))
+
+  const openClawConfigPath = path.join(openClawHome, 'config.yaml')
+  const openClawConfigConfigured = configHasHoncho(readYaml(openClawConfigPath))
+
+  const claudeHonchoPath = path.join(claudeHome, 'honcho.json')
+  const claudeHonchoConfigured = hasOwnTruthy(readJson(claudeHonchoPath), HONCHO_CONFIG_KEYS)
+
+  // Legacy/compatibility signals stay read-only and only contribute to detection.
+  const hermesEnvPath = path.join(hermesHome, '.env')
+  const hermesEnvConfigured = envConfigured(readEnvFile(hermesEnvPath))
+  const hermesConfigPath = path.join(hermesHome, 'config.yaml')
+  const hermesConfigConfigured = configHasHoncho(readYaml(hermesConfigPath))
+
+  const localDirs = [
+    path.join(homeDir, '.honcho'),
+    path.join(homeDir, '.config', 'honcho'),
+    path.join(openClawHome, 'honcho'),
+    path.join(claudeHome, 'honcho'),
+    path.join(hermesHome, 'honcho'),
+  ]
+
+  const sources: Array<HonchoDetectionSource> = [
+    {
+      id: 'process-env',
+      label: 'Process environment',
+      present: processEnvConfigured,
+      configured: processEnvConfigured,
+      details: processEnvConfigured ? 'Honcho env var present in process environment.' : 'No Honcho env var in process environment.',
+    },
+    fileSource(
+      'openclaw-env',
+      'OpenClaw .env',
+      openClawEnvPath,
+      openClawEnvConfigured,
+      openClawEnvConfigured ? 'Honcho env var present in OpenClaw .env.' : 'No Honcho env var in OpenClaw .env.',
+    ),
+    fileSource(
+      'openclaw-config',
+      'OpenClaw config.yaml',
+      openClawConfigPath,
+      openClawConfigConfigured,
+      openClawConfigConfigured ? 'Honcho keys found in OpenClaw config.' : 'No Honcho keys found in OpenClaw config.',
+    ),
+    fileSource(
+      'claude-honcho-json',
+      'Claude honcho.json',
+      claudeHonchoPath,
+      claudeHonchoConfigured,
+      claudeHonchoConfigured ? 'Claude Honcho config file has usable keys.' : 'No Claude Honcho config file with usable keys.',
+    ),
+    fileSource(
+      'hermes-env',
+      'Hermes .env compatibility',
+      hermesEnvPath,
+      hermesEnvConfigured,
+      hermesEnvConfigured ? 'Honcho env var present in Hermes .env.' : 'No Honcho env var in Hermes .env.',
+    ),
+    fileSource(
+      'hermes-config',
+      'Hermes config.yaml compatibility',
+      hermesConfigPath,
+      hermesConfigConfigured,
+      hermesConfigConfigured ? 'Honcho keys found in Hermes config.' : 'No Honcho keys found in Hermes config.',
+    ),
+    ...localDirs.map((dir) => ({
+      id: `dir:${dir}`,
+      label: path.basename(dir) || dir,
+      path: dir,
+      present: fs.existsSync(dir),
+      configured: false,
+      details: fs.existsSync(dir) ? 'Local Honcho directory exists; configuration still needs verification.' : 'Directory not found.',
+    })),
+  ]
+
+  const configured = sources.some((source) => source.configured)
+  const present = configured || sources.some((source) => source.present)
+  const mode: HonchoIntegrationStatus['mode'] = configured
+    ? 'ready'
+    : present
+      ? 'detected-unconfigured'
+      : 'not-detected'
+
+  return {
+    id: 'honcho',
+    label: 'Honcho memory',
+    available: present,
+    configured,
+    safeToUse: configured,
+    mode,
+    summary: configured
+      ? 'Honcho memory configuration detected. Workspace can safely gate Honcho-backed features behind explicit user action.'
+      : present
+        ? 'Honcho presence detected, but no usable config/token was found. Honcho-backed features remain disabled.'
+        : 'Honcho not detected. Optional Honcho-backed memory features remain hidden/disabled.',
+    sources,
+    checkedAt: options.now ?? Date.now(),
+  }
+}


### PR DESCRIPTION
Slice B of overnight swarm work. Adds bounded local-only Honcho detection (no calls, no writes, no secrets) and repo-identity gating for the background update probe so wrong-remote URLs cannot trigger spurious updateAvailable. 7/7 targeted tests pass; full suite 88/88; pnpm build green. Files: src/server/integration-detection.{ts,test.ts}, src/routes/api/integrations.ts, src/routes/api/claude-update.ts, src/routes/api/-claude-update.test.ts, src/routeTree.gen.ts. Triage by swarm12 dirty-worktree-pr-slicing skill.