### PR TITLE
fix(vite): probe /api/sessions on dashboard URL and cache result

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,10 +34,10 @@ function resolveClaudeAgentDir(env: Record<string, string>): string | null {
   // Resolve relative to the workspace root (parent of hermes-workspace/)
   const workspaceRoot = dirname(resolve('.'))
   candidates.push(
-    resolve(workspaceRoot, 'hermes-agent'),            // sibling (old README)
-    resolve(workspaceRoot, '..', 'hermes-agent'),      // one level up
-    resolve(os.homedir(), '.claude', 'hermes-agent'),  // Nous installer default
-    resolve(os.homedir(), 'hermes-agent'),             // ~/hermes-agent
+    resolve(workspaceRoot, 'hermes-agent'), // sibling (old README)
+    resolve(workspaceRoot, '..', 'hermes-agent'), // one level up
+    resolve(os.homedir(), '.claude', 'hermes-agent'), // Nous installer default
+    resolve(os.homedir(), 'hermes-agent'), // ~/hermes-agent
   )
 
   for (const candidate of candidates) {
@@ -85,6 +85,31 @@ async function isClaudeAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const claudeApiUrl = env.CLAUDE_API_URL?.trim() || 'http://127.0.0.1:8642'
+  // Dashboard URL — where /api/sessions actually lives. The Hermes Agent
+  // (port 8642) does not serve /api/sessions; the Hermes Dashboard does
+  // (default port 9119). The Vite dev-server health probe used to hit
+  // /api/sessions on the agent URL, producing a 404 every 15 seconds in
+  // setups where the dashboard runs separately. See #276.
+  const claudeDashboardUrl =
+    env.HERMES_DASHBOARD_URL?.trim() ||
+    env.CLAUDE_DASHBOARD_URL?.trim() ||
+    'http://127.0.0.1:9119'
+
+  // Cache the most recent successful /api/connection-status result so we
+  // don't hammer the agent + dashboard with three fetches every 15s when
+  // the answer hasn't changed. Negative results are cached for a much
+  // shorter window so transient outages recover quickly.
+  type ConnectionStatusBody = {
+    ok: boolean
+    mode: 'enhanced' | 'portable' | 'disconnected'
+    backend: string
+  }
+  let connectionStatusCache: {
+    expiresAt: number
+    body: ConnectionStatusBody
+  } | null = null
+  const CONNECTION_STATUS_CACHE_OK_MS = 60_000
+  const CONNECTION_STATUS_CACHE_FAIL_MS = 5_000
 
   // Hermes Agent auto-start state
   let claudeAgentChild: ChildProcess | null = null
@@ -132,7 +157,15 @@ const config = defineConfig(({ mode, command }) => {
       const useGatewayRun = existsSync(resolve(agentDir, 'gateway', 'run.py'))
       commandArgs = useGatewayRun
         ? ['-m', 'gateway.run']
-        : ['-m', 'uvicorn', 'webapi.app:app', '--host', '0.0.0.0', '--port', '8642']
+        : [
+            '-m',
+            'uvicorn',
+            'webapi.app:app',
+            '--host',
+            '0.0.0.0',
+            '--port',
+            '8642',
+          ]
       launchCwd = agentDir
       console.log(
         `[hermes-agent] Starting from ${agentDir} using ${launchCmd} (${useGatewayRun ? 'gateway.run' : 'uvicorn'})`,
@@ -147,27 +180,23 @@ const config = defineConfig(({ mode, command }) => {
       return
     }
 
-    const child = spawn(
-      launchCmd,
-      commandArgs,
-      {
-        cwd: launchCwd,
-        detached: false, // keep tied to vite process — stops when dev server stops
-        stdio: 'pipe',
-        env: {
-          ...process.env,
-          PATH: [
-            resolve(os.homedir(), '.claude', 'bin'),
-            resolve(os.homedir(), '.local', 'bin'),
-            agentDir ? resolve(agentDir, '.venv', 'bin') : '',
-            agentDir ? resolve(agentDir, 'venv', 'bin') : '',
-            process.env.PATH || '',
-          ]
-            .filter(Boolean)
-            .join(':'),
-        },
+    const child = spawn(launchCmd, commandArgs, {
+      cwd: launchCwd,
+      detached: false, // keep tied to vite process — stops when dev server stops
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        PATH: [
+          resolve(os.homedir(), '.claude', 'bin'),
+          resolve(os.homedir(), '.local', 'bin'),
+          agentDir ? resolve(agentDir, '.venv', 'bin') : '',
+          agentDir ? resolve(agentDir, 'venv', 'bin') : '',
+          process.env.PATH || '',
+        ]
+          .filter(Boolean)
+          .join(':'),
       },
-    )
+    })
 
     claudeAgentChild = child
     claudeAgentStarted = true
@@ -479,7 +508,7 @@ const config = defineConfig(({ mode, command }) => {
           ws: true,
           rewrite: (path) => path.replace(/^\/ws-claude/, ''),
         },
-// REST API proxy: API proxy for Hermes backend
+        // REST API proxy: API proxy for Hermes backend
         '/api/claude-proxy': {
           target: proxyTarget,
           changeOrigin: true,
@@ -534,39 +563,66 @@ const config = defineConfig(({ mode, command }) => {
               req.method === 'GET' &&
               requestPath === '/api/connection-status'
             ) {
+              const sendCached = (body: ConnectionStatusBody) => {
+                res.statusCode = body.ok ? 200 : 502
+                res.setHeader('content-type', 'application/json')
+                res.end(JSON.stringify(body))
+              }
+
+              if (
+                connectionStatusCache &&
+                connectionStatusCache.expiresAt > Date.now()
+              ) {
+                sendCached(connectionStatusCache.body)
+                return
+              }
+
+              const cacheAndSend = (
+                body: ConnectionStatusBody,
+                ttlMs: number,
+              ) => {
+                connectionStatusCache = {
+                  expiresAt: Date.now() + ttlMs,
+                  body,
+                }
+                sendCached(body)
+              }
+
               try {
-                // Check for enhanced Hermes Agent gateway first (has /api/sessions)
+                // Probe the agent for /v1/models and the dashboard for
+                // /api/sessions in parallel. /api/sessions lives on the
+                // dashboard, not the agent, so probing it on the agent URL
+                // (the previous behaviour) produced a 404 every 15s when
+                // the dashboard ran on a separate port. See #276.
                 const [modelsRes, sessionsRes] = await Promise.all([
                   fetch(`${claudeApiUrl}/v1/models`, {
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
-                  fetch(`${claudeApiUrl}/api/sessions?limit=1`, {
+                  fetch(`${claudeDashboardUrl}/api/sessions?limit=1`, {
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                 ])
                 const hasModels = modelsRes?.ok ?? false
                 const hasSessions = sessionsRes?.ok ?? false
                 if (hasModels && hasSessions) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
+                  cacheAndSend(
+                    {
                       ok: true,
                       mode: 'enhanced',
                       backend: claudeApiUrl,
-                    }),
+                    },
+                    CONNECTION_STATUS_CACHE_OK_MS,
                   )
                   return
                 }
                 if (hasModels) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
+                  cacheAndSend(
+                    {
                       ok: true,
                       mode: 'portable',
                       backend: claudeApiUrl,
-                    }),
+                    },
+                    CONNECTION_STATUS_CACHE_OK_MS,
                   )
                   return
                 }
@@ -574,24 +630,24 @@ const config = defineConfig(({ mode, command }) => {
                 const healthRes = await fetch(`${claudeApiUrl}/health`, {
                   signal: AbortSignal.timeout(3000),
                 })
-                res.statusCode = healthRes.ok ? 200 : 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
+                cacheAndSend(
+                  {
                     ok: healthRes.ok,
                     mode: 'enhanced',
                     backend: claudeApiUrl,
-                  }),
+                  },
+                  healthRes.ok
+                    ? CONNECTION_STATUS_CACHE_OK_MS
+                    : CONNECTION_STATUS_CACHE_FAIL_MS,
                 )
               } catch {
-                res.statusCode = 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
+                cacheAndSend(
+                  {
                     ok: false,
                     mode: 'disconnected',
                     backend: claudeApiUrl,
-                  }),
+                  },
+                  CONNECTION_STATUS_CACHE_FAIL_MS,
                 )
               }
               return


### PR DESCRIPTION
## Summary

Fixes #276.

The Vite dev server's inline `/api/connection-status` handler in `vite.config.ts` probed `/api/sessions` on the **agent** URL (default `http://127.0.0.1:8642`). The Hermes Agent does not serve `/api/sessions` — the Hermes Dashboard does (default `http://127.0.0.1:9119`). Anywhere the dashboard runs on a separate port (any setup that sets `CLAUDE_DASHBOARD_URL` / `HERMES_DASHBOARD_URL`), this produced a 404 in the browser console every 15 seconds.

The reporter notes that the production-side route `src/server/gateway-capabilities.ts` already does the right thing via `ensureGatewayProbed()`; only the dev-server inline handler had the bug.

## Fix

Two small changes in `vite.config.ts`:

1. **Resolve a dedicated dashboard URL** from env (`HERMES_DASHBOARD_URL`, `CLAUDE_DASHBOARD_URL`, fallback `http://127.0.0.1:9119`) and probe `/api/sessions?limit=1` there. This mirrors the resolution path already used by `gateway-capabilities.ts`.
2. **Cache the resolved payload** for 60s on success (5s on failure) so a tight poll loop doesn't fan out three fetches every cycle when the answer hasn't changed.

The `/v1/models` and `/health` probes still hit the agent URL — portable-mode detection is unchanged.

## Behaviour

Before:
- Agent on `:8642`, dashboard on `:9119` → `GET http://localhost:8642/api/sessions?limit=1` → 404 every 15s.

After:
- Same setup → `GET http://localhost:9119/api/sessions?limit=1` → 200 once, then served from cache for 60s.
- Single-port setups (agent and dashboard collocated, or dashboard absent) keep working: `hasSessions` falls to `false`, falls through to portable mode, then `/health` — same as before.

## Verification

```
pnpm dev
# in another shell:
curl http://localhost:3000/api/connection-status
# {"ok":true,"mode":"portable","backend":"http://127.0.0.1:8642"}
curl http://localhost:3000/api/connection-status
curl http://localhost:3000/api/connection-status
# all three return immediately, only the first triggers outbound probes
```

`pnpm test` — 547 passing, 11 failing. All 11 failures are **pre-existing on `main`** (markdown plugin exports, chat-message-list, send-stream `persistActiveRun`, swarm-kanban types) and have nothing to do with this change. Verified by reverting the patch and re-running: identical failure set.

`tsc --noEmit` reports no errors in `vite.config.ts`. `prettier --check` passes. `vite.config.ts` is in the eslint ignore set so eslint is not applicable.

## Scope

Single file. No public API change. No env var rename. Production code path (`src/server/gateway-capabilities.ts`) is untouched.

Fixes outsourc-e/hermes-workspace#276