### PR TITLE
fix: return complete enhanced gateway capabilities

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -896,6 +896,8 @@ export function getEnhancedCapabilities(): EnhancedCapabilities {
     jobs: capabilities.jobs,
     mcp: capabilities.mcp,
     mcpFallback: capabilities.mcpFallback,
+    conductor: capabilities.conductor,
+    kanban: capabilities.kanban,
   }
 }
 


### PR DESCRIPTION
## Summary
- include the newer enhanced capability fields in `getEnhancedCapabilities()`
- keep the exported capability snapshot aligned with the runtime probe state
- avoid UI/probe desync around gateway feature availability

## Root cause
The runtime probe tracks newer enhanced capabilities such as `conductor` and `kanban`, but `getEnhancedCapabilities()` was still returning the older subset. That made the exported capability object incomplete and could desynchronize downstream UI logic from the actual probed backend state. In issue #275, that mismatch lined up with the remaining false-positive behavior after the earlier reconnect/probe fixes.

## Validation
- verified the diff is isolated to `src/server/gateway-capabilities.ts`
- confirmed the missing fields are part of `EnhancedCapabilities` and runtime `capabilities` state
- no unrelated file changes included

Closes #275.