### PR TITLE
fix: show distinct gateway-auth-rejected message and stop misrouting 'token' errors (#239)

### DIFF
--- a/src/lib/connection-errors.test.ts
+++ b/src/lib/connection-errors.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyConnectionError,
+  getConnectionErrorInfo,
+  getConnectionErrorMessage,
+} from './connection-errors'
+
+describe('classifyConnectionError', () => {
+  it('returns gateway_unreachable when no error and no status', () => {
+    expect(classifyConnectionError()).toBe('gateway_unreachable')
+    expect(classifyConnectionError('')).toBe('gateway_unreachable')
+    expect(classifyConnectionError(null, null)).toBe('gateway_unreachable')
+  })
+
+  it('classifies HTTP 401 as clawsuite_auth_required', () => {
+    expect(classifyConnectionError('boom', 401)).toBe('clawsuite_auth_required')
+  })
+
+  it('classifies HTTP 403 as gateway_pairing_required', () => {
+    expect(classifyConnectionError('boom', 403)).toBe(
+      'gateway_pairing_required',
+    )
+  })
+
+  it('classifies pairing keywords as gateway_pairing_required', () => {
+    expect(classifyConnectionError('device is not paired')).toBe(
+      'gateway_pairing_required',
+    )
+    expect(classifyConnectionError('please pair the device')).toBe(
+      'gateway_pairing_required',
+    )
+  })
+
+  it('classifies explicit gateway-token rejection as gateway_auth_rejected (issue #239)', () => {
+    // The exact wording in the bug report.
+    expect(
+      classifyConnectionError('Hermes Agent rejected the connection token'),
+    ).toBe('gateway_auth_rejected')
+    expect(classifyConnectionError('missing gateway auth')).toBe(
+      'gateway_auth_rejected',
+    )
+    expect(classifyConnectionError('invalid token')).toBe(
+      'gateway_auth_rejected',
+    )
+    expect(classifyConnectionError('token expired')).toBe(
+      'gateway_auth_rejected',
+    )
+    expect(classifyConnectionError('Unauthorized')).toBe(
+      'gateway_auth_rejected',
+    )
+  })
+
+  it('does NOT misclassify benign uses of the word "token" as auth failures', () => {
+    // Regression: previously `lower.includes('token')` matched any error
+    // mentioning the word "token", routing benign network errors to a
+    // "Log in again" prompt.
+    expect(classifyConnectionError('failed to fetch token from /api/foo')).toBe(
+      'gateway_unreachable',
+    )
+    expect(classifyConnectionError('cancelled token before request')).toBe(
+      'unknown',
+    )
+  })
+
+  it('classifies network errors as gateway_unreachable', () => {
+    expect(classifyConnectionError('ECONNREFUSED 127.0.0.1:8642')).toBe(
+      'gateway_unreachable',
+    )
+    expect(classifyConnectionError('getaddrinfo ENOTFOUND example')).toBe(
+      'gateway_unreachable',
+    )
+    expect(classifyConnectionError('NetworkError when fetching')).toBe(
+      'gateway_unreachable',
+    )
+  })
+
+  it('classifies handshake errors', () => {
+    expect(classifyConnectionError('invalid nonce')).toBe('handshake_failed')
+    expect(classifyConnectionError('handshake failed')).toBe('handshake_failed')
+  })
+
+  it('classifies timeouts', () => {
+    expect(classifyConnectionError('request timeout')).toBe('handshake_timeout')
+    expect(classifyConnectionError('timed out after 30s')).toBe(
+      'handshake_timeout',
+    )
+  })
+
+  it('classifies disconnects', () => {
+    expect(classifyConnectionError('connection closed')).toBe('disconnected')
+    expect(classifyConnectionError('client disconnect')).toBe('disconnected')
+  })
+
+  it('falls through to unknown for unrelated errors', () => {
+    expect(classifyConnectionError('something weird happened')).toBe('unknown')
+  })
+
+  it('accepts Error instances as input', () => {
+    expect(classifyConnectionError(new Error('Unauthorized'))).toBe(
+      'gateway_auth_rejected',
+    )
+  })
+})
+
+describe('getConnectionErrorMessage', () => {
+  it('returns a distinct gateway-specific message for gateway_auth_rejected', () => {
+    // Regression: previously this case was a fallthrough that re-used the
+    // ClawSuite-login text, telling users to "Enter your password" when
+    // their actual problem was the gateway refusing their device token.
+    const gateway = getConnectionErrorMessage('gateway_auth_rejected')
+    const clawsuite = getConnectionErrorMessage('clawsuite_auth_required')
+    expect(gateway.title).not.toBe(clawsuite.title)
+    expect(gateway.description).not.toBe(clawsuite.description)
+    expect(gateway.title.toLowerCase()).toContain('gateway')
+    // The action should point the user at re-pairing / token config, not
+    // at entering a password.
+    expect(gateway.action?.toLowerCase()).not.toContain('password')
+  })
+
+  it('returns a non-empty message for every kind', () => {
+    const kinds = [
+      'clawsuite_auth_required',
+      'gateway_auth_rejected',
+      'gateway_pairing_required',
+      'gateway_unreachable',
+      'handshake_failed',
+      'handshake_timeout',
+      'disconnected',
+      'unknown',
+    ] as const
+    for (const kind of kinds) {
+      const info = getConnectionErrorMessage(kind)
+      expect(info.title.length).toBeGreaterThan(0)
+      expect(info.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('getConnectionErrorInfo', () => {
+  it('combines kind, title, and details', () => {
+    const info = getConnectionErrorInfo(
+      'Hermes Agent rejected the connection token',
+    )
+    expect(info.kind).toBe('gateway_auth_rejected')
+    expect(info.title.toLowerCase()).toContain('gateway')
+    expect(info.details).toBe('Hermes Agent rejected the connection token')
+  })
+
+  it('suppresses generic details that duplicate the title', () => {
+    const info = getConnectionErrorInfo('unauthorized', 401)
+    expect(info.kind).toBe('clawsuite_auth_required')
+    expect(info.details).toBeUndefined()
+  })
+
+  it('does not misroute benign "token" details to auth failure', () => {
+    const info = getConnectionErrorInfo('failed to fetch token from /api/foo')
+    expect(info.kind).toBe('gateway_unreachable')
+  })
+})

--- a/src/lib/connection-errors.ts
+++ b/src/lib/connection-errors.ts
@@ -8,11 +8,33 @@ export type ConnectionErrorKind =
   | 'disconnected'
   | 'unknown'
 
+// Markers that indicate an auth failure happened (used to qualify generic
+// keywords like "token" so we don't misclassify network noise).
+const AUTH_FAILURE_MARKERS = [
+  'unauthorized',
+  'unauthenticated',
+  'forbidden',
+  'invalid',
+  'expired',
+  'rejected',
+  'denied',
+  'missing',
+  'no auth',
+  'auth failed',
+  'auth required',
+  '401',
+  '403',
+]
+
+function looksLikeAuthFailure(lower: string): boolean {
+  return AUTH_FAILURE_MARKERS.some((marker) => lower.includes(marker))
+}
+
 export function classifyConnectionError(
   error?: string | Error | null,
   status?: number | null,
 ): ConnectionErrorKind {
-  const msg = typeof error === 'string' ? error : error?.message ?? ''
+  const msg = typeof error === 'string' ? error : (error?.message ?? '')
   const lower = msg.toLowerCase()
   if (!lower && !status) return 'gateway_unreachable'
   if (status === 401) return 'clawsuite_auth_required'
@@ -23,12 +45,18 @@ export function classifyConnectionError(
   ) {
     return 'gateway_pairing_required'
   }
+  // Gateway auth rejection: the gateway received our request but refused
+  // the device's auth token. Match on phrases that clearly indicate an
+  // auth failure — generic words like "token" only count when paired with
+  // an auth-failure marker (rejected/invalid/expired/etc.) so that benign
+  // strings like "failed to fetch token from /api/x" don't get misrouted
+  // to a "log in again" prompt.
   if (
     lower.includes('missing gateway auth') ||
     lower.includes('gateway auth') ||
-    lower.includes('token') ||
     lower.includes('forbidden') ||
-    lower.includes('unauthorized')
+    lower.includes('unauthorized') ||
+    (lower.includes('token') && looksLikeAuthFailure(lower))
   ) {
     return 'gateway_auth_rejected'
   }
@@ -71,17 +99,17 @@ export function getConnectionErrorMessage(
         action: 'Enter your password to continue',
       }
     case 'gateway_auth_rejected':
-    case 'clawsuite_auth_required':
       return {
-        title: 'Claude Login Required',
-        description: 'This instance requires a password to access.',
-        action: 'Enter your password to continue',
+        title: 'Gateway rejected this device',
+        description:
+          "The gateway is reachable, but it refused this device's auth token. The token is missing, invalid, or expired.",
+        action:
+          'Re-pair this device with the gateway, or check that the gateway auth token is configured correctly.',
       }
     case 'gateway_pairing_required':
       return {
         title: 'Pair this device first',
-        description:
-          'This device is not paired with the gateway yet.',
+        description: 'This device is not paired with the gateway yet.',
         action: 'Run `claude pair` on the gateway machine, then reconnect.',
       }
     case 'gateway_unreachable':
@@ -95,7 +123,8 @@ export function getConnectionErrorMessage(
         title: 'Connection could not be verified',
         description:
           'The gateway responded, but the secure connection handshake did not complete.',
-        action: 'Try reconnecting. If it keeps failing, check gateway pairing and auth.',
+        action:
+          'Try reconnecting. If it keeps failing, check gateway pairing and auth.',
       }
     case 'handshake_timeout':
       return {
@@ -125,9 +154,7 @@ export function getConnectionErrorInfo(
   const kind = classifyConnectionError(error, status)
   const base = getConnectionErrorMessage(kind)
   const details =
-    typeof error === 'string'
-      ? error.trim()
-      : error?.message?.trim() ?? ''
+    typeof error === 'string' ? error.trim() : (error?.message?.trim() ?? '')
 
   const showDetails =
     details.length > 0 &&


### PR DESCRIPTION
## Summary

Fixes the wrong UI message when the gateway refuses a device's auth token (the user-visible string is _"Hermes Agent rejected the connection token"_).

Two related bugs in `src/lib/connection-errors.ts`:

### 1. Dead-code `case` fallthrough

`getConnectionErrorMessage` had a duplicate `case 'clawsuite_auth_required':` label sitting between `case 'gateway_auth_rejected':` and its body:

```ts
case 'gateway_auth_rejected':
case 'clawsuite_auth_required':   // ← unreachable; already handled above
  return {
    title: 'Claude Login Required',
    description: 'This instance requires a password to access.',
    action: 'Enter your password to continue',
  }
```

Because `clawsuite_auth_required` is handled by the previous arm, every `gateway_auth_rejected` ended up rendering the **ClawSuite** "Login Required / Enter your password" UI — which is the wrong remedy when the actual problem is the gateway refusing the device token. (No password to enter — you need to re-pair / fix the gateway token.)

### 2. Over-broad `'token'` heuristic in `classifyConnectionError`

```ts
lower.includes('token') ||  // matches anything containing the word "token"
```

Any error whose message merely contained the substring `token` (including benign network errors like `failed to fetch token from /api/foo`, `cancellation token`, etc.) got classified as `gateway_auth_rejected`, which compounded bug #1 by sending the user to a "log in again" prompt.

## Fix

- **Give `gateway_auth_rejected` its own dedicated message** that tells the user the gateway refused the device's token and points them at re-pairing / checking the gateway token (not at typing a password).
- **Tighten the heuristic:** `'token'` is now a hit only when paired with an auth-failure marker (`unauthorized`, `forbidden`, `rejected`, `invalid`, `expired`, `missing`, `401`, `403`, …). Bare `'token'` strings fall through to the network/unknown bucket as before.

The two fixes work together — the heuristic stops over-matching, and even when `gateway_auth_rejected` _does_ legitimately fire, the user now sees an accurate message.

## Tests

Added `src/lib/connection-errors.test.ts` with 17 specs covering:

- Original behavior for HTTP 401/403, pairing, network, handshake, timeout, disconnect, unknown.
- **Regression test for issue #239:** the literal error string `"Hermes Agent rejected the connection token"` must classify to `gateway_auth_rejected`, and `getConnectionErrorMessage('gateway_auth_rejected')` must return a different title/description than `clawsuite_auth_required` and must not tell the user to enter a password.
- **Regression test for the heuristic:** `"failed to fetch token from /api/foo"` must classify to `gateway_unreachable`, not `gateway_auth_rejected`.
- Each `ConnectionErrorKind` returns a non-empty title and description.

```
$ pnpm vitest run src/lib/connection-errors.test.ts
 ✓ src/lib/connection-errors.test.ts (17 tests) 2ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Full suite before fix: `19 failed | 172 passed`. After fix: `19 failed | 189 passed` — same pre-existing failures (in `markdown.test`, `chat-message-list.test`, `-models.test`, `-servers.test`), no regressions, +17 new passing tests.

Fixes #239
