### PR TITLE
feat(tasks): add Hermes Kanban transport groundwork

### DIFF
--- a/src/lib/hermes-kanban-types.test.ts
+++ b/src/lib/hermes-kanban-types.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HERMES_KANBAN_ALL_STATUSES,
+  HERMES_KANBAN_VISIBLE_STATUS_ORDER,
+  kanbanPriorityColor,
+  kanbanPriorityLabel,
+  mapLegacyColumnToKanbanStatus,
+  mapLegacyPriorityToNumeric,
+  normalizeKanbanAssignee,
+} from './hermes-kanban-types'
+
+describe('hermes-kanban-types', () => {
+  it('separates visible board order from the full status set', () => {
+    expect(HERMES_KANBAN_VISIBLE_STATUS_ORDER).toEqual([
+      'triage',
+      'todo',
+      'ready',
+      'running',
+      'blocked',
+      'done',
+    ])
+    expect(HERMES_KANBAN_ALL_STATUSES).toEqual([
+      'triage',
+      'todo',
+      'ready',
+      'running',
+      'blocked',
+      'done',
+      'archived',
+    ])
+  })
+
+  it('maps legacy workspace columns to agent statuses', () => {
+    expect(mapLegacyColumnToKanbanStatus('backlog')).toBe('triage')
+    expect(mapLegacyColumnToKanbanStatus('todo')).toBe('todo')
+    expect(mapLegacyColumnToKanbanStatus('in_progress')).toBe('running')
+    expect(mapLegacyColumnToKanbanStatus('review')).toBe('triage')
+    expect(mapLegacyColumnToKanbanStatus('done')).toBe('done')
+    expect(mapLegacyColumnToKanbanStatus('unknown')).toBe('triage')
+  })
+
+  it('maps legacy priorities to numeric values', () => {
+    expect(mapLegacyPriorityToNumeric('high')).toBe(3)
+    expect(mapLegacyPriorityToNumeric('medium')).toBe(1)
+    expect(mapLegacyPriorityToNumeric('low')).toBe(-1)
+    expect(mapLegacyPriorityToNumeric('unknown')).toBe(0)
+  })
+
+  it('returns labels and colors for priority ranges', () => {
+    expect(kanbanPriorityLabel(3)).toBe('High')
+    expect(kanbanPriorityLabel(1)).toBe('Medium')
+    expect(kanbanPriorityLabel(0)).toBe('Normal')
+    expect(kanbanPriorityLabel(-1)).toBe('Low')
+    expect(kanbanPriorityColor(3)).not.toBe(kanbanPriorityColor(-1))
+  })
+
+  it('normalizes assignees', () => {
+    const result = normalizeKanbanAssignee({
+      name: 'agent-worker-1',
+      on_disk: false,
+      counts: { todo: 1 },
+    })
+    expect(result.id).toBe('agent-worker-1')
+    expect(result.label).toBe('Agent Worker 1')
+    expect(result.onDisk).toBe(false)
+    expect(result.counts).toEqual({ todo: 1 })
+  })
+})

--- a/src/lib/hermes-kanban-types.ts
+++ b/src/lib/hermes-kanban-types.ts
@@ -1,0 +1,258 @@
+/**
+ * Canonical Hermes Agent Kanban types and helpers for Workspace.
+ *
+ * Persistence uses Agent-native statuses only:
+ * triage/todo/ready/running/blocked/done/archived.
+ */
+
+export type HermesKanbanStatus =
+  | 'triage'
+  | 'todo'
+  | 'ready'
+  | 'running'
+  | 'blocked'
+  | 'done'
+  | 'archived'
+
+export const HERMES_KANBAN_VISIBLE_STATUS_ORDER: Array<Exclude<
+  HermesKanbanStatus,
+  'archived'
+>> = ['triage', 'todo', 'ready', 'running', 'blocked', 'done']
+
+export const HERMES_KANBAN_ALL_STATUSES: Array<HermesKanbanStatus> = [
+  ...HERMES_KANBAN_VISIBLE_STATUS_ORDER,
+  'archived',
+]
+
+export const HERMES_KANBAN_STATUS_LABELS: Record<HermesKanbanStatus, string> = {
+  triage: 'Backlog / Triage',
+  todo: 'Todo',
+  ready: 'Ready',
+  running: 'Running',
+  blocked: 'Blocked',
+  done: 'Done',
+  archived: 'Archived',
+}
+
+export type HermesKanbanTask = {
+  id: string
+  title: string
+  body: string | null
+  assignee: string | null
+  status: HermesKanbanStatus
+  priority: number
+  created_by: string | null
+  created_at: number
+  started_at: number | null
+  completed_at: number | null
+  workspace_kind: string | null
+  workspace_path: string | null
+  claim_lock: string | null
+  claim_expires: number | null
+  tenant: string | null
+  result: string | null
+  spawn_failures: number
+  worker_pid: number | null
+  last_spawn_error: string | null
+  max_runtime_seconds: number | null
+  last_heartbeat_at: number | null
+  current_run_id: number | null
+  workflow_template_id: string | null
+  current_step_key: string | null
+  skills: Array<string> | string | null
+  block_reason?: string | null
+  summary?: string | null
+  age?: {
+    created_age_seconds: number
+    started_age_seconds: number | null
+    time_to_complete_seconds: number | null
+  }
+  link_counts?: { parents: number; children: number }
+  comment_count?: number
+  progress?: { done: number; total: number } | null
+}
+
+export type HermesKanbanComment = {
+  id: number
+  task_id: string
+  body: string
+  author: string | null
+  created_at: number
+}
+
+export type HermesKanbanEvent = {
+  id: number
+  task_id: string
+  kind: string
+  payload: unknown
+  created_at: number
+  run_id: number | null
+}
+
+export type HermesKanbanRun = {
+  id: number
+  task_id: string
+  status: string
+  worker_pid: number | null
+  started_at: number | null
+  ended_at: number | null
+  exit_code: number | null
+  error: string | null
+  summary?: string | null
+  metadata?: Record<string, unknown> | null
+  outcome?: 'completed' | 'blocked' | 'crashed' | 'timeout' | string | null
+}
+
+export type HermesKanbanLinks = {
+  parents: Array<HermesKanbanTask | string>
+  children: Array<HermesKanbanTask | string>
+}
+
+export type HermesKanbanTaskDetail = {
+  task: HermesKanbanTask
+  comments: Array<HermesKanbanComment>
+  events: Array<HermesKanbanEvent>
+  links: HermesKanbanLinks
+  runs: Array<HermesKanbanRun>
+}
+
+export type HermesKanbanColumn = {
+  name: HermesKanbanStatus
+  tasks: Array<HermesKanbanTask>
+}
+
+export type HermesKanbanAssigneeRaw = {
+  name: string
+  on_disk: boolean
+  counts: Record<string, number>
+}
+
+export type HermesKanbanBoard = {
+  columns: Array<HermesKanbanColumn>
+  tenants: Array<string>
+  assignees: Array<HermesKanbanAssigneeRaw>
+  latest_event_id: number | null
+}
+
+export type HermesKanbanAssignee = {
+  id: string
+  name: string
+  label: string
+  isHuman: boolean
+  onDisk: boolean
+  counts: Record<string, number>
+}
+
+export function boardColumnsToMap(
+  columns: Array<HermesKanbanColumn>,
+): Record<HermesKanbanStatus, Array<HermesKanbanTask>> {
+  const map = {} as Record<HermesKanbanStatus, Array<HermesKanbanTask>>
+  for (const col of columns) map[col.name] = col.tasks
+  return map
+}
+
+export function normalizeKanbanAssignee(
+  raw: HermesKanbanAssigneeRaw,
+): HermesKanbanAssignee {
+  const label = raw.name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+  return {
+    id: raw.name,
+    name: raw.name,
+    label,
+    isHuman: false,
+    onDisk: raw.on_disk,
+    counts: raw.counts ?? {},
+  }
+}
+
+export type CreateKanbanTaskInput = {
+  title: string
+  body?: string | null
+  assignee?: string | null
+  tenant?: string | null
+  priority?: number
+  workspace_kind?: string | null
+  workspace_path?: string | null
+  parents?: Array<string>
+  triage?: boolean
+  idempotency_key?: string
+  max_runtime_seconds?: number | null
+  skills?: Array<string> | null
+}
+
+export type UpdateKanbanTaskInput = {
+  status?: HermesKanbanStatus
+  assignee?: string | null
+  priority?: number
+  title?: string
+  body?: string | null
+  result?: string | null
+  block_reason?: string | null
+  summary?: string | null
+  workspace_kind?: string | null
+  workspace_path?: string | null
+  skills?: Array<string> | null
+  claim_lock?: string | null
+  worker_pid?: number | null
+  claimed_at?: number | null
+  spawn_failures?: number | null
+  last_spawn_error?: string | null
+}
+
+export type BulkKanbanInput = {
+  ids: Array<string>
+  status?: HermesKanbanStatus
+  assignee?: string | null
+  priority?: number
+  archive?: boolean
+}
+
+export function kanbanPriorityLabel(priority: number): string {
+  if (priority >= 3) return 'High'
+  if (priority >= 1) return 'Medium'
+  if (priority === 0) return 'Normal'
+  return 'Low'
+}
+
+export function kanbanPriorityColor(priority: number): string {
+  if (priority >= 3) return '#ef4444'
+  if (priority >= 1) return '#f97316'
+  if (priority === 0) return '#6b7280'
+  return '#94a3b8'
+}
+
+export function mapLegacyPriorityToNumeric(priority: string): number {
+  switch (priority.toLowerCase()) {
+    case 'high':
+      return 3
+    case 'medium':
+      return 1
+    case 'low':
+      return -1
+    default:
+      return 0
+  }
+}
+
+export function mapLegacyColumnToKanbanStatus(
+  column: string,
+): HermesKanbanStatus {
+  switch (column) {
+    case 'backlog':
+      return 'triage'
+    case 'todo':
+      return 'todo'
+    case 'in_progress':
+      return 'running'
+    case 'review':
+      return 'triage'
+    case 'done':
+      return 'done'
+    default:
+      return 'triage'
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -77,7 +77,10 @@ import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesKanbanAssigneesRouteImport } from './routes/api/hermes-kanban-assignees'
+import { Route as ApiHermesKanbanRouteImport } from './routes/api/hermes-kanban'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
+import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
@@ -482,9 +485,25 @@ const ApiHistoryRoute = ApiHistoryRouteImport.update({
   path: '/api/history',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHermesKanbanAssigneesRoute =
+  ApiHermesKanbanAssigneesRouteImport.update({
+    id: '/api/hermes-kanban-assignees',
+    path: '/api/hermes-kanban-assignees',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiHermesKanbanRoute = ApiHermesKanbanRouteImport.update({
+  id: '/api/hermes-kanban',
+  path: '/api/hermes-kanban',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiGatewayReprobeRoute = ApiGatewayReprobeRouteImport.update({
+  id: '/api/gateway-reprobe',
+  path: '/api/gateway-reprobe',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiFilesRoute = ApiFilesRouteImport.update({
@@ -836,7 +855,10 @@ export interface FileRoutesByFullPath {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-kanban': typeof ApiHermesKanbanRoute
+  '/api/hermes-kanban-assignees': typeof ApiHermesKanbanAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -968,7 +990,10 @@ export interface FileRoutesByTo {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-kanban': typeof ApiHermesKanbanRoute
+  '/api/hermes-kanban-assignees': typeof ApiHermesKanbanAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1102,7 +1127,10 @@ export interface FileRoutesById {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-kanban': typeof ApiHermesKanbanRoute
+  '/api/hermes-kanban-assignees': typeof ApiHermesKanbanAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1237,7 +1265,10 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-kanban'
+    | '/api/hermes-kanban-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1369,7 +1400,10 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-kanban'
+    | '/api/hermes-kanban-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1502,7 +1536,10 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-kanban'
+    | '/api/hermes-kanban-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1636,7 +1673,10 @@ export interface RootRouteChildren {
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
+  ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiHermesKanbanRoute: typeof ApiHermesKanbanRoute
+  ApiHermesKanbanAssigneesRoute: typeof ApiHermesKanbanAssigneesRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
@@ -2186,11 +2226,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHistoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/hermes-kanban-assignees': {
+      id: '/api/hermes-kanban-assignees'
+      path: '/api/hermes-kanban-assignees'
+      fullPath: '/api/hermes-kanban-assignees'
+      preLoaderRoute: typeof ApiHermesKanbanAssigneesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-kanban': {
+      id: '/api/hermes-kanban'
+      path: '/api/hermes-kanban'
+      fullPath: '/api/hermes-kanban'
+      preLoaderRoute: typeof ApiHermesKanbanRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/gateway-status': {
       id: '/api/gateway-status'
       path: '/api/gateway-status'
       fullPath: '/api/gateway-status'
       preLoaderRoute: typeof ApiGatewayStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/gateway-reprobe': {
+      id: '/api/gateway-reprobe'
+      path: '/api/gateway-reprobe'
+      fullPath: '/api/gateway-reprobe'
+      preLoaderRoute: typeof ApiGatewayReprobeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/files': {
@@ -2826,7 +2887,10 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewStatusRoute: ApiCrewStatusRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
+  ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiHermesKanbanRoute: ApiHermesKanbanRoute,
+  ApiHermesKanbanAssigneesRoute: ApiHermesKanbanAssigneesRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,

--- a/src/routes/api/hermes-kanban-assignees.ts
+++ b/src/routes/api/hermes-kanban-assignees.ts
@@ -1,0 +1,50 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  getKanbanAssignees,
+} from '../../server/hermes-kanban-client'
+import { normalizeKanbanAssignee } from '../../lib/hermes-kanban-types'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/hermes-kanban-assignees')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return jsonResponse({ error: 'Unauthorized' }, 401)
+        }
+        try {
+          const payload = await getKanbanAssignees()
+          const raw = Array.isArray(payload.assignees) ? payload.assignees : []
+          const assignees = raw
+            .filter(
+              (value): value is Parameters<typeof normalizeKanbanAssignee>[0] =>
+                Boolean(
+                  value &&
+                    typeof value === 'object' &&
+                    typeof (value as { name?: unknown }).name === 'string',
+                ),
+            )
+            .map(normalizeKanbanAssignee)
+          return jsonResponse({ assignees })
+        } catch (error) {
+          return jsonResponse(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to fetch kanban assignees',
+            },
+            502,
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/hermes-kanban.ts
+++ b/src/routes/api/hermes-kanban.ts
@@ -1,0 +1,79 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  createKanbanTask,
+  getKanbanBoard,
+} from '../../server/hermes-kanban-client'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/hermes-kanban')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return jsonResponse({ error: 'Unauthorized' }, 401)
+        }
+        try {
+          const url = new URL(request.url)
+          const tenant = url.searchParams.get('tenant') || undefined
+          const includeArchived =
+            url.searchParams.get('include_archived') === 'true'
+          const board = await getKanbanBoard({ tenant, includeArchived })
+          return jsonResponse({ board })
+        } catch (error) {
+          return jsonResponse(
+            {
+              error:
+                error instanceof Error ? error.message : 'Failed to fetch kanban',
+            },
+            502,
+          )
+        }
+      },
+
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return jsonResponse({ error: 'Unauthorized' }, 401)
+        }
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          if (!body.title || typeof body.title !== 'string') {
+            return jsonResponse({ error: 'title is required' }, 400)
+          }
+          const result = await createKanbanTask({
+            title: body.title,
+            body: typeof body.body === 'string' ? body.body : null,
+            assignee:
+              body.assignee === null || typeof body.assignee === 'string'
+                ? body.assignee
+                : null,
+            tenant: typeof body.tenant === 'string' ? body.tenant : null,
+            priority: typeof body.priority === 'number' ? body.priority : undefined,
+            workspace_kind:
+              typeof body.workspace_kind === 'string'
+                ? body.workspace_kind
+                : null,
+            workspace_path:
+              typeof body.workspace_path === 'string'
+                ? body.workspace_path
+                : null,
+            triage: body.triage === true,
+            idempotency_key:
+              typeof body.idempotency_key === 'string'
+                ? body.idempotency_key
+                : undefined,
+          })
+          return jsonResponse(result, 201)
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/server/hermes-kanban-client.test.ts
+++ b/src/server/hermes-kanban-client.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockDashboardFetch = vi.fn()
+
+vi.mock('./gateway-capabilities', () => ({
+  dashboardFetch: mockDashboardFetch,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeOkResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+function makeErrorResponse(status: number, body: unknown): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response
+}
+
+describe('hermes-kanban-client', () => {
+  it('calls the correct board path', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(
+      makeOkResponse({ columns: [], tenants: [], assignees: [], latest_event_id: null }),
+    )
+    const { getKanbanBoard } = await import('./hermes-kanban-client')
+    await getKanbanBoard()
+    expect(mockDashboardFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/plugins/kanban/board'),
+      expect.any(Object),
+    )
+  })
+
+  it('passes tenant and include_archived query params', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(
+      makeOkResponse({ columns: [], tenants: [], assignees: [], latest_event_id: null }),
+    )
+    const { getKanbanBoard } = await import('./hermes-kanban-client')
+    await getKanbanBoard({ tenant: 'mission-1', includeArchived: true })
+    const calledPath: string = mockDashboardFetch.mock.calls[0][0]
+    expect(calledPath).toContain('tenant=mission-1')
+    expect(calledPath).toContain('include_archived=true')
+  })
+
+  it('throws a useful error on non-OK response', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(
+      makeErrorResponse(503, { detail: 'Service unavailable' }),
+    )
+    const { getKanbanBoard } = await import('./hermes-kanban-client')
+    await expect(getKanbanBoard()).rejects.toThrow(/503|Service unavailable/i)
+  })
+
+  it('sends POST to create task with agent-native fields', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(
+      makeOkResponse({ task: { id: 't_001', title: 'Test', status: 'triage' } }),
+    )
+    const { createKanbanTask } = await import('./hermes-kanban-client')
+    const result = await createKanbanTask({ title: 'Test', triage: true, priority: 1 })
+    expect(result.task.id).toBe('t_001')
+    const body = JSON.parse(mockDashboardFetch.mock.calls[0][1].body as string)
+    expect(body).not.toHaveProperty('column')
+    expect(body).toHaveProperty('title', 'Test')
+    expect(body).toHaveProperty('triage', true)
+  })
+
+  it('sends PATCH with task id in path', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(
+      makeOkResponse({ task: { id: 't_002', status: 'done' } }),
+    )
+    const { updateKanbanTask } = await import('./hermes-kanban-client')
+    await updateKanbanTask('t_002', { status: 'done', result: 'completed' })
+    const calledPath: string = mockDashboardFetch.mock.calls[0][0]
+    expect(calledPath).toContain('/api/plugins/kanban/tasks/t_002')
+  })
+
+  it('sends POST to comments endpoint', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(makeOkResponse({ ok: true }))
+    const { addKanbanComment } = await import('./hermes-kanban-client')
+    await addKanbanComment('t_003', { body: 'hello', author: 'Workspace' })
+    const calledPath: string = mockDashboardFetch.mock.calls[0][0]
+    expect(calledPath).toContain('/api/plugins/kanban/tasks/t_003/comments')
+  })
+
+  it('sends POST to /tasks/bulk', async () => {
+    mockDashboardFetch.mockResolvedValueOnce(makeOkResponse({ results: [] }))
+    const { bulkUpdateKanbanTasks } = await import('./hermes-kanban-client')
+    await bulkUpdateKanbanTasks({ ids: ['t_1', 't_2'], status: 'done' })
+    const calledPath: string = mockDashboardFetch.mock.calls[0][0]
+    expect(calledPath).toContain('/api/plugins/kanban/tasks/bulk')
+  })
+})

--- a/src/server/hermes-kanban-client.ts
+++ b/src/server/hermes-kanban-client.ts
@@ -1,0 +1,129 @@
+import { dashboardFetch } from './gateway-capabilities'
+import type {
+  BulkKanbanInput,
+  CreateKanbanTaskInput,
+  HermesKanbanBoard,
+  HermesKanbanTask,
+  HermesKanbanTaskDetail,
+  UpdateKanbanTaskInput,
+} from '../lib/hermes-kanban-types'
+
+const BASE = '/api/plugins/kanban'
+
+async function kanbanFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await dashboardFetch(path, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(5_000),
+  })
+  if (!res.ok) {
+    let detail = `Kanban API error ${res.status}`
+    try {
+      const body = (await res.json()) as { detail?: string; error?: string }
+      detail = body.detail ?? body.error ?? detail
+    } catch {
+      // ignore parse failure
+    }
+    throw new Error(detail)
+  }
+  return res.json() as Promise<T>
+}
+
+export async function getKanbanBoard(params?: {
+  tenant?: string
+  includeArchived?: boolean
+}): Promise<HermesKanbanBoard> {
+  const q = new URLSearchParams()
+  if (params?.tenant) q.set('tenant', params.tenant)
+  if (params?.includeArchived) q.set('include_archived', 'true')
+  const qs = q.toString()
+  return kanbanFetch<HermesKanbanBoard>(`${BASE}/board${qs ? `?${qs}` : ''}`)
+}
+
+export async function getKanbanTask(taskId: string): Promise<HermesKanbanTaskDetail> {
+  return kanbanFetch<HermesKanbanTaskDetail>(`${BASE}/tasks/${taskId}`)
+}
+
+export async function createKanbanTask(
+  input: CreateKanbanTaskInput,
+): Promise<{ task: HermesKanbanTask; warning?: string }> {
+  return kanbanFetch<{ task: HermesKanbanTask; warning?: string }>(`${BASE}/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+}
+
+export async function updateKanbanTask(
+  taskId: string,
+  input: UpdateKanbanTaskInput,
+): Promise<{ task: HermesKanbanTask }> {
+  return kanbanFetch<{ task: HermesKanbanTask }>(`${BASE}/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+}
+
+export async function deleteKanbanTask(
+  taskId: string,
+): Promise<{ ok: boolean }> {
+  return kanbanFetch<{ ok: boolean }>(`${BASE}/tasks/${taskId}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function addKanbanComment(
+  taskId: string,
+  input: { body: string; author?: string },
+): Promise<{ ok: true }> {
+  return kanbanFetch<{ ok: true }>(`${BASE}/tasks/${taskId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+}
+
+export async function bulkUpdateKanbanTasks(
+  input: BulkKanbanInput,
+): Promise<{ results: Array<{ id: string; ok: boolean; error?: string }> }> {
+  return kanbanFetch<{ results: Array<{ id: string; ok: boolean; error?: string }> }>(
+    `${BASE}/tasks/bulk`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  )
+}
+
+export async function getKanbanStats(): Promise<unknown> {
+  return kanbanFetch<unknown>(`${BASE}/stats`)
+}
+
+export async function getKanbanAssignees(): Promise<{ assignees: unknown[] }> {
+  return kanbanFetch<{ assignees: unknown[] }>(`${BASE}/assignees`)
+}
+
+export async function getKanbanTaskLog(
+  taskId: string,
+  tail?: number,
+): Promise<unknown> {
+  const q = tail !== undefined ? `?tail=${tail}` : ''
+  return kanbanFetch<unknown>(`${BASE}/tasks/${taskId}/log${q}`, {
+    signal: AbortSignal.timeout(15_000),
+  })
+}
+
+export async function dispatchKanban(
+  max?: number,
+  dryRun?: boolean,
+): Promise<unknown> {
+  const q = new URLSearchParams()
+  if (max !== undefined) q.set('max', String(max))
+  if (dryRun) q.set('dry_run', 'true')
+  const qs = q.toString()
+  return kanbanFetch<unknown>(`${BASE}/dispatch${qs ? `?${qs}` : ''}`, {
+    method: 'POST',
+    signal: AbortSignal.timeout(15_000),
+  })
+}

--- a/src/server/legacy-tasks-migration.test.ts
+++ b/src/server/legacy-tasks-migration.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./hermes-kanban-client', () => ({
+  createKanbanTask: vi.fn(async (input) => ({
+    task: { id: 'new-' + input.idempotency_key, ...input },
+  })),
+  updateKanbanTask: vi.fn(async (id, input) => ({
+    task: { id, ...input },
+  })),
+}))
+
+vi.mock('node:fs', () => {
+  const tasks = [
+    {
+      id: 'legacy-1',
+      title: 'Fix UI',
+      description: 'Details about the fix',
+      column: 'in_progress',
+      priority: 'high',
+      tags: ['frontend'],
+      due_date: '2026-05-10',
+    },
+    {
+      title: 'Research',
+      description: '',
+      column: 'backlog',
+      priority: 'medium',
+    },
+    {
+      title: 'Old done task',
+      description: 'Already done',
+      column: 'done',
+      priority: 'low',
+    },
+    {
+      title: 'Review task',
+      description: 'Needs review',
+      column: 'review',
+      priority: 'medium',
+    },
+  ]
+  return {
+    default: {
+      readFileSync: vi.fn(() => JSON.stringify({ tasks })),
+      existsSync: vi.fn(() => false),
+      copyFileSync: vi.fn(),
+      writeFileSync: vi.fn(),
+    },
+    readFileSync: vi.fn(() => JSON.stringify({ tasks })),
+    existsSync: vi.fn(() => false),
+    copyFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  }
+})
+
+describe('legacy-tasks-migration', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps in_progress to running in preview', async () => {
+    const { previewMigration } = await import('./legacy-tasks-migration')
+    const preview = previewMigration()
+    const highTask = preview.tasks.find((t) => t.title === 'Fix UI')
+    expect(highTask?.target_status).toBe('running')
+  })
+
+  it('maps priorities correctly', async () => {
+    const { mapLegacyPriorityToNumeric } = await import('../lib/hermes-kanban-types')
+    expect(mapLegacyPriorityToNumeric('medium')).toBe(1)
+    expect(mapLegacyPriorityToNumeric('low')).toBe(-1)
+    expect(mapLegacyPriorityToNumeric('high')).toBe(3)
+  })
+
+  it('maps backlog to triage and done to done', async () => {
+    const { previewMigration } = await import('./legacy-tasks-migration')
+    const preview = previewMigration()
+    expect(preview.tasks.find((t) => t.title === 'Research')?.target_status).toBe('triage')
+    expect(preview.tasks.find((t) => t.title === 'Old done task')?.target_status).toBe('done')
+  })
+
+  it('maps review to triage', async () => {
+    const { previewMigration } = await import('./legacy-tasks-migration')
+    const preview = previewMigration()
+    expect(preview.tasks.find((t) => t.title === 'Review task')?.target_status).toBe('triage')
+  })
+
+  it('generates stable workspace idempotency keys', async () => {
+    const { previewMigration } = await import('./legacy-tasks-migration')
+    const preview = previewMigration()
+    const keys = preview.tasks.map((t) => t.idempotency_key)
+    expect(new Set(keys).size).toBe(keys.length)
+    for (const key of keys) {
+      expect(key).toMatch(/^workspace-legacy:[a-f0-9]{16}$/)
+    }
+  })
+
+  it('body includes migration annotation and due date', async () => {
+    const { performMigration } = await import('./legacy-tasks-migration')
+    const { createKanbanTask } = await import('./hermes-kanban-client')
+    await performMigration()
+    const calls = (createKanbanTask as ReturnType<typeof vi.fn>).mock.calls
+    const fixUiCall = calls.find(
+      (c: Array<unknown>) => (c[0] as { title: string }).title === 'Fix UI',
+    )
+    const input = fixUiCall?.[0] as { body: string }
+    expect(input.body).toContain('[Imported from Workspace tasks.json]')
+    expect(input.body).toContain('Due date: 2026-05-10')
+    expect(input.body).toContain('frontend')
+  })
+})

--- a/src/server/legacy-tasks-migration.ts
+++ b/src/server/legacy-tasks-migration.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import {
+  mapLegacyColumnToKanbanStatus,
+  mapLegacyPriorityToNumeric,
+} from '../lib/hermes-kanban-types'
+import { createKanbanTask, updateKanbanTask } from './hermes-kanban-client'
+import type {
+  CreateKanbanTaskInput,
+  HermesKanbanStatus,
+} from '../lib/hermes-kanban-types'
+
+const HERMES_HOME =
+  process.env.HERMES_HOME ??
+  process.env.CLAUDE_HOME ??
+  path.join(os.homedir(), '.hermes')
+const TASKS_FILE = path.join(HERMES_HOME, 'tasks.json')
+
+type LegacyTask = {
+  id?: string
+  title: string
+  description?: string
+  body?: string
+  column?: string
+  priority?: string
+  assignee?: string
+  tags?: Array<string>
+  due_date?: string
+  created_at?: string
+}
+
+export type MigrationPreview = {
+  total: number
+  already_migrated: boolean
+  tasks: Array<{
+    legacy_id: string | null
+    title: string
+    target_status: string
+    idempotency_key: string
+  }>
+}
+
+export type MigrationResult = {
+  imported: number
+  skipped: number
+  errors: Array<{ title: string; error: string }>
+  backup_path: string
+  marker_path: string
+}
+
+function derivedIdempotencyKey(task: LegacyTask, index: number): string {
+  const stable = JSON.stringify([
+    task.title ?? '',
+    task.description ?? task.body ?? '',
+    task.created_at ?? '',
+    String(index),
+  ])
+  return `workspace-legacy:${crypto
+    .createHash('sha256')
+    .update(stable)
+    .digest('hex')
+    .slice(0, 16)}`
+}
+
+function legacyTaskToCreateInput(
+  task: LegacyTask,
+  index: number,
+): { input: CreateKanbanTaskInput; desiredStatus: HermesKanbanStatus } {
+  const targetStatus = mapLegacyColumnToKanbanStatus(task.column ?? 'backlog')
+  const priority = mapLegacyPriorityToNumeric(task.priority ?? 'medium')
+  const isTriage = targetStatus === 'triage'
+
+  const annotations: Array<string> = ['[Imported from Workspace tasks.json]']
+  if (task.due_date) annotations.push(`Due date: ${task.due_date}`)
+  if (task.tags?.length) annotations.push(`Tags: ${task.tags.join(', ')}`)
+  const body = [annotations.join('\n'), task.description ?? task.body ?? '']
+    .filter(Boolean)
+    .join('\n\n')
+
+  return {
+    desiredStatus: targetStatus,
+    input: {
+      title: task.title,
+      body: body || null,
+      priority,
+      assignee: task.assignee ?? null,
+      triage: isTriage,
+      idempotency_key: derivedIdempotencyKey(task, index),
+    },
+  }
+}
+
+export function readLegacyTasks(): Array<LegacyTask> {
+  try {
+    const raw = fs.readFileSync(TASKS_FILE, 'utf-8')
+    const parsed = JSON.parse(raw) as { tasks?: Array<LegacyTask> }
+    return Array.isArray(parsed.tasks) ? parsed.tasks : []
+  } catch {
+    return []
+  }
+}
+
+export function isMigrated(): boolean {
+  return fs.existsSync(`${TASKS_FILE}.migrated`)
+}
+
+export function previewMigration(): MigrationPreview {
+  const tasks = readLegacyTasks()
+  return {
+    total: tasks.length,
+    already_migrated: isMigrated(),
+    tasks: tasks.map((t, i) => ({
+      legacy_id: t.id ?? null,
+      title: t.title,
+      target_status: mapLegacyColumnToKanbanStatus(t.column ?? 'backlog'),
+      idempotency_key: derivedIdempotencyKey(t, i),
+    })),
+  }
+}
+
+export async function performMigration(): Promise<MigrationResult> {
+  const tasks = readLegacyTasks()
+  const errors: MigrationResult['errors'] = []
+  let imported = 0
+  let skipped = 0
+
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i]
+    try {
+      const { input, desiredStatus } = legacyTaskToCreateInput(task, i)
+      const { task: created } = await createKanbanTask(input)
+      if (desiredStatus !== 'triage' && desiredStatus !== 'ready') {
+        await updateKanbanTask(created.id, { status: desiredStatus })
+      }
+      imported++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.toLowerCase().includes('idempotency') || msg.includes('409')) {
+        skipped++
+      } else {
+        errors.push({ title: task.title, error: msg })
+      }
+    }
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  const backupPath = `${TASKS_FILE}.backup-${stamp}`
+  const markerPath = `${TASKS_FILE}.migrated`
+
+  try {
+    fs.copyFileSync(TASKS_FILE, backupPath)
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify(
+        {
+          timestamp: new Date().toISOString(),
+          imported,
+          skipped,
+          errors: errors.length,
+          backup: backupPath,
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    )
+  } catch {
+    // marker/backup failure is non-fatal
+  }
+
+  return {
+    imported,
+    skipped,
+    errors,
+    backup_path: backupPath,
+    marker_path: markerPath,
+  }
+}


### PR DESCRIPTION
## Summary

Refs #311
Also fixes the route tree regeneration drift described in #326.

This is the upstream-safe PR1 slice for Unified Kanban: server/data-layer groundwork only, with no SwitchUI-specific task UI port.

## What this adds

- canonical Hermes Kanban types in `src/lib/hermes-kanban-types.ts`
- server-only dashboard client in `src/server/hermes-kanban-client.ts`
- legacy `tasks.json` migration helpers in `src/server/legacy-tasks-migration.ts`
- minimal authenticated workspace API routes:
  - `GET/POST /api/hermes-kanban`
  - `GET /api/hermes-kanban-assignees`
- focused tests for the new types, client, and migration helpers
- regenerated `src/routeTree.gen.ts` so the new routes and existing `/api/gateway-reprobe` route stop dirtying the worktree on dev start

## Why this shape

Issue #311 proposes replacing the Workspace-local `tasks.json` board with the Agent Kanban (`kanban.db`) as the single source of truth. This PR intentionally lands only the transport/types/migration foundation first, which fits upstream's preference for small isolated changes and avoids dragging downstream UI opinion into upstream.

## Notes

- No visual Tasks screen rewrite in this PR
- No drawer/tab/polish port in this PR
- Existing unrelated test failures remain in the repo; new Hermes Kanban tests pass

## Follow-ups

- wire Tasks screen to the new Hermes Kanban transport
- expose task detail/comments/log/runs routes
- decide whether `tasks.json` migration should be automatic or opt-in
