### PR TITLE
fix(jobs): send Create Job prompt as input string (#312)

### DIFF
--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildJobMutationPayload,
   findJobById,
   getJobErrorText,
   getLatestJobOutputText,
@@ -63,5 +64,25 @@ describe('job helpers', () => {
     expect(getJobErrorText({ ...job, last_run_error: '  boom  ' })).toBe('boom')
     expect(getJobErrorText({ ...job, last_run_error: null, error: 'oops' })).toBe('oops')
     expect(getJobErrorText(null)).toBeNull()
+  })
+})
+
+
+describe('job mutation payloads', () => {
+  it('sends prompt as input for Hermes cron APIs that require an input string', () => {
+    expect(
+      buildJobMutationPayload({
+        name: 'Daily summary',
+        schedule: 'every 30m',
+        prompt: 'summarize the latest notes',
+        deliver: ['local'],
+      }),
+    ).toEqual({
+      name: 'Daily summary',
+      schedule: 'every 30m',
+      prompt: 'summarize the latest notes',
+      input: 'summarize the latest notes',
+      deliver: ['local'],
+    })
   })
 })

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -162,18 +162,29 @@ function errorMessageFromBody(body: unknown, fallback: string): string {
   return fallback
 }
 
-export async function createJob(input: {
+type JobMutationInput = {
   schedule: string
   prompt: string
   name?: string
   deliver?: Array<string>
   skills?: Array<string>
   repeat?: number
-}): Promise<ClaudeJob> {
+}
+
+export function buildJobMutationPayload(input: JobMutationInput): JobMutationInput & { input: string } {
+  const prompt = typeof input.prompt === 'string' ? input.prompt : ''
+  return {
+    ...input,
+    prompt,
+    input: prompt,
+  }
+}
+
+export async function createJob(input: JobMutationInput): Promise<ClaudeJob> {
   const res = await fetch(CLAUDE_API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    body: JSON.stringify(buildJobMutationPayload(input)),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
@@ -186,10 +197,14 @@ export async function updateJob(
   jobId: string,
   updates: Record<string, unknown>,
 ): Promise<ClaudeJob> {
+  const payload =
+    typeof updates.prompt === 'string'
+      ? { ...updates, input: updates.prompt }
+      : updates
   const res = await fetch(`${CLAUDE_API}/${jobId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(updates),
+    body: JSON.stringify(payload),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))


### PR DESCRIPTION
Closes #312.

**Root cause**
The Hermes cron API validates an `input` string on job creation/update. The Workspace UI was sending only `prompt`, so all Create Job calls failed with 'should be a valid string' validation errors.

**Fix**
- Send the UI prompt under both `prompt` and `input`
- Mirror prompt → input on job updates when present, preventing the same class of validation failure on edit

**Files**
- `src/lib/jobs-api.ts`
- `src/lib/jobs-api.test.ts`

**Verification**
- `pnpm test src/lib/jobs-api.test.ts` ✓
- `pnpm build` ✓