### PR TITLE
fix(settings): verified-only green dot + single-dot precedence for provider cards

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -398,10 +398,22 @@ function HermesContent() {
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
           {PROVIDER_CARDS.map((p) => {
             const isActive = activeProvider === p.id
+            const localOnline =
+              localDiscovery?.providers.find((lp) => lp.id === p.id)?.online ===
+              true
+            // verified = truly available right now. OAuth status isn't tracked
+            // here, so OAuth providers stay neutral until an actual session
+            // check is wired. Local providers require live discovery hit.
+            const verified =
+              (p.authType === 'none' && localOnline) ||
+              (p.authType === 'api_key' &&
+                !!p.envKey &&
+                !!configuredKeys[p.envKey])
+            const missingKey = p.authType === 'api_key' && !verified
+            // hasKey gates click — keep OAuth + local clickable (existing
+            // behaviour) so users can still authenticate via the card.
             const hasKey =
-              p.authType === 'none' ||
-              p.authType === 'oauth' ||
-              (p.envKey ? !!configuredKeys[p.envKey] : false)
+              p.authType === 'none' || p.authType === 'oauth' || verified
             return (
               <button
                 key={p.id}
@@ -414,21 +426,20 @@ function HermesContent() {
                   isActive
                     ? 'ring-2 ring-accent-500 shadow-md'
                     : 'hover:brightness-110',
-                  !hasKey && p.authType === 'api_key' && 'opacity-60',
+                  missingKey && 'opacity-60',
                 )}
                 style={cardStyle}
               >
                 <div className="flex w-full items-center justify-between">
                   <ProviderLogo provider={p.id} size={32} />
-                  {isActive && (
+                  {/* Single-dot precedence: active > missing-key > verified > none */}
+                  {isActive ? (
                     <span className="size-2 rounded-full bg-green-500" />
-                  )}
-                  {!isActive && hasKey && (
-                    <span className="size-2 rounded-full bg-green-500/40" />
-                  )}
-                  {!hasKey && p.authType === 'api_key' && (
+                  ) : missingKey ? (
                     <span className="size-2 rounded-full bg-red-500/60" />
-                  )}
+                  ) : verified ? (
+                    <span className="size-2 rounded-full bg-green-500/40" />
+                  ) : null}
                 </div>
                 <span className="text-xs font-semibold mt-1">{p.name}</span>
                 <span className="text-[9px]" style={mutedStyle}>


### PR DESCRIPTION
## Summary

- Provider cards in Settings › Model & Provider previously showed a green checkmark for local providers (`authType: 'none'`) even when they were offline
- Adds `localOnline` check via the live-discovery response so green only shows when the provider is actually reachable
- Fixes precedence: `active > missing-key > verified > neutral` — a single status dot per card, no ambiguous stacking
- `missingKey` now drives the `opacity-60` dim rather than the old `!hasKey` check, which was too broad

## Test plan

- [ ] Ollama offline → card shows no green dot, not dimmed (clickable to configure)
- [ ] Ollama online → card shows green dot
- [ ] API key provider with no key set → dimmed (opacity-60)
- [ ] API key provider with key set → green dot when reachable
- [ ] Active provider card → ring highlight, no dot overlap

Worked with Interstellar Code