### PR TITLE
fix: normalize job deliver field from array to string

### DIFF
--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -170,10 +170,20 @@ export async function createJob(input: {
   skills?: Array<string>
   repeat?: number
 }): Promise<ClaudeJob> {
+  // Normalize deliver: backend expects a string, but the form sends an array
+  const normalizedDeliver = Array.isArray(input.deliver)
+    ? input.deliver.join(',')
+    : input.deliver
+
+  const payload = {
+    ...input,
+    ...(normalizedDeliver !== undefined ? { deliver: normalizedDeliver } : {}),
+  }
+
   const res = await fetch(CLAUDE_API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    body: JSON.stringify(payload),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))


### PR DESCRIPTION
## Problem

When creating a job through the Workspace UI, the form sends the `deliver` field as a `string[]` (e.g. `["local", "telegram"]`), but the Hermes Agent backend `CronJobCreate` Pydantic model expects a plain `str`. This causes a validation error:

```
Input should be a valid string
```

Fixes #312

## Root Cause

The `CreateJobDialog` component collects delivery options as an array (`DELIVERY_OPTIONS = ["local", "telegram", "discord"]`), and `handleFormSubmit` passes `deliver: form.deliver` directly. The `createJob()` function in `jobs-api.ts` then JSON-stringifies this array and POSTs it. The backend rejects `["local"]` for a `str`-typed field.

## Fix

Normalize the `deliver` array into a comma-separated string in `createJob()` (`src/lib/jobs-api.ts`) before sending to the API. This keeps the UI working with arrays while the backend receives the string format it expects.

## Testing

- Create a job via the UI with one or more delivery options selected
- Verify the POST body sends `deliver: "local"` or `deliver: "local,telegram"` instead of `deliver: ["local"]`
- Verify the job is created without validation errors