### PR TITLE
fix(slash-menu): add /plugins to autocomplete and export DEFAULT_SLASH_COMMANDS

### DIFF
--- a/src/components/slash-command-menu.test.tsx
+++ b/src/components/slash-command-menu.test.tsx
@@ -4,9 +4,42 @@ import { DEFAULT_SLASH_COMMANDS } from './slash-command-menu'
 
 describe('DEFAULT_SLASH_COMMANDS', () => {
   it('includes /plugins in the slash autocomplete list', () => {
-    const plugin = DEFAULT_SLASH_COMMANDS.find((item) => item.command === '/plugins')
+    const plugin = DEFAULT_SLASH_COMMANDS.find(
+      (item) => item.command === '/plugins',
+    )
 
     expect(plugin).toBeTruthy()
     expect(plugin?.description).toBe('List installed plugins and their status')
+  })
+
+  it('exposes the core slash commands users expect', () => {
+    const commands = DEFAULT_SLASH_COMMANDS.map((entry) => entry.command)
+    for (const required of [
+      '/new',
+      '/clear',
+      '/model',
+      '/save',
+      '/skills',
+      '/plugins',
+      '/skin',
+      '/help',
+    ]) {
+      expect(commands).toContain(required)
+    }
+  })
+
+  it('defines a non-empty description for every entry', () => {
+    for (const entry of DEFAULT_SLASH_COMMANDS) {
+      expect(entry.command.startsWith('/')).toBe(true)
+      expect(entry.description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not duplicate any command label', () => {
+    const seen = new Set<string>()
+    for (const entry of DEFAULT_SLASH_COMMANDS) {
+      expect(seen.has(entry.command)).toBe(false)
+      seen.add(entry.command)
+    }
   })
 })

--- a/src/components/slash-command-menu.tsx
+++ b/src/components/slash-command-menu.tsx
@@ -13,28 +13,29 @@ import { useAutocompleteFilter } from '@/components/ui/autocomplete'
 import { Command, CommandItem, CommandList } from '@/components/ui/command'
 import { cn } from '@/lib/utils'
 
-type SlashCommandDefinition = {
+export type SlashCommandDefinition = {
   command: string
   description: string
 }
 
-type SlashCommandMenuProps = {
+export type SlashCommandMenuProps = {
   open: boolean
   query: string
   onSelect: (command: SlashCommandDefinition) => void
 }
 
-type SlashCommandMenuHandle = {
+export type SlashCommandMenuHandle = {
   moveSelection: (step: number) => void
   selectActive: () => boolean
 }
 
-const SLASH_COMMANDS: Array<SlashCommandDefinition> = [
+export const DEFAULT_SLASH_COMMANDS: Array<SlashCommandDefinition> = [
   { command: '/new', description: 'Start new session' },
   { command: '/clear', description: 'Clear screen and start fresh' },
   { command: '/model', description: 'Show or change the current model' },
   { command: '/save', description: 'Save the current conversation' },
   { command: '/skills', description: 'Browse and manage skills' },
+  { command: '/plugins', description: 'List installed plugins and their status' },
   { command: '/skin', description: 'Change the display theme' },
   { command: '/help', description: 'Show available commands' },
 ]
@@ -48,9 +49,9 @@ const SlashCommandMenu = forwardRef(function SlashCommandMenu(
 
   const filteredCommands = useMemo(() => {
     const normalizedQuery = query.trim()
-    if (!normalizedQuery) return SLASH_COMMANDS
+    if (!normalizedQuery) return DEFAULT_SLASH_COMMANDS
 
-    return SLASH_COMMANDS.filter((item) =>
+    return DEFAULT_SLASH_COMMANDS.filter((item) =>
       filter.contains(
         item,
         normalizedQuery,


### PR DESCRIPTION
## Summary

Fixes a pre-existing failing test (`src/components/slash-command-menu.test.tsx`) and the underlying bug it was specifying: the chat slash-command autocomplete was missing `/plugins`, even though the workspace has a real `/api/plugins` backend route.

## What was broken

The test suite already contained a spec that imports `DEFAULT_SLASH_COMMANDS` and asserts `/plugins` is in it:

```ts
import { DEFAULT_SLASH_COMMANDS } from './slash-command-menu'

describe('DEFAULT_SLASH_COMMANDS', () => {
  it('includes /plugins in the slash autocomplete list', () => {
    const plugin = DEFAULT_SLASH_COMMANDS.find(
      (item) => item.command === '/plugins',
    )
    expect(plugin).toBeTruthy()
    expect(plugin?.description).toBe('List installed plugins and their status')
  })
})
```

But `slash-command-menu.tsx`:
1. Declared the list as `const SLASH_COMMANDS` (wrong name) and didn't export it → `DEFAULT_SLASH_COMMANDS` was `undefined` at import time, the test crashed with `TypeError: Cannot read properties of undefined`.
2. Was missing the `/plugins` entry entirely.

End-user impact: typing `/plug` in the chat composer showed nothing in autocomplete, even though `/plugins` is a perfectly valid command — the message is forwarded to the agent, which already supports it via the `/api/plugins` route.

## Fix

- Rename `SLASH_COMMANDS` → `DEFAULT_SLASH_COMMANDS` and `export` it so the rest of the codebase (and the test) can introspect the list.
- Add `{ command: '/plugins', description: 'List installed plugins and their status' }` to the list, in alphabetically-grouped position next to `/skills`.
- `export` the three previously-private helper types (`SlashCommandDefinition`, `SlashCommandMenuProps`, `SlashCommandMenuHandle`) since `chat-composer.tsx` already imports two of them; making them explicit public types matches what the importer was already relying on.

No call-site changes — the only consumer (`chat-composer.tsx`) imports the types and the component, both of which still work the same way.

## Tests

Extended the existing test with three additional regression specs:

- The list contains every core command (`/new`, `/clear`, `/model`, `/save`, `/skills`, `/plugins`, `/skin`, `/help`).
- Every entry has a non-empty description and starts with `/`.
- No command label is duplicated.

```
$ pnpm vitest run src/components/slash-command-menu.test.tsx
 ✓ src/components/slash-command-menu.test.tsx (4 tests) 2ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full suite before fix: `19 failed | 172 passed`. After fix: `18 failed | 176 passed` — one fewer failure (the slash-menu test now passes), three new passing specs, no regressions. The remaining 18 failures are pre-existing and unrelated (markdown plugins, models route YAML, MCP servers helper, chat-message-list helper).
