### PR TITLE
fix: mount UsageMeter at root so search-modal Usage tile works (#258)

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import appCss from '../styles.css?url'
 import { SearchModal } from '@/components/search/search-modal'
+import { UsageMeter } from '@/components/usage-meter'
 import { TerminalShortcutListener } from '@/components/terminal-shortcut-listener'
 import { GlobalShortcutListener } from '@/components/global-shortcut-listener'
 import { WorkspaceShell } from '@/components/workspace-shell'
@@ -367,6 +368,9 @@ function RootLayout() {
             </ErrorBoundary>
           </WorkspaceShell>
           <SearchModal />
+          {/* UsageMeter must be mounted at root so the OPEN_USAGE event from
+              the search modal's Usage tile has a listener. See #258. */}
+          <UsageMeter />
           <KeyboardShortcutsModal />
           <UpdateCenterNotifier />
           {rootSurfaceState.showPostOnboardingOverlays ? (


### PR DESCRIPTION
Fixes #258. The Usage tile in the search modal emits `OPEN_USAGE` but UsageMeter wasn't mounted, so the event had no listener. One-line fix: mount it next to SearchModal in `__root.tsx`.

Component renders no UI when closed (just an effect with the listener), so no visual side effects.

## Test plan
- `pnpm build` clean
- Open search modal (Cmd+K) \u2192 click Usage tile \u2192 modal opens