### PR TITLE
fix: bump hardcoded MiniMax-M2.5 references to M2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ workspace-final-markdown-review.md
 
 # Local sibling projects (do not ship)
 skills-bundle/
+
+# Local agent artifacts (audit dumps, temporary playwright scripts)
+.hermes/
+.env.bak-*

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -223,7 +223,7 @@ const PROVIDER_CARDS: Array<{
     id: 'minimax',
     name: 'MiniMax',
     logo: '/providers/minimax.png',
-    models: ['MiniMax-M2.5', 'MiniMax-M2.5-Lightning'],
+    models: ['MiniMax-M2.7', 'MiniMax-M2.7-Lightning'],
     authType: 'api_key',
     envKey: 'MINIMAX_API_KEY',
   },

--- a/src/lib/format-model-name.ts
+++ b/src/lib/format-model-name.ts
@@ -29,8 +29,8 @@ const MODEL_MAP: Record<string, string> = {
   'gemini-2.0-flash': 'Gemini 2.0 Flash',
   'gemini-2.5-pro': 'Gemini 2.5 Pro',
   'gemini-2.5-flash': 'Gemini 2.5 Flash',
-  'MiniMax-M2.5': 'MiniMax M2.5',
-  'MiniMax-M2.5-Lightning': 'MiniMax M2.5 Lightning',
+  'MiniMax-M2.7': 'MiniMax M2.7',
+  'MiniMax-M2.7-Lightning': 'MiniMax M2.7 Lightning',
 }
 
 const PROVIDER_LABELS: Record<string, string> = {

--- a/src/screens/gateway/components/config-wizards.tsx
+++ b/src/screens/gateway/components/config-wizards.tsx
@@ -243,8 +243,8 @@ export const PROVIDER_COMMON_MODELS: Record<string, Array<{ value: string; label
     { value: 'fireworks/accounts/fireworks/models/qwen2p5-72b-instruct', label: 'Qwen 2.5 72B' },
   ],
   minimax: [
-    { value: 'minimax/MiniMax-M2.5', label: 'MiniMax M2.5' },
-    { value: 'minimax/MiniMax-M2.5-Lightning', label: 'MiniMax M2.5 Lightning' },
+    { value: 'minimax/MiniMax-M2.7', label: 'MiniMax M2.7' },
+    { value: 'minimax/MiniMax-M2.7-Lightning', label: 'MiniMax M2.7 Lightning' },
   ],
   xai: [
     { value: 'xai/grok-beta', label: 'Grok Beta' },

--- a/src/screens/gateway/components/hub-constants.tsx
+++ b/src/screens/gateway/components/hub-constants.tsx
@@ -53,7 +53,7 @@ export const MODEL_PRESET_MAP: Record<string, string> = {
   sonnet: 'anthropic/claude-sonnet-4-6',
   codex: 'openai/gpt-5.3-codex',
   flash: 'google/gemini-2.5-flash',
-  minimax: 'minimax/MiniMax-M2.5',
+  minimax: 'minimax/MiniMax-M2.7',
 }
 
 export type GatewayModelEntry = {

--- a/src/screens/gateway/components/team-panel.tsx
+++ b/src/screens/gateway/components/team-panel.tsx
@@ -21,7 +21,7 @@ export const MODEL_PRESETS = [
   { id: 'sonnet', label: 'Claude Sonnet 4.6', desc: 'Fast & capable — Anthropic' },
   { id: 'codex', label: 'GPT-5 Codex', desc: 'Code specialist — OpenAI' },
   { id: 'flash', label: 'Gemini 2.5 Flash', desc: 'Quick & cheap — Google' },
-  { id: 'minimax', label: 'MiniMax M2.5', desc: 'Cost efficient — MiniMax' },
+  { id: 'minimax', label: 'MiniMax M2.7', desc: 'Cost efficient — MiniMax' },
   { id: 'pc1-coder', label: 'PC1 Coder (97 TPS)', desc: 'Qwen3-Coder 30B · Local · RTX 4090' },
   { id: 'pc1-planner', label: 'PC1 Planner (175 TPS)', desc: 'Qwen3-30B Sonnet Distill MoE · Local · RTX 4090' },
   { id: 'pc1-critic', label: 'PC1 Critic (83 TPS)', desc: 'Qwen3-14B Opus Distill · Local · RTX 4090' },


### PR DESCRIPTION
Closes #227

MiniMax shipped M2.7 in April 2026 (https://www.minimax.io/models/text/m27). The Workspace UI still hardcoded `MiniMax-M2.5` / `MiniMax-M2.5-Lightning` in 5 places — model presets, the gateway hub, settings dialog, and the formatter.

The reported bug: clicking the MiniMax preset would force-rewrite the user's `config.yaml` model from `MiniMax-M2.7` back to `MiniMax-M2.5`, which most users no longer have access to → Hermes stops responding.

Also includes a `.gitignore` chore for `.hermes/` scratch + `.env.bak-*` timestamped backups.