### PR TITLE
fix(context): add kimi-k2.6 256k context window support

### DIFF
--- a/src/server/context-usage.ts
+++ b/src/server/context-usage.ts
@@ -36,6 +36,7 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'o3-mini': 200_000,
   'gemini-2.5-flash': 1_000_000,
   'gemini-2.5-pro': 1_000_000,
+  'kimi-k2.6': 256_000,
 }
 
 const CHARS_PER_TOKEN = 3.5


### PR DESCRIPTION
## Bug Description

The context usage calculator in `src/server/context-usage.ts` defaults unknown models to 200k tokens. When using `kimi-k2.6`, this causes incorrect 100% context pressure alerts on new chats with only a few messages.

## Root Cause

`MODEL_CONTEXT_WINDOWS` map does not include `kimi-k2.6`, so `getContextWindow()` falls back to the default 200k value.

## Fix

Add `kimi-k2.6: 256_000` to the `MODEL_CONTEXT_WINDOWS` map.

## Changes

- `src/server/context-usage.ts`: Add kimi-k2.6 with 256k context window

## Testing

- Verified kimi-k2.6 is correctly recognized and returns 256k instead of 200k
- Context percentage calculation now accurate for this model

Fixes false-positive "Context Window Getting Full - 100%" warnings.