### PR TITLE
fix: stabilize local update status and CSP

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -33,11 +33,11 @@ const APP_CSP = [
   "base-uri 'self'",
   "object-src 'none'",
   "form-action 'self'",
-  "frame-ancestors 'none'",
-  "script-src 'self' 'unsafe-inline'",
-  "style-src 'self' 'unsafe-inline'",
+  // frame-ancestors is ignored in meta CSP and must be sent as an HTTP header.
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
   "img-src 'self' data: blob: https:",
-  "font-src 'self' data:",
+  "font-src 'self' data: https://fonts.gstatic.com",
   "connect-src 'self' ws: wss: http: https:",
   "worker-src 'self' blob:",
   "media-src 'self' blob: data:",
@@ -352,7 +352,7 @@ function RootLayout() {
     <QueryClientProvider client={queryClient}>
       <Toaster />
       {mounted && rootSurfaceState.showLogin ? <LoginScreen /> : null}
-      {mounted && rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
+      {mounted && rootSurfaceState.showOnboarding ? <ClaudeOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>
           <GlobalShortcutListener />

--- a/src/server/update-system.ts
+++ b/src/server/update-system.ts
@@ -345,6 +345,7 @@ function agentRepoPath(): string | null {
   const candidates = [
     process.env.HERMES_AGENT_REPO,
     join(homedir(), '.hermes', 'hermes-agent'),
+    join(homedir(), 'Projects', 'hermes-agent'),
     join(homedir(), 'hermes-agent'),
   ]
   for (const candidate of candidates) {
@@ -355,11 +356,14 @@ function agentRepoPath(): string | null {
 }
 
 export function readAgentUpdateStatus(): ProductUpdateStatus {
-  const version =
-    exec('hermes', ['--version'], { timeout: 10_000 })?.split('\n')[0] ??
-    'unknown'
-  const path = exec('which', ['hermes'])
   const repoPath = agentRepoPath()
+  const repoHermes = repoPath ? join(repoPath, 'venv', 'bin', 'hermes') : null
+  const path =
+    repoHermes && existsSync(repoHermes) ? repoHermes : exec('which', ['hermes'])
+  const version =
+    (path ? exec(path, ['--version'], { timeout: 10_000 }) : null)?.split(
+      '\n',
+    )[0] ?? 'unknown'
 
   if (!repoPath) {
     return {


### PR DESCRIPTION
## Summary
- Fix root onboarding crash by rendering the existing `ClaudeOnboarding` component.
- Relax the local meta CSP enough for Monaco/editor assets and Google Fonts used by the workspace.
- Let the update center detect a source checkout at `~/Projects/hermes-agent` and run that checkout's venv `hermes` binary for version detection.

## Test plan
- `pnpm -s exec tsc --noEmit --pretty false` — still fails due to pre-existing unrelated errors; changed files have 0 TypeScript errors.
- Smoke-tested local endpoints: `/api/connection-status`, `/api/gateway-status`, `/api/models`, `/api/update/status`, `/api/files`, `/api/memory/list`, `/api/skills` all returned HTTP 200.
- Browser smoke-tested `/`, `/files`, and `/settings/providers`; no critical console errors, CSP errors, or onboarding reference errors observed.
