### PR TITLE
Resolve workspace update stashes

### DIFF
--- a/docs/swarm/ROLES.md
+++ b/docs/swarm/ROLES.md
@@ -45,7 +45,7 @@ Default skills:
 - `swarm-review-learning-loop`
 - `self-improvement`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 
@@ -110,7 +110,7 @@ Default skills:
 - `byte-verified-code-review`
 - `swarm-review-learning-loop`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 
@@ -173,7 +173,7 @@ Default skills:
 - `pc1-ollama-gguf-bench`
 - `swarm-bench-worker`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 
@@ -259,7 +259,7 @@ Default skills:
 
 - `swarm-worker-core`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 
@@ -289,7 +289,7 @@ Default skills:
 - `swarm-worker-core`
 - `byte-verified-code-review`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 
@@ -318,7 +318,7 @@ Default skills:
 - `claude-promo`
 - `songwriting-and-ai-music`
 
-Default model: GPT-5.4
+Default model: GPT-5.5
 
 When to use:
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-provid
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
+import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
@@ -487,6 +488,11 @@ const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   path: '/api/gateway-status',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiGatewayReprobeRoute = ApiGatewayReprobeRouteImport.update({
+  id: '/api/gateway-reprobe',
+  path: '/api/gateway-reprobe',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiFilesRoute = ApiFilesRouteImport.update({
   id: '/api/files',
   path: '/api/files',
@@ -836,6 +842,7 @@ export interface FileRoutesByFullPath {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -968,6 +975,7 @@ export interface FileRoutesByTo {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -1102,6 +1110,7 @@ export interface FileRoutesById {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -1237,6 +1246,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1369,6 +1379,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1502,6 +1513,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1636,6 +1648,7 @@ export interface RootRouteChildren {
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
+  ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
@@ -2191,6 +2204,13 @@ declare module '@tanstack/react-router' {
       path: '/api/gateway-status'
       fullPath: '/api/gateway-status'
       preLoaderRoute: typeof ApiGatewayStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/gateway-reprobe': {
+      id: '/api/gateway-reprobe'
+      path: '/api/gateway-reprobe'
+      fullPath: '/api/gateway-reprobe'
+      preLoaderRoute: typeof ApiGatewayReprobeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/files': {
@@ -2826,6 +2846,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewStatusRoute: ApiCrewStatusRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
+  ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -467,8 +467,9 @@ const config = defineConfig(({ mode, command }) => {
       ],
     },
     server: {
-      // Force IPv4 — 'localhost' resolves to ::1 (IPv6) on Windows, breaking connectivity
-      host: '0.0.0.0',
+      // Bind to loopback by default for local safety. Operators who need LAN,
+      // Tailscale, or container exposure can opt in explicitly with HOST=0.0.0.0.
+      host: process.env.HOST || '127.0.0.1',
       // Port precedence:
       //   1. --port CLI flag (wins, but we no longer hardcode it in package.json)
       //   2. $PORT env var (for containers, reverse proxies, WhatsApp bridge collisions, etc. — see #96)


### PR DESCRIPTION
## Summary
- Regenerate TanStack route tree for the existing `/api/gateway-reprobe` route.
- Respect `HOST` for Vite dev-server binding, defaulting to loopback for local safety.
- Update swarm role default-model docs from GPT-5.4 to GPT-5.5.

## Verification
- `pnpm build` passed.
- `pnpm exec eslint vite.config.ts src/router-route-resolution.test.ts` completed with 0 errors; vite.config.ts is ignored by ESLint config.
- `pnpm test` currently has unrelated pre-existing failures in kanban/models/gateway-capabilities/i18n/context/chat/swarm/profile tests; `src/router-route-resolution.test.ts` passed in that run.
