### PR TITLE
fix(operations): 'Needs setup' state for agents with no model configured (#270)

### DIFF
--- a/src/screens/agents/components/operations-agent-card.tsx
+++ b/src/screens/agents/components/operations-agent-card.tsx
@@ -268,10 +268,30 @@ export function OperationsAgentCard({
         <div className="absolute right-0 flex items-center gap-1">
           <button
             type="button"
-            aria-label={isActive ? `Pause ${displayName}` : `Run ${displayName} now`}
-            onClick={() => void handlePlayPause()}
-            disabled={isSending && !isActive}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--theme-muted)] transition-colors hover:bg-[var(--theme-bg)] hover:text-[var(--theme-text)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label={
+              agent.needsSetup
+                ? `Configure ${displayName} before running`
+                : isActive ? `Pause ${displayName}` : `Run ${displayName} now`
+            }
+            onClick={() => {
+              if (agent.needsSetup) {
+                onOpenSettings(agent.id)
+                return
+              }
+              void handlePlayPause()
+            }}
+            disabled={(isSending && !isActive)}
+            title={
+              agent.needsSetup
+                ? 'No model configured — open settings to set one up'
+                : undefined
+            }
+            className={cn(
+              'inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-[var(--theme-bg)] disabled:cursor-not-allowed disabled:opacity-60',
+              agent.needsSetup
+                ? 'text-amber-300 hover:text-amber-200'
+                : 'text-[var(--theme-muted)] hover:text-[var(--theme-text)]',
+            )}
           >
             <HugeiconsIcon
               icon={isActive ? PauseIcon : PlayIcon}
@@ -322,6 +342,17 @@ export function OperationsAgentCard({
         <p className="w-full truncate text-[10px] text-[var(--theme-muted)]/80">
           {agent.jobs.length > 0 ? `${agent.jobs.length} scheduled job${agent.jobs.length === 1 ? '' : 's'}` : 'Manual only'}
         </p>
+        {agent.needsSetup ? (
+          <button
+            type="button"
+            onClick={() => onOpenSettings(agent.id)}
+            className="mt-1 inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-amber-300/40 bg-amber-300/10 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-amber-200 transition-colors hover:bg-amber-300/20"
+            title="This agent has no model configured. Click to set one up."
+          >
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-300" />
+            Needs setup — click to configure
+          </button>
+        ) : null}
       </div>
 
       <AnimatePresence initial={false}>

--- a/src/screens/agents/hooks/use-operations.ts
+++ b/src/screens/agents/hooks/use-operations.ts
@@ -68,6 +68,13 @@ export type OperationsAgent = GatewayConfigAgent & {
   progressValue: number
   progressStatus: 'running' | 'queued' | 'failed' | 'complete' | 'thinking'
   recentOutputs: OperationsOutputItem[]
+  /**
+   * True when the agent's profile has no model configured (blank model in
+   * config.yaml). Dispatching into an unconfigured agent hangs because
+   * hermes-agent has nothing to call. Show 'Needs setup' state instead.
+   * See #270.
+   */
+  needsSetup: boolean
 }
 
 type ConfigPayload = {
@@ -567,6 +574,8 @@ export function useOperations() {
         .sort((left, right) => right.timestamp - left.timestamp)
         .slice(0, 5)
 
+      const needsSetup = !agent.model || agent.model.trim().length === 0
+
       return {
         ...agent,
         meta,
@@ -586,6 +595,7 @@ export function useOperations() {
         progressValue: getProgressValue(status, latestSession),
         progressStatus: getProgressStatus(status, latestSession),
         recentOutputs,
+        needsSetup,
       } satisfies OperationsAgent
     })
   }, [


### PR DESCRIPTION
Fixes #270.

When a user spawns one of the preset agents (Sage / Trader / Builder / Scribe / Ops), `seedAgentPresets()` writes the system prompt but the profile's `config.yaml` model section stays blank by default. Dispatching into the agent then hangs because there's nothing for hermes-agent to call.

## What this changes

- New `OperationsAgent.needsSetup: boolean` \u2014 true when `agent.model` is empty.
- Operations agent card shows an amber 'Needs setup \u2014 click to configure' button below the description when `needsSetup` is true.
- The play button turns amber and routes to `onOpenSettings` instead of trying to run the agent. Tooltip explains why.
- Once the user picks a model in settings, `needsSetup` flips false and the agent dispatches normally.

## Test plan

- pnpm build clean
- Visual: Operations screen with a fresh-install profile that has no model \u2014 card shows amber CTA, play button turns amber, click routes to settings.
- Visual: After setting a model, banner disappears and play resumes normal behavior.