### PR TITLE
fix(server): respect Hermes home via canonical getHermesRoot helper

### DIFF
--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -46,7 +46,7 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
 ])
 
 function getHermesRoot(): string {
-  return path.join(os.homedir(), '.hermes')
+  return process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
 }
 
 export function getProfilesRoot(): string {

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import path from 'node:path'
+
+import { getHermesRoot } from './claude-paths'
 
 export type PersistedRunToolCall = {
   id: string
@@ -33,7 +34,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(process.env.HERMES_HOME ?? homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(getClaudeRoot(), 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -33,7 +33,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(process.env.HERMES_HOME ?? homedir(), '.hermes', 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { getHermesRoot } from './claude-paths'
+import { getHermesRoot } from './hermes-paths'
 
 export type PersistedRunToolCall = {
   id: string
@@ -34,7 +34,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(getClaudeRoot(), 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(getHermesRoot(), 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')


### PR DESCRIPTION
Supersedes #199.

Includes Norbert's original fix (cc4c757de) and a follow-up that routes `run-store`'s `RUNS_ROOT` through the canonical `getHermesRoot()` helper added in #205, so `HERMES_HOME` does not double-nest the Hermes data root when it already points at the Hermes root.

## Why supersede #199
The original PR's branch lives on a fork. swarm6's release-cut review flagged a one-line semantic bug in `src/server/run-store.ts`: if `HERMES_HOME=/tmp/hermes-home`, the original code would incorrectly resolve runs under a nested Hermes directory instead of directly under the configured Hermes root. This PR fixes that and is mergeable from our repo.

Co-authored-by: Norbert Billa <hello@armanoide.net>

## Verification
- `pnpm build`: ✅ pass
- `pnpm test`: ✅ 27 files / 96 tests pass

## Files changed
- `src/server/profiles-browser.ts` (+1 -1) — Norbert's original fix
- `src/server/run-store.ts` (+3 -2) — route through `getHermesRoot()`

## Closes
Closes #199 (superseded)