### PR TITLE
feat: reconcile Majestic12 dashboard OS screens

### DIFF
--- a/scripts/generate-hermes-proof-status.mjs
+++ b/scripts/generate-hermes-proof-status.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const AI_SYSTEMS = process.env.MAJESTIC12_ROOT || '/Users/majestic12/ai-systems'
+const HERMES_HOME = process.env.HERMES_HOME || '/Users/majestic12/.hermes'
+const CRON_DIR = join(HERMES_HOME, 'cron')
+const JOBS_FILE = join(CRON_DIR, 'jobs.json')
+const OUTPUT_DIR = join(CRON_DIR, 'output')
+const STATE_DIR = join(AI_SYSTEMS, 'state')
+
+function todayChicago() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date())
+}
+
+function safeJson(path) {
+  if (!existsSync(path)) return null
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function normalizeJobs(payload) {
+  if (Array.isArray(payload)) return payload
+  if (payload && Array.isArray(payload.jobs)) return payload.jobs
+  if (payload && payload.jobs && typeof payload.jobs === 'object') return Object.values(payload.jobs)
+  if (payload && typeof payload === 'object') return Object.values(payload).filter((v) => v && typeof v === 'object' && ('id' in v || 'job_id' in v))
+  return []
+}
+
+async function fetchJson(url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 2500)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return { ok: true, url, data: await res.json() }
+  } catch (error) {
+    return { ok: false, url, error: error instanceof Error ? error.message : String(error) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function readJobs() {
+  const sources = [
+    'http://127.0.0.1:3000/api/hermes-jobs?include_disabled=true',
+    'http://127.0.0.1:9119/api/cron/jobs?include_disabled=true',
+    'http://127.0.0.1:8642/api/jobs?include_disabled=true',
+  ]
+  const attempts = []
+  let selected = null
+  for (const url of sources) {
+    const attempt = await fetchJson(url)
+    const jobs = attempt.ok ? normalizeJobs(attempt.data) : []
+    attempts.push(attempt.ok ? { url, ok: true, job_count: jobs.length } : { url, ok: false, error: attempt.error })
+    if (!selected && jobs.length > 0) selected = { jobs, source: url }
+  }
+  if (selected) return { ...selected, api_attempts: attempts, fallback_reason: null }
+
+  let payload = null
+  let localError = null
+  try {
+    payload = safeJson(JOBS_FILE)
+  } catch (error) {
+    localError = error instanceof Error ? error.message : String(error)
+  }
+  const fallbackReasons = attempts
+    .filter((attempt) => !attempt.ok || attempt.job_count === 0)
+    .map((attempt) => attempt.ok ? `${attempt.url}: no jobs` : `${attempt.url}: ${attempt.error}`)
+  if (localError) fallbackReasons.push(`${JOBS_FILE}: ${localError}`)
+  return {
+    jobs: normalizeJobs(payload),
+    source: JOBS_FILE,
+    api_attempts: attempts,
+    fallback_reason: fallbackReasons.join('; ') || 'API job sources unavailable or empty',
+  }
+}
+
+function listOutputs(jobId) {
+  const dir = join(OUTPUT_DIR, jobId)
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.md') || name.endsWith('.json') || name.endsWith('.txt'))
+    .map((name) => {
+      const path = join(dir, name)
+      const st = statSync(path)
+      return { path, filename: name, size: st.size, mtime: st.mtime.toISOString() }
+    })
+    .sort((a, b) => b.mtime.localeCompare(a.mtime))
+}
+
+function hasEvidence(text) {
+  const lower = text.toLowerCase()
+  return [
+    '/users/majestic12/', 'http://', 'https://', 'source:', 'sources:', 'evidence',
+    'ledger', 'api', '.json', '.md', '.yaml', '.yml', '.csv', '.db', 'sqlite',
+  ].some((needle) => lower.includes(needle))
+}
+
+function hasApprovalGate(text) {
+  const lower = text.toLowerCase()
+  return ['approval', 'approve', 'wilson', 'proposal', 'gate', 'requires confirmation'].some((needle) => lower.includes(needle))
+}
+
+function laneForJob(job) {
+  const name = String(job.name || '').toLowerCase()
+  if (name.includes('janet') || name.includes('feynman')) return 'trading-intelligence'
+  if (name.includes('research') || name.includes('curie')) return 'research-radar'
+  if (name.includes('performance') || name.includes('waitzkin')) return 'performance-learning'
+  if (name.includes('life') || name.includes('alfred')) return 'life-admin'
+  if (name.includes('truth') || name.includes('scribe') || name.includes('curator')) return 'truth-infrastructure'
+  if (name.includes('synthesis') || name.includes('alignment') || name.includes('reddington')) return 'council-synthesis'
+  return 'operations'
+}
+
+function statusFor(job, latestOutput, content) {
+  if (job.enabled === false || job.state === 'paused') return 'scheduled'
+  if (!job.last_run_at && !job.lastRunAt) return 'scheduled'
+  const success = job.last_run_success ?? job.lastRunSuccess ?? job.lastRun?.status
+  if (success === false || success === 'error' || job.last_error || job.lastRunError) return 'failed'
+  if (!latestOutput) return 'output_missing'
+  if (!hasEvidence(content || '')) return 'evidence_missing'
+  if (hasApprovalGate(content || '')) return 'approval_required'
+  return 'ran_successfully'
+}
+
+function proofFailureReason(job, latestOutput, outputReadable, content, status) {
+  if (status === 'ran_successfully') return null
+  if (status === 'scheduled') return 'scheduled_or_no_last_run_at'
+  if (status === 'failed') return job.last_error || job.lastRunError || job.lastRun?.error || 'last run failed'
+  if (status === 'output_missing') return 'last_run_at present but no readable output artifact was found'
+  if (status === 'evidence_missing') return 'output artifact exists but evidence markers were not detected'
+  if (status === 'approval_required') return 'output contains proposal/approval-gate language and remains unproven until approved or classified'
+  if (!latestOutput) return 'output_missing'
+  if (!outputReadable) return 'output_unreadable'
+  if (!hasEvidence(content || '')) return 'evidence_missing'
+  return 'unproven_status'
+}
+
+function normalizeJob(job) {
+  const jobId = String(job.id || job.job_id || job.jobId || '')
+  const outputs = jobId ? listOutputs(jobId) : []
+  const latest = outputs[0] || null
+  let content = ''
+  let outputReadable = false
+  if (latest) {
+    try {
+      content = readFileSync(latest.path, 'utf8')
+      outputReadable = true
+    } catch {}
+  }
+  const schedule = typeof job.schedule === 'string'
+    ? job.schedule
+    : (job.schedule_display || job.schedule?.display || job.schedule?.expr || '')
+  const status = statusFor(job, latest, content)
+  const proven = status === 'ran_successfully'
+  return {
+    agent: String(job.name || '').split(' daily ')[0] || String(job.name || jobId),
+    job_id: jobId,
+    name: job.name || '',
+    schedule,
+    next_run_at: job.next_run_at || job.nextRunAt || null,
+    last_run_at: job.last_run_at || job.lastRunAt || job.lastRun?.startedAt || null,
+    last_run_success: job.last_run_success ?? job.lastRunSuccess ?? null,
+    status,
+    error: job.last_error || job.lastRunError || job.lastRun?.error || null,
+    lane: laneForJob(job),
+    output: latest ? { path: latest.path, size: latest.size, modified_at: latest.mtime } : null,
+    proof_failure_reason: proofFailureReason(job, latest, outputReadable, content, status),
+    intake_contract: {
+      agent: String(job.name || '').split(' daily ')[0] || String(job.name || jobId),
+      job_id: jobId,
+      run_at: job.last_run_at || job.lastRunAt || null,
+      lane: laneForJob(job),
+      evidence: hasEvidence(content) ? ['detected in output'] : [],
+      freshness_labels: [],
+      truth_debt: [],
+      recommendations: [],
+      skill_candidates: [],
+      approval_gates: hasApprovalGate(content) ? ['approval language detected'] : [],
+    },
+    checks: {
+      proven,
+      output_readable: outputReadable,
+      evidence_present: latest ? hasEvidence(content) : false,
+      proposal_first_guardrail: latest ? hasApprovalGate(content) || !/(sent|deleted|traded|placed order|created calendar|emailed)/i.test(content) : true,
+    },
+  }
+}
+
+function markdown(packet) {
+  const lines = []
+  lines.push(`# Hermes Jobs Proof Status — ${packet.generated_for}`)
+  lines.push('')
+  lines.push(`Generated: ${packet.generated_at}`)
+  lines.push(`Source: ${packet.source}`)
+  if (packet.fallback_reason) lines.push(`Fallback reason: ${packet.fallback_reason}`)
+  if (packet.run_window) {
+    lines.push(`Run window: ${packet.run_window.earliest_next_run_at ?? 'null'} → ${packet.run_window.latest_next_run_at ?? 'null'}`)
+  }
+  lines.push('')
+  lines.push('## Summary')
+  for (const [key, value] of Object.entries(packet.summary)) lines.push(`- ${key}: ${value}`)
+  lines.push('')
+  lines.push('## Intake Contract')
+  lines.push('- agent')
+  lines.push('- job_id')
+  lines.push('- run_at')
+  lines.push('- lane')
+  lines.push('- evidence')
+  lines.push('- freshness_labels')
+  lines.push('- truth_debt')
+  lines.push('- recommendations')
+  lines.push('- skill_candidates')
+  lines.push('- approval_gates')
+  lines.push('')
+  lines.push('## Jobs')
+  for (const job of packet.jobs) {
+    lines.push(`### ${job.name || job.job_id}`)
+    lines.push(`- status: ${job.status}`)
+    lines.push(`- job_id: ${job.job_id}`)
+    lines.push(`- schedule: ${job.schedule}`)
+    lines.push(`- next_run_at: ${job.next_run_at ?? 'null'}`)
+    lines.push(`- last_run_at: ${job.last_run_at ?? 'null'}`)
+    lines.push(`- error: ${job.error ?? 'null'}`)
+    lines.push(`- output: ${job.output?.path ?? 'missing'}`)
+    lines.push(`- evidence_present: ${job.checks.evidence_present}`)
+    lines.push(`- proven: ${job.checks.proven}`)
+    lines.push(`- proof_failure_reason: ${job.proof_failure_reason ?? 'null'}`)
+  }
+  return lines.join('\n') + '\n'
+}
+
+export async function generateHermesProofStatus({ write = true, date = null } = {}) {
+  const { jobs, source, api_attempts, fallback_reason } = await readJobs()
+  if (!date) {
+    const next = jobs
+      .map((job) => job.next_run_at || job.nextRunAt)
+      .filter(Boolean)
+      .sort()[0]
+    date = next ? String(next).slice(0, 10) : todayChicago()
+  }
+  const normalized = jobs.map(normalizeJob).sort((a, b) => String(a.next_run_at || '').localeCompare(String(b.next_run_at || '')))
+  const summary = normalized.reduce((acc, job) => {
+    acc.total += 1
+    acc[job.status] = (acc[job.status] || 0) + 1
+    if (!job.checks.proven) acc.unproven += 1
+    return acc
+  }, { total: 0, scheduled: 0, ran_successfully: 0, failed: 0, output_missing: 0, evidence_missing: 0, approval_required: 0, unproven: 0 })
+  const packet = {
+    type: 'hermes_jobs_proof_status',
+    generated_at: new Date().toISOString(),
+    generated_for: date,
+    source,
+    api_attempts,
+    api_liveness: Object.fromEntries(api_attempts.map((attempt) => [
+      attempt.url,
+      { live: attempt.ok, job_count: attempt.job_count ?? 0, error: attempt.error ?? null },
+    ])),
+    fallback_reason,
+    run_window: {
+      requested_date: date,
+      earliest_next_run_at: normalized.map((job) => job.next_run_at).filter(Boolean).sort()[0] || null,
+      latest_next_run_at: normalized.map((job) => job.next_run_at).filter(Boolean).sort().at(-1) || null,
+      jobs_with_last_run_at: normalized.filter((job) => Boolean(job.last_run_at)).length,
+      jobs_without_last_run_at: normalized.filter((job) => !job.last_run_at).length,
+    },
+    paths: { jobs_file: JOBS_FILE, output_dir: OUTPUT_DIR, state_dir: STATE_DIR },
+    summary,
+    jobs: normalized,
+  }
+  if (write) {
+    mkdirSync(STATE_DIR, { recursive: true })
+    writeFileSync(join(STATE_DIR, `hermes_jobs_proof_status_${date}.json`), JSON.stringify(packet, null, 2) + '\n')
+    writeFileSync(join(STATE_DIR, `hermes_jobs_proof_status_${date}.md`), markdown(packet))
+    writeFileSync(join(STATE_DIR, 'hermes_output_intake_contract.md'), `# Hermes Output Intake Contract\n\nEvery local agent run should produce proposal-first output with these fields:\n\n- agent\n- job_id\n- run_at\n- lane\n- evidence\n- freshness_labels\n- truth_debt\n- recommendations\n- skill_candidates\n- approval_gates\n\nExternal-world actions remain approval-gated: no email, calendar, reminders, trades, deletes, launchd, port exposure, or protected file edits without Wilson approval.\n`)
+  }
+  return packet
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const dateArg = process.argv.find((arg) => arg.startsWith('--date='))?.slice('--date='.length)
+  const envDate = process.env.HERMES_PROOF_DATE
+  const date = dateArg || envDate || null
+  const packet = await generateHermesProofStatus({ write: true, date })
+  console.log(JSON.stringify(packet, null, 2))
+}

--- a/scripts/verify-hermes-proof-loop.mjs
+++ b/scripts/verify-hermes-proof-loop.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { generateHermesProofStatus } from './generate-hermes-proof-status.mjs'
+
+const AI_SYSTEMS = process.env.MAJESTIC12_ROOT || '/Users/majestic12/ai-systems'
+const HERMES_HOME = process.env.HERMES_HOME || '/Users/majestic12/.hermes'
+const STATE_DIR = join(AI_SYSTEMS, 'state')
+const JOBS_FILE = join(HERMES_HOME, 'cron', 'jobs.json')
+const OUTPUT_DIR = join(HERMES_HOME, 'cron', 'output')
+
+function todayChicago() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date())
+}
+
+async function probe(url) {
+  const controller = new AbortController()
+  const started = Date.now()
+  const timer = setTimeout(() => controller.abort(), 3000)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    const text = await res.text()
+    return { url, live: res.ok, status: res.status, ms: Date.now() - started, sample: text.slice(0, 180) }
+  } catch (error) {
+    return { url, live: false, ms: Date.now() - started, error: error instanceof Error ? error.message : String(error) }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function invariantFailures(packet) {
+  const failures = []
+  for (const job of packet.jobs || []) {
+    if (job.checks?.proven !== (job.status === 'ran_successfully')) {
+      failures.push(`${job.job_id}: checks.proven=${job.checks?.proven} while status=${job.status}`)
+    }
+    if (['output_missing', 'evidence_missing', 'approval_required', 'failed', 'scheduled'].includes(job.status) && job.checks?.proven) {
+      failures.push(`${job.job_id}: unproven status marked proven (${job.status})`)
+    }
+    if (job.status !== 'ran_successfully' && !job.proof_failure_reason) {
+      failures.push(`${job.job_id}: missing proof_failure_reason for ${job.status}`)
+    }
+  }
+  return failures
+}
+
+const requestedDate = process.argv.find((arg) => arg.startsWith('--date='))?.slice('--date='.length) || todayChicago()
+const packet = await generateHermesProofStatus({ write: false, date: requestedDate })
+const artifactJson = join(STATE_DIR, `hermes_jobs_proof_status_${requestedDate}.json`)
+const artifactMd = join(STATE_DIR, `hermes_jobs_proof_status_${requestedDate}.md`)
+const probes = await Promise.all([
+  probe('http://127.0.0.1:3000/api/hermes-jobs'),
+  probe(`http://127.0.0.1:3000/api/hermes-proof-status?date=${requestedDate}`),
+  probe('http://127.0.0.1:9119/api/cron/jobs'),
+  probe('http://127.0.0.1:8642/api/jobs'),
+])
+const failures = invariantFailures(packet)
+const result = {
+  type: 'hermes_proof_loop_verification',
+  checked_at: new Date().toISOString(),
+  requested_date: requestedDate,
+  paths: {
+    jobs_file: JOBS_FILE,
+    output_dir: OUTPUT_DIR,
+    artifact_json: artifactJson,
+    artifact_md: artifactMd,
+  },
+  path_exists: {
+    jobs_file: existsSync(JOBS_FILE),
+    output_dir: existsSync(OUTPUT_DIR),
+    artifact_json: existsSync(artifactJson),
+    artifact_md: existsSync(artifactMd),
+  },
+  artifact_sizes: {
+    artifact_json: existsSync(artifactJson) ? statSync(artifactJson).size : 0,
+    artifact_md: existsSync(artifactMd) ? statSync(artifactMd).size : 0,
+  },
+  summary: packet.summary,
+  run_window: packet.run_window,
+  api_liveness: packet.api_liveness,
+  route_probes: probes.map(({ sample, ...rest }) => rest),
+  invariant_failures: failures,
+  ok: failures.length === 0 && existsSync(JOBS_FILE),
+}
+console.log(JSON.stringify(result, null, 2))
+if (!result.ok) process.exit(1)

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -51,9 +51,7 @@ type CommandAction = {
   label: string
   keywords: string
   shortcut?: string
-  icon: React.ComponentProps<
-    typeof import('@hugeicons/react').HugeiconsIcon
-  >['icon']
+  icon: React.ComponentProps<typeof HugeiconsIcon>['icon']
   onSelect: () => void
 }
 

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -8,11 +8,15 @@ import {
   ArrowUp01Icon,
   BrainIcon,
   Chat01Icon,
+  Clock01Icon,
   CommandLineIcon,
+  DashboardSquare01Icon,
   File01Icon,
   McpServerIcon,
   PuzzleIcon,
+  Rocket01Icon,
   Settings01Icon,
+  UserGroupIcon,
 } from '@hugeicons/core-free-icons'
 import type React from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
@@ -168,6 +172,33 @@ export function CommandPalette({ pathname, sessions }: CommandPaletteProps) {
   const screenActions = useMemo<Array<CommandAction>>(
     () => [
       {
+        id: 'screen-home',
+        group: 'Screens',
+        label: 'Home',
+        keywords: 'dashboard needs wilson cockpit command center',
+        shortcut: 'Go',
+        icon: DashboardSquare01Icon,
+        onSelect: () => void navigate({ to: '/dashboard' }),
+      },
+      {
+        id: 'screen-company-flow',
+        group: 'Screens',
+        label: 'Company Flow',
+        keywords: 'agents graph circuit bottlenecks proof approvals next moves',
+        shortcut: 'Go',
+        icon: Rocket01Icon,
+        onSelect: () => void navigate({ to: '/company-flow' }),
+      },
+      {
+        id: 'screen-agents',
+        group: 'Screens',
+        label: 'Agents',
+        keywords: 'hermes employees company drivers support specialists capability map',
+        shortcut: 'Go',
+        icon: UserGroupIcon,
+        onSelect: () => void navigate({ to: '/agents' }),
+      },
+      {
         id: 'screen-chat',
         group: 'Screens',
         label: 'Chat',
@@ -175,6 +206,33 @@ export function CommandPalette({ pathname, sessions }: CommandPaletteProps) {
         shortcut: 'Go',
         icon: Chat01Icon,
         onSelect: () => void navigate({ to: '/chat' }),
+      },
+      {
+        id: 'screen-work',
+        group: 'Screens',
+        label: 'Work',
+        keywords: 'tasks projects approvals execution loops',
+        shortcut: 'Go',
+        icon: Clock01Icon,
+        onSelect: () => void navigate({ to: '/tasks' }),
+      },
+      {
+        id: 'screen-schedule',
+        group: 'Screens',
+        label: 'Schedule',
+        keywords: 'calendar reminders daily agenda apple today tomorrow',
+        shortcut: 'Go',
+        icon: Clock01Icon,
+        onSelect: () => void navigate({ to: '/schedule' }),
+      },
+      {
+        id: 'screen-domains',
+        group: 'Screens',
+        label: 'Domains',
+        keywords: 'finance research worldview performance golf treasure ideas inbox',
+        shortcut: 'Go',
+        icon: BrainIcon,
+        onSelect: () => void navigate({ to: '/domains' }),
       },
       {
         id: 'screen-files',

--- a/src/components/dashboard-overflow-panel.tsx
+++ b/src/components/dashboard-overflow-panel.tsx
@@ -4,11 +4,14 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   BrainIcon,
   ComputerTerminal01Icon,
+  Clock01Icon,
+  DashboardSquare01Icon,
   File01Icon,
   McpServerIcon,
   MessageMultiple01Icon,
   Moon02Icon,
   PuzzleIcon,
+  Rocket01Icon,
   Settings01Icon,
   Sun02Icon,
   UserGroupIcon,
@@ -24,9 +27,12 @@ type OverflowItem = {
 }
 
 const SYSTEM_ITEMS: Array<OverflowItem> = [
+  { icon: DashboardSquare01Icon, label: 'Company Flow', to: '/company-flow' },
+  { icon: Clock01Icon, label: 'Schedule', to: '/schedule' },
+  { icon: BrainIcon, label: 'Domains', to: '/domains' },
   { icon: File01Icon, label: 'Files', to: '/files' },
   { icon: ComputerTerminal01Icon, label: 'Terminal', to: '/terminal' },
-  { icon: BrainIcon, label: 'Memory', to: '/memory' },
+  { icon: BrainIcon, label: 'Brain', to: '/memory' },
 ]
 
 const CLAUDE_ITEMS: Array<OverflowItem> = [

--- a/src/components/dashboard-overflow-panel.tsx
+++ b/src/components/dashboard-overflow-panel.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   BrainIcon,
-  ComputerTerminal01Icon,
   Clock01Icon,
+  ComputerTerminal01Icon,
   DashboardSquare01Icon,
   File01Icon,
   McpServerIcon,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as Swarm2RouteImport } from './routes/swarm2'
 import { Route as SwarmRouteImport } from './routes/swarm'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ScheduleRouteImport } from './routes/schedule'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
 import { Route as OperationsRouteImport } from './routes/operations'
@@ -24,9 +25,12 @@ import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
+import { Route as DomainsRouteImport } from './routes/domains'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
+import { Route as CompanyFlowRouteImport } from './routes/company-flow'
 import { Route as AgoraRouteImport } from './routes/agora'
+import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -81,6 +85,7 @@ import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesProofStatusRouteImport } from './routes/api/hermes-proof-status'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
@@ -91,6 +96,8 @@ import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection
 import { Route as ApiConnectionSettingsRouteImport } from './routes/api/connection-settings'
 import { Route as ApiConductorStopRouteImport } from './routes/api/conductor-stop'
 import { Route as ApiConductorSpawnRouteImport } from './routes/api/conductor-spawn'
+import { Route as ApiCompanyFlowRouteImport } from './routes/api/company-flow'
+import { Route as ApiCommandCenterStatusRouteImport } from './routes/api/command-center-status'
 import { Route as ApiClaudeUpdateRouteImport } from './routes/api/claude-update'
 import { Route as ApiClaudeTasksAssigneesRouteImport } from './routes/api/claude-tasks-assignees'
 import { Route as ApiClaudeTasksRouteImport } from './routes/api/claude-tasks'
@@ -181,6 +188,11 @@ const SettingsRoute = SettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ScheduleRoute = ScheduleRouteImport.update({
+  id: '/schedule',
+  path: '/schedule',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProfilesRoute = ProfilesRouteImport.update({
   id: '/profiles',
   path: '/profiles',
@@ -221,6 +233,11 @@ const FilesRoute = FilesRouteImport.update({
   path: '/files',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DomainsRoute = DomainsRouteImport.update({
+  id: '/domains',
+  path: '/domains',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -231,9 +248,19 @@ const ConductorRoute = ConductorRouteImport.update({
   path: '/conductor',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CompanyFlowRoute = CompanyFlowRouteImport.update({
+  id: '/company-flow',
+  path: '/company-flow',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AgoraRoute = AgoraRouteImport.update({
   id: '/agora',
   path: '/agora',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentsRoute = AgentsRouteImport.update({
+  id: '/agents',
+  path: '/agents',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -507,6 +534,11 @@ const ApiHistoryRoute = ApiHistoryRouteImport.update({
   path: '/api/history',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHermesProofStatusRoute = ApiHermesProofStatusRouteImport.update({
+  id: '/api/hermes-proof-status',
+  path: '/api/hermes-proof-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
@@ -555,6 +587,16 @@ const ApiConductorStopRoute = ApiConductorStopRouteImport.update({
 const ApiConductorSpawnRoute = ApiConductorSpawnRouteImport.update({
   id: '/api/conductor-spawn',
   path: '/api/conductor-spawn',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiCompanyFlowRoute = ApiCompanyFlowRouteImport.update({
+  id: '/api/company-flow',
+  path: '/api/company-flow',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiCommandCenterStatusRoute = ApiCommandCenterStatusRouteImport.update({
+  id: '/api/command-center-status',
+  path: '/api/command-center-status',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiClaudeUpdateRoute = ApiClaudeUpdateRouteImport.update({
@@ -833,9 +875,12 @@ const ApiMcpNameLogsRoute = ApiMcpNameLogsRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agents': typeof AgentsRoute
   '/agora': typeof AgoraRoute
+  '/company-flow': typeof CompanyFlowRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/domains': typeof DomainsRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -844,6 +889,7 @@ export interface FileRoutesByFullPath {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/schedule': typeof ScheduleRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -860,6 +906,8 @@ export interface FileRoutesByFullPath {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/command-center-status': typeof ApiCommandCenterStatusRoute
+  '/api/company-flow': typeof ApiCompanyFlowRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -870,6 +918,7 @@ export interface FileRoutesByFullPath {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-proof-status': typeof ApiHermesProofStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -971,9 +1020,12 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agents': typeof AgentsRoute
   '/agora': typeof AgoraRoute
+  '/company-flow': typeof CompanyFlowRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/domains': typeof DomainsRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -982,6 +1034,7 @@ export interface FileRoutesByTo {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/schedule': typeof ScheduleRoute
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
@@ -997,6 +1050,8 @@ export interface FileRoutesByTo {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/command-center-status': typeof ApiCommandCenterStatusRoute
+  '/api/company-flow': typeof ApiCompanyFlowRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -1007,6 +1062,7 @@ export interface FileRoutesByTo {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-proof-status': typeof ApiHermesProofStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1109,9 +1165,12 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agents': typeof AgentsRoute
   '/agora': typeof AgoraRoute
+  '/company-flow': typeof CompanyFlowRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/domains': typeof DomainsRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -1120,6 +1179,7 @@ export interface FileRoutesById {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/schedule': typeof ScheduleRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1136,6 +1196,8 @@ export interface FileRoutesById {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/command-center-status': typeof ApiCommandCenterStatusRoute
+  '/api/company-flow': typeof ApiCompanyFlowRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -1146,6 +1208,7 @@ export interface FileRoutesById {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-proof-status': typeof ApiHermesProofStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1249,9 +1312,12 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$'
+    | '/agents'
     | '/agora'
+    | '/company-flow'
     | '/conductor'
     | '/dashboard'
+    | '/domains'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1260,6 +1326,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/schedule'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1276,6 +1343,8 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/command-center-status'
+    | '/api/company-flow'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1286,6 +1355,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-proof-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1387,9 +1457,12 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$'
+    | '/agents'
     | '/agora'
+    | '/company-flow'
     | '/conductor'
     | '/dashboard'
+    | '/domains'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1398,6 +1471,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/schedule'
     | '/skills'
     | '/swarm'
     | '/swarm2'
@@ -1413,6 +1487,8 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/command-center-status'
+    | '/api/company-flow'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1423,6 +1499,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-proof-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1524,9 +1601,12 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$'
+    | '/agents'
     | '/agora'
+    | '/company-flow'
     | '/conductor'
     | '/dashboard'
+    | '/domains'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1535,6 +1615,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/schedule'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1551,6 +1632,8 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/command-center-status'
+    | '/api/company-flow'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1561,6 +1644,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-proof-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1663,9 +1747,12 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  AgentsRoute: typeof AgentsRoute
   AgoraRoute: typeof AgoraRoute
+  CompanyFlowRoute: typeof CompanyFlowRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
+  DomainsRoute: typeof DomainsRoute
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
   JobsRoute: typeof JobsRoute
@@ -1674,6 +1761,7 @@ export interface RootRouteChildren {
   OperationsRoute: typeof OperationsRoute
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
+  ScheduleRoute: typeof ScheduleRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
   SwarmRoute: typeof SwarmRoute
@@ -1690,6 +1778,8 @@ export interface RootRouteChildren {
   ApiClaudeTasksRoute: typeof ApiClaudeTasksRouteWithChildren
   ApiClaudeTasksAssigneesRoute: typeof ApiClaudeTasksAssigneesRoute
   ApiClaudeUpdateRoute: typeof ApiClaudeUpdateRoute
+  ApiCommandCenterStatusRoute: typeof ApiCommandCenterStatusRoute
+  ApiCompanyFlowRoute: typeof ApiCompanyFlowRoute
   ApiConductorSpawnRoute: typeof ApiConductorSpawnRoute
   ApiConductorStopRoute: typeof ApiConductorStopRoute
   ApiConnectionSettingsRoute: typeof ApiConnectionSettingsRoute
@@ -1700,6 +1790,7 @@ export interface RootRouteChildren {
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiHermesProofStatusRoute: typeof ApiHermesProofStatusRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
@@ -1824,6 +1915,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/schedule': {
+      id: '/schedule'
+      path: '/schedule'
+      fullPath: '/schedule'
+      preLoaderRoute: typeof ScheduleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/profiles': {
       id: '/profiles'
       path: '/profiles'
@@ -1880,6 +1978,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FilesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/domains': {
+      id: '/domains'
+      path: '/domains'
+      fullPath: '/domains'
+      preLoaderRoute: typeof DomainsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard': {
       id: '/dashboard'
       path: '/dashboard'
@@ -1894,11 +1999,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ConductorRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/company-flow': {
+      id: '/company-flow'
+      path: '/company-flow'
+      fullPath: '/company-flow'
+      preLoaderRoute: typeof CompanyFlowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/agora': {
       id: '/agora'
       path: '/agora'
       fullPath: '/agora'
       preLoaderRoute: typeof AgoraRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agents': {
+      id: '/agents'
+      path: '/agents'
+      fullPath: '/agents'
+      preLoaderRoute: typeof AgentsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$': {
@@ -2279,6 +2398,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHistoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/hermes-proof-status': {
+      id: '/api/hermes-proof-status'
+      path: '/api/hermes-proof-status'
+      fullPath: '/api/hermes-proof-status'
+      preLoaderRoute: typeof ApiHermesProofStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/gateway-status': {
       id: '/api/gateway-status'
       path: '/api/gateway-status'
@@ -2347,6 +2473,20 @@ declare module '@tanstack/react-router' {
       path: '/api/conductor-spawn'
       fullPath: '/api/conductor-spawn'
       preLoaderRoute: typeof ApiConductorSpawnRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/company-flow': {
+      id: '/api/company-flow'
+      path: '/api/company-flow'
+      fullPath: '/api/company-flow'
+      preLoaderRoute: typeof ApiCompanyFlowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/command-center-status': {
+      id: '/api/command-center-status'
+      path: '/api/command-center-status'
+      fullPath: '/api/command-center-status'
+      preLoaderRoute: typeof ApiCommandCenterStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/claude-update': {
@@ -2893,9 +3033,12 @@ const ApiSwarmMemoryRouteWithChildren = ApiSwarmMemoryRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  AgentsRoute: AgentsRoute,
   AgoraRoute: AgoraRoute,
+  CompanyFlowRoute: CompanyFlowRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
+  DomainsRoute: DomainsRoute,
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
   JobsRoute: JobsRoute,
@@ -2904,6 +3047,7 @@ const rootRouteChildren: RootRouteChildren = {
   OperationsRoute: OperationsRoute,
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
+  ScheduleRoute: ScheduleRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,
   SwarmRoute: SwarmRoute,
@@ -2920,6 +3064,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiClaudeTasksRoute: ApiClaudeTasksRouteWithChildren,
   ApiClaudeTasksAssigneesRoute: ApiClaudeTasksAssigneesRoute,
   ApiClaudeUpdateRoute: ApiClaudeUpdateRoute,
+  ApiCommandCenterStatusRoute: ApiCommandCenterStatusRoute,
+  ApiCompanyFlowRoute: ApiCompanyFlowRoute,
   ApiConductorSpawnRoute: ApiConductorSpawnRoute,
   ApiConductorStopRoute: ApiConductorStopRoute,
   ApiConnectionSettingsRoute: ApiConnectionSettingsRoute,
@@ -2930,6 +3076,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiHermesProofStatusRoute: ApiHermesProofStatusRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,

--- a/src/routes/agents.tsx
+++ b/src/routes/agents.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { AgentsScreen } from '@/screens/agents/agents-screen'
+
+export const Route = createFileRoute('/agents')({
+  ssr: false,
+  component: function AgentsRoute() {
+    usePageTitle('Agents')
+    return <AgentsScreen />
+  },
+})

--- a/src/routes/api/command-center-status.ts
+++ b/src/routes/api/command-center-status.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { buildCommandCenterStatus } from '../../server/command-center-data'
+
+export const Route = createFileRoute('/api/command-center-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const url = new URL(request.url)
+        return json(await buildCommandCenterStatus({
+          refresh: url.searchParams.get('refresh') === '1',
+        }))
+      },
+    },
+  },
+})

--- a/src/routes/api/company-flow.ts
+++ b/src/routes/api/company-flow.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { buildCompanyFlowPacket } from '../../server/command-center-data'
+
+export const Route = createFileRoute('/api/company-flow')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        return json(await buildCompanyFlowPacket())
+      },
+    },
+  },
+})

--- a/src/routes/api/hermes-proof-status.ts
+++ b/src/routes/api/hermes-proof-status.ts
@@ -1,8 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { isAuthenticated } from '../../server/auth-middleware'
+import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
 
 function todayChicago(): string {
   return new Intl.DateTimeFormat('en-CA', {
@@ -16,7 +16,7 @@ function todayChicago(): string {
 export const Route = createFileRoute('/api/hermes-proof-status')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
+      GET: ({ request }) => {
         if (!isAuthenticated(request)) {
           return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
         }

--- a/src/routes/api/hermes-proof-status.ts
+++ b/src/routes/api/hermes-proof-status.ts
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+function todayChicago(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+}
+
+export const Route = createFileRoute('/api/hermes-proof-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+        }
+        const url = new URL(request.url)
+        const requestedDate = url.searchParams.get('date')
+        if (requestedDate && !/^\d{4}-\d{2}-\d{2}$/.test(requestedDate)) {
+          return new Response(JSON.stringify({ error: 'Invalid date' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        const root = process.env.MAJESTIC12_ROOT || '/Users/majestic12/ai-systems'
+        const stateDir = join(root, 'state')
+        let statePath = join(root, 'state', `hermes_jobs_proof_status_${requestedDate || todayChicago()}.json`)
+        try {
+          if (!requestedDate || !existsSync(statePath) || url.searchParams.get('refresh') === '1') {
+            const args = [join(root, 'hermes-workspace', 'scripts', 'generate-hermes-proof-status.mjs')]
+            if (requestedDate) args.push(`--date=${requestedDate}`)
+            execFileSync('node', args, {
+              cwd: join(root, 'hermes-workspace'),
+              timeout: 30_000,
+              stdio: ['ignore', 'pipe', 'pipe'],
+            })
+          }
+          if (!requestedDate) {
+            const latest = readdirSync(stateDir)
+              .filter((name) => /^hermes_jobs_proof_status_\d{4}-\d{2}-\d{2}\.json$/.test(name))
+              .sort()
+              .at(-1)
+            if (latest) statePath = join(stateDir, latest)
+          }
+          const body = readFileSync(statePath, 'utf8')
+          return new Response(body, { headers: { 'Content-Type': 'application/json' } })
+        } catch (error) {
+          return new Response(
+            JSON.stringify({
+              error: 'Failed to generate Hermes proof status',
+              detail: error instanceof Error ? error.message : String(error),
+              statePath,
+            }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/company-flow.tsx
+++ b/src/routes/company-flow.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { CompanyFlowScreen } from '@/screens/company-flow/company-flow-screen'
+
+export const Route = createFileRoute('/company-flow')({
+  ssr: false,
+  component: CompanyFlowRoute,
+})
+
+function CompanyFlowRoute() {
+  usePageTitle('Company Flow')
+  return <CompanyFlowScreen />
+}

--- a/src/routes/domains.tsx
+++ b/src/routes/domains.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { DomainsScreen } from '@/screens/domains/domains-screen'
+
+export const Route = createFileRoute('/domains')({
+  ssr: false,
+  component: DomainsRoute,
+})
+
+function DomainsRoute() {
+  usePageTitle('Domains')
+  return <DomainsScreen />
+}

--- a/src/routes/schedule.tsx
+++ b/src/routes/schedule.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { ScheduleScreen } from '@/screens/schedule/schedule-screen'
+
+export const Route = createFileRoute('/schedule')({
+  ssr: false,
+  component: ScheduleRoute,
+})
+
+function ScheduleRoute() {
+  usePageTitle('Schedule')
+  return <ScheduleScreen />
+}

--- a/src/screens/company-flow/company-flow-screen.tsx
+++ b/src/screens/company-flow/company-flow-screen.tsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Add01Icon, Alert02Icon, ArrowRight01Icon, RefreshIcon } from '@hugeicons/core-free-icons'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+
+type FlowNode = {
+  id: string
+  type: string
+  label: string
+  column: number
+  status: 'live' | 'stale' | 'inferred' | 'missing' | 'blocked' | 'ready'
+  priority?: 'critical' | 'high' | 'medium' | 'low'
+  detail?: string
+  href?: string
+}
+
+type FlowEdge = {
+  id: string
+  source: string
+  target: string
+  label: string
+  status: 'healthy' | 'blocked' | 'attention'
+}
+
+type FlowItem = {
+  id: string
+  title: string
+  detail: string
+  status: FlowNode['status']
+  priority: 'critical' | 'high' | 'medium' | 'low'
+  owner?: string
+  action?: string
+  href?: string
+  evidence?: string
+}
+
+type CompanyFlowPacket = {
+  generated_at: string
+  summary: Record<string, number>
+  health: Record<string, string>
+  nodes: FlowNode[]
+  edges: FlowEdge[]
+  needs_wilson: FlowItem[]
+  bottlenecks: FlowItem[]
+  gains: FlowItem[]
+  next_moves: FlowItem[]
+  skill_candidates: FlowItem[]
+  company?: {
+    operating_model: string
+    primary_drivers: Array<{ id: string; name: string }>
+    support_specialists: Array<{ id: string; name: string }>
+    skill_inventory: { total: number; mapped_to_hermes: number }
+  }
+  automation_queue?: FlowItem[]
+}
+
+const COLUMN_LABELS = [
+  'Brain + Sources',
+  'Hermes Drivers',
+  'Jobs + Automations',
+  'Outputs',
+  'Proof',
+  'Approvals',
+  'Gains',
+  'Next Moves',
+]
+
+const STATUS_CLASS: Record<FlowNode['status'], string> = {
+  live: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200',
+  ready: 'border-sky-500/30 bg-sky-500/10 text-sky-200',
+  blocked: 'border-amber-500/40 bg-amber-500/10 text-amber-100 shadow-[0_0_24px_rgba(245,158,11,0.12)]',
+  missing: 'border-red-500/40 bg-red-500/10 text-red-100 shadow-[0_0_24px_rgba(239,68,68,0.12)]',
+  stale: 'border-orange-500/30 bg-orange-500/10 text-orange-100',
+  inferred: 'border-neutral-500/30 bg-neutral-500/10 text-neutral-200',
+}
+
+function priorityRank(priority?: FlowItem['priority']) {
+  if (priority === 'critical') return 0
+  if (priority === 'high') return 1
+  if (priority === 'medium') return 2
+  return 3
+}
+
+async function createTaskFromMove(item: FlowItem) {
+  const response = await fetch('/api/hermes-tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: item.title,
+      description: [
+        item.detail,
+        item.action ? `Next action: ${item.action}` : '',
+        item.evidence ? `Evidence: ${item.evidence}` : '',
+      ].filter(Boolean).join('\n\n'),
+      column: 'todo',
+      priority: item.priority === 'critical' || item.priority === 'high' ? 'high' : 'medium',
+      assignee: item.owner || null,
+      tags: ['company-flow', item.status, item.priority],
+      created_by: 'company-flow',
+    }),
+  })
+  if (!response.ok) throw new Error(`Failed to create task: ${response.status}`)
+  return response.json()
+}
+
+export function CompanyFlowScreen() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [filter, setFilter] = useState<'all' | 'blocked' | 'agents' | 'proof' | 'next'>('all')
+
+  const flowQuery = useQuery({
+    queryKey: ['company-flow'],
+    queryFn: async () => {
+      const response = await fetch('/api/company-flow')
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      return (await response.json()) as CompanyFlowPacket
+    },
+    refetchInterval: 30_000,
+  })
+
+  const createTaskMutation = useMutation({
+    mutationFn: createTaskFromMove,
+    onSuccess: () => {
+      toast('Mission task created')
+      void queryClient.invalidateQueries({ queryKey: ['hermes', 'tasks'] })
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : 'Failed to create task', { type: 'error' }),
+  })
+
+  const packet = flowQuery.data
+  const selectedNode = packet?.nodes.find((node) => node.id === selectedId) ?? packet?.nodes[0]
+  const selectedEdges = useMemo(() => {
+    if (!packet || !selectedNode) return []
+    return packet.edges.filter((edge) => edge.source === selectedNode.id || edge.target === selectedNode.id)
+  }, [packet, selectedNode])
+
+  const visibleNodes = useMemo(() => {
+    const nodes = packet?.nodes ?? []
+    if (filter === 'blocked') return nodes.filter((node) => node.status === 'blocked' || node.status === 'missing')
+    if (filter === 'agents') return nodes.filter((node) => node.type === 'agent' || node.type === 'support')
+    if (filter === 'proof') return nodes.filter((node) => node.type === 'proof' || node.type === 'approval' || node.type === 'output')
+    if (filter === 'next') return nodes.filter((node) => node.type === 'next_move' || node.type === 'skill_candidate')
+    return nodes
+  }, [filter, packet])
+
+  const nodesByColumn = useMemo(() => {
+    const grouped = new Map<number, FlowNode[]>()
+    for (const node of visibleNodes) {
+      const list = grouped.get(node.column) ?? []
+      list.push(node)
+      grouped.set(node.column, list)
+    }
+    for (const list of grouped.values()) {
+      list.sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority) || a.label.localeCompare(b.label))
+    }
+    return grouped
+  }, [visibleNodes])
+
+  return (
+    <div className="min-h-full bg-[radial-gradient(circle_at_top_left,rgba(20,184,166,0.08),transparent_32rem),var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 px-4 py-5 sm:px-6 lg:px-8">
+        <header className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Majestic12 Operating System</p>
+              <h1 className="mt-1 text-xl font-semibold tracking-tight">Company Flow</h1>
+              <p className="mt-1 max-w-3xl text-sm text-[var(--theme-muted)]">
+                Hermes-led circuit of sources, primary agents, support specialists, jobs, automations, proof, approvals, gains, and next moves. Broken flow is the work.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void flowQuery.refetch()}
+                className="inline-flex items-center gap-1.5 rounded-md border border-[var(--theme-border)] px-3 py-2 text-xs text-[var(--theme-muted)] hover:text-[var(--theme-text)]"
+              >
+                <HugeiconsIcon icon={RefreshIcon} size={14} />
+                Refresh
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate({ to: '/tasks' })}
+                className="rounded-md bg-[var(--theme-accent)] px-3 py-2 text-xs font-semibold text-white"
+              >
+                Work board
+              </button>
+            </div>
+          </div>
+          <div className="mt-3 rounded-md border border-teal-500/20 bg-teal-500/5 px-3 py-2 text-[11px] text-[var(--theme-muted)]">
+            <span className="font-semibold text-teal-200">Operating model:</span> Hermes agents drive the company. Reddington orchestrates, domain agents execute, Cowork keeps rhythm, and Claude Code handles engineering only when Hermes delegates it. Nothing is treated as proven until the proof stage says so.
+          </div>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-6">
+            {[
+              ['Hermes Drivers', packet?.summary.hermes_primary_drivers ?? packet?.company?.primary_drivers.length ?? 0],
+              ['Support', packet?.summary.support_specialists ?? packet?.company?.support_specialists.length ?? 0],
+              ['Broken flows', packet?.summary.broken_flows ?? 0],
+              ['Automations', packet?.summary.automations_ready ?? packet?.automation_queue?.length ?? 0],
+              ['Skills', packet?.summary.skills_total ?? packet?.company?.skill_inventory.total ?? 0],
+              ['Identity Issues', packet?.summary.identity_issues ?? 0],
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2">
+                <div className="text-lg font-bold tabular-nums">{value}</div>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--theme-muted)]">{label}</div>
+              </div>
+            ))}
+          </div>
+        </header>
+
+        <div className="flex flex-wrap gap-2">
+          {([
+            ['all', 'All'],
+            ['blocked', 'Broken'],
+            ['agents', 'Agents'],
+            ['proof', 'Proof'],
+            ['next', 'Next Moves'],
+          ] as const).map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setFilter(id)}
+              className={cn(
+                'rounded-md border px-3 py-1.5 text-xs transition-colors',
+                filter === id
+                  ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/15 text-[var(--theme-text)]'
+                  : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-[var(--theme-text)]',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid min-h-[680px] gap-4 2xl:grid-cols-[minmax(0,1fr)_340px]">
+          <section className="overflow-x-auto rounded-lg border border-[var(--theme-border)] bg-[rgba(8,12,18,0.45)] p-3">
+            {flowQuery.isLoading ? (
+              <div className="flex h-full min-h-[420px] items-center justify-center text-sm text-[var(--theme-muted)]">Loading company circuit...</div>
+            ) : flowQuery.isError ? (
+              <div className="flex h-full min-h-[420px] items-center justify-center px-4 text-center text-sm text-red-300">Company Flow failed to load. The circuit is unavailable rather than assumed healthy; refresh after the local API is reachable.</div>
+            ) : (
+              <div className="grid min-w-[1320px] grid-cols-8 gap-3">
+                {COLUMN_LABELS.map((label, column) => (
+                  <div key={label} className="min-h-[620px] rounded-md border border-[var(--theme-border)] bg-[var(--theme-card)]/60 p-2">
+                    <div className="sticky top-0 z-10 mb-2 rounded border border-[var(--theme-border)] bg-[var(--theme-card)] px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.13em] text-[var(--theme-muted)]">
+                      {label}
+                    </div>
+                    <div className="space-y-2">
+                      {(nodesByColumn.get(column) ?? []).map((node) => {
+                        const outgoing = packet?.edges.filter((edge) => edge.source === node.id) ?? []
+                        return (
+                          <button
+                            key={node.id}
+                            type="button"
+                            onClick={() => setSelectedId(node.id)}
+                            className={cn(
+                              'group w-full rounded-md border p-2 text-left transition-transform hover:-translate-y-0.5',
+                              STATUS_CLASS[node.status],
+                              selectedNode?.id === node.id && 'ring-1 ring-[var(--theme-accent)]',
+                            )}
+                          >
+                            <div className="flex items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="truncate text-xs font-semibold">{node.label}</div>
+                                <div className="mt-0.5 text-[9px] uppercase tracking-[0.12em] opacity-70">{node.type}</div>
+                              </div>
+                              {(node.status === 'blocked' || node.status === 'missing') ? (
+                                <HugeiconsIcon icon={Alert02Icon} size={14} className="shrink-0" />
+                              ) : null}
+                            </div>
+                            {node.detail ? <p className="mt-1 line-clamp-2 text-[10px] opacity-75">{node.detail}</p> : null}
+                            {outgoing.length > 0 ? (
+                              <div className="mt-2 flex flex-wrap gap-1">
+                                {outgoing.slice(0, 2).map((edge) => (
+                                  <span key={edge.id} className="inline-flex items-center gap-1 rounded bg-black/20 px-1.5 py-0.5 text-[9px] opacity-80">
+                                    {edge.label}
+                                    <HugeiconsIcon icon={ArrowRight01Icon} size={10} />
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <aside className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)]">
+            <div className="border-b border-[var(--theme-border)] px-4 py-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Inspector</p>
+              <h2 className="mt-1 text-base font-semibold">{selectedNode?.label ?? 'Select a node'}</h2>
+              <p className="mt-1 text-xs text-[var(--theme-muted)]">{selectedNode?.detail ?? 'Click a circuit node to inspect its evidence and next action.'}</p>
+            </div>
+            <div className="space-y-4 p-4">
+              {selectedNode ? (
+                <>
+                  <div className={cn('rounded-md border px-3 py-2 text-xs', STATUS_CLASS[selectedNode.status])}>
+                    {selectedNode.status.toUpperCase()} · {selectedNode.priority ?? 'normal'}
+                  </div>
+                  {selectedEdges.length > 0 ? (
+                    <section>
+                      <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Connected Flow</h3>
+                      <div className="space-y-2">
+                        {selectedEdges.map((edge) => (
+                          <div key={edge.id} className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs">
+                            <div className="font-medium">{edge.label}</div>
+                            <div className="mt-1 font-mono text-[10px] text-[var(--theme-muted)]">{edge.source} {'->'} {edge.target}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </section>
+                  ) : null}
+                  {selectedNode.href ? (
+                    <button
+                      type="button"
+                      onClick={() => navigate({ to: selectedNode.href as never })}
+                      className="w-full rounded-md border border-[var(--theme-border)] px-3 py-2 text-xs font-semibold hover:border-[var(--theme-accent)]"
+                    >
+                      Open source surface
+                    </button>
+                  ) : null}
+                </>
+              ) : null}
+
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Top Next Moves</h3>
+                <div className="space-y-2">
+                  {[...(packet?.next_moves ?? [])].sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority)).slice(0, 3).map((item) => (
+                    <div key={item.id} className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                      <div className="text-xs font-semibold">{item.title}</div>
+                      <p className="mt-1 text-[11px] text-[var(--theme-muted)]">{item.detail}</p>
+                      <button
+                        type="button"
+                        disabled={createTaskMutation.isPending}
+                        onClick={() => createTaskMutation.mutate(item)}
+                        className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-[var(--theme-accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white disabled:opacity-60"
+                      >
+                        <HugeiconsIcon icon={Add01Icon} size={12} />
+                        Stage task
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/company-flow/company-flow-screen.tsx
+++ b/src/screens/company-flow/company-flow-screen.tsx
@@ -41,20 +41,20 @@ type CompanyFlowPacket = {
   generated_at: string
   summary: Record<string, number>
   health: Record<string, string>
-  nodes: FlowNode[]
-  edges: FlowEdge[]
-  needs_wilson: FlowItem[]
-  bottlenecks: FlowItem[]
-  gains: FlowItem[]
-  next_moves: FlowItem[]
-  skill_candidates: FlowItem[]
+  nodes: Array<FlowNode>
+  edges: Array<FlowEdge>
+  needs_wilson: Array<FlowItem>
+  bottlenecks: Array<FlowItem>
+  gains: Array<FlowItem>
+  next_moves: Array<FlowItem>
+  skill_candidates: Array<FlowItem>
   company?: {
     operating_model: string
     primary_drivers: Array<{ id: string; name: string }>
     support_specialists: Array<{ id: string; name: string }>
     skill_inventory: { total: number; mapped_to_hermes: number }
   }
-  automation_queue?: FlowItem[]
+  automation_queue?: Array<FlowItem>
 }
 
 const COLUMN_LABELS = [
@@ -148,7 +148,7 @@ export function CompanyFlowScreen() {
   }, [filter, packet])
 
   const nodesByColumn = useMemo(() => {
-    const grouped = new Map<number, FlowNode[]>()
+    const grouped = new Map<number, Array<FlowNode>>()
     for (const node of visibleNodes) {
       const list = grouped.get(node.column) ?? []
       list.push(node)

--- a/src/screens/domains/domains-screen.tsx
+++ b/src/screens/domains/domains-screen.tsx
@@ -14,10 +14,10 @@ type DomainHub = {
   currentTruth: string
   nextAction: string
   agent: string
-  sources: string[]
+  sources: Array<string>
 }
 
-const DOMAINS: DomainHub[] = [
+const DOMAINS: Array<DomainHub> = [
   {
     id: 'finance',
     title: 'Finance Intelligence',

--- a/src/screens/domains/domains-screen.tsx
+++ b/src/screens/domains/domains-screen.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Add01Icon, BrainIcon, ChartLineData01Icon, GolfHoleIcon, MapsGlobal01Icon, Satellite01Icon } from '@hugeicons/core-free-icons'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+
+type DomainHub = {
+  id: string
+  title: string
+  tone: string
+  icon: typeof BrainIcon
+  description: string
+  currentTruth: string
+  nextAction: string
+  agent: string
+  sources: string[]
+}
+
+const DOMAINS: DomainHub[] = [
+  {
+    id: 'finance',
+    title: 'Finance Intelligence',
+    tone: 'border-emerald-500/30 bg-emerald-500/10',
+    icon: ChartLineData01Icon,
+    description: 'Bloomberg-style awareness for savings, investing research, risk, watchlists, and money decisions.',
+    currentTruth: 'Proposal-only: no trades, brokerage actions, spending, or money movement without Wilson approval.',
+    nextAction: 'Build a daily finance brief with source freshness, risks, and watchlist deltas.',
+    agent: 'Feynman',
+    sources: ['company filings', 'watchlists', 'proof outputs', 'official sources'],
+  },
+  {
+    id: 'research-worldview',
+    title: 'Research + Worldview',
+    tone: 'border-sky-500/30 bg-sky-500/10',
+    icon: Satellite01Icon,
+    description: 'NASA/world imagery, news topics, geopolitical signals, and monitored research interests.',
+    currentTruth: 'News and imagery are signals until source-backed and freshness-labeled.',
+    nextAction: 'Route topics into a daily research radar task with evidence requirements.',
+    agent: 'Da Vinci',
+    sources: ['NASA Worldview', 'Earthdata', 'official news/source feeds', 'brain topics'],
+  },
+  {
+    id: 'performance',
+    title: 'Performance + Golf',
+    tone: 'border-lime-500/30 bg-lime-500/10',
+    icon: GolfHoleIcon,
+    description: 'Practice loops, body/recovery, motivation, accountability, and Wilson performance gains.',
+    currentTruth: 'Useful only if it changes practice, recovery, focus, or accountability today.',
+    nextAction: 'Create a daily MIQ and practice-accountability rail.',
+    agent: 'Waitzkin',
+    sources: ['practice notes', 'round data', 'body signals', 'daily agenda'],
+  },
+  {
+    id: 'treasure',
+    title: 'Treasure + Field Intel',
+    tone: 'border-amber-500/30 bg-amber-500/10',
+    icon: MapsGlobal01Icon,
+    description: 'Palantir-style map intelligence, provenance, field planning, and research gates.',
+    currentTruth: 'Field actions stay gated; provenance and source quality matter before confidence.',
+    nextAction: 'Map current leads, missing evidence, and safest next research step.',
+    agent: 'Hermes-treasure',
+    sources: ['maps', 'local notes', 'provenance files', 'field constraints'],
+  },
+  {
+    id: 'ideas',
+    title: 'Ideas + Topics Inbox',
+    tone: 'border-violet-500/30 bg-violet-500/10',
+    icon: BrainIcon,
+    description: 'Capture interests once, route them to the right agent, and turn repeated workflows into skill candidates.',
+    currentTruth: 'Ideas become useful when they are routed, sourced, planned, and revisited.',
+    nextAction: 'Capture one high-leverage idea and assign a research/planning owner.',
+    agent: 'Reddington',
+    sources: ['idea inbox', 'brain files', 'agent outputs', 'skill candidates'],
+  },
+]
+
+async function createIdeaTask(input: { title: string; description: string; domain: DomainHub }) {
+  const response = await fetch('/api/hermes-tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: input.title,
+      description: [
+        input.description,
+        `Domain: ${input.domain.title}`,
+        `Agent: ${input.domain.agent}`,
+        `Source standard: evidence-labeled with source, freshness, confidence, impact, and live/stale/inferred/missing.`,
+        `Next action: ${input.domain.nextAction}`,
+      ].join('\n\n'),
+      column: 'todo',
+      priority: 'medium',
+      assignee: input.domain.agent,
+      tags: ['idea-inbox', input.domain.id, 'source-backed'],
+      created_by: 'domains',
+    }),
+  })
+  if (!response.ok) throw new Error(`Failed to create idea task: ${response.status}`)
+  return response.json()
+}
+
+export function DomainsScreen() {
+  const queryClient = useQueryClient()
+  const [selectedDomainId, setSelectedDomainId] = useState('ideas')
+  const [idea, setIdea] = useState('')
+  const [detail, setDetail] = useState('')
+  const selectedDomain = useMemo(
+    () => DOMAINS.find((domain) => domain.id === selectedDomainId) ?? DOMAINS[0],
+    [selectedDomainId],
+  )
+
+  const createMutation = useMutation({
+    mutationFn: createIdeaTask,
+    onSuccess: () => {
+      toast('Idea routed to Mission Control')
+      setIdea('')
+      setDetail('')
+      void queryClient.invalidateQueries({ queryKey: ['hermes', 'tasks'] })
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : 'Failed to route idea', { type: 'error' }),
+  })
+
+  function submitIdea() {
+    const title = idea.trim()
+    if (!title) {
+      toast('Add an idea or topic first', { type: 'error' })
+      return
+    }
+    createMutation.mutate({
+      title,
+      description: detail.trim() || 'Plan how to get the best information daily, then execute systematically inside the safe local loop.',
+      domain: selectedDomain,
+    })
+  }
+
+  return (
+    <div className="min-h-full bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.08),transparent_28rem),var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Domain Hubs</p>
+          <h1 className="mt-1 text-xl font-semibold">Wilson Intelligence Domains</h1>
+          <p className="mt-1 max-w-3xl text-sm text-[var(--theme-muted)]">
+            Finance, research/world imagery, performance, treasure, and ideas are not separate toys; each routes through the same source {'->'} agent {'->'} proof {'->'} bottleneck {'->'} next-move loop.
+          </p>
+          <div className="mt-3 grid gap-2 text-[11px] sm:grid-cols-3">
+            <div className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2"><span className="font-semibold text-[var(--theme-text)]">Source standard:</span> evidence, freshness, confidence, impact.</div>
+            <div className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2"><span className="font-semibold text-[var(--theme-text)]">Truth label:</span> live, stale, inferred, missing, or proposal-only.</div>
+            <div className="rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2"><span className="font-semibold text-[var(--theme-text)]">Action gate:</span> external-world changes require Wilson approval.</div>
+          </div>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_420px]">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {DOMAINS.map((domain) => (
+              <button
+                key={domain.id}
+                type="button"
+                onClick={() => setSelectedDomainId(domain.id)}
+                className={cn(
+                  'min-h-[220px] rounded-lg border p-4 text-left transition-transform hover:-translate-y-0.5',
+                  domain.tone,
+                  selectedDomain.id === domain.id && 'ring-1 ring-[var(--theme-accent)]',
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="inline-flex size-10 items-center justify-center rounded-md border border-white/10 bg-black/20">
+                    <HugeiconsIcon icon={domain.icon} size={22} />
+                  </div>
+                  <span className="rounded-full border border-white/10 bg-black/20 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                    {domain.agent} · proposal rail
+                  </span>
+                </div>
+                <h2 className="mt-4 text-base font-semibold">{domain.title}</h2>
+                <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{domain.description}</p>
+                <div className="mt-4 rounded-md border border-white/10 bg-black/15 p-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">Next</p>
+                  <p className="mt-1 text-xs">{domain.nextAction}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <aside className="space-y-4">
+            <section className={cn('rounded-lg border p-4', selectedDomain.tone)}>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Selected Hub</p>
+              <h2 className="mt-2 text-lg font-semibold">{selectedDomain.title}</h2>
+              <p className="mt-2 text-sm text-[var(--theme-muted)]">{selectedDomain.currentTruth}</p>
+              <div className="mt-3 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-100">
+                Planning rail only: this card describes the operating model and source map. It is not claiming a live feed until evidence appears in Company Flow or a proof artifact.
+              </div>
+              <div className="mt-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Source map</p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {selectedDomain.sources.map((source) => (
+                    <span key={source} className="rounded-full border border-white/10 bg-black/20 px-2 py-1 text-[10px] text-[var(--theme-muted)]">{source}</span>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Ideas Inbox</p>
+              <h2 className="mt-1 text-base font-semibold">Route an idea to Hermes</h2>
+              <div className="mt-3 space-y-3">
+                <input
+                  value={idea}
+                  onChange={(event) => setIdea(event.target.value)}
+                  placeholder="Topic, idea, lead, question, or opportunity"
+                  className="w-full rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm outline-none focus:border-[var(--theme-accent)]"
+                />
+                <textarea
+                  value={detail}
+                  onChange={(event) => setDetail(event.target.value)}
+                  placeholder="What should Hermes learn, monitor, plan, or improve?"
+                  rows={5}
+                  className="w-full resize-none rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm outline-none focus:border-[var(--theme-accent)]"
+                />
+                <button
+                  type="button"
+                  disabled={createMutation.isPending}
+                  onClick={submitIdea}
+                  className="inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[var(--theme-accent)] px-3 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                >
+                  <HugeiconsIcon icon={Add01Icon} size={16} />
+                  Stage routed planning task
+                </button>
+              </div>
+            </section>
+          </aside>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/schedule/schedule-screen.tsx
+++ b/src/screens/schedule/schedule-screen.tsx
@@ -21,9 +21,9 @@ type CommandStatus = {
   generated_at: string
   health: Record<string, string>
   summary: Record<string, number>
-  schedule: StatusItem[]
-  next_moves: StatusItem[]
-  needs_wilson: StatusItem[]
+  schedule: Array<StatusItem>
+  next_moves: Array<StatusItem>
+  needs_wilson: Array<StatusItem>
 }
 
 async function createScheduleTask(item: StatusItem) {

--- a/src/screens/schedule/schedule-screen.tsx
+++ b/src/screens/schedule/schedule-screen.tsx
@@ -1,0 +1,182 @@
+import { useMemo } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Add01Icon, Calendar03Icon, RefreshIcon } from '@hugeicons/core-free-icons'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+
+type StatusItem = {
+  id: string
+  title: string
+  detail: string
+  status: 'live' | 'stale' | 'inferred' | 'missing' | 'blocked' | 'ready'
+  priority: 'critical' | 'high' | 'medium' | 'low'
+  owner?: string
+  action?: string
+  href?: string
+  evidence?: string
+}
+
+type CommandStatus = {
+  generated_at: string
+  health: Record<string, string>
+  summary: Record<string, number>
+  schedule: StatusItem[]
+  next_moves: StatusItem[]
+  needs_wilson: StatusItem[]
+}
+
+async function createScheduleTask(item: StatusItem) {
+  const response = await fetch('/api/hermes-tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: item.title,
+      description: [
+        item.detail,
+        item.action ? `Action: ${item.action}` : '',
+        'Apple autonomy policy: this screen stages local tasks only. Real Calendar/Reminder writes are not wired here yet; when enabled, only reversible low-risk local items are allowed without extra approval. Deletions, invites, shared calendars, external attendees, email/messages, and outward-facing actions require Wilson approval.',
+      ].filter(Boolean).join('\n\n'),
+      column: 'todo',
+      priority: item.priority === 'critical' || item.priority === 'high' ? 'high' : 'medium',
+      assignee: item.owner || 'Alfred',
+      tags: ['schedule', 'apple-reminders', 'daily-os'],
+      created_by: 'schedule',
+    }),
+  })
+  if (!response.ok) throw new Error(`Failed to create task: ${response.status}`)
+  return response.json()
+}
+
+export function ScheduleScreen() {
+  const queryClient = useQueryClient()
+  const statusQuery = useQuery({
+    queryKey: ['command-center-status'],
+    queryFn: async () => {
+      const response = await fetch('/api/command-center-status?refresh=1')
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      return (await response.json()) as CommandStatus
+    },
+    refetchInterval: 30_000,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createScheduleTask,
+    onSuccess: () => {
+      toast('Schedule planning task staged')
+      void queryClient.invalidateQueries({ queryKey: ['hermes', 'tasks'] })
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : 'Failed to create schedule task', { type: 'error' }),
+  })
+
+  const packet = statusQuery.data
+  const jobs = packet?.schedule ?? []
+  const scheduleMove = useMemo(
+    () => packet?.next_moves.find((item) => item.id === 'daily-apple-rail') ?? {
+      id: 'daily-apple-rail',
+      title: 'Dial in today and tomorrow schedule rails',
+      detail: 'Stage the daily rail from jobs, tasks, and Wilson-needed decisions; do not mutate Apple Calendar/Reminders from this screen.',
+      status: 'ready' as const,
+      priority: 'high' as const,
+      owner: 'Alfred',
+      action: 'Prepare the daily rail.',
+    },
+    [packet],
+  )
+
+  return (
+    <div className="min-h-full bg-[linear-gradient(180deg,rgba(34,197,94,0.06),transparent_22rem),var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Daily OS</p>
+              <h1 className="mt-1 flex items-center gap-2 text-xl font-semibold">
+                <HugeiconsIcon icon={Calendar03Icon} size={22} />
+                Schedule
+              </h1>
+              <p className="mt-1 max-w-3xl text-sm text-[var(--theme-muted)]">
+                Apple Calendar and Reminders policy rail for today/tomorrow. Current UI stages local planning tasks only; real Apple writes are intentionally not wired here. When enabled, only reversible low-risk local items are allowed without extra approval.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void statusQuery.refetch()}
+              className="inline-flex items-center gap-1.5 rounded-md border border-[var(--theme-border)] px-3 py-2 text-xs text-[var(--theme-muted)] hover:text-[var(--theme-text)]"
+            >
+              <HugeiconsIcon icon={RefreshIcon} size={14} />
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)]">
+            <div className="border-b border-[var(--theme-border)] px-4 py-3">
+              <h2 className="text-sm font-semibold">Today + Tomorrow Job Rail</h2>
+              <p className="mt-1 text-xs text-[var(--theme-muted)]">Hermes jobs that should feed daily planning, reminders, and review loops. This is an evidence rail, not proof of Apple mutation.</p>
+            </div>
+            <div className="divide-y divide-[var(--theme-border)]">
+              {statusQuery.isLoading ? (
+                <div className="p-4 text-sm text-[var(--theme-muted)]">Loading schedule...</div>
+              ) : statusQuery.isError ? (
+                <div className="p-4 text-sm text-red-300">Schedule rail failed to load. No calendar/reminder action was attempted.</div>
+              ) : jobs.length === 0 ? (
+                <div className="p-4 text-sm text-[var(--theme-muted)]">No scheduled jobs found in the local proof packet.</div>
+              ) : jobs.map((item) => (
+                <div key={item.id} className="flex flex-wrap items-start justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className={cn(
+                        'size-2 rounded-full',
+                        item.status === 'live' ? 'bg-emerald-500' : item.status === 'blocked' ? 'bg-amber-500' : 'bg-neutral-500',
+                      )} />
+                      <h3 className="truncate text-sm font-medium">{item.title}</h3>
+                    </div>
+                    <p className="mt-1 text-xs text-[var(--theme-muted)]">{item.detail}</p>
+                    {item.evidence ? <p className="mt-1 truncate font-mono text-[10px] text-[var(--theme-muted)]">{item.evidence}</p> : null}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={createMutation.isPending}
+                    onClick={() => createMutation.mutate(item)}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-[var(--theme-border)] px-2.5 py-1.5 text-[11px] hover:border-[var(--theme-accent)] disabled:opacity-60"
+                  >
+                    <HugeiconsIcon icon={Add01Icon} size={12} />
+                    Stage task
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <aside className="space-y-4">
+            <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Next Best Move</p>
+              <h2 className="mt-2 text-base font-semibold">{scheduleMove.title}</h2>
+              <p className="mt-2 text-xs text-[var(--theme-muted)]">{scheduleMove.detail}</p>
+              <button
+                type="button"
+                disabled={createMutation.isPending}
+                onClick={() => createMutation.mutate(scheduleMove)}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-[var(--theme-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
+              >
+                <HugeiconsIcon icon={Add01Icon} size={14} />
+                Stage daily rail task
+              </button>
+            </section>
+            <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Apple Safety Contract</p>
+              <div className="mt-3 space-y-2 text-xs text-[var(--theme-muted)]">
+                <p><span className="font-semibold text-[var(--theme-text)]">Current implementation:</span> stages Hermes tasks only; it does not write Apple Calendar or Reminders.</p>
+                <p><span className="font-semibold text-[var(--theme-text)]">Future allowed lane:</span> create/update reversible, low-risk local reminders and calendar blocks only.</p>
+                <p><span className="font-semibold text-[var(--theme-text)]">Approval required:</span> deletes, invites, shared calendars, external attendees, messages/email, launchd, exposed ports, secrets, or anything outward-facing.</p>
+                <p><span className="font-semibold text-[var(--theme-text)]">Proof:</span> every automatic change should leave a task or output artifact with timestamp and reason.</p>
+              </div>
+            </section>
+          </aside>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/server/command-center-data.ts
+++ b/src/server/command-center-data.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { listTasks } from './tasks-store'
@@ -640,7 +640,7 @@ function buildHermesCompany({
         id: `skill-${slug(path.slice(SKILLS_DIR.length + 1))}`,
         source_path: path,
         source_type: 'skill' as const,
-        owner_agent: owners.length ? owners.map((owner) => HERMES_AGENT_DEFAULTS[owner]?.name ?? displayNameFromId(owner)).join(', ') : 'Unmapped',
+        owner_agent: owners.length ? owners.map((owner) => HERMES_AGENT_DEFAULTS[owner].name).join(', ') : 'Unmapped',
         project: skillCategory(path),
         freshness: statSync(path).mtime.toISOString(),
         confidence: owners.length ? 'medium' as const : 'low' as const,
@@ -797,7 +797,7 @@ export async function buildCommandCenterStatus({ refresh = false } = {}): Promis
   const proofPath = latestProofPath()
   const proof = proofPath ? readJson(proofPath) as Record<string, unknown> | null : null
   const proofSummary = (proof?.summary && typeof proof.summary === 'object')
-    ? proof.summary as Record<string, number>
+    ? proof.summary as Partial<Record<string, number>>
     : {}
   const jobs = normalizeJobs(readJson(JOBS_FILE))
   const tasks = listTasks({ includeDone: true })

--- a/src/server/command-center-data.ts
+++ b/src/server/command-center-data.ts
@@ -1,0 +1,1345 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { listTasks } from './tasks-store'
+
+type RawJob = Record<string, unknown>
+
+export type CommandCenterStatus = {
+  generated_at: string
+  horizon: 'today_tomorrow'
+  health: {
+    workspace_ui: 'live' | 'down'
+    gateway: 'live' | 'down'
+    dashboard_api: 'live' | 'auth_gated' | 'down'
+  }
+  summary: {
+    needs_wilson: number
+    jobs_total: number
+    approvals_required: number
+    unproven: number
+    broken_flows: number
+    tasks_open: number
+	  gains: number
+	  next_moves: number
+	  hermes_primary_drivers: number
+	  support_specialists: number
+	  skills_total: number
+	  automations_ready: number
+	  identity_issues: number
+	}
+  needs_wilson: Array<CommandCenterItem>
+  bottlenecks: Array<CommandCenterItem>
+	  gains: Array<CommandCenterItem>
+	  next_moves: Array<CommandCenterItem>
+	  schedule: Array<CommandCenterItem>
+	  company: HermesCompany
+	  automation_queue: Array<HermesAutomationQueueItem>
+	  evidence_ledger: Array<HermesEvidenceRecord>
+	  sections: Array<CommandCenterSection>
+	  sources: Array<CommandCenterSource>
+	  proof: Record<string, unknown> | null
+	}
+
+export type CommandCenterItem = {
+  id: string
+  title: string
+  detail: string
+  status: 'live' | 'stale' | 'inferred' | 'missing' | 'blocked' | 'ready'
+  priority: 'critical' | 'high' | 'medium' | 'low'
+  owner?: string
+  action?: string
+  href?: string
+  evidence?: string
+}
+
+export type CommandCenterSection = {
+  id: string
+  label: string
+  status: 'live' | 'needs_attention' | 'planned'
+  current_truth: string
+  bottleneck: string
+  next_action: string
+  href: string
+}
+
+export type CommandCenterSource = {
+  id: string
+  label: string
+  path: string
+  status: 'live' | 'missing'
+  modified_at?: string
+}
+
+export type HermesEmployee = {
+  id: string
+  name: string
+  department: string
+  operating_role: 'primary_driver' | 'support_specialist'
+  role: string
+  mission: string
+  health: 'live' | 'needs_attention' | 'missing'
+  proof_status: CommandCenterItem['status']
+  capabilities: Array<string>
+  owned_projects: Array<string>
+  current_work: string
+  blocker: string
+  next_move: string
+  needed_data: Array<string>
+  jobs: number
+  tasks: number
+  source_paths: Array<string>
+  identity_issues: Array<string>
+}
+
+export type HermesCompany = {
+  operating_model: 'hermes_led_with_support_specialists'
+  primary_drivers: Array<HermesEmployee>
+  support_specialists: Array<HermesEmployee>
+  skill_inventory: {
+    total: number
+    by_category: Record<string, number>
+    mapped_to_hermes: number
+  }
+  top_bottlenecks: Array<CommandCenterItem>
+}
+
+export type HermesAutomationQueueItem = CommandCenterItem & {
+  cadence: 'nightly' | 'daily' | 'continuous'
+  driver: string
+  support?: string
+  autonomy: 'local_autonomous' | 'approval_gated'
+}
+
+export type HermesEvidenceRecord = {
+  id: string
+  source_path: string
+  source_type: 'profile' | 'skill' | 'job' | 'proof' | 'handoff' | 'task' | 'brain' | 'system'
+  owner_agent: string
+  project: string
+  freshness: string
+  confidence: 'high' | 'medium' | 'low'
+  impact: 'critical' | 'high' | 'medium' | 'low'
+  status: 'live' | 'stale' | 'inferred' | 'missing' | 'conflict'
+  recommended_task: string
+}
+
+export type CompanyFlowPacket = CommandCenterStatus & {
+  mode: 'full_loop_with_external_gates'
+  nodes: Array<FlowNode>
+  edges: Array<FlowEdge>
+  skill_candidates: Array<CommandCenterItem>
+}
+
+export type FlowNode = {
+  id: string
+  type: 'source' | 'agent' | 'support' | 'job' | 'automation' | 'output' | 'proof' | 'approval' | 'project' | 'gain' | 'next_move' | 'skill_candidate'
+  label: string
+  column: number
+  status: CommandCenterItem['status']
+  priority?: CommandCenterItem['priority']
+  detail?: string
+  href?: string
+}
+
+export type FlowEdge = {
+  id: string
+  source: string
+  target: string
+  label: string
+  status: 'healthy' | 'blocked' | 'attention'
+}
+
+const AI_SYSTEMS = process.env.MAJESTIC12_ROOT || '/Users/majestic12/ai-systems'
+const HERMES_HOME = process.env.HERMES_HOME || join(os.homedir(), '.hermes')
+const WORKSPACE = join(AI_SYSTEMS, 'hermes-workspace')
+const STATE_DIR = join(AI_SYSTEMS, 'state')
+const BRIDGE_DIR = join(AI_SYSTEMS, 'bridge', 'hermes_to_cowork')
+const JOBS_FILE = join(HERMES_HOME, 'cron', 'jobs.json')
+const OUTPUT_DIR = join(HERMES_HOME, 'cron', 'output')
+const PROFILES_DIR = join(HERMES_HOME, 'profiles')
+const SKILLS_DIR = join(HERMES_HOME, 'skills')
+
+const SOURCE_PATHS = [
+  {
+    id: 'doctrine',
+    label: 'Majestic12 doctrine',
+    path: '/Users/majestic12/brain/design/majestic12_os_agent_company_doctrine_2026-04-29.md',
+  },
+  {
+    id: 'source-radar',
+    label: 'Source radar implementation',
+    path: '/Users/majestic12/brain/improvement/company_project_source_radar_implementation_2026-04-29.md',
+  },
+  {
+    id: 'truth-debt',
+    label: 'Truth debt',
+    path: '/Users/majestic12/brain/state/company_project_source_radar_truth_debt_2026-04-29.md',
+  },
+  {
+    id: 'handoffs',
+    label: 'Hermes to Cowork handoffs',
+    path: join(AI_SYSTEMS, 'bridge', 'hermes_to_cowork'),
+  },
+  {
+    id: 'shared-goals-todos',
+    label: 'Shared goals + todo board',
+    path: join(HERMES_HOME, 'tasks.json'),
+  },
+  {
+    id: 'startup-mission',
+    label: 'Startup acceleration mission packet',
+    path: join(AI_SYSTEMS, 'state', 'agent_startup_mission_current.json'),
+  },
+]
+
+function normalizeJobs(payload: unknown): Array<RawJob> {
+  if (Array.isArray(payload)) return payload as Array<RawJob>
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>
+    if (Array.isArray(record.jobs)) return record.jobs as Array<RawJob>
+    if (record.jobs && typeof record.jobs === 'object') {
+      return Object.values(record.jobs) as Array<RawJob>
+    }
+  }
+  return []
+}
+
+function readJson(path: string): unknown | null {
+  try {
+    if (!existsSync(path)) return null
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function latestProofPath(): string | null {
+  try {
+    const latest = readdirSync(STATE_DIR)
+      .filter((name) => /^hermes_jobs_proof_status_\d{4}-\d{2}-\d{2}\.json$/.test(name))
+      .sort()
+      .at(-1)
+    return latest ? join(STATE_DIR, latest) : null
+  } catch {
+    return null
+  }
+}
+
+function refreshProof(): void {
+  try {
+    execFileSync('node', [join(WORKSPACE, 'scripts', 'generate-hermes-proof-status.mjs')], {
+      cwd: WORKSPACE,
+      timeout: 30_000,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+  } catch {
+    // The command center must degrade gracefully if Hermes is temporarily down.
+  }
+}
+
+async function probeHealth(url: string): Promise<'live' | 'auth_gated' | 'down'> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(1800) })
+    if (res.ok) return 'live'
+    if (res.status === 401 || res.status === 403) return 'auth_gated'
+    return 'down'
+  } catch {
+    return 'down'
+  }
+}
+
+function readSources(): Array<CommandCenterSource> {
+  return SOURCE_PATHS.map((source) => {
+    try {
+      const st = statSync(source.path)
+      return {
+        ...source,
+        status: 'live' as const,
+        modified_at: st.mtime.toISOString(),
+      }
+    } catch {
+      return { ...source, status: 'missing' as const }
+    }
+  })
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function jobId(job: RawJob): string {
+  return asString(job.id) || asString(job.job_id) || asString(job.jobId)
+}
+
+function jobName(job: RawJob): string {
+  return asString(job.name) || jobId(job) || 'Unnamed job'
+}
+
+function agentNameFromJob(name: string): string {
+  return name.split(' daily ')[0].replace(/ nightly .*/, '').trim() || name
+}
+
+function jobSchedule(job: RawJob): string {
+  if (typeof job.schedule === 'string') return job.schedule
+  const schedule = job.schedule as Record<string, unknown> | undefined
+  return asString(job.schedule_display) || asString(schedule?.display) || asString(schedule?.expr)
+}
+
+function buildOutputPath(id: string): string | null {
+  const dir = join(OUTPUT_DIR, id)
+  try {
+    const latest = readdirSync(dir)
+      .filter((name) => /\.(md|json|txt)$/.test(name))
+      .sort()
+      .at(-1)
+    return latest ? join(dir, latest) : null
+  } catch {
+    return null
+  }
+}
+
+function proofJobs(proof: Record<string, unknown> | null): Array<Record<string, unknown>> {
+  return Array.isArray(proof?.jobs) ? proof.jobs as Array<Record<string, unknown>> : []
+}
+
+const HERMES_AGENT_DEFAULTS: Record<string, {
+  name: string
+  department: string
+  operating_role: HermesEmployee['operating_role']
+  role: string
+  mission: string
+  owned_projects: Array<string>
+  next_move: string
+}> = {
+  reddington: {
+    name: 'Reddington',
+    department: 'Executive',
+    operating_role: 'primary_driver',
+    role: 'CEO / whole-system orchestrator',
+    mission: 'Translate Wilson intent into ranked next moves and seize the highest-leverage bottleneck.',
+    owned_projects: ['Majestic12 OS', 'Mission Control', 'Company priorities'],
+    next_move: 'Rank the company queue and assign each blocker to an owner.',
+  },
+  hermes_curator: {
+    name: 'Hermes Curator',
+    department: 'Truth Infrastructure',
+    operating_role: 'primary_driver',
+    role: 'Source truth, proof, system health, attribution',
+    mission: 'Maintain source maps, truth debt, dashboard/API health, proof packets, and proposal-first infrastructure upgrades.',
+    owned_projects: ['Proof packets', 'Source maps', 'Dashboard health'],
+    next_move: 'Classify proof outputs and turn unresolved evidence into owned tasks.',
+  },
+  scribe: {
+    name: 'Scribe',
+    department: 'Memory',
+    operating_role: 'primary_driver',
+    role: 'Durable memory and knowledge promotion',
+    mission: 'Convert raw activity into durable wikis, ledgers, review queues, skills, truth labels, and state summaries.',
+    owned_projects: ['Memory', 'Knowledge base', 'Promotion queue'],
+    next_move: 'Promote the most useful agent outputs into evidence-labeled memory.',
+  },
+  strategist: {
+    name: 'Strategist',
+    department: 'Strategy',
+    operating_role: 'primary_driver',
+    role: 'Portfolio architecture and leverage ranking',
+    mission: 'Rank the highest-leverage moves across Majestic12 and keep mini-companies pointed at moonshot outcomes.',
+    owned_projects: ['Portfolio strategy', 'Moonshot ranking', 'Company architecture'],
+    next_move: 'Pressure-test the top projects against bottleneck, proof, and leverage.',
+  },
+  feynman: {
+    name: 'Feynman',
+    department: 'Finance + World Intelligence',
+    operating_role: 'primary_driver',
+    role: 'Markets, equities, earth intelligence',
+    mission: 'Produce proposal-first investing, personal-interest, and geopolitical intelligence from sourced public data.',
+    owned_projects: ['JanetStreet', 'Finance radar', 'World intelligence'],
+    next_move: 'Publish source-backed market/world radar with no action until approval gates clear.',
+  },
+  waitzkin: {
+    name: 'Waitzkin',
+    department: 'Performance',
+    operating_role: 'primary_driver',
+    role: 'Golf performance and accountability',
+    mission: 'Make Wilson world-class at golf through practice design, round review, mental-game integration, and learning loops.',
+    owned_projects: ['Citadel', 'Golf practice', 'Performance accountability'],
+    next_move: 'Publish the current golf scoreboard and next practice protocol.',
+  },
+  da_vinci: {
+    name: 'Da Vinci',
+    department: 'Research + Invention',
+    operating_role: 'primary_driver',
+    role: 'Research polymath and invention synthesis',
+    mission: 'Connect science, design, engineering, art, biology, history, and weird edges into usable questions and prototypes.',
+    owned_projects: ['Research synthesis', 'Prototype ideas', 'Creative invention'],
+    next_move: 'Route one high-upside idea into a sourced experiment plan.',
+  },
+  curie: {
+    name: 'Curie',
+    department: 'Research Radar',
+    operating_role: 'primary_driver',
+    role: 'Science and research signal scout',
+    mission: 'Scan research signals and convert promising findings into sourced next-step briefs.',
+    owned_projects: ['Research radar', 'Science watch'],
+    next_move: 'Produce one high-signal research brief with source freshness and confidence.',
+  },
+  alfred: {
+    name: 'Alfred',
+    department: 'Life Admin',
+    operating_role: 'primary_driver',
+    role: 'Life admin and daily operating rails',
+    mission: 'Keep Wilson’s day, reminders, admin loose ends, and practical context organized.',
+    owned_projects: ['Life admin', 'Reminders', 'Daily agenda'],
+    next_move: 'Prepare today/tomorrow admin risks and reminders needing cleanup.',
+  },
+  hermes_treasure: {
+    name: 'Hermes Treasure',
+    department: 'Field Research',
+    operating_role: 'primary_driver',
+    role: 'Treasure, provenance, and field research gates',
+    mission: 'Maintain clue provenance, field gates, map/intel planning, and research safety constraints.',
+    owned_projects: ['Treasure research', 'Field gates', 'Provenance'],
+    next_move: 'Update active clues, confidence, and field gate status from sourced files.',
+  },
+  claude_code: {
+    name: 'Claude Code',
+    department: 'Engineering Support',
+    operating_role: 'support_specialist',
+    role: 'Engineering/build support assigned by Hermes',
+    mission: 'Build, test, harden, and verify the local OS, dashboard, adapters, and runtime when Hermes assigns engineering work.',
+    owned_projects: ['Command Center engineering', 'Build/test reliability'],
+    next_move: 'Run app reliability loops only when delegated by Hermes.',
+  },
+  cowork: {
+    name: 'Cowork',
+    department: 'Scheduling Support',
+    operating_role: 'support_specialist',
+    role: 'Recurrence, scheduling rhythm, handoffs, proof timing',
+    mission: 'Keep recurring scans, reviews, proof loops, and agent rhythms alive while distinguishing scheduled from proven.',
+    owned_projects: ['Cron rhythm', 'Handoffs', 'Proof timing'],
+    next_move: 'Maintain schedule rhythm after Hermes sets priorities.',
+  },
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+}
+
+function displayNameFromId(id: string): string {
+  return id.split('_').map((part) => part ? part[0].toUpperCase() + part.slice(1) : part).join(' ')
+}
+
+function normalizeOwner(value: string): string {
+  const clean = slug(value.replace(/\bdaily\b|\bnightly\b|\bmorning\b|\bproof\b|\bcheck\b/gi, ' '))
+  if (clean.includes('hermes_curator')) return 'hermes_curator'
+  if (clean.includes('hermes_treasure')) return 'hermes_treasure'
+  if (clean.includes('claude')) return 'claude_code'
+  if (clean.includes('cowork')) return 'cowork'
+  if (clean === 'hermes' || /^hermes_\d/.test(clean)) return 'hermes_curator'
+  if (clean.includes('majestic12') || clean.includes('os_radar')) return 'strategist'
+  return clean.split('_')[0] || clean
+}
+
+function readText(path: string): string {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function firstMarkdownValue(text: string, label: string): string {
+  const match = text.match(new RegExp(`^${label}:\\s*(.+)$`, 'im'))
+  return match?.[1]?.trim() ?? ''
+}
+
+function listSkillFiles(dir = SKILLS_DIR): Array<string> {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) return listSkillFiles(path)
+      return entry.name === 'SKILL.md' ? [path] : []
+    })
+  } catch {
+    return []
+  }
+}
+
+function skillCategory(path: string): string {
+  const relative = path.startsWith(SKILLS_DIR) ? path.slice(SKILLS_DIR.length + 1) : path
+  return relative.split('/')[0] || 'uncategorized'
+}
+
+function summarizeSkills(skillFiles: Array<string>): HermesCompany['skill_inventory'] {
+  const byCategory: Record<string, number> = {}
+  for (const path of skillFiles) {
+    const category = skillCategory(path)
+    byCategory[category] = (byCategory[category] ?? 0) + 1
+  }
+  return {
+    total: skillFiles.length,
+    by_category: byCategory,
+    mapped_to_hermes: skillFiles.filter((path) => agentCapabilitiesFromSkillPath(path).length > 0).length,
+  }
+}
+
+function agentCapabilitiesFromSkillPath(path: string): Array<string> {
+  const rel = path.toLowerCase()
+  const owners: Array<string> = []
+  if (/janetstreet|kalshi|polymarket|finance|blogwatcher|worldview/.test(rel)) owners.push('feynman')
+  if (/citadel|golf|performance/.test(rel)) owners.push('waitzkin')
+  if (/scribe|obsidian|note|ocr|documents|knowledge|session-compounding/.test(rel)) owners.push('scribe')
+  if (/capability-spine|life-admin|maps|google-workspace|airtable|notion/.test(rel)) owners.push('reddington')
+  if (/dashboard|hardening|debugging|filesystem|skill-authoring|mcp|github|test-driven|systematic/.test(rel)) owners.push('hermes_curator')
+  if (/creative|design|diagram|research-paper|arxiv|llm-wiki/.test(rel)) owners.push('da_vinci')
+  if (/claude-code|codex|opencode|node-inspect|python-debugpy/.test(rel)) owners.push('claude_code')
+  return [...new Set(owners)]
+}
+
+function capabilityLabelsForAgent(id: string, skillFiles: Array<string>): Array<string> {
+  const defaults: Record<string, Array<string>> = {
+    reddington: ['CEO orchestration', 'Priority ranking', 'Bottleneck seizure', 'Company alignment'],
+    hermes_curator: ['Proof packets', 'Source maps', 'Truth debt', 'Dashboard/API health'],
+    scribe: ['Memory promotion', 'Knowledge hygiene', 'Durable ledgers', 'State summaries'],
+    strategist: ['Portfolio ranking', 'Moonshot architecture', 'Leverage analysis'],
+    feynman: ['Equities research', 'World intelligence', 'Risk-gated proposals', 'Market radar'],
+    waitzkin: ['Golf practice design', 'Performance review', 'Accountability loops'],
+    da_vinci: ['Research synthesis', 'Creative invention', 'Prototype questions'],
+    curie: ['Research scan', 'Scientific signal triage'],
+    alfred: ['Life admin', 'Reminder cleanup', 'Daily logistics'],
+    hermes_treasure: ['Provenance', 'Field gates', 'Map/intel planning'],
+    claude_code: ['Code implementation', 'Type/build verification', 'App hardening'],
+    cowork: ['Cron rhythm', 'Handoffs', 'Schedule timing'],
+  }
+  const skillCategories = skillFiles
+    .filter((path) => agentCapabilitiesFromSkillPath(path).includes(id))
+    .map((path) => skillCategory(path).replace(/-/g, ' '))
+  return [...new Set([...(defaults[id] ?? []), ...skillCategories])].slice(0, 8)
+}
+
+function employeeProofStatus(rows: Array<Record<string, unknown>>, id: string): CommandCenterItem['status'] {
+  const agentRows = rows.filter((row) => normalizeOwner(asString(row.agent) || asString(row.name)) === id)
+  if (!agentRows.length) return 'inferred'
+  if (agentRows.some((row) => asString(row.status) === 'approval_required')) return 'blocked'
+  if (agentRows.some((row) => ['failed', 'output_missing', 'evidence_missing'].includes(asString(row.status)))) return 'blocked'
+  if (agentRows.some((row) => asString(row.status) === 'scheduled')) return 'inferred'
+  return 'live'
+}
+
+function latestBridgePath(): string | null {
+  try {
+    const latest = readdirSync(BRIDGE_DIR)
+      .filter((name) => /\.(json|md|txt)$/.test(name))
+      .sort()
+      .at(-1)
+    return latest ? join(BRIDGE_DIR, latest) : null
+  } catch {
+    return null
+  }
+}
+
+function buildHermesCompany({
+  jobs,
+  tasks,
+  proofRows,
+}: {
+  jobs: Array<RawJob>
+  tasks: ReturnType<typeof listTasks>
+  proofRows: Array<Record<string, unknown>>
+}): { company: HermesCompany; evidence: Array<HermesEvidenceRecord> } {
+  const skillFiles = listSkillFiles()
+  const employeeIds = new Set<string>(Object.keys(HERMES_AGENT_DEFAULTS))
+  try {
+    for (const name of readdirSync(PROFILES_DIR)) {
+      if (statSync(join(PROFILES_DIR, name)).isDirectory()) employeeIds.add(slug(name))
+    }
+  } catch {
+    // Missing profile directory is handled as evidence below.
+  }
+  for (const job of jobs) employeeIds.add(normalizeOwner(agentNameFromJob(jobName(job))))
+
+  const employees = [...employeeIds].map((id): HermesEmployee => {
+    const defaults = HERMES_AGENT_DEFAULTS[id] ?? {
+      name: displayNameFromId(id),
+      department: 'Project Specialist',
+      operating_role: 'primary_driver' as const,
+      role: 'Hermes project specialist',
+      mission: 'Own a Hermes project lane and produce sourced outputs, proof, blockers, and next moves.',
+      owned_projects: [displayNameFromId(id)],
+      next_move: 'Publish current status, blocker, proof, and next action.',
+    }
+    const profileDir = join(PROFILES_DIR, id)
+    const missionPath = join(profileDir, 'MISSION.md')
+    const soulPath = join(profileDir, 'SOUL.md')
+    const missionText = readText(missionPath)
+    const soulText = readText(soulPath)
+    const role = firstMarkdownValue(missionText, 'Role') || defaults.role
+    const mission = firstMarkdownValue(missionText, 'Mission') || defaults.mission
+    const agentJobs = jobs.filter((job) => normalizeOwner(agentNameFromJob(jobName(job))) === id)
+    const agentTasks = tasks.filter((task) => normalizeOwner(task.assignee ?? '') === id)
+    const identityIssues = id !== 'feynman' && /# Feynman|I am Feynman/i.test(soulText)
+      ? ['SOUL.md appears copied from Feynman; use MISSION.md as canonical until repaired.']
+      : []
+    const proofStatus = employeeProofStatus(proofRows, id)
+    const blocker = identityIssues[0]
+      || (proofStatus === 'blocked' ? 'Proof or approval gate is blocking durable truth.' : '')
+      || (agentTasks.find((task) => task.column === 'review')?.title ?? '')
+      || 'No critical blocker surfaced.'
+    const currentWork = agentTasks[0]?.title
+      || (agentJobs[0] ? `${jobName(agentJobs[0])} · ${jobSchedule(agentJobs[0]) || 'unscheduled'}` : '')
+
+    return {
+      id,
+      name: defaults.name,
+      department: defaults.department,
+      operating_role: defaults.operating_role,
+      role,
+      mission,
+      health: identityIssues.length || proofStatus === 'blocked' ? 'needs_attention' : existsSync(profileDir) || agentJobs.length ? 'live' : 'missing',
+      proof_status: proofStatus,
+      capabilities: capabilityLabelsForAgent(id, skillFiles),
+      owned_projects: defaults.owned_projects,
+      current_work: currentWork || 'No current work assigned in local tasks/jobs.',
+      blocker,
+      next_move: defaults.next_move,
+      needed_data: identityIssues.length ? ['Correct profile SOUL.md attribution'] : proofStatus === 'blocked' ? ['Proof classification', 'Output evidence review'] : ['Fresh output artifact'],
+      jobs: agentJobs.length,
+      tasks: agentTasks.length,
+      source_paths: [missionPath, soulPath].filter(existsSync),
+      identity_issues: identityIssues,
+    }
+  })
+
+  const primaryDrivers = employees
+    .filter((employee) => employee.operating_role === 'primary_driver')
+    .sort((a, b) => (a.id === 'reddington' ? -1 : b.id === 'reddington' ? 1 : a.department.localeCompare(b.department)))
+  const supportSpecialists = employees
+    .filter((employee) => employee.operating_role === 'support_specialist')
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const evidence: Array<HermesEvidenceRecord> = [
+    ...employees.flatMap((employee) => employee.source_paths.map((path) => ({
+      id: `profile-${employee.id}-${path.endsWith('SOUL.md') ? 'soul' : 'mission'}`,
+      source_path: path,
+      source_type: 'profile' as const,
+      owner_agent: employee.name,
+      project: employee.department,
+      freshness: statSync(path).mtime.toISOString(),
+      confidence: path.endsWith('MISSION.md') ? 'high' as const : 'medium' as const,
+      impact: employee.identity_issues.length ? 'critical' as const : 'medium' as const,
+      status: employee.identity_issues.length && path.endsWith('SOUL.md') ? 'conflict' as const : 'live' as const,
+      recommended_task: employee.identity_issues.length
+        ? `Repair ${employee.name} identity attribution from canonical MISSION.md.`
+        : `Keep ${employee.name} mission and ownership current.`,
+    }))),
+    ...skillFiles.slice(0, 80).map((path) => {
+      const owners = agentCapabilitiesFromSkillPath(path)
+      return {
+        id: `skill-${slug(path.slice(SKILLS_DIR.length + 1))}`,
+        source_path: path,
+        source_type: 'skill' as const,
+        owner_agent: owners.length ? owners.map((owner) => HERMES_AGENT_DEFAULTS[owner]?.name ?? displayNameFromId(owner)).join(', ') : 'Unmapped',
+        project: skillCategory(path),
+        freshness: statSync(path).mtime.toISOString(),
+        confidence: owners.length ? 'medium' as const : 'low' as const,
+        impact: owners.length ? 'medium' as const : 'high' as const,
+        status: owners.length ? 'inferred' as const : 'missing' as const,
+        recommended_task: owners.length ? 'Verify this skill belongs in the mapped agent capability set.' : 'Assign this skill to a Hermes owner or retire it from active capability planning.',
+      }
+    }),
+  ]
+  const bridgePath = latestBridgePath()
+  if (bridgePath) {
+    evidence.push({
+      id: 'latest-handoff',
+      source_path: bridgePath,
+      source_type: 'handoff',
+      owner_agent: 'Hermes',
+      project: 'Command Center',
+      freshness: statSync(bridgePath).mtime.toISOString(),
+      confidence: 'medium',
+      impact: 'high',
+      status: 'live',
+      recommended_task: 'Use the latest handoff as supporting evidence, not as canonical employee identity.',
+    })
+  }
+
+  const skillInventory = summarizeSkills(skillFiles)
+  const identityIssueCount = employees.reduce((total, employee) => total + employee.identity_issues.length, 0)
+  const topBottlenecks: Array<CommandCenterItem> = [
+    {
+      id: 'bottleneck-agent-identity-attribution',
+      title: 'Repair Hermes employee identity attribution',
+      detail: `${identityIssueCount} profile identity issue${identityIssueCount === 1 ? '' : 's'} detected. MISSION.md remains canonical until SOUL.md is repaired.`,
+      status: identityIssueCount ? 'blocked' : 'ready',
+      priority: identityIssueCount ? 'critical' : 'low',
+      owner: 'Hermes Curator + Reddington',
+      action: 'Create repair tasks for each contaminated profile and keep Cowork/Claude Code labeled as support.',
+      href: '/agents',
+      evidence: PROFILES_DIR,
+    },
+    {
+      id: 'bottleneck-skill-capability-map',
+      title: 'Map Hermes skills to employees and projects',
+      detail: `${skillInventory.total} local skills found; ${skillInventory.mapped_to_hermes} currently map to a likely Hermes owner by local heuristics.`,
+      status: skillInventory.mapped_to_hermes < skillInventory.total ? 'blocked' : 'ready',
+      priority: 'high',
+      owner: 'Hermes Curator',
+      action: 'Turn unmapped high-value skills into owner-verification tasks.',
+      href: '/skills',
+      evidence: SKILLS_DIR,
+    },
+    {
+      id: 'bottleneck-proof-promotion',
+      title: 'Promote proof outputs into tasks, memory, and next moves',
+      detail: 'Outputs are not durable company truth until proof and approval states are classified.',
+      status: proofRows.some((row) => asString(row.status) !== 'ran_successfully') ? 'blocked' : 'ready',
+      priority: 'high',
+      owner: 'Hermes Curator + Scribe',
+      action: 'Classify each proof row and route durable gains into memory or work.',
+      href: '/company-flow',
+      evidence: latestProofPath() || undefined,
+    },
+  ]
+
+  return {
+    company: {
+      operating_model: 'hermes_led_with_support_specialists',
+      primary_drivers: primaryDrivers,
+      support_specialists: supportSpecialists,
+      skill_inventory: skillInventory,
+      top_bottlenecks: topBottlenecks,
+    },
+    evidence,
+  }
+}
+
+function buildAutomationQueue(company: HermesCompany): Array<HermesAutomationQueueItem> {
+  return [
+    {
+      id: 'automation-proof-bottlenecks',
+      title: 'Nightly proof + bottleneck loop',
+      detail: 'Hermes Curator classifies runs, proof gaps, approvals, and broken flows; Reddington ranks the top blockage.',
+      status: 'ready',
+      priority: 'critical',
+      owner: 'Hermes Curator',
+      driver: 'Hermes Curator',
+      support: 'Cowork handles recurrence timing only',
+      cadence: 'nightly',
+      autonomy: 'local_autonomous',
+      action: 'Run local proof generation, update evidence ledger, and create tasks for unresolved blockers.',
+      href: '/company-flow',
+    },
+    {
+      id: 'automation-project-radar',
+      title: 'Nightly project radar loop',
+      detail: 'Hermes agents scan owned project files, report current state, missed data, owner, proof, and next action.',
+      status: 'ready',
+      priority: 'high',
+      owner: 'Reddington',
+      driver: 'Reddington',
+      support: 'Scribe promotes durable findings',
+      cadence: 'nightly',
+      autonomy: 'local_autonomous',
+      action: 'Create project status tasks for stale, missing, or conflicting evidence.',
+      href: '/domains',
+    },
+    {
+      id: 'automation-daily-planning',
+      title: 'Daily planning loop',
+      detail: 'Reddington prepares tomorrow’s top 3 moves from agent outputs, proof, schedule pressure, and Wilson-needed decisions.',
+      status: 'ready',
+      priority: 'high',
+      owner: 'Reddington',
+      driver: 'Reddington',
+      support: 'Alfred and Cowork support agenda/rhythm',
+      cadence: 'daily',
+      autonomy: 'local_autonomous',
+      action: 'Publish today/tomorrow plan and create internal tasks; external actions still require Wilson approval.',
+      href: '/schedule',
+    },
+    {
+      id: 'automation-memory-promotion',
+      title: 'Memory promotion loop',
+      detail: 'Scribe turns approved outputs into durable brain entries with source, freshness, confidence, and impact labels.',
+      status: 'ready',
+      priority: 'high',
+      owner: 'Scribe',
+      driver: 'Scribe',
+      support: 'Hermes Curator validates source truth',
+      cadence: 'nightly',
+      autonomy: 'local_autonomous',
+      action: 'Queue promotion candidates and conflict-resolution tasks instead of overwriting disagreeing facts.',
+      href: '/memory',
+    },
+    {
+      id: 'automation-app-reliability',
+      title: 'Command Center reliability loop',
+      detail: 'Hermes detects route/API/startup failures and delegates engineering implementation to Claude Code only when code work is needed.',
+      status: 'ready',
+      priority: 'high',
+      owner: 'Hermes Curator',
+      driver: 'Hermes Curator',
+      support: 'Claude Code handles assigned code/build/test work',
+      cadence: 'continuous',
+      autonomy: 'local_autonomous',
+      action: 'Smoke core routes and APIs, then stage engineering tasks for failures.',
+      href: '/agents',
+      evidence: company.support_specialists.find((employee) => employee.id === 'claude_code')?.source_paths[0],
+    },
+  ]
+}
+
+export async function buildCommandCenterStatus({ refresh = false } = {}): Promise<CommandCenterStatus> {
+  if (refresh) refreshProof()
+  const proofPath = latestProofPath()
+  const proof = proofPath ? readJson(proofPath) as Record<string, unknown> | null : null
+  const proofSummary = (proof?.summary && typeof proof.summary === 'object')
+    ? proof.summary as Record<string, number>
+    : {}
+  const jobs = normalizeJobs(readJson(JOBS_FILE))
+  const tasks = listTasks({ includeDone: true })
+  const openTasks = tasks.filter((task) => task.column !== 'done')
+  const sources = readSources()
+  const proofJobRows = proofJobs(proof)
+  const approvalRows = proofJobRows.filter((job) => job.status === 'approval_required')
+  const missingRows = proofJobRows.filter((job) =>
+    ['failed', 'output_missing', 'evidence_missing', 'scheduled'].includes(asString(job.status)),
+  )
+  const { company, evidence } = buildHermesCompany({ jobs, tasks, proofRows: proofJobRows })
+  const automationQueue = buildAutomationQueue(company)
+  const identityIssueCount = [...company.primary_drivers, ...company.support_specialists]
+    .reduce((total, employee) => total + employee.identity_issues.length, 0)
+
+  const health = {
+    workspace_ui: 'live' as const,
+    gateway: (await probeHealth('http://127.0.0.1:8642/health')) === 'live' ? 'live' as const : 'down' as const,
+    dashboard_api: await probeHealth('http://127.0.0.1:9119/api/health'),
+  }
+
+  const needsWilson: Array<CommandCenterItem> = [
+    ...company.top_bottlenecks.filter((item) => item.status === 'blocked').slice(0, 2),
+    ...approvalRows.slice(0, 4).map((job) => ({
+      id: `approval-${asString(job.job_id)}`,
+      title: `${asString(job.name) || asString(job.agent)} needs classification`,
+      detail: asString(job.proof_failure_reason) || 'Output is proposal-gated and needs approval before it becomes proven truth.',
+      status: 'blocked' as const,
+      priority: 'high' as const,
+      owner: asString(job.agent),
+      action: 'Review output and approve, reject, or turn into a task.',
+      href: '/company-flow',
+      evidence: asString((job.output as Record<string, unknown> | null)?.path),
+    })),
+    ...sources.filter((source) => source.status === 'missing').map((source) => ({
+      id: `missing-${source.id}`,
+      title: `${source.label} missing`,
+      detail: 'A command-center source file is not available, so related claims must stay missing/inferred.',
+      status: 'missing' as const,
+      priority: 'medium' as const,
+      action: 'Restore the source or update the source map.',
+      href: '/memory',
+      evidence: source.path,
+    })),
+  ]
+
+  const bottlenecks: Array<CommandCenterItem> = [
+    ...company.top_bottlenecks,
+    ...needsWilson,
+    ...missingRows.slice(0, 4).map((job) => ({
+      id: `proof-${asString(job.job_id)}`,
+      title: `${asString(job.name) || asString(job.agent)} is unproven`,
+      detail: asString(job.proof_failure_reason) || `Proof status: ${asString(job.status) || 'unknown'}`,
+      status: 'blocked' as const,
+      priority: asString(job.status) === 'failed' ? 'critical' as const : 'high' as const,
+      owner: asString(job.agent),
+      action: 'Repair the proof path, classify the output, or convert the blockage into an owned next-step task.',
+      href: '/jobs',
+      evidence: asString((job.output as Record<string, unknown> | null)?.path),
+    })),
+  ]
+
+  const gains: Array<CommandCenterItem> = proofJobRows
+    .filter((job) => asString((job.output as Record<string, unknown> | null)?.path))
+    .slice(0, 5)
+    .map((job) => ({
+      id: `gain-${asString(job.job_id)}`,
+      title: `${asString(job.agent) || asString(job.name)} produced an artifact`,
+      detail: 'Useful progress exists, but remains evidence-labeled until classified.',
+      status: 'live' as const,
+      priority: 'medium' as const,
+      owner: asString(job.agent),
+      action: 'Promote the durable finding or convert it into the next task.',
+      href: '/company-flow',
+      evidence: asString((job.output as Record<string, unknown> | null)?.path),
+    }))
+
+  const nextMoves: Array<CommandCenterItem> = [
+    {
+      id: 'review-approval-queue',
+      title: 'Clear the approval-required proof queue',
+      detail: `${approvalRows.length} outputs have evidence but are not proven until Wilson or the curator classifies them.`,
+      status: approvalRows.length ? 'blocked' : 'ready',
+      priority: approvalRows.length ? 'critical' : 'low',
+      owner: 'Wilson + Hermes-curator',
+      action: 'Classify each output into approved truth, next-step task, or discard; do not mark proven from proposal language alone.',
+      href: '/company-flow',
+      evidence: proofPath || undefined,
+    },
+    {
+      id: 'startup-cadence-shared-board',
+      title: 'Compress startup cadence around a shared goals/todo board',
+      detail: 'Agents are blocked when goals, Scribe outputs, and next-step tasks are not visible in one packet. Stage a fast-cycle mission board first; scheduler compression remains an approval-gated control-plane change.',
+      status: 'blocked',
+      priority: 'critical',
+      owner: 'Reddington + Hermes employees',
+      action: 'Publish the current mission packet, route every blocked Hermes agent to one next task, then let Cowork maintain recurrence timing.',
+      href: '/company-flow',
+      evidence: join(AI_SYSTEMS, 'state', 'agent_startup_mission_current.json'),
+    },
+    ...automationQueue.slice(0, 3).map((automation) => ({
+      id: `next-${automation.id}`,
+      title: automation.title,
+      detail: automation.detail,
+      status: automation.status,
+      priority: automation.priority,
+      owner: automation.owner,
+      action: automation.action,
+      href: automation.href,
+      evidence: automation.evidence,
+    })),
+    {
+      id: 'daily-apple-rail',
+      title: 'Dial in today and tomorrow schedule rails',
+      detail: 'Use Hermes to keep reversible Calendar/Reminder items aligned with current tasks, jobs, and Wilson-needed decisions.',
+      status: 'ready',
+      priority: 'high',
+      owner: 'Alfred',
+      action: 'Create/update low-risk reminders; require approval for deletes, invites, shared calendars, and external attendees.',
+      href: '/schedule',
+    },
+    {
+      id: 'idea-inbox-loop',
+      title: 'Route new ideas into daily agent loops',
+      detail: 'Capture topics once, assign the best agent, require source standards, and let repeated workflows become skill candidates.',
+      status: 'ready',
+      priority: 'medium',
+      owner: 'Reddington',
+      action: 'Use the Ideas Inbox to create source-backed planning tasks.',
+      href: '/domains',
+    },
+  ]
+
+  const schedule = jobs
+    .map((job) => ({
+      id: `schedule-${jobId(job)}`,
+      title: jobName(job),
+      detail: `${jobSchedule(job) || 'No schedule'} · next ${asString(job.next_run_at) || 'unknown'}`,
+      status: asString(job.last_status) === 'ok' ? 'live' as const : 'inferred' as const,
+      priority: 'medium' as const,
+      owner: agentNameFromJob(jobName(job)),
+      action: 'Verify output after the next run.',
+      href: '/jobs',
+      evidence: buildOutputPath(jobId(job)) || undefined,
+    }))
+    .slice(0, 12)
+
+  const sections: Array<CommandCenterSection> = [
+    {
+      id: 'home',
+      label: 'Home',
+      status: needsWilson.length ? 'needs_attention' : 'live',
+      current_truth: `${needsWilson.length} Wilson-needed items across proof, schedule, and source truth.`,
+      bottleneck: needsWilson[0]?.title || 'No critical decision surfaced.',
+      next_action: nextMoves[0]?.title || 'Run the daily review.',
+      href: '/dashboard',
+    },
+    {
+      id: 'company-flow',
+      label: 'Company Flow',
+      status: bottlenecks.length ? 'needs_attention' : 'live',
+      current_truth: `${company.primary_drivers.length} Hermes primary drivers, ${company.support_specialists.length} support specialists, ${jobs.length} jobs.`,
+      bottleneck: bottlenecks[0]?.title || 'No broken flow detected.',
+      next_action: 'Inspect the circuit grid and clear the first blocked edge.',
+      href: '/company-flow',
+    },
+    {
+      id: 'agents',
+      label: 'Agents',
+      status: identityIssueCount ? 'needs_attention' : 'live',
+      current_truth: `Hermes agents are the core drivers; Cowork and Claude Code are support specialists.`,
+      bottleneck: identityIssueCount ? `${identityIssueCount} profile identity attribution issue(s) detected.` : 'No identity blocker detected.',
+      next_action: 'Open Hermes Company View and repair the top attribution issue.',
+      href: '/agents',
+    },
+    {
+      id: 'work',
+      label: 'Work',
+      status: openTasks.length ? 'live' : 'planned',
+      current_truth: `${openTasks.length} open tasks, ${tasks.length - openTasks.length} completed tasks.`,
+      bottleneck: openTasks.find((task) => task.column === 'review')?.title || 'No review task at the top.',
+      next_action: 'Convert the top next move into a task.',
+      href: '/tasks',
+    },
+    {
+      id: 'brain',
+      label: 'Brain',
+      status: sources.some((source) => source.status === 'missing') ? 'needs_attention' : 'live',
+      current_truth: `${sources.filter((source) => source.status === 'live').length}/${sources.length} source nodes are available.`,
+      bottleneck: sources.find((source) => source.status === 'missing')?.label || 'Promotion queue needs regular review.',
+      next_action: 'Promote durable findings from agent outputs.',
+      href: '/memory',
+    },
+    {
+      id: 'schedule',
+      label: 'Schedule',
+      status: 'planned',
+      current_truth: `${schedule.length} Hermes jobs feed today/tomorrow planning.`,
+      bottleneck: 'Apple Calendar/Reminders are read/planning rails only until reversible-action audit logs are implemented.',
+      next_action: 'Create the daily schedule rail task.',
+      href: '/schedule',
+    },
+    {
+      id: 'domains',
+      label: 'Domains',
+      status: 'planned',
+      current_truth: 'Finance, research/world imagery, performance, treasure, and ideas are mapped as domain hubs with source standards.',
+      bottleneck: 'Domains need recurring source-backed briefs; no domain should act from unlabeled or stale intel.',
+      next_action: 'Capture one high-leverage idea and route it to an agent.',
+      href: '/domains',
+    },
+  ]
+
+  return {
+    generated_at: new Date().toISOString(),
+    horizon: 'today_tomorrow',
+    health,
+    summary: {
+      needs_wilson: needsWilson.length,
+      jobs_total: jobs.length || Number(proofSummary.total ?? 0),
+      approvals_required: Number(proofSummary.approval_required ?? approvalRows.length),
+      unproven: Number(proofSummary.unproven ?? 0),
+      broken_flows: bottlenecks.length,
+      tasks_open: openTasks.length,
+      gains: gains.length,
+      next_moves: nextMoves.length,
+      hermes_primary_drivers: company.primary_drivers.length,
+      support_specialists: company.support_specialists.length,
+      skills_total: company.skill_inventory.total,
+      automations_ready: automationQueue.filter((item) => item.status === 'ready').length,
+      identity_issues: identityIssueCount,
+    },
+    needs_wilson: needsWilson,
+    bottlenecks,
+    gains,
+    next_moves: nextMoves,
+    schedule,
+    company,
+    automation_queue: automationQueue,
+    evidence_ledger: evidence,
+    sections,
+    sources,
+    proof,
+  }
+}
+
+export async function buildCompanyFlowPacket(): Promise<CompanyFlowPacket> {
+  const status = await buildCommandCenterStatus({ refresh: true })
+  const proofRows = proofJobs(status.proof)
+  const nodes = new Map<string, FlowNode>()
+  const edges: Array<FlowEdge> = []
+
+  const flowStatusRank: Record<CommandCenterItem['status'], number> = {
+    missing: 0,
+    blocked: 1,
+    stale: 2,
+    inferred: 3,
+    ready: 4,
+    live: 5,
+  }
+  const addNode = (node: FlowNode) => {
+    const current = nodes.get(node.id)
+    if (!current) {
+      nodes.set(node.id, node)
+      return
+    }
+    nodes.set(node.id, {
+      ...current,
+      ...node,
+      status: flowStatusRank[current.status] <= flowStatusRank[node.status] ? current.status : node.status,
+      priority: current.priority === 'critical' || node.priority === 'critical' ? 'critical' : node.priority ?? current.priority,
+    })
+  }
+  const edgeCounts = new Map<string, number>()
+  const addEdge = (edge: FlowEdge) => {
+    const count = edgeCounts.get(edge.id) ?? 0
+    edgeCounts.set(edge.id, count + 1)
+    edges.push(count === 0 ? edge : { ...edge, id: `${edge.id}-${count + 1}` })
+  }
+
+  addNode({
+    id: 'agent-reddington',
+    type: 'agent',
+    label: 'Reddington CEO',
+    column: 1,
+    status: status.company.primary_drivers.find((agent) => agent.id === 'reddington')?.health === 'needs_attention' ? 'blocked' : 'live',
+    priority: 'high',
+    detail: 'Hermes CEO/chief orchestrator. Cowork and Claude Code support; they do not drive strategy.',
+    href: '/agents',
+  })
+
+  for (const source of status.sources) {
+    addNode({
+      id: `source-${source.id}`,
+      type: 'source',
+      label: source.label,
+      column: 0,
+      status: source.status === 'live' ? 'live' : 'missing',
+      detail: source.path,
+      href: '/memory',
+    })
+    addEdge({
+      id: `edge-${source.id}-reddington`,
+      source: `source-${source.id}`,
+      target: 'agent-reddington',
+      label: 'feeds',
+      status: source.status === 'live' ? 'healthy' : 'blocked',
+    })
+  }
+
+  for (const employee of status.company.primary_drivers) {
+    const agentNode = `agent-${employee.id.replace(/_/g, '-')}`
+    addNode({
+      id: agentNode,
+      type: 'agent',
+      label: employee.id === 'reddington' ? 'Reddington CEO' : employee.name,
+      column: 1,
+      status: employee.health === 'needs_attention' ? 'blocked' : employee.health === 'missing' ? 'missing' : employee.proof_status,
+      priority: employee.health === 'needs_attention' ? 'high' : 'medium',
+      detail: `${employee.department}: ${employee.current_work}`,
+      href: '/agents',
+    })
+    if (employee.id !== 'reddington') {
+      addEdge({
+        id: `edge-reddington-${agentNode}`,
+        source: 'agent-reddington',
+        target: agentNode,
+        label: 'orchestrates',
+        status: employee.health === 'needs_attention' ? 'attention' : 'healthy',
+      })
+    }
+  }
+
+  for (const support of status.company.support_specialists) {
+    const supportNode = `support-${support.id.replace(/_/g, '-')}`
+    addNode({
+      id: supportNode,
+      type: 'support',
+      label: `${support.name} support`,
+      column: 1,
+      status: support.health === 'needs_attention' ? 'blocked' : 'inferred',
+      priority: 'medium',
+      detail: `${support.department}: ${support.role}. Assigned by Hermes, not the main driver.`,
+      href: '/agents',
+    })
+    addEdge({
+      id: `edge-reddington-${supportNode}`,
+      source: 'agent-reddington',
+      target: supportNode,
+      label: 'delegates support work',
+      status: support.health === 'needs_attention' ? 'attention' : 'healthy',
+    })
+  }
+
+  for (const automation of status.automation_queue) {
+    const automationNode = `automation-${automation.id}`
+    addNode({
+      id: automationNode,
+      type: 'automation',
+      label: automation.title,
+      column: 2,
+      status: automation.status,
+      priority: automation.priority,
+      detail: `${automation.driver} · ${automation.cadence} · ${automation.autonomy}`,
+      href: automation.href,
+    })
+    addEdge({
+      id: `edge-reddington-${automationNode}`,
+      source: 'agent-reddington',
+      target: automationNode,
+      label: 'queues',
+      status: automation.status === 'blocked' ? 'blocked' : 'attention',
+    })
+  }
+
+  for (const row of proofRows) {
+    const id = asString(row.job_id)
+    const agent = asString(row.agent) || agentNameFromJob(asString(row.name))
+    const agentNode = `agent-${normalizeOwner(agent).replace(/_/g, '-')}`
+    const jobNode = `job-${id}`
+    const output = row.output as Record<string, unknown> | null
+    const outputPath = asString(output?.path)
+    const statusValue = asString(row.status)
+    const isBlocked = statusValue !== 'ran_successfully'
+
+    addNode({
+      id: agentNode,
+      type: 'agent',
+      label: agent,
+      column: 1,
+      status: isBlocked ? 'blocked' : 'live',
+      priority: isBlocked ? 'high' : 'medium',
+      detail: asString(row.lane) || 'Agent lane',
+      href: '/agents',
+    })
+    addNode({
+      id: jobNode,
+      type: 'job',
+      label: asString(row.name) || id,
+      column: 2,
+      status: isBlocked ? 'blocked' : 'live',
+      priority: isBlocked ? 'high' : 'medium',
+      detail: `${asString(row.schedule)} · next ${asString(row.next_run_at) || 'unknown'}`,
+      href: '/jobs',
+    })
+    addEdge({
+      id: `edge-reddington-${agentNode}`,
+      source: 'agent-reddington',
+      target: agentNode,
+      label: 'orchestrates',
+      status: 'attention',
+    })
+    addEdge({
+      id: `edge-${agentNode}-${jobNode}`,
+      source: agentNode,
+      target: jobNode,
+      label: 'scheduled by',
+      status: isBlocked ? 'attention' : 'healthy',
+    })
+
+    if (outputPath) {
+      const outputNode = `output-${id}`
+      addNode({
+        id: outputNode,
+        type: 'output',
+        label: `${agent} output`,
+        column: 3,
+        status: 'live',
+        detail: outputPath,
+        href: '/company-flow',
+      })
+      addEdge({
+        id: `edge-${jobNode}-${outputNode}`,
+        source: jobNode,
+        target: outputNode,
+        label: 'produces',
+        status: 'healthy',
+      })
+      const proofNode = `proof-${id}`
+      addNode({
+        id: proofNode,
+        type: 'proof',
+        label: statusValue || 'proof pending',
+        column: 4,
+        status: isBlocked ? 'blocked' : 'live',
+        priority: isBlocked ? 'high' : 'medium',
+        detail: asString(row.proof_failure_reason) || 'Proof status',
+        href: '/company-flow',
+      })
+      addEdge({
+        id: `edge-${outputNode}-${proofNode}`,
+        source: outputNode,
+        target: proofNode,
+        label: 'proves',
+        status: isBlocked ? 'blocked' : 'healthy',
+      })
+      if (statusValue === 'approval_required') {
+        const approvalNode = `approval-${id}`
+        addNode({
+          id: approvalNode,
+          type: 'approval',
+          label: `${agent} approval`,
+          column: 5,
+          status: 'blocked',
+          priority: 'critical',
+          detail: 'Evidence exists, but the output needs classification before becoming durable truth.',
+          href: '/company-flow',
+        })
+        addEdge({
+          id: `edge-${proofNode}-${approvalNode}`,
+          source: proofNode,
+          target: approvalNode,
+          label: 'requires approval',
+          status: 'blocked',
+        })
+      }
+    }
+  }
+
+  for (const gain of status.gains) {
+    addNode({
+      id: gain.id,
+      type: 'gain',
+      label: gain.title,
+      column: 6,
+      status: gain.status,
+      priority: gain.priority,
+      detail: gain.detail,
+      href: gain.href,
+    })
+  }
+
+  for (const move of status.next_moves) {
+    addNode({
+      id: move.id,
+      type: 'next_move',
+      label: move.title,
+      column: 7,
+      status: move.status,
+      priority: move.priority,
+      detail: move.detail,
+      href: move.href,
+    })
+    addEdge({
+      id: `edge-reddington-${move.id}`,
+      source: 'agent-reddington',
+      target: move.id,
+      label: 'recommends',
+      status: move.status === 'blocked' ? 'blocked' : 'attention',
+    })
+  }
+
+  const skillCandidates = [
+    {
+      id: 'skill-approval-review-loop',
+      title: 'Approval review loop',
+      detail: 'Repeated proof classification should become a reusable curator skill after Wilson approves the workflow.',
+      status: 'ready' as const,
+      priority: 'medium' as const,
+      owner: 'Hermes-curator',
+      action: 'Draft a skill candidate once the review loop succeeds twice.',
+      href: '/skills',
+    },
+  ]
+  for (const candidate of skillCandidates) {
+    addNode({
+      id: candidate.id,
+      type: 'skill_candidate',
+      label: candidate.title,
+      column: 7,
+      status: candidate.status,
+      priority: candidate.priority,
+      detail: candidate.detail,
+      href: candidate.href,
+    })
+  }
+
+  return {
+    ...status,
+    mode: 'full_loop_with_external_gates',
+    nodes: [...nodes.values()],
+    edges,
+    skill_candidates: skillCandidates,
+  }
+}


### PR DESCRIPTION
## Summary
- Reconciles the Majestic12 dashboard OS additions onto the current upstream v2.2.0 line.
- Adds/keeps Agents, Company Flow, Domains, and Schedule routes/screens.
- Adds command-center/dashboard proof data adapters and API routes.
- Removes accidental runtime artifacts from the original local divergent commit.

## Verification
- pnpm install: passed locally in isolated worktree.
- pnpm build: passed locally in isolated worktree.
- routeTree.gen.ts includes /agents, /company-flow, /domains, /schedule, and /api/company-flow.

## Notes
- Full pnpm test currently has broader upstream/test-suite failures unrelated to the build reconciliation; see local proof artifact at /Users/majestic12/brain/state/m12_github_workspace_reconcile_latest.md.
- Direct upstream push is unavailable for furrwilson-collab because upstream permission is READ, so this PR comes from the authenticated fork.

## Local proof
- Reconciled worktree: /Users/majestic12/ai-systems/hermes-workspace-merge
- Branch: m12/dashboard-os-merge
- Commit: eaeefca961fccb30c0509e0644f53e6323bbb1b1