### PR TITLE
fix: harden workspace swarm prompt submission

### DIFF
--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -8,7 +8,7 @@ import { isAuthenticated } from '../../server/auth-middleware'
 import { newestCheckpointFromMessages, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
 import { createOrUpdateMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
-import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
+import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
 import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 
@@ -644,9 +644,11 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
     }
   }
 
-  // Give the TUI a beat to ingest the paste before submitting. Some workers
-  // render slower and otherwise keep the pasted text sitting at the prompt.
-  await sleep(120)
+  // Give the TUI enough time to ingest the paste before submitting. The Hermes
+  // prompt can visually contain the pasted text before prompt_toolkit is ready
+  // to accept Enter; sending a confirmation Enter shortly after the first one
+  // prevents the user-visible failure mode where the task sits at the prompt.
+  await sleep(2000)
   const enter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
   if (!enter.ok) {
     return {
@@ -654,6 +656,19 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
       ok: false,
       output: '',
       error: enter.error,
+      durationMs: Date.now() - startedAt,
+      exitCode: null,
+      delivery: 'tmux',
+    }
+  }
+  await sleep(1000)
+  const confirmEnter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
+  if (!confirmEnter.ok) {
+    return {
+      workerId,
+      ok: false,
+      output: '',
+      error: confirmEnter.error,
       durationMs: Date.now() - startedAt,
       exitCode: null,
       delivery: 'tmux',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,9 +46,11 @@ function resolveClaudeAgentDir(env: Record<string, string>): string | null {
   return null
 }
 
-/** Find the `claude` CLI binary installed by Nous's installer. */
+/** Find the Hermes CLI binary used to start the local gateway. */
 function resolveClaudeBinary(): string | null {
   const candidates = [
+    process.env.HERMES_CLI_BIN || '',
+    resolve(os.homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
     resolve(os.homedir(), '.claude', 'bin', 'claude'),
     resolve(os.homedir(), '.local', 'bin', 'claude'),
   ]


### PR DESCRIPTION
Follow-up to #302.

## What changed
- Prefer Hermes CLI path in Vite runtime resolution.
- Wait longer after tmux paste before submitting to Hermes TUI.
- Send a confirmation Enter to prevent prompts sitting visibly in the input without executing.

## Verification
- corepack pnpm vitest run src/routes/api/-swarm-dispatch.test.ts --reporter=dot
- corepack pnpm run build
- launchd Workspace restart
- /api/ping 200
- /api/swarm-health 200
- live tmux swarm dispatch auto-submitted; no recent spawn hermes/tmux ENOENT in Workspace logs