### PR TITLE
Remove  Duplicate HTTP cookie security warnings

### DIFF
--- a/server-entry.js
+++ b/server-entry.js
@@ -54,20 +54,6 @@ if (isNonLoopbackHost(host)) {
     )
   }
 
-  // Warn when serving over plain HTTP with a password: NODE_ENV=production
-  // sets the Secure flag on session cookies, which browsers silently drop
-  // over http://.  Operators must set COOKIE_SECURE=0 for plain-HTTP LAN
-  // deployments.  See #149.
-  const cookieSecureOverride = (process.env.COOKIE_SECURE || '').trim().toLowerCase()
-  const cookieSecureExplicit = cookieSecureOverride === '0' || cookieSecureOverride === 'false' || cookieSecureOverride === 'no'
-  if (!cookieSecureExplicit && process.env.NODE_ENV === 'production') {
-    console.warn(
-      '\n[workspace] warning: plain-HTTP LAN deployment detected.\n' +
-        '  NODE_ENV=production enables the Secure flag on session cookies.\n' +
-        '  Browsers silently drop Secure cookies over http://, so login will fail.\n' +
-        '  Add COOKIE_SECURE=0 to your .env to fix this.  See #149.\n',
-    )
-  }
 
   // Warn when serving over plain HTTP with a password: NODE_ENV=production
   // sets the Secure flag on session cookies, which browsers silently drop


### PR DESCRIPTION
Removed Duplicate warnings related to plain HTTP deployments and cookie security.