### PR TITLE
fix: normalize jobs API response shape to always return {jobs:[]}

### DIFF
--- a/src/routes/api/claude-jobs.ts
+++ b/src/routes/api/claude-jobs.ts
@@ -17,6 +17,36 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+/**
+ * Normalise the jobs response so callers always receive `{ jobs: [...] }`.
+ *
+ * Some Hermes gateway versions return a bare array instead of the expected
+ * `{ jobs: [] }` envelope. This helper wraps bare arrays so the workspace UI
+ * never has to special-case both shapes.
+ */
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/claude-jobs')({
   server: {
     handlers: {
@@ -44,10 +74,7 @@ export const Route = createFileRoute('/api/claude-jobs')({
           : await fetch(`${CLAUDE_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {


### PR DESCRIPTION
## Summary

Some Hermes gateway versions return a bare array from `/api/jobs` instead of the expected `{ jobs: [] }` envelope. The workspace jobs screen then fails to render because it destructures `.jobs` on the response.

## Changes

Adds a `jobsResponse()` helper to `claude-jobs.ts` that:
- Reads the full response body once (avoids double-consume issues with `res.body`)  
- If the response is a bare array, wraps it as `{ jobs: data }`
- If the response is already an object, passes it through unchanged
- On parse failure, returns the raw text (graceful degradation)

Wires the GET handler to use `jobsResponse()` instead of passing `res.body` directly.

## Test Plan
- [ ] Jobs screen renders correctly when gateway returns `{ jobs: [...] }`
- [ ] Jobs screen renders correctly when gateway returns a bare `[...]` array
- [ ] Non-OK responses (4xx/5xx) are passed through unchanged
