### PR TITLE
feat(composer): bottom-row context controls (profile · workspace · reasoning · model · context ring) + correct workspace catalog

### DIFF
--- a/src/routes/api/-files.test.ts
+++ b/src/routes/api/-files.test.ts
@@ -42,10 +42,7 @@ describe('ensureWorkspacePath (#121)', () => {
     // The new check (path.relative) correctly rejects it.
     const rel = path.relative(root, sibling)
     const escapes =
-      !rel ||
-      rel.startsWith('..') ||
-      rel === '..' ||
-      path.isAbsolute(rel)
+      !rel || rel.startsWith('..') || rel === '..' || path.isAbsolute(rel)
     expect(escapes).toBe(true)
   })
 
@@ -57,10 +54,7 @@ describe('ensureWorkspacePath (#121)', () => {
 
     const rel = path.relative(root, escape)
     expect(
-      !rel ||
-        rel.startsWith('..') ||
-        rel === '..' ||
-        path.isAbsolute(rel),
+      !rel || rel.startsWith('..') || rel === '..' || path.isAbsolute(rel),
     ).toBe(true)
   })
 
@@ -72,10 +66,7 @@ describe('ensureWorkspacePath (#121)', () => {
 
     const rel = path.relative(root, inside)
     expect(
-      !rel ||
-        rel.startsWith('..') ||
-        rel === '..' ||
-        path.isAbsolute(rel),
+      !rel || rel.startsWith('..') || rel === '..' || path.isAbsolute(rel),
     ).toBe(false)
   })
 

--- a/src/routes/api/-workspace.test.ts
+++ b/src/routes/api/-workspace.test.ts
@@ -1,0 +1,153 @@
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadWorkspaceCatalog, saveWorkspaceSelection } from './workspace'
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+
+async function makeDir(...parts: Array<string>) {
+  const dir = path.join(...parts)
+  await fs.mkdir(dir, { recursive: true })
+  return dir
+}
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hermes-workspace-route-'))
+  process.env = { ...originalEnv }
+  process.env.HERMES_HOME = path.join(tempRoot, '.hermes')
+  delete process.env.HERMES_WORKSPACE_DIR
+  delete process.env.CLAUDE_WORKSPACE_DIR
+  delete process.env.HERMES_WEBUI_DEFAULT_WORKSPACE
+  await fs.mkdir(process.env.HERMES_HOME, { recursive: true })
+})
+
+afterEach(async () => {
+  process.env = { ...originalEnv }
+  await fs.rm(tempRoot, { recursive: true, force: true })
+})
+
+describe('workspace API catalog semantics', () => {
+  it('uses the Hermes profile default workspace instead of ~/.hermes state', async () => {
+    const project = await makeDir(tempRoot, 'workspace')
+    await fs.writeFile(
+      path.join(process.env.HERMES_HOME!, 'config.yaml'),
+      `default_workspace: ${JSON.stringify(project)}\n`,
+      'utf-8',
+    )
+
+    const catalog = await loadWorkspaceCatalog()
+
+    expect(catalog).toMatchObject({
+      path: project,
+      folderName: 'Home',
+      source: 'config.default_workspace',
+      isValid: true,
+      last: project,
+    })
+    expect(catalog.workspaces).toEqual([{ name: 'Home', path: project }])
+    expect(catalog.path).not.toBe(process.env.HERMES_HOME)
+  })
+
+  it('ignores legacy persisted Hermes state paths as workspaces', async () => {
+    const project = await makeDir(tempRoot, 'workspace')
+    await fs.writeFile(
+      path.join(process.env.HERMES_HOME!, 'config.yaml'),
+      `default_workspace: ${JSON.stringify(project)}
+`,
+      'utf-8',
+    )
+    await fs.mkdir(path.join(process.env.HERMES_HOME!, 'webui_state'), {
+      recursive: true,
+    })
+    await fs.writeFile(
+      path.join(process.env.HERMES_HOME!, 'webui_state', 'workspaces.json'),
+      JSON.stringify({
+        workspaces: [
+          { name: 'Bad Hermes Home', path: process.env.HERMES_HOME },
+          { name: 'Home', path: project },
+        ],
+        last: process.env.HERMES_HOME,
+      }),
+      'utf-8',
+    )
+    await fs.writeFile(
+      path.join(process.env.HERMES_HOME!, 'webui_state', 'last_workspace.txt'),
+      `${process.env.HERMES_HOME}
+`,
+      'utf-8',
+    )
+
+    const catalog = await loadWorkspaceCatalog()
+
+    expect(catalog.path).toBe(project)
+    expect(catalog.workspaces).toEqual([{ name: 'Home', path: project }])
+  })
+
+  it('rejects manual selection of Hermes state directories', async () => {
+    await expect(
+      saveWorkspaceSelection({ path: process.env.HERMES_HOME!, name: 'State' }),
+    ).rejects.toThrow('cannot be used as workspaces')
+  })
+
+  it('rejects manual selection of system directories', async () => {
+    await expect(
+      saveWorkspaceSelection({ path: '/', name: 'Root' }),
+    ).rejects.toThrow('System directories cannot be used as workspaces')
+  })
+
+  it('honors CLAUDE_HOME as the profile root when HERMES_HOME is unset', async () => {
+    const claudeHome = path.join(tempRoot, '.claude-home')
+    const project = await makeDir(tempRoot, 'claude-workspace')
+    delete process.env.HERMES_HOME
+    process.env.CLAUDE_HOME = claudeHome
+    await fs.mkdir(claudeHome, { recursive: true })
+    await fs.writeFile(
+      path.join(claudeHome, 'config.yaml'),
+      `default_workspace: ${JSON.stringify(project)}
+`,
+      'utf-8',
+    )
+
+    const catalog = await loadWorkspaceCatalog()
+
+    expect(catalog.path).toBe(project)
+    await saveWorkspaceSelection({ path: project, name: 'Claude Workspace' })
+    await expect(
+      fs.readFile(
+        path.join(claudeHome, 'webui_state', 'last_workspace.txt'),
+        'utf-8',
+      ),
+    ).resolves.toBe(`${project}
+`)
+  })
+
+  it('persists the selected workspace in profile-local Web UI state', async () => {
+    const homeProject = await makeDir(tempRoot, 'workspace')
+    const selectedProject = await makeDir(tempRoot, 'client-app')
+    process.env.HERMES_WEBUI_DEFAULT_WORKSPACE = homeProject
+
+    const saved = await saveWorkspaceSelection({
+      path: selectedProject,
+      name: 'Client App',
+    })
+
+    expect(saved.path).toBe(selectedProject)
+    expect(saved.folderName).toBe('Client App')
+    expect(saved.workspaces).toContainEqual({
+      name: 'Client App',
+      path: selectedProject,
+    })
+    await expect(
+      fs.readFile(
+        path.join(
+          process.env.HERMES_HOME!,
+          'webui_state',
+          'last_workspace.txt',
+        ),
+        'utf-8',
+      ),
+    ).resolves.toBe(`${selectedProject}\n`)
+  })
+})

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -1,4 +1,3 @@
-import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { execFile } from 'node:child_process'
@@ -16,15 +15,9 @@ import {
   requireJsonContentType,
   safeErrorMessage,
 } from '../../server/rate-limit'
+import { loadWorkspaceCatalog } from './workspace'
 
 const execFileAsync = promisify(execFile)
-
-const WORKSPACE_ROOT = (
-  process.env.HERMES_WORKSPACE_DIR ||
-  process.env.CLAUDE_WORKSPACE_DIR ||
-  process.env.HERMES_HOME || process.env.CLAUDE_HOME ||
-  path.join(os.homedir(), '.hermes')
-).trim()
 
 type FileEntry = {
   name: string
@@ -43,14 +36,22 @@ type FileEntry = {
  * form rejects any candidate that escapes the root via `..` segments or
  * that resolves to an absolute path outside the root. See #121.
  */
-function ensureWorkspacePath(input: string) {
+async function getWorkspaceRoot(): Promise<string> {
+  const catalog = await loadWorkspaceCatalog()
+  if (!catalog.isValid || !catalog.path) {
+    throw new Error('No valid workspace selected')
+  }
+  return catalog.path
+}
+
+function ensureWorkspacePath(input: string, workspaceRoot: string) {
   const raw = input.trim()
-  if (!raw) return WORKSPACE_ROOT
+  if (!raw) return workspaceRoot
   const resolved = path.isAbsolute(raw)
     ? path.resolve(raw)
-    : path.resolve(WORKSPACE_ROOT, raw)
-  if (resolved === WORKSPACE_ROOT) return resolved
-  const relative = path.relative(WORKSPACE_ROOT, resolved)
+    : path.resolve(workspaceRoot, raw)
+  if (resolved === workspaceRoot) return resolved
+  const relative = path.relative(workspaceRoot, resolved)
   if (
     !relative ||
     relative.startsWith('..') ||
@@ -62,8 +63,8 @@ function ensureWorkspacePath(input: string) {
   return resolved
 }
 
-function toRelative(resolvedPath: string) {
-  const relative = path.relative(WORKSPACE_ROOT, resolvedPath)
+function toRelative(resolvedPath: string, workspaceRoot: string) {
+  const relative = path.relative(workspaceRoot, resolvedPath)
   return relative || ''
 }
 
@@ -121,6 +122,7 @@ type ReadDirectoryOptions = {
   maxDepth: number
   maxEntries: number | null
   countedEntries: { value: number }
+  workspaceRoot: string
 }
 
 function parseMaxDepth(input: string | null): number | null {
@@ -163,7 +165,7 @@ async function readDirectory(
 
     if (IGNORED_DIRS.has(entry.name)) continue
     const fullPath = path.join(dirPath, entry.name)
-    const relativePath = toRelative(fullPath)
+    const relativePath = toRelative(fullPath, options.workspaceRoot)
     try {
       const stats = await fs.stat(fullPath)
       if (entry.isDirectory()) {
@@ -195,9 +197,9 @@ async function readDirectory(
   return sortEntries(mapped)
 }
 
-async function readGlobDirectory(globPath: string) {
+async function readGlobDirectory(globPath: string, workspaceRoot: string) {
   const { directoryPath, regex } = parseGlobPattern(globPath)
-  const resolvedDirectory = ensureWorkspacePath(directoryPath)
+  const resolvedDirectory = ensureWorkspacePath(directoryPath, workspaceRoot)
   const entries = await fs.readdir(resolvedDirectory, { withFileTypes: true })
   const mapped: Array<FileEntry> = []
 
@@ -207,7 +209,7 @@ async function readGlobDirectory(globPath: string) {
     const stats = await fs.stat(fullPath)
     mapped.push({
       name: entry.name,
-      path: toRelative(fullPath),
+      path: toRelative(fullPath, workspaceRoot),
       type: entry.isDirectory() ? 'folder' : 'file',
       size: stats.size,
       modifiedAt: stats.mtime.toISOString(),
@@ -215,7 +217,7 @@ async function readGlobDirectory(globPath: string) {
   }
 
   return {
-    root: toRelative(resolvedDirectory),
+    root: toRelative(resolvedDirectory, workspaceRoot),
     entries: sortEntries(mapped),
   }
 }
@@ -260,16 +262,21 @@ export const Route = createFileRoute('/api/files')({
             url.searchParams.get('maxEntries'),
           )
 
+          const workspaceRoot = await getWorkspaceRoot()
+
           if (action === 'list' && hasGlob(inputPath)) {
-            const globListing = await readGlobDirectory(inputPath)
+            const globListing = await readGlobDirectory(
+              inputPath,
+              workspaceRoot,
+            )
             return json({
               root: globListing.root,
-              base: WORKSPACE_ROOT,
+              base: workspaceRoot,
               entries: globListing.entries,
             })
           }
 
-          const resolvedPath = ensureWorkspacePath(inputPath)
+          const resolvedPath = ensureWorkspacePath(inputPath, workspaceRoot)
 
           if (action === 'read') {
             const buffer = await fs.readFile(resolvedPath)
@@ -277,13 +284,13 @@ export const Route = createFileRoute('/api/files')({
               const mime = getMimeType(resolvedPath)
               return json({
                 type: 'image',
-                path: toRelative(resolvedPath),
+                path: toRelative(resolvedPath, workspaceRoot),
                 content: `data:${mime};base64,${buffer.toString('base64')}`,
               })
             }
             return json({
               type: 'text',
-              path: toRelative(resolvedPath),
+              path: toRelative(resolvedPath, workspaceRoot),
               content: buffer.toString('utf8'),
             })
           }
@@ -304,10 +311,11 @@ export const Route = createFileRoute('/api/files')({
             maxDepth: maxDepthParam ?? MAX_DIRECTORY_DEPTH,
             maxEntries: maxEntriesParam,
             countedEntries: { value: 0 },
+            workspaceRoot,
           })
           return json({
-            root: toRelative(resolvedPath),
-            base: WORKSPACE_ROOT,
+            root: toRelative(resolvedPath, workspaceRoot),
+            base: workspaceRoot,
             entries: tree,
           })
         } catch (err) {
@@ -324,6 +332,7 @@ export const Route = createFileRoute('/api/files')({
         }
 
         try {
+          const workspaceRoot = await getWorkspaceRoot()
           const contentType = request.headers.get('content-type') || ''
           if (!contentType.includes('multipart/form-data')) {
             const csrfCheck = requireJsonContentType(request)
@@ -340,7 +349,10 @@ export const Route = createFileRoute('/api/files')({
             if (!(file instanceof File)) {
               return json({ error: 'Missing file' }, { status: 400 })
             }
-            const resolvedTarget = ensureWorkspacePath(targetPath)
+            const resolvedTarget = ensureWorkspacePath(
+              targetPath,
+              workspaceRoot,
+            )
             const isDir = (await fs.stat(resolvedTarget)).isDirectory()
             const destination = isDir
               ? path.join(resolvedTarget, file.name)
@@ -348,7 +360,10 @@ export const Route = createFileRoute('/api/files')({
             await fs.mkdir(path.dirname(destination), { recursive: true })
             const buffer = Buffer.from(await file.arrayBuffer())
             await fs.writeFile(destination, buffer)
-            return json({ ok: true, path: toRelative(destination) })
+            return json({
+              ok: true,
+              path: toRelative(destination, workspaceRoot),
+            })
           }
 
           const body = (await request.json().catch(() => ({}))) as Record<
@@ -358,24 +373,36 @@ export const Route = createFileRoute('/api/files')({
           const action = typeof body.action === 'string' ? body.action : 'write'
 
           if (action === 'mkdir') {
-            const dirPath = ensureWorkspacePath(String(body.path || ''))
+            const dirPath = ensureWorkspacePath(
+              String(body.path || ''),
+              workspaceRoot,
+            )
             await fs.mkdir(dirPath, { recursive: true })
-            return json({ ok: true, path: toRelative(dirPath) })
+            return json({ ok: true, path: toRelative(dirPath, workspaceRoot) })
           }
 
           if (action === 'rename') {
-            const fromPath = ensureWorkspacePath(String(body.from || ''))
-            const toPath = ensureWorkspacePath(String(body.to || ''))
+            const fromPath = ensureWorkspacePath(
+              String(body.from || ''),
+              workspaceRoot,
+            )
+            const toPath = ensureWorkspacePath(
+              String(body.to || ''),
+              workspaceRoot,
+            )
             await fs.mkdir(path.dirname(toPath), { recursive: true })
             await fs.rename(fromPath, toPath)
-            return json({ ok: true, path: toRelative(toPath) })
+            return json({ ok: true, path: toRelative(toPath, workspaceRoot) })
           }
 
           if (action === 'delete') {
             if (!requireLocalOrAuth(request)) {
               return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
             }
-            const targetPath = ensureWorkspacePath(String(body.path || ''))
+            const targetPath = ensureWorkspacePath(
+              String(body.path || ''),
+              workspaceRoot,
+            )
             try {
               // Try macOS trash command first
               await execFileAsync('trash', [targetPath])
@@ -386,11 +413,14 @@ export const Route = createFileRoute('/api/files')({
             return json({ ok: true })
           }
 
-          const filePath = ensureWorkspacePath(String(body.path || ''))
+          const filePath = ensureWorkspacePath(
+            String(body.path || ''),
+            workspaceRoot,
+          )
           const content = typeof body.content === 'string' ? body.content : ''
           await fs.mkdir(path.dirname(filePath), { recursive: true })
           await fs.writeFile(filePath, content, 'utf8')
-          return json({ ok: true, path: toRelative(filePath) })
+          return json({ ok: true, path: toRelative(filePath, workspaceRoot) })
         } catch (err) {
           return json({ error: safeErrorMessage(err) }, { status: 500 })
         }

--- a/src/routes/api/workspace.ts
+++ b/src/routes/api/workspace.ts
@@ -1,17 +1,141 @@
 /**
- * Phase 2.6: Workspace detection API
- * Auto-detects workspace from Hermes config, env, or default paths
+ * Hermes workspace API.
+ *
+ * Important distinction: HERMES_HOME / ~/.hermes is Hermes state/config, not the
+ * user's project workspace. Workspace resolution intentionally mirrors the
+ * Hermes Web UI semantics: active profile config first, then user workspace
+ * defaults such as ~/workspace. Never fall back to ~/.hermes as a workspace.
  */
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
+import YAML from 'yaml'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
+import { requireJsonContentType } from '../../server/rate-limit'
+import {
+  getActiveProfileName,
+  readProfile,
+} from '../../server/profiles-browser'
+
+type WorkspaceEntry = {
+  name: string
+  path: string
+}
+
+type WorkspaceDetectionResponse = {
+  path: string
+  folderName: string
+  source: string
+  isValid: boolean
+  workspaces: Array<WorkspaceEntry>
+  last: string
+}
+
+type WorkspaceState = {
+  workspaces?: Array<WorkspaceEntry>
+  last?: string
+}
 
 function extractFolderName(fullPath: string): string {
-  const parts = fullPath.replace(/\\/g, '/').split('/')
-  return parts[parts.length - 1] || 'workspace'
+  const parts = fullPath.replace(/\\/g, '/').split('/').filter(Boolean)
+  return parts.at(-1) || 'workspace'
+}
+
+function expandHome(input: string): string {
+  if (input === '~') return os.homedir()
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2))
+  return input
+}
+
+function normalizeCandidate(input: string): string {
+  return path.resolve(expandHome(input.trim()))
+}
+
+function pathContains(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate)
+  return (
+    Boolean(relative) &&
+    !relative.startsWith('..') &&
+    !path.isAbsolute(relative)
+  )
+}
+
+function isPathOrChild(parent: string, candidate: string): boolean {
+  const normalizedParent = normalizeCandidate(parent)
+  const normalizedCandidate = normalizeCandidate(candidate)
+  return (
+    normalizedCandidate === normalizedParent ||
+    pathContains(normalizedParent, normalizedCandidate)
+  )
+}
+
+function exactBlockedSystemRoots(): Array<string> {
+  return ['/', 'C:/']
+}
+
+function blockedSystemSubtrees(): Array<string> {
+  return [
+    '/bin',
+    '/sbin',
+    '/etc',
+    '/usr',
+    '/boot',
+    '/proc',
+    '/sys',
+    '/dev',
+    '/root',
+    '/private/etc',
+    '/private/var/db',
+    '/private/var/log',
+    'C:/Windows',
+    'C:/Program Files',
+    'C:/Program Files (x86)',
+  ]
+}
+
+function isBlockedSystemPath(candidatePath: string): boolean {
+  const normalized = normalizeCandidate(candidatePath)
+  return (
+    exactBlockedSystemRoots().some(
+      (root) => normalizeCandidate(root) === normalized,
+    ) || blockedSystemSubtrees().some((root) => isPathOrChild(root, normalized))
+  )
+}
+
+function isHermesStatePath(candidatePath: string): boolean {
+  const normalized = normalizeCandidate(candidatePath)
+  const stateRoots = Array.from(
+    new Set(
+      [
+        process.env.HERMES_HOME,
+        process.env.CLAUDE_HOME,
+        path.join(os.homedir(), '.hermes'),
+        activeProfileHome(),
+      ]
+        .map((value) => readString(value))
+        .filter(Boolean)
+        .map(normalizeCandidate),
+    ),
+  )
+
+  return stateRoots.some(
+    (root) => normalized === root || pathContains(root, normalized),
+  )
+}
+
+function assertWorkspaceAllowed(candidatePath: string): void {
+  if (isHermesStatePath(candidatePath)) {
+    throw new Error(
+      'Hermes profile/state directories cannot be used as workspaces',
+    )
+  }
+  if (isBlockedSystemPath(candidatePath)) {
+    throw new Error(
+      `System directories cannot be used as workspaces: ${candidatePath}`,
+    )
+  }
 }
 
 async function isValidDirectory(dirPath: string): Promise<boolean> {
@@ -23,24 +147,174 @@ async function isValidDirectory(dirPath: string): Promise<boolean> {
   }
 }
 
-async function detectWorkspace(savedPath?: string): Promise<{
-  path: string
-  folderName: string
-  source: string
-  isValid: boolean
-}> {
-  // Priority 1: Saved path from localStorage (passed via query param)
-  if (savedPath) {
-    const isValid = await isValidDirectory(savedPath)
-    if (isValid) {
-      return {
-        path: savedPath,
-        folderName: extractFolderName(savedPath),
-        source: 'localStorage',
-        isValid: true,
+async function readYamlConfig(
+  configPath: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.readFile(configPath, 'utf-8')
+    const parsed = YAML.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+async function firstValidDirectory(
+  candidates: Array<{ path: string; source: string; create?: boolean }>,
+): Promise<{ path: string; source: string } | null> {
+  for (const candidate of candidates) {
+    const raw = candidate.path.trim()
+    if (!raw || raw === '.') continue
+    const resolved = normalizeCandidate(raw)
+    if (candidate.create) {
+      try {
+        await fs.mkdir(resolved, { recursive: true })
+      } catch {
+        // Continue to next candidate.
       }
     }
-    // Saved path is stale, fall through to auto-detect
+    if (isHermesStatePath(resolved) || isBlockedSystemPath(resolved)) continue
+    if (await isValidDirectory(resolved)) {
+      return { path: resolved, source: candidate.source }
+    }
+  }
+  return null
+}
+
+function activeProfileHome(): string {
+  try {
+    const active = getActiveProfileName()
+    return readProfile(active).path
+  } catch {
+    return (
+      process.env.HERMES_HOME ??
+      process.env.CLAUDE_HOME ??
+      path.join(os.homedir(), '.hermes')
+    )
+  }
+}
+
+function workspaceStateDir(): string {
+  return path.join(activeProfileHome(), 'webui_state')
+}
+
+function workspaceStateFile(): string {
+  return path.join(workspaceStateDir(), 'workspaces.json')
+}
+
+function lastWorkspaceFile(): string {
+  return path.join(workspaceStateDir(), 'last_workspace.txt')
+}
+
+async function readWorkspaceState(): Promise<WorkspaceState> {
+  try {
+    const raw = await fs.readFile(workspaceStateFile(), 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed))
+      return { workspaces: parsed as Array<WorkspaceEntry> }
+    if (parsed && typeof parsed === 'object') return parsed as WorkspaceState
+  } catch {
+    // No persisted state yet.
+  }
+  return {}
+}
+
+async function writeWorkspaceState(state: WorkspaceState): Promise<void> {
+  const stateDir = workspaceStateDir()
+  await fs.mkdir(stateDir, { recursive: true })
+  await fs.writeFile(
+    workspaceStateFile(),
+    JSON.stringify(
+      {
+        workspaces: state.workspaces ?? [],
+        last: state.last ?? '',
+      },
+      null,
+      2,
+    ),
+    'utf-8',
+  )
+  if (state.last) {
+    await fs.writeFile(lastWorkspaceFile(), `${state.last}\n`, 'utf-8')
+  }
+}
+
+async function configuredDefaultWorkspace(): Promise<{
+  path: string
+  source: string
+} | null> {
+  const profileHome = activeProfileHome()
+  const cfg = await readYamlConfig(path.join(profileHome, 'config.yaml'))
+  const terminal = cfg.terminal
+  const terminalCwd =
+    terminal && typeof terminal === 'object' && !Array.isArray(terminal)
+      ? readString((terminal as Record<string, unknown>).cwd)
+      : ''
+
+  return firstValidDirectory([
+    { path: process.env.HERMES_WORKSPACE_DIR ?? '', source: 'env' },
+    { path: process.env.CLAUDE_WORKSPACE_DIR ?? '', source: 'env' },
+    { path: process.env.HERMES_WEBUI_DEFAULT_WORKSPACE ?? '', source: 'env' },
+    { path: readString(cfg.workspace), source: 'config.workspace' },
+    {
+      path: readString(cfg.default_workspace),
+      source: 'config.default_workspace',
+    },
+    { path: terminalCwd, source: 'config.terminal.cwd' },
+    { path: path.join(os.homedir(), 'workspace'), source: 'home.workspace' },
+    { path: path.join(os.homedir(), 'work'), source: 'home.work' },
+    {
+      path: path.join(os.homedir(), 'workspace'),
+      source: 'home.workspace.created',
+      create: true,
+    },
+  ])
+}
+
+function dedupeWorkspaces(
+  workspaces: Array<WorkspaceEntry>,
+): Array<WorkspaceEntry> {
+  const seen = new Set<string>()
+  const cleaned: Array<WorkspaceEntry> = []
+  for (const workspace of workspaces) {
+    const rawPath = readString(workspace.path)
+    if (!rawPath) continue
+    const normalized = normalizeCandidate(rawPath)
+    if (isHermesStatePath(normalized) || isBlockedSystemPath(normalized))
+      continue
+    if (seen.has(normalized)) continue
+    seen.add(normalized)
+    const name = readString(workspace.name) || extractFolderName(normalized)
+    cleaned.push({ name: name === 'default' ? 'Home' : name, path: normalized })
+  }
+  return cleaned
+}
+
+async function cleanExistingWorkspaces(
+  workspaces: Array<WorkspaceEntry>,
+): Promise<Array<WorkspaceEntry>> {
+  const cleaned = dedupeWorkspaces(workspaces)
+  const existing: Array<WorkspaceEntry> = []
+  for (const workspace of cleaned) {
+    if (await isValidDirectory(workspace.path)) existing.push(workspace)
+  }
+  return existing
+}
+
+export async function loadWorkspaceCatalog(): Promise<WorkspaceDetectionResponse> {
+  const state = await readWorkspaceState()
+  const configured = await configuredDefaultWorkspace()
+  const fallback = configured ?? { path: '', source: 'none' }
+  let workspaces = await cleanExistingWorkspaces(state.workspaces ?? [])
+
+  if (workspaces.length === 0 && fallback.path) {
+    workspaces = [{ name: 'Home', path: fallback.path }]
   }
 
   // Priority 2: Environment variable
@@ -55,41 +329,68 @@ async function detectWorkspace(savedPath?: string): Promise<{
         folderName: extractFolderName(envWorkspace),
         source: 'env',
         isValid: true,
+        workspaces,
+        last: envWorkspace,
       }
     }
   }
 
-  // Priority 3: Default Claude workspace path
-  const defaultPath = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
-  const defaultValid = await isValidDirectory(defaultPath)
-  if (defaultValid) {
-    return {
-      path: defaultPath,
-      folderName: extractFolderName(defaultPath),
-      source: 'default',
-      isValid: true,
+  const savedLast = readString(state.last)
+  const lastFromFile = await (async () => {
+    try {
+      return (await fs.readFile(lastWorkspaceFile(), 'utf-8')).trim()
+    } catch {
+      return ''
     }
-  }
+  })()
+  const lastCandidate =
+    [savedLast, lastFromFile, fallback.path].find(Boolean) ?? ''
+  const normalizedLast = lastCandidate ? normalizeCandidate(lastCandidate) : ''
+  const activeWorkspace =
+    workspaces.find((workspace) => workspace.path === normalizedLast) ??
+    workspaces.at(0)
+  const active =
+    activeWorkspace ??
+    (fallback.path ? { name: 'Home', path: fallback.path } : undefined)
+  const activePath = active ? active.path : ''
 
-  // Priority 4: Claude home directory
-  const claudeDir = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
-  const claudeDirValid = await isValidDirectory(claudeDir)
-  if (claudeDirValid) {
-    return {
-      path: claudeDir,
-      folderName: path.basename(claudeDir),
-      source: 'default',
-      isValid: true,
-    }
-  }
-
-  // Nothing found
   return {
-    path: '',
-    folderName: '',
-    source: 'none',
-    isValid: false,
+    path: activePath,
+    folderName: active ? active.name || extractFolderName(active.path) : '',
+    source:
+      activePath && activePath === fallback.path
+        ? fallback.source
+        : 'workspace-state',
+    isValid: Boolean(activePath),
+    workspaces,
+    last: activePath,
   }
+}
+
+export async function saveWorkspaceSelection(input: {
+  path?: string
+  name?: string
+}): Promise<WorkspaceDetectionResponse> {
+  const rawPath = readString(input.path)
+  if (!rawPath) throw new Error('path is required')
+  const target = normalizeCandidate(rawPath)
+  assertWorkspaceAllowed(target)
+  if (!(await isValidDirectory(target))) {
+    throw new Error(`Path is not an existing directory: ${target}`)
+  }
+
+  const current = await loadWorkspaceCatalog()
+  const next = dedupeWorkspaces([
+    ...current.workspaces,
+    {
+      path: target,
+      name:
+        readString(input.name) ||
+        (current.workspaces.length === 0 ? 'Home' : extractFolderName(target)),
+    },
+  ])
+  await writeWorkspaceState({ workspaces: next, last: target })
+  return loadWorkspaceCatalog()
 }
 
 export const Route = createFileRoute('/api/workspace')({
@@ -100,12 +401,7 @@ export const Route = createFileRoute('/api/workspace')({
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         try {
-          const url = new URL(request.url)
-          const savedPath = url.searchParams.get('saved') || undefined
-
-          const result = await detectWorkspace(savedPath)
-
-          return json(result)
+          return json(await loadWorkspaceCatalog())
         } catch (err) {
           return json(
             {
@@ -113,9 +409,33 @@ export const Route = createFileRoute('/api/workspace')({
               folderName: '',
               source: 'error',
               isValid: false,
+              workspaces: [],
+              last: '',
               error: err instanceof Error ? err.message : String(err),
             },
             { status: 500 },
+          )
+        }
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const contentTypeError = requireJsonContentType(request)
+        if (contentTypeError) return contentTypeError
+        try {
+          const body = (await request.json()) as {
+            path?: string
+            name?: string
+          }
+          return json(await saveWorkspaceSelection(body))
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 400 },
           )
         }
       },

--- a/src/screens/chat/components/chat-composer-context-controls.test.ts
+++ b/src/screens/chat/components/chat-composer-context-controls.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = () =>
+  readFileSync(
+    resolve(process.cwd(), 'src/screens/chat/components/chat-composer.tsx'),
+    'utf8',
+  )
+
+describe('ChatComposer context controls', () => {
+  it('wires profile selection through the existing profile APIs', () => {
+    const src = source()
+
+    expect(src).toContain("fetch('/api/profiles/list')")
+    expect(src).toContain("fetch('/api/profiles/activate'")
+    expect(src).toContain('Activated profile')
+  })
+
+  it('surfaces workspace and reasoning controls next to the model picker', () => {
+    const src = source()
+
+    expect(src).toContain("fetch('/api/workspace')")
+    expect(src).toContain('Workspace context')
+    expect(src).toContain('workspaceSelectMutation')
+    expect(src).toContain('workspaceEntries.map')
+    expect(src).toContain('SEARCH_MODAL_EVENTS.TOGGLE_FILE_EXPLORER')
+    expect(src).toContain('Reasoning effort')
+    expect(src).toContain("['medium', 'Medium']")
+    expect(src).toContain("['high', 'High']")
+  })
+})

--- a/src/screens/chat/components/chat-composer-model-switch.test.ts
+++ b/src/screens/chat/components/chat-composer-model-switch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
-  getZeroForkModelInfoFlags,
   MODEL_SWITCH_BLOCKED_TOAST,
+  getZeroForkModelInfoFlags,
   shouldBlockZeroForkModelSwitch,
 } from './chat-composer-model-switch'
 

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -3,13 +3,14 @@ import {
   Add01Icon,
   ArrowDown01Icon,
   ArrowUp02Icon,
+  AttachmentIcon,
   Cancel01Icon,
   Delete01Icon,
   Mic01Icon,
   StopIcon,
 } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   memo,
   useCallback,
@@ -20,6 +21,12 @@ import {
   useRef,
   useState,
 } from 'react'
+import {
+  MODEL_SWITCH_BLOCKED_TOAST,
+  getZeroForkModelInfoFlags,
+  shouldBlockZeroForkModelSwitch,
+} from './chat-composer-model-switch'
+import { ContextBar } from './context-bar'
 import type { CSSProperties, Ref } from 'react'
 
 import type { ModelCatalogEntry, ModelSwitchResponse } from '@/lib/model-types'
@@ -37,6 +44,7 @@ import { SlashCommandMenu } from '@/components/slash-command-menu'
 import { useSettings } from '@/hooks/use-settings'
 import { MOBILE_TAB_BAR_OFFSET } from '@/components/mobile-tab-bar'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useSessionModelStore } from '@/stores/session-model-store'
 import { Button } from '@/components/ui/button'
 import { usePinnedModels } from '@/hooks/use-pinned-models'
 // import { ModeSelector } from '@/components/mode-selector'
@@ -45,10 +53,10 @@ import { useVoiceInput } from '@/hooks/use-voice-input'
 import { useVoiceRecorder } from '@/hooks/use-voice-recorder'
 import { toast } from '@/components/ui/toast'
 import {
-  getZeroForkModelInfoFlags,
-  MODEL_SWITCH_BLOCKED_TOAST,
-  shouldBlockZeroForkModelSwitch,
-} from './chat-composer-model-switch'
+  SEARCH_MODAL_EVENTS,
+  emitSearchModalEvent,
+} from '@/hooks/use-search-modal'
+import { setLocalModelOverride } from '@/screens/chat/local-model-override'
 
 type ChatComposerAttachment = {
   id: string
@@ -60,7 +68,7 @@ type ChatComposerAttachment = {
   kind?: 'image' | 'file' | 'audio'
 }
 
-type ThinkingLevel = 'off' | 'low' | 'adaptive'
+type ThinkingLevel = 'off' | 'low' | 'medium' | 'high'
 
 type ChatComposerProps = {
   onSubmit: (
@@ -102,7 +110,8 @@ type ChatComposerHandle = {
 
 function nextThinkingLevel(level: ThinkingLevel): ThinkingLevel {
   if (level === 'off') return 'low'
-  if (level === 'low') return 'adaptive'
+  if (level === 'low') return 'medium'
+  if (level === 'medium') return 'high'
   return 'off'
 }
 
@@ -121,6 +130,33 @@ type SessionStatusApiResponse = {
 
 type GatewayStatusApiResponse = {
   mode?: string
+}
+
+type ProfileSummary = {
+  name: string
+  active?: boolean
+  model?: string
+  provider?: string
+  skillCount?: number
+}
+
+type ProfilesListResponse = {
+  profiles?: Array<ProfileSummary>
+  activeProfile?: string
+}
+
+type WorkspaceEntry = {
+  name: string
+  path: string
+}
+
+type WorkspaceDetectionResponse = {
+  path?: string
+  folderName?: string
+  source?: string
+  isValid?: boolean
+  workspaces?: Array<WorkspaceEntry>
+  last?: string
 }
 
 type ModelInfoApiResponse = {
@@ -262,14 +298,12 @@ async function fetchModelsForProvider(
   }
 
   const payload = (await response.json()) as ClaudeAvailableModelsResponse
-  return (payload.models || []).map((model) => ({
+  return payload.models.map((model) => ({
     id: model.id,
     name: model.id,
     provider: normalizedProvider,
   }))
 }
-
-import { setLocalModelOverride } from '../chat-screen'
 
 const LOCAL_PROVIDERS_SET = new Set(['ollama', 'atomic-chat'])
 
@@ -694,6 +728,53 @@ async function fetchModelInfo(): Promise<ModelInfoApiResponse | null> {
   return (await response.json()) as ModelInfoApiResponse
 }
 
+async function fetchProfiles(): Promise<ProfilesListResponse> {
+  const response = await fetch('/api/profiles/list')
+  if (!response.ok) {
+    throw new Error(await readResponseError(response))
+  }
+  return (await response.json()) as ProfilesListResponse
+}
+
+async function activateProfile(name: string): Promise<void> {
+  const response = await fetch('/api/profiles/activate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  })
+  if (!response.ok) {
+    throw new Error(await readResponseError(response))
+  }
+}
+
+async function fetchWorkspaceContext(): Promise<WorkspaceDetectionResponse> {
+  const response = await fetch('/api/workspace')
+  if (!response.ok) {
+    throw new Error(await readResponseError(response))
+  }
+  return (await response.json()) as WorkspaceDetectionResponse
+}
+
+function shortPathLabel(pathValue: string): string {
+  if (!pathValue) return 'Workspace'
+  const parts = pathValue.replace(/\\/g, '/').split('/').filter(Boolean)
+  return parts.at(-1) || pathValue
+}
+
+function thinkingLabel(level: ThinkingLevel): string {
+  if (level === 'off') return 'None'
+  if (level === 'low') return 'Low'
+  if (level === 'medium') return 'Medium'
+  return 'High'
+}
+
+function profileMeta(profile: ProfileSummary): string {
+  return [profile.model, profile.provider]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter(Boolean)
+    .join(' · ')
+}
+
 function focusPromptTarget(target: HTMLTextAreaElement | null) {
   if (!target) return
   try {
@@ -720,6 +801,7 @@ function ChatComposerComponent({
   embedded = false,
   hideModelSelector = false,
 }: ChatComposerProps) {
+  const queryClient = useQueryClient()
   const mobileKeyboardInset = useWorkspaceStore((s) => s.mobileKeyboardInset)
   const mobileComposerFocused = useWorkspaceStore(
     (s) => s.mobileComposerFocused,
@@ -745,12 +827,15 @@ function ChatComposerComponent({
   } | null>(null)
   const [focusAfterSubmitTick, setFocusAfterSubmitTick] = useState(0)
   const { settings: composerSettings } = useSettings()
-  const chatNavMode = composerSettings.mobileChatNavMode ?? 'dock'
+  const chatNavMode = composerSettings.mobileChatNavMode
   const [isMobileViewport, setIsMobileViewport] = useState(() => {
     if (typeof window === 'undefined') return false
     return window.matchMedia('(max-width: 767px)').matches
   })
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false)
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false)
+  const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false)
+  const [isThinkingMenuOpen, setIsThinkingMenuOpen] = useState(false)
   const [isProviderSwitcherExpanded, setIsProviderSwitcherExpanded] =
     useState(false)
   const [isMobileActionsMenuOpen, setIsMobileActionsMenuOpen] = useState(false)
@@ -776,11 +861,14 @@ function ChatComposerComponent({
   const promptRef = useRef<HTMLTextAreaElement | null>(null)
   const slashMenuRef = useRef<SlashCommandMenuHandle | null>(null)
   const attachmentInputRef = useRef<HTMLInputElement | null>(null)
+  const profileMenuRef = useRef<HTMLDivElement | null>(null)
   const dragCounterRef = useRef(0)
   const shouldRefocusAfterSendRef = useRef(false)
   const submittingRef = useRef(false)
   const pendingSubmitAfterAttachmentsRef = useRef(false)
   const modelSelectorRef = useRef<HTMLDivElement | null>(null)
+  const workspaceMenuRef = useRef<HTMLDivElement | null>(null)
+  const thinkingMenuRef = useRef<HTMLDivElement | null>(null)
   const composerWrapperRef = useRef<HTMLDivElement | null>(null)
   const focusFrameRef = useRef<number | null>(null)
 
@@ -853,52 +941,80 @@ function ChatComposerComponent({
     [modelInfoQuery.data],
   )
 
+  const profilesQuery = useQuery({
+    queryKey: ['profiles', 'composer'],
+    queryFn: fetchProfiles,
+    retry: false,
+    staleTime: 15_000,
+  })
+  const workspaceContextQuery = useQuery({
+    queryKey: ['workspace', 'composer-context'],
+    queryFn: fetchWorkspaceContext,
+    retry: false,
+    staleTime: 30_000,
+  })
+  const profileActivateMutation = useMutation({
+    mutationFn: activateProfile,
+    onSuccess: async (_data, profileName) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['profiles'] }),
+        queryClient.invalidateQueries({ queryKey: ['workspace'] }),
+        queryClient.invalidateQueries({ queryKey: ['claude', 'models'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['claude', 'session-status-model'],
+        }),
+      ])
+      setIsProfileMenuOpen(false)
+      toast(`Activated profile ${profileName}`)
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error ? error.message : 'Failed to activate profile',
+      )
+    },
+  })
+  const workspaceSelectMutation = useMutation({
+    mutationFn: async (workspace: { path: string; name?: string }) => {
+      const response = await fetch('/api/workspace', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(workspace),
+      })
+      if (!response.ok) {
+        throw new Error(await readResponseError(response))
+      }
+      return (await response.json()) as WorkspaceDetectionResponse
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['workspace', 'composer-context'],
+      })
+      setIsWorkspaceMenuOpen(false)
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error ? error.message : 'Failed to switch workspace',
+      )
+    },
+  })
+
   // Phase 4.2: (pinned model tracking kept for future use)
   void modelsQuery.data
 
-  const modelSwitchMutation = useMutation({
-    mutationFn: async function doSwitchModel(payload: {
-      model: string
-      provider?: string
-      sessionKey?: string
-    }) {
-      return await switchModel(
-        payload.model,
-        payload.provider,
-        payload.sessionKey,
-      )
-    },
-    onSuccess: function onSuccess(payload: ModelSwitchResponse, variables) {
-      const provider = readText(payload.resolved?.modelProvider)
-      const model = readText(payload.resolved?.model)
-      const resolvedModel =
-        provider && model ? `${provider}/${model}` : model || variables.model
-      setModelNotice({
-        tone: 'success',
-        message: `Model switched to ${resolvedModel}`,
-      })
-      setIsModelMenuOpen(false)
-      void currentModelQuery.refetch()
-    },
-    onError: function onError(error, variables) {
-      const message = error instanceof Error ? error.message : String(error)
-      if (isTimeoutErrorMessage(message)) {
-        setModelNotice({
-          tone: 'error',
-          message: 'Request timed out',
-          retryModel: variables.model,
-          retryProvider: variables.provider,
-        })
-        return
-      }
-      setModelNotice({
-        tone: 'error',
-        message: message || 'Failed to switch model',
-        retryModel: variables.model,
-        retryProvider: variables.provider,
-      })
-    },
-  })
+  // Per-session model override, persisted to localStorage keyed by sessionKey.
+  // Drives both the composer label and the model passed to startStreaming.
+  // Replaces an earlier flow that PATCHed ~/.hermes/config.yaml — that path
+  // 404s and would clobber the global default for every channel anyway.
+  const persistedSessionModel = useSessionModelStore((s) =>
+    s.getModel(sessionKey),
+  )
+  const setPersistedSessionModel = useSessionModelStore((s) => s.setModel)
+
+  // Model switching is now per-session via the persistent store above.
+  // Previously this issued a PATCH /api/hermes-proxy/api/config to write to
+  // ~/.hermes/config.yaml — that endpoint 404s and would clobber the global
+  // default for every channel anyway. The mutation block + retry callback +
+  // dead onError handler were removed alongside it.
 
   const handleModelSelect = useCallback(
     function handleModelSelect(nextModel: string, provider?: string) {
@@ -919,30 +1035,57 @@ function ChatComposerComponent({
         return
       }
       setModelNotice(null)
-      setCurrentSelectedModel(getResolvedModelKey(model, provider))
-      modelSwitchMutation.mutate({
-        model,
-        provider,
-        sessionKey: normalizedSessionKey,
-      })
+      const resolved = getResolvedModelKey(model, provider)
+      // Per-session, browser-local persistence. No global config write —
+      // picking a model here only affects this chat. The actual model is
+      // passed on each request via the chat-completion `model` field.
+      if (normalizedSessionKey) {
+        setPersistedSessionModel(normalizedSessionKey, resolved)
+      }
+      setIsModelMenuOpen(false)
     },
     [
       gatewayModeQuery.data,
-      modelSwitchMutation,
       sessionKey,
+      setPersistedSessionModel,
       zeroForkModelInfoFlags,
     ],
   )
 
-  const retryModel = modelNotice?.retryModel ?? ''
-  const retryProvider = modelNotice?.retryProvider
-  const handleRetryModelSwitch = useCallback(
-    function handleRetryModelSwitch() {
-      if (!retryModel) return
-      handleModelSelect(retryModel, retryProvider)
+  const handleThinkingSelect = useCallback(
+    function handleThinkingSelect(level: ThinkingLevel) {
+      if (onThinkingLevelChange) {
+        onThinkingLevelChange(level)
+      } else {
+        setInternalThinkingLevel(level)
+      }
+      setIsThinkingMenuOpen(false)
     },
-    [handleModelSelect, retryModel, retryProvider],
+    [onThinkingLevelChange],
   )
+
+  const handleOpenWorkspaceManager = useCallback(() => {
+    setIsWorkspaceMenuOpen(false)
+    emitSearchModalEvent(SEARCH_MODAL_EVENTS.TOGGLE_FILE_EXPLORER)
+  }, [])
+
+  const activeProfileName =
+    profilesQuery.data?.activeProfile ||
+    profilesQuery.data?.profiles?.find((profile) => profile.active)?.name ||
+    'default'
+  const activeProfile = profilesQuery.data?.profiles?.find(
+    (profile) => profile.name === activeProfileName,
+  )
+  const workspaceEntries = workspaceContextQuery.data?.workspaces ?? []
+  const detectedWorkspacePath = workspaceContextQuery.data?.path ?? ''
+  const activeWorkspace = workspaceEntries.find(
+    (workspace) => workspace.path === detectedWorkspacePath,
+  )
+  const workspaceButtonLabel =
+    activeWorkspace?.name ||
+    workspaceContextQuery.data?.folderName ||
+    shortPathLabel(detectedWorkspacePath) ||
+    'Workspace'
 
   const currentModel = currentModelQuery.data ?? ''
 
@@ -951,28 +1094,25 @@ function ChatComposerComponent({
   // model/provider configured in ~/.hermes/config.yaml. Users switch
   // via the model selector or Settings page.
 
-  // When model switches to Claude 4.6 and thinking is 'off', auto-upgrade to 'adaptive'
+  // When model switches to Claude 4.6 and thinking is 'off', auto-upgrade to medium effort
   const prevModelRef = useRef('')
   useEffect(() => {
     if (!currentModel || currentModel === prevModelRef.current) return
     prevModelRef.current = currentModel
     if (isClaude46Model(currentModel) && thinkingLevel === 'off') {
       if (onThinkingLevelChange) {
-        onThinkingLevelChange('adaptive')
+        onThinkingLevelChange('medium')
       } else {
-        setInternalThinkingLevel('adaptive')
+        setInternalThinkingLevel('medium')
       }
     }
   }, [currentModel, thinkingLevel, onThinkingLevelChange])
 
-  const isModelSwitcherDisabled = disabled || modelSwitchMutation.isPending
+  const isModelSwitcherDisabled = disabled
   const draftStorageKey = useMemo(
     () => toDraftStorageKey(sessionKey),
     [sessionKey],
   )
-  const [currentSelectedModel, setCurrentSelectedModel] = useState<
-    string | null
-  >(null)
   // On new chat, currentModel is empty until a session is created.
   // Read the runtime model from the models query (first item is from the current provider).
   const configuredModel = useMemo(() => {
@@ -981,8 +1121,10 @@ function ChatComposerComponent({
     const first = models[0]
     return typeof first === 'string' ? first : first.id || first.name || ''
   }, [modelsQuery.data])
+  // Derive the label directly from the store so navigation between sessions
+  // updates without a render-window flash from a stale React-state mirror.
   const modelButtonLabel =
-    currentSelectedModel || currentModel || configuredModel || '⚕ Hermes Agent'
+    persistedSessionModel || currentModel || configuredModel || '⚕ Hermes Agent'
 
   // Measure composer height and set CSS variable for scroll padding
   useLayoutEffect(() => {
@@ -1075,7 +1217,6 @@ function ChatComposerComponent({
     if (isMobileViewport) return
     // Only focus on focusKey change (session switch), not on every disabled toggle
     focusPrompt()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusKey, isMobileViewport])
 
   useLayoutEffect(() => {
@@ -1094,19 +1235,36 @@ function ChatComposerComponent({
   }, [draftStorageKey])
 
   useEffect(() => {
-    if (!isModelMenuOpen) return
+    if (
+      !isModelMenuOpen &&
+      !isProfileMenuOpen &&
+      !isWorkspaceMenuOpen &&
+      !isThinkingMenuOpen
+    )
+      return
     function handleOutsideClick(event: MouseEvent) {
-      if (!modelSelectorRef.current) return
-      if (modelSelectorRef.current.contains(event.target as Node)) return
+      const target = event.target as Node
+      if (modelSelectorRef.current?.contains(target)) return
+      if (profileMenuRef.current?.contains(target)) return
+      if (workspaceMenuRef.current?.contains(target)) return
+      if (thinkingMenuRef.current?.contains(target)) return
       setIsModelMenuOpen(false)
       setIsProviderSwitcherExpanded(false)
+      setIsProfileMenuOpen(false)
+      setIsWorkspaceMenuOpen(false)
+      setIsThinkingMenuOpen(false)
     }
 
     document.addEventListener('mousedown', handleOutsideClick)
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick)
     }
-  }, [isModelMenuOpen])
+  }, [
+    isModelMenuOpen,
+    isProfileMenuOpen,
+    isWorkspaceMenuOpen,
+    isThinkingMenuOpen,
+  ])
 
   const persistDraft = useCallback(
     function persistDraft(nextValue: string) {
@@ -2084,7 +2242,7 @@ function ChatComposerComponent({
                         >
                           <span className="rounded-lg bg-orange-100 dark:bg-orange-900/30 p-1.5 text-orange-600 dark:text-orange-400">
                             <HugeiconsIcon
-                              icon={Add01Icon}
+                              icon={AttachmentIcon}
                               size={24}
                               strokeWidth={1.5}
                             />
@@ -2231,8 +2389,9 @@ function ChatComposerComponent({
                             const LOCAL_PROVIDER_IDS = ['ollama', 'atomic-chat']
                             const isLocal =
                               (typeof m !== 'string' &&
-                              (m as Record<string, unknown>).description ===
-                                'local') || LOCAL_PROVIDER_IDS.includes(mProvider)
+                                (m as Record<string, unknown>).description ===
+                                  'local') ||
+                              LOCAL_PROVIDER_IDS.includes(mProvider)
                             return {
                               id: mId,
                               name: mName,
@@ -2404,231 +2563,12 @@ function ChatComposerComponent({
                     onClick={handleOpenAttachmentPicker}
                   >
                     <HugeiconsIcon
-                      icon={Add01Icon}
+                      icon={AttachmentIcon}
                       size={20}
                       strokeWidth={1.5}
                     />
                   </Button>
                 </PromptInputAction>
-                {hasDraft && !isLoading && (
-                  <PromptInputAction tooltip="Clear draft">
-                    <Button
-                      size="icon-sm"
-                      variant="ghost"
-                      className="rounded-lg text-primary-400 hover:bg-primary-100 dark:hover:bg-primary-800 hover:text-red-600"
-                      aria-label="Clear draft"
-                      onClick={handleClearDraft}
-                    >
-                      <HugeiconsIcon
-                        icon={Cancel01Icon}
-                        size={20}
-                        strokeWidth={1.5}
-                      />
-                    </Button>
-                  </PromptInputAction>
-                )}
-                {/* Token counter — bottom bar, mirrors Hermes style, triggers at ~25 tokens */}
-                {value.length >= 100 && (
-                  <span className="ml-1 text-[10px] text-primary-400 tabular-nums select-none">
-                    ~{Math.ceil(value.length / 4)} tokens
-                  </span>
-                )}
-
-                {!hideModelSelector ? (
-                  <div
-                    className="ml-0.5 md:ml-1 flex min-w-0 items-center"
-                    ref={modelSelectorRef}
-                  >
-                  <button
-                    type="button"
-                    onClick={() => setIsModelMenuOpen((prev) => !prev)}
-                    disabled={isModelSwitcherDisabled}
-                    className="inline-flex h-7 max-w-[8rem] items-center rounded-full bg-primary-100/70 px-1.5 md:max-w-none md:px-2.5 text-[11px] font-medium text-primary-600 hover:bg-primary-200/80 dark:hover:bg-primary-800/60 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
-                    title={modelButtonLabel}
-                  >
-                    <span className="max-w-[5.5rem] truncate sm:max-w-[8.5rem] md:max-w-[12rem]">
-                      {modelButtonLabel}
-                    </span>
-                  </button>
-                  {isModelMenuOpen && (
-                    <>
-                      <div
-                        className="fixed inset-0 z-[199]"
-                        onClick={() => setIsModelMenuOpen(false)}
-                      />
-                      <div className="absolute bottom-full left-0 mb-2 z-[200] min-w-[16rem] max-w-[calc(100vw-2rem)] sm:max-w-[28rem] overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900 animate-in fade-in slide-in-from-bottom-2 duration-150">
-                        <div className="max-h-[20rem] overflow-y-auto overflow-x-hidden p-1">
-                          {(() => {
-                            const allModels = modelsQuery.data?.models ?? []
-                            const defaultProvider =
-                              modelsQuery.data?.currentProvider ?? ''
-                            if (allModels.length === 0) {
-                              return (
-                                <div className="p-4 text-center text-sm text-neutral-500">
-                                  No models available
-                                </div>
-                              )
-                            }
-                            const parsed = allModels.map((m) => {
-                              const mId = String(
-                                typeof m === 'string'
-                                  ? m
-                                  : m.id || m.model || m.name || 'unknown',
-                              )
-                              const mName = String(
-                                typeof m === 'string'
-                                  ? m
-                                  : m.name ||
-                                      m.displayName ||
-                                      m.label ||
-                                      m.id ||
-                                      m.model ||
-                                      m,
-                              )
-                              const mProvider =
-                                typeof m === 'string'
-                                  ? defaultProvider
-                                  : ((m as Record<string, unknown>)
-                                      .provider as string) || defaultProvider
-                              const isLocal =
-                                typeof m !== 'string' &&
-                                (m as Record<string, unknown>).description ===
-                                  'local'
-                              return {
-                                id: mId,
-                                name: mName,
-                                provider: mProvider,
-                                isLocal,
-                              }
-                            })
-                            const pinnedEntries = parsed.filter((e) =>
-                              isPinned(e.id),
-                            )
-                            const unpinnedGroups = new Map<
-                              string,
-                              typeof parsed
-                            >()
-                            for (const entry of parsed) {
-                              if (isPinned(entry.id)) continue
-                              const group =
-                                unpinnedGroups.get(entry.provider) ?? []
-                              group.push(entry)
-                              unpinnedGroups.set(entry.provider, group)
-                            }
-                            const renderEntry = (entry: (typeof parsed)[0]) => {
-                              const isActive =
-                                entry.id === currentModel ||
-                                `${defaultProvider}/${entry.id}` ===
-                                  currentModel
-                              return (
-                                <div
-                                  key={entry.id}
-                                  className="group relative flex items-center"
-                                >
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      handleModelSelect(
-                                        entry.id,
-                                        entry.provider || undefined,
-                                      )
-                                      setIsModelMenuOpen(false)
-                                    }}
-                                    className={`flex flex-1 items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors ${
-                                      isActive
-                                        ? 'border-l-2 border-accent-500 bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100'
-                                        : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/50'
-                                    }`}
-                                  >
-                                    <span className="flex-1 truncate">
-                                      {entry.name}
-                                    </span>
-                                    {entry.isLocal && (
-                                      <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-700">
-                                        local
-                                      </span>
-                                    )}
-                                    {isActive && (
-                                      <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />
-                                    )}
-                                  </button>
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      togglePin(entry.id)
-                                    }}
-                                    className={`absolute right-2 rounded p-1 transition-opacity ${
-                                      isPinned(entry.id)
-                                        ? 'text-accent-500 opacity-80 hover:opacity-100'
-                                        : 'text-neutral-400 opacity-0 group-hover:opacity-60 hover:!opacity-100 hover:text-accent-500'
-                                    }`}
-                                    aria-label={
-                                      isPinned(entry.id)
-                                        ? `Unpin ${entry.name}`
-                                        : `Pin ${entry.name}`
-                                    }
-                                  >
-                                    <svg
-                                      width="12"
-                                      height="12"
-                                      viewBox="0 0 24 24"
-                                      fill={
-                                        isPinned(entry.id)
-                                          ? 'currentColor'
-                                          : 'none'
-                                      }
-                                      stroke="currentColor"
-                                      strokeWidth="2"
-                                    >
-                                      <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
-                                    </svg>
-                                  </button>
-                                </div>
-                              )
-                            }
-                            return (
-                              <>
-                                {pinnedEntries.length > 0 && (
-                                  <div className="mb-1 border-b border-neutral-200 dark:border-neutral-700 pb-1">
-                                    <div className="mb-1 flex items-center gap-1 px-3 text-[11px] font-medium uppercase tracking-wider text-neutral-500">
-                                      <svg
-                                        width="12"
-                                        height="12"
-                                        viewBox="0 0 24 24"
-                                        fill="currentColor"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                        className="text-accent-500"
-                                      >
-                                        <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
-                                      </svg>
-                                      <span>Pinned</span>
-                                    </div>
-                                    {pinnedEntries.map(renderEntry)}
-                                  </div>
-                                )}
-                                {Array.from(unpinnedGroups.entries())
-                                  .sort((a, b) => a[0].localeCompare(b[0]))
-                                  .map(([provider, models]) => (
-                                    <div key={provider}>
-                                      <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400">
-                                        {provider}
-                                      </div>
-                                      {models.map(renderEntry)}
-                                    </div>
-                                  ))}
-                              </>
-                            )
-                          })()}
-                        </div>
-                      </div>
-                    </>
-                  )}
-                  </div>
-                ) : null}
-              </div>
-              <div className="ml-1 flex shrink-0 items-center gap-0.5 md:gap-1">
                 {voiceInput.isSupported || voiceRecorder.isSupported ? (
                   <PromptInputAction
                     tooltip={
@@ -2686,6 +2626,494 @@ function ChatComposerComponent({
                     </Button>
                   </PromptInputAction>
                 ) : null}
+                {hasDraft && !isLoading && (
+                  <PromptInputAction tooltip="Clear draft">
+                    <Button
+                      size="icon-sm"
+                      variant="ghost"
+                      className="rounded-lg text-primary-400 hover:bg-primary-100 dark:hover:bg-primary-800 hover:text-red-600"
+                      aria-label="Clear draft"
+                      onClick={handleClearDraft}
+                    >
+                      <HugeiconsIcon
+                        icon={Cancel01Icon}
+                        size={20}
+                        strokeWidth={1.5}
+                      />
+                    </Button>
+                  </PromptInputAction>
+                )}
+                {/* Token counter — bottom bar, mirrors Hermes style, triggers at ~25 tokens */}
+                {value.length >= 100 && (
+                  <span className="ml-1 text-[10px] text-primary-400 tabular-nums select-none">
+                    ~{Math.ceil(value.length / 4)} tokens
+                  </span>
+                )}
+
+                {!hideModelSelector ? (
+                  <>
+                    <div
+                      className="relative ml-0.5 flex min-w-0 items-center"
+                      ref={profileMenuRef}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsProfileMenuOpen((open) => !open)
+                          setIsWorkspaceMenuOpen(false)
+                          setIsThinkingMenuOpen(false)
+                          setIsModelMenuOpen(false)
+                        }}
+                        disabled={disabled || profileActivateMutation.isPending}
+                        className="inline-flex h-8 max-w-[8rem] items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-primary-800/60"
+                        title={
+                          activeProfile
+                            ? `${activeProfile.name}${profileMeta(activeProfile) ? ` · ${profileMeta(activeProfile)}` : ''}`
+                            : activeProfileName
+                        }
+                      >
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                          <circle cx="12" cy="7" r="4" />
+                        </svg>
+                        <span className="truncate">{activeProfileName}</span>
+                        <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
+                      </button>
+                      {isProfileMenuOpen && (
+                        <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[14rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
+                          <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
+                            Agent profile
+                          </div>
+                          {(profilesQuery.data?.profiles ?? []).map(
+                            (profile) => {
+                              const selected =
+                                profile.name === activeProfileName
+                              return (
+                                <button
+                                  key={profile.name}
+                                  type="button"
+                                  onClick={() => {
+                                    if (selected) {
+                                      setIsProfileMenuOpen(false)
+                                      return
+                                    }
+                                    profileActivateMutation.mutate(profile.name)
+                                  }}
+                                  className={cn(
+                                    'flex w-full flex-col rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                                    selected
+                                      ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                      : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60',
+                                  )}
+                                >
+                                  <span className="flex items-center gap-2">
+                                    <span className="truncate font-medium">
+                                      {profile.name}
+                                    </span>
+                                    {selected ? (
+                                      <span className="text-[10px] text-accent-500">
+                                        active
+                                      </span>
+                                    ) : null}
+                                  </span>
+                                  {profileMeta(profile) ? (
+                                    <span className="mt-0.5 max-w-[12rem] truncate text-[11px] text-neutral-500">
+                                      {profileMeta(profile)}
+                                    </span>
+                                  ) : null}
+                                </button>
+                              )
+                            },
+                          )}
+                          {profilesQuery.isError ? (
+                            <div className="px-3 py-2 text-xs text-red-500">
+                              Failed to load profiles
+                            </div>
+                          ) : null}
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      className="relative ml-0.5 hidden min-w-0 items-center sm:flex"
+                      ref={workspaceMenuRef}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsWorkspaceMenuOpen((open) => !open)
+                          setIsProfileMenuOpen(false)
+                          setIsThinkingMenuOpen(false)
+                          setIsModelMenuOpen(false)
+                        }}
+                        className="inline-flex h-8 max-w-[9rem] items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 dark:hover:bg-primary-800/60"
+                        title={detectedWorkspacePath || 'Workspace context'}
+                      >
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                        </svg>
+                        <span className="truncate">{workspaceButtonLabel}</span>
+                        <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
+                      </button>
+                      {isWorkspaceMenuOpen && (
+                        <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[19rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
+                          <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
+                            Workspace context
+                          </div>
+                          <div className="max-h-56 overflow-y-auto">
+                            {workspaceEntries.length > 0 ? (
+                              workspaceEntries.map((workspace) => {
+                                const selected =
+                                  workspace.path === detectedWorkspacePath
+                                return (
+                                  <button
+                                    key={workspace.path}
+                                    type="button"
+                                    onClick={() => {
+                                      if (selected) {
+                                        setIsWorkspaceMenuOpen(false)
+                                        return
+                                      }
+                                      workspaceSelectMutation.mutate(workspace)
+                                    }}
+                                    className={cn(
+                                      'flex w-full flex-col rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                                      selected
+                                        ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                        : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60',
+                                    )}
+                                  >
+                                    <span className="flex items-center gap-2">
+                                      <span className="truncate font-medium">
+                                        {workspace.name ||
+                                          shortPathLabel(workspace.path)}
+                                      </span>
+                                      {selected ? (
+                                        <span className="text-[10px] text-accent-500">
+                                          active
+                                        </span>
+                                      ) : null}
+                                    </span>
+                                    <span className="mt-0.5 max-w-[16rem] truncate font-mono text-[11px] text-neutral-500">
+                                      {workspace.path}
+                                    </span>
+                                  </button>
+                                )
+                              })
+                            ) : (
+                              <div className="px-3 py-2 text-xs text-neutral-500">
+                                No valid workspaces detected
+                              </div>
+                            )}
+                          </div>
+                          {workspaceContextQuery.isError ? (
+                            <div className="px-3 py-2 text-xs text-red-500">
+                              Failed to load workspaces
+                            </div>
+                          ) : null}
+                          <div className="my-1 h-px bg-neutral-200 dark:bg-neutral-800" />
+                          <button
+                            type="button"
+                            onClick={handleOpenWorkspaceManager}
+                            className="w-full rounded-lg px-3 py-2 text-left text-sm text-neutral-700 transition-colors hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60"
+                          >
+                            Show files sidebar…
+                          </button>
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      className="relative ml-0.5 hidden min-w-0 items-center sm:flex"
+                      ref={thinkingMenuRef}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsThinkingMenuOpen((open) => !open)
+                          setIsProfileMenuOpen(false)
+                          setIsWorkspaceMenuOpen(false)
+                          setIsModelMenuOpen(false)
+                        }}
+                        className={cn(
+                          'inline-flex h-8 items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 dark:hover:bg-primary-800/60',
+                          thinkingLevel === 'off' && 'opacity-70',
+                        )}
+                        title={`Reasoning effort: ${thinkingLabel(thinkingLevel)}`}
+                      >
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.46 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z" />
+                          <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.46 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z" />
+                        </svg>
+                        <span>{thinkingLabel(thinkingLevel)}</span>
+                        <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
+                      </button>
+                      {isThinkingMenuOpen && (
+                        <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[10rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
+                          {(
+                            [
+                              ['off', 'None'],
+                              ['low', 'Low'],
+                              ['medium', 'Medium'],
+                              ['high', 'High'],
+                            ] as Array<[ThinkingLevel, string]>
+                          ).map(([level, label]) => (
+                            <button
+                              key={level}
+                              type="button"
+                              onClick={() => handleThinkingSelect(level)}
+                              className={cn(
+                                'flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                                thinkingLevel === level
+                                  ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                  : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60',
+                              )}
+                            >
+                              <span>{label}</span>
+                              {thinkingLevel === level ? (
+                                <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />
+                              ) : null}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : null}
+
+                {!hideModelSelector ? (
+                  <div
+                    className="relative ml-0.5 md:ml-1 flex min-w-0 items-center"
+                    ref={modelSelectorRef}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIsModelMenuOpen((prev) => !prev)
+                        setIsProfileMenuOpen(false)
+                        setIsWorkspaceMenuOpen(false)
+                        setIsThinkingMenuOpen(false)
+                      }}
+                      disabled={isModelSwitcherDisabled}
+                      className="inline-flex h-8 max-w-[9rem] items-center rounded-full bg-primary-100/70 px-2 md:max-w-none md:px-3 text-xs font-medium text-primary-600 hover:bg-primary-200/80 dark:hover:bg-primary-800/60 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                      title={modelButtonLabel}
+                    >
+                      <span className="max-w-[5.5rem] truncate sm:max-w-[8.5rem] md:max-w-[12rem]">
+                        {modelButtonLabel}
+                      </span>
+                    </button>
+                    {isModelMenuOpen && (
+                      <>
+                        <div
+                          className="fixed inset-0 z-[199]"
+                          onClick={() => setIsModelMenuOpen(false)}
+                        />
+                        <div className="absolute bottom-full left-0 mb-2 z-[200] w-[min(28rem,calc(100vw-2rem))] min-w-[18rem] origin-bottom-left overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900 animate-in fade-in slide-in-from-bottom-2 duration-150">
+                          <div className="max-h-[20rem] overflow-y-auto overflow-x-hidden p-1">
+                            {(() => {
+                              const allModels = modelsQuery.data?.models ?? []
+                              const defaultProvider =
+                                modelsQuery.data?.currentProvider ?? ''
+                              if (allModels.length === 0) {
+                                return (
+                                  <div className="p-4 text-center text-sm text-neutral-500">
+                                    No models available
+                                  </div>
+                                )
+                              }
+                              const parsed = allModels.map((m) => {
+                                const mId = String(
+                                  typeof m === 'string'
+                                    ? m
+                                    : m.id || m.model || m.name || 'unknown',
+                                )
+                                const mName = String(
+                                  typeof m === 'string'
+                                    ? m
+                                    : m.name ||
+                                        m.displayName ||
+                                        m.label ||
+                                        m.id ||
+                                        m.model ||
+                                        m,
+                                )
+                                const mProvider =
+                                  typeof m === 'string'
+                                    ? defaultProvider
+                                    : ((m as Record<string, unknown>)
+                                        .provider as string) || defaultProvider
+                                const isLocal =
+                                  typeof m !== 'string' &&
+                                  (m as Record<string, unknown>).description ===
+                                    'local'
+                                return {
+                                  id: mId,
+                                  name: mName,
+                                  provider: mProvider,
+                                  isLocal,
+                                }
+                              })
+                              const pinnedEntries = parsed.filter((e) =>
+                                isPinned(e.id),
+                              )
+                              const unpinnedGroups = new Map<
+                                string,
+                                typeof parsed
+                              >()
+                              for (const entry of parsed) {
+                                if (isPinned(entry.id)) continue
+                                const group =
+                                  unpinnedGroups.get(entry.provider) ?? []
+                                group.push(entry)
+                                unpinnedGroups.set(entry.provider, group)
+                              }
+                              const renderEntry = (
+                                entry: (typeof parsed)[0],
+                              ) => {
+                                const isActive =
+                                  entry.id === currentModel ||
+                                  `${defaultProvider}/${entry.id}` ===
+                                    currentModel
+                                return (
+                                  <div
+                                    key={entry.id}
+                                    className="group relative flex items-center"
+                                  >
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        handleModelSelect(
+                                          entry.id,
+                                          entry.provider || undefined,
+                                        )
+                                        setIsModelMenuOpen(false)
+                                      }}
+                                      className={`flex flex-1 items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors ${
+                                        isActive
+                                          ? 'border-l-2 border-accent-500 bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100'
+                                          : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/50'
+                                      }`}
+                                    >
+                                      <span className="flex-1 truncate">
+                                        {entry.name}
+                                      </span>
+                                      {entry.isLocal && (
+                                        <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-700">
+                                          local
+                                        </span>
+                                      )}
+                                      {isActive && (
+                                        <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />
+                                      )}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        togglePin(entry.id)
+                                      }}
+                                      className={`absolute right-2 rounded p-1 transition-opacity ${
+                                        isPinned(entry.id)
+                                          ? 'text-accent-500 opacity-80 hover:opacity-100'
+                                          : 'text-neutral-400 opacity-0 group-hover:opacity-60 hover:!opacity-100 hover:text-accent-500'
+                                      }`}
+                                      aria-label={
+                                        isPinned(entry.id)
+                                          ? `Unpin ${entry.name}`
+                                          : `Pin ${entry.name}`
+                                      }
+                                    >
+                                      <svg
+                                        width="12"
+                                        height="12"
+                                        viewBox="0 0 24 24"
+                                        fill={
+                                          isPinned(entry.id)
+                                            ? 'currentColor'
+                                            : 'none'
+                                        }
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                      >
+                                        <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
+                                      </svg>
+                                    </button>
+                                  </div>
+                                )
+                              }
+                              return (
+                                <>
+                                  {pinnedEntries.length > 0 && (
+                                    <div className="mb-1 border-b border-neutral-200 dark:border-neutral-700 pb-1">
+                                      <div className="mb-1 flex items-center gap-1 px-3 text-[11px] font-medium uppercase tracking-wider text-neutral-500">
+                                        <svg
+                                          width="12"
+                                          height="12"
+                                          viewBox="0 0 24 24"
+                                          fill="currentColor"
+                                          stroke="currentColor"
+                                          strokeWidth="2"
+                                          className="text-accent-500"
+                                        >
+                                          <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
+                                        </svg>
+                                        <span>Pinned</span>
+                                      </div>
+                                      {pinnedEntries.map(renderEntry)}
+                                    </div>
+                                  )}
+                                  {Array.from(unpinnedGroups.entries())
+                                    .sort((a, b) => a[0].localeCompare(b[0]))
+                                    .map(([provider, models]) => (
+                                      <div key={provider}>
+                                        <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400">
+                                          {provider}
+                                        </div>
+                                        {models.map(renderEntry)}
+                                      </div>
+                                    ))}
+                                </>
+                              )
+                            })()}
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+              <div className="ml-1 flex shrink-0 items-center gap-0.5 md:gap-1">
+                <ContextBar compact sessionId={sessionKey} />
                 {isLoading ? (
                   <PromptInputAction tooltip="Stop generation">
                     <Button

--- a/src/screens/chat/local-model-override.ts
+++ b/src/screens/chat/local-model-override.ts
@@ -1,0 +1,10 @@
+// Module-level local model override — set by composer when user picks a local model.
+// Avoids prop threading. Reset when switching back to cloud models.
+//
+// Lives in its own file so chat-screen.tsx remains a components-only module —
+// React Fast Refresh requires modules to export only components, otherwise
+// HMR falls back to full-page reload.
+export let _localModelOverride = ''
+export function setLocalModelOverride(model: string) {
+  _localModelOverride = model
+}

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -45,7 +45,11 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
 ])
 
 function getHermesRoot(): string {
-  return process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+  return (
+    process.env.HERMES_HOME ??
+    process.env.CLAUDE_HOME ??
+    path.join(os.homedir(), '.hermes')
+  )
 }
 
 function getClaudeRoot(): string {
@@ -95,9 +99,10 @@ function safeReadText(filePath: string): string {
 function readYamlConfig(configPath: string): Record<string, unknown> {
   if (!fs.existsSync(configPath)) return {}
   try {
-    return (
-      (YAML.parse(safeReadText(configPath)) as Record<string, unknown>) || {}
-    )
+    const parsed = YAML.parse(safeReadText(configPath)) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {}
   } catch {
     return {}
   }
@@ -312,7 +317,6 @@ export function setActiveProfile(name: string): void {
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   fs.mkdirSync(getClaudeRoot(), { recursive: true })
   fs.writeFileSync(getActiveProfilePath(), `${normalized}\n`, 'utf-8')
-  // eslint-disable-next-line no-console
   console.warn(
     `[profiles] Active profile set to "${normalized}". Restart the Hermes Agent gateway for this profile switch to take effect.`,
   )

--- a/src/stores/session-model-store.ts
+++ b/src/stores/session-model-store.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+/**
+ * Per-session model preference.
+ *
+ * Stored locally in the browser keyed by sessionKey, so a user can pick a
+ * different model for one chat without affecting the global default in
+ * `~/.hermes/config.yaml` or any other channel (Telegram, Discord, etc.).
+ *
+ * On every send, the workspace passes this value as the `model` field in
+ * the chat-completion request body. The gateway uses it for that request
+ * only; nothing else mutates.
+ *
+ * Cleared automatically when the session is deleted.
+ */
+type State = {
+  models: Record<string, string>
+}
+
+type Actions = {
+  getModel: (sessionKey: string | null | undefined) => string | undefined
+  setModel: (sessionKey: string, model: string) => void
+  clearModel: (sessionKey: string) => void
+}
+
+export const useSessionModelStore = create<State & Actions>()(
+  persist(
+    (set, get) => ({
+      models: {},
+      getModel: (sessionKey) => {
+        if (!sessionKey) return undefined
+        return get().models[sessionKey]
+      },
+      setModel: (sessionKey, model) => {
+        if (!sessionKey) return
+        const trimmed = model.trim()
+        if (!trimmed) return
+        set((state) => ({
+          models: { ...state.models, [sessionKey]: trimmed },
+        }))
+      },
+      clearModel: (sessionKey) => {
+        if (!sessionKey) return
+        set((state) => {
+          if (!(sessionKey in state.models)) return state
+          const next = { ...state.models }
+          delete next[sessionKey]
+          return { models: next }
+        })
+      },
+    }),
+    {
+      name: 'hermes-session-model',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ models: state.models }),
+    },
+  ),
+)


### PR DESCRIPTION
## Summary

The composer workspace selector and file browser now resolve through one profile-local workspace catalog, so \`~/.hermes\` remains runtime state instead of becoming the project root.

## Problem

The composer's workspace chip was detecting \`~/.hermes\` as the workspace, conflating Hermes runtime state with the user's actual project directory. The files sidebar inherited the same wrong path. There was no clean way to switch between known workspaces.

## Changes

- **\`/api/workspace\`** reworked into a profile-local workspace catalog
- **\`/api/files\`** now uses the same workspace catalog as the composer
- **Block** \`~/.hermes\`, Hermes profile dirs, and system roots from being selected as workspaces
- **Profile-local** workspace state — invalidated after profile switches
- **Workspace selector dropdown** lists known workspaces from the backend catalog and allows quick switching
- **\"Show files sidebar…\"** action opens the in-place file sidebar (same as chat header button), instead of navigating to \`/files\`
- **Removed \"Add path manually…\"** button (used \`window.prompt\` — not suitable for remote workspaces)
- **Composer bottom controls** layout: attachment, mic, profile, workspace, reasoning, model, context ring near send button

## Screenshot

Composer bottom controls after the fix:

![Composer bottom controls](https://raw.githubusercontent.com/Interstellar-code/hermes-workspace/local/.omc/screenshots/composer-bottom-controls.png)

## Validation

- \`pnpm vitest run src/routes/api/-files.test.ts src/routes/api/-workspace.test.ts src/screens/chat/components/chat-composer-context-controls.test.ts src/screens/chat/components/chat-composer-model-switch.test.ts\` — pass
- \`pnpm eslint\` on touched files — clean
- \`pnpm build\` — green
- LSP diagnostics on changed files — clean

## Lore

Constraint: Hermes Web UI treats workspaces/spaces separately from profile state.
Rejected: Keep localStorage saved workspace paths (stale saved paths could keep showing \`~/.hermes\`).
Rejected: Keep \`/api/files\` fallback to \`HERMES_HOME\` (files sidebar would still browse runtime state).
Confidence: high
Scope-risk: moderate
Directive: Do not reintroduce \`HERMES_HOME\`/\`CLAUDE_HOME\` as project workspace fallbacks; use \`/api/workspace\` catalog instead.
Not-tested: dedicated Spaces manager UI remains follow-up.

Worked with Interstellar Code