### PR TITLE
Treat missing worker chat DB as no-session state

### DIFF
--- a/src/server/swarm-chat-reader.test.ts
+++ b/src/server/swarm-chat-reader.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readWorkerMessages } from './swarm-chat-reader'
+
+describe('readWorkerMessages', () => {
+  it('treats a missing state.db as an unavailable session, not a UI error', () => {
+    const profilePath = mkdtempSync(join(tmpdir(), 'swarm-chat-reader-'))
+
+    try {
+      const result = readWorkerMessages(profilePath, 30)
+
+      expect(result).toEqual({
+        sessionId: null,
+        sessionTitle: null,
+        messages: [],
+        ok: false,
+      })
+      expect(result.error).toBeUndefined()
+    } finally {
+      rmSync(profilePath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/swarm-chat-reader.ts
+++ b/src/server/swarm-chat-reader.ts
@@ -147,7 +147,6 @@ export function readWorkerMessages(profilePath: string, limit: number): SwarmCha
       sessionTitle: null,
       messages: [],
       ok: false,
-      error: `state.db missing at ${dbPath}`,
     }
   }
   try {


### PR DESCRIPTION
## Summary
- Treat a missing worker `state.db` as an unavailable/no-session state instead of a live-chat error
- Add a regression test for uninitialized worker profiles

## Verification
- `pnpm vitest run src/server/swarm-chat-reader.test.ts`
- `pnpm build`