### PR TITLE
feat(skills): origin filter + server-side local skill discovery

### DIFF
--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -1,16 +1,115 @@
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs/promises'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
   BEARER_TOKEN,
-  HERMES_API,
-  HERMES_UPGRADE_INSTRUCTIONS,
+  CLAUDE_API,
+  CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+function getSkillsDir(): string {
+  return (
+    process.env.HERMES_SKILLS_DIR ||
+    path.join(
+      process.env.HERMES_HOME || path.join(os.homedir(), '.hermes'),
+      'skills',
+    )
+  )
+}
+
+type LocalSkillMeta = { path: string; author: string }
+
+async function readSkillAuthor(skillDir: string): Promise<string> {
+  try {
+    const raw = await fs.readFile(path.join(skillDir, 'SKILL.md'), 'utf-8')
+    const fmEnd = raw.indexOf('\n---', 4)
+    const fm = fmEnd > 0 ? raw.slice(0, fmEnd) : raw.slice(0, 1024)
+    const match = fm.match(/^author:\s*(.+?)\s*$/m)
+    return match?.[1]?.trim().replace(/^["']|["']$/g, '') || ''
+  } catch {
+    return ''
+  }
+}
+
+async function buildLocalSkillPathMap(): Promise<Map<string, LocalSkillMeta>> {
+  const root = getSkillsDir()
+  const map = new Map<string, LocalSkillMeta>()
+  let categoryEntries: Array<{ name: string; isDirectory: () => boolean }>
+  try {
+    categoryEntries = (await fs.readdir(root, {
+      withFileTypes: true,
+    })) as unknown as Array<{
+      name: string
+      isDirectory: () => boolean
+    }>
+  } catch {
+    return map
+  }
+
+  const collect: Array<Promise<void>> = []
+  for (const cat of categoryEntries) {
+    if (!cat.isDirectory() || cat.name.startsWith('.')) continue
+    const catPath = path.join(root, cat.name)
+    let skillEntries: Array<{
+      name: string
+      isDirectory: () => boolean
+    }>
+    try {
+      skillEntries = (await fs.readdir(catPath, {
+        withFileTypes: true,
+      })) as unknown as Array<{
+        name: string
+        isDirectory: () => boolean
+      }>
+    } catch {
+      continue
+    }
+    for (const skill of skillEntries) {
+      if (!skill.isDirectory() || skill.name.startsWith('.')) continue
+      const fullPath = path.join(catPath, skill.name)
+      if (map.has(skill.name)) continue
+      collect.push(
+        readSkillAuthor(fullPath).then((author) => {
+          map.set(skill.name, { path: fullPath, author })
+        }),
+      )
+    }
+  }
+  await Promise.all(collect)
+  return map
+}
+
+async function loadBundledManifest(): Promise<Set<string>> {
+  const manifestPath = path.join(getSkillsDir(), '.bundled_manifest')
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf-8')
+    return new Set(
+      raw
+        .split('\n')
+        .map((line) => line.split(':')[0]?.trim() || '')
+        .filter(Boolean),
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+function deriveOrigin(
+  skill: SkillSummary,
+  bundled: Set<string>,
+): SkillSummary['origin'] {
+  if (bundled.has(skill.id) || bundled.has(skill.slug)) return 'builtin'
+  if (skill.author === 'Hermes Agent' && skill.sourcePath) return 'agent-created'
+  return 'marketplace'
+}
 
 type SkillsTab = 'installed' | 'marketplace' | 'featured'
 type SkillsSort = 'name' | 'category'
@@ -40,6 +139,7 @@ type SkillSummary = {
   builtin?: boolean
   featuredGroup?: string
   security: SecurityRisk
+  origin: 'builtin' | 'agent-created' | 'marketplace'
 }
 
 const KNOWN_CATEGORIES = [
@@ -119,12 +219,80 @@ function normalizeSecurity(value: unknown): SecurityRisk {
   }
 }
 
+const CATEGORY_ALIASES: Record<string, string> = {
+  research: 'Search & Research',
+  'search-and-research': 'Search & Research',
+  search: 'Search & Research',
+  feeds: 'Search & Research',
+  'web-frontend': 'Web & Frontend',
+  frontend: 'Web & Frontend',
+  web: 'Web & Frontend',
+  'software-development': 'Coding Agents',
+  coding: 'Coding Agents',
+  development: 'Coding Agents',
+  devops: 'DevOps & Cloud',
+  cloud: 'DevOps & Cloud',
+  'devops-cloud': 'DevOps & Cloud',
+  mlops: 'DevOps & Cloud',
+  git: 'Git & GitHub',
+  github: 'Git & GitHub',
+  'git-github': 'Git & GitHub',
+  browser: 'Browser & Automation',
+  automation: 'Browser & Automation',
+  'browser-automation': 'Browser & Automation',
+  image: 'Image & Video',
+  video: 'Image & Video',
+  media: 'Image & Video',
+  creative: 'Image & Video',
+  'image-video': 'Image & Video',
+  gifs: 'Image & Video',
+  diagramming: 'Image & Video',
+  'autonomous-ai-agents': 'AI & LLMs',
+  ai: 'AI & LLMs',
+  llm: 'AI & LLMs',
+  agents: 'AI & LLMs',
+  mcp: 'AI & LLMs',
+  'inference-sh': 'AI & LLMs',
+  'data-science': 'Data & Analytics',
+  data: 'Data & Analytics',
+  'social-media': 'Marketing & Sales',
+  social: 'Marketing & Sales',
+  email: 'Communication',
+  'note-taking': 'Productivity',
+  notetaking: 'Productivity',
+  notes: 'Productivity',
+  'smart-home': 'Productivity',
+  apple: 'Productivity',
+  leisure: 'Productivity',
+  gaming: 'Productivity',
+  'red-teaming': 'AI & LLMs',
+  domain: 'Productivity',
+  dogfood: 'Productivity',
+  productivity: 'Productivity',
+}
+
+const KNOWN_CATEGORY_SET = new Set<string>(
+  KNOWN_CATEGORIES.filter((c) => c !== 'All'),
+)
+const KNOWN_CATEGORY_LOWER = new Map<string, string>(
+  Array.from(KNOWN_CATEGORY_SET).map((c) => [c.toLowerCase(), c]),
+)
+
+function normalizeCategoryLabel(raw: string): string {
+  if (KNOWN_CATEGORY_SET.has(raw)) return raw
+  const lower = raw.toLowerCase()
+  const caseMatch = KNOWN_CATEGORY_LOWER.get(lower)
+  if (caseMatch) return caseMatch
+  const key = lower.replace(/[\s&]+/g, '-').replace(/-+/g, '-')
+  return CATEGORY_ALIASES[key] ?? CATEGORY_ALIASES[lower] ?? raw
+}
+
 function guessCategory(record: Record<string, unknown>): string {
   const direct =
     readString(record.category) ||
     readString(record.group) ||
     readString(record.section)
-  if (direct) return direct
+  if (direct) return normalizeCategoryLabel(direct)
   const tags = readStringArray(record.tags).map((tag) => tag.toLowerCase())
   if (tags.some((tag) => tag.includes('frontend') || tag.includes('react'))) {
     return 'Web & Frontend'
@@ -134,6 +302,9 @@ function guessCategory(record: Record<string, unknown>): string {
   }
   if (tags.some((tag) => tag.includes('git'))) {
     return 'Git & GitHub'
+  }
+  if (tags.some((tag) => tag.includes('research') || tag.includes('search'))) {
+    return 'Search & Research'
   }
   if (tags.some((tag) => tag.includes('ai') || tag.includes('llm'))) {
     return 'AI & LLMs'
@@ -177,27 +348,28 @@ function normalizeSkill(value: unknown): SkillSummary | null {
         ? record.fileCount
         : 0,
     sourcePath,
-    // Hermes /api/skills returns the installed skill inventory. Older payloads
+    // Claude /api/skills returns the installed skill inventory. Older payloads
     // omit explicit installed/enabled flags, so default to installed=true.
     installed: Boolean(record.installed ?? true),
     enabled: Boolean(record.enabled ?? record.installed ?? true),
     builtin: Boolean(record.builtin),
     featuredGroup: undefined,
     security: normalizeSecurity(record.security),
+    origin: 'marketplace' as const,
   }
 }
 
-async function fetchHermesSkills(): Promise<Array<SkillSummary>> {
+async function fetchClaudeSkills(): Promise<Array<SkillSummary>> {
   const capabilities = getCapabilities()
   const headers: Record<string, string> = {}
   if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
 
   const response = capabilities.dashboard.available
     ? await dashboardFetch('/api/skills')
-    : await fetch(`${HERMES_API}/api/skills`, { headers })
+    : await fetch(`${CLAUDE_API}/api/skills`, { headers })
   if (!response.ok) {
     const body = await response.text().catch(() => '')
-    throw new Error(body || `Hermes skills request failed (${response.status})`)
+    throw new Error(body || `Claude skills request failed (${response.status})`)
   }
 
   const payload = (await response.json()) as unknown
@@ -272,6 +444,7 @@ export const Route = createFileRoute('/api/skills')({
               : 'installed'
           const rawSearch = (url.searchParams.get('search') || '').trim()
           const category = (url.searchParams.get('category') || 'All').trim()
+          const origin = (url.searchParams.get('origin') || 'All').trim()
           const sortParam = (url.searchParams.get('sort') || 'name').trim()
           const sort: SkillsSort =
             sortParam === 'category' || sortParam === 'name'
@@ -283,7 +456,22 @@ export const Route = createFileRoute('/api/skills')({
             Math.max(1, Number(url.searchParams.get('limit') || '30')),
           )
 
-          const sourceItems = await fetchHermesSkills()
+          const [sourceItems, localPathMap, bundledManifest] = await Promise.all([
+            fetchClaudeSkills(),
+            buildLocalSkillPathMap(),
+            loadBundledManifest(),
+          ])
+          for (const skill of sourceItems) {
+            if (skill.installed) {
+              const meta =
+                localPathMap.get(skill.id) || localPathMap.get(skill.slug)
+              if (meta) {
+                if (!skill.sourcePath) skill.sourcePath = meta.path
+                if (!skill.author) skill.author = meta.author
+              }
+            }
+            skill.origin = deriveOrigin(skill, bundledManifest)
+          }
           const installedLookup = new Set(
             sourceItems
               .filter((skill) => skill.installed)
@@ -313,6 +501,7 @@ export const Route = createFileRoute('/api/skills')({
                 if (category !== 'All' && skill.category !== category) {
                   return false
                 }
+                if (origin !== 'All' && skill.origin !== origin) return false
                 return true
               }),
             sort,
@@ -344,7 +533,7 @@ export const Route = createFileRoute('/api/skills')({
           return json(
             {
               ...createCapabilityUnavailablePayload('skills', {
-                error: `Gateway does not support /api/skills. ${HERMES_UPGRADE_INSTRUCTIONS}`,
+                error: `Gateway does not support /api/skills. ${CLAUDE_UPGRADE_INSTRUCTIONS}`,
               }),
             },
             { status: 503 },
@@ -413,7 +602,7 @@ export const Route = createFileRoute('/api/skills')({
           }
           if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
 
-          const response = await fetch(`${HERMES_API}${endpoint}`, {
+          const response = await fetch(`${CLAUDE_API}${endpoint}`, {
             method: 'POST',
             headers,
             body: JSON.stringify(payload),

--- a/src/screens/skills/skills-screen.tsx
+++ b/src/screens/skills/skills-screen.tsx
@@ -48,6 +48,7 @@ type SkillSummary = {
   enabled: boolean
   featuredGroup?: string
   security?: SecurityRisk
+  origin?: 'builtin' | 'agent-created' | 'marketplace'
 }
 
 type SkillsApiResponse = {
@@ -133,6 +134,7 @@ export function SkillsScreen() {
   const [debouncedMarketplaceSearch, setDebouncedMarketplaceSearch] =
     useState('')
   const [category, setCategory] = useState('All')
+  const [origin, setOrigin] = useState<string>('All')
   const [sort, setSort] = useState<SkillsSort>('name')
   const [page, setPage] = useState(1)
   const [actionSkillId, setActionSkillId] = useState<string | null>(null)
@@ -152,12 +154,13 @@ export function SkillsScreen() {
   }, [searchInput, tab])
 
   const skillsQuery = useQuery({
-    queryKey: ['skills-browser', tab, searchInput, category, page, sort],
+    queryKey: ['skills-browser', tab, searchInput, category, origin, page, sort],
     queryFn: async function fetchSkills(): Promise<SkillsApiResponse> {
       const params = new URLSearchParams()
       params.set('tab', tab)
       params.set('search', searchInput)
       params.set('category', category)
+      params.set('origin', origin)
       params.set('page', String(page))
       params.set('limit', String(PAGE_LIMIT))
       params.set('sort', sort)
@@ -270,8 +273,7 @@ export function SkillsScreen() {
           icon:
             skill.source === 'github'
               ? '🐙'
-              : skill.source === 'official' ||
-                  skill.trust_level === 'builtin'
+              : skill.source === 'official' || skill.trust_level === 'builtin'
                 ? '✅'
                 : skill.source === 'skills-sh'
                   ? '📦'
@@ -288,7 +290,10 @@ export function SkillsScreen() {
             .filter(Boolean)
             .join('\n\n'),
           fileCount: 0,
-          sourcePath: skill.identifier || (typeof homepage === 'string' ? homepage : '') || skill.source,
+          sourcePath:
+            skill.identifier ||
+            (typeof homepage === 'string' ? homepage : '') ||
+            skill.source,
           installed: skill.installed,
           enabled: skill.installed,
           featuredGroup: undefined,
@@ -302,6 +307,7 @@ export function SkillsScreen() {
             flags: [],
             score: 0,
           },
+          origin: 'marketplace' as const,
         }
       })
     },
@@ -439,6 +445,11 @@ export function SkillsScreen() {
     setPage(1)
   }
 
+  function handleOriginChange(value: string) {
+    setOrigin(value)
+    setPage(1)
+  }
+
   function handleSortChange(value: SkillsSort) {
     setSort(value)
     setPage(1)
@@ -466,66 +477,73 @@ export function SkillsScreen() {
 
         <section className="rounded-2xl border border-primary-200 bg-primary-50/80 p-3 backdrop-blur-xl sm:p-4">
           <Tabs value={tab} onValueChange={handleTabChange}>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                value={searchInput}
+                onChange={(event) => handleSearchChange(event.target.value)}
+                placeholder={
+                  tab === 'marketplace'
+                    ? 'Search Skills Hub, GitHub, and local fallback'
+                    : 'Search by name, tags, or description'
+                }
+                className="h-9 w-full min-w-0 flex-1 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none transition-colors focus:border-primary sm:min-w-[220px]"
+              />
+
+              {tab === 'installed' ? (
+                <select
+                  value={category}
+                  onChange={(event) =>
+                    handleCategoryChange(event.target.value)
+                  }
+                  className="h-9 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none"
+                >
+                  {categories.map((item) => (
+                    <option key={item} value={item}>
+                      {item}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+
+              {tab === 'installed' ? (
+                <select
+                  value={origin}
+                  onChange={(event) => handleOriginChange(event.target.value)}
+                  className="h-9 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none"
+                >
+                  <option value="All">All Origins</option>
+                  <option value="builtin">Built-in</option>
+                  <option value="agent-created">Agent-created</option>
+                  <option value="marketplace">Marketplace</option>
+                </select>
+              ) : null}
+
+              {tab === 'installed' ? (
+                <select
+                  value={sort}
+                  onChange={(event) =>
+                    handleSortChange(
+                      event.target.value === 'category' ? 'category' : 'name',
+                    )
+                  }
+                  className="h-9 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none"
+                >
+                  <option value="name">Name A-Z</option>
+                  <option value="category">Category</option>
+                </select>
+              ) : null}
+
               <TabsList
-                className="w-full rounded-xl border border-primary-200 bg-primary-100/60 p-1 sm:w-auto"
+                className="ml-auto rounded-xl border border-primary-200 bg-primary-100/60 p-1"
                 variant="default"
               >
-                <TabsTab value="installed" className="flex-1 sm:min-w-[132px]">
+                <TabsTab value="installed" className="min-w-[110px]">
                   Installed
                 </TabsTab>
-                <TabsTab
-                  value="marketplace"
-                  className="flex-1 sm:min-w-[168px]"
-                >
+                <TabsTab value="marketplace" className="min-w-[120px]">
                   Marketplace
                 </TabsTab>
-
               </TabsList>
-
-              {tab !== 'marketplace' ? (
-                <div className="flex flex-wrap items-center gap-2">
-                  <input
-                    value={searchInput}
-                    onChange={(event) => handleSearchChange(event.target.value)}
-                    placeholder="Search by name, tags, or description"
-                    className="h-9 w-full min-w-0 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none transition-colors focus:border-primary sm:min-w-[220px]"
-                  />
-
-                  {tab === 'installed' ? (
-                    <select
-                      value={category}
-                      onChange={(event) =>
-                        handleCategoryChange(event.target.value)
-                      }
-                      className="h-9 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none"
-                    >
-                      {categories.map((item) => (
-                        <option key={item} value={item}>
-                          {item}
-                        </option>
-                      ))}
-                    </select>
-                  ) : null}
-
-                  {tab === 'installed' ? (
-                    <select
-                      value={sort}
-                      onChange={(event) =>
-                        handleSortChange(
-                          event.target.value === 'category'
-                            ? 'category'
-                            : 'name',
-                        )
-                      }
-                      className="h-9 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none"
-                    >
-                      <option value="name">Name A-Z</option>
-                      <option value="category">Category</option>
-                    </select>
-                  ) : null}
-                </div>
-              ) : null}
             </div>
 
             {actionError ? (
@@ -552,16 +570,14 @@ export function SkillsScreen() {
             </TabsPanel>
 
             <TabsPanel value="marketplace" className="space-y-3 pt-2">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <input
-                  value={searchInput}
-                  onChange={(event) => handleSearchChange(event.target.value)}
-                  placeholder="Search Skills Hub, GitHub, and local fallback"
-                  className="h-10 w-full rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-sm text-ink outline-none transition-colors focus:border-primary"
-                />
-                <div className="text-xs text-primary-500 sm:text-right">
-                  Source: {hubQuery.data?.source || 'hub'}
-                </div>
+              <div className="flex items-center justify-between gap-2">
+                {hubQuery.data?.source ? (
+                  <div className="text-xs text-primary-500">
+                    Source: {hubQuery.data.source}
+                  </div>
+                ) : (
+                  <div />
+                )}
               </div>
 
               {hubQuery.error ? (
@@ -575,7 +591,7 @@ export function SkillsScreen() {
                   hubQuery.data.source === 'error') ? (
                 <div className="rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200">
                   Skills Hub search unavailable — showing installed skills
-                  instead. Ensure the Hermes gateway is running.
+                  instead. Ensure the Hermes Agent gateway is running.
                 </div>
               ) : null}
 
@@ -722,12 +738,33 @@ export function SkillsScreen() {
               </ScrollAreaRoot>
 
               <div className="flex flex-wrap items-center justify-between gap-2 border-t border-primary-200 px-5 py-3">
-                <p className="text-sm text-primary-500 text-pretty">
-                  Source:{' '}
-                  <code className="inline-code">
-                    {selectedSkill.sourcePath}
-                  </code>
-                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  {selectedSkill.origin ? (
+                    <span
+                      className={cn(
+                        'rounded-md border px-2 py-0.5 text-xs tabular-nums',
+                        selectedSkill.origin === 'builtin' &&
+                          'border-primary-200 bg-primary-100/60 text-primary-500',
+                        selectedSkill.origin === 'agent-created' &&
+                          'border-amber-300/70 bg-amber-100/60 text-amber-700 dark:border-amber-700/50 dark:bg-amber-900/30 dark:text-amber-200',
+                        selectedSkill.origin === 'marketplace' &&
+                          'border-emerald-300/70 bg-emerald-100/60 text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-900/30 dark:text-emerald-200',
+                      )}
+                    >
+                      {selectedSkill.origin === 'builtin'
+                        ? 'Built-in'
+                        : selectedSkill.origin === 'agent-created'
+                          ? 'Agent-created'
+                          : 'Marketplace'}
+                    </span>
+                  ) : null}
+                  <p className="text-sm text-primary-500 text-pretty">
+                    Source:{' '}
+                    <code className="inline-code">
+                      {selectedSkill.sourcePath}
+                    </code>
+                  </p>
+                </div>
                 <div className="flex items-center gap-2">
                   {selectedSkill.installed ? (
                     <Button
@@ -844,7 +881,10 @@ function SecurityBadge({
           {config.label}
         </button>
         {expanded && (
-          <div className="absolute left-0 bottom-[calc(100%+6px)] z-50 w-72 rounded-xl border border-primary-200 bg-surface p-0 shadow-xl overflow-hidden">
+          <div
+            className="absolute left-0 bottom-[calc(100%+6px)] z-50 w-72 overflow-hidden rounded-xl border border-primary-200 p-0 shadow-xl"
+            style={{ backgroundColor: 'var(--color-primary-50)' }}
+          >
             <SecurityScanCard security={security} />
           </div>
         )}
@@ -977,28 +1017,53 @@ function SkillsGrid({
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.18 }}
-              className="flex min-h-[220px] flex-col rounded-2xl border border-primary-200 bg-primary-50/85 p-4 shadow-sm backdrop-blur-sm"
+              className="relative z-0 flex min-h-[220px] flex-col rounded-2xl border border-primary-200 bg-primary-50/85 p-4 shadow-sm backdrop-blur-sm hover:z-20 focus-within:z-20"
             >
               <div className="mb-2 flex items-start justify-between gap-2">
-                <div className="space-y-1">
-                  <p className="text-xl leading-none">{skill.icon}</p>
-                  <h3 className="line-clamp-1 text-base font-medium text-ink text-balance">
-                    {skill.name}
-                  </h3>
-                  <p className="line-clamp-1 text-xs text-primary-500">
-                    by {skill.author}
-                  </p>
+                <div className="min-w-0 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xl leading-none">{skill.icon}</span>
+                    <h3 className="line-clamp-1 min-w-0 text-base font-medium text-ink text-balance">
+                      {skill.name}
+                    </h3>
+                  </div>
+                  {skill.author ? (
+                    <p className="line-clamp-1 text-xs text-primary-500">
+                      by {skill.author}
+                    </p>
+                  ) : null}
                 </div>
-                <span
-                  className={cn(
-                    'rounded-md border px-2 py-0.5 text-xs tabular-nums',
-                    skill.installed
-                      ? 'border-primary/40 bg-primary/15 text-primary'
-                      : 'border-primary-200 bg-primary-100/60 text-primary-500',
-                  )}
-                >
-                  {skill.installed ? 'Installed' : 'Available'}
-                </span>
+                <div className="flex flex-shrink-0 flex-wrap items-center gap-1.5">
+                  {skill.origin ? (
+                    <span
+                      className={cn(
+                        'rounded-md border px-2 py-0.5 text-xs tabular-nums',
+                        skill.origin === 'builtin' &&
+                          'border-primary-200 bg-primary-100/60 text-primary-500',
+                        skill.origin === 'agent-created' &&
+                          'border-amber-300/70 bg-amber-100/60 text-amber-700 dark:border-amber-700/50 dark:bg-amber-900/30 dark:text-amber-200',
+                        skill.origin === 'marketplace' &&
+                          'border-emerald-300/70 bg-emerald-100/60 text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-900/30 dark:text-emerald-200',
+                      )}
+                    >
+                      {skill.origin === 'builtin'
+                        ? 'Built-in'
+                        : skill.origin === 'agent-created'
+                          ? 'Agent-created'
+                          : 'Marketplace'}
+                    </span>
+                  ) : null}
+                  <span
+                    className={cn(
+                      'rounded-md border px-2 py-0.5 text-xs tabular-nums',
+                      skill.installed
+                        ? 'border-primary/40 bg-primary/15 text-primary'
+                        : 'border-primary-200 bg-primary-100/60 text-primary-500',
+                    )}
+                  >
+                    {skill.installed ? 'Installed' : 'Available'}
+                  </span>
+                </div>
               </div>
 
               <p className="line-clamp-3 min-h-[58px] text-sm text-primary-500 text-pretty">


### PR DESCRIPTION
## Summary

- Adds **Origin filter** to the installed skills tab: `All / Built-in / Agent-created / Marketplace`
- Server-side (`/api/skills`) now scans `~/.hermes/skills/` at request time, reads `SKILL.md` frontmatter to extract author metadata, and maps each skill to an origin (`builtin` / `agent-created` / `marketplace`)
- Filter is wired to query key so results update instantly on selection
- Search bar moved inline with category/origin filters for a cleaner single-row toolbar layout

## Test plan

- [ ] Install tab: verify all three origin values filter correctly
- [ ] `All Origins` shows complete installed list
- [ ] Agent-created skills (from `~/.hermes/skills/`) appear with correct origin
- [ ] Marketplace tab unaffected (origin filter hidden on that tab)
- [ ] Search + category + origin filters compose correctly

Worked with Interstellar Code