### PR TITLE
fix: show all crew members on Swarm page (not just swarm\d+ IDs)

### DIFF
--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -473,7 +473,7 @@ function rankMember(roomIds: Array<string>) {
 function sortSwarmMembers(members: Array<CrewMember>, roomIds: Array<string>) {
   const rank = rankMember(roomIds)
   return [...members]
-    .filter((member) => /^swarm\d+$/i.test(member.id))
+    .filter((member) => member.id && member.id.trim().length > 0)
     .sort((a, b) => {
       const r = rank(a) - rank(b)
       if (r !== 0) return r


### PR DESCRIPTION
## Problem

The Swarm and Operations pages show "No swarm workers discovered from crew status yet." when actual agents are running and the `/api/crew-status` endpoint returns them correctly.

## Root Cause

The `sortSwarmMembers` function in `src/screens/swarm2/swarm2-screen.tsx` (line 476) filters crew members with regex `/^swarm\d+$/i`, which only matches IDs like `swarm1`, `swarm2`. Real agent IDs that don't match this pattern are silently discarded.

## Fix

Changed the filter from `/^swarm\d+$/i.test(member.id)` to `member.id && member.id.trim().length > 0`, which accepts any non-empty agent ID while still filtering out falsy/empty values.

## Verification

The Swarm page now correctly displays all agents with their role, status, task panels, and chat interfaces.

## Related

- The `/api/crew-status` endpoint was working correctly throughout — this was purely a client-side display bug.