### PR TITLE
feat: wire playground auth and Founder Vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@react-three/rapier": "^2.2.0",
+    "@supabase/supabase-js": "^2.105.3",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-router": "^1.132.0",

--- a/playground-ws-worker/src/worker.ts
+++ b/playground-ws-worker/src/worker.ts
@@ -32,6 +32,8 @@ type AnalyticsEvent = {
   id: string
   name?: string
   color?: string
+  user_id?: string
+  username?: string
   world?: string
   text?: string
   ts: number
@@ -41,6 +43,8 @@ type PlayerDailySummary = {
   id: string
   name?: string
   color?: string
+  user_id?: string
+  username?: string
   firstSeen: number
   lastSeen: number
   lastWorld?: string
@@ -54,6 +58,9 @@ interface PresenceMsg {
   id: string
   worldId?: string
   world?: string
+  userId?: string
+  user_id?: string
+  username?: string
   x?: number
   y?: number
   z?: number
@@ -182,7 +189,7 @@ export class PlaygroundHubV2 {
 
   notePlayer(
     id: string,
-    patch: Partial<PlayerDailySummary> & { name?: string; color?: string; lastWorld?: string },
+    patch: Partial<PlayerDailySummary> & { name?: string; color?: string; user_id?: string; username?: string; lastWorld?: string },
     ts = Date.now(),
   ) {
     this.ensureAnalyticsDay(ts)
@@ -193,6 +200,8 @@ export class PlaygroundHubV2 {
           ...patch,
           name: patch.name ?? current.name,
           color: patch.color ?? current.color,
+          user_id: patch.user_id ?? current.user_id,
+          username: patch.username ?? current.username,
           lastSeen: ts,
           lastWorld: patch.lastWorld ?? current.lastWorld,
           lastChatAt: patch.lastChatAt ?? current.lastChatAt,
@@ -203,6 +212,8 @@ export class PlaygroundHubV2 {
           id,
           name: patch.name,
           color: patch.color,
+          user_id: patch.user_id,
+          username: patch.username,
           firstSeen: ts,
           lastSeen: ts,
           lastWorld: patch.lastWorld,
@@ -433,6 +444,8 @@ export class PlaygroundHubV2 {
       this.notePlayer(body.id, {
         name: typeof body.name === 'string' ? body.name : undefined,
         color: typeof body.color === 'string' ? body.color : undefined,
+        user_id: typeof body.user_id === 'string' ? body.user_id : typeof body.userId === 'string' ? body.userId : undefined,
+        username: typeof body.username === 'string' ? body.username : undefined,
         lastWorld: world,
         joins: wasNew ? (this.playerDaily.get(body.id)?.joins || 0) + 1 : (this.playerDaily.get(body.id)?.joins || 0),
       }, now)
@@ -443,6 +456,8 @@ export class PlaygroundHubV2 {
           id: body.id,
           name: typeof body.name === 'string' ? body.name : undefined,
           color: typeof body.color === 'string' ? body.color : undefined,
+          user_id: typeof body.user_id === 'string' ? body.user_id : typeof body.userId === 'string' ? body.userId : undefined,
+          username: typeof body.username === 'string' ? body.username : undefined,
           world,
           ts: now,
         })
@@ -454,6 +469,8 @@ export class PlaygroundHubV2 {
           id: body.id,
           name: typeof body.name === 'string' ? body.name : undefined,
           color: typeof body.color === 'string' ? body.color : undefined,
+          user_id: typeof body.user_id === 'string' ? body.user_id : typeof body.userId === 'string' ? body.userId : undefined,
+          username: typeof body.username === 'string' ? body.username : undefined,
           world,
           ts: now,
         })
@@ -505,6 +522,8 @@ export class PlaygroundHubV2 {
       this.notePlayer(body.id, {
         name: typeof body.name === 'string' ? body.name : undefined,
         color: typeof body.color === 'string' ? body.color : undefined,
+        user_id: typeof body.user_id === 'string' ? body.user_id : typeof body.userId === 'string' ? body.userId : undefined,
+        username: typeof body.username === 'string' ? body.username : undefined,
         lastWorld: (body.world || body.worldId) as string | undefined,
         lastChatAt: body.ts,
         chats: (this.playerDaily.get(body.id)?.chats || 0) + 1,
@@ -514,6 +533,8 @@ export class PlaygroundHubV2 {
         id: body.id,
         name: typeof body.name === 'string' ? body.name : undefined,
         color: typeof body.color === 'string' ? body.color : undefined,
+        user_id: typeof body.user_id === 'string' ? body.user_id : typeof body.userId === 'string' ? body.userId : undefined,
+        username: typeof body.username === 'string' ? body.username : undefined,
         world: (body.world || body.worldId) as string | undefined,
         text: typeof body.text === 'string' ? body.text.slice(0, 160) : undefined,
         ts: body.ts,
@@ -622,6 +643,8 @@ export class PlaygroundHubV2 {
       this.notePlayer(msg.id, {
         name: typeof msg.name === 'string' ? msg.name : undefined,
         color: typeof msg.color === 'string' ? msg.color : undefined,
+        user_id: typeof msg.user_id === 'string' ? msg.user_id : typeof msg.userId === 'string' ? msg.userId : undefined,
+        username: typeof msg.username === 'string' ? msg.username : undefined,
         lastWorld: world,
         joins: wasNew ? (this.playerDaily.get(msg.id)?.joins || 0) + 1 : (this.playerDaily.get(msg.id)?.joins || 0),
       }, now)
@@ -648,6 +671,8 @@ export class PlaygroundHubV2 {
       this.notePlayer(msg.id, {
         name: typeof msg.name === 'string' ? msg.name : undefined,
         color: typeof msg.color === 'string' ? msg.color : undefined,
+        user_id: typeof msg.user_id === 'string' ? msg.user_id : typeof msg.userId === 'string' ? msg.userId : undefined,
+        username: typeof msg.username === 'string' ? msg.username : undefined,
         lastWorld: (msg.world || msg.worldId) as string | undefined,
         lastChatAt: typeof msg.ts === 'number' ? msg.ts : Date.now(),
         chats: (this.playerDaily.get(msg.id)?.chats || 0) + 1,
@@ -657,6 +682,8 @@ export class PlaygroundHubV2 {
         id: msg.id,
         name: typeof msg.name === 'string' ? msg.name : undefined,
         color: typeof msg.color === 'string' ? msg.color : undefined,
+        user_id: typeof msg.user_id === 'string' ? msg.user_id : typeof msg.userId === 'string' ? msg.userId : undefined,
+        username: typeof msg.username === 'string' ? msg.username : undefined,
         world: (msg.world || msg.worldId) as string | undefined,
         text: typeof msg.text === 'string' ? msg.text.slice(0, 160) : undefined,
         ts: typeof msg.ts === 'number' ? msg.ts : Date.now(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@react-three/rapier':
         specifier: ^2.2.0
         version: 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0)
+      '@supabase/supabase-js':
+        specifier: ^2.105.3
+        version: 2.105.3
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.1(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -1841,6 +1844,33 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@supabase/auth-js@2.105.3':
+    resolution: {integrity: sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.3':
+    resolution: {integrity: sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.1':
+    resolution: {integrity: sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==}
+
+  '@supabase/postgrest-js@2.105.3':
+    resolution: {integrity: sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.3':
+    resolution: {integrity: sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.3':
+    resolution: {integrity: sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.3':
+    resolution: {integrity: sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==}
+    engines: {node: '>=20.0.0'}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -2343,6 +2373,9 @@ packages:
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -3904,6 +3937,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -8107,6 +8144,46 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.3
 
+  '@supabase/auth-js@2.105.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.1': {}
+
+  '@supabase/postgrest-js@2.105.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.3':
+    dependencies:
+      '@supabase/phoenix': 0.4.1
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.105.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.3':
+    dependencies:
+      '@supabase/auth-js': 2.105.3
+      '@supabase/functions-js': 2.105.3
+      '@supabase/postgrest-js': 2.105.3
+      '@supabase/realtime-js': 2.105.3
+      '@supabase/storage-js': 2.105.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -8718,6 +8795,10 @@ snapshots:
     optional: true
 
   '@types/webxr@0.5.24': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -10674,6 +10755,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iceberg-js@0.8.1: {}
 
   iconv-corefoundation@1.1.7:
     dependencies:

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,78 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+
+export type Profile = {
+  id: string
+  username: string | null
+  display_name: string | null
+  avatar_url: string | null
+  discord_id?: string | null
+  x_handle?: string | null
+  is_founder: boolean
+  founder_rank: number | null
+  founder_claimed?: boolean | null
+  claimed_rewards: Json
+  created_at?: string
+  updated_at?: string | null
+}
+
+export type Database = {
+  public: {
+    Tables: {
+      profiles: {
+        Row: Profile
+        Insert: Partial<Omit<Profile, 'id'>> & { id: string }
+        Update: Partial<Profile>
+      }
+    }
+    Functions: {
+      claim_founder_vault: {
+        Args: Record<string, never>
+        Returns: Profile | Profile[] | Json
+      }
+    }
+  }
+}
+
+type HermesSupabaseClient = SupabaseClient<Database>
+
+const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {}
+
+export const supabaseUrl = env.VITE_SUPABASE_URL?.trim() ?? ''
+export const supabaseAnonKey = env.VITE_SUPABASE_ANON_KEY?.trim() ?? ''
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey)
+
+function createMockSupabaseClient(): HermesSupabaseClient {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    neq: () => builder,
+    maybeSingle: async () => ({ data: null, error: null }),
+    single: async () => ({ data: null, error: null }),
+    upsert: () => builder,
+    update: () => builder,
+  }
+
+  return {
+    auth: {
+      getSession: async () => ({ data: { session: null }, error: null }),
+      getUser: async () => ({ data: { user: null }, error: null }),
+      onAuthStateChange: () => ({ data: { subscription: { id: 'mock', callback: () => undefined, unsubscribe: () => undefined } } }),
+      signInWithOAuth: async () => ({ data: { provider: 'google', url: '' }, error: null }),
+      signOut: async () => ({ error: null }),
+    },
+    from: () => builder,
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as HermesSupabaseClient
+}
+
+export const supabase: HermesSupabaseClient = isSupabaseConfigured
+  ? createClient<Database>(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    })
+  : (createMockSupabaseClient() as HermesSupabaseClient)

--- a/src/screens/playground/components/playground-world-3d.tsx
+++ b/src/screens/playground/components/playground-world-3d.tsx
@@ -3015,6 +3015,8 @@ export function PlaygroundWorld3D({
   monsterDefeated,
   onMonsterAttack,
   multiplayerName,
+  multiplayerUserId,
+  multiplayerUsername,
   onIncomingChat,
   onRemotePlayersChange,
   objectiveTargetId,
@@ -3039,6 +3041,8 @@ export function PlaygroundWorld3D({
   monsterDefeated: boolean
   onMonsterAttack: () => void
   multiplayerName?: string
+  multiplayerUserId?: string
+  multiplayerUsername?: string
   onIncomingChat?: (msg: IncomingChat) => void
   onRemotePlayersChange?: (players: Record<string, MpRemotePlayer>) => void
   objectiveTargetId?: string | null
@@ -3065,6 +3069,8 @@ export function PlaygroundWorld3D({
     positionRef: positionForMp,
     yawRef: playerYaw,
     name: multiplayerName,
+    userId: multiplayerUserId,
+    username: multiplayerUsername,
     onChat: onIncomingChat,
   })
   // Expose sendChat + multiplayer info globally so HUD/chat panel can read it.

--- a/src/screens/playground/hooks/use-playground-auth.ts
+++ b/src/screens/playground/hooks/use-playground-auth.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Session } from '@supabase/supabase-js'
+import { isSupabaseConfigured, supabase, type Json, type Profile } from '@/lib/supabase'
+import type { PlaygroundItemId, PlayerProfile } from '../lib/playground-rpg'
+
+export const FOUNDER_REWARD_IDS: PlaygroundItemId[] = [
+  'founder-cape',
+  'founder-banner',
+  'aether-50',
+  'coins-1000',
+  'trader-trial',
+  'founder-title',
+  'founder-pet',
+]
+
+type AuthStatus = 'guest' | 'loading' | 'signed-in' | 'error'
+
+export type PlaygroundAuthState = {
+  configured: boolean
+  status: AuthStatus
+  session: Session | null
+  profile: Profile | null
+  error: string | null
+}
+
+function asRewardIds(value: Json | undefined): string[] {
+  if (!value) return []
+  if (Array.isArray(value)) return value.filter((entry): entry is string => typeof entry === 'string')
+  if (typeof value === 'object') {
+    const rewards = (value as { founder_vault?: unknown; rewards?: unknown }).founder_vault
+      ?? (value as { rewards?: unknown }).rewards
+    if (Array.isArray(rewards)) return rewards.filter((entry): entry is string => typeof entry === 'string')
+    return Object.entries(value)
+      .filter(([, claimed]) => Boolean(claimed))
+      .map(([id]) => id)
+  }
+  return []
+}
+
+export function profileToPlayerPatch(profile: Profile): Partial<PlayerProfile> {
+  const username = profile.username?.trim() || profile.display_name?.trim() || ''
+  const claimedRewards = asRewardIds(profile.claimed_rewards)
+  const founderClaimed = Boolean(profile.founder_claimed) || FOUNDER_REWARD_IDS.every((id) => claimedRewards.includes(id))
+  return {
+    userId: profile.id,
+    username: username || null,
+    displayName: username,
+    avatarUrl: profile.avatar_url,
+    founderRank: profile.founder_rank,
+    isFounder: Boolean(profile.is_founder),
+    founderClaimed,
+    claimedRewards,
+    inventory: claimedRewards.filter((id): id is PlaygroundItemId => FOUNDER_REWARD_IDS.includes(id as PlaygroundItemId)),
+  }
+}
+
+export function usePlaygroundAuth(onProfile?: (patch: Partial<PlayerProfile>, profile: Profile) => void) {
+  const [state, setState] = useState<PlaygroundAuthState>({
+    configured: isSupabaseConfigured,
+    status: isSupabaseConfigured ? 'loading' : 'guest',
+    session: null,
+    profile: null,
+    error: null,
+  })
+
+  const loadProfile = useCallback(async (session: Session | null) => {
+    if (!isSupabaseConfigured || !session?.user?.id) {
+      setState((prev) => ({ ...prev, status: 'guest', session: null, profile: null, error: null }))
+      return null
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', session.user.id)
+        .maybeSingle()
+
+      if (error) throw error
+
+      const fallbackProfile: Profile = {
+        id: session.user.id,
+        username: null,
+        display_name: session.user.user_metadata?.full_name ?? session.user.email?.split('@')[0] ?? null,
+        avatar_url: session.user.user_metadata?.avatar_url ?? null,
+        is_founder: false,
+        founder_rank: null,
+        founder_claimed: false,
+        claimed_rewards: [],
+      }
+      const profile = data ?? fallbackProfile
+      setState({ configured: true, status: 'signed-in', session, profile, error: null })
+      onProfile?.(profileToPlayerPatch(profile), profile)
+      return profile
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Supabase profile unavailable'
+      setState((prev) => ({ ...prev, status: 'error', session, error: message }))
+      return null
+    }
+  }, [onProfile])
+
+  useEffect(() => {
+    let cancelled = false
+    async function boot() {
+      if (!isSupabaseConfigured) return
+      try {
+        const { data, error } = await supabase.auth.getSession()
+        if (error) throw error
+        if (!cancelled) void loadProfile(data.session)
+      } catch (error) {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : 'Auth unavailable'
+          setState((prev) => ({ ...prev, status: 'error', error: message }))
+        }
+      }
+    }
+    void boot()
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      void loadProfile(session)
+    })
+    return () => {
+      cancelled = true
+      data.subscription.unsubscribe()
+    }
+  }, [loadProfile])
+
+  const signIn = useCallback(() => {
+    if (typeof window === 'undefined') return
+    if (!isSupabaseConfigured) {
+      window.location.href = '/auth/signin'
+      return
+    }
+    supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: window.location.href },
+    }).catch(() => {
+      window.location.href = '/auth/signin'
+    })
+  }, [])
+
+  const signOut = useCallback(async () => {
+    try {
+      await supabase.auth.signOut()
+    } catch {
+      // Guest fallback: local save remains intact.
+    }
+    setState((prev) => ({ ...prev, status: 'guest', session: null, profile: null, error: null }))
+  }, [])
+
+  const syncUsername = useCallback(async (username: string) => {
+    const clean = username.trim()
+    if (!clean) return { ok: false, error: 'Choose a builder name first.' }
+    if (!isSupabaseConfigured || !state.session?.user?.id) return { ok: true as const }
+
+    try {
+      const { data: existing, error: lookupError } = await (supabase.from('profiles') as any)
+        .select('id, username')
+        .eq('username', clean)
+        .maybeSingle()
+      if (lookupError) throw lookupError
+      if (existing && existing.id !== state.session.user.id) {
+        return { ok: false, error: 'That builder name is already claimed.' }
+      }
+
+      const { data, error } = await (supabase.from('profiles') as any)
+        .upsert({ id: state.session.user.id, username: clean, display_name: clean }, { onConflict: 'id' })
+        .select('*')
+        .single()
+      if (error) throw error
+      if (data) {
+        setState((prev) => ({ ...prev, profile: data }))
+        onProfile?.(profileToPlayerPatch(data), data)
+      }
+      return { ok: true as const }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Could not sync username. Guest save kept locally.'
+      return { ok: false, error: message }
+    }
+  }, [onProfile, state.session])
+
+  const claimFounderVault = useCallback(async () => {
+    if (!isSupabaseConfigured || !state.session?.user?.id) {
+      return { ok: false, error: 'Sign in to claim the Founder Vault.' }
+    }
+    try {
+      const { data, error } = await (supabase.rpc as any)('claim_founder_vault')
+      if (error) throw error
+      const profile = Array.isArray(data) ? data[0] : data && typeof data === 'object' && 'id' in data ? data as Profile : null
+      const claimedRewards = profile ? asRewardIds(profile.claimed_rewards) : FOUNDER_REWARD_IDS
+      if (profile) {
+        setState((prev) => ({ ...prev, profile }))
+        onProfile?.(profileToPlayerPatch(profile), profile)
+      }
+      return { ok: true as const, rewardIds: claimedRewards.length ? claimedRewards : FOUNDER_REWARD_IDS }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Founder Vault claim failed.'
+      return { ok: false, error: message }
+    }
+  }, [onProfile, state.session])
+
+  return useMemo(() => ({
+    ...state,
+    signIn,
+    signOut,
+    syncUsername,
+    claimFounderVault,
+  }), [claimFounderVault, signIn, signOut, state, syncUsername])
+}

--- a/src/screens/playground/hooks/use-playground-multiplayer.ts
+++ b/src/screens/playground/hooks/use-playground-multiplayer.ts
@@ -31,12 +31,15 @@ export type RemotePlayer = {
   yaw: number
   lastChat?: string
   lastChatAt?: number
+  userId?: string
+  user_id?: string
+  username?: string
   ts: number
   avatar?: AvatarConfig
 }
 
 type PresenceWire = RemotePlayer & { kind: 'presence' }
-type ChatWire = { kind: 'chat'; id: string; name: string; color: string; world: PlaygroundWorldId; text: string; ts: number }
+type ChatWire = { kind: 'chat'; id: string; name: string; color: string; userId?: string; user_id?: string; username?: string; world: PlaygroundWorldId; text: string; ts: number }
 type LeaveWire = { kind: 'leave'; id: string }
 type CountWire = { kind: 'count'; online: number; byWorld?: Record<string, number>; peakToday?: number; ts: number }
 type Wire = PresenceWire | ChatWire | LeaveWire | CountWire
@@ -98,6 +101,8 @@ export function usePlaygroundMultiplayer({
   positionRef,
   yawRef,
   name,
+  userId,
+  username,
   onChat,
 }: {
   world: PlaygroundWorldId
@@ -105,6 +110,8 @@ export function usePlaygroundMultiplayer({
   positionRef: React.MutableRefObject<{ x: number; y: number; z: number } | null>
   yawRef: React.MutableRefObject<number>
   name?: string
+  userId?: string
+  username?: string
   onChat?: (msg: IncomingChat) => void
 }) {
   const selfId = useMemo(() => getSelfId(), [])
@@ -205,6 +212,9 @@ export function usePlaygroundMultiplayer({
               id: selfId,
               name: myName,
               color: myColor,
+              userId,
+              user_id: userId,
+              username,
               world,
               interior,
               x: pos.x,
@@ -260,7 +270,7 @@ export function usePlaygroundMultiplayer({
       try { ws?.close() } catch {}
       wsRef.current = null
     }
-  }, [selfId, mergePresence])
+  }, [selfId, myName, myColor, userId, username, world, interior, positionRef, yawRef, mergePresence])
 
   // Open BroadcastChannel
   useEffect(() => {
@@ -328,6 +338,9 @@ export function usePlaygroundMultiplayer({
           id: selfId,
           name: myName,
           color: myColor,
+          userId,
+          user_id: userId,
+          username,
           world,
           interior,
           x: pos.x,
@@ -358,7 +371,7 @@ export function usePlaygroundMultiplayer({
       })
     }, PRESENCE_INTERVAL_MS)
     return () => window.clearInterval(tick)
-  }, [selfId, myName, myColor, world, interior, positionRef, yawRef])
+  }, [selfId, myName, myColor, userId, username, world, interior, positionRef, yawRef])
 
   // ───── HTTP polling transport (reliable fallback) ─────
   // WebSockets have too many failure modes (CF DO hibernation, bg-tab
@@ -390,6 +403,9 @@ export function usePlaygroundMultiplayer({
             id: selfId,
             name: myName,
             color: myColor,
+            userId,
+            user_id: userId,
+            username,
             world,
             interior,
             x: pos.x,
@@ -448,7 +464,7 @@ export function usePlaygroundMultiplayer({
       window.removeEventListener('pagehide', onUnload)
       onUnload()
     }
-  }, [selfId, myName, myColor, world, interior, positionRef, yawRef, mergePresence])
+  }, [selfId, myName, myColor, userId, username, world, interior, positionRef, yawRef, mergePresence])
 
   // Also send chats over HTTP so they propagate even when WS is dead.
   // We override sendChat to do both.
@@ -462,9 +478,9 @@ export function usePlaygroundMultiplayer({
     fetch(`${baseUrl}/chat`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ id: selfId, name: myName, color: myColor, world, text: trimmed.slice(0, 240), ts: Date.now() }),
+      body: JSON.stringify({ id: selfId, name: myName, color: myColor, userId, user_id: userId, username, world, text: trimmed.slice(0, 240), ts: Date.now() }),
     }).catch(() => {})
-  }, [selfId, myName, myColor, world])
+  }, [selfId, myName, myColor, userId, username, world])
 
   // Immediately re-send presence when the tab becomes visible (after being
   // backgrounded). Background tabs are throttled by the browser and can stop
@@ -486,6 +502,9 @@ export function usePlaygroundMultiplayer({
             id: selfId,
             name: myName,
             color: myColor,
+            userId,
+            user_id: userId,
+            username,
             world,
             interior,
             x: pos.x,
@@ -506,7 +525,7 @@ export function usePlaygroundMultiplayer({
       document.removeEventListener('visibilitychange', onVisible)
       window.removeEventListener('focus', onVisible)
     }
-  }, [selfId, myName, myColor, world, interior, positionRef, yawRef])
+  }, [selfId, myName, myColor, userId, username, world, interior, positionRef, yawRef])
 
   const sendChat = useCallback((text: string) => {
     const trimmed = text.trim()
@@ -516,7 +535,10 @@ export function usePlaygroundMultiplayer({
       id: selfId,
       name: myName,
       color: myColor,
-      world,
+          userId,
+          user_id: userId,
+          username,
+          world,
       text: trimmed.slice(0, 240),
       ts: Date.now(),
     }
@@ -526,7 +548,7 @@ export function usePlaygroundMultiplayer({
       try { wsRef.current.send(JSON.stringify(wire)) } catch {}
     }
     httpSendChat(trimmed) // HTTP polling transport — always works
-  }, [selfId, myName, myColor, world, httpSendChat])
+  }, [selfId, myName, myColor, userId, username, world, httpSendChat])
 
   // World-scoped remote players: never render people from other worlds.
   const visibleRemotes = useMemo(() => {

--- a/src/screens/playground/hooks/use-playground-rpg.ts
+++ b/src/screens/playground/hooks/use-playground-rpg.ts
@@ -81,6 +81,13 @@ function defaultProfile(): PlayerProfile {
     xp: 0,
     titlesUnlocked: [],
     lastZone: 'training',
+    userId: null,
+    username: null,
+    avatarUrl: null,
+    founderRank: null,
+    isFounder: false,
+    founderClaimed: false,
+    claimedRewards: [],
   }
 }
 
@@ -139,7 +146,14 @@ function normalizeState(raw: Partial<PlaygroundRpgState> | null): PlaygroundRpgS
   const profile: PlayerProfile = {
     ...base.playerProfile,
     ...rawProfile,
-    displayName: rawProfile?.displayName ?? '',
+    displayName: rawProfile?.displayName ?? rawProfile?.username ?? '',
+    username: rawProfile?.username ?? null,
+    userId: rawProfile?.userId ?? null,
+    avatarUrl: rawProfile?.avatarUrl ?? null,
+    founderRank: rawProfile?.founderRank ?? null,
+    isFounder: Boolean(rawProfile?.isFounder),
+    founderClaimed: Boolean(rawProfile?.founderClaimed),
+    claimedRewards: Array.from(new Set(rawProfile?.claimedRewards ?? [])),
     avatarConfig: { ...base.playerProfile.avatarConfig, ...(rawProfile?.avatarConfig ?? {}) },
     equipped: { ...EMPTY_EQUIPPED, ...(rawProfile?.equipped ?? {}) },
     inventory: Array.from(new Set(rawProfile?.inventory ?? legacyInventory ?? [])),
@@ -292,12 +306,26 @@ export function usePlaygroundRpg() {
     }, kind === 'title' ? 6500 : 4500)
   }, [])
 
+  const hydrateAuthProfile = useCallback((patch: Partial<PlayerProfile>) => {
+    setState((prev) => ({
+      ...prev,
+      playerProfile: {
+        ...prev.playerProfile,
+        ...patch,
+        displayName: patch.displayName ?? patch.username ?? prev.playerProfile.displayName,
+        claimedRewards: Array.from(new Set(patch.claimedRewards ?? prev.playerProfile.claimedRewards ?? [])),
+        inventory: Array.from(new Set([...(prev.playerProfile.inventory ?? []), ...(patch.inventory ?? [])])),
+      },
+    }))
+  }, [])
+
   const setDisplayName = useCallback((displayName: string) => {
     setState((prev) => ({
       ...prev,
       playerProfile: {
         ...prev.playerProfile,
         displayName,
+        username: displayName.trim() || prev.playerProfile.username || null,
       },
     }))
   }, [])
@@ -359,16 +387,17 @@ export function usePlaygroundRpg() {
       return completeQuestState(next, quest)
     })
     if (completedQuest) {
-      pushToast('quest', 'Quest Complete', completedQuest.title)
-      pushToast('xp', '+ XP', `+${completedQuest.reward.xp} XP`)
-      if (completedQuest.reward.items?.length) {
-        for (const itemId of completedQuest.reward.items) {
+      const questToast = completedQuest as PlaygroundQuest
+      pushToast('quest', 'Quest Complete', questToast.title)
+      pushToast('xp', '+ XP', `+${questToast.reward.xp} XP`)
+      if (questToast.reward.items?.length) {
+        for (const itemId of questToast.reward.items) {
           const item = itemById(itemId)
           if (item) pushToast('item', '+ Item', item.name)
         }
       }
-      if (completedQuest.reward.title) {
-        pushToast('title', 'Title Unlocked', completedQuest.reward.title)
+      if (questToast.reward.title) {
+        pushToast('title', 'Title Unlocked', questToast.reward.title)
       }
     }
   }, [pushToast])
@@ -385,6 +414,25 @@ export function usePlaygroundRpg() {
     for (const itemId of items) {
       const item = itemById(itemId)
       if (item) pushToast('item', '+ Item', item.name)
+    }
+  }, [pushToast])
+
+  const claimFounderRewards = useCallback((rewardIds: PlaygroundItemId[]) => {
+    if (!rewardIds.length) return
+    setState((prev) => ({
+      ...prev,
+      playerProfile: {
+        ...prev.playerProfile,
+        inventory: Array.from(new Set([...prev.playerProfile.inventory, ...rewardIds])),
+        claimedRewards: Array.from(new Set([...(prev.playerProfile.claimedRewards ?? []), ...rewardIds])),
+        founderClaimed: true,
+        titlesUnlocked: Array.from(new Set([...prev.playerProfile.titlesUnlocked, 'Founder'])),
+      },
+    }))
+    pushToast('title', 'Founder Vault Claimed', 'Founder rewards added to your inventory.')
+    for (const itemId of rewardIds) {
+      const item = itemById(itemId)
+      if (item) pushToast('item', '+ Founder Reward', item.name)
     }
   }, [pushToast])
 
@@ -547,6 +595,7 @@ export function usePlaygroundRpg() {
     worlds: PLAYGROUND_WORLDS,
     skills: PLAYGROUND_SKILLS,
     stats,
+    hydrateAuthProfile,
     setDisplayName,
     setAvatarConfig,
     setLastZone,
@@ -556,6 +605,7 @@ export function usePlaygroundRpg() {
     unlockWorld,
     grantItems,
     grantSkillXp,
+    claimFounderRewards,
     openInventory,
     equipItem,
     unequipSlot,

--- a/src/screens/playground/lib/playground-rpg.ts
+++ b/src/screens/playground/lib/playground-rpg.ts
@@ -36,6 +36,13 @@ export type PlaygroundItemId =
   | 'arena-medal'
   | 'song-fragment'
   | 'oracle-riddle'
+  | 'founder-cape'
+  | 'founder-banner'
+  | 'aether-50'
+  | 'coins-1000'
+  | 'trader-trial'
+  | 'founder-title'
+  | 'founder-pet'
 
 export type QuestObjectiveType =
   | 'talk_to_npc'
@@ -120,6 +127,13 @@ export type QuestProgressEntry = {
 }
 
 export type PlayerProfile = {
+  userId?: string | null
+  username?: string | null
+  avatarUrl?: string | null
+  founderRank?: number | null
+  isFounder?: boolean
+  founderClaimed?: boolean
+  claimedRewards?: string[]
   displayName: string
   avatarConfig: AvatarConfig
   equipped: EquippedItems
@@ -353,6 +367,58 @@ export const PLAYGROUND_ITEMS: PlaygroundItem[] = [
     icon: '🏅',
     rarity: 'legendary',
     description: 'Awarded for surviving the Duel of Models in the Benchmark Arena.',
+  },
+  {
+    id: 'founder-cape',
+    name: 'Founder Cape',
+    icon: '🧥',
+    rarity: 'legendary',
+    description: 'Animated gold-trim cloak cosmetic reserved for founders.',
+    slot: 'cloak',
+    accent: '#d9b35f',
+    stat: { label: 'Founder Guard', value: 7 },
+  },
+  {
+    id: 'founder-banner',
+    name: 'Founder Banner',
+    icon: '🏳️',
+    rarity: 'legendary',
+    description: 'Guild banner for founder house halls.',
+  },
+  {
+    id: 'aether-50',
+    name: 'Aether x50',
+    icon: '💠',
+    rarity: 'epic',
+    description: 'Premium crafting currency granted by the Founder Vault.',
+  },
+  {
+    id: 'coins-1000',
+    name: 'Coins x1000',
+    icon: '🪙',
+    rarity: 'epic',
+    description: 'Starter bankroll for shops and trade experiments.',
+  },
+  {
+    id: 'trader-trial',
+    name: 'Trader Agent Trial',
+    icon: '🤖',
+    rarity: 'epic',
+    description: 'Trial access to the Trader Agent.',
+  },
+  {
+    id: 'founder-title',
+    name: 'Founder Title',
+    icon: '👑',
+    rarity: 'legendary',
+    description: 'Permanent account title for launch founders.',
+  },
+  {
+    id: 'founder-pet',
+    name: 'Founder Pet',
+    icon: '🐉',
+    rarity: 'legendary',
+    description: 'Tiny aether wyrm companion.',
   },
 ]
 

--- a/src/screens/playground/playground-screen.tsx
+++ b/src/screens/playground/playground-screen.tsx
@@ -5,6 +5,7 @@ import { PlaygroundChat, type ChatMessage } from './components/playground-chat'
 import { PlaygroundCustomizer } from './components/playground-customizer'
 import { PlaygroundDialog } from './components/playground-dialog'
 import { PlaygroundHeroCanvas } from './components/playground-hero-canvas'
+import { FounderVaultPanel } from './components/founder-vault-panel'
 import { PlaygroundHud } from './components/playground-hud'
 import { PlaygroundJournal } from './components/playground-journal'
 import { PlaygroundMap } from './components/playground-map'
@@ -12,6 +13,7 @@ import { PlaygroundMinimap } from './components/playground-minimap'
 import { PlaygroundSidePanel } from './components/playground-sidepanel'
 import { PlaygroundWorld3D } from './components/playground-world-3d'
 import { Toast } from './components/toast'
+import { usePlaygroundAuth, FOUNDER_REWARD_IDS } from './hooks/use-playground-auth'
 import { usePlaygroundRpg } from './hooks/use-playground-rpg'
 import { playgroundAudio, usePlaygroundAudioMuted } from './lib/playground-audio'
 import { autoNarrateWorld, cancelNarration, isNarrationMuted, setNarrationMuted, narrateWorldNow } from './lib/playground-narration'
@@ -59,6 +61,7 @@ class PlaygroundErrorBoundary extends Component<
 
 export function PlaygroundScreen() {
   const rpg = usePlaygroundRpg()
+  const auth = usePlaygroundAuth(rpg.hydrateAuthProfile)
   const audioMuted = usePlaygroundAudioMuted()
   const [launched, setLaunched] = useState(false)
   const [world, setWorld] = useState<PlaygroundWorldId>(rpg.state.playerProfile.lastZone)
@@ -72,6 +75,9 @@ export function PlaygroundScreen() {
   const [mapOpen, setMapOpen] = useState(false)
   const [archiveOpen, setArchiveOpen] = useState(false)
   const [tutorialCompleteOpen, setTutorialCompleteOpen] = useState(false)
+  const [founderVaultOpen, setFounderVaultOpen] = useState(false)
+  const [founderClaiming, setFounderClaiming] = useState(false)
+  const [authNotice, setAuthNotice] = useState<string | null>(null)
   const [forgeIntro, setForgeIntro] = useState<ForgeIntroState>({ open: false, flavor: '', loading: false })
   const [transitioning, setTransitioning] = useState(false)
   const [monsterHp, setMonsterHp] = useState(44)
@@ -118,6 +124,7 @@ export function PlaygroundScreen() {
   const currentObjective = rpg.currentObjective
   const forgeUnlocked = rpg.state.unlockedWorlds.includes('forge')
   const monsterDefeated = rpg.state.completedQuests.includes('training-bonus-wisp')
+  const founderVaultEligible = Boolean(rpg.state.playerProfile.isFounder && !rpg.state.playerProfile.founderClaimed)
   const remotePlayersInZone = useMemo(
     () => Object.values(remotePlayers).filter((player) => player.world === world),
     [remotePlayers, world],
@@ -137,6 +144,10 @@ export function PlaygroundScreen() {
     if (typeof window === 'undefined') return
     forgeIntroSeenRef.current = window.localStorage.getItem(FORGE_INTRO_STORAGE_KEY) === '1'
   }, [])
+
+  useEffect(() => {
+    if (founderVaultEligible) setFounderVaultOpen(true)
+  }, [founderVaultEligible])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -430,6 +441,25 @@ export function PlaygroundScreen() {
     }
   }
 
+  async function handleFounderClaim() {
+    setFounderClaiming(true)
+    try {
+      const result = await auth.claimFounderVault()
+      if (!result.ok) {
+        setAuthNotice(result.error)
+        return
+      }
+      const claimedRewardIds = result.rewardIds ?? []
+      const rewardIds = (claimedRewardIds.length ? claimedRewardIds : FOUNDER_REWARD_IDS)
+        .filter((id): id is (typeof FOUNDER_REWARD_IDS)[number] => FOUNDER_REWARD_IDS.includes(id as (typeof FOUNDER_REWARD_IDS)[number]))
+      rpg.claimFounderRewards(rewardIds)
+      setFounderVaultOpen(false)
+      setAuthNotice('Founder Vault claimed. Rewards are now in your inventory.')
+    } finally {
+      setFounderClaiming(false)
+    }
+  }
+
   function handlePortal() {
     if (world === 'training' && !forgeUnlocked) return
     if (world === 'training') {
@@ -509,9 +539,23 @@ export function PlaygroundScreen() {
         <TitleScreen
           displayName={rpg.state.playerProfile.displayName}
           tutorialComplete={rpg.state.completedQuests.includes('training-q5')}
+          authStatus={auth.status}
+          authError={auth.error ?? authNotice}
+          signedIn={auth.status === 'signed-in'}
+          requiresUsername={auth.status === 'signed-in' && !rpg.state.playerProfile.username}
           onChangeDisplayName={rpg.setDisplayName}
           onCustomize={() => setCustomizerOpen(true)}
-          onEnter={() => setLaunched(true)}
+          onSignIn={auth.signIn}
+          onEnter={async () => {
+            const result = await auth.syncUsername(rpg.state.playerProfile.displayName)
+            if (!result.ok) {
+              setAuthNotice(result.error)
+              if (result.error.includes('already claimed')) return
+            } else {
+              setAuthNotice(null)
+            }
+            setLaunched(true)
+          }}
         />
         <PlaygroundCustomizer
           open={customizerOpen}
@@ -541,7 +585,9 @@ export function PlaygroundScreen() {
           playerHelmet={equippedVisuals.helmet}
           portalLabel={world === 'training' ? 'Forge Gate' : 'World Portal'}
           portalLocked={world === 'training' && !forgeUnlocked}
-          multiplayerName={rpg.state.playerProfile.displayName || undefined}
+          multiplayerName={rpg.state.playerProfile.displayName || rpg.state.playerProfile.username || undefined}
+          multiplayerUserId={rpg.state.playerProfile.userId ?? undefined}
+          multiplayerUsername={rpg.state.playerProfile.username ?? undefined}
           monsterHp={monsterHp}
           monsterHpMax={monsterHpMax}
           monsterDefeated={monsterDefeated}
@@ -691,6 +737,8 @@ export function PlaygroundScreen() {
         {adminMode ? <PlaygroundAdminPanel /> : null}
         <PlaygroundUtilityDock
           audioMuted={audioMuted}
+          signedIn={auth.status === 'signed-in'}
+          onSignIn={auth.signIn}
           narrationMuted={narrationMuted}
           onCustomize={() => setCustomizerOpen(true)}
           onToggleAudio={() => playgroundAudio.toggleMuted()}
@@ -721,6 +769,15 @@ export function PlaygroundScreen() {
             setWorld('training')
           }}
         />
+        <FounderVaultModal
+          open={founderVaultOpen}
+          eligible={founderVaultEligible}
+          claimedRewardIds={rpg.state.playerProfile.claimedRewards ?? []}
+          claiming={founderClaiming}
+          error={authNotice}
+          onClose={() => setFounderVaultOpen(false)}
+          onClaim={() => void handleFounderClaim()}
+        />
         <ForgeArrivalOverlay open={forgeIntro.open} flavor={forgeIntro.flavor} loading={forgeIntro.loading} />
         <LowHpOverlay active={lowHpActive} />
         <CameraPresetToast />
@@ -733,16 +790,27 @@ export function PlaygroundScreen() {
 function TitleScreen({
   displayName,
   tutorialComplete,
+  authStatus,
+  authError,
+  signedIn,
+  requiresUsername,
   onChangeDisplayName,
   onCustomize,
+  onSignIn,
   onEnter,
 }: {
   displayName: string
   tutorialComplete: boolean
+  authStatus: 'guest' | 'loading' | 'signed-in' | 'error'
+  authError: string | null
+  signedIn: boolean
+  requiresUsername: boolean
   onChangeDisplayName: (value: string) => void
   onCustomize: () => void
-  onEnter: () => void
+  onSignIn: () => void
+  onEnter: () => Promise<void>
 }) {
+  const [entering, setEntering] = useState(false)
   const canEnter = displayName.trim().length > 0
 
   useEffect(() => {
@@ -847,6 +915,17 @@ function TitleScreen({
               >
                 ❖ Identify Yourself
               </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-white/58">
+                <span className="rounded-full border border-white/10 bg-black/30 px-2.5 py-1 uppercase tracking-[0.12em]">
+                  {signedIn ? 'Signed in' : authStatus === 'loading' ? 'Checking account…' : 'Guest mode'}
+                </span>
+                {!signedIn ? (
+                  <button type="button" onClick={onSignIn} className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-2.5 py-1 font-bold text-cyan-100 hover:bg-cyan-300/18">
+                    Sign in for Founder Vault
+                  </button>
+                ) : null}
+                {requiresUsername ? <span className="text-amber-100/80">Pick a unique builder name to sync your account.</span> : null}
+              </div>
               <input
                 value={displayName}
                 onChange={(event) => onChangeDisplayName(event.target.value.slice(0, 24))}
@@ -870,8 +949,15 @@ function TitleScreen({
                 </button>
                 <button
                   type="button"
-                  onClick={onEnter}
-                  disabled={!canEnter}
+                  onClick={async () => {
+                    setEntering(true)
+                    try {
+                      await onEnter()
+                    } finally {
+                      setEntering(false)
+                    }
+                  }}
+                  disabled={!canEnter || entering}
                   className="flex-1 rounded-xl border-2 px-6 py-3 text-base font-extrabold uppercase tracking-[0.18em] transition-all hover:scale-[1.02] disabled:opacity-40 disabled:hover:scale-100"
                   style={{
                     borderColor: '#facc15',
@@ -882,9 +968,14 @@ function TitleScreen({
                       : 'none',
                   }}
                 >
-                  Enter the Realm
+                  {entering ? 'Syncing…' : 'Enter the Realm'}
                 </button>
               </div>
+              {authError ? (
+                <p className="mt-3 rounded-xl border border-amber-300/20 bg-amber-300/8 px-3 py-2 text-xs text-amber-100/85">
+                  {authError}
+                </p>
+              ) : null}
             </div>
             <div className="grid gap-2 text-[12px] sm:grid-cols-3">
               <PremiumFeatureCard icon="❁" title="Six Worlds" desc="Training Grounds → Forge → Arena" />
@@ -1150,6 +1241,51 @@ function CameraPresetToast() {
   )
 }
 
+function FounderVaultModal({
+  open,
+  eligible,
+  claimedRewardIds,
+  claiming,
+  error,
+  onClose,
+  onClaim,
+}: {
+  open: boolean
+  eligible: boolean
+  claimedRewardIds: string[]
+  claiming: boolean
+  error: string | null
+  onClose: () => void
+  onClaim: () => void
+}) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-[92] flex items-center justify-center bg-black/70 p-4 backdrop-blur-md">
+      <div className="relative">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-10 rounded-full border border-white/12 bg-black/45 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-white/75 hover:bg-white/10"
+        >
+          Close
+        </button>
+        <FounderVaultPanel eligible={eligible && !claiming} claimedRewardIds={claimedRewardIds} onClaim={onClaim} />
+        {claiming ? (
+          <div className="absolute inset-x-6 bottom-6 rounded-2xl border border-amber-300/20 bg-black/75 px-4 py-3 text-sm font-bold text-amber-100">
+            Claiming Founder Vault…
+          </div>
+        ) : null}
+        {error ? (
+          <div className="mt-3 rounded-2xl border border-amber-300/20 bg-black/70 px-4 py-3 text-sm text-amber-100">
+            {error}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+
 const HERMES_LORE_LINES = [
   'Hermes carried prompts between the gods of Olympus and the builders of Earth.',
   'A Hermes Agent is just a fast, faithful messenger — with memory.',
@@ -1249,6 +1385,8 @@ function PlaygroundHelpHud({ worldName }: { worldName: string }) {
 
 function PlaygroundUtilityDock({
   audioMuted,
+  signedIn,
+  onSignIn,
   onCustomize,
   onToggleAudio,
   onReplayNarration,
@@ -1256,6 +1394,8 @@ function PlaygroundUtilityDock({
   narrationMuted,
 }: {
   audioMuted: boolean
+  signedIn: boolean
+  onSignIn: () => void
   onCustomize: () => void
   onToggleAudio: () => void
   onReplayNarration: () => void
@@ -1297,6 +1437,15 @@ function PlaygroundUtilityDock({
   }
   return (
     <div className="pointer-events-auto fixed bottom-[78px] right-3 z-[70] flex flex-col gap-1.5">
+      {!signedIn ? (
+        <button
+          onClick={onSignIn}
+          className="flex h-10 w-10 items-center justify-center rounded-xl border border-amber-300/25 bg-black/65 text-base text-amber-100 backdrop-blur-xl hover:bg-amber-300/15"
+          title="Sign in for account sync and Founder Vault"
+        >
+          🔐
+        </button>
+      ) : null}
       <button
         onClick={captureScreenshot}
         className="flex h-10 w-10 items-center justify-center rounded-xl border border-white/15 bg-black/65 text-base text-cyan-100 backdrop-blur-xl hover:bg-cyan-400/20"


### PR DESCRIPTION
## Summary
- adds env-gated Supabase client with mock fallback for guest-safe playground auth
- hydrates signed-in profiles into game player state and syncs builder usernames back to profiles
- integrates the Founder Vault panel with claim_founder_vault RPC, local reward inventory hydration, and celebration toasts
- forwards authenticated user_id/username metadata through playground multiplayer presence/chat while preserving anonymous sessions

## Verification
- pnpm run build
- scoped TypeScript check for touched playground/auth files showed no new app errors; only pre-existing worker/three/playground baseline errors remained
- env presence check confirmed VITE_SUPABASE_URL/VITE_SUPABASE_ANON_KEY are missing locally; staging RPC E2E needs deployed env credentials
- local dev server route smoke: /world returned HTTP 200
