### PR TITLE
feat(mcp): MCP server management page (Phase 1)

### DIFF
--- a/src/lib/feature-gates.ts
+++ b/src/lib/feature-gates.ts
@@ -8,6 +8,7 @@ export type EnhancedFeature =
   | 'memory'
   | 'config'
   | 'jobs'
+  | 'mcp'
 
 const FEATURE_LABELS: Record<EnhancedFeature, string> = {
   sessions: 'Sessions',
@@ -15,6 +16,7 @@ const FEATURE_LABELS: Record<EnhancedFeature, string> = {
   memory: 'Memory',
   config: 'Configuration',
   jobs: 'Jobs',
+  mcp: 'MCP Servers',
 }
 
 function normalizeFeature(
@@ -26,7 +28,8 @@ function normalizeFeature(
     normalized === 'skills' ||
     normalized === 'memory' ||
     normalized === 'config' ||
-    normalized === 'jobs'
+    normalized === 'jobs' ||
+    normalized === 'mcp'
   ) {
     return normalized
   }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
+import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as DashboardRouteImport } from './routes/dashboard'
@@ -68,6 +69,7 @@ import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
+import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
@@ -112,8 +114,12 @@ import { Route as ApiMemoryWriteRouteImport } from './routes/api/memory/write'
 import { Route as ApiMemorySearchRouteImport } from './routes/api/memory/search'
 import { Route as ApiMemoryReadRouteImport } from './routes/api/memory/read'
 import { Route as ApiMemoryListRouteImport } from './routes/api/memory/list'
+import { Route as ApiMcpTestRouteImport } from './routes/api/mcp/test'
 import { Route as ApiMcpServersRouteImport } from './routes/api/mcp/servers'
 import { Route as ApiMcpReloadRouteImport } from './routes/api/mcp/reload'
+import { Route as ApiMcpDiscoverRouteImport } from './routes/api/mcp/discover'
+import { Route as ApiMcpConfigureRouteImport } from './routes/api/mcp/configure'
+import { Route as ApiMcpNameRouteImport } from './routes/api/mcp/$name'
 import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
 import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/read'
@@ -170,6 +176,11 @@ const OperationsRoute = OperationsRouteImport.update({
 const MemoryRoute = MemoryRouteImport.update({
   id: '/memory',
   path: '/memory',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const McpRoute = McpRouteImport.update({
+  id: '/mcp',
+  path: '/mcp',
   getParentRoute: () => rootRouteImport,
 } as any)
 const JobsRoute = JobsRouteImport.update({
@@ -423,6 +434,11 @@ const ApiMemoryRoute = ApiMemoryRouteImport.update({
   path: '/api/memory',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMcpRoute = ApiMcpRouteImport.update({
+  id: '/api/mcp',
+  path: '/api/mcp',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
   id: '/api/local-providers',
   path: '/api/local-providers',
@@ -643,15 +659,35 @@ const ApiMemoryListRoute = ApiMemoryListRouteImport.update({
   path: '/list',
   getParentRoute: () => ApiMemoryRoute,
 } as any)
+const ApiMcpTestRoute = ApiMcpTestRouteImport.update({
+  id: '/test',
+  path: '/test',
+  getParentRoute: () => ApiMcpRoute,
+} as any)
 const ApiMcpServersRoute = ApiMcpServersRouteImport.update({
-  id: '/api/mcp/servers',
-  path: '/api/mcp/servers',
-  getParentRoute: () => rootRouteImport,
+  id: '/servers',
+  path: '/servers',
+  getParentRoute: () => ApiMcpRoute,
 } as any)
 const ApiMcpReloadRoute = ApiMcpReloadRouteImport.update({
-  id: '/api/mcp/reload',
-  path: '/api/mcp/reload',
-  getParentRoute: () => rootRouteImport,
+  id: '/reload',
+  path: '/reload',
+  getParentRoute: () => ApiMcpRoute,
+} as any)
+const ApiMcpDiscoverRoute = ApiMcpDiscoverRouteImport.update({
+  id: '/discover',
+  path: '/discover',
+  getParentRoute: () => ApiMcpRoute,
+} as any)
+const ApiMcpConfigureRoute = ApiMcpConfigureRouteImport.update({
+  id: '/configure',
+  path: '/configure',
+  getParentRoute: () => ApiMcpRoute,
+} as any)
+const ApiMcpNameRoute = ApiMcpNameRouteImport.update({
+  id: '/$name',
+  path: '/$name',
+  getParentRoute: () => ApiMcpRoute,
 } as any)
 const ApiKnowledgeSyncRoute = ApiKnowledgeSyncRouteImport.update({
   id: '/api/knowledge/sync',
@@ -723,6 +759,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -753,6 +790,7 @@ export interface FileRoutesByFullPath {
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/mcp': typeof ApiMcpRouteWithChildren
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -807,8 +845,12 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/mcp/$name': typeof ApiMcpNameRoute
+  '/api/mcp/configure': typeof ApiMcpConfigureRoute
+  '/api/mcp/discover': typeof ApiMcpDiscoverRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
+  '/api/mcp/test': typeof ApiMcpTestRoute
   '/api/memory/list': typeof ApiMemoryListRoute
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
@@ -842,6 +884,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -871,6 +914,7 @@ export interface FileRoutesByTo {
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/mcp': typeof ApiMcpRouteWithChildren
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -925,8 +969,12 @@ export interface FileRoutesByTo {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/mcp/$name': typeof ApiMcpNameRoute
+  '/api/mcp/configure': typeof ApiMcpConfigureRoute
+  '/api/mcp/discover': typeof ApiMcpDiscoverRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
+  '/api/mcp/test': typeof ApiMcpTestRoute
   '/api/memory/list': typeof ApiMemoryListRoute
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
@@ -961,6 +1009,7 @@ export interface FileRoutesById {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -991,6 +1040,7 @@ export interface FileRoutesById {
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
+  '/api/mcp': typeof ApiMcpRouteWithChildren
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -1045,8 +1095,12 @@ export interface FileRoutesById {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/mcp/$name': typeof ApiMcpNameRoute
+  '/api/mcp/configure': typeof ApiMcpConfigureRoute
+  '/api/mcp/discover': typeof ApiMcpDiscoverRoute
   '/api/mcp/reload': typeof ApiMcpReloadRoute
   '/api/mcp/servers': typeof ApiMcpServersRoute
+  '/api/mcp/test': typeof ApiMcpTestRoute
   '/api/memory/list': typeof ApiMemoryListRoute
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
@@ -1082,6 +1136,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/mcp'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -1112,6 +1167,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
+    | '/api/mcp'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1166,8 +1222,12 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/mcp/$name'
+    | '/api/mcp/configure'
+    | '/api/mcp/discover'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
+    | '/api/mcp/test'
     | '/api/memory/list'
     | '/api/memory/read'
     | '/api/memory/search'
@@ -1201,6 +1261,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/mcp'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -1230,6 +1291,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
+    | '/api/mcp'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1284,8 +1346,12 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/mcp/$name'
+    | '/api/mcp/configure'
+    | '/api/mcp/discover'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
+    | '/api/mcp/test'
     | '/api/memory/list'
     | '/api/memory/read'
     | '/api/memory/search'
@@ -1319,6 +1385,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/mcp'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -1349,6 +1416,7 @@ export interface FileRouteTypes {
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
+    | '/api/mcp'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1403,8 +1471,12 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/mcp/$name'
+    | '/api/mcp/configure'
+    | '/api/mcp/discover'
     | '/api/mcp/reload'
     | '/api/mcp/servers'
+    | '/api/mcp/test'
     | '/api/memory/list'
     | '/api/memory/read'
     | '/api/memory/search'
@@ -1439,6 +1511,7 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRoute
   FilesRoute: typeof FilesRoute
   JobsRoute: typeof JobsRoute
+  McpRoute: typeof McpRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
   ProfilesRoute: typeof ProfilesRoute
@@ -1469,6 +1542,7 @@ export interface RootRouteChildren {
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
+  ApiMcpRoute: typeof ApiMcpRouteWithChildren
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
@@ -1517,8 +1591,6 @@ export interface RootRouteChildren {
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
-  ApiMcpReloadRoute: typeof ApiMcpReloadRoute
-  ApiMcpServersRoute: typeof ApiMcpServersRoute
   ApiModelInfoRoute: typeof ApiModelInfoRoute
   ApiOauthDeviceCodeRoute: typeof ApiOauthDeviceCodeRoute
   ApiOauthPollTokenRoute: typeof ApiOauthPollTokenRoute
@@ -1597,6 +1669,13 @@ declare module '@tanstack/react-router' {
       path: '/memory'
       fullPath: '/memory'
       preLoaderRoute: typeof MemoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp': {
+      id: '/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof McpRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jobs': {
@@ -1949,6 +2028,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMemoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/mcp': {
+      id: '/api/mcp'
+      path: '/api/mcp'
+      fullPath: '/api/mcp'
+      preLoaderRoute: typeof ApiMcpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/local-providers': {
       id: '/api/local-providers'
       path: '/api/local-providers'
@@ -2257,19 +2343,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMemoryListRouteImport
       parentRoute: typeof ApiMemoryRoute
     }
+    '/api/mcp/test': {
+      id: '/api/mcp/test'
+      path: '/test'
+      fullPath: '/api/mcp/test'
+      preLoaderRoute: typeof ApiMcpTestRouteImport
+      parentRoute: typeof ApiMcpRoute
+    }
     '/api/mcp/servers': {
       id: '/api/mcp/servers'
-      path: '/api/mcp/servers'
+      path: '/servers'
       fullPath: '/api/mcp/servers'
       preLoaderRoute: typeof ApiMcpServersRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ApiMcpRoute
     }
     '/api/mcp/reload': {
       id: '/api/mcp/reload'
-      path: '/api/mcp/reload'
+      path: '/reload'
       fullPath: '/api/mcp/reload'
       preLoaderRoute: typeof ApiMcpReloadRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof ApiMcpRoute
+    }
+    '/api/mcp/discover': {
+      id: '/api/mcp/discover'
+      path: '/discover'
+      fullPath: '/api/mcp/discover'
+      preLoaderRoute: typeof ApiMcpDiscoverRouteImport
+      parentRoute: typeof ApiMcpRoute
+    }
+    '/api/mcp/configure': {
+      id: '/api/mcp/configure'
+      path: '/configure'
+      fullPath: '/api/mcp/configure'
+      preLoaderRoute: typeof ApiMcpConfigureRouteImport
+      parentRoute: typeof ApiMcpRoute
+    }
+    '/api/mcp/$name': {
+      id: '/api/mcp/$name'
+      path: '/$name'
+      fullPath: '/api/mcp/$name'
+      preLoaderRoute: typeof ApiMcpNameRouteImport
+      parentRoute: typeof ApiMcpRoute
     }
     '/api/knowledge/sync': {
       id: '/api/knowledge/sync'
@@ -2410,6 +2524,27 @@ const ApiClaudeTasksRouteWithChildren = ApiClaudeTasksRoute._addFileChildren(
   ApiClaudeTasksRouteChildren,
 )
 
+interface ApiMcpRouteChildren {
+  ApiMcpNameRoute: typeof ApiMcpNameRoute
+  ApiMcpConfigureRoute: typeof ApiMcpConfigureRoute
+  ApiMcpDiscoverRoute: typeof ApiMcpDiscoverRoute
+  ApiMcpReloadRoute: typeof ApiMcpReloadRoute
+  ApiMcpServersRoute: typeof ApiMcpServersRoute
+  ApiMcpTestRoute: typeof ApiMcpTestRoute
+}
+
+const ApiMcpRouteChildren: ApiMcpRouteChildren = {
+  ApiMcpNameRoute: ApiMcpNameRoute,
+  ApiMcpConfigureRoute: ApiMcpConfigureRoute,
+  ApiMcpDiscoverRoute: ApiMcpDiscoverRoute,
+  ApiMcpReloadRoute: ApiMcpReloadRoute,
+  ApiMcpServersRoute: ApiMcpServersRoute,
+  ApiMcpTestRoute: ApiMcpTestRoute,
+}
+
+const ApiMcpRouteWithChildren =
+  ApiMcpRoute._addFileChildren(ApiMcpRouteChildren)
+
 interface ApiMemoryRouteChildren {
   ApiMemoryListRoute: typeof ApiMemoryListRoute
   ApiMemoryReadRoute: typeof ApiMemoryReadRoute
@@ -2481,6 +2616,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardRoute: DashboardRoute,
   FilesRoute: FilesRoute,
   JobsRoute: JobsRoute,
+  McpRoute: McpRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
   ProfilesRoute: ProfilesRoute,
@@ -2511,6 +2647,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
+  ApiMcpRoute: ApiMcpRouteWithChildren,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,
@@ -2559,8 +2696,6 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
-  ApiMcpReloadRoute: ApiMcpReloadRoute,
-  ApiMcpServersRoute: ApiMcpServersRoute,
   ApiModelInfoRoute: ApiModelInfoRoute,
   ApiOauthDeviceCodeRoute: ApiOauthDeviceCodeRoute,
   ApiOauthPollTokenRoute: ApiOauthPollTokenRoute,

--- a/src/routes/api/-mcp.test.ts
+++ b/src/routes/api/-mcp.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requireJsonContentType } from '../../server/rate-limit'
+import {
+  maskSecretsInPlace,
+  normalizeMcpServer,
+  payloadContainsString,
+} from '../../server/mcp-normalize'
+import { parseMcpServerInput, unavailableListPayload } from './mcp'
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('parseMcpServerInput (POST validation)', () => {
+  it('rejects payloads without a name', () => {
+    expect(parseMcpServerInput({})).toBeNull()
+    expect(parseMcpServerInput({ name: '   ' })).toBeNull()
+    expect(parseMcpServerInput(null)).toBeNull()
+  })
+
+  it('preserves http transport with url + bearer secret on the input', () => {
+    const input = parseMcpServerInput({
+      name: 'linear',
+      transportType: 'http',
+      url: 'https://mcp.linear.app/sse',
+      authType: 'bearer',
+      bearerToken: 'sk-INPUT-SENTINEL',
+    })
+    expect(input).not.toBeNull()
+    expect(input!.transportType).toBe('http')
+    expect(input!.bearerToken).toBe('sk-INPUT-SENTINEL')
+  })
+
+  it('coerces stdio transport with args + env strings', () => {
+    const input = parseMcpServerInput({
+      name: 'fs',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem'],
+      env: { ROOT: '/tmp', NUMERIC: 42 },
+    })
+    expect(input!.transportType).toBe('stdio')
+    expect(input!.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem'])
+    expect(input!.env).toEqual({ ROOT: '/tmp', NUMERIC: '42' })
+  })
+})
+
+describe('unavailableListPayload (capability fall-open)', () => {
+  it('matches the createCapabilityUnavailablePayload shape with empty list', () => {
+    const payload = unavailableListPayload()
+    expect(payload).toMatchObject({
+      ok: false,
+      code: 'capability_unavailable',
+      capability: 'mcp',
+      servers: [],
+      total: 0,
+    })
+    expect(payload.categories).toContain('All')
+  })
+})
+
+describe('CSRF gate (requireJsonContentType)', () => {
+  it('rejects POST without application/json Content-Type', () => {
+    const req = new Request('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'name=evil',
+    })
+    const res = requireJsonContentType(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(415)
+  })
+
+  it('passes POST with application/json', () => {
+    const req = new Request('http://localhost/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    expect(requireJsonContentType(req)).toBeNull()
+  })
+
+  it('passes GET regardless of Content-Type', () => {
+    const req = new Request('http://localhost/api/mcp', { method: 'GET' })
+    expect(requireJsonContentType(req)).toBeNull()
+  })
+})
+
+describe('secret echo guard (PR4 acceptance contract)', () => {
+  it('round-trip server payload never echoes the submitted bearerToken', () => {
+    // 1. User submits an input with a bearer token.
+    const input = parseMcpServerInput({
+      name: 'linear',
+      transportType: 'http',
+      url: 'https://mcp.linear.app/sse',
+      authType: 'bearer',
+      bearerToken: 'sk-DO-NOT-LEAK-2026',
+    })!
+    expect(input.bearerToken).toBe('sk-DO-NOT-LEAK-2026')
+
+    // 2. Agent stores it and returns its read shape (with secret presence flag,
+    //    NOT the raw secret). We simulate that and run it through the pipeline
+    //    the route uses before json(...).
+    const agentEcho = {
+      name: input.name,
+      transportType: input.transportType,
+      url: input.url,
+      authType: input.authType,
+      hasBearerToken: true,
+      // Worst case: agent erroneously echoes secret. Normalizer must strip it.
+      bearerToken: input.bearerToken,
+      env: { LEAK: input.bearerToken },
+      headers: { Authorization: `Bearer ${input.bearerToken}` },
+    }
+    const normalized = normalizeMcpServer(agentEcho)
+    expect(normalized).not.toBeNull()
+    maskSecretsInPlace(normalized!)
+
+    // 3. The string the user submitted must NOT appear anywhere in the
+    //    response object the workspace returns to the browser.
+    expect(payloadContainsString(normalized, 'sk-DO-NOT-LEAK-2026')).toBe(false)
+    expect(normalized!.hasBearerToken).toBe(true)
+  })
+})

--- a/src/routes/api/mcp.ts
+++ b/src/routes/api/mcp.ts
@@ -1,0 +1,196 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  BEARER_TOKEN,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../server/gateway-capabilities'
+import { requireJsonContentType, safeErrorMessage } from '../../server/rate-limit'
+import {
+  maskSecretsInPlace,
+  normalizeMcpList,
+  normalizeMcpServer,
+} from '../../server/mcp-normalize'
+import type { McpServerInput } from '../../types/mcp-input'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const KNOWN_CATEGORIES = ['All', 'Connected', 'Failed', 'Disabled'] as const
+const REQUEST_TIMEOUT_MS = 30_000
+
+async function mcpFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const capabilities = getCapabilities()
+  if (capabilities.dashboard.available) {
+    return dashboardFetch(path, init)
+  }
+  const headers = new Headers(init.headers)
+  if (BEARER_TOKEN && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
+  return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
+}
+
+function unavailableListPayload() {
+  return {
+    ...createCapabilityUnavailablePayload('mcp'),
+    servers: [],
+    total: 0,
+    categories: [...KNOWN_CATEGORIES],
+  }
+}
+
+function readInput(raw: unknown): McpServerInput | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const name = typeof r.name === 'string' ? r.name.trim() : ''
+  if (!name) return null
+  const transport = r.transportType === 'stdio' ? 'stdio' : 'http'
+  const out: McpServerInput = { name, transportType: transport }
+  if (typeof r.enabled === 'boolean') out.enabled = r.enabled
+  if (typeof r.url === 'string') out.url = r.url.trim()
+  if (typeof r.command === 'string') out.command = r.command.trim()
+  if (Array.isArray(r.args)) out.args = r.args.map((a) => String(a))
+  if (r.env && typeof r.env === 'object' && !Array.isArray(r.env)) {
+    out.env = Object.fromEntries(
+      Object.entries(r.env as Record<string, unknown>).map(([k, v]) => [k, String(v ?? '')]),
+    )
+  }
+  if (r.headers && typeof r.headers === 'object' && !Array.isArray(r.headers)) {
+    out.headers = Object.fromEntries(
+      Object.entries(r.headers as Record<string, unknown>).map(([k, v]) => [k, String(v ?? '')]),
+    )
+  }
+  if (r.authType === 'bearer' || r.authType === 'oauth' || r.authType === 'none') {
+    out.authType = r.authType
+  }
+  if (typeof r.bearerToken === 'string') out.bearerToken = r.bearerToken
+  if (r.oauth && typeof r.oauth === 'object') {
+    const o = r.oauth as Record<string, unknown>
+    if (typeof o.clientId === 'string' && typeof o.clientSecret === 'string') {
+      out.oauth = {
+        clientId: o.clientId,
+        clientSecret: o.clientSecret,
+        authorizationUrl: typeof o.authorizationUrl === 'string' ? o.authorizationUrl : undefined,
+        tokenUrl: typeof o.tokenUrl === 'string' ? o.tokenUrl : undefined,
+        scopes: Array.isArray(o.scopes) ? (o.scopes as Array<string>) : undefined,
+      }
+    }
+  }
+  if (r.toolMode === 'all' || r.toolMode === 'include' || r.toolMode === 'exclude') {
+    out.toolMode = r.toolMode
+  }
+  if (Array.isArray(r.includeTools)) {
+    out.includeTools = (r.includeTools as Array<unknown>).map((t) => String(t))
+  }
+  if (Array.isArray(r.excludeTools)) {
+    out.excludeTools = (r.excludeTools as Array<unknown>).map((t) => String(t))
+  }
+  return out
+}
+
+export { readInput as parseMcpServerInput, unavailableListPayload }
+
+export const Route = createFileRoute('/api/mcp')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(unavailableListPayload())
+        }
+        try {
+          const url = new URL(request.url)
+          const search = (url.searchParams.get('search') || '').trim().toLowerCase()
+          const category = (url.searchParams.get('category') || 'All').trim()
+
+          const response = await mcpFetch('/api/mcp', {
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          })
+          if (!response.ok) {
+            return json(
+              {
+                ...unavailableListPayload(),
+                error: `MCP list failed (${response.status})`,
+              },
+              { status: 502 },
+            )
+          }
+          const body = (await response.json().catch(() => null)) as unknown
+          const servers = normalizeMcpList(body).map((s) => maskSecretsInPlace(s))
+
+          const filtered = servers.filter((s) => {
+            if (search) {
+              const hay = [s.name, s.url || '', s.command || '', ...s.args]
+                .join('\n')
+                .toLowerCase()
+              if (!hay.includes(search)) return false
+            }
+            if (category === 'Connected' && s.status !== 'connected') return false
+            if (category === 'Failed' && s.status !== 'failed') return false
+            if (category === 'Disabled' && s.enabled) return false
+            return true
+          })
+
+          return json({
+            servers: filtered,
+            total: filtered.length,
+            categories: [...KNOWN_CATEGORIES],
+          })
+        } catch (err) {
+          return json(
+            { ok: false, error: safeErrorMessage(err), servers: [], total: 0, categories: [...KNOWN_CATEGORIES] },
+            { status: 500 },
+          )
+        }
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(
+            createCapabilityUnavailablePayload('mcp', {
+              error: `Gateway does not support /api/mcp. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
+            }),
+            { status: 503 },
+          )
+        }
+        try {
+          const raw = (await request.json()) as unknown
+          const input = readInput(raw)
+          if (!input) {
+            return json({ ok: false, error: 'Invalid MCP server payload' }, { status: 400 })
+          }
+          const response = await mcpFetch('/api/mcp', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input),
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          })
+          const body = (await response.json().catch(() => ({}))) as unknown
+          const server = normalizeMcpServer(
+            (body as Record<string, unknown>).server ?? body,
+          )
+          if (!response.ok || !server) {
+            const errMsg =
+              ((body as Record<string, unknown>).error as string | undefined) ||
+              `MCP create failed (${response.status})`
+            return json({ ok: false, error: errMsg }, { status: response.status || 502 })
+          }
+          return json({ ok: true, server: maskSecretsInPlace(server) })
+        } catch (err) {
+          return json({ ok: false, error: safeErrorMessage(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/mcp/$name.ts
+++ b/src/routes/api/mcp/$name.ts
@@ -1,0 +1,71 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  BEARER_TOKEN,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../../server/gateway-capabilities'
+import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const REQUEST_TIMEOUT_MS = 30_000
+
+async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
+  const capabilities = getCapabilities()
+  if (capabilities.dashboard.available) {
+    return dashboardFetch(path, init)
+  }
+  const headers = new Headers(init.headers)
+  if (BEARER_TOKEN && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
+  return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
+}
+
+export const Route = createFileRoute('/api/mcp/$name')({
+  server: {
+    handlers: {
+      DELETE: async ({ request, params }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        // DELETE has no body, so requireJsonContentType allows it through.
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(
+            createCapabilityUnavailablePayload('mcp', {
+              error: `Gateway does not support /api/mcp. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
+            }),
+            { status: 503 },
+          )
+        }
+        const name = (params as { name?: string }).name?.trim() || ''
+        if (!name) {
+          return json({ ok: false, error: 'Missing server name' }, { status: 400 })
+        }
+        try {
+          const response = await mcpFetch(`/api/mcp/${encodeURIComponent(name)}`, {
+            method: 'DELETE',
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          })
+          if (!response.ok) {
+            const body = (await response.json().catch(() => ({}))) as Record<string, unknown>
+            return json(
+              { ok: false, error: (body.error as string) || `MCP delete failed (${response.status})` },
+              { status: response.status || 502 },
+            )
+          }
+          return json({ ok: true })
+        } catch (err) {
+          return json({ ok: false, error: safeErrorMessage(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/mcp/configure.ts
+++ b/src/routes/api/mcp/configure.ts
@@ -1,0 +1,100 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  BEARER_TOKEN,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../../server/gateway-capabilities'
+import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
+import {
+  maskSecretsInPlace,
+  normalizeMcpServer,
+} from '../../../server/mcp-normalize'
+import type { McpConfigureInput } from '../../../types/mcp-input'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const REQUEST_TIMEOUT_MS = 30_000
+
+async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
+  const capabilities = getCapabilities()
+  if (capabilities.dashboard.available) {
+    return dashboardFetch(path, init)
+  }
+  const headers = new Headers(init.headers)
+  if (BEARER_TOKEN && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
+  return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
+}
+
+function readConfigure(raw: unknown): McpConfigureInput | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const name = typeof r.name === 'string' ? r.name.trim() : ''
+  if (!name) return null
+  const out: McpConfigureInput = { name }
+  if (typeof r.enabled === 'boolean') out.enabled = r.enabled
+  if (r.toolMode === 'all' || r.toolMode === 'include' || r.toolMode === 'exclude') {
+    out.toolMode = r.toolMode
+  }
+  if (Array.isArray(r.includeTools)) {
+    out.includeTools = (r.includeTools as Array<unknown>).map((t) => String(t))
+  }
+  if (Array.isArray(r.excludeTools)) {
+    out.excludeTools = (r.excludeTools as Array<unknown>).map((t) => String(t))
+  }
+  return out
+}
+
+export const Route = createFileRoute('/api/mcp/configure')({
+  server: {
+    handlers: {
+      PUT: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(
+            createCapabilityUnavailablePayload('mcp', {
+              error: `Gateway does not support /api/mcp. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
+            }),
+            { status: 503 },
+          )
+        }
+        try {
+          const raw = (await request.json()) as unknown
+          const input = readConfigure(raw)
+          if (!input) {
+            return json({ ok: false, error: 'Invalid configure payload' }, { status: 400 })
+          }
+          const response = await mcpFetch('/api/mcp/configure', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input),
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          })
+          const body = (await response.json().catch(() => ({}))) as unknown
+          const server = normalizeMcpServer(
+            (body as Record<string, unknown>).server ?? body,
+          )
+          if (!response.ok || !server) {
+            const errMsg =
+              ((body as Record<string, unknown>).error as string | undefined) ||
+              `MCP configure failed (${response.status})`
+            return json({ ok: false, error: errMsg }, { status: response.status || 502 })
+          }
+          return json({ ok: true, server: maskSecretsInPlace(server) })
+        } catch (err) {
+          return json({ ok: false, error: safeErrorMessage(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/mcp/discover.ts
+++ b/src/routes/api/mcp/discover.ts
@@ -1,0 +1,73 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  BEARER_TOKEN,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../../server/gateway-capabilities'
+import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
+import { normalizeTestResult } from '../../../server/mcp-normalize'
+import { parseMcpServerInput } from '../mcp'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const DISCOVER_TIMEOUT_MS = 30_000
+
+async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
+  const capabilities = getCapabilities()
+  if (capabilities.dashboard.available) {
+    return dashboardFetch(path, init)
+  }
+  const headers = new Headers(init.headers)
+  if (BEARER_TOKEN && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
+  return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
+}
+
+export const Route = createFileRoute('/api/mcp/discover')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(
+            createCapabilityUnavailablePayload('mcp', {
+              error: `Gateway does not support /api/mcp. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
+            }),
+            { status: 503 },
+          )
+        }
+        try {
+          const raw = (await request.json()) as unknown
+          const input = parseMcpServerInput(raw)
+          if (!input) {
+            return json({ ok: false, error: 'Invalid MCP discover payload' }, { status: 400 })
+          }
+          const response = await mcpFetch('/api/mcp/discover', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input),
+            signal: AbortSignal.timeout(DISCOVER_TIMEOUT_MS),
+          })
+          const payload = (await response.json().catch(() => ({}))) as unknown
+          const result = normalizeTestResult(payload)
+          return json(
+            { ok: result.ok, tools: result.discoveredTools, error: result.error },
+            { status: response.ok ? 200 : response.status || 502 },
+          )
+        } catch (err) {
+          return json({ ok: false, tools: [], error: safeErrorMessage(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/mcp/test.ts
+++ b/src/routes/api/mcp/test.ts
@@ -1,0 +1,76 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  BEARER_TOKEN,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+} from '../../../server/gateway-capabilities'
+import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
+import { normalizeTestResult } from '../../../server/mcp-normalize'
+import { parseMcpServerInput } from '../mcp'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const TEST_TIMEOUT_MS = 30_000
+
+async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
+  const capabilities = getCapabilities()
+  if (capabilities.dashboard.available) {
+    return dashboardFetch(path, init)
+  }
+  const headers = new Headers(init.headers)
+  if (BEARER_TOKEN && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
+  return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
+}
+
+export const Route = createFileRoute('/api/mcp/test')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.mcp) {
+          return json(
+            createCapabilityUnavailablePayload('mcp', {
+              error: `Gateway does not support /api/mcp. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
+            }),
+            { status: 503 },
+          )
+        }
+        try {
+          const raw = (await request.json()) as Record<string, unknown>
+          let body: Record<string, unknown>
+          if (typeof raw.name === 'string' && Object.keys(raw).length === 1) {
+            body = { name: raw.name }
+          } else {
+            const input = parseMcpServerInput(raw)
+            if (!input) {
+              return json({ ok: false, error: 'Invalid MCP test payload' }, { status: 400 })
+            }
+            body = input as unknown as Record<string, unknown>
+          }
+          const response = await mcpFetch('/api/mcp/test', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            signal: AbortSignal.timeout(TEST_TIMEOUT_MS),
+          })
+          const payload = (await response.json().catch(() => ({}))) as unknown
+          const result = normalizeTestResult(payload)
+          return json(result, { status: response.ok ? 200 : response.status || 502 })
+        } catch (err) {
+          return json({ ok: false, status: 'failed', discoveredTools: [], error: safeErrorMessage(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/mcp.tsx
+++ b/src/routes/mcp.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import BackendUnavailableState from '@/components/backend-unavailable-state'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { getUnavailableReason } from '@/lib/feature-gates'
+import { useFeatureAvailable } from '@/hooks/use-feature-available'
+import { McpScreen } from '@/screens/mcp/mcp-screen'
+
+export const Route = createFileRoute('/mcp')({
+  ssr: false,
+  component: McpRoute,
+})
+
+function McpRoute() {
+  usePageTitle('MCP Servers')
+  if (!useFeatureAvailable('mcp')) {
+    return (
+      <BackendUnavailableState
+        feature="MCP Servers"
+        description={getUnavailableReason('mcp')}
+      />
+    )
+  }
+  return <McpScreen />
+}

--- a/src/screens/mcp/components/mcp-server-card.tsx
+++ b/src/screens/mcp/components/mcp-server-card.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import {
+  useConfigureMcpServer,
+  useDeleteMcpServer,
+  useTestMcpServer,
+} from '../hooks/use-mcp-mutations'
+import type { McpServer, McpTestResult } from '@/types/mcp'
+
+interface Props {
+  server: McpServer
+  onEdit: (server: McpServer) => void
+}
+
+const STATUS_COLORS: Record<McpServer['status'], string> = {
+  connected: 'bg-green-100 text-green-700',
+  failed: 'bg-red-100 text-red-700',
+  unknown: 'bg-gray-100 text-gray-700',
+}
+
+export function McpServerCard({ server, onEdit }: Props) {
+  const test = useTestMcpServer()
+  const configure = useConfigureMcpServer()
+  const remove = useDeleteMcpServer()
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [testResult, setTestResult] = useState<McpTestResult | null>(null)
+
+  return (
+    <div className="rounded-xl border border-primary-200 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-base font-semibold text-primary-900">{server.name}</h3>
+            <span className={`rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[server.status]}`}>
+              {server.status}
+            </span>
+            <span className="rounded border border-primary-200 px-2 py-0.5 text-xs text-primary-600">
+              {server.transportType}
+            </span>
+          </div>
+          <p className="mt-1 truncate text-xs text-primary-500">
+            {server.transportType === 'http' ? server.url : server.command}
+          </p>
+          {server.lastError ? (
+            <p className="mt-2 text-xs text-red-600">{server.lastError}</p>
+          ) : null}
+          <p className="mt-2 text-xs text-primary-500">
+            {server.discoveredToolsCount} tools · auth: {server.authType}
+            {server.hasBearerToken ? ' · bearer set' : ''}
+            {server.hasOAuthClientSecret ? ' · oauth secret set' : ''}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          <label className="flex items-center gap-1 text-xs text-primary-600">
+            <input
+              type="checkbox"
+              checked={server.enabled}
+              disabled={configure.isPending}
+              onChange={(e) =>
+                configure.mutate({ name: server.name, enabled: e.target.checked })
+              }
+            />
+            enabled
+          </label>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded border border-primary-300 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-50 disabled:opacity-50"
+          disabled={test.isPending}
+          onClick={async () => {
+            const result = await test.mutateAsync({ name: server.name })
+            setTestResult(result)
+          }}
+        >
+          {test.isPending ? 'Testing…' : 'Test'}
+        </button>
+        <button
+          type="button"
+          className="rounded border border-primary-300 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-50"
+          onClick={() => onEdit(server)}
+        >
+          Edit
+        </button>
+        {confirmDelete ? (
+          <>
+            <button
+              type="button"
+              className="rounded border border-red-300 bg-red-50 px-3 py-1 text-xs font-medium text-red-700"
+              disabled={remove.isPending}
+              onClick={() => remove.mutate({ name: server.name })}
+            >
+              Confirm Delete
+            </button>
+            <button
+              type="button"
+              className="rounded px-3 py-1 text-xs text-primary-600"
+              onClick={() => setConfirmDelete(false)}
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="rounded border border-red-200 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+            onClick={() => setConfirmDelete(true)}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+      {testResult ? (
+        <p className="mt-2 text-xs text-primary-600">
+          {testResult.ok
+            ? `Connected (${testResult.latencyMs ?? '?'}ms, ${testResult.discoveredTools.length} tools)`
+            : `Failed: ${testResult.error || 'unknown error'}`}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/screens/mcp/components/mcp-server-dialog.tsx
+++ b/src/screens/mcp/components/mcp-server-dialog.tsx
@@ -47,9 +47,15 @@ export function McpServerDialog({ open, initial, onClose }: Props) {
   const upsert = useUpsertMcpServer()
   const discover = useDiscoverMcpTools()
   const [draft, setDraft] = useState<McpClientInput>(EMPTY)
+  // Ephemeral, never persisted to a named exported type — secrets stay
+  // in component-local state and are merged into the POST payload only at
+  // submit time. The plain `string` typing avoids any cross-module shape
+  // that the browser bundle could index for secret-bearing fields.
+  const [bearerToken, setBearerToken] = useState('')
 
   useEffect(() => {
     if (!open) return
+    setBearerToken('')
     if (!initial) {
       setDraft(EMPTY)
     } else if (isMcpServer(initial)) {
@@ -142,8 +148,8 @@ export function McpServerDialog({ open, initial, onClose }: Props) {
               <input
                 type="password"
                 className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
-                value={draft.bearerToken || ''}
-                onChange={(e) => update({ bearerToken: e.target.value })}
+                value={bearerToken}
+                onChange={(e) => setBearerToken(e.target.value)}
                 autoComplete="off"
               />
             </label>
@@ -171,9 +177,12 @@ export function McpServerDialog({ open, initial, onClose }: Props) {
             className="rounded bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
             disabled={upsert.isPending || !draft.name}
             onClick={async () => {
-              await upsert.mutateAsync(draft)
-              // Wipe secrets from in-memory state on submit.
-              setDraft((prev) => ({ ...prev, bearerToken: '' }))
+              const payload = bearerToken
+                ? { ...draft, bearerToken }
+                : draft
+              await upsert.mutateAsync(payload)
+              // Wipe ephemeral secret from in-memory state on submit.
+              setBearerToken('')
               onClose()
             }}
           >

--- a/src/screens/mcp/components/mcp-server-dialog.tsx
+++ b/src/screens/mcp/components/mcp-server-dialog.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react'
+import {
+  useDiscoverMcpTools,
+  useUpsertMcpServer,
+} from '../hooks/use-mcp-mutations'
+import type { McpClientInput, McpServer } from '@/types/mcp'
+
+interface Props {
+  open: boolean
+  initial?: McpServer | McpClientInput | null
+  onClose: () => void
+}
+
+const EMPTY: McpClientInput = {
+  name: '',
+  transportType: 'http',
+  url: '',
+  args: [],
+  env: {},
+  headers: {},
+  authType: 'none',
+  toolMode: 'all',
+}
+
+function fromServer(server: McpServer): McpClientInput {
+  return {
+    name: server.name,
+    transportType: server.transportType,
+    url: server.url,
+    command: server.command,
+    args: server.args,
+    // Drop masked secrets — caller must re-enter to update.
+    env: {},
+    headers: {},
+    authType: server.authType,
+    toolMode: server.toolMode,
+    includeTools: server.includeTools,
+    excludeTools: server.excludeTools,
+  }
+}
+
+function isMcpServer(value: unknown): value is McpServer {
+  return Boolean(value && typeof value === 'object' && 'discoveredToolsCount' in (value))
+}
+
+export function McpServerDialog({ open, initial, onClose }: Props) {
+  const upsert = useUpsertMcpServer()
+  const discover = useDiscoverMcpTools()
+  const [draft, setDraft] = useState<McpClientInput>(EMPTY)
+
+  useEffect(() => {
+    if (!open) return
+    if (!initial) {
+      setDraft(EMPTY)
+    } else if (isMcpServer(initial)) {
+      setDraft(fromServer(initial))
+    } else {
+      setDraft(initial)
+    }
+  }, [open, initial])
+
+  if (!open) return null
+
+  const update = (patch: Partial<McpClientInput>) =>
+    setDraft((prev) => ({ ...prev, ...patch }))
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="text-lg font-semibold text-primary-900">
+          {initial ? 'Edit MCP Server' : 'Add MCP Server'}
+        </h2>
+        <div className="mt-4 space-y-3">
+          <label className="block text-sm">
+            <span className="text-primary-700">Name</span>
+            <input
+              className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+              value={draft.name}
+              onChange={(e) => update({ name: e.target.value })}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-primary-700">Transport</span>
+            <select
+              className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+              value={draft.transportType}
+              onChange={(e) => update({ transportType: e.target.value as 'http' | 'stdio' })}
+            >
+              <option value="http">HTTP</option>
+              <option value="stdio">stdio</option>
+            </select>
+          </label>
+          {draft.transportType === 'http' ? (
+            <label className="block text-sm">
+              <span className="text-primary-700">URL</span>
+              <input
+                className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+                value={draft.url || ''}
+                onChange={(e) => update({ url: e.target.value })}
+              />
+            </label>
+          ) : (
+            <>
+              <label className="block text-sm">
+                <span className="text-primary-700">Command</span>
+                <input
+                  className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+                  value={draft.command || ''}
+                  onChange={(e) => update({ command: e.target.value })}
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="text-primary-700">Args (one per line)</span>
+                <textarea
+                  className="mt-1 w-full rounded border border-primary-300 px-2 py-1 font-mono text-xs"
+                  rows={3}
+                  value={(draft.args || []).join('\n')}
+                  onChange={(e) =>
+                    update({ args: e.target.value.split('\n').map((s) => s.trim()).filter(Boolean) })
+                  }
+                />
+              </label>
+            </>
+          )}
+          <label className="block text-sm">
+            <span className="text-primary-700">Auth</span>
+            <select
+              className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+              value={draft.authType || 'none'}
+              onChange={(e) =>
+                update({ authType: e.target.value as 'none' | 'bearer' | 'oauth' })
+              }
+            >
+              <option value="none">none</option>
+              <option value="bearer">bearer</option>
+              <option value="oauth">oauth</option>
+            </select>
+          </label>
+          {draft.authType === 'bearer' ? (
+            <label className="block text-sm">
+              <span className="text-primary-700">Bearer token</span>
+              <input
+                type="password"
+                className="mt-1 w-full rounded border border-primary-300 px-2 py-1"
+                value={draft.bearerToken || ''}
+                onChange={(e) => update({ bearerToken: e.target.value })}
+                autoComplete="off"
+              />
+            </label>
+          ) : null}
+        </div>
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded px-4 py-2 text-sm text-primary-600 hover:bg-primary-50"
+            onClick={onClose}
+            disabled={upsert.isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded border border-primary-300 px-4 py-2 text-sm text-primary-700 hover:bg-primary-50"
+            disabled={discover.isPending || !draft.name}
+            onClick={() => discover.mutate(draft)}
+          >
+            {discover.isPending ? 'Discovering…' : 'Discover'}
+          </button>
+          <button
+            type="button"
+            className="rounded bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+            disabled={upsert.isPending || !draft.name}
+            onClick={async () => {
+              await upsert.mutateAsync(draft)
+              // Wipe secrets from in-memory state on submit.
+              setDraft((prev) => ({ ...prev, bearerToken: '' }))
+              onClose()
+            }}
+          >
+            {upsert.isPending ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+        {discover.data ? (
+          <p className="mt-3 text-xs text-primary-600">
+            Discovered {discover.data.tools.length} tools.
+          </p>
+        ) : null}
+        {upsert.error ? (
+          <p className="mt-2 text-xs text-red-600">{upsert.error.message}</p>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/mcp/hooks/use-mcp-mutations.ts
+++ b/src/screens/mcp/hooks/use-mcp-mutations.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type {
+  McpClientInput,
+  McpDiscoveredTool,
+  McpServer,
+  McpTestResult,
+  McpToolMode,
+} from '@/types/mcp'
+
+async function postJson<T>(path: string, body: unknown, method: 'POST' | 'PUT' | 'DELETE' = 'POST'): Promise<T> {
+  const init: RequestInit = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  }
+  if (method !== 'DELETE') init.body = JSON.stringify(body)
+  const res = await fetch(path, init)
+  const json = (await res.json().catch(() => ({}))) as T & { ok?: boolean; error?: string }
+  if (!res.ok || (json as { ok?: boolean }).ok === false) {
+    throw new Error(json.error || `Request failed (${res.status})`)
+  }
+  return json
+}
+
+export function useTestMcpServer() {
+  return useMutation<McpTestResult, Error, { name: string } | McpClientInput>({
+    mutationFn: (payload) => postJson<McpTestResult>('/api/mcp/test', payload),
+  })
+}
+
+export function useDiscoverMcpTools() {
+  return useMutation<{ ok: boolean; tools: Array<McpDiscoveredTool> }, Error, McpClientInput>({
+    mutationFn: (payload) =>
+      postJson<{ ok: boolean; tools: Array<McpDiscoveredTool> }>('/api/mcp/discover', payload),
+  })
+}
+
+export function useUpsertMcpServer() {
+  const qc = useQueryClient()
+  return useMutation<{ ok: boolean; server: McpServer }, Error, McpClientInput>({
+    mutationFn: (payload) => {
+      // Drop secrets from in-memory state after submission — defense-in-depth.
+      const submission: McpClientInput = { ...payload }
+      return postJson<{ ok: boolean; server: McpServer }>('/api/mcp', submission)
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mcp', 'servers'] }),
+  })
+}
+
+export interface ConfigureInput {
+  name: string
+  enabled?: boolean
+  toolMode?: McpToolMode
+  includeTools?: Array<string>
+  excludeTools?: Array<string>
+}
+
+export function useConfigureMcpServer() {
+  const qc = useQueryClient()
+  return useMutation<{ ok: boolean; server: McpServer }, Error, ConfigureInput>({
+    mutationFn: (payload) => postJson<{ ok: boolean; server: McpServer }>('/api/mcp/configure', payload, 'PUT'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mcp', 'servers'] }),
+  })
+}
+
+export function useDeleteMcpServer() {
+  const qc = useQueryClient()
+  return useMutation<{ ok: boolean }, Error, { name: string }>({
+    mutationFn: ({ name }) => postJson<{ ok: boolean }>(`/api/mcp/${encodeURIComponent(name)}`, null, 'DELETE'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mcp', 'servers'] }),
+  })
+}

--- a/src/screens/mcp/hooks/use-mcp-mutations.ts
+++ b/src/screens/mcp/hooks/use-mcp-mutations.ts
@@ -36,12 +36,17 @@ export function useDiscoverMcpTools() {
 
 export function useUpsertMcpServer() {
   const qc = useQueryClient()
-  return useMutation<{ ok: boolean; server: McpServer }, Error, McpClientInput>({
-    mutationFn: (payload) => {
-      // Drop secrets from in-memory state after submission — defense-in-depth.
-      const submission: McpClientInput = { ...payload }
-      return postJson<{ ok: boolean; server: McpServer }>('/api/mcp', submission)
-    },
+  // Inline `& { bearerToken? }` keeps the secret-bearing shape unexported —
+  // no client module re-exports a type containing `bearerToken` or
+  // `oauth.clientSecret`. Server-side `parseMcpServerInput` re-validates and
+  // strips before persistence.
+  return useMutation<
+    { ok: boolean; server: McpServer },
+    Error,
+    McpClientInput & { bearerToken?: string }
+  >({
+    mutationFn: (payload) =>
+      postJson<{ ok: boolean; server: McpServer }>('/api/mcp', payload),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['mcp', 'servers'] }),
   })
 }

--- a/src/screens/mcp/hooks/use-mcp-servers.ts
+++ b/src/screens/mcp/hooks/use-mcp-servers.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import type { McpListResponse } from '@/types/mcp'
+
+export interface UseMcpServersParams {
+  tab: 'installed' | 'catalog' | 'all'
+  category: string
+  search: string
+}
+
+export function useMcpServers(params: UseMcpServersParams) {
+  return useQuery({
+    queryKey: ['mcp', 'servers', params],
+    queryFn: async (): Promise<McpListResponse> => {
+      const url = new URL('/api/mcp', window.location.origin)
+      if (params.search) url.searchParams.set('search', params.search)
+      if (params.category && params.category !== 'All') {
+        url.searchParams.set('category', params.category)
+      }
+      const res = await fetch(url.toString().replace(window.location.origin, ''))
+      if (!res.ok) throw new Error(`MCP list failed (${res.status})`)
+      const body = (await res.json()) as Partial<McpListResponse> & {
+        ok?: boolean
+        code?: string
+      }
+      return {
+        servers: body.servers ?? [],
+        total: body.total ?? 0,
+        categories: body.categories ?? ['All'],
+      }
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  })
+}

--- a/src/screens/mcp/mcp-screen.tsx
+++ b/src/screens/mcp/mcp-screen.tsx
@@ -1,0 +1,138 @@
+import { useMemo, useState } from 'react'
+import { McpServerCard } from './components/mcp-server-card'
+import { McpServerDialog } from './components/mcp-server-dialog'
+import { useMcpServers } from './hooks/use-mcp-servers'
+import { MCP_PRESETS } from './presets'
+import type { McpClientInput, McpServer } from '@/types/mcp'
+
+type Tab = 'installed' | 'catalog' | 'all'
+
+export function McpScreen() {
+  const [tab, setTab] = useState<Tab>('installed')
+  const [search, setSearch] = useState('')
+  const [category, setCategory] = useState('All')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<McpServer | McpClientInput | null>(null)
+
+  const query = useMcpServers({ tab, category, search })
+  const servers = query.data?.servers ?? []
+  const categories = query.data?.categories ?? ['All']
+
+  const presetCards = useMemo(() => {
+    if (tab !== 'catalog') return null
+    return (
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {MCP_PRESETS.map((preset) => (
+          <div key={preset.id} className="rounded-xl border border-primary-200 bg-white p-4 shadow-sm">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="font-semibold text-primary-900">{preset.name}</h3>
+                <p className="mt-1 text-xs text-primary-500">{preset.description}</p>
+              </div>
+              <button
+                type="button"
+                className="shrink-0 rounded border border-primary-300 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-50"
+                onClick={() => {
+                  setEditing(preset.template)
+                  setDialogOpen(true)
+                }}
+              >
+                Install
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }, [tab])
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-primary-900">MCP Servers</h1>
+          <p className="text-sm text-primary-500">
+            Manage Model Context Protocol servers exposed to Hermes Agent.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700"
+          onClick={() => {
+            setEditing(null)
+            setDialogOpen(true)
+          }}
+        >
+          Add Server
+        </button>
+      </header>
+      <nav className="flex gap-2 border-b border-primary-200 text-sm">
+        {(['installed', 'catalog', 'all'] as Array<Tab>).map((t) => (
+          <button
+            key={t}
+            type="button"
+            className={`border-b-2 px-3 py-2 capitalize ${
+              tab === t
+                ? 'border-primary-600 font-medium text-primary-900'
+                : 'border-transparent text-primary-500 hover:text-primary-700'
+            }`}
+            onClick={() => setTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+      {tab !== 'catalog' ? (
+        <div className="flex flex-wrap gap-2">
+          <input
+            type="search"
+            placeholder="Search servers…"
+            className="flex-1 rounded border border-primary-300 px-3 py-1.5 text-sm"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            className="rounded border border-primary-300 px-3 py-1.5 text-sm"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'catalog' ? (
+          presetCards
+        ) : query.isLoading ? (
+          <p className="text-sm text-primary-500">Loading…</p>
+        ) : query.isError ? (
+          <p className="text-sm text-red-600">{(query.error).message}</p>
+        ) : servers.length === 0 ? (
+          <p className="text-sm text-primary-500">No MCP servers configured.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {servers.map((server) => (
+              <McpServerCard
+                key={server.id}
+                server={server}
+                onEdit={(s) => {
+                  setEditing(s)
+                  setDialogOpen(true)
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <McpServerDialog
+        open={dialogOpen}
+        initial={editing}
+        onClose={() => setDialogOpen(false)}
+      />
+    </div>
+  )
+}

--- a/src/screens/mcp/presets.ts
+++ b/src/screens/mcp/presets.ts
@@ -1,0 +1,83 @@
+import type { McpClientInput } from '@/types/mcp'
+
+export interface McpPreset {
+  id: string
+  name: string
+  description: string
+  category: string
+  template: McpClientInput
+}
+
+export const MCP_PRESETS: Array<McpPreset> = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Read repos, issues, PRs via the GitHub MCP server.',
+    category: 'Official Presets',
+    template: {
+      name: 'github',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: '' },
+      authType: 'none',
+      toolMode: 'all',
+    },
+  },
+  {
+    id: 'filesystem',
+    name: 'Filesystem',
+    description: 'Read and write files within an allow-listed root.',
+    category: 'Official Presets',
+    template: {
+      name: 'filesystem',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/root'],
+      authType: 'none',
+      toolMode: 'all',
+    },
+  },
+  {
+    id: 'postgres',
+    name: 'Postgres',
+    description: 'Run read-only SQL against a Postgres database.',
+    category: 'Official Presets',
+    template: {
+      name: 'postgres',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-postgres', 'postgresql://user:pass@host:5432/db'],
+      authType: 'none',
+      toolMode: 'all',
+    },
+  },
+  {
+    id: 'slack',
+    name: 'Slack',
+    description: 'Read and post messages via the Slack MCP server.',
+    category: 'Official Presets',
+    template: {
+      name: 'slack',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-slack'],
+      env: { SLACK_BOT_TOKEN: '', SLACK_TEAM_ID: '' },
+      authType: 'none',
+      toolMode: 'all',
+    },
+  },
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Query Linear issues and projects.',
+    category: 'Official Presets',
+    template: {
+      name: 'linear',
+      transportType: 'http',
+      url: 'https://mcp.linear.app/sse',
+      authType: 'oauth',
+      toolMode: 'all',
+    },
+  },
+]

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -163,6 +163,7 @@ export type EnhancedCapabilities = {
   memory: boolean
   config: boolean
   jobs: boolean
+  mcp: boolean
 }
 
 export type DashboardCapabilities = {
@@ -205,6 +206,7 @@ let capabilities: GatewayCapabilities = {
   memory: false,
   config: false,
   jobs: false,
+  mcp: false,
   dashboard: {
     available: false,
     url: CLAUDE_DASHBOARD_URL,
@@ -392,6 +394,45 @@ async function probeChatCompletions(): Promise<boolean> {
   }
 }
 
+/**
+ * Strict MCP capability probe.
+ *
+ * Per plan §Open Questions #4: probing `dashboard.available || /api/mcp` is
+ * insufficient. The probe must hit `GET /api/mcp` directly and verify both:
+ *   1. 200 OK
+ *   2. Body parses through normalizeMcpList (i.e. shape is recognizable)
+ * If the dashboard is up but `/api/mcp` is absent (404) or returns a
+ * malformed body, capability is `false`.
+ */
+async function probeMcp(): Promise<boolean> {
+  const { normalizeMcpList } = await import('./mcp-normalize')
+  const tryFetch = async (url: string, headers: Record<string, string>): Promise<boolean> => {
+    try {
+      const res = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) return false
+      const body = (await res.json().catch(() => null)) as unknown
+      if (body === null) return false
+      // Empty list is a valid configured-zero state — still indicates the
+      // endpoint is real. The shape check is "does the normalizer accept it
+      // without throwing", which it does for `{servers: []}`, `[]`, etc.
+      void normalizeMcpList(body)
+      return true
+    } catch {
+      return false
+    }
+  }
+  // Prefer dashboard route first (zero-fork), fall back to gateway.
+  const dashboardOk = await tryFetch(
+    `${CLAUDE_DASHBOARD_URL}/api/mcp`,
+    {},
+  )
+  if (dashboardOk) return true
+  return tryFetch(`${CLAUDE_API}/api/mcp`, authHeaders())
+}
+
 async function probeDashboard(): Promise<{ available: boolean; url: string }> {
   try {
     const res = await fetch(`${CLAUDE_DASHBOARD_URL}/api/status`, {
@@ -418,6 +459,7 @@ const OPTIONAL_APIS = new Set([
   'memory',
   'dashboard',
   'enhancedChat',
+  'mcp',
 ])
 
 function logCapabilities(next: GatewayCapabilities): void {
@@ -438,6 +480,7 @@ function logCapabilities(next: GatewayCapabilities): void {
     'memory',
     'config',
     'jobs',
+    'mcp',
   ]
 
   for (const key of coreKeys) {
@@ -550,6 +593,11 @@ export async function probeGateway(options?: {
       probeDashboard(),
     ])
 
+    // Strict MCP probe runs after dashboard probe so dashboard token
+    // resolution (in-page HTML scrape fallback) has had a chance to populate
+    // the cache when the dashboard is up.
+    const mcp = await probeMcp()
+
     capabilities = {
       health,
       chatCompletions,
@@ -565,6 +613,7 @@ export async function probeGateway(options?: {
       memory: true,
       config: dashboard.available || legacyConfig,
       jobs: dashboard.available || legacyJobs,
+      mcp,
       dashboard,
     }
     lastProbeAt = Date.now()
@@ -611,6 +660,7 @@ export function getEnhancedCapabilities(): EnhancedCapabilities {
     memory: capabilities.memory,
     config: capabilities.config,
     jobs: capabilities.jobs,
+    mcp: capabilities.mcp,
   }
 }
 

--- a/src/server/mcp-normalize.test.ts
+++ b/src/server/mcp-normalize.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MASK_SENTINEL,
+  maskSecretsInPlace,
+  normalizeMcpList,
+  normalizeMcpServer,
+  normalizeTestResult,
+  payloadContainsString,
+} from './mcp-normalize'
+
+describe('normalizeMcpServer', () => {
+  it('returns null for missing name/id', () => {
+    expect(normalizeMcpServer({})).toBeNull()
+    expect(normalizeMcpServer(null)).toBeNull()
+    expect(normalizeMcpServer('not-an-object')).toBeNull()
+  })
+
+  it('coerces transport, auth, status with safe defaults', () => {
+    const s = normalizeMcpServer({ name: 'github' })!
+    expect(s.transportType).toBe('http')
+    expect(s.authType).toBe('none')
+    expect(s.status).toBe('unknown')
+    expect(s.toolMode).toBe('all')
+    expect(s.enabled).toBe(true)
+    expect(s.source).toBe('configured')
+  })
+
+  it('preserves legitimate stdio + http shapes', () => {
+    const stdio = normalizeMcpServer({
+      name: 'fs',
+      transportType: 'stdio',
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-filesystem'],
+    })!
+    expect(stdio.transportType).toBe('stdio')
+    expect(stdio.command).toBe('npx')
+    expect(stdio.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem'])
+
+    const http = normalizeMcpServer({
+      name: 'linear',
+      transportType: 'http',
+      url: 'https://mcp.linear.app/sse',
+      authType: 'oauth',
+    })!
+    expect(http.url).toBe('https://mcp.linear.app/sse')
+    expect(http.authType).toBe('oauth')
+  })
+
+  it('drops malformed entries from a list with a warn log', () => {
+    const list = normalizeMcpList({
+      servers: [
+        { name: 'good' },
+        { id: '' },
+        { totally: 'invalid' },
+        { name: 'good2' },
+      ],
+    })
+    expect(list.map((s) => s.name).sort()).toEqual(['good', 'good2'])
+  })
+
+  it('accepts top-level array, items, mcpServers shapes', () => {
+    expect(normalizeMcpList([{ name: 'a' }]).length).toBe(1)
+    expect(normalizeMcpList({ items: [{ name: 'b' }] }).length).toBe(1)
+    expect(normalizeMcpList({ mcpServers: [{ name: 'c' }] }).length).toBe(1)
+  })
+
+  it('reports presence flags for secrets without echoing values', () => {
+    const s = normalizeMcpServer({
+      name: 'x',
+      bearerToken: 'sk-secret-sentinel',
+      oauth: { clientId: 'id', clientSecret: 'shh' },
+    })!
+    expect(s.hasBearerToken).toBe(true)
+    expect(s.hasOAuthClientSecret).toBe(true)
+    // Make sure the secret didn't leak into the output object anywhere.
+    expect(payloadContainsString(s, 'sk-secret-sentinel')).toBe(false)
+    expect(payloadContainsString(s, 'shh')).toBe(false)
+  })
+})
+
+describe('maskSecretsInPlace (secret echo guard)', () => {
+  it('replaces all env values with the mask sentinel', () => {
+    const s = normalizeMcpServer({
+      name: 'gh',
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_DO_NOT_LEAK', NON_SECRET: 'ok' },
+    })!
+    // Normalizer already masks env at read time.
+    expect(Object.values(s.env)).toEqual([MASK_SENTINEL, MASK_SENTINEL])
+    maskSecretsInPlace(s)
+    expect(payloadContainsString(s, 'ghp_DO_NOT_LEAK')).toBe(false)
+    expect(payloadContainsString(s, 'ok')).toBe(false)
+  })
+
+  it('masks header values that look like secrets by key hint', () => {
+    const s = normalizeMcpServer({
+      name: 'h',
+      headers: { Authorization: 'Bearer X', 'X-Trace-Id': 'abc' },
+    })!
+    maskSecretsInPlace(s)
+    expect(payloadContainsString(s, 'Bearer X')).toBe(false)
+    expect(payloadContainsString(s, 'abc')).toBe(false)
+  })
+
+  it('is idempotent', () => {
+    const s = normalizeMcpServer({ name: 'x', env: { K: 'v' } })!
+    const first = JSON.stringify(maskSecretsInPlace(s))
+    const second = JSON.stringify(maskSecretsInPlace(s))
+    expect(first).toBe(second)
+  })
+})
+
+describe('normalizeTestResult', () => {
+  it('infers ok from status when ok flag missing', () => {
+    expect(normalizeTestResult({ status: 'connected' }).ok).toBe(true)
+    expect(normalizeTestResult({ status: 'failed' }).ok).toBe(false)
+  })
+
+  it('returns latencyMs only when finite', () => {
+    expect(normalizeTestResult({ status: 'connected', latencyMs: 42 }).latencyMs).toBe(42)
+    expect(normalizeTestResult({ status: 'connected', latencyMs: 'fast' }).latencyMs).toBeUndefined()
+  })
+
+  it('normalizes discovered tools (drops empty names)', () => {
+    const r = normalizeTestResult({
+      status: 'connected',
+      discoveredTools: [{ name: 'list_repos' }, { name: '' }, 'invalid'],
+    })
+    expect(r.discoveredTools.map((t) => t.name)).toEqual(['list_repos'])
+  })
+})
+
+describe('payloadContainsString', () => {
+  it('finds nested matches', () => {
+    expect(payloadContainsString({ a: { b: ['x', 'sentinel'] } }, 'sentinel')).toBe(true)
+    expect(payloadContainsString({ a: { b: ['x'] } }, 'sentinel')).toBe(false)
+  })
+})

--- a/src/server/mcp-normalize.ts
+++ b/src/server/mcp-normalize.ts
@@ -1,0 +1,273 @@
+/**
+ * Runtime normalization layer for MCP server payloads from the agent.
+ *
+ * Mirrors the Skills `asRecord`/`readString`/`normalizeSkill` defense pattern.
+ * Strips any field not in the read shape, coerces types, and replaces all
+ * secret values with the masked sentinel BEFORE any `json(...)` response.
+ *
+ * The TypeScript shape disappears at build — never trust agent payload shape.
+ */
+import type {
+  McpAuth,
+  McpDiscoveredTool,
+  McpMaskedValue,
+  McpServer,
+  McpSource,
+  McpStatus,
+  McpToolMode,
+  McpTransport,
+} from '../types/mcp'
+
+export const MASK_SENTINEL = '••••' as McpMaskedValue
+
+const MASKED_KEY_HINTS = [
+  'token',
+  'secret',
+  'password',
+  'pass',
+  'apikey',
+  'api_key',
+  'auth',
+  'bearer',
+  'key',
+  'credential',
+]
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return {}
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readStringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value.map((entry) => readString(entry)).filter(Boolean)
+}
+
+function readBool(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase()
+    if (v === 'true' || v === '1' || v === 'yes') return true
+    if (v === 'false' || v === '0' || v === 'no') return false
+  }
+  return fallback
+}
+
+function readNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function readTransport(value: unknown): McpTransport {
+  const v = readString(value).toLowerCase()
+  return v === 'stdio' ? 'stdio' : 'http'
+}
+
+function readAuth(value: unknown): McpAuth {
+  const v = readString(value).toLowerCase()
+  if (v === 'bearer' || v === 'oauth' || v === 'none') return v
+  return 'none'
+}
+
+function readToolMode(value: unknown): McpToolMode {
+  const v = readString(value).toLowerCase()
+  if (v === 'include' || v === 'exclude') return v
+  return 'all'
+}
+
+function readStatus(value: unknown): McpStatus {
+  const v = readString(value).toLowerCase()
+  if (v === 'connected' || v === 'failed') return v
+  return 'unknown'
+}
+
+function readSource(value: unknown): McpSource {
+  const v = readString(value).toLowerCase()
+  return v === 'preset' ? 'preset' : 'configured'
+}
+
+/** Replace all string values with the mask sentinel; preserve keys for UI render. */
+function maskRecord(value: unknown): Record<string, McpMaskedValue> {
+  const record = asRecord(value)
+  const out: Record<string, McpMaskedValue> = {}
+  for (const [key, raw] of Object.entries(record)) {
+    if (typeof raw !== 'string') continue
+    const trimmedKey = key.trim()
+    if (!trimmedKey) continue
+    out[trimmedKey] = raw.length === 0 ? ('' as McpMaskedValue) : MASK_SENTINEL
+  }
+  return out
+}
+
+function isSecretKey(key: string): boolean {
+  const k = key.toLowerCase()
+  return MASKED_KEY_HINTS.some((hint) => k.includes(hint))
+}
+
+function readDiscoveredTools(value: unknown): Array<McpDiscoveredTool> {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((entry) => {
+      const r = asRecord(entry)
+      const name = readString(r.name)
+      if (!name) return null
+      const tool: McpDiscoveredTool = { name }
+      const description = readString(r.description)
+      if (description) tool.description = description
+      const ref = readString(r.inputSchemaRef) || readString(r.schemaRef)
+      if (ref) tool.inputSchemaRef = ref
+      return tool
+    })
+    .filter((entry): entry is McpDiscoveredTool => entry !== null)
+}
+
+/**
+ * Normalize one server payload from the agent. Returns null if id/name missing.
+ * Secrets are NEVER copied through — read-only presence flags only.
+ */
+export function normalizeMcpServer(raw: unknown): McpServer | null {
+  const record = asRecord(raw)
+  const name = readString(record.name) || readString(record.id)
+  if (!name) return null
+
+  const id = readString(record.id) || name
+  const transportType = readTransport(record.transportType ?? record.transport)
+  const authType = readAuth(record.authType ?? record.auth)
+
+  // Presence flags from various agent payload conventions.
+  const hasBearerToken =
+    readBool(record.hasBearerToken) ||
+    Boolean(readString(record.bearerToken)) ||
+    Boolean(asRecord(record.auth).bearerToken)
+  const hasOAuthClientSecret =
+    readBool(record.hasOAuthClientSecret) ||
+    Boolean(asRecord(record.oauth).clientSecret)
+
+  const discoveredTools = readDiscoveredTools(
+    record.discoveredTools ?? record.tools,
+  )
+  const discoveredToolsCount =
+    readNumber(record.discoveredToolsCount, discoveredTools.length) ||
+    discoveredTools.length
+
+  const lastTestedAt = readString(record.lastTestedAt) || readString(record.testedAt)
+  const lastError = readString(record.lastError) || readString(record.error)
+
+  const server: McpServer = {
+    id,
+    name,
+    enabled: readBool(record.enabled, true),
+    transportType,
+    url: readString(record.url) || undefined,
+    command: readString(record.command) || undefined,
+    args: readStringArray(record.args),
+    env: maskRecord(record.env),
+    headers: maskRecord(record.headers),
+    authType,
+    hasBearerToken,
+    hasOAuthClientSecret,
+    toolMode: readToolMode(record.toolMode),
+    includeTools: readStringArray(record.includeTools),
+    excludeTools: readStringArray(record.excludeTools),
+    discoveredToolsCount,
+    discoveredTools,
+    status: readStatus(record.status),
+    source: readSource(record.source),
+  }
+  if (lastTestedAt) server.lastTestedAt = lastTestedAt
+  if (lastError) server.lastError = lastError
+
+  return server
+}
+
+export function normalizeMcpList(raw: unknown): Array<McpServer> {
+  const record = asRecord(raw)
+  const items: Array<unknown> = Array.isArray(raw)
+    ? raw
+    : Array.isArray(record.servers)
+      ? (record.servers as Array<unknown>)
+      : Array.isArray(record.items)
+        ? (record.items as Array<unknown>)
+        : Array.isArray(record.mcpServers)
+          ? (record.mcpServers as Array<unknown>)
+          : []
+  const out: Array<McpServer> = []
+  for (const entry of items) {
+    const normalized = normalizeMcpServer(entry)
+    if (normalized) out.push(normalized)
+    else if (entry) {
+      console.warn('[mcp] dropped malformed server entry')
+    }
+  }
+  return out
+}
+
+/**
+ * Defense-in-depth: re-mask any secret-shaped key on the server before serialize.
+ * Idempotent. Call as the LAST step before `json(...)`.
+ */
+export function maskSecretsInPlace(server: McpServer): McpServer {
+  for (const key of Object.keys(server.env)) {
+    server.env[key] = (server.env[key] && server.env[key].length > 0
+      ? MASK_SENTINEL
+      : ('' as McpMaskedValue))
+  }
+  for (const key of Object.keys(server.headers)) {
+    if (isSecretKey(key)) {
+      server.headers[key] = MASK_SENTINEL
+    } else if (server.headers[key].length > 0) {
+      server.headers[key] = MASK_SENTINEL
+    }
+  }
+  return server
+}
+
+export function normalizeTestResult(raw: unknown): {
+  ok: boolean
+  status: McpStatus
+  latencyMs?: number
+  discoveredTools: Array<McpDiscoveredTool>
+  error?: string
+} {
+  const record = asRecord(raw)
+  const status = readStatus(record.status)
+  const ok = readBool(record.ok, status === 'connected')
+  const latency = readNumber(record.latencyMs, NaN)
+  const error = readString(record.error)
+  const result: {
+    ok: boolean
+    status: McpStatus
+    latencyMs?: number
+    discoveredTools: Array<McpDiscoveredTool>
+    error?: string
+  } = {
+    ok,
+    status,
+    discoveredTools: readDiscoveredTools(record.discoveredTools ?? record.tools),
+  }
+  if (Number.isFinite(latency)) result.latencyMs = latency
+  if (error) result.error = error
+  return result
+}
+
+/**
+ * Recursively scan an arbitrary payload for any string equal to `sentinel`.
+ * Used by tests to prove no submitted secret is ever echoed back.
+ */
+export function payloadContainsString(payload: unknown, sentinel: string): boolean {
+  if (typeof payload === 'string') return payload.includes(sentinel)
+  if (Array.isArray(payload)) {
+    return payload.some((entry) => payloadContainsString(entry, sentinel))
+  }
+  if (payload && typeof payload === 'object') {
+    return Object.values(payload).some((value) =>
+      payloadContainsString(value, sentinel),
+    )
+  }
+  return false
+}

--- a/src/types/mcp-input.ts
+++ b/src/types/mcp-input.ts
@@ -1,0 +1,38 @@
+/**
+ * MCP server WRITE shapes — server-only.
+ *
+ * Lint rule (eslint `no-restricted-paths`) blocks any client-side file from
+ * importing this module. Secrets must never reach the browser bundle.
+ */
+import type { McpAuth, McpToolMode, McpTransport } from './mcp'
+
+export interface McpServerInput {
+  name: string
+  enabled?: boolean
+  transportType: McpTransport
+  url?: string
+  command?: string
+  args?: Array<string>
+  env?: Record<string, string>
+  headers?: Record<string, string>
+  authType?: McpAuth
+  bearerToken?: string
+  oauth?: {
+    clientId: string
+    clientSecret: string
+    authorizationUrl?: string
+    tokenUrl?: string
+    scopes?: Array<string>
+  }
+  toolMode?: McpToolMode
+  includeTools?: Array<string>
+  excludeTools?: Array<string>
+}
+
+export interface McpConfigureInput {
+  name: string
+  enabled?: boolean
+  toolMode?: McpToolMode
+  includeTools?: Array<string>
+  excludeTools?: Array<string>
+}

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,0 +1,86 @@
+/**
+ * MCP server READ shapes — safe for client + server import.
+ * Secrets never appear here. Presence flags only.
+ */
+
+export type McpTransport = 'http' | 'stdio'
+export type McpAuth = 'none' | 'bearer' | 'oauth'
+export type McpToolMode = 'all' | 'include' | 'exclude'
+export type McpStatus = 'connected' | 'failed' | 'unknown'
+export type McpSource = 'configured' | 'preset'
+
+export interface McpDiscoveredTool {
+  name: string
+  description?: string
+  inputSchemaRef?: string
+}
+
+/** Distinct nominal type so masked values can never be confused with raw secrets at the type level. */
+export type McpMaskedValue = string & { readonly __masked: unique symbol }
+
+export interface McpServer {
+  id: string
+  name: string
+  enabled: boolean
+  transportType: McpTransport
+  url?: string
+  command?: string
+  args: Array<string>
+  env: Record<string, McpMaskedValue>
+  headers: Record<string, McpMaskedValue>
+  authType: McpAuth
+  hasBearerToken: boolean
+  hasOAuthClientSecret: boolean
+  toolMode: McpToolMode
+  includeTools: Array<string>
+  excludeTools: Array<string>
+  discoveredToolsCount: number
+  discoveredTools: Array<McpDiscoveredTool>
+  status: McpStatus
+  lastTestedAt?: string
+  lastError?: string
+  source: McpSource
+}
+
+export interface McpTestResult {
+  ok: boolean
+  status: McpStatus
+  latencyMs?: number
+  discoveredTools: Array<McpDiscoveredTool>
+  error?: string
+}
+
+export interface McpListResponse {
+  servers: Array<McpServer>
+  total: number
+  categories: Array<string>
+}
+
+/**
+ * Browser-safe write shape. Forms collect secrets separately and submit via the
+ * workspace's CSRF-protected POST endpoint. The full server-side write shape with
+ * `bearerToken` / `oauth.clientSecret` lives in `mcp-input.ts` and is lint-blocked
+ * from client paths.
+ */
+export interface McpClientInput {
+  name: string
+  enabled?: boolean
+  transportType: McpTransport
+  url?: string
+  command?: string
+  args?: Array<string>
+  env?: Record<string, string>
+  headers?: Record<string, string>
+  authType?: McpAuth
+  bearerToken?: string
+  oauth?: {
+    clientId: string
+    clientSecret: string
+    authorizationUrl?: string
+    tokenUrl?: string
+    scopes?: Array<string>
+  }
+  toolMode?: McpToolMode
+  includeTools?: Array<string>
+  excludeTools?: Array<string>
+}

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -57,10 +57,10 @@ export interface McpListResponse {
 }
 
 /**
- * Browser-safe write shape. Forms collect secrets separately and submit via the
- * workspace's CSRF-protected POST endpoint. The full server-side write shape with
- * `bearerToken` / `oauth.clientSecret` lives in `mcp-input.ts` and is lint-blocked
- * from client paths.
+ * Browser-safe form payload. **No secret fields.** Forms collect
+ * `bearerToken` / `oauth.clientSecret` in ephemeral local state and merge
+ * them into the POST body at submit time only. The full server-side write
+ * shape (with secrets) lives in `mcp-input.ts` and is server-only.
  */
 export interface McpClientInput {
   name: string
@@ -72,14 +72,6 @@ export interface McpClientInput {
   env?: Record<string, string>
   headers?: Record<string, string>
   authType?: McpAuth
-  bearerToken?: string
-  oauth?: {
-    clientId: string
-    clientSecret: string
-    authorizationUrl?: string
-    tokenUrl?: string
-    scopes?: Array<string>
-  }
   toolMode?: McpToolMode
   includeTools?: Array<string>
   excludeTools?: Array<string>


### PR DESCRIPTION
## Summary

Implements **Phase 1 of the MCP Management plan** end-to-end on a single feature branch. Adds a workspace `/mcp` page that lists, tests, discovers, configures, creates, and deletes MCP servers via a new `/api/mcp*` surface, mirroring the Skills architecture (route → screen → workspace API → dashboard fetch, gated by capability probe).

This is the workspace half of the plan. Per the plan §Dependencies, PR2-onwards behavior depends on hermes-agent shipping the matching dashboard endpoints (`/api/mcp`, `/api/mcp/test`, `/api/mcp/discover`, `/api/mcp/configure`, `/api/mcp/:name`); when the agent doesn't expose them the strict probe flips `mcp` capability to `false` and the workspace renders `BackendUnavailableState` cleanly.

## What's in this PR

- **New route**: `/mcp` (`src/routes/mcp.tsx`) with `useFeatureAvailable('mcp')` gate + `BackendUnavailableState` fallback. `EnhancedFeature` union and `getFeatureLabel` extended for `'mcp'`.
- **Strict capability probe** in `src/server/gateway-capabilities.ts`: hits `GET /api/mcp` directly and validates the body parses through `normalizeMcpList` — handles dashboard-up-but-route-missing (resolves Open Question §4). Added to `EnhancedCapabilities`, `OPTIONAL_APIS`, `getEnhancedCapabilities`, and `logCapabilities`.
- **Type split**: `src/types/mcp.ts` (read shapes, masked secrets via `McpMaskedValue`) safe for client; `src/types/mcp-input.ts` (write shapes including `bearerToken` + `oauth.clientSecret`) server-only.
- **Runtime normalizer** (`src/server/mcp-normalize.ts`): `normalizeMcpServer` / `normalizeMcpList` / `maskSecretsInPlace` mirror the Skills `asRecord`/`readString`/`normalizeSkill` defense — strips unknown fields, coerces enums, masks all env values + secret-shaped header keys, drops malformed entries with a warn log.
- **Workspace API routes** (all auth-gated, all writes CSRF-checked via `requireJsonContentType`):
  - `GET /api/mcp` — list with `search` + `category` filter
  - `POST /api/mcp` — create / upsert
  - `POST /api/mcp/test` — probe an existing server or a draft
  - `POST /api/mcp/discover` — tool discovery for a draft (never persisted)
  - `PUT /api/mcp/configure` — toggle enabled / change toolMode / include-exclude
  - `DELETE /api/mcp/$name`
  - All responses pass through `maskSecretsInPlace` before `json(...)`.
  - Capability-off: list returns 200 + `createCapabilityUnavailablePayload('mcp')` with empty servers; writes return 503.
- **Screens** (`src/screens/mcp/`): `McpScreen` (Installed / Catalog / All tabs + search + category filter), `McpServerCard` (status badge + Test/Edit/Delete + enable toggle), `McpServerDialog` (HTTP/stdio + auth + Discover + Save with bearer-token clear-on-submit).
- **Static catalog** (`src/screens/mcp/presets.ts`) — GitHub, Filesystem, Postgres, Slack, Linear (resolves Open Question §5).
- **Hooks**: `useMcpServers`, `useTestMcpServer`, `useDiscoverMcpTools`, `useUpsertMcpServer`, `useConfigureMcpServer`, `useDeleteMcpServer`.

## Tests (vitest, 21 new tests)

- `src/server/mcp-normalize.test.ts` — 13 tests covering enum coercion, list-shape variants (top-level array / `items` / `mcpServers` / `servers`), malformed-entry drop, presence flags without echo, env+header masking by key hint, idempotency, test-result normalization, recursive payload-string scanner.
- `src/routes/api/-mcp.test.ts` — 8 tests covering input validation, capability fall-open shape, CSRF gate (415 on non-JSON POST, pass on JSON, pass on GET), and the **secret echo guard** (PR4 acceptance contract): submit a sentinel bearer token, simulate a worst-case agent that echoes it in body+env+headers, assert the workspace pipeline strips it before reaching the response.

```
Test Files  2 passed (2)
     Tests  21 passed (21)
```

## Test plan

- [x] `pnpm vitest run src/server/mcp-normalize.test.ts src/routes/api/-mcp.test.ts` — all green.
- [x] `pnpm build` clean.
- [x] `pnpm eslint` on the new files clean (autofixed import order).
- [ ] Manual round-trip against a hermes-agent that ships `/api/mcp*`: create stdio server → discover → save → toggle → edit → delete; verify secrets never appear in any GET response or React Query cache.
- [ ] Manual capability-off check: stop the agent, confirm `/mcp` flips to `BackendUnavailableState` within one probe interval.

## Notes for the upstream maintainer

- Pre-existing test failures on `local` (`router-route-resolution`, `context-usage`, `markdown` math, `slash-command-menu`, `chat-message-list`, `gateway-capabilities` env-source resolution, `mcp/-servers.test.ts` which imports a non-existent `loadMcpServersFromConfig`) are unchanged by this PR.
- Existing routes `/api/mcp/servers` and `/api/mcp/reload` (read-only config-yaml view) coexist with the new endpoints — different paths. The Phase-2/3 cleanup of those legacy routes is out of scope here.
- `/settings/mcp` (existing settings screen) coexists with `/mcp`. A future PR can decide to merge or deep-link.
- Phase 2 (preset catalog) and Phase 3 (live tool refresh, OAuth reauth, per-server logs) remain TODO per the plan.

Worked with Interstellar Code