### PR TITLE
docs: add Swarm v1 release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@
 
 ---
 
+## Swarm Mode
+
+Project Agent Swarm turns the workspace into a live control plane: unlimited Project Agents, 1 orchestrator, 0 humans manually dispatching.
+Persistent tmux workers keep context across tasks, rotate safely, and report proof-bearing checkpoints.
+Role-based dispatch routes builders, reviewers, docs, research, ops, triage, QA, and lab lanes without turning Eric into the task router.
+A byte-verified review gate protects release branches before PRs ship.
+Autonomous PR/issue lanes, lab experiments, and the repair playbook keep the machine moving while humans handle judgment.
+
+Start here: [docs/swarm/](./docs/swarm/)
+
+- **Orchestrator Chat** — ask the control plane for one task, a decomposed mission, or a full broadcast.
+- **Multi-Agent Control Plane** — see persistent Project Agents, roles, state, runtime, and routing wires in one surface.
+- **Kanban TaskBoard** — plan backlog, ready, running, review, blocked, and done lanes without leaving the workspace.
+- **Reports + Inbox** — review checkpoints, blockers, handoffs, and ready-for-human decisions.
+- **TUI View built in** — attach to tmux-backed workers or fall back to a live shell/log stream.
+
+---
+
 ## ✨ Features
 
 - 🤖 **Hermes Agent Integration** — Direct gateway connection with real-time SSE streaming

--- a/docs/swarm/ARCHITECTURE.md
+++ b/docs/swarm/ARCHITECTURE.md
@@ -1,0 +1,310 @@
+# Swarm Architecture
+
+Swarm Mode is built around a durable loop: intent enters through Aurora, dispatch flows through the orchestrator, workers execute in persistent sessions, checkpoints return to the control plane, and only judgment-worthy decisions reach Eric.
+
+## The loop
+
+```text
+┌────────┐
+│ Eric   │
+└───┬────┘
+    │ intent, judgment, approval
+    ▼
+┌────────────┐
+│ Aurora     │
+│ main agent │
+└───┬────────┘
+    │ translates intent into SwarmBrief
+    ▼
+┌────────────────────────────┐
+│ swarm3 / Orchestrator      │
+│ routing, drift, escalation │
+└───┬────────────────────────┘
+    │ dispatches by role + standing mission
+    ▼
+┌────────────────────────────────────────────────────┐
+│ Project Agents                                      │
+│ swarm4 research  swarm5 build  swarm6 review        │
+│ swarm7 docs      swarm8 ops    swarm9 lab           │
+│ swarm10 patches  swarm11 QA    swarm12 triage       │
+└───┬────────────────────────────────────────────────┘
+    │ proof-bearing checkpoint
+    ▼
+┌────────────────────────────┐
+│ Reports / Inbox / runtime  │
+└───┬────────────────────────┘
+    │ orchestrator decides next route
+    ▼
+┌─────────────────────────────────────┐
+│ continue / repair / review / input  │
+└─────────────────────────────────────┘
+```
+
+The key rule: workers do not free-style message Eric. They checkpoint. The orchestrator routes. Aurora handles judgment. Eric approves the few things that matter.
+
+## Canonical flow
+
+1. Eric states an outcome.
+2. Aurora names the work and frames it into a SwarmBrief.
+3. The orchestrator selects the right worker or decomposes the work.
+4. The worker executes inside its persistent profile and tmux runtime.
+5. The worker returns a canonical checkpoint.
+6. The notification router sends the checkpoint to the orchestrator by default.
+7. The orchestrator decides whether to continue, repair, hand off, review, or escalate.
+8. Reports and Inbox make the state inspectable.
+
+## SwarmBrief shape
+
+The canonical YAML lives in `SWARM_SPEC.md` section 3. This is the public shape:
+
+```yaml
+brief_id: brief-<timestamp>-<slug>
+worker: swarm<N>
+project: <project-name>
+goal: <one-sentence end state>
+why_now: <trigger>
+scope:
+  - bounded item
+deliverables:
+  - exact artifact path
+test_or_proof:
+  - command, review, screenshot, artifact, or byte check
+constraints:
+  - hard limits
+checkpoint_contract:
+  state: DONE|HANDOFF|BLOCKED|NEEDS_REVIEW|NEEDS_INPUT
+  files_changed: list
+  commands_run: list
+  proof: tests/build/smoke/review evidence
+  next_action: exact handoff
+  blockers: exact blocker
+escalation:
+  on_blocked: route
+  on_done: route
+budget:
+  wall_clock_hours: 2
+```
+
+A brief is not a prompt dump. It is the smallest operating contract that lets a worker execute without inventing scope.
+
+## Checkpoint contract
+
+Workers return this block:
+
+```text
+STATE: DONE | BLOCKED | NEEDS_INPUT | HANDOFF | IN_PROGRESS | NEEDS_REVIEW
+FILES_CHANGED: exact paths or none
+COMMANDS_RUN: exact commands or none
+RESULT: concrete result/proof
+BLOCKER: blocker or none
+NEXT_ACTION: exact recommended next action
+```
+
+Good checkpoints contain evidence. Bad checkpoints contain adjectives. The swarm optimizes for evidence.
+
+## Notification routing
+
+The notification router lives in `src/server/swarm-notifications.ts`.
+
+Current behavior:
+
+- Checkpoints route to the orchestrator worker by default.
+- The default orchestrator worker is `swarm3`.
+- The tmux target is `swarm-swarm3`.
+- Duplicate raw checkpoints are suppressed via `runtime.json`.
+- `NEEDS_INPUT` escalates to the main session.
+- If the orchestrator tmux session is unreachable, the checkpoint escalates to the main session.
+- `DONE`, `HANDOFF`, and `BLOCKED` go to the orchestrator first.
+- The main session receives direct escalation only when human input is needed or the orchestrator cannot be reached.
+
+That split matters. Without it, the main chat becomes a trash fire of worker trivia. Technical term.
+
+## Standing missions vs ad-hoc dispatches
+
+### Standing missions
+
+A standing mission is a worker's permanent responsibility. Examples:
+
+- Scribe maintains docs and handoffs.
+- Reviewer owns the byte-verified review gate.
+- Triage works the PR/issues lane.
+- Lab runs model/runtime experiments.
+- Foundation maintains health and repair infrastructure.
+
+Standing missions are how idle workers stay useful without waiting for Eric to invent busywork.
+
+### Ad-hoc dispatches
+
+An ad-hoc dispatch is a bounded task. It still uses the same profile, same role, same checkpoint format, and same Greenlight Gate.
+
+Examples:
+
+- "Update docs/swarm/QUICKSTART.md for the new Add Swarm dialog."
+- "Review PR #42 and return APPROVED/CHANGES_REQUESTED with byte evidence."
+- "Reproduce issue #17 and write a minimal failing test."
+
+The system should treat ad-hoc dispatches as missions with smaller blast radius, not as casual chat requests.
+
+## The three permanent lanes
+
+### Lane A — Launch / demo / creative build lane
+
+Purpose: ship coordinated launch artifacts, demos, media, and release-facing assets.
+
+Typical owners:
+
+- Builder for implementation
+- Mirror Integrations for assets
+- Sage for narrative and research
+- QA for smoke checks
+- Scribe for README/showcase copy
+
+### Lane B — Issues + PR autopilot
+
+Purpose: keep open GitHub issues and PRs moving.
+
+Typical owners:
+
+- Triage as primary processor
+- Overflow for backup
+- Reviewer for gatekeeping
+- QA for regression proof
+
+Core loop:
+
+```text
+scan -> score -> reproduce -> patch -> test -> PR -> review -> human approval
+```
+
+### Lane C — Lab / experiments
+
+Purpose: run experiments without destabilizing the product lane.
+
+Typical owner:
+
+- Lab
+
+Examples:
+
+- local-model benchmark runs
+- runtime comparisons
+- speculative performance experiments
+- prototype loops
+
+Lab gets autonomy because isolation lowers risk. The product lane gets evidence when Lab finds something real.
+
+## Greenlight Gate
+
+The swarm can prepare risky actions. It cannot silently take them.
+
+Require explicit human approval before:
+
+- `git push --force`
+- PR merge or close
+- issue close without explicit instruction
+- release creation
+- npm/pnpm publish
+- public X/Discord/blog posts
+- financial transactions
+- destructive file operations
+- core service restarts
+
+Docs and local files can be drafted aggressively. Externally visible actions stay gated.
+
+## Auto-repair playbook
+
+The repair playbook maps known failure modes to safe fixes. The orchestrator should consult it before escalating.
+
+Examples of repair classes:
+
+- missing tmux session
+- stale worker runtime
+- profile path mismatch
+- build/test failure with known command
+- checkpoint timeout
+- auth/token unavailable
+- branch drift
+
+Repair is bounded. If a fix would become destructive, externally visible, or speculative, escalate.
+
+## Runtime state
+
+Each worker has a runtime record with fields like:
+
+- worker ID
+- role
+- state
+- phase
+- current task
+- cwd
+- last output time
+- last check-in
+- last summary/result
+- next action
+- blocked reason
+- checkpoint status
+- task counts
+- cron counts
+
+The UI uses this to render cards, Reports, Inbox, and runtime attach targets.
+
+## Control-plane endpoints
+
+Important endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/swarm-roster` | Return configured Project Agents and role metadata. |
+| `GET /api/swarm-runtime` | Return runtime state and tmux attachability. |
+| `GET /api/swarm-missions` | Return mission and assignment history. |
+| `POST /api/swarm-dispatch` | Send work to one or more Project Agents. |
+| `POST /api/swarm-tmux-start` | Start a tmux-backed worker session. |
+| `POST /api/swarm-tmux-stop` | Stop a worker tmux session. |
+| `POST /api/swarm-tmux-scroll` | Scroll a tmux session from the UI. |
+| `GET /api/swarm-health` | Summarize local swarm health. |
+
+## Failure philosophy
+
+The system should fail in ways that tell the next actor exactly what to do.
+
+Good blocker:
+
+```text
+BLOCKER: gh auth status failed with missing token; cannot create PR.
+NEXT_ACTION: Provide a GitHub token or run gh auth login, then re-run PR creation.
+```
+
+Bad blocker:
+
+```text
+BLOCKER: sandbox issue.
+```
+
+No. Absolutely not. The machine either has the tool, token, file, process, or it does not. Name the exact missing piece.
+
+## Review gate
+
+The review lane exists because autonomous work without review is just entropy in a nice jacket.
+
+Reviewer expectations:
+
+- read the diff
+- run tests/build/smoke
+- byte-check naming-sensitive changes when needed
+- verify generated files are intentional
+- produce a verdict
+- never merge without approval
+
+## Release architecture checklist
+
+Before calling a Swarm v1 release credible:
+
+- Orchestrator can dispatch workers.
+- Workers persist in tmux sessions.
+- Workers have role metadata and profiles.
+- Runtime view can attach or fall back.
+- Reports shows checkpoints.
+- Inbox surfaces review/input items.
+- `NEEDS_INPUT` escalates to the main session.
+- Greenlight Gate is documented and respected.
+- Docs explain how to run it without tribal knowledge.

--- a/docs/swarm/QUICKSTART.md
+++ b/docs/swarm/QUICKSTART.md
@@ -1,0 +1,257 @@
+# Swarm Mode Quickstart
+
+This quickstart gets a local Project Workspace checkout running, confirms profile auto-detection, starts a tmux-backed Project Agent, dispatches a first task, and shows where to review the result.
+
+## 0. Prerequisites
+
+You need:
+
+- Node.js 22+
+- pnpm
+- git
+- tmux for persistent TUI-backed workers
+- a configured Project Agent profile under `~/.hermes/profiles/`
+
+The workspace can still render without tmux, but tmux is what makes the worker sessions feel alive instead of one-shot and disposable.
+
+## 1. Clone the workspace
+
+```bash
+git clone https://github.com/outsourc-e/hermes-workspace.git
+cd hermes-workspace
+```
+
+## 2. Install dependencies
+
+```bash
+pnpm install
+```
+
+## 3. Start the workspace
+
+```bash
+pnpm dev
+```
+
+Open the local URL printed by Vite/TanStack Start. In most local setups that is:
+
+```text
+http://localhost:3000
+```
+
+Some release lanes run on `:3002`; trust the terminal output if it differs.
+
+## 4. First-run profile detection
+
+On first run, the workspace looks for Project Agent profiles in:
+
+```text
+~/.hermes/profiles/
+```
+
+Each worker profile can include:
+
+```text
+~/.hermes/profiles/<workerId>/
+  MEMORY.md
+  SOUL.md
+  USER.md
+  memory/IDENTITY.md
+  runtime.json
+  skills/
+```
+
+The roster and runtime APIs use that profile shape to populate worker cards, runtime state, model labels, tmux session names, checkpoint status, and recent summaries.
+
+If a worker exists in the roster but has no local profile, it can still appear as roster-only. Create or import the profile before expecting persistent memory, skill loading, or tmux launch to work.
+
+## 5. Spawn a tmux-backed worker
+
+There are two supported paths.
+
+### Option A: rotate/start script
+
+If your environment has the helper script installed, use:
+
+```bash
+/tmp/aurora-rotate-worker.sh swarm7
+```
+
+Replace `swarm7` with the worker ID you want. The convention is:
+
+```text
+tmux session: swarm-<workerId>
+profile:      ~/.hermes/profiles/<workerId>
+```
+
+After the script starts the session, open Swarm Mode and use Runtime view to attach to the TUI.
+
+### Option B: Add Swarm dialog
+
+In the workspace:
+
+1. Open Swarm Mode.
+2. Choose Add Swarm.
+3. Pick a role preset.
+4. Set worker ID, display name, model, specialty, mission, and skills.
+5. Save.
+6. Start the worker session from the card or Runtime view.
+
+The role presets fill the important defaults: role, specialty, mission, system prompt, skills, and default model. You can edit them before saving.
+
+## 6. Dispatch the first task
+
+The dispatch API is:
+
+```text
+POST /api/swarm-dispatch
+```
+
+Minimal single-worker example:
+
+```bash
+curl -X POST http://localhost:3000/api/swarm-dispatch   -H 'Content-Type: application/json'   -d '{
+    "workerIds": ["swarm7"],
+    "prompt": "Write a short checkpoint explaining what you can see in your current workspace. Do not modify files.",
+    "timeoutSeconds": 240,
+    "waitForCheckpoint": true
+  }'
+```
+
+Assignment-form example:
+
+```bash
+curl -X POST http://localhost:3000/api/swarm-dispatch   -H 'Content-Type: application/json'   -d '{
+    "missionTitle": "Docs smoke test",
+    "assignments": [
+      {
+        "workerId": "swarm7",
+        "task": "Review docs/swarm/README.md and return a checkpoint with one improvement suggestion.",
+        "rationale": "Scribe owns docs and handoff quality."
+      }
+    ],
+    "waitForCheckpoint": true,
+    "checkpointPollSeconds": 90
+  }'
+```
+
+Expected response shape:
+
+```json
+{
+  "missionId": "mission-...",
+  "assignments": [
+    { "workerId": "swarm7", "task": "..." }
+  ],
+  "results": [
+    {
+      "workerId": "swarm7",
+      "ok": true,
+      "delivery": "tmux",
+      "checkpointStatus": "checkpointed"
+    }
+  ]
+}
+```
+
+If `waitForCheckpoint` is true, the API waits for a fresh checkpoint from runtime state or worker chat. If it times out, the worker may still be running; inspect Runtime view before assuming failure.
+
+## 7. View Reports + Inbox
+
+Open Swarm Mode, then switch the view to Reports.
+
+Reports gives you:
+
+- mission history
+- assignment state
+- worker checkpoints
+- blockers
+- `NEEDS_REVIEW` items
+- ready-for-human Inbox cards
+- route-to-reviewer actions
+
+The Inbox is where the swarm asks for judgment instead of trying to be brave in public. Good.
+
+## 8. Use the Kanban TaskBoard
+
+Switch to Kanban view for planning. The board is useful when you want a visual queue but still want dispatch to happen through the orchestrator.
+
+Recommended lane meanings:
+
+| Lane | Meaning |
+| --- | --- |
+| Backlog | Useful but not ready. |
+| Ready | Clear enough to dispatch. |
+| Running | Worker owns it now. |
+| Review | Needs reviewer or Eric. |
+| Blocked | Needs repair, input, auth, or scope cut. |
+| Done | Verified checkpoint landed. |
+
+## 9. Add a worker with role presets
+
+The Add Swarm dialog includes these presets:
+
+- Orchestrator
+- Builder
+- Reviewer
+- Triage
+- Lab
+- Sage
+- Scribe
+- Foundation
+- QA
+- Mirror Integrations
+- Custom
+
+Pick the closest role first, then tune. Avoid starting from Custom unless you are intentionally creating a new lane. Presets encode the operating contract so the worker knows whether it is allowed to build, review, triage, research, or just report.
+
+## 10. First-task checklist
+
+Before trusting a new worker:
+
+- It appears in the roster.
+- Its profile exists under `~/.hermes/profiles/<workerId>/`.
+- Runtime view can attach to tmux or open a shell/log stream.
+- `/api/swarm-dispatch` can deliver a task.
+- The worker returns the canonical checkpoint format.
+- Reports shows the checkpoint.
+- The orchestrator can route the next action.
+
+## 11. Common fixes
+
+### Worker card exists but TUI does not attach
+
+Check tmux:
+
+```bash
+tmux ls
+```
+
+Expected session name:
+
+```text
+swarm-<workerId>
+```
+
+Start or rotate the worker if the session is missing.
+
+### Dispatch returns timeout
+
+A timeout means the API did not see a fresh checkpoint in time. It does not always mean the worker failed.
+
+Check:
+
+- Runtime view
+- worker `runtime.json`
+- worker chat transcript
+- Reports tab after refresh
+
+### Worker has wrong role/model/skills
+
+Open Add Swarm or edit the roster config, then restart the worker session. Role, model, and skills are part of the worker identity; changing them mid-task creates weird ghosts. Weird ghosts are expensive.
+
+## 12. Safe operating boundary
+
+The swarm can prepare commits, branches, PR bodies, review verdicts, issues, and release notes. It should not merge, force-push, publish, announce publicly, close issues, or perform destructive file operations without explicit human approval.
+
+That boundary is the Greenlight Gate. Keep it boring.

--- a/docs/swarm/README.md
+++ b/docs/swarm/README.md
@@ -1,0 +1,104 @@
+# Swarm Mode
+
+Swarm Mode is the Project Workspace control plane for Project Agents: persistent workers, a standing orchestrator, a review gate, and enough runtime visibility that the system is understandable instead of mystical.
+
+The release promise is simple:
+
+- Unlimited Project Agents can exist.
+- One orchestrator translates intent into dispatch.
+- Zero humans have to manually route every task.
+- Every worker has a role, a profile, a mission, and a checkpoint contract.
+- Every risky action still routes through the Greenlight Gate.
+
+This is not a chat wrapper with tabs. It is the operating surface for a local agent swarm.
+
+## Start here
+
+- [QUICKSTART.md](./QUICKSTART.md) — clone, run, detect profiles, spawn workers, dispatch the first task.
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — loop, SwarmBrief shape, notification routing, lanes, review, repair.
+- [SKILLS.md](./SKILLS.md) — bundled swarm skills, auto-loading, and custom skill conventions.
+- [ROLES.md](./ROLES.md) — role presets used by the Add Swarm dialog and the canonical project specs.
+
+## The 30-second model
+
+Eric talks to Aurora. Aurora turns intent into a brief. The orchestrator routes that brief to the right Project Agent. Workers execute inside persistent tmux sessions, checkpoint with proof, and the orchestrator decides whether to continue, repair, escalate, or put a card in the Inbox.
+
+```text
+Eric -> Aurora -> swarm3/orchestrator -> role workers -> checkpoints -> reports/inbox -> review/escalation
+```
+
+The important move is that dispatch becomes a system, not a vibe. The worker is not just "another model call." It is a named lane with memory, runtime state, default skills, a profile, and a job.
+
+## What ships in v1
+
+### Orchestrator Chat
+
+The orchestrator chat is the main command surface. Use it to ask for one action, a decomposed plan, or a broadcast. It can route to specific workers, create missions, wait for checkpoints, and push follow-up prompts when a worker drifts.
+
+### Multi-Agent Control Plane
+
+The Swarm surface shows workers as operational cards: role, state, current task, model, recent signal, room membership, and action affordances. You can inspect the topology instead of guessing which agent is alive.
+
+### Kanban TaskBoard
+
+The TaskBoard gives the swarm a planning surface: backlog, ready, running, review, blocked, done. It is intentionally boring. Boring task state beats a beautiful graveyard of half-finished chats.
+
+### Reports + Inbox
+
+Reports and Inbox are where the swarm becomes reviewable. Checkpoints with `NEEDS_REVIEW`, blockers, handoffs, and escalation-worthy summaries land here so Eric can approve the few things that need judgment.
+
+### TUI View built in
+
+Runtime view attaches to tmux-backed workers when available. If tmux is not available, the workspace falls back to a shell or log tail. The goal is direct observability: if a Project Agent is doing something, you can see the lane.
+
+## Core terms
+
+| Term | Meaning |
+| --- | --- |
+| Project Agent | A named, persistent worker with a role, profile, skills, and runtime state. |
+| Orchestrator | The Project Agent responsible for dispatch, drift detection, routing, and escalation. |
+| SwarmBrief | The canonical task shape sent from orchestrator to worker. |
+| Standing mission | A permanent responsibility a worker resumes when idle. |
+| Ad-hoc dispatch | A one-off task sent through the same checkpoint contract. |
+| Checkpoint | The proof-bearing status block returned by a worker. |
+| Greenlight Gate | Human approval boundary for irreversible or externally visible actions. |
+| Repair playbook | Known failures mapped to safe repairs before escalation. |
+
+## Mental model for users
+
+The workspace gives you three levels of control:
+
+1. Ask the orchestrator for an outcome.
+2. Inspect and steer the mission from the control plane.
+3. Drop into the worker runtime only when you need exact evidence.
+
+You should not need to babysit every step. You should be able to ask for a release doc pass, see the docs worker take it, watch the checkpoint land, send the reviewer lane next, and approve the PR only when the review says it is real.
+
+## What Swarm Mode is good at
+
+- Release trains with docs, build, review, QA, and PR steps.
+- Autonomous issue triage with bounded repair lanes.
+- Research + build loops where one worker scouts and another ships.
+- Long-running lab experiments that should not pollute the product lane.
+- Handoffs where context preservation matters more than raw model cleverness.
+
+## What Swarm Mode deliberately does not do
+
+- It does not remove human approval for irreversible external actions.
+- It does not make workers talk directly to Eric.
+- It does not require every worker to run on the same machine forever.
+- It does not pretend chat history is a project management system.
+- It does not solve bad specs. It makes bad specs visible faster. Which is less romantic, but more useful.
+
+## Release-path docs
+
+Read these in order if you are testing the v1 release:
+
+1. [QUICKSTART.md](./QUICKSTART.md)
+2. [ARCHITECTURE.md](./ARCHITECTURE.md)
+3. [ROLES.md](./ROLES.md)
+4. [SKILLS.md](./SKILLS.md)
+
+## Canonical spec
+
+The canonical runtime contract is `SWARM_SPEC.md` in the swarm specs directory. This docs set explains the public surface; the spec wins when implementation details conflict.

--- a/docs/swarm/ROLES.md
+++ b/docs/swarm/ROLES.md
@@ -1,0 +1,400 @@
+# Swarm Role Presets
+
+The Add Swarm dialog ships with role presets so new Project Agents start with a real operating contract instead of a blank textarea and optimism. Pick the closest preset, tune the mission, then start the worker.
+
+Each role has:
+
+- specialty
+- default skills
+- default model
+- when to use it
+- canonical spec reference
+
+Canonical project specs live in the swarm specs directory at:
+
+```text
+/swarm-specs/projects/<worker>.md
+```
+
+Use those specs as the source of truth for standing missions. The role preset is the fast-start shape; the project spec is the durable contract.
+
+## Preset summary
+
+| Preset | Default model | Use when |
+| --- | --- | --- |
+| Orchestrator | GPT-5.4 | You need dispatch, routing, drift detection, and escalation. |
+| Builder | GPT-5.5 | You need product code shipped with tests/build proof. |
+| Reviewer | GPT-5.4 | You need byte-verified review and merge readiness. |
+| Triage | GPT-5.5 | You need issues/PRs scored, reproduced, patched, or prepared. |
+| Lab | GPT-5.4 | You need isolated experiments or local-model benchmarking. |
+| Sage | GPT-5.5 | You need research, synthesis, scripts, or launch copy. |
+| Scribe | GPT-5.5 | You need docs, specs, handoffs, skills hygiene, memory curation. |
+| Foundation | GPT-5.4 | You need runtime, repair, infra, health, or lifecycle work. |
+| QA | GPT-5.4 | You need regression, smoke, expected-vs-actual verification. |
+| Mirror Integrations | GPT-5.4 | You need upstream sync, integrations, or asset packs. |
+| Custom | user-selected | You are creating a lane that does not fit an existing preset. |
+
+## Orchestrator
+
+Specialty: control-plane state, dispatch, drift detection, escalation.
+
+Default skills:
+
+- `swarm-orchestrator`
+- `swarm-worker-core`
+- `swarm-review-learning-loop`
+- `self-improvement`
+
+Default model: GPT-5.4
+
+When to use:
+
+- routing multi-worker missions
+- translating intent into SwarmBriefs
+- interpreting checkpoints
+- detecting drift
+- re-prompting workers
+- escalating blockers
+- managing standing missions
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm3.md
+```
+
+Good checkpoint:
+
+```text
+STATE: HANDOFF
+RESULT: Routed docs release to swarm7 and review gate to swarm6 after docs checkpoint.
+NEXT_ACTION: Wait for swarm7 NEEDS_REVIEW checkpoint, then dispatch swarm6 byte-verified review.
+```
+
+## Builder
+
+Specialty: full-stack implementation, fast ship cycles.
+
+Default skills:
+
+- `swarm-worker-core`
+- `byte-verified-code-review`
+
+Default model: GPT-5.5
+
+When to use:
+
+- product UI
+- backend endpoints
+- integrations
+- bug fixes
+- feature slices
+- focused refactors
+
+Canonical spec examples:
+
+```text
+/swarm-specs/projects/swarm5.md
+/swarm-specs/projects/swarm10.md
+```
+
+Builder should ship narrow diffs, not renovate the cathedral because a button looked lonely.
+
+## Reviewer
+
+Specialty: byte-verified code review, naming, tests, build gate.
+
+Default skills:
+
+- `swarm-worker-core`
+- `byte-verified-code-review`
+- `swarm-review-learning-loop`
+
+Default model: GPT-5.4
+
+When to use:
+
+- PR readiness
+- release branch gates
+- generated-file sanity checks
+- fragile naming changes
+- regression review
+- build/test verification
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm6.md
+```
+
+Reviewer verdicts should be one of:
+
+- APPROVED
+- CHANGES_REQUESTED
+- BLOCKED
+
+## Triage
+
+Specialty: autonomous PR/issues processor.
+
+Default skills:
+
+- `swarm-worker-core`
+- `byte-verified-code-review`
+- `swarm-review-learning-loop`
+
+Default model: GPT-5.5
+
+When to use:
+
+- issue backlog scan
+- PR feedback triage
+- reproduction notes
+- minimal failing tests
+- small fix branches
+- issue ranking
+
+Canonical spec examples:
+
+```text
+/swarm-specs/projects/swarm12.md
+/swarm-specs/projects/swarm1.md
+```
+
+Triage should never silently merge or close. It prepares the work and asks for the gate.
+
+## Lab
+
+Specialty: local-model R&D, spec-dec, benchmarking.
+
+Default skills:
+
+- `swarm-worker-core`
+- `pc1-ollama-gguf-bench`
+- `swarm-bench-worker`
+
+Default model: GPT-5.4
+
+When to use:
+
+- local model testing
+- throughput comparisons
+- speculative runtime improvements
+- isolated prototypes
+- experiment logs
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm9.md
+```
+
+Lab is allowed to be weird because it is isolated. Product lanes are not.
+
+## Sage
+
+Specialty: research, scripts, X content, creative briefs.
+
+Default skills:
+
+- `swarm-worker-core`
+- `last30days`
+- `pdf-and-paper-deep-reading`
+
+Default model: GPT-5.5
+
+When to use:
+
+- technical research
+- market/model scan
+- launch angles
+- thread drafts
+- creative briefs
+- citations
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm4.md
+```
+
+Sage drafts; humans approve public posting.
+
+## Scribe
+
+Specialty: docs, skills hygiene, memory curation.
+
+Default skills:
+
+- `swarm-worker-core`
+- `last30days`
+- `creative-writing`
+
+Default model: GPT-5.5
+
+When to use:
+
+- README updates
+- docs trees
+- release notes
+- handoffs
+- specs
+- runbooks
+- skill documentation
+- memory hygiene reports
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm7.md
+```
+
+Scribe makes the system legible. This is less glamorous than building the system and usually more responsible for whether anyone can use it.
+
+## Foundation
+
+Specialty: infra, repair playbook, autopilot wiring.
+
+Default skills:
+
+- `swarm-worker-core`
+
+Default model: GPT-5.4
+
+When to use:
+
+- runtime APIs
+- health checks
+- tmux lifecycle
+- profile detection
+- repair playbook updates
+- orchestrator loop wiring
+- backend contracts
+
+Canonical spec examples:
+
+```text
+/swarm-specs/projects/swarm8.md
+/swarm-specs/projects/swarm2.md
+```
+
+Foundation keeps the floor from turning into soup.
+
+## QA
+
+Specialty: regression QA, render verification, expected-vs-actual checks.
+
+Default skills:
+
+- `swarm-worker-core`
+- `byte-verified-code-review`
+
+Default model: GPT-5.4
+
+When to use:
+
+- smoke tests
+- regression checks
+- UI expected-vs-actual passes
+- artifact verification
+- post-build confidence
+- release sanity
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm11.md
+```
+
+QA should say exactly what was checked, exactly what failed, and exactly how to reproduce it.
+
+## Mirror Integrations
+
+Specialty: asset packs, upstream sync, integrations.
+
+Default skills:
+
+- `swarm-worker-core`
+- `claude-promo`
+- `songwriting-and-ai-music`
+
+Default model: GPT-5.4
+
+When to use:
+
+- upstream diff watching
+- integration packaging
+- asset collection
+- creative asset generation
+- cross-lane support
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/swarm10.md
+```
+
+Mirror Integrations is the lane for portable useful things, not random shiny distractions. There will be random shiny distractions. They are sneaky.
+
+## Custom
+
+Specialty: user-defined.
+
+Default skills: none.
+
+Default model: user-selected.
+
+When to use:
+
+- the worker does not fit an existing role
+- you are testing a new lane
+- you need temporary specialization
+- a future preset is being prototyped
+
+Canonical spec:
+
+```text
+/swarm-specs/projects/<new-worker>.md
+```
+
+Custom workers should still get:
+
+- `swarm-worker-core`
+- a role description
+- a specialty
+- a mission
+- a checkpoint contract
+- a clear approval boundary
+
+Blank custom workers become expensive autocomplete. Add structure first.
+
+## Choosing the right role
+
+Use this routing rule:
+
+| If the work is mostly... | Send it to... |
+| --- | --- |
+| deciding who should do what | Orchestrator |
+| changing product code | Builder |
+| proving a branch is safe | Reviewer |
+| chewing through issues/PRs | Triage |
+| experimenting away from release | Lab |
+| researching or drafting narrative | Sage |
+| explaining, documenting, preserving context | Scribe |
+| runtime/health/repair infrastructure | Foundation |
+| checking behavior and regressions | QA |
+| upstream/integration/assets | Mirror Integrations |
+| none of the above | Custom |
+
+## Adding a new role preset
+
+1. Define the role in the UI preset list.
+2. Give it a one-line specialty.
+3. Give it a standing mission.
+4. Choose default skills.
+5. Choose default model.
+6. Create a canonical project spec.
+7. Add it to this document.
+8. Dispatch a tiny smoke task and verify a checkpoint.
+
+If step 6 feels like too much work, the role probably is not real yet.

--- a/docs/swarm/SKILLS.md
+++ b/docs/swarm/SKILLS.md
@@ -1,0 +1,240 @@
+# Swarm Skills
+
+Skills are the reusable operating knowledge behind Swarm Mode. A role preset names the skills a worker should load; the profile and skills path make those skills available at runtime.
+
+A skill is not a vibe. It is a procedure: when to use it, what commands to run, what files matter, what pitfalls exist, and how to verify the result.
+
+## Bundled swarm skills
+
+| Skill | Use it for |
+| --- | --- |
+| `swarm-orchestrator` | Orchestrator loop, dispatch, drift detection, re-prompts, escalation, mission routing. |
+| `swarm-worker-core` | Base worker contract: phases, checkpoints, runtime state, blockers, handoffs. |
+| `swarm-review-learning-loop` | Capture review learnings, recurring failures, and skill improvements after tasks. |
+| `byte-verified-code-review` | Review diffs with byte-level proof for naming-sensitive and generated-file changes. |
+| `swarm-bench-worker` | Benchmark/lab work for local models, runtime experiments, and result logging. |
+| `swarm-pr-worker` | GitHub issue/PR workflow, triage, patching, PR prep, review feedback. |
+| `swarm-ui-worker` | UI implementation lane for Project Workspace surfaces. |
+| `swarm-dev-runtime` | Runtime contracts, backend APIs, lifecycle, health, and repair wiring. |
+| `swarm-memory` | File-backed memory expectations for workers and orchestrator history. |
+| `swarm-orchestration-loop` | Canonical orchestration/review loop for persistent worker fleets. |
+| `swarm-review-learning-loop` | Shared loop for turning task outcomes into durable improvements. |
+
+Some installations may name the byte review skill differently. If the exact skill is not present, use the available review skill that enforces byte checks, diff review, tests, build, smoke, and verdict discipline.
+
+## How skills auto-load
+
+When you clone the repo and run the workspace, worker sessions load skills from the configured Project Agent profile. In Eric's release environment, profiles point at a shared skills directory, commonly exposed to workers as:
+
+```text
+~/.ocplatform/workspace/skills/
+```
+
+A worker profile can also carry profile-local skills under:
+
+```text
+~/.hermes/profiles/<workerId>/skills/
+```
+
+The important rule is that the worker's runtime must be able to resolve the skill name from its profile. The UI can display a role's default skills, but the worker still needs the skill files available locally.
+
+## Role-to-skill defaults
+
+| Role | Default skills |
+| --- | --- |
+| Orchestrator | `swarm-orchestrator`, `swarm-worker-core`, `swarm-review-learning-loop`, `self-improvement` |
+| Builder | `swarm-worker-core`, `byte-verified-code-review` |
+| Reviewer | `swarm-worker-core`, `byte-verified-code-review`, `swarm-review-learning-loop` |
+| Triage | `swarm-worker-core`, `byte-verified-code-review`, `swarm-review-learning-loop` |
+| Lab | `swarm-worker-core`, `pc1-ollama-gguf-bench`, `swarm-bench-worker` |
+| Sage | `swarm-worker-core`, `last30days`, `pdf-and-paper-deep-reading` |
+| Scribe | `swarm-worker-core`, `last30days`, `creative-writing` |
+| Foundation | `swarm-worker-core` |
+| QA | `swarm-worker-core`, `byte-verified-code-review` |
+| Mirror Integrations | `swarm-worker-core`, `claude-promo`, `songwriting-and-ai-music` |
+| Custom | no default skills |
+
+## What each core skill contributes
+
+### swarm-worker-core
+
+Base contract for every Project Agent:
+
+- understand the task
+- set phase
+- execute the next meaningful step
+- verify
+- checkpoint
+- continue, escalate, or stop cleanly
+
+If a worker has only one skill, it should have this one.
+
+### swarm-orchestrator
+
+Used by the orchestrator lane. It owns:
+
+- mission decomposition
+- role-based routing
+- drift detection
+- checkpoint interpretation
+- re-prompting
+- escalation
+- lane priority
+- handoff hygiene
+
+The orchestrator should not be the best coder in the room. It should be the worker that makes every other worker useful.
+
+### swarm-review-learning-loop
+
+Used after completed work and reviews to convert outcome into memory or skill improvements. This prevents the swarm from repeatedly stepping on the same rake and calling it research.
+
+### byte-verified-code-review
+
+Used for review gates. It forces proof instead of "looks fine":
+
+- inspect exact diff
+- byte-check fragile naming or generated output
+- run tests/build/smoke
+- state verdict
+- document blockers precisely
+
+### swarm-bench-worker
+
+Used by Lab for local-model and runtime experiments:
+
+- benchmark plan
+- controlled run
+- result capture
+- reproducibility notes
+- escalation threshold
+
+### swarm-pr-worker
+
+Used by PR/issues lanes:
+
+- issue scan
+- scoring
+- reproduction
+- branch discipline
+- fix/test/PR prep
+- review feedback handling
+
+### swarm-ui-worker
+
+Used by UI builders:
+
+- route inspection
+- component boundaries
+- visual state
+- smoke checks
+- build verification
+
+### swarm-dev-runtime
+
+Used by Foundation/runtime lanes:
+
+- API contracts
+- profile/runtime state
+- health checks
+- lifecycle repair
+- tmux/gateway integration
+
+## Adding custom skills
+
+Create a skill directory with a `SKILL.md` file:
+
+```text
+skills/my-skill/
+  SKILL.md
+  references/
+  templates/
+  scripts/
+```
+
+Recommended frontmatter:
+
+```yaml
+---
+name: my-skill
+description: One sentence explaining when a worker must load this skill.
+---
+```
+
+Recommended sections:
+
+```markdown
+# My Skill
+
+## Trigger
+When to use it.
+
+## Steps
+1. Exact first step.
+2. Exact second step.
+3. Verification.
+
+## Pitfalls
+- Known failure mode.
+- Exact unblock action.
+
+## Output contract
+What the worker must return.
+```
+
+## Adding a custom skill to a worker
+
+1. Add the skill folder to the shared skills directory or the worker profile's `skills/` directory.
+2. Add the skill name to the role preset or worker roster entry.
+3. Restart or rotate the worker session so the profile reloads.
+4. Dispatch a small task that requires the skill.
+5. Verify the checkpoint names the skill and returns proof.
+
+## Skill hygiene rules
+
+A skill should be patched when:
+
+- a command is stale
+- a path changed
+- a setup assumption is wrong
+- a worker hit a recurring error not documented there
+- the user's preferred workflow changed
+- a better verification step exists
+
+Do not create a memory note for a procedure that belongs in a skill. Memory stores durable facts; skills store repeatable workflows.
+
+## Skill loading checklist
+
+Before blaming a worker:
+
+- Does the skill exist by exact name?
+- Does the worker profile have access to the skills directory?
+- Did the session start after the skill was added?
+- Does the role preset include the skill?
+- Did the task require the worker to load it?
+- Did the checkpoint show evidence that the procedure was followed?
+
+## Minimum viable skill for Swarm v1
+
+For a useful worker:
+
+```text
+swarm-worker-core
+```
+
+For a useful orchestrator:
+
+```text
+swarm-orchestrator
+swarm-worker-core
+swarm-review-learning-loop
+```
+
+For a useful reviewer:
+
+```text
+swarm-worker-core
+byte-verified-code-review
+swarm-review-learning-loop
+```
+
+Everything else is specialization.


### PR DESCRIPTION
## Summary
- Adds Swarm Mode pitch near the top of README
- Adds docs/swarm overview, quickstart, architecture, skills, and roles docs
- Documents Project Agent dispatch, tmux-backed workers, Reports + Inbox, role presets, notification routing, permanent lanes, Greenlight Gate, and repair playbook

## Verification
- pnpm build
- Link existence check for README + docs/swarm markdown links
- Naming scan: no user-facing "Hermes Code", no CLAUDE_HOME, no .openclaw in docs/swarm