### PR TITLE
fix: add legacy claude-workspace/claude-agent remote aliases for update checker

### DIFF
--- a/src/routes/api/claude-update.ts
+++ b/src/routes/api/claude-update.ts
@@ -32,13 +32,13 @@ export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
     name: 'origin',
     label: 'Hermes Workspace',
     expectedRepo: 'hermes-workspace',
-    aliases: ['hermes-workspace', 'outsourc-e/hermes-workspace'],
+    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
   },
   {
     name: 'upstream',
     label: 'Hermes Agent',
     expectedRepo: 'hermes-agent',
-    aliases: ['hermes-agent', 'NousResearch/hermes-agent'],
+    aliases: ['claude-agent', 'hermes-agent', 'NousResearch/hermes-agent'],
   },
 ]
 


### PR DESCRIPTION
## Summary

Installs that were set up before the `claude` → `hermes` rename (pre-v2.0) may have their git remotes named `claude-workspace` and `claude-agent` rather than the current `hermes-workspace` / `hermes-agent` names. Without these aliases the update checker misidentifies the remote and the Update Center shows a misleading "Remote URL does not match expected repo" error even though the install is perfectly healthy.

## Changes

Adds `claude-workspace` and `claude-agent` as backward-compatible aliases in `UPDATE_REMOTE_DEFINITIONS` so both old and new remote naming conventions are recognised.

No behaviour change for new installs — the new names are still matched first.

## Test Plan
- [ ] Update Center shows correct status on a new install (hermes-workspace/hermes-agent remotes)
- [ ] Update Center shows correct status on a legacy install (claude-workspace/claude-agent remotes)
- [ ] Existing `remoteUrlMatchesExpectedRepo` unit tests still pass
