### PR TITLE
fix: correct vite dev proxy port and /cron route link

### DIFF
--- a/src/screens/agents/components/operations-agent-card.tsx
+++ b/src/screens/agents/components/operations-agent-card.tsx
@@ -412,7 +412,7 @@ export function OperationsAgentCard({
                   </div>
                   <div className="mt-3 flex justify-end">
                     <Button
-                      render={<a href="/cron" />}
+                      render={<a href="/jobs" />}
                       variant="secondary"
                       className="h-8 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 text-xs font-medium text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
                     >
@@ -426,7 +426,7 @@ export function OperationsAgentCard({
                     No scheduled jobs
                   </p>
                   <Button
-                    render={<a href="/cron" />}
+                    render={<a href="/jobs" />}
                     variant="secondary"
                     className="h-8 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 text-xs font-medium text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
                   >

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,10 @@ async function isClaudeAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const claudeApiUrl = env.CLAUDE_API_URL?.trim() || 'http://127.0.0.1:8642'
+  const claudeDashboardUrl =
+    env.HERMES_DASHBOARD_URL?.trim() ||
+    env.CLAUDE_DASHBOARD_URL?.trim() ||
+    'http://127.0.0.1:9119'
 
   // Hermes Agent auto-start state
   let claudeAgentChild: ChildProcess | null = null
@@ -540,7 +544,7 @@ const config = defineConfig(({ mode, command }) => {
                   fetch(`${claudeApiUrl}/v1/models`, {
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
-                  fetch(`${claudeApiUrl}/api/sessions?limit=1`, {
+                  fetch(`${claudeDashboardUrl}/api/sessions?limit=1`, {
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                 ])


### PR DESCRIPTION
## Summary

Two endpoint routing bugs in Workspace:

### #276 — Vite dev server polls /api/sessions on wrong port
The connection-status handler in vite.config.ts probed /api/sessions on the gateway URL (default :8642), but this endpoint only exists on the dashboard service (default :9119). This caused a 404 in the browser console every 15 seconds during development.

Fix: Resolve the dashboard URL from the same env precedence as gateway-capabilities.ts (HERMES_DASHBOARD_URL > CLAUDE_DASHBOARD_URL > default http://127.0.0.1:9119) and use it for the /api/sessions probe.

### #277 — /cron link leads to 404
The +Add Job button on the Operations page (operations-agent-card.tsx) linked to /cron, but the actual route is /jobs.

Fix: Changed both href=/cron instances to href=/jobs.

Fixes #276
Fixes #277