### PR TITLE
fix: fall back when conductor dashboard API is unavailable

### DIFF
--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -134,8 +134,15 @@ export const Route = createFileRoute('/api/conductor-spawn')({
         if (!missionId) return json({ ok: false, error: 'missionId required' }, { status: 400 })
 
         const capabilities = await ensureGatewayProbed()
-        if (!capabilities.dashboard.available) {
-          return json({ ok: false, error: 'Hermes dashboard API is unavailable' }, { status: 503 })
+        if (!capabilities.conductor) {
+          return json(
+            {
+              ok: false,
+              error:
+                'Conductor dashboard mode is unavailable on this Hermes Agent build. Update Hermes Workspace to use portable mode for mission execution, or run a backend that exposes /api/conductor/missions.',
+            },
+            { status: 501 },
+          )
         }
 
         const res = await dashboardFetch(`/api/conductor/missions/${encodeURIComponent(missionId)}?lines=${lines}`)
@@ -177,7 +184,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           const missionName = `conductor-${Date.now()}`
           const capabilities = await ensureGatewayProbed()
 
-          if (!capabilities.dashboard.available) {
+          if (!capabilities.conductor) {
             return json({
               ok: true,
               mode: 'portable',


### PR DESCRIPTION
## Summary
- gate Conductor dashboard-mode spawn on the dedicated `conductor` capability instead of generic dashboard availability
- fall back to portable mode when the backend dashboard is present but `/api/conductor/missions` is not supported
- return a clearer unsupported response for mission polling when conductor dashboard mode is unavailable

## Root cause
Workspace was using `dashboard.available` as the spawn gate in `/api/conductor-spawn`. On upstream Hermes Agent installs, the dashboard service may exist without the Conductor mission API. That caused Workspace to attempt dashboard mission creation anyway, which then failed with `405 Method Not Allowed` from `/api/conductor/missions`.

## Validation
- verified route diff manually
- confirmed behavior change is isolated to `src/routes/api/conductor-spawn.ts`
- attempted targeted vitest run, but there is currently no dedicated test file for this route in the repo

Closes #313.