### PR TITLE
fix: load kanban task assignees from Hermes profiles

### DIFF
--- a/src/routes/api/claude-tasks-assignees.ts
+++ b/src/routes/api/claude-tasks-assignees.ts
@@ -7,15 +7,29 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, CLAUDE_API } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, CLAUDE_API, CLAUDE_DASHBOARD_URL } from '../../server/gateway-capabilities'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import YAML from 'yaml'
 
+type RawAssignee = {
+  id?: unknown
+  name?: unknown
+  label?: unknown
+  isHuman?: unknown
+  is_human?: unknown
+}
+
+type TaskAssignee = {
+  id: string
+  label: string
+  isHuman: boolean
+}
+
 const CLAUDE_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
 const CONFIG_PATH = path.join(CLAUDE_HOME, 'config.yaml')
-const PROFILES_PATH = path.join(os.homedir(), '.claude', 'profiles')
+const PROFILES_PATH = path.join(CLAUDE_HOME, 'profiles')
 
 function readConfig(): Record<string, unknown> {
   try {
@@ -29,7 +43,11 @@ function getProfileNames(): string[] {
   try {
     return fs.readdirSync(PROFILES_PATH).filter(name => {
       try {
-        return fs.statSync(path.join(PROFILES_PATH, name)).isDirectory()
+        const profilePath = path.join(PROFILES_PATH, name)
+        return (
+          fs.statSync(profilePath).isDirectory() &&
+          fs.existsSync(path.join(profilePath, 'config.yaml'))
+        )
       } catch {
         return false
       }
@@ -43,6 +61,62 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+function titleCaseProfile(name: string): string {
+  return name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function normalizeAssigneePayload(payload: unknown, humanReviewer: string | null): Array<TaskAssignee> {
+  const record = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : null
+  const rawAssignees = Array.isArray(payload)
+    ? payload
+    : Array.isArray(record?.assignees)
+      ? record.assignees
+      : []
+
+  const seen = new Set<string>()
+  const assignees: Array<TaskAssignee> = []
+
+  for (const raw of rawAssignees) {
+    const item = typeof raw === 'string' ? { id: raw, label: raw } : raw as RawAssignee
+    const id = typeof item.id === 'string'
+      ? item.id
+      : typeof item.name === 'string'
+        ? item.name
+        : null
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const label = typeof item.label === 'string' && item.label.trim().length > 0
+      ? item.label
+      : titleCaseProfile(id)
+    assignees.push({
+      id,
+      label,
+      isHuman: item.isHuman === true || item.is_human === true || id === humanReviewer,
+    })
+  }
+
+  return assignees
+}
+
+async function fetchJson(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(2000),
+      headers: authHeaders(),
+    })
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
 export const Route = createFileRoute('/api/claude-tasks-assignees')({
   server: {
     handlers: {
@@ -51,32 +125,42 @@ export const Route = createFileRoute('/api/claude-tasks-assignees')({
           return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
         }
 
-        // Try gateway first — it may have a richer endpoint
-        try {
-          const res = await fetch(`${CLAUDE_API}/api/tasks/assignees`, {
-            signal: AbortSignal.timeout(2000),
-            headers: authHeaders(),
-          })
-          if (res.ok) {
-            return new Response(await res.text(), {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
-            })
-          }
-        } catch {
-          // fall through to local profile discovery
-        }
-
-        // Fall back: derive from profile directories + config
         const config = readConfig()
         const tasksConfig = (config.tasks ?? {}) as Record<string, unknown>
         const humanReviewer = (tasksConfig.human_reviewer as string) || null
-        const profiles = getProfileNames()
 
-        const assignees = profiles.map(id => ({ id, label: id, isHuman: id === humanReviewer }))
-        if (humanReviewer && !profiles.includes(humanReviewer)) {
-          assignees.unshift({ id: humanReviewer, label: humanReviewer, isHuman: true })
+        // Prefer the dashboard plugin endpoint: it is the source used by the
+        // Hermes kanban CLI and includes ~/.hermes/profiles plus assignees
+        // already present on the board.
+        const remotePayload =
+          await fetchJson(`${CLAUDE_DASHBOARD_URL}/api/plugins/kanban/assignees`) ??
+          await fetchJson(`${CLAUDE_API}/api/tasks/assignees`)
+        const remoteAssignees = remotePayload
+          ? normalizeAssigneePayload(remotePayload, humanReviewer)
+          : []
+
+        const profiles = getProfileNames()
+        const merged = new Map<string, TaskAssignee>()
+        for (const assignee of remoteAssignees) {
+          merged.set(assignee.id, assignee)
         }
+        for (const id of profiles) {
+          if (!merged.has(id)) {
+            merged.set(id, { id, label: titleCaseProfile(id), isHuman: id === humanReviewer })
+          }
+        }
+        if (humanReviewer && !merged.has(humanReviewer)) {
+          merged.set(humanReviewer, {
+            id: humanReviewer,
+            label: titleCaseProfile(humanReviewer),
+            isHuman: true,
+          })
+        }
+
+        const assignees = Array.from(merged.values()).sort((a, b) => {
+          if (a.isHuman !== b.isHuman) return a.isHuman ? -1 : 1
+          return a.label.localeCompare(b.label)
+        })
 
         return new Response(
           JSON.stringify({ assignees, humanReviewer }),


### PR DESCRIPTION
## Summary
- Use the Hermes dashboard kanban assignee endpoint as the preferred source for task assignees
- Normalize dashboard `{ name, on_disk, counts }` assignee payloads into the Tasks UI `{ id, label, isHuman }` shape
- Fall back to `$HERMES_HOME/profiles/<name>/config.yaml` instead of the legacy `~/.claude/profiles` path
- Keep the configured human reviewer in the assignee list

## Test Plan
- `corepack pnpm build`
- `corepack pnpm vitest run src/screens/tasks/tasks-ux.test.ts`
- Verified `/api/claude-tasks-assignees` returns human reviewer plus Hermes profiles
