### PR TITLE
fix(docker): re-add python3 to runtime image (regression of #161/#185)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,11 @@ RUN pnpm build
 
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
+# python3 is required by scripts/pty-helper.py (terminal feature). Originally
+# added in PR #185 for issue #161; regressed by the 2026-05-01 rename commit
+# efcb7d14 and re-added here per issue #259.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
 


### PR DESCRIPTION
Fixes #259.

PR #185 added `python3` to the runtime Dockerfile to make the terminal feature work in Docker (`scripts/pty-helper.py` is invoked at runtime). The 2026-05-01 rename commit (`efcb7d14`, "migrate legacy Hermes codename bytes") silently dropped it.

One-line restore + inline comment explaining why so the next rename pass doesn't trip over it.

## Test plan
- Image builds clean
- Terminal feature works in Docker once published