### PR TITLE
fix: clean Hermes Workspace setup and branding copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Start here: [docs/swarm/](./docs/swarm/)
 curl -fsSL https://raw.githubusercontent.com/outsourc-e/hermes-workspace/main/install.sh | bash
 ```
 
-This installs `hermes-agent` from PyPI, clones this repo, sets up `.env`, and installs deps. Then:
+This installs `hermes-agent` via Nous's official installer, clones this repo, sets up `.env`, and installs dependencies. Then:
 
 ```bash
 hermes gateway run                  # terminal 1
@@ -91,7 +91,7 @@ Open http://localhost:3000. That's it.
 
 ### Already running `hermes-agent`? Attach the workspace to it
 
-If you already have `hermes-agent` installed (via Nous's installer, `pip install`, systemd, Docker, etc.) and it's serving the gateway at `http://<host>:8642`, you don't need to reinstall anything — just point the workspace at it.
+If you already have `hermes-agent` installed (via Nous's official installer, a source checkout, systemd, Docker, or another existing setup) and it's serving the gateway at `http://<host>:8642`, you don't need to reinstall anything — just point the workspace at it.
 
 ```bash
 git clone https://github.com/outsourc-e/hermes-workspace.git
@@ -168,7 +168,7 @@ Example Hermes Agent gateway setup (from scratch):
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 
 # Configure a provider + start the gateway
-claude setup
+hermes setup
 hermes gateway run
 ```
 
@@ -218,7 +218,7 @@ HERMES_API_URL=http://127.0.0.1:8642
 
 # Optional: provider keys the Hermes Agent gateway can read at runtime.
 # You only need the key(s) for whichever provider(s) you actually use.
-# ANTHROPIC_API_KEY=sk-ant-...         # Claude
+# ANTHROPIC_API_KEY=***         # Anthropic
 # OPENAI_API_KEY=sk-...                # GPT / o-series
 # OPENROUTER_API_KEY=sk-or-v1-...      # OpenRouter (incl. free models)
 # GOOGLE_API_KEY=AIza...               # Gemini
@@ -339,7 +339,7 @@ Edit `.env` and add **at least one** LLM provider key — whichever provider you
 
 ```env
 # Pick one (or more). You do NOT need all of these.
-ANTHROPIC_API_KEY=sk-ant-...           # Claude
+# ANTHROPIC_API_KEY=***         # Anthropic
 # OPENAI_API_KEY=sk-...                # GPT / o-series
 # OPENROUTER_API_KEY=sk-or-v1-...      # OpenRouter (free models available)
 # GOOGLE_API_KEY=AIza...               # Gemini
@@ -362,7 +362,7 @@ This pulls two pre-built images and starts them:
 
 No local build. First run takes a minute to pull; subsequent starts are instant.
 Agent state (config, sessions, skills, memory, credentials) persists in the
-`claude-data` named volume, so containers can be recreated without data loss.
+legacy-named `claude-data` Docker volume, so containers can be recreated without data loss.
 
 ### Step 3: Access the Workspace
 
@@ -602,7 +602,7 @@ Your Hermes Agent gateway isn't running. Start it:
 hermes gateway run
 ```
 
-First-time run? Do `claude setup` first to pick a provider and model.
+First-time run? Do `hermes setup` first to pick a provider and model.
 
 ### Ollama: chat returns empty or model shows "Offline"
 
@@ -665,7 +665,7 @@ If using Docker Compose and getting auth errors:
    ```
    Look for: `[gateway] http://hermes-agent:8642 mode=...` — if it shows `mode=disconnected`, the agent isn't running correctly.
 
-### Docker: "claude webapi command not found"
+### Docker: older `claude webapi` docs are wrong
 
 The `claude webapi` command referenced in older docs doesn't exist. The correct command is:
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #   1. Verifies Node 22+, git, pnpm
 #   2. Installs hermes-agent via Nous's official upstream installer
 #   3. Clones hermes-workspace
-#   4. Sets up .env, enables the Claude HTTP API, installs deps,
+#   4. Sets up .env, enables the Hermes API server, installs deps,
 #      and links bundled skills
 #
 # Re-runnable. Will skip anything already installed.
@@ -34,7 +34,7 @@ banner() {
   cat <<'EOF'
 
    ╭────────────────────────────────────────────╮
-   │  PROJECT WORKSPACE — zero-fork installer   │
+   │  HERMES WORKSPACE — zero-fork installer   │
    │  outsourc-e/hermes-workspace               │
    ╰────────────────────────────────────────────╯
 
@@ -111,15 +111,15 @@ green "  pnpm $(pnpm --version) ✓"
 # ─── install hermes-agent (delegate to Nous upstream installer) ──────────
 # hermes-agent is NOT on PyPI. It installs from source via Nous's own
 # script, which handles PEP 668, uv, Python toolchain, Termux, etc. We
-# only need to ensure `claude` ends up on PATH before continuing.
+# only need to ensure `hermes` ends up on PATH before continuing.
 
 cyan "→ Installing hermes-agent (via Nous upstream installer)…"
-# Pick up claude if it was installed in a prior run but not on PATH yet
-ensure_path "$HOME/.claude/bin"
+# Pick up hermes if it was installed in a prior run but not on PATH yet
+ensure_path "$HOME/.hermes/bin"
 ensure_path "$HOME/.local/bin"
 
-if command -v claude &>/dev/null; then
-  green "  hermes-agent already installed ✓ ($(command -v claude))"
+if command -v hermes &>/dev/null; then
+  green "  hermes-agent already installed ✓ ($(command -v hermes))"
 else
   yellow "  Delegating to: $NOUS_INSTALLER_URL"
   if ! curl -fsSL "$NOUS_INSTALLER_URL" | bash; then
@@ -128,16 +128,16 @@ else
     red "    curl -fsSL $NOUS_INSTALLER_URL | bash"
     exit 1
   fi
-  # Nous typically installs `claude` to ~/.hermes/bin or ~/.local/bin
-  ensure_path "$HOME/.claude/bin"
+  # Nous typically installs `hermes` to ~/.hermes/bin or ~/.local/bin
+  ensure_path "$HOME/.hermes/bin"
   ensure_path "$HOME/.local/bin"
-  if ! command -v claude &>/dev/null; then
-    red "  hermes-agent installed, but 'claude' is not on PATH in this shell."
+  if ! command -v hermes &>/dev/null; then
+    red "  hermes-agent installed, but 'hermes' is not on PATH in this shell."
     yellow "  Open a new shell (or: source ~/.bashrc / ~/.zshrc) and re-run:"
     yellow "    curl -fsSL https://hermes-workspace.com/install.sh | bash"
     exit 1
   fi
-  green "  hermes-agent installed ✓ ($(command -v claude))"
+  green "  hermes-agent installed ✓ ($(command -v hermes))"
 fi
 
 # ─── clone workspace ──────────────────────────────────────────────────────
@@ -165,25 +165,25 @@ fi
 ensure_env_key "$INSTALL_DIR/.env" "HERMES_API_URL" "http://127.0.0.1:${GATEWAY_PORT}"
 green "  .env ready ✓"
 
-cyan "→ Enabling Claude HTTP API…"
-CLAUDE_ENV_PATH="$(claude config env-path 2>/dev/null || true)"
-if [[ -z "$CLAUDE_ENV_PATH" ]]; then
-  CLAUDE_ENV_PATH="$HOME/.claude/.env"
+cyan "→ Enabling Hermes API server…"
+HERMES_ENV_PATH="$(hermes config env-path 2>/dev/null || true)"
+if [[ -z "$HERMES_ENV_PATH" ]]; then
+  HERMES_ENV_PATH="$HOME/.hermes/.env"
 fi
-ensure_env_key "$CLAUDE_ENV_PATH" "API_SERVER_ENABLED" "true"
-green "  Claude env updated: $CLAUDE_ENV_PATH ✓"
+ensure_env_key "$HERMES_ENV_PATH" "API_SERVER_ENABLED" "true"
+green "  Hermes env updated: $HERMES_ENV_PATH ✓"
 
 # Guard against a common foot-gun: users editing ~/.hermes/.env by hand and
 # writing env var names without underscores (APISERVERENABLED vs
 # API_SERVER_ENABLED). The gateway reads exact names — typos are silently
 # ignored, which produces a "gateway starts but API server never binds"
 # failure that's hard to diagnose from the UI.
-if [[ -f "$CLAUDE_ENV_PATH" ]]; then
-  SUSPICIOUS=$(grep -E "^(API[A-Z]+|CLAUDE[A-Z]+)=" "$CLAUDE_ENV_PATH" 2>/dev/null \
-    | grep -vE "^(API_|CLAUDE_)" || true)
+if [[ -f "$HERMES_ENV_PATH" ]]; then
+  SUSPICIOUS=$(grep -E "^(API[A-Z]+|HERMES[A-Z]+)=" "$HERMES_ENV_PATH" 2>/dev/null \
+    | grep -vE "^(API_|HERMES_)" || true)
   if [[ -n "$SUSPICIOUS" ]]; then
     yellow ""
-    yellow "⚠  Found env var names missing underscores in $CLAUDE_ENV_PATH:"
+    yellow "⚠  Found env var names missing underscores in $HERMES_ENV_PATH:"
     echo "$SUSPICIOUS" | sed 's/^/      /'
     yellow "   The gateway reads names with underscores (API_SERVER_ENABLED,"
     yellow "   not APISERVERENABLED). These lines will be silently ignored."
@@ -196,15 +196,15 @@ cyan "→ Installing npm deps (pnpm install)…"
 pnpm install --silent
 green "  deps installed ✓"
 
-# ─── seed Claude skills (Conductor needs workspace-dispatch) ─────────────
+# ─── seed Hermes skills (Conductor needs workspace-dispatch) ─────────────
 
 cyan "→ Linking bundled skills into ~/.hermes/skills…"
-CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
-mkdir -p "$CLAUDE_SKILLS_DIR"
+HERMES_SKILLS_DIR="$HOME/.hermes/skills"
+mkdir -p "$HERMES_SKILLS_DIR"
 if [[ -d "$INSTALL_DIR/skills" ]]; then
   for skill_path in "$INSTALL_DIR/skills"/*/; do
     skill_name=$(basename "$skill_path")
-    target="$CLAUDE_SKILLS_DIR/$skill_name"
+    target="$HERMES_SKILLS_DIR/$skill_name"
     if [[ -e "$target" || -L "$target" ]]; then
       continue
     fi
@@ -225,7 +225,7 @@ Next steps (two terminals):
 
   1) Start the Hermes Agent gateway:
        hermes gateway run
-     (first run may prompt for claude setup)
+     (first run may prompt for hermes setup)
 
   2) Start the workspace UI:
        cd $INSTALL_DIR && pnpm dev

--- a/src/components/connection-startup-screen.tsx
+++ b/src/components/connection-startup-screen.tsx
@@ -22,9 +22,6 @@ function detectPlatform(): Platform {
 function getSetupSteps(
   platform: Platform,
 ): Array<{ title: string; command: string; note?: string }> {
-  const pip = platform === 'windows' ? 'pip' : 'pip3'
-  const python = platform === 'windows' ? 'python' : 'python3'
-
   return [
     {
       title: 'Use any OpenAI-compatible backend',
@@ -33,12 +30,13 @@ function getSetupSteps(
     },
     {
       title: 'Optional: install Hermes Agent locally',
-      command: `${pip} install hermes-agent`,
+      command:
+        'curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash',
       note: 'Vanilla hermes-agent unlocks sessions, skills, memory, jobs, and config automatically — no fork required',
     },
     {
       title: 'Set up your agent',
-      command: 'claude setup',
+      command: 'hermes setup',
       note: 'Pick your providers once; Hermes Agent stores them under ~/.hermes',
     },
     {

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1374,7 +1374,7 @@ function _AdvancedContent() {
           <div className="w-full max-w-sm">
             <Input
               type="url"
-              placeholder="https://api.claudeworkspace.app"
+              placeholder="http://127.0.0.1:8642"
               value={settings.claudeUrl}
               onChange={(e) => validateAndUpdateUrl(e.target.value)}
               className="h-8 w-full rounded-lg border-primary-200 text-sm"

--- a/src/routes/api/claude-config.ts
+++ b/src/routes/api/claude-config.ts
@@ -1,6 +1,6 @@
 /**
  * Hermes Config API — read/write ~/.hermes/config.yaml and ~/.hermes/.env
- * Gives the web UI the same config power as `claude setup`
+ * Gives the web UI the same config power as `hermes setup`
  */
 import fs from 'node:fs'
 import path from 'node:path'

--- a/src/routes/api/workspace.ts
+++ b/src/routes/api/workspace.ts
@@ -45,7 +45,7 @@ async function detectWorkspace(savedPath?: string): Promise<{
 
   // Priority 2: Environment variable
   const envWorkspace =
-    process.env.CLAUDE_WORKSPACE_DIR?.trim() ||
+    process.env.HERMES_WORKSPACE_DIR?.trim() ||
     process.env.CLAUDE_WORKSPACE_DIR?.trim()
   if (envWorkspace) {
     const isValid = await isValidDirectory(envWorkspace)
@@ -53,7 +53,7 @@ async function detectWorkspace(savedPath?: string): Promise<{
       return {
         path: envWorkspace,
         folderName: extractFolderName(envWorkspace),
-        source: 'claude',
+        source: 'env',
         isValid: true,
       }
     }

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -855,7 +855,7 @@ type LoaderStyleOption = { value: LoaderStyle; label: string }
 
 const LOADER_STYLES: Array<LoaderStyleOption> = [
   { value: 'dots', label: 'Dots' },
-  { value: 'braille-claude', label: 'Claude' },
+  { value: 'braille-claude', label: 'Hermes' },
   { value: 'braille-orbit', label: 'Orbit' },
   { value: 'braille-breathe', label: 'Breathe' },
   { value: 'braille-pulse', label: 'Pulse' },
@@ -1172,7 +1172,7 @@ function ClaudeConfigSection({
         </SettingsRow>
         <SettingsRow
           label="Model"
-          description="The model Claude uses for conversations."
+          description="The default model Hermes Agent uses for conversations."
         >
           <div className="flex w-full max-w-sm gap-2">
             {availableModels.length > 0 ? (
@@ -1447,7 +1447,7 @@ function ClaudeConfigSection({
       >
         <SettingsRow
           label="Config location"
-          description="Where Claude stores its configuration."
+          description="Where Hermes Agent stores its configuration."
         >
           <span
             className="text-xs font-mono"

--- a/src/screens/chat/components/connection-status-message.tsx
+++ b/src/screens/chat/components/connection-status-message.tsx
@@ -59,7 +59,7 @@ function classifyConnectionError(
     return {
       title: 'Hermes Agent gateway not running',
       description: 'The Hermes Agent gateway is not running on port 8642.',
-      action: 'Run: pip install -U hermes-agent && hermes gateway run',
+      action: 'Run the official Hermes installer, then start the gateway with: hermes gateway run',
     }
   }
 

--- a/src/screens/files/files-screen.tsx
+++ b/src/screens/files/files-screen.tsx
@@ -1026,14 +1026,14 @@ export function FilesScreen() {
       })
       if (!res.ok)
         throw new Error(
-          `HTTP ${res.status} — check that CLAUDE_WORKSPACE_DIR is set`,
+          `HTTP ${res.status} — check that HERMES_WORKSPACE_DIR is set`,
         )
       const data = (await res.json()) as FilesListResponse
       setEntries(Array.isArray(data.entries) ? data.entries : [])
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         setTreeError(
-          'Could not load files — request timed out. Check that CLAUDE_WORKSPACE_DIR is set.',
+          'Could not load files — request timed out. Check that HERMES_WORKSPACE_DIR is set.',
         )
       } else {
         setTreeError(err instanceof Error ? err.message : String(err))

--- a/src/screens/settings/components/provider-wizard.tsx
+++ b/src/screens/settings/components/provider-wizard.tsx
@@ -80,7 +80,7 @@ function getAuthTypeMeta(authType: ProviderAuthType): AuthTypeMeta {
     return {
       title: 'CLI Token',
       description:
-        'Use your existing Hermes CLI auth token (from Hermes Agent Code / claude.ai)',
+        'Use your existing Hermes CLI auth token (from Claude Code / claude.ai)',
     }
   }
 
@@ -559,7 +559,7 @@ export function ProviderWizard({
                     <p className="mt-1 text-sm text-primary-600 text-pretty">
                       This will run{' '}
                       <code className="font-mono text-primary-800">
-                        claude setup
+                        hermes setup
                       </code>{' '}
                       in the terminal to start the OAuth flow. A browser window
                       will open for you to sign in with Google.
@@ -571,7 +571,7 @@ export function ProviderWizard({
                         onClick={function onLaunchOAuth() {
                           window.open('/terminal', '_blank')
                           setVerificationMessage(
-                            'Run "claude setup" in the terminal and select Google OAuth when prompted. ' +
+                            'Run "hermes setup" in the terminal and select Google OAuth when prompted. ' +
                               'A browser window will open for sign-in. Once complete, Hermes Agent will restart automatically.',
                           )
                           setVerifyState('warning')
@@ -586,7 +586,7 @@ export function ProviderWizard({
                           In the terminal, run:
                         </p>
                         <pre className="mt-1 rounded-lg bg-primary-200/60 px-2 py-1.5 text-xs font-mono text-primary-900">
-                          claude setup
+                          hermes setup
                         </pre>
                         <p className="mt-1.5 text-xs text-primary-600 text-pretty">
                           Select <strong>Google Antigravity</strong> →{' '}
@@ -625,7 +625,7 @@ export function ProviderWizard({
                         onClick={function onLaunchCLI() {
                           window.open('/terminal', '_blank')
                           setVerificationMessage(
-                            'Run "claude setup" in the terminal and select Anthropic → CLI Token. ' +
+                            'Run "hermes setup" in the terminal and select Anthropic → CLI Token. ' +
                               'It will detect compatible local credentials and import them automatically.',
                           )
                           setVerifyState('warning')
@@ -640,7 +640,7 @@ export function ProviderWizard({
                           In the terminal, run:
                         </p>
                         <pre className="mt-1 rounded-lg bg-primary-200/60 px-2 py-1.5 text-xs font-mono text-primary-900">
-                          claude setup
+                          hermes setup
                         </pre>
                         <p className="mt-1.5 text-xs text-primary-600 text-pretty">
                           Select <strong>Anthropic</strong> →{' '}
@@ -654,7 +654,7 @@ export function ProviderWizard({
                         <p className="text-xs text-amber-800 text-pretty">
                           <strong>Requires:</strong> Claude Code or Hermes CLI
                           must be installed and authenticated first. Run{' '}
-                          <code className="font-mono">claude</code> in terminal
+                          <code className="font-mono">hermes</code> in terminal
                           to verify.
                         </p>
                       </div>


### PR DESCRIPTION
## Summary
- clean Hermes Workspace setup/install copy to use Hermes naming consistently
- remove misleading Claude-era references in installer and UI copy
- align README and setup wording with the current Hermes Workspace flow

## Verification
- pnpm build passed locally.
- pnpm test currently fails with 11 failing tests (branch not fully green); failures appear in existing exported/test-surface areas such as context usage, MCP server config, markdown plugin exports, slash commands, and chat message list.

## Notes
- Branch: `fix/branding-copy-cleanup`
- Commit: `0fbfac77`
