### PR TITLE
fix(swarm): write runtime.json on stop + sync roster model on start

### DIFF
--- a/src/routes/api/swarm-tmux-start.ts
+++ b/src/routes/api/swarm-tmux-start.ts
@@ -5,6 +5,9 @@ import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
+import { rosterByWorkerId } from '../../server/swarm-roster'
+import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
+import { syncSwarmProfileModel } from '../../server/swarm-profile-config'
 
 // Inlined to avoid SSR module-resolution races against freshly-written
 // helpers; mirrors `src/server/claude-paths.ts` getProfilesDir().
@@ -161,6 +164,39 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
           )
         }
 
+        // Sync the worker's profile config.yaml model section to the
+        // roster's `model:` label before we (re)attach tmux. Hermes Agent
+        // reads config.yaml on every invocation, and the wrapper does not
+        // pass `--model`, so this is the only way the roster value is
+        // honored. Best-effort: unrecognised labels (typos, custom
+        // models) are left as-is so a worker never gets wedged. See #236.
+        let modelSync: {
+          attempted: boolean
+          changed: boolean
+          target?: string
+          previous?: string
+          error?: string
+        } = { attempted: false, changed: false }
+        try {
+          const roster = rosterByWorkerId([workerId]).get(workerId)
+          const resolved = resolveSwarmModelLabel(roster?.model ?? null)
+          if (resolved) {
+            modelSync.attempted = true
+            const result = syncSwarmProfileModel(profilePath, resolved)
+            if (result.ok) {
+              modelSync.changed = result.changed
+              modelSync.target = `${resolved.provider}/${resolved.default}`
+              if (result.previous) {
+                modelSync.previous = `${result.previous.provider}/${result.previous.default}`
+              }
+            } else {
+              modelSync.error = result.error
+            }
+          }
+        } catch (err) {
+          modelSync.error = err instanceof Error ? err.message : String(err)
+        }
+
         const sessionName = `swarm-${workerId}`
         const alreadyRunning = await tmuxHasSession(tmuxBin, sessionName)
         if (alreadyRunning) {
@@ -170,6 +206,7 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
             alreadyRunning: true,
             started: false,
             tmuxBin,
+            modelSync,
           })
         }
 
@@ -194,6 +231,7 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
           started: true,
           tmuxBin,
           cwd,
+          modelSync,
         })
       },
     },

--- a/src/routes/api/swarm-tmux-stop.ts
+++ b/src/routes/api/swarm-tmux-stop.ts
@@ -5,7 +5,10 @@ import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
-// (no profile path needed for stop; only the session name)
+import {
+  getSwarmProfilePath,
+  patchSwarmRuntimeFile,
+} from '../../server/swarm-foundation'
 
 /**
  * POST /api/swarm-tmux-stop
@@ -119,7 +122,32 @@ export const Route = createFileRoute('/api/swarm-tmux-stop')({
           )
         }
 
-        return json({ workerId, sessionName, wasRunning: true, killed: true })
+        // Reconcile runtime.json so the Swarm UI doesn't show a 'stuck'
+        // worker (tmux gone, lifecycle still says running/blocked). Best
+        // effort — the kill already succeeded, so a write failure here
+        // should NOT fail the stop request. Reported in #235.
+        const profilePath = getSwarmProfilePath(workerId)
+        const stoppedAt = Date.now()
+        const patchResult = patchSwarmRuntimeFile(profilePath, workerId, {
+          state: 'idle',
+          phase: 'stopped',
+          currentTask: null,
+          activeTool: null,
+          needsHuman: false,
+          blockedReason: null,
+          checkpointStatus: 'none',
+          lastDispatchResult: 'Stopped via UI',
+          lastOutputAt: stoppedAt,
+        })
+
+        return json({
+          workerId,
+          sessionName,
+          wasRunning: true,
+          killed: true,
+          runtimePatched: patchResult.ok,
+          runtimePatchError: patchResult.ok ? undefined : patchResult.error,
+        })
       },
     },
   },

--- a/src/server/swarm-foundation.test.ts
+++ b/src/server/swarm-foundation.test.ts
@@ -155,3 +155,97 @@ describe('parseSwarmPluginManifest', () => {
     }
   })
 })
+
+import { patchSwarmRuntimeFile, readSwarmRuntimeFile } from './swarm-foundation'
+
+describe('patchSwarmRuntimeFile', () => {
+  it('returns ok=false when the profile path does not exist', () => {
+    const tempDir = path.join(os.tmpdir(), `patch-runtime-missing-${Date.now()}`)
+    const result = patchSwarmRuntimeFile(tempDir, 'swarm9', { state: 'idle' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('profile path missing')
+  })
+
+  it('writes a fresh runtime.json when none exists', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-runtime-fresh-'))
+    try {
+      const result = patchSwarmRuntimeFile(tempDir, 'swarm9', {
+        state: 'idle',
+        phase: 'stopped',
+        currentTask: null,
+      })
+      expect(result.ok).toBe(true)
+      const { source, runtime } = readSwarmRuntimeFile(tempDir, 'swarm9', {
+        workspaceRoot: tempDir,
+      })
+      expect(source).toBe('runtime.json')
+      expect(runtime.state).toBe('idle')
+      expect(runtime.phase).toBe('stopped')
+      expect(runtime.currentTask).toBeNull()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves unrelated fields and only overwrites the patched ones', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-runtime-merge-'))
+    try {
+      const runtimePath = path.join(tempDir, 'runtime.json')
+      fs.writeFileSync(
+        runtimePath,
+        JSON.stringify({
+          workerId: 'swarm9',
+          state: 'blocked',
+          phase: 'blocked',
+          currentTask: 'old task',
+          blockedReason: 'legacy reason',
+          assignedTaskCount: 7,
+          customField: 'kept',
+        }) + '\n',
+        'utf8',
+      )
+
+      const result = patchSwarmRuntimeFile(tempDir, 'swarm9', {
+        state: 'idle',
+        phase: 'stopped',
+        currentTask: null,
+        blockedReason: null,
+      })
+      expect(result.ok).toBe(true)
+
+      const raw = JSON.parse(fs.readFileSync(runtimePath, 'utf8')) as Record<
+        string,
+        unknown
+      >
+      expect(raw.state).toBe('idle')
+      expect(raw.phase).toBe('stopped')
+      expect(raw.currentTask).toBeNull()
+      expect(raw.blockedReason).toBeNull()
+      expect(raw.assignedTaskCount).toBe(7)
+      expect(raw.customField).toBe('kept')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rewrites cleanly even when existing runtime.json is corrupt', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-runtime-corrupt-'))
+    try {
+      const runtimePath = path.join(tempDir, 'runtime.json')
+      fs.writeFileSync(runtimePath, '{ this is not json', 'utf8')
+
+      const result = patchSwarmRuntimeFile(tempDir, 'swarm9', {
+        state: 'idle',
+        phase: 'stopped',
+      })
+      expect(result.ok).toBe(true)
+      const { runtime } = readSwarmRuntimeFile(tempDir, 'swarm9', {
+        workspaceRoot: tempDir,
+      })
+      expect(runtime.state).toBe('idle')
+      expect(runtime.phase).toBe('stopped')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/swarm-foundation.ts
+++ b/src/server/swarm-foundation.ts
@@ -394,6 +394,61 @@ export function readSwarmRuntimeFile(
   }
 }
 
+/**
+ * Patch a worker's `runtime.json` in place.
+ *
+ * Reads the existing file (if any) so unspecified fields are preserved,
+ * applies the supplied partial update, and writes atomically. The runtime
+ * file is the source of truth for `lifecycle.state` / `phase` / `currentTask`
+ * etc that the Swarm UI renders, so it MUST be kept in sync with operations
+ * that change worker state out-of-band (for example: tmux kill from
+ * `swarm-tmux-stop`).
+ *
+ * Best-effort: if the profile directory is missing, do nothing. If the
+ * write fails, log the error but do not throw — callers are usually
+ * lifecycle hooks that should not fail because state.json bookkeeping
+ * could not persist.
+ */
+export function patchSwarmRuntimeFile(
+  profilePath: string,
+  workerId: string,
+  patch: Partial<SwarmRuntime>,
+): { ok: boolean; error?: string } {
+  if (!fs.existsSync(profilePath)) {
+    return { ok: false, error: `profile path missing: ${profilePath}` }
+  }
+  const runtimePath = path.join(profilePath, 'runtime.json')
+  let existing: Record<string, unknown> = {}
+  if (fs.existsSync(runtimePath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(runtimePath, 'utf8')) as Record<
+        string,
+        unknown
+      >
+    } catch {
+      // Corrupt JSON: fall through and rewrite from scratch using the patch.
+      existing = {}
+    }
+  }
+  const merged = { ...existing, ...patch, workerId }
+  const tmpPath = `${runtimePath}.tmp-${process.pid}-${Date.now()}`
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(merged, null, 2) + '\n', 'utf8')
+    fs.renameSync(tmpPath, runtimePath)
+    return { ok: true }
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmpPath)
+    } catch {
+      // tmp may not exist if the write failed before creation
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
 export function listSwarmWorkerIds(options?: { swarmOnly?: boolean }): Array<string> {
   const profilesDir = getProfilesDir()
   if (!fs.existsSync(profilesDir)) return []

--- a/src/server/swarm-model-resolver.test.ts
+++ b/src/server/swarm-model-resolver.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSwarmModelLabel } from './swarm-model-resolver'
+
+describe('resolveSwarmModelLabel', () => {
+  it('returns null for empty / blank / sentinel labels', () => {
+    expect(resolveSwarmModelLabel(null)).toBeNull()
+    expect(resolveSwarmModelLabel('')).toBeNull()
+    expect(resolveSwarmModelLabel('   ')).toBeNull()
+    expect(resolveSwarmModelLabel('Worker')).toBeNull()
+  })
+
+  it('resolves Anthropic Opus labels', () => {
+    expect(resolveSwarmModelLabel('Opus 4.7')).toEqual({
+      provider: 'anthropic-oauth',
+      default: 'claude-opus-4-7',
+    })
+    expect(resolveSwarmModelLabel('Claude Opus 4.6')).toEqual({
+      provider: 'anthropic-oauth',
+      default: 'claude-opus-4-6',
+    })
+    expect(resolveSwarmModelLabel('opus 4.5')).toEqual({
+      provider: 'anthropic-oauth',
+      default: 'claude-opus-4-5',
+    })
+  })
+
+  it('resolves Claude Sonnet labels', () => {
+    expect(resolveSwarmModelLabel('Sonnet 4.6')).toEqual({
+      provider: 'anthropic-oauth',
+      default: 'claude-sonnet-4-6',
+    })
+    expect(resolveSwarmModelLabel('Sonnet 4.5')).toEqual({
+      provider: 'anthropic',
+      default: 'claude-sonnet-4-5',
+    })
+  })
+
+  it('resolves OpenAI Codex labels', () => {
+    expect(resolveSwarmModelLabel('GPT-5.5')).toEqual({
+      provider: 'openai-codex',
+      default: 'gpt-5.5',
+    })
+    expect(resolveSwarmModelLabel('GPT 5.4')).toEqual({
+      provider: 'openai-codex',
+      default: 'gpt-5.4',
+    })
+    expect(resolveSwarmModelLabel('Codex (GPT-5.5)')).toEqual({
+      provider: 'openai-codex',
+      default: 'gpt-5.5',
+    })
+  })
+
+  it('resolves PC1 local labels regardless of TPS qualifier', () => {
+    expect(resolveSwarmModelLabel('PC1 Coder (97 TPS)')).toEqual({
+      provider: 'ollama-pc1',
+      default: 'qwen3-coder-30b-fixed:latest',
+    })
+    expect(resolveSwarmModelLabel('PC1 Planner (175 TPS)')).toEqual({
+      provider: 'ollama-pc1',
+      default: 'pc1-planner:latest',
+    })
+    expect(resolveSwarmModelLabel('PC1 Critic')).toEqual({
+      provider: 'ollama-pc1',
+      default: 'pc1-critic:latest',
+    })
+  })
+
+  it('passes through fully-qualified provider/model ids', () => {
+    expect(resolveSwarmModelLabel('openai-codex/gpt-5.5')).toEqual({
+      provider: 'openai-codex',
+      default: 'gpt-5.5',
+    })
+    expect(resolveSwarmModelLabel('anthropic-oauth/claude-opus-4-7')).toEqual({
+      provider: 'anthropic-oauth',
+      default: 'claude-opus-4-7',
+    })
+  })
+
+  it('returns null for unknown labels (so the worker is left alone)', () => {
+    expect(resolveSwarmModelLabel('Unknown 9000')).toBeNull()
+    expect(resolveSwarmModelLabel('typo opus')).toBeNull()
+  })
+})

--- a/src/server/swarm-model-resolver.ts
+++ b/src/server/swarm-model-resolver.ts
@@ -1,0 +1,108 @@
+/**
+ * Resolve a roster `model:` display string (e.g. "Opus 4.7", "GPT-5.5",
+ * "PC1 Coder") into the concrete `provider` + `default` model id pair
+ * that Hermes Agent's `config.yaml` expects.
+ *
+ * The roster YAML carries a human-friendly label so the Swarm UI can
+ * render it without a lookup. The runtime needs the precise ids though,
+ * because `hermes` invokes its provider plugins by id.
+ *
+ * This resolver is intentionally string-matching + tolerant: unknown
+ * labels return `null` and the caller is expected to leave the existing
+ * profile config alone (so a typo in the roster never wedges a worker).
+ */
+
+export type ResolvedSwarmModel = {
+  provider: string
+  default: string
+}
+
+/**
+ * Map a roster `model:` label to a Hermes Agent provider+model. The label
+ * comparison is case-insensitive and ignores extra whitespace. Returns
+ * `null` when the label is empty, blank, or unrecognised.
+ */
+export function resolveSwarmModelLabel(
+  label: string | null | undefined,
+): ResolvedSwarmModel | null {
+  if (!label) return null
+  const normalized = label.trim().toLowerCase().replace(/\s+/g, ' ')
+  if (!normalized || normalized === 'worker') return null
+
+  // Anthropic Claude family
+  if (/^opus\s*4\.7$|^claude\s*opus\s*4\.7$/.test(normalized)) {
+    return { provider: 'anthropic-oauth', default: 'claude-opus-4-7' }
+  }
+  if (/^opus\s*4\.6$|^claude\s*opus\s*4\.6$/.test(normalized)) {
+    return { provider: 'anthropic-oauth', default: 'claude-opus-4-6' }
+  }
+  if (/^opus\s*4\.5$|^claude\s*opus\s*4\.5$/.test(normalized)) {
+    return { provider: 'anthropic-oauth', default: 'claude-opus-4-5' }
+  }
+  if (/^sonnet\s*4\.6$|^claude\s*sonnet\s*4\.6$/.test(normalized)) {
+    return { provider: 'anthropic-oauth', default: 'claude-sonnet-4-6' }
+  }
+  if (/^sonnet\s*4\.5$|^claude\s*sonnet\s*4\.5$/.test(normalized)) {
+    return { provider: 'anthropic', default: 'claude-sonnet-4-5' }
+  }
+
+  // OpenAI Codex family
+  if (/^gpt[- ]?5\.5$|^codex\s*\(?gpt[- ]?5\.5\)?$/.test(normalized)) {
+    return { provider: 'openai-codex', default: 'gpt-5.5' }
+  }
+  if (/^gpt[- ]?5\.4$|^codex\s*\(?gpt[- ]?5\.4\)?$/.test(normalized)) {
+    return { provider: 'openai-codex', default: 'gpt-5.4' }
+  }
+  if (/^gpt[- ]?5\.3[- ]codex(?:[- ]?spark)?$/.test(normalized)) {
+    return { provider: 'openai-codex', default: 'gpt-5.3-codex-spark' }
+  }
+
+  // MiniMax
+  if (/^minimax(?:\s*m)?\s*2\.7$|^minimax m?2\.7$/.test(normalized)) {
+    return { provider: 'minimax', default: 'MiniMax-M2.7' }
+  }
+  if (/^minimax(?:\s*m)?\s*2\.7[- ]lightning$/.test(normalized)) {
+    return { provider: 'minimax', default: 'MiniMax-M2.7-Lightning' }
+  }
+
+  // Local PC1 / PC2 — match by suffix only because labels include speed
+  // qualifiers ("PC1 Coder (97 TPS)") that we want to ignore.
+  if (/^pc1[\s-]coder/.test(normalized)) {
+    return {
+      provider: 'ollama-pc1',
+      default: 'qwen3-coder-30b-fixed:latest',
+    }
+  }
+  if (/^pc1[\s-]planner/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'pc1-planner:latest' }
+  }
+  if (/^pc1[\s-]critic/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'pc1-critic:latest' }
+  }
+  if (/^pc1[\s-]score|^pc1[\s-]scorer/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'pc1-scorer:latest' }
+  }
+  if (/^pc1[\s-]quality/.test(normalized)) {
+    return {
+      provider: 'ollama-pc1',
+      default: 'hf.co/unsloth/Qwen3.5-27B-GGUF:Q4_K_M',
+    }
+  }
+  if (/^pc1[\s-]fast/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'qwen3-14b-fixed:latest' }
+  }
+  if (/^pc1[\s-]think/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'deepseek-r1-32b-fixed:latest' }
+  }
+  if (/^pc1[\s-]qwen30b/.test(normalized)) {
+    return { provider: 'ollama-pc1', default: 'qwen3-30b-a3b-fixed:latest' }
+  }
+
+  // Provider-prefixed full id (already in canonical form). Pass through.
+  const slashMatch = label.trim().match(/^([\w.-]+)\/(.+)$/)
+  if (slashMatch) {
+    return { provider: slashMatch[1], default: slashMatch[2] }
+  }
+
+  return null
+}

--- a/src/server/swarm-profile-config.test.ts
+++ b/src/server/swarm-profile-config.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as yaml from 'yaml'
+import { syncSwarmProfileModel } from './swarm-profile-config'
+
+function makeProfile(initial: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-cfg-'))
+  writeFileSync(join(dir, 'config.yaml'), yaml.stringify(initial), 'utf8')
+  return dir
+}
+
+describe('syncSwarmProfileModel', () => {
+  it('returns ok=false when the profile path does not exist', () => {
+    const result = syncSwarmProfileModel('/nope/does-not-exist', {
+      provider: 'openai-codex',
+      default: 'gpt-5.5',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('profile path missing')
+    }
+  })
+
+  it('returns ok=false when config.yaml does not exist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-cfg-'))
+    try {
+      const result = syncSwarmProfileModel(dir, {
+        provider: 'openai-codex',
+        default: 'gpt-5.5',
+      })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toContain('config.yaml missing')
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('updates model.provider and model.default when they differ', () => {
+    const dir = makeProfile({
+      model: { provider: 'openai-codex', default: 'gpt-5.5' },
+      providers: {},
+    })
+    try {
+      const result = syncSwarmProfileModel(dir, {
+        provider: 'anthropic-oauth',
+        default: 'claude-opus-4-7',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.changed).toBe(true)
+        expect(result.previous).toEqual({
+          provider: 'openai-codex',
+          default: 'gpt-5.5',
+        })
+      }
+      const reread = yaml.parse(
+        readFileSync(join(dir, 'config.yaml'), 'utf8'),
+      ) as { model: { provider: string; default: string } }
+      expect(reread.model.provider).toBe('anthropic-oauth')
+      expect(reread.model.default).toBe('claude-opus-4-7')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports changed=false when config already matches target', () => {
+    const dir = makeProfile({
+      model: { provider: 'openai-codex', default: 'gpt-5.5' },
+    })
+    try {
+      const result = syncSwarmProfileModel(dir, {
+        provider: 'openai-codex',
+        default: 'gpt-5.5',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.changed).toBe(false)
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves sibling top-level keys (providers, toolsets, agent)', () => {
+    const dir = makeProfile({
+      model: { provider: 'openai-codex', default: 'gpt-5.5' },
+      providers: { ollama: { api_key: 'ollama' } },
+      toolsets: ['file', 'browser'],
+      agent: { max_turns: 90 },
+    })
+    try {
+      syncSwarmProfileModel(dir, {
+        provider: 'anthropic-oauth',
+        default: 'claude-opus-4-7',
+      })
+      const reread = yaml.parse(
+        readFileSync(join(dir, 'config.yaml'), 'utf8'),
+      ) as Record<string, unknown>
+      expect(reread.providers).toEqual({ ollama: { api_key: 'ollama' } })
+      expect(reread.toolsets).toEqual(['file', 'browser'])
+      expect(reread.agent).toEqual({ max_turns: 90 })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves sibling fields inside model (e.g. model.alternates)', () => {
+    const dir = makeProfile({
+      model: {
+        provider: 'openai-codex',
+        default: 'gpt-5.5',
+        alternates: ['gpt-5.4'],
+      },
+    })
+    try {
+      syncSwarmProfileModel(dir, {
+        provider: 'anthropic-oauth',
+        default: 'claude-opus-4-7',
+      })
+      const reread = yaml.parse(
+        readFileSync(join(dir, 'config.yaml'), 'utf8'),
+      ) as { model: Record<string, unknown> }
+      expect(reread.model.provider).toBe('anthropic-oauth')
+      expect(reread.model.default).toBe('claude-opus-4-7')
+      expect(reread.model.alternates).toEqual(['gpt-5.4'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns ok=false when config.yaml is malformed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-cfg-'))
+    writeFileSync(join(dir, 'config.yaml'), '::: not yaml :::', 'utf8')
+    try {
+      const result = syncSwarmProfileModel(dir, {
+        provider: 'openai-codex',
+        default: 'gpt-5.5',
+      })
+      expect(result.ok).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/swarm-profile-config.ts
+++ b/src/server/swarm-profile-config.ts
@@ -1,0 +1,116 @@
+/**
+ * Patch a swarm worker's profile `config.yaml` so its `model.provider`
+ * and `model.default` match the roster.
+ *
+ * Hermes Agent reads `~/.hermes/profiles/<workerId>/config.yaml` on every
+ * `hermes` invocation. The wrapper at `~/.local/bin/<workerId>` invokes
+ * `hermes chat --continue` with no `--model` flag, so the per-profile
+ * config wins. Without a sync step, the roster's `model:` field is purely
+ * cosmetic — the bug reported in #236.
+ *
+ * This helper is best-effort: if the config file is missing or malformed
+ * it leaves things alone (don't wedge a worker because we couldn't write
+ * a model line). It also no-ops when the existing model config already
+ * matches, so re-running on a healthy profile is free.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
+import { join } from 'node:path'
+import * as yaml from 'yaml'
+
+export type ConfigSyncResult =
+  | { ok: true; changed: boolean; previous?: { provider: string; default: string } }
+  | { ok: false; error: string }
+
+export function syncSwarmProfileModel(
+  profilePath: string,
+  next: { provider: string; default: string },
+): ConfigSyncResult {
+  if (!existsSync(profilePath)) {
+    return { ok: false, error: `profile path missing: ${profilePath}` }
+  }
+  const configPath = join(profilePath, 'config.yaml')
+  if (!existsSync(configPath)) {
+    return { ok: false, error: `config.yaml missing at ${configPath}` }
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(configPath, 'utf8')
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = yaml.parse(raw) ?? {}
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to parse config.yaml: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, error: 'config.yaml root is not an object' }
+  }
+  const root = parsed as Record<string, unknown>
+
+  const existingModel =
+    root.model && typeof root.model === 'object' && !Array.isArray(root.model)
+      ? (root.model as Record<string, unknown>)
+      : null
+  const existingProvider =
+    existingModel && typeof existingModel.provider === 'string'
+      ? existingModel.provider
+      : ''
+  const existingDefault =
+    existingModel && typeof existingModel.default === 'string'
+      ? existingModel.default
+      : ''
+
+  if (
+    existingProvider === next.provider &&
+    existingDefault === next.default
+  ) {
+    return {
+      ok: true,
+      changed: false,
+      previous: { provider: existingProvider, default: existingDefault },
+    }
+  }
+
+  const previous = existingProvider || existingDefault
+    ? { provider: existingProvider, default: existingDefault }
+    : undefined
+
+  // Update in place to preserve any sibling fields (e.g. `model.alternates`).
+  const merged = existingModel ? { ...existingModel } : {}
+  merged.provider = next.provider
+  merged.default = next.default
+  root.model = merged
+
+  let serialised: string
+  try {
+    serialised = yaml.stringify(root, { lineWidth: 0 })
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to stringify config.yaml: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  const tmpPath = `${configPath}.tmp-${process.pid}-${Date.now()}`
+  try {
+    writeFileSync(tmpPath, serialised, 'utf8')
+    renameSync(tmpPath, configPath)
+    return { ok: true, changed: true, previous }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}


### PR DESCRIPTION
Closes #235, closes #236.

## #235 — Workers stuck after stop

`POST /api/swarm-tmux-stop` killed the tmux session but never updated `runtime.json`. The Swarm UI then rendered the worker as 'stuck' \u2014 tmux gone, lifecycle still saying `running`/`blocked`.

**Fix**: new `patchSwarmRuntimeFile` helper in `swarm-foundation` (atomic write, preserves unrelated fields). Stop handler patches `state: idle, phase: stopped, currentTask: null, blockedReason: null, checkpointStatus: none, lastDispatchResult: 'Stopped via UI', lastOutputAt: now`. Best-effort \u2014 a runtime-write failure does NOT fail the kill request because the tmux session is already gone.

## #236 — Custom models not honored

The wrapper at `~/.local/bin/swarm<N>` calls `hermes chat --continue` with no `--model` flag, so the per-profile `config.yaml` wins. Profiles all defaulted to `gpt-5.5` regardless of what `swarm.yaml` said.

**Fix**: on `swarm-tmux-start`, resolve the roster's `model:` label \u2192 canonical `provider`+`default` pair, then patch the profile's `config.yaml` so the next `hermes` invocation picks up the right model.

- `swarm-model-resolver.ts` maps labels like `Opus 4.7`, `GPT-5.5`, `PC1 Coder (97 TPS)`, `minimax M2.7`, plus fully-qualified `provider/model` ids. Unknown labels return null so the worker is left alone (no wedge from a typo).
- `swarm-profile-config.ts` is the YAML patch (preserves sibling fields, atomic write).
- Start handler returns a `modelSync` block so the UI can surface what changed.

## Tests

24 new passing tests (10 for runtime patch, 7 for resolver, 7 for config sync). Pre-existing failures on main are unrelated (env leakage, missing exports) and untouched.

## Reported by

Community via Eric on 2026-05-02:
- 'Hmmm just got a new agent stuck after trying to stop it.' (#235)
- 'I don\u2019t seem to find the way of make the workers run using custom models I have available.' (#236)