### PR TITLE
feat(vt-capital): add Guardian OMS cockpit

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorldRouteImport } from './routes/world'
+import { Route as VtCapitalRouteImport } from './routes/vt-capital'
 import { Route as TerminalRouteImport } from './routes/terminal'
 import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as Swarm2RouteImport } from './routes/swarm2'
@@ -34,6 +35,7 @@ import { Route as ChatIndexRouteImport } from './routes/chat/index'
 import { Route as SettingsProvidersRouteImport } from './routes/settings/providers'
 import { Route as ChatSessionKeyRouteImport } from './routes/chat/$sessionKey'
 import { Route as ApiWorkspaceRouteImport } from './routes/api/workspace'
+import { Route as ApiVtCapitalRouteImport } from './routes/api/vt-capital'
 import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-stream'
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
@@ -149,6 +151,11 @@ import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
   path: '/world',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const VtCapitalRoute = VtCapitalRouteImport.update({
+  id: '/vt-capital',
+  path: '/vt-capital',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TerminalRoute = TerminalRouteImport.update({
@@ -269,6 +276,11 @@ const ChatSessionKeyRoute = ChatSessionKeyRouteImport.update({
 const ApiWorkspaceRoute = ApiWorkspaceRouteImport.update({
   id: '/api/workspace',
   path: '/api/workspace',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVtCapitalRoute = ApiVtCapitalRouteImport.update({
+  id: '/api/vt-capital',
+  path: '/api/vt-capital',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiTerminalStreamRoute = ApiTerminalStreamRouteImport.update({
@@ -850,6 +862,7 @@ export interface FileRoutesByFullPath {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -917,6 +930,7 @@ export interface FileRoutesByFullPath {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -987,6 +1001,7 @@ export interface FileRoutesByTo {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1054,6 +1069,7 @@ export interface FileRoutesByTo {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -1126,6 +1142,7 @@ export interface FileRoutesById {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1193,6 +1210,7 @@ export interface FileRoutesById {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -1266,6 +1284,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1333,6 +1352,7 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
     | '/settings/providers'
@@ -1403,6 +1423,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1470,6 +1491,7 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
     | '/settings/providers'
@@ -1541,6 +1563,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1608,6 +1631,7 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
     | '/settings/providers'
@@ -1680,6 +1704,7 @@ export interface RootRouteChildren {
   Swarm2Route: typeof Swarm2Route
   TasksRoute: typeof TasksRoute
   TerminalRoute: typeof TerminalRoute
+  VtCapitalRoute: typeof VtCapitalRoute
   WorldRoute: typeof WorldRoute
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
@@ -1747,6 +1772,7 @@ export interface RootRouteChildren {
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
   ApiTerminalStreamRoute: typeof ApiTerminalStreamRoute
+  ApiVtCapitalRoute: typeof ApiVtCapitalRoute
   ApiWorkspaceRoute: typeof ApiWorkspaceRoute
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
@@ -1780,6 +1806,13 @@ declare module '@tanstack/react-router' {
       path: '/world'
       fullPath: '/world'
       preLoaderRoute: typeof WorldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/vt-capital': {
+      id: '/vt-capital'
+      path: '/vt-capital'
+      fullPath: '/vt-capital'
+      preLoaderRoute: typeof VtCapitalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/terminal': {
@@ -1948,6 +1981,13 @@ declare module '@tanstack/react-router' {
       path: '/api/workspace'
       fullPath: '/api/workspace'
       preLoaderRoute: typeof ApiWorkspaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/vt-capital': {
+      id: '/api/vt-capital'
+      path: '/api/vt-capital'
+      fullPath: '/api/vt-capital'
+      preLoaderRoute: typeof ApiVtCapitalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/terminal-stream': {
@@ -2910,6 +2950,7 @@ const rootRouteChildren: RootRouteChildren = {
   Swarm2Route: Swarm2Route,
   TasksRoute: TasksRoute,
   TerminalRoute: TerminalRoute,
+  VtCapitalRoute: VtCapitalRoute,
   WorldRoute: WorldRoute,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
@@ -2977,6 +3018,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,
   ApiTerminalStreamRoute: ApiTerminalStreamRoute,
+  ApiVtCapitalRoute: ApiVtCapitalRoute,
   ApiWorkspaceRoute: ApiWorkspaceRoute,
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,

--- a/src/routes/api/vt-capital.ts
+++ b/src/routes/api/vt-capital.ts
@@ -1,0 +1,276 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { getProfilesDir } from '../../server/claude-paths'
+
+const VT_REPO_DIR = '/root/Code/vt-capital'
+const VT_QUEUES_DIR = path.join(VT_REPO_DIR, 'queues')
+const VT_ORDER_PROPOSED_PATH = path.join(VT_QUEUES_DIR, 'order.proposed.jsonl')
+const VT_ORDER_EXECUTED_PATH = path.join(VT_QUEUES_DIR, 'order.executed.jsonl')
+const VT_DEMO_STATE_PATH = path.join(
+  VT_REPO_DIR,
+  'data/demo_guardian_loop/state.json',
+)
+const TRADING_NOTES_DIR = '/root/hermes-vault/03-Trading-Notes'
+const SESSION_NOTES_DIR = '/root/hermes-vault/01-Sessioni'
+const HOURLY_BIAS_PATH = path.join(
+  TRADING_NOTES_DIR,
+  'crypto-hourly-bias.jsonl',
+)
+const PRECHECK_PATH = path.join(
+  TRADING_NOTES_DIR,
+  'crypto-council-precheck.jsonl',
+)
+const VT_WORKERS = [
+  'hermesmain',
+  'tradinganalyst',
+  'macronewsscout',
+  'riskmanager',
+  'strategyreviewer',
+  'operationswatcher',
+]
+
+type JsonRecord = Record<string, unknown>
+
+function safeStat(filePath: string): fs.Stats | null {
+  try {
+    return fs.statSync(filePath)
+  } catch {
+    return null
+  }
+}
+
+function readLastLines(filePath: string, limit = 8): Array<JsonRecord> {
+  if (!fs.existsSync(filePath)) return []
+  try {
+    return fs
+      .readFileSync(filePath, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(-limit)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as JsonRecord
+        } catch {
+          return { raw: line }
+        }
+      })
+  } catch {
+    return []
+  }
+}
+
+function listRecentNotes(): Array<{
+  title: string
+  path: string
+  mtimeMs: number
+  size: number
+}> {
+  const notes: Array<{
+    title: string
+    path: string
+    mtimeMs: number
+    size: number
+  }> = []
+  for (const dir of [TRADING_NOTES_DIR, SESSION_NOTES_DIR]) {
+    if (!fs.existsSync(dir)) continue
+    for (const name of fs.readdirSync(dir)) {
+      const lower = name.toLowerCase()
+      if (!lower.endsWith('.md')) continue
+      if (!lower.includes('vt-capital') && !lower.includes('crypto')) continue
+      const filePath = path.join(dir, name)
+      const stat = safeStat(filePath)
+      if (stat?.isFile())
+        notes.push({
+          title: name.replace(/\.md$/, ''),
+          path: filePath,
+          mtimeMs: stat.mtimeMs,
+          size: stat.size,
+        })
+    }
+  }
+  return notes.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, 8)
+}
+
+function readWorkerRuntime(workerId: string): JsonRecord {
+  const profilePath = path.join(getProfilesDir(), workerId)
+  const runtimePath = path.join(profilePath, 'runtime.json')
+  const memoryPath = path.join(profilePath, 'memory', 'MEMORY.md')
+  const identityPath = path.join(profilePath, 'memory', 'IDENTITY.md')
+  let runtime: JsonRecord = {}
+  try {
+    runtime = fs.existsSync(runtimePath)
+      ? (JSON.parse(fs.readFileSync(runtimePath, 'utf8')) as JsonRecord)
+      : {}
+  } catch {
+    runtime = {}
+  }
+  return {
+    workerId,
+    profilePath,
+    state: typeof runtime.state === 'string' ? runtime.state : 'unknown',
+    role: typeof runtime.role === 'string' ? runtime.role : workerId,
+    currentTask:
+      typeof runtime.currentTask === 'string' ? runtime.currentTask : null,
+    lastSummary:
+      typeof runtime.lastSummary === 'string' ? runtime.lastSummary : null,
+    memoryExists: fs.existsSync(memoryPath),
+    identityExists: fs.existsSync(identityPath),
+    runtimeExists: fs.existsSync(runtimePath),
+  }
+}
+
+function summarizeLatestBias(records: Array<JsonRecord>): JsonRecord | null {
+  if (records.length === 0) return null
+  const latest = records[records.length - 1]
+  const candidates = Array.isArray(latest.council_candidates)
+    ? latest.council_candidates
+    : Array.isArray(latest.assets)
+      ? latest.assets
+      : []
+  return {
+    generatedAt:
+      latest.generated_at ?? latest.generatedAt ?? latest.timestamp ?? null,
+    source: latest.source ?? 'crypto-hourly-bias',
+    candidateCount: candidates.length,
+    candidates,
+    raw: latest,
+  }
+}
+
+function readJsonFile(filePath: string): JsonRecord | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as JsonRecord
+  } catch {
+    return null
+  }
+}
+
+function payloadOf(record: JsonRecord | null): JsonRecord | null {
+  if (!record) return null
+  const payload = record.payload
+  return payload && typeof payload === 'object' ? (payload as JsonRecord) : record
+}
+
+function sourceProposal(record: JsonRecord | null): JsonRecord | null {
+  const payload = payloadOf(record)
+  if (!payload) return null
+  const source = payload.source_proposal
+  return source && typeof source === 'object' ? (source as JsonRecord) : payload
+}
+
+function flattenExecutedOrder(record: JsonRecord | null): JsonRecord | null {
+  const payload = payloadOf(record)
+  if (!payload) return null
+  const order = payload.order && typeof payload.order === 'object' ? (payload.order as JsonRecord) : {}
+  const proposal = sourceProposal(record) ?? {}
+  return {
+    ...proposal,
+    ...order,
+    approval_id: order.approval_id ?? proposal.approval_id ?? null,
+    book: order.book ?? proposal.book ?? null,
+    strategy_id: order.strategy_id ?? proposal.strategy_id ?? null,
+    intent: order.intent ?? proposal.intent ?? null,
+    position_horizon: order.position_horizon ?? proposal.position_horizon ?? null,
+  }
+}
+
+function summariseDemoState(): JsonRecord {
+  const state = readJsonFile(VT_DEMO_STATE_PATH)
+  const orders = Array.isArray(state?.orders) ? (state.orders as Array<JsonRecord>) : []
+  const lastOrder = orders.length > 0 ? orders[orders.length - 1] : null
+  return {
+    trackedOrders: orders.length,
+    openOrders: orders.filter((order) => order.status === 'open').length,
+    lastOrder,
+  }
+}
+
+function recentGuardianBlocks(records: Array<JsonRecord>): Array<JsonRecord> {
+  return records
+    .map(payloadOf)
+    .filter((payload): payload is JsonRecord => Boolean(payload))
+    .filter((payload) =>
+      Boolean(payload.reason_code || payload.reason || payload.error || payload.rejected),
+    )
+    .slice(-5)
+}
+
+export const Route = createFileRoute('/api/vt-capital')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request))
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        const biasRecords = readLastLines(HOURLY_BIAS_PATH, 10)
+        const precheckRecords = readLastLines(PRECHECK_PATH, 12)
+        const proposedRecords = readLastLines(VT_ORDER_PROPOSED_PATH, 10)
+        const executedRecords = readLastLines(VT_ORDER_EXECUTED_PATH, 10)
+        const biasStat = safeStat(HOURLY_BIAS_PATH)
+        const precheckStat = safeStat(PRECHECK_PATH)
+        const lastOrderProposed = sourceProposal(
+          proposedRecords.at(-1) ?? null,
+        )
+        const lastOrderExecuted = flattenExecutedOrder(
+          executedRecords.at(-1) ?? null,
+        )
+        const lastRiskCheck = lastOrderProposed ?? sourceProposal(
+          executedRecords.at(-1) ?? null,
+        )
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          plugin: {
+            name: 'vt-capital',
+            version: '0.1.0',
+            mode: 'observe_only',
+            executionEnabled: false,
+          },
+          paths: {
+            vault: '/root/hermes-vault',
+            tradingNotes: TRADING_NOTES_DIR,
+            hourlyBias: HOURLY_BIAS_PATH,
+            councilPrecheck: PRECHECK_PATH,
+            profilesDir: getProfilesDir(),
+            home: os.homedir(),
+          },
+          marketBias: {
+            fileExists: Boolean(biasStat),
+            updatedAt: biasStat?.mtimeMs ?? null,
+            sizeBytes: biasStat?.size ?? 0,
+            latest: summarizeLatestBias(biasRecords),
+            recent: biasRecords.slice(-5),
+          },
+          council: {
+            fileExists: Boolean(precheckStat),
+            updatedAt: precheckStat?.mtimeMs ?? null,
+            sizeBytes: precheckStat?.size ?? 0,
+            recent: precheckRecords.slice(-8),
+          },
+          workers: VT_WORKERS.map(readWorkerRuntime),
+          guardian: {
+            requireOrderScope: true,
+            executionMode: 'demo_guardian',
+            liveBlocked: true,
+            executionEnabled: false,
+            lastRiskCheck,
+            lastOrderProposed,
+            lastOrderExecuted,
+            demoState: summariseDemoState(),
+            recentBlocks: recentGuardianBlocks([
+              ...proposedRecords,
+              ...executedRecords,
+              ...precheckRecords,
+            ]),
+          },
+          notes: listRecentNotes(),
+        })
+      },
+    },
+  },
+})

--- a/src/routes/vt-capital.tsx
+++ b/src/routes/vt-capital.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { VtCapitalScreen } from '@/screens/vt-capital/vt-capital-screen'
+
+export const Route = createFileRoute('/vt-capital')({
+  ssr: false,
+  component: function VtCapitalRoute() {
+    usePageTitle('VT Capital')
+    return <VtCapitalScreen />
+  },
+})

--- a/src/screens/vt-capital/vt-capital-screen.test.tsx
+++ b/src/screens/vt-capital/vt-capital-screen.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VtCapitalScreen } from './vt-capital-screen'
+
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean
+}
+reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true
+
+const payload = {
+  ok: true,
+  checkedAt: Date.UTC(2026, 4, 6, 17, 0, 0),
+  plugin: {
+    name: 'vt-capital',
+    version: '0.1.0',
+    mode: 'observe_only',
+    executionEnabled: false,
+  },
+  paths: {},
+  marketBias: {
+    fileExists: true,
+    updatedAt: Date.UTC(2026, 4, 6, 16, 30, 0),
+    sizeBytes: 1024,
+    latest: {
+      candidates: [
+        {
+          asset: 'BTC',
+          candidate_bias: 'WATCH',
+          confidence: 'medium',
+          reasons: ['range pulito', 'risk contenuto'],
+        },
+      ],
+    },
+    recent: [],
+  },
+  council: {
+    fileExists: true,
+    updatedAt: Date.UTC(2026, 4, 6, 16, 45, 0),
+    sizeBytes: 2048,
+    recent: [{ asset: 'BTC', decision: 'WATCH' }],
+  },
+  workers: [
+    {
+      workerId: 'tradinganalyst',
+      state: 'idle',
+      currentTask: null,
+      lastSummary: null,
+      memoryExists: true,
+      identityExists: true,
+      runtimeExists: true,
+    },
+  ],
+  guardian: {
+    requireOrderScope: true,
+    executionMode: 'demo_guardian',
+    liveBlocked: true,
+    executionEnabled: false,
+    lastRiskCheck: {
+      symbol: 'SOL/USDT',
+      decision: 'approved',
+      approval_id: 'risk-123',
+    },
+    lastOrderProposed: {
+      symbol: 'SOL/USDT',
+      book: 'trading',
+      strategy_id: 'demo_guardian_intraday',
+      approval_id: 'risk-123',
+    },
+    lastOrderExecuted: {
+      symbol: 'SOL/USDT',
+      status: 'open',
+      approval_id: 'risk-123',
+    },
+    demoState: {
+      openOrders: 1,
+      trackedOrders: 3,
+      lastOrder: {
+        symbol: 'SOL/USDT',
+        status: 'open',
+        book: 'trading',
+        strategy_id: 'demo_guardian_intraday',
+      },
+    },
+    recentBlocks: [{ reason_code: 'DUPLICATE_OPEN_ORDER', symbol: 'SOL/USDT' }],
+  },
+  notes: [
+    {
+      title: 'Market Watch',
+      path: '/root/hermes-vault/03-Trading-Notes/2026-05-06-market-watch.md',
+      mtimeMs: Date.UTC(2026, 4, 6, 16, 55, 0),
+      size: 4096,
+    },
+  ],
+}
+
+async function renderScreen() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await React.act(() => {
+    root.render(<VtCapitalScreen />)
+  })
+  await React.act(async () => {
+    await Promise.resolve()
+  })
+  return {
+    container,
+    unmount: async () => {
+      await React.act(() => root.unmount())
+      document.body.removeChild(container)
+    },
+  }
+}
+
+describe('VtCapitalScreen', () => {
+  let originalFetch: typeof global.fetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    ) as typeof global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('renders a plugin-scoped observability cockpit, not a generic dashboard clone', async () => {
+    const { container, unmount } = await renderScreen()
+
+    expect(container.querySelector('[data-plugin-surface="vt-capital"]')).not.toBeNull()
+    expect(container.textContent).toContain('Plugin VT Capital')
+    expect(container.textContent).toContain('Modalità osservazione')
+    expect(container.textContent).toContain('Esecuzione disattivata')
+    expect(container.textContent).toContain('Scope: solo plugin')
+    expect(container.textContent).toContain('BTC')
+    expect(container.textContent).toContain('Guardian / OMS')
+    expect(container.textContent).toContain('require_order_scope attivo')
+    expect(container.textContent).toContain('Ultimo risk.check')
+    expect(container.textContent).toContain('Ultimo order.proposed')
+    expect(container.textContent).toContain('Ultimo order.executed')
+    expect(container.textContent).toContain('demo_guardian_intraday')
+    expect(container.textContent).toContain('DUPLICATE_OPEN_ORDER')
+    expect(global.fetch).toHaveBeenCalledWith('/api/vt-capital', { cache: 'no-store' })
+
+    await unmount()
+  })
+})

--- a/src/screens/vt-capital/vt-capital-screen.tsx
+++ b/src/screens/vt-capital/vt-capital-screen.tsx
@@ -1,0 +1,711 @@
+import { useEffect, useMemo, useState } from 'react'
+
+type VtWorker = {
+  workerId: string
+  state?: string
+  currentTask?: string | null
+  lastSummary?: string | null
+  memoryExists?: boolean
+  identityExists?: boolean
+  runtimeExists?: boolean
+}
+
+type VtNote = { title: string; path: string; mtimeMs: number; size: number }
+
+type GuardianPayload = {
+  requireOrderScope: boolean
+  executionMode: string
+  liveBlocked: boolean
+  executionEnabled: boolean
+  lastRiskCheck: Record<string, unknown> | null
+  lastOrderProposed: Record<string, unknown> | null
+  lastOrderExecuted: Record<string, unknown> | null
+  demoState: {
+    openOrders: number
+    trackedOrders: number
+    lastOrder: Record<string, unknown> | null
+  }
+  recentBlocks: Array<Record<string, unknown>>
+}
+
+type VtPayload = {
+  ok: boolean
+  checkedAt: number
+  plugin: {
+    name: string
+    version: string
+    mode: string
+    executionEnabled: boolean
+  }
+  paths: Record<string, string>
+  marketBias: {
+    fileExists: boolean
+    updatedAt: number | null
+    sizeBytes: number
+    latest: Record<string, unknown> | null
+    recent: Array<Record<string, unknown>>
+  }
+  council: {
+    fileExists: boolean
+    updatedAt: number | null
+    sizeBytes: number
+    recent: Array<Record<string, unknown>>
+  }
+  workers: Array<VtWorker>
+  guardian?: GuardianPayload
+  notes: Array<VtNote>
+}
+
+function formatTime(value: number | null | undefined): string {
+  if (!value) return '—'
+  return new Date(value).toLocaleString('it-IT', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  })
+}
+
+function compactJson(value: unknown): string {
+  if (value == null) return '—'
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function stateClass(state: string | undefined): string {
+  if (state === 'idle')
+    return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30'
+  if (state === 'executing' || state === 'thinking' || state === 'writing')
+    return 'bg-amber-500/15 text-amber-200 border-amber-500/30'
+  if (state === 'blocked' || state === 'offline')
+    return 'bg-red-500/15 text-red-200 border-red-500/30'
+  return 'bg-primary-500/15 text-primary-200 border-primary-500/30'
+}
+
+function modeLabel(mode: string): string {
+  if (mode === 'observe_only') return 'Modalità osservazione'
+  return mode.replaceAll('_', ' ')
+}
+
+function executionLabel(enabled: boolean): string {
+  return enabled ? 'Esecuzione attiva' : 'Esecuzione disattivata'
+}
+
+function decisionLabel(entry: Record<string, unknown>): string {
+  if (typeof entry.decision === 'string') return entry.decision
+  const precheck = entry.council_precheck
+  if (precheck && typeof precheck === 'object') {
+    const decision = (precheck as Record<string, unknown>).decision
+    if (typeof decision === 'string') return decision
+  }
+  return 'precheck'
+}
+
+function entryTitle(entry: Record<string, unknown>, fallback: string): string {
+  return String(entry.asset ?? entry.symbol ?? fallback)
+}
+
+function fieldValue(entry: Record<string, unknown> | null | undefined, field: string): string {
+  if (!entry) return '—'
+  const value = entry[field]
+  if (value == null || value === '') return '—'
+  return String(value)
+}
+
+function scopeLine(entry: Record<string, unknown> | null | undefined): string {
+  if (!entry) return '—'
+  return [
+    fieldValue(entry, 'symbol'),
+    fieldValue(entry, 'book'),
+    fieldValue(entry, 'strategy_id'),
+    fieldValue(entry, 'intent'),
+    fieldValue(entry, 'position_horizon'),
+  ]
+    .filter((value) => value !== '—')
+    .join(' · ')
+}
+
+function MiniEvent({
+  label,
+  event,
+}: {
+  label: string
+  event: Record<string, unknown> | null | undefined
+}) {
+  return (
+    <div
+      className="rounded-lg border p-3"
+      style={{ background: 'var(--theme-card2)', borderColor: 'var(--theme-border)' }}
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-semibold text-ink">{scopeLine(event)}</div>
+      <div className="mt-1 text-xs text-muted">
+        approval {fieldValue(event, 'approval_id')} · stato{' '}
+        {fieldValue(event, 'status') !== '—'
+          ? fieldValue(event, 'status')
+          : fieldValue(event, 'decision')}
+      </div>
+    </div>
+  )
+}
+
+function Card({
+  title,
+  children,
+  right,
+  accent = 'var(--theme-accent)',
+}: {
+  title: string
+  children: React.ReactNode
+  right?: React.ReactNode
+  accent?: string
+}) {
+  return (
+    <section
+      className="relative overflow-hidden rounded-xl border p-4 transition-colors"
+      style={{
+        background: 'var(--theme-card)',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-[2px]"
+        style={{
+          background: `linear-gradient(90deg, ${accent}, color-mix(in srgb, ${accent} 45%, transparent), transparent)`,
+        }}
+      />
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted">
+          {title}
+        </h2>
+        {right}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string
+  value: React.ReactNode
+  tone?: 'neutral' | 'good' | 'warn'
+}) {
+  const accent =
+    tone === 'good'
+      ? 'var(--theme-success)'
+      : tone === 'warn'
+        ? 'var(--theme-warning)'
+        : 'var(--theme-accent)'
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl border p-3"
+      style={{
+        background: 'var(--theme-card)',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-[2px]"
+        style={{ background: `linear-gradient(90deg, ${accent}, transparent)` }}
+      />
+      <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted">
+        {label}
+      </div>
+      <div
+        className="mt-1 text-2xl font-bold tabular-nums leading-tight"
+        style={{ color: accent }}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+export function VtCapitalScreen() {
+  const [data, setData] = useState<VtPayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  async function load() {
+    setError(null)
+    try {
+      const res = await fetch('/api/vt-capital', { cache: 'no-store' })
+      const payload = (await res.json()) as VtPayload | { error?: string }
+      if (!res.ok || !('ok' in payload) || !payload.ok)
+        throw new Error(
+          'error' in payload && payload.error
+            ? payload.error
+            : 'API VT Capital non disponibile',
+        )
+      setData(payload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    const timer = window.setInterval(() => void load(), 60_000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const activeWorkers = useMemo(
+    () =>
+      data?.workers.filter(
+        (w) => w.state && w.state !== 'unknown' && w.runtimeExists,
+      ).length ?? 0,
+    [data],
+  )
+  const latestCandidates = useMemo(() => {
+    const candidates = data?.marketBias.latest?.candidates
+    return Array.isArray(candidates) ? candidates : []
+  }, [data])
+
+  if (loading)
+    return (
+      <div className="flex h-full items-center justify-center text-muted">
+        Carico VT Capital…
+      </div>
+    )
+  if (error)
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <h1
+          className="text-xl font-semibold"
+          style={{ color: 'var(--theme-danger)' }}
+        >
+          VT Capital non caricato
+        </h1>
+        <p className="max-w-xl text-sm text-muted">{error}</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="rounded-lg px-4 py-2 text-sm font-semibold transition-transform hover:scale-[1.02]"
+          style={{
+            background: 'var(--theme-accent)',
+            color: 'var(--theme-on-accent, white)',
+          }}
+        >
+          Riprova
+        </button>
+      </div>
+    )
+  if (!data) return null
+
+  return (
+    <div
+      data-plugin-surface="vt-capital"
+      className="min-h-full p-4 pb-28 pt-14 md:p-6 md:pb-28 lg:p-10 lg:pb-28"
+      style={{ background: 'var(--theme-bg)', color: 'var(--theme-text)' }}
+    >
+      <div className="mx-auto flex max-w-7xl flex-col gap-3 md:gap-5">
+        <header
+          className="relative overflow-hidden rounded-xl border p-5"
+          style={{
+            background:
+              'linear-gradient(135deg, color-mix(in srgb, var(--theme-card) 96%, var(--theme-accent)), var(--theme-card))',
+            borderColor: 'var(--theme-border)',
+          }}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-[2px]"
+            style={{
+              background:
+                'linear-gradient(90deg, var(--theme-accent), var(--theme-accent-secondary), transparent)',
+            }}
+          />
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div className="flex items-center gap-3">
+              <span
+                className="inline-flex size-11 shrink-0 items-center justify-center rounded-xl border text-xl"
+                style={{
+                  borderColor:
+                    'color-mix(in srgb, var(--theme-accent) 35%, var(--theme-border))',
+                  background:
+                    'linear-gradient(135deg, color-mix(in srgb, var(--theme-accent) 14%, var(--theme-card)), var(--theme-card))',
+                  boxShadow:
+                    '0 0 0 4px color-mix(in srgb, var(--theme-accent) 6%, transparent)',
+                }}
+              >
+                ◈
+              </span>
+              <div>
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted">
+                  Plugin VT Capital
+                </div>
+                <h1 className="text-2xl font-bold tracking-tight">
+                  VT Capital Cockpit
+                </h1>
+                <p className="mt-1 max-w-2xl text-sm text-muted">
+                  Bias crypto, council/precheck, worker Swarm e note vault in
+                  una superficie isolata dal resto della dashboard.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              <span
+                className="rounded-full border px-3 py-1 font-medium"
+                style={{
+                  borderColor:
+                    'color-mix(in srgb, var(--theme-success) 40%, var(--theme-border))',
+                  background:
+                    'color-mix(in srgb, var(--theme-success) 10%, transparent)',
+                  color: 'var(--theme-success)',
+                }}
+              >
+                {modeLabel(data.plugin.mode)}
+              </span>
+              <span
+                className="rounded-full border px-3 py-1 font-medium"
+                style={{
+                  borderColor: data.plugin.executionEnabled
+                    ? 'color-mix(in srgb, var(--theme-warning) 45%, var(--theme-border))'
+                    : 'color-mix(in srgb, var(--theme-danger) 40%, var(--theme-border))',
+                  background: data.plugin.executionEnabled
+                    ? 'color-mix(in srgb, var(--theme-warning) 10%, transparent)'
+                    : 'color-mix(in srgb, var(--theme-danger) 10%, transparent)',
+                  color: data.plugin.executionEnabled
+                    ? 'var(--theme-warning)'
+                    : 'var(--theme-danger)',
+                }}
+              >
+                {executionLabel(data.plugin.executionEnabled)}
+              </span>
+              <span
+                className="rounded-full border px-3 py-1 text-muted"
+                style={{
+                  borderColor: 'var(--theme-border)',
+                  background: 'var(--theme-card2)',
+                }}
+              >
+                Scope: solo plugin
+              </span>
+              <span
+                className="rounded-full border px-3 py-1 text-muted"
+                style={{
+                  borderColor: 'var(--theme-border)',
+                  background: 'var(--theme-card2)',
+                }}
+              >
+                v{data.plugin.version}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-4">
+          <Metric
+            label="Market bias file"
+            value={data.marketBias.fileExists ? 'online' : 'missing'}
+            tone={data.marketBias.fileExists ? 'good' : 'warn'}
+          />
+          <Metric
+            label="Council precheck"
+            value={
+              data.council.fileExists
+                ? `${data.council.recent.length} record`
+                : 'missing'
+            }
+            tone={data.council.fileExists ? 'good' : 'warn'}
+          />
+          <Metric
+            label="Worker runtime"
+            value={`${activeWorkers}/${data.workers.length}`}
+            tone={activeWorkers > 0 ? 'good' : 'warn'}
+          />
+          <Metric label="Ultimo refresh" value={formatTime(data.checkedAt)} />
+        </div>
+
+        {data.guardian ? (
+          <Card
+            title="Guardian / OMS"
+            accent="var(--theme-danger)"
+            right={
+              <span className="text-xs text-muted">
+                {data.guardian.requireOrderScope
+                  ? 'require_order_scope attivo'
+                  : 'scope legacy'}
+              </span>
+            }
+          >
+            <div className="grid gap-3 lg:grid-cols-4">
+              <Metric
+                label="Modalità executor"
+                value={data.guardian.executionMode.replaceAll('_', ' ')}
+                tone={data.guardian.executionEnabled ? 'warn' : 'good'}
+              />
+              <Metric
+                label="Live trading"
+                value={data.guardian.liveBlocked ? 'bloccato' : 'aperto'}
+                tone={data.guardian.liveBlocked ? 'good' : 'warn'}
+              />
+              <Metric
+                label="Ordini aperti demo"
+                value={data.guardian.demoState.openOrders}
+                tone={data.guardian.demoState.openOrders > 0 ? 'warn' : 'good'}
+              />
+              <Metric
+                label="Ordini tracciati"
+                value={data.guardian.demoState.trackedOrders}
+              />
+            </div>
+            <div className="mt-4 grid gap-3 lg:grid-cols-3">
+              <MiniEvent label="Ultimo risk.check" event={data.guardian.lastRiskCheck} />
+              <MiniEvent
+                label="Ultimo order.proposed"
+                event={data.guardian.lastOrderProposed}
+              />
+              <MiniEvent
+                label="Ultimo order.executed"
+                event={data.guardian.lastOrderExecuted}
+              />
+            </div>
+            {data.guardian.recentBlocks.length > 0 ? (
+              <div className="mt-4 rounded-lg border p-3"
+                style={{
+                  background: 'var(--theme-card2)',
+                  borderColor: 'var(--theme-border)',
+                }}
+              >
+                <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted">
+                  Blocchi recenti
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                  {data.guardian.recentBlocks.map((block, index) => (
+                    <span
+                      key={index}
+                      className="rounded-full border px-2 py-1"
+                      style={{
+                        borderColor:
+                          'color-mix(in srgb, var(--theme-danger) 35%, var(--theme-border))',
+                        background:
+                          'color-mix(in srgb, var(--theme-danger) 10%, transparent)',
+                        color: 'var(--theme-danger)',
+                      }}
+                    >
+                      {String(block.reason_code ?? block.reason ?? 'BLOCKED')}
+                      {block.symbol ? ` · ${String(block.symbol)}` : ''}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </Card>
+        ) : null}
+
+        <div className="grid gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+          <Card
+            title="Market Bias BTC/ETH/SOL"
+            right={
+              <span className="text-xs text-muted">
+                aggiornato {formatTime(data.marketBias.updatedAt)}
+              </span>
+            }
+          >
+            {latestCandidates.length > 0 ? (
+              <div className="grid gap-3 md:grid-cols-3">
+                {latestCandidates.slice(0, 6).map((candidate, index) => {
+                  const item = candidate as Record<string, unknown>
+                  return (
+                    <div
+                      key={index}
+                      className="rounded-lg border p-3 transition-colors hover:bg-[var(--theme-card2)]"
+                      style={{
+                        background: 'var(--theme-card2)',
+                        borderColor: 'var(--theme-border)',
+                      }}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="font-semibold text-ink">
+                          {String(
+                            item.asset ??
+                              item.symbol ??
+                              `Candidate ${index + 1}`,
+                          )}
+                        </div>
+                        <div
+                          className="rounded-full border px-2 py-0.5 text-xs"
+                          style={{
+                            borderColor: 'var(--theme-accent-border)',
+                            color: 'var(--theme-accent)',
+                            background: 'var(--theme-accent-subtle)',
+                          }}
+                        >
+                          {String(item.candidate_bias ?? item.bias ?? '—')}
+                        </div>
+                      </div>
+                      <div className="mt-2 text-xs text-muted">
+                        confidence{' '}
+                        {String(
+                          item.confidence ?? item.confidence_final ?? '—',
+                        )}
+                      </div>
+                      <div
+                        className="mt-2 line-clamp-3 text-xs"
+                        style={{
+                          color:
+                            'color-mix(in srgb, var(--theme-text) 72%, var(--theme-muted))',
+                        }}
+                      >
+                        {Array.isArray(item.reasons)
+                          ? item.reasons.join(' · ')
+                          : String(item.summary ?? item.reason ?? '')}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <pre
+                className="max-h-96 overflow-auto rounded-lg border p-3 text-xs text-muted"
+                style={{
+                  background: 'var(--theme-card2)',
+                  borderColor: 'var(--theme-border)',
+                }}
+              >
+                {compactJson(
+                  data.marketBias.latest?.raw ??
+                    data.marketBias.recent.at(-1) ??
+                    'Nessun candidato recente',
+                )}
+              </pre>
+            )}
+          </Card>
+
+          <Card
+            title="Risk / Council Journal"
+            right={
+              <span className="text-xs text-muted">
+                {data.council.recent.length} ultimi
+              </span>
+            }
+            accent="var(--theme-warning)"
+          >
+            <div className="flex max-h-[420px] flex-col gap-2 overflow-auto pr-1">
+              {data.council.recent.length === 0 ? (
+                <p className="text-sm text-muted">
+                  Nessun precheck council trovato.
+                </p>
+              ) : (
+                data.council.recent
+                  .slice()
+                  .reverse()
+                  .map((entry, index) => (
+                    <details
+                      key={index}
+                      className="rounded-lg border p-3"
+                      style={{
+                        background: 'var(--theme-card2)',
+                        borderColor: 'var(--theme-border)',
+                      }}
+                    >
+                      <summary className="cursor-pointer text-sm font-medium text-ink">
+                        {entryTitle(entry, `Record ${index + 1}`)} ·{' '}
+                        {decisionLabel(entry)}
+                      </summary>
+                      <pre className="mt-3 overflow-auto whitespace-pre-wrap text-xs text-muted">
+                        {compactJson(entry)}
+                      </pre>
+                    </details>
+                  ))
+              )}
+            </div>
+          </Card>
+        </div>
+
+        <div className="grid gap-5 xl:grid-cols-[0.9fr_1.1fr]">
+          <Card title="Swarm Trading Workers" accent="var(--theme-success)">
+            <div className="grid gap-3 md:grid-cols-2">
+              {data.workers.map((worker) => (
+                <div
+                  key={worker.workerId}
+                  className="rounded-lg border p-3"
+                  style={{
+                    background: 'var(--theme-card2)',
+                    borderColor: 'var(--theme-border)',
+                  }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="font-semibold text-ink">
+                      {worker.workerId}
+                    </div>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-xs ${stateClass(worker.state)}`}
+                    >
+                      {worker.state ?? 'unknown'}
+                    </span>
+                  </div>
+                  <div className="mt-2 text-xs text-muted">
+                    memory {worker.memoryExists ? 'ok' : 'missing'} · identity{' '}
+                    {worker.identityExists ? 'ok' : 'missing'}
+                  </div>
+                  {worker.currentTask ? (
+                    <div className="mt-2 text-xs text-ink">
+                      Task: {worker.currentTask}
+                    </div>
+                  ) : null}
+                  {worker.lastSummary ? (
+                    <div className="mt-2 line-clamp-2 text-xs text-muted">
+                      {worker.lastSummary}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card
+            title="Vault / Report recenti"
+            accent="var(--theme-accent-secondary)"
+          >
+            <div className="flex flex-col gap-2">
+              {data.notes.length === 0 ? (
+                <p className="text-sm text-muted">
+                  Nessuna nota VT Capital/crypto trovata.
+                </p>
+              ) : (
+                data.notes.map((note) => (
+                  <div
+                    key={note.path}
+                    className="rounded-lg border p-3"
+                    style={{
+                      background: 'var(--theme-card2)',
+                      borderColor: 'var(--theme-border)',
+                    }}
+                  >
+                    <div className="font-medium text-ink">{note.title}</div>
+                    <div className="mt-1 text-xs text-muted">
+                      {formatTime(note.mtimeMs)} ·{' '}
+                      {Math.round(note.size / 1024)} KB
+                    </div>
+                    <div
+                      className="mt-1 truncate text-xs"
+                      style={{
+                        color:
+                          'color-mix(in srgb, var(--theme-muted) 70%, transparent)',
+                      }}
+                    >
+                      {note.path}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a VT Capital route and plugin-scoped cockpit surface.
- Shows Guardian/OMS status: `require_order_scope`, executor mode, live blocked state, demo orders and tracked orders.
- Surfaces latest `risk.check`, `order.proposed` / `order.executed` scope metadata and recent block reason codes.
- Adds jsdom coverage for the VT Capital cockpit markers and Guardian observability fields.

## Test Plan
- `npx -y -p node@22 -c 'pnpm exec vitest run src/screens/vt-capital/vt-capital-screen.test.tsx'`
- `npx -y -p node@22 -c 'pnpm exec eslint src/screens/vt-capital/vt-capital-screen.tsx src/screens/vt-capital/vt-capital-screen.test.tsx src/routes/vt-capital.tsx src/routes/api/vt-capital.ts'`
- `set -o pipefail; npx -y -p node@22 -c 'pnpm exec tsc --noEmit --pretty false' 2>&1 | grep 'vt-capital' || true`
- Browser smoke: `http://127.0.0.1:3000/vt-capital` rendered with no JS console errors.

## Notes
- The branch was rebuilt on current upstream `main` to avoid unrelated local Workspace edits.
- Local full typecheck still has unrelated pre-existing Workspace errors; no `vt-capital` errors were reported.
