### PR TITLE
fix(chat): scope sends to active workspace (#340)

### DIFF
--- a/src/lib/workspace-message-scope.test.ts
+++ b/src/lib/workspace-message-scope.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildWorkspaceScopedTextMessage } from './workspace-message-scope'
+
+describe('buildWorkspaceScopedTextMessage', () => {
+  it('prepends an explicit active workspace directive to plain text chat messages', () => {
+    expect(
+      buildWorkspaceScopedTextMessage('Run the tests', {
+        path: '/Users/eric/projects/hermes-workspace',
+        folderName: 'hermes-workspace',
+        isValid: true,
+      }),
+    ).toBe(
+      '<workspace_context active="true" name="hermes-workspace" path="/Users/eric/projects/hermes-workspace" />\n\nRun the tests',
+    )
+  })
+
+  it('does not duplicate the directive if the message is retried', () => {
+    const scoped = buildWorkspaceScopedTextMessage('Run the tests', {
+      path: '/Users/eric/work',
+      folderName: 'work',
+      isValid: true,
+    })
+    expect(
+      buildWorkspaceScopedTextMessage(scoped, {
+        path: '/Users/eric/other',
+        folderName: 'other',
+        isValid: true,
+      }),
+    ).toBe(scoped)
+  })
+
+  it('leaves messages unchanged when no valid workspace exists', () => {
+    expect(
+      buildWorkspaceScopedTextMessage('hello', {
+        path: '',
+        folderName: '',
+        isValid: false,
+      }),
+    ).toBe('hello')
+  })
+})

--- a/src/lib/workspace-message-scope.ts
+++ b/src/lib/workspace-message-scope.ts
@@ -1,0 +1,30 @@
+export type WorkspaceScope = {
+  path?: string
+  folderName?: string
+  isValid?: boolean
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function buildWorkspaceDirective(workspace: WorkspaceScope): string {
+  const path = workspace.path?.trim() ?? ''
+  if (!path || workspace.isValid === false) return ''
+  const name = workspace.folderName?.trim() || path.split('/').filter(Boolean).at(-1) || 'workspace'
+  return `<workspace_context active="true" name="${escapeAttribute(name)}" path="${escapeAttribute(path)}" />`
+}
+
+export function buildWorkspaceScopedTextMessage(
+  message: string,
+  workspace: WorkspaceScope | null | undefined,
+): string {
+  if (message.includes('<workspace_context active="true"')) return message
+  const directive = workspace ? buildWorkspaceDirective(workspace) : ''
+  if (!directive) return message
+  return `${directive}\n\n${message}`
+}

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { buildResolvedSessionHeaders } from '../../lib/send-stream-session-headers'
+import { buildWorkspaceScopedTextMessage } from '../../lib/workspace-message-scope'
 import {
   collectSyntheticLiveToolEvents,
   createSyntheticLiveToolTracker,
@@ -8,6 +9,7 @@ import { resolveSessionKey } from '../../server/session-utils'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { publishChatEvent } from '../../server/chat-event-bus'
+import { loadWorkspaceCatalog } from './workspace'
 import {
   registerActiveSendRun,
   unregisterActiveSendRun,
@@ -371,6 +373,12 @@ export const Route = createFileRoute('/api/send-stream')({
           resolvedFriendlyId = sessionKey
         }
 
+        const workspaceScope = await loadWorkspaceCatalog().catch(() => null)
+        const scopedMessage = buildWorkspaceScopedTextMessage(
+          getChatMessage(message, attachments),
+          workspaceScope,
+        )
+
         // Create streaming response using the SHARED server connection
         const encoder = new TextEncoder()
         let streamClosed = false
@@ -512,7 +520,7 @@ export const Route = createFileRoute('/api/send-stream')({
 
                 try {
                   const userContent = buildMultimodalContent(
-                    message,
+                    scopedMessage,
                     attachments,
                   )
                   // Inject locale preference so the agent responds in the user's language
@@ -570,7 +578,7 @@ export const Route = createFileRoute('/api/send-stream')({
                     >()
                     try {
                       const responsesStream = streamResponses({
-                        input: typeof message === 'string' ? message : '',
+                        input: scopedMessage,
                         conversationHistory: effectiveHistory,
                         model:
                           typeof body.model === 'string' ? body.model : undefined,
@@ -958,7 +966,7 @@ export const Route = createFileRoute('/api/send-stream')({
                 await streamChat(
                 sessionKey,
                 {
-                  message: getChatMessage(message, attachments),
+                  message: scopedMessage,
                   model:
                     typeof body.model === 'string' ? body.model : undefined,
                   system_message: thinking,


### PR DESCRIPTION
Closes #340.

**Root cause**
`send-stream` did not pass the active workspace selection from `/api/workspace` to the model. Result: agents had no idea which workspace the chat was happening in, so chat-place steering did nothing.

**Fix**
- New `workspace-message-scope` helper loads the active workspace catalog and prepends a `workspace_context` directive to model input
- Applied across portable multimodal user content, Responses API text input, and enhanced `streamChat` message
- Avoids duplicate directives on retry
- User-visible/persisted chat text is unchanged; only model-directed input is scoped

**Files**
- `src/lib/workspace-message-scope.ts`
- `src/routes/api/send-stream.ts`
- `src/lib/workspace-message-scope.test.ts`

**Verification**
- `pnpm test src/lib/workspace-message-scope.test.ts` ✓
- `pnpm build` ✓