### PR TITLE
fix: tighten enhancedChat probe so vanilla agent routes via portable chat (#261)

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -375,6 +375,48 @@ async function probe(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Stricter probe for the legacy enhanced chat-stream endpoint.
+ *
+ * The previous probe used a generic GET and treated any non-404/403 status
+ * as "available". That misclassified vanilla hermes-agent (which serves a
+ * router-level handler that 405s/400s GETs to that path) as having the
+ * enhanced fork's session-stream capability. Workspace then fell through
+ * to streamChat() which posts to /api/sessions/{id}/chat/stream — vanilla
+ * agent returns 404 there at runtime and chat appears to fail with
+ * "Authentication error" because the bundle's error mapper is overly
+ * generous about what it interprets as auth failures. See #261.
+ *
+ * Real enhanced-fork gateways respond to GET on the probe path with one
+ * of: 405 Method Not Allowed (it's POST-only there too) but also expose
+ * the path in their router; we cannot distinguish reliably from a generic
+ * status code on GET, so we POST a tiny no-op body and look for a
+ * structured error shape that only the fork emits.
+ */
+async function probeEnhancedChatStream(): Promise<boolean> {
+  try {
+    const res = await fetch(`${CLAUDE_API}/api/sessions/__probe__/chat/stream`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: '{}',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+    // Vanilla hermes-agent has no such endpoint — dashboard layer 404s,
+    // gateway 404s, anything in between 404s. Enhanced fork accepts POST
+    // and returns either a 4xx structured error (validation) or starts a
+    // stream; either way the path is registered.
+    if (res.status === 404 || res.status === 403) return false
+    // 405 = the path exists but POST is wrong. That's still vanilla — no
+    // enhanced fork would 405 a POST to its own chat/stream endpoint.
+    if (res.status === 405) return false
+    // 401 means auth gate is wired; treat as available so token-gated
+    // setups don't get downgraded by a missing token at probe time.
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function probeChatCompletions(): Promise<boolean> {
   try {
     const getRes = await fetch(`${CLAUDE_API}/v1/chat/completions`, {
@@ -543,7 +585,7 @@ export async function probeGateway(options?: {
       probeChatCompletions(),
       probe('/v1/models'),
       probe('/api/sessions'),
-      probe('/api/sessions/__probe__/chat/stream'),
+      probeEnhancedChatStream(),
       probe('/api/skills'),
       probe('/api/config'),
       probe('/api/jobs'),


### PR DESCRIPTION
## Why

aksbit's diagnostic in #261 showed workspace calling `POST /api/sessions/{id}/chat/stream` against vanilla hermes-agent and getting 404s rendered as 'Authentication error'. Looking at the code path:

1. `getChatMode()` returns `'portable'` only when `enhancedChat` capability is false.
2. The capability probe used a generic GET that treated any non-404/403 as 'available'.
3. Vanilla agent's session router 405s/400s a GET to that path \u2014 not 404 \u2014 so the probe lied.
4. `getChatMode()` returned `'enhanced-claude'`, send-stream took the streamChat branch, and posted to a path that doesn't exist at runtime.

## Fix

Replace generic probe with `probeEnhancedChatStream()`:
- POST (the real method) instead of GET
- Treat 404/405 as 'not available'
- Treat any other status as available (covers fork variants + auth-gated setups)

After this, `enhancedChat` is correctly `false` on any vanilla agent build, `chatMode === 'portable'`, and send-stream takes the `openaiChat` path that actually works.

## Test plan

- `pnpm build` clean
- Manual smoke: with vanilla `nousresearch/hermes-agent`, capability log should show `missing=[enhancedChat]` and chat-send should work end-to-end via /v1/chat/completions.

## Refs
Fixes #261. The other half of #261 (auth cast + available-models 404) was addressed in #265 (merged).