### PR TITLE
feat: restore system metrics footer

### DIFF
--- a/src/components/system-metrics-footer.tsx
+++ b/src/components/system-metrics-footer.tsx
@@ -1,14 +1,6 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  CheckmarkCircle02Icon,
-  CpuIcon,
-  DatabaseIcon,
-  HardDriveIcon,
-  WifiDisconnected02Icon,
-} from '@hugeicons/core-free-icons'
 import { cn } from '@/lib/utils'
 
 type SystemMetrics = {
@@ -57,38 +49,65 @@ function formatBytes(bytes: number): string {
   return `${value >= 10 || unit === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`
 }
 
-function metricTone(percent: number): 'good' | 'warn' | 'hot' {
-  if (percent >= 90) return 'hot'
+function metricTone(percent: number): 'normal' | 'warn' | 'critical' {
+  if (percent >= 90) return 'critical'
   if (percent >= 75) return 'warn'
-  return 'good'
+  return 'normal'
 }
 
-function MetricPill({
-  icon,
+function formatCheckedAt(checkedAt: number): string {
+  const ageSeconds = Math.max(0, Math.round((Date.now() - checkedAt) / 1000))
+  if (ageSeconds < 5) return 'now'
+  if (ageSeconds < 60) return `${ageSeconds}s ago`
+
+  const ageMinutes = Math.round(ageSeconds / 60)
+  return `${ageMinutes}m ago`
+}
+
+function MetricItem({
   label,
   value,
-  tone = 'good',
+  tone = 'normal',
 }: {
-  icon: typeof CpuIcon
   label: string
   value: string
-  tone?: 'good' | 'warn' | 'hot' | 'muted'
+  tone?: 'normal' | 'warn' | 'critical' | 'muted' | 'accent'
 }) {
   return (
-    <div
+    <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium shadow-sm backdrop-blur-md',
-        tone === 'good' &&
-          'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
-        tone === 'warn' && 'border-amber-400/30 bg-amber-500/10 text-amber-100',
-        tone === 'hot' && 'border-red-400/30 bg-red-500/10 text-red-100',
-        tone === 'muted' && 'border-white/10 bg-white/5 text-primary-100/75',
+        'inline-flex min-w-0 items-baseline gap-1.5 whitespace-nowrap',
+        tone === 'normal' && 'text-[var(--theme-text)]/80',
+        tone === 'warn' && 'text-amber-300/90',
+        tone === 'critical' && 'text-red-300/95',
+        tone === 'muted' && 'text-[var(--theme-muted)]',
+        tone === 'accent' && 'text-[var(--theme-accent)]',
       )}
     >
-      <HugeiconsIcon icon={icon} size={13} strokeWidth={1.7} />
-      <span className="uppercase tracking-[0.12em] opacity-60">{label}</span>
-      <span className="tabular-nums">{value}</span>
-    </div>
+      <span className="text-[9px] font-medium uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+        {label}
+      </span>
+      <span className="truncate font-medium tabular-nums">{value}</span>
+    </span>
+  )
+}
+
+function Separator() {
+  return <span className="h-3 w-px shrink-0 bg-[var(--theme-border)]" aria-hidden />
+}
+
+function StatusDot({ tone }: { tone: 'ok' | 'warn' | 'critical' | 'muted' }) {
+  return (
+    <span
+      className={cn(
+        'inline-block size-1.5 rounded-full',
+        tone === 'ok' && 'bg-[var(--theme-accent)]',
+        tone === 'warn' && 'bg-amber-300/90',
+        tone === 'critical' && 'bg-red-300/95',
+        tone === 'muted' && 'bg-[var(--theme-muted)]',
+      )}
+      aria-hidden
+    />
   )
 }
 
@@ -101,49 +120,57 @@ export function SystemMetricsFooter({ leftOffsetPx = 0 }: { leftOffsetPx?: numbe
   })
 
   const hermesHealthy = data?.hermes.status === 'connected' || data?.hermes.status === 'enhanced'
+  const hermesTone = hermesHealthy ? 'accent' : data?.hermes.status === 'disconnected' ? 'critical' : 'warn'
+  const hermesDotTone = hermesHealthy ? 'ok' : data?.hermes.status === 'disconnected' ? 'critical' : 'warn'
 
   return (
     <footer
-      className="fixed bottom-0 right-0 z-40 hidden h-8 items-center justify-center border-t border-l border-white/10 bg-neutral-950/85 px-4 text-xs text-primary-100 shadow-[0_-8px_24px_rgba(0,0,0,0.22)] backdrop-blur-xl md:flex"
+      className="fixed bottom-0 right-0 z-40 hidden h-7 items-center border-t border-[var(--theme-border)] bg-[var(--theme-card)] px-4 text-[11px] leading-none text-[var(--theme-text)] shadow-[inset_0_1px_0_rgba(255,255,255,0.025)] md:flex"
       data-testid="system-metrics-footer"
       aria-label="System metrics footer"
       style={{ left: leftOffsetPx }}
     >
-      <div className="flex max-w-full items-center gap-2 overflow-hidden">
+      <div className="flex max-w-full items-center justify-center gap-3 overflow-hidden opacity-85">
         {data ? (
           <>
-            <MetricPill
-              icon={CpuIcon}
+            <MetricItem
               label="CPU"
-              value={`${data.cpu.loadPercent}% (${data.cpu.loadAverage1m}/${data.cpu.cores})`}
+              value={`${data.cpu.loadPercent}%`}
               tone={metricTone(data.cpu.loadPercent)}
             />
-            <MetricPill
-              icon={DatabaseIcon}
+            <Separator />
+            <MetricItem
               label="RAM"
-              value={`${data.memory.usedPercent}% ${formatBytes(data.memory.usedBytes)}/${formatBytes(data.memory.totalBytes)}`}
+              value={`${formatBytes(data.memory.usedBytes)} / ${formatBytes(data.memory.totalBytes)}`}
               tone={metricTone(data.memory.usedPercent)}
             />
-            <MetricPill
-              icon={HardDriveIcon}
+            <Separator />
+            <MetricItem
               label="Disk"
-              value={`${data.disk.usedPercent}% ${formatBytes(data.disk.usedBytes)}/${formatBytes(data.disk.totalBytes)}`}
+              value={`${data.disk.usedPercent}%`}
               tone={metricTone(data.disk.usedPercent)}
             />
-            <MetricPill
-              icon={hermesHealthy ? CheckmarkCircle02Icon : WifiDisconnected02Icon}
-              label="Hermes"
-              value={data.hermes.status}
-              tone={hermesHealthy ? 'good' : 'warn'}
+            <Separator />
+            <span className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap">
+              <StatusDot tone={hermesDotTone} />
+              <MetricItem label="Hermes" value={data.hermes.status} tone={hermesTone} />
+            </span>
+            <Separator />
+            <MetricItem
+              label="Updated"
+              value={formatCheckedAt(data.checkedAt)}
+              tone="muted"
             />
           </>
         ) : (
-          <MetricPill
-            icon={isError ? WifiDisconnected02Icon : CpuIcon}
-            label="Metrics"
-            value={isError ? 'unavailable' : 'loading'}
-            tone={isError ? 'warn' : 'muted'}
-          />
+          <span className="inline-flex items-center gap-2 whitespace-nowrap text-[var(--theme-muted)]">
+            <StatusDot tone={isError ? 'warn' : 'muted'} />
+            <MetricItem
+              label="Metrics"
+              value={isError ? 'unavailable' : 'loading'}
+              tone={isError ? 'warn' : 'muted'}
+            />
+          </span>
         )}
       </div>
     </footer>

--- a/src/components/system-metrics-footer.tsx
+++ b/src/components/system-metrics-footer.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  CheckmarkCircle02Icon,
+  CpuIcon,
+  DatabaseIcon,
+  HardDriveIcon,
+  WifiDisconnected02Icon,
+} from '@hugeicons/core-free-icons'
+import { cn } from '@/lib/utils'
+
+type SystemMetrics = {
+  checkedAt: number
+  cpu: {
+    loadPercent: number
+    loadAverage1m: number
+    cores: number
+  }
+  memory: {
+    usedBytes: number
+    totalBytes: number
+    usedPercent: number
+  }
+  disk: {
+    path: string
+    usedBytes: number
+    totalBytes: number
+    usedPercent: number
+  }
+  hermes: {
+    status: 'connected' | 'enhanced' | 'partial' | 'disconnected'
+    health: boolean
+    dashboard: boolean
+  }
+}
+
+async function fetchSystemMetrics(): Promise<SystemMetrics> {
+  const response = await fetch('/api/system-metrics', { cache: 'no-store' })
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  return response.json() as Promise<SystemMetrics>
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+
+  return `${value >= 10 || unit === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`
+}
+
+function metricTone(percent: number): 'good' | 'warn' | 'hot' {
+  if (percent >= 90) return 'hot'
+  if (percent >= 75) return 'warn'
+  return 'good'
+}
+
+function MetricPill({
+  icon,
+  label,
+  value,
+  tone = 'good',
+}: {
+  icon: typeof CpuIcon
+  label: string
+  value: string
+  tone?: 'good' | 'warn' | 'hot' | 'muted'
+}) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium shadow-sm backdrop-blur-md',
+        tone === 'good' &&
+          'border-emerald-400/25 bg-emerald-500/10 text-emerald-100',
+        tone === 'warn' && 'border-amber-400/30 bg-amber-500/10 text-amber-100',
+        tone === 'hot' && 'border-red-400/30 bg-red-500/10 text-red-100',
+        tone === 'muted' && 'border-white/10 bg-white/5 text-primary-100/75',
+      )}
+    >
+      <HugeiconsIcon icon={icon} size={13} strokeWidth={1.7} />
+      <span className="uppercase tracking-[0.12em] opacity-60">{label}</span>
+      <span className="tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+export function SystemMetricsFooter() {
+  const { data, isError, isFetching } = useQuery({
+    queryKey: ['system-metrics-footer'],
+    queryFn: fetchSystemMetrics,
+    refetchInterval: 5_000,
+    staleTime: 4_000,
+  })
+
+  const hermesHealthy = data?.hermes.status === 'connected' || data?.hermes.status === 'enhanced'
+
+  return (
+    <footer
+      className="fixed inset-x-0 bottom-0 z-40 hidden h-8 items-center justify-center border-t border-white/10 bg-neutral-950/85 px-4 text-xs text-primary-100 shadow-[0_-8px_24px_rgba(0,0,0,0.22)] backdrop-blur-xl md:flex"
+      data-testid="system-metrics-footer"
+      aria-label="System metrics footer"
+    >
+      <div className="flex max-w-full items-center gap-2 overflow-x-auto">
+        {data ? (
+          <>
+            <MetricPill
+              icon={CpuIcon}
+              label="CPU"
+              value={`${data.cpu.loadPercent}% (${data.cpu.loadAverage1m}/${data.cpu.cores})`}
+              tone={metricTone(data.cpu.loadPercent)}
+            />
+            <MetricPill
+              icon={DatabaseIcon}
+              label="RAM"
+              value={`${data.memory.usedPercent}% ${formatBytes(data.memory.usedBytes)}/${formatBytes(data.memory.totalBytes)}`}
+              tone={metricTone(data.memory.usedPercent)}
+            />
+            <MetricPill
+              icon={HardDriveIcon}
+              label="Disk"
+              value={`${data.disk.usedPercent}% ${formatBytes(data.disk.usedBytes)}/${formatBytes(data.disk.totalBytes)}`}
+              tone={metricTone(data.disk.usedPercent)}
+            />
+            <MetricPill
+              icon={hermesHealthy ? CheckmarkCircle02Icon : WifiDisconnected02Icon}
+              label="Hermes"
+              value={data.hermes.status}
+              tone={hermesHealthy ? 'good' : 'warn'}
+            />
+          </>
+        ) : (
+          <MetricPill
+            icon={isError ? WifiDisconnected02Icon : CpuIcon}
+            label="Metrics"
+            value={isError ? 'unavailable' : 'loading'}
+            tone={isError ? 'warn' : 'muted'}
+          />
+        )}
+        {isFetching && data ? (
+          <span className="text-[10px] uppercase tracking-[0.16em] text-primary-100/35">
+            refreshing
+          </span>
+        ) : null}
+      </div>
+    </footer>
+  )
+}

--- a/src/components/system-metrics-footer.tsx
+++ b/src/components/system-metrics-footer.tsx
@@ -92,23 +92,24 @@ function MetricPill({
   )
 }
 
-export function SystemMetricsFooter() {
-  const { data, isError, isFetching } = useQuery({
+export function SystemMetricsFooter({ leftOffsetPx = 0 }: { leftOffsetPx?: number }) {
+  const { data, isError } = useQuery({
     queryKey: ['system-metrics-footer'],
     queryFn: fetchSystemMetrics,
-    refetchInterval: 5_000,
-    staleTime: 4_000,
+    refetchInterval: 15_000,
+    staleTime: 14_000,
   })
 
   const hermesHealthy = data?.hermes.status === 'connected' || data?.hermes.status === 'enhanced'
 
   return (
     <footer
-      className="fixed inset-x-0 bottom-0 z-40 hidden h-8 items-center justify-center border-t border-white/10 bg-neutral-950/85 px-4 text-xs text-primary-100 shadow-[0_-8px_24px_rgba(0,0,0,0.22)] backdrop-blur-xl md:flex"
+      className="fixed bottom-0 right-0 z-40 hidden h-8 items-center justify-center border-t border-l border-white/10 bg-neutral-950/85 px-4 text-xs text-primary-100 shadow-[0_-8px_24px_rgba(0,0,0,0.22)] backdrop-blur-xl md:flex"
       data-testid="system-metrics-footer"
       aria-label="System metrics footer"
+      style={{ left: leftOffsetPx }}
     >
-      <div className="flex max-w-full items-center gap-2 overflow-x-auto">
+      <div className="flex max-w-full items-center gap-2 overflow-hidden">
         {data ? (
           <>
             <MetricPill
@@ -144,11 +145,6 @@ export function SystemMetricsFooter() {
             tone={isError ? 'warn' : 'muted'}
           />
         )}
-        {isFetching && data ? (
-          <span className="text-[10px] uppercase tracking-[0.16em] text-primary-100/35">
-            refreshing
-          </span>
-        ) : null}
       </div>
     </footer>
   )

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -39,7 +39,7 @@ import { MobilePageHeader } from '@/components/mobile-page-header'
 import { MobileTerminalInput } from '@/components/terminal/mobile-terminal-input'
 import { ClaudeReconnectBanner } from '@/components/claude-reconnect-banner'
 import { useMobileKeyboard } from '@/hooks/use-mobile-keyboard'
-// System metrics footer removed — not used in Hermes Workspace
+import { SystemMetricsFooter } from '@/components/system-metrics-footer'
 import { CommandPalette } from '@/components/command-palette'
 import { useSettings } from '@/hooks/use-settings'
 // ActivityTicker moved to dashboard-only (too noisy for global header)
@@ -393,7 +393,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
       </div>
 
       <MobileHamburgerMenu />
-      {/* System metrics footer removed */}
+      {!isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
+        <SystemMetricsFooter />
+      ) : null}
       <CommandPalette pathname={pathname} sessions={sessions} />
     </>
   )

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -321,7 +321,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 : !isMobile &&
                     !isOnChatRoute &&
                     settings.showSystemMetricsFooter
-                  ? 'pb-[calc(1.5rem+1.75rem)]'
+                  ? 'pb-7'
                   : '',
             ].join(' ')}
             data-tour="chat-area"

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -394,7 +394,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
       <MobileHamburgerMenu />
       {!isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
-        <SystemMetricsFooter />
+        <SystemMetricsFooter leftOffsetPx={sidebarCollapsed ? 48 : 300} />
       ) : null}
       <CommandPalette pathname={pathname} sessions={sessions} />
     </>

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { getTheme, setTheme } from '@/lib/theme'
@@ -72,6 +73,10 @@ export const useSettingsStore = create<SettingsState>()(
 )
 
 export function useSettings() {
+  useEffect(() => {
+    void useSettingsStore.persist.rehydrate()
+  }, [])
+
   const settings = useSettingsStore(function selectSettings(state) {
     return state.settings
   })

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-str
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
 import { Route as ApiTerminalCloseRouteImport } from './routes/api/terminal-close'
+import { Route as ApiSystemMetricsRouteImport } from './routes/api/system-metrics'
 import { Route as ApiSwarmTmuxStopRouteImport } from './routes/api/swarm-tmux-stop'
 import { Route as ApiSwarmTmuxStartRouteImport } from './routes/api/swarm-tmux-start'
 import { Route as ApiSwarmTmuxScrollRouteImport } from './routes/api/swarm-tmux-scroll'
@@ -250,6 +251,11 @@ const ApiTerminalInputRoute = ApiTerminalInputRouteImport.update({
 const ApiTerminalCloseRoute = ApiTerminalCloseRouteImport.update({
   id: '/api/terminal-close',
   path: '/api/terminal-close',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSystemMetricsRoute = ApiSystemMetricsRouteImport.update({
+  id: '/api/system-metrics',
+  path: '/api/system-metrics',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSwarmTmuxStopRoute = ApiSwarmTmuxStopRouteImport.update({
@@ -787,6 +793,7 @@ export interface FileRoutesByFullPath {
   '/api/swarm-tmux-scroll': typeof ApiSwarmTmuxScrollRoute
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
+  '/api/system-metrics': typeof ApiSystemMetricsRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -905,6 +912,7 @@ export interface FileRoutesByTo {
   '/api/swarm-tmux-scroll': typeof ApiSwarmTmuxScrollRoute
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
+  '/api/system-metrics': typeof ApiSystemMetricsRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -1025,6 +1033,7 @@ export interface FileRoutesById {
   '/api/swarm-tmux-scroll': typeof ApiSwarmTmuxScrollRoute
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
+  '/api/system-metrics': typeof ApiSystemMetricsRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -1146,6 +1155,7 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-scroll'
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
+    | '/api/system-metrics'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1264,6 +1274,7 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-scroll'
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
+    | '/api/system-metrics'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1383,6 +1394,7 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-scroll'
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
+    | '/api/system-metrics'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1503,6 +1515,7 @@ export interface RootRouteChildren {
   ApiSwarmTmuxScrollRoute: typeof ApiSwarmTmuxScrollRoute
   ApiSwarmTmuxStartRoute: typeof ApiSwarmTmuxStartRoute
   ApiSwarmTmuxStopRoute: typeof ApiSwarmTmuxStopRoute
+  ApiSystemMetricsRoute: typeof ApiSystemMetricsRoute
   ApiTerminalCloseRoute: typeof ApiTerminalCloseRoute
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
@@ -1709,6 +1722,13 @@ declare module '@tanstack/react-router' {
       path: '/api/terminal-close'
       fullPath: '/api/terminal-close'
       preLoaderRoute: typeof ApiTerminalCloseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/system-metrics': {
+      id: '/api/system-metrics'
+      path: '/api/system-metrics'
+      fullPath: '/api/system-metrics'
+      preLoaderRoute: typeof ApiSystemMetricsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/swarm-tmux-stop': {
@@ -2545,6 +2565,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSwarmTmuxScrollRoute: ApiSwarmTmuxScrollRoute,
   ApiSwarmTmuxStartRoute: ApiSwarmTmuxStartRoute,
   ApiSwarmTmuxStopRoute: ApiSwarmTmuxStopRoute,
+  ApiSystemMetricsRoute: ApiSystemMetricsRoute,
   ApiTerminalCloseRoute: ApiTerminalCloseRoute,
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,

--- a/src/routes/api/system-metrics.ts
+++ b/src/routes/api/system-metrics.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  ensureGatewayProbed,
+  getConnectionStatus,
+} from '../../server/gateway-capabilities'
+
+type SystemMetricsResponse = {
+  checkedAt: number
+  cpu: {
+    loadPercent: number
+    loadAverage1m: number
+    cores: number
+  }
+  memory: {
+    usedBytes: number
+    totalBytes: number
+    usedPercent: number
+  }
+  disk: {
+    path: string
+    usedBytes: number
+    totalBytes: number
+    usedPercent: number
+  }
+  hermes: {
+    status: 'connected' | 'enhanced' | 'partial' | 'disconnected'
+    health: boolean
+    dashboard: boolean
+  }
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function readCpu() {
+  const cores = Math.max(1, os.cpus().length)
+  const loadAverage1m = os.loadavg()[0] ?? 0
+  const loadPercent = clampPercent((loadAverage1m / cores) * 100)
+
+  return {
+    loadPercent,
+    loadAverage1m: Math.round(loadAverage1m * 100) / 100,
+    cores,
+  }
+}
+
+function readMemory() {
+  const totalBytes = os.totalmem()
+  const freeBytes = os.freemem()
+  const usedBytes = Math.max(0, totalBytes - freeBytes)
+  const usedPercent = clampPercent((usedBytes / totalBytes) * 100)
+
+  return {
+    usedBytes,
+    totalBytes,
+    usedPercent,
+  }
+}
+
+function readDisk() {
+  const diskPath = process.env.HERMES_WORKSPACE_METRICS_DISK_PATH || os.homedir()
+
+  try {
+    const stats = fs.statfsSync(diskPath)
+    const totalBytes = stats.blocks * stats.bsize
+    const freeBytes = stats.bavail * stats.bsize
+    const usedBytes = Math.max(0, totalBytes - freeBytes)
+    const usedPercent = totalBytes > 0 ? clampPercent((usedBytes / totalBytes) * 100) : 0
+
+    return {
+      path: diskPath,
+      usedBytes,
+      totalBytes,
+      usedPercent,
+    }
+  } catch {
+    return {
+      path: diskPath,
+      usedBytes: 0,
+      totalBytes: 0,
+      usedPercent: 0,
+    }
+  }
+}
+
+export const Route = createFileRoute('/api/system-metrics')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authResult = isAuthenticated(request)
+        if (authResult !== true) return authResult as unknown as Response
+
+        const caps = await ensureGatewayProbed()
+        const status = getConnectionStatus()
+
+        const body: SystemMetricsResponse = {
+          checkedAt: Date.now(),
+          cpu: readCpu(),
+          memory: readMemory(),
+          disk: readDisk(),
+          hermes: {
+            status,
+            health: caps.health,
+            dashboard: caps.dashboard.available,
+          },
+        }
+
+        return Response.json(body)
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- restore the System metrics footer behind the existing settings toggle
- add a /api/system-metrics endpoint for CPU, memory, disk, and Hermes status
- fix persisted settings hydration so the toggle survives refreshes
- refine the footer into a subtle theme-native status bar with no polling flicker and sidebar-aware offset

## Test Plan
- corepack pnpm exec eslint src/components/system-metrics-footer.tsx src/components/workspace-shell.tsx
- corepack pnpm build
- local smoke check: footer renders, starts after the sidebar at 300px, does not overlap, and shows CPU/RAM/Disk/Hermes/Updated
