### PR TITLE
fix: show cron jobs across Hermes profiles

### DIFF
--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -4,6 +4,11 @@
 
 const CLAUDE_API = '/api/claude-jobs'
 
+export type JobProfileOption = {
+  name: string
+  active?: boolean
+}
+
 export type ClaudeJob = {
   id: string
   name: string
@@ -23,6 +28,9 @@ export type ClaudeJob = {
   skills?: Array<string>
   repeat?: { times?: number; completed?: number }
   run_count?: number
+  profile?: string
+  profile_name?: string
+  jobId?: string
 }
 
 export type HermesJob = ClaudeJob
@@ -56,7 +64,9 @@ export function findJobById(
 }
 
 export function normalizeJobState(state: unknown): string | null {
-  return typeof state === 'string' && state.trim() ? state.trim().toLowerCase() : null
+  return typeof state === 'string' && state.trim()
+    ? state.trim().toLowerCase()
+    : null
 }
 
 export function isFailedJobState(state: unknown): boolean {
@@ -89,7 +99,8 @@ export function getLatestJobOutputText(outputs: Array<JobOutput>): string {
   let latestTimestamp = Number.NEGATIVE_INFINITY
 
   for (const output of outputs) {
-    const content = typeof output.content === 'string' ? output.content.trim() : ''
+    const content =
+      typeof output.content === 'string' ? output.content.trim() : ''
     if (!content) continue
 
     const timestamp = new Date(output.timestamp).getTime()
@@ -102,7 +113,9 @@ export function getLatestJobOutputText(outputs: Array<JobOutput>): string {
   return latestContent
 }
 
-export function getJobErrorText(job: ClaudeJob | null | undefined): string | null {
+export function getJobErrorText(
+  job: ClaudeJob | null | undefined,
+): string | null {
   if (!job) return null
 
   const candidates = [job.last_run_error, job.error]
@@ -116,7 +129,7 @@ export function getJobErrorText(job: ClaudeJob | null | undefined): string | nul
 }
 
 export async function fetchJobs(): Promise<Array<ClaudeJob>> {
-  const res = await fetch(`${CLAUDE_API}?include_disabled=true`)
+  const res = await fetch(`${CLAUDE_API}?include_disabled=true&profiles=all`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
   const data = await res.json()
   return normalizeJobsResponse(data)
@@ -139,8 +152,9 @@ function errorMessageFromBody(body: unknown, fallback: string): string {
         .map((item) => {
           if (typeof item === 'string') return item
           if (item && typeof item === 'object') {
-            const msg = (item as { msg?: unknown; message?: unknown }).msg
-              ?? (item as { message?: unknown }).message
+            const msg =
+              (item as { msg?: unknown; message?: unknown }).msg ??
+              (item as { message?: unknown }).message
             if (typeof msg === 'string') return msg
           }
           return JSON.stringify(item)
@@ -169,9 +183,12 @@ type JobMutationInput = {
   deliver?: Array<string>
   skills?: Array<string>
   repeat?: number
+  profile?: string
 }
 
-export function buildJobMutationPayload(input: JobMutationInput): JobMutationInput & { input: string } {
+export function buildJobMutationPayload(
+  input: JobMutationInput,
+): JobMutationInput & { input: string } {
   const prompt = typeof input.prompt === 'string' ? input.prompt : ''
   return {
     ...input,
@@ -188,7 +205,9 @@ export async function createJob(input: JobMutationInput): Promise<ClaudeJob> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to create job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to create job: ${res.status}`),
+    )
   }
   return (await res.json()).job
 }
@@ -208,7 +227,9 @@ export async function updateJob(
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to update job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to update job: ${res.status}`),
+    )
   }
   return (await res.json()).job
 }
@@ -217,7 +238,9 @@ export async function deleteJob(jobId: string): Promise<void> {
   const res = await fetch(`${CLAUDE_API}/${jobId}`, { method: 'DELETE' })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to delete job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to delete job: ${res.status}`),
+    )
   }
 }
 
@@ -227,7 +250,9 @@ export async function pauseJob(jobId: string): Promise<ClaudeJob> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to pause job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to pause job: ${res.status}`),
+    )
   }
   return (await res.json()).job
 }
@@ -238,7 +263,9 @@ export async function resumeJob(jobId: string): Promise<ClaudeJob> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to resume job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to resume job: ${res.status}`),
+    )
   }
   return (await res.json()).job
 }
@@ -249,9 +276,33 @@ export async function triggerJob(jobId: string): Promise<ClaudeJob> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(errorMessageFromBody(body, `Failed to trigger job: ${res.status}`))
+    throw new Error(
+      errorMessageFromBody(body, `Failed to trigger job: ${res.status}`),
+    )
   }
   return (await res.json()).job
+}
+
+export async function fetchJobProfiles(): Promise<Array<JobProfileOption>> {
+  const res = await fetch('/api/profiles/list')
+  if (!res.ok) throw new Error(`Failed to fetch profiles: ${res.status}`)
+  const cronProfileNamePattern = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+  const data = (await res.json()) as {
+    profiles?: Array<{ name?: unknown; active?: unknown; exists?: unknown }>
+  }
+  return Array.isArray(data.profiles)
+    ? data.profiles
+        .map((profile) => ({
+          name: typeof profile.name === 'string' ? profile.name : '',
+          active: profile.active === true,
+          exists: profile.exists !== false,
+        }))
+        .filter(
+          (profile) =>
+            profile.exists && cronProfileNamePattern.test(profile.name),
+        )
+        .map(({ name, active }) => ({ name, active }))
+    : []
 }
 
 export async function fetchJobOutput(

--- a/src/routes/api/claude-jobs.$jobId.ts
+++ b/src/routes/api/claude-jobs.$jobId.ts
@@ -11,6 +11,13 @@ import {
   dashboardFetch,
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
+import {
+  createProfileCronJob,
+  parseProfileJobId,
+  readProfileCronOutputs,
+  runProfileCronAction,
+  updateProfileCronJob,
+} from '../../server/hermes-cron-profiles'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -34,11 +41,27 @@ export const Route = createFileRoute('/api/claude-jobs/$jobId')({
             status: 401,
           })
         }
-        const capabilities = await ensureGatewayProbed()
-        if (!capabilities.jobs) return notSupported()
-
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
+        const parsed = parseProfileJobId(params.jobId)
+        if (parsed.profile && (action === 'output' || action === 'runs')) {
+          const limit = Number(url.searchParams.get('limit') ?? '10')
+          const outputs = readProfileCronOutputs(
+            parsed.profile,
+            parsed.jobId,
+            Number.isFinite(limit) ? limit : 10,
+          )
+          return new Response(
+            JSON.stringify(action === 'runs' ? { runs: [] } : { outputs }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
+        }
+
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.jobs) return notSupported()
 
         if (capabilities.dashboard.available) {
           const dashboardPath = action
@@ -66,12 +89,55 @@ export const Route = createFileRoute('/api/claude-jobs/$jobId')({
             status: 401,
           })
         }
-        const capabilities = await ensureGatewayProbed()
-        if (!capabilities.jobs) return notSupported()
-
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
         const body = await request.text()
+        const parsed = parseProfileJobId(params.jobId)
+        if (parsed.profile && action) {
+          const profileAction =
+            action === 'run' || action === 'run-if-due'
+              ? 'run'
+              : action === 'delete'
+                ? 'remove'
+                : action
+          if (!['pause', 'resume', 'run', 'remove'].includes(profileAction)) {
+            return new Response(
+              JSON.stringify({
+                ok: false,
+                error: `Unsupported cron action: ${action}`,
+              }),
+              {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            )
+          }
+          try {
+            const result = runProfileCronAction(
+              parsed.profile,
+              parsed.jobId,
+              profileAction as 'pause' | 'resume' | 'run' | 'remove',
+            )
+            return new Response(JSON.stringify(result), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          } catch (error) {
+            return new Response(
+              JSON.stringify({
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+              {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            )
+          }
+        }
+
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.jobs) return notSupported()
 
         if (capabilities.dashboard.available) {
           const dashboardAction = action === 'run' ? 'trigger' : action
@@ -109,10 +175,73 @@ export const Route = createFileRoute('/api/claude-jobs/$jobId')({
             status: 401,
           })
         }
+        const body = await request.text()
+        const parsed = parseProfileJobId(params.jobId)
+        if (parsed.profile) {
+          try {
+            const updates = body
+              ? (JSON.parse(body) as Record<string, unknown>)
+              : {}
+            const targetProfile =
+              typeof updates.profile === 'string' && updates.profile.trim()
+                ? updates.profile.trim()
+                : parsed.profile
+            let result: Record<string, unknown>
+            if (targetProfile === parsed.profile) {
+              result = updateProfileCronJob(
+                parsed.profile,
+                parsed.jobId,
+                updates,
+              )
+            } else {
+              const created = createProfileCronJob(targetProfile, updates)
+              const createdJobId =
+                typeof created.jobId === 'string'
+                  ? parseProfileJobId(created.jobId)
+                  : null
+              try {
+                const removePrevious = runProfileCronAction(
+                  parsed.profile,
+                  parsed.jobId,
+                  'remove',
+                )
+                result = {
+                  ...created,
+                  movedFrom: `${parsed.profile}:${parsed.jobId}`,
+                  removePrevious,
+                }
+              } catch (removeError) {
+                if (createdJobId?.profile) {
+                  try {
+                    runProfileCronAction(
+                      createdJobId.profile,
+                      createdJobId.jobId,
+                      'remove',
+                    )
+                  } catch {
+                    // Best-effort rollback; surface the original remove error below.
+                  }
+                }
+                throw removeError
+              }
+            }
+            return new Response(JSON.stringify(result), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          } catch (error) {
+            return new Response(
+              JSON.stringify({
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+              { status: 400, headers: { 'Content-Type': 'application/json' } },
+            )
+          }
+        }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
-        const body = await request.text()
         const res = capabilities.dashboard.available
           ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
               method: 'PUT',
@@ -134,6 +263,28 @@ export const Route = createFileRoute('/api/claude-jobs/$jobId')({
           return new Response(JSON.stringify({ error: 'Unauthorized' }), {
             status: 401,
           })
+        }
+        const parsed = parseProfileJobId(params.jobId)
+        if (parsed.profile) {
+          try {
+            const result = runProfileCronAction(
+              parsed.profile,
+              parsed.jobId,
+              'remove',
+            )
+            return new Response(JSON.stringify(result), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          } catch (error) {
+            return new Response(
+              JSON.stringify({
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+              { status: 400, headers: { 'Content-Type': 'application/json' } },
+            )
+          }
         }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()

--- a/src/routes/api/claude-jobs.ts
+++ b/src/routes/api/claude-jobs.ts
@@ -9,8 +9,11 @@ import {
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
-  getCapabilities,
 } from '../../server/gateway-capabilities'
+import {
+  createProfileCronJob,
+  listProfileCronJobs,
+} from '../../server/hermes-cron-profiles'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 function authHeaders(): Record<string, string> {
@@ -56,6 +59,14 @@ export const Route = createFileRoute('/api/claude-jobs')({
             status: 401,
           })
         }
+        const url = new URL(request.url)
+        const aggregateProfiles = url.searchParams.get('profiles') !== 'active'
+        if (aggregateProfiles) {
+          return new Response(JSON.stringify({ jobs: listProfileCronJobs() }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) {
           return new Response(
@@ -67,7 +78,6 @@ export const Route = createFileRoute('/api/claude-jobs')({
             { status: 200, headers: { 'Content-Type': 'application/json' } },
           )
         }
-        const url = new URL(request.url)
         const params = url.searchParams.toString()
         const res = capabilities.dashboard.available
           ? await dashboardFetch(`/api/cron/jobs${params ? `?${params}` : ''}`)
@@ -82,6 +92,37 @@ export const Route = createFileRoute('/api/claude-jobs')({
             status: 401,
           })
         }
+        const body = await request.text()
+        let parsedBody: Record<string, unknown> = {}
+        try {
+          parsedBody = body ? (JSON.parse(body) as Record<string, unknown>) : {}
+        } catch {
+          return new Response(
+            JSON.stringify({ ok: false, error: 'Invalid JSON body' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        const profile =
+          typeof parsedBody.profile === 'string' && parsedBody.profile.trim()
+            ? parsedBody.profile.trim()
+            : null
+        if (profile) {
+          try {
+            const result = createProfileCronJob(profile, parsedBody)
+            return new Response(JSON.stringify(result), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          } catch (error) {
+            return new Response(
+              JSON.stringify({
+                ok: false,
+                error: error instanceof Error ? error.message : String(error),
+              }),
+              { status: 400, headers: { 'Content-Type': 'application/json' } },
+            )
+          }
+        }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) {
           return new Response(
@@ -93,7 +134,6 @@ export const Route = createFileRoute('/api/claude-jobs')({
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
-        const body = await request.text()
         const res = capabilities.dashboard.available
           ? await dashboardFetch('/api/cron/jobs', {
               method: 'POST',

--- a/src/screens/jobs/create-job-dialog.tsx
+++ b/src/screens/jobs/create-job-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Cancel01Icon } from '@hugeicons/core-free-icons'
+import type { JobProfileOption } from '@/lib/jobs-api'
 
 const SCHEDULE_PRESETS = [
   { label: 'Every 15m', value: 'every 15m' },
@@ -19,8 +20,10 @@ const DELIVERY_OPTIONS = ['local', 'telegram', 'discord'] as const
 type CreateJobDialogProps = {
   open: boolean
   isSubmitting?: boolean
+  profiles: Array<JobProfileOption>
   onOpenChange: (open: boolean) => void
   onSubmit: (input: {
+    profile: string
     name: string
     schedule: string
     prompt: string
@@ -30,8 +33,9 @@ type CreateJobDialogProps = {
   }) => void | Promise<void>
 }
 
-function getInitialState() {
+function getInitialState(profile = 'default') {
   return {
+    profile,
     name: '',
     schedule: 'every 30m',
     prompt: '',
@@ -45,14 +49,17 @@ function getInitialState() {
 export function CreateJobDialog({
   open,
   isSubmitting = false,
+  profiles,
   onOpenChange,
   onSubmit,
 }: CreateJobDialogProps) {
-  const [form, setForm] = useState(getInitialState)
+  const activeProfile =
+    profiles.find((profile) => profile.active)?.name ?? profiles[0].name
+  const [form, setForm] = useState(() => getInitialState(activeProfile))
 
   useEffect(() => {
     if (!open) {
-      setForm(getInitialState())
+      setForm(getInitialState(activeProfile))
       return
     }
 
@@ -70,7 +77,17 @@ export function CreateJobDialog({
       document.body.style.overflow = previousOverflow
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [open, onOpenChange])
+  }, [open, onOpenChange, activeProfile])
+
+  useEffect(() => {
+    if (open) {
+      setForm((current) => {
+        if (profiles.some((profile) => profile.name === current.profile))
+          return current
+        return { ...current, profile: activeProfile }
+      })
+    }
+  }, [activeProfile, open, profiles])
 
   function toggleDelivery(target: string) {
     setForm((current) => {
@@ -94,6 +111,7 @@ export function CreateJobDialog({
       .filter(Boolean)
 
     void onSubmit({
+      profile: form.profile,
       name: form.name.trim(),
       schedule: form.schedule.trim(),
       prompt: form.prompt.trim(),
@@ -164,6 +182,36 @@ export function CreateJobDialog({
             </div>
 
             <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+              <section className="space-y-2">
+                <label className="text-sm font-medium">Profile</label>
+                <select
+                  value={form.profile}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      profile: event.target.value,
+                    }))
+                  }
+                  required
+                  className="w-full rounded-xl border px-3 py-2.5 text-sm focus:outline-none focus:ring-1"
+                  style={{
+                    background: 'var(--theme-input)',
+                    borderColor: 'var(--theme-border)',
+                    color: 'var(--theme-text)',
+                  }}
+                >
+                  {profiles.map((profile) => (
+                    <option key={profile.name} value={profile.name}>
+                      {profile.name}
+                      {profile.active ? ' (active)' : ''}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs" style={{ color: 'var(--theme-muted)' }}>
+                  Cron jobs are stored under the selected Hermes profile.
+                </p>
+              </section>
+
               <section className="space-y-2">
                 <label className="text-sm font-medium">Name</label>
                 <input

--- a/src/screens/jobs/edit-job-dialog.tsx
+++ b/src/screens/jobs/edit-job-dialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Cancel01Icon } from '@hugeicons/core-free-icons'
-import type { ClaudeJob } from '@/lib/jobs-api'
+import type { ClaudeJob, JobProfileOption } from '@/lib/jobs-api'
 
 const SCHEDULE_PRESETS = [
   { label: 'Every 15m', value: 'every 15m' },
@@ -21,8 +21,10 @@ type EditJobDialogProps = {
   job: ClaudeJob | null
   open: boolean
   isSubmitting?: boolean
+  profiles: Array<JobProfileOption>
   onOpenChange: (open: boolean) => void
   onSubmit: (input: {
+    profile: string
     name: string
     schedule: string
     prompt: string
@@ -37,7 +39,7 @@ function readScheduleValue(job: ClaudeJob): string {
     return job.schedule_display.trim()
   }
   const schedule = job.schedule
-  if (schedule && typeof schedule === 'object') {
+  if (typeof schedule === 'object') {
     const record = schedule
     const candidates = [
       record.expression,
@@ -64,6 +66,7 @@ function getInitialState(job: ClaudeJob | null) {
       : null
 
   return {
+    profile: job?.profile ?? 'default',
     name: job?.name ?? '',
     schedule: job ? readScheduleValue(job) : 'every 30m',
     prompt: job?.prompt ?? '',
@@ -82,6 +85,7 @@ export function EditJobDialog({
   job,
   open,
   isSubmitting = false,
+  profiles,
   onOpenChange,
   onSubmit,
 }: EditJobDialogProps) {
@@ -133,6 +137,7 @@ export function EditJobDialog({
       .filter(Boolean)
 
     void onSubmit({
+      profile: form.profile,
       name: form.name.trim(),
       schedule: form.schedule.trim(),
       prompt: form.prompt.trim(),
@@ -203,6 +208,49 @@ export function EditJobDialog({
             </div>
 
             <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+              <section className="space-y-2">
+                <label className="text-sm font-medium">Profile</label>
+                <select
+                  value={form.profile}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      profile: event.target.value,
+                    }))
+                  }
+                  required
+                  className="w-full rounded-xl border px-3 py-2.5 text-sm focus:outline-none focus:ring-1"
+                  style={{
+                    background: 'var(--theme-input)',
+                    borderColor: 'var(--theme-border)',
+                    color: 'var(--theme-text)',
+                  }}
+                >
+                  {profiles.map((profile) => (
+                    <option key={profile.name} value={profile.name}>
+                      {profile.name}
+                      {profile.active ? ' (active)' : ''}
+                    </option>
+                  ))}
+                </select>
+                {job.profile && form.profile !== job.profile ? (
+                  <p
+                    className="text-xs"
+                    style={{ color: 'var(--theme-muted)' }}
+                  >
+                    Saving will recreate this cron job in {form.profile} and
+                    remove it from {job.profile}.
+                  </p>
+                ) : (
+                  <p
+                    className="text-xs"
+                    style={{ color: 'var(--theme-muted)' }}
+                  >
+                    Cron jobs are stored under the selected Hermes profile.
+                  </p>
+                )}
+              </section>
+
               <section className="space-y-2">
                 <label className="text-sm font-medium">Name</label>
                 <input

--- a/src/screens/jobs/jobs-screen.tsx
+++ b/src/screens/jobs/jobs-screen.tsx
@@ -25,6 +25,7 @@ import {
   createJob,
   deleteJob,
   fetchJobOutput,
+  fetchJobProfiles,
   fetchJobs,
   pauseJob,
   resumeJob,
@@ -33,6 +34,7 @@ import {
 } from '@/lib/jobs-api'
 
 const QUERY_KEY = ['claude', 'jobs'] as const
+const PROFILES_QUERY_KEY = ['claude', 'job-profiles'] as const
 
 function formatNextRun(nextRun?: string | null): string {
   if (!nextRun) return '—'
@@ -152,6 +154,14 @@ function JobCard({
             {job.prompt}
           </p>
           <div className="mb-2 flex flex-wrap items-center gap-3 text-[10px] text-[var(--theme-muted)]">
+            {job.profile && (
+              <>
+                <span className="rounded-md border border-[var(--theme-border)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wide text-[var(--theme-text)]">
+                  {job.profile}
+                </span>
+                <span>·</span>
+              </>
+            )}
             <span>{job.schedule_display || 'custom'}</span>
             <span>·</span>
             <span>Next: {formatNextRun(job.next_run_at)}</span>
@@ -301,6 +311,18 @@ export function JobsScreen() {
     queryFn: fetchJobs,
     refetchInterval: 30_000,
   })
+  const profilesQuery = useQuery({
+    queryKey: PROFILES_QUERY_KEY,
+    queryFn: fetchJobProfiles,
+    staleTime: 60_000,
+  })
+  const profiles = useMemo(
+    () =>
+      profilesQuery.data?.length
+        ? profilesQuery.data
+        : [{ name: 'default', active: true }],
+    [profilesQuery.data],
+  )
 
   const pauseMutation = useMutation({
     mutationFn: pauseJob,
@@ -347,6 +369,7 @@ export function JobsScreen() {
     mutationFn: async (payload: {
       jobId: string
       updates: {
+        profile: string
         name: string
         schedule: string
         prompt: string
@@ -373,13 +396,15 @@ export function JobsScreen() {
     const q = search.toLowerCase()
     return jobs.filter(
       (j) =>
-        j.name?.toLowerCase().includes(q) ||
-        j.prompt?.toLowerCase().includes(q),
+        j.name.toLowerCase().includes(q) ||
+        j.prompt.toLowerCase().includes(q) ||
+        j.profile?.toLowerCase().includes(q),
     )
   }, [jobsQuery.data, search])
 
   const handleCreate = useCallback(
     async (input: {
+      profile: string
       name: string
       schedule: string
       prompt: string
@@ -395,134 +420,147 @@ export function JobsScreen() {
   return (
     <div className="min-h-full overflow-y-auto bg-surface text-ink">
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
-      <header className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <HugeiconsIcon
-            icon={Clock01Icon}
-            size={18}
-            className="text-[var(--theme-accent)]"
-          />
-          <h1 className="text-base font-semibold text-[var(--theme-text)]">
-            Jobs
-          </h1>
-          {jobsQuery.data && (
-            <span className="ml-1 text-xs text-[var(--theme-muted)]">
-              ({jobsQuery.data.length})
-            </span>
+        <header className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <HugeiconsIcon
+                icon={Clock01Icon}
+                size={18}
+                className="text-[var(--theme-accent)]"
+              />
+              <h1 className="text-base font-semibold text-[var(--theme-text)]">
+                Jobs
+              </h1>
+              {jobsQuery.data && (
+                <span className="ml-1 text-xs text-[var(--theme-muted)]">
+                  ({jobsQuery.data.length})
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() =>
+                  void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+                }
+                className="rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-hover)]"
+                title="Refresh"
+              >
+                <HugeiconsIcon
+                  icon={RefreshIcon}
+                  size={16}
+                  className="text-[var(--theme-muted)]"
+                />
+              </button>
+              <button
+                onClick={() => setShowCreate(true)}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                style={{ background: 'var(--theme-accent)' }}
+              >
+                <HugeiconsIcon icon={Add01Icon} size={14} />
+                New Job
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <div className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
+          <div className="relative">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={14}
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--theme-muted)]"
+            />
+            <input
+              type="text"
+              placeholder="Search jobs..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-input)] py-1.5 pl-8 pr-3 text-xs text-[var(--theme-text)] placeholder:text-[var(--theme-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--theme-accent)]"
+            />
+          </div>
+          {profilesQuery.isError ? (
+            <p
+              className="mt-2 text-xs"
+              style={{ color: 'var(--theme-warning)' }}
+            >
+              Profile list failed to load. New jobs will default to the default
+              profile until profiles refresh.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
+          {jobsQuery.isLoading ? (
+            <div className="flex items-center justify-center py-12 text-sm text-[var(--theme-muted)]">
+              Loading jobs...
+            </div>
+          ) : jobsQuery.isError ? (
+            <div
+              className="flex items-center justify-center py-12 text-sm"
+              style={{ color: 'var(--theme-danger)' }}
+            >
+              Failed to load jobs:{' '}
+              {jobsQuery.error instanceof Error
+                ? jobsQuery.error.message
+                : 'Unknown error'}
+            </div>
+          ) : filteredJobs.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-[var(--theme-muted)]">
+              <HugeiconsIcon
+                icon={Clock01Icon}
+                size={32}
+                className="mb-3 opacity-40"
+              />
+              <p className="text-sm font-medium">No scheduled jobs</p>
+              <p className="mt-1 text-xs">
+                No cron jobs found across Hermes profiles
+              </p>
+            </div>
+          ) : (
+            <AnimatePresence mode="popLayout">
+              {filteredJobs.map((job) => (
+                <JobCard
+                  key={job.id}
+                  job={job}
+                  onPause={(id) => pauseMutation.mutate(id)}
+                  onResume={(id) => resumeMutation.mutate(id)}
+                  onTrigger={(id) => triggerMutation.mutate(id)}
+                  onEdit={(selectedJob) => setEditingJob(selectedJob)}
+                  onDelete={(id) => {
+                    if (confirm(`Delete job "${job.name}"?`)) {
+                      deleteMutation.mutate(id)
+                    }
+                  }}
+                />
+              ))}
+            </AnimatePresence>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() =>
-              void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
-            }
-            className="rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-hover)]"
-            title="Refresh"
-          >
-            <HugeiconsIcon
-              icon={RefreshIcon}
-              size={16}
-              className="text-[var(--theme-muted)]"
-            />
-          </button>
-          <button
-            onClick={() => setShowCreate(true)}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-            style={{ background: 'var(--theme-accent)' }}
-          >
-            <HugeiconsIcon icon={Add01Icon} size={14} />
-            New Job
-          </button>
-        </div>
-      </div>
-      </header>
 
-      <div className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
-        <div className="relative">
-          <HugeiconsIcon
-            icon={Search01Icon}
-            size={14}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--theme-muted)]"
-          />
-          <input
-            type="text"
-            placeholder="Search jobs..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-input)] py-1.5 pl-8 pr-3 text-xs text-[var(--theme-text)] placeholder:text-[var(--theme-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--theme-accent)]"
-          />
-        </div>
+        <CreateJobDialog
+          open={showCreate}
+          profiles={profiles}
+          onOpenChange={setShowCreate}
+          onSubmit={handleCreate}
+          isSubmitting={createMutation.isPending}
+        />
+        <EditJobDialog
+          job={editingJob}
+          open={editingJob !== null}
+          profiles={profiles}
+          onOpenChange={(open) => {
+            if (!open) setEditingJob(null)
+          }}
+          onSubmit={async (updates) => {
+            if (!editingJob) return
+            await updateMutation.mutateAsync({
+              jobId: editingJob.id,
+              updates,
+            })
+          }}
+          isSubmitting={updateMutation.isPending}
+        />
       </div>
-
-      <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
-        {jobsQuery.isLoading ? (
-          <div className="flex items-center justify-center py-12 text-sm text-[var(--theme-muted)]">
-            Loading jobs...
-          </div>
-        ) : jobsQuery.isError ? (
-          <div
-            className="flex items-center justify-center py-12 text-sm"
-            style={{ color: 'var(--theme-danger)' }}
-          >
-            Failed to load jobs:{' '}
-            {jobsQuery.error instanceof Error
-              ? jobsQuery.error.message
-              : 'Unknown error'}
-          </div>
-        ) : filteredJobs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-[var(--theme-muted)]">
-            <HugeiconsIcon
-              icon={Clock01Icon}
-              size={32}
-              className="mb-3 opacity-40"
-            />
-            <p className="text-sm font-medium">No scheduled jobs</p>
-            <p className="mt-1 text-xs">Create one to get started</p>
-          </div>
-        ) : (
-          <AnimatePresence mode="popLayout">
-            {filteredJobs.map((job) => (
-              <JobCard
-                key={job.id}
-                job={job}
-                onPause={(id) => pauseMutation.mutate(id)}
-                onResume={(id) => resumeMutation.mutate(id)}
-                onTrigger={(id) => triggerMutation.mutate(id)}
-                onEdit={(job) => setEditingJob(job)}
-                onDelete={(id) => {
-                  if (confirm(`Delete job "${job.name}"?`)) {
-                    deleteMutation.mutate(id)
-                  }
-                }}
-              />
-            ))}
-          </AnimatePresence>
-        )}
-      </div>
-
-      <CreateJobDialog
-        open={showCreate}
-        onOpenChange={setShowCreate}
-        onSubmit={handleCreate}
-        isSubmitting={createMutation.isPending}
-      />
-      <EditJobDialog
-        job={editingJob}
-        open={editingJob !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditingJob(null)
-        }}
-        onSubmit={async (updates) => {
-          if (!editingJob) return
-          await updateMutation.mutateAsync({
-            jobId: editingJob.id,
-            updates,
-          })
-        }}
-        isSubmitting={updateMutation.isPending}
-      />
-    </div>
     </div>
   )
 }

--- a/src/server/hermes-cron-profiles.ts
+++ b/src/server/hermes-cron-profiles.ts
@@ -1,0 +1,334 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import { getHermesRoot, getProfilesDir } from './claude-paths'
+
+const PROFILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+const JOB_ID_RE = /^[A-Fa-f0-9]{8,64}$/
+
+type RawCronJob = Record<string, unknown>
+
+type CronJobsFile = {
+  jobs?: Array<RawCronJob>
+}
+
+export type ProfileCronJob = RawCronJob & {
+  id: string
+  jobId: string
+  profile: string
+  profile_name: string
+  name: string
+  prompt: string
+  enabled: boolean
+  state: string
+  schedule_display: string
+  next_run_at: string | null
+  last_run_at: string | null
+  last_run_success: boolean | null
+  last_run_error: string | null
+  deliver: Array<string>
+}
+
+export type ParsedProfileJobId = {
+  profile: string | null
+  jobId: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function readString(...values: Array<unknown>): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function normalizeDeliver(value: unknown): Array<string> {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (entry): entry is string =>
+        typeof entry === 'string' && entry.trim().length > 0,
+    )
+  }
+  if (typeof value === 'string' && value.trim()) return [value.trim()]
+  return []
+}
+
+function lastRunSuccess(job: RawCronJob): boolean | null {
+  const status = readString(job.last_status, job.lastRunStatus, job.status)
+  if (!status) return null
+  const normalized = status.toLowerCase()
+  if (
+    ['ok', 'success', 'succeeded', 'completed', 'complete', 'done'].includes(
+      normalized,
+    )
+  )
+    return true
+  if (
+    ['error', 'failed', 'fail', 'failure', 'cancelled', 'canceled'].includes(
+      normalized,
+    )
+  )
+    return false
+  return null
+}
+
+function profileHome(profile: string): string {
+  if (profile === 'default') return getHermesRoot()
+  return join(getProfilesDir(), profile)
+}
+
+function outputDir(profile: string, jobId: string): string {
+  return join(profileHome(profile), 'cron', 'output', jobId)
+}
+
+function readJobsFile(path: string): Array<RawCronJob> {
+  if (!existsSync(path)) return []
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as
+      | CronJobsFile
+      | Array<RawCronJob>
+    if (Array.isArray(parsed)) return parsed
+    return Array.isArray(parsed.jobs) ? parsed.jobs : []
+  } catch {
+    return []
+  }
+}
+
+export function listCronProfiles(): Array<{ profile: string; home: string }> {
+  const entries = [{ profile: 'default', home: getHermesRoot() }]
+  const profilesDir = getProfilesDir()
+  if (!existsSync(profilesDir)) return entries
+  for (const name of readdirSync(profilesDir).sort()) {
+    if (!PROFILE_NAME_RE.test(name)) continue
+    const home = join(profilesDir, name)
+    try {
+      if (statSync(home).isDirectory()) entries.push({ profile: name, home })
+    } catch {
+      // Ignore profiles that disappear while scanning.
+    }
+  }
+  return entries
+}
+
+export function listProfileCronJobs(): Array<ProfileCronJob> {
+  const rows: Array<ProfileCronJob> = []
+  for (const entry of listCronProfiles()) {
+    const jobs = readJobsFile(join(entry.home, 'cron', 'jobs.json'))
+    for (const job of jobs) {
+      const rawId = readString(job.id, job.jobId)
+      if (!rawId) continue
+      const schedule = asRecord(job.schedule)
+      const display =
+        readString(
+          job.schedule_display,
+          schedule.display,
+          schedule.expr,
+          job.cron,
+        ) ?? '* * * * *'
+      const state =
+        readString(job.state, job.status) ??
+        (readBoolean(job.enabled, true) ? 'scheduled' : 'paused')
+      rows.push({
+        ...job,
+        id: `${entry.profile}:${rawId}`,
+        jobId: rawId,
+        profile: entry.profile,
+        profile_name: entry.profile,
+        name: readString(job.name, job.title) ?? rawId,
+        prompt: readString(job.prompt, job.input, job.description) ?? '',
+        enabled: readBoolean(job.enabled, state !== 'paused'),
+        state,
+        schedule_display: display,
+        next_run_at: readString(job.next_run_at, job.nextRunAt),
+        last_run_at: readString(job.last_run_at, job.lastRunAt),
+        last_run_success: lastRunSuccess(job),
+        last_run_error: readString(job.last_error, job.lastRunError),
+        deliver: normalizeDeliver(job.deliver),
+      })
+    }
+  }
+  return rows.sort(
+    (a, b) =>
+      a.profile.localeCompare(b.profile) || a.name.localeCompare(b.name),
+  )
+}
+
+export function parseProfileJobId(value: string): ParsedProfileJobId {
+  const index = value.indexOf(':')
+  if (index <= 0) return { profile: null, jobId: value }
+  const profile = value.slice(0, index)
+  const jobId = value.slice(index + 1)
+  if (!PROFILE_NAME_RE.test(profile) || !JOB_ID_RE.test(jobId))
+    return { profile: null, jobId: value }
+  return { profile, jobId }
+}
+
+function validateProfileAndMaybeJob(profile: string, jobId?: string): void {
+  if (
+    !PROFILE_NAME_RE.test(profile) ||
+    (jobId !== undefined && !JOB_ID_RE.test(jobId))
+  ) {
+    throw new Error('Invalid profile or job id')
+  }
+  if (!listCronProfiles().some((entry) => entry.profile === profile)) {
+    throw new Error(`Unknown Hermes profile: ${profile}`)
+  }
+}
+
+function normalizeCreateArgs(
+  profile: string,
+  input: Record<string, unknown>,
+): Array<string> {
+  validateProfileAndMaybeJob(profile)
+  const schedule = readString(input.schedule)
+  const prompt = readString(input.prompt, input.input) ?? ''
+  if (!schedule) throw new Error('Schedule is required')
+  const args = ['--profile', profile, 'cron', 'create']
+  const name = readString(input.name)
+  if (name) args.push('--name', name)
+  const deliver = Array.isArray(input.deliver)
+    ? input.deliver
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : []
+  if (deliver.length > 0) args.push('--deliver', deliver.join(','))
+  const skills = Array.isArray(input.skills)
+    ? input.skills
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : []
+  for (const skill of skills) args.push('--skill', skill)
+  const repeat =
+    typeof input.repeat === 'number' && Number.isFinite(input.repeat)
+      ? String(input.repeat)
+      : null
+  if (repeat) args.push('--repeat', repeat)
+  args.push(schedule, prompt)
+  return args
+}
+
+function parseCreatedJobId(output: string): string | null {
+  return output.match(/Created job:\s*([A-Fa-f0-9]{8,64})/)?.[1] ?? null
+}
+
+export function createProfileCronJob(
+  profile: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const output = execFileSync('hermes', normalizeCreateArgs(profile, input), {
+    encoding: 'utf8',
+    timeout: 30_000,
+  })
+  const createdId = parseCreatedJobId(output)
+  const job = createdId
+    ? (listProfileCronJobs().find(
+        (entry) => entry.profile === profile && entry.jobId === createdId,
+      ) ?? null)
+    : null
+  return {
+    ok: true,
+    output,
+    job,
+    jobId: createdId ? `${profile}:${createdId}` : undefined,
+  }
+}
+
+export function runProfileCronAction(
+  profile: string,
+  jobId: string,
+  action: 'pause' | 'resume' | 'run' | 'remove',
+): Record<string, unknown> {
+  validateProfileAndMaybeJob(profile, jobId)
+  const cliAction = action === 'remove' ? 'remove' : action
+  const output = execFileSync(
+    'hermes',
+    ['--profile', profile, 'cron', cliAction, jobId],
+    {
+      encoding: 'utf8',
+      timeout: 30_000,
+    },
+  )
+  const job =
+    listProfileCronJobs().find(
+      (entry) => entry.profile === profile && entry.jobId === jobId,
+    ) ?? null
+  return { ok: true, output, job }
+}
+
+export function updateProfileCronJob(
+  profile: string,
+  jobId: string,
+  updates: Record<string, unknown>,
+): Record<string, unknown> {
+  validateProfileAndMaybeJob(profile, jobId)
+  const args = ['--profile', profile, 'cron', 'edit', jobId]
+  const name = readString(updates.name)
+  const schedule = readString(updates.schedule)
+  const prompt = readString(updates.prompt, updates.input)
+  const deliver = Array.isArray(updates.deliver)
+    ? updates.deliver
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : []
+  if (name) args.push('--name', name)
+  if (schedule) args.push('--schedule', schedule)
+  if (prompt !== null) args.push('--prompt', prompt)
+  if (deliver.length > 0) args.push('--deliver', deliver.join(','))
+  const repeat =
+    typeof updates.repeat === 'number' && Number.isFinite(updates.repeat)
+      ? String(updates.repeat)
+      : null
+  if (repeat) args.push('--repeat', repeat)
+  const output = execFileSync('hermes', args, {
+    encoding: 'utf8',
+    timeout: 30_000,
+  })
+  const job =
+    listProfileCronJobs().find(
+      (entry) => entry.profile === profile && entry.jobId === jobId,
+    ) ?? null
+  return { ok: true, output, job }
+}
+
+export function readProfileCronOutputs(
+  profile: string,
+  jobId: string,
+  limit: number,
+): Array<{
+  filename: string
+  timestamp: string
+  content: string
+  size: number
+}> {
+  if (!PROFILE_NAME_RE.test(profile) || !JOB_ID_RE.test(jobId)) return []
+  const dir = outputDir(profile, jobId)
+  if (!existsSync(dir)) return []
+  try {
+    return readdirSync(dir)
+      .filter((name) => !name.startsWith('.'))
+      .sort()
+      .reverse()
+      .slice(0, Math.max(1, Math.min(limit, 50)))
+      .map((name) => {
+        const path = join(dir, name)
+        const stat = statSync(path)
+        return {
+          filename: basename(name),
+          timestamp: stat.mtime.toISOString(),
+          content: readFileSync(path, 'utf8'),
+          size: stat.size,
+        }
+      })
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- aggregate Hermes cron jobs from default and all profile homes for the Jobs screen
- annotate jobs with their source profile and make profile names searchable
- route profile-prefixed cron output/actions back to the owning Hermes profile

## Test Plan
- pnpm build