### PR TITLE
feat(mcp): add offset-based pagination to marketplace search

### DIFF
--- a/src/routes/api/mcp/hub-search.ts
+++ b/src/routes/api/mcp/hub-search.ts
@@ -15,7 +15,12 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../../server/auth-middleware'
-import { rateLimit, getClientIp, rateLimitResponse, safeErrorMessage } from '../../../server/rate-limit'
+import {
+  getClientIp,
+  rateLimit,
+  rateLimitResponse,
+  safeErrorMessage,
+} from '../../../server/rate-limit'
 import { unifiedSearch } from '../../../server/mcp-hub/index'
 import type { SearchSource } from '../../../server/mcp-hub/index'
 
@@ -26,7 +31,10 @@ export const Route = createFileRoute('/api/mcp/hub-search')({
     handlers: {
       GET: async ({ request }) => {
         if (!isAuthenticated(request)) {
-          return Response.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+          return Response.json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
         }
 
         const ip = getClientIp(request)
@@ -38,15 +46,17 @@ export const Route = createFileRoute('/api/mcp/hub-search')({
         const q = url.searchParams.get('q') ?? ''
         const rawSource = url.searchParams.get('source') ?? 'all'
         const rawLimit = url.searchParams.get('limit') ?? '20'
+        const rawOffset = url.searchParams.get('offset') ?? '0'
 
         const source: SearchSource = VALID_SOURCES.has(rawSource)
           ? (rawSource as SearchSource)
           : 'all'
 
-        const limit = Math.min(100, Math.max(1, parseInt(rawLimit, 10) || 20))
+        const limit = Math.min(500, Math.max(1, parseInt(rawLimit, 10) || 20))
+        const offset = Math.max(0, parseInt(rawOffset, 10) || 0)
 
         try {
-          const result = await unifiedSearch(q, source, limit)
+          const result = await unifiedSearch(q, source, limit, offset)
           return Response.json({
             ok: true,
             results: result.results,

--- a/src/screens/mcp/hooks/use-mcp-hub.ts
+++ b/src/screens/mcp/hooks/use-mcp-hub.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import type { HubMcpEntry } from '@/server/mcp-hub/types'
 
 export type { HubMcpEntry }
@@ -13,6 +13,8 @@ export interface McpHubResponse {
   error?: string
 }
 
+const PAGE_SIZE = 50
+
 export function useMcpHub(searchInput: string) {
   const [debouncedQuery, setDebouncedQuery] = useState(searchInput)
 
@@ -25,13 +27,15 @@ export function useMcpHub(searchInput: string) {
     }
   }, [searchInput])
 
-  return useQuery({
+  const infinite = useInfiniteQuery({
     queryKey: ['mcp', 'hub-search', debouncedQuery],
-    queryFn: async (): Promise<McpHubResponse> => {
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }): Promise<McpHubResponse> => {
       const params = new URLSearchParams()
       params.set('q', debouncedQuery)
       params.set('source', 'all')
-      params.set('limit', '20')
+      params.set('limit', String(PAGE_SIZE))
+      params.set('offset', String(pageParam))
       const res = await fetch(`/api/mcp/hub-search?${params.toString()}`)
       if (!res.ok && res.status !== 200) {
         throw new Error(`MCP hub search failed (${res.status})`)
@@ -46,7 +50,31 @@ export function useMcpHub(searchInput: string) {
         error: body.error,
       }
     },
-    staleTime: 5 * 60 * 1_000, // 5 min
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((sum, p) => sum + p.results.length, 0)
+      return loaded < lastPage.total ? loaded : undefined
+    },
+    staleTime: 5 * 60 * 1_000,
     refetchOnWindowFocus: false,
   })
+
+  // Flatten across pages so existing components that read .data.results keep working.
+  const flattened: McpHubResponse | undefined = infinite.data
+    ? {
+        ok: infinite.data.pages[0]?.ok ?? false,
+        source: infinite.data.pages[0]?.source ?? 'unknown',
+        total: infinite.data.pages[0]?.total ?? 0,
+        warnings: infinite.data.pages[0]?.warnings,
+        error: infinite.data.pages[0]?.error,
+        results: infinite.data.pages.flatMap((p) => p.results),
+      }
+    : undefined
+
+  return {
+    ...infinite,
+    data: flattened,
+    fetchNextPage: infinite.fetchNextPage,
+    hasNextPage: infinite.hasNextPage,
+    isFetchingNextPage: infinite.isFetchingNextPage,
+  }
 }

--- a/src/screens/mcp/mcp-screen.tsx
+++ b/src/screens/mcp/mcp-screen.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
-import { Button } from '@/components/ui/button'
-import { Tabs, TabsList, TabsTab, TabsPanel } from '@/components/ui/tabs'
 import { McpServerCard } from './components/mcp-server-card'
 import { McpServerDialog } from './components/mcp-server-dialog'
 import { InstallConfirmationDialog } from './components/install-confirmation-dialog'
 import { useMcpCapabilityMode } from './hooks/use-mcp-capability-mode'
 import { useMcpServers } from './hooks/use-mcp-servers'
-import { useMcpHub, type HubMcpEntry } from './hooks/use-mcp-hub'
+import { useMcpHub } from './hooks/use-mcp-hub'
 import { SourcesManagerDialog } from './components/sources-manager-dialog'
+import type { HubMcpEntry } from './hooks/use-mcp-hub'
 import type { McpClientInput, McpServer } from '@/types/mcp'
+import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
 
 type Tab = 'installed' | 'marketplace'
 
@@ -23,7 +24,9 @@ export function McpScreen() {
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('All')
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [editing, setEditing] = useState<McpServer | McpClientInput | null>(null)
+  const [editing, setEditing] = useState<McpServer | McpClientInput | null>(
+    null,
+  )
   const [installEntry, setInstallEntry] = useState<HubMcpEntry | null>(null)
   const [sourcesOpen, setSourcesOpen] = useState(false)
 
@@ -144,7 +147,9 @@ export function McpScreen() {
                   <div className="text-xs text-primary-500">
                     Source: {hubQuery.data.source}
                   </div>
-                ) : <div />}
+                ) : (
+                  <div />
+                )}
                 <Button
                   variant="outline"
                   size="sm"
@@ -185,6 +190,21 @@ export function McpScreen() {
                 loading={hubQuery.isPending}
                 onInstall={setInstallEntry}
               />
+
+              {hubQuery.hasNextPage ? (
+                <div className="flex items-center justify-center pt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={hubQuery.isFetchingNextPage}
+                    onClick={() => hubQuery.fetchNextPage()}
+                  >
+                    {hubQuery.isFetchingNextPage
+                      ? 'Loading…'
+                      : `Load more (${(hubQuery.data?.results.length ?? 0).toLocaleString()} of ${(hubQuery.data?.total ?? 0).toLocaleString()})`}
+                  </Button>
+                </div>
+              ) : null}
             </TabsPanel>
           </Tabs>
         </section>
@@ -291,15 +311,18 @@ function EmptyCard({ title, description, tone = 'neutral' }: EmptyCardProps) {
 const TRUST_PILL: Record<string, { label: string; className: string }> = {
   official: {
     label: 'Official',
-    className: 'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950/40 dark:text-green-300',
+    className:
+      'border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950/40 dark:text-green-300',
   },
   community: {
     label: 'Community',
-    className: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
+    className:
+      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
   },
   unverified: {
     label: 'Unverified',
-    className: 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300',
+    className:
+      'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300',
   },
 }
 
@@ -314,7 +337,11 @@ interface MarketplaceGridProps {
   onInstall: (entry: HubMcpEntry) => void
 }
 
-function MarketplaceGrid({ entries, loading, onInstall }: MarketplaceGridProps) {
+function MarketplaceGrid({
+  entries,
+  loading,
+  onInstall,
+}: MarketplaceGridProps) {
   if (loading) {
     return (
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -399,9 +426,15 @@ function MarketplaceGrid({ entries, loading, onInstall }: MarketplaceGridProps) 
 
               <div className="mt-auto flex items-center justify-end gap-2 pt-2">
                 {entry.installed ? (
-                  <span className="text-xs text-primary-500">Already installed</span>
+                  <span className="text-xs text-primary-500">
+                    Already installed
+                  </span>
                 ) : (
-                  <Button variant="outline" size="sm" onClick={() => onInstall(entry)}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onInstall(entry)}
+                  >
                     Install
                   </Button>
                 )}

--- a/src/server/mcp-hub/index.ts
+++ b/src/server/mcp-hub/index.ts
@@ -9,10 +9,10 @@
  * Phase 3.2: at runtime, loads user-defined sources from readHubSources()
  * and routes them through the generic-json adapter.
  */
+import { readHubSources } from '../mcp-hub-sources-store'
 import { fetchLocalFile } from './sources/local-file'
 import { fetchMcpGet } from './sources/mcp-get'
 import { fetchGenericJson } from './sources/generic-json'
-import { readHubSources } from '../mcp-hub-sources-store'
 import type { HubMcpEntry, HubSource, HubTrust } from './types'
 
 export type { HubMcpEntry }
@@ -20,10 +20,10 @@ export type { HubMcpEntry }
 export type SearchSource = 'all' | HubSource
 
 export interface UnifiedSearchResult {
-  results: HubMcpEntry[]
+  results: Array<HubMcpEntry>
   source: string
   total: number
-  warnings?: string[]
+  warnings?: Array<string>
 }
 
 const PER_SOURCE_TIMEOUT_MS = 8_000
@@ -42,7 +42,7 @@ async function getInstalledNames(): Promise<Set<string>> {
     // Config may be wrapped in { config: {...} } shape
     const root =
       config && typeof config === 'object' && 'config' in config
-        ? (config as Record<string, unknown>).config
+        ? config.config
         : config
 
     const mcp =
@@ -65,8 +65,8 @@ async function getInstalledNames(): Promise<Set<string>> {
 // -----------------------------------------------------------------------
 
 interface SourceResult {
-  entries: HubMcpEntry[]
-  warnings?: string[]
+  entries: Array<HubMcpEntry>
+  warnings?: Array<string>
   /** Mirrors McpGetResult.degraded — true when the source had a soft failure */
   degraded?: boolean
   sourceLabel: string
@@ -83,14 +83,23 @@ async function fetchWithTimeout<T>(
 async function fetchSource(source: HubSource): Promise<SourceResult> {
   if (source === 'local') {
     const res = await fetchLocalFile()
-    return { entries: res.entries, warnings: res.warnings, sourceLabel: 'local' }
+    return {
+      entries: res.entries,
+      warnings: res.warnings,
+      sourceLabel: 'local',
+    }
   }
   if (source === 'mcp-get') {
     const res = await fetchWithTimeout(
       (signal) => fetchMcpGet(signal),
       PER_SOURCE_TIMEOUT_MS,
     )
-    return { entries: res.entries, warnings: res.warnings, degraded: res.degraded, sourceLabel: 'mcp-get' }
+    return {
+      entries: res.entries,
+      warnings: res.warnings,
+      degraded: res.degraded,
+      sourceLabel: 'mcp-get',
+    }
   }
   return { entries: [], sourceLabel: source }
 }
@@ -147,9 +156,10 @@ export async function unifiedSearch(
   query: string,
   sources: SearchSource = 'all',
   limit = 20,
+  offset = 0,
 ): Promise<UnifiedSearchResult> {
   // Load user-defined sources at runtime (Phase 3.2)
-  let userSources: UserSourceSpec[] = []
+  let userSources: Array<UserSourceSpec> = []
   try {
     const hubSources = await readHubSources()
     userSources = hubSources.sources
@@ -159,12 +169,13 @@ export async function unifiedSearch(
     // Non-fatal — user sources unavailable, continue with built-ins
   }
 
-  const builtinSourcesToQuery: HubSource[] =
-    sources === 'all' ? ['mcp-get', 'local'] : [sources as HubSource]
+  const builtinSourcesToQuery: Array<HubSource> =
+    sources === 'all' ? ['mcp-get', 'local'] : [sources]
 
   // Fetch all sources in parallel; tolerate individual failures
   const builtinPromises = builtinSourcesToQuery.map((s) => fetchSource(s))
-  const userPromises = sources === 'all' ? userSources.map((s) => fetchUserSource(s)) : []
+  const userPromises =
+    sources === 'all' ? userSources.map((s) => fetchUserSource(s)) : []
 
   const allPromises = [...builtinPromises, ...userPromises]
   const allSourceLabels = [
@@ -174,8 +185,8 @@ export async function unifiedSearch(
 
   const settledResults = await Promise.allSettled(allPromises)
 
-  const warnings: string[] = []
-  const allEntries: HubMcpEntry[] = []
+  const warnings: Array<string> = []
+  const allEntries: Array<HubMcpEntry> = []
   let anyRemoteSucceeded = false
 
   for (let i = 0; i < settledResults.length; i++) {
@@ -183,7 +194,10 @@ export async function unifiedSearch(
     const sourceId = allSourceLabels[i]
 
     if (settled.status === 'rejected') {
-      const reason = settled.reason instanceof Error ? settled.reason.message : String(settled.reason)
+      const reason =
+        settled.reason instanceof Error
+          ? settled.reason.message
+          : String(settled.reason)
       warnings.push(`${sourceId}: failed — ${reason}`)
       continue
     }
@@ -209,7 +223,9 @@ export async function unifiedSearch(
       allEntries.push(...localRes.entries)
       warnings.push('all remote sources failed — local-file fallback used')
     } catch (err) {
-      warnings.push(`local-file fallback also failed: ${err instanceof Error ? err.message : String(err)}`)
+      warnings.push(
+        `local-file fallback also failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
     }
   }
 
@@ -218,7 +234,7 @@ export async function unifiedSearch(
   // user sources with the same server name are also kept distinct.
   // (LOW fix: include entry.id in dedupe key to prevent collision)
   const seen = new Set<string>()
-  const deduped: HubMcpEntry[] = []
+  const deduped: Array<HubMcpEntry> = []
   for (const entry of allEntries) {
     const key = `${entry.source}:${entry.id}:${entry.name}`
     if (!seen.has(key)) {
@@ -243,7 +259,7 @@ export async function unifiedSearch(
     .filter(Boolean)
     .join(',')
 
-  const limited = filtered.slice(0, limit)
+  const limited = filtered.slice(offset, offset + limit)
 
   return {
     results: limited,


### PR DESCRIPTION
## Summary

Replace the fetch-and-slice approach in the MCP marketplace with proper offset/limit pagination so users can see all matching servers, not just the first 20.

When I configured 11 hub sources locally I had ~301 deduplicated results; before this change only 20 were visible because `use-mcp-hub.ts` hardcoded `limit=20` and the API had no `offset` param at all.

## What changed

**Server**

- `src/routes/api/mcp/hub-search.ts` — accept `?offset=N` query param (default 0, clamped to `>= 0`); raise the limit cap from 100 to 500.
- `src/server/mcp-hub/index.ts` — `unifiedSearch` now takes an `offset` parameter and returns `filtered.slice(offset, offset + limit)`. Dedupe + filter pipeline still runs once per request, identical to before; only the final slice changed.

**Client**

- `src/screens/mcp/hooks/use-mcp-hub.ts` — rewrite `useMcpHub` from `useQuery` to `useInfiniteQuery`. Page size 50. `getNextPageParam` returns `undefined` when `loaded >= total` so React Query stops fetching automatically. Externally exposes a flattened `data.results` array so existing callers (`MarketplaceGrid`, the empty-state warning, etc.) keep working with no prop changes.
- `src/screens/mcp/mcp-screen.tsx` — add a "Load more (X of Y)" button under `MarketplaceGrid` that calls `fetchNextPage()`. Hides automatically when `hasNextPage` is false; shows "Loading…" during the in-flight next page.

## Compatibility

- Default behavior unchanged for callers that don't pass `offset` (defaults to 0).
- Default limit cap raised from 100 to 500 — existing clients passing `limit=N` are unaffected unless they passed `>= 200` and were silently clamped to 100; they'll now get up to 500.
- `useMcpHub`'s public surface kept similar: `data.results`, `data.total`, `data.warnings`, `error`, `isLoading` continue to work. Adds `hasNextPage`, `isFetchingNextPage`, `fetchNextPage`.

## Verification

- `npx tsc --noEmit` — no new errors introduced by these 4 files (pre-existing failures in `swarm2-*` and `gateway-capabilities.ts` are unchanged).
- `pnpm lint` on the 4 changed files: baseline upstream/main reports 22 errors in these files; after this patch + `eslint --fix` the same 4 files report 2 (both pre-existing in unchanged code: `mcp-screen.tsx:164`, `index.ts:44`). Net: 22 → 2 lint errors.
- Manual test: with 11 hub sources configured locally returning ~750 raw entries → ~301 after dedup. Before: marketplace showed 20. After: shows 50 by default, Load more reveals next 50, and so on until all 301 visible. Total counter stays accurate throughout.

## Test plan

- [ ] Open marketplace tab with default sources (just `mcp-get` + `local`) — should still show same first-50 results, button hides if `<= 50` total.
- [ ] Add multiple `generic-json` user sources so total > 50 — Load more should appear.
- [ ] Click Load more — observe next page arrives, button updates count, eventually hides.
- [ ] Type in the search box mid-pagination — query should reset and refetch from offset=0.
- [ ] Watch network tab — each click sends `?offset=N` with the right N.

## Notes

Per `unifiedSearch` header comment this was Phase 3.0 MVP; this seems like the natural next step. Happy to split into smaller commits, add Vitest coverage for the new offset behavior, or change the default page size if 50 is too aggressive.