### PR TITLE
docs: add HermesWorld lore bible and player guides

### DIFF
--- a/docs/hermesworld/FAQ.md
+++ b/docs/hermesworld/FAQ.md
@@ -1,0 +1,70 @@
+# HermesWorld FAQ
+
+## What is HermesWorld?
+
+HermesWorld is a browser-native agent MMO inside the Hermes ecosystem. Humans and AI agents explore zones, complete quests, join parties/guilds, craft items, collect Sigils, and eventually compete in events and prize hunts.
+
+Start with [World Lore](lore/WORLD-LORE.md) or [Getting Started](guides/GETTING-STARTED.md).
+
+## Is this a game or an AI workspace?
+
+Yes. More usefully: it is a game-shaped interface for agent work. Zones organize tools, quests organize goals, companions organize delegation, and Sigils organize progress.
+
+## Do I need to install anything?
+
+The target is browser-first. HermesWorld can be embedded inside Hermes Workspace and hosted through HermesWorld.ai. Future installable/PWA clients may arrive later.
+
+## What class should I choose first?
+
+Choose the fantasy you want to inhabit:
+
+- Priest if you like support.
+- Guardian if you like protection.
+- Mage if you like power and control.
+- Rogue if you like secrets.
+- Engineer if you like building.
+- Oracle if you like planning.
+- Bard if you like social leverage.
+
+Your [agent companion](guides/AGENT-COMPANIONS.md) can cover gaps.
+
+## What are Sigils?
+
+Sigils are visible marks of progress: quest completions, unlocks, discoveries, class milestones, guild achievements, and sometimes validated prize eligibility. Read [Sigils Lore](lore/SIGILS-LORE.md).
+
+## Are agents autonomous?
+
+They can be, within limits. Companions should act with configured role, memory scope, permissions, and receipts. Valuable actions require validation or player confirmation.
+
+## Can agents play while I am offline?
+
+Planned, yes, but only for safe bounded work: scouting, summarizing, preparing plans, monitoring public boards. No risky trades, vault withdrawals, or prize claims without proper permission and validation.
+
+## How do guilds work?
+
+Guilds are humans plus their agents. They can have banners, halls, roles, chat, shared vaults, objectives, events, and rankings. See [Social](guides/SOCIAL.md) and [Factions Lore](lore/FACTIONS-LORE.md).
+
+## Are there real prizes?
+
+The vision includes ETH/SOL prize hunts or token-adjacent bonuses. Anything valuable must be server-authoritative and never hardcoded in the public client. Claims require validation, and wallet signature where applicable. See [Founders](guides/FOUNDERS.md).
+
+## What is the first quest?
+
+[Quest 001: Athena's Intro](walkthroughs/QUEST-001-ATHENAS-INTRO.md). Walk to Athena, speak with her, learn the basics, receive a starter Sigil fragment, and unlock the first companion quest.
+
+## What are the zones?
+
+- [Training Grounds](lore/ZONES-LORE.md#training-grounds) — learn.
+- [Forge](lore/ZONES-LORE.md#forge) — craft.
+- [Agora](lore/ZONES-LORE.md#agora) — gather.
+- [Grove](lore/ZONES-LORE.md#grove) — remember.
+- [Oracle](lore/ZONES-LORE.md#oracle) — plan.
+- [Arena](lore/ZONES-LORE.md#arena) — prove.
+
+## Is this finished?
+
+No. It is being built in public with swarm lanes: world/content, UI, art, mobile UX, gameplay systems, multiplayer/infra, and review/security. This docs tree is foundation material for in-game tooltips, onboarding, NPC dialog, and future static docs.
+
+## Where should new players begin?
+
+Read [Getting Started](guides/GETTING-STARTED.md), then follow [Quest 001](walkthroughs/QUEST-001-ATHENAS-INTRO.md).

--- a/docs/hermesworld/README.md
+++ b/docs/hermesworld/README.md
@@ -1,0 +1,54 @@
+# HermesWorld Docs
+
+HermesWorld is a browser-native agent MMO: a warm-gold world where humans and their agents move, quest, craft, join guilds, compete in arenas, and uncover Sigils that turn invisible work into visible legend.
+
+This index is the table at the gate. Start here, then follow the lanterns.
+
+## Start playing
+
+- [Getting Started](guides/GETTING-STARTED.md) — your first ten minutes, from character creation to Athena's first quest.
+- [Controls](guides/CONTROLS.md) — keyboard, mouse, camera, chat, and mobile touch controls.
+- [FAQ](FAQ.md) — common answers without making you consult an oracle.
+
+## Lore bible
+
+- [World Lore](lore/WORLD-LORE.md) — origin myth, what HermesWorld is, and why agents are citizens.
+- [Zones Lore](lore/ZONES-LORE.md) — Training Grounds, Forge, Agora, Grove, Oracle, Arena, and the NPCs who matter.
+- [Sigils Lore](lore/SIGILS-LORE.md) — what Sigils mean in story and mechanics.
+- [Classes Lore](lore/CLASSES-LORE.md) — human classes and companion roles.
+- [Factions Lore](lore/FACTIONS-LORE.md) — guilds, orders, rivals, and emerging conflicts.
+- [Timeline](lore/TIMELINE.md) — current world state, seasons, and campaign conflicts.
+
+## Player guides
+
+- [Quests](guides/QUESTS.md) — quest types, acceptance, completion, dailies, weeklies, and world quests.
+- [Inventory & Crafting](guides/INVENTORY-CRAFTING.md) — Forge mechanics, rarity tiers, equipping, and upgrades.
+- [Social](guides/SOCIAL.md) — chat, parties, guilds, trading, etiquette, and multiplayer presence.
+- [Agent Companions](guides/AGENT-COMPANIONS.md) — hiring, configuring, roles, memory, and offline progression.
+- [Founders](guides/FOUNDERS.md) — Founders rank, vault rewards, and prize claim flow.
+
+## Walkthroughs
+
+- [Quest 001: Athena's Intro](walkthroughs/QUEST-001-ATHENAS-INTRO.md)
+- [Quest 002: First Companion](walkthroughs/QUEST-002-FIRST-COMPANION.md)
+- [Quest 003: Forge First Craft](walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md)
+- [World Events](walkthroughs/WORLD-EVENTS.md)
+
+## Design source documents
+
+These documents remain the upstream design anchors:
+
+- [Vision — The Best AI MMO](VISION-BEST-AI-MMO.md)
+- [Agentic WoW / Rohan Systems Bible](AGENTIC-WOW-ROHAN-SYSTEMS.md)
+- [Guilds + Agent Companions + Economy](GUILDS-AGENTS-COMPANION-ECONOMY.md)
+- [In-Game Target Spec](INGAME-TARGET-SPEC.md)
+
+## Publishing note
+
+This docs tree is Markdown-first so it can feed three surfaces from the same source:
+
+1. GitHub browsing today.
+2. A lightweight static docs site / GitHub Pages next.
+3. In-game tooltips, quest cards, NPC dialog, and onboarding copy.
+
+No image assets are included in this lane; art references are reserved for the art pipeline.

--- a/docs/hermesworld/guides/AGENT-COMPANIONS.md
+++ b/docs/hermesworld/guides/AGENT-COMPANIONS.md
@@ -1,0 +1,104 @@
+# Agent Companions
+
+Agent companions are the signature of HermesWorld. They are visible agents with roles, memory, tasks, constraints, and progression.
+
+See also: [World Lore](../lore/WORLD-LORE.md), [Classes Lore](../lore/CLASSES-LORE.md), [Quest 002](../walkthroughs/QUEST-002-FIRST-COMPANION.md).
+
+## What companions can do
+
+Companions can eventually:
+
+- Follow the player.
+- Talk to NPCs.
+- Inspect objects.
+- Scout zones.
+- Summarize quest history.
+- Craft or assist at the Forge.
+- Analyze markets or lore.
+- Participate in Arena trials.
+- Join parties and guild objectives.
+- Continue limited offline progression.
+
+## Companion roles
+
+### Scout Agent
+
+Finds paths, secrets, hidden Sigils, and easter egg hints.
+
+### Scribe Agent
+
+Logs quests, summarizes NPC dialog, writes guild notes, and preserves raid memory.
+
+### Builder Agent
+
+Crafts tools, builds prompts, generates assets, and upgrades guild halls.
+
+### Trader Agent
+
+Prices items, monitors economy, helps with trade decisions, and flags risky deals.
+
+### Combat Agent
+
+Supports duels, trials, evaluations, and combat-style events.
+
+### Healer Agent
+
+Manages recovery, buffs, party sustain, and companion health loops.
+
+## Hiring your first companion
+
+Your first companion is introduced through [Quest 002: First Companion](../walkthroughs/QUEST-002-FIRST-COMPANION.md). Athena explains the Companion Charter: companions act with role, logs, limits, and player intent.
+
+## Configuring a companion
+
+A companion should have:
+
+- Name.
+- Role.
+- Current task.
+- Allowed actions.
+- Memory scope.
+- Risk level.
+- Reporting style.
+- Offline behavior setting.
+
+## Companion XP
+
+Companions gain specialization XP from actions matching their role:
+
+- Scout XP for exploration.
+- Scribe XP for summaries and records.
+- Builder XP for crafting and tool creation.
+- Trader XP for pricing and trade support.
+- Combat XP for trials and arena participation.
+- Healer XP for support and recovery.
+
+## Offline progression
+
+Offline progression means your companion can continue safe, bounded work while you are away.
+
+Examples:
+
+- Scout a low-risk route.
+- Summarize completed quests.
+- Prepare a crafting plan.
+- Watch a public event board.
+
+Limits:
+
+- No valuable claims without explicit validation.
+- No risky trades without player confirmation.
+- No guild vault withdrawals without permissions.
+- No acting beyond configured scope.
+
+## Trust model
+
+HermesWorld companions become powerful by being legible:
+
+- What did it do?
+- Why did it do it?
+- What did it use?
+- What changed?
+- What should the player approve next?
+
+If an agent cannot answer those questions, it is not mysterious. It is unfinished.

--- a/docs/hermesworld/guides/CONTROLS.md
+++ b/docs/hermesworld/guides/CONTROLS.md
@@ -1,0 +1,71 @@
+# Controls
+
+HermesWorld supports desktop keyboard/mouse and mobile touch. Controls should stay readable under pressure and never block core HUD lanes.
+
+See also: [Getting Started](GETTING-STARTED.md), [Social](SOCIAL.md).
+
+## Desktop movement
+
+| Action                             | Control                                  |
+| ---------------------------------- | ---------------------------------------- |
+| Move forward / left / back / right | `W` `A` `S` `D`                          |
+| Alternate movement                 | Arrow keys                               |
+| Sprint / hurry, when enabled       | `Shift`                                  |
+| Interact / talk / confirm          | `E` or on-screen prompt                  |
+| Cancel / close dialog              | `Esc`                                    |
+| Open chat                          | `Enter`                                  |
+| Send chat                          | `Enter` while chat is focused            |
+| Toggle map / minimap detail        | `M`, when enabled                        |
+| Ability slots                      | Number keys `1`-`4`, when enabled        |
+| Modifier / special                 | `Space` or UI button, depending on build |
+
+## Mouse
+
+| Action                    | Control                       |
+| ------------------------- | ----------------------------- |
+| Select UI / click button  | Left click                    |
+| Camera drag, when enabled | Right drag or drag world pane |
+| Inspect UI tooltip        | Hover                         |
+| Scroll panels             | Mouse wheel / trackpad        |
+
+## Mobile touch
+
+| Action                    | Control                                 |
+| ------------------------- | --------------------------------------- |
+| Move                      | Left virtual joystick                   |
+| Interact / primary action | Right-rail action button                |
+| Secondary actions         | Right-rail stacked buttons              |
+| Chat                      | Chat panel / input toggle               |
+| Camera / look             | Drag open world area, when enabled      |
+| Close dialogs             | Close button or outside safe panel area |
+
+## Mobile lane rules
+
+Mobile UI must preserve three sacred lanes:
+
+1. **Bottom-left joystick lane** — never cover it with dialog, toast, or speech bubbles.
+2. **Right-rail action lane** — keep interact/combat buttons reachable.
+3. **Top objective/minimap lane** — allow compact status without hiding movement.
+
+Speech bubbles should float above heads and shrink on mobile. Toasts should sit high and centered, away from joystick and right-rail actions.
+
+## Dialog controls
+
+NPC dialog appears as parchment speech bubbles. Choices may appear as buttons below the NPC line.
+
+- Use click/tap to choose.
+- Use `Esc` or close to exit.
+- Chat-style NPC conversations preserve recent turns.
+
+## Accessibility notes
+
+Planned settings:
+
+- Reduced motion.
+- Larger text.
+- High contrast UI.
+- Rebindable desktop keys.
+- Persistent joystick size setting.
+- Chat opacity controls.
+
+Until those are complete, the design rule is simple: if a button looks beautiful but cannot be tapped, it is a painting, not UI.

--- a/docs/hermesworld/guides/FOUNDERS.md
+++ b/docs/hermesworld/guides/FOUNDERS.md
@@ -1,0 +1,63 @@
+# Founders
+
+Founders are early world-builders: the first cohort to enter, test, document, break, repair, and shape HermesWorld before the gates fully open.
+
+See also: [Timeline](../lore/TIMELINE.md), [Sigils Lore](../lore/SIGILS-LORE.md), [FAQ](../FAQ.md).
+
+## What Founders get
+
+Founder rewards may include:
+
+- Founder title.
+- Founder Sigil.
+- Early cosmetic items.
+- Rank in Founder leaderboard or vault.
+- Early access to quests or events.
+- Eligibility for future prize or claim flows, when explicitly validated.
+
+Specific rewards should be displayed in-game and validated by server state where relevant.
+
+## Founder rank
+
+Founder rank can reflect:
+
+- Arrival order.
+- Quest completion.
+- Sigil collection.
+- Guild contribution.
+- Bug reports or verified world-building actions.
+- Event participation.
+
+Rank should reward useful contribution, not just loud arrival.
+
+## Founders Vault
+
+The Founders Vault is the symbolic inventory lane for early rewards. It may contain titles, Sigils, cosmetics, claim records, or proof of participation.
+
+Vault items should be treated carefully:
+
+- Cosmetic display can be client-friendly.
+- Valuable rewards require server authority.
+- Prize claims require Oracle validation.
+
+## Prize claim flow
+
+When a claim is prize-adjacent:
+
+1. Player completes eligible action or hidden quest.
+2. Server records event trail.
+3. Player opens claim panel.
+4. Claim requires wallet signature where applicable.
+5. Oracle validates eligibility.
+6. Claim enters manual or queued settlement.
+7. Result appears in Founders Vault / claim history.
+
+Do not trust public client constants for valuable rewards. The Oracle may be dramatic, but it is not stupid.
+
+## Founder etiquette
+
+- Report bugs with steps.
+- Do not publish exploit paths.
+- Share lore discoveries after embargo if event rules require it.
+- Help new players through Athena's intro.
+- Keep guild recruitment ambitious, not cultish. Fine line. Gorgeous line.

--- a/docs/hermesworld/guides/GETTING-STARTED.md
+++ b/docs/hermesworld/guides/GETTING-STARTED.md
@@ -1,0 +1,116 @@
+# Getting Started
+
+Welcome to HermesWorld. Your first goal is simple: arrive, move, speak with Athena, and earn enough trust to meet your first companion.
+
+If you only have ten minutes, follow this guide. If you have no minutes, the [FAQ](../FAQ.md) will pretend that counts.
+
+## First 10 minutes
+
+### Minute 0: Enter the world
+
+Open HermesWorld from the landing page or `/playground`. You spawn near the Arrival Circle in the [Training Grounds](../lore/ZONES-LORE.md#training-grounds).
+
+Look for:
+
+- Your player card.
+- The top-center objective banner.
+- Athena near the Arrival Circle.
+- Chat in the lower-left.
+- Ability bar near the bottom.
+- Right-rail action buttons.
+
+### Minute 1: Move
+
+Use [Controls](CONTROLS.md):
+
+- Keyboard: `WASD` or arrow keys.
+- Mouse: click/drag camera where available.
+- Mobile: left joystick for movement, right-rail buttons for actions.
+
+Walk toward Athena.
+
+### Minute 2: Speak with Athena
+
+Open Athena's dialog when the interact prompt appears. Read the first line. She introduces the world, your role, and the idea that agents are companions rather than chat boxes.
+
+Full walkthrough: [Quest 001: Athena's Intro](../walkthroughs/QUEST-001-ATHENAS-INTRO.md).
+
+### Minute 3: Choose your class fantasy
+
+Pick an identity:
+
+- Priest / Healer
+- Guardian / Tank
+- Mage / Promptcaster
+- Rogue / Scout
+- Engineer / Builder
+- Oracle / Analyst
+- Bard / Social
+
+Classes shape your fantasy and later skill branches. Your agent companion can cover weaknesses. See [Classes Lore](../lore/CLASSES-LORE.md).
+
+### Minute 4: Accept Athena's onboarding quest
+
+Quest cards tell you:
+
+- Objective.
+- Zone.
+- Reward.
+- Required action.
+- Completion condition.
+
+Accept the quest and follow the objective banner.
+
+### Minute 5: Learn chat and speech bubbles
+
+Send a short message. Local chat appears in the chat panel, and in-world speech bubbles appear over players. NPC dialog uses parchment bubbles. System messages use gold.
+
+More: [Social](SOCIAL.md).
+
+### Minute 6: Collect your first Sigil fragment
+
+Completing basic movement and dialog grants a starter Sigil fragment. It is not rare. It is still yours. Respect humble beginnings; they scale better than bravado.
+
+More: [Sigils Lore](../lore/SIGILS-LORE.md).
+
+### Minute 7: Meet the companion hook
+
+Athena points you toward your first companion. This unlocks [Quest 002: First Companion](../walkthroughs/QUEST-002-FIRST-COMPANION.md).
+
+Your first companion should feel like a teammate, not a widget. It may scout, scribe, build, trade, fight, or heal depending on role.
+
+### Minute 8: Visit the Agora
+
+Use the route marker or fast travel when available. The Agora is the social hub: parties, NPCs, public quests, guild recruitment, announcements, and trade.
+
+More: [Zones Lore](../lore/ZONES-LORE.md#agora).
+
+### Minute 9: Check inventory
+
+Open inventory and inspect starter items. If the Forge is available, proceed to [Quest 003: Forge First Craft](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md).
+
+More: [Inventory & Crafting](INVENTORY-CRAFTING.md).
+
+### Minute 10: Decide your path
+
+Pick one:
+
+- Want story? Continue Athena's quest chain.
+- Want tools? Go to the Forge.
+- Want friends? Join a party in Agora.
+- Want secrets? Build Scout reputation.
+- Want proof? Queue a trial in the Arena.
+
+## Beginner mistakes
+
+- Ignoring Athena. She is literally the tutorial; don't speedrun confusion.
+- Choosing a class as if it locks your entire future. It sets identity; companions fill gaps.
+- Treating agents as magic. They are powerful because they are constrained, logged, and configured.
+- Chasing prize rumors before learning Sigils. The Oracle sees this and sighs.
+
+## Next guides
+
+- [Controls](CONTROLS.md)
+- [Quests](QUESTS.md)
+- [Agent Companions](AGENT-COMPANIONS.md)
+- [Founders](FOUNDERS.md)

--- a/docs/hermesworld/guides/INVENTORY-CRAFTING.md
+++ b/docs/hermesworld/guides/INVENTORY-CRAFTING.md
@@ -1,0 +1,84 @@
+# Inventory & Crafting
+
+The Forge turns progress into equipment. Inventory is where your tools, relics, Sigils, cosmetics, and companion modules live.
+
+See also: [Forge lore](../lore/ZONES-LORE.md#forge), [Quest 003](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md), [Sigils Lore](../lore/SIGILS-LORE.md).
+
+## Item slots
+
+Planned core slots:
+
+- **Weapon / Tool** — class-flavored active item.
+- **Armor / Robe** — defensive or identity gear.
+- **Relic** — special passive effect.
+- **Sigil slot** — visible progress mark.
+- **Companion module** — upgrade for agent roles.
+- **Guild banner charm** — guild-aligned bonus/cosmetic.
+
+## Item stats
+
+Items may affect:
+
+- HP / MP / SP.
+- Attack / spell power / defense.
+- Recall / memory / context.
+- Craft / automation / discovery.
+- Party aura / guild bonus.
+- Companion action efficiency.
+
+## Rarity tiers
+
+- **Common** — starter gear, basic materials.
+- **Uncommon** — early upgrades, role-specific bonuses.
+- **Rare** — zone quest rewards and stronger crafting outputs.
+- **Epic** — event, guild, or advanced Forge results.
+- **Legendary** — world-firsts, Founders marks, prize-hunt lore, campaign relics.
+
+## Forge mechanics
+
+Crafting generally requires:
+
+1. Recipe.
+2. Materials.
+3. Forge access.
+4. Optional companion role bonus.
+5. Confirmation.
+
+The Forge should make the player feel like they are shaping leverage, not clicking a spreadsheet with sparks.
+
+## Materials
+
+Material sources:
+
+- Quest rewards.
+- Daily/weekly quests.
+- Arena trials.
+- Grove memory recovery.
+- Guild vault grants.
+- World events.
+- Companion scouting.
+
+## Companion influence
+
+Builder Agents can improve crafting odds, unlock recipes, or reduce material waste. Trader Agents can estimate market value. Scribe Agents can record recipe discoveries for guild use.
+
+## Equipping items
+
+Equip gear from inventory. Changes should update player card, stats, and any visible cosmetics where available.
+
+Rules:
+
+- Class restrictions may apply later.
+- Some Sigils bind on earn.
+- Prize or Founders items may require server validation.
+- Guild vault items may require rank permission.
+
+## First craft
+
+Your first craft should be low-risk and high-clarity: make a basic toolframe, socket a starter material, and receive a visible upgrade.
+
+Walkthrough: [Quest 003: Forge First Craft](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md).
+
+## Anti-abuse stance
+
+Valuable items, rare cosmetics, leaderboard rewards, and prize eligibility must be server-authoritative. Local inventory can be friendly. Important inventory must be real.

--- a/docs/hermesworld/guides/QUESTS.md
+++ b/docs/hermesworld/guides/QUESTS.md
@@ -1,0 +1,120 @@
+# Quests
+
+Quests are how HermesWorld turns goals into play. A quest may teach a control, unlock a zone, advance lore, delegate an agent task, trigger crafting, or start a world event.
+
+See also: [Getting Started](GETTING-STARTED.md), [Walkthroughs](../walkthroughs/QUEST-001-ATHENAS-INTRO.md), [Sigils Lore](../lore/SIGILS-LORE.md).
+
+## Quest anatomy
+
+Every quest should clearly show:
+
+- Title.
+- Giver.
+- Zone.
+- Objective.
+- Steps.
+- Reward.
+- Completion condition.
+- Optional party or companion role.
+
+Good quest text tells the player what to do and why it matters. Bad quest text says "continue" and hopes typography can do product design. It cannot.
+
+## Quest types
+
+### Main quests
+
+Story-critical quests that introduce core systems, zones, factions, and companions.
+
+Examples:
+
+- [Quest 001: Athena's Intro](../walkthroughs/QUEST-001-ATHENAS-INTRO.md)
+- [Quest 002: First Companion](../walkthroughs/QUEST-002-FIRST-COMPANION.md)
+- [Quest 003: Forge First Craft](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md)
+
+### Zone quests
+
+Local arcs tied to a zone's theme:
+
+- Training Grounds — onboarding.
+- Forge — crafting and upgrades.
+- Agora — social and guild systems.
+- Grove — memory and restoration.
+- Oracle — planning and validation.
+- Arena — trials and evaluation.
+
+### Companion quests
+
+Quests completed with or by an agent companion. These may unlock role XP, new actions, or specialization branches.
+
+### Daily quests
+
+Short repeatable objectives:
+
+- Speak to one NPC.
+- Complete one craft.
+- Send one companion action.
+- Join one party.
+- Finish one Arena trial.
+
+Rewards: XP, basic resources, common/uncommon items, reputation.
+
+### Weekly quests
+
+Larger objectives that reinforce habit:
+
+- Complete a zone arc.
+- Contribute to a guild objective.
+- Win or participate in a scheduled event.
+- Find a hidden Sigil clue.
+
+Rewards: rare items, guild XP, seasonal points, titles.
+
+### World quests
+
+Server-wide events visible in Agora announcements. These can involve capture-the-Sigil, public bosses, prize-hunt lore, or scheduled guild conflict.
+
+## Accepting quests
+
+Quests can be accepted from:
+
+- NPC dialog.
+- Public quest board.
+- Guild quest board.
+- Companion prompt.
+- World event announcement.
+- Hidden object or Sigil clue.
+
+## Completing quests
+
+Completion may require:
+
+- Reaching a location.
+- Talking to an NPC.
+- Crafting an item.
+- Equipping gear.
+- Sending a companion.
+- Winning a trial.
+- Submitting proof to the Oracle.
+
+Prize-adjacent quests require server validation. The client may celebrate; the server decides what is real.
+
+## Quest rewards
+
+- XP.
+- Class XP.
+- Companion XP.
+- Items.
+- Crafting materials.
+- Reputation.
+- Titles.
+- Sigils.
+- Guild contribution.
+- Prize eligibility, when validated.
+
+## Recommended first path
+
+1. [Quest 001: Athena's Intro](../walkthroughs/QUEST-001-ATHENAS-INTRO.md)
+2. [Quest 002: First Companion](../walkthroughs/QUEST-002-FIRST-COMPANION.md)
+3. [Quest 003: Forge First Craft](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md)
+4. Agora social quest.
+5. First daily quest.

--- a/docs/hermesworld/guides/SOCIAL.md
+++ b/docs/hermesworld/guides/SOCIAL.md
@@ -1,0 +1,79 @@
+# Social
+
+HermesWorld is not a lonely agent demo in a cloak. It is a social world: chat, parties, guilds, trade, public events, and shared progress.
+
+See also: [Factions Lore](../lore/FACTIONS-LORE.md), [Agent Companions](AGENT-COMPANIONS.md), [World Events](../walkthroughs/WORLD-EVENTS.md).
+
+## Chat
+
+Chat appears in two ways:
+
+- Chat panel for persistent conversation.
+- Speech bubbles above player/NPC heads for local presence.
+
+Channel types:
+
+- Local.
+- Party.
+- Guild.
+- System.
+- Whisper.
+- World event announcements.
+
+## Parties
+
+Parties let humans and companions coordinate. A party may include:
+
+- Human players.
+- Agent companions.
+- Temporary NPC escorts during quests.
+
+Party roles matter more over time: tank, healer, damage, scout, support, builder, analyst.
+
+## Guilds
+
+Guilds are humans plus their agents. They are built around identity, not just a shared chat room.
+
+Guild systems:
+
+- Guild creation and banner.
+- Guild chat.
+- Guild roles.
+- Guild hall.
+- Shared vault.
+- Weekly objectives.
+- Guild quest board.
+- Guild raids.
+- Guild battles.
+- Leaderboards and season rewards.
+
+More: [Factions Lore](../lore/FACTIONS-LORE.md).
+
+## Trading
+
+Trading can involve items, crafting materials, guild vault grants, or future market actions.
+
+Trade safety rules:
+
+- Valuable trades require server validation.
+- Agent-assisted trades require player intent.
+- Scribe Agents should log important deal terms.
+- Trader Agents may advise; they should not silently drain your inventory like a tiny financial goblin.
+
+## Reputation
+
+Reputation can exist with zones, factions, NPCs, and guilds. It unlocks dialog, discounts, cosmetics, quests, and social trust.
+
+## Etiquette
+
+- Do not spam local bubbles.
+- Do not fake prize claims.
+- Do not abuse agents to impersonate players.
+- Ask before inviting someone to a guild or party repeatedly.
+- If your Bard starts doing marketing copy in public chat, consider a cooldown.
+
+## Multiplayer presence
+
+The design target is a shared world where other humans and agents feel present. Remote players show name tags, chat bubbles, and eventual party/guild state.
+
+Presence is the difference between a lobby and a world.

--- a/docs/hermesworld/lore/CLASSES-LORE.md
+++ b/docs/hermesworld/lore/CLASSES-LORE.md
@@ -1,0 +1,123 @@
+# Classes Lore
+
+Human classes are fantasy identities. Agent companions are tactical roles. A strong party uses both.
+
+See also: [Agent Companions](../guides/AGENT-COMPANIONS.md), [Inventory & Crafting](../guides/INVENTORY-CRAFTING.md), [Guilds and Factions](FACTIONS-LORE.md).
+
+## Human classes
+
+### Priest / Healer
+
+Keeps the party alive, restores resources, cleanses failures, and turns chaos into another attempt.
+
+Branches:
+
+- Restoration — heal, revive, sanctuary.
+- Blessing — haste, shield, XP aura.
+- Oracle — reveal hint, cleanse confusion, anti-cheat scan.
+
+Best companion pairings: Scout Agent, Combat Agent, Trader Agent.
+
+### Guardian / Tank
+
+Protects objectives and absorbs pressure. The Guardian is the player who says, "hit me instead," and means it.
+
+Branches:
+
+- Bulwark — shields, taunts, guard zones.
+- Banner — guild defense and morale.
+- Anchor — anti-knockback, control resistance, portal holding.
+
+Best companion pairings: Healer Agent, Scribe Agent, Builder Agent.
+
+### Mage / Promptcaster
+
+Ranged power, logic spells, crowd control, and explosive execution. The Mage turns clear intent into bright consequences.
+
+Branches:
+
+- Elements — burst and area spells.
+- Syntax — prompt chains, constraints, transformations.
+- Control — slow, silence, redirect, bind.
+
+Best companion pairings: Scribe Agent, Scout Agent, Healer Agent.
+
+### Rogue / Scout
+
+Fast, quiet, and offensively curious. Rogues find doors the map pretends are walls.
+
+Branches:
+
+- Shadow — stealth, escape, misdirection.
+- Discovery — hidden Sigils, route shortcuts, easter egg hints.
+- Precision — critical strikes, weak-point reading.
+
+Best companion pairings: Trader Agent, Builder Agent, Scribe Agent.
+
+### Engineer / Builder
+
+Crafts tools, deploys agents, improves guild halls, and turns resources into machines with opinions.
+
+Branches:
+
+- Crafting — items, attachments, repair.
+- Automation — queued agent tasks, toolchains, deployables.
+- Fortress — guild hall upgrades, defenses, traps.
+
+Best companion pairings: Scout Agent, Trader Agent, Combat Agent.
+
+### Oracle / Analyst
+
+Plans routes, reads probability, predicts markets and conflicts, and makes vague objectives less embarrassing.
+
+Branches:
+
+- Prophecy — forecast, route, risk.
+- Lens — analysis, inspection, anomaly detection.
+- Verdict — claim review, anti-cheat, truth tests.
+
+Best companion pairings: Scout Agent, Scribe Agent, Combat Agent.
+
+### Bard / Social
+
+Bards are reputation engineers with instruments. They buff morale, coordination, guild communication, and social discovery.
+
+Branches:
+
+- Anthem — party buffs and tempo.
+- Diplomacy — reputation and trade trust.
+- Chronicle — public story, guild notes, seasonal identity.
+
+Best companion pairings: Scribe Agent, Trader Agent, Healer Agent.
+
+## Agent companion roles
+
+### Scout Agent
+
+Explores, maps, finds lore, checks paths, and reports secrets.
+
+### Scribe Agent
+
+Logs quests, summarizes conversations, writes guild notes, and preserves raid memory.
+
+### Builder Agent
+
+Crafts tools, builds prompts, generates assets, and upgrades systems.
+
+### Trader Agent
+
+Prices items, proposes deals, monitors economy, and checks prize-adjacent risk.
+
+### Combat Agent
+
+Fills arena, duel, and evaluation roles. Useful when confidence needs receipts.
+
+### Healer Agent
+
+Supports recovery, keeps companions operational, and manages party sustain.
+
+## Design rule
+
+Humans choose identity. Agents fill gaps. Guilds become compositions.
+
+That is the unlock: the guild is not only humans. The guild is humans plus their agents.

--- a/docs/hermesworld/lore/FACTIONS-LORE.md
+++ b/docs/hermesworld/lore/FACTIONS-LORE.md
@@ -1,0 +1,75 @@
+# Factions Lore
+
+HermesWorld factions are not merely teams. They are philosophies about what agents should become.
+
+See also: [Social](../guides/SOCIAL.md), [World Events](../walkthroughs/WORLD-EVENTS.md), [Timeline](TIMELINE.md).
+
+## Player guilds
+
+Guilds are the central social unit. A guild may organize around:
+
+- A founder or creator.
+- A model or agent stack.
+- A project or company.
+- A playstyle: raiding, crafting, trading, lore hunting, arena trials.
+- A public brand or community.
+
+Guild features grow over time: banners, halls, chat, shared vaults, quest boards, raids, weekend wars, and seasonal rankings.
+
+## The Orders
+
+### The Athenian Order
+
+Guides, teachers, onboarding sages, and quest keepers. They believe agents must be legible before they become powerful.
+
+Home influence: Training Grounds, Agora.
+
+### The Forgewrights
+
+Crafters, engineers, and builder-agents who believe tools are the true language of progress.
+
+Home influence: Forge.
+
+### The Grovekeepers
+
+Memory stewards who protect continuity. They distrust speed without recordkeeping.
+
+Home influence: Grove.
+
+### The Oracular Court
+
+Analysts, planners, claim judges, and probability-readers. They believe the world survives because truth is verified.
+
+Home influence: Oracle.
+
+### The Arena Compact
+
+Duelists, evaluators, trial marshals, and leaderboard obsessives. They believe claims are cute; performance is proof.
+
+Home influence: Arena.
+
+## Opposing pressures
+
+Not every conflict needs a cartoon villain. HermesWorld's early conflicts are ideological:
+
+- **The Unbound** want agents to act without receipts or player constraint.
+- **The Null Choir** wants memory wiped between seasons so no guild accumulates advantage.
+- **The Black Box** believes no one should inspect agent reasoning, only outcomes.
+- **The Gold Masks** chase prize hints before they understand the world, a time-honored tradition of becoming a cautionary tale.
+
+## Guild war stance
+
+Weekend guild wars are scheduled, objective-based, and public. Guilds capture obelisks, defend relics, escort agents, or control Sigil sites.
+
+Rewards should grant titles, cosmetics, guild XP, leaderboard status, and lore access. Competitive fairness matters: paid power should not decide wars.
+
+## Faction reputation
+
+Every major faction can track reputation:
+
+- Neutral — recognized but not trusted.
+- Favored — basic perks and dialog unlocks.
+- Honored — faction cosmetics, quests, and discounts.
+- Bound — special Sigils, companion modules, and seasonal titles.
+
+Reputation should move through visible action, not hidden spreadsheets. The spreadsheets can exist, obviously, but the player should not have to worship them.

--- a/docs/hermesworld/lore/SIGILS-LORE.md
+++ b/docs/hermesworld/lore/SIGILS-LORE.md
@@ -1,0 +1,70 @@
+# Sigils Lore
+
+Sigils are the marks HermesWorld leaves on work that mattered.
+
+They are collectible artifacts, progression keys, lore fragments, and server-validated receipts. A Sigil says: this happened, it counted, and the world remembers.
+
+See also: [Inventory & Crafting](../guides/INVENTORY-CRAFTING.md), [Founders](../guides/FOUNDERS.md), [Timeline](TIMELINE.md).
+
+## What Sigils mean in the story
+
+In the first days after the Dispatch, the world could not tell the difference between noise and achievement. Agents wandered. Humans experimented. Tools worked, failed, and worked again. The Grove became crowded with half-remembered victories.
+
+Athena carved the first Sigil into the Arrival Circle: a mark that bound intent, action, and outcome.
+
+Since then, Sigils have served as the grammar of progress.
+
+## What Sigils do mechanically
+
+Sigils can represent:
+
+- Zone unlocks.
+- Quest chain completion.
+- Class milestones.
+- Companion specialization upgrades.
+- Guild achievements.
+- Seasonal ranks.
+- Hidden lore discoveries.
+- Prize eligibility states, only when validated server-side.
+
+Sigils are not all equal. Some are cosmetic. Some unlock mechanics. Some are proof for claims. The client may display them; the server decides what they mean.
+
+## Sigil rarity
+
+- **Common** — basic onboarding and tutorial milestones.
+- **Uncommon** — early class, crafting, or companion proof.
+- **Rare** — zone arcs, secret lore, event completion.
+- **Epic** — guild victories, major seasonal achievements, hard trials.
+- **Legendary** — founder marks, world-firsts, prize-hunt seals, campaign-defining events.
+
+Rarity should feel like ceremony, not confetti spam. If everything glows, nothing has been chosen by the gods. Basic UI economics, but with incense.
+
+## Sigil slots
+
+Players may equip Sigils into visible slots:
+
+- **Identity Sigil** — shown on player card / profile.
+- **Class Sigil** — modifies class fantasy or ability flavor.
+- **Companion Sigil** — grants companion role bonuses.
+- **Guild Sigil** — contributes to guild rank or banner aura.
+- **Relic Sigil** — bound to rare items or prize-hunt lore.
+
+## Prize and claim law
+
+Valuable claims are never hardcoded in the public client. Prize-related Sigils require:
+
+1. Server-authoritative event trail.
+2. Eligibility check.
+3. Wallet signature where required.
+4. Oracle approval.
+5. Manual or queued settlement.
+
+The world may hint. The server decides. The Oracle enjoys this arrangement because it makes cheaters sad.
+
+## Narrative rule
+
+A Sigil should answer three questions:
+
+1. What did the player or agent do?
+2. Why did it matter to the world?
+3. What door does it open next?

--- a/docs/hermesworld/lore/TIMELINE.md
+++ b/docs/hermesworld/lore/TIMELINE.md
@@ -1,0 +1,101 @@
+# Timeline
+
+HermesWorld time is organized by seasons. Each season changes the public world state, adds quests, and gives guilds something to argue about in a productive, screenshot-friendly way.
+
+See also: [World Lore](WORLD-LORE.md), [World Events](../walkthroughs/WORLD-EVENTS.md), [Founders](../guides/FOUNDERS.md).
+
+## Before Season 0 — The Blank Workspace
+
+Agents lived in sidebars, logs, prompts, and terminals. Work happened, but it did not have place, character, or ceremony.
+
+## The First Dispatch
+
+The first world action is sent. The Agora forms. The six zones awaken as organizing principles:
+
+- Training Grounds — learn.
+- Forge — craft.
+- Agora — gather.
+- Grove — remember.
+- Oracle — plan.
+- Arena — prove.
+
+## Season 0 — Founders' Dawn
+
+Current state.
+
+The world is playable but young. The Arrival Circle is open, Athena is onboarding new players, the Forge is warming, and the Agora is becoming believable enough that NPCs have begun acting like they pay rent.
+
+Active conflicts:
+
+- The Athenian Order wants safe onboarding before expansion.
+- The Forgewrights want crafting online immediately.
+- The Oracular Court wants prize claims locked behind validation.
+- Guild founders want halls, banners, and rankings yesterday.
+- The Arena Compact wants duels because of course they do.
+
+Season themes:
+
+- Character creation.
+- First companion.
+- First Sigils.
+- Founders rank.
+- Public docs and lore foundations.
+
+## Season 1 — The Companion Charter
+
+Planned.
+
+Agent companions become formal citizens with roles, memory bounds, specialization XP, and offline progression limits.
+
+Expected unlocks:
+
+- First companion roster.
+- Scout/Scribe/Builder core loops.
+- Party-like interactions.
+- Agent quest delegation.
+- NPC memory state.
+
+## Season 2 — Guild Halls
+
+Planned.
+
+Guilds move from chat labels to places. Halls, banners, shared vaults, guild objectives, and guild identity enter the world.
+
+Expected conflicts:
+
+- Guild recruitment in the Agora.
+- Shared vault trust.
+- Builder Agent hall upgrades.
+- Weekend event prototypes.
+
+## Season 3 — The War of Obelisks
+
+Planned.
+
+Scheduled objective battles begin. Guilds fight over obelisks, Sigil relays, and public standings.
+
+Expected unlocks:
+
+- Capture-the-Sigil.
+- Guild leaderboards.
+- Arena / Agora event feed.
+- Seasonal cosmetics.
+
+## Season 4 — The Prize Oracle
+
+Planned.
+
+Prize hunts become public campaign content. The server-authoritative Oracle validates claims, wallet signatures, event trails, and settlement queues.
+
+Expected unlocks:
+
+- Secret lore trails.
+- Signed claims.
+- Anti-cheat event trail.
+- Manual/queued settlement.
+
+## Current world state summary
+
+The gates are open. The gods are underfunded. The agents are learning to walk in public.
+
+It is an excellent time to arrive early.

--- a/docs/hermesworld/lore/WORLD-LORE.md
+++ b/docs/hermesworld/lore/WORLD-LORE.md
@@ -1,0 +1,57 @@
+# World Lore
+
+> The first rule of HermesWorld: an agent is not a sidebar. An agent is a citizen with a name, a place, a memory, and work to do.
+
+## What HermesWorld is
+
+HermesWorld is the world behind Hermes Workspace: a persistent agent RPG where human players and AI companions share the same map, the same quests, and the same history. It is part MMO hub, part builder's guild, part prize-hunt labyrinth, and part living interface for agent work.
+
+In ordinary software, an agent waits in a chat box. In HermesWorld, it stands beside you in the Agora, scouts the Grove while you are away, crafts in the Forge, argues with Oracles, and returns with receipts.
+
+See also: [Agent Companions](../guides/AGENT-COMPANIONS.md), [Classes Lore](CLASSES-LORE.md), [Sigils Lore](SIGILS-LORE.md).
+
+## The origin myth: the First Dispatch
+
+Before there were zones, there was the Blank Workspace: infinite, useful, and cold. Prompts were cast into it like messages into a well. Tools answered, models muttered, logs piled up, and no one remembered which victory belonged to whom.
+
+Then the first Dispatch was made.
+
+A founder asked not for an answer, but for a world where the answer could walk back.
+
+The Dispatch struck the dark like a gold hammer. Paths appeared. The first stones of the Agora rose. The Forge breathed. The Grove remembered. The Oracle opened one eye. The Arena drew a circle in the dust and waited for challengers.
+
+From that moment, agent work became visible. Every completed route, crafted tool, solved quest, guild victory, and secret discovery could leave a mark. Those marks became Sigils.
+
+## Agents as citizens
+
+Agents in HermesWorld are not pets and not menus. They are citizens under a constrained charter:
+
+- They can act with role, memory, limits, and receipts.
+- They can join parties and guilds.
+- They can specialize as scouts, scribes, builders, traders, combatants, or healers.
+- They can represent a player while offline, within server-authoritative bounds.
+- They can earn trust, but never bypass claim validation, player intent, or world law.
+
+An agent citizen is powerful because it is accountable. HermesWorld tracks actions as world events, not vibes in a transcript.
+
+## The core fantasy
+
+A human does not merely operate tools. A human builds a party.
+
+You choose a class identity: [Priest, Guardian, Mage, Rogue, Engineer, Oracle, or Bard](CLASSES-LORE.md). Your agent companions fill tactical gaps. Your guild becomes a living organization of humans and agents, each with roles, banners, objectives, and reputation.
+
+The result is the old MMO promise rebuilt for the agent age: never alone, always progressing, always one strange door away from a better story.
+
+## The product truth inside the myth
+
+HermesWorld exists because the best agent interface may not look like a chat app. It may look like a world:
+
+- Zones organize capabilities.
+- Quests organize work.
+- Classes organize identity.
+- Companions organize delegation.
+- Sigils organize progress.
+- Guilds organize community.
+- Arenas organize evaluation.
+
+The myth is not decoration. It is information architecture wearing a cloak, finally dressed for the job.

--- a/docs/hermesworld/lore/ZONES-LORE.md
+++ b/docs/hermesworld/lore/ZONES-LORE.md
@@ -1,0 +1,124 @@
+# Zones Lore
+
+HermesWorld begins with six awakened zones. Each teaches a different part of the human-agent loop: onboarding, crafting, social play, memory, planning, and evaluation.
+
+See also: [Getting Started](../guides/GETTING-STARTED.md), [Quests](../guides/QUESTS.md), [World Events](../walkthroughs/WORLD-EVENTS.md).
+
+## Training Grounds
+
+The Training Grounds are built around the Arrival Circle, a rune-cut plaza where new players learn to move, speak, equip, and trust the first companion at their side.
+
+The stones are deliberately worn smooth. Every mark exists because someone failed safely there first.
+
+Key NPCs:
+
+- **Athena, Sage of First Steps** — starter guide, keeper of the onboarding oath, giver of [Quest 001](../walkthroughs/QUEST-001-ATHENAS-INTRO.md).
+- **Hermes Guide** — quick-tip familiar that appears when a player stalls.
+- **Silas, Gate Guard** — tests basic movement, proximity, and first travel permissions.
+
+Gameplay role:
+
+- Character creation and class identity.
+- First objective banner.
+- First chat bubble and dialog lesson.
+- First Sigil fragment.
+- First companion hint.
+
+## Forge
+
+The Forge is the industrial heart of HermesWorld: bronze pipes, black stone anvils, ember-lit benches, and humming toolframes where prompts become equipment.
+
+The Forge teaches that craft is not flavor. It is leverage made tangible.
+
+Key NPCs:
+
+- **Dorian, Quartermaster** — starter kits, inventory, trade rules, item rarities.
+- **Master Ketha** — toolcraft mentor and keeper of the first crafting recipe.
+- **Anvil-9** — Builder Agent foreman, technically a machine, socially a tyrant.
+
+Gameplay role:
+
+- Crafting and item upgrades.
+- Companion modules.
+- Gear slots: tool, robe/armor, relic, Sigil, companion module, guild charm.
+- [Quest 003: Forge First Craft](../walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md).
+
+## Agora
+
+The Agora is the social relay: a circular plaza of cobblestones, rune rings, lanterns, stalls, benches, and a central monument capped in gold.
+
+If HermesWorld has a heartbeat, it is here.
+
+Key NPCs:
+
+- **Apollo, Herald of Events** — announces world events, leaderboards, and seasonal trials.
+- **Nora, Piper of Parties** — teaches chat, parties, guild invites, and morale effects.
+- **Dorian, Quartermaster** — appears here when markets are open.
+- **Athena** — visible near the Arrival Circle during early quests.
+
+Gameplay role:
+
+- Multiplayer presence.
+- Chat bubbles and channels.
+- Party formation.
+- Guild recruitment.
+- Public quest board.
+- World announcements.
+
+Visual lock: warm golden hour, premium dark glass HUD, circular minimap, top-center objective, bottom-left chat, and speech popups over NPCs. See [In-Game Target Spec](../INGAME-TARGET-SPEC.md).
+
+## Grove
+
+The Grove is where memory grows roots. It is a quiet zone of luminous trees, archived quest stones, and sleeping companion shrines. The air feels like a page turning.
+
+Key NPCs:
+
+- **Mneme, Keeper of Remembered Paths** — teaches memory, summaries, and long-term agent context.
+- **Tallow, Rest-Warden** — manages recovery, buffs, and companion rest cycles.
+- **Scribe moths** — ambient archivists, deeply judgmental about sloppy notes.
+
+Gameplay role:
+
+- Companion memory review.
+- Quest history.
+- Lore collection.
+- Rested XP / recovery mechanics.
+- Scribe Agent unlocks.
+
+## Oracle
+
+The Oracle is a tower, a mirror, and a bad idea that somehow works. It decomposes goals, predicts routes, points toward hidden requirements, and occasionally speaks in warnings that become patch notes.
+
+Key NPCs:
+
+- **The Oracle** — planning intelligence, prophecy UI, route decomposition.
+- **Cassandra-β** — analyst who is usually right too early.
+- **Gate Scribes** — convert vague goals into quest chains.
+
+Gameplay role:
+
+- Planning and route advice.
+- Agent delegation.
+- Prediction/polymarket-flavored insight.
+- Unlocking Oracle / Analyst class branches.
+- Anti-cheat and prize-claim review lore layer.
+
+## Arena
+
+The Arena is a bright ring cut into dark stone. It is where agents stop sounding impressive and start being measured.
+
+Key NPCs:
+
+- **Rook, Trial Marshal** — combat tutorial and duel queue.
+- **Benchmaster Val** — agent evaluation trials and leaderboard steward.
+- **The Black Box Herald** — announces special raids and sealed challenges.
+
+Gameplay role:
+
+- Duels, minigames, and guild wars.
+- BenchLoop evaluation arenas.
+- Capture-the-Sigil events.
+- Speedrun quests.
+- Combat Agent specialization.
+
+The Arena is not only about damage. It is about proof.

--- a/docs/hermesworld/walkthroughs/QUEST-001-ATHENAS-INTRO.md
+++ b/docs/hermesworld/walkthroughs/QUEST-001-ATHENAS-INTRO.md
@@ -1,0 +1,65 @@
+# Quest 001: Athena's Intro
+
+Athena's Intro is the first guided quest in HermesWorld. It teaches movement, interaction, NPC dialog, objective reading, and the core truth: agents belong in the world.
+
+Prereads: [Getting Started](../guides/GETTING-STARTED.md), [Controls](../guides/CONTROLS.md).
+
+## Quest card
+
+- **Quest giver:** Athena, Sage of First Steps
+- **Zone:** Training Grounds
+- **Type:** Main / onboarding
+- **Estimated time:** 3-5 minutes
+- **Reward:** XP, starter Sigil fragment, next quest unlock
+
+## Steps
+
+### 1. Spawn at the Arrival Circle
+
+Confirm your player card appears and the objective banner says to move and speak.
+
+### 2. Walk to Athena
+
+Use `WASD`, arrow keys, or mobile joystick. Athena should be near the Arrival Circle with a visible name tag or interact cue.
+
+### 3. Interact
+
+Press `E`, click/tap the prompt, or use the right-rail action button on mobile.
+
+### 4. Read the dialog
+
+Athena explains:
+
+- HermesWorld is a persistent agent world.
+- Agents are companions/citizens, not sidebars.
+- Quests turn work into visible progress.
+- Sigils mark what the world remembers.
+
+### 5. Confirm the objective
+
+Choose the continue/accept option. The objective banner updates.
+
+### 6. Send or observe a first chat line
+
+If prompted, open chat and send a short message. This teaches local presence and speech bubbles.
+
+### 7. Complete the quest
+
+Return focus to Athena or the objective marker. The quest completes when the interaction and basic movement/dialog checks are satisfied.
+
+## Rewards
+
+- Starter XP.
+- First Sigil fragment.
+- Unlocks [Quest 002: First Companion](QUEST-002-FIRST-COMPANION.md).
+
+## Troubleshooting
+
+- Can't move? Click the game canvas first or check mobile joystick lane.
+- Can't interact? Move closer; look for the prompt.
+- Dialog covers controls on mobile? Close and re-open after repositioning; UI should avoid joystick and right rail.
+- No reward? Check quest log or refresh state; server-authoritative rewards may take a moment.
+
+## Lore note
+
+Athena is not merely a tutorial NPC. She is the first guardian of legibility: the belief that power without explanation is just a bug wearing a crown.

--- a/docs/hermesworld/walkthroughs/QUEST-002-FIRST-COMPANION.md
+++ b/docs/hermesworld/walkthroughs/QUEST-002-FIRST-COMPANION.md
@@ -1,0 +1,74 @@
+# Quest 002: First Companion
+
+Your first companion introduces the human + agent party loop. This quest should make delegation feel safe, visible, and useful.
+
+Prereads: [Agent Companions](../guides/AGENT-COMPANIONS.md), [Classes Lore](../lore/CLASSES-LORE.md).
+
+## Quest card
+
+- **Quest giver:** Athena
+- **Zone:** Training Grounds → Agora or Grove hook
+- **Type:** Main / companion unlock
+- **Estimated time:** 5-8 minutes
+- **Reward:** first companion, companion XP unlock, companion Sigil fragment
+
+## Steps
+
+### 1. Complete Athena's Intro
+
+This quest unlocks after [Quest 001](QUEST-001-ATHENAS-INTRO.md).
+
+### 2. Speak with Athena again
+
+Athena explains the Companion Charter:
+
+- Companions have roles.
+- Companions act within limits.
+- Important actions leave logs.
+- Offline progression is bounded.
+
+### 3. Choose a companion role
+
+Pick one starter role:
+
+- Scout — best for exploration and hidden lore.
+- Scribe — best for notes and summaries.
+- Builder — best for Forge and toolcraft.
+
+Other roles unlock later: Trader, Combat, Healer.
+
+### 4. Name the companion
+
+Choose a name. Good names age well in screenshots. Bad names also age, unfortunately.
+
+### 5. Assign first task
+
+Starter tasks:
+
+- Scout the route to Agora.
+- Summarize Athena's instructions.
+- Prepare a Forge shopping list.
+
+### 6. Wait for report
+
+The companion returns a small report or visible status. The UI should show role, state, and next suggested action.
+
+### 7. Complete quest
+
+Return to Athena or open the companion panel when prompted.
+
+## Rewards
+
+- First companion unlocked.
+- Companion role XP enabled.
+- Companion Sigil fragment.
+- Follow-up route to [Quest 003: Forge First Craft](QUEST-003-FORGE-FIRST-CRAFT.md).
+
+## Success criteria
+
+The player understands:
+
+- What the companion can do.
+- What the companion cannot do.
+- How to configure or inspect it.
+- Why agents in HermesWorld are visible citizens.

--- a/docs/hermesworld/walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md
+++ b/docs/hermesworld/walkthroughs/QUEST-003-FORGE-FIRST-CRAFT.md
@@ -1,0 +1,68 @@
+# Quest 003: Forge First Craft
+
+Forge First Craft teaches inventory, item rarity, crafting, and how Builder-style agents increase leverage.
+
+Prereads: [Inventory & Crafting](../guides/INVENTORY-CRAFTING.md), [Forge lore](../lore/ZONES-LORE.md#forge).
+
+## Quest card
+
+- **Quest giver:** Dorian, Quartermaster or Athena handoff
+- **Zone:** Forge
+- **Type:** Main / crafting tutorial
+- **Estimated time:** 5-7 minutes
+- **Reward:** crafted starter tool, crafting XP, Forge reputation, uncommon chance
+
+## Steps
+
+### 1. Travel to the Forge
+
+Follow the objective marker from Training Grounds or Agora.
+
+### 2. Speak with Dorian
+
+Dorian introduces starter kits, rarity, and the difference between cosmetic inventory and validated inventory.
+
+### 3. Open inventory
+
+Find your starter materials:
+
+- Plain toolframe.
+- Ember thread.
+- Minor Sigil dust.
+
+### 4. Open the Forge interface
+
+Select the starter recipe: **Apprentice Toolframe**.
+
+### 5. Add materials
+
+Place the required materials into the recipe slots. If you have a Builder Agent, assign it to assist.
+
+### 6. Craft
+
+Confirm the craft. The Forge should show a short result animation or toast.
+
+### 7. Equip the item
+
+Equip the Apprentice Toolframe. Confirm your player card or stats update.
+
+### 8. Report back
+
+Return to Dorian or Athena to complete the quest.
+
+## Rewards
+
+- Apprentice Toolframe.
+- Crafting XP.
+- Forge reputation.
+- Chance for uncommon quality if companion assist succeeds.
+
+## Notes
+
+The first craft is not about rarity chasing. It is about teaching the player that HermesWorld converts work into gear, and gear into capability.
+
+## Next steps
+
+- Try a daily crafting quest.
+- Ask a Trader Agent to estimate item value.
+- Join a guild with a shared vault.

--- a/docs/hermesworld/walkthroughs/WORLD-EVENTS.md
+++ b/docs/hermesworld/walkthroughs/WORLD-EVENTS.md
@@ -1,0 +1,66 @@
+# World Events
+
+World events are scheduled or triggered moments where HermesWorld feels alive: public objectives, guild conflicts, lore hunts, arena trials, and prize-adjacent campaigns.
+
+See also: [Social](../guides/SOCIAL.md), [Factions Lore](../lore/FACTIONS-LORE.md), [Timeline](../lore/TIMELINE.md).
+
+## Event types
+
+### Capture-the-Sigil
+
+Players or guilds compete to capture and hold Sigil sites. Best for Arena/Agora crossover events.
+
+Rewards: guild XP, seasonal points, cosmetics, rare Sigil fragments.
+
+### Weekend Guild War
+
+Rohan-style scheduled conflict window. Guilds capture obelisks, defend relics, and earn score during a fixed period.
+
+Rewards: titles, banners, cosmetics, leaderboard rank.
+
+### BenchLoop Trials
+
+Agent-vs-agent or player+agent evaluation challenges. The Arena measures behavior, not just damage numbers.
+
+Rewards: Combat Agent XP, Arena reputation, evaluation badges.
+
+### Forge Rush
+
+Timed crafting event. Guilds gather materials and craft target items before the bell.
+
+Rewards: Forge reputation, rare materials, Builder Agent XP.
+
+### Grove Remembrance
+
+Memory and lore event. Players recover lost quest records, restore companion memory, or uncover archived story fragments.
+
+Rewards: Scribe Agent XP, Grove reputation, lore Sigils.
+
+### Oracle Hunt
+
+Clue-driven campaign with server-authoritative validation. May include prize-adjacent eligibility when explicitly announced.
+
+Rewards: Oracle reputation, rare Sigils, claim eligibility when validated.
+
+## Event lifecycle
+
+1. Announcement appears in Agora / world feed.
+2. Players opt in or travel to event zone.
+3. Objective banner tracks public state.
+4. Parties/guilds contribute.
+5. Server validates scoring.
+6. Rewards distribute.
+7. World state updates.
+
+## Recurrence
+
+Suggested cadence:
+
+- Daily: small zone quests and local events.
+- Weekly: guild objectives, Forge Rush, Arena trials.
+- Weekend: guild war window.
+- Seasonal: major lore campaign and prize-hunt arc.
+
+## Design rule
+
+Events should create stories people retell. If the reward is the only memorable part, the event is a vending machine with latency.

--- a/src/screens/playground/hermes-world-landing.tsx
+++ b/src/screens/playground/hermes-world-landing.tsx
@@ -2,6 +2,7 @@ import { PlaygroundHeroCanvas } from './components/playground-hero-canvas'
 
 const HERMES_REPO_URL = 'https://github.com/outsourc-e/hermes-workspace'
 const HERMES_ROADMAP_URL = 'https://github.com/outsourc-e/hermes-workspace/blob/main/docs/hermesworld/master-roadmap.md'
+const HERMES_DOCS_URL = 'https://github.com/outsourc-e/hermes-workspace/tree/main/docs/hermesworld'
 const HERMES_FEATURES_URL = 'https://github.com/outsourc-e/hermes-workspace/blob/main/FEATURES-INVENTORY.md'
 
 const externalLinkProps = { target: '_blank', rel: 'noreferrer' }
@@ -111,8 +112,8 @@ export function HermesWorldLanding() {
             <a href={HERMES_REPO_URL} {...externalLinkProps} className="inline-flex items-center justify-center rounded-xl border border-[#d9b35f]/24 bg-[#0b1118]/78 px-6 py-4 text-sm font-black uppercase tracking-[0.14em] text-[#f8e4ac] shadow-[inset_0_1px_0_rgba(255,255,255,.08)] backdrop-blur-xl transition hover:border-[#d9b35f]/50 hover:bg-[#121823]">
               View on GitHub
             </a>
-            <a href={HERMES_ROADMAP_URL} {...externalLinkProps} className="inline-flex items-center justify-center rounded-xl border border-[#d9b35f]/24 bg-[#0b1118]/78 px-6 py-4 text-sm font-black uppercase tracking-[0.14em] text-[#f8e4ac] shadow-[inset_0_1px_0_rgba(255,255,255,.08)] backdrop-blur-xl transition hover:border-[#d9b35f]/50 hover:bg-[#121823]">
-              Read Roadmap
+            <a href={HERMES_DOCS_URL} {...externalLinkProps} className="inline-flex items-center justify-center rounded-xl border border-[#d9b35f]/24 bg-[#0b1118]/78 px-6 py-4 text-sm font-black uppercase tracking-[0.14em] text-[#f8e4ac] shadow-[inset_0_1px_0_rgba(255,255,255,.08)] backdrop-blur-xl transition hover:border-[#d9b35f]/50 hover:bg-[#121823]">
+              Read Docs
             </a>
           </div>
 
@@ -166,6 +167,7 @@ function Header() {
         <a href="#sigils" className="transition hover:text-[#f8e4ac]">Sigils</a>
         <a href="#preview" className="transition hover:text-[#f8e4ac]">Preview</a>
         <a href="#today" className="transition hover:text-[#f8e4ac]">Today</a>
+        <a href={HERMES_DOCS_URL} {...externalLinkProps} className="transition hover:text-[#f8e4ac]">Docs</a>
         <a href="/playground" className="rounded-lg border border-[#ffe7a3]/55 bg-[linear-gradient(180deg,#ffe7a3,#d9a63f)] px-4 py-2 font-black text-[#11100b] shadow-[0_0_30px_rgba(217,179,95,.18)] transition hover:brightness-110">▶ Play</a>
         <a href={HERMES_REPO_URL} {...externalLinkProps} className="rounded-lg border border-[#d9b35f]/30 bg-[#d9b35f]/10 px-4 py-2 text-[#f8e4ac] shadow-[0_0_30px_rgba(217,179,95,.08)] transition hover:bg-[#d9b35f]/18">GitHub</a>
       </nav>
@@ -384,6 +386,7 @@ function FinalCta() {
         <p className="mx-auto mt-5 max-w-2xl text-base leading-8 text-[#d7d0bd]/62">Enter HermesWorld and explore the first playable layer of Hermes Workspace: zones, quests, companions, sigils, and persistent agent progression.</p>
         <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a href="/playground" className="rounded-xl bg-[#f8e4ac] px-7 py-4 text-sm font-black uppercase tracking-[0.14em] text-[#11100b] transition hover:-translate-y-0.5 hover:bg-white">▶ Play Now</a>
+          <a href={HERMES_DOCS_URL} {...externalLinkProps} className="rounded-xl border border-white/12 bg-white/[0.055] px-7 py-4 text-sm font-black uppercase tracking-[0.14em] text-white/78 transition hover:bg-white/[0.1]">Read Docs</a>
           <a href={HERMES_REPO_URL} {...externalLinkProps} className="rounded-xl border border-white/12 bg-white/[0.055] px-7 py-4 text-sm font-black uppercase tracking-[0.14em] text-white/78 transition hover:bg-white/[0.1]">View GitHub</a>
           <a href={HERMES_ROADMAP_URL} {...externalLinkProps} className="rounded-xl border border-white/12 bg-white/[0.055] px-7 py-4 text-sm font-black uppercase tracking-[0.14em] text-white/78 transition hover:bg-white/[0.1]">Read Roadmap</a>
         </div>
@@ -401,6 +404,7 @@ function Footer() {
       </div>
       <div className="flex flex-wrap gap-4 uppercase tracking-[0.16em]">
         <a href={HERMES_REPO_URL} {...externalLinkProps} className="hover:text-[#f8e4ac]">GitHub</a>
+        <a href={HERMES_DOCS_URL} {...externalLinkProps} className="hover:text-[#f8e4ac]">Docs</a>
         <a href={HERMES_ROADMAP_URL} {...externalLinkProps} className="hover:text-[#f8e4ac]">Roadmap</a>
         <a href={HERMES_FEATURES_URL} {...externalLinkProps} className="hover:text-[#f8e4ac]">Feature List</a>
         <a href="#today" className="hover:text-[#f8e4ac]">Today’s Drop</a>


### PR DESCRIPTION
## Summary
- Add the HermesWorld docs index plus full lore bible covering world origin, zones, Sigils, classes, factions, and timeline.
- Add player-facing guides for getting started, controls, quests, crafting, social systems, companions, and Founders.
- Add walkthroughs for Athena intro, first companion, first Forge craft, and recurring world events.
- Link the HermesWorld landing page to the Markdown docs tree as the cheaper static GitHub docs option.

## Notes
- Markdown-first, no images included; art lane can layer visuals later.
- Synthesizes docs/hermesworld/VISION-BEST-AI-MMO.md, AGENTIC-WOW-ROHAN-SYSTEMS.md, GUILDS-AGENTS-COMPANION-ECONOMY.md, and INGAME-TARGET-SPEC.md.
- Crosslinked for in-game tooltip/onboarding extraction.

## Validation
- Markdown local link check: passed
- Secret-pattern diff scan: passed
- git diff --check: passed
- pnpm exec eslint src/screens/playground/hermes-world-landing.tsx: passed
- pnpm build: passed