### PR TITLE
fix(auth): warn at startup when Secure cookies will break plain-HTTP LAN login

### DIFF
--- a/server-entry.js
+++ b/server-entry.js
@@ -68,6 +68,21 @@ if (isNonLoopbackHost(host)) {
         '  Add COOKIE_SECURE=0 to your .env to fix this.  See #149.\n',
     )
   }
+
+  // Warn when serving over plain HTTP with a password: NODE_ENV=production
+  // sets the Secure flag on session cookies, which browsers silently drop
+  // over http://.  Operators must set COOKIE_SECURE=0 for plain-HTTP LAN
+  // deployments.  See #149.
+  const cookieSecureOverride = (process.env.COOKIE_SECURE || '').trim().toLowerCase()
+  const cookieSecureExplicit = cookieSecureOverride === '0' || cookieSecureOverride === 'false' || cookieSecureOverride === 'no'
+  if (!cookieSecureExplicit && process.env.NODE_ENV === 'production') {
+    console.warn(
+      '\n[workspace] warning: plain-HTTP LAN deployment detected.\n' +
+        '  NODE_ENV=production enables the Secure flag on session cookies.\n' +
+        '  Browsers silently drop Secure cookies over http://, so login will fail.\n' +
+        '  Add COOKIE_SECURE=0 to your .env to fix this.  See #149.\n',
+    )
+  }
 }
 
 const MIME_TYPES = {


### PR DESCRIPTION
## Summary

- Adds a startup warning in `server-entry.js` when the server is running in production mode with a non-loopback bind address but without HTTPS
- `NODE_ENV=production` enables the `Secure` flag on session cookies; browsers silently drop Secure cookies over plain HTTP, causing login to fail with no visible error on LAN deployments
- Fix: log a clear warning pointing users to `COOKIE_SECURE=0` as the escape hatch

## Why

Silent login failure on LAN (`HOST=0.0.0.0`) with no error message is a sharp edge that's hard to diagnose. Closes #149.

## Test plan

- [ ] Start server with `NODE_ENV=production HOST=0.0.0.0` (no `COOKIE_SECURE=0`) — warning appears in logs
- [ ] Start server with `NODE_ENV=production HOST=0.0.0.0 COOKIE_SECURE=0` — no warning
- [ ] Start server with `HOST=127.0.0.1` — no warning

Worked with Interstellar Code