### PR TITLE
fix(swarm): verify tmux session survived startup before dispatching

### DIFF
--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -575,6 +575,29 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
 
   // Give the agent a moment to render its prompt before sending keys.
   await sleep(1200)
+
+  // Verify the session survived startup — if hermes exits immediately (bad PATH,
+  // missing API key, model not configured, etc.) the tmux session dies and all
+  // subsequent send-keys/paste-buffer calls would fail with "can't find pane".
+  // Surfacing the actual exit output here is much more helpful than propagating
+  // tmux's cryptic pane-not-found error downstream.
+  if (!(await tmuxHasSession(tmuxBin, sessionName))) {
+    // Try to capture whatever the pane printed before dying.
+    const captured = await execFileAsync(tmuxBin, [
+      'capture-pane',
+      '-t', sessionName,
+      '-p',
+      '-S', '-50',
+    ], 3_000)
+    const lastLines = (captured.ok ? captured.stdout : '').trim().slice(-800)
+    return {
+      ok: false,
+      error: lastLines
+        ? `Session ${sessionName} exited immediately. Last output:\n${lastLines}`
+        : `Session ${sessionName} exited immediately — agent binary may not be in PATH or failed to start`,
+    }
+  }
+
   return { ok: true, tmuxBin, sessionName }
 }
 


### PR DESCRIPTION
## Problem

Swarm workers immediately enter a blocked state with `cant find pane: swarm-X` even when tmux is installed and accessible. Multiple users affected (#244) with tmux 3.6a+ confirmed working.

Addresses #244

## Root Cause

When `ensureLiveTmuxSession` creates a tmux session with `tmux new-session -d -s swarm-X ... hermes chat --tui`, the hermes binary may exit immediately inside the tmux session (wrong PATH, missing venv, no API key configured, model not found, etc.). Since hermes was the session's only process, the tmux session dies.

The dispatch code then does a blind 1200ms sleep and returns `{ ok: true }` without checking whether the session is still alive. All subsequent `send-keys` and `paste-buffer` calls fail with tmux's native `cant find pane: swarm-X` error, which propagates as the blocker message — completely hiding the real reason the agent failed to start.

## Fix

After the startup sleep, re-check that the tmux session still exists using `tmuxHasSession`. If the session died:

1. Attempt `tmux capture-pane -t swarm-X -p -S -50` to grab whatever the agent printed before exiting
2. Return `{ ok: false, error: "Session swarm-X exited immediately. Last output:\n..." }` with the captured output

This surfaces the actual failure (e.g. `command not found: hermes`, `API key not set`, `model not available`) instead of tmux's cryptic pane-not-found message.

## Note

This is a **diagnostic improvement**, not a complete fix. The underlying reasons why hermes fails to start in the worker's tmux session vary per user (PATH issues, missing config, wrong binary). But this change transforms an opaque "can't find pane" blocker into an actionable error message that users (and we) can actually debug.

## Testing

- Tested by temporarily setting `resolveHermesBin()` to return a non-existent path → session exits immediately → error shows "exited immediately — agent binary may not be in PATH" instead of "can't find pane"
- Normal case (hermes starts successfully) is unchanged — the session survives the 1200ms sleep and the check passes