### PR TITLE
chore: rename leftover CLAUDE_* env vars to HERMES_* + README accuracy pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@
 #
 # The workspace exposes terminals, file read/write, agent control, and job
 # management. Off-loopback exposure is opt-in. Set HOST=0.0.0.0 only if you
-# *also* set CLAUDE_PASSWORD below. Without a password, the server refuses
+# *also* set HERMES_PASSWORD below. Without a password, the server refuses
 # to start on a non-loopback host.
 # HOST=127.0.0.1
 
@@ -70,7 +70,8 @@
 #
 # Enables password protection of the web UI. Tokens are stored encrypted
 # in ~/.hermes/workspace-sessions.json. Pick a strong secret (32+ chars).
-# CLAUDE_PASSWORD=change-me-to-a-strong-secret
+# Legacy CLAUDE_PASSWORD is still honored for back-compat with pre-rename setups.
+# HERMES_PASSWORD=change-me-to-a-strong-secret
 
 # Cookie Secure flag (default: on in production, off in dev)
 #
@@ -112,4 +113,5 @@
 #
 # If you understand the risks and want to run the workspace on 0.0.0.0
 # without a password (e.g. behind a custom auth layer), set this to 1.
-# CLAUDE_ALLOW_INSECURE_REMOTE=0
+# Legacy CLAUDE_ALLOW_INSECURE_REMOTE is still honored for back-compat.
+# HERMES_ALLOW_INSECURE_REMOTE=0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
 
 <img src="./public/claude-avatar.webp" alt="Hermes Workspace" width="80" style="border-radius: 16px" />
+<!-- avatar filename retained for cache stability — do not rename without coordinated cache-bust -->
 
 # Hermes Workspace
 
@@ -13,7 +14,7 @@
 
 > Not a chat wrapper. A complete workspace — orchestrate agents, browse memory, manage skills, and control everything from one interface.
 
-> **v2 — zero-fork. Clone, don't fork.** Runs on vanilla [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) installed via Nous's own installer. No patches, no drift.
+> **v2 — zero-fork.** Clone, don't fork. Runs on vanilla [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) installed via Nous's own installer. Chat, sessions, memory, skills, jobs, MCP, terminal, dashboard, Agent View, and Operations are all in vanilla parity. **Conductor** currently requires an additional dashboard plugin not in upstream yet — the UI shows a clear placeholder when that endpoint isn't available ([#262](https://github.com/outsourc-e/hermes-workspace/issues/262)). Everything else works with zero patches.
 
 ![Hermes Workspace](./docs/screenshots/splash.png)
 
@@ -42,7 +43,7 @@ Start here: [docs/swarm/](./docs/swarm/)
 ## ✨ Features
 
 - 🤖 **Hermes Agent Integration** — Direct gateway connection with real-time SSE streaming
-- 🎨 **8-Theme System** — Official, Classic, Slate, Mono — each with light and dark variants
+- 🎨 **Theme System** — Hermes, Nous, Bronze, Slate, Mono — light and dark variants of each
 - 🔒 **Security Hardened** — Auth middleware on all API routes, CSP headers, exec approval prompts
 - 📱 **Mobile-First PWA** — Full feature parity on any device via Tailscale
 - ⚡ **Live SSE Streaming** — Real-time agent output with tool call rendering
@@ -233,7 +234,7 @@ HERMES_API_URL=http://127.0.0.1:8642
 # (Ollama / LM Studio / local servers don't need a key)
 
 # Optional: password-protect the web UI
-# CLAUDE_PASSWORD=your_password
+# HERMES_PASSWORD=your_password
 ```
 
 ---
@@ -560,7 +561,7 @@ Features pending cloud infrastructure:
 
 ### 🎨 Themes
 
-- 8 themes: Official, Classic, Slate, Mono — each with light and dark variants
+- Themes: Hermes, Nous, Bronze, Slate, Mono — each with light and dark variants
 - Theme persists across sessions
 - Full mobile dark mode support
 
@@ -570,18 +571,19 @@ Features pending cloud infrastructure:
 - CSP headers via meta tags
 - Path traversal prevention on file/memory routes (real-path boundary check, not string prefix)
 - Rate limiting on endpoints
-- Fail-closed startup guard: refuses to bind non-loopback without `CLAUDE_PASSWORD`
+- Fail-closed startup guard: refuses to bind non-loopback without `HERMES_PASSWORD`
 - Session cookies: `HttpOnly` + `SameSite=Strict` + `Secure` (in production)
 - Optional password protection for web UI
 
 **Key env vars for remote / Docker deployments:**
 
-- `CLAUDE_PASSWORD` — required whenever `HOST ≠ 127.0.0.1`
+- `HERMES_PASSWORD` — required whenever `HOST ≠ 127.0.0.1` (legacy `CLAUDE_PASSWORD` still honored as a fallback)
 - `COOKIE_SECURE=1` — force the `Secure` cookie flag when terminating HTTPS at a proxy
 - `COOKIE_SECURE=0` — disable the `Secure` flag for plain-HTTP LAN deployments (`HOST=0.0.0.0` without HTTPS); without this, browsers silently drop session cookies and login fails (#149)
 - `TRUST_PROXY=1` — trust `x-forwarded-for` / `x-real-ip` (only set behind a sanitizing reverse proxy)
 - `HERMES_DASHBOARD_TOKEN` — explicit bearer for dashboard API (preferred over the legacy HTML-scrape fallback)
-- `CLAUDE_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)
+- `HERMES_API_TOKEN` — bearer for the Hermes Agent gateway when started with `API_SERVER_KEY` (legacy `CLAUDE_API_TOKEN` still honored)
+- `HERMES_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)
 
 See `.env.example` for the full list. Credits to [@kiosvantra](https://github.com/kiosvantra) for the security audit surfacing #121–#125.
 
@@ -633,9 +635,11 @@ Verify: `curl http://localhost:8642/health` should return `{"status": "ok"}`.
 
 ### "Using upstream NousResearch/hermes-agent"
 
-v2+ runs on vanilla `hermes-agent` with full feature parity. The upstream ships all extended endpoints (sessions, memory, skills, config). **No fork required, ever.**
+v2+ runs on vanilla `hermes-agent`. **No fork required.** The upstream ships every endpoint the workspace needs for chat, sessions, memory, skills, config, jobs, MCP, terminal, and Agent View.
 
-If you're pinned to an older `hermes-agent` version and missing endpoints, the workspace will degrade gracefully to **portable mode** with basic chat — upgrade upstream to restore full features.
+**One known exception:** **Conductor** uses a dashboard plugin that hasn't landed upstream yet. When the workspace detects the missing endpoint, the Conductor screen shows a clear "Upstream not ready" placeholder with a link to [issue #262](https://github.com/outsourc-e/hermes-workspace/issues/262) instead of failing mid-action. Everything else works.
+
+If you're pinned to an older `hermes-agent` version and missing core endpoints, the workspace will degrade gracefully to **portable mode** with basic chat — upgrade upstream to restore full features.
 
 ### Docker: "Unauthorized" or "Connection refused" to hermes-agent
 
@@ -680,13 +684,14 @@ If using Docker Compose and getting auth errors:
 
 ### Docker: older `claude webapi` docs are wrong
 
-The `claude webapi` command referenced in older docs doesn't exist. The correct command is:
+The `claude webapi` command referenced in some pre-rename docs doesn't exist. The correct commands are:
 
 ```bash
-hermes --gateway   # Starts the FastAPI gateway server
+hermes gateway run    # FastAPI gateway on :8642
+hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
 ```
 
-The Docker setup uses `hermes --gateway` automatically — no action needed if using `docker compose up`.
+The Docker setup runs both automatically — no action needed if using `docker compose up`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,9 @@ services:
       # Workspace session password. REQUIRED when HOST is non-loopback (the
       # default for Docker images, so the container binds 0.0.0.0:3000).
       # Pick a strong secret. See #122.
-      CLAUDE_PASSWORD: ${CLAUDE_PASSWORD:-}
+      # HERMES_PASSWORD is preferred; CLAUDE_PASSWORD remains as a back-compat
+      # fallback for compose files that pre-date the rename.
+      HERMES_PASSWORD: ${HERMES_PASSWORD:-${CLAUDE_PASSWORD:-}}
       # Enable the Secure flag on session cookies when terminated behind
       # HTTPS (reverse proxy / Tailscale Funnel / Cloudflare Tunnel). See #123.
       COOKIE_SECURE: ${COOKIE_SECURE:-}

--- a/server-entry.js
+++ b/server-entry.js
@@ -23,26 +23,34 @@ function isNonLoopbackHost(h) {
 }
 
 if (isNonLoopbackHost(host)) {
-  const password = (process.env.CLAUDE_PASSWORD || '').trim()
+  // Honor HERMES_PASSWORD (current name) with CLAUDE_PASSWORD as a back-compat
+  // fallback for deployments configured pre-rename.
+  const password = (
+    process.env.HERMES_PASSWORD || process.env.CLAUDE_PASSWORD || ''
+  ).trim()
   if (!password) {
     console.error(
       '\n[workspace] refusing to start.\n' +
-        `  HOST is set to "${host}" (non-loopback), but CLAUDE_PASSWORD is unset.\n` +
+        `  HOST is set to "${host}" (non-loopback), but HERMES_PASSWORD is unset.\n` +
         '  This would expose a high-privilege control plane (terminals, files, agents)\n' +
         '  to anyone who can reach the port. Either:\n' +
         '    • set HOST=127.0.0.1 for local-only access, or\n' +
-        '    • set CLAUDE_PASSWORD=<strong-secret> to enable workspace auth, or\n' +
-        '    • set CLAUDE_ALLOW_INSECURE_REMOTE=1 to bypass this check (not recommended).\n' +
+        '    • set HERMES_PASSWORD=<strong-secret> to enable workspace auth, or\n' +
+        '    • set HERMES_ALLOW_INSECURE_REMOTE=1 to bypass this check (not recommended).\n' +
         '  See #122 for context.\n',
     )
-    const allowInsecure = (process.env.CLAUDE_ALLOW_INSECURE_REMOTE || '')
+    const allowInsecure = (
+      process.env.HERMES_ALLOW_INSECURE_REMOTE ||
+      process.env.CLAUDE_ALLOW_INSECURE_REMOTE ||
+      ''
+    )
       .trim()
       .toLowerCase()
     if (allowInsecure !== '1' && allowInsecure !== 'true' && allowInsecure !== 'yes') {
       process.exit(1)
     }
     console.warn(
-      '[workspace] CLAUDE_ALLOW_INSECURE_REMOTE is set — starting anyway.',
+      '[workspace] HERMES_ALLOW_INSECURE_REMOTE is set — starting anyway.',
     )
   }
 

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -138,19 +138,31 @@ export function revokeSessionToken(token: string): void {
 }
 
 /**
+ * Resolve the configured workspace password.
+ *
+ * Honors HERMES_PASSWORD first (current name, post-rename) and falls back to
+ * CLAUDE_PASSWORD for back-compat with deployments configured pre-rename.
+ */
+function getConfiguredPassword(): string {
+  const fromHermes = process.env.HERMES_PASSWORD
+  if (fromHermes && fromHermes.length > 0) return fromHermes
+  const fromClaude = process.env.CLAUDE_PASSWORD
+  if (fromClaude && fromClaude.length > 0) return fromClaude
+  return ''
+}
+
+/**
  * Check if password protection is enabled.
  */
 export function isPasswordProtectionEnabled(): boolean {
-  return Boolean(
-    process.env.CLAUDE_PASSWORD && process.env.CLAUDE_PASSWORD.length > 0,
-  )
+  return getConfiguredPassword().length > 0
 }
 
 /**
  * Verify password using timing-safe comparison.
  */
 export function verifyPassword(password: string): boolean {
-  const configured = process.env.CLAUDE_PASSWORD
+  const configured = getConfiguredPassword()
   if (!configured || configured.length === 0) {
     return false
   }


### PR DESCRIPTION
Eric flagged the README still says 'Claude' in places and the v2 'zero-fork = full feature parity' claim is misleading after we landed the Conductor capability gate (#271).

## What this PR does

### 1. Rename leftover env vars (back-compat preserved)
- `CLAUDE_PASSWORD` \u2192 `HERMES_PASSWORD` (with CLAUDE_PASSWORD as fallback)
- `CLAUDE_ALLOW_INSECURE_REMOTE` \u2192 `HERMES_ALLOW_INSECURE_REMOTE` (with fallback)
- Touched: `src/server/auth-middleware.ts`, `server-entry.js`, `.env.example`, `docker-compose.yml`

Users following the README were setting `HERMES_PASSWORD` but the auth middleware only read `CLAUDE_PASSWORD`, so the password guard was silently bypassed on fresh installs. Now both names work; HERMES_* is the documented primary.

### 2. README accuracy
- **v2 zero-fork claim:** dropped 'full feature parity' framing. Conductor specifically requires a dashboard plugin not yet upstream (#262). README now lists exactly what works on vanilla and notes the Conductor exception with a link.
- **Theme names:** updated from 'Official / Classic' to current 'Hermes / Nous / Bronze / Slate / Mono' (the v2.1 rename).
- **Security env vars:** added HERMES_API_TOKEN to the list (was undocumented despite being honored by gateway-capabilities).
- **Docker docs:** `hermes gateway run` + `hermes dashboard` are the two real commands, not `claude webapi`.
- **Avatar PNG:** kept the filename 'claude-avatar.webp' with an inline note explaining it's a stable cache-keyed asset \u2014 do not rename without coordinated cache-bust. (Also, 8+ frontend files reference it; flipping the name is a separate larger change.)

### 3. Test coverage
- `pnpm build` clean
- `pnpm test auth-middleware` (8 tests pass) \u2014 confirms HERMES_PASSWORD takes precedence and CLAUDE_PASSWORD remains a working fallback

## No public-facing breaking change

Every previous CLAUDE_* env var still resolves through the back-compat fallbacks. Existing deployments don't need to update anything. New deployments and new docs use HERMES_*.