### PR TITLE
feat: add VITE_HERMESWORLD_ENABLED env var to optionally hide HermesWorld link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,10 @@
 # ═════════════════════════════════════════════════════════════════
 # HermesWorld (multiplayer hub + online chip)
 # ═════════════════════════════════════════════════════════════════
+# Set to 0 to hide the "HermesWorld" link in the sidebar.
+# Default is enabled (1).
+# VITE_HERMESWORLD_ENABLED=1
+
 # When set, HermesWorld tabs on different devices/networks meet on the hub.
 # Without these, multiplayer falls back to BroadcastChannel (same-browser only).
 # Public hosted Cloudflare Worker hub:

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -1033,7 +1033,9 @@ function ChatSidebarComponent({
       )}
 
       {/* ── HermesWorld featured link (gold castle, NEW badge) ────── */}
-      {!isVisuallyCollapsed && (
+      {/* Hide when VITE_HERMESWORLD_ENABLED is explicitly '0' */}
+      {!isVisuallyCollapsed &&
+        (import.meta as any).env?.VITE_HERMESWORLD_ENABLED !== '0' && (
         <div className="px-2 pb-2">
           <Link
             to="/playground"


### PR DESCRIPTION
## What

Adds an opt-out for the HermesWorld sidebar link via `VITE_HERMESWORLD_ENABLED=0` in `.env`.

## Why

Not everyone wants gamification/playground links in their workspace sidebar. This gives operators a clean way to disable it without forking or patching.

## Changes

- **`src/screens/chat/components/chat-sidebar.tsx`** — Gate the HermesWorld link behind `VITE_HERMESWORLD_ENABLED !== '0'`
- **`.env.example`** — Document the new env var with default (enabled)

## Behavior

| Setting | Result |
|---|---|
| Unset or `1` | HermesWorld link visible (default) |
| `0` | HermesWorld link hidden |

Backwards compatible — no breaking changes.