### PR TITLE
fix: add legacy claude-workspace/claude-agent remote aliases for update checker

### DIFF
--- a/src/routes/api/claude-update.ts
+++ b/src/routes/api/claude-update.ts
@@ -32,13 +32,13 @@ export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
     name: 'origin',
     label: 'Hermes Workspace',
     expectedRepo: 'hermes-workspace',
-    aliases: ['hermes-workspace', 'outsourc-e/hermes-workspace'],
+    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
   },
   {
     name: 'upstream',
     label: 'Hermes Agent',
     expectedRepo: 'hermes-agent',
-    aliases: ['hermes-agent', 'NousResearch/hermes-agent'],
+    aliases: ['claude-agent', 'hermes-agent', 'NousResearch/hermes-agent'],
   },
 ]
 


### PR DESCRIPTION
Users who set up their workspace before the rename from `claude-workspace` to `hermes-workspace` (and `claude-agent` to `hermes-agent`) have remotes with the old names. The update checker fails to recognize their repos as valid remotes, showing spurious "unrecognized remote" warnings or silently skipping update detection.

Add `claude-workspace` and `claude-agent` as legacy aliases alongside the existing `hermes-workspace` and `hermes-agent` aliases so the update checker works for both old and new remote naming conventions.