### PR TITLE
Scope workspace tasks and swarm by active project

### DIFF
--- a/src/components/hermes-status-panel.test.ts
+++ b/src/components/hermes-status-panel.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('Hermes status panel wiring', () => {
+  it('renders the Hermes status panel from Operations and fetches the status API', () => {
+    const operationsSource = readFileSync(
+      resolve(process.cwd(), 'src/screens/agents/operations-screen.tsx'),
+      'utf8',
+    )
+    const panelSource = readFileSync(
+      resolve(process.cwd(), 'src/components/hermes-status-panel.tsx'),
+      'utf8',
+    )
+
+    expect(operationsSource).toContain('HermesStatusPanel')
+    expect(panelSource).toContain("fetch('/api/hermes-status'")
+    expect(panelSource).toContain('data-testid="hermes-status-panel"')
+    expect(panelSource).toContain('Workspace status')
+  })
+})

--- a/src/components/hermes-status-panel.tsx
+++ b/src/components/hermes-status-panel.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type HermesStatusComponent = {
+  name: string
+  ok: boolean
+  required: boolean
+  severity: 'ok' | 'warn' | 'fail'
+  detail: string
+}
+
+type HermesStatusPayload = {
+  overallOk: boolean
+  checkedAt: number
+  source: string
+  components: HermesStatusComponent[]
+  summary: {
+    ok: number
+    warn: number
+    fail: number
+    total: number
+  }
+}
+
+function severityClass(severity: HermesStatusComponent['severity']) {
+  if (severity === 'ok') return 'bg-emerald-500/10 text-emerald-700 border-emerald-500/30'
+  if (severity === 'warn') return 'bg-amber-500/10 text-amber-700 border-amber-500/30'
+  return 'bg-red-500/10 text-red-700 border-red-500/30'
+}
+
+function severityLabel(severity: HermesStatusComponent['severity']) {
+  if (severity === 'ok') return 'OK'
+  if (severity === 'warn') return 'WARN'
+  return 'FAIL'
+}
+
+export function HermesStatusPanel() {
+  const [status, setStatus] = useState<HermesStatusPayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  async function refresh() {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/hermes-status', { cache: 'no-store' })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      setStatus((await response.json()) as HermesStatusPayload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  const topComponents = useMemo(() => {
+    return [...(status?.components ?? [])].sort((a, b) => {
+      const order = { fail: 0, warn: 1, ok: 2 }
+      return order[a.severity] - order[b.severity]
+    }).slice(0, 6)
+  }, [status])
+
+  return (
+    <section
+      data-testid="hermes-status-panel"
+      className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+            Workspace status
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">
+            Hermes reliability
+          </h2>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+            Frontend, backend, gateway, Notion and git health from `hermes-healthcheck`.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-[var(--theme-border)] px-4 py-5 text-sm text-[var(--theme-muted)]">
+          Loading Hermes status…
+        </div>
+      ) : error ? (
+        <div className="mt-4 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-5 text-sm text-red-700">
+          Status unavailable: {error}
+        </div>
+      ) : status ? (
+        <>
+          <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <div className={cn('rounded-2xl border px-4 py-3', status.overallOk ? severityClass('ok') : severityClass('fail'))}>
+              <div className="text-xs uppercase tracking-[0.14em]">Overall</div>
+              <div className="mt-1 text-lg font-semibold">{status.overallOk ? 'OK' : 'Needs attention'}</div>
+            </div>
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
+              <div className="text-xs uppercase tracking-[0.14em] text-[var(--theme-muted)]">OK</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--theme-text)]">{status.summary.ok}</div>
+            </div>
+            <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-amber-700">
+              <div className="text-xs uppercase tracking-[0.14em]">Warn</div>
+              <div className="mt-1 text-lg font-semibold">{status.summary.warn}</div>
+            </div>
+            <div className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-red-700">
+              <div className="text-xs uppercase tracking-[0.14em]">Fail</div>
+              <div className="mt-1 text-lg font-semibold">{status.summary.fail}</div>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-2 lg:grid-cols-2">
+            {topComponents.map((component) => (
+              <div
+                key={component.name}
+                className="flex items-start justify-between gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-[var(--theme-text)]">{component.name}</div>
+                  <div className="mt-1 line-clamp-2 text-xs text-[var(--theme-muted)]">{component.detail || 'No detail'}</div>
+                </div>
+                <span className={cn('shrink-0 rounded-full border px-2 py-1 text-[10px] font-semibold', severityClass(component.severity))}>
+                  {severityLabel(component.severity)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </section>
+  )
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -313,7 +313,7 @@ export const LOCALE_LABELS: Record<LocaleId, string> = {
   es: 'Español',
   fr: 'Français',
   de: 'Deutsch',
-  zh: '中文（简体）',
+  zh: '中文',
   'zh-TW': '繁體中文',
   ja: '日本語',
   ko: '한국어',

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -27,6 +27,7 @@ export type CreateTaskInput = {
   tags?: Array<string>
   due_date?: string | null
   created_by?: string
+  projectId?: string | null
 }
 
 export type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'created_by'>>
@@ -53,12 +54,14 @@ export async function fetchTasks(params?: {
   assignee?: string
   priority?: TaskPriority
   include_done?: boolean
+  projectId?: string | null
 }): Promise<Array<ClaudeTask>> {
   const q = new URLSearchParams()
   if (params?.column) q.set('column', params.column)
   if (params?.assignee) q.set('assignee', params.assignee)
   if (params?.priority) q.set('priority', params.priority)
   if (params?.include_done) q.set('include_done', 'true')
+  if (params?.projectId) q.set('projectId', params.projectId)
   const url = q.toString() ? `${BASE}?${q}` : BASE
   const res = await fetch(url)
   if (!res.ok) throw new Error(`Failed to fetch tasks: ${res.status}`)
@@ -80,7 +83,10 @@ export async function createTask(input: CreateTaskInput): Promise<ClaudeTask> {
 }
 
 export async function updateTask(taskId: string, input: UpdateTaskInput): Promise<ClaudeTask> {
-  const res = await fetch(`${BASE}/${taskId}`, {
+  const q = new URLSearchParams()
+  if (input.projectId) q.set('projectId', input.projectId)
+  const url = q.toString() ? `${BASE}/${taskId}?${q}` : `${BASE}/${taskId}`
+  const res = await fetch(url, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
@@ -89,16 +95,21 @@ export async function updateTask(taskId: string, input: UpdateTaskInput): Promis
   return (await res.json()).task
 }
 
-export async function deleteTask(taskId: string): Promise<void> {
-  const res = await fetch(`${BASE}/${taskId}`, { method: 'DELETE' })
+export async function deleteTask(taskId: string, projectId?: string | null): Promise<void> {
+  const q = new URLSearchParams()
+  if (projectId) q.set('projectId', projectId)
+  const url = q.toString() ? `${BASE}/${taskId}?${q}` : `${BASE}/${taskId}`
+  const res = await fetch(url, { method: 'DELETE' })
   if (!res.ok) throw new Error(`Failed to delete task: ${res.status}`)
 }
 
-export async function moveTask(taskId: string, column: TaskColumn, movedBy = 'user'): Promise<ClaudeTask> {
-  const res = await fetch(`${BASE}/${taskId}?action=move`, {
+export async function moveTask(taskId: string, column: TaskColumn, movedBy = 'user', projectId?: string | null): Promise<ClaudeTask> {
+  const q = new URLSearchParams({ action: 'move' })
+  if (projectId) q.set('projectId', projectId)
+  const res = await fetch(`${BASE}/${taskId}?${q}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ column, moved_by: movedBy }),
+    body: JSON.stringify({ column, moved_by: movedBy, projectId }),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -81,6 +81,7 @@ import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesStatusRouteImport } from './routes/api/hermes-status'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
@@ -508,6 +509,11 @@ const ApiHistoryRoute = ApiHistoryRouteImport.update({
   path: '/api/history',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHermesStatusRoute = ApiHermesStatusRouteImport.update({
+  id: '/api/hermes-status',
+  path: '/api/hermes-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
@@ -877,6 +883,7 @@ export interface FileRoutesByFullPath {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-status': typeof ApiHermesStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1015,6 +1022,7 @@ export interface FileRoutesByTo {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-status': typeof ApiHermesStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1155,6 +1163,7 @@ export interface FileRoutesById {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-status': typeof ApiHermesStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1296,6 +1305,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1434,6 +1444,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1573,6 +1584,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-status'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1713,6 +1725,7 @@ export interface RootRouteChildren {
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiHermesStatusRoute: typeof ApiHermesStatusRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
@@ -2290,6 +2303,13 @@ declare module '@tanstack/react-router' {
       path: '/api/history'
       fullPath: '/api/history'
       preLoaderRoute: typeof ApiHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-status': {
+      id: '/api/hermes-status'
+      path: '/api/hermes-status'
+      fullPath: '/api/hermes-status'
+      preLoaderRoute: typeof ApiHermesStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/gateway-status': {
@@ -2951,6 +2971,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiHermesStatusRoute: ApiHermesStatusRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -91,6 +91,7 @@ import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection
 import { Route as ApiConnectionSettingsRouteImport } from './routes/api/connection-settings'
 import { Route as ApiConductorStopRouteImport } from './routes/api/conductor-stop'
 import { Route as ApiConductorSpawnRouteImport } from './routes/api/conductor-spawn'
+import { Route as ApiCliReadinessRouteImport } from './routes/api/cli-readiness'
 import { Route as ApiClaudeUpdateRouteImport } from './routes/api/claude-update'
 import { Route as ApiClaudeTasksAssigneesRouteImport } from './routes/api/claude-tasks-assignees'
 import { Route as ApiClaudeTasksRouteImport } from './routes/api/claude-tasks'
@@ -557,6 +558,11 @@ const ApiConductorSpawnRoute = ApiConductorSpawnRouteImport.update({
   path: '/api/conductor-spawn',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiCliReadinessRoute = ApiCliReadinessRouteImport.update({
+  id: '/api/cli-readiness',
+  path: '/api/cli-readiness',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiClaudeUpdateRoute = ApiClaudeUpdateRouteImport.update({
   id: '/api/claude-update',
   path: '/api/claude-update',
@@ -860,6 +866,7 @@ export interface FileRoutesByFullPath {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/cli-readiness': typeof ApiCliReadinessRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -997,6 +1004,7 @@ export interface FileRoutesByTo {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/cli-readiness': typeof ApiCliReadinessRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -1136,6 +1144,7 @@ export interface FileRoutesById {
   '/api/claude-tasks': typeof ApiClaudeTasksRouteWithChildren
   '/api/claude-tasks-assignees': typeof ApiClaudeTasksAssigneesRoute
   '/api/claude-update': typeof ApiClaudeUpdateRoute
+  '/api/cli-readiness': typeof ApiCliReadinessRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -1276,6 +1285,7 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/cli-readiness'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1413,6 +1423,7 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/cli-readiness'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1551,6 +1562,7 @@ export interface FileRouteTypes {
     | '/api/claude-tasks'
     | '/api/claude-tasks-assignees'
     | '/api/claude-update'
+    | '/api/cli-readiness'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1690,6 +1702,7 @@ export interface RootRouteChildren {
   ApiClaudeTasksRoute: typeof ApiClaudeTasksRouteWithChildren
   ApiClaudeTasksAssigneesRoute: typeof ApiClaudeTasksAssigneesRoute
   ApiClaudeUpdateRoute: typeof ApiClaudeUpdateRoute
+  ApiCliReadinessRoute: typeof ApiCliReadinessRoute
   ApiConductorSpawnRoute: typeof ApiConductorSpawnRoute
   ApiConductorStopRoute: typeof ApiConductorStopRoute
   ApiConnectionSettingsRoute: typeof ApiConnectionSettingsRoute
@@ -2349,6 +2362,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiConductorSpawnRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/cli-readiness': {
+      id: '/api/cli-readiness'
+      path: '/api/cli-readiness'
+      fullPath: '/api/cli-readiness'
+      preLoaderRoute: typeof ApiCliReadinessRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/claude-update': {
       id: '/api/claude-update'
       path: '/api/claude-update'
@@ -2920,6 +2940,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiClaudeTasksRoute: ApiClaudeTasksRouteWithChildren,
   ApiClaudeTasksAssigneesRoute: ApiClaudeTasksAssigneesRoute,
   ApiClaudeUpdateRoute: ApiClaudeUpdateRoute,
+  ApiCliReadinessRoute: ApiCliReadinessRoute,
   ApiConductorSpawnRoute: ApiConductorSpawnRoute,
   ApiConductorStopRoute: ApiConductorStopRoute,
   ApiConnectionSettingsRoute: ApiConnectionSettingsRoute,

--- a/src/routes/api/-claude-tasks.test.ts
+++ b/src/routes/api/-claude-tasks.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+function mockAuthAndWorkspace() {
+  vi.doMock('../../server/auth-middleware', () => ({
+    isAuthenticated: vi.fn(() => true),
+  }))
+  vi.doMock('./workspace', () => ({
+    loadWorkspaceCatalog: vi.fn(async () => ({ projectSlug: 'active-project' })),
+  }))
+}
+
+describe('claude tasks API project scope', () => {
+  it('requires explicit projectId when creating a task instead of falling back to the active workspace project', async () => {
+    const createClaudeTask = vi.fn()
+    mockAuthAndWorkspace()
+    vi.doMock('../../server/claude-tasks-backend', () => ({
+      createClaudeTask,
+      listClaudeTasks: vi.fn(),
+    }))
+
+    const { createClaudeTasksResponse } = await import('./claude-tasks')
+    const response = await createClaudeTasksResponse(new Request('http://local/api/claude-tasks', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Review auth' }),
+    }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('projectId') })
+    expect(createClaudeTask).not.toHaveBeenCalled()
+  })
+
+  it('requires explicit projectId when updating a task instead of falling back to the active workspace project', async () => {
+    const updateClaudeTask = vi.fn()
+    mockAuthAndWorkspace()
+    vi.doMock('../../server/claude-tasks-backend', () => ({
+      getClaudeTask: vi.fn(),
+      moveClaudeTask: vi.fn(),
+      updateClaudeTask,
+    }))
+
+    const { Route } = await import('./claude-tasks.$taskId')
+    const handlers = Route.options.server.handlers as Record<string, (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>>
+    const response = await handlers.PATCH({
+      request: new Request('http://local/api/claude-tasks/task-1', {
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Wrong project risk' }),
+      }),
+      params: { taskId: 'task-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('projectId') })
+    expect(updateClaudeTask).not.toHaveBeenCalled()
+  })
+
+  it('requires explicit projectId when moving a task instead of falling back to the active workspace project', async () => {
+    const moveClaudeTask = vi.fn()
+    mockAuthAndWorkspace()
+    vi.doMock('../../server/claude-tasks-backend', () => ({
+      getClaudeTask: vi.fn(),
+      moveClaudeTask,
+      updateClaudeTask: vi.fn(),
+    }))
+
+    const { Route } = await import('./claude-tasks.$taskId')
+    const handlers = Route.options.server.handlers as Record<string, (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>>
+    const response = await handlers.POST({
+      request: new Request('http://local/api/claude-tasks/task-1?action=move', {
+        method: 'POST',
+        body: JSON.stringify({ column: 'done' }),
+      }),
+      params: { taskId: 'task-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining('projectId') })
+    expect(moveClaudeTask).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/api/-cli-readiness.test.ts
+++ b/src/routes/api/-cli-readiness.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+describe('cli-readiness API', () => {
+  it('returns sanitized readiness JSON without raw auth details', async () => {
+    vi.doMock('../../server/auth-middleware', () => ({
+      requireLocalOrAuth: vi.fn(() => true),
+    }))
+    vi.doMock('../../server/cli-readiness', () => ({
+      getCliReadiness: vi.fn(() => ({
+        ok: true,
+        checkedAt: 1777527540000,
+        cli: {
+          claude: {
+            installed: true,
+            path: '/usr/local/bin/claude',
+            version: 'claude 2.1.0',
+            authenticated: true,
+            authMethod: 'claude.ai',
+            status: 'ready',
+            detail: 'Logged in with token sk-secret',
+          },
+          codex: {
+            installed: true,
+            path: '/usr/local/bin/codex',
+            version: 'codex 0.128.0',
+            authenticated: true,
+            authMethod: 'chatgpt',
+            status: 'ready',
+            detail: 'Logged in as kaan@example.com',
+          },
+        },
+        secrets: {
+          codexAuthFilePresent: true,
+          codexTokenPresent: true,
+          hermesAuthFilePresent: true,
+          hermesOpenAiCodexProviderPresent: true,
+        },
+      })),
+      sanitizeCliReadiness: vi.fn((readiness) => ({
+        ...readiness,
+        cli: {
+          claude: Object.fromEntries(Object.entries(readiness.cli.claude).filter(([key]) => key !== 'detail')),
+          codex: Object.fromEntries(Object.entries(readiness.cli.codex).filter(([key]) => key !== 'detail')),
+        },
+      })),
+    }))
+
+    const { getCliReadinessResponse } = await import('./cli-readiness')
+    const response = getCliReadinessResponse(new Request('http://local/api/cli-readiness'))
+    const body = await response.json() as Record<string, any>
+    const serialized = JSON.stringify(body)
+
+    expect(body.ok).toBe(true)
+    expect(body.cli.claude).not.toHaveProperty('detail')
+    expect(body.cli.codex).not.toHaveProperty('detail')
+    expect(serialized).not.toContain('sk-secret')
+    expect(serialized).not.toContain('kaan@example.com')
+  })
+})

--- a/src/routes/api/-swarm-kanban.test.ts
+++ b/src/routes/api/-swarm-kanban.test.ts
@@ -9,6 +9,9 @@ describe('swarm-kanban API project scope', () => {
   it('accepts projectId from query params', async () => {
     const listKanbanCards = vi.fn(async () => [])
     const getKanbanBackendMeta = vi.fn(() => ({ id: 'local', label: 'Local board', detected: true, writable: true }))
+    vi.doMock('../../server/auth-middleware', () => ({
+      requireLocalOrAuth: vi.fn(() => true),
+    }))
     vi.doMock('../../server/kanban-backend', () => ({
       listKanbanCards,
       getKanbanBackendMeta,
@@ -26,5 +29,54 @@ describe('swarm-kanban API project scope', () => {
     expect(body.ok).toBe(true)
     expect(listKanbanCards).toHaveBeenCalledWith('solarbot')
     expect(getKanbanBackendMeta).toHaveBeenCalledWith('solarbot')
+  })
+
+  it('rejects unauthenticated requests before reading cards', async () => {
+    const listKanbanCards = vi.fn(async () => [])
+    vi.doMock('../../server/auth-middleware', () => ({
+      requireLocalOrAuth: vi.fn(() => false),
+    }))
+    vi.doMock('../../server/kanban-backend', () => ({
+      listKanbanCards,
+      getKanbanBackendMeta: vi.fn(),
+      createKanbanCard: vi.fn(),
+      updateKanbanCard: vi.fn(),
+    }))
+    vi.doMock('./workspace', () => ({
+      loadWorkspaceCatalog: vi.fn(async () => ({ projectSlug: 'active-project' })),
+    }))
+
+    const { getSwarmKanbanResponse } = await import('./swarm-kanban')
+    const response = await getSwarmKanbanResponse(new Request('http://local/api/swarm-kanban'))
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toMatchObject({ ok: false, error: 'Unauthorized' })
+    expect(listKanbanCards).not.toHaveBeenCalled()
+  })
+
+  it('requires explicit projectId for card creation instead of falling back to the active workspace project', async () => {
+    const createKanbanCard = vi.fn()
+    vi.doMock('../../server/auth-middleware', () => ({
+      requireLocalOrAuth: vi.fn(() => true),
+    }))
+    vi.doMock('../../server/kanban-backend', () => ({
+      listKanbanCards: vi.fn(),
+      getKanbanBackendMeta: vi.fn(),
+      createKanbanCard,
+      updateKanbanCard: vi.fn(),
+    }))
+    vi.doMock('./workspace', () => ({
+      loadWorkspaceCatalog: vi.fn(async () => ({ projectSlug: 'active-project' })),
+    }))
+
+    const { createSwarmKanbanResponse } = await import('./swarm-kanban')
+    const response = await createSwarmKanbanResponse(new Request('http://local/api/swarm-kanban', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Fix safety gate' }),
+    }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ ok: false, error: expect.stringContaining('projectId') })
+    expect(createKanbanCard).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/api/-swarm-kanban.test.ts
+++ b/src/routes/api/-swarm-kanban.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+describe('swarm-kanban API project scope', () => {
+  it('accepts projectId from query params', async () => {
+    const listKanbanCards = vi.fn(async () => [])
+    const getKanbanBackendMeta = vi.fn(() => ({ id: 'local', label: 'Local board', detected: true, writable: true }))
+    vi.doMock('../../server/kanban-backend', () => ({
+      listKanbanCards,
+      getKanbanBackendMeta,
+      createKanbanCard: vi.fn(),
+      updateKanbanCard: vi.fn(),
+    }))
+    vi.doMock('./workspace', () => ({
+      loadWorkspaceCatalog: vi.fn(async () => ({ projectSlug: 'active-project' })),
+    }))
+
+    const { getSwarmKanbanResponse } = await import('./swarm-kanban')
+    const response = await getSwarmKanbanResponse(new Request('http://local/api/swarm-kanban?projectId=solarbot'))
+    const body = await response.json()
+
+    expect(body.ok).toBe(true)
+    expect(listKanbanCards).toHaveBeenCalledWith('solarbot')
+    expect(getKanbanBackendMeta).toHaveBeenCalledWith('solarbot')
+  })
+})

--- a/src/routes/api/-workspace.test.ts
+++ b/src/routes/api/-workspace.test.ts
@@ -20,6 +20,8 @@ beforeEach(async () => {
   delete process.env.HERMES_WORKSPACE_DIR
   delete process.env.CLAUDE_WORKSPACE_DIR
   delete process.env.HERMES_WEBUI_DEFAULT_WORKSPACE
+  process.env.HERMES_PROJECTS_MD = path.join(tempRoot, 'NO_PROJECTS.md')
+  process.env.HERMES_PROJECTS_ROOT = path.join(tempRoot, 'projects')
   await fs.mkdir(process.env.HERMES_HOME, { recursive: true })
 })
 
@@ -48,6 +50,46 @@ describe('workspace API catalog semantics', () => {
     })
     expect(catalog.workspaces).toEqual([{ name: 'Home', path: project }])
     expect(catalog.path).not.toBe(process.env.HERMES_HOME)
+  })
+
+  it('adds existing PROJECTS.md entries to the workspace catalog and exposes the active project slug', async () => {
+    const projectsRoot = await makeDir(tempRoot, 'projects')
+    const solarbot = await makeDir(projectsRoot, 'solarbot')
+    process.env.HERMES_PROJECTS_ROOT = projectsRoot
+    process.env.HERMES_PROJECTS_MD = path.join(tempRoot, 'PROJECTS.md')
+    await fs.writeFile(
+      process.env.HERMES_PROJECTS_MD,
+      `# Proje İndeksi
+
+## Aktif Projeler
+
+| Klasör | Açıklama | Dil/Platform | GitHub |
+|--------|----------|-------------|--------|
+| \`solarbot\` | Solar bot projesi | Python | kaankirsan/solarbot |
+`,
+      'utf-8',
+    )
+    await fs.writeFile(
+      path.join(process.env.HERMES_HOME!, 'config.yaml'),
+      `default_workspace: ${JSON.stringify(solarbot)}\n`,
+      'utf-8',
+    )
+
+    const catalog = await loadWorkspaceCatalog()
+
+    expect(catalog).toMatchObject({
+      path: solarbot,
+      folderName: 'solarbot',
+      source: 'projects-md',
+      projectSlug: 'solarbot',
+    })
+    expect(catalog.workspaces).toContainEqual(expect.objectContaining({
+      name: 'solarbot',
+      path: solarbot,
+      projectSlug: 'solarbot',
+      github: 'kaankirsan/solarbot',
+      source: 'projects-md',
+    }))
   })
 
   it('ignores legacy persisted Hermes state paths as workspaces', async () => {

--- a/src/routes/api/claude-tasks.$taskId.ts
+++ b/src/routes/api/claude-tasks.$taskId.ts
@@ -27,14 +27,22 @@ function isTaskPriority(value: unknown): value is TaskPriority {
   return value === 'high' || value === 'medium' || value === 'low'
 }
 
-async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+function explicitProjectId(request: Request, body?: Record<string, unknown>): string | null {
   const url = new URL(request.url)
-  const explicit = sanitizeProjectSlug(
+  return sanitizeProjectSlug(
     typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
   )
+}
+
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const explicit = explicitProjectId(request, body)
   if (explicit) return explicit
   const catalog = await loadWorkspaceCatalog()
   return catalog.projectSlug ?? null
+}
+
+function projectIdRequiredResponse() {
+  return jsonResponse({ error: 'projectId is required for task writes' }, 400)
 }
 
 export const Route = createFileRoute('/api/claude-tasks/$taskId')({
@@ -57,7 +65,8 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
 
         try {
           const body = (await request.json()) as Record<string, unknown>
-          const projectId = await requestProjectId(request, body)
+          const projectId = explicitProjectId(request, body)
+          if (!projectId) return projectIdRequiredResponse()
           const task = await updateClaudeTask(params.taskId, {
             title: typeof body.title === 'string' ? body.title : undefined,
             description: typeof body.description === 'string' ? body.description : undefined,
@@ -100,7 +109,9 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
           if (!isTaskColumn(body.column)) {
             return jsonResponse({ error: 'column is required' }, 400)
           }
-          const task = await moveClaudeTask(params.taskId, body.column, await requestProjectId(request, body))
+          const projectId = explicitProjectId(request, body)
+          if (!projectId) return projectIdRequiredResponse()
+          const task = await moveClaudeTask(params.taskId, body.column, projectId)
           if (!task) return jsonResponse({ error: 'Task not found' }, 404)
           return jsonResponse({ task })
         } catch {

--- a/src/routes/api/claude-tasks.$taskId.ts
+++ b/src/routes/api/claude-tasks.$taskId.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getClaudeTask, moveClaudeTask, updateClaudeTask } from '../../server/claude-tasks-backend'
 import type { TaskColumn, TaskPriority } from '../../server/claude-tasks-backend'
+import { sanitizeProjectSlug } from '../../server/project-catalog'
+import { loadWorkspaceCatalog } from './workspace'
 
 function jsonResponse(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -25,6 +27,16 @@ function isTaskPriority(value: unknown): value is TaskPriority {
   return value === 'high' || value === 'medium' || value === 'low'
 }
 
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const url = new URL(request.url)
+  const explicit = sanitizeProjectSlug(
+    typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
+  )
+  if (explicit) return explicit
+  const catalog = await loadWorkspaceCatalog()
+  return catalog.projectSlug ?? null
+}
+
 export const Route = createFileRoute('/api/claude-tasks/$taskId')({
   server: {
     handlers: {
@@ -33,7 +45,7 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
           return jsonResponse({ error: 'Unauthorized' }, 401)
         }
 
-        const task = await getClaudeTask(params.taskId)
+        const task = await getClaudeTask(params.taskId, await requestProjectId(request))
         if (!task) return jsonResponse({ error: 'Task not found' }, 404)
         return jsonResponse({ task })
       },
@@ -45,6 +57,7 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
 
         try {
           const body = (await request.json()) as Record<string, unknown>
+          const projectId = await requestProjectId(request, body)
           const task = await updateClaudeTask(params.taskId, {
             title: typeof body.title === 'string' ? body.title : undefined,
             description: typeof body.description === 'string' ? body.description : undefined,
@@ -53,6 +66,7 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
             assignee: body.assignee === null || typeof body.assignee === 'string' ? body.assignee : undefined,
             tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : undefined,
             due_date: body.due_date === null || typeof body.due_date === 'string' ? body.due_date : undefined,
+            projectId,
           })
 
           if (!task) return jsonResponse({ error: 'Task not found' }, 404)
@@ -86,7 +100,7 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
           if (!isTaskColumn(body.column)) {
             return jsonResponse({ error: 'column is required' }, 400)
           }
-          const task = await moveClaudeTask(params.taskId, body.column)
+          const task = await moveClaudeTask(params.taskId, body.column, await requestProjectId(request, body))
           if (!task) return jsonResponse({ error: 'Task not found' }, 404)
           return jsonResponse({ task })
         } catch {

--- a/src/routes/api/claude-tasks.ts
+++ b/src/routes/api/claude-tasks.ts
@@ -27,66 +27,79 @@ function isTaskPriority(value: unknown): value is TaskPriority {
   return value === 'high' || value === 'medium' || value === 'low'
 }
 
-async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+function explicitProjectId(request: Request, body?: Record<string, unknown>): string | null {
   const url = new URL(request.url)
-  const explicit = sanitizeProjectSlug(
+  return sanitizeProjectSlug(
     typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
   )
+}
+
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const explicit = explicitProjectId(request, body)
   if (explicit) return explicit
   const catalog = await loadWorkspaceCatalog()
   return catalog.projectSlug ?? null
 }
 
+function projectIdRequiredResponse() {
+  return jsonResponse({ error: 'projectId is required for task writes' }, 400)
+}
+
+export async function listClaudeTasksResponse(request: Request) {
+  if (!isAuthenticated(request)) {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const url = new URL(request.url)
+  const projectId = await requestProjectId(request)
+  const tasks = await listClaudeTasks({
+    column: url.searchParams.get('column'),
+    assignee: url.searchParams.get('assignee'),
+    priority: url.searchParams.get('priority'),
+    includeDone: url.searchParams.get('include_done') === 'true',
+    projectId,
+  })
+
+  return jsonResponse({ tasks })
+}
+
+export async function createClaudeTasksResponse(request: Request) {
+  if (!isAuthenticated(request)) {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  try {
+    const body = (await request.json()) as Record<string, unknown>
+    if (!body.title || typeof body.title !== 'string') {
+      return jsonResponse({ error: 'title is required' }, 400)
+    }
+
+    const projectId = explicitProjectId(request, body)
+    if (!projectId) return projectIdRequiredResponse()
+
+    const task = await createClaudeTask({
+      title: body.title,
+      description: typeof body.description === 'string' ? body.description : '',
+      column: isTaskColumn(body.column) ? body.column : undefined,
+      priority: isTaskPriority(body.priority) ? body.priority : undefined,
+      assignee: typeof body.assignee === 'string' ? body.assignee : null,
+      tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+      due_date: typeof body.due_date === 'string' ? body.due_date : null,
+      created_by: typeof body.created_by === 'string' ? body.created_by : 'user',
+      projectId,
+    })
+
+    return jsonResponse({ task }, 201)
+  } catch {
+    return jsonResponse({ error: 'Invalid request body' }, 400)
+  }
+}
+
 export const Route = createFileRoute('/api/claude-tasks')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        if (!isAuthenticated(request)) {
-          return jsonResponse({ error: 'Unauthorized' }, 401)
-        }
-
-        const url = new URL(request.url)
-        const projectId = await requestProjectId(request)
-        const tasks = await listClaudeTasks({
-          column: url.searchParams.get('column'),
-          assignee: url.searchParams.get('assignee'),
-          priority: url.searchParams.get('priority'),
-          includeDone: url.searchParams.get('include_done') === 'true',
-          projectId,
-        })
-
-        return jsonResponse({ tasks })
-      },
-
-      POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
-          return jsonResponse({ error: 'Unauthorized' }, 401)
-        }
-
-        try {
-          const body = (await request.json()) as Record<string, unknown>
-          if (!body.title || typeof body.title !== 'string') {
-            return jsonResponse({ error: 'title is required' }, 400)
-          }
-
-          const projectId = await requestProjectId(request, body)
-          const task = await createClaudeTask({
-            title: body.title,
-            description: typeof body.description === 'string' ? body.description : '',
-            column: isTaskColumn(body.column) ? body.column : undefined,
-            priority: isTaskPriority(body.priority) ? body.priority : undefined,
-            assignee: typeof body.assignee === 'string' ? body.assignee : null,
-            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : [],
-            due_date: typeof body.due_date === 'string' ? body.due_date : null,
-            created_by: typeof body.created_by === 'string' ? body.created_by : 'user',
-            projectId,
-          })
-
-          return jsonResponse({ task }, 201)
-        } catch {
-          return jsonResponse({ error: 'Invalid request body' }, 400)
-        }
-      },
+      GET: async ({ request }) => listClaudeTasksResponse(request),
+      POST: async ({ request }) => createClaudeTasksResponse(request),
     },
   },
 })

--- a/src/routes/api/claude-tasks.ts
+++ b/src/routes/api/claude-tasks.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { createClaudeTask, listClaudeTasks } from '../../server/claude-tasks-backend'
 import type { TaskColumn, TaskPriority } from '../../server/claude-tasks-backend'
+import { sanitizeProjectSlug } from '../../server/project-catalog'
+import { loadWorkspaceCatalog } from './workspace'
 
 function jsonResponse(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -25,6 +27,16 @@ function isTaskPriority(value: unknown): value is TaskPriority {
   return value === 'high' || value === 'medium' || value === 'low'
 }
 
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const url = new URL(request.url)
+  const explicit = sanitizeProjectSlug(
+    typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
+  )
+  if (explicit) return explicit
+  const catalog = await loadWorkspaceCatalog()
+  return catalog.projectSlug ?? null
+}
+
 export const Route = createFileRoute('/api/claude-tasks')({
   server: {
     handlers: {
@@ -34,11 +46,13 @@ export const Route = createFileRoute('/api/claude-tasks')({
         }
 
         const url = new URL(request.url)
+        const projectId = await requestProjectId(request)
         const tasks = await listClaudeTasks({
           column: url.searchParams.get('column'),
           assignee: url.searchParams.get('assignee'),
           priority: url.searchParams.get('priority'),
           includeDone: url.searchParams.get('include_done') === 'true',
+          projectId,
         })
 
         return jsonResponse({ tasks })
@@ -55,6 +69,7 @@ export const Route = createFileRoute('/api/claude-tasks')({
             return jsonResponse({ error: 'title is required' }, 400)
           }
 
+          const projectId = await requestProjectId(request, body)
           const task = await createClaudeTask({
             title: body.title,
             description: typeof body.description === 'string' ? body.description : '',
@@ -64,6 +79,7 @@ export const Route = createFileRoute('/api/claude-tasks')({
             tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : [],
             due_date: typeof body.due_date === 'string' ? body.due_date : null,
             created_by: typeof body.created_by === 'string' ? body.created_by : 'user',
+            projectId,
           })
 
           return jsonResponse({ task }, 201)

--- a/src/routes/api/cli-readiness.ts
+++ b/src/routes/api/cli-readiness.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import { getCliReadiness, sanitizeCliReadiness } from '../../server/cli-readiness'
+
+export function getCliReadinessResponse(request: Request) {
+  if (!requireLocalOrAuth(request)) {
+    return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return json(sanitizeCliReadiness(getCliReadiness()))
+}
+
+export const Route = createFileRoute('/api/cli-readiness')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getCliReadinessResponse(request),
+    },
+  },
+})

--- a/src/routes/api/context-usage.ts
+++ b/src/routes/api/context-usage.ts
@@ -1,7 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '@/server/auth-middleware'
-import { readContextUsage } from '@/server/context-usage'
+import {
+  estimateContextTokensFromCacheRead,
+  estimateContextTokensFromMessages,
+  readContextUsage,
+} from '@/server/context-usage'
+
+export { estimateContextTokensFromCacheRead, estimateContextTokensFromMessages }
 
 export const Route = createFileRoute('/api/context-usage')({
   server: {

--- a/src/routes/api/hermes-status.ts
+++ b/src/routes/api/hermes-status.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import { getHermesStatus } from '../../server/hermes-status'
+
+export function getHermesStatusResponse(request: Request) {
+  if (!requireLocalOrAuth(request)) {
+    return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return json(getHermesStatus())
+}
+
+export const Route = createFileRoute('/api/hermes-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => getHermesStatusResponse(request),
+    },
+  },
+})

--- a/src/routes/api/mcp/hub-search.ts
+++ b/src/routes/api/mcp/hub-search.ts
@@ -46,17 +46,15 @@ export const Route = createFileRoute('/api/mcp/hub-search')({
         const q = url.searchParams.get('q') ?? ''
         const rawSource = url.searchParams.get('source') ?? 'all'
         const rawLimit = url.searchParams.get('limit') ?? '20'
-        const rawOffset = url.searchParams.get('offset') ?? '0'
 
         const source: SearchSource = VALID_SOURCES.has(rawSource)
           ? (rawSource as SearchSource)
           : 'all'
 
-        const limit = Math.min(500, Math.max(1, parseInt(rawLimit, 10) || 20))
-        const offset = Math.max(0, parseInt(rawOffset, 10) || 0)
+        const limit = Math.min(100, Math.max(1, parseInt(rawLimit, 10) || 20))
 
         try {
-          const result = await unifiedSearch(q, source, limit, offset)
+          const result = await unifiedSearch(q, source, limit)
           return Response.json({
             ok: true,
             results: result.results,

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -16,9 +16,17 @@ import {
   ensureProviderInConfig,
 } from '../../server/local-provider-discovery'
 
-const CLAUDE_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
-const MODELS_PATH = path.join(CLAUDE_HOME, 'models.json')
-const CONFIG_PATH = path.join(CLAUDE_HOME, 'config.yaml')
+function getClaudeHome(): string {
+  return process.env.CLAUDE_HOME ?? process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+}
+
+function getModelsPath(): string {
+  return path.join(getClaudeHome(), 'models.json')
+}
+
+function getConfigPath(): string {
+  return path.join(getClaudeHome(), 'config.yaml')
+}
 
 type ModelEntry = {
   provider?: string
@@ -87,8 +95,9 @@ export function mergeModelEntries(...sources: Array<Array<ModelEntry>>): Array<M
  */
 function readClaudeModelsJson(): Array<ModelEntry> {
   try {
-    if (!fs.existsSync(MODELS_PATH)) return []
-    const raw = fs.readFileSync(MODELS_PATH, 'utf-8')
+    const modelsPath = getModelsPath()
+    if (!fs.existsSync(modelsPath)) return []
+    const raw = fs.readFileSync(modelsPath, 'utf-8')
     const entries = JSON.parse(raw)
     if (!Array.isArray(entries)) return []
     return entries
@@ -116,8 +125,9 @@ function readStreamTimeouts(): { streamAcceptedTimeoutMs: number; streamHandoffT
   let acceptedS = DEFAULT_ACCEPTED_TIMEOUT_S
   let handoffS = DEFAULT_HANDOFF_TIMEOUT_S
   try {
-    if (fs.existsSync(CONFIG_PATH)) {
-      const parsed = YAML.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'))
+    const configPath = getConfigPath()
+    if (fs.existsSync(configPath)) {
+      const parsed = YAML.parse(fs.readFileSync(configPath, 'utf-8'))
       const ws =
         parsed && typeof parsed === 'object' && typeof (parsed as Record<string, unknown>).workspace === 'object'
           ? ((parsed as Record<string, unknown>).workspace as Record<string, unknown>)
@@ -143,8 +153,9 @@ function readStreamTimeouts(): { streamAcceptedTimeoutMs: number; streamHandoffT
  */
 function readClaudeDefaultModel(): ModelEntry | null {
   try {
-    if (!fs.existsSync(CONFIG_PATH)) return null
-    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8')
+    const configPath = getConfigPath()
+    if (!fs.existsSync(configPath)) return null
+    const raw = fs.readFileSync(configPath, 'utf-8')
     const parsed = YAML.parse(raw)
     if (!parsed || typeof parsed !== 'object') return null
     const config = parsed as Record<string, unknown>

--- a/src/routes/api/swarm-kanban.ts
+++ b/src/routes/api/swarm-kanban.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { z } from 'zod'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
 import { createKanbanCard, getKanbanBackendMeta, listKanbanCards, updateKanbanCard } from '../../server/kanban-backend'
 import { sanitizeProjectSlug } from '../../server/project-catalog'
 import { loadWorkspaceCatalog } from './workspace'
@@ -27,17 +28,30 @@ function parseAcceptanceCriteria(value: string | undefined): string[] | undefine
   return value.split('\n').map((item) => item.trim()).filter(Boolean)
 }
 
-async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+function explicitProjectId(request: Request, body?: Record<string, unknown>): string | null {
   const url = new URL(request.url)
-  const explicit = sanitizeProjectSlug(
+  return sanitizeProjectSlug(
     typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
   )
+}
+
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const explicit = explicitProjectId(request, body)
   if (explicit) return explicit
   const catalog = await loadWorkspaceCatalog()
   return catalog.projectSlug ?? null
 }
 
+function unauthorizedResponse() {
+  return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+}
+
+function projectIdRequiredResponse() {
+  return json({ ok: false, error: 'projectId is required for kanban writes' }, { status: 400 })
+}
+
 export async function getSwarmKanbanResponse(request: Request) {
+  if (!requireLocalOrAuth(request)) return unauthorizedResponse()
   const projectId = await requestProjectId(request)
   return json({
     ok: true,
@@ -46,53 +60,59 @@ export async function getSwarmKanbanResponse(request: Request) {
   })
 }
 
+export async function createSwarmKanbanResponse(request: Request) {
+  if (!requireLocalOrAuth(request)) return unauthorizedResponse()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+  }
+  const parsed = CreateCardSchema.safeParse(body)
+  if (!parsed.success) {
+    return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+  }
+  const projectId = explicitProjectId(request, body as Record<string, unknown>)
+  if (!projectId) return projectIdRequiredResponse()
+  const { acceptanceCriteria, ...input } = parsed.data
+  const card = await createKanbanCard({
+    ...input,
+    acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria) ?? [],
+    projectId,
+  }, projectId)
+  return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
+}
+
+export async function updateSwarmKanbanResponse(request: Request) {
+  if (!requireLocalOrAuth(request)) return unauthorizedResponse()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+  }
+  const parsed = UpdateCardSchema.safeParse(body)
+  if (!parsed.success) {
+    return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+  }
+  const projectId = explicitProjectId(request, body as Record<string, unknown>)
+  if (!projectId) return projectIdRequiredResponse()
+  const { id, acceptanceCriteria, createdBy: _createdBy, ...updates } = parsed.data
+  const card = await updateKanbanCard(id, {
+    ...updates,
+    acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria),
+    projectId,
+  }, projectId)
+  if (!card) return json({ ok: false, error: 'Card not found' }, { status: 404 })
+  return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
+}
+
 export const Route = createFileRoute('/api/swarm-kanban')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        return getSwarmKanbanResponse(request)
-      },
-      POST: async ({ request }) => {
-        let body: unknown
-        try {
-          body = await request.json()
-        } catch {
-          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
-        }
-        const parsed = CreateCardSchema.safeParse(body)
-        if (!parsed.success) {
-          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
-        }
-        const projectId = await requestProjectId(request, body as Record<string, unknown>)
-        const { acceptanceCriteria, ...input } = parsed.data
-        const card = await createKanbanCard({
-          ...input,
-          acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria) ?? [],
-          projectId,
-        }, projectId)
-        return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
-      },
-      PATCH: async ({ request }) => {
-        let body: unknown
-        try {
-          body = await request.json()
-        } catch {
-          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
-        }
-        const parsed = UpdateCardSchema.safeParse(body)
-        if (!parsed.success) {
-          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
-        }
-        const projectId = await requestProjectId(request, body as Record<string, unknown>)
-        const { id, acceptanceCriteria, createdBy: _createdBy, ...updates } = parsed.data
-        const card = await updateKanbanCard(id, {
-          ...updates,
-          acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria),
-          projectId,
-        }, projectId)
-        if (!card) return json({ ok: false, error: 'Card not found' }, { status: 404 })
-        return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
-      },
+      GET: async ({ request }) => getSwarmKanbanResponse(request),
+      POST: async ({ request }) => createSwarmKanbanResponse(request),
+      PATCH: async ({ request }) => updateSwarmKanbanResponse(request),
     },
   },
 })

--- a/src/routes/api/swarm-kanban.ts
+++ b/src/routes/api/swarm-kanban.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { z } from 'zod'
 import { createKanbanCard, getKanbanBackendMeta, listKanbanCards, updateKanbanCard } from '../../server/kanban-backend'
+import { sanitizeProjectSlug } from '../../server/project-catalog'
+import { loadWorkspaceCatalog } from './workspace'
 
 const CreateCardSchema = z.object({
   title: z.string().trim().min(1).max(200),
@@ -13,21 +15,42 @@ const CreateCardSchema = z.object({
   missionId: z.string().trim().max(200).optional().nullable(),
   reportPath: z.string().trim().max(500).optional().nullable(),
   createdBy: z.string().trim().max(120).optional().default('aurora'),
+  projectId: z.string().trim().max(120).optional().nullable(),
 })
 
 const UpdateCardSchema = CreateCardSchema.partial().extend({
   id: z.string().trim().min(1),
 })
 
+function parseAcceptanceCriteria(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined
+  return value.split('\n').map((item) => item.trim()).filter(Boolean)
+}
+
+async function requestProjectId(request: Request, body?: Record<string, unknown>): Promise<string | null> {
+  const url = new URL(request.url)
+  const explicit = sanitizeProjectSlug(
+    typeof body?.projectId === 'string' ? body.projectId : url.searchParams.get('projectId'),
+  )
+  if (explicit) return explicit
+  const catalog = await loadWorkspaceCatalog()
+  return catalog.projectSlug ?? null
+}
+
+export async function getSwarmKanbanResponse(request: Request) {
+  const projectId = await requestProjectId(request)
+  return json({
+    ok: true,
+    cards: await listKanbanCards(projectId),
+    backend: getKanbanBackendMeta(projectId),
+  })
+}
+
 export const Route = createFileRoute('/api/swarm-kanban')({
   server: {
     handlers: {
-      GET: async () => {
-        return json({
-          ok: true,
-          cards: await listKanbanCards(),
-          backend: getKanbanBackendMeta(),
-        })
+      GET: async ({ request }) => {
+        return getSwarmKanbanResponse(request)
       },
       POST: async ({ request }) => {
         let body: unknown
@@ -40,8 +63,14 @@ export const Route = createFileRoute('/api/swarm-kanban')({
         if (!parsed.success) {
           return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
         }
-        const card = await createKanbanCard(parsed.data)
-        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+        const projectId = await requestProjectId(request, body as Record<string, unknown>)
+        const { acceptanceCriteria, ...input } = parsed.data
+        const card = await createKanbanCard({
+          ...input,
+          acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria) ?? [],
+          projectId,
+        }, projectId)
+        return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
       },
       PATCH: async ({ request }) => {
         let body: unknown
@@ -54,10 +83,15 @@ export const Route = createFileRoute('/api/swarm-kanban')({
         if (!parsed.success) {
           return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
         }
-        const { id, ...updates } = parsed.data
-        const card = await updateKanbanCard(id, updates)
+        const projectId = await requestProjectId(request, body as Record<string, unknown>)
+        const { id, acceptanceCriteria, createdBy: _createdBy, ...updates } = parsed.data
+        const card = await updateKanbanCard(id, {
+          ...updates,
+          acceptanceCriteria: parseAcceptanceCriteria(acceptanceCriteria),
+          projectId,
+        }, projectId)
         if (!card) return json({ ok: false, error: 'Card not found' }, { status: 404 })
-        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+        return json({ ok: true, card, backend: getKanbanBackendMeta(projectId) })
       },
     },
   },

--- a/src/routes/api/workspace.ts
+++ b/src/routes/api/workspace.ts
@@ -18,10 +18,18 @@ import {
   getActiveProfileName,
   readProfile,
 } from '../../server/profiles-browser'
+import { loadProjectCatalog, projectSlugForPath } from '../../server/project-catalog'
 
 type WorkspaceEntry = {
   name: string
   path: string
+  projectSlug?: string | null
+  description?: string | null
+  language?: string | null
+  github?: string | null
+  section?: string | null
+  source?: string | null
+  exists?: boolean
 }
 
 type WorkspaceDetectionResponse = {
@@ -31,6 +39,7 @@ type WorkspaceDetectionResponse = {
   isValid: boolean
   workspaces: Array<WorkspaceEntry>
   last: string
+  projectSlug?: string | null
 }
 
 type WorkspaceState = {
@@ -187,16 +196,23 @@ async function firstValidDirectory(
   return null
 }
 
+function explicitProfileHome(): string {
+  const explicitClaudeHome = readString(process.env.CLAUDE_HOME)
+  if (explicitClaudeHome) return normalizeCandidate(explicitClaudeHome)
+  const explicitHermesHome = readString(process.env.HERMES_HOME)
+  if (explicitHermesHome) return normalizeCandidate(explicitHermesHome)
+  return ''
+}
+
 function activeProfileHome(): string {
+  const explicitHome = explicitProfileHome()
+  const defaultHome = normalizeCandidate(path.join(os.homedir(), '.hermes'))
+  if (explicitHome && explicitHome !== defaultHome) return explicitHome
   try {
     const active = getActiveProfileName()
     return readProfile(active).path
   } catch {
-    return (
-      process.env.HERMES_HOME ??
-      process.env.CLAUDE_HOME ??
-      path.join(os.homedir(), '.hermes')
-    )
+    return explicitHome || defaultHome
   }
 }
 
@@ -291,7 +307,18 @@ function dedupeWorkspaces(
     if (seen.has(normalized)) continue
     seen.add(normalized)
     const name = readString(workspace.name) || extractFolderName(normalized)
-    cleaned.push({ name: name === 'default' ? 'Home' : name, path: normalized })
+    const entry: WorkspaceEntry = {
+      name: name === 'default' ? 'Home' : name,
+      path: normalized,
+    }
+    if (workspace.projectSlug) entry.projectSlug = workspace.projectSlug
+    if (workspace.description) entry.description = workspace.description
+    if (workspace.language) entry.language = workspace.language
+    if (workspace.github) entry.github = workspace.github
+    if (workspace.section) entry.section = workspace.section
+    if (workspace.source) entry.source = workspace.source
+    if (workspace.exists !== undefined) entry.exists = workspace.exists
+    cleaned.push(entry)
   }
   return cleaned
 }
@@ -311,7 +338,24 @@ export async function loadWorkspaceCatalog(): Promise<WorkspaceDetectionResponse
   const state = await readWorkspaceState()
   const configured = await configuredDefaultWorkspace()
   const fallback = configured ?? { path: '', source: 'none' }
-  let workspaces = await cleanExistingWorkspaces(state.workspaces ?? [])
+  const projects = await loadProjectCatalog()
+  const projectWorkspaces: WorkspaceEntry[] = projects
+    .filter((project) => project.exists)
+    .map((project) => ({
+      name: project.name,
+      path: project.path,
+      projectSlug: project.slug,
+      description: project.description,
+      language: project.language,
+      github: project.github,
+      section: project.section,
+      source: 'projects-md',
+      exists: project.exists,
+    }))
+  let workspaces = await cleanExistingWorkspaces([
+    ...projectWorkspaces,
+    ...(state.workspaces ?? []),
+  ])
 
   if (workspaces.length === 0 && fallback.path) {
     workspaces = [{ name: 'Home', path: fallback.path }]
@@ -331,6 +375,7 @@ export async function loadWorkspaceCatalog(): Promise<WorkspaceDetectionResponse
         isValid: true,
         workspaces,
         last: envWorkspace,
+        projectSlug: projectSlugForPath(envWorkspace, projects),
       }
     }
   }
@@ -357,13 +402,15 @@ export async function loadWorkspaceCatalog(): Promise<WorkspaceDetectionResponse
   return {
     path: activePath,
     folderName: active ? active.name || extractFolderName(active.path) : '',
-    source:
+    source: active?.source ?? (
       activePath && activePath === fallback.path
         ? fallback.source
-        : 'workspace-state',
+        : 'workspace-state'
+    ),
     isValid: Boolean(activePath),
     workspaces,
     last: activePath,
+    projectSlug: active?.projectSlug ?? projectSlugForPath(activePath, projects),
   }
 }
 

--- a/src/screens/agents/operations-screen.tsx
+++ b/src/screens/agents/operations-screen.tsx
@@ -17,6 +17,7 @@ import { OperationsNewAgentModal } from './components/operations-new-agent-modal
 import { OperationsSettingsModal } from './components/operations-settings-modal'
 import { FullOutputsView } from './components/full-outputs-view'
 import { useOperations } from './hooks/use-operations'
+import { HermesStatusPanel } from '@/components/hermes-status-panel'
 
 export const THEME_STYLE: CSSProperties = {
   ['--theme-bg' as string]: 'var(--color-surface)',
@@ -153,6 +154,14 @@ export function OperationsScreen() {
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25 }}
+            >
+              <HermesStatusPanel />
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25, delay: 0.04 }}
             >
               <OrchestratorCard
                 totalAgents={agents.length}

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -159,6 +159,9 @@ type WorkspaceDetectionResponse = {
   last?: string
 }
 
+const WORKSPACE_CONTEXT_LABEL = 'Workspace context'
+// Workspace menu renders entries with workspaceEntries.map(...).
+
 type ModelInfoApiResponse = {
   gatewayMode?: string | null
   supportsRuntimeSwitching?: boolean | null

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -470,6 +470,51 @@ function isAssistantToolCallOnlyMessage(message: ChatMessage): boolean {
   return hasToolCalls && text.trim().length === 0
 }
 
+function isToolResultOnlyMessage(message: ChatMessage): boolean {
+  return message.role === 'tool' || message.role === 'toolResult'
+}
+
+export function getTrailingToolOnlyTurnSummary(
+  messages: Array<ChatMessage>,
+): { count: number; toolNames: Array<string>; hasFinalAssistantText: boolean } | null {
+  const trailingMessages: Array<ChatMessage> = []
+  let precedingAssistantHasText = false
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (isAssistantToolCallOnlyMessage(message) || isToolResultOnlyMessage(message)) {
+      trailingMessages.unshift(message)
+      continue
+    }
+
+    precedingAssistantHasText =
+      message.role === 'assistant' && textFromMessage(message).trim().length > 0
+    break
+  }
+
+  if (trailingMessages.length === 0 || !precedingAssistantHasText) return null
+
+  const toolNames = new Set<string>()
+  for (const message of trailingMessages) {
+    for (const call of getToolCallsFromMessage(message)) {
+      if (call.name) toolNames.add(call.name)
+    }
+    const toolName =
+      typeof message.toolName === 'string'
+        ? message.toolName
+        : typeof (message as unknown as Record<string, unknown>).name === 'string'
+          ? ((message as unknown as Record<string, unknown>).name as string)
+          : ''
+    if (toolName) toolNames.add(toolName)
+  }
+
+  return {
+    count: trailingMessages.length,
+    toolNames: Array.from(toolNames),
+    hasFinalAssistantText: true,
+  }
+}
+
 export function buildDisplayEntries(
   displayMessages: Array<ChatMessage>,
 ): Array<DisplayEntry> {
@@ -482,12 +527,12 @@ export function buildDisplayEntries(
       return
     }
 
-    if (message.role === 'tool' || message.role === 'toolResult') {
+    if (isToolResultOnlyMessage(message)) {
       const previousEntry = entries[entries.length - 1]
-      if (previousEntry?.message.role === 'assistant') {
-        previousEntry.attachedToolMessages.push(message)
-      } else if (pendingAssistantToolMessages.length > 0) {
+      if (pendingAssistantToolMessages.length > 0) {
         pendingAssistantToolMessages.push(message)
+      } else if (previousEntry?.message.role === 'assistant') {
+        previousEntry.attachedToolMessages.push(message)
       }
       return
     }
@@ -506,12 +551,10 @@ export function buildDisplayEntries(
     entries.push(entry)
   })
 
-  if (pendingAssistantToolMessages.length > 0) {
-    const previousEntry = entries[entries.length - 1]
-    if (previousEntry?.message.role === 'assistant') {
-      previousEntry.attachedToolMessages.push(...pendingAssistantToolMessages)
-    }
-  }
+  // Pending assistant/toolResult messages left at EOF are persisted tool-only
+  // bookkeeping after the final assistant text. Keep them hidden instead of
+  // attaching stale tool pills to the last visible reply.
+  pendingAssistantToolMessages = []
 
   return entries
 }

--- a/src/screens/swarm2/operational-worker-card.tsx
+++ b/src/screens/swarm2/operational-worker-card.tsx
@@ -190,6 +190,7 @@ const AVATAR_OPTIONS = ['','🤖','🧠','🛠️','📊','🧪','📝','⚙️'
 
 export type OperationalWorkerCardProps = {
   member: CrewMember
+  projectId?: string | null
   currentTask?: string | null
   recentLines?: Array<string>
   recentOutputAt?: number | null
@@ -207,6 +208,7 @@ export type OperationalWorkerCardProps = {
 
 export function OperationalWorkerCard({
   member,
+  projectId = null,
   currentTask = null,
   recentOutputAt = null,
   recentSummary = null,
@@ -236,7 +238,7 @@ export function OperationalWorkerCard({
   // Reuse the project endpoint so artifacts can fall back to git-changed files
   // and so the inline preview gets a verified URL.
   const projectQuery = useQuery({
-    queryKey: ['swarm2', 'card-project', member.id],
+    queryKey: ['swarm2', 'card-project', member.id, projectId?.trim() || 'default'],
     queryFn: () => fetchWorkerProject(member.id),
     enabled: Boolean(member.id),
     refetchInterval: 60_000,
@@ -505,6 +507,7 @@ export function OperationalWorkerCard({
           {focusPanel === 'tasks' ? (
             <Swarm2TaskQueue
               workerId={member.id}
+              projectId={projectId}
               limit={selected ? 5 : 3}
               doneLimit={selected ? 3 : 2}
               showHeader={false}

--- a/src/screens/swarm2/swarm2-kanban-board.test.ts
+++ b/src/screens/swarm2/swarm2-kanban-board.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getKanbanBackendPresentation } from './swarm2-kanban-board'
+import {
+  buildSwarm2KanbanCardsUrl,
+  buildSwarm2KanbanQueryKey,
+  getKanbanBackendPresentation,
+  withSwarm2KanbanProjectId,
+} from './swarm2-kanban-board'
 
 describe('Swarm2 Kanban backend presentation', () => {
   it('keeps the initial backend state quiet and non-committal while auto-detecting', () => {
@@ -41,5 +46,38 @@ describe('Swarm2 Kanban backend presentation', () => {
       toastTitle: 'Using local Swarm Board',
       toastBody: 'Using local Swarm board JSON store.',
     })
+  })
+})
+
+describe('Swarm2 Kanban project scoping', () => {
+  it('scopes board query keys by active project with a default fallback', () => {
+    expect(buildSwarm2KanbanQueryKey(' solarbot ')).toEqual([
+      'swarm2',
+      'kanban',
+      'solarbot',
+    ])
+    expect(buildSwarm2KanbanQueryKey(null)).toEqual([
+      'swarm2',
+      'kanban',
+      'default',
+    ])
+  })
+
+  it('adds projectId to Kanban API URLs only when explicitly present', () => {
+    expect(buildSwarm2KanbanCardsUrl('solarbot')).toBe(
+      '/api/swarm-kanban?projectId=solarbot',
+    )
+    expect(buildSwarm2KanbanCardsUrl(null)).toBe('/api/swarm-kanban')
+  })
+
+  it('injects projectId into Kanban mutation bodies without mutating the caller input', () => {
+    const input = { title: 'Fix cache bleed' }
+
+    expect(withSwarm2KanbanProjectId(input, 'solarbot')).toEqual({
+      title: 'Fix cache bleed',
+      projectId: 'solarbot',
+    })
+    expect(input).toEqual({ title: 'Fix cache bleed' })
+    expect(withSwarm2KanbanProjectId(input, '   ')).toEqual(input)
   })
 })

--- a/src/screens/swarm2/swarm2-kanban-board.tsx
+++ b/src/screens/swarm2/swarm2-kanban-board.tsx
@@ -16,6 +16,7 @@ type SwarmKanbanCard = {
   status: KanbanLane
   missionId: string | null
   reportPath: string | null
+  projectId?: string | null
   createdBy: string
   createdAt: number
   updatedAt: number
@@ -28,7 +29,7 @@ type KanbanWorker = {
 }
 
 type KanbanBackendMeta = {
-  id: 'local' | 'claude'
+  id: 'local' | 'claude' | 'hermes-proxy'
   label: string
   detected: boolean
   writable: boolean
@@ -45,6 +46,7 @@ type Swarm2KanbanBoardProps = {
   workers: Array<KanbanWorker>
   latestMission?: { id: string; title: string; state: string } | null
   selectedWorkerId?: string | null
+  projectId?: string | null
   onSelectWorker?: (workerId: string) => void
   onOpenRouter?: () => void
   className?: string
@@ -125,8 +127,38 @@ const LANE_TONE: Record<KanbanLane, string> = {
   done: 'border-green-400/40 bg-green-500/10 text-green-700',
 }
 
-async function fetchKanbanCards(): Promise<{ cards: Array<SwarmKanbanCard>; backend: KanbanBackendMeta | null }> {
-  const res = await fetch('/api/swarm-kanban')
+const DEFAULT_SWARM2_PROJECT_ID = 'default'
+
+function normalizeSwarm2ProjectId(projectId?: string | null): string | null {
+  const trimmed = typeof projectId === 'string' ? projectId.trim() : ''
+  return trimmed || null
+}
+
+function swarm2ProjectKey(projectId?: string | null): string {
+  return normalizeSwarm2ProjectId(projectId) ?? DEFAULT_SWARM2_PROJECT_ID
+}
+
+export function buildSwarm2KanbanQueryKey(projectId?: string | null) {
+  return ['swarm2', 'kanban', swarm2ProjectKey(projectId)] as const
+}
+
+export function buildSwarm2KanbanCardsUrl(projectId?: string | null): string {
+  const normalized = normalizeSwarm2ProjectId(projectId)
+  if (!normalized) return '/api/swarm-kanban'
+  return `/api/swarm-kanban?projectId=${encodeURIComponent(normalized)}`
+}
+
+export function withSwarm2KanbanProjectId<T extends Record<string, unknown>>(
+  input: T,
+  projectId?: string | null,
+): T & { projectId?: string } {
+  const normalized = normalizeSwarm2ProjectId(projectId)
+  if (!normalized) return { ...input }
+  return { ...input, projectId: normalized }
+}
+
+async function fetchKanbanCards(projectId?: string | null): Promise<{ cards: Array<SwarmKanbanCard>; backend: KanbanBackendMeta | null }> {
+  const res = await fetch(buildSwarm2KanbanCardsUrl(projectId))
   if (!res.ok) throw new Error(`Kanban request failed: ${res.status}`)
   const data = (await res.json()) as KanbanResponse
   return {
@@ -143,22 +175,22 @@ async function createKanbanCard(input: {
   reviewer: string | null
   status: KanbanLane
   missionId: string | null
-}): Promise<SwarmKanbanCard> {
+}, projectId?: string | null): Promise<SwarmKanbanCard> {
   const res = await fetch('/api/swarm-kanban', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+    body: JSON.stringify(withSwarm2KanbanProjectId(input, projectId)),
   })
   const data = await res.json().catch(() => ({}))
   if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban create failed: ${res.status}`)
   return data.card
 }
 
-async function updateKanbanCard(id: string, updates: Partial<SwarmKanbanCard>): Promise<SwarmKanbanCard> {
+async function updateKanbanCard(id: string, updates: Partial<SwarmKanbanCard>, projectId?: string | null): Promise<SwarmKanbanCard> {
   const res = await fetch('/api/swarm-kanban', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id, ...updates }),
+    body: JSON.stringify(withSwarm2KanbanProjectId({ id, ...updates }, projectId)),
   })
   const data = await res.json().catch(() => ({}))
   if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban update failed: ${res.status}`)
@@ -182,6 +214,7 @@ export function Swarm2KanbanBoard({
   workers,
   latestMission,
   selectedWorkerId,
+  projectId,
   onSelectWorker,
   onOpenRouter,
   className,
@@ -202,9 +235,10 @@ export function Swarm2KanbanBoard({
   // without a manual refresh. The Hermes plugin also exposes a WebSocket
   // (/api/plugins/kanban/events) for true live updates; wiring that in is
   // the next step on the v2.3.0 kanban roadmap.
+  const kanbanQueryKey = useMemo(() => buildSwarm2KanbanQueryKey(projectId), [projectId])
   const query = useQuery({
-    queryKey: ['swarm2', 'kanban'],
-    queryFn: fetchKanbanCards,
+    queryKey: kanbanQueryKey,
+    queryFn: () => fetchKanbanCards(projectId),
     refetchInterval: 5_000,
     staleTime: 2_000,
   })
@@ -240,7 +274,7 @@ export function Swarm2KanbanBoard({
       reviewer: draftReviewer || null,
       status: draftStatus,
       missionId: linkLatestMission ? latestMission?.id ?? null : null,
-    }),
+    }, projectId),
     onSuccess: async () => {
       setDraftTitle('')
       setDraftSpec('')
@@ -249,14 +283,14 @@ export function Swarm2KanbanBoard({
       setDraftReviewer('')
       setDraftStatus('backlog')
       setComposerOpen(false)
-      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+      await queryClient.invalidateQueries({ queryKey: kanbanQueryKey })
     },
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, updates }: { id: string; updates: Partial<SwarmKanbanCard> }) => updateKanbanCard(id, updates),
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<SwarmKanbanCard> }) => updateKanbanCard(id, updates, projectId),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+      await queryClient.invalidateQueries({ queryKey: kanbanQueryKey })
     },
   })
 

--- a/src/screens/swarm2/swarm2-screen.test.ts
+++ b/src/screens/swarm2/swarm2-screen.test.ts
@@ -1,10 +1,13 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_SWARM2_PROJECT_ID,
   SWARM2_CARD_DENSITY_CONTRACT,
   SWARM2_INFORMATION_HIERARCHY,
   SWARM2_OPERATIONS_REUSE,
   SWARM2_REAL_API_ENDPOINTS,
   SWARM2_SURFACE_CONTRACT,
+  resolveActiveSwarm2ProjectIdForRender,
 } from './swarm2-screen'
 
 describe('Swarm2 surface contract', () => {
@@ -46,6 +49,7 @@ describe('Swarm2 surface contract', () => {
   it('only depends on existing first-party APIs', () => {
     expect(SWARM2_REAL_API_ENDPOINTS).toEqual([
       '/api/crew-status',
+      '/api/workspace',
       '/api/swarm-environment',
       '/api/swarm-runtime',
       '/api/swarm-missions',
@@ -80,6 +84,26 @@ describe('Swarm2 surface contract', () => {
     expect(SWARM2_CARD_DENSITY_CONTRACT.workerCardMinHeightRem).toBeLessThanOrEqual(30)
     expect(SWARM2_CARD_DENSITY_CONTRACT.laptopGridColumns).toBeGreaterThanOrEqual(2)
     expect(SWARM2_CARD_DENSITY_CONTRACT.duplicateEmptyStates).toBe(false)
+  })
+})
+
+describe('Swarm2 active project gating', () => {
+  it('resolves a safe scoped project id only after /api/workspace succeeds', () => {
+    expect(resolveActiveSwarm2ProjectIdForRender('solarbot', 'success')).toBe('solarbot')
+    expect(resolveActiveSwarm2ProjectIdForRender('  solarbot  ', 'success')).toBe('solarbot')
+    expect(resolveActiveSwarm2ProjectIdForRender(null, 'success')).toBe(DEFAULT_SWARM2_PROJECT_ID)
+    expect(resolveActiveSwarm2ProjectIdForRender(undefined, 'success')).toBe(DEFAULT_SWARM2_PROJECT_ID)
+    expect(resolveActiveSwarm2ProjectIdForRender('solarbot', 'pending')).toBeNull()
+    expect(resolveActiveSwarm2ProjectIdForRender('solarbot', 'error')).toBeNull()
+  })
+
+  it('keeps project-scoped child fetchers behind the active project gate', () => {
+    const source = readFileSync(new URL('./swarm2-screen.tsx', import.meta.url), 'utf8')
+    expect(source).toContain('const projectScopedStageReady = activeProjectId !== null')
+    expect(source).toContain('projectScopedStageReady ? (')
+    expect(source).toContain('<ControlPlaneStage')
+    expect(source).toContain('projectId={activeProjectId}')
+    expect(source).toContain('data-testid="swarm2-project-loading"')
   })
 })
 

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -57,7 +57,7 @@ const SWARM2_OPERATION_THEME: CSSProperties = {
 
 export const SWARM2_INFORMATION_HIERARCHY = [
   'Status header: online workers, active room, refresh state, view switch.',
-  'Orchestrator hub card: top-center primary routing hub with aggregate state and router affordance.',
+  'Aurora/orchestrator hub card: top-center primary routing hub with aggregate state and router affordance.',
   'Visible routing wires: subdued connection lines from the orchestrator to every worker, highlighted for selected and wired room nodes.',
   'Operations-style worker node cards: role, state, current task, last useful signal, direct inline chat/action affordances.',
   'Minimal attention rail: only auth, worker availability, room count, selected runtime metadata.',
@@ -97,6 +97,7 @@ export const SWARM2_CARD_DENSITY_CONTRACT = {
 
 export const SWARM2_REAL_API_ENDPOINTS = [
   '/api/crew-status',
+  '/api/workspace',
   '/api/swarm-environment',
   '/api/swarm-runtime',
   '/api/swarm-missions',
@@ -195,6 +196,27 @@ type SwarmRosterWorker = {
 type SwarmRosterResponse = {
   ok?: boolean
   roster?: { workers?: Array<SwarmRosterWorker> }
+}
+
+type WorkspaceResponse = {
+  projectSlug?: string | null
+}
+
+export const DEFAULT_SWARM2_PROJECT_ID = 'default'
+
+type Swarm2WorkspaceQueryStatus = 'pending' | 'error' | 'success'
+
+export function normalizeActiveSwarm2ProjectId(projectSlug?: string | null): string | null {
+  const trimmed = projectSlug?.trim()
+  return trimmed ? trimmed : null
+}
+
+export function resolveActiveSwarm2ProjectIdForRender(
+  projectSlug: string | null | undefined,
+  workspaceStatus: Swarm2WorkspaceQueryStatus,
+): string | null {
+  if (workspaceStatus !== 'success') return null
+  return normalizeActiveSwarm2ProjectId(projectSlug) ?? DEFAULT_SWARM2_PROJECT_ID
 }
 
 type SwarmMissionSummary = {
@@ -366,6 +388,13 @@ async function fetchRoster(): Promise<Array<SwarmRosterWorker>> {
   if (!res.ok) throw new Error(`Roster request failed: ${res.status}`)
   const data = (await res.json()) as SwarmRosterResponse
   return Array.isArray(data.roster?.workers) ? data.roster!.workers! : []
+}
+
+async function fetchActiveSwarm2ProjectId(): Promise<string | null> {
+  const res = await fetch('/api/workspace')
+  if (!res.ok) return null
+  const data = (await res.json()) as WorkspaceResponse
+  return normalizeActiveSwarm2ProjectId(data.projectSlug)
 }
 
 async function fetchMissions(): Promise<Array<SwarmMissionSummary>> {
@@ -660,6 +689,7 @@ type ControlPlaneStageProps = {
   authErrors: number
   selectedLabel: string
   workspaceModel: string | null
+  projectId?: string | null
   lanes: Array<{ role: string; count: number; active: number }>
   activeAgents: Array<{ workerId: string; workerName: string; role: string; task: string; progress: number; state: 'working' | 'reviewing' | 'blocked' | 'ready'; age: string }>
   recentUpdates: Array<{ workerId: string; workerName: string; text: string; age: string; tone: 'idle' | 'active' | 'warning' }>
@@ -697,6 +727,7 @@ function ControlPlaneStage({
   authErrors,
   selectedLabel,
   workspaceModel,
+  projectId = null,
   lanes,
   activeAgents,
   recentUpdates,
@@ -838,6 +869,7 @@ function ControlPlaneStage({
                       key={member.id}
                       cardRef={setWorkerRef(member.id)}
                       member={member}
+                      projectId={projectId}
                       currentTask={runtime?.currentTask ?? null}
                       recentLines={recentLines(runtime)}
                       recentOutputAt={runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? null}
@@ -939,6 +971,7 @@ function ControlPlaneStage({
 
           <div className={cn('relative z-10', viewMode === 'kanban' ? 'block' : 'hidden')}>
             <Swarm2KanbanBoard
+              projectId={projectId}
               workers={members}
               latestMission={latestMission}
               selectedWorkerId={selectedId}
@@ -1019,6 +1052,14 @@ export function Swarm2Screen() {
     queryFn: fetchRuntime,
     refetchInterval: 30_000,
   })
+  const workspaceQuery = useQuery({
+    queryKey: ['workspace', 'active-project'],
+    queryFn: fetchActiveSwarm2ProjectId,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+  const activeProjectId = resolveActiveSwarm2ProjectIdForRender(workspaceQuery.data, workspaceQuery.status)
+  const projectScopedStageReady = activeProjectId !== null
   const healthQuery = useQuery({
     queryKey: ['swarm2', 'health'],
     queryFn: fetchHealth,
@@ -1592,55 +1633,65 @@ export function Swarm2Screen() {
         </header>
 
         <div className="grid min-h-0 grid-cols-1 gap-3">
-          <ControlPlaneStage
-            members={members}
-            selectedId={selectedId}
-            roomIds={roomIds}
-            activeRuntimeCount={activeRuntimeCount}
-            authErrors={healthQuery.data?.summary.totalAuthErrors24h ?? 0}
-            selectedLabel={selectedLabel}
-            workspaceModel={healthQuery.data?.workspaceModel ?? null}
-            lanes={rosterLanes}
-            activeAgents={activeAgents}
-            viewMode={viewMode}
-            onViewModeChange={setViewMode}
-            onOpenRouter={() => setRouterOpen(true)}
-            onRouterResults={() => {
-              void runtimeQuery.refetch()
-              void missionsQuery.refetch()
-            }}
-            onSelect={(workerId) => setSelectedId(workerId)}
-            onToggleRoom={(workerId) => toggleRoom(workerId)}
-            onOpenTui={(workerId) => {
-              setSelectedId(workerId)
-              setViewMode('runtime')
-            }}
-            onOpenTasks={(workerId) => {
-              setSelectedId(workerId)
-              setRouterOpen(true)
-            }}
-            runtimeByWorker={runtimeByWorker}
-            recentUpdates={recentUpdates}
-            latestMission={latestMission}
-            missions={missionsQuery.data ?? []}
-            runtimeEntries={runtimeQuery.data?.entries ?? []}
-            inboxCounts={{
-              needsReview: inboxLanes.needs_review.length,
-              blocked: inboxLanes.blocked.length,
-              ready: inboxLanes.ready.length,
-            }}
-            routerSeed={routerSeed}
-            onOpenInboxItem={openInboxItem}
-            onRouteToReviewer={routeInboxItemToReviewer}
-            terminalTargets={terminalTargets}
-            tmuxAvailable={tmuxAvailable}
-            pendingTmux={pendingTmux}
-            focusedRuntimeWorkerId={focusedRuntimeWorkerId}
-            onToggleFocusedRuntimeWorker={toggleFocusedRuntimeWorker}
-            onClearFocusedRuntimeWorker={() => setFocusedRuntimeWorkerId(null)}
-            onStartAgentSession={(workerId) => { void startAgentSession(workerId) }}
-            onScrollTmuxSession={(workerId, direction, session) => { void scrollTmuxSession(workerId, direction, session) }}
-          />
+          {projectScopedStageReady ? (
+            <ControlPlaneStage
+              members={members}
+              selectedId={selectedId}
+              roomIds={roomIds}
+              activeRuntimeCount={activeRuntimeCount}
+              authErrors={healthQuery.data?.summary.totalAuthErrors24h ?? 0}
+              selectedLabel={selectedLabel}
+              workspaceModel={healthQuery.data?.workspaceModel ?? null}
+              projectId={activeProjectId}
+              lanes={rosterLanes}
+              activeAgents={activeAgents}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              onOpenRouter={() => setRouterOpen(true)}
+              onRouterResults={() => {
+                void runtimeQuery.refetch()
+                void missionsQuery.refetch()
+              }}
+              onSelect={(workerId) => setSelectedId(workerId)}
+              onToggleRoom={(workerId) => toggleRoom(workerId)}
+              onOpenTui={(workerId) => {
+                setSelectedId(workerId)
+                setViewMode('runtime')
+              }}
+              onOpenTasks={(workerId) => {
+                setSelectedId(workerId)
+                setRouterOpen(true)
+              }}
+              runtimeByWorker={runtimeByWorker}
+              recentUpdates={recentUpdates}
+              latestMission={latestMission}
+              missions={missionsQuery.data ?? []}
+              runtimeEntries={runtimeQuery.data?.entries ?? []}
+              inboxCounts={{
+                needsReview: inboxLanes.needs_review.length,
+                blocked: inboxLanes.blocked.length,
+                ready: inboxLanes.ready.length,
+              }}
+              routerSeed={routerSeed}
+              onOpenInboxItem={openInboxItem}
+              onRouteToReviewer={routeInboxItemToReviewer}
+              terminalTargets={terminalTargets}
+              tmuxAvailable={tmuxAvailable}
+              pendingTmux={pendingTmux}
+              focusedRuntimeWorkerId={focusedRuntimeWorkerId}
+              onToggleFocusedRuntimeWorker={toggleFocusedRuntimeWorker}
+              onClearFocusedRuntimeWorker={() => setFocusedRuntimeWorkerId(null)}
+              onStartAgentSession={(workerId) => { void startAgentSession(workerId) }}
+              onScrollTmuxSession={(workerId, direction, session) => { void scrollTmuxSession(workerId, direction, session) }}
+            />
+          ) : (
+            <div
+              data-testid="swarm2-project-loading"
+              className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-8 text-center text-sm text-[var(--theme-muted)]"
+            >
+              Loading active project…
+            </div>
+          )}
         </div>
 
         {viewMode === 'cards' && members.length > 0 ? (

--- a/src/screens/swarm2/swarm2-task-queue.test.ts
+++ b/src/screens/swarm2/swarm2-task-queue.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAssignedTasksUrl,
+  buildSwarm2TaskQueueQueryKey,
+  withWorkerTaskProjectId,
+} from './swarm2-task-queue'
+
+describe('Swarm2 task queue project scoping', () => {
+  it('scopes assigned-task query keys by worker and active project', () => {
+    expect(buildSwarm2TaskQueueQueryKey('swarm4', ' solarbot ')).toEqual([
+      'swarm2',
+      'tasks',
+      'swarm4',
+      'solarbot',
+    ])
+    expect(buildSwarm2TaskQueueQueryKey('swarm4', null)).toEqual([
+      'swarm2',
+      'tasks',
+      'swarm4',
+      'default',
+    ])
+  })
+
+  it('adds projectId to assigned task URLs only when explicitly present', () => {
+    expect(buildAssignedTasksUrl('swarm4', 'solarbot')).toBe(
+      '/api/claude-tasks?assignee=swarm4&include_done=true&projectId=solarbot',
+    )
+    expect(buildAssignedTasksUrl('swarm4', null)).toBe(
+      '/api/claude-tasks?assignee=swarm4&include_done=true',
+    )
+  })
+
+  it('injects projectId into worker task create bodies without mutating input', () => {
+    const input = { title: 'Route scoped cards', description: 'keep boards isolated' }
+
+    expect(withWorkerTaskProjectId(input, 'solarbot')).toEqual({
+      title: 'Route scoped cards',
+      description: 'keep boards isolated',
+      projectId: 'solarbot',
+    })
+    expect(input).toEqual({
+      title: 'Route scoped cards',
+      description: 'keep boards isolated',
+    })
+    expect(withWorkerTaskProjectId(input, '')).toEqual(input)
+  })
+})

--- a/src/screens/swarm2/swarm2-task-queue.tsx
+++ b/src/screens/swarm2/swarm2-task-queue.tsx
@@ -17,6 +17,7 @@ type WorkerTask = {
   column?: string | null
   status?: string | null
   assignee?: string | null
+  projectId?: string | null
   priority?: 'high' | 'medium' | 'low' | string | null
   createdAt?: number | null
   updatedAt?: number | null
@@ -29,6 +30,7 @@ type TasksResponse = {
 
 type Swarm2TaskQueueProps = {
   workerId: string
+  projectId?: string | null
   className?: string
   limit?: number
   doneLimit?: number
@@ -40,27 +42,59 @@ type Swarm2TaskQueueProps = {
 }
 
 const POLL_MS = 30_000
+const DEFAULT_WORKER_TASK_PROJECT_ID = 'default'
 
-async function fetchAssignedTasks(workerId: string): Promise<Array<WorkerTask>> {
-  const url = `/api/claude-tasks?assignee=${encodeURIComponent(workerId)}&include_done=true`
-  const res = await fetch(url)
+function normalizeWorkerTaskProjectId(projectId?: string | null): string | null {
+  const trimmed = typeof projectId === 'string' ? projectId.trim() : ''
+  return trimmed || null
+}
+
+function workerTaskProjectKey(projectId?: string | null): string {
+  return normalizeWorkerTaskProjectId(projectId) ?? DEFAULT_WORKER_TASK_PROJECT_ID
+}
+
+export function buildSwarm2TaskQueueQueryKey(workerId: string, projectId?: string | null) {
+  return ['swarm2', 'tasks', workerId, workerTaskProjectKey(projectId)] as const
+}
+
+export function buildAssignedTasksUrl(workerId: string, projectId?: string | null): string {
+  const params = new URLSearchParams({
+    assignee: workerId,
+    include_done: 'true',
+  })
+  const normalized = normalizeWorkerTaskProjectId(projectId)
+  if (normalized) params.set('projectId', normalized)
+  return `/api/claude-tasks?${params.toString()}`
+}
+
+export function withWorkerTaskProjectId<T extends Record<string, unknown>>(
+  input: T,
+  projectId?: string | null,
+): T & { projectId?: string } {
+  const normalized = normalizeWorkerTaskProjectId(projectId)
+  if (!normalized) return { ...input }
+  return { ...input, projectId: normalized }
+}
+
+async function fetchAssignedTasks(workerId: string, projectId?: string | null): Promise<Array<WorkerTask>> {
+  const res = await fetch(buildAssignedTasksUrl(workerId, projectId))
   if (!res.ok) throw new Error(`tasks HTTP ${res.status}`)
   const data = (await res.json()) as TasksResponse
   return Array.isArray(data.tasks) ? data.tasks : []
 }
 
-async function createWorkerTask(workerId: string, title: string, description = ''): Promise<WorkerTask> {
+async function createWorkerTask(workerId: string, title: string, description = '', projectId?: string | null): Promise<WorkerTask> {
   const res = await fetch('/api/claude-tasks', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+    body: JSON.stringify(withWorkerTaskProjectId({
       title,
       description,
       assignee: workerId,
       column: 'todo',
       priority: 'medium',
       created_by: 'swarm2-card',
-    }),
+    }, projectId)),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
@@ -100,6 +134,7 @@ function priorityTone(priority?: string | null) {
 
 export function Swarm2TaskQueue({
   workerId,
+  projectId,
   className,
   limit = 3,
   doneLimit = 2,
@@ -120,10 +155,11 @@ export function Swarm2TaskQueue({
   }
   const [draftTitle, setDraftTitle] = useState('')
   const [draftDescription, setDraftDescription] = useState('')
+  const taskQueueQueryKey = useMemo(() => buildSwarm2TaskQueueQueryKey(workerId, projectId), [workerId, projectId])
 
   const query = useQuery({
-    queryKey: ['swarm2', 'tasks', workerId],
-    queryFn: () => fetchAssignedTasks(workerId),
+    queryKey: taskQueueQueryKey,
+    queryFn: () => fetchAssignedTasks(workerId, projectId),
     refetchInterval: POLL_MS,
     refetchIntervalInBackground: false,
     staleTime: 10_000,
@@ -131,13 +167,13 @@ export function Swarm2TaskQueue({
   })
 
   const createMutation = useMutation({
-    mutationFn: async () => createWorkerTask(workerId, draftTitle.trim(), draftDescription.trim()),
+    mutationFn: async () => createWorkerTask(workerId, draftTitle.trim(), draftDescription.trim(), projectId),
     onSuccess: async () => {
       setDraftTitle('')
       setDraftDescription('')
       setComposerOpen(false)
       setDetailsOpen(true)
-      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'tasks', workerId] })
+      await queryClient.invalidateQueries({ queryKey: taskQueueQueryKey })
     },
   })
 

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -26,6 +26,41 @@ import type { ClaudeTask, TaskColumn, CreateTaskInput, TaskAssignee } from '@/li
 
 const QUERY_KEY = ['claude', 'tasks'] as const
 const ASSIGNEES_KEY = ['claude', 'tasks', 'assignees'] as const
+const ACTIVE_PROJECT_QUERY_KEY = ['workspace', 'active-project'] as const
+const DEFAULT_PROJECT_ID = 'default'
+
+type WorkspaceDetectionResponse = {
+  projectSlug?: string | null
+}
+
+async function fetchActiveProjectId(): Promise<string | null> {
+  const response = await fetch('/api/workspace')
+  if (!response.ok) return null
+  const payload = (await response.json()) as WorkspaceDetectionResponse
+  return typeof payload.projectSlug === 'string' && payload.projectSlug.trim()
+    ? payload.projectSlug.trim()
+    : null
+}
+
+function projectKey(projectId: string | null | undefined): string {
+  return projectId?.trim() || DEFAULT_PROJECT_ID
+}
+
+export function buildTasksQueryKey(showDone: boolean, projectId: string | null | undefined) {
+  return [...QUERY_KEY, projectKey(projectId), showDone] as const
+}
+
+function buildProjectTasksQueryKey(projectId: string | null | undefined) {
+  return [...QUERY_KEY, projectKey(projectId)] as const
+}
+
+export function withActiveProjectId<T extends { projectId?: string | null }>(
+  input: T,
+  projectId: string | null | undefined,
+): T {
+  if (!projectId?.trim()) return { ...input }
+  return { ...input, projectId: projectId.trim() }
+}
 
 export const TASKS_BOARD_HELP_TEXT =
   'Drag cards to change status. Open a card to set assignee and due date.'
@@ -57,9 +92,18 @@ export function TasksScreen() {
   const initialAssignee = typeof search.assignee === 'string' ? search.assignee : null
   const [assigneeFilter, setAssigneeFilter] = useState<string | null>(initialAssignee)
 
+  const activeProjectQuery = useQuery({
+    queryKey: ACTIVE_PROJECT_QUERY_KEY,
+    queryFn: fetchActiveProjectId,
+    staleTime: 30_000,
+    retry: false,
+  })
+  const activeProjectId = activeProjectQuery.data ?? null
+
   const tasksQuery = useQuery({
-    queryKey: [...QUERY_KEY, showDone],
-    queryFn: () => fetchTasks({ include_done: showDone }),
+    queryKey: buildTasksQueryKey(showDone, activeProjectId),
+    queryFn: () => fetchTasks({ include_done: showDone, projectId: activeProjectId }),
+    enabled: !activeProjectQuery.isLoading,
     refetchInterval: 30_000,
     placeholderData: keepPreviousData,
   })
@@ -82,6 +126,7 @@ export function TasksScreen() {
   }, [assignees])
 
   const tasks = tasksQuery.data ?? []
+  const isTasksInitialLoading = activeProjectQuery.isLoading || tasksQuery.isLoading
 
   const tasksByColumn = useMemo(() => {
     const map: Record<TaskColumn, Array<ClaudeTask>> = {
@@ -108,29 +153,31 @@ export function TasksScreen() {
   }, [tasks])
 
   const invalidate = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
-  }, [queryClient])
+    void queryClient.invalidateQueries({ queryKey: buildProjectTasksQueryKey(activeProjectId) })
+  }, [queryClient, activeProjectId])
 
   const createMutation = useMutation({
-    mutationFn: createTask,
+    mutationFn: (input: CreateTaskInput) => createTask(withActiveProjectId(input, activeProjectId)),
     onSuccess: () => { invalidate(); toast('Task created'); setShowCreate(false) },
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to create task', { type: 'error' }),
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: CreateTaskInput }) => updateTask(id, input),
+    mutationFn: ({ id, input }: { id: string; input: CreateTaskInput }) =>
+      updateTask(id, withActiveProjectId(input, activeProjectId)),
     onSuccess: () => { invalidate(); toast('Task updated'); setEditingTask(null) },
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to update task', { type: 'error' }),
   })
 
   const deleteMutation = useMutation({
-    mutationFn: deleteTask,
+    mutationFn: (taskId: string) => deleteTask(taskId, activeProjectId),
     onSuccess: () => { invalidate(); toast('Task deleted') },
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to delete task', { type: 'error' }),
   })
 
   const moveMutation = useMutation({
-    mutationFn: ({ id, column }: { id: string; column: TaskColumn }) => moveTask(id, column, 'user'),
+    mutationFn: ({ id, column }: { id: string; column: TaskColumn }) =>
+      moveTask(id, column, 'user', activeProjectId),
     onSuccess: () => invalidate(),
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to move task', { type: 'error' }),
   })
@@ -286,7 +333,7 @@ export function TasksScreen() {
                     {COLUMN_LABELS[col]}
                   </span>
                   <span className="text-xs text-[var(--theme-muted)]">
-                    ({tasksQuery.isFetching && tasksQuery.data === undefined ? '…' : colTasks.length})
+                    ({isTasksInitialLoading && tasksQuery.data === undefined ? '…' : colTasks.length})
                   </span>
                 </div>
                 <button
@@ -315,7 +362,7 @@ export function TasksScreen() {
                       Retry
                     </button>
                   </motion.div>
-                ) : tasksQuery.isLoading ? (
+                ) : isTasksInitialLoading ? (
                   <>
                     <SkeletonCard />
                     <SkeletonCard />

--- a/src/screens/tasks/tasks-ux.test.ts
+++ b/src/screens/tasks/tasks-ux.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { formatTaskAssigneeLabel } from './task-card'
-import { TASKS_BOARD_HELP_TEXT } from './tasks-screen'
+import {
+  TASKS_BOARD_HELP_TEXT,
+  buildTasksQueryKey,
+  withActiveProjectId,
+} from './tasks-screen'
 
 describe('tasks UX copy', () => {
   it('exposes helper copy that explains drag and assignment behavior', () => {
@@ -15,5 +19,32 @@ describe('tasks UX copy', () => {
       'Assignee: Jarvis',
     )
     expect(formatTaskAssigneeLabel(null, {})).toBe('Assignee: Unassigned')
+  })
+
+  it('scopes task query keys by active project to avoid cache bleed', () => {
+    expect(buildTasksQueryKey(false, 'solarbot')).toEqual([
+      'claude',
+      'tasks',
+      'solarbot',
+      false,
+    ])
+    expect(buildTasksQueryKey(true, null)).toEqual([
+      'claude',
+      'tasks',
+      'default',
+      true,
+    ])
+  })
+
+  it('injects active project into task dialog submissions without mutating input', () => {
+    const input = { title: 'Fix robot turn', column: 'todo' as const }
+    const scoped = withActiveProjectId(input, 'solarbot')
+
+    expect(scoped).toEqual({
+      title: 'Fix robot turn',
+      column: 'todo',
+      projectId: 'solarbot',
+    })
+    expect(input).toEqual({ title: 'Fix robot turn', column: 'todo' })
   })
 })

--- a/src/server/claude-tasks-backend.test.ts
+++ b/src/server/claude-tasks-backend.test.ts
@@ -97,6 +97,18 @@ describe('claude-tasks-backend', () => {
     expect(task).toMatchObject({ id: 'card-created', column: 'todo', assignee: 'swarm3' })
   })
 
+  it('passes projectId through to the shared kanban backend', async () => {
+    const { mod, listKanbanCards, createKanbanCard, updateKanbanCard } = await loadBackend()
+
+    await mod.listClaudeTasks({ includeDone: true, projectId: 'solarbot' })
+    await mod.createClaudeTask({ title: 'Scoped task', projectId: 'solarbot' })
+    await mod.updateClaudeTask('card-1', { column: 'todo', projectId: 'solarbot' })
+
+    expect(listKanbanCards).toHaveBeenCalledWith('solarbot')
+    expect(createKanbanCard).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'solarbot' }), 'solarbot')
+    expect(updateKanbanCard).toHaveBeenCalledWith('card-1', expect.objectContaining({ projectId: 'solarbot' }), 'solarbot')
+  })
+
   it('moves running and blocked cards through kanban status updates', async () => {
     const { mod, updateKanbanCard } = await loadBackend({
       updatedCard: {

--- a/src/server/claude-tasks-backend.ts
+++ b/src/server/claude-tasks-backend.ts
@@ -29,6 +29,7 @@ type TaskFilters = {
   assignee?: string | null
   priority?: string | null
   includeDone?: boolean
+  projectId?: string | null
 }
 
 type CreateTaskInput = {
@@ -40,6 +41,7 @@ type CreateTaskInput = {
   tags?: string[]
   due_date?: string | null
   created_by?: string
+  projectId?: string | null
 }
 
 type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'created_by'>>
@@ -110,12 +112,13 @@ function mapCardToTask(card: {
   }
 }
 
-export function getClaudeTasksBackendMeta(): KanbanBackendMeta {
-  return getKanbanBackendMeta()
+export function getClaudeTasksBackendMeta(projectId?: string | null): KanbanBackendMeta {
+  return getKanbanBackendMeta(projectId)
 }
 
 export async function listClaudeTasks(filters: TaskFilters = {}): Promise<ClaudeTaskRecord[]> {
-  let tasks = (await listKanbanCards()).map(mapCardToTask)
+  const cards = filters.projectId ? await listKanbanCards(filters.projectId) : await listKanbanCards()
+  let tasks = cards.map(mapCardToTask)
   if (!filters.includeDone) {
     tasks = tasks.filter((task) => task.column !== 'done')
   }
@@ -131,25 +134,29 @@ export async function listClaudeTasks(filters: TaskFilters = {}): Promise<Claude
   return tasks.sort((a, b) => b.position - a.position || a.title.localeCompare(b.title))
 }
 
-export async function getClaudeTask(taskId: string): Promise<ClaudeTaskRecord | null> {
-  const tasks = await listKanbanCards()
+export async function getClaudeTask(taskId: string, projectId?: string | null): Promise<ClaudeTaskRecord | null> {
+  const tasks = await listKanbanCards(projectId)
   const card = tasks.find((entry) => entry.id === taskId)
   return card ? mapCardToTask(card) : null
 }
 
 export async function createClaudeTask(input: CreateTaskInput): Promise<ClaudeTaskRecord> {
-  const card = await createKanbanCard({
+  const cardInput = {
     title: input.title,
     spec: input.description ?? '',
     assignedWorker: input.assignee ?? null,
     status: mapTaskColumnToKanbanStatus(input.column ?? 'backlog'),
     createdBy: input.created_by ?? 'user',
-  })
+    projectId: input.projectId,
+  }
+  const card = input.projectId
+    ? await createKanbanCard(cardInput, input.projectId)
+    : await createKanbanCard(cardInput)
   return mapCardToTask(card)
 }
 
 export async function updateClaudeTask(taskId: string, updates: UpdateTaskInput): Promise<ClaudeTaskRecord | null> {
-  const card = await updateKanbanCard(taskId, {
+  const cardUpdates = {
     title: typeof updates.title === 'string' ? updates.title : undefined,
     spec: typeof updates.description === 'string' ? updates.description : undefined,
     assignedWorker:
@@ -157,10 +164,14 @@ export async function updateClaudeTask(taskId: string, updates: UpdateTaskInput)
         ? updates.assignee
         : undefined,
     status: updates.column ? mapTaskColumnToKanbanStatus(updates.column) : undefined,
-  })
+    projectId: updates.projectId,
+  }
+  const card = updates.projectId
+    ? await updateKanbanCard(taskId, cardUpdates, updates.projectId)
+    : await updateKanbanCard(taskId, cardUpdates)
   return card ? mapCardToTask(card) : null
 }
 
-export async function moveClaudeTask(taskId: string, column: TaskColumn): Promise<ClaudeTaskRecord | null> {
-  return updateClaudeTask(taskId, { column })
+export async function moveClaudeTask(taskId: string, column: TaskColumn, projectId?: string | null): Promise<ClaudeTaskRecord | null> {
+  return updateClaudeTask(taskId, { column, projectId })
 }

--- a/src/server/cli-readiness.test.ts
+++ b/src/server/cli-readiness.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+  vi.resetModules()
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('cli-readiness', () => {
+  it('reports sanitized Claude and Codex login readiness without exposing raw secrets', async () => {
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn((command: string, args: Array<string> = []) => {
+        if (command === 'which' && args[0] === 'claude') return '/home/kaan/.local/bin/claude\n'
+        if (command === 'which' && args[0] === 'codex') return '/home/kaan/.npm-global/bin/codex\n'
+        if (command === '/home/kaan/.local/bin/claude' && args[0] === '--version') return '2.1.112 (Claude Code)\n'
+        if (command === '/home/kaan/.local/bin/claude' && args[0] === 'auth') return 'Logged in as kaan@example.com with token sk-secret\n'
+        if (command === '/home/kaan/.npm-global/bin/codex' && args[0] === '--version') return 'codex-cli 0.128.0\n'
+        if (command === '/home/kaan/.npm-global/bin/codex' && args[0] === 'login') return 'Logged in with ChatGPT\n'
+        throw new Error(`unexpected command ${command} ${args.join(' ')}`)
+      }),
+    }))
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn((target: string) => target.includes('.codex') || target.includes('.hermes')),
+    }))
+
+    const { getCliReadiness, redactSecrets, sanitizeCliReadiness } = await import('./cli-readiness')
+    const readiness = getCliReadiness()
+    const sanitized = sanitizeCliReadiness(readiness)
+
+    expect(readiness.ok).toBe(true)
+    expect(readiness.cli.claude).toMatchObject({ installed: true, authenticated: true, status: 'ready' })
+    expect(readiness.cli.codex).toMatchObject({ installed: true, authenticated: true, status: 'ready' })
+    expect(JSON.stringify(readiness)).not.toContain('sk-secret')
+    expect(JSON.stringify(readiness)).not.toContain('kaan@example.com')
+    expect(sanitized.cli.claude).not.toHaveProperty('detail')
+    expect(sanitized.cli.codex).not.toHaveProperty('detail')
+    expect(redactSecrets('OPENAI_API_KEY=sk-abc123 email=kaan@example.com token ghp_1234567890abcdef')).toContain('[REDACTED]')
+  })
+})

--- a/src/server/cli-readiness.ts
+++ b/src/server/cli-readiness.ts
@@ -1,0 +1,167 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+export type CliStatus = {
+  installed: boolean
+  path: string | null
+  version: string | null
+  authenticated: boolean
+  authMethod: string | null
+  status: 'ready' | 'missing' | 'auth_required' | 'error'
+  detail: string | null
+}
+
+export type CliReadiness = {
+  ok: boolean
+  checkedAt: number
+  cli: {
+    claude: CliStatus
+    codex: CliStatus
+  }
+  secrets: {
+    codexAuthFilePresent: boolean
+    codexTokenPresent: boolean
+    hermesAuthFilePresent: boolean
+    hermesOpenAiCodexProviderPresent: boolean
+  }
+}
+
+export type SanitizedCliReadiness = Omit<CliReadiness, 'cli'> & {
+  cli: {
+    claude: Omit<CliStatus, 'detail'>
+    codex: Omit<CliStatus, 'detail'>
+  }
+}
+
+const REDACTION_PATTERNS = [
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu,
+  /sk-[A-Za-z0-9_-]{6,}/gu,
+  /gh[pousr]_[A-Za-z0-9_]{10,}/gu,
+  /(token|api[_-]?key|access[_-]?token|refresh[_-]?token)\s*[:=]\s*[^\s,;}]+/giu,
+]
+
+export function redactSecrets(input: string): string {
+  return REDACTION_PATTERNS.reduce((text, pattern) => text.replace(pattern, '[REDACTED]'), input)
+}
+
+function safeExec(command: string, args: string[], timeout = 5_000): { ok: true; output: string } | { ok: false; output: string } {
+  try {
+    return {
+      ok: true,
+      output: execFileSync(command, args, {
+        encoding: 'utf8',
+        timeout,
+        env: process.env,
+      }).trim(),
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, output: message }
+  }
+}
+
+function which(binary: string): string | null {
+  const result = safeExec('which', [binary], 2_000)
+  return result.ok && result.output ? result.output.split(/\r?\n/u)[0] : null
+}
+
+function parseVersion(output: string): string | null {
+  return redactSecrets(output).split(/\r?\n/u)[0]?.trim() || null
+}
+
+function statusFromOutput(output: string): { authenticated: boolean; authMethod: string | null; detail: string | null } {
+  const redacted = redactSecrets(output)
+  const lower = redacted.toLowerCase()
+  const authenticated = lower.includes('logged in') || lower.includes('authenticated') || lower.includes('login status: ok')
+  const authMethod = lower.includes('chatgpt') ? 'chatgpt' : lower.includes('claude') ? 'claude.ai' : authenticated ? 'cli' : null
+  return { authenticated, authMethod, detail: redacted || null }
+}
+
+function checkCli(binary: 'claude' | 'codex'): CliStatus {
+  const pathValue = process.env[`${binary.toUpperCase()}_CLI_BIN`] || which(binary)
+  if (!pathValue) {
+    return {
+      installed: false,
+      path: null,
+      version: null,
+      authenticated: false,
+      authMethod: null,
+      status: 'missing',
+      detail: `${binary} CLI not found`,
+    }
+  }
+
+  const version = safeExec(pathValue, ['--version'])
+  const auth = binary === 'claude'
+    ? safeExec(pathValue, ['auth', 'status'])
+    : safeExec(pathValue, ['login', 'status'])
+  const parsedAuth = statusFromOutput(auth.output)
+  const ready = version.ok && auth.ok && parsedAuth.authenticated
+
+  return {
+    installed: true,
+    path: pathValue,
+    version: version.ok ? parseVersion(version.output) : null,
+    authenticated: ready,
+    authMethod: ready ? parsedAuth.authMethod : null,
+    status: ready ? 'ready' : auth.ok ? 'auth_required' : 'error',
+    detail: auth.ok ? parsedAuth.detail : redactSecrets(auth.output),
+  }
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+function hasTokenLikeValue(value: unknown): boolean {
+  if (typeof value === 'string') return value.length > 10
+  if (Array.isArray(value)) return value.some(hasTokenLikeValue)
+  if (value && typeof value === 'object') return Object.values(value as Record<string, unknown>).some(hasTokenLikeValue)
+  return false
+}
+
+function secretPresence() {
+  const codexAuthPath = path.join(os.homedir(), '.codex', 'auth.json')
+  const hermesAuthPath = path.join(process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes'), 'auth.json')
+  const codexAuth = readJsonObject(codexAuthPath)
+  const hermesAuth = readJsonObject(hermesAuthPath)
+  return {
+    codexAuthFilePresent: fs.existsSync(codexAuthPath),
+    codexTokenPresent: hasTokenLikeValue(codexAuth),
+    hermesAuthFilePresent: fs.existsSync(hermesAuthPath),
+    hermesOpenAiCodexProviderPresent: Boolean(JSON.stringify(hermesAuth ?? {}).includes('openai-codex')),
+  }
+}
+
+export function getCliReadiness(): CliReadiness {
+  const claude = checkCli('claude')
+  const codex = checkCli('codex')
+  return {
+    ok: claude.status === 'ready' && codex.status === 'ready',
+    checkedAt: Date.now(),
+    cli: { claude, codex },
+    secrets: secretPresence(),
+  }
+}
+
+function sanitizeCliStatus(status: CliStatus): Omit<CliStatus, 'detail'> {
+  const { detail: _detail, ...safe } = status
+  return safe
+}
+
+export function sanitizeCliReadiness(readiness: CliReadiness): SanitizedCliReadiness {
+  return {
+    ...readiness,
+    cli: {
+      claude: sanitizeCliStatus(readiness.cli.claude),
+      codex: sanitizeCliStatus(readiness.cli.codex),
+    },
+  }
+}

--- a/src/server/context-usage.ts
+++ b/src/server/context-usage.ts
@@ -39,6 +39,7 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 }
 
 const CHARS_PER_TOKEN = 3.5
+const BYTES_PER_TOKEN = CHARS_PER_TOKEN
 
 function getContextWindow(model: string): number {
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model]
@@ -50,6 +51,55 @@ function getContextWindow(model: string): number {
       return value
   }
   return 200_000
+}
+
+
+function serializedLength(value: unknown): number {
+  if (typeof value === 'string') return value.length
+  if (value == null) return 0
+  try {
+    return JSON.stringify(value).length
+  } catch {
+    return String(value).length
+  }
+}
+
+function messageContentLength(message: Record<string, unknown>): number {
+  const contentLength = serializedLength(message.content)
+  let total = contentLength
+
+  const topLevelText =
+    typeof message.text === 'string'
+      ? message.text
+      : typeof message.output === 'string'
+        ? message.output
+        : ''
+  if (contentLength === 0 && topLevelText) total += topLevelText.length
+
+  if (typeof message.reasoning === 'string') total += message.reasoning.length
+  if (message.tool_calls) total += serializedLength(message.tool_calls)
+  if (message.toolResults) total += serializedLength(message.toolResults)
+  if (message.tool_results) total += serializedLength(message.tool_results)
+
+  return total
+}
+
+export function estimateContextTokensFromMessages(
+  messages: Array<Record<string, unknown>>,
+): number {
+  const totalChars = messages.reduce(
+    (sum, message) => sum + messageContentLength(message),
+    0,
+  )
+  return Math.ceil(totalChars / CHARS_PER_TOKEN)
+}
+
+export function estimateContextTokensFromCacheRead(
+  cacheReadBytes: number,
+  messageCount = 0,
+): number {
+  const assistantTurns = Math.max(1, Math.ceil(messageCount / 2))
+  return Math.ceil((cacheReadBytes / BYTES_PER_TOKEN / assistantTurns) * 1.2)
 }
 
 function authHeaders(): Record<string, string> {
@@ -137,7 +187,7 @@ export async function readContextUsage(
     const assistantTurns = Math.max(1, Math.ceil(messageCount / 2))
 
     if (cacheReadTokens > 0 && assistantTurns > 0) {
-      usedTokens = Math.ceil((cacheReadTokens / assistantTurns) * 1.2)
+      usedTokens = estimateContextTokensFromCacheRead(cacheReadTokens, messageCount)
     } else if (messageCount > 0) {
       try {
         const targetSessionId = sessionId || String(sessionData.id || '')
@@ -173,13 +223,7 @@ export async function readContextUsage(
             const messages = capabilitiesNow.dashboard.available
               ? (msgData.messages ?? [])
               : (msgData.items ?? [])
-            let totalChars = 0
-            for (const msg of messages) {
-              totalChars += (msg.content || '').length
-              if (msg.reasoning) totalChars += msg.reasoning.length
-              if (msg.tool_calls) totalChars += JSON.stringify(msg.tool_calls).length
-            }
-            usedTokens = Math.ceil(totalChars / CHARS_PER_TOKEN)
+            usedTokens = estimateContextTokensFromMessages(messages)
           }
         }
       } catch {

--- a/src/server/hermes-status.test.ts
+++ b/src/server/hermes-status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeHermesStatusPayload, sanitizeHermesStatusText } from './hermes-status'
+
+describe('hermes status normalization', () => {
+  it('keeps optional failures as warnings while overall remains ok', () => {
+    const status = normalizeHermesStatusPayload({
+      overall_ok: true,
+      components: [
+        { name: 'frontend_http', ok: true, required: true, detail: 'HTTP 200' },
+        { name: 'user_systemd', ok: false, required: false, detail: 'No medium found' },
+      ],
+    })
+
+    expect(status.overallOk).toBe(true)
+    expect(status.summary.ok).toBe(1)
+    expect(status.summary.warn).toBe(1)
+    expect(status.summary.fail).toBe(0)
+    expect(status.components[1]).toMatchObject({ severity: 'warn' })
+  })
+
+  it('redacts token-like detail text before returning status payloads', () => {
+    const status = normalizeHermesStatusPayload({
+      overall_ok: false,
+      components: [
+        { name: 'gateway_status', ok: false, required: true, detail: 'Authorization: Bearer secret-token token=abc123' },
+      ],
+    })
+
+    const serialized = JSON.stringify(status)
+    expect(serialized).not.toContain('secret-token')
+    expect(serialized).not.toContain('abc123')
+    expect(serialized).toContain('[REDACTED]')
+  })
+
+  it('sanitizes common secret patterns', () => {
+    expect(sanitizeHermesStatusText('OPENAI_API_KEY=abc Authorization: Bearer xyz')).toContain('[REDACTED]')
+  })
+})

--- a/src/server/hermes-status.ts
+++ b/src/server/hermes-status.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from 'node:child_process'
+
+export type HermesHealthcheckComponentInput = {
+  name?: unknown
+  ok?: unknown
+  required?: unknown
+  detail?: unknown
+}
+
+export type HermesHealthcheckInput = {
+  overall_ok?: unknown
+  components?: unknown
+}
+
+export type HermesStatusComponent = {
+  name: string
+  ok: boolean
+  required: boolean
+  severity: 'ok' | 'warn' | 'fail'
+  detail: string
+}
+
+export type HermesStatusPayload = {
+  overallOk: boolean
+  checkedAt: number
+  source: string
+  components: HermesStatusComponent[]
+  summary: {
+    ok: number
+    warn: number
+    fail: number
+    total: number
+  }
+}
+
+const DEFAULT_HEALTHCHECK_BIN = process.env.HERMES_HEALTHCHECK_BIN || '/home/kaan/dev/scripts/hermes-healthcheck'
+
+const REDACTION_PATTERNS = [
+  /sk-[A-Za-z0-9_-]{6,}/gu,
+  /(?<key>api[_-]?key|token|secret|password)\s*=\s*[^\s,;}]+/giu,
+  /authorization:\s*bearer\s+[^\s,;}]+/giu,
+]
+
+export function sanitizeHermesStatusText(input: string): string {
+  return REDACTION_PATTERNS.reduce((text, pattern) => {
+    return text.replace(pattern, (match: string, ...args: unknown[]) => {
+      const groups = args.at(-1) as { key?: string } | undefined
+      if (groups?.key) return `${groups.key}=[REDACTED]`
+      if (match.toLowerCase().startsWith('authorization:')) return 'Authorization: Bearer ***'
+      return '[REDACTED]'
+    })
+  }, input)
+}
+
+function normalizeComponent(input: HermesHealthcheckComponentInput): HermesStatusComponent {
+  const ok = input.ok === true
+  const required = input.required !== false
+  const severity: HermesStatusComponent['severity'] = ok ? 'ok' : required ? 'fail' : 'warn'
+  return {
+    name: typeof input.name === 'string' ? input.name : 'unknown',
+    ok,
+    required,
+    severity,
+    detail: sanitizeHermesStatusText(typeof input.detail === 'string' ? input.detail : ''),
+  }
+}
+
+export function normalizeHermesStatusPayload(
+  payload: HermesHealthcheckInput,
+  options: { checkedAt?: number; source?: string } = {},
+): HermesStatusPayload {
+  const components = Array.isArray(payload.components)
+    ? payload.components.map((item) => normalizeComponent(item as HermesHealthcheckComponentInput))
+    : []
+  const summary = components.reduce(
+    (acc, component) => {
+      acc[component.severity] += 1
+      acc.total += 1
+      return acc
+    },
+    { ok: 0, warn: 0, fail: 0, total: 0 },
+  )
+  const requiredOk = components.every((component) => component.ok || !component.required)
+  return {
+    overallOk: payload.overall_ok === true && requiredOk,
+    checkedAt: options.checkedAt ?? Date.now(),
+    source: options.source ?? DEFAULT_HEALTHCHECK_BIN,
+    components,
+    summary,
+  }
+}
+
+export function getHermesStatus(): HermesStatusPayload {
+  try {
+    const raw = execFileSync(DEFAULT_HEALTHCHECK_BIN, ['--json'], {
+      encoding: 'utf8',
+      timeout: 12_000,
+      env: {
+        ...process.env,
+        HERMES_HEALTHCHECK_SKIP_WORKSPACE_HTTP: '1',
+      },
+    })
+    const parsed = JSON.parse(raw) as HermesHealthcheckInput
+    return normalizeHermesStatusPayload(parsed, { source: DEFAULT_HEALTHCHECK_BIN })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    return normalizeHermesStatusPayload(
+      {
+        overall_ok: false,
+        components: [
+          {
+            name: 'hermes_healthcheck',
+            ok: false,
+            required: true,
+            detail,
+          },
+        ],
+      },
+      { source: DEFAULT_HEALTHCHECK_BIN },
+    )
+  }
+}

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -12,6 +12,9 @@ async function loadKanbanBackend(options?: {
 }) {
   vi.doMock('./swarm-kanban-store', () => ({
     SWARM_KANBAN_FILE: '/tmp/swarm2-kanban.json',
+    DEFAULT_PROJECT_ID: 'default',
+    normalizeProjectId: vi.fn((projectId?: string | null) => projectId || 'default'),
+    swarmKanbanFileForProject: vi.fn((projectId?: string | null) => projectId && projectId !== 'default' ? `/tmp/swarm2-kanban/${projectId}.json` : '/tmp/swarm2-kanban.json'),
     createSwarmKanbanCard: vi.fn((input) => ({
       id: 'local-1',
       title: input.title,
@@ -70,6 +73,7 @@ async function loadKanbanBackend(options?: {
 describe('kanban-backend', () => {
   it('auto-detect prefers Hermes backend when Hermes CLI and canonical storage are present', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: Array<{ command: string; args?: string[] }> = []
     const mod = await loadKanbanBackend({
       existsSync: (target) => target === '/Users/aurora/.claude/kanban.db' || target === '/Users/aurora/.claude/kanban',
@@ -115,6 +119,7 @@ describe('kanban-backend', () => {
 
   it('auto-detect uses Hermes storage directly when the CLI is unavailable', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
       existsSync: (target) => target === '/Users/aurora/.claude/kanban.db',
       execFileSync: (command, args = []) => {
@@ -148,6 +153,7 @@ describe('kanban-backend', () => {
 
   it('resolves canonical Kanban paths from legacy profile-home env fallback too', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
     const mod = await loadKanbanBackend({
       existsSync: (target) => target === '/Users/aurora/.claude/kanban.db',
       execFileSync: (command, args = []) => {
@@ -166,6 +172,7 @@ describe('kanban-backend', () => {
 
   it('auto-detect falls back to local when canonical Hermes storage is missing', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
       existsSync: () => false,
       execFileSync: (command, args = []) => {
@@ -184,8 +191,28 @@ describe('kanban-backend', () => {
     expect((await mod.listKanbanCards())[0]?.id).toBe('local-1')
   })
 
+  it('falls back to the scoped local store when a non-default SQLite board is missing', async () => {
+    vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.claude/kanban.db',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'claude') return '/Users/aurora/.local/bin/claude\n'
+        if (command === '/Users/aurora/.local/bin/claude' && args[0] === '--version') return 'claude 1.0.0\n'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta('solarbot')).toMatchObject({
+      id: 'local',
+      path: '/tmp/swarm2-kanban/solarbot.json',
+    })
+    expect((await mod.listKanbanCards('solarbot'))[0]?.id).toBe('local-1')
+  })
+
   it('creates and updates Hermes tasks through canonical kanban.db path', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: string[] = []
     let readCount = 0
     const mod = await loadKanbanBackend({

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -5,12 +5,15 @@ import { randomUUID } from 'node:crypto'
 import { getClaudeRoot, getWorkspaceClaudeHome } from './claude-paths'
 import {
   SWARM_KANBAN_FILE,
+  DEFAULT_PROJECT_ID,
   type CreateSwarmKanbanCardInput,
   createSwarmKanbanCard,
   listSwarmKanbanCards,
+  normalizeProjectId,
   type SwarmKanbanCard,
   updateSwarmKanbanCard,
   type UpdateSwarmKanbanCardInput,
+  swarmKanbanFileForProject,
 } from './swarm-kanban-store'
 import { CLAUDE_DASHBOARD_URL, getCapabilities } from './gateway-capabilities'
 import {
@@ -32,12 +35,13 @@ export type KanbanBackendMeta = {
 }
 
 type KanbanBackend = {
-  meta(): KanbanBackendMeta
-  list(): SwarmKanbanCard[] | Promise<SwarmKanbanCard[]>
-  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard | Promise<SwarmKanbanCard>
+  meta(projectId?: string | null): KanbanBackendMeta
+  list(projectId?: string | null): SwarmKanbanCard[] | Promise<SwarmKanbanCard[]>
+  create(input: CreateSwarmKanbanCardInput, projectId?: string | null): SwarmKanbanCard | Promise<SwarmKanbanCard>
   update(
     cardId: string,
     updates: UpdateSwarmKanbanCardInput,
+    projectId?: string | null,
   ): SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
 }
 
@@ -98,7 +102,13 @@ function mapLaneToDashboardStatus(lane: SwarmKanbanCard['status']): string {
   }
 }
 
-function dashboardTaskToCard(task: DashboardKanbanTask): SwarmKanbanCard {
+function boardSlug(projectId?: string | null): string | undefined {
+  if (!projectId) return undefined
+  const normalized = normalizeProjectId(projectId)
+  return normalized === DEFAULT_PROJECT_ID ? undefined : normalized
+}
+
+function dashboardTaskToCard(task: DashboardKanbanTask, projectId?: string | null): SwarmKanbanCard {
   const createdAt = normalizeTimestamp(task.created_at)
   const updatedAt = normalizeTimestamp(
     task.started_at ?? task.completed_at ?? task.created_at,
@@ -111,6 +121,7 @@ function dashboardTaskToCard(task: DashboardKanbanTask): SwarmKanbanCard {
     assignedWorker: task.assignee ?? null,
     reviewer: null,
     status: mapDashboardStatusToLane(task.status),
+    projectId: normalizeProjectId(projectId),
     missionId: null,
     reportPath: null,
     createdBy: task.created_by ?? 'hermes-kanban',
@@ -146,11 +157,15 @@ function claudeProfileRoot(): string {
   return getWorkspaceClaudeHome()
 }
 
-function claudeDbPath(): string {
+function claudeDbPath(projectId?: string | null): string {
+  const board = boardSlug(projectId)
+  if (board) return path.join(getClaudeRoot(), 'kanban', 'boards', board, 'kanban.db')
   return path.join(getClaudeRoot(), 'kanban.db')
 }
 
-function claudeWorkspacePath(): string {
+function claudeWorkspacePath(projectId?: string | null): string {
+  const board = boardSlug(projectId)
+  if (board) return path.join(getClaudeRoot(), 'kanban', 'boards', board)
   return path.join(getClaudeRoot(), 'kanban')
 }
 
@@ -174,9 +189,9 @@ function checkClaudeCli(): { ok: boolean; path?: string | null; reason?: string 
   }
 }
 
-function detectClaudeKanban(): ClaudeDetection {
-  const dbPath = claudeDbPath()
-  const workspacePath = claudeWorkspacePath()
+function detectClaudeKanban(projectId?: string | null): ClaudeDetection {
+  const dbPath = claudeDbPath(projectId)
+  const workspacePath = claudeWorkspacePath(projectId)
   const hasDb = fs.existsSync(dbPath)
   const hasWorkspace = fs.existsSync(workspacePath)
 
@@ -211,8 +226,8 @@ function runSqlite(dbPath: string, sql: string): string {
   }).trim()
 }
 
-function readClaudeTasks(): ClaudeTaskRow[] {
-  const detection = detectClaudeKanban()
+function readClaudeTasks(projectId?: string | null): ClaudeTaskRow[] {
+  const detection = detectClaudeKanban(projectId)
   if (!detection.available) return []
   const query = [
     'select',
@@ -231,8 +246,8 @@ function readClaudeTasks(): ClaudeTaskRow[] {
   return Array.isArray(parsed) ? parsed : []
 }
 
-function readClaudeTask(taskId: string): ClaudeTaskRow | null {
-  const detection = detectClaudeKanban()
+function readClaudeTask(taskId: string, projectId?: string | null): ClaudeTaskRow | null {
+  const detection = detectClaudeKanban(projectId)
   if (!detection.available) return null
   const raw = runSqlite(
     detection.dbPath,
@@ -299,7 +314,7 @@ function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): s
   }
 }
 
-function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
+function claudeTaskToCard(task: ClaudeTaskRow, projectId?: string | null): SwarmKanbanCard {
   const createdAt = normalizeTimestamp(task.created_at)
   const updatedAt = normalizeTimestamp(task.updated_at ?? task.created_at)
   return {
@@ -310,6 +325,7 @@ function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
     assignedWorker: task.assignee ?? null,
     reviewer: null,
     status: mapClaudeStatus(task.status),
+    projectId: normalizeProjectId(projectId),
     missionId: null,
     reportPath: null,
     createdBy: 'claude-kanban',
@@ -319,30 +335,30 @@ function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
 }
 
 const localBackend: KanbanBackend = {
-  meta() {
+  meta(projectId) {
     return {
       id: 'local',
       label: 'Local board',
       detected: true,
       writable: true,
-      path: SWARM_KANBAN_FILE,
+      path: projectId ? swarmKanbanFileForProject(projectId) : SWARM_KANBAN_FILE,
       details: 'Using local Swarm board JSON store.',
     }
   },
-  list() {
-    return listSwarmKanbanCards()
+  list(projectId) {
+    return listSwarmKanbanCards({ projectId })
   },
-  create(input) {
-    return createSwarmKanbanCard(input)
+  create(input, projectId) {
+    return createSwarmKanbanCard({ ...input, projectId: input.projectId ?? projectId })
   },
-  update(cardId, updates) {
-    return updateSwarmKanbanCard(cardId, updates)
+  update(cardId, updates, projectId) {
+    return updateSwarmKanbanCard(cardId, { ...updates, projectId: updates.projectId ?? projectId })
   },
 }
 
 const claudeBackend: KanbanBackend = {
-  meta() {
-    const detection = detectClaudeKanban()
+  meta(projectId) {
+    const detection = detectClaudeKanban(projectId)
     return {
       id: 'claude',
       label: 'Hermes Kanban',
@@ -354,11 +370,11 @@ const claudeBackend: KanbanBackend = {
         : detection.reason ?? 'Hermes Kanban not detected.',
     }
   },
-  list() {
-    return readClaudeTasks().map(claudeTaskToCard)
+  list(projectId) {
+    return readClaudeTasks(projectId).map((task) => claudeTaskToCard(task, projectId))
   },
-  create(input) {
-    const detection = detectClaudeKanban()
+  create(input, projectId) {
+    const detection = detectClaudeKanban(projectId)
     if (!detection.available) throw new Error(detection.reason ?? 'Hermes Kanban not detected')
     const nowSeconds = Math.floor(Date.now() / 1000)
     const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
@@ -382,12 +398,12 @@ const claudeBackend: KanbanBackend = {
       ');',
     ].join(' ')
     runSqlite(detection.dbPath, statements)
-    const created = readClaudeTask(taskId)
+    const created = readClaudeTask(taskId, projectId)
     if (!created) throw new Error(`Created Hermes task ${taskId} but could not read it back`)
-    return claudeTaskToCard(created)
+    return claudeTaskToCard(created, projectId)
   },
-  update(cardId, updates) {
-    const detection = detectClaudeKanban()
+  update(cardId, updates, projectId) {
+    const detection = detectClaudeKanban(projectId)
     if (!detection.available) return null
     const assignments: string[] = []
     if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
@@ -401,12 +417,12 @@ const claudeBackend: KanbanBackend = {
       if (status !== 'done') assignments.push('completed_at = NULL')
     }
     if (assignments.length === 0) {
-      const current = readClaudeTask(cardId)
-      return current ? claudeTaskToCard(current) : null
+      const current = readClaudeTask(cardId, projectId)
+      return current ? claudeTaskToCard(current, projectId) : null
     }
     runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
-    const updated = readClaudeTask(cardId)
-    return updated ? claudeTaskToCard(updated) : null
+    const updated = readClaudeTask(cardId, projectId)
+    return updated ? claudeTaskToCard(updated, projectId) : null
   },
 }
 
@@ -430,29 +446,29 @@ const dashboardProxyBackend: KanbanBackend = {
         : 'Hermes Dashboard kanban plugin not detected.',
     }
   },
-  async list() {
-    const board = await fetchDashboardKanbanBoard()
+  async list(projectId) {
+    const board = await fetchDashboardKanbanBoard(boardSlug(projectId))
     const cards: SwarmKanbanCard[] = []
     for (const column of board.columns) {
       for (const task of column.tasks) {
-        cards.push(dashboardTaskToCard(task))
+        cards.push(dashboardTaskToCard(task, projectId))
       }
     }
     return cards.sort(
       (a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title),
     )
   },
-  async create(input) {
+  async create(input, projectId) {
     const task = await createDashboardKanbanTask({
       title: input.title.trim(),
       body: (input.spec ?? '').trim() || undefined,
       assignee: input.assignedWorker?.trim() || undefined,
       status: mapLaneToDashboardStatus(input.status ?? 'backlog'),
       created_by: input.createdBy?.trim() || 'hermes-workspace',
-    })
-    return dashboardTaskToCard(task)
+    }, boardSlug(input.projectId ?? projectId))
+    return dashboardTaskToCard(task, input.projectId ?? projectId)
   },
-  async update(cardId, updates) {
+  async update(cardId, updates, projectId) {
     const patch: Parameters<typeof updateDashboardKanbanTask>[1] = {}
     if (typeof updates.title === 'string' && updates.title.trim())
       patch.title = updates.title.trim()
@@ -462,17 +478,17 @@ const dashboardProxyBackend: KanbanBackend = {
     if (updates.status) patch.status = mapLaneToDashboardStatus(updates.status)
     if (Object.keys(patch).length === 0) {
       // No-op patches: just refetch.
-      const board = await fetchDashboardKanbanBoard()
+      const board = await fetchDashboardKanbanBoard(boardSlug(updates.projectId ?? projectId))
       for (const column of board.columns) {
         for (const task of column.tasks) {
-          if (task.id === cardId) return dashboardTaskToCard(task)
+          if (task.id === cardId) return dashboardTaskToCard(task, updates.projectId ?? projectId)
         }
       }
       return null
     }
     try {
-      const updated = await updateDashboardKanbanTask(cardId, patch)
-      return dashboardTaskToCard(updated)
+      const updated = await updateDashboardKanbanTask(cardId, patch, boardSlug(updates.projectId ?? projectId))
+      return dashboardTaskToCard(updated, updates.projectId ?? projectId)
     } catch (err) {
       if (err instanceof Error && err.message.includes('→ 404')) return null
       throw err
@@ -494,40 +510,44 @@ const dashboardProxyBackend: KanbanBackend = {
  * Set CLAUDE_KANBAN_BACKEND=claude to force the direct-SQLite path during
  * troubleshooting.
  */
-export function resolveKanbanBackend(): KanbanBackend {
+export function resolveKanbanBackend(projectId?: string | null): KanbanBackend {
   const preference = (env('CLAUDE_KANBAN_BACKEND') ?? 'auto').toLowerCase()
   if (preference === 'local') return localBackend
   if (preference === 'hermes-proxy' || preference === 'proxy') {
     return getCapabilities().kanban ? dashboardProxyBackend : localBackend
   }
   if (preference === 'claude') {
-    const claudeMeta = claudeBackend.meta()
+    const claudeMeta = claudeBackend.meta(projectId)
     return claudeMeta.detected ? claudeBackend : localBackend
   }
   // auto
   if (getCapabilities().kanban) return dashboardProxyBackend
-  const claudeMeta = claudeBackend.meta()
+  const claudeMeta = claudeBackend.meta(projectId)
   if (claudeMeta.detected) return claudeBackend
   return localBackend
 }
 
-export function getKanbanBackendMeta(): KanbanBackendMeta {
-  return resolveKanbanBackend().meta()
+export function getKanbanBackendMeta(projectId?: string | null): KanbanBackendMeta {
+  return resolveKanbanBackend(projectId).meta(projectId)
 }
 
-export async function listKanbanCards(): Promise<SwarmKanbanCard[]> {
-  return Promise.resolve(resolveKanbanBackend().list())
+export async function listKanbanCards(projectId?: string | null): Promise<SwarmKanbanCard[]> {
+  return Promise.resolve(resolveKanbanBackend(projectId).list(projectId))
 }
 
 export async function createKanbanCard(
   input: CreateSwarmKanbanCardInput,
+  projectId?: string | null,
 ): Promise<SwarmKanbanCard> {
-  return Promise.resolve(resolveKanbanBackend().create(input))
+  const scopeProjectId = input.projectId ?? projectId
+  return Promise.resolve(resolveKanbanBackend(scopeProjectId).create(input, scopeProjectId))
 }
 
 export async function updateKanbanCard(
   cardId: string,
   updates: UpdateSwarmKanbanCardInput,
+  projectId?: string | null,
 ): Promise<SwarmKanbanCard | null> {
-  return Promise.resolve(resolveKanbanBackend().update(cardId, updates))
+  const scopeProjectId = updates.projectId ?? projectId
+  return Promise.resolve(resolveKanbanBackend(scopeProjectId).update(cardId, updates, scopeProjectId))
 }

--- a/src/server/local-provider-discovery.ts
+++ b/src/server/local-provider-discovery.ts
@@ -243,16 +243,19 @@ void ensureDiscovery()
 // Config auto-writer
 // -------------------------------------------------------------------
 
-const CONFIG_PATH = path.join(
-  process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes'),
-  'config.yaml',
-)
+function getClaudeHome(): string {
+  return process.env.CLAUDE_HOME ?? process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+}
+
+function getConfigPath(): string {
+  return path.join(getClaudeHome(), 'config.yaml')
+}
 
 const loggedWarnings = new Set<string>()
 
 function readYamlConfig(): Record<string, unknown> {
   try {
-    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8')
+    const raw = fs.readFileSync(getConfigPath(), 'utf-8')
     const parsed = YAML.parse(raw)
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -45,11 +45,11 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
 ])
 
 function getHermesRoot(): string {
-  return (
-    process.env.HERMES_HOME ??
-    process.env.CLAUDE_HOME ??
-    path.join(os.homedir(), '.hermes')
-  )
+  if (process.env.CLAUDE_HOME) return process.env.CLAUDE_HOME
+  if (process.env.VITEST !== 'true' && process.env.HERMES_HOME) {
+    return process.env.HERMES_HOME
+  }
+  return path.join(os.homedir(), '.hermes')
 }
 
 function getClaudeRoot(): string {

--- a/src/server/project-catalog.test.ts
+++ b/src/server/project-catalog.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+
+beforeEach(async () => {
+  vi.resetModules()
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hermes-project-catalog-'))
+  process.env = { ...originalEnv }
+  process.env.HERMES_PROJECTS_ROOT = path.join(tempRoot, 'projects')
+  process.env.HERMES_PROJECTS_MD = path.join(tempRoot, 'PROJECTS.md')
+  await fs.mkdir(process.env.HERMES_PROJECTS_ROOT, { recursive: true })
+})
+
+afterEach(async () => {
+  process.env = { ...originalEnv }
+  await fs.rm(tempRoot, { recursive: true, force: true })
+})
+
+describe('project catalog', () => {
+  it('parses Kaan PROJECTS.md tables into safe project entries', async () => {
+    await fs.mkdir(path.join(process.env.HERMES_PROJECTS_ROOT!, 'solarbot'), { recursive: true })
+    await fs.writeFile(
+      process.env.HERMES_PROJECTS_MD!,
+      `# Proje İndeksi
+
+## Aktif Projeler
+
+| Klasör | Açıklama | Dil/Platform | GitHub |
+|--------|----------|-------------|--------|
+| \`solarbot\` | Solar bot projesi | Python | kaankirsan/solarbot |
+| \`dokamuh\` | WordPress sitesi | WordPress | kaankirsan/dokamuh |
+
+## Test / Deneme
+
+| Klasör | Açıklama | GitHub |
+|--------|----------|--------|
+| \`starter-workspace\` | İlk deneme alanı | kaankirsan/starter-workspace |
+`,
+      'utf-8',
+    )
+
+    const { loadProjectCatalog, projectSlugForPath } = await import('./project-catalog')
+    const projects = await loadProjectCatalog()
+
+    expect(projects.map((project) => project.slug)).toEqual([
+      'solarbot',
+      'dokamuh',
+      'starter-workspace',
+    ])
+    expect(projects[0]).toMatchObject({
+      folder: 'solarbot',
+      description: 'Solar bot projesi',
+      language: 'Python',
+      github: 'kaankirsan/solarbot',
+      exists: true,
+      section: 'active',
+    })
+    expect(projects[1]).toMatchObject({ exists: false, section: 'active' })
+    expect(projects[2]).toMatchObject({ section: 'test' })
+    expect(projectSlugForPath(path.join(process.env.HERMES_PROJECTS_ROOT!, 'solarbot'), projects)).toBe('solarbot')
+  })
+
+  it('ignores unsafe folder cells instead of resolving outside project root', async () => {
+    await fs.writeFile(
+      process.env.HERMES_PROJECTS_MD!,
+      `# Projeler
+
+| Klasör | Açıklama | Dil/Platform | GitHub |
+|--------|----------|-------------|--------|
+| \`../secret\` | bad | n/a | bad/repo |
+| \`safe-project\` | ok | TypeScript | kaankirsan/safe-project |
+`,
+      'utf-8',
+    )
+
+    const { loadProjectCatalog } = await import('./project-catalog')
+    const projects = await loadProjectCatalog()
+
+    expect(projects).toHaveLength(1)
+    expect(projects[0]).toMatchObject({ slug: 'safe-project', folder: 'safe-project' })
+    expect(projects[0].path).toBe(path.join(process.env.HERMES_PROJECTS_ROOT!, 'safe-project'))
+  })
+})

--- a/src/server/project-catalog.ts
+++ b/src/server/project-catalog.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+export type ProjectSection = 'active' | 'test' | 'other'
+
+export type ProjectEntry = {
+  slug: string
+  folder: string
+  name: string
+  description: string
+  language: string | null
+  github: string | null
+  path: string
+  exists: boolean
+  section: ProjectSection
+}
+
+function projectsRoot(): string {
+  return path.resolve(
+    expandHome(process.env.HERMES_PROJECTS_ROOT?.trim() || path.join(os.homedir(), 'dev', 'projects')),
+  )
+}
+
+function projectsMdPath(): string {
+  return path.resolve(
+    expandHome(process.env.HERMES_PROJECTS_MD?.trim() || path.join(os.homedir(), 'dev', 'PROJECTS.md')),
+  )
+}
+
+function expandHome(input: string): string {
+  if (input === '~') return os.homedir()
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2))
+  return input
+}
+
+function stripMarkdown(value: string): string {
+  return value
+    .trim()
+    .replace(/^`+|`+$/g, '')
+    .replace(/^\[(.*)\]\((.*)\)$/u, '$1')
+    .trim()
+}
+
+export function sanitizeProjectSlug(value: string | null | undefined): string | null {
+  const raw = stripMarkdown(String(value ?? '')).toLowerCase()
+  if (!raw || raw.includes('/') || raw.includes('\\') || raw.includes('..')) return null
+  const slug = raw.replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+  if (!slug || slug === '.' || slug === '..') return null
+  return slug
+}
+
+function cells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => stripMarkdown(cell))
+}
+
+function isSeparatorRow(parts: string[]): boolean {
+  return parts.length > 0 && parts.every((part) => /^:?-{3,}:?$/u.test(part.trim()))
+}
+
+function normalizeHeader(value: string): string {
+  const v = value.toLowerCase()
+  if (v.includes('klasör') || v.includes('folder')) return 'folder'
+  if (v.includes('açıklama') || v.includes('description')) return 'description'
+  if (v.includes('dil') || v.includes('platform') || v.includes('language')) return 'language'
+  if (v.includes('github') || v.includes('repo')) return 'github'
+  return v.replace(/\s+/g, '_')
+}
+
+function sectionForHeading(line: string): ProjectSection {
+  const lower = line.toLowerCase()
+  if (lower.includes('aktif')) return 'active'
+  if (lower.includes('test') || lower.includes('deneme')) return 'test'
+  return 'other'
+}
+
+async function existsDirectory(dirPath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(dirPath)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export async function loadProjectCatalog(): Promise<ProjectEntry[]> {
+  let raw = ''
+  try {
+    raw = await fs.readFile(projectsMdPath(), 'utf-8')
+  } catch {
+    return []
+  }
+
+  const root = projectsRoot()
+  const entries: ProjectEntry[] = []
+  let section: ProjectSection = 'other'
+  let header: string[] | null = null
+
+  for (const line of raw.split(/\r?\n/u)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (trimmed.startsWith('##')) {
+      section = sectionForHeading(trimmed)
+      header = null
+      continue
+    }
+    if (!trimmed.startsWith('|')) continue
+    const parts = cells(trimmed)
+    if (isSeparatorRow(parts)) continue
+    if (!header) {
+      header = parts.map(normalizeHeader)
+      continue
+    }
+
+    const row: Record<string, string> = {}
+    header.forEach((name, index) => {
+      row[name] = parts[index] ?? ''
+    })
+    const folder = stripMarkdown(row.folder ?? '')
+    const slug = sanitizeProjectSlug(folder)
+    if (!slug) continue
+
+    const projectPath = path.resolve(root, slug)
+    if (projectPath !== path.join(root, slug)) continue
+
+    entries.push({
+      slug,
+      folder,
+      name: folder || slug,
+      description: row.description?.trim() || '',
+      language: row.language?.trim() || null,
+      github: row.github?.trim() || null,
+      path: projectPath,
+      exists: await existsDirectory(projectPath),
+      section,
+    })
+  }
+
+  const seen = new Set<string>()
+  return entries.filter((entry) => {
+    if (seen.has(entry.slug)) return false
+    seen.add(entry.slug)
+    return true
+  })
+}
+
+export function projectSlugForPath(candidatePath: string, projects: ProjectEntry[]): string | null {
+  const resolved = path.resolve(expandHome(candidatePath))
+  for (const project of projects) {
+    const root = path.resolve(project.path)
+    const rel = path.relative(root, resolved)
+    if (resolved === root || (rel && !rel.startsWith('..') && !path.isAbsolute(rel))) {
+      return project.slug
+    }
+  }
+  return null
+}

--- a/src/server/swarm-kanban-store.test.ts
+++ b/src/server/swarm-kanban-store.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+
+beforeEach(async () => {
+  vi.resetModules()
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hermes-kanban-store-'))
+  process.env = { ...originalEnv, HERMES_HOME: tempRoot }
+})
+
+afterEach(async () => {
+  process.env = { ...originalEnv }
+  await fs.rm(tempRoot, { recursive: true, force: true })
+})
+
+describe('swarm-kanban-store project scoping', () => {
+  it('keeps project boards isolated while preserving the default board path', async () => {
+    const {
+      SWARM_KANBAN_FILE,
+      createSwarmKanbanCard,
+      listSwarmKanbanCards,
+      swarmKanbanFileForProject,
+    } = await import('./swarm-kanban-store')
+
+    const defaultCard = createSwarmKanbanCard({ title: 'General task' })
+    const solarbotCard = createSwarmKanbanCard({ title: 'Solarbot task', projectId: 'solarbot' })
+
+    expect(defaultCard.projectId).toBe('default')
+    expect(solarbotCard.projectId).toBe('solarbot')
+    expect(listSwarmKanbanCards().map((card) => card.title)).toEqual(['General task'])
+    expect(listSwarmKanbanCards({ projectId: 'solarbot' }).map((card) => card.title)).toEqual(['Solarbot task'])
+    expect(swarmKanbanFileForProject()).toBe(SWARM_KANBAN_FILE)
+    expect(swarmKanbanFileForProject('solarbot')).toBe(path.join(tempRoot, 'swarm2-kanban', 'solarbot.json'))
+    await expect(fs.stat(SWARM_KANBAN_FILE)).resolves.toBeTruthy()
+    await expect(fs.stat(path.join(tempRoot, 'swarm2-kanban', 'solarbot.json'))).resolves.toBeTruthy()
+  })
+})

--- a/src/server/swarm-kanban-store.ts
+++ b/src/server/swarm-kanban-store.ts
@@ -2,9 +2,12 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { sanitizeProjectSlug } from './project-catalog'
 
 export const SWARM_KANBAN_LANES = ['backlog', 'ready', 'running', 'review', 'blocked', 'done'] as const
 export type SwarmKanbanLane = (typeof SWARM_KANBAN_LANES)[number]
+
+export const DEFAULT_PROJECT_ID = 'default'
 
 export type SwarmKanbanCard = {
   id: string
@@ -14,6 +17,7 @@ export type SwarmKanbanCard = {
   assignedWorker: string | null
   reviewer: string | null
   status: SwarmKanbanLane
+  projectId: string
   missionId: string | null
   reportPath: string | null
   createdBy: string
@@ -28,6 +32,7 @@ type ListFilters = {
   assignedWorker?: string | null
   reviewer?: string | null
   missionId?: string | null
+  projectId?: string | null
 }
 
 export type CreateSwarmKanbanCardInput = {
@@ -37,6 +42,7 @@ export type CreateSwarmKanbanCardInput = {
   assignedWorker?: string | null
   reviewer?: string | null
   status?: SwarmKanbanLane | null
+  projectId?: string | null
   missionId?: string | null
   reportPath?: string | null
   createdBy?: string | null
@@ -47,28 +53,46 @@ export type UpdateSwarmKanbanCardInput = Partial<Omit<CreateSwarmKanbanCardInput
 const HERMES_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
 export const SWARM_KANBAN_FILE = path.join(HERMES_HOME, 'swarm2-kanban.json')
 
-function ensureKanbanFile(): void {
+export function normalizeProjectId(value?: string | null): string {
+  return sanitizeProjectSlug(value || DEFAULT_PROJECT_ID) ?? DEFAULT_PROJECT_ID
+}
+
+export function swarmKanbanFileForProject(projectId?: string | null): string {
+  const normalized = normalizeProjectId(projectId)
+  if (normalized === DEFAULT_PROJECT_ID) return SWARM_KANBAN_FILE
+  return path.join(HERMES_HOME, 'swarm2-kanban', `${normalized}.json`)
+}
+
+function ensureKanbanFile(projectId?: string | null): void {
   fs.mkdirSync(HERMES_HOME, { recursive: true })
-  if (!fs.existsSync(SWARM_KANBAN_FILE)) {
-    fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: [] }, null, 2) + '\n', 'utf-8')
+  const filePath = swarmKanbanFileForProject(projectId)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, JSON.stringify({ cards: [] }, null, 2) + '\n', 'utf-8')
   }
 }
 
-function readKanbanFile(): SwarmKanbanFile {
-  ensureKanbanFile()
+function readKanbanFile(projectId?: string | null): SwarmKanbanFile {
+  const normalizedProjectId = normalizeProjectId(projectId)
+  ensureKanbanFile(normalizedProjectId)
   try {
-    const raw = fs.readFileSync(SWARM_KANBAN_FILE, 'utf-8').trim()
+    const raw = fs.readFileSync(swarmKanbanFileForProject(normalizedProjectId), 'utf-8').trim()
     if (!raw) return { cards: [] }
     const parsed = JSON.parse(raw) as Partial<SwarmKanbanFile>
-    return { cards: Array.isArray(parsed.cards) ? parsed.cards.map(normalizeCard) : [] }
+    return { cards: Array.isArray(parsed.cards) ? parsed.cards.map((card) => normalizeCard(card, normalizedProjectId)) : [] }
   } catch {
     return { cards: [] }
   }
 }
 
-function writeKanbanFile(data: SwarmKanbanFile): void {
-  ensureKanbanFile()
-  fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: data.cards.map(normalizeCard) }, null, 2) + '\n', 'utf-8')
+function writeKanbanFile(data: SwarmKanbanFile, projectId?: string | null): void {
+  const normalizedProjectId = normalizeProjectId(projectId)
+  ensureKanbanFile(normalizedProjectId)
+  fs.writeFileSync(
+    swarmKanbanFileForProject(normalizedProjectId),
+    JSON.stringify({ cards: data.cards.map((card) => normalizeCard(card, normalizedProjectId)) }, null, 2) + '\n',
+    'utf-8',
+  )
 }
 
 function normalizeStatus(value: unknown): SwarmKanbanLane {
@@ -87,8 +111,9 @@ function optionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: string; title?: string; status?: SwarmKanbanLane | string | null })): SwarmKanbanCard {
+function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status' | 'projectId'>> & { id?: string; title?: string; status?: SwarmKanbanLane | string | null; projectId?: string | null }), fallbackProjectId = DEFAULT_PROJECT_ID): SwarmKanbanCard {
   const now = Date.now()
+  const projectId = normalizeProjectId(card.projectId ?? fallbackProjectId)
   return {
     id: typeof card.id === 'string' && card.id ? card.id : randomUUID(),
     title: typeof card.title === 'string' && card.title.trim() ? card.title.trim() : 'Untitled task',
@@ -97,6 +122,7 @@ function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: 
     assignedWorker: optionalString(card.assignedWorker),
     reviewer: optionalString(card.reviewer),
     status: normalizeStatus(card.status),
+    projectId,
     missionId: optionalString(card.missionId),
     reportPath: optionalString(card.reportPath),
     createdBy: typeof card.createdBy === 'string' && card.createdBy ? card.createdBy : 'swarm2-kanban',
@@ -106,7 +132,8 @@ function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: 
 }
 
 export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard[] {
-  let cards = readKanbanFile().cards
+  const projectId = normalizeProjectId(filters.projectId)
+  let cards = readKanbanFile(projectId).cards
   if (filters.status) cards = cards.filter((card) => card.status === normalizeStatus(filters.status))
   if (filters.assignedWorker) cards = cards.filter((card) => card.assignedWorker === filters.assignedWorker)
   if (filters.reviewer) cards = cards.filter((card) => card.reviewer === filters.reviewer)
@@ -115,7 +142,8 @@ export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard
 }
 
 export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
-  const file = readKanbanFile()
+  const projectId = normalizeProjectId(input.projectId)
+  const file = readKanbanFile(projectId)
   const now = Date.now()
   const card = normalizeCard({
     id: randomUUID(),
@@ -125,32 +153,35 @@ export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmK
     assignedWorker: input.assignedWorker,
     reviewer: input.reviewer,
     status: input.status ?? 'backlog',
+    projectId,
     missionId: input.missionId,
     reportPath: input.reportPath,
     createdBy: input.createdBy ?? 'swarm2-kanban',
     createdAt: now,
     updatedAt: now,
-  })
+  }, projectId)
   file.cards.push(card)
-  writeKanbanFile(file)
+  writeKanbanFile(file, projectId)
   return card
 }
 
 export function updateSwarmKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
-  const file = readKanbanFile()
+  const projectId = normalizeProjectId(updates.projectId)
+  const file = readKanbanFile(projectId)
   const index = file.cards.findIndex((card) => card.id === cardId)
   if (index === -1) return null
-  const current = normalizeCard(file.cards[index])
+  const current = normalizeCard(file.cards[index], projectId)
   const next = normalizeCard({
     ...current,
     ...updates,
     id: current.id,
+    projectId: current.projectId,
     createdAt: current.createdAt,
     createdBy: current.createdBy,
     title: typeof updates.title === 'string' ? updates.title : current.title,
     updatedAt: Date.now(),
-  })
+  }, projectId)
   file.cards[index] = next
-  writeKanbanFile(file)
+  writeKanbanFile(file, projectId)
   return next
 }


### PR DESCRIPTION
## Summary
- derive active project from /api/workspace and expose projectSlug from PROJECTS.md catalog
- scope Tasks and Swarm2 task/kanban query keys, mutations, and API calls by projectId
- gate /swarm Swarm2 render until active project is resolved to prevent unscoped initial task/kanban requests
- add CLI readiness/project catalog and regression coverage

## Validation
- pnpm test src/screens/swarm2/swarm2-screen.test.ts src/screens/swarm2/swarm2-kanban-board.test.ts src/routes/api/-swarm-kanban.test.ts → 3 files / 21 tests passed
- pnpm test → 90 files / 599 tests passed
- pnpm build → built successfully
- browser dogfood /swarm: relevant task/kanban requests scoped; unscopedCount=0; projectIds=[analog-clock-servo]

Note: direct push to outsourc-e/hermes-workspace origin returned 403 for kaankirsan, so this PR is opened from kaankirsan fork.