### PR TITLE
fix(routes): use ClaudeOnboarding instead of undefined HermesOnboarding

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -352,7 +352,7 @@ function RootLayout() {
     <QueryClientProvider client={queryClient}>
       <Toaster />
       {mounted && rootSurfaceState.showLogin ? <LoginScreen /> : null}
-      {mounted && rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
+      {mounted && rootSurfaceState.showOnboarding ? <ClaudeOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>
           <GlobalShortcutListener />


### PR DESCRIPTION
Closes #222
Closes #225

## Summary

`src/routes/__root.tsx` imports `ClaudeOnboarding` on line 22 but the JSX on line 355 calls `<HermesOnboarding />` — which is not defined in the module scope.

When `rootSurfaceState.showOnboarding === true` (first install / not yet onboarded), the browser throws:

\`\`\`
ReferenceError: HermesOnboarding is not defined
\`\`\`

…and `/chat/new` renders the \"Something went wrong\" error boundary instead of the onboarding wizard. Reported in #222 (5+ users affected, including a re-report in #225). Looks like a leftover from the Claude → Hermes rebrand where the JSX site was renamed but the imported symbol still uses the old name.

## Fix

Rename the JSX element to match the imported symbol. One-character diff (`Hermes` → `Claude`) on line 355.

## Test plan

- [x] `pnpm exec tsc --noEmit` — passes
- [x] Open `/chat/new` from a browser without an onboarding cookie — wizard renders instead of the error boundary
- [x] Existing onboarded sessions still load the workspace shell