### PR TITLE
fix(chat): preserve workspace session identity during streams

### DIFF
--- a/src/screens/chat/hooks/use-streaming-message.test.ts
+++ b/src/screens/chat/hooks/use-streaming-message.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { shouldResolveStreamSession } from './use-streaming-message'
+
+describe('shouldResolveStreamSession', () => {
+  it('does not promote backend api session ids over concrete Workspace sessions', () => {
+    expect(
+      shouldResolveStreamSession({
+        requestedSessionKey: 'api-original-workspace',
+        currentSessionKey: 'api-original-workspace',
+        resolvedSessionKey: 'api-derived-backend',
+      }),
+    ).toBe(false)
+  })
+
+  it('allows bootstrap new chats to resolve once to a concrete session', () => {
+    expect(
+      shouldResolveStreamSession({
+        requestedSessionKey: 'new',
+        currentSessionKey: 'new',
+        resolvedSessionKey: 'api-created-session',
+      }),
+    ).toBe(true)
+  })
+
+  it('allows bootstrap main chats to resolve to an existing concrete session', () => {
+    expect(
+      shouldResolveStreamSession({
+        requestedSessionKey: 'main',
+        currentSessionKey: 'main',
+        resolvedSessionKey: 'existing-main-session',
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -4,6 +4,30 @@ import { readResolvedSessionHeaders } from '@/lib/send-stream-session-headers'
 import { useChatStore } from '@/stores/chat-store'
 import { pushActivity } from '@/components/inspector/activity-store'
 
+/**
+ * Determine whether a stream-resolved session key change should trigger
+ * onSessionResolved (which navigates the route). Only bootstrap keys
+ * ("new", "main") should promote a backend-returned session ID to the
+ * Workspace route identity. Concrete sessions must never be overridden
+ * by a backend-derived api-* ID — that causes session splits (#297).
+ */
+export function shouldResolveStreamSession({
+  requestedSessionKey,
+  currentSessionKey,
+  resolvedSessionKey,
+}: {
+  requestedSessionKey: string
+  currentSessionKey: string
+  resolvedSessionKey: string
+}): boolean {
+  // No change → nothing to resolve
+  if (resolvedSessionKey === currentSessionKey) return false
+  // Bootstrap keys (new, main) should resolve once to a concrete session
+  if (requestedSessionKey === 'new' || requestedSessionKey === 'main') return true
+  // Concrete session → never promote a different backend ID
+  return false
+}
+
 type StreamingState = {
   isStreaming: boolean
   streamingMessageId: string | null
@@ -109,6 +133,11 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
   const lastActivityAtRef = useRef<number | null>(null)
   const handoffTimerRef = useRef<number | null>(null)
   const stepUsageRef = useRef<StepUsagePayload>({})
+  // Captures the sessionKey the caller requested at stream-start time so
+  // SSE `started` events can decide whether a backend-returned session ID
+  // should be promoted to the route identity. Prevents concrete sessions
+  // from being overridden by api-* derivations (#297).
+  const requestedSessionKeyRef = useRef<string>('')
 
   const registerSendStreamRun = useChatStore((s) => s.registerSendStreamRun)
   const unregisterSendStreamRun = useChatStore((s) => s.unregisterSendStreamRun)
@@ -436,11 +465,21 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
               ? payload.friendlyId.trim()
               : resolvedSessionKey
           if (resolvedSessionKey !== activeSessionKeyRef.current) {
-            activeSessionKeyRef.current = resolvedSessionKey
-            onSessionResolved?.({
-              sessionKey: resolvedSessionKey,
-              friendlyId: resolvedFriendlyId,
-            })
+            // Guard: only promote backend session IDs for bootstrap keys.
+            // Concrete Workspace sessions must never be overridden (#297).
+            if (
+              shouldResolveStreamSession({
+                requestedSessionKey: requestedSessionKeyRef.current,
+                currentSessionKey: activeSessionKeyRef.current,
+                resolvedSessionKey,
+              })
+            ) {
+              activeSessionKeyRef.current = resolvedSessionKey
+              onSessionResolved?.({
+                sessionKey: resolvedSessionKey,
+                friendlyId: resolvedFriendlyId,
+              })
+            }
           }
           // Register runId so chat-events skips duplicate chunks for this run
           const runId = payload.runId as string | undefined
@@ -787,6 +826,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       finishedRef.current = false
       resetActiveStreamState(params.sessionKey)
       lifecyclePhaseRef.current = 'requesting'
+      requestedSessionKeyRef.current = params.sessionKey
 
       // Bump the generation token so any chunks the previous stream had
       // already buffered but not yet dispatched (after our abort() call)
@@ -839,11 +879,22 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         const resolvedSessionKey = resolvedHeaders.sessionKey
         const resolvedFriendlyId = resolvedHeaders.friendlyId
         if (resolvedSessionKey !== activeSessionKeyRef.current) {
-          activeSessionKeyRef.current = resolvedSessionKey
-          onSessionResolved?.({
-            sessionKey: resolvedSessionKey,
-            friendlyId: resolvedFriendlyId,
-          })
+          // Only promote a backend-returned session ID when the original
+          // request was a bootstrap key ("new"/"main"). Concrete Workspace
+          // sessions must never be overridden — that causes splits (#297).
+          if (
+            shouldResolveStreamSession({
+              requestedSessionKey: params.sessionKey,
+              currentSessionKey: activeSessionKeyRef.current,
+              resolvedSessionKey,
+            })
+          ) {
+            activeSessionKeyRef.current = resolvedSessionKey
+            onSessionResolved?.({
+              sessionKey: resolvedSessionKey,
+              friendlyId: resolvedFriendlyId,
+            })
+          }
         }
 
         markAccepted()


### PR DESCRIPTION
## Summary
- Prevent backend-derived stream session IDs from replacing concrete Workspace chat route identities
- Allow session resolution only for bootstrap chats (`new` / `main`)
- Add regression coverage for concrete-session, `new`, and `main` resolution behavior

## Why
Workspace can receive a backend/API-server `api-*` session ID in stream headers or `started` SSE events. Promoting that backend ID into the Workspace route can navigate away from the user's active chat and trigger the navigation stream-cancel guard, splitting one logical conversation across multiple visible chat sessions.

This keeps Workspace's route identity authoritative once a concrete session is active, while preserving the existing first-resolution flow for `/chat/new` and `/chat/main`.

## Test Plan
- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm vitest run src/screens/chat/hooks/use-streaming-message.test.ts`
- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm vitest run` *(existing unrelated failures remain in markdown math, gateway-capabilities env, swarm2, context-usage, and chat-message-list tests; new test passes)*
