### PR TITLE
fix: include symlinked profiles in workspace discovery

### DIFF
--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
@@ -37,7 +37,16 @@ function buildCrewDefinitions(): CrewDefinition[] {
   const profilesDir = join(getClaudeRoot(), 'profiles')
   const dynamicProfiles = existsSync(profilesDir)
     ? readdirSync(profilesDir, { withFileTypes: true })
-        .filter((entry) => entry.isDirectory())
+        .filter((entry) => {
+          const profilePath = join(profilesDir, entry.name)
+          if (entry.isDirectory()) return true
+          if (!entry.isSymbolicLink()) return false
+          try {
+            return statSync(profilePath).isDirectory()
+          } catch {
+            return false
+          }
+        })
         .map((entry) => entry.name)
         .sort()
     : []

--- a/src/server/__tests__/profiles-browser.test.ts
+++ b/src/server/__tests__/profiles-browser.test.ts
@@ -47,6 +47,42 @@ async function loadMod() {
 }
 
 describe('profiles-browser', () => {
+  describe('listProfiles', () => {
+    it('includes symlinked profiles when the target is a directory', async () => {
+      const root = path.join('/home/testuser', '.hermes')
+      const profilesRoot = path.join(root, 'profiles')
+      const kayPath = path.join(profilesRoot, 'kay')
+      const brokenPath = path.join(profilesRoot, 'broken')
+
+      existsSync.mockImplementation((p: string) => {
+        return p === root || p === profilesRoot || p === kayPath || p === brokenPath
+      })
+      readdirSync.mockImplementation((p: string) => {
+        if (p === profilesRoot) {
+          return [
+            { name: 'kay', isDirectory: () => false, isSymbolicLink: () => true },
+            { name: 'broken', isDirectory: () => false, isSymbolicLink: () => true },
+            { name: 'README.md', isDirectory: () => false, isSymbolicLink: () => false },
+          ] as never
+        }
+        return []
+      })
+      statSync.mockImplementation((p: string) => {
+        if (p === kayPath) return { isDirectory: () => true, isFile: () => false, mtimeMs: 0 } as never
+        if (p === brokenPath) throw new Error('broken symlink')
+        return { isDirectory: () => false, isFile: () => false, mtimeMs: 0 } as never
+      })
+
+      const mod = await loadMod()
+      const names = mod.listProfiles().map((profile) => profile.name)
+
+      expect(names).toContain('default')
+      expect(names).toContain('kay')
+      expect(names).not.toContain('broken')
+      expect(names).not.toContain('README.md')
+    })
+  })
+
   describe('setActiveProfile', () => {
     it('emits console.warn about gateway restart when setting non-default profile', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -169,9 +169,16 @@ export function listProfiles(): Array<ProfileSummary> {
     }
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue
       const name = entry.name
       const profilePath = path.join(profilesRoot, name)
+      if (!entry.isDirectory()) {
+        if (!entry.isSymbolicLink()) continue
+        try {
+          if (!fs.statSync(profilePath).isDirectory()) continue
+        } catch {
+          continue
+        }
+      }
       const configPath = path.join(profilePath, 'config.yaml')
       const envPath = path.join(profilePath, '.env')
       const skillsDir = path.join(profilePath, 'skills')


### PR DESCRIPTION
## Summary
- Include symlinked profile directories in workspace profile discovery
- Apply the same symlink-aware filtering to crew status profile lookup
- Add regression coverage for symlinked profile directories

## Test Plan
- `pnpm vitest run src/server/__tests__/profiles-browser.test.ts`
- `pnpm build`

## Notes
This supports deployments where profile directories under the workspace config are symlinks to profile data elsewhere on disk.
