### PR TITLE
feat(theme): add Matrix dark/light theme

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -909,6 +909,7 @@ function AppearanceContent() {
 
 const ENTERPRISE_THEME_FAMILIES: Array<ThemeId> = [
   'claude-nous',
+  'matrix',
   'claude-official',
   'claude-classic',
   'claude-slate',
@@ -934,6 +935,22 @@ const ENTERPRISE_THEMES = THEMES.map((theme) => ({
             accent: '#2557B7',
             text: '#16315F',
           }
+      : theme.id === 'matrix'
+        ? {
+            bg: '#020804',
+            panel: '#07130A',
+            border: 'rgba(0,255,65,0.28)',
+            accent: '#00FF41',
+            text: '#D8FFE3',
+          }
+        : theme.id === 'matrix-light'
+          ? {
+              bg: '#F4FFF6',
+              panel: '#FFFFFF',
+              border: 'rgba(0,126,34,0.2)',
+              accent: '#008F2D',
+              text: '#062A12',
+            }
       : theme.id === 'claude-official'
       ? {
           bg: '#0A0E1A',

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,6 +1,8 @@
 export type ThemeId =
   | 'claude-nous'
   | 'claude-nous-light'
+  | 'matrix'
+  | 'matrix-light'
   | 'claude-official'
   | 'claude-official-light'
   | 'claude-classic'
@@ -25,6 +27,18 @@ export const THEMES: Array<{
     label: 'Nous Light',
     description: 'Cold paper white with restrained cobalt framing',
     icon: '◲',
+  },
+  {
+    id: 'matrix',
+    label: 'Matrix',
+    description: 'Black glass terminal field with phosphor green signal glow',
+    icon: '▣',
+  },
+  {
+    id: 'matrix-light',
+    label: 'Matrix Light',
+    description: 'White terminal paper with green signal accents',
+    icon: '▣',
   },
   {
     id: 'claude-official',
@@ -72,6 +86,7 @@ const LIGHT_THEME_MAP: Record<
   Extract<ThemeId, `${string}-light`>
 > = {
   'claude-nous': 'claude-nous-light',
+  matrix: 'matrix-light',
   'claude-official': 'claude-official-light',
   'claude-classic': 'claude-classic-light',
   'claude-slate': 'claude-slate-light',
@@ -81,6 +96,7 @@ const DARK_THEME_MAP: Record<
   Exclude<ThemeId, `${string}-light`>
 > = {
   'claude-nous-light': 'claude-nous',
+  'matrix-light': 'matrix',
   'claude-official-light': 'claude-official',
   'claude-classic-light': 'claude-classic',
   'claude-slate-light': 'claude-slate',
@@ -88,6 +104,7 @@ const DARK_THEME_MAP: Record<
 
 const LIGHT_THEMES = new Set<ThemeId>([
   'claude-nous-light',
+  'matrix-light',
   'claude-official-light',
   'claude-classic-light',
   'claude-slate-light',

--- a/src/styles.css
+++ b/src/styles.css
@@ -710,6 +710,97 @@ code {
 }
 
 /* ── Hermes Workspace Themes ── */
+
+[data-theme='matrix'] {
+  --theme-bg: #020804;
+  --theme-sidebar: #030d06;
+  --theme-panel: #041008;
+  --theme-card: #07130a;
+  --theme-card2: #0a1c0f;
+  --theme-border: rgba(0, 255, 65, 0.28);
+  --theme-border-subtle: rgba(0, 255, 65, 0.13);
+  --theme-text: #d8ffe3;
+  --theme-muted: rgba(216, 255, 227, 0.58);
+  --theme-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.72);
+  --theme-shadow-2: 0 10px 28px rgba(0, 0, 0, 0.62);
+  --theme-shadow-3: 0 18px 54px rgba(0, 0, 0, 0.72);
+  --theme-glass: rgba(2, 8, 4, 0.88);
+  --theme-focus: #00ff41;
+  --theme-accent: #00ff41;
+  --theme-accent-secondary: #7cff9b;
+  --theme-accent-subtle: rgba(0, 255, 65, 0.13);
+  --theme-accent-border: rgba(0, 255, 65, 0.36);
+  --theme-active: #00ff41;
+  --theme-link: #7cff9b;
+  --theme-success: #00ff41;
+  --theme-warning: #d6ff5f;
+  --theme-danger: #ff5f6d;
+  --theme-stripe: rgba(0, 255, 65, 0.055);
+  --theme-header-bg: #030d06;
+  --theme-header-border: rgba(0, 255, 65, 0.26);
+  --chat-user-bg: #07230d;
+  --chat-user-border: rgba(0, 255, 65, 0.34);
+  --chat-user-foreground: #eaffef;
+  --chat-assistant-bg: #041008;
+  --chat-assistant-border: rgba(0, 255, 65, 0.15);
+  --chat-assistant-foreground: #d8ffe3;
+  --composer-bg: #020b05;
+  --composer-border: rgba(0, 255, 65, 0.3);
+  --composer-placeholder: rgba(216, 255, 227, 0.42);
+  --tool-card-bg: #041008;
+  --tool-card-border: rgba(0, 255, 65, 0.2);
+  --tool-card-title: #eaffef;
+  --tool-card-muted: rgba(216, 255, 227, 0.56);
+  --code-bg: #010602;
+  --code-border: rgba(0, 255, 65, 0.18);
+  --theme-input: #07130a;
+}
+
+[data-theme='matrix-light'] {
+  --theme-bg: #f4fff6;
+  --theme-sidebar: #eafff0;
+  --theme-panel: #f0fff4;
+  --theme-card: #ffffff;
+  --theme-card2: #f4fff6;
+  --theme-border: rgba(0, 126, 34, 0.2);
+  --theme-border-subtle: rgba(0, 126, 34, 0.1);
+  --theme-text: #062a12;
+  --theme-muted: rgba(6, 42, 18, 0.55);
+  --theme-shadow-1: 0 1px 2px rgba(0, 80, 20, 0.08);
+  --theme-shadow-2: 0 10px 28px rgba(0, 80, 20, 0.1);
+  --theme-shadow-3: 0 18px 54px rgba(0, 80, 20, 0.14);
+  --theme-glass: rgba(244, 255, 246, 0.88);
+  --theme-focus: #008f2d;
+  --theme-accent: #008f2d;
+  --theme-accent-secondary: #006b22;
+  --theme-accent-subtle: rgba(0, 143, 45, 0.1);
+  --theme-accent-border: rgba(0, 143, 45, 0.3);
+  --theme-active: #008f2d;
+  --theme-link: #006b22;
+  --theme-success: #008f2d;
+  --theme-warning: #7a6200;
+  --theme-danger: #c0392b;
+  --theme-stripe: rgba(0, 143, 45, 0.04);
+  --theme-header-bg: #eafff0;
+  --theme-header-border: rgba(0, 126, 34, 0.18);
+  --chat-user-bg: #eafff1;
+  --chat-user-border: rgba(0, 126, 34, 0.22);
+  --chat-user-foreground: #062a12;
+  --chat-assistant-bg: #ffffff;
+  --chat-assistant-border: rgba(0, 126, 34, 0.12);
+  --chat-assistant-foreground: #062a12;
+  --composer-bg: #f4fff6;
+  --composer-border: rgba(0, 126, 34, 0.22);
+  --composer-placeholder: rgba(6, 42, 18, 0.38);
+  --tool-card-bg: #f0fff4;
+  --tool-card-border: rgba(0, 126, 34, 0.15);
+  --tool-card-title: #062a12;
+  --tool-card-muted: rgba(6, 42, 18, 0.55);
+  --code-bg: #eafff0;
+  --code-border: rgba(0, 126, 34, 0.14);
+  --theme-input: #ffffff;
+}
+
 [data-theme='claude-official'] {
   --theme-bg: #0a0e1a;
   /* Sidebar gets a deeper shade than the main bg so the column


### PR DESCRIPTION
## Summary

Adds a new **Matrix** theme family (dark + light) to Hermes Workspace.

- **Matrix dark** — cinematic black glass terminal surface with phosphor green (`#00FF41`) signal glow
- **Matrix light** — white terminal paper with green signal accents (`#008F2D`)

## What's included

- Full CSS token set: `bg`, `sidebar`, `panel`, `card`, `chat bubbles`, `composer`, `tool cards`, `code blocks`, `input`
- Registered in `ThemeId` union, `THEMES` array, `LIGHT_THEME_MAP`, `DARK_THEME_MAP`, `LIGHT_THEMES`
- Added to `ENTERPRISE_THEME_FAMILIES` with accurate color preview swatches in the settings dialog
- Light/dark toggle works correctly (paired variants)

## Screenshots

> **Matrix dark** — active in the Settings › Theme panel

<!-- drag-and-drop screenshot 1 here: Settings dialog with Matrix ACTIVE card -->

> **Matrix** — full theme picker showing dark + light variants alongside existing themes

<!-- drag-and-drop screenshot 2 here: Full theme grid with Matrix and Matrix Light cards -->

> **Matrix dark** — applied across the full workspace UI (Swarm screen)

<!-- drag-and-drop screenshot 3 here: Swarm screen rendered in Matrix theme -->

## Test plan

- [ ] Matrix dark renders correctly — phosphor green accents, black glass surfaces
- [ ] Matrix light renders correctly — white background, green accents
- [ ] Light/dark toggle in Settings switches between `matrix` ↔ `matrix-light`
- [ ] Matrix appears in Enterprise Theme picker with correct swatch preview
- [ ] All existing themes unaffected
- [ ] No console errors on theme switch

Worked with Interstellar Code