### PR TITLE
fix(swarm): treat missing worker chat state.db as no-session

### DIFF
--- a/src/server/swarm-chat-reader.test.ts
+++ b/src/server/swarm-chat-reader.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readWorkerMessages } from './swarm-chat-reader'
+
+describe('readWorkerMessages', () => {
+  it('treats a missing state.db as an unavailable session, not a UI error', () => {
+    const profilePath = mkdtempSync(join(tmpdir(), 'swarm-chat-reader-'))
+
+    try {
+      const result = readWorkerMessages(profilePath, 30)
+
+      expect(result).toEqual({
+        sessionId: null,
+        sessionTitle: null,
+        messages: [],
+        ok: false,
+      })
+      expect(result.error).toBeUndefined()
+    } finally {
+      rmSync(profilePath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/swarm-chat-reader.ts
+++ b/src/server/swarm-chat-reader.ts
@@ -147,7 +147,6 @@ export function readWorkerMessages(profilePath: string, limit: number): SwarmCha
       sessionTitle: null,
       messages: [],
       ok: false,
-      error: `state.db missing at ${dbPath}`,
     }
   }
   try {


### PR DESCRIPTION
## Summary

Swarm worker chat readers currently surface a raw \`state.db missing\` error when a worker profile hasn't been provisioned yet. Treat that condition as "no session" — return an empty message list rather than propagating the file-not-found exception to the UI.

## Change

- \`src/server/swarm-chat-reader.ts\` — drop the throw on missing \`state.db\` in \`readWorkerMessages\`; let upstream callers receive an empty message list when the worker has not been provisioned
- \`src/server/swarm-chat-reader.test.ts\` — new regression test for the missing \`state.db\` path

## Diff

2 files changed, +25 / -1.

## Test

- \`pnpm vitest run src/server/swarm-chat-reader.test.ts\` — pass

Workspace-only fix, no hermes-agent changes.

Worked with Interstellar Code