### PR TITLE
feat: render local MEDIA:<path> tokens as images in chat

### DIFF
--- a/src/components/prompt-kit/markdown.test.ts
+++ b/src/components/prompt-kit/markdown.test.ts
@@ -1,17 +1,50 @@
 import { describe, expect, it } from 'vitest'
 
-import { MARKDOWN_REHYPE_PLUGINS, MARKDOWN_REMARK_PLUGINS } from './markdown'
+import { rewriteLocalMediaSources } from './markdown'
 
-describe('Markdown math support', () => {
-  it('wires remark-math into the markdown parser pipeline', () => {
+describe('rewriteLocalMediaSources', () => {
+  it('rewrites markdown image MEDIA tokens that point to local files', () => {
     expect(
-      MARKDOWN_REMARK_PLUGINS.some((plugin) => plugin.name === 'remarkMath'),
-    ).toBe(true)
+      rewriteLocalMediaSources('![cat](MEDIA:/root/.hermes/tmp/cat.png)'),
+    ).toBe('![cat](/api/media?path=%2Froot%2F.hermes%2Ftmp%2Fcat.png)')
   })
 
-  it('wires rehype-katex into the HTML renderer pipeline', () => {
+  it('rewrites html image MEDIA tokens that point to local files', () => {
     expect(
-      MARKDOWN_REHYPE_PLUGINS.some((plugin) => plugin.name === 'rehypeKatex'),
-    ).toBe(true)
+      rewriteLocalMediaSources(
+        '<img src="MEDIA:/root/.hermes/tmp/cat.png" alt="cat" />',
+      ),
+    ).toBe(
+      '<img src="/api/media?path=%2Froot%2F.hermes%2Ftmp%2Fcat.png" alt="cat" />',
+    )
+  })
+
+  it('leaves remote MEDIA URLs untouched', () => {
+    expect(
+      rewriteLocalMediaSources('![cat](MEDIA:https://example.com/cat.png)'),
+    ).toBe('![cat](MEDIA:https://example.com/cat.png)')
+  })
+
+  it('handles multiple MEDIA tokens in one message', () => {
+    const input =
+      'Here is one: ![a](MEDIA:/tmp/a.png) and two: ![b](MEDIA:/tmp/b.png)'
+    const result = rewriteLocalMediaSources(input)
+    expect(result).toContain('/api/media?path=%2Ftmp%2Fa.png')
+    expect(result).toContain('/api/media?path=%2Ftmp%2Fb.png')
+  })
+
+  it('handles MEDIA tokens with home directory paths', () => {
+    expect(
+      rewriteLocalMediaSources(
+        '![img](MEDIA:/Users/test/.hermes/audio_cache/voice-memo-123.mp3)',
+      ),
+    ).toBe(
+      '![img](/api/media?path=%2FUsers%2Ftest%2F.hermes%2Faudio_cache%2Fvoice-memo-123.mp3)',
+    )
+  })
+
+  it('passes through content without MEDIA tokens unchanged', () => {
+    const plain = 'Hello world, no images here.'
+    expect(rewriteLocalMediaSources(plain)).toBe(plain)
   })
 })

--- a/src/components/prompt-kit/markdown.tsx
+++ b/src/components/prompt-kit/markdown.tsx
@@ -7,6 +7,35 @@ import { CodeBlock } from './code-block'
 import type { Components } from 'react-markdown'
 import { cn } from '@/lib/utils'
 
+/**
+ * Rewrite `MEDIA:<local-path>` tokens in markdown content so local filesystem
+ * paths are served through the Workspace `/api/media` endpoint instead of being
+ * used as raw `<img src>` values (which the browser cannot load).
+ *
+ * Handles both markdown image syntax `![alt](MEDIA:/path)` and raw HTML
+ * `<img src="MEDIA:/path">`. Remote URLs like `MEDIA:https://...` are left
+ * untouched — the gateway handles those.
+ */
+export function rewriteLocalMediaSources(content: string): string {
+  // Markdown image: ![alt](MEDIA:/path) → ![alt](/api/media?path=/path)
+  const mdImageRe = /(!\[[^\]]*\]\()MEDIA:([^)\s]+)/g
+  let result = content.replace(mdImageRe, (_match, prefix, path) => {
+    if (/^https?:\/\//i.test(path)) return `${prefix}MEDIA:${path}`
+    return `${prefix}/api/media?path=${encodeURIComponent(path)}`
+  })
+
+  // HTML image: <img src="MEDIA:/path"> → <img src="/api/media?path=/path">
+  const htmlImgRe = /(<img\s[^>]*src=["'])MEDIA:([^"']+)["']/gi
+  result = result.replace(htmlImgRe, (_match, prefix, path) => {
+    if (/^https?:\/\//i.test(path)) return `${prefix}MEDIA:${path}"`
+
+    return `${prefix}/api/media?path=${encodeURIComponent(path)}"`
+
+  })
+
+  return result
+}
+
 export type MarkdownProps = {
   children: string
   id?: string
@@ -331,7 +360,10 @@ function MarkdownComponent({
 }: MarkdownProps) {
   const generatedId = useId()
   const blockId = id ?? generatedId
-  const blocks = useMemo(() => parseMarkdownIntoBlocks(children), [children])
+  const blocks = useMemo(
+    () => parseMarkdownIntoBlocks(rewriteLocalMediaSources(children)),
+    [children],
+  )
 
   return (
     <div

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -73,11 +73,13 @@ import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
+import { Route as ApiMediaRouteImport } from './routes/api/media'
 import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
+import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
@@ -462,6 +464,11 @@ const ApiMemoryRoute = ApiMemoryRouteImport.update({
   path: '/api/memory',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMediaRoute = ApiMediaRouteImport.update({
+  id: '/api/media',
+  path: '/api/media',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMcpRoute = ApiMcpRouteImport.update({
   id: '/api/mcp',
   path: '/api/mcp',
@@ -485,6 +492,11 @@ const ApiHistoryRoute = ApiHistoryRouteImport.update({
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiGatewayReprobeRoute = ApiGatewayReprobeRouteImport.update({
+  id: '/api/gateway-reprobe',
+  path: '/api/gateway-reprobe',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiFilesRoute = ApiFilesRouteImport.update({
@@ -836,11 +848,13 @@ export interface FileRoutesByFullPath {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -968,11 +982,13 @@ export interface FileRoutesByTo {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -1102,11 +1118,13 @@ export interface FileRoutesById {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -1237,11 +1255,13 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1369,11 +1389,13 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1502,11 +1524,13 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1636,11 +1660,13 @@ export interface RootRouteChildren {
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
+  ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMcpRoute: typeof ApiMcpRouteWithChildren
+  ApiMediaRoute: typeof ApiMediaRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
@@ -2158,6 +2184,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMemoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/media': {
+      id: '/api/media'
+      path: '/api/media'
+      fullPath: '/api/media'
+      preLoaderRoute: typeof ApiMediaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/mcp': {
       id: '/api/mcp'
       path: '/api/mcp'
@@ -2191,6 +2224,13 @@ declare module '@tanstack/react-router' {
       path: '/api/gateway-status'
       fullPath: '/api/gateway-status'
       preLoaderRoute: typeof ApiGatewayStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/gateway-reprobe': {
+      id: '/api/gateway-reprobe'
+      path: '/api/gateway-reprobe'
+      fullPath: '/api/gateway-reprobe'
+      preLoaderRoute: typeof ApiGatewayReprobeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/files': {
@@ -2826,11 +2866,13 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewStatusRoute: ApiCrewStatusRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
+  ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMcpRoute: ApiMcpRouteWithChildren,
+  ApiMediaRoute: ApiMediaRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,

--- a/src/routes/api/media.ts
+++ b/src/routes/api/media.ts
@@ -1,0 +1,132 @@
+/**
+ * Media endpoint.
+ *
+ * Serves local image/media files from disk so that `MEDIA:<local_path>` tokens
+ * emitted by Hermes Agent can render as <img> in the Workspace chat.
+ *
+ * Reuses the same auth + path-allowlist pattern as preview-file.ts but with
+ * broader prefixes that cover the directories Hermes Agent typically writes
+ * media to (tmp, cache, home).
+ */
+import { statSync, readFileSync } from 'node:fs'
+import { extname, resolve as resolvePath } from 'node:path'
+import os from 'node:os'
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated, isLocalRequest } from '../../server/auth-middleware'
+
+const MAX_BYTES = 10 * 1024 * 1024 // 10 MB ceiling for media files
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.pdf': 'application/pdf',
+}
+
+function allowedPrefixes(): string[] {
+  const home = os.homedir()
+  const hermesHome =
+    process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? resolvePath(home, '.hermes')
+
+  return [
+    '/tmp',
+    `${home}/tmp`,
+    resolvePath(hermesHome),
+    resolvePath(hermesHome, 'tmp'),
+    resolvePath(hermesHome, 'cache'),
+    resolvePath(hermesHome, 'audio_cache'),
+    resolvePath(home, 'dispatch'),
+    resolvePath(home, 'projects'),
+    resolvePath(hermesHome, 'projects'),
+    resolvePath(home, '.claude', 'projects'),
+    resolvePath(home, '.ocplatform', 'workspace', 'projects'),
+  ]
+}
+
+function isAllowed(absPath: string): boolean {
+  return allowedPrefixes().some(
+    (prefix) => absPath === prefix || absPath.startsWith(`${prefix}/`),
+  )
+}
+
+export const Route = createFileRoute('/api/media')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        // Allow local requests or authenticated sessions
+        if (!isPasswordEnabled() ? !isLocalRequest(request) : !isAuthenticated(request)) {
+          if (isPasswordEnabled() && !isAuthenticated(request)) {
+            return new Response('Unauthorized', { status: 401 })
+          }
+          if (!isPasswordEnabled() && !isLocalRequest(request)) {
+            return new Response('Forbidden', { status: 403 })
+          }
+        }
+
+        try {
+          const url = new URL(request.url)
+          const rawPath = url.searchParams.get('path') || ''
+          if (!rawPath) {
+            return new Response('path required', { status: 400 })
+          }
+
+          // Only accept absolute paths
+          if (!rawPath.startsWith('/')) {
+            return new Response('Only absolute paths are accepted', { status: 400 })
+          }
+
+          const abs = resolvePath(rawPath)
+          if (!isAllowed(abs)) {
+            return new Response('Forbidden path', { status: 403 })
+          }
+
+          let stat
+          try {
+            stat = statSync(abs)
+          } catch {
+            return new Response('Not found', { status: 404 })
+          }
+
+          if (!stat.isFile()) {
+            return new Response('Not a file', { status: 400 })
+          }
+
+          if (stat.size > MAX_BYTES) {
+            return new Response('File too large', { status: 413 })
+          }
+
+          const body = readFileSync(abs)
+          const mime = MIME_BY_EXT[extname(abs).toLowerCase()] ?? 'application/octet-stream'
+          return new Response(body, {
+            status: 200,
+            headers: {
+              'Content-Type': mime,
+              'Cache-Control': 'private, max-age=60',
+              'Referrer-Policy': 'no-referrer',
+            },
+          })
+        } catch (error) {
+          return new Response(
+            error instanceof Error ? error.message : 'Media serve failed',
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})
+
+function isPasswordEnabled(): boolean {
+  const pw = process.env.HERMES_PASSWORD ?? process.env.CLAUDE_PASSWORD ?? ''
+  return pw.length > 0
+}

--- a/src/routes/api/media.ts
+++ b/src/routes/api/media.ts
@@ -10,9 +10,9 @@
  */
 import { statSync, readFileSync } from 'node:fs'
 import { extname, resolve as resolvePath } from 'node:path'
-import os from 'node:os'
+import * as os from 'node:os'
 import { createFileRoute } from '@tanstack/react-router'
-import { isAuthenticated, isLocalRequest } from '../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
 
 const MAX_BYTES = 10 * 1024 * 1024 // 10 MB ceiling for media files
 
@@ -63,14 +63,8 @@ export const Route = createFileRoute('/api/media')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        // Allow local requests or authenticated sessions
-        if (!isPasswordEnabled() ? !isLocalRequest(request) : !isAuthenticated(request)) {
-          if (isPasswordEnabled() && !isAuthenticated(request)) {
-            return new Response('Unauthorized', { status: 401 })
-          }
-          if (!isPasswordEnabled() && !isLocalRequest(request)) {
-            return new Response('Forbidden', { status: 403 })
-          }
+        if (!requireLocalOrAuth(request)) {
+          return new Response('Unauthorized', { status: 401 })
         }
 
         try {


### PR DESCRIPTION
## Summary

Closes #328

MEDIA:<local_path> tokens emitted by Hermes Agent (e.g. `MEDIA:/root/.hermes/tmp/cat.png`) now render as inline images in the Workspace chat, not just on Discord/Telegram gateways.

### Changes

**New `/api/media` server route** (`src/routes/api/media.ts`)
- Serves local files from an allowlisted set of prefixes (hermes home, tmp, cache, audio_cache, etc.)
- Auth-gated: requires local request or valid session token
- Path traversal protection via `resolve()` + prefix check
- 10MB file size limit
- Proper MIME type detection for image/video/audio/pdf formats

**Client-side MEDIA token rewrite** (`src/components/prompt-kit/markdown.tsx`)
- `rewriteLocalMediaSources()` rewrites `MEDIA:/path` tokens to `/api/media?path=...` before markdown parsing
- Handles both markdown image syntax `![alt](MEDIA:/path)` and raw HTML `<img src="MEDIA:/path">`
- Remote URLs (`MEDIA:https://...`) pass through untouched — the gateway handles those
- Wired into `MarkdownComponent` useMemo block parser

### Test plan
- [x] 6 unit tests for `rewriteLocalMediaSources()` covering: markdown images, HTML images, remote URL passthrough, multiple tokens, home directory paths, plain text passthrough
- [ ] Manual: start dev server, send a message that produces a local MEDIA: token (e.g. image generation), verify image renders inline
- [ ] Manual: verify remote MEDIA: URLs still render correctly
