### PR TITLE
fix(api/models): merge Hermes models into Operations picker (#339)

### DIFF
--- a/src/routes/api/-models.test.ts
+++ b/src/routes/api/-models.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { mergeModelEntries } from './models'
+
+describe('mergeModelEntries', () => {
+  it('keeps local catalog entries and appends Hermes backend models without duplicates', () => {
+    const merged = mergeModelEntries(
+      [
+        { id: 'workspace/default', name: 'Workspace default', provider: 'workspace' },
+        { id: 'openai/gpt-4.1', name: 'GPT-4.1 from local catalog', provider: 'openai' },
+      ],
+      [
+        { id: 'openai/gpt-4.1', name: 'GPT-4.1 from Hermes', provider: 'openai' },
+        { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet', provider: 'anthropic' },
+      ],
+    )
+
+    expect(merged.map((model) => model.id)).toEqual([
+      'workspace/default',
+      'openai/gpt-4.1',
+      'anthropic/claude-sonnet-4.5',
+    ])
+    expect(merged[1]?.name).toBe('GPT-4.1 from local catalog')
+  })
+
+  it('normalizes string model ids from Hermes-compatible /v1/models responses', () => {
+    expect(mergeModelEntries(['openrouter/qwen/qwen3-coder'])).toEqual([
+      {
+        id: 'openrouter/qwen/qwen3-coder',
+        name: 'openrouter/qwen/qwen3-coder',
+        provider: 'openrouter',
+      },
+    ])
+  })
+})

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -66,6 +66,22 @@ function normalizeModel(entry: unknown): ModelEntry | null {
   }
 }
 
+export function mergeModelEntries(...sources: Array<Array<ModelEntry>>): Array<ModelEntry> {
+  const merged: Array<ModelEntry> = []
+  const seen = new Set<string>()
+
+  for (const source of sources) {
+    for (const model of source) {
+      const normalized = normalizeModel(model)
+      if (!normalized || seen.has(normalized.id)) continue
+      merged.push(normalized)
+      seen.add(normalized.id)
+    }
+  }
+
+  return merged
+}
+
 /**
  * Read user-configured models from active profile's models.json.
  */
@@ -194,22 +210,22 @@ export const Route = createFileRoute('/api/models')({
             models.unshift(defaultModel)
           }
 
-          // Fallback: if no models.json, fetch from hermes-agent /v1/models
-          if (models.length === 0 && getGatewayCapabilities().models) {
-            models = await fetchClaudeModels()
-            source = 'hermes-agent'
+          // Merge the authoritative Hermes model catalog whenever it is
+          // available. Previously, a non-empty models.json stopped here, so the
+          // Operations picker only showed the local Workspace subset and drifted
+          // from the CLI/backend model universe.
+          if (getGatewayCapabilities().models) {
+            const hermesModels = await fetchClaudeModels()
+            models = mergeModelEntries(models, hermesModels)
+            source = source === 'models.json' ? 'models.json+hermes-agent' : 'hermes-agent'
           }
 
           // Merge auto-discovered local models (Ollama, Atomic Chat, etc.)
           await ensureDiscovery()
           const localModels = getDiscoveredModels()
-          const existingIds = new Set(models.map((m) => m.id))
+          models = mergeModelEntries(models, localModels)
           for (const m of localModels) {
-            if (!existingIds.has(m.id)) {
-              models.push(m)
-              existingIds.add(m.id)
-              ensureProviderInConfig(m.provider)
-            }
+            ensureProviderInConfig(m.provider)
           }
 
           const configuredProviders = Array.from(


### PR DESCRIPTION
Closes #339.

**Root cause**
`/api/models` returned only the local `~/.hermes/models.json` cache when present, dropping the authoritative `/v1/models` catalog from the Hermes backend. Result: Operations model picker showed a stale subset of models that didn't match what the CLI saw.

**Fix**
`mergeModelEntries()` now keeps local/default entries first while appending CLI/backend-only models with stable dedupe. Operations picker now matches the CLI inventory.

**Files**
- `src/routes/api/models.ts`
- `src/routes/api/-models.test.ts`

**Verification**
- `pnpm test src/routes/api/-models.test.ts` ✓
- `pnpm build` ✓