### PR TITLE
fix(dev): auth header on gateway probes + expanded vite watch.ignored

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -474,6 +474,36 @@ const config = defineConfig(({ mode, command }) => {
       port: process.env.PORT ? Number(process.env.PORT) : 3000,
       strictPort: false, // allow fallback if port is taken, but log clearly
       allowedHosts: true,
+      watch: {
+        ignored: [
+          // Generated route tree — TanStack Router's file watcher detects its
+          // own output as a change → infinite regeneration loop.
+          '**/routeTree.gen.ts',
+          // Local portable session store, rewritten on every chat send.
+          // Without this, the watcher fires on every message → spurious
+          // server-side reload events / test churn during development.
+          '**/.runtime/**',
+          // Internal TanStack Start state cache.
+          '**/.tanstack/**',
+          // Local plan/notes/scratch state used by OMC tooling — never
+          // imported by the module graph, but file events still spam logs.
+          '**/.omc/**',
+          '**/.omx/**',
+          // Build artifacts.
+          '**/dist/**',
+          '**/.output/**',
+          // Test/coverage outputs.
+          '**/coverage/**',
+          '**/playwright-report/**',
+          '**/test-results/**',
+          // Editor / agent metadata.
+          '**/.vscode/**',
+          '**/.claude/**',
+          '**/.cursor/**',
+          // Loose log files.
+          '**/*.log',
+        ],
+      },
       proxy: {
         // WebSocket proxy: clients connect to /ws-claude on the Hermes Workspace
         // server (any IP/port), which internally forwards to the local server.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,6 +85,11 @@ async function isClaudeAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const claudeApiUrl = env.CLAUDE_API_URL?.trim() || 'http://127.0.0.1:8642'
+  const claudeApiToken =
+    env.HERMES_API_TOKEN?.trim() || env.CLAUDE_API_TOKEN?.trim() || ''
+  const probeHeaders: Record<string, string> = claudeApiToken
+    ? { Authorization: `Bearer ${claudeApiToken}` }
+    : {}
 
   // Hermes Agent auto-start state
   let claudeAgentChild: ChildProcess | null = null
@@ -538,9 +543,11 @@ const config = defineConfig(({ mode, command }) => {
                 // Check for enhanced Hermes Agent gateway first (has /api/sessions)
                 const [modelsRes, sessionsRes] = await Promise.all([
                   fetch(`${claudeApiUrl}/v1/models`, {
+                    headers: probeHeaders,
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                   fetch(`${claudeApiUrl}/api/sessions?limit=1`, {
+                    headers: probeHeaders,
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                 ])


### PR DESCRIPTION
## Summary

- Sends `Authorization: Bearer <HERMES_API_TOKEN>` on startup connection-status probes (`/v1/models`, `/api/sessions`) so the dev server correctly detects a gateway secured with `API_SERVER_KEY`
- Adds comprehensive `watch.ignored` list to prevent spurious HMR reloads from:
  - `routeTree.gen.ts` (TanStack Router regenerates this on every route change → infinite loop without the ignore)
  - `.runtime/**` (session store rewritten on every chat message)
  - `.tanstack/**`, `.omc/**`, `.omx/**`, `.claude/**`, `.cursor/**`, `.vscode/**`
  - Build artifacts, test outputs, log files

## Test plan

- [ ] `pnpm dev` with `API_SERVER_KEY` set — gateway capability probe returns 200 instead of 401
- [ ] Edit a route file — HMR fires once, not in an infinite loop
- [ ] Chat send — no spurious server reload from `.runtime/` write

Worked with Interstellar Code