### PR TITLE
fix: connect conductor controls to mission API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,8 @@
 # Set to 1 to force the Secure attribute on session cookies even when
 # NODE_ENV is not production — useful when terminating TLS at a reverse
 # proxy. Set to 0 to force it off (only safe for localhost HTTP).
-# COOKIE_SECURE=1
+# COOKIE_SECURE=1   # use behind HTTPS / reverse proxy
+# COOKIE_SECURE=0   # required for plain HTTP on HOST=0.0.0.0 / LAN access
 
 # Trust proxy-forwarded headers (default: off)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Features pending cloud infrastructure:
 
 - `HERMES_PASSWORD` — required whenever `HOST ≠ 127.0.0.1`
 - `COOKIE_SECURE=1` — force the `Secure` cookie flag when terminating HTTPS at a proxy
+- `COOKIE_SECURE=0` — required for plain HTTP LAN access on `HOST=0.0.0.0` so the browser will actually send the auth cookie
 - `TRUST_PROXY=1` — trust `x-forwarded-for` / `x-real-ip` (only set behind a sanitizing reverse proxy)
 - `HERMES_DASHBOARD_TOKEN` — explicit bearer for dashboard API (preferred over the legacy HTML-scrape fallback)
 - `HERMES_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type Props = {
   open: boolean
@@ -34,17 +35,19 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-function formatUpdatedAt(updatedAt?: number): string {
+function formatUpdatedAt(
+  updatedAt: number | undefined,
+  use24HourTime: boolean,
+): string {
   if (typeof updatedAt !== 'number') return ''
   const value = new Date(updatedAt)
   const now = new Date()
   if (value.toDateString() === now.toDateString()) {
-    return timeFormatter.format(value)
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: !use24HourTime,
+    }).format(value)
   }
   return dayFormatter.format(value)
 }
@@ -57,6 +60,10 @@ export function MobileSessionsPanel({
   onSelectSession,
   onNewChat,
 }: Props) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+
   useEffect(() => {
     if (!open) return
     function handleKeyDown(event: KeyboardEvent) {
@@ -120,7 +127,10 @@ export function MobileSessionsPanel({
               <div className="space-y-1">
                 {sessions.map((session) => {
                   const active = session.friendlyId === activeFriendlyId
-                  const timestamp = formatUpdatedAt(session.updatedAt)
+                  const timestamp = formatUpdatedAt(
+                    session.updatedAt,
+                    use24HourTime,
+                  )
                   return (
                     <button
                       key={session.key}

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1229,6 +1229,16 @@ function ChatContent() {
           />
         </Row>
         <Row
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={cs.use24HourTime}
+            onCheckedChange={(c) => updateCS({ use24HourTime: c })}
+            aria-label="Use 24-hour time"
+          />
+        </Row>
+        <Row
           label="Enter key behavior"
           description={
             cs.enterBehavior === 'newline'
@@ -1971,7 +1981,7 @@ export function SettingsDialog({
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="inset-0 h-full w-full max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
+      <DialogContent className="left-0 top-0 h-[100dvh] w-screen max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
         <div className="flex h-full min-h-0 flex-col">
           <div className="flex items-center justify-between border-b border-primary-200 bg-primary-50/80 px-4 py-4 md:rounded-t-2xl md:px-5">
             <div>

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/components/usage-meter/context-alert-modal.tsx
+++ b/src/components/usage-meter/context-alert-modal.tsx
@@ -121,7 +121,7 @@ function ContextAlertModalComponent({
               )}
               <Recommendation
                 icon="🗜️"
-                text="Enable auto-compaction in Settings → Config to automatically manage context"
+                text="Auto-compaction is configured in ~/.hermes/config.yaml under the compression section"
               />
               <Recommendation
                 icon="📋"

--- a/src/components/usage-meter/usage-details-modal.tsx
+++ b/src/components/usage-meter/usage-details-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { formatModelName } from '@/lib/format-model-name'
 
 type ModelUsage = {
@@ -81,10 +82,10 @@ function formatTokens(value: number): string {
   return Math.round(value).toString()
 }
 
-function formatTimestamp(value?: number): string {
+function formatTimestamp(value: number | undefined, use24HourTime: boolean): string {
   if (!value) return '—'
   const date = new Date(value < 1_000_000_000_000 ? value * 1000 : value)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
 }
 
 function formatResetTime(iso?: string): string {
@@ -259,7 +260,7 @@ function buildCsv(usage: UsageSummary): string {
   )
   usage.sessions.forEach((session) => {
     rows.push(
-      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt)},${formatTimestamp(session.updatedAt)}`,
+      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt, use24HourTime)},${formatTimestamp(session.updatedAt, use24HourTime)}`,
     )
   })
   return rows.join('\n')
@@ -441,8 +442,8 @@ export function UsageDetailsModal({
                         {formatTokens(session.outputTokens)} out
                       </div>
                       <div className="text-xs text-primary-500">
-                        {formatTimestamp(session.startedAt)} →{' '}
-                        {formatTimestamp(session.updatedAt)}
+                        {formatTimestamp(session.startedAt, use24HourTime)} →{' '}
+                        {formatTimestamp(session.updatedAt, use24HourTime)}
                       </div>
                       <div className="font-semibold text-primary-900">
                         {formatCurrency(session.costUsd)}
@@ -473,7 +474,7 @@ export function UsageDetailsModal({
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-primary-500">
                 Auto-polls every 30s · Last updated{' '}
-                {formatTimestamp(providerUpdatedAt ?? undefined)}
+                {formatTimestamp(providerUpdatedAt ?? undefined, use24HourTime)}
               </div>
               <Button
                 size="sm"
@@ -529,7 +530,7 @@ export function UsageDetailsModal({
                         <div className="flex items-center gap-2">
                           {statusBadge(provider.status)}
                           <span className="text-[10px] text-primary-400">
-                            {formatTimestamp(provider.updatedAt)}
+                            {formatTimestamp(provider.updatedAt, use24HourTime)}
                           </span>
                         </div>
                       </div>

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,10 +11,9 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
@@ -77,8 +76,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const { settings } = useSettings()
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
+  const sidebarPinned = useWorkspaceStore((s) => s.sidebarPinned)
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
+  const toggleSidebarPinned = useWorkspaceStore((s) => s.toggleSidebarPinned)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
@@ -150,7 +151,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed && !sidebarPinned
 
   // Sessions query — shared across sidebar and chat
   const sessionsQuery = useQuery({
@@ -311,7 +312,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 creatingSession={creatingSession}
                 onCreateSession={startNewChat}
                 isCollapsed={sidebarCollapsed}
+                isPinned={sidebarPinned}
                 onToggleCollapse={toggleSidebar}
+                onTogglePinned={toggleSidebarPinned}
                 onSelectSession={handleSelectSession}
                 onActiveSessionDelete={handleActiveSessionDelete}
                 sessionsLoading={sessionsLoading}

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -53,6 +53,7 @@ export type ChatSettings = {
    * surprised by sound on next page load.
    */
   soundOnChatComplete: boolean
+  use24HourTime: boolean
 }
 
 type ChatSettingsState = {
@@ -72,6 +73,7 @@ function defaultChatSettings(): ChatSettings {
     chatWidth: 'comfortable',
     sidebarHoverExpand: false,
     soundOnChatComplete: false,
+    use24HourTime: false,
   }
 }
 

--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeJobsResponse } from './jobs-api'
+import type { HermesJob } from './jobs-api'
+
+const job = {
+  id: 'job-1',
+  name: 'Example job',
+  prompt: 'Run the example job',
+  schedule: {},
+  enabled: true,
+  state: 'scheduled',
+} satisfies HermesJob
+
+describe('normalizeJobsResponse', () => {
+  it('accepts dashboard cron jobs returned as a top-level array', () => {
+    expect(normalizeJobsResponse([job])).toEqual([job])
+  })
+
+  it('accepts gateway jobs returned in an object wrapper', () => {
+    expect(normalizeJobsResponse({ jobs: [job] })).toEqual([job])
+  })
+
+  it('falls back to an empty list for unexpected payloads', () => {
+    expect(normalizeJobsResponse({ jobs: null })).toEqual([])
+  })
+})

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -30,11 +30,24 @@ export type JobOutput = {
   size: number
 }
 
+export function normalizeJobsResponse(data: unknown): Array<HermesJob> {
+  if (Array.isArray(data)) return data
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'jobs' in data &&
+    Array.isArray(data.jobs)
+  ) {
+    return data.jobs as Array<HermesJob>
+  }
+  return []
+}
+
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  const data = (await res.json()) as unknown
+  return normalizeJobsResponse(data)
 }
 
 export async function createJob(input: {

--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -4,12 +4,14 @@ import { getRootSurfaceState } from './-root-layout-state'
 describe('root layout surface state', () => {
   it('shows fullscreen onboarding until onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -18,9 +20,46 @@ describe('root layout surface state', () => {
 
   it('shows workspace shell and post-onboarding overlays after completion', () => {
     expect(getRootSurfaceState(true)).toEqual({
+      showLogin: false,
       showOnboarding: false,
       showWorkspaceShell: true,
       showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('shows login when auth is required and not authenticated, regardless of onboarding state', () => {
+    const unauthed = { authRequired: true, authenticated: false }
+    const expected = {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+
+    expect(getRootSurfaceState(false, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(null, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(true, unauthed)).toEqual(expected)
+  })
+
+  it('does not gate on auth when auth is not required', () => {
+    expect(
+      getRootSurfaceState(true, { authRequired: false, authenticated: false }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
+      showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('does not gate on auth when authenticated', () => {
+    expect(
+      getRootSurfaceState(false, { authRequired: true, authenticated: true }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: true,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
     })
   })
 })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -1,14 +1,31 @@
 export type RootSurfaceState = {
+  showLogin: boolean
   showOnboarding: boolean
   showWorkspaceShell: boolean
   showPostOnboardingOverlays: boolean
 }
 
+export type RootAuthStatus = {
+  authRequired: boolean
+  authenticated: boolean
+}
+
 export function getRootSurfaceState(
   onboardingComplete: boolean | null,
+  authStatus: RootAuthStatus | null = null,
 ): RootSurfaceState {
+  if (authStatus?.authRequired && !authStatus.authenticated) {
+    return {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+  }
+
   if (onboardingComplete !== true) {
     return {
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -16,6 +33,7 @@ export function getRootSurfaceState(
   }
 
   return {
+    showLogin: false,
     showOnboarding: false,
     showWorkspaceShell: true,
     showPostOnboardingOverlays: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import {
   ONBOARDING_KEY,
 } from '@/components/onboarding/hermes-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { LoginScreen } from '@/components/auth/login-screen'
+import { fetchHermesAuthStatus, type AuthStatus } from '@/lib/hermes-auth'
 import { getRootSurfaceState } from './-root-layout-state'
 
 
@@ -249,6 +251,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
   useApplyChatWidth()
 
   useEffect(() => {
@@ -297,11 +300,29 @@ function RootLayout() {
     }
   }, [])
 
-  const rootSurfaceState = getRootSurfaceState(onboardingComplete)
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    let cancelled = false
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (!cancelled) setAuthStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ authenticated: true, authRequired: false })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />
+      {rootSurfaceState.showLogin ? <LoginScreen /> : null}
       {rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -17,12 +17,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
-import {
-  HERMES_API,
-  BEARER_TOKEN,
-  dashboardFetch,
-  ensureGatewayProbed,
-} from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API, dashboardFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
 
 let cachedSkill: string | null = null
 
@@ -53,10 +48,7 @@ function loadDispatchSkill(): string {
     resolve(repoRoot(), 'skills/workspace-dispatch/SKILL.md'),
     resolve(process.cwd(), 'skills/workspace-dispatch/SKILL.md'),
     resolve(process.env.HOME ?? '~', '.hermes/skills/workspace-dispatch/SKILL.md'),
-    resolve(
-      process.env.HOME ?? '~',
-      '.ocplatform/workspace/skills/workspace-dispatch/SKILL.md',
-    ),
+    resolve(process.env.HOME ?? '~', '.ocplatform/workspace/skills/workspace-dispatch/SKILL.md'),
   ]
   for (const p of candidates) {
     try {
@@ -91,8 +83,7 @@ function buildOrchestratorPrompt(
   },
 ): string {
   const outputBase = options.projectsDir || '/tmp'
-  const outputPrefix =
-    outputBase === '/tmp' ? '/tmp/dispatch-<slug>' : `${outputBase}/dispatch-<slug>`
+  const outputPrefix = outputBase === '/tmp' ? '/tmp/dispatch-<slug>' : `${outputBase}/dispatch-<slug>`
 
   return [
     'You are a mission orchestrator. Execute this mission autonomously.',
@@ -104,24 +95,12 @@ function buildOrchestratorPrompt(
     '## Mission',
     '',
     `Goal: ${goal}`,
-    ...(options.orchestratorModel
-      ? ['', `Use model: ${options.orchestratorModel} for the orchestrator`]
-      : []),
-    ...(options.workerModel
-      ? ['', `Use model: ${options.workerModel} for all workers`]
-      : []),
+    ...(options.orchestratorModel ? ['', `Use model: ${options.orchestratorModel} for the orchestrator`] : []),
+    ...(options.workerModel ? ['', `Use model: ${options.workerModel} for all workers`] : []),
     ...(options.maxParallel > 1
-      ? [
-          '',
-          `Run up to ${options.maxParallel} workers in parallel when tasks are independent`,
-        ]
-      : [
-          '',
-          'Spawn workers one at a time. Do NOT wait for workers to finish — the UI handles tracking.',
-        ]),
-    ...(options.supervised
-      ? ['', 'Supervised mode is enabled. Require approval before each task.']
-      : []),
+      ? ['', `Run up to ${options.maxParallel} workers in parallel when tasks are independent`]
+      : ['', 'Spawn workers one at a time. Do NOT wait for workers to finish — the UI handles tracking.']),
+    ...(options.supervised ? ['', 'Supervised mode is enabled. Require approval before each task.'] : []),
     '',
     '## Critical Rules',
     '- Use create_task / delegate_task to create worker agents for each task',
@@ -146,30 +125,58 @@ function nowPlusSecondsIso(seconds: number): string {
   return t.toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
-async function createHermesJob(payload: {
-  name: string
-  schedule: string
-  prompt: string
-  deliver?: string
-}): Promise<{ id?: string; name?: string; error?: string }> {
+async function createConductorMission(payload: { name: string; prompt: string }): Promise<{
+  id?: string
+  name?: string
+  sessionKey?: string
+  sessionKeyPrefix?: string
+  error?: string
+}> {
   const body = JSON.stringify({
     name: payload.name,
-    schedule: payload.schedule,
     prompt: payload.prompt,
-    deliver: payload.deliver ?? 'local',
   })
   const capabilities = await ensureGatewayProbed()
-  const res = capabilities.dashboard.available
-    ? await dashboardFetch('/api/cron/jobs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body,
-      })
-    : await fetch(`${HERMES_API}/api/jobs`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders() },
-        body,
-      })
+  if (capabilities.dashboard.available) {
+    const res = await dashboardFetch('/api/conductor/missions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    const text = await res.text()
+    let data: {
+      id?: string
+      name?: string
+      session_id?: string
+      error?: string
+      detail?: string
+    } = {}
+    try {
+      data = JSON.parse(text)
+    } catch {
+      return { error: text || `HTTP ${res.status}` }
+    }
+    if (!res.ok || data.error || data.detail) {
+      return { error: data.error || data.detail || `HTTP ${res.status}` }
+    }
+    return {
+      id: data.id,
+      name: data.name,
+      sessionKey: data.session_id,
+    }
+  }
+
+  const cronBody = JSON.stringify({
+    name: payload.name,
+    schedule: nowPlusSecondsIso(5),
+    prompt: payload.prompt,
+    deliver: 'local',
+  })
+  const res = await fetch(`${HERMES_API}/api/jobs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: cronBody,
+  })
   const text = await res.text()
   let data: { job?: { id?: string; name?: string }; error?: string } = {}
   try {
@@ -180,12 +187,48 @@ async function createHermesJob(payload: {
   if (!res.ok || data.error) {
     return { error: data.error || `HTTP ${res.status}` }
   }
-  return { id: data.job?.id, name: data.job?.name }
+  return {
+    id: data.job?.id,
+    name: data.job?.name,
+    sessionKeyPrefix: data.job?.id ? `cron_${data.job.id}_` : undefined,
+  }
 }
 
 export const Route = createFileRoute('/api/conductor-spawn')({
   server: {
     handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const missionId = url.searchParams.get('missionId')?.trim()
+        const requestedLines = Number(url.searchParams.get('lines') || '200')
+        const lines = Number.isFinite(requestedLines) ? Math.min(2000, Math.max(1, requestedLines)) : 200
+        if (!missionId) {
+          return json({ ok: false, error: 'missionId required' }, { status: 400 })
+        }
+
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.dashboard.available) {
+          return json({ ok: false, error: 'Hermes dashboard API is unavailable' }, { status: 503 })
+        }
+
+        const res = await dashboardFetch(`/api/conductor/missions/${encodeURIComponent(missionId)}?lines=${lines}`)
+        const text = await res.text()
+        let mission: Record<string, unknown> = {}
+        try {
+          mission = JSON.parse(text) as Record<string, unknown>
+        } catch {
+          return json({ ok: false, error: text || `HTTP ${res.status}` }, { status: res.ok ? 502 : res.status })
+        }
+        if (!res.ok) {
+          const error = typeof mission.detail === 'string' ? mission.detail : typeof mission.error === 'string' ? mission.error : `HTTP ${res.status}`
+          return json({ ok: false, error }, { status: res.status })
+        }
+        return json({ ok: true, mission })
+      },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
@@ -194,9 +237,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
         if (csrfCheck) return csrfCheck
 
         try {
-          const body = (await request
-            .json()
-            .catch(() => ({}))) as ConductorSpawnBody
+          const body = (await request.json().catch(() => ({}))) as ConductorSpawnBody
           const goal = readOptionalString(body.goal)
           const orchestratorModel = readOptionalString(body.orchestratorModel)
           const workerModel = readOptionalString(body.workerModel)
@@ -218,30 +259,24 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           })
 
           const jobName = `conductor-${Date.now()}`
-          // Schedule a one-shot job ~5s in the future so the cron loop
-          // picks it up promptly without racing with the create response.
-          const result = await createHermesJob({
+          const result = await createConductorMission({
             name: jobName,
-            schedule: nowPlusSecondsIso(5),
             prompt,
-            deliver: 'local',
           })
 
           if (result.error) {
-            return json(
-              { ok: false, error: result.error },
-              { status: 502 },
-            )
+            return json({ ok: false, error: result.error }, { status: 502 })
           }
 
-          // Hermes runs cron jobs in sessions keyed `cron_<jobId>_<timestamp>`.
-          // We can't know the timestamp until the cron loop fires, so we return
-          // a prefix and the UI polls for any session whose key starts with it.
+          // Dashboard-backed Conductor starts immediately. Legacy gateway-only
+          // fallback still uses cron sessions keyed `cron_<jobId>_<timestamp>`.
           const jobId = result.id ?? jobName
+          const dashboardBacked = Boolean(result.id && !result.sessionKeyPrefix)
           return json({
             ok: true,
-            sessionKey: `cron_${jobId}_pending`,
-            sessionKeyPrefix: `cron_${jobId}_`,
+            missionId: dashboardBacked ? jobId : null,
+            sessionKey: result.sessionKey ?? (dashboardBacked ? null : `cron_${jobId}_pending`),
+            sessionKeyPrefix: result.sessionKeyPrefix ?? (dashboardBacked ? null : `cron_${jobId}_`),
             jobId,
             jobName: result.name ?? jobName,
             runId: null,
@@ -250,8 +285,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           return json(
             {
               ok: false,
-              error:
-                error instanceof Error ? error.message : String(error),
+              error: error instanceof Error ? error.message : String(error),
             },
             { status: 500 },
           )

--- a/src/routes/api/conductor-stop.ts
+++ b/src/routes/api/conductor-stop.ts
@@ -2,7 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
-import { deleteSession, ensureGatewayProbed } from '../../server/hermes-api'
+import { deleteSession } from '../../server/hermes-api'
+import {
+  dashboardFetch,
+  ensureGatewayProbed,
+} from '../../server/gateway-capabilities'
 
 export const Route = createFileRoute('/api/conductor-stop')({
   server: {
@@ -15,7 +19,6 @@ export const Route = createFileRoute('/api/conductor-stop')({
         if (csrfCheck) return csrfCheck
 
         try {
-          await ensureGatewayProbed()
           const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
           const sessionKeys = Array.isArray(body.sessionKeys)
             ? body.sessionKeys.filter(
@@ -23,8 +26,30 @@ export const Route = createFileRoute('/api/conductor-stop')({
                   typeof value === 'string' && value.trim().length > 0,
               )
             : []
+          const missionIds = Array.isArray(body.missionIds)
+            ? body.missionIds.filter(
+                (value): value is string =>
+                  typeof value === 'string' && value.trim().length > 0,
+              )
+            : []
 
           let deleted = 0
+          let stoppedMissions = 0
+          const capabilities = await ensureGatewayProbed()
+          if (capabilities.dashboard.available) {
+            for (const missionId of missionIds) {
+              try {
+                const res = await dashboardFetch(
+                  `/api/conductor/missions/${encodeURIComponent(missionId)}`,
+                  { method: 'DELETE' },
+                )
+                if (res.ok) stoppedMissions += 1
+              } catch {
+                // Ignore per-mission stop errors so session cleanup still runs.
+              }
+            }
+          }
+
           for (const sessionKey of sessionKeys) {
             try {
               await deleteSession(sessionKey)
@@ -34,7 +59,7 @@ export const Route = createFileRoute('/api/conductor-stop')({
             }
           }
 
-          return json({ ok: true, deleted })
+          return json({ ok: true, deleted, stoppedMissions })
         } catch (error) {
           return json(
             {

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -1,6 +1,9 @@
 /**
- * Jobs API proxy — forwards individual job operations to Hermes FastAPI
- * or the upstream dashboard cron API.
+ * Per-job Hermes Workspace jobs proxy.
+ *
+ * Issue #162: use the same Hermes Agent profile resolution as the main jobs
+ * list route so reads, updates, triggers, and deletes all hit the same
+ * profile-scoped cron state.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -11,6 +14,10 @@ import {
   dashboardFetch,
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -39,11 +46,13 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
 
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardPath = action
-            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const res = await dashboardFetch(dashboardPath)
           return new Response(await res.text(), {
             status: res.status,
@@ -52,8 +61,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${url.search}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
@@ -72,12 +81,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
         const body = await request.text()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardAction = action === 'run' ? 'trigger' : action
           const dashboardPath = dashboardAction
-            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const method = dashboardAction ? 'POST' : 'PUT'
           const res = await dashboardFetch(dashboardPath, {
             method,
@@ -91,8 +102,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -112,14 +123,17 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ updates: body ? JSON.parse(body) : {} }),
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,
@@ -138,11 +152,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
               headers: authHeaders(),
             })

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -1,5 +1,9 @@
 /**
- * Jobs API proxy — forwards to Hermes FastAPI /api/jobs
+ * Jobs API proxy for Hermes Workspace.
+ *
+ * Issue #162: resolve the jobs profile in one place, then forward it to the
+ * Hermes dashboard / FastAPI jobs endpoints so the screen reflects the active
+ * Hermes Agent profile instead of silently drifting to another profile.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -9,9 +13,12 @@ import {
   HERMES_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
-  getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -62,11 +69,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 200, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
         const url = new URL(request.url)
-        const params = url.searchParams.toString()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs${params ? `?${params}` : ''}`)
-          : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
+          ? await dashboardFetch(`/api/cron/jobs${search}`)
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               headers: authHeaders(),
             })
         return jobsResponse(res)
@@ -88,14 +97,18 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch('/api/cron/jobs', {
+          ? await dashboardFetch(`/api/cron/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body,
             })
-          : await fetch(`${HERMES_API}/api/jobs`, {
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -17,6 +17,31 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
     handlers: {
@@ -44,10 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -48,13 +48,9 @@ export const Route = createFileRoute('/api/history')({
             })
           }
           // "main" doesn't exist in Hermes — resolve it to the user's real
-          // main chat session. We prefer (in order):
-          //   1. The most recent session with a real human-set title
-          //      (label !== id, e.g. "hows everything"). This is what users
-          //      actually mean by "main".
-          //   2. The most recent non-internal session with messages.
-          // Cron + Operations per-agent sessions are skipped so the
-          // orchestrator chat doesn't latch onto runtime junk.
+          // active chat session. Prefer the most recently active non-internal
+          // session with messages, and only fall back to a titled session when
+          // there is no better active candidate.
           if (sessionKey === 'main') {
             try {
               const sessions = await listSessions(30, 0)
@@ -66,18 +62,18 @@ export const Route = createFileRoute('/api/history')({
                 const t = (s.title ?? '').trim()
                 return t.length > 0 && t !== s.id
               }
-              const titled = sessions.find(
-                (s) => !isInternalKey(s.id) && hasRealTitle(s),
+              const active = sessions.find(
+                (s) =>
+                  !isInternalKey(s.id) &&
+                  typeof s.message_count === 'number' &&
+                  s.message_count > 0,
               )
-              const fallback = titled
+              const titled = active
                 ? null
                 : sessions.find(
-                    (s) =>
-                      !isInternalKey(s.id) &&
-                      typeof s.message_count === 'number' &&
-                      s.message_count > 0,
+                    (s) => !isInternalKey(s.id) && hasRealTitle(s),
                   )
-              const candidate = titled ?? fallback
+              const candidate = active ?? titled
               if (candidate) {
                 sessionKey = candidate.id
               } else {

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -544,10 +544,10 @@ export const Route = createFileRoute('/api/send-stream')({
               }
 
               if (SESSION_BOOTSTRAP_KEYS.has(sessionKey)) {
-                // 'main' should land in the user's existing main chat,
-                // not spin up a brand new session every time. Skip cron
-                // and Operations per-agent sessions so the orchestrator
-                // chat doesn't latch onto them.
+                // 'main' should land in the user's real active chat session,
+                // not an older titled thread. Skip cron and Operations sessions,
+                // prefer the most recently active session with messages, and
+                // only fall back to a titled session when nothing active exists.
                 let reused: string | null = null
                 if (sessionKey === 'main') {
                   try {
@@ -563,18 +563,18 @@ export const Route = createFileRoute('/api/send-stream')({
                       const t = (s.title ?? '').trim()
                       return t.length > 0 && t !== s.id
                     }
-                    const titled = recent.find(
-                      (s) => !isInternal(s.id) && hasRealTitle(s),
+                    const active = recent.find(
+                      (s) =>
+                        !isInternal(s.id) &&
+                        typeof s.message_count === 'number' &&
+                        s.message_count > 0,
                     )
-                    const fallback = titled
+                    const titled = active
                       ? null
                       : recent.find(
-                          (s) =>
-                            !isInternal(s.id) &&
-                            typeof s.message_count === 'number' &&
-                            s.message_count > 0,
+                          (s) => !isInternal(s.id) && hasRealTitle(s),
                         )
-                    const candidate = titled ?? fallback
+                    const candidate = active ?? titled
                     if (candidate) reused = candidate.id
                   } catch {
                     // fall through to createSession()

--- a/src/routes/api/terminal-input.ts
+++ b/src/routes/api/terminal-input.ts
@@ -12,7 +12,6 @@ export const Route = createFileRoute('/api/terminal-input')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        // Auth check
         if (!isAuthenticated(request)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'Unauthorized' }),
@@ -23,10 +22,6 @@ export const Route = createFileRoute('/api/terminal-input')({
         if (csrfCheck) return csrfCheck
 
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal:${ip}`, 10, 60_000)) {
-          return rateLimitResponse()
-        }
-
         const body = (await request.json().catch(() => ({}))) as Record<
           string,
           unknown
@@ -34,6 +29,14 @@ export const Route = createFileRoute('/api/terminal-input')({
         const sessionId =
           typeof body.sessionId === 'string' ? body.sessionId : ''
         const data = typeof body.data === 'string' ? body.data : ''
+
+        const rateKey = sessionId
+          ? `terminal:${ip}:${sessionId}`
+          : `terminal:${ip}`
+        if (!rateLimit(rateKey, 600, 60_000)) {
+          return rateLimitResponse()
+        }
+
         const session = getTerminalSession(sessionId)
         if (!session) {
           return new Response(JSON.stringify({ ok: false }), {

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,10 +40,13 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return new Response(
+            JSON.stringify({ ok: false, missing: true, sessionId }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
         }
         session.resize(cols, rows)
         return new Response(JSON.stringify({ ok: true }), {

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -788,6 +788,18 @@ function ChatDisplaySection() {
           />
         </SettingsRow>
         <SettingsRow
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={chatSettings.use24HourTime}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ use24HourTime: checked })
+            }
+            aria-label="Use 24-hour time"
+          />
+        </SettingsRow>
+        <SettingsRow
           label="Enter key behavior"
           description={
             chatSettings.enterBehavior === 'newline'

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -575,7 +575,12 @@ export function buildDisplayEntries(
       return
     }
 
-    if (message.role === 'tool' || message.role === 'toolResult') {
+    if (
+      message.role === 'tool' ||
+      message.role === 'toolResult' ||
+      message.role === 'toolresult' ||
+      message.role === 'tool_result'
+    ) {
       const previousEntry = entries[entries.length - 1]
       if (previousEntry?.message.role === 'assistant') {
         previousEntry.attachedToolMessages.push(message)
@@ -1041,7 +1046,12 @@ function ChatMessageListComponent({
   const toolResultsByCallId = useMemo(() => {
     const map = new Map<string, ChatMessage>()
     for (const message of messages) {
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = message.toolCallId
       if (typeof toolCallId === 'string' && toolCallId.trim().length > 0) {
         map.set(toolCallId, message)
@@ -1087,7 +1097,12 @@ function ChatMessageListComponent({
         count += 1
       }
 
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = (message.toolCallId || '').trim()
       if (toolCallId.length > 0 && seenToolCallIds.has(toolCallId)) continue
       if (toolCallId.length > 0) {

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -13,19 +13,17 @@ import {
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
   PuzzleIcon,
 
   Rocket01Icon,
   Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
-import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,8 +31,9 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
+import { t } from '@/lib/i18n'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
   TooltipContent,
@@ -115,7 +114,9 @@ type ChatSidebarProps = {
   creatingSession: boolean
   onCreateSession: () => void
   isCollapsed: boolean
+  isPinned: boolean
   onToggleCollapse: () => void
+  onTogglePinned: () => void
   onSelectSession?: () => void
   onActiveSessionDelete?: () => void
   sessionsLoading: boolean
@@ -124,15 +125,11 @@ type ChatSidebarProps = {
   onRetrySessions: () => void
 }
 
-
-
 // ── Reusable nav item ───────────────────────────────────────────────────
 
 type NavItemDef = {
   kind: 'link' | 'button'
   to?: string
-  search?: Record<string, unknown>
-  hash?: string
   icon: unknown
   label: string
   active: boolean
@@ -152,7 +149,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -229,9 +226,7 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to!}
-                  search={item.search}
-                  hash={item.hash}
+                  to={item.to}
                   onClick={handleSelect}
                   className={cls}
                   data-tour={item.dataTour}
@@ -247,9 +242,7 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to!}
-        search={item.search}
-        hash={item.hash}
+        to={item.to}
         onClick={handleSelect}
         className={cls}
         data-tour={item.dataTour}
@@ -496,7 +489,9 @@ function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
   isCollapsed,
+  isPinned,
   onToggleCollapse,
+  onTogglePinned,
   onSelectSession,
   onActiveSessionDelete,
   sessionsLoading,
@@ -526,8 +521,11 @@ function ChatSidebarComponent({
 
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
-      const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      const detail = (event as CustomEvent<ChatOpenSettingsDetail | undefined>)
+        .detail
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -581,8 +579,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -886,7 +882,7 @@ function ChatSidebarComponent({
                 to="/chat"
                 className={cn(
                   buttonVariants({ variant: 'ghost', size: 'sm' }),
-                  'w-full pl-1.5 justify-start gap-2',
+                  'w-full pl-1.5 pr-20 justify-start gap-2',
                 )}
               >
                 <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
@@ -896,6 +892,36 @@ function ChatSidebarComponent({
           ) : null}
         </AnimatePresence>
         <TooltipProvider>
+          {!isVisuallyCollapsed ? (
+            <TooltipRoot>
+              <TooltipTrigger
+                onClick={onTogglePinned}
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+                    aria-pressed={isPinned}
+                    className={cn(
+                      'absolute right-9 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100',
+                      isPinned &&
+                        'bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] opacity-100',
+                    )}
+                    data-tour="sidebar-pin-toggle"
+                  >
+                    <HugeiconsIcon
+                      icon={isPinned ? PinOffIcon : PinIcon}
+                      size={18}
+                      strokeWidth={1.75}
+                    />
+                  </Button>
+                }
+              />
+              <TooltipContent side="right">
+                {isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+              </TooltipContent>
+            </TooltipRoot>
+          ) : null}
           <TooltipRoot>
             <TooltipTrigger
               onClick={handleSidebarToggle}
@@ -1202,6 +1228,7 @@ function areSidebarPropsEqual(
   if (prevProps.activeFriendlyId !== nextProps.activeFriendlyId) return false
   if (prevProps.creatingSession !== nextProps.creatingSession) return false
   if (prevProps.isCollapsed !== nextProps.isCollapsed) return false
+  if (prevProps.isPinned !== nextProps.isPinned) return false
   if (prevProps.sessionsLoading !== nextProps.sessionsLoading) return false
   if (prevProps.sessionsFetching !== nextProps.sessionsFetching) return false
   if (prevProps.sessionsError !== nextProps.sessionsError) return false

--- a/src/screens/chat/components/message-item.test.ts
+++ b/src/screens/chat/components/message-item.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildInlineToolRenderPlan } from './message-item'
+import { buildInlineToolRenderPlan, compactInlineToolRenderPlan } from './message-item'
 import type { ChatMessage } from '../types'
 
 describe('buildInlineToolRenderPlan', () => {
@@ -43,6 +43,105 @@ describe('buildInlineToolRenderPlan', () => {
         },
       },
       { kind: 'text', text: 'After tool.' },
+    ])
+  })
+})
+
+describe('compactInlineToolRenderPlan', () => {
+  it('stacks consecutive tool calls without moving surrounding text', () => {
+    const plan = compactInlineToolRenderPlan([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+
+    expect(plan).toEqual([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+  })
+
+  it('keeps separate stacks when text appears between tool calls', () => {
+    const plan = compactInlineToolRenderPlan([
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+    ])
+
+    expect(plan).toEqual([
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
     ])
   })
 })

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -232,15 +232,40 @@ export function compactInlineToolRenderPlan(
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
   if (!msg) return ''
-  // Prefer text from content blocks (exec stdout, Read output, etc.)
+  // Prefer text from structured content blocks first.
   if (Array.isArray(msg.content)) {
     const text = msg.content
-      .filter((b: any) => b?.type === 'text' && b?.text)
-      .map((b: any) => b.text as string)
+      .flatMap((block: any) => {
+        if (!block || typeof block !== 'object') return []
+        if (block.type === 'text' && typeof block.text === 'string') {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          typeof block.text === 'string'
+        ) {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          Array.isArray(block.content)
+        ) {
+          return block.content
+            .filter((part: any) => part?.type === 'text' && part?.text)
+            .map((part: any) => String(part.text))
+        }
+        return []
+      })
       .join('\n')
     if (text.trim()) return text
   }
-  // Fallback to details serialized
+  // Fallback to top-level text/body/message fields.
+  const raw = msg as Record<string, unknown>
+  for (const key of ['text', 'body', 'message']) {
+    const value = raw[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  // Then structured details.
   if (msg.details && typeof msg.details === 'object') {
     return JSON.stringify(msg.details, null, 2)
   }

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -158,6 +158,10 @@ export type InlineRenderPlanItem =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; section: InlineToolSection }
 
+export type CompactInlineRenderPlanItem =
+  | { kind: 'text'; text: string }
+  | { kind: 'tools'; sections: Array<InlineToolSection> }
+
 export function buildInlineToolRenderPlan(
   message: ChatMessage,
   toolSections: Array<InlineToolSection>,
@@ -198,6 +202,32 @@ export function buildInlineToolRenderPlan(
   }
 
   return plan
+}
+
+export function compactInlineToolRenderPlan(
+  plan: Array<InlineRenderPlanItem>,
+): Array<CompactInlineRenderPlanItem> {
+  const compactPlan: Array<CompactInlineRenderPlanItem> = []
+  let pendingToolSections: Array<InlineToolSection> = []
+
+  const flushTools = () => {
+    if (pendingToolSections.length === 0) return
+    compactPlan.push({ kind: 'tools', sections: pendingToolSections })
+    pendingToolSections = []
+  }
+
+  for (const item of plan) {
+    if (item.kind === 'tool') {
+      pendingToolSections.push(item.section)
+      continue
+    }
+
+    flushTools()
+    compactPlan.push(item)
+  }
+
+  flushTools()
+  return compactPlan
 }
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
@@ -1404,8 +1434,6 @@ function InlineToolSectionItem({
   const hasInputData =
     toolSection.input && Object.keys(toolSection.input).length > 0
   const hasOutputData = !!(toolSection.outputText || toolSection.errorText)
-  // Always expandable — show args, output, or at minimum the tool name/state
-  const hasExpandableContent = true
 
   return (
     <div>
@@ -1452,11 +1480,9 @@ function InlineToolSectionItem({
           {isRunning && (
             <span className="size-1.5 rounded-full animate-pulse bg-indigo-500" />
           )}
-          {hasExpandableContent && (
-            <span className="text-[8px] opacity-30 ml-0.5">
-              {open ? '▾' : '▸'}
-            </span>
-          )}
+          <span className="text-[8px] opacity-30 ml-0.5">
+            {open ? '▾' : '▸'}
+          </span>
         </div>
         {isRunning && (
           <div className="px-2.5 pb-1.5 text-[10px] text-primary-400">
@@ -1577,11 +1603,78 @@ function InlineToolSectionItem({
 function ToolCallGroup({
   toolSections,
   expandAll,
+  isStreaming,
 }: {
   toolSections: Array<InlineToolSection>
   expandAll?: boolean
   isStreaming?: boolean
 }) {
+  const [open, setOpen] = useState(Boolean(expandAll))
+  useEffect(() => {
+    if (expandAll) setOpen(true)
+  }, [expandAll])
+
+  if (toolSections.length > 1) {
+    const runningCount = toolSections.filter((section) => section.state === 'input-available' || section.state === 'input-streaming').length
+    const errorCount = toolSections.filter((section) => section.state === 'output-error').length
+    const doneCount = toolSections.length - runningCount - errorCount
+    const labels = Array.from(new Set(toolSections.map((section) => formatToolDisplayLabel(section.type, section.input))))
+    const visibleLabels = labels.slice(0, 3).join(', ')
+    const overflowLabel = labels.length > 3 ? ` +${labels.length - 3} more` : ''
+    const statusLabel =
+      runningCount > 0
+        ? `${runningCount} running`
+        : errorCount > 0
+          ? `${errorCount} failed`
+          : `${doneCount} done`
+
+    return (
+      <div className="my-3 w-full max-w-[min(100%,700px)] border-l-2 border-primary-200/60 pl-3">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-primary-600 hover:bg-primary-50/70"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="font-mono font-semibold text-ink">Tool activity</span>
+          <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] tabular-nums text-primary-600">
+            {toolSections.length} calls
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] opacity-60">
+            {visibleLabels}
+            {overflowLabel}
+          </span>
+          <span
+            className={cn(
+              'shrink-0 text-[10px] tabular-nums',
+              errorCount > 0
+                ? 'text-red-500'
+                : runningCount > 0 || isStreaming
+                  ? 'text-indigo-500'
+                  : 'text-green-600',
+            )}
+          >
+            {statusLabel}
+          </span>
+          <span className="shrink-0 text-[9px] opacity-40">
+            {open ? '▾' : '▸'}
+          </span>
+        </button>
+        {open && (
+          <div className="mt-2 flex flex-col gap-2.5">
+            {toolSections.map((toolSection, index) => (
+              <InlineToolSectionItem
+                key={toolSection.key || `${toolSection.type}-${index}`}
+                toolSection={toolSection}
+                index={index}
+                forceOpen={expandAll}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2.5 my-3 w-full max-w-[min(100%,700px)]">
       {toolSections.map((toolSection, index) => (
@@ -1694,8 +1787,8 @@ function MessageItemComponent({
   }, [])
 
   // Simulate streaming is only active while words are still being revealed
-  const totalWords = countWords(displayText)
-  const revealComplete = revealedWordCount >= totalWords && totalWords > 0
+  const displayWordCount = countWords(displayText)
+  const revealComplete = revealedWordCount >= displayWordCount && displayWordCount > 0
   const effectiveIsStreaming =
     remoteStreamingActive || (_simulateStreaming && !revealComplete)
   const assistantDisplayText = effectiveIsStreaming ? revealedText : displayText
@@ -1705,7 +1798,7 @@ function MessageItemComponent({
   )
 
   useEffect(() => {
-    const totalWords = countWords(displayText)
+    const nextTotalWords = countWords(displayText)
     const previousText = previousTextRef.current
     const previousLength = previousTextLengthRef.current
     const textGrew =
@@ -1713,7 +1806,7 @@ function MessageItemComponent({
       displayText.startsWith(previousText)
     const textChanged = displayText !== previousText
 
-    targetWordCountRef.current = totalWords
+    targetWordCountRef.current = nextTotalWords
     previousTextRef.current = displayText
     previousTextLengthRef.current = displayText.length
 
@@ -1722,12 +1815,12 @@ function MessageItemComponent({
         window.clearInterval(revealTimerRef.current)
         revealTimerRef.current = null
       }
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
     if (textChanged && !textGrew) {
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
@@ -1736,25 +1829,25 @@ function MessageItemComponent({
     }
 
     // Don't start animation if already fully revealed
-    setRevealedWordCount((currentWordCount) => {
-      if (currentWordCount >= totalWords) {
-        return currentWordCount
+    setRevealedWordCount((wordCount) => {
+      if (wordCount >= nextTotalWords) {
+        return wordCount
       }
 
       function tick() {
-        setRevealedWordCount((currentWordCount) => {
+        setRevealedWordCount((visibleWordCount) => {
           const targetWordCount = targetWordCountRef.current
-          if (currentWordCount >= targetWordCount) {
+          if (visibleWordCount >= targetWordCount) {
             if (revealTimerRef.current !== null) {
               window.clearInterval(revealTimerRef.current)
               revealTimerRef.current = null
             }
-            return currentWordCount
+            return visibleWordCount
           }
 
           const nextWordCount = Math.min(
             targetWordCount,
-            currentWordCount + WORDS_PER_TICK,
+            visibleWordCount + WORDS_PER_TICK,
           )
 
           if (
@@ -1770,7 +1863,7 @@ function MessageItemComponent({
       }
 
       revealTimerRef.current = window.setInterval(tick, TICK_INTERVAL_MS)
-      return currentWordCount
+      return wordCount
     })
   }, [displayText, effectiveIsStreaming])
 
@@ -1996,6 +2089,10 @@ function MessageItemComponent({
   const inlineRenderPlan = useMemo(
     () => buildInlineToolRenderPlan(message, finalToolSections),
     [message, finalToolSections],
+  )
+  const compactInlineRenderPlan = useMemo(
+    () => compactInlineToolRenderPlan(inlineRenderPlan),
+    [inlineRenderPlan],
   )
   const hasToolCalls = finalToolSections.length > 0
   const shouldRenderMessageBubble =
@@ -2322,11 +2419,11 @@ function MessageItemComponent({
             )}
             {!isUser && hasToolCalls && (
               <div className="flex flex-col gap-2">
-                {inlineRenderPlan.map((item, index) =>
-                  item.kind === 'tool' ? (
+                {compactInlineRenderPlan.map((item, index) =>
+                  item.kind === 'tools' ? (
                     <ToolCallGroup
-                      key={item.section.key || `tool-${index}`}
-                      toolSections={[item.section]}
+                      key={item.sections.map((section) => section.key).join(':') || `tools-${index}`}
+                      toolSections={item.sections}
                       expandAll={expandAllToolSections}
                       isStreaming={effectiveIsStreaming}
                     />
@@ -2341,11 +2438,6 @@ function MessageItemComponent({
                             'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                             effectiveIsStreaming && 'chat-streaming-content',
                           )}
-                          style={
-                            isUser
-                              ? { color: 'var(--chat-user-foreground)' }
-                              : undefined
-                          }
                         >
                           {item.text}
                         </MessageContent>
@@ -2370,11 +2462,6 @@ function MessageItemComponent({
                         'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                         effectiveIsStreaming && 'chat-streaming-content',
                       )}
-                      style={
-                        isUser
-                          ? { color: 'var(--chat-user-foreground)' }
-                          : undefined
-                      }
                     >
                       {assistantDisplayText}
                     </MessageContent>

--- a/src/screens/chat/components/message-timestamp.tsx
+++ b/src/screens/chat/components/message-timestamp.tsx
@@ -1,3 +1,5 @@
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
+
 type MessageTimestampProps = {
   timestamp: number
 }
@@ -10,14 +12,14 @@ function isSameDay(a: Date, b: Date): boolean {
   )
 }
 
-function formatShort(timestamp: number): string {
+function formatShort(timestamp: number, use24HourTime: boolean): string {
   const date = new Date(timestamp)
   const now = new Date()
   if (isSameDay(date, now)) {
     return new Intl.DateTimeFormat('en-US', {
       hour: 'numeric',
       minute: '2-digit',
-      hour12: true,
+      hour12: !use24HourTime,
     }).format(date)
   }
 
@@ -27,22 +29,24 @@ function formatShort(timestamp: number): string {
   }).format(date)
 }
 
-function formatFull(timestamp: number): string {
-  const value = new Intl.DateTimeFormat('en-US', {
+function formatFull(timestamp: number, use24HourTime: boolean): string {
+  return new Intl.DateTimeFormat('en-US', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
-    hour12: true,
+    hour12: !use24HourTime,
   }).format(new Date(timestamp))
-  return value
 }
 
 export function MessageTimestamp({ timestamp }: MessageTimestampProps) {
-  const shortLabel = formatShort(timestamp)
-  const fullLabel = formatFull(timestamp)
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+  const shortLabel = formatShort(timestamp, use24HourTime)
+  const fullLabel = formatFull(timestamp, use24HourTime)
 
   return (
     <span

--- a/src/screens/chat/components/sidebar/session-item.tsx
+++ b/src/screens/chat/components/sidebar/session-item.tsx
@@ -18,6 +18,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from '@/components/ui/menu'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type SessionItemProps = {
   session: SessionMeta
@@ -34,21 +35,24 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-function formatSessionTimestamp(timestamp?: number | null): string {
+function formatSessionTimestamp(
+  timestamp: number | undefined | null,
+  use24HourTime: boolean,
+): string {
   if (!timestamp) return ''
   const date = new Date(timestamp)
   const now = new Date()
   const sameDay = date.toDateString() === now.toDateString()
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: !use24HourTime,
+  })
   return (sameDay ? timeFormatter : dayFormatter).format(date)
 }
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isUuidLike(value: string): boolean {
   return UUID_PATTERN.test(value.trim())
@@ -102,6 +106,9 @@ function SessionItemComponent({
   onRename,
   onDelete,
 }: SessionItemProps) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
   const isGenerating = session.titleStatus === 'generating'
   const isError = session.titleStatus === 'error'
   const baseTitle = getSessionDisplayTitle(session, isGenerating)
@@ -117,11 +124,11 @@ function SessionItemComponent({
       return session.titleError || 'Could not generate a title'
     }
     const parts: Array<string> = []
-    const formatted = formatSessionTimestamp(updatedAt)
+    const formatted = formatSessionTimestamp(updatedAt, use24HourTime)
     if (formatted) parts.push(formatted)
     if (session.friendlyId) parts.push(getFriendlyIdLabel(session.friendlyId))
     return parts.join(' • ')
-  }, [isError, session.friendlyId, session.titleError, updatedAt])
+  }, [isError, session.friendlyId, session.titleError, updatedAt, use24HourTime])
 
   return (
     <Link

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -7,7 +7,7 @@ export type ToolCallContent = {
 }
 
 export type ToolResultContent = {
-  type: 'toolResult'
+  type: 'toolResult' | 'tool_result'
   toolCallId?: string
   toolName?: string
   content?: Array<{ type?: string; text?: string }>
@@ -27,7 +27,11 @@ export type ThinkingContent = {
   thinkingSignature?: string
 }
 
-export type MessageContent = TextContent | ToolCallContent | ThinkingContent
+export type MessageContent =
+  | TextContent
+  | ToolCallContent
+  | ToolResultContent
+  | ThinkingContent
 
 export type ChatAttachment = {
   id?: string

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -144,7 +144,10 @@ export function findToolResultForCall(
   messages: Array<ChatMessage>,
 ): ChatMessage | undefined {
   return messages.find(
-    (msg) => msg.role === 'toolResult' && msg.toolCallId === toolCallId,
+    (msg) =>
+      ['toolResult', 'toolresult', 'tool_result', 'tool'].includes(
+        String(msg.role || ''),
+      ) && msg.toolCallId === toolCallId,
   )
 }
 

--- a/src/screens/gateway/conductor.tsx
+++ b/src/screens/gateway/conductor.tsx
@@ -1,15 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  ArrowDown01Icon,
-  ArrowRight01Icon,
-  PlayIcon,
-  Rocket01Icon,
-  Search01Icon,
-  Settings01Icon,
-  TaskDone01Icon,
-} from '@hugeicons/core-free-icons'
+import { ArrowDown01Icon, ArrowRight01Icon, PlayIcon, Rocket01Icon, Search01Icon, Settings01Icon, TaskDone01Icon } from '@hugeicons/core-free-icons'
 import { Button } from '@/components/ui/button'
 import { Markdown } from '@/components/prompt-kit/markdown'
 import { OfficeView } from './components/office-view'
@@ -106,6 +98,27 @@ const QUICK_ACTIONS: Array<{
 const AGENT_NAMES = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
 const AGENT_EMOJIS = ['🤖', '⚡', '🔥', '🌊', '🌿', '💫', '🔮', '⭐']
 const BLENDED_COST_PER_MILLION_TOKENS = 5
+const CONDUCTOR_GOAL_DRAFT_STORAGE_KEY = 'conductor:goal-draft'
+
+function loadConductorGoalDraft(): string {
+  try {
+    return globalThis.localStorage?.getItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function persistConductorGoalDraft(value: string): void {
+  try {
+    if (value.trim()) {
+      globalThis.localStorage?.setItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY, value)
+    } else {
+      globalThis.localStorage?.removeItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY)
+    }
+  } catch {
+    // Ignore storage failures; the in-memory state still works.
+  }
+}
 
 function getAgentPersona(index: number) {
   return {
@@ -122,39 +135,19 @@ function formatUsd(value: number): string {
   return `$${value.toFixed(value >= 0.1 ? 2 : 3)}`
 }
 
-function MissionCostSection({
-  totalTokens,
-  workers,
-  expanded,
-  onToggle,
-}: {
-  totalTokens: number
-  workers: MissionCostWorker[]
-  expanded: boolean
-  onToggle: () => void
-}) {
+function MissionCostSection({ totalTokens, workers, expanded, onToggle }: { totalTokens: number; workers: MissionCostWorker[]; expanded: boolean; onToggle: () => void }) {
   const estimatedCost = estimateTokenCost(totalTokens)
 
   return (
     <div className="overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-        className="flex w-full items-start justify-between gap-4 text-left"
-      >
+      <button type="button" onClick={onToggle} aria-expanded={expanded} className="flex w-full items-start justify-between gap-4 text-left">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Cost</p>
           <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Approximate at $5 / 1M tokens blended from input/output pricing.</p>
         </div>
         <span className="inline-flex items-center gap-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs font-medium text-[var(--theme-text)]">
           {expanded ? 'Hide' : 'Show'}
-          <HugeiconsIcon
-            icon={ArrowDown01Icon}
-            size={16}
-            strokeWidth={1.7}
-            className={cn('transition-transform duration-200', expanded ? 'rotate-180' : 'rotate-0')}
-          />
+          <HugeiconsIcon icon={ArrowDown01Icon} size={16} strokeWidth={1.7} className={cn('transition-transform duration-200', expanded ? 'rotate-180' : 'rotate-0')} />
         </span>
       </button>
 
@@ -180,7 +173,9 @@ function MissionCostSection({
               <div className="divide-y divide-[var(--theme-border)]">
                 {workers.map((worker) => (
                   <div key={worker.id} className="flex items-center gap-3 px-4 py-3 text-sm">
-                    <span className="font-medium text-[var(--theme-text)]">{worker.personaEmoji} {worker.personaName}</span>
+                    <span className="font-medium text-[var(--theme-text)]">
+                      {worker.personaEmoji} {worker.personaName}
+                    </span>
                     <span className="min-w-0 flex-1 truncate text-[var(--theme-muted)]">{worker.label}</span>
                     <span className="text-xs text-[var(--theme-muted)]">{worker.totalTokens.toLocaleString()} tok</span>
                     <span className="min-w-[4.5rem] text-right font-medium text-[var(--theme-text)]">{formatUsd(estimateTokenCost(worker.totalTokens))}</span>
@@ -210,15 +205,7 @@ const WORKING_STEPS = [
   '🚀 Almost there…',
 ]
 
-function CyclingStatus({
-  steps,
-  intervalMs = 3000,
-  isPaused = false,
-}: {
-  steps: string[]
-  intervalMs?: number
-  isPaused?: boolean
-}) {
+function CyclingStatus({ steps, intervalMs = 3000, isPaused = false }: { steps: string[]; intervalMs?: number; isPaused?: boolean }) {
   const [step, setStep] = useState(0)
 
   useEffect(() => {
@@ -230,9 +217,7 @@ function CyclingStatus({
   if (isPaused) {
     return (
       <div className="flex items-center gap-3 py-3">
-        <div className="flex size-3.5 items-center justify-center rounded-full border border-amber-400/60 bg-amber-500/10 text-[9px] text-amber-300">
-          ||
-        </div>
+        <div className="flex size-3.5 items-center justify-center rounded-full border border-amber-400/60 bg-amber-500/10 text-[9px] text-amber-300">||</div>
         <p className="text-sm text-[var(--theme-muted)]">Paused</p>
       </div>
     )
@@ -354,27 +339,12 @@ function WorkerCard({
   const dot = getWorkerDot(worker.status)
   const persona = getAgentPersona(index)
   const workerOutput = conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
-  const workerStartedAt =
-    typeof worker.raw.createdAt === 'string'
-      ? worker.raw.createdAt
-      : typeof worker.raw.startedAt === 'string'
-        ? worker.raw.startedAt
-        : conductor.missionStartedAt
+  const workerStartedAt = typeof worker.raw.createdAt === 'string' ? worker.raw.createdAt : typeof worker.raw.startedAt === 'string' ? worker.raw.startedAt : conductor.missionStartedAt
   const workerEndTime =
-    worker.status === 'complete' || worker.status === 'stale'
-      ? new Date(worker.updatedAt ?? new Date().toISOString()).getTime()
-      : conductor.isPaused
-        ? conductor.pausedAtMs ?? now
-        : now
+    worker.status === 'complete' || worker.status === 'stale' ? new Date(worker.updatedAt ?? new Date().toISOString()).getTime() : conductor.isPaused ? (conductor.pausedAtMs ?? now) : now
 
   return (
-    <div
-      key={worker.key}
-      className={cn(
-        'overflow-hidden rounded-2xl border border-[var(--theme-border)] border-l-4 bg-[var(--theme-card)] px-4 py-3',
-        getWorkerBorderClass(worker.status),
-      )}
-    >
+    <div key={worker.key} className={cn('overflow-hidden rounded-2xl border border-[var(--theme-border)] border-l-4 bg-[var(--theme-card)] px-4 py-3', getWorkerBorderClass(worker.status))}>
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
@@ -510,9 +480,7 @@ function groupModelsByProvider(models: AvailableModel[]) {
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([provider, providerModels]) => ({
       provider,
-      models: [...providerModels].sort((a, b) =>
-        getModelDisplayName(a, a.id).localeCompare(getModelDisplayName(b, b.id)),
-      ),
+      models: [...providerModels].sort((a, b) => getModelDisplayName(a, a.id).localeCompare(getModelDisplayName(b, b.id))),
     }))
 }
 
@@ -595,9 +563,7 @@ function ModelSelectorDropdown({
           }}
           className={cn(
             'inline-flex min-h-[3rem] w-full items-center justify-between gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-left text-sm text-[var(--theme-text)] shadow-[0_8px_24px_color-mix(in_srgb,var(--theme-shadow)_18%,transparent)] transition-colors',
-            disabled
-              ? 'cursor-not-allowed opacity-60'
-              : 'hover:border-[var(--theme-accent)] focus:border-[var(--theme-accent)]',
+            disabled ? 'cursor-not-allowed opacity-60' : 'hover:border-[var(--theme-accent)] focus:border-[var(--theme-accent)]',
           )}
           aria-haspopup="listbox"
           aria-expanded={open}
@@ -605,21 +571,11 @@ function ModelSelectorDropdown({
         >
           <span className="inline-flex min-w-0 items-center gap-2">
             <span className="inline-flex items-center gap-2 rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-1 text-xs font-medium text-[var(--theme-text)]">
-              <span
-                className={cn(
-                  'size-2 rounded-full',
-                  value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]',
-                )}
-              />
+              <span className={cn('size-2 rounded-full', value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
               <span className="truncate">{getModelDisplayName(selectedModel, value)}</span>
             </span>
           </span>
-          <HugeiconsIcon
-            icon={ArrowDown01Icon}
-            size={16}
-            strokeWidth={1.8}
-            className={cn('shrink-0 text-[var(--theme-muted)] transition-transform', open && 'rotate-180')}
-          />
+          <HugeiconsIcon icon={ArrowDown01Icon} size={16} strokeWidth={1.8} className={cn('shrink-0 text-[var(--theme-muted)] transition-transform', open && 'rotate-180')} />
         </button>
 
         {open ? (
@@ -633,30 +589,19 @@ function ModelSelectorDropdown({
                 }}
                 className={cn(
                   'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors',
-                  !value
-                    ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]'
-                    : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
+                  !value ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
                 )}
                 role="option"
                 aria-selected={!value}
               >
-                <span
-                  className={cn(
-                    'size-2 rounded-full',
-                    !value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]',
-                  )}
-                />
+                <span className={cn('size-2 rounded-full', !value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
                 <span className="min-w-0 flex-1 truncate">Default (auto)</span>
-                <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
-                  Auto
-                </span>
+                <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">Auto</span>
               </button>
 
               {groupedModels.map((group) => (
                 <div key={group.provider} className="mt-2 first:mt-3">
-                  <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
-                    {group.provider}
-                  </div>
+                  <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">{group.provider}</div>
                   <div className="space-y-1">
                     {group.models.map((model) => {
                       const modelId = model.id ?? ''
@@ -671,19 +616,12 @@ function ModelSelectorDropdown({
                           }}
                           className={cn(
                             'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors',
-                            active
-                              ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]'
-                              : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
+                            active ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
                           )}
                           role="option"
                           aria-selected={active}
                         >
-                          <span
-                            className={cn(
-                              'size-2 rounded-full',
-                              active ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]',
-                            )}
-                          />
+                          <span className={cn('size-2 rounded-full', active ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
                           <span className="min-w-0 flex-1 truncate">{getModelDisplayName(model, modelId)}</span>
                           <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
                             {group.provider}
@@ -773,7 +711,7 @@ function deriveSessionStatus(session: GatewaySession): 'running' | 'completed' |
 
 export function Conductor() {
   const conductor = useConductorGateway()
-  const [goalDraft, setGoalDraft] = useState('')
+  const [goalDraft, setGoalDraft] = useState(() => loadConductorGoalDraft())
   const [missionModalOpen, setMissionModalOpen] = useState(false)
   const [continueDraft, setContinueDraft] = useState('')
   const [continueModalOpen, setContinueModalOpen] = useState(false)
@@ -794,7 +732,10 @@ export function Conductor() {
     queryKey: ['conductor', 'models'],
     queryFn: async () => {
       const res = await fetch('/api/models')
-      const data = (await res.json()) as { ok?: boolean; models?: Array<{ id?: string; provider?: string; name?: string }> }
+      const data = (await res.json()) as {
+        ok?: boolean
+        models?: Array<{ id?: string; provider?: string; name?: string }>
+      }
       return data.models ?? []
     },
     enabled: settingsOpen,
@@ -825,9 +766,7 @@ export function Conductor() {
 
         if (cancelled) return
         setDirectoryBrowserPath(typeof data.root === 'string' && data.root.trim() ? data.root : directoryBrowserPath)
-        setDirectoryBrowserEntries(
-          Array.isArray(data.entries) ? data.entries.filter((entry) => entry?.type === 'folder') : [],
-        )
+        setDirectoryBrowserEntries(Array.isArray(data.entries) ? data.entries.filter((entry) => entry?.type === 'folder') : [])
       } catch (error) {
         if (cancelled) return
         setDirectoryBrowserEntries([])
@@ -853,16 +792,21 @@ export function Conductor() {
   }, [conductor.isPaused, conductor.phase])
 
   useEffect(() => {
+    persistConductorGoalDraft(goalDraft)
+  }, [goalDraft])
+
+  useEffect(() => {
     if (!conductor.isPaused) return
     setNow(conductor.pausedAtMs ?? Date.now())
   }, [conductor.isPaused, conductor.pausedAtMs])
-
 
   // Set body background to match Conductor theme so no gray shows behind keyboard/tab bar
   useEffect(() => {
     const prev = document.body.style.backgroundColor
     document.body.style.backgroundColor = 'var(--color-surface)'
-    return () => { document.body.style.backgroundColor = prev }
+    return () => {
+      document.body.style.backgroundColor = prev
+    }
   }, [])
 
   const phase: ConductorPhase = useMemo(() => {
@@ -875,6 +819,7 @@ export function Conductor() {
   const handleNewMission = () => {
     conductor.resetMission()
     setGoalDraft('')
+    persistConductorGoalDraft('')
     setMissionModalOpen(false)
     setContinueDraft('')
     setContinueModalOpen(false)
@@ -887,6 +832,8 @@ export function Conductor() {
     setMissionModalOpen(false)
     setContinueDraft('')
     await conductor.sendMission(trimmed)
+    persistConductorGoalDraft('')
+    setGoalDraft('')
   }
 
   const handleQuickActionSelect = (action: (typeof QUICK_ACTIONS)[number]) => {
@@ -906,9 +853,7 @@ export function Conductor() {
     const continuationSummarySource =
       completeSummary ??
       Object.values(conductor.workerOutputs).find((output) => output.trim()) ??
-      conductor.workers
-        .map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))
-        .find((output) => output.trim()) ??
+      conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).find((output) => output.trim()) ??
       conductor.streamText
 
     const combinedPrompt = [
@@ -999,9 +944,7 @@ export function Conductor() {
       const s = session as GatewaySession
       const updatedAt = typeof s.updatedAt === 'string' ? new Date(s.updatedAt).getTime() : typeof s.updatedAt === 'number' ? s.updatedAt : 0
       const statusText = `${s.status ?? ''} ${s.kind ?? ''}`.toLowerCase()
-      const status = /error|failed/.test(statusText) ? 'error' as const
-        : /pause/.test(statusText) ? 'paused' as const
-        : Date.now() - updatedAt < 120_000 ? 'active' as const : 'idle' as const
+      const status = /error|failed/.test(statusText) ? ('error' as const) : /pause/.test(statusText) ? ('paused' as const) : Date.now() - updatedAt < 120_000 ? ('active' as const) : ('idle' as const)
       return {
         id: s.key ?? `session-${i}`,
         name: OFFICE_NAMES[i % OFFICE_NAMES.length],
@@ -1055,10 +998,9 @@ export function Conductor() {
   }, [conductor.conductorSettings.workerModel, conductor.goal, conductor.isPaused, conductor.tasks, conductor.workerOutputs, conductor.workers])
 
   const completePhaseProjectPath = useMemo(() => {
-    const workerOutputTexts = [
-      ...Object.values(conductor.workerOutputs),
-      ...conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)),
-    ].filter(Boolean)
+    const workerOutputTexts = [...Object.values(conductor.workerOutputs), ...conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(
+      Boolean,
+    )
 
     for (const text of workerOutputTexts) {
       const extractedPath = extractProjectPath(text)
@@ -1077,14 +1019,9 @@ export function Conductor() {
     const candidates = buildProjectPathCandidates(conductor.workers, conductor.missionStartedAt)
     return candidates[0] ?? null
   }, [conductor.tasks, conductor.streamText, conductor.workerOutputs, conductor.workers, conductor.missionStartedAt])
-  const completePhaseOutputLabel = useMemo(
-    () => getOutputDisplayName(completePhaseProjectPath),
-    [completePhaseProjectPath],
-  )
+  const completePhaseOutputLabel = useMemo(() => getOutputDisplayName(completePhaseProjectPath), [completePhaseProjectPath])
 
-  const previewUrl = completePhaseProjectPath
-    ? `/api/preview-file?path=${encodeURIComponent(`${completePhaseProjectPath}/index.html`)}`
-    : null
+  const previewUrl = completePhaseProjectPath ? `/api/preview-file?path=${encodeURIComponent(`${completePhaseProjectPath}/index.html`)}` : null
 
   const selectedHistoryOutputPath = useMemo(() => {
     const entry = conductor.selectedHistoryEntry
@@ -1099,13 +1036,8 @@ export function Conductor() {
     )
     return candidates[0] ?? null
   }, [conductor.selectedHistoryEntry])
-  const selectedHistoryOutputLabel = useMemo(
-    () => getOutputDisplayName(selectedHistoryOutputPath),
-    [selectedHistoryOutputPath],
-  )
-  const selectedHistoryPreviewUrl = selectedHistoryOutputPath
-    ? `/api/preview-file?path=${encodeURIComponent(`${selectedHistoryOutputPath}/index.html`)}`
-    : null
+  const selectedHistoryOutputLabel = useMemo(() => getOutputDisplayName(selectedHistoryOutputPath), [selectedHistoryOutputPath])
+  const selectedHistoryPreviewUrl = selectedHistoryOutputPath ? `/api/preview-file?path=${encodeURIComponent(`${selectedHistoryOutputPath}/index.html`)}` : null
 
   // Skip preview probe for history entries — /tmp files are ephemeral and won't exist later.
   // Only probe if the mission just completed (still in complete phase with matching output path).
@@ -1148,9 +1080,7 @@ export function Conductor() {
     const summarySource =
       completeSummary ??
       Object.values(conductor.workerOutputs).find((output) => output.trim()) ??
-      conductor.workers
-        .map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))
-        .find((output) => output.trim()) ??
+      conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).find((output) => output.trim()) ??
       conductor.streamText
     return truncateContinuationText(summarySource ?? '')
   }, [completeSummary, conductor.streamText, conductor.workerOutputs, conductor.workers])
@@ -1165,9 +1095,7 @@ export function Conductor() {
   const filteredSessions = (() => {
     const sessions = conductor.recentSessions
     if (activityFilter === 'all') return sessions
-    return sessions
-      .filter((session) => ((session.label as string) ?? '').startsWith('worker-'))
-      .filter((session) => deriveSessionStatus(session as GatewaySession) === activityFilter)
+    return sessions.filter((session) => ((session.label as string) ?? '').startsWith('worker-')).filter((session) => deriveSessionStatus(session as GatewaySession) === activityFilter)
   })()
   const activityItems: Array<MissionHistoryEntry | GatewaySession> = hasMissionHistory ? filteredHistory : filteredSessions
   const ACTIVITY_PAGE_SIZE = 3
@@ -1199,9 +1127,7 @@ export function Conductor() {
       const showHistoryOutputFallback = !!historyOutputText && (!selectedHistoryOutputPath || selectedHistoryPreview.unavailable)
       const historyStatusLabel = selectedHistoryEntry.status === 'completed' ? 'Complete' : 'Stopped'
       const historyStatusClasses =
-        selectedHistoryEntry.status === 'completed'
-          ? 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300'
-          : 'border border-red-400/35 bg-red-500/10 text-red-300'
+        selectedHistoryEntry.status === 'completed' ? 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300' : 'border border-red-400/35 bg-red-500/10 text-red-300'
 
       return (
         <div className="flex min-h-dvh flex-col overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
@@ -1223,7 +1149,8 @@ export function Conductor() {
                     </p>
                     <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">{selectedHistoryEntry.goal}</h1>
                     <p className="mt-2 text-xs text-[var(--theme-muted-2)]">
-                      {selectedHistoryEntry.workerCount}/{Math.max(selectedHistoryEntry.workerCount, 1)} workers finished · {formatDurationRange(selectedHistoryEntry.startedAt, selectedHistoryEntry.completedAt, now)} total elapsed
+                      {selectedHistoryEntry.workerCount}/{Math.max(selectedHistoryEntry.workerCount, 1)} workers finished ·{' '}
+                      {formatDurationRange(selectedHistoryEntry.startedAt, selectedHistoryEntry.completedAt, now)} total elapsed
                     </p>
                   </div>
                   <div className="flex gap-2">
@@ -1258,12 +1185,7 @@ export function Conductor() {
                     </a>
                   </div>
                   <div className="mt-4 overflow-auto rounded-2xl border border-[var(--theme-border)] bg-white">
-                    <iframe
-                      src={selectedHistoryPreviewUrl!}
-                      className="h-[clamp(280px,55vh,520px)] w-full"
-                      sandbox="allow-scripts allow-same-origin"
-                      title="Mission history output preview"
-                    />
+                    <iframe src={selectedHistoryPreviewUrl!} className="h-[clamp(280px,55vh,520px)] w-full" sandbox="allow-scripts allow-same-origin" title="Mission history output preview" />
                   </div>
                 </section>
               ) : selectedHistoryOutputPath && selectedHistoryPreview.loading ? (
@@ -1274,7 +1196,9 @@ export function Conductor() {
                   </div>
                 </section>
               ) : selectedHistoryOutputPath && selectedHistoryPreview.unavailable ? (
-                showHistoryOutputFallback ? null : <p className="px-1 text-sm text-[var(--theme-muted)]">No preview available.</p>
+                showHistoryOutputFallback ? null : (
+                  <p className="px-1 text-sm text-[var(--theme-muted)]">No preview available.</p>
+                )
               ) : null}
 
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
@@ -1282,9 +1206,7 @@ export function Conductor() {
                   <div>
                     <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Summary</p>
                   </div>
-                  <span className={cn('rounded-full px-3 py-1 text-xs font-medium', historyStatusClasses)}>
-                    {historyStatusLabel}
-                  </span>
+                  <span className={cn('rounded-full px-3 py-1 text-xs font-medium', historyStatusClasses)}>{historyStatusLabel}</span>
                 </div>
                 <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
                   {historySummary ? (
@@ -1298,9 +1220,13 @@ export function Conductor() {
                     {historyWorkerDetails.map((worker: MissionHistoryWorkerDetail, index) => (
                       <div key={`${selectedHistoryEntry.id}-worker-${index}`} className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm">
                         <span className={cn('size-2 rounded-full', selectedHistoryEntry.status === 'completed' ? 'bg-emerald-400' : 'bg-red-400')} />
-                        <span className="font-medium text-[var(--theme-text)]">{worker.personaEmoji} {worker.personaName}</span>
+                        <span className="font-medium text-[var(--theme-text)]">
+                          {worker.personaEmoji} {worker.personaName}
+                        </span>
                         <span className="text-[var(--theme-muted)]">{worker.label}</span>
-                        <span className="ml-auto text-xs text-[var(--theme-muted)]">{getShortModelName(worker.model)} · {worker.totalTokens.toLocaleString()} tok</span>
+                        <span className="ml-auto text-xs text-[var(--theme-muted)]">
+                          {getShortModelName(worker.model)} · {worker.totalTokens.toLocaleString()} tok
+                        </span>
                       </div>
                     ))}
                   </div>
@@ -1331,7 +1257,8 @@ export function Conductor() {
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output</p>
                       <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                        Preview unavailable{selectedHistoryOutputPath ? ` for ${selectedHistoryOutputLabel}` : ''}.
+                        Preview unavailable
+                        {selectedHistoryOutputPath ? ` for ${selectedHistoryOutputLabel}` : ''}.
                       </p>
                     </div>
                   </div>
@@ -1407,13 +1334,15 @@ export function Conductor() {
               />
             </section>
 
-            {(hasMissionHistory || conductor.recentSessions.length > 0) ? (
+            {hasMissionHistory || conductor.recentSessions.length > 0 ? (
               <section className="mt-6 w-full space-y-3">
                 <div className="flex items-center gap-3">
                   <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Recent Missions</h2>
                   {activityTotalPages > 1 && (
                     <div className="ml-auto flex items-center gap-1.5">
-                      <span className="text-[10px] text-[var(--theme-muted-2)]">{safeActivityPage + 1}/{activityTotalPages}</span>
+                      <span className="text-[10px] text-[var(--theme-muted-2)]">
+                        {safeActivityPage + 1}/{activityTotalPages}
+                      </span>
                       <button
                         type="button"
                         disabled={safeActivityPage === 0}
@@ -1469,9 +1398,7 @@ export function Conductor() {
                               <span
                                 className={cn(
                                   'w-[76px] shrink-0 rounded-full border px-2 py-0.5 text-center text-[10px] font-medium uppercase tracking-[0.12em]',
-                                  entry.status === 'completed'
-                                    ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-300'
-                                    : 'border-red-400/35 bg-red-500/10 text-red-300',
+                                  entry.status === 'completed' ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-300' : 'border-red-400/35 bg-red-500/10 text-red-300',
                                 )}
                               >
                                 {entry.status === 'completed' ? 'Complete' : 'Failed'}
@@ -1496,18 +1423,10 @@ export function Conductor() {
                                   ? recentSession.createdAt
                                   : null
                           const sessionStatus = deriveSessionStatus(recentSession)
-                          const dotClass =
-                            sessionStatus === 'completed'
-                              ? 'bg-emerald-400'
-                              : sessionStatus === 'failed'
-                                ? 'bg-red-400'
-                                : 'bg-sky-400 animate-pulse'
+                          const dotClass = sessionStatus === 'completed' ? 'bg-emerald-400' : sessionStatus === 'failed' ? 'bg-red-400' : 'bg-sky-400 animate-pulse'
 
                           return (
-                            <div
-                              key={recentSession.key}
-                              className="flex items-center gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm"
-                            >
+                            <div key={recentSession.key} className="flex items-center gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm">
                               <span className="min-w-0 flex-1 truncate font-medium capitalize text-[var(--theme-text)]">{displayName}</span>
                               <span
                                 className={cn(
@@ -1531,7 +1450,8 @@ export function Conductor() {
                   </div>
                 ) : (
                   <div className="rounded-xl border border-dashed border-[var(--theme-border)] px-4 py-6 text-center text-sm text-[var(--theme-muted)]">
-                    No {activityFilter === 'all' ? '' : `${activityFilter} `}{hasMissionHistory ? 'missions' : 'sessions'} found
+                    No {activityFilter === 'all' ? '' : `${activityFilter} `}
+                    {hasMissionHistory ? 'missions' : 'sessions'} found
                   </div>
                 )}
               </section>
@@ -1605,11 +1525,7 @@ export function Conductor() {
                   />
 
                   <div className="flex justify-end">
-                    <Button
-                      type="submit"
-                      disabled={!goalDraft.trim() || conductor.isSending}
-                      className="rounded-full bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]"
-                    >
+                    <Button type="submit" disabled={!goalDraft.trim() || conductor.isSending} className="rounded-full bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]">
                       {conductor.isSending ? 'Launching...' : 'Launch Mission'}
                       <HugeiconsIcon icon={ArrowRight01Icon} size={16} strokeWidth={1.7} />
                     </Button>
@@ -1736,10 +1652,7 @@ export function Conductor() {
           )}
 
           {directoryBrowserOpen ? (
-            <div
-              className="fixed inset-0 z-[70] flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_55%,transparent)] px-4 py-6 backdrop-blur-md"
-              onClick={closeDirectoryBrowser}
-            >
+            <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_55%,transparent)] px-4 py-6 backdrop-blur-md" onClick={closeDirectoryBrowser}>
               <div
                 className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-6"
                 onClick={(event) => event.stopPropagation()}
@@ -1785,9 +1698,7 @@ export function Conductor() {
                               onClick={() => setDirectoryBrowserPath(crumb.path)}
                               className={cn(
                                 'rounded-md px-1.5 py-0.5 transition-colors',
-                                crumb.path === directoryBrowserPath
-                                  ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]'
-                                  : 'text-[var(--theme-text)] hover:bg-[var(--theme-card2)]',
+                                crumb.path === directoryBrowserPath ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-card2)]',
                               )}
                             >
                               {crumb.label}
@@ -1806,9 +1717,7 @@ export function Conductor() {
                   </div>
 
                   {directoryBrowserError ? (
-                    <div className="rounded-2xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-4 py-3 text-sm text-[var(--theme-warning)]">
-                      {directoryBrowserError}
-                    </div>
+                    <div className="rounded-2xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-4 py-3 text-sm text-[var(--theme-warning)]">{directoryBrowserError}</div>
                   ) : null}
 
                   <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)]">
@@ -1842,9 +1751,7 @@ export function Conductor() {
                           ))}
                         </div>
                       ) : (
-                        <div className="px-4 py-10 text-center text-sm text-[var(--theme-muted)]">
-                          No folders found in this location.
-                        </div>
+                        <div className="px-4 py-10 text-center text-sm text-[var(--theme-muted)]">No folders found in this location.</div>
                       )}
                     </div>
                   </div>
@@ -1901,9 +1808,7 @@ export function Conductor() {
             <div className="space-y-2 text-center">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-accent)]">Mission Decomposition</p>
               <h1 className="text-2xl font-semibold tracking-tight">{conductor.goal}</h1>
-              <p className="text-sm text-[var(--theme-muted-2)]">
-                The agent is breaking the mission into workers. Once they spawn, this view flips into the active board.
-              </p>
+              <p className="text-sm text-[var(--theme-muted-2)]">The agent is breaking the mission into workers. Once they spawn, this view flips into the active board.</p>
             </div>
 
             <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
@@ -1912,27 +1817,19 @@ export function Conductor() {
                   <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Planning</p>
                   <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Analyzing your request and preparing agents</p>
                 </div>
-                <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300 animate-pulse">
-                  Working
-                </span>
+                <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300 animate-pulse">Working</span>
               </div>
               <div className="mt-4 min-h-[200px] overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
                 {conductor.planText ? (
                   <div className="space-y-4">
-                    <Markdown className="max-h-[500px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
-                      {conductor.planText.replace(/(.{20,}?)\1+/g, '$1')}
-                    </Markdown>
+                    <Markdown className="max-h-[500px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{conductor.planText.replace(/(.{20,}?)\1+/g, '$1')}</Markdown>
                     <PlanningIndicator />
                   </div>
                 ) : (
                   <PlanningIndicator />
                 )}
               </div>
-              {conductor.streamError && (
-                <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-600">
-                  {conductor.streamError}
-                </div>
-              )}
+              {conductor.streamError && <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-600">{conductor.streamError}</div>}
               {conductor.timeoutWarning && (
                 <div className="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-amber-400/40 bg-amber-500/10 px-5 py-3">
                   <p className="text-sm text-amber-700">⚠️ Planning is taking longer than expected...</p>
@@ -1947,14 +1844,9 @@ export function Conductor() {
               )}
               {conductor.tasks.length > 0 && (
                 <div className="mt-4 space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
-                    Identified Tasks ({conductor.tasks.length})
-                  </p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Identified Tasks ({conductor.tasks.length})</p>
                   {conductor.tasks.map((task) => (
-                    <div
-                      key={task.id}
-                      className="flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm"
-                    >
+                    <div key={task.id} className="flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm">
                       <span className="size-2 rounded-full bg-zinc-500" />
                       <span className="text-[var(--theme-text)]">{task.title}</span>
                     </div>
@@ -1997,11 +1889,7 @@ export function Conductor() {
                     >
                       Retry Mission
                     </Button>
-                    <Button
-                      type="button"
-                      onClick={handleNewMission}
-                      className="rounded-xl bg-[var(--theme-accent)] px-4 text-white hover:bg-[var(--theme-accent-strong)]"
-                    >
+                    <Button type="button" onClick={handleNewMission} className="rounded-xl bg-[var(--theme-accent)] px-4 text-white hover:bg-[var(--theme-accent-strong)]">
                       New Mission
                     </Button>
                   </div>
@@ -2016,7 +1904,8 @@ export function Conductor() {
                   </p>
                   <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">{conductor.goal}</h1>
                   <p className="mt-2 text-xs text-[var(--theme-muted-2)]">
-                    {completedWorkers}/{Math.max(totalWorkers, completedWorkers)} workers finished · {formatElapsedTime(conductor.missionStartedAt, conductor.completedAt ? new Date(conductor.completedAt).getTime() : now)} total elapsed
+                    {completedWorkers}/{Math.max(totalWorkers, completedWorkers)} workers finished ·{' '}
+                    {formatElapsedTime(conductor.missionStartedAt, conductor.completedAt ? new Date(conductor.completedAt).getTime() : now)} total elapsed
                   </p>
                 </div>
                 <div className="flex gap-2">
@@ -2029,11 +1918,7 @@ export function Conductor() {
                       Continue
                     </Button>
                   ) : null}
-                  <Button
-                    type="button"
-                    onClick={handleNewMission}
-                    className="rounded-xl bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]"
-                  >
+                  <Button type="button" onClick={handleNewMission} className="rounded-xl bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]">
                     New Mission
                   </Button>
                 </div>
@@ -2045,9 +1930,7 @@ export function Conductor() {
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output Preview</p>
-                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                      {completePhaseProjectPath.split('/').pop() || 'index.html'}
-                    </p>
+                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{completePhaseProjectPath.split('/').pop() || 'index.html'}</p>
                   </div>
                   <div className="flex items-center gap-2">
                     <a
@@ -2068,12 +1951,7 @@ export function Conductor() {
                   </div>
                 </div>
                 <div className="mt-4 overflow-auto rounded-2xl border border-[var(--theme-border)] bg-white">
-                  <iframe
-                    src={previewUrl!}
-                    className="h-[clamp(280px,55vh,520px)] w-full"
-                    sandbox="allow-scripts allow-same-origin"
-                    title="Mission output preview"
-                  />
+                  <iframe src={previewUrl!} className="h-[clamp(280px,55vh,520px)] w-full" sandbox="allow-scripts allow-same-origin" title="Mission output preview" />
                 </div>
               </section>
             ) : completePhaseProjectPath && previewState.loading && !conductor.streamError ? (
@@ -2086,38 +1964,41 @@ export function Conductor() {
             ) : null}
 
             {/* Worker output fallback — show when no iframe preview is available */}
-            {(!completePhaseProjectPath || previewState.unavailable) && (() => {
-              const outputSections = conductor.workers
-                .map((worker, index) => {
-                  const output = (conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).trim()
-                  if (!output) return null
-                  const persona = getAgentPersona(index)
-                  return { key: worker.key, persona, label: worker.label, output }
-                })
-                .filter((section): section is NonNullable<typeof section> => section !== null)
+            {(!completePhaseProjectPath || previewState.unavailable) &&
+              (() => {
+                const outputSections = conductor.workers
+                  .map((worker, index) => {
+                    const output = (conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).trim()
+                    if (!output) return null
+                    const persona = getAgentPersona(index)
+                    return {
+                      key: worker.key,
+                      persona,
+                      label: worker.label,
+                      output,
+                    }
+                  })
+                  .filter((section): section is NonNullable<typeof section> => section !== null)
 
-              const fallbackText = outputSections.length > 0
-                ? outputSections.map((s) => `### ${s.persona.emoji} ${s.persona.name} · ${s.label}\n\n${s.output}`).join('\n\n---\n\n')
-                : conductor.streamText.trim()
+                const fallbackText =
+                  outputSections.length > 0 ? outputSections.map((s) => `### ${s.persona.emoji} ${s.persona.name} · ${s.label}\n\n${s.output}`).join('\n\n---\n\n') : conductor.streamText.trim()
 
-              if (!fallbackText) return null
+                if (!fallbackText) return null
 
-              return (
-                <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output</p>
-                      <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                        {completePhaseProjectPath ? `Preview unavailable for ${completePhaseOutputLabel}` : 'Agent work output'}
-                      </p>
+                return (
+                  <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output</p>
+                        <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{completePhaseProjectPath ? `Preview unavailable for ${completePhaseOutputLabel}` : 'Agent work output'}</p>
+                      </div>
                     </div>
-                  </div>
-                  <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                    <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{fallbackText}</Markdown>
-                  </div>
-                </section>
-              )
-            })()}
+                    <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
+                      <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{fallbackText}</Markdown>
+                    </div>
+                  </section>
+                )
+              })()}
 
             {conductor.tasks.length > 1 && completedTaskOutputs.length > 0 && (
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
@@ -2129,10 +2010,7 @@ export function Conductor() {
                 </div>
                 <div className="mt-4 space-y-3">
                   {completedTaskOutputs.map((task) => (
-                    <div
-                      key={task.id}
-                      className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-4"
-                    >
+                    <div key={task.id} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-4">
                       <div className="flex items-center justify-between gap-3">
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
@@ -2166,12 +2044,12 @@ export function Conductor() {
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Summary</p>
                 </div>
-                <span className={cn(
-                  'rounded-full px-3 py-1 text-xs font-medium',
-                  conductor.streamError
-                    ? 'border border-red-400/35 bg-red-500/10 text-red-300'
-                    : 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300',
-                )}>
+                <span
+                  className={cn(
+                    'rounded-full px-3 py-1 text-xs font-medium',
+                    conductor.streamError ? 'border border-red-400/35 bg-red-500/10 text-red-300' : 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300',
+                  )}
+                >
                   {conductor.streamError ? 'Stopped' : 'Complete'}
                 </span>
               </div>
@@ -2192,9 +2070,13 @@ export function Conductor() {
                     return (
                       <div key={worker.key} className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm">
                         <span className="size-2 rounded-full bg-emerald-400" />
-                        <span className="font-medium text-[var(--theme-text)]">{persona.emoji} {persona.name}</span>
+                        <span className="font-medium text-[var(--theme-text)]">
+                          {persona.emoji} {persona.name}
+                        </span>
                         <span className="text-[var(--theme-muted)]">{worker.label}</span>
-                        <span className="ml-auto text-xs text-[var(--theme-muted)]">{shortModelName} · {worker.totalTokens.toLocaleString()} tok</span>
+                        <span className="ml-auto text-xs text-[var(--theme-muted)]">
+                          {shortModelName} · {worker.totalTokens.toLocaleString()} tok
+                        </span>
                       </div>
                     )
                   })}
@@ -2202,12 +2084,7 @@ export function Conductor() {
               )}
               {(totalTokens > 0 || completeMissionCostWorkers.length > 0) && (
                 <div className="mt-4">
-                  <MissionCostSection
-                    totalTokens={totalTokens}
-                    workers={completeMissionCostWorkers}
-                    expanded={completeCostExpanded}
-                    onToggle={() => setCompleteCostExpanded((current) => !current)}
-                  />
+                  <MissionCostSection totalTokens={totalTokens} workers={completeMissionCostWorkers} expanded={completeCostExpanded} onToggle={() => setCompleteCostExpanded((current) => !current)} />
                 </div>
               )}
               {conductor.streamText && completeSummary && (
@@ -2219,7 +2096,6 @@ export function Conductor() {
                 </details>
               )}
             </section>
-
           </div>
 
           {continueModalOpen ? (
@@ -2307,7 +2183,9 @@ export function Conductor() {
               <div className="mt-2 flex items-center justify-center gap-2 text-xs text-[var(--theme-muted)]">
                 <span>{formatElapsedMilliseconds(conductor.isPaused ? conductor.pausedElapsedMs : conductor.missionElapsedMs)}</span>
                 <span className="text-[var(--theme-border)]">·</span>
-                <span>{completedWorkers}/{Math.max(totalWorkers, 1)} complete</span>
+                <span>
+                  {completedWorkers}/{Math.max(totalWorkers, 1)} complete
+                </span>
                 <span className="text-[var(--theme-border)]">·</span>
                 <span>{activeWorkerCount} active</span>
               </div>
@@ -2381,15 +2259,7 @@ export function Conductor() {
             </section>
           )}
           <section className="h-[360px] overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_24px_80px_var(--theme-shadow)]">
-            <OfficeView
-              agentRows={officeAgentRows}
-              missionRunning
-              onViewOutput={() => {}}
-              processType="parallel"
-              companyName="Conductor Office"
-              containerHeight={360}
-              hideHeader
-            />
+            <OfficeView agentRows={officeAgentRows} missionRunning onViewOutput={() => {}} processType="parallel" companyName="Conductor Office" containerHeight={360} hideHeader />
           </section>
 
           {conductor.tasks.length > 0 ? (
@@ -2400,14 +2270,7 @@ export function Conductor() {
                 </h2>
                 {conductor.tasks.map((task) => {
                   const isSelected = selectedTaskId === task.id
-                  const statusDot =
-                    task.status === 'complete'
-                      ? 'bg-emerald-400'
-                      : task.status === 'running'
-                        ? 'bg-sky-400 animate-pulse'
-                        : task.status === 'failed'
-                          ? 'bg-red-400'
-                          : 'bg-zinc-500'
+                  const statusDot = task.status === 'complete' ? 'bg-emerald-400' : task.status === 'running' ? 'bg-sky-400 animate-pulse' : task.status === 'failed' ? 'bg-red-400' : 'bg-zinc-500'
                   return (
                     <button
                       key={task.id}
@@ -2415,9 +2278,7 @@ export function Conductor() {
                       onClick={() => setSelectedTaskId(isSelected ? null : task.id)}
                       className={cn(
                         'w-full rounded-xl border px-3 py-2.5 text-left text-sm transition-colors',
-                        isSelected
-                          ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)]'
-                          : 'border-[var(--theme-border)] bg-[var(--theme-card)] hover:border-[var(--theme-accent)]',
+                        isSelected ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)]' : 'border-[var(--theme-border)] bg-[var(--theme-card)] hover:border-[var(--theme-accent)]',
                       )}
                     >
                       <div className="flex items-center gap-2">
@@ -2437,27 +2298,20 @@ export function Conductor() {
                 ) : null}
                 {(() => {
                   const selectedTask = selectedTaskId ? conductor.tasks.find((task) => task.id === selectedTaskId) : null
-                  const displayWorkers = selectedTask?.workerKey
-                    ? conductor.workers.filter((worker) => worker.key === selectedTask.workerKey)
-                    : conductor.workers
+                  const displayWorkers = selectedTask?.workerKey ? conductor.workers.filter((worker) => worker.key === selectedTask.workerKey) : conductor.workers
                   return (
                     <div className="grid gap-3 md:grid-cols-2">
                       {displayWorkers.map((worker, index) => {
-                        return (
-                          <WorkerCard
-                            key={worker.key}
-                            worker={worker}
-                            index={index}
-                            conductor={conductor}
-                            now={now}
-                          />
-                        )
+                        return <WorkerCard key={worker.key} worker={worker} index={index} conductor={conductor} now={now} />
                       })}
                       {displayWorkers.length === 0 && (
                         <div className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-8 text-center text-sm text-[var(--theme-muted)] md:col-span-2">
-                          <div className="flex items-center justify-center gap-3">
-                            <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
-                            <span>Spawning workers…</span>
+                          <div className="flex flex-col items-center gap-2">
+                            <div className="flex items-center justify-center gap-3">
+                              <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
+                              <span>Spawning workers...</span>
+                            </div>
+                            {conductor.planText ? <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">{conductor.planText}</p> : null}
                           </div>
                         </div>
                       )}
@@ -2470,28 +2324,22 @@ export function Conductor() {
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-2">
                 {conductor.workers.map((worker, index) => {
-                  return (
-                    <WorkerCard
-                      key={worker.key}
-                      worker={worker}
-                      index={index}
-                      conductor={conductor}
-                      now={now}
-                    />
-                  )
+                  return <WorkerCard key={worker.key} worker={worker} index={index} conductor={conductor} now={now} />
                 })}
                 {conductor.workers.length === 0 && (
                   <div className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-8 text-center text-sm text-[var(--theme-muted)] md:col-span-2">
-                    <div className="flex items-center justify-center gap-3">
-                      <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
-                      <span>Spawning workers…</span>
+                    <div className="flex flex-col items-center gap-2">
+                      <div className="flex items-center justify-center gap-3">
+                        <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
+                        <span>Spawning workers...</span>
+                      </div>
+                      {conductor.planText ? <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">{conductor.planText}</p> : null}
                     </div>
                   </div>
                 )}
               </div>
             </div>
           )}
-
         </div>
       </main>
     </div>

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -250,6 +250,13 @@ function loadPersistedMission(): PersistedMission | null {
     if (!goal || (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') || streamText === null || planText === null || !workerKeys || !workerLabels) {
       return null
     }
+    const activeWithoutTracking =
+      (phase === 'decomposing' || phase === 'running') &&
+      !missionId &&
+      workerKeys.length === 0 &&
+      workerLabels.length === 0
+    if (activeWithoutTracking) return null
+
     return {
       missionId,
       goal,

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -17,6 +17,22 @@ type HistoryResponse = {
   error?: string
 }
 
+type ConductorMissionRecord = {
+  id?: string
+  name?: string
+  status?: string
+  error?: string
+  session_id?: string | null
+  lines?: unknown
+  exit_code?: number | null
+}
+
+type ConductorMissionResponse = {
+  ok?: boolean
+  mission?: ConductorMissionRecord
+  error?: string
+}
+
 type MissionPhase = 'idle' | 'decomposing' | 'running' | 'complete'
 
 export type ConductorSettings = {
@@ -38,6 +54,7 @@ const DEFAULT_CONDUCTOR_SETTINGS: ConductorSettings = {
 }
 
 type PersistedMission = {
+  missionId: string | null
   goal: string
   phase: MissionPhase
   missionStartedAt: string | null
@@ -57,7 +74,12 @@ type PersistedMission = {
 type StreamEvent =
   | { type: 'assistant'; text: string }
   | { type: 'thinking'; text: string }
-  | { type: 'tool'; name?: string; phase?: string; data?: Record<string, unknown> }
+  | {
+      type: 'tool'
+      name?: string
+      phase?: string
+      data?: Record<string, unknown>
+    }
   | { type: 'done'; state?: string; message?: string }
   | { type: 'error'; message: string }
   | { type: 'started'; runId?: string; sessionKey?: string }
@@ -122,14 +144,9 @@ function getAgentPersona(index: number) {
   }
 }
 
-
 function extractTasksFromPlan(planText: string): ConductorTask[] {
   const tasks: ConductorTask[] = []
-  const patterns = [
-    /^\s*(\d+)\.\s+(.+)$/gm,
-    /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm,
-    /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm,
-  ]
+  const patterns = [/^\s*(\d+)\.\s+(.+)$/gm, /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm, /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm]
 
   const seen = new Set<string>()
   for (const pattern of patterns) {
@@ -140,7 +157,13 @@ function extractTasksFromPlan(planText: string): ConductorTask[] {
       const id = `task-${num}`
       if (!seen.has(id) && title.length > 3 && title.length < 200) {
         seen.add(id)
-        tasks.push({ id, title, status: 'pending', workerKey: null, output: null })
+        tasks.push({
+          id,
+          title,
+          status: 'pending',
+          workerKey: null,
+          output: null,
+        })
       }
     }
   }
@@ -184,6 +207,7 @@ function loadPersistedMission(): PersistedMission | null {
     if (!raw) return null
 
     const parsed = JSON.parse(raw) as Record<string, unknown>
+    const missionId = readString(parsed.missionId)
     const goal = typeof parsed.goal === 'string' ? parsed.goal : null
     const phase = parsed.phase
     const streamText = typeof parsed.streamText === 'string' ? parsed.streamText : null
@@ -192,22 +216,13 @@ function loadPersistedMission(): PersistedMission | null {
     const workerLabels = Array.isArray(parsed.workerLabels) ? parsed.workerLabels.filter((value): value is string => typeof value === 'string') : null
     const workerOutputs =
       parsed.workerOutputs && typeof parsed.workerOutputs === 'object' && !Array.isArray(parsed.workerOutputs)
-        ? Object.fromEntries(
-            Object.entries(parsed.workerOutputs as Record<string, unknown>).filter(
-              (entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string',
-            ),
-          )
+        ? Object.fromEntries(Object.entries(parsed.workerOutputs as Record<string, unknown>).filter((entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'))
         : {}
-    const missionStartedAt =
-      parsed.missionStartedAt === null || parsed.missionStartedAt === undefined ? null : toIso(parsed.missionStartedAt)
+    const missionStartedAt = parsed.missionStartedAt === null || parsed.missionStartedAt === undefined ? null : toIso(parsed.missionStartedAt)
     const isPaused = parsed.isPaused === true
     const pausedElapsedMs = typeof parsed.pausedElapsedMs === 'number' && Number.isFinite(parsed.pausedElapsedMs) ? Math.max(0, parsed.pausedElapsedMs) : 0
-    const accumulatedPausedMs =
-      typeof parsed.accumulatedPausedMs === 'number' && Number.isFinite(parsed.accumulatedPausedMs)
-        ? Math.max(0, parsed.accumulatedPausedMs)
-        : 0
-    const pauseStartedAt =
-      parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined ? null : toIso(parsed.pauseStartedAt)
+    const accumulatedPausedMs = typeof parsed.accumulatedPausedMs === 'number' && Number.isFinite(parsed.accumulatedPausedMs) ? Math.max(0, parsed.accumulatedPausedMs) : 0
+    const pauseStartedAt = parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined ? null : toIso(parsed.pauseStartedAt)
     const completedAt = parsed.completedAt === null || parsed.completedAt === undefined ? null : toIso(parsed.completedAt)
     const tasks = Array.isArray(parsed.tasks)
       ? parsed.tasks
@@ -217,11 +232,7 @@ function loadPersistedMission(): PersistedMission | null {
             const id = readString(record.id)
             const title = readString(record.title)
             const status = record.status
-            if (
-              !id ||
-              !title ||
-              (status !== 'pending' && status !== 'running' && status !== 'complete' && status !== 'failed')
-            ) {
+            if (!id || !title || (status !== 'pending' && status !== 'running' && status !== 'complete' && status !== 'failed')) {
               return null
             }
 
@@ -236,30 +247,20 @@ function loadPersistedMission(): PersistedMission | null {
           .filter((task): task is ConductorTask => task !== null)
       : []
 
-    if (
-      !goal ||
-      (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') ||
-      streamText === null ||
-      planText === null ||
-      !workerKeys ||
-      !workerLabels
-    ) {
+    if (!goal || (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') || streamText === null || planText === null || !workerKeys || !workerLabels) {
       return null
     }
-    // Never restore running/decomposing — if the browser closed mid-mission, it's dead.
-    // Only restore 'complete' (reviewable) or 'idle'.
-    const isStale = phase === 'running' || phase === 'decomposing'
-
     return {
-      goal: isStale ? '' : goal,
-      phase: isStale ? 'idle' : phase,
-      missionStartedAt: isStale ? null : missionStartedAt,
-      isPaused: isStale ? false : isPaused,
-      pausedElapsedMs: isStale ? 0 : pausedElapsedMs,
-      accumulatedPausedMs: isStale ? 0 : accumulatedPausedMs,
-      pauseStartedAt: isStale ? null : pauseStartedAt,
-      workerKeys: isStale ? [] : workerKeys,
-      workerLabels: isStale ? [] : workerLabels,
+      missionId,
+      goal,
+      phase,
+      missionStartedAt,
+      isPaused,
+      pausedElapsedMs,
+      accumulatedPausedMs,
+      pauseStartedAt,
+      workerKeys,
+      workerLabels,
       workerOutputs,
       streamText,
       planText,
@@ -313,10 +314,7 @@ function loadMissionHistory(): MissionHistoryEntry[] {
         return true
       })
       .map((entry) => {
-        const projectPath =
-          (typeof entry.projectPath === 'string' && entry.projectPath.trim()) ||
-          extractProjectPath(typeof entry.projectPath === 'string' ? entry.projectPath : '') ||
-          null
+        const projectPath = (typeof entry.projectPath === 'string' && entry.projectPath.trim()) || extractProjectPath(typeof entry.projectPath === 'string' ? entry.projectPath : '') || null
         const outputText = typeof entry.outputText === 'string' ? entry.outputText : undefined
         const streamText = typeof entry.streamText === 'string' ? entry.streamText : undefined
         const outputPath =
@@ -471,8 +469,6 @@ function toWorker(session: GatewaySession): ConductorWorker | null {
   }
 }
 
-
-
 function extractHistoryMessageText(message: HistoryMessage | undefined): string {
   if (!message) return ''
   if (typeof message.content === 'string') return message.content
@@ -498,6 +494,47 @@ function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string
   return best
 }
 
+function readMissionLines(mission: ConductorMissionRecord | null | undefined): string[] {
+  if (!Array.isArray(mission?.lines)) return []
+  return mission.lines.filter((line): line is string => typeof line === 'string')
+}
+
+function extractSessionIdFromMission(mission: ConductorMissionRecord | null | undefined): string | null {
+  const direct = readString(mission?.session_id)
+  if (direct) return direct
+
+  const lines = readMissionLines(mission)
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const match = lines[index].match(/\bsession_id:\s*([A-Za-z0-9_.:-]+)/)
+    if (match?.[1]) return match[1]
+  }
+  return null
+}
+
+function formatMissionLog(lines: string[]): string {
+  return lines
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+    .join('\n')
+    .slice(-10_000)
+}
+
+function isFailedMissionStatus(status: string | null): boolean {
+  return status === 'failed' || status === 'error' || status === 'errored' || status === 'cancelled' || status === 'canceled'
+}
+
+function isCompletedMissionStatus(status: string | null): boolean {
+  return status === 'complete' || status === 'completed' || status === 'succeeded' || status === 'success'
+}
+
+async function fetchConductorMission(missionId: string): Promise<ConductorMissionRecord> {
+  const response = await fetch(`/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`)
+  const payload = (await response.json().catch(() => ({}))) as ConductorMissionResponse
+  if (!response.ok || !payload.ok || !payload.mission) {
+    throw new Error(payload.error || `Failed to load conductor mission ${missionId}`)
+  }
+  return payload.mission
+}
 
 function extractProjectPath(text: string): string | null {
   const structuredPatterns = [
@@ -533,16 +570,8 @@ function extractProjectPath(text: string): string | null {
   return null
 }
 
-function buildMissionOutputPath(
-  workers: ConductorWorker[],
-  workerOutputs: Record<string, string>,
-  tasks: ConductorTask[],
-  streamText: string,
-): string | null {
-  const workerOutputTexts = [
-    ...Object.values(workerOutputs),
-    ...workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)),
-  ].filter(Boolean)
+function buildMissionOutputPath(workers: ConductorWorker[], workerOutputs: Record<string, string>, tasks: ConductorTask[], streamText: string): string | null {
+  const workerOutputTexts = [...Object.values(workerOutputs), ...workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(Boolean)
 
   for (const text of workerOutputTexts) {
     const extractedPath = extractProjectPath(text)
@@ -564,7 +593,10 @@ function buildMissionOutputPath(
 function summarizeWorkers(workers: ConductorWorker[]): string[] {
   return workers.map((worker) => {
     const output = getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
-    const firstLine = output.split(/\n+/).map((line) => line.trim()).find(Boolean)
+    const firstLine = output
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .find(Boolean)
     const statusLabel = worker.status === 'stale' ? 'failed' : worker.status
     return `${worker.displayName}: ${firstLine ?? `${statusLabel} · ${worker.totalTokens.toLocaleString()} tok`}`
   })
@@ -587,12 +619,7 @@ function buildCompleteSummary(params: {
   const seconds = totalSeconds % 60
   const duration = hours > 0 ? `${hours}h ${minutes}m ${seconds}s` : minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
 
-  const lines = [
-    streamError ? `❌ ${streamError}` : '✅ Mission completed successfully',
-    '',
-    `**Goal:** ${goal}`,
-    `**Duration:** ${duration}`,
-  ]
+  const lines = [streamError ? `❌ ${streamError}` : '✅ Mission completed successfully', '', `**Goal:** ${goal}`, `**Duration:** ${duration}`]
 
   if (totalWorkers > 0) {
     lines.push(`**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`)
@@ -630,9 +657,9 @@ async function fetchWorkerOutput(sessionKey: string, limit = 5): Promise<string>
   return getLastAssistantMessage(payload.messages)
 }
 
-
 export function useConductorGateway() {
   const [initialMission] = useState<PersistedMission | null>(() => loadPersistedMission())
+  const [missionId, setMissionId] = useState<string | null>(() => initialMission?.missionId ?? null)
   const [phase, setPhase] = useState<MissionPhase>(() => initialMission?.phase ?? 'idle')
   const [goal, setGoal] = useState(() => initialMission?.goal ?? '')
   const [orchestratorSessionKey, setOrchestratorSessionKey] = useState<string | null>(() => initialMission?.workerKeys[0] ?? null)
@@ -736,28 +763,74 @@ export function useConductorGateway() {
     refetchInterval: false,
   })
 
+  const missionStatusQuery = useQuery({
+    queryKey: ['conductor', 'mission-status', missionId],
+    queryFn: async () => {
+      if (!missionId) return null
+      return fetchConductorMission(missionId)
+    },
+    enabled: Boolean(missionId) && phase !== 'idle',
+    refetchInterval: phase === 'decomposing' || phase === 'running' ? 2_500 : false,
+  })
+
   const workers = sessionsQuery.data ?? []
-  const activeWorkers = useMemo(
-    () => workers.filter((worker) => worker.status === 'running' || worker.status === 'idle'),
-    [workers],
-  )
+  const activeWorkers = useMemo(() => workers.filter((worker) => worker.status === 'running' || worker.status === 'idle'), [workers])
   const hasPersistedMission = initialMission !== null
+
+  useEffect(() => {
+    const mission = missionStatusQuery.data
+    if (!mission) return
+
+    const status = readString(mission.status)?.toLowerCase() ?? null
+    const realSessionKey = extractSessionIdFromMission(mission)
+    const lines = readMissionLines(mission)
+    const missionLog = formatMissionLog(lines)
+
+    if (realSessionKey) {
+      setOrchestratorSessionKey(realSessionKey)
+      setMissionWorkerKeys((current) => {
+        if (current.has(realSessionKey)) return current
+        const next = new Set(current)
+        next.add(realSessionKey)
+        return next
+      })
+      setPlanText((current) => (current && !current.startsWith('Conductor mission') ? current : 'Orchestrator session attached. Tracking worker activity...'))
+      lastActivityAtRef.current = Date.now()
+      setTimeoutWarning(false)
+    } else if (phase === 'decomposing' || phase === 'running') {
+      setPlanText((current) => current || `Conductor mission ${status ?? 'running'}. Waiting for Hermes to report the session...`)
+    }
+
+    if (missionLog) {
+      setStreamText((current) => (current === missionLog ? current : missionLog))
+      lastActivityAtRef.current = Date.now()
+      setTimeoutWarning(false)
+    }
+
+    if (isFailedMissionStatus(status)) {
+      doneRef.current = true
+      setStreamError(mission.error || 'Conductor mission failed')
+      setCompletedAt((value) => value ?? new Date().toISOString())
+      setPhase('complete')
+    } else if (isCompletedMissionStatus(status)) {
+      doneRef.current = true
+      setCompletedAt((value) => value ?? new Date().toISOString())
+      setPhase('complete')
+    }
+  }, [missionStatusQuery.data, phase])
 
   const getMissionElapsedMs = (referenceTime = Date.now()) => {
     if (!missionStartedAt) return 0
     const startedMs = new Date(missionStartedAt).getTime()
     if (!Number.isFinite(startedMs)) return 0
     const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-    const inFlightPausedMs =
-      isPaused && Number.isFinite(pauseStartedMs) ? Math.max(0, referenceTime - pauseStartedMs) : 0
+    const inFlightPausedMs = isPaused && Number.isFinite(pauseStartedMs) ? Math.max(0, referenceTime - pauseStartedMs) : 0
     return Math.max(0, referenceTime - startedMs - accumulatedPausedMs - inFlightPausedMs)
   }
 
   useEffect(() => {
     if (missionWorkerLabels.size === 0 || workers.length === 0) return
-    const matchedKeys = workers
-      .filter((worker) => missionWorkerLabels.has(worker.label))
-      .map((worker) => worker.key)
+    const matchedKeys = workers.filter((worker) => missionWorkerLabels.has(worker.label)).map((worker) => worker.key)
 
     if (matchedKeys.length === 0) return
 
@@ -806,9 +879,7 @@ export function useConductorGateway() {
   useEffect(() => {
     if (phase !== 'running' && phase !== 'decomposing') return
 
-    const workerSnapshot = workers
-      .map((worker) => `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`)
-      .join('|')
+    const workerSnapshot = workers.map((worker) => `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`).join('|')
 
     if (workerSnapshot && workerSnapshot !== lastWorkerSnapshotRef.current) {
       lastWorkerSnapshotRef.current = workerSnapshot
@@ -886,9 +957,12 @@ export function useConductorGateway() {
       }
     }
 
-    const timer = window.setInterval(() => {
-      void fetchAll()
-    }, hasRunningWorkers ? 5_000 : 2_000)
+    const timer = window.setInterval(
+      () => {
+        void fetchAll()
+      },
+      hasRunningWorkers ? 5_000 : 2_000,
+    )
 
     return () => {
       cancelled = true
@@ -916,29 +990,27 @@ export function useConductorGateway() {
         const worker = workers[index]
         if (!worker) return task
         const workerOutput = workerOutputs[worker.key] ?? null
-        const newStatus: ConductorTask['status'] =
-          worker.status === 'complete'
-            ? 'complete'
-            : worker.status === 'stale'
-              ? 'failed'
-              : worker.status === 'running'
-                ? 'running'
-                : task.status
+        const newStatus: ConductorTask['status'] = worker.status === 'complete' ? 'complete' : worker.status === 'stale' ? 'failed' : worker.status === 'running' ? 'running' : task.status
         if (task.workerKey === worker.key && task.status === newStatus && task.output === workerOutput) return task
-        return { ...task, workerKey: worker.key, status: newStatus, output: workerOutput }
+        return {
+          ...task,
+          workerKey: worker.key,
+          status: newStatus,
+          output: workerOutput,
+        }
       })
       const changed = updated.some((task, index) => task !== current[index])
       return changed ? updated : current
     })
   }, [workers, workerOutputs, tasks.length])
 
-    // Save/update history entry on complete — re-runs when workerOutputs arrive
+  // Save/update history entry on complete — re-runs when workerOutputs arrive
   // so the entry gets enriched with actual worker content instead of empty text.
   const historySaveCountRef = useRef(0)
   useEffect(() => {
     if (phase !== 'complete' || !goal || !completedAt || !missionStartedAt) return
 
-    const missionId = `mission-${new Date(missionStartedAt).getTime()}`
+    const missionHistoryId = `mission-${new Date(missionStartedAt).getTime()}`
     const outputPath = buildMissionOutputPath(workers, workerOutputs, tasks, streamText)
     const workerSummary = summarizeWorkers(workers)
     const outputText = buildMissionOutputText(workers, workerOutputs, streamText)
@@ -963,7 +1035,7 @@ export function useConductorGateway() {
       }
     })
     const entry: MissionHistoryEntry = {
-      id: missionId,
+      id: missionHistoryId,
       goal,
       startedAt: missionStartedAt,
       completedAt,
@@ -987,13 +1059,11 @@ export function useConductorGateway() {
     if (historySaveCountRef.current === 0) {
       historySavedRef.current = true
       setMissionHistory((current) => {
-        if (current.some((e) => e.id === missionId)) return current
+        if (current.some((e) => e.id === missionHistoryId)) return current
         return [entry, ...current].slice(0, MAX_HISTORY_ENTRIES)
       })
     } else {
-      setMissionHistory((current) =>
-        current.map((e) => (e.id === missionId ? entry : e)),
-      )
+      setMissionHistory((current) => current.map((e) => (e.id === missionHistoryId ? entry : e)))
     }
     historySaveCountRef.current += 1
   }, [phase, goal, completedAt, missionStartedAt, workers, streamError, workerOutputs, tasks, streamText])
@@ -1011,6 +1081,7 @@ export function useConductorGateway() {
     }
 
     persistMission({
+      missionId,
       goal,
       phase,
       missionStartedAt,
@@ -1026,7 +1097,23 @@ export function useConductorGateway() {
       completedAt,
       tasks,
     })
-  }, [phase, goal, missionStartedAt, isPaused, pausedElapsedMs, accumulatedPausedMs, pauseStartedAt, completedAt, missionWorkerKeys, missionWorkerLabels, workerOutputs, streamText, planText, tasks])
+  }, [
+    missionId,
+    phase,
+    goal,
+    missionStartedAt,
+    isPaused,
+    pausedElapsedMs,
+    accumulatedPausedMs,
+    pauseStartedAt,
+    completedAt,
+    missionWorkerKeys,
+    missionWorkerLabels,
+    workerOutputs,
+    streamText,
+    planText,
+    tasks,
+  ])
 
   const dismissTimeoutWarning = () => {
     lastActivityAtRef.current = Date.now()
@@ -1036,6 +1123,7 @@ export function useConductorGateway() {
   const clearMissionState = () => {
     doneRef.current = false
     clearPersistedMission()
+    setMissionId(null)
     setPhase('idle')
     setGoal('')
     setOrchestratorSessionKey(null)
@@ -1070,6 +1158,7 @@ export function useConductorGateway() {
       lastWorkerSnapshotRef.current = ''
       setTimeoutWarning(false)
       setGoal(trimmed)
+      setMissionId(null)
       setOrchestratorSessionKey(null)
       setStreamText('')
       setPlanText('')
@@ -1087,8 +1176,26 @@ export function useConductorGateway() {
       setSelectedHistoryEntry(null)
       seenToolCallRef.current = false
       historySavedRef.current = false
-      setMissionStartedAt(new Date().toISOString())
+      const startedAt = new Date().toISOString()
+      setMissionStartedAt(startedAt)
       setPhase('decomposing')
+      persistMission({
+        missionId: null,
+        goal: trimmed,
+        phase: 'decomposing',
+        missionStartedAt: startedAt,
+        isPaused: false,
+        pausedElapsedMs: 0,
+        accumulatedPausedMs: 0,
+        pauseStartedAt: null,
+        workerKeys: [],
+        workerLabels: [],
+        workerOutputs: {},
+        streamText: '',
+        planText: '',
+        completedAt: null,
+        tasks: [],
+      })
 
       // Spawn a dedicated orchestrator session via the server
       const response = await fetch('/api/conductor-spawn', {
@@ -1104,39 +1211,42 @@ export function useConductorGateway() {
 
       const result = (await response.json()) as {
         ok?: boolean
+        missionId?: string | null
         sessionKey?: string
-        sessionKeyPrefix?: string
+        sessionKeyPrefix?: string | null
         jobId?: string
         error?: string
       }
-      if (!result.ok || !result.sessionKey) {
+      if (!result.ok || (!result.sessionKey && !result.sessionKeyPrefix && !result.missionId)) {
         throw new Error(result.error ?? 'Failed to spawn orchestrator')
       }
 
-      // Hermes runs cron jobs in sessions keyed `cron_<jobId>_<timestamp>`.
-      // The session doesn't exist yet at spawn time — the cron loop creates
-      // it within ~5s. Poll /api/sessions until we find one matching the
-      // prefix, then track it as the orchestrator session.
-      const orchestratorKey = result.sessionKey
-      const prefix = result.sessionKeyPrefix
-      setOrchestratorSessionKey(orchestratorKey)
-      setMissionWorkerKeys((current) => {
-        if (current.has(orchestratorKey)) return current
-        const next = new Set(current)
-        next.add(orchestratorKey)
-        return next
-      })
+      const nextMissionId = result.missionId ?? null
+      setMissionId(nextMissionId)
 
-      if (prefix) {
+      // Legacy gateway-only fallback runs cron jobs in sessions keyed
+      // `cron_<jobId>_<timestamp>`. Dashboard-backed Conductor missions report
+      // their real Hermes session through the mission status endpoint instead.
+      const orchestratorKey = result.sessionKey ?? null
+      const prefix = result.sessionKeyPrefix
+      if (orchestratorKey) {
+        setOrchestratorSessionKey(orchestratorKey)
+        setMissionWorkerKeys((current) => {
+          if (current.has(orchestratorKey)) return current
+          const next = new Set(current)
+          next.add(orchestratorKey)
+          return next
+        })
+      }
+
+      if (prefix && orchestratorKey) {
         // Async: resolve the placeholder to the real session key once it exists.
         const resolveOrchestrator = async () => {
           for (let attempt = 0; attempt < 30; attempt += 1) {
             await new Promise((resolve) => setTimeout(resolve, 1500))
             try {
               const sessionPayload = await fetchSessions()
-              const sessions = Array.isArray(sessionPayload.sessions)
-                ? sessionPayload.sessions
-                : []
+              const sessions = Array.isArray(sessionPayload.sessions) ? sessionPayload.sessions : []
               const match = sessions.find((session) => {
                 const key = typeof session.key === 'string' ? session.key : ''
                 return key.startsWith(prefix)
@@ -1160,7 +1270,7 @@ export function useConductorGateway() {
       }
 
       // Transition to running — the orchestrator is alive, workers will appear via polling
-      setPlanText(`Orchestrator spawned. Decomposing mission and spawning workers...`)
+      setPlanText(nextMissionId ? 'Conductor mission launched. Waiting for Hermes session and worker activity...' : 'Orchestrator spawned. Decomposing mission and spawning workers...')
       setPhase('running')
     },
     onError: (error) => {
@@ -1203,8 +1313,7 @@ export function useConductorGateway() {
       }
 
       const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-      const additionalPausedMs =
-        Number.isFinite(pauseStartedMs) ? Math.max(0, now - pauseStartedMs) : 0
+      const additionalPausedMs = Number.isFinite(pauseStartedMs) ? Math.max(0, now - pauseStartedMs) : 0
       setAccumulatedPausedMs((current) => current + additionalPausedMs)
       setPauseStartedAt(null)
       setIsPaused(false)
@@ -1214,12 +1323,13 @@ export function useConductorGateway() {
 
   const stopMission = async () => {
     const sessionKeys = [...new Set([...missionWorkerKeys, ...workers.map((worker) => worker.key)])]
+    const missionIds = missionId ? [missionId] : []
 
     try {
       await fetch('/api/conductor-stop', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ sessionKeys }),
+        body: JSON.stringify({ sessionKeys, missionIds }),
       })
     } catch {
       // Best effort cleanup.
@@ -1238,7 +1348,10 @@ export function useConductorGateway() {
     const currentGoal = goal
     resetMission()
     await new Promise((resolve) => setTimeout(resolve, 100))
-    await sendMission.mutateAsync({ nextGoal: currentGoal, settings: conductorSettings })
+    await sendMission.mutateAsync({
+      nextGoal: currentGoal,
+      settings: conductorSettings,
+    })
   }
 
   return {

--- a/src/screens/profiles/profiles-screen.tsx
+++ b/src/screens/profiles/profiles-screen.tsx
@@ -178,8 +178,9 @@ export function ProfilesScreen() {
     }
   }, [createOpen, wizardStep, allModels.length, fetchAllModels])
 
+  const profileNamePattern = /^[a-z0-9][a-z0-9_-]{0,63}$/
   const nameValid =
-    /^[A-Za-z0-9_-]+$/.test(newProfileName.trim()) &&
+    profileNamePattern.test(newProfileName.trim()) &&
     newProfileName.trim() !== 'default'
 
   function resetWizard() {
@@ -542,7 +543,7 @@ export function ProfilesScreen() {
                   />
                   {newProfileName.trim() && !nameValid ? (
                     <p className="text-xs text-red-500">
-                      Use letters, numbers, underscores, or hyphens. Cannot be
+                      Use lowercase letters, numbers, underscores, or hyphens. Cannot be
                       &quot;default&quot;.
                     </p>
                   ) : newProfileName.trim() && nameValid ? (
@@ -788,9 +789,9 @@ export function ProfilesScreen() {
                 autoFocus
               />
               {renameValue.trim() &&
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim()) && (
+                !profileNamePattern.test(renameValue.trim()) && (
                   <p className="text-xs text-red-500">
-                    Use letters, numbers, underscores, or hyphens.
+                    Use lowercase letters, numbers, underscores, or hyphens.
                   </p>
                 )}
             </div>
@@ -812,7 +813,7 @@ export function ProfilesScreen() {
               disabled={
                 !renameTarget ||
                 !renameValue.trim() ||
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim())
+                !profileNamePattern.test(renameValue.trim())
               }
             >
               Rename

--- a/src/server/jobs-profile-resolution.test.ts
+++ b/src/server/jobs-profile-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+  sanitizeProfileName,
+} from './jobs-profile-resolution'
+
+describe('sanitizeProfileName', () => {
+  it('accepts simple profile names', () => {
+    expect(sanitizeProfileName('aurora')).toBe('aurora')
+    expect(sanitizeProfileName(' swarm6 ')).toBe('swarm6')
+  })
+
+  it('rejects empty and path-like values', () => {
+    expect(sanitizeProfileName('')).toBeNull()
+    expect(sanitizeProfileName('   ')).toBeNull()
+    expect(sanitizeProfileName('../etc')).toBeNull()
+    expect(sanitizeProfileName('a/b')).toBeNull()
+    expect(sanitizeProfileName('a\\b')).toBeNull()
+  })
+})
+
+describe('resolveJobsProfile', () => {
+  it('prefers explicit ?profile= query param', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?profile=query-one')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'query-one',
+    )
+  })
+
+  it('falls back to HERMES_PROFILE env var', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'env-one',
+    )
+  })
+
+  it('falls back to file-backed active profile when env is absent', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'file-one')).toBe('file-one')
+  })
+
+  it('ignores the default sentinel from active_profile', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'default')).toBeNull()
+  })
+})
+
+describe('buildJobsProfileSearch', () => {
+  it('adds the resolved profile while preserving other params', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?limit=10')
+    expect(buildJobsProfileSearch(url, 'aurora')).toBe(
+      '?limit=10&profile=aurora',
+    )
+  })
+
+  it('replaces any inbound profile query with the resolved profile', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', 'new')).toBe(
+      '?limit=10&profile=new',
+    )
+  })
+
+  it('drops profile from the query when no resolved profile exists', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', null)).toBe(
+      '?limit=10',
+    )
+  })
+})

--- a/src/server/jobs-profile-resolution.ts
+++ b/src/server/jobs-profile-resolution.ts
@@ -1,0 +1,55 @@
+import { getActiveProfileName } from './profiles-browser'
+
+export function sanitizeProfileName(
+  name: string | null | undefined,
+): string | null {
+  if (!name) return null
+  const trimmed = String(name).trim()
+  if (!trimmed) return null
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('..')
+  ) {
+    return null
+  }
+  return trimmed
+}
+
+export function resolveJobsProfile(
+  url: URL,
+  envProfile = process.env.HERMES_PROFILE,
+  activeProfileResolver: () => string = getActiveProfileName,
+): string | null {
+  const fromQuery = sanitizeProfileName(url.searchParams.get('profile'))
+  if (fromQuery) return fromQuery
+
+  const fromEnv = sanitizeProfileName(envProfile)
+  if (fromEnv) return fromEnv
+
+  try {
+    const fromFile = sanitizeProfileName(activeProfileResolver())
+    if (fromFile && fromFile !== 'default') return fromFile
+  } catch {
+    // ignore file-backed profile lookup failures
+  }
+
+  return null
+}
+
+export function buildJobsProfileSearch(
+  urlOrSearch: URL | string,
+  profile: string | null,
+): string {
+  const sourceSearch =
+    typeof urlOrSearch === 'string' ? urlOrSearch : urlOrSearch.search
+  const params = new URLSearchParams(
+    sourceSearch.startsWith('?') ? sourceSearch.slice(1) : sourceSearch,
+  )
+
+  params.delete('profile')
+  if (profile) params.set('profile', profile)
+
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -137,7 +137,10 @@ export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(results, workspaceRoot, path.join(workspaceRoot, 'MEMORY.md'))
+  for (const subdir of ['memory', 'memories']) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, subdir))
+  }
 
   results.sort(compareMemoryFiles)
   return results

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -3,13 +3,15 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listProfiles } from './profiles-browser'
+import { listProfiles, renameProfile } from './profiles-browser'
 
-describe('listProfiles', () => {
+describe('profiles-browser integration', () => {
   let tempHome: string
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-workspace-profiles-'))
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-'),
+    )
     vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
   })
 
@@ -24,16 +26,126 @@ describe('listProfiles', () => {
     const namedProfileRoot = path.join(profilesRoot, 'jarvis')
 
     fs.mkdirSync(namedProfileRoot, { recursive: true })
-    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'jarvis\n', 'utf-8')
-    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: default-model\n', 'utf-8')
-    fs.writeFileSync(path.join(namedProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'jarvis\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'model: default-model\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(namedProfileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
 
     const profiles = listProfiles()
     const names = profiles.map((profile) => profile.name)
 
     expect(names).toContain('default')
     expect(names).toContain('jarvis')
-    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(false)
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(true)
+    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(
+      false,
+    )
+    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(
+      true,
+    )
+  })
+
+  it('renames a profile and rewrites local/global stale references', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+    const newProfileRoot = path.join(profilesRoot, 'dr_kwon')
+
+    fs.mkdirSync(path.join(oldProfileRoot, 'skills', 'demo-skill'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(hermesRoot, 'team', 'handoffs'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'alan\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'SOUL.md'),
+      '<!-- Profile: alan (Primary: gpt-5.4) -->\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'config.yaml'),
+      'mcp:\n  command: ~/.hermes/profiles/alan/openbb-env/bin/openbb-mcp\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+      `Path: ${hermesRoot}/profiles/alan/data\n`,
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'sharedPath: ~/.hermes/profiles/alan/shared\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team-agents.md'),
+      'Agent alan owns this lane\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+      'handoff from alan with ~/.hermes/profiles/alan/path\n',
+      'utf-8',
+    )
+
+    const renamed = renameProfile('alan', 'dr_kwon')
+
+    expect(renamed.name).toBe('dr_kwon')
+    expect(fs.existsSync(oldProfileRoot)).toBe(false)
+    expect(fs.existsSync(newProfileRoot)).toBe(true)
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8'),
+    ).toBe('dr_kwon\n')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'SOUL.md'), 'utf-8'),
+    ).toContain('Profile: dr_kwon')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'config.yaml'), 'utf-8'),
+    ).toContain('~/.hermes/profiles/dr_kwon/openbb-env/bin/openbb-mcp')
+    expect(
+      fs.readFileSync(
+        path.join(newProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toContain(`${hermesRoot}/profiles/dr_kwon/data`)
+    expect(fs.readFileSync(path.join(hermesRoot, 'config.yaml'), 'utf-8')).toContain(
+      '~/.hermes/profiles/dr_kwon/shared',
+    )
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'team-agents.md'), 'utf-8'),
+    ).toContain('Agent alan owns this lane')
+    expect(
+      fs.readFileSync(
+        path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+        'utf-8',
+      ),
+    ).toContain('~/.hermes/profiles/dr_kwon/path')
+  })
+
+  it('rejects new profile names that the Hermes CLI would reject', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+
+    fs.mkdirSync(oldProfileRoot, { recursive: true })
+
+    expect(() => renameProfile('alan', 'Dr_Kwon')).toThrow(
+      /Invalid profile name/i,
+    )
   })
 })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -27,6 +28,23 @@ export type ProfileDetail = {
   skillsDir?: string
 }
 
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const TEXT_REWRITE_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.jsonl',
+  '.toml',
+  '.env',
+  '.plist',
+  '.sh',
+  '.js',
+  '.ts',
+  '.tsx',
+])
+
 function getHermesRoot(): string {
   return path.join(os.homedir(), '.hermes')
 }
@@ -45,8 +63,14 @@ function getActiveProfilePath(): string {
  */
 function validateProfileName(name: string): string {
   const trimmed = validateProfileIdentifier(name)
-  if (trimmed === 'default')
+  if (trimmed === 'default') {
     throw new Error('Default profile cannot be modified here')
+  }
+  if (!PROFILE_NAME_RE.test(trimmed)) {
+    throw new Error(
+      "Invalid profile name. Use lowercase letters, numbers, underscores, or hyphens, and start with a letter or number.",
+    )
+  }
   return trimmed
 }
 
@@ -252,7 +276,7 @@ export function readProfile(name: string): ProfileDetail {
   const profilePath =
     normalized === 'default'
       ? getHermesRoot()
-      : path.join(getProfilesRoot(), validateProfileName(normalized))
+      : path.join(getProfilesRoot(), validateProfileIdentifier(normalized))
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   const configPath = path.join(profilePath, 'config.yaml')
   const envPath = path.join(profilePath, '.env')
@@ -279,7 +303,7 @@ export function setActiveProfile(name: string): void {
     if (fs.existsSync(activePath)) fs.unlinkSync(activePath)
     return
   }
-  const normalized = validateProfileName(trimmed)
+  const normalized = validateProfileIdentifier(trimmed)
   const profilePath = path.join(getProfilesRoot(), normalized)
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   fs.mkdirSync(getHermesRoot(), { recursive: true })
@@ -405,14 +429,138 @@ export function updateProfileConfig(
   return readProfile(normalized)
 }
 
+function replaceTextReferences(
+  input: string,
+  oldName: string,
+  newName: string,
+): string {
+  const escapedOld = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const absoluteProfileOld = `${getHermesRoot()}/profiles/${oldName}`
+  const absoluteProfileNew = `${getHermesRoot()}/profiles/${newName}`
+
+  return input
+    .replaceAll(absoluteProfileOld, absoluteProfileNew)
+    .replaceAll(`~/.hermes/profiles/${oldName}`, `~/.hermes/profiles/${newName}`)
+    .replaceAll(`profiles/${oldName}/`, `profiles/${newName}/`)
+    .replaceAll(`ai.hermes.gateway-${oldName}`, `ai.hermes.gateway-${newName}`)
+    .replace(
+      new RegExp(`(<!--\\s*Profile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+    .replace(
+      new RegExp(`(\\bProfile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+}
+
+function rewriteTextFileIfPresent(
+  filePath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(filePath)) return
+  try {
+    const original = safeReadText(filePath)
+    const updated = replaceTextReferences(original, oldName, newName)
+    if (updated !== original) {
+      fs.writeFileSync(filePath, updated, 'utf-8')
+    }
+  } catch {
+    // ignore non-text or unreadable files
+  }
+}
+
+function rewriteTextFilesRecursive(
+  rootPath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(rootPath)) return
+  const stack = [rootPath]
+  while (stack.length > 0) {
+    const current = stack.pop() as string
+    let entries: Array<fs.Dirent> = []
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+        continue
+      }
+      if (!TEXT_REWRITE_EXTENSIONS.has(path.extname(entry.name))) continue
+      rewriteTextFileIfPresent(fullPath, oldName, newName)
+    }
+  }
+}
+
+function migrateLaunchAgentProfile(
+  oldName: string,
+  newName: string,
+): void {
+  if (process.platform !== 'darwin') return
+  const launchAgentsDir = path.join(os.homedir(), 'Library', 'LaunchAgents')
+  const oldPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${oldName}.plist`)
+  const newPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${newName}.plist`)
+  if (!fs.existsSync(oldPlist)) return
+
+  rewriteTextFileIfPresent(oldPlist, oldName, newName)
+  try {
+    if (fs.existsSync(newPlist)) fs.rmSync(newPlist, { force: true })
+    fs.renameSync(oldPlist, newPlist)
+  } catch {
+    return
+  }
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  if (uid == null) return
+  try {
+    execFileSync('launchctl', ['bootout', `gui/${uid}`, oldPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootout failures
+  }
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, newPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootstrap failures
+  }
+}
+
+function migrateGlobalProfileReferences(oldName: string, newName: string): void {
+  const hermesRoot = getHermesRoot()
+  const directFiles = [
+    path.join(hermesRoot, 'config.yaml'),
+    path.join(hermesRoot, 'SOUL.md'),
+    path.join(hermesRoot, 'team-agents.md'),
+    path.join(hermesRoot, 'team', 'cron.md'),
+    path.join(hermesRoot, 'team', 'day-30-runbook.md'),
+  ]
+  for (const filePath of directFiles) {
+    rewriteTextFileIfPresent(filePath, oldName, newName)
+  }
+  rewriteTextFilesRecursive(path.join(hermesRoot, 'team', 'handoffs'), oldName, newName)
+}
+
 export function renameProfile(oldName: string, newName: string): ProfileDetail {
-  const from = validateProfileName(oldName)
+  const from = validateProfileIdentifier(oldName)
   const to = validateProfileName(newName)
   const fromPath = path.join(getProfilesRoot(), from)
   const toPath = path.join(getProfilesRoot(), to)
   if (!fs.existsSync(fromPath)) throw new Error('Profile not found')
   if (fs.existsSync(toPath)) throw new Error('Target profile already exists')
+
   fs.renameSync(fromPath, toPath)
+  rewriteTextFilesRecursive(toPath, from, to)
+  migrateGlobalProfileReferences(from, to)
+  migrateLaunchAgentProfile(from, to)
+
   if (getActiveProfileName() === from) {
     fs.writeFileSync(getActiveProfilePath(), `${to}\n`, 'utf-8')
   }

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 
 type WorkspaceState = {
   sidebarCollapsed: boolean
+  sidebarPinned: boolean
   fileExplorerCollapsed: boolean
   chatFocusMode: boolean
   /** Currently active sub-page route (e.g. '/skills', '/channels') — null means chat-only */
@@ -17,6 +18,8 @@ type WorkspaceState = {
   mobileComposerFocused: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebarPinned: () => void
+  setSidebarPinned: (pinned: boolean) => void
   toggleFileExplorer: () => void
   setFileExplorerCollapsed: (collapsed: boolean) => void
   toggleChatFocusMode: () => void
@@ -34,6 +37,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      sidebarPinned: false,
       fileExplorerCollapsed: true,
       chatFocusMode: false,
       activeSubPage: null,
@@ -43,8 +47,28 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       mobileKeyboardInset: 0,
       mobileComposerFocused: false,
       toggleSidebar: () =>
-        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+        set((s) => {
+          const nextCollapsed = !s.sidebarCollapsed
+          return {
+            sidebarCollapsed: nextCollapsed,
+            sidebarPinned: nextCollapsed ? false : s.sidebarPinned,
+          }
+        }),
+      setSidebarCollapsed: (collapsed) =>
+        set((s) => ({
+          sidebarCollapsed: collapsed,
+          sidebarPinned: collapsed ? false : s.sidebarPinned,
+        })),
+      toggleSidebarPinned: () =>
+        set((s) => ({
+          sidebarPinned: !s.sidebarPinned,
+          sidebarCollapsed: s.sidebarPinned ? s.sidebarCollapsed : false,
+        })),
+      setSidebarPinned: (pinned) =>
+        set((s) => ({
+          sidebarPinned: pinned,
+          sidebarCollapsed: pinned ? false : s.sidebarCollapsed,
+        })),
       toggleFileExplorer: () =>
         set((s) => ({ fileExplorerCollapsed: !s.fileExplorerCollapsed })),
       setFileExplorerCollapsed: (collapsed) =>
@@ -65,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       name: 'hermes-workspace-v1',
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarPinned: state.sidebarPinned,
         fileExplorerCollapsed: state.fileExplorerCollapsed,
         chatPanelOpen: state.chatPanelOpen,
         chatPanelSessionKey: state.chatPanelSessionKey,


### PR DESCRIPTION
## Summary
- Route dashboard Conductor starts through the Hermes mission API and persist the returned mission ID.
- Poll mission status so the UI can attach the real session ID, surface logs/errors, and finish missions cleanly.
- Stop both dashboard missions and tracked worker sessions; ignore restored active state that has no mission or worker tracking.

## Test plan
- `pnpm build`
- `git diff --check`

## Notes
- Requires NousResearch/hermes-agent#18133 for the new mission API.
- Full `tsc` and focused lint are still blocked by pre-existing workspace baseline issues outside this fix.
