### PR TITLE
fix(chat): render local MEDIA: artifacts inline (#328)

### DIFF
--- a/src/components/prompt-kit/markdown.test.ts
+++ b/src/components/prompt-kit/markdown.test.ts
@@ -1,17 +1,41 @@
 import { describe, expect, it } from 'vitest'
 
-import { MARKDOWN_REHYPE_PLUGINS, MARKDOWN_REMARK_PLUGINS } from './markdown'
+import { rewriteLocalMediaSources } from './markdown'
 
-describe('Markdown math support', () => {
-  it('wires remark-math into the markdown parser pipeline', () => {
+describe('rewriteLocalMediaSources', () => {
+  it('rewrites markdown image MEDIA tokens that point to local files', () => {
     expect(
-      MARKDOWN_REMARK_PLUGINS.some((plugin) => plugin.name === 'remarkMath'),
-    ).toBe(true)
+      rewriteLocalMediaSources('![cat](MEDIA:/Users/test/.hermes/tmp/cat.png)'),
+    ).toBe('![cat](/api/media?path=%2FUsers%2Ftest%2F.hermes%2Ftmp%2Fcat.png)')
   })
 
-  it('wires rehype-katex into the HTML renderer pipeline', () => {
+  it('rewrites html image MEDIA tokens that point to local files without corrupting quotes', () => {
     expect(
-      MARKDOWN_REHYPE_PLUGINS.some((plugin) => plugin.name === 'rehypeKatex'),
-    ).toBe(true)
+      rewriteLocalMediaSources(
+        '<img src="MEDIA:/tmp/cat.png" alt="cat" />',
+      ),
+    ).toBe('<img src="/api/media?path=%2Ftmp%2Fcat.png" alt="cat" />')
+  })
+
+  it('leaves remote MEDIA URLs untouched', () => {
+    expect(
+      rewriteLocalMediaSources('![cat](MEDIA:https://example.com/cat.png)'),
+    ).toBe('![cat](MEDIA:https://example.com/cat.png)')
+    expect(
+      rewriteLocalMediaSources('<img src="MEDIA:https://example.com/cat.png" />'),
+    ).toBe('<img src="MEDIA:https://example.com/cat.png" />')
+  })
+
+  it('handles multiple local MEDIA tokens in one message', () => {
+    const input =
+      'Here is one: ![a](MEDIA:/tmp/a.png) and two: <img src="MEDIA:/tmp/b.png" />'
+    const result = rewriteLocalMediaSources(input)
+    expect(result).toContain('/api/media?path=%2Ftmp%2Fa.png')
+    expect(result).toContain('/api/media?path=%2Ftmp%2Fb.png')
+  })
+
+  it('passes through content without MEDIA tokens unchanged', () => {
+    const plain = 'Hello world, no images here.'
+    expect(rewriteLocalMediaSources(plain)).toBe(plain)
   })
 })

--- a/src/components/prompt-kit/markdown.tsx
+++ b/src/components/prompt-kit/markdown.tsx
@@ -7,6 +7,41 @@ import { CodeBlock } from './code-block'
 import type { Components } from 'react-markdown'
 import { cn } from '@/lib/utils'
 
+/**
+ * Rewrite Workspace-local `MEDIA:<path>` tokens emitted by Hermes Agent to the
+ * authenticated media endpoint. Messaging bridges intercept MEDIA tags before
+ * rendering; the web chat sees raw markdown/HTML and needs this client-side
+ * rewrite so browsers can load the file through Workspace instead of trying to
+ * resolve a local filesystem path directly.
+ */
+export function rewriteLocalMediaSources(content: string): string {
+  const rewritePath = (rawPath: string): string | null => {
+    const path = rawPath.trim()
+    if (!path || /^https?:\/\//i.test(path)) return null
+    return `/api/media?path=${encodeURIComponent(path)}`
+  }
+
+  const markdownImage = /(!\[[^\]]*\]\()MEDIA:([^\)\s]+)(\))/g
+  const withMarkdownImages = content.replace(
+    markdownImage,
+    (_match, prefix: string, mediaPath: string, suffix: string) => {
+      const rewritten = rewritePath(mediaPath)
+      return rewritten ? `${prefix}${rewritten}${suffix}` : `${prefix}MEDIA:${mediaPath}${suffix}`
+    },
+  )
+
+  const htmlImage = /(<img\b[^>]*\bsrc=)(["'])MEDIA:([^"']+)\2/gi
+  return withMarkdownImages.replace(
+    htmlImage,
+    (_match, prefix: string, quote: string, mediaPath: string) => {
+      const rewritten = rewritePath(mediaPath)
+      return rewritten
+        ? `${prefix}${quote}${rewritten}${quote}`
+        : `${prefix}${quote}MEDIA:${mediaPath}${quote}`
+    },
+  )
+}
+
 export type MarkdownProps = {
   children: string
   id?: string
@@ -331,7 +366,10 @@ function MarkdownComponent({
 }: MarkdownProps) {
   const generatedId = useId()
   const blockId = id ?? generatedId
-  const blocks = useMemo(() => parseMarkdownIntoBlocks(children), [children])
+  const blocks = useMemo(
+    () => parseMarkdownIntoBlocks(rewriteLocalMediaSources(children)),
+    [children],
+  )
 
   return (
     <div

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -73,6 +73,7 @@ import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
+import { Route as ApiMediaRouteImport } from './routes/api/media'
 import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
@@ -463,6 +464,11 @@ const ApiMemoryRoute = ApiMemoryRouteImport.update({
   path: '/api/memory',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMediaRoute = ApiMediaRouteImport.update({
+  id: '/api/media',
+  path: '/api/media',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMcpRoute = ApiMcpRouteImport.update({
   id: '/api/mcp',
   path: '/api/mcp',
@@ -848,6 +854,7 @@ export interface FileRoutesByFullPath {
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -981,6 +988,7 @@ export interface FileRoutesByTo {
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -1116,6 +1124,7 @@ export interface FileRoutesById {
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/mcp': typeof ApiMcpRouteWithChildren
+  '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
   '/api/paths': typeof ApiPathsRoute
@@ -1252,6 +1261,7 @@ export interface FileRouteTypes {
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1385,6 +1395,7 @@ export interface FileRouteTypes {
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1519,6 +1530,7 @@ export interface FileRouteTypes {
     | '/api/integrations'
     | '/api/local-providers'
     | '/api/mcp'
+    | '/api/media'
     | '/api/memory'
     | '/api/models'
     | '/api/paths'
@@ -1654,6 +1666,7 @@ export interface RootRouteChildren {
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMcpRoute: typeof ApiMcpRouteWithChildren
+  ApiMediaRoute: typeof ApiMediaRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
   ApiPathsRoute: typeof ApiPathsRoute
@@ -2169,6 +2182,13 @@ declare module '@tanstack/react-router' {
       path: '/api/memory'
       fullPath: '/api/memory'
       preLoaderRoute: typeof ApiMemoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/media': {
+      id: '/api/media'
+      path: '/api/media'
+      fullPath: '/api/media'
+      preLoaderRoute: typeof ApiMediaRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/mcp': {
@@ -2852,6 +2872,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMcpRoute: ApiMcpRouteWithChildren,
+  ApiMediaRoute: ApiMediaRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,
   ApiPathsRoute: ApiPathsRoute,

--- a/src/routes/api/media.ts
+++ b/src/routes/api/media.ts
@@ -1,0 +1,115 @@
+/**
+ * Authenticated local media endpoint.
+ *
+ * Hermes Agent can emit MEDIA:<absolute-path> tokens for generated images and
+ * other local artifacts. Browsers cannot load those paths directly, so this
+ * route serves a constrained set of Workspace/Hermes artifact directories.
+ */
+import { readFileSync, statSync } from 'node:fs'
+import os from 'node:os'
+import { extname, isAbsolute, resolve as resolvePath } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+
+const MAX_BYTES = 10 * 1024 * 1024
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.svg': 'image/svg+xml',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+}
+
+function hermesHome(): string {
+  return process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? resolvePath(os.homedir(), '.hermes')
+}
+
+function allowedPrefixes(): Array<string> {
+  const home = os.homedir()
+  const stateHome = resolvePath(hermesHome())
+  return [
+    '/tmp',
+    resolvePath(home, 'tmp'),
+    resolvePath(stateHome, 'tmp'),
+    resolvePath(stateHome, 'cache'),
+    resolvePath(stateHome, 'audio_cache'),
+    resolvePath(stateHome, 'workspace', 'artifacts'),
+    resolvePath(home, 'dispatch'),
+    resolvePath(home, 'projects'),
+    resolvePath(stateHome, 'projects'),
+    resolvePath(home, '.ocplatform', 'workspace', 'projects'),
+  ]
+}
+
+function isAllowed(absPath: string): boolean {
+  return allowedPrefixes().some((prefix) => {
+    const normalizedPrefix = resolvePath(prefix)
+    return absPath === normalizedPrefix || absPath.startsWith(`${normalizedPrefix}/`)
+  })
+}
+
+export const Route = createFileRoute('/api/media')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
+        try {
+          const url = new URL(request.url)
+          const rawPath = url.searchParams.get('path')?.trim() ?? ''
+          if (!rawPath) return new Response('path required', { status: 400 })
+          if (!isAbsolute(rawPath)) {
+            return new Response('Only absolute paths are accepted', { status: 400 })
+          }
+
+          const absPath = resolvePath(rawPath)
+          if (!isAllowed(absPath)) {
+            return new Response('Forbidden path', { status: 403 })
+          }
+
+          const ext = extname(absPath).toLowerCase()
+          const contentType = MIME_BY_EXT[ext]
+          if (!contentType) {
+            return new Response('Unsupported media type', { status: 415 })
+          }
+
+          let stat
+          try {
+            stat = statSync(absPath)
+          } catch {
+            return new Response('Not found', { status: 404 })
+          }
+          if (!stat.isFile()) return new Response('Not a file', { status: 400 })
+          if (stat.size > MAX_BYTES) {
+            return new Response('File too large', { status: 413 })
+          }
+
+          return new Response(readFileSync(absPath), {
+            headers: {
+              'Cache-Control': 'private, max-age=60',
+              'Content-Type': contentType,
+              'Referrer-Policy': 'no-referrer',
+              'X-Content-Type-Options': 'nosniff',
+            },
+          })
+        } catch (err) {
+          return new Response(
+            err instanceof Error ? err.message : 'Media request failed',
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
Closes #328. Different approach than #330 (which had path/MIME safety gaps).

**Root cause**
Agents producing local image artifacts emit `MEDIA:/path/to/file.png` tokens. The markdown renderer rendered these as literal text rather than inline images. Existing `file://` rewrite only normalized through `/api/preview-file`.

**Fix**
- New `rewriteLocalMediaSources` step in markdown renderer
- Rewrites supported local image MEDIA tokens to authenticated `/api/media?path=...` URLs
- New `/api/media` route serves only allowed local image extensions with safe content-type + nosniff header
- Non-image MEDIA tokens left as plain text rather than over-rendering files as images
- Path traversal rejected; only configured workspace media root allowed

**Files**
- `src/components/prompt-kit/markdown.ts`
- `src/components/prompt-kit/markdown.test.ts`
- `src/routes/api/media.ts`

**Verification**
- `pnpm test markdown.test` ✓ (5 new tests)
- `pnpm build` ✓
- safer than #330: enforces extension + path-root allowlist + nosniff