### PR TITLE
Embed hosted HermesWorld runtime

### DIFF
--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -191,7 +191,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
   const isEmbeddedSurface =
     search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
-  const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
+  const isChromeFreeSurface = isEmbeddedSurface || isOnPlaygroundRoute || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
     !isChromeFreeSurface && !isMobile && !isOnChatRoute && !sidebarCollapsed

--- a/src/routes/playground.tsx
+++ b/src/routes/playground.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { usePageTitle } from '@/hooks/use-page-title'
-import { PlaygroundScreen } from '@/screens/playground/playground-screen'
+import { HermesWorldEmbed } from '@/screens/playground/hermes-world-embed'
 
 export const Route = createFileRoute('/playground')({
   ssr: false,
@@ -9,5 +9,5 @@ export const Route = createFileRoute('/playground')({
 
 function PlaygroundRoute() {
   usePageTitle('HermesWorld')
-  return <PlaygroundScreen />
+  return <HermesWorldEmbed />
 }

--- a/src/screens/playground/hermes-world-embed.tsx
+++ b/src/screens/playground/hermes-world-embed.tsx
@@ -1,0 +1,43 @@
+import { useMemo, useState } from 'react'
+
+const HERMES_WORLD_ORIGIN = 'https://hermes-world.ai'
+
+export function HermesWorldEmbed() {
+  const [loaded, setLoaded] = useState(false)
+  const src = useMemo(() => {
+    const url = new URL('/play/', HERMES_WORLD_ORIGIN)
+    url.searchParams.set('embed', 'workspace')
+    url.searchParams.set('source', 'hermes-workspace')
+    return url.toString()
+  }, [])
+
+  return (
+    <main className="fixed inset-0 z-0 overflow-hidden bg-[#050015] text-white">
+      {!loaded && (
+        <div className="absolute inset-0 flex items-center justify-center bg-[radial-gradient(circle_at_50%_35%,rgba(168,85,247,.24),transparent_48%),#050015]">
+          <div className="rounded-3xl border border-white/12 bg-black/35 px-6 py-5 text-center shadow-2xl backdrop-blur-xl">
+            <div className="text-xs font-bold uppercase tracking-[0.24em] text-cyan-200/70">Hermes Workspace</div>
+            <div className="mt-2 text-2xl font-black tracking-tight">Opening HermesWorld…</div>
+            <div className="mt-2 text-sm text-white/58">Runtime hosted by hermes-world.ai</div>
+          </div>
+        </div>
+      )}
+      <iframe
+        title="HermesWorld"
+        src={src}
+        className="h-[100dvh] w-screen border-0 bg-[#050015]"
+        allow="fullscreen; clipboard-read; clipboard-write; gamepad"
+        referrerPolicy="strict-origin-when-cross-origin"
+        onLoad={() => setLoaded(true)}
+      />
+      <a
+        href={`${HERMES_WORLD_ORIGIN}/play/`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="fixed right-3 top-3 z-10 rounded-full border border-white/15 bg-black/45 px-3 py-1.5 text-xs font-bold uppercase tracking-[0.16em] text-white/70 backdrop-blur transition hover:border-cyan-200/40 hover:text-white"
+      >
+        Open full
+      </a>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary\n- replaces the Workspace /playground surface with a hosted hermes-world.ai iframe runtime\n- marks /playground as chrome-free so HermesWorld receives the full viewport\n- keeps prize-sensitive game runtime separable from the open Workspace client\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm build