### PR TITLE
fix: allow workspace production server to start

### DIFF
--- a/server-entry.js
+++ b/server-entry.js
@@ -68,21 +68,6 @@ if (isNonLoopbackHost(host)) {
         '  Add COOKIE_SECURE=0 to your .env to fix this.  See #149.\n',
     )
   }
-
-  // Warn when serving over plain HTTP with a password: NODE_ENV=production
-  // sets the Secure flag on session cookies, which browsers silently drop
-  // over http://.  Operators must set COOKIE_SECURE=0 for plain-HTTP LAN
-  // deployments.  See #149.
-  const cookieSecureOverride = (process.env.COOKIE_SECURE || '').trim().toLowerCase()
-  const cookieSecureExplicit = cookieSecureOverride === '0' || cookieSecureOverride === 'false' || cookieSecureOverride === 'no'
-  if (!cookieSecureExplicit && process.env.NODE_ENV === 'production') {
-    console.warn(
-      '\n[workspace] warning: plain-HTTP LAN deployment detected.\n' +
-        '  NODE_ENV=production enables the Secure flag on session cookies.\n' +
-        '  Browsers silently drop Secure cookies over http://, so login will fail.\n' +
-        '  Add COOKIE_SECURE=0 to your .env to fix this.  See #149.\n',
-    )
-  }
 }
 
 const MIME_TYPES = {


### PR DESCRIPTION
## Summary
- Remove a duplicate `cookieSecureOverride` declaration in `server-entry.js`.
- This lets the static/production Workspace server start cleanly instead of throwing a syntax error.

## Why
Jarno's local launchd Workspace was running the Vite dev server, which caused periodic HMR/page reloads in the UI. Switching launchd to the static production server exposed this duplicate declaration. Removing it makes production launchd viable and avoids the recurring dev-server refresh loop.

## Verification
- `node --check server-entry.js`
- Local launchd switched to `NODE_ENV=production` + `pnpm exec node server-entry.js`
- `GET http://127.0.0.1:3000/api/ping` returns 200
- `GET http://127.0.0.1:3000/api/swarm-health` returns 200
- Browser stayed on the same navigation for ~3 minutes, `navCount=1`
- Workspace log after static start has 0 Vite/HMR/page-reload markers