### PR TITLE
docs(docker): clarify Skills Hub fallback mode (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ No local build. First run takes a minute to pull; subsequent starts are instant.
 Agent state (config, sessions, skills, memory, credentials) persists in the
 `hermes-data` named volume, so containers can be recreated without data loss.
 
+> **Skills Hub note:** the published `ghcr.io/outsourc-e/hermes-workspace` image
+> includes the bundled skills fallback. Full Marketplace / Skills Hub registry
+> search needs the Python `scripts/skills-search.py` runtime plus a Hermes Agent
+> source/install tree; use the source/dev Docker overlay or a derived image if
+> you need non-bundled hub results from an image-only deployment. The
+> `/api/skills/hub-search` response includes `source: "bundled-skills-fallback"`
+> and a `warning` when the container is running fallback-only mode.
+
 ### Step 3: Access the Workspace
 
 Open `http://localhost:3000` and complete the onboarding.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,42 @@ This means the Vite SSR server tried `GET /api/gateway-status` which internally 
 
 ---
 
+### Docker: Skills Hub / Marketplace only shows bundled skills
+
+The published `ghcr.io/outsourc-e/hermes-workspace` image is intentionally
+self-contained for the Workspace UI and bundled skills. It does **not** include a
+full Hermes Agent source checkout plus Python Skills Hub dependencies for
+non-bundled registry search.
+
+When full hub search is unavailable, `GET /api/skills/hub-search` falls back to
+installed/bundled skills and returns:
+
+```json
+{
+  "source": "bundled-skills-fallback",
+  "warning": "Skills Hub search is unavailable in this runtime; showing bundled skills fallback."
+}
+```
+
+To enable full Marketplace / Skills Hub registry search in Docker, use one of:
+
+1. The source/dev overlay, which builds from local source:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+   ```
+
+2. A derived image that adds `python3`, `scripts/skills-search.py`, and the
+   Hermes Agent Python package/source tree expected by the search script.
+
+3. A host-mounted Hermes Agent checkout plus matching environment variables, if
+   your deployment platform supports bind mounts.
+
+If you only need the skills bundled with the Workspace image, no action is
+required; the fallback mode is expected.
+
+---
+
 ## Diagnostic bundle
 
 If nothing above helps, run this and share the output:


### PR DESCRIPTION
Closes #157

## Summary
- Documents that the published GHCR image uses bundled Skills Hub fallback mode by default.
- Adds Docker troubleshooting guidance for enabling full non-bundled Skills Hub registry search via source/dev overlay, derived image, or host-mounted Hermes Agent checkout.
- Calls out the existing `/api/skills/hub-search` `source: "bundled-skills-fallback"` and warning fields so image-only operators can tell which mode they are in.

## Test plan
- `pnpm test`
- `pnpm build`