### PR TITLE
fix(server): respect Hermes home via canonical getHermesRoot helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,8 @@
 # Set to 1 to force the Secure attribute on session cookies even when
 # NODE_ENV is not production — useful when terminating TLS at a reverse
 # proxy. Set to 0 to force it off (only safe for localhost HTTP).
-# COOKIE_SECURE=1
+# COOKIE_SECURE=1   # use behind HTTPS / reverse proxy
+# COOKIE_SECURE=0   # required for plain HTTP on HOST=0.0.0.0 / LAN access
 
 # Trust proxy-forwarded headers (default: off)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Features pending cloud infrastructure:
 
 - `HERMES_PASSWORD` — required whenever `HOST ≠ 127.0.0.1`
 - `COOKIE_SECURE=1` — force the `Secure` cookie flag when terminating HTTPS at a proxy
+- `COOKIE_SECURE=0` — required for plain HTTP LAN access on `HOST=0.0.0.0` so the browser will actually send the auth cookie
 - `TRUST_PROXY=1` — trust `x-forwarded-for` / `x-real-ip` (only set behind a sanitizing reverse proxy)
 - `HERMES_DASHBOARD_TOKEN` — explicit bearer for dashboard API (preferred over the legacy HTML-scrape fallback)
 - `HERMES_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)

--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ No local build. First run takes a minute to pull; subsequent starts are instant.
 Agent state (config, sessions, skills, memory, credentials) persists in the
 `hermes-data` named volume, so containers can be recreated without data loss.
 
+> **Skills Hub note:** the published `ghcr.io/outsourc-e/hermes-workspace` image
+> includes the bundled skills fallback. Full Marketplace / Skills Hub registry
+> search needs the Python `scripts/skills-search.py` runtime plus a Hermes Agent
+> source/install tree; use the source/dev Docker overlay or a derived image if
+> you need non-bundled hub results from an image-only deployment. The
+> `/api/skills/hub-search` response includes `source: "bundled-skills-fallback"`
+> and a `warning` when the container is running fallback-only mode.
+
 ### Step 3: Access the Workspace
 
 Open `http://localhost:3000` and complete the onboarding.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,23 @@
 
 If you discover a security vulnerability in Hermes Workspace, please report it responsibly.
 
-**Do NOT open a public GitHub issue for security vulnerabilities.**
+**Do not open a public GitHub issue for security vulnerabilities.** Public issues are for non-sensitive bugs only.
 
-Instead, report via [GitHub Security Advisories](https://github.com/outsourc-e/hermes-workspace/security/advisories) or DM [@ericousodev on X](https://x.com/ericousodev).
+Preferred disclosure channels:
+
+1. [GitHub Private Vulnerability Reporting / Security Advisories](https://github.com/outsourc-e/hermes-workspace/security/advisories/new)
+2. Email: [security@buildingthefuture.io](mailto:security@buildingthefuture.io)
+
+If GitHub reports that private vulnerability reporting is disabled, use the email address above and include enough detail for maintainers to reproduce the issue safely.
+
+Maintainer action required: GitHub private vulnerability reporting is controlled in repository settings under **Settings → Code security and analysis → Private vulnerability reporting**. That setting must be enabled by a repository administrator; this policy file provides the public fallback channel but does not change the repository setting.
+
+Please include:
+
+- affected version, commit, or deployment mode
+- reproduction steps or a proof-of-concept, if safe to share
+- expected impact and affected data/systems
+- any suggested remediation or mitigation
 
 We will acknowledge your report within 48 hours and aim to provide a fix within 7 days for critical issues.
 

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,42 @@ This means the Vite SSR server tried `GET /api/gateway-status` which internally 
 
 ---
 
+### Docker: Skills Hub / Marketplace only shows bundled skills
+
+The published `ghcr.io/outsourc-e/hermes-workspace` image is intentionally
+self-contained for the Workspace UI and bundled skills. It does **not** include a
+full Hermes Agent source checkout plus Python Skills Hub dependencies for
+non-bundled registry search.
+
+When full hub search is unavailable, `GET /api/skills/hub-search` falls back to
+installed/bundled skills and returns:
+
+```json
+{
+  "source": "bundled-skills-fallback",
+  "warning": "Skills Hub search is unavailable in this runtime; showing bundled skills fallback."
+}
+```
+
+To enable full Marketplace / Skills Hub registry search in Docker, use one of:
+
+1. The source/dev overlay, which builds from local source:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+   ```
+
+2. A derived image that adds `python3`, `scripts/skills-search.py`, and the
+   Hermes Agent Python package/source tree expected by the search script.
+
+3. A host-mounted Hermes Agent checkout plus matching environment variables, if
+   your deployment platform supports bind mounts.
+
+If you only need the skills bundled with the Workspace image, no action is
+required; the fallback mode is expected.
+
+---
+
 ## Diagnostic bundle
 
 If nothing above helps, run this and share the output:

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type Props = {
   open: boolean
@@ -34,17 +35,19 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-function formatUpdatedAt(updatedAt?: number): string {
+function formatUpdatedAt(
+  updatedAt: number | undefined,
+  use24HourTime: boolean,
+): string {
   if (typeof updatedAt !== 'number') return ''
   const value = new Date(updatedAt)
   const now = new Date()
   if (value.toDateString() === now.toDateString()) {
-    return timeFormatter.format(value)
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: !use24HourTime,
+    }).format(value)
   }
   return dayFormatter.format(value)
 }
@@ -57,6 +60,10 @@ export function MobileSessionsPanel({
   onSelectSession,
   onNewChat,
 }: Props) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+
   useEffect(() => {
     if (!open) return
     function handleKeyDown(event: KeyboardEvent) {
@@ -120,7 +127,10 @@ export function MobileSessionsPanel({
               <div className="space-y-1">
                 {sessions.map((session) => {
                   const active = session.friendlyId === activeFriendlyId
-                  const timestamp = formatUpdatedAt(session.updatedAt)
+                  const timestamp = formatUpdatedAt(
+                    session.updatedAt,
+                    use24HourTime,
+                  )
                   return (
                     <button
                       key={session.key}

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1229,6 +1229,16 @@ function ChatContent() {
           />
         </Row>
         <Row
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={cs.use24HourTime}
+            onCheckedChange={(c) => updateCS({ use24HourTime: c })}
+            aria-label="Use 24-hour time"
+          />
+        </Row>
+        <Row
           label="Enter key behavior"
           description={
             cs.enterBehavior === 'newline'
@@ -1971,7 +1981,7 @@ export function SettingsDialog({
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="inset-0 h-full w-full max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
+      <DialogContent className="left-0 top-0 h-[100dvh] w-screen max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
         <div className="flex h-full min-h-0 flex-col">
           <div className="flex items-center justify-between border-b border-primary-200 bg-primary-50/80 px-4 py-4 md:rounded-t-2xl md:px-5">
             <div>

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/components/usage-meter/context-alert-modal.tsx
+++ b/src/components/usage-meter/context-alert-modal.tsx
@@ -121,7 +121,7 @@ function ContextAlertModalComponent({
               )}
               <Recommendation
                 icon="🗜️"
-                text="Enable auto-compaction in Settings → Config to automatically manage context"
+                text="Auto-compaction is configured in ~/.hermes/config.yaml under the compression section"
               />
               <Recommendation
                 icon="📋"

--- a/src/components/usage-meter/usage-details-modal.tsx
+++ b/src/components/usage-meter/usage-details-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { formatModelName } from '@/lib/format-model-name'
 
 type ModelUsage = {
@@ -81,10 +82,10 @@ function formatTokens(value: number): string {
   return Math.round(value).toString()
 }
 
-function formatTimestamp(value?: number): string {
+function formatTimestamp(value: number | undefined, use24HourTime: boolean): string {
   if (!value) return '—'
   const date = new Date(value < 1_000_000_000_000 ? value * 1000 : value)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
 }
 
 function formatResetTime(iso?: string): string {
@@ -259,7 +260,7 @@ function buildCsv(usage: UsageSummary): string {
   )
   usage.sessions.forEach((session) => {
     rows.push(
-      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt)},${formatTimestamp(session.updatedAt)}`,
+      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt, use24HourTime)},${formatTimestamp(session.updatedAt, use24HourTime)}`,
     )
   })
   return rows.join('\n')
@@ -441,8 +442,8 @@ export function UsageDetailsModal({
                         {formatTokens(session.outputTokens)} out
                       </div>
                       <div className="text-xs text-primary-500">
-                        {formatTimestamp(session.startedAt)} →{' '}
-                        {formatTimestamp(session.updatedAt)}
+                        {formatTimestamp(session.startedAt, use24HourTime)} →{' '}
+                        {formatTimestamp(session.updatedAt, use24HourTime)}
                       </div>
                       <div className="font-semibold text-primary-900">
                         {formatCurrency(session.costUsd)}
@@ -473,7 +474,7 @@ export function UsageDetailsModal({
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-primary-500">
                 Auto-polls every 30s · Last updated{' '}
-                {formatTimestamp(providerUpdatedAt ?? undefined)}
+                {formatTimestamp(providerUpdatedAt ?? undefined, use24HourTime)}
               </div>
               <Button
                 size="sm"
@@ -529,7 +530,7 @@ export function UsageDetailsModal({
                         <div className="flex items-center gap-2">
                           {statusBadge(provider.status)}
                           <span className="text-[10px] text-primary-400">
-                            {formatTimestamp(provider.updatedAt)}
+                            {formatTimestamp(provider.updatedAt, use24HourTime)}
                           </span>
                         </div>
                       </div>

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,10 +11,9 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
@@ -77,8 +76,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const { settings } = useSettings()
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
+  const sidebarPinned = useWorkspaceStore((s) => s.sidebarPinned)
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
+  const toggleSidebarPinned = useWorkspaceStore((s) => s.toggleSidebarPinned)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
@@ -150,7 +151,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed && !sidebarPinned
 
   // Sessions query — shared across sidebar and chat
   const sessionsQuery = useQuery({
@@ -311,7 +312,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 creatingSession={creatingSession}
                 onCreateSession={startNewChat}
                 isCollapsed={sidebarCollapsed}
+                isPinned={sidebarPinned}
                 onToggleCollapse={toggleSidebar}
+                onTogglePinned={toggleSidebarPinned}
                 onSelectSession={handleSelectSession}
                 onActiveSessionDelete={handleActiveSessionDelete}
                 sessionsLoading={sessionsLoading}

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -53,6 +53,7 @@ export type ChatSettings = {
    * surprised by sound on next page load.
    */
   soundOnChatComplete: boolean
+  use24HourTime: boolean
 }
 
 type ChatSettingsState = {
@@ -72,6 +73,7 @@ function defaultChatSettings(): ChatSettings {
     chatWidth: 'comfortable',
     sidebarHoverExpand: false,
     soundOnChatComplete: false,
+    use24HourTime: false,
   }
 }
 

--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeJobsResponse } from './jobs-api'
+import type { HermesJob } from './jobs-api'
+
+const job = {
+  id: 'job-1',
+  name: 'Example job',
+  prompt: 'Run the example job',
+  schedule: {},
+  enabled: true,
+  state: 'scheduled',
+} satisfies HermesJob
+
+describe('normalizeJobsResponse', () => {
+  it('accepts dashboard cron jobs returned as a top-level array', () => {
+    expect(normalizeJobsResponse([job])).toEqual([job])
+  })
+
+  it('accepts gateway jobs returned in an object wrapper', () => {
+    expect(normalizeJobsResponse({ jobs: [job] })).toEqual([job])
+  })
+
+  it('falls back to an empty list for unexpected payloads', () => {
+    expect(normalizeJobsResponse({ jobs: null })).toEqual([])
+  })
+})

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -30,11 +30,24 @@ export type JobOutput = {
   size: number
 }
 
+export function normalizeJobsResponse(data: unknown): Array<HermesJob> {
+  if (Array.isArray(data)) return data
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'jobs' in data &&
+    Array.isArray(data.jobs)
+  ) {
+    return data.jobs as Array<HermesJob>
+  }
+  return []
+}
+
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  const data = (await res.json()) as unknown
+  return normalizeJobsResponse(data)
 }
 
 export async function createJob(input: {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,7 +47,9 @@ import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
+import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesUpdateRouteImport } from './routes/api/hermes-update'
 import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
 import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
 import { Route as ApiHermesJobsRouteImport } from './routes/api/hermes-jobs'
@@ -287,9 +289,19 @@ const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
   path: '/api/local-providers',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiIntegrationsRoute = ApiIntegrationsRouteImport.update({
+  id: '/api/integrations',
+  path: '/api/integrations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHistoryRoute = ApiHistoryRouteImport.update({
   id: '/api/history',
   path: '/api/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesUpdateRoute = ApiHermesUpdateRouteImport.update({
+  id: '/api/hermes-update',
+  path: '/api/hermes-update',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHermesTasksAssigneesRoute = ApiHermesTasksAssigneesRouteImport.update({
@@ -565,7 +577,9 @@ export interface FileRoutesByFullPath {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -653,7 +667,9 @@ export interface FileRoutesByTo {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -743,7 +759,9 @@ export interface FileRoutesById {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -834,7 +852,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -922,7 +942,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1011,7 +1033,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1101,7 +1125,9 @@ export interface RootRouteChildren {
   ApiHermesJobsRoute: typeof ApiHermesJobsRouteWithChildren
   ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
   ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
+  ApiHermesUpdateRoute: typeof ApiHermesUpdateRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
+  ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
@@ -1413,11 +1439,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiLocalProvidersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/integrations': {
+      id: '/api/integrations'
+      path: '/api/integrations'
+      fullPath: '/api/integrations'
+      preLoaderRoute: typeof ApiIntegrationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/history': {
       id: '/api/history'
       path: '/api/history'
       fullPath: '/api/history'
       preLoaderRoute: typeof ApiHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-update': {
+      id: '/api/hermes-update'
+      path: '/api/hermes-update'
+      fullPath: '/api/hermes-update'
+      preLoaderRoute: typeof ApiHermesUpdateRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/hermes-tasks-assignees': {
@@ -1881,7 +1921,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHermesJobsRoute: ApiHermesJobsRouteWithChildren,
   ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
   ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
+  ApiHermesUpdateRoute: ApiHermesUpdateRoute,
   ApiHistoryRoute: ApiHistoryRoute,
+  ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-str
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
 import { Route as ApiTerminalCloseRouteImport } from './routes/api/terminal-close'
+import { Route as ApiSwarmKanbanRouteImport } from './routes/api/swarm-kanban'
 import { Route as ApiStartHermesRouteImport } from './routes/api/start-hermes'
 import { Route as ApiStartAgentRouteImport } from './routes/api/start-agent'
 import { Route as ApiSkillsRouteImport } from './routes/api/skills'
@@ -212,6 +213,11 @@ const ApiTerminalInputRoute = ApiTerminalInputRouteImport.update({
 const ApiTerminalCloseRoute = ApiTerminalCloseRouteImport.update({
   id: '/api/terminal-close',
   path: '/api/terminal-close',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSwarmKanbanRoute = ApiSwarmKanbanRouteImport.update({
+  id: '/api/swarm-kanban',
+  path: '/api/swarm-kanban',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiStartHermesRoute = ApiStartHermesRouteImport.update({
@@ -595,6 +601,7 @@ export interface FileRoutesByFullPath {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -685,6 +692,7 @@ export interface FileRoutesByTo {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -777,6 +785,7 @@ export interface FileRoutesById {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -870,6 +879,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -960,6 +970,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1051,6 +1062,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1143,6 +1155,7 @@ export interface RootRouteChildren {
   ApiSkillsRoute: typeof ApiSkillsRouteWithChildren
   ApiStartAgentRoute: typeof ApiStartAgentRoute
   ApiStartHermesRoute: typeof ApiStartHermesRoute
+  ApiSwarmKanbanRoute: typeof ApiSwarmKanbanRoute
   ApiTerminalCloseRoute: typeof ApiTerminalCloseRoute
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
@@ -1332,6 +1345,13 @@ declare module '@tanstack/react-router' {
       path: '/api/terminal-close'
       fullPath: '/api/terminal-close'
       preLoaderRoute: typeof ApiTerminalCloseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/swarm-kanban': {
+      id: '/api/swarm-kanban'
+      path: '/api/swarm-kanban'
+      fullPath: '/api/swarm-kanban'
+      preLoaderRoute: typeof ApiSwarmKanbanRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/start-hermes': {
@@ -1939,6 +1959,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSkillsRoute: ApiSkillsRouteWithChildren,
   ApiStartAgentRoute: ApiStartAgentRoute,
   ApiStartHermesRoute: ApiStartHermesRoute,
+  ApiSwarmKanbanRoute: ApiSwarmKanbanRoute,
   ApiTerminalCloseRoute: ApiTerminalCloseRoute,
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,

--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -4,12 +4,14 @@ import { getRootSurfaceState } from './-root-layout-state'
 describe('root layout surface state', () => {
   it('shows fullscreen onboarding until onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -18,9 +20,46 @@ describe('root layout surface state', () => {
 
   it('shows workspace shell and post-onboarding overlays after completion', () => {
     expect(getRootSurfaceState(true)).toEqual({
+      showLogin: false,
       showOnboarding: false,
       showWorkspaceShell: true,
       showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('shows login when auth is required and not authenticated, regardless of onboarding state', () => {
+    const unauthed = { authRequired: true, authenticated: false }
+    const expected = {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+
+    expect(getRootSurfaceState(false, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(null, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(true, unauthed)).toEqual(expected)
+  })
+
+  it('does not gate on auth when auth is not required', () => {
+    expect(
+      getRootSurfaceState(true, { authRequired: false, authenticated: false }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
+      showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('does not gate on auth when authenticated', () => {
+    expect(
+      getRootSurfaceState(false, { authRequired: true, authenticated: true }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: true,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
     })
   })
 })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -1,14 +1,31 @@
 export type RootSurfaceState = {
+  showLogin: boolean
   showOnboarding: boolean
   showWorkspaceShell: boolean
   showPostOnboardingOverlays: boolean
 }
 
+export type RootAuthStatus = {
+  authRequired: boolean
+  authenticated: boolean
+}
+
 export function getRootSurfaceState(
   onboardingComplete: boolean | null,
+  authStatus: RootAuthStatus | null = null,
 ): RootSurfaceState {
+  if (authStatus?.authRequired && !authStatus.authenticated) {
+    return {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+  }
+
   if (onboardingComplete !== true) {
     return {
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -16,6 +33,7 @@ export function getRootSurfaceState(
   }
 
   return {
+    showLogin: false,
     showOnboarding: false,
     showWorkspaceShell: true,
     showPostOnboardingOverlays: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import {
   ONBOARDING_KEY,
 } from '@/components/onboarding/hermes-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { LoginScreen } from '@/components/auth/login-screen'
+import { fetchHermesAuthStatus, type AuthStatus } from '@/lib/hermes-auth'
 import { getRootSurfaceState } from './-root-layout-state'
 
 
@@ -249,6 +251,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
   useApplyChatWidth()
 
   useEffect(() => {
@@ -297,11 +300,29 @@ function RootLayout() {
     }
   }, [])
 
-  const rootSurfaceState = getRootSurfaceState(onboardingComplete)
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    let cancelled = false
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (!cancelled) setAuthStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ authenticated: true, authRequired: false })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />
+      {rootSurfaceState.showLogin ? <LoginScreen /> : null}
       {rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>

--- a/src/routes/api/-hermes-update.test.ts
+++ b/src/routes/api/-hermes-update.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createRemoteStatus, remoteUrlMatchesExpectedRepo } from './hermes-update'
+
+describe('hermes update repo gating', () => {
+  it('matches Claude/Hermes workspace repo aliases', () => {
+    expect(remoteUrlMatchesExpectedRepo('https://github.com/example/claude-workspace.git', ['claude-workspace', 'hermes-workspace'])).toBe(true)
+    expect(remoteUrlMatchesExpectedRepo('git@github.com:outsourc-e/hermes-workspace.git', ['claude-workspace', 'outsourc-e/hermes-workspace'])).toBe(true)
+  })
+
+  it('blocks update availability for wrong remote repos even when heads differ', () => {
+    const status = createRemoteStatus({
+      name: 'origin',
+      label: 'Hermes Workspace',
+      expectedRepo: 'hermes-workspace',
+      aliases: ['claude-workspace', 'hermes-workspace'],
+      url: 'https://github.com/example/not-workspace.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(false)
+    expect(status.updateAvailable).toBe(false)
+    expect(status.error).toContain('expected hermes-workspace')
+  })
+
+  it('allows update availability only for the expected repo with a newer remote head', () => {
+    const status = createRemoteStatus({
+      name: 'upstream',
+      label: 'Hermes Agent',
+      expectedRepo: 'hermes-agent',
+      aliases: ['claude-agent', 'hermes-agent'],
+      url: 'https://github.com/NousResearch/hermes-agent.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(true)
+    expect(status.updateAvailable).toBe(true)
+    expect(status.error).toBeNull()
+  })
+})

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -1,6 +1,9 @@
 /**
- * Jobs API proxy — forwards individual job operations to Hermes FastAPI
- * or the upstream dashboard cron API.
+ * Per-job Hermes Workspace jobs proxy.
+ *
+ * Issue #162: use the same Hermes Agent profile resolution as the main jobs
+ * list route so reads, updates, triggers, and deletes all hit the same
+ * profile-scoped cron state.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -11,6 +14,10 @@ import {
   dashboardFetch,
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -39,11 +46,13 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
 
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardPath = action
-            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const res = await dashboardFetch(dashboardPath)
           return new Response(await res.text(), {
             status: res.status,
@@ -52,8 +61,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${url.search}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
@@ -72,12 +81,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
         const body = await request.text()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardAction = action === 'run' ? 'trigger' : action
           const dashboardPath = dashboardAction
-            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const method = dashboardAction ? 'POST' : 'PUT'
           const res = await dashboardFetch(dashboardPath, {
             method,
@@ -91,8 +102,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -112,14 +123,17 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ updates: body ? JSON.parse(body) : {} }),
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,
@@ -138,11 +152,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
               headers: authHeaders(),
             })

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -1,5 +1,9 @@
 /**
- * Jobs API proxy — forwards to Hermes FastAPI /api/jobs
+ * Jobs API proxy for Hermes Workspace.
+ *
+ * Issue #162: resolve the jobs profile in one place, then forward it to the
+ * Hermes dashboard / FastAPI jobs endpoints so the screen reflects the active
+ * Hermes Agent profile instead of silently drifting to another profile.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -9,9 +13,12 @@ import {
   HERMES_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
-  getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -62,11 +69,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 200, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
         const url = new URL(request.url)
-        const params = url.searchParams.toString()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs${params ? `?${params}` : ''}`)
-          : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
+          ? await dashboardFetch(`/api/cron/jobs${search}`)
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               headers: authHeaders(),
             })
         return jobsResponse(res)
@@ -88,14 +97,18 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch('/api/cron/jobs', {
+          ? await dashboardFetch(`/api/cron/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body,
             })
-          : await fetch(`${HERMES_API}/api/jobs`, {
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -17,6 +17,31 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
     handlers: {
@@ -44,10 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {

--- a/src/routes/api/hermes-update.ts
+++ b/src/routes/api/hermes-update.ts
@@ -1,0 +1,160 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { isAuthenticated } from '../../server/auth-middleware'
+
+type RemoteName = 'origin' | 'upstream'
+
+type RemoteStatus = {
+  name: RemoteName
+  label: string
+  url: string | null
+  expectedRepo: string
+  expectedAliases: Array<string>
+  repoMatches: boolean
+  remoteHead: string | null
+  currentHead: string | null
+  updateAvailable: boolean
+  error: string | null
+}
+
+type RemoteDefinition = {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+}
+
+export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
+  {
+    name: 'origin',
+    label: 'Hermes Workspace',
+    expectedRepo: 'hermes-workspace',
+    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
+  },
+  {
+    name: 'upstream',
+    label: 'Hermes Agent',
+    expectedRepo: 'hermes-agent',
+    aliases: ['claude-agent', 'hermes-agent', 'NousResearch/hermes-agent'],
+  },
+]
+
+function git(args: string[], timeout = 5000): string | null {
+  try {
+    return execFileSync('git', args, { cwd: process.cwd(), encoding: 'utf8', timeout }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function pkgVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as { version?: string }
+    return pkg.version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export function remoteUrlMatchesExpectedRepo(url: string | null, aliases: Array<string>): boolean {
+  if (!url) return false
+  const normalizedUrl = url
+    .toLowerCase()
+    .replace(/^git@github\.com:/, 'github.com/')
+    .replace(/^https?:\/\//, '')
+    .replace(/\.git$/, '')
+  return aliases.some((alias) => normalizedUrl.includes(alias.toLowerCase().replace(/\.git$/, '')))
+}
+
+export function createRemoteStatus(input: {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+  url: string | null
+  currentHead: string | null
+  remoteHead: string | null
+  lsRemoteFailed?: boolean
+}): RemoteStatus {
+  const repoMatches = remoteUrlMatchesExpectedRepo(input.url, input.aliases)
+  let error: string | null = null
+  if (!input.url) {
+    error = 'Remote is not configured.'
+  } else if (!repoMatches) {
+    error = `Remote URL does not match expected ${input.expectedRepo} repo.`
+  } else if (!input.remoteHead || input.lsRemoteFailed) {
+    error = 'Unable to read remote HEAD.'
+  }
+
+  return {
+    name: input.name,
+    label: input.label,
+    url: input.url,
+    expectedRepo: input.expectedRepo,
+    expectedAliases: input.aliases,
+    repoMatches,
+    remoteHead: repoMatches ? input.remoteHead : null,
+    currentHead: input.currentHead,
+    updateAvailable: Boolean(repoMatches && input.currentHead && input.remoteHead && input.currentHead !== input.remoteHead),
+    error,
+  }
+}
+
+function remoteStatus(definition: RemoteDefinition, currentHead: string | null): RemoteStatus {
+  const url = git(['remote', 'get-url', definition.name])
+  const repoMatches = remoteUrlMatchesExpectedRepo(url, definition.aliases)
+  let remoteHead: string | null = null
+  let lsRemoteFailed = false
+
+  if (url && repoMatches) {
+    const raw = git(['ls-remote', url, 'HEAD'], 8000)
+    remoteHead = raw?.split(/\s+/)[0] ?? null
+    lsRemoteFailed = !remoteHead
+  }
+
+  return createRemoteStatus({
+    name: definition.name,
+    label: definition.label,
+    expectedRepo: definition.expectedRepo,
+    aliases: definition.aliases,
+    url,
+    currentHead,
+    remoteHead,
+    lsRemoteFailed,
+  })
+}
+
+export const Route = createFileRoute('/api/hermes-update')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const currentHead = git(['rev-parse', 'HEAD'])
+        const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+        const dirty = Boolean(git(['status', '--porcelain']))
+        const remotes = UPDATE_REMOTE_DEFINITIONS.map((definition) => remoteStatus(definition, currentHead))
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          app: {
+            name: 'Hermes Workspace',
+            version: pkgVersion(),
+            branch,
+            currentHead,
+            dirty,
+          },
+          remotes,
+          updateAvailable: remotes.some((remote) => remote.updateAvailable),
+          manualConfirmRequired: true,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -48,13 +48,9 @@ export const Route = createFileRoute('/api/history')({
             })
           }
           // "main" doesn't exist in Hermes — resolve it to the user's real
-          // main chat session. We prefer (in order):
-          //   1. The most recent session with a real human-set title
-          //      (label !== id, e.g. "hows everything"). This is what users
-          //      actually mean by "main".
-          //   2. The most recent non-internal session with messages.
-          // Cron + Operations per-agent sessions are skipped so the
-          // orchestrator chat doesn't latch onto runtime junk.
+          // active chat session. Prefer the most recently active non-internal
+          // session with messages, and only fall back to a titled session when
+          // there is no better active candidate.
           if (sessionKey === 'main') {
             try {
               const sessions = await listSessions(30, 0)
@@ -66,18 +62,18 @@ export const Route = createFileRoute('/api/history')({
                 const t = (s.title ?? '').trim()
                 return t.length > 0 && t !== s.id
               }
-              const titled = sessions.find(
-                (s) => !isInternalKey(s.id) && hasRealTitle(s),
+              const active = sessions.find(
+                (s) =>
+                  !isInternalKey(s.id) &&
+                  typeof s.message_count === 'number' &&
+                  s.message_count > 0,
               )
-              const fallback = titled
+              const titled = active
                 ? null
                 : sessions.find(
-                    (s) =>
-                      !isInternalKey(s.id) &&
-                      typeof s.message_count === 'number' &&
-                      s.message_count > 0,
+                    (s) => !isInternalKey(s.id) && hasRealTitle(s),
                   )
-              const candidate = titled ?? fallback
+              const candidate = active ?? titled
               if (candidate) {
                 sessionKey = candidate.id
               } else {

--- a/src/routes/api/integrations.ts
+++ b/src/routes/api/integrations.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { detectHonchoIntegration } from '../../server/integration-detection'
+
+export const Route = createFileRoute('/api/integrations')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          integrations: {
+            honcho: detectHonchoIntegration(),
+          },
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -544,10 +544,10 @@ export const Route = createFileRoute('/api/send-stream')({
               }
 
               if (SESSION_BOOTSTRAP_KEYS.has(sessionKey)) {
-                // 'main' should land in the user's existing main chat,
-                // not spin up a brand new session every time. Skip cron
-                // and Operations per-agent sessions so the orchestrator
-                // chat doesn't latch onto them.
+                // 'main' should land in the user's real active chat session,
+                // not an older titled thread. Skip cron and Operations sessions,
+                // prefer the most recently active session with messages, and
+                // only fall back to a titled session when nothing active exists.
                 let reused: string | null = null
                 if (sessionKey === 'main') {
                   try {
@@ -563,18 +563,18 @@ export const Route = createFileRoute('/api/send-stream')({
                       const t = (s.title ?? '').trim()
                       return t.length > 0 && t !== s.id
                     }
-                    const titled = recent.find(
-                      (s) => !isInternal(s.id) && hasRealTitle(s),
+                    const active = recent.find(
+                      (s) =>
+                        !isInternal(s.id) &&
+                        typeof s.message_count === 'number' &&
+                        s.message_count > 0,
                     )
-                    const fallback = titled
+                    const titled = active
                       ? null
                       : recent.find(
-                          (s) =>
-                            !isInternal(s.id) &&
-                            typeof s.message_count === 'number' &&
-                            s.message_count > 0,
+                          (s) => !isInternal(s.id) && hasRealTitle(s),
                         )
-                    const candidate = titled ?? fallback
+                    const candidate = active ?? titled
                     if (candidate) reused = candidate.id
                   } catch {
                     // fall through to createSession()

--- a/src/routes/api/swarm-kanban.ts
+++ b/src/routes/api/swarm-kanban.ts
@@ -1,0 +1,60 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { z } from 'zod'
+import { createKanbanCard, getKanbanBackendMeta, listKanbanCards, updateKanbanCard } from '../../server/kanban-backend'
+
+const CreateCardSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  spec: z.string().trim().max(5000).optional().default(''),
+  acceptanceCriteria: z.string().trim().max(5000).optional().default(''),
+  assignedWorker: z.string().trim().max(120).optional().nullable(),
+  reviewer: z.string().trim().max(120).optional().nullable(),
+  status: z.enum(['backlog', 'ready', 'running', 'review', 'blocked', 'done']).optional().default('backlog'),
+  missionId: z.string().trim().max(200).optional().nullable(),
+  reportPath: z.string().trim().max(500).optional().nullable(),
+  createdBy: z.string().trim().max(120).optional().default('aurora'),
+})
+
+const UpdateCardSchema = CreateCardSchema.partial().extend({
+  id: z.string().trim().min(1),
+})
+
+export const Route = createFileRoute('/api/swarm-kanban')({
+  server: {
+    handlers: {
+      GET: async () => {
+        return json({ ok: true, cards: listKanbanCards(), backend: getKanbanBackendMeta() })
+      },
+      POST: async ({ request }) => {
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+        }
+        const parsed = CreateCardSchema.safeParse(body)
+        if (!parsed.success) {
+          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+        }
+        const card = createKanbanCard(parsed.data)
+        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+      },
+      PATCH: async ({ request }) => {
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+        }
+        const parsed = UpdateCardSchema.safeParse(body)
+        if (!parsed.success) {
+          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+        }
+        const { id, ...updates } = parsed.data
+        const card = updateKanbanCard(id, updates)
+        if (!card) return json({ ok: false, error: 'Card not found' }, { status: 404 })
+        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+      },
+    },
+  },
+})

--- a/src/routes/api/terminal-input.ts
+++ b/src/routes/api/terminal-input.ts
@@ -12,7 +12,6 @@ export const Route = createFileRoute('/api/terminal-input')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        // Auth check
         if (!isAuthenticated(request)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'Unauthorized' }),
@@ -23,10 +22,6 @@ export const Route = createFileRoute('/api/terminal-input')({
         if (csrfCheck) return csrfCheck
 
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal:${ip}`, 10, 60_000)) {
-          return rateLimitResponse()
-        }
-
         const body = (await request.json().catch(() => ({}))) as Record<
           string,
           unknown
@@ -34,6 +29,14 @@ export const Route = createFileRoute('/api/terminal-input')({
         const sessionId =
           typeof body.sessionId === 'string' ? body.sessionId : ''
         const data = typeof body.data === 'string' ? body.data : ''
+
+        const rateKey = sessionId
+          ? `terminal:${ip}:${sessionId}`
+          : `terminal:${ip}`
+        if (!rateLimit(rateKey, 600, 60_000)) {
+          return rateLimitResponse()
+        }
+
         const session = getTerminalSession(sessionId)
         if (!session) {
           return new Response(JSON.stringify({ ok: false }), {

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,10 +40,13 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return new Response(
+            JSON.stringify({ ok: false, missing: true, sessionId }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
         }
         session.resize(cols, rows)
         return new Response(JSON.stringify({ ok: true }), {

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -788,6 +788,18 @@ function ChatDisplaySection() {
           />
         </SettingsRow>
         <SettingsRow
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={chatSettings.use24HourTime}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ use24HourTime: checked })
+            }
+            aria-label="Use 24-hour time"
+          />
+        </SettingsRow>
+        <SettingsRow
           label="Enter key behavior"
           description={
             chatSettings.enterBehavior === 'newline'

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -575,7 +575,12 @@ export function buildDisplayEntries(
       return
     }
 
-    if (message.role === 'tool' || message.role === 'toolResult') {
+    if (
+      message.role === 'tool' ||
+      message.role === 'toolResult' ||
+      message.role === 'toolresult' ||
+      message.role === 'tool_result'
+    ) {
       const previousEntry = entries[entries.length - 1]
       if (previousEntry?.message.role === 'assistant') {
         previousEntry.attachedToolMessages.push(message)
@@ -1041,7 +1046,12 @@ function ChatMessageListComponent({
   const toolResultsByCallId = useMemo(() => {
     const map = new Map<string, ChatMessage>()
     for (const message of messages) {
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = message.toolCallId
       if (typeof toolCallId === 'string' && toolCallId.trim().length > 0) {
         map.set(toolCallId, message)
@@ -1087,7 +1097,12 @@ function ChatMessageListComponent({
         count += 1
       }
 
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = (message.toolCallId || '').trim()
       if (toolCallId.length > 0 && seenToolCallIds.has(toolCallId)) continue
       if (toolCallId.length > 0) {

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -13,19 +13,17 @@ import {
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
   PuzzleIcon,
 
   Rocket01Icon,
   Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
-import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,8 +31,9 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
+import { t } from '@/lib/i18n'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
   TooltipContent,
@@ -115,7 +114,9 @@ type ChatSidebarProps = {
   creatingSession: boolean
   onCreateSession: () => void
   isCollapsed: boolean
+  isPinned: boolean
   onToggleCollapse: () => void
+  onTogglePinned: () => void
   onSelectSession?: () => void
   onActiveSessionDelete?: () => void
   sessionsLoading: boolean
@@ -124,15 +125,11 @@ type ChatSidebarProps = {
   onRetrySessions: () => void
 }
 
-
-
 // ── Reusable nav item ───────────────────────────────────────────────────
 
 type NavItemDef = {
   kind: 'link' | 'button'
   to?: string
-  search?: Record<string, unknown>
-  hash?: string
   icon: unknown
   label: string
   active: boolean
@@ -152,7 +149,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -229,9 +226,7 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to!}
-                  search={item.search}
-                  hash={item.hash}
+                  to={item.to}
                   onClick={handleSelect}
                   className={cls}
                   data-tour={item.dataTour}
@@ -247,9 +242,7 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to!}
-        search={item.search}
-        hash={item.hash}
+        to={item.to}
         onClick={handleSelect}
         className={cls}
         data-tour={item.dataTour}
@@ -496,7 +489,9 @@ function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
   isCollapsed,
+  isPinned,
   onToggleCollapse,
+  onTogglePinned,
   onSelectSession,
   onActiveSessionDelete,
   sessionsLoading,
@@ -526,8 +521,11 @@ function ChatSidebarComponent({
 
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
-      const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      const detail = (event as CustomEvent<ChatOpenSettingsDetail | undefined>)
+        .detail
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -581,8 +579,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -886,7 +882,7 @@ function ChatSidebarComponent({
                 to="/chat"
                 className={cn(
                   buttonVariants({ variant: 'ghost', size: 'sm' }),
-                  'w-full pl-1.5 justify-start gap-2',
+                  'w-full pl-1.5 pr-20 justify-start gap-2',
                 )}
               >
                 <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
@@ -896,6 +892,36 @@ function ChatSidebarComponent({
           ) : null}
         </AnimatePresence>
         <TooltipProvider>
+          {!isVisuallyCollapsed ? (
+            <TooltipRoot>
+              <TooltipTrigger
+                onClick={onTogglePinned}
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+                    aria-pressed={isPinned}
+                    className={cn(
+                      'absolute right-9 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100',
+                      isPinned &&
+                        'bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] opacity-100',
+                    )}
+                    data-tour="sidebar-pin-toggle"
+                  >
+                    <HugeiconsIcon
+                      icon={isPinned ? PinOffIcon : PinIcon}
+                      size={18}
+                      strokeWidth={1.75}
+                    />
+                  </Button>
+                }
+              />
+              <TooltipContent side="right">
+                {isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+              </TooltipContent>
+            </TooltipRoot>
+          ) : null}
           <TooltipRoot>
             <TooltipTrigger
               onClick={handleSidebarToggle}
@@ -1202,6 +1228,7 @@ function areSidebarPropsEqual(
   if (prevProps.activeFriendlyId !== nextProps.activeFriendlyId) return false
   if (prevProps.creatingSession !== nextProps.creatingSession) return false
   if (prevProps.isCollapsed !== nextProps.isCollapsed) return false
+  if (prevProps.isPinned !== nextProps.isPinned) return false
   if (prevProps.sessionsLoading !== nextProps.sessionsLoading) return false
   if (prevProps.sessionsFetching !== nextProps.sessionsFetching) return false
   if (prevProps.sessionsError !== nextProps.sessionsError) return false

--- a/src/screens/chat/components/message-item.test.ts
+++ b/src/screens/chat/components/message-item.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildInlineToolRenderPlan } from './message-item'
+import { buildInlineToolRenderPlan, compactInlineToolRenderPlan } from './message-item'
 import type { ChatMessage } from '../types'
 
 describe('buildInlineToolRenderPlan', () => {
@@ -43,6 +43,105 @@ describe('buildInlineToolRenderPlan', () => {
         },
       },
       { kind: 'text', text: 'After tool.' },
+    ])
+  })
+})
+
+describe('compactInlineToolRenderPlan', () => {
+  it('stacks consecutive tool calls without moving surrounding text', () => {
+    const plan = compactInlineToolRenderPlan([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+
+    expect(plan).toEqual([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+  })
+
+  it('keeps separate stacks when text appears between tool calls', () => {
+    const plan = compactInlineToolRenderPlan([
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+    ])
+
+    expect(plan).toEqual([
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
     ])
   })
 })

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -232,15 +232,40 @@ export function compactInlineToolRenderPlan(
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
   if (!msg) return ''
-  // Prefer text from content blocks (exec stdout, Read output, etc.)
+  // Prefer text from structured content blocks first.
   if (Array.isArray(msg.content)) {
     const text = msg.content
-      .filter((b: any) => b?.type === 'text' && b?.text)
-      .map((b: any) => b.text as string)
+      .flatMap((block: any) => {
+        if (!block || typeof block !== 'object') return []
+        if (block.type === 'text' && typeof block.text === 'string') {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          typeof block.text === 'string'
+        ) {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          Array.isArray(block.content)
+        ) {
+          return block.content
+            .filter((part: any) => part?.type === 'text' && part?.text)
+            .map((part: any) => String(part.text))
+        }
+        return []
+      })
       .join('\n')
     if (text.trim()) return text
   }
-  // Fallback to details serialized
+  // Fallback to top-level text/body/message fields.
+  const raw = msg as Record<string, unknown>
+  for (const key of ['text', 'body', 'message']) {
+    const value = raw[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  // Then structured details.
   if (msg.details && typeof msg.details === 'object') {
     return JSON.stringify(msg.details, null, 2)
   }

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -158,6 +158,10 @@ export type InlineRenderPlanItem =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; section: InlineToolSection }
 
+export type CompactInlineRenderPlanItem =
+  | { kind: 'text'; text: string }
+  | { kind: 'tools'; sections: Array<InlineToolSection> }
+
 export function buildInlineToolRenderPlan(
   message: ChatMessage,
   toolSections: Array<InlineToolSection>,
@@ -198,6 +202,32 @@ export function buildInlineToolRenderPlan(
   }
 
   return plan
+}
+
+export function compactInlineToolRenderPlan(
+  plan: Array<InlineRenderPlanItem>,
+): Array<CompactInlineRenderPlanItem> {
+  const compactPlan: Array<CompactInlineRenderPlanItem> = []
+  let pendingToolSections: Array<InlineToolSection> = []
+
+  const flushTools = () => {
+    if (pendingToolSections.length === 0) return
+    compactPlan.push({ kind: 'tools', sections: pendingToolSections })
+    pendingToolSections = []
+  }
+
+  for (const item of plan) {
+    if (item.kind === 'tool') {
+      pendingToolSections.push(item.section)
+      continue
+    }
+
+    flushTools()
+    compactPlan.push(item)
+  }
+
+  flushTools()
+  return compactPlan
 }
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
@@ -1404,8 +1434,6 @@ function InlineToolSectionItem({
   const hasInputData =
     toolSection.input && Object.keys(toolSection.input).length > 0
   const hasOutputData = !!(toolSection.outputText || toolSection.errorText)
-  // Always expandable — show args, output, or at minimum the tool name/state
-  const hasExpandableContent = true
 
   return (
     <div>
@@ -1452,11 +1480,9 @@ function InlineToolSectionItem({
           {isRunning && (
             <span className="size-1.5 rounded-full animate-pulse bg-indigo-500" />
           )}
-          {hasExpandableContent && (
-            <span className="text-[8px] opacity-30 ml-0.5">
-              {open ? '▾' : '▸'}
-            </span>
-          )}
+          <span className="text-[8px] opacity-30 ml-0.5">
+            {open ? '▾' : '▸'}
+          </span>
         </div>
         {isRunning && (
           <div className="px-2.5 pb-1.5 text-[10px] text-primary-400">
@@ -1577,11 +1603,78 @@ function InlineToolSectionItem({
 function ToolCallGroup({
   toolSections,
   expandAll,
+  isStreaming,
 }: {
   toolSections: Array<InlineToolSection>
   expandAll?: boolean
   isStreaming?: boolean
 }) {
+  const [open, setOpen] = useState(Boolean(expandAll))
+  useEffect(() => {
+    if (expandAll) setOpen(true)
+  }, [expandAll])
+
+  if (toolSections.length > 1) {
+    const runningCount = toolSections.filter((section) => section.state === 'input-available' || section.state === 'input-streaming').length
+    const errorCount = toolSections.filter((section) => section.state === 'output-error').length
+    const doneCount = toolSections.length - runningCount - errorCount
+    const labels = Array.from(new Set(toolSections.map((section) => formatToolDisplayLabel(section.type, section.input))))
+    const visibleLabels = labels.slice(0, 3).join(', ')
+    const overflowLabel = labels.length > 3 ? ` +${labels.length - 3} more` : ''
+    const statusLabel =
+      runningCount > 0
+        ? `${runningCount} running`
+        : errorCount > 0
+          ? `${errorCount} failed`
+          : `${doneCount} done`
+
+    return (
+      <div className="my-3 w-full max-w-[min(100%,700px)] border-l-2 border-primary-200/60 pl-3">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-primary-600 hover:bg-primary-50/70"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="font-mono font-semibold text-ink">Tool activity</span>
+          <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] tabular-nums text-primary-600">
+            {toolSections.length} calls
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] opacity-60">
+            {visibleLabels}
+            {overflowLabel}
+          </span>
+          <span
+            className={cn(
+              'shrink-0 text-[10px] tabular-nums',
+              errorCount > 0
+                ? 'text-red-500'
+                : runningCount > 0 || isStreaming
+                  ? 'text-indigo-500'
+                  : 'text-green-600',
+            )}
+          >
+            {statusLabel}
+          </span>
+          <span className="shrink-0 text-[9px] opacity-40">
+            {open ? '▾' : '▸'}
+          </span>
+        </button>
+        {open && (
+          <div className="mt-2 flex flex-col gap-2.5">
+            {toolSections.map((toolSection, index) => (
+              <InlineToolSectionItem
+                key={toolSection.key || `${toolSection.type}-${index}`}
+                toolSection={toolSection}
+                index={index}
+                forceOpen={expandAll}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2.5 my-3 w-full max-w-[min(100%,700px)]">
       {toolSections.map((toolSection, index) => (
@@ -1694,8 +1787,8 @@ function MessageItemComponent({
   }, [])
 
   // Simulate streaming is only active while words are still being revealed
-  const totalWords = countWords(displayText)
-  const revealComplete = revealedWordCount >= totalWords && totalWords > 0
+  const displayWordCount = countWords(displayText)
+  const revealComplete = revealedWordCount >= displayWordCount && displayWordCount > 0
   const effectiveIsStreaming =
     remoteStreamingActive || (_simulateStreaming && !revealComplete)
   const assistantDisplayText = effectiveIsStreaming ? revealedText : displayText
@@ -1705,7 +1798,7 @@ function MessageItemComponent({
   )
 
   useEffect(() => {
-    const totalWords = countWords(displayText)
+    const nextTotalWords = countWords(displayText)
     const previousText = previousTextRef.current
     const previousLength = previousTextLengthRef.current
     const textGrew =
@@ -1713,7 +1806,7 @@ function MessageItemComponent({
       displayText.startsWith(previousText)
     const textChanged = displayText !== previousText
 
-    targetWordCountRef.current = totalWords
+    targetWordCountRef.current = nextTotalWords
     previousTextRef.current = displayText
     previousTextLengthRef.current = displayText.length
 
@@ -1722,12 +1815,12 @@ function MessageItemComponent({
         window.clearInterval(revealTimerRef.current)
         revealTimerRef.current = null
       }
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
     if (textChanged && !textGrew) {
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
@@ -1736,25 +1829,25 @@ function MessageItemComponent({
     }
 
     // Don't start animation if already fully revealed
-    setRevealedWordCount((currentWordCount) => {
-      if (currentWordCount >= totalWords) {
-        return currentWordCount
+    setRevealedWordCount((wordCount) => {
+      if (wordCount >= nextTotalWords) {
+        return wordCount
       }
 
       function tick() {
-        setRevealedWordCount((currentWordCount) => {
+        setRevealedWordCount((visibleWordCount) => {
           const targetWordCount = targetWordCountRef.current
-          if (currentWordCount >= targetWordCount) {
+          if (visibleWordCount >= targetWordCount) {
             if (revealTimerRef.current !== null) {
               window.clearInterval(revealTimerRef.current)
               revealTimerRef.current = null
             }
-            return currentWordCount
+            return visibleWordCount
           }
 
           const nextWordCount = Math.min(
             targetWordCount,
-            currentWordCount + WORDS_PER_TICK,
+            visibleWordCount + WORDS_PER_TICK,
           )
 
           if (
@@ -1770,7 +1863,7 @@ function MessageItemComponent({
       }
 
       revealTimerRef.current = window.setInterval(tick, TICK_INTERVAL_MS)
-      return currentWordCount
+      return wordCount
     })
   }, [displayText, effectiveIsStreaming])
 
@@ -1996,6 +2089,10 @@ function MessageItemComponent({
   const inlineRenderPlan = useMemo(
     () => buildInlineToolRenderPlan(message, finalToolSections),
     [message, finalToolSections],
+  )
+  const compactInlineRenderPlan = useMemo(
+    () => compactInlineToolRenderPlan(inlineRenderPlan),
+    [inlineRenderPlan],
   )
   const hasToolCalls = finalToolSections.length > 0
   const shouldRenderMessageBubble =
@@ -2322,11 +2419,11 @@ function MessageItemComponent({
             )}
             {!isUser && hasToolCalls && (
               <div className="flex flex-col gap-2">
-                {inlineRenderPlan.map((item, index) =>
-                  item.kind === 'tool' ? (
+                {compactInlineRenderPlan.map((item, index) =>
+                  item.kind === 'tools' ? (
                     <ToolCallGroup
-                      key={item.section.key || `tool-${index}`}
-                      toolSections={[item.section]}
+                      key={item.sections.map((section) => section.key).join(':') || `tools-${index}`}
+                      toolSections={item.sections}
                       expandAll={expandAllToolSections}
                       isStreaming={effectiveIsStreaming}
                     />
@@ -2341,11 +2438,6 @@ function MessageItemComponent({
                             'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                             effectiveIsStreaming && 'chat-streaming-content',
                           )}
-                          style={
-                            isUser
-                              ? { color: 'var(--chat-user-foreground)' }
-                              : undefined
-                          }
                         >
                           {item.text}
                         </MessageContent>
@@ -2370,11 +2462,6 @@ function MessageItemComponent({
                         'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                         effectiveIsStreaming && 'chat-streaming-content',
                       )}
-                      style={
-                        isUser
-                          ? { color: 'var(--chat-user-foreground)' }
-                          : undefined
-                      }
                     >
                       {assistantDisplayText}
                     </MessageContent>

--- a/src/screens/chat/components/message-timestamp.tsx
+++ b/src/screens/chat/components/message-timestamp.tsx
@@ -1,3 +1,5 @@
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
+
 type MessageTimestampProps = {
   timestamp: number
 }
@@ -10,14 +12,14 @@ function isSameDay(a: Date, b: Date): boolean {
   )
 }
 
-function formatShort(timestamp: number): string {
+function formatShort(timestamp: number, use24HourTime: boolean): string {
   const date = new Date(timestamp)
   const now = new Date()
   if (isSameDay(date, now)) {
     return new Intl.DateTimeFormat('en-US', {
       hour: 'numeric',
       minute: '2-digit',
-      hour12: true,
+      hour12: !use24HourTime,
     }).format(date)
   }
 
@@ -27,22 +29,24 @@ function formatShort(timestamp: number): string {
   }).format(date)
 }
 
-function formatFull(timestamp: number): string {
-  const value = new Intl.DateTimeFormat('en-US', {
+function formatFull(timestamp: number, use24HourTime: boolean): string {
+  return new Intl.DateTimeFormat('en-US', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
-    hour12: true,
+    hour12: !use24HourTime,
   }).format(new Date(timestamp))
-  return value
 }
 
 export function MessageTimestamp({ timestamp }: MessageTimestampProps) {
-  const shortLabel = formatShort(timestamp)
-  const fullLabel = formatFull(timestamp)
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+  const shortLabel = formatShort(timestamp, use24HourTime)
+  const fullLabel = formatFull(timestamp, use24HourTime)
 
   return (
     <span

--- a/src/screens/chat/components/sidebar/session-item.tsx
+++ b/src/screens/chat/components/sidebar/session-item.tsx
@@ -18,6 +18,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from '@/components/ui/menu'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type SessionItemProps = {
   session: SessionMeta
@@ -34,21 +35,24 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-function formatSessionTimestamp(timestamp?: number | null): string {
+function formatSessionTimestamp(
+  timestamp: number | undefined | null,
+  use24HourTime: boolean,
+): string {
   if (!timestamp) return ''
   const date = new Date(timestamp)
   const now = new Date()
   const sameDay = date.toDateString() === now.toDateString()
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: !use24HourTime,
+  })
   return (sameDay ? timeFormatter : dayFormatter).format(date)
 }
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isUuidLike(value: string): boolean {
   return UUID_PATTERN.test(value.trim())
@@ -102,6 +106,9 @@ function SessionItemComponent({
   onRename,
   onDelete,
 }: SessionItemProps) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
   const isGenerating = session.titleStatus === 'generating'
   const isError = session.titleStatus === 'error'
   const baseTitle = getSessionDisplayTitle(session, isGenerating)
@@ -117,11 +124,11 @@ function SessionItemComponent({
       return session.titleError || 'Could not generate a title'
     }
     const parts: Array<string> = []
-    const formatted = formatSessionTimestamp(updatedAt)
+    const formatted = formatSessionTimestamp(updatedAt, use24HourTime)
     if (formatted) parts.push(formatted)
     if (session.friendlyId) parts.push(getFriendlyIdLabel(session.friendlyId))
     return parts.join(' • ')
-  }, [isError, session.friendlyId, session.titleError, updatedAt])
+  }, [isError, session.friendlyId, session.titleError, updatedAt, use24HourTime])
 
   return (
     <Link

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -7,7 +7,7 @@ export type ToolCallContent = {
 }
 
 export type ToolResultContent = {
-  type: 'toolResult'
+  type: 'toolResult' | 'tool_result'
   toolCallId?: string
   toolName?: string
   content?: Array<{ type?: string; text?: string }>
@@ -27,7 +27,11 @@ export type ThinkingContent = {
   thinkingSignature?: string
 }
 
-export type MessageContent = TextContent | ToolCallContent | ThinkingContent
+export type MessageContent =
+  | TextContent
+  | ToolCallContent
+  | ToolResultContent
+  | ThinkingContent
 
 export type ChatAttachment = {
   id?: string

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -144,7 +144,10 @@ export function findToolResultForCall(
   messages: Array<ChatMessage>,
 ): ChatMessage | undefined {
   return messages.find(
-    (msg) => msg.role === 'toolResult' && msg.toolCallId === toolCallId,
+    (msg) =>
+      ['toolResult', 'toolresult', 'tool_result', 'tool'].includes(
+        String(msg.role || ''),
+      ) && msg.toolCallId === toolCallId,
   )
 }
 

--- a/src/screens/profiles/profiles-screen.tsx
+++ b/src/screens/profiles/profiles-screen.tsx
@@ -178,8 +178,9 @@ export function ProfilesScreen() {
     }
   }, [createOpen, wizardStep, allModels.length, fetchAllModels])
 
+  const profileNamePattern = /^[a-z0-9][a-z0-9_-]{0,63}$/
   const nameValid =
-    /^[A-Za-z0-9_-]+$/.test(newProfileName.trim()) &&
+    profileNamePattern.test(newProfileName.trim()) &&
     newProfileName.trim() !== 'default'
 
   function resetWizard() {
@@ -542,7 +543,7 @@ export function ProfilesScreen() {
                   />
                   {newProfileName.trim() && !nameValid ? (
                     <p className="text-xs text-red-500">
-                      Use letters, numbers, underscores, or hyphens. Cannot be
+                      Use lowercase letters, numbers, underscores, or hyphens. Cannot be
                       &quot;default&quot;.
                     </p>
                   ) : newProfileName.trim() && nameValid ? (
@@ -788,9 +789,9 @@ export function ProfilesScreen() {
                 autoFocus
               />
               {renameValue.trim() &&
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim()) && (
+                !profileNamePattern.test(renameValue.trim()) && (
                   <p className="text-xs text-red-500">
-                    Use letters, numbers, underscores, or hyphens.
+                    Use lowercase letters, numbers, underscores, or hyphens.
                   </p>
                 )}
             </div>
@@ -812,7 +813,7 @@ export function ProfilesScreen() {
               disabled={
                 !renameTarget ||
                 !renameValue.trim() ||
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim())
+                !profileNamePattern.test(renameValue.trim())
               }
             >
               Rename

--- a/src/screens/swarm2/swarm2-kanban-board.test.ts
+++ b/src/screens/swarm2/swarm2-kanban-board.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getKanbanBackendPresentation } from './swarm2-kanban-board'
+
+describe('Swarm2 Kanban backend presentation', () => {
+  it('keeps the initial backend state quiet and non-committal while auto-detecting', () => {
+    expect(getKanbanBackendPresentation(null)).toMatchObject({
+      badgeLabel: 'Detecting board',
+      badgeTone: 'unknown',
+      toastTitle: 'Detecting Swarm Board backend',
+    })
+  })
+
+  it('presents detected Kanban as the default shared board, not a backend demo', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'hermes',
+      label: 'Hermes Kanban',
+      detected: true,
+      writable: true,
+      details: 'Canonical storage detected',
+      path: '/tmp/kanban.db',
+    })).toMatchObject({
+      badgeLabel: 'Shared board',
+      badgeTone: 'hermes',
+      toastTitle: 'Board connected',
+      toastBody: 'Cards and status changes are using the canonical Kanban store.',
+      title: 'Canonical storage detected',
+    })
+  })
+
+  it('presents local storage as an automatic fallback, not a manual control', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'local',
+      label: 'Local board',
+      detected: true,
+      writable: true,
+      details: 'Using local Swarm board JSON store.',
+      path: '/tmp/swarm2-kanban.json',
+    })).toMatchObject({
+      badgeLabel: 'Local fallback',
+      badgeTone: 'local',
+      toastTitle: 'Using local Swarm Board',
+      toastBody: 'Using local Swarm board JSON store.',
+    })
+  })
+})

--- a/src/screens/swarm2/swarm2-kanban-board.tsx
+++ b/src/screens/swarm2/swarm2-kanban-board.tsx
@@ -1,0 +1,433 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { cn } from '@/lib/utils'
+
+type KanbanLane = 'backlog' | 'ready' | 'running' | 'review' | 'blocked' | 'done'
+
+type SwarmKanbanCard = {
+  id: string
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: KanbanLane
+  missionId: string | null
+  reportPath: string | null
+  createdBy: string
+  createdAt: number
+  updatedAt: number
+}
+
+type KanbanWorker = {
+  id: string
+  displayName?: string | null
+  role?: string | null
+}
+
+type KanbanBackendMeta = {
+  id: 'local' | 'hermes'
+  label: string
+  detected: boolean
+  writable: boolean
+  details?: string | null
+  path?: string | null
+}
+
+type KanbanResponse = {
+  cards?: Array<SwarmKanbanCard>
+  backend?: KanbanBackendMeta
+}
+
+type Swarm2KanbanBoardProps = {
+  workers: Array<KanbanWorker>
+  latestMission?: { id: string; title: string; state: string } | null
+  selectedWorkerId?: string | null
+  onSelectWorker?: (workerId: string) => void
+  onOpenRouter?: () => void
+  className?: string
+}
+
+type KanbanBackendPresentation = {
+  badgeLabel: string
+  badgeTone: 'hermes' | 'local' | 'unknown'
+  toastTitle: string
+  toastBody: string
+  title: string | undefined
+}
+
+export function getKanbanBackendPresentation(backend: KanbanBackendMeta | null | undefined): KanbanBackendPresentation {
+  if (!backend) {
+    return {
+      badgeLabel: 'Detecting board',
+      badgeTone: 'unknown',
+      toastTitle: 'Detecting Swarm Board backend',
+      toastBody: 'Checking Hermes Kanban before falling back locally.',
+      title: undefined,
+    }
+  }
+  if (backend.id === 'hermes' && backend.detected) {
+    return {
+      badgeLabel: 'Shared board',
+      badgeTone: 'hermes',
+      toastTitle: 'Board connected',
+      toastBody: 'Cards and status changes are using the canonical Kanban store.',
+      title: backend.details ?? backend.path ?? 'Canonical Kanban store detected',
+    }
+  }
+  return {
+    badgeLabel: 'Local fallback',
+    badgeTone: 'local',
+    toastTitle: 'Using local Swarm Board',
+    toastBody: backend.details || 'Hermes Kanban is not available yet. Cards stay local and the board will switch automatically when Hermes storage is detected.',
+    title: backend.details ?? backend.path ?? 'Local Swarm Board fallback',
+  }
+}
+
+const LANES: Array<{ id: KanbanLane; label: string; hint: string }> = [
+  { id: 'backlog', label: 'Backlog', hint: 'Captured, not committed' },
+  { id: 'ready', label: 'Ready', hint: 'Spec clear, safe to dispatch' },
+  { id: 'running', label: 'Running', hint: 'Worker executing' },
+  { id: 'review', label: 'Review', hint: 'Needs peer/human check' },
+  { id: 'blocked', label: 'Blocked', hint: 'Needs input or dependency' },
+  { id: 'done', label: 'Done', hint: 'Accepted / archived' },
+]
+
+const LANE_TONE: Record<KanbanLane, string> = {
+  backlog: 'border-slate-400/40 bg-slate-500/10 text-slate-700',
+  ready: 'border-blue-400/40 bg-blue-500/10 text-blue-700',
+  running: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-700',
+  review: 'border-violet-400/40 bg-violet-500/10 text-violet-700',
+  blocked: 'border-red-400/40 bg-red-500/10 text-red-700',
+  done: 'border-green-400/40 bg-green-500/10 text-green-700',
+}
+
+async function fetchKanbanCards(): Promise<{ cards: Array<SwarmKanbanCard>; backend: KanbanBackendMeta | null }> {
+  const res = await fetch('/api/swarm-kanban')
+  if (!res.ok) throw new Error(`Kanban request failed: ${res.status}`)
+  const data = (await res.json()) as KanbanResponse
+  return {
+    cards: Array.isArray(data.cards) ? data.cards : [],
+    backend: data.backend ?? null,
+  }
+}
+
+async function createKanbanCard(input: {
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: KanbanLane
+  missionId: string | null
+}): Promise<SwarmKanbanCard> {
+  const res = await fetch('/api/swarm-kanban', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban create failed: ${res.status}`)
+  return data.card
+}
+
+async function updateKanbanCard(id: string, updates: Partial<SwarmKanbanCard>): Promise<SwarmKanbanCard> {
+  const res = await fetch('/api/swarm-kanban', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, ...updates }),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban update failed: ${res.status}`)
+  return data.card
+}
+
+function splitCriteria(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+}
+
+function workerLabel(workers: Array<KanbanWorker>, workerId: string | null): string {
+  if (!workerId) return 'Unassigned'
+  const worker = workers.find((item) => item.id === workerId)
+  return worker?.displayName || workerId
+}
+
+export function Swarm2KanbanBoard({
+  workers,
+  latestMission,
+  selectedWorkerId,
+  onSelectWorker,
+  onOpenRouter,
+  className,
+}: Swarm2KanbanBoardProps) {
+  const queryClient = useQueryClient()
+  const [composerOpen, setComposerOpen] = useState(false)
+  const [draftTitle, setDraftTitle] = useState('')
+  const [draftSpec, setDraftSpec] = useState('')
+  const [draftCriteria, setDraftCriteria] = useState('')
+  const [draftWorker, setDraftWorker] = useState(selectedWorkerId ?? '')
+  const [draftReviewer, setDraftReviewer] = useState('')
+  const [draftStatus, setDraftStatus] = useState<KanbanLane>('backlog')
+  const [linkLatestMission, setLinkLatestMission] = useState(Boolean(latestMission))
+  const [backendToast, setBackendToast] = useState<KanbanBackendPresentation | null>(null)
+  const lastToastedBackendKey = useRef<string | null>(null)
+
+  const query = useQuery({
+    queryKey: ['swarm2', 'kanban'],
+    queryFn: fetchKanbanCards,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+
+  const backend = query.data?.backend ?? null
+  const backendPresentation = useMemo(() => getKanbanBackendPresentation(backend), [backend])
+
+  useEffect(() => {
+    if (!backend) return
+    const backendKey = `${backend.id}:${backend.detected ? 'detected' : 'fallback'}:${backend.path ?? ''}`
+    if (lastToastedBackendKey.current === backendKey) return
+    lastToastedBackendKey.current = backendKey
+
+    const storageKey = 'swarm2-kanban-backend-toast'
+    if (typeof window !== 'undefined') {
+      const lastSessionToast = window.sessionStorage.getItem(storageKey)
+      if (lastSessionToast === backendKey) return
+      window.sessionStorage.setItem(storageKey, backendKey)
+    }
+
+    const nextToast = getKanbanBackendPresentation(backend)
+    setBackendToast(nextToast)
+    const timeout = window.setTimeout(() => setBackendToast(null), 4_500)
+    return () => window.clearTimeout(timeout)
+  }, [backend])
+
+  const createMutation = useMutation({
+    mutationFn: () => createKanbanCard({
+      title: draftTitle.trim(),
+      spec: draftSpec.trim(),
+      acceptanceCriteria: splitCriteria(draftCriteria),
+      assignedWorker: draftWorker || null,
+      reviewer: draftReviewer || null,
+      status: draftStatus,
+      missionId: linkLatestMission ? latestMission?.id ?? null : null,
+    }),
+    onSuccess: async () => {
+      setDraftTitle('')
+      setDraftSpec('')
+      setDraftCriteria('')
+      setDraftWorker(selectedWorkerId ?? '')
+      setDraftReviewer('')
+      setDraftStatus('backlog')
+      setComposerOpen(false)
+      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<SwarmKanbanCard> }) => updateKanbanCard(id, updates),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+    },
+  })
+
+  const cardsByLane = useMemo(() => {
+    const map = new Map<KanbanLane, Array<SwarmKanbanCard>>()
+    for (const lane of LANES) map.set(lane.id, [])
+    for (const card of query.data?.cards ?? []) {
+      const bucket = map.get(card.status) ?? map.get('backlog')!
+      bucket.push(card)
+    }
+    return map
+  }, [query.data])
+
+  const total = query.data?.cards.length ?? 0
+  const reviewCount = cardsByLane.get('review')?.length ?? 0
+  const blockedCount = cardsByLane.get('blocked')?.length ?? 0
+
+  return (
+    <section className={cn('rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-[0_24px_80px_var(--theme-shadow)]', className)}>
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Manual planning</div>
+          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Swarm Board</h2>
+          <p className="mt-1 max-w-3xl text-xs leading-relaxed text-[var(--theme-muted-2)]">
+            Auto-detects the shared Kanban store by default; if it is unavailable, cards stay in a local fallback. Dispatch stays explicit through Router.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--theme-muted)]">
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{total} cards</span>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-2 py-1 font-medium',
+              backendPresentation.badgeTone === 'hermes'
+                ? 'border-violet-400/40 bg-violet-500/10 text-violet-700'
+                : backendPresentation.badgeTone === 'local'
+                  ? 'border-amber-400/40 bg-amber-500/10 text-amber-700'
+                  : 'border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-muted)]',
+            )}
+            title={backendPresentation.title}
+            aria-live="polite"
+          >
+            <span className={cn(
+              'h-1.5 w-1.5 rounded-full',
+              backendPresentation.badgeTone === 'hermes' ? 'bg-violet-500' : backendPresentation.badgeTone === 'local' ? 'bg-amber-500' : 'bg-[var(--theme-muted)]',
+            )} />
+            {backendPresentation.badgeLabel}
+          </span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{reviewCount} review</span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{blockedCount} blocked</span>
+          <button
+            type="button"
+            onClick={() => {
+              setDraftWorker(selectedWorkerId ?? '')
+              setLinkLatestMission(Boolean(latestMission))
+              setComposerOpen((open) => !open)
+            }}
+            className="rounded-full bg-[var(--theme-accent)] px-3 py-1.5 font-semibold text-primary-950 hover:bg-[var(--theme-accent-strong)]"
+          >
+            New card
+          </button>
+        </div>
+      </div>
+
+      {backendToast ? (
+        <div className="fixed right-4 top-4 z-50 max-w-sm rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-3 text-sm text-[var(--theme-text)] shadow-[0_18px_60px_var(--theme-shadow)]" role="status" aria-live="polite">
+          <div className="flex items-start gap-3">
+            <span className={cn(
+              'mt-1 h-2 w-2 shrink-0 rounded-full',
+              backendToast.badgeTone === 'hermes' ? 'bg-violet-500' : backendToast.badgeTone === 'local' ? 'bg-amber-500' : 'bg-[var(--theme-muted)]',
+            )} />
+            <div>
+              <div className="font-semibold">{backendToast.toastTitle}</div>
+              <div className="mt-1 text-xs leading-relaxed text-[var(--theme-muted-2)]">{backendToast.toastBody}</div>
+            </div>
+            <button type="button" onClick={() => setBackendToast(null)} className="ml-1 rounded-full px-1.5 text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" aria-label="Dismiss backend notice">×</button>
+          </div>
+        </div>
+      ) : null}
+
+      {composerOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4 py-6 backdrop-blur-sm">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_30px_100px_var(--theme-shadow)]">
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Manual planning</div>
+                <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">New board card</h3>
+                <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Spec work before routing it to an agent. Dispatch stays explicit through Router.</p>
+              </div>
+              <button type="button" onClick={() => setComposerOpen(false)} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-1.5 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]">Close</button>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Title</span>
+                <input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} placeholder="e.g. Review board UX safety" className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Spec</span>
+                <textarea value={draftSpec} onChange={(event) => setDraftSpec(event.target.value)} rows={4} placeholder="Short task spec / context" className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Acceptance criteria</span>
+                <textarea value={draftCriteria} onChange={(event) => setDraftCriteria(event.target.value)} rows={3} placeholder="One per line" className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Assigned worker</span>
+                <select value={draftWorker} onChange={(event) => setDraftWorker(event.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  <option value="">Unassigned</option>
+                  {workers.map((worker) => <option key={worker.id} value={worker.id}>{worker.displayName || worker.id}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Reviewer</span>
+                <select value={draftReviewer} onChange={(event) => setDraftReviewer(event.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  <option value="">Unassigned</option>
+                  {workers.map((worker) => <option key={worker.id} value={worker.id}>{worker.displayName || worker.id}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Status</span>
+                <select value={draftStatus} onChange={(event) => setDraftStatus(event.target.value as KanbanLane)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  {LANES.map((lane) => <option key={lane.id} value={lane.id}>{lane.label}</option>)}
+                </select>
+              </label>
+              <label className="flex items-center gap-2 self-end rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted)]">
+                <input type="checkbox" checked={linkLatestMission} disabled={!latestMission} onChange={(event) => setLinkLatestMission(event.target.checked)} />
+                Link latest mission{latestMission ? `: ${latestMission.title}` : ''}
+              </label>
+              {createMutation.error ? <div className="rounded-xl border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-700 md:col-span-2">{createMutation.error.message}</div> : null}
+              <div className="flex justify-end gap-2 md:col-span-2">
+                <button type="button" onClick={() => setComposerOpen(false)} className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-xs font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)]">Cancel</button>
+                <button type="button" disabled={!draftTitle.trim() || createMutation.isPending} onClick={() => void createMutation.mutateAsync()} className="rounded-xl bg-[var(--theme-accent)] px-3 py-2 text-xs font-semibold text-primary-950 disabled:opacity-50">{createMutation.isPending ? 'Saving…' : 'Create card'}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-700">Kanban failed to load: {query.error.message}</div>
+      ) : query.isPending ? (
+        <div className="mb-3 rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-muted)]">
+          Loading board cards and backend source…
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-3 2xl:grid-cols-6">
+        {LANES.map((lane) => {
+          const laneCards = cardsByLane.get(lane.id) ?? []
+          return (
+            <div key={lane.id} className="min-h-64 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-2">
+              <div className="mb-2 flex items-center justify-between gap-2 px-1">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]', LANE_TONE[lane.id])}>{lane.label}</span>
+                    <span className="text-[10px] text-[var(--theme-muted)]">{laneCards.length}</span>
+                  </div>
+                  <div className="mt-1 text-[10px] text-[var(--theme-muted)]">{lane.hint}</div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                {query.isPending ? (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-3 text-xs text-[var(--theme-muted)]">Waiting for source…</div>
+                ) : laneCards.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-3 text-xs text-[var(--theme-muted)]">Empty</div>
+                ) : laneCards.map((card) => (
+                  <article key={card.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 text-left shadow-sm">
+                    <div className="text-sm font-semibold leading-snug text-[var(--theme-text)]">{card.title}</div>
+                    {card.spec ? <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-[var(--theme-muted-2)]">{card.spec}</p> : null}
+                    {card.acceptanceCriteria.length ? (
+                      <ul className="mt-2 space-y-1 text-[11px] text-[var(--theme-muted)]">
+                        {card.acceptanceCriteria.slice(0, 3).map((item, index) => <li key={`${card.id}-ac-${index}`}>✓ {item}</li>)}
+                        {card.acceptanceCriteria.length > 3 ? <li>+{card.acceptanceCriteria.length - 3} more</li> : null}
+                      </ul>
+                    ) : null}
+                    <div className="mt-3 space-y-1 text-[10px] text-[var(--theme-muted)]">
+                      <div>Owner: <span className="font-semibold text-[var(--theme-text)]">{workerLabel(workers, card.assignedWorker)}</span></div>
+                      <div>Reviewer: <span className="font-semibold text-[var(--theme-text)]">{workerLabel(workers, card.reviewer)}</span></div>
+                      {card.missionId ? <div className="truncate" title={card.missionId}>Mission: {card.missionId}</div> : null}
+                      {card.reportPath ? <div className="truncate" title={card.reportPath}>Report: {card.reportPath}</div> : null}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {card.assignedWorker ? (
+                        <button type="button" onClick={() => onSelectWorker?.(card.assignedWorker!)} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Open worker</button>
+                      ) : null}
+                      {card.status !== 'running' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'running' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Run</button> : null}
+                      {card.status !== 'review' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'review' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Review</button> : null}
+                      {card.status !== 'done' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'done' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Done</button> : null}
+                      {onOpenRouter ? <button type="button" onClick={onOpenRouter} className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-accent-strong)]">Router</button> : null}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/server/hermes-paths.ts
+++ b/src/server/hermes-paths.ts
@@ -1,0 +1,58 @@
+import { homedir } from 'node:os'
+import { dirname, join, normalize, sep } from 'node:path'
+
+function isProfilesChild(pathValue: string): boolean {
+  const parts = normalize(pathValue).split(sep).filter(Boolean)
+  return parts.length >= 2 && parts.at(-2) === 'profiles'
+}
+
+function isProfileHome(pathValue: string): boolean {
+  const parts = normalize(pathValue).split(sep).filter(Boolean)
+  return parts.length >= 3 && parts.at(-3) === 'profiles' && parts.at(-1) === 'home'
+}
+
+function hermesRootFromProfile(pathValue: string): string | null {
+  if (isProfilesChild(pathValue)) {
+    return dirname(dirname(pathValue))
+  }
+  if (isProfileHome(pathValue)) {
+    return dirname(dirname(dirname(pathValue)))
+  }
+  return null
+}
+
+export function getHermesRoot(): string {
+  const envHome = process.env.HERMES_HOME || process.env.CLAUDE_HOME
+  if (envHome) {
+    const profileRoot = hermesRootFromProfile(envHome)
+    if (profileRoot) return profileRoot
+    return envHome
+  }
+
+  const osHome = homedir()
+  const profileRoot = hermesRootFromProfile(osHome)
+  if (profileRoot) return profileRoot
+  return join(osHome, '.hermes')
+}
+
+export function getProfilesDir(): string {
+  return join(getHermesRoot(), 'profiles')
+}
+
+export function getWorkspaceHermesHome(): string {
+  return getHermesRoot()
+}
+
+export function getProfileHermesHome(profileId: string): string {
+  return join(getProfilesDir(), profileId)
+}
+
+export function getUserHomeForHermesRoot(): string {
+  const root = getHermesRoot()
+  if (root.endsWith(`${sep}.hermes`)) return dirname(root)
+  return homedir()
+}
+
+export function getLocalBinDir(): string {
+  return join(getUserHomeForHermesRoot(), '.local', 'bin')
+}

--- a/src/server/integration-detection.test.ts
+++ b/src/server/integration-detection.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { detectHonchoIntegration } from './integration-detection'
+
+const tempDirs: Array<string> = []
+
+function tempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honcho-detect-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('detectHonchoIntegration', () => {
+  it('keeps Honcho disabled when no local presence or config exists', () => {
+    const homeDir = tempHome()
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('not-detected')
+    expect(status.available).toBe(false)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects local Honcho presence without enabling unsafe use', () => {
+    const homeDir = tempHome()
+    fs.mkdirSync(path.join(homeDir, '.honcho'), { recursive: true })
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('detected-unconfigured')
+    expect(status.available).toBe(true)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects Honcho config from OpenClaw env/config without exposing secret values', () => {
+    const homeDir = tempHome()
+    const openClawHome = path.join(homeDir, '.openclaw')
+    fs.mkdirSync(openClawHome, { recursive: true })
+    fs.writeFileSync(path.join(openClawHome, '.env'), 'HONCHO_API_KEY=secret-value\n')
+    fs.writeFileSync(path.join(openClawHome, 'config.yaml'), 'honcho:\n  enabled: true\n')
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome,
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.configured).toBe(true)
+    expect(status.safeToUse).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-env' && source.configured)).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-config' && source.configured)).toBe(true)
+    expect(JSON.stringify(status)).not.toContain('secret-value')
+  })
+
+  it('detects Claude honcho.json as a configured Honcho source', () => {
+    const homeDir = tempHome()
+    const claudeHome = path.join(homeDir, '.claude')
+    fs.mkdirSync(claudeHome, { recursive: true })
+    fs.writeFileSync(path.join(claudeHome, 'honcho.json'), JSON.stringify({ appId: 'workspace', baseUrl: 'http://localhost:8787' }))
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome,
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.sources.some((source) => source.id === 'claude-honcho-json' && source.configured)).toBe(true)
+  })
+})

--- a/src/server/integration-detection.ts
+++ b/src/server/integration-detection.ts
@@ -1,0 +1,257 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import YAML from 'yaml'
+
+export type HonchoDetectionSource = {
+  id: string
+  label: string
+  path?: string
+  present: boolean
+  configured: boolean
+  details: string
+}
+
+export type HonchoIntegrationStatus = {
+  id: 'honcho'
+  label: 'Honcho memory'
+  available: boolean
+  configured: boolean
+  safeToUse: boolean
+  mode: 'ready' | 'detected-unconfigured' | 'not-detected'
+  summary: string
+  sources: Array<HonchoDetectionSource>
+  checkedAt: number
+}
+
+type DetectHonchoOptions = {
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+  openClawHome?: string
+  claudeHome?: string
+  hermesHome?: string
+  now?: number
+}
+
+const HONCHO_ENV_KEYS = [
+  'HONCHO_API_KEY',
+  'HONCHO_APP_ID',
+  'HONCHO_BASE_URL',
+  'HONCHO_URL',
+  'HONCHO_ENVIRONMENT',
+] as const
+
+const HONCHO_CONFIG_KEYS = [
+  'enabled',
+  'api_key',
+  'apiKey',
+  'app_id',
+  'appId',
+  'url',
+  'base_url',
+  'baseUrl',
+] as const
+
+function expandHome(value: string, homeDir: string): string {
+  if (value === '~') return homeDir
+  if (value.startsWith('~/')) return path.join(homeDir, value.slice(2))
+  return value
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readYaml(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = YAML.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readEnvFile(filePath: string): Record<string, string> {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const env: Record<string, string> = {}
+    for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      env[key] = value
+    }
+    return env
+  } catch {
+    return {}
+  }
+}
+
+function hasOwnTruthy(record: Record<string, unknown> | null | undefined, keys: ReadonlyArray<string>): boolean {
+  if (!record) return false
+  return keys.some((key) => {
+    const value = record[key]
+    return typeof value === 'string' ? Boolean(value.trim()) : Boolean(value)
+  })
+}
+
+function objectAt(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
+  const value = record?.[key]
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function envConfigured(env: Record<string, string | undefined>): boolean {
+  return HONCHO_ENV_KEYS.some((key) => Boolean(env[key]?.trim()))
+}
+
+function configHasHoncho(record: Record<string, unknown> | null): boolean {
+  const honchoConfig = objectAt(record, 'honcho')
+  const memoryConfig = objectAt(record, 'memory')
+  const integrationsConfig = objectAt(record, 'integrations')
+  const integrationsHoncho = objectAt(integrationsConfig, 'honcho')
+  const provider = String(memoryConfig?.provider ?? '').toLowerCase()
+
+  return (
+    hasOwnTruthy(honchoConfig, HONCHO_CONFIG_KEYS) ||
+    (provider.includes('honcho') && hasOwnTruthy(memoryConfig, ['provider', 'honcho'])) ||
+    hasOwnTruthy(integrationsHoncho, HONCHO_CONFIG_KEYS)
+  )
+}
+
+function fileSource(id: string, label: string, filePath: string, configured: boolean, details: string): HonchoDetectionSource {
+  return {
+    id,
+    label,
+    path: filePath,
+    present: fs.existsSync(filePath),
+    configured,
+    details,
+  }
+}
+
+export function detectHonchoIntegration(options: DetectHonchoOptions = {}): HonchoIntegrationStatus {
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? os.homedir()
+  const openClawHome = expandHome(options.openClawHome ?? env.OPENCLAW_HOME ?? path.join(homeDir, '.openclaw'), homeDir)
+  const claudeHome = expandHome(options.claudeHome ?? env.CLAUDE_HOME ?? path.join(homeDir, '.claude'), homeDir)
+  const hermesHome = expandHome(options.hermesHome ?? env.HERMES_HOME ?? path.join(homeDir, '.hermes'), homeDir)
+
+  const processEnvConfigured = envConfigured(env)
+
+  const openClawEnvPath = path.join(openClawHome, '.env')
+  const openClawEnvConfigured = envConfigured(readEnvFile(openClawEnvPath))
+
+  const openClawConfigPath = path.join(openClawHome, 'config.yaml')
+  const openClawConfigConfigured = configHasHoncho(readYaml(openClawConfigPath))
+
+  const claudeHonchoPath = path.join(claudeHome, 'honcho.json')
+  const claudeHonchoConfigured = hasOwnTruthy(readJson(claudeHonchoPath), HONCHO_CONFIG_KEYS)
+
+  // Legacy/compatibility signals stay read-only and only contribute to detection.
+  const hermesEnvPath = path.join(hermesHome, '.env')
+  const hermesEnvConfigured = envConfigured(readEnvFile(hermesEnvPath))
+  const hermesConfigPath = path.join(hermesHome, 'config.yaml')
+  const hermesConfigConfigured = configHasHoncho(readYaml(hermesConfigPath))
+
+  const localDirs = [
+    path.join(homeDir, '.honcho'),
+    path.join(homeDir, '.config', 'honcho'),
+    path.join(openClawHome, 'honcho'),
+    path.join(claudeHome, 'honcho'),
+    path.join(hermesHome, 'honcho'),
+  ]
+
+  const sources: Array<HonchoDetectionSource> = [
+    {
+      id: 'process-env',
+      label: 'Process environment',
+      present: processEnvConfigured,
+      configured: processEnvConfigured,
+      details: processEnvConfigured ? 'Honcho env var present in process environment.' : 'No Honcho env var in process environment.',
+    },
+    fileSource(
+      'openclaw-env',
+      'OpenClaw .env',
+      openClawEnvPath,
+      openClawEnvConfigured,
+      openClawEnvConfigured ? 'Honcho env var present in OpenClaw .env.' : 'No Honcho env var in OpenClaw .env.',
+    ),
+    fileSource(
+      'openclaw-config',
+      'OpenClaw config.yaml',
+      openClawConfigPath,
+      openClawConfigConfigured,
+      openClawConfigConfigured ? 'Honcho keys found in OpenClaw config.' : 'No Honcho keys found in OpenClaw config.',
+    ),
+    fileSource(
+      'claude-honcho-json',
+      'Claude honcho.json',
+      claudeHonchoPath,
+      claudeHonchoConfigured,
+      claudeHonchoConfigured ? 'Claude Honcho config file has usable keys.' : 'No Claude Honcho config file with usable keys.',
+    ),
+    fileSource(
+      'hermes-env',
+      'Hermes .env compatibility',
+      hermesEnvPath,
+      hermesEnvConfigured,
+      hermesEnvConfigured ? 'Honcho env var present in Hermes .env.' : 'No Honcho env var in Hermes .env.',
+    ),
+    fileSource(
+      'hermes-config',
+      'Hermes config.yaml compatibility',
+      hermesConfigPath,
+      hermesConfigConfigured,
+      hermesConfigConfigured ? 'Honcho keys found in Hermes config.' : 'No Honcho keys found in Hermes config.',
+    ),
+    ...localDirs.map((dir) => ({
+      id: `dir:${dir}`,
+      label: path.basename(dir) || dir,
+      path: dir,
+      present: fs.existsSync(dir),
+      configured: false,
+      details: fs.existsSync(dir) ? 'Local Honcho directory exists; configuration still needs verification.' : 'Directory not found.',
+    })),
+  ]
+
+  const configured = sources.some((source) => source.configured)
+  const present = configured || sources.some((source) => source.present)
+  const mode: HonchoIntegrationStatus['mode'] = configured
+    ? 'ready'
+    : present
+      ? 'detected-unconfigured'
+      : 'not-detected'
+
+  return {
+    id: 'honcho',
+    label: 'Honcho memory',
+    available: present,
+    configured,
+    safeToUse: configured,
+    mode,
+    summary: configured
+      ? 'Honcho memory configuration detected. Workspace can safely gate Honcho-backed features behind explicit user action.'
+      : present
+        ? 'Honcho presence detected, but no usable config/token was found. Honcho-backed features remain disabled.'
+        : 'Honcho not detected. Optional Honcho-backed memory features remain hidden/disabled.',
+    sources,
+    checkedAt: options.now ?? Date.now(),
+  }
+}

--- a/src/server/jobs-profile-resolution.test.ts
+++ b/src/server/jobs-profile-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+  sanitizeProfileName,
+} from './jobs-profile-resolution'
+
+describe('sanitizeProfileName', () => {
+  it('accepts simple profile names', () => {
+    expect(sanitizeProfileName('aurora')).toBe('aurora')
+    expect(sanitizeProfileName(' swarm6 ')).toBe('swarm6')
+  })
+
+  it('rejects empty and path-like values', () => {
+    expect(sanitizeProfileName('')).toBeNull()
+    expect(sanitizeProfileName('   ')).toBeNull()
+    expect(sanitizeProfileName('../etc')).toBeNull()
+    expect(sanitizeProfileName('a/b')).toBeNull()
+    expect(sanitizeProfileName('a\\b')).toBeNull()
+  })
+})
+
+describe('resolveJobsProfile', () => {
+  it('prefers explicit ?profile= query param', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?profile=query-one')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'query-one',
+    )
+  })
+
+  it('falls back to HERMES_PROFILE env var', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'env-one',
+    )
+  })
+
+  it('falls back to file-backed active profile when env is absent', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'file-one')).toBe('file-one')
+  })
+
+  it('ignores the default sentinel from active_profile', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'default')).toBeNull()
+  })
+})
+
+describe('buildJobsProfileSearch', () => {
+  it('adds the resolved profile while preserving other params', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?limit=10')
+    expect(buildJobsProfileSearch(url, 'aurora')).toBe(
+      '?limit=10&profile=aurora',
+    )
+  })
+
+  it('replaces any inbound profile query with the resolved profile', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', 'new')).toBe(
+      '?limit=10&profile=new',
+    )
+  })
+
+  it('drops profile from the query when no resolved profile exists', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', null)).toBe(
+      '?limit=10',
+    )
+  })
+})

--- a/src/server/jobs-profile-resolution.ts
+++ b/src/server/jobs-profile-resolution.ts
@@ -1,0 +1,55 @@
+import { getActiveProfileName } from './profiles-browser'
+
+export function sanitizeProfileName(
+  name: string | null | undefined,
+): string | null {
+  if (!name) return null
+  const trimmed = String(name).trim()
+  if (!trimmed) return null
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('..')
+  ) {
+    return null
+  }
+  return trimmed
+}
+
+export function resolveJobsProfile(
+  url: URL,
+  envProfile = process.env.HERMES_PROFILE,
+  activeProfileResolver: () => string = getActiveProfileName,
+): string | null {
+  const fromQuery = sanitizeProfileName(url.searchParams.get('profile'))
+  if (fromQuery) return fromQuery
+
+  const fromEnv = sanitizeProfileName(envProfile)
+  if (fromEnv) return fromEnv
+
+  try {
+    const fromFile = sanitizeProfileName(activeProfileResolver())
+    if (fromFile && fromFile !== 'default') return fromFile
+  } catch {
+    // ignore file-backed profile lookup failures
+  }
+
+  return null
+}
+
+export function buildJobsProfileSearch(
+  urlOrSearch: URL | string,
+  profile: string | null,
+): string {
+  const sourceSearch =
+    typeof urlOrSearch === 'string' ? urlOrSearch : urlOrSearch.search
+  const params = new URLSearchParams(
+    sourceSearch.startsWith('?') ? sourceSearch.slice(1) : sourceSearch,
+  )
+
+  params.delete('profile')
+  if (profile) params.set('profile', profile)
+
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+async function loadKanbanBackend(options?: {
+  existsSync?: (path: string) => boolean
+  execFileSync?: (command: string, args?: string[]) => string
+}) {
+  vi.doMock('./swarm-kanban-store', () => ({
+    SWARM_KANBAN_FILE: '/tmp/swarm2-kanban.json',
+    createSwarmKanbanCard: vi.fn((input) => ({
+      id: 'local-1',
+      title: input.title,
+      spec: input.spec ?? '',
+      acceptanceCriteria: input.acceptanceCriteria ?? [],
+      assignedWorker: input.assignedWorker ?? null,
+      reviewer: input.reviewer ?? null,
+      status: input.status ?? 'backlog',
+      missionId: input.missionId ?? null,
+      reportPath: input.reportPath ?? null,
+      createdBy: input.createdBy ?? 'swarm2-kanban',
+      createdAt: 1,
+      updatedAt: 1,
+    })),
+    listSwarmKanbanCards: vi.fn(() => [{
+      id: 'local-1',
+      title: 'Local task',
+      spec: '',
+      acceptanceCriteria: [],
+      assignedWorker: null,
+      reviewer: null,
+      status: 'backlog',
+      missionId: null,
+      reportPath: null,
+      createdBy: 'local',
+      createdAt: 1,
+      updatedAt: 1,
+    }]),
+    updateSwarmKanbanCard: vi.fn((cardId, updates) => ({
+      id: cardId,
+      title: updates.title ?? 'Local task',
+      spec: updates.spec ?? '',
+      acceptanceCriteria: [],
+      assignedWorker: updates.assignedWorker ?? null,
+      reviewer: null,
+      status: updates.status ?? 'backlog',
+      missionId: null,
+      reportPath: null,
+      createdBy: 'local',
+      createdAt: 1,
+      updatedAt: 2,
+    })),
+  }))
+
+  vi.doMock('node:fs', () => ({
+    existsSync: vi.fn((path: string) => options?.existsSync?.(path) ?? false),
+  }))
+
+  vi.doMock('node:child_process', () => ({
+    execFileSync: vi.fn((command: string, args?: string[]) => options?.execFileSync?.(command, args) ?? ''),
+  }))
+
+  return import('./kanban-backend')
+}
+
+describe('kanban-backend', () => {
+  it('auto-detect prefers Hermes backend when Hermes CLI and canonical storage are present', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const sqliteCalls: Array<{ command: string; args?: string[] }> = []
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db' || target === '/Users/aurora/.hermes/kanban',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        if (command === 'sqlite3') {
+          sqliteCalls.push({ command, args })
+          return JSON.stringify([
+            {
+              id: 't_12345678',
+              title: 'Hermes task',
+              body: 'Backed by sqlite',
+              status: 'running',
+              assignee: 'swarm2',
+              created_at: 1777527540,
+              updated_at: 1777527644,
+            },
+          ])
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      writable: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+
+    const cards = mod.listKanbanCards()
+    expect(cards).toHaveLength(1)
+    expect(cards[0]).toMatchObject({
+      id: 't_12345678',
+      title: 'Hermes task',
+      status: 'running',
+      assignedWorker: 'swarm2',
+      createdBy: 'hermes-kanban',
+    })
+    expect(sqliteCalls[0]?.args?.[0]).toBe('/Users/aurora/.hermes/kanban.db')
+  })
+
+  it('auto-detect uses Hermes storage directly when the CLI is unavailable', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') throw new Error('not found')
+        if (command === 'sqlite3') {
+          return JSON.stringify([
+            {
+              id: 't_direct',
+              title: 'Direct Hermes task',
+              body: '',
+              status: 'ready',
+              assignee: null,
+              created_at: 1777527540,
+              updated_at: 1777527644,
+            },
+          ])
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      writable: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+    expect(mod.getKanbanBackendMeta().details).toContain('direct local storage access')
+    expect(mod.listKanbanCards()[0]).toMatchObject({ id: 't_direct', status: 'ready' })
+  })
+
+  it('resolves canonical Kanban paths from CLAUDE_HOME profile homes too', async () => {
+    vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.hermes/profiles/swarm5/home')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') throw new Error('not found')
+        if (command === 'sqlite3') return '[]'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+  })
+
+  it('auto-detect falls back to local when canonical Hermes storage is missing', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: () => false,
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'local',
+      detected: true,
+      writable: true,
+      path: '/tmp/swarm2-kanban.json',
+    })
+    expect(mod.listKanbanCards()[0]?.id).toBe('local-1')
+  })
+
+  it('creates and updates Hermes tasks through canonical kanban.db path', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const sqliteCalls: string[] = []
+    let readCount = 0
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db' || target === '/Users/aurora/.hermes/kanban',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        if (command === 'sqlite3') {
+          sqliteCalls.push(args.join(' '))
+          const sql = args[2] ?? ''
+          if (sql.includes('where id =')) {
+            readCount += 1
+            return JSON.stringify([
+              {
+                id: 't_deadbeef',
+                title: readCount === 1 ? 'Created Hermes task' : 'Updated Hermes task',
+                body: 'Task body',
+                status: readCount === 1 ? 'queued' : 'done',
+                assignee: 'swarm6',
+                created_at: 1777527540,
+                updated_at: 1777527644,
+              },
+            ])
+          }
+          return '[]'
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    const created = mod.createKanbanCard({ title: 'Created Hermes task', spec: 'Task body', assignedWorker: 'swarm6', status: 'backlog' })
+    const updated = mod.updateKanbanCard('t_deadbeef', { title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
+
+    expect(created).toMatchObject({ id: 't_deadbeef', title: 'Created Hermes task', status: 'backlog', assignedWorker: 'swarm6', createdBy: 'hermes-kanban' })
+    expect(updated).toMatchObject({ id: 't_deadbeef', title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
+    expect(sqliteCalls.every((call) => call.startsWith('/Users/aurora/.hermes/kanban.db '))).toBe(true)
+    expect(sqliteCalls.some((call) => call.includes('insert into tasks'))).toBe(true)
+    expect(sqliteCalls.some((call) => call.includes('update tasks set'))).toBe(true)
+  })
+})

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -1,0 +1,347 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { getHermesRoot, getWorkspaceHermesHome } from './hermes-paths'
+import {
+  SWARM_KANBAN_FILE,
+  type CreateSwarmKanbanCardInput,
+  createSwarmKanbanCard,
+  listSwarmKanbanCards,
+  type SwarmKanbanCard,
+  updateSwarmKanbanCard,
+  type UpdateSwarmKanbanCardInput,
+} from './swarm-kanban-store'
+
+export type KanbanBackendId = 'local' | 'hermes'
+
+export type KanbanBackendMeta = {
+  id: KanbanBackendId
+  label: string
+  detected: boolean
+  writable: boolean
+  details?: string | null
+  path?: string | null
+}
+
+type KanbanBackend = {
+  meta(): KanbanBackendMeta
+  list(): SwarmKanbanCard[]
+  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard
+  update(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null
+}
+
+type HermesTaskRow = {
+  id: string
+  title: string
+  body?: string | null
+  status?: string | null
+  assignee?: string | null
+  created_at?: number | string | null
+  updated_at?: number | string | null
+}
+
+type HermesDetection = {
+  available: boolean
+  cliPath?: string | null
+  dbPath: string
+  workspacePath: string
+  reason?: string
+}
+
+function env(name: string): string | null {
+  const value = process.env[name]
+  return value && value.trim() ? value.trim() : null
+}
+
+function hermesProfileRoot(): string {
+  return getWorkspaceHermesHome()
+}
+
+function hermesDbPath(): string {
+  return path.join(getHermesRoot(), 'kanban.db')
+}
+
+function hermesWorkspacePath(): string {
+  return path.join(getHermesRoot(), 'kanban')
+}
+
+function hermesCliPath(): string | null {
+  try {
+    const output = execFileSync('which', ['hermes'], { encoding: 'utf8', timeout: 5_000 }).trim()
+    return output || null
+  } catch {
+    return null
+  }
+}
+
+function checkHermesCli(): { ok: boolean; path?: string | null; reason?: string } {
+  const cli = hermesCliPath()
+  if (!cli) return { ok: false, reason: 'hermes CLI not found on PATH' }
+  try {
+    execFileSync(cli, ['--version'], { encoding: 'utf8', timeout: 10_000, env: { ...process.env, HERMES_HOME: hermesProfileRoot() } })
+    return { ok: true, path: cli }
+  } catch (error) {
+    return { ok: false, path: cli, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+function detectHermesKanban(): HermesDetection {
+  const dbPath = hermesDbPath()
+  const workspacePath = hermesWorkspacePath()
+  const hasDb = fs.existsSync(dbPath)
+  const hasWorkspace = fs.existsSync(workspacePath)
+
+  if (!hasDb && !hasWorkspace) {
+    return {
+      available: false,
+      cliPath: null,
+      dbPath,
+      workspacePath,
+      reason: 'Hermes Kanban storage not found; using the local Swarm Board fallback.',
+    }
+  }
+
+  const cli = checkHermesCli()
+  return {
+    available: true,
+    cliPath: cli.ok ? cli.path ?? null : null,
+    dbPath,
+    workspacePath,
+    reason: cli.ok ? undefined : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
+  }
+}
+
+function sqliteQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+function runSqlite(dbPath: string, sql: string): string {
+  return execFileSync('sqlite3', [dbPath, '-json', sql], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  }).trim()
+}
+
+function readHermesTasks(): HermesTaskRow[] {
+  const detection = detectHermesKanban()
+  if (!detection.available) return []
+  const query = [
+    'select',
+    'id,',
+    'title,',
+    'body,',
+    'status,',
+    'assignee,',
+    'created_at,',
+    'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
+    'from tasks',
+    'order by created_at desc, id desc;',
+  ].join(' ')
+  const raw = runSqlite(detection.dbPath, query)
+  const parsed = raw ? (JSON.parse(raw) as HermesTaskRow[]) : []
+  return Array.isArray(parsed) ? parsed : []
+}
+
+function readHermesTask(taskId: string): HermesTaskRow | null {
+  const detection = detectHermesKanban()
+  if (!detection.available) return null
+  const raw = runSqlite(
+    detection.dbPath,
+    `select id, title, body, status, assignee, created_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
+  )
+  const parsed = raw ? (JSON.parse(raw) as HermesTaskRow[]) : []
+  return Array.isArray(parsed) && parsed[0] ? parsed[0] : null
+}
+
+function normalizeTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : Math.round(value * 1000)
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const asNum = Number(value)
+    if (Number.isFinite(asNum)) return normalizeTimestamp(asNum)
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return Date.now()
+}
+
+function mapHermesStatus(status: string | null | undefined): SwarmKanbanCard['status'] {
+  switch ((status ?? '').toLowerCase()) {
+    case 'queued':
+    case 'todo':
+    case 'triage':
+      return 'backlog'
+    case 'ready':
+      return 'ready'
+    case 'running':
+    case 'claimed':
+    case 'in_progress':
+      return 'running'
+    case 'review':
+      return 'review'
+    case 'blocked':
+      return 'blocked'
+    case 'done':
+    case 'complete':
+    case 'completed':
+      return 'done'
+    default:
+      return 'backlog'
+  }
+}
+
+function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): string {
+  switch (status) {
+    case 'backlog':
+      return 'queued'
+    case 'ready':
+      return 'ready'
+    case 'running':
+      return 'running'
+    case 'review':
+      return 'review'
+    case 'blocked':
+      return 'blocked'
+    case 'done':
+      return 'done'
+    default:
+      return 'queued'
+  }
+}
+
+function hermesTaskToCard(task: HermesTaskRow): SwarmKanbanCard {
+  const createdAt = normalizeTimestamp(task.created_at)
+  const updatedAt = normalizeTimestamp(task.updated_at ?? task.created_at)
+  return {
+    id: task.id,
+    title: task.title,
+    spec: task.body ?? '',
+    acceptanceCriteria: [],
+    assignedWorker: task.assignee ?? null,
+    reviewer: null,
+    status: mapHermesStatus(task.status),
+    missionId: null,
+    reportPath: null,
+    createdBy: 'hermes-kanban',
+    createdAt,
+    updatedAt,
+  }
+}
+
+const localBackend: KanbanBackend = {
+  meta() {
+    return {
+      id: 'local',
+      label: 'Local board',
+      detected: true,
+      writable: true,
+      path: SWARM_KANBAN_FILE,
+      details: 'Using local Swarm board JSON store.',
+    }
+  },
+  list() {
+    return listSwarmKanbanCards()
+  },
+  create(input) {
+    return createSwarmKanbanCard(input)
+  },
+  update(cardId, updates) {
+    return updateSwarmKanbanCard(cardId, updates)
+  },
+}
+
+const hermesBackend: KanbanBackend = {
+  meta() {
+    const detection = detectHermesKanban()
+    return {
+      id: 'hermes',
+      label: 'Hermes Kanban',
+      detected: detection.available,
+      writable: detection.available,
+      path: fs.existsSync(detection.dbPath) ? detection.dbPath : null,
+      details: detection.available
+        ? detection.reason ?? `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`
+        : detection.reason ?? 'Hermes Kanban not detected.',
+    }
+  },
+  list() {
+    return readHermesTasks().map(hermesTaskToCard)
+  },
+  create(input) {
+    const detection = detectHermesKanban()
+    if (!detection.available) throw new Error(detection.reason ?? 'Hermes Kanban not detected')
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
+    const status = mapBoardStatus(input.status ?? 'backlog')
+    const statements = [
+      'insert into tasks (',
+      'id, title, body, assignee, status, priority, created_by, created_at, workspace_kind, workspace_path',
+      ') values (',
+      [
+        sqliteQuote(taskId),
+        sqliteQuote(input.title.trim()),
+        sqliteQuote((input.spec ?? '').trim()),
+        input.assignedWorker?.trim() ? sqliteQuote(input.assignedWorker.trim()) : 'NULL',
+        sqliteQuote(status),
+        '0',
+        sqliteQuote(input.createdBy?.trim() || 'swarm2-kanban'),
+        String(nowSeconds),
+        sqliteQuote('scratch'),
+        sqliteQuote(path.join(detection.workspacePath, 'workspaces', taskId)),
+      ].join(', '),
+      ');',
+    ].join(' ')
+    runSqlite(detection.dbPath, statements)
+    const created = readHermesTask(taskId)
+    if (!created) throw new Error(`Created Hermes task ${taskId} but could not read it back`)
+    return hermesTaskToCard(created)
+  },
+  update(cardId, updates) {
+    const detection = detectHermesKanban()
+    if (!detection.available) return null
+    const assignments: string[] = []
+    if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
+    if (typeof updates.spec === 'string') assignments.push(`body = ${sqliteQuote(updates.spec)}`)
+    if (updates.assignedWorker !== undefined) assignments.push(`assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`)
+    if (updates.status) {
+      const status = mapBoardStatus(updates.status)
+      assignments.push(`status = ${sqliteQuote(status)}`)
+      if (status === 'running') assignments.push(`started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`)
+      if (status === 'done') assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
+      if (status !== 'done') assignments.push('completed_at = NULL')
+    }
+    if (assignments.length === 0) {
+      const current = readHermesTask(cardId)
+      return current ? hermesTaskToCard(current) : null
+    }
+    runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
+    const updated = readHermesTask(cardId)
+    return updated ? hermesTaskToCard(updated) : null
+  },
+}
+
+export function resolveKanbanBackend(): KanbanBackend {
+  const preference = (env('HERMES_KANBAN_BACKEND') ?? 'auto').toLowerCase()
+  if (preference === 'local') return localBackend
+  const hermesMeta = hermesBackend.meta()
+  if (preference === 'hermes') return hermesMeta.detected ? hermesBackend : localBackend
+  return hermesMeta.detected ? hermesBackend : localBackend
+}
+
+export function getKanbanBackendMeta(): KanbanBackendMeta {
+  return resolveKanbanBackend().meta()
+}
+
+export function listKanbanCards(): SwarmKanbanCard[] {
+  return resolveKanbanBackend().list()
+}
+
+export function createKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
+  return resolveKanbanBackend().create(input)
+}
+
+export function updateKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
+  return resolveKanbanBackend().update(cardId, updates)
+}

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -137,7 +137,10 @@ export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(results, workspaceRoot, path.join(workspaceRoot, 'MEMORY.md'))
+  for (const subdir of ['memory', 'memories']) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, subdir))
+  }
 
   results.sort(compareMemoryFiles)
   return results

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -3,13 +3,15 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listProfiles } from './profiles-browser'
+import { listProfiles, renameProfile } from './profiles-browser'
 
-describe('listProfiles', () => {
+describe('profiles-browser integration', () => {
   let tempHome: string
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-workspace-profiles-'))
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-'),
+    )
     vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
   })
 
@@ -24,16 +26,126 @@ describe('listProfiles', () => {
     const namedProfileRoot = path.join(profilesRoot, 'jarvis')
 
     fs.mkdirSync(namedProfileRoot, { recursive: true })
-    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'jarvis\n', 'utf-8')
-    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: default-model\n', 'utf-8')
-    fs.writeFileSync(path.join(namedProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'jarvis\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'model: default-model\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(namedProfileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
 
     const profiles = listProfiles()
     const names = profiles.map((profile) => profile.name)
 
     expect(names).toContain('default')
     expect(names).toContain('jarvis')
-    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(false)
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(true)
+    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(
+      false,
+    )
+    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(
+      true,
+    )
+  })
+
+  it('renames a profile and rewrites local/global stale references', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+    const newProfileRoot = path.join(profilesRoot, 'dr_kwon')
+
+    fs.mkdirSync(path.join(oldProfileRoot, 'skills', 'demo-skill'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(hermesRoot, 'team', 'handoffs'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'alan\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'SOUL.md'),
+      '<!-- Profile: alan (Primary: gpt-5.4) -->\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'config.yaml'),
+      'mcp:\n  command: ~/.hermes/profiles/alan/openbb-env/bin/openbb-mcp\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+      `Path: ${hermesRoot}/profiles/alan/data\n`,
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'sharedPath: ~/.hermes/profiles/alan/shared\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team-agents.md'),
+      'Agent alan owns this lane\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+      'handoff from alan with ~/.hermes/profiles/alan/path\n',
+      'utf-8',
+    )
+
+    const renamed = renameProfile('alan', 'dr_kwon')
+
+    expect(renamed.name).toBe('dr_kwon')
+    expect(fs.existsSync(oldProfileRoot)).toBe(false)
+    expect(fs.existsSync(newProfileRoot)).toBe(true)
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8'),
+    ).toBe('dr_kwon\n')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'SOUL.md'), 'utf-8'),
+    ).toContain('Profile: dr_kwon')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'config.yaml'), 'utf-8'),
+    ).toContain('~/.hermes/profiles/dr_kwon/openbb-env/bin/openbb-mcp')
+    expect(
+      fs.readFileSync(
+        path.join(newProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toContain(`${hermesRoot}/profiles/dr_kwon/data`)
+    expect(fs.readFileSync(path.join(hermesRoot, 'config.yaml'), 'utf-8')).toContain(
+      '~/.hermes/profiles/dr_kwon/shared',
+    )
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'team-agents.md'), 'utf-8'),
+    ).toContain('Agent alan owns this lane')
+    expect(
+      fs.readFileSync(
+        path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+        'utf-8',
+      ),
+    ).toContain('~/.hermes/profiles/dr_kwon/path')
+  })
+
+  it('rejects new profile names that the Hermes CLI would reject', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+
+    fs.mkdirSync(oldProfileRoot, { recursive: true })
+
+    expect(() => renameProfile('alan', 'Dr_Kwon')).toThrow(
+      /Invalid profile name/i,
+    )
   })
 })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -46,7 +46,7 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
 ])
 
 function getHermesRoot(): string {
-  return path.join(os.homedir(), '.hermes')
+  return process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
 }
 
 export function getProfilesRoot(): string {

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -27,6 +28,23 @@ export type ProfileDetail = {
   skillsDir?: string
 }
 
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const TEXT_REWRITE_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.jsonl',
+  '.toml',
+  '.env',
+  '.plist',
+  '.sh',
+  '.js',
+  '.ts',
+  '.tsx',
+])
+
 function getHermesRoot(): string {
   return path.join(os.homedir(), '.hermes')
 }
@@ -45,8 +63,14 @@ function getActiveProfilePath(): string {
  */
 function validateProfileName(name: string): string {
   const trimmed = validateProfileIdentifier(name)
-  if (trimmed === 'default')
+  if (trimmed === 'default') {
     throw new Error('Default profile cannot be modified here')
+  }
+  if (!PROFILE_NAME_RE.test(trimmed)) {
+    throw new Error(
+      "Invalid profile name. Use lowercase letters, numbers, underscores, or hyphens, and start with a letter or number.",
+    )
+  }
   return trimmed
 }
 
@@ -252,7 +276,7 @@ export function readProfile(name: string): ProfileDetail {
   const profilePath =
     normalized === 'default'
       ? getHermesRoot()
-      : path.join(getProfilesRoot(), validateProfileName(normalized))
+      : path.join(getProfilesRoot(), validateProfileIdentifier(normalized))
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   const configPath = path.join(profilePath, 'config.yaml')
   const envPath = path.join(profilePath, '.env')
@@ -279,7 +303,7 @@ export function setActiveProfile(name: string): void {
     if (fs.existsSync(activePath)) fs.unlinkSync(activePath)
     return
   }
-  const normalized = validateProfileName(trimmed)
+  const normalized = validateProfileIdentifier(trimmed)
   const profilePath = path.join(getProfilesRoot(), normalized)
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   fs.mkdirSync(getHermesRoot(), { recursive: true })
@@ -405,14 +429,138 @@ export function updateProfileConfig(
   return readProfile(normalized)
 }
 
+function replaceTextReferences(
+  input: string,
+  oldName: string,
+  newName: string,
+): string {
+  const escapedOld = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const absoluteProfileOld = `${getHermesRoot()}/profiles/${oldName}`
+  const absoluteProfileNew = `${getHermesRoot()}/profiles/${newName}`
+
+  return input
+    .replaceAll(absoluteProfileOld, absoluteProfileNew)
+    .replaceAll(`~/.hermes/profiles/${oldName}`, `~/.hermes/profiles/${newName}`)
+    .replaceAll(`profiles/${oldName}/`, `profiles/${newName}/`)
+    .replaceAll(`ai.hermes.gateway-${oldName}`, `ai.hermes.gateway-${newName}`)
+    .replace(
+      new RegExp(`(<!--\\s*Profile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+    .replace(
+      new RegExp(`(\\bProfile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+}
+
+function rewriteTextFileIfPresent(
+  filePath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(filePath)) return
+  try {
+    const original = safeReadText(filePath)
+    const updated = replaceTextReferences(original, oldName, newName)
+    if (updated !== original) {
+      fs.writeFileSync(filePath, updated, 'utf-8')
+    }
+  } catch {
+    // ignore non-text or unreadable files
+  }
+}
+
+function rewriteTextFilesRecursive(
+  rootPath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(rootPath)) return
+  const stack = [rootPath]
+  while (stack.length > 0) {
+    const current = stack.pop() as string
+    let entries: Array<fs.Dirent> = []
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+        continue
+      }
+      if (!TEXT_REWRITE_EXTENSIONS.has(path.extname(entry.name))) continue
+      rewriteTextFileIfPresent(fullPath, oldName, newName)
+    }
+  }
+}
+
+function migrateLaunchAgentProfile(
+  oldName: string,
+  newName: string,
+): void {
+  if (process.platform !== 'darwin') return
+  const launchAgentsDir = path.join(os.homedir(), 'Library', 'LaunchAgents')
+  const oldPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${oldName}.plist`)
+  const newPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${newName}.plist`)
+  if (!fs.existsSync(oldPlist)) return
+
+  rewriteTextFileIfPresent(oldPlist, oldName, newName)
+  try {
+    if (fs.existsSync(newPlist)) fs.rmSync(newPlist, { force: true })
+    fs.renameSync(oldPlist, newPlist)
+  } catch {
+    return
+  }
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  if (uid == null) return
+  try {
+    execFileSync('launchctl', ['bootout', `gui/${uid}`, oldPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootout failures
+  }
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, newPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootstrap failures
+  }
+}
+
+function migrateGlobalProfileReferences(oldName: string, newName: string): void {
+  const hermesRoot = getHermesRoot()
+  const directFiles = [
+    path.join(hermesRoot, 'config.yaml'),
+    path.join(hermesRoot, 'SOUL.md'),
+    path.join(hermesRoot, 'team-agents.md'),
+    path.join(hermesRoot, 'team', 'cron.md'),
+    path.join(hermesRoot, 'team', 'day-30-runbook.md'),
+  ]
+  for (const filePath of directFiles) {
+    rewriteTextFileIfPresent(filePath, oldName, newName)
+  }
+  rewriteTextFilesRecursive(path.join(hermesRoot, 'team', 'handoffs'), oldName, newName)
+}
+
 export function renameProfile(oldName: string, newName: string): ProfileDetail {
-  const from = validateProfileName(oldName)
+  const from = validateProfileIdentifier(oldName)
   const to = validateProfileName(newName)
   const fromPath = path.join(getProfilesRoot(), from)
   const toPath = path.join(getProfilesRoot(), to)
   if (!fs.existsSync(fromPath)) throw new Error('Profile not found')
   if (fs.existsSync(toPath)) throw new Error('Target profile already exists')
+
   fs.renameSync(fromPath, toPath)
+  rewriteTextFilesRecursive(toPath, from, to)
+  migrateGlobalProfileReferences(from, to)
+  migrateLaunchAgentProfile(from, to)
+
   if (getActiveProfileName() === from) {
     fs.writeFileSync(getActiveProfilePath(), `${to}\n`, 'utf-8')
   }

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import path from 'node:path'
+
+import { getHermesRoot } from './claude-paths'
 
 export type PersistedRunToolCall = {
   id: string
@@ -33,7 +34,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(process.env.HERMES_HOME ?? homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(getClaudeRoot(), 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -33,7 +33,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(process.env.HERMES_HOME ?? homedir(), '.hermes', 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { getHermesRoot } from './claude-paths'
+import { getHermesRoot } from './hermes-paths'
 
 export type PersistedRunToolCall = {
   id: string
@@ -34,7 +34,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(getClaudeRoot(), 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(getHermesRoot(), 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/server/swarm-kanban-store.ts
+++ b/src/server/swarm-kanban-store.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export const SWARM_KANBAN_LANES = ['backlog', 'ready', 'running', 'review', 'blocked', 'done'] as const
+export type SwarmKanbanLane = (typeof SWARM_KANBAN_LANES)[number]
+
+export type SwarmKanbanCard = {
+  id: string
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: SwarmKanbanLane
+  missionId: string | null
+  reportPath: string | null
+  createdBy: string
+  createdAt: number
+  updatedAt: number
+}
+
+type SwarmKanbanFile = { cards: SwarmKanbanCard[] }
+
+type ListFilters = {
+  status?: string | null
+  assignedWorker?: string | null
+  reviewer?: string | null
+  missionId?: string | null
+}
+
+export type CreateSwarmKanbanCardInput = {
+  title: string
+  spec?: string
+  acceptanceCriteria?: string[]
+  assignedWorker?: string | null
+  reviewer?: string | null
+  status?: SwarmKanbanLane | null
+  missionId?: string | null
+  reportPath?: string | null
+  createdBy?: string | null
+}
+
+export type UpdateSwarmKanbanCardInput = Partial<Omit<CreateSwarmKanbanCardInput, 'createdBy'>>
+
+const HERMES_HOME = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+export const SWARM_KANBAN_FILE = path.join(HERMES_HOME, 'swarm2-kanban.json')
+
+function ensureKanbanFile(): void {
+  fs.mkdirSync(HERMES_HOME, { recursive: true })
+  if (!fs.existsSync(SWARM_KANBAN_FILE)) {
+    fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: [] }, null, 2) + '\n', 'utf-8')
+  }
+}
+
+function readKanbanFile(): SwarmKanbanFile {
+  ensureKanbanFile()
+  try {
+    const raw = fs.readFileSync(SWARM_KANBAN_FILE, 'utf-8').trim()
+    if (!raw) return { cards: [] }
+    const parsed = JSON.parse(raw) as Partial<SwarmKanbanFile>
+    return { cards: Array.isArray(parsed.cards) ? parsed.cards.map(normalizeCard) : [] }
+  } catch {
+    return { cards: [] }
+  }
+}
+
+function writeKanbanFile(data: SwarmKanbanFile): void {
+  ensureKanbanFile()
+  fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: data.cards.map(normalizeCard) }, null, 2) + '\n', 'utf-8')
+}
+
+function normalizeStatus(value: unknown): SwarmKanbanLane {
+  if (value === 'todo') return 'ready'
+  if (value === 'in_progress' || value === 'doing') return 'running'
+  return SWARM_KANBAN_LANES.includes(value as SwarmKanbanLane) ? (value as SwarmKanbanLane) : 'backlog'
+}
+
+function normalizeCriteria(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+  if (typeof value === 'string') return value.split('\n').map((item) => item.trim()).filter(Boolean)
+  return []
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: string; title?: string; status?: SwarmKanbanLane | string | null })): SwarmKanbanCard {
+  const now = Date.now()
+  return {
+    id: typeof card.id === 'string' && card.id ? card.id : randomUUID(),
+    title: typeof card.title === 'string' && card.title.trim() ? card.title.trim() : 'Untitled task',
+    spec: typeof card.spec === 'string' ? card.spec : '',
+    acceptanceCriteria: normalizeCriteria(card.acceptanceCriteria),
+    assignedWorker: optionalString(card.assignedWorker),
+    reviewer: optionalString(card.reviewer),
+    status: normalizeStatus(card.status),
+    missionId: optionalString(card.missionId),
+    reportPath: optionalString(card.reportPath),
+    createdBy: typeof card.createdBy === 'string' && card.createdBy ? card.createdBy : 'swarm2-kanban',
+    createdAt: typeof card.createdAt === 'number' ? card.createdAt : now,
+    updatedAt: typeof card.updatedAt === 'number' ? card.updatedAt : now,
+  }
+}
+
+export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard[] {
+  let cards = readKanbanFile().cards
+  if (filters.status) cards = cards.filter((card) => card.status === normalizeStatus(filters.status))
+  if (filters.assignedWorker) cards = cards.filter((card) => card.assignedWorker === filters.assignedWorker)
+  if (filters.reviewer) cards = cards.filter((card) => card.reviewer === filters.reviewer)
+  if (filters.missionId) cards = cards.filter((card) => card.missionId === filters.missionId)
+  return [...cards].sort((a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title))
+}
+
+export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
+  const file = readKanbanFile()
+  const now = Date.now()
+  const card = normalizeCard({
+    id: randomUUID(),
+    title: input.title,
+    spec: input.spec,
+    acceptanceCriteria: input.acceptanceCriteria,
+    assignedWorker: input.assignedWorker,
+    reviewer: input.reviewer,
+    status: input.status ?? 'backlog',
+    missionId: input.missionId,
+    reportPath: input.reportPath,
+    createdBy: input.createdBy ?? 'swarm2-kanban',
+    createdAt: now,
+    updatedAt: now,
+  })
+  file.cards.push(card)
+  writeKanbanFile(file)
+  return card
+}
+
+export function updateSwarmKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
+  const file = readKanbanFile()
+  const index = file.cards.findIndex((card) => card.id === cardId)
+  if (index === -1) return null
+  const current = normalizeCard(file.cards[index])
+  const next = normalizeCard({
+    ...current,
+    ...updates,
+    id: current.id,
+    createdAt: current.createdAt,
+    createdBy: current.createdBy,
+    title: typeof updates.title === 'string' ? updates.title : current.title,
+    updatedAt: Date.now(),
+  })
+  file.cards[index] = next
+  writeKanbanFile(file)
+  return next
+}

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 
 type WorkspaceState = {
   sidebarCollapsed: boolean
+  sidebarPinned: boolean
   fileExplorerCollapsed: boolean
   chatFocusMode: boolean
   /** Currently active sub-page route (e.g. '/skills', '/channels') — null means chat-only */
@@ -17,6 +18,8 @@ type WorkspaceState = {
   mobileComposerFocused: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebarPinned: () => void
+  setSidebarPinned: (pinned: boolean) => void
   toggleFileExplorer: () => void
   setFileExplorerCollapsed: (collapsed: boolean) => void
   toggleChatFocusMode: () => void
@@ -34,6 +37,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      sidebarPinned: false,
       fileExplorerCollapsed: true,
       chatFocusMode: false,
       activeSubPage: null,
@@ -43,8 +47,28 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       mobileKeyboardInset: 0,
       mobileComposerFocused: false,
       toggleSidebar: () =>
-        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+        set((s) => {
+          const nextCollapsed = !s.sidebarCollapsed
+          return {
+            sidebarCollapsed: nextCollapsed,
+            sidebarPinned: nextCollapsed ? false : s.sidebarPinned,
+          }
+        }),
+      setSidebarCollapsed: (collapsed) =>
+        set((s) => ({
+          sidebarCollapsed: collapsed,
+          sidebarPinned: collapsed ? false : s.sidebarPinned,
+        })),
+      toggleSidebarPinned: () =>
+        set((s) => ({
+          sidebarPinned: !s.sidebarPinned,
+          sidebarCollapsed: s.sidebarPinned ? s.sidebarCollapsed : false,
+        })),
+      setSidebarPinned: (pinned) =>
+        set((s) => ({
+          sidebarPinned: pinned,
+          sidebarCollapsed: pinned ? false : s.sidebarCollapsed,
+        })),
       toggleFileExplorer: () =>
         set((s) => ({ fileExplorerCollapsed: !s.fileExplorerCollapsed })),
       setFileExplorerCollapsed: (collapsed) =>
@@ -65,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       name: 'hermes-workspace-v1',
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarPinned: state.sidebarPinned,
         fileExplorerCollapsed: state.fileExplorerCollapsed,
         chatPanelOpen: state.chatPanelOpen,
         chatPanelSessionKey: state.chatPanelSessionKey,


### PR DESCRIPTION
Supersedes #199.

Includes Norbert's original fix (cc4c757de) and a follow-up that routes `run-store`'s `RUNS_ROOT` through the canonical `getHermesRoot()` helper added in #205, so `HERMES_HOME` does not double-nest the Hermes data root when it already points at the Hermes root.

## Why supersede #199
The original PR's branch lives on a fork. swarm6's release-cut review flagged a one-line semantic bug in `src/server/run-store.ts`: if `HERMES_HOME=/tmp/hermes-home`, the original code would incorrectly resolve runs under a nested Hermes directory instead of directly under the configured Hermes root. This PR fixes that and is mergeable from our repo.

Co-authored-by: Norbert Billa <hello@armanoide.net>

## Verification
- `pnpm build`: ✅ pass
- `pnpm test`: ✅ 27 files / 96 tests pass

## Files changed
- `src/server/profiles-browser.ts` (+1 -1) — Norbert's original fix
- `src/server/run-store.ts` (+3 -2) — route through `getHermesRoot()`

## Closes
Closes #199 (superseded)

