### PR TITLE
fix(chat): recovery buffer for vanishing last message after refresh

### DIFF
--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -9,6 +9,10 @@ import {
   persistPendingMessage,
   readPendingMessage,
 } from '../pending-send'
+import {
+  clearRecoveryMessage,
+  readRecoveryMessage,
+} from '../../../stores/chat-store'
 import { useChatSettingsStore } from '../../../hooks/use-chat-settings'
 import type { PendingSendPayload } from '../pending-send'
 import type { QueryClient } from '@tanstack/react-query'
@@ -216,6 +220,38 @@ function hasConfirmedPendingMessage(
   })
 }
 
+/**
+ * Extract the best available string ID from a ChatMessage without type-unsafe
+ * `as any` casts. ChatMessage carries `[key: string]: unknown` so bracket
+ * access is perfectly legal and keeps TypeScript's narrowing intact.
+ */
+function extractMsgId(msg: ChatMessage): string {
+  const id =
+    msg['id'] ?? msg['message_id'] ?? msg['clientId'] ?? msg['client_id']
+  return typeof id === 'string' ? id : ''
+}
+
+/** Check whether a history array already contains an equivalent message. */
+function historyContainsMessage(
+  messages: Array<ChatMessage>,
+  candidate: ChatMessage,
+): boolean {
+  if (!candidate.role) return false
+  const candidateText = textFromMessage(candidate).trim()
+  const candidateId = extractMsgId(candidate)
+
+  return messages.some((msg) => {
+    if (msg.role !== candidate.role) return false
+    const msgId = extractMsgId(msg)
+    if (candidateId && msgId && candidateId === msgId) return true
+    if (candidateText) {
+      const msgText = textFromMessage(msg).trim()
+      if (msgText === candidateText) return true
+    }
+    return false
+  })
+}
+
 export function useChatHistory({
   activeFriendlyId,
   activeSessionKey,
@@ -297,25 +333,46 @@ export function useChatHistory({
       const cached = queryClient.getQueryData(historyKey)
       const optimisticMessages = Array.isArray((cached as any)?.messages)
         ? (cached as any).messages.filter((message: any) => {
-            if (message.status === 'sending') return true
-            if (message.__optimisticId) return true
-            return Boolean(message.clientId)
-          })
+          if (message.status === 'sending') return true
+          if (message.__optimisticId) return true
+          return Boolean(message.clientId)
+        })
         : []
 
       const serverData = await fetchHistory({
         sessionKey: sessionKeyForHistory,
         friendlyId: activeFriendlyId,
       })
-      if (!optimisticMessages.length) return serverData
+
+      let dataWithRecovery = serverData
+
+      // Merge recovery buffer: if the backend history hasn't caught up with a
+      // recently-streamed assistant message (e.g. after dev refresh), inject it
+      // so the message doesn't vanish from the UI.
+      if (typeof window !== 'undefined') {
+        const recoveryMessage = readRecoveryMessage(sessionKeyForHistory)
+        if (recoveryMessage) {
+          if (historyContainsMessage(serverData.messages, recoveryMessage)) {
+            clearRecoveryMessage(sessionKeyForHistory)
+          } else {
+            const mergedMessages = [...serverData.messages, recoveryMessage]
+            mergedMessages.sort(
+              (a, b) => getMessageTimestamp(a) - getMessageTimestamp(b),
+            )
+            dataWithRecovery = { ...serverData, messages: mergedMessages }
+          }
+        }
+      }
+
+      if (!optimisticMessages.length) return dataWithRecovery
 
       const merged = mergeOptimisticHistoryMessages(
-        serverData.messages,
+        dataWithRecovery.messages,
         optimisticMessages,
       )
 
       return {
-        ...serverData,
+        ...dataWithRecovery,
         messages: merged,
       }
     },
@@ -399,8 +456,8 @@ export function useChatHistory({
   const historyMessages = useMemo(() => {
     const messages = persistedPending
       ? mergeOptimisticHistoryMessages(rawHistoryMessages, [
-          persistedPending.optimisticMessage,
-        ])
+        persistedPending.optimisticMessage,
+      ])
       : rawHistoryMessages
     const last = messages[messages.length - 1]
     const lastId =
@@ -430,7 +487,7 @@ export function useChatHistory({
         const text = textFromMessage(msg)
         const execNotification = parseExecNotification(text)
         if (execNotification) {
-          ;(msg as any).__execNotification = execNotification
+          ; (msg as any).__execNotification = execNotification
           return true
         }
         if ((msg as any).__execNotification) {
@@ -444,7 +501,8 @@ export function useChatHistory({
         // they quote these phrases somewhere inside the text.
         if (text.startsWith('Pre-compaction memory flush')) return false
         if (text.startsWith('Store durable memories now')) return false
-        if (text.startsWith('Summarize this naturally for the user')) return false
+        if (text.startsWith('Summarize this naturally for the user'))
+          return false
         if (text.startsWith('APPEND new content only and do not overwrite'))
           return false
         if (
@@ -516,7 +574,7 @@ export function useChatHistory({
           filtered.splice(i, 1)
           i--
         } else {
-          ;(msg as any).__isNarration = true
+          ; (msg as any).__isNarration = true
         }
       }
     }

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -161,12 +161,17 @@ function normalizeTimestamp(value: unknown): number | null {
 }
 
 export function getMessageTimestamp(message: ChatMessage): number {
-  const candidates = [
-    (message as any).createdAt,
-    (message as any).created_at,
-    (message as any).timestamp,
-    (message as any).time,
-    (message as any).ts,
+  // ChatMessage has `[key: string]: unknown`, so bracket access is safe and
+  // avoids `as any`. `message.timestamp` is the canonical typed field;
+  // the others are alternative shapes used by different backends.
+  // Recovery messages always arrive with `timestamp` set to Date.now() (ms),
+  // which normalizeTimestamp returns as-is, so sort order is always correct.
+  const candidates: Array<unknown> = [
+    message['createdAt'],
+    message['created_at'],
+    message.timestamp,
+    message['time'],
+    message['ts'],
   ]
 
   for (const candidate of candidates) {
@@ -211,7 +216,7 @@ export function normalizeSessions(
         : deriveFriendlyIdFromKey(session.friendlyId ?? session.key)
     const friendlyIdCandidate =
       typeof session.friendlyId === 'string' &&
-      session.friendlyId.trim().length > 0
+        session.friendlyId.trim().length > 0
         ? session.friendlyId.trim()
         : deriveFriendlyIdFromKey(key)
 
@@ -225,9 +230,10 @@ export function normalizeSessions(
         : undefined
     const derivedTitle =
       typeof session.derivedTitle === 'string' &&
-      session.derivedTitle.trim().length > 0
+        session.derivedTitle.trim().length > 0
         ? session.derivedTitle.trim()
-        : typeof session.preview === 'string' && session.preview.trim().length > 0
+        : typeof session.preview === 'string' &&
+          session.preview.trim().length > 0
           ? session.preview.trim()
           : undefined
     const titleStatus = deriveTitleStatus(

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -133,10 +133,7 @@ type ChatState = {
 
   /** Sessions currently waiting for a response — survives component unmount */
   waitingSessionKeys: Set<string>
-  waitingSessionMeta: Record<
-    string,
-    { since: number; runId: string | null }
-  >
+  waitingSessionMeta: Record<string, { since: number; runId: string | null }>
   /** Mark a session as waiting for a response */
   setSessionWaiting: (sessionKey: string, runId?: string | null) => void
   /** Clear waiting state for a session */
@@ -194,6 +191,54 @@ export function restoreStreamingState(
     sessionStorage.removeItem(storageKey)
     return null
   }
+}
+
+const RECOVERY_MSG_PREFIX = 'claude_recovery_msg_'
+const RECOVERY_MSG_TTL_MS = 5 * 60 * 1000
+
+export function persistRecoveryMessage(
+  sessionKey: string,
+  message: ChatMessage,
+): void {
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.setItem(
+      `${RECOVERY_MSG_PREFIX}${sessionKey}`,
+      JSON.stringify({ message, storedAt: Date.now() }),
+    )
+  } catch {
+    // Ignore storage write failures (quota, private mode, etc.).
+  }
+}
+
+export function readRecoveryMessage(sessionKey: string): ChatMessage | null {
+  if (typeof sessionStorage === 'undefined') return null
+  const key = `${RECOVERY_MSG_PREFIX}${sessionKey}`
+  const raw = sessionStorage.getItem(key)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as {
+      message?: ChatMessage
+      storedAt?: number
+    }
+    if (!parsed.message) return null
+    if (
+      typeof parsed.storedAt !== 'number' ||
+      Date.now() - parsed.storedAt > RECOVERY_MSG_TTL_MS
+    ) {
+      sessionStorage.removeItem(key)
+      return null
+    }
+    return parsed.message
+  } catch {
+    sessionStorage.removeItem(key)
+    return null
+  }
+}
+
+export function clearRecoveryMessage(sessionKey: string): void {
+  if (typeof sessionStorage === 'undefined') return
+  sessionStorage.removeItem(`${RECOVERY_MSG_PREFIX}${sessionKey}`)
 }
 
 const WAITING_TTL_MS = 120_000
@@ -985,7 +1030,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
             timestamp: getMessageEventTime(cleanedMessage) ?? now,
             __receiveTime: now,
             __realtimeSequence: realtimeMessageSequence++,
-            __streamingStatus: (event.state === 'interrupted' ? 'interrupted' : 'complete') as any,
+            __streamingStatus: (event.state === 'interrupted'
+              ? 'interrupted'
+              : 'complete') as any,
             ...(streamToolCallsToEmbed
               ? { __streamToolCalls: streamToolCallsToEmbed }
               : {}),
@@ -1079,6 +1126,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
               set({ realtimeMessages: messages })
             }
           }
+
+          // Persist the final assistant message to sessionStorage so it survives
+          // dev refresh / tab navigation until backend history catches up.
+          persistRecoveryMessage(sessionKey, completeMessage)
         }
 
         // Clear streaming state immediately — tool calls are preserved via


### PR DESCRIPTION
## Summary

Fixes a UX bug where the final assistant message disappears from chat history after a dev refresh / tab navigation when the backend has not yet flushed the just-streamed message to disk.

## Problem

When an assistant message finishes streaming (\`done\` event fires), the workspace shows it in realtime state immediately. But there is a small window where:

1. Stream completes → realtime state cleared
2. User refreshes / navigates / dev HMR reload
3. \`historyQuery\` refetches \`/api/sessions/.../messages\`
4. Backend hasn't persisted the just-completed message yet → returns history without it
5. UI renders the stale history → **last message vanishes**

## Fix

Adds a sessionStorage-backed recovery buffer for the most recently completed assistant message:

- **\`src/stores/chat-store.ts\`**: \`persistRecoveryMessage(sessionKey, message)\` writes the complete message to \`sessionStorage\` (5-minute TTL) inside the \`done\` event handler. Also adds \`readRecoveryMessage\` and \`clearRecoveryMessage\` helpers
- **\`src/screens/chat/hooks/use-chat-history.ts\`**: inside the \`historyQuery\` queryFn, after \`fetchHistory\` returns:
  - If recovery message present and history already contains it (by id or text match) → clear buffer
  - Else → merge recovery message into history sorted by timestamp
- **Type-safety refactor**: replaces \`(msg as any).id || (msg as any).message_id || ...\` casts with bracket access on a typed shape, addressing the TypeScript-safety concern flagged in review

## Behavior

- Buffer self-clears once backend history catches up (no permanent dupe risk)
- 5-minute TTL prevents stale buffer leak across long browser sessions
- Per-session sessionStorage key — no cross-session bleed
- No-op on environments without \`sessionStorage\` (SSR-safe)

## Diff

3 files changed, +141 / -26.

Workspace-only fix, no hermes-agent changes.

Worked with Interstellar Code