### PR TITLE
docs: ChatGPT prompt batch 001 - portraits, icons, sigils, zones

### DIFF
--- a/docs/hermesworld/CHATGPT-PROMPT-BATCH-001.md
+++ b/docs/hermesworld/CHATGPT-PROMPT-BATCH-001.md
@@ -1,0 +1,269 @@
+# ChatGPT Prompt Batch 001 — HermesWorld Assets
+
+Use these prompts directly in ChatGPT image generation. Each prompt is self-contained and includes the style lock, subject, composition, and artifact constraints.
+
+Global handling note: download each PNG, keep the exact suggested filename, and place it in the matching folder under `/Users/aurora/Downloads/hermesworld-assets/`.
+
+---
+
+## BATCH A: NPC Portraits
+
+Style lock for all Batch A prompts: stylized fantasy MMO, premium dark fantasy with cyan/amber accents, warm parchment tones, painterly brushwork, 3/4 portrait, detailed faces, expressive, painted in the spirit of WoW/RuneScape concept art, no text, no logo, no watermark.
+
+### A1: Trader Merchant
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld NPC trader merchant from the Agora marketplace: a middle-aged man with a kind smile, weathered face, clever eyes, neatly trimmed beard, leather merchant apron over layered linen and wool, small bronze clasps, coin pouch, rolled parchment receipts, and subtle market-stall details behind him. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: warm amber lantern light from one side with a faint controlled cyan magical rim light. Background: softly blurred Agora marketplace with banners, stone columns, and warm stalls, not distracting. Composition: chest-up 3/4 portrait, centered, strong silhouette, readable at game UI size. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: trader-merchant.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A2: Quest Giver Elder Sage
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld quest giver elder sage: an ancient white-bearded mystic with wise eyes, deep brow lines, layered parchment-colored robes, bronze and gold trim, and a rune-engraved wooden staff held near his shoulder. The staff emits a restrained cyan glow from carved runes. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: soft amber firelight across the beard and cheekbones, cyan rune light catching the staff hand and robe edges. Background: blurred stone library alcove with candles and faint arcane glyphs, atmospheric but not busy. Composition: chest-up 3/4 portrait, centered, noble and readable. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: quest-giver-elder-sage.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A3: Female Warrior Captain
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld female warrior captain: confident, battle-tested, upright posture, one visible scar across the cheek, focused eyes, dark hair pulled back, gold-trimmed armor with worn steel plates, bronze fittings, leather straps, and a short crimson or deep amber cloak edge. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: heroic warm amber key light with subtle cool cyan edge light reflecting from polished armor. Background: blurred fortress banner and stone archway, low depth of field. Composition: chest-up 3/4 portrait, centered, strong readable silhouette, authoritative expression. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: female-warrior-captain.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A4: Mysterious Hooded Scholar
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld mysterious hooded scholar: face mostly obscured beneath a deep charcoal hood, only watchful eyes and a hint of nose visible, holding an ancient glowing tome open at chest level. The tome pages emit a controlled cyan magical light with tiny rune sparks, while the robe has amber stitching and bronze clasps. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, expressive detailed face area despite the shadow, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: cyan underlight from the book, warm amber candle glow on robe folds. Background: dim archive shelves and parchment scrolls, softly blurred. Composition: chest-up 3/4 portrait, centered, enigmatic silhouette, readable at UI scale. No readable text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: mysterious-hooded-scholar.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A5: Innkeeper
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld innkeeper: jovial middle-aged tavern host with ruddy cheeks, broad welcoming smile, expressive laugh lines, short tousled hair, woven shirt, rolled sleeves, simple leather vest, and a small towel or tankard detail. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: cozy amber hearth light, very subtle cyan window rim light so it still belongs to HermesWorld. Background: softly blurred tavern interior with wooden beams, candles, and warm shelves, no readable signs. Composition: chest-up 3/4 portrait, centered, friendly and instantly recognizable. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: innkeeper.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A6: Smith
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld blacksmith NPC: muscular build, soot-streaked face and forearms, intense but approachable expression, close-cropped hair or tied-back hair, heavy leather apron, bronze rivets, thick gloves, and a large hammer resting over one shoulder. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: hot amber forge glow across the face and hammer head, faint cyan reflection from an enchanted metal ingot off-frame. Background: blurred forge shapes, anvil silhouette, sparks, dark stone walls. Composition: chest-up 3/4 portrait, centered, strong readable silhouette. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: smith.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A7: Healer Priestess
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld healer priestess: serene expression, calm eyes, elegant white robes with warm parchment undertones, gold embroidery, small bronze clasp, softly glowing hands, and a gentle halo-like ambient light without looking saintly or overexposed. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: soft warm amber key light mixed with controlled cyan healing glow around the hands and robe edges. Background: blurred temple infirmary with candles, stone arch, herbs, and clean linen shapes. Composition: chest-up 3/4 portrait, centered, tranquil and readable. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: healer-priestess.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+### A8: Beggar Info Broker
+
+```text
+Create a high-quality 3/4 portrait of a HermesWorld beggar and info broker: hooded figure in worn layered cloth, watchful sharp eyes, thin knowing smile, weathered hands, patched cloak, hidden bronze token necklace, and subtle spy-network details like folded notes and small charms tucked into the clothing. Style: stylized fantasy MMO, premium dark fantasy with cyan and amber accents, warm parchment tones, painterly brushwork, detailed expressive face, concept art quality in the spirit of WoW/RuneScape character portraits. Lighting: low amber alley lantern light with a narrow cyan glint in the eyes or from a hidden charm. Background: softly blurred Agora side alley, stone wall, cloth awning, no readable signs. Composition: chest-up 3/4 portrait, centered, suspicious but charismatic, readable at UI scale. No text, no UI, no logo, no watermark, no photorealism, no anime, no plastic mobile-game look.
+```
+
+Note for Eric: Save the result as: beggar-info-broker.png in /Users/aurora/Downloads/hermesworld-assets/portraits/
+
+---
+
+## BATCH B: Item Icons
+
+Style lock for all Batch B prompts: 1024x1024 square, stylized 3D rendered fantasy item icon, isometric 3/4 view, dark obsidian background with subtle glow, gold/bronze metallic accents, Diablo-style polish, centered, well-lit, no text, no UI, no logo, no watermark.
+
+### B1: Bronze Sword
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a bronze sword, centered on a dark obsidian background with a subtle warm glow. The sword should be shown in isometric 3/4 view, slightly angled, with a polished bronze blade, gold-toned crossguard, worn leather grip, tiny engraved runes, and crisp beveled edges. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: bronze-sword.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B2: Healing Potion
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a healing potion: a red glass vial filled with glowing crimson liquid, centered on a dark obsidian background with a subtle amber halo. Show the vial in isometric 3/4 view with a cork stopper, bronze wire clasp, small parchment tag without readable writing, glass highlights, and a few tiny magical bubbles inside. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: healing-potion.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B3: Magic Scroll
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a magic scroll: rolled warm parchment unfurling slightly, bronze end caps, tied with a small cord, emitting a controlled cyan magical glow from the parchment edges. Center it on a dark obsidian background with subtle cyan and amber rim light. Show it in isometric 3/4 view with crisp curled paper silhouette and painterly material detail. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze accents, readable at small size. No readable text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: magic-scroll.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B4: Ornate Iron Key
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of an ornate iron key, centered on a dark obsidian background with a subtle amber glow. The key should be shown in isometric 3/4 view, made of dark iron with bronze wear on the edges, an elaborate circular bow, carved notches, small turquoise/cyan enamel inset, and a heavy ancient-dungeon feel. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: ornate-iron-key.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B5: Amber Glowing Gem
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a glowing amber gemstone, centered on a dark obsidian background with a subtle golden aura. Show the gem in isometric 3/4 view as a faceted crystal with warm internal light, bronze setting fragments around the base, sharp reflective facets, and tiny floating dust motes. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: amber-glowing-gem.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B6: Wooden Shield With Sigil
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a wooden shield with a simple fantasy sigil, centered on a dark obsidian background with subtle amber edge glow. Show the shield in isometric 3/4 view with layered dark oak planks, bronze rim, worn leather straps, small scratches, and a painted cyan-and-gold abstract winged mark that is symbolic but contains no letters. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: wooden-shield-sigil.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B7: Leather Pouch With Coins
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a leather pouch with coins spilling out, centered on a dark obsidian background with subtle warm glow. Show it in isometric 3/4 view: worn brown leather pouch, tied cord, bronze buckle, several gold and bronze coins tumbling forward, crisp silhouettes, polished highlights, and soft contact shadow. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: leather-pouch-coins.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B8: Open Spell Tome
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of an open spell tome, centered on a dark obsidian background with a controlled cyan magical glow. Show the tome in isometric 3/4 view with thick aged parchment pages, dark leather cover, bronze corner guards, raised spine bands, glowing page edges, and small abstract rune-like marks that are not readable text. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No readable text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: open-spell-tome.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B9: Wizard Staff With Crystal
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a wizard staff with a crystal, centered on a dark obsidian background with a subtle cyan and amber glow. Show the staff in isometric 3/4 view, diagonal composition, carved dark wood shaft, bronze bands, gold filigree, and a faceted cyan crystal at the top emitting restrained magical light. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: wizard-staff-crystal.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B10: Hunting Bow
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a hunting bow, centered on a dark obsidian background with a subtle warm amber glow. Show the bow in isometric 3/4 view with curved dark wood limbs, bronze fittings, taut string, leather grip, small feather charm, and a few tasteful cyan inlays near the handle. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: hunting-bow.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B11: Gold Ring With Gem
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a gold ring with a gemstone, centered on a dark obsidian background with a subtle amber halo. Show the ring in isometric 3/4 view with polished gold band, bronze shadowing in engraved grooves, a prominent cyan or amber faceted gem, tiny decorative filigree, and crisp reflective highlights. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: gold-ring-gem.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+### B12: Founder Cape
+
+```text
+Create a 1024x1024 square stylized 3D rendered fantasy item icon of a Founder Cape, centered on a dark obsidian background with a subtle regal glow. Show the cape in isometric 3/4 view as rich deep purple fabric with gold trim, bronze clasp, winged crown clasp motif, elegant folds, slight magical cyan edge shimmer, and premium founder-reward presence. Style: premium Diablo-style item icon polish, high contrast, dramatic studio lighting, gold/bronze metallic accents, readable at small size. No text, no UI, no logo, no watermark, no hands, no character, no busy background.
+```
+
+Note for Eric: Save the result as: founder-cape.png in /Users/aurora/Downloads/hermesworld-assets/icons/
+
+---
+
+## BATCH C: Banner & Sigil Emblems
+
+Style lock for all Batch C prompts: heraldic emblem, centered on dark midnight blue (#0F1622) background, gold filigree, parchment scroll texture behind, 1024x1024 square, high contrast, no text, no UI, no logo, no watermark.
+
+### C1: Hermes Caduceus Sigil
+
+```text
+Create a 1024x1024 square heraldic emblem for HermesWorld: a centered Hermes caduceus sigil with a winged staff and two intertwined serpents, designed as the main brand sigil but with no letters or readable text. Background: dark midnight blue (#0F1622). Behind the emblem, include a subtle warm parchment scroll texture. Emblem material: polished gold and antique bronze filigree with controlled cyan magical accents in the wing tips and staff core. Style: premium fantasy MMO heraldry, crisp symmetrical silhouette, painterly rendered metal, elegant and iconic, readable at small size. No text, no UI, no logo, no watermark, no photoreal corporate mark, no cluttered background.
+```
+
+Note for Eric: Save the result as: hermes-caduceus-sigil.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+### C2: Guild Banner — Order of Aether
+
+```text
+Create a 1024x1024 square heraldic guild banner emblem for HermesWorld: Order of Aether, centered on a dark midnight blue (#0F1622) background with a subtle parchment scroll texture behind. Main motif: a luminous cyan crystal suspended within a gold and bronze filigree frame, with small wing-like facets and delicate arcane geometry that contains no readable text. Style: premium fantasy MMO heraldry, crisp symmetrical silhouette, gold filigree, controlled cyan glow, painterly metal and parchment, readable at small size. No text, no UI, no logo, no watermark, no cluttered background.
+```
+
+Note for Eric: Save the result as: order-of-aether-banner.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+### C3: Guild Banner — Iron Wolves
+
+```text
+Create a 1024x1024 square heraldic guild banner emblem for HermesWorld: Iron Wolves, centered on a dark midnight blue (#0F1622) background with a subtle parchment scroll texture behind. Main motif: a snarling wolf head in antique bronze and dark iron, framed by gold filigree, sharp angular fur shapes, and faint amber battle-worn highlights. Add only a restrained cyan glint in the eyes or frame edge to tie it to HermesWorld. Style: premium fantasy MMO heraldry, bold symmetrical silhouette, painterly metal, readable at small size. No text, no UI, no logo, no watermark, no cluttered background.
+```
+
+Note for Eric: Save the result as: iron-wolves-banner.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+### C4: Guild Banner — Sun Sentinels
+
+```text
+Create a 1024x1024 square heraldic guild banner emblem for HermesWorld: Sun Sentinels, centered on a dark midnight blue (#0F1622) background with a subtle parchment scroll texture behind. Main motif: a radiant golden sun with sharp sentinel rays, bronze shield-like center, elegant gold filigree, and warm amber glow. Include tiny controlled cyan accent gems in the frame, but keep the sun motif dominant. Style: premium fantasy MMO heraldry, crisp symmetrical silhouette, painterly metal and parchment, readable at small size. No text, no UI, no logo, no watermark, no cluttered background.
+```
+
+Note for Eric: Save the result as: sun-sentinels-banner.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+### C5: Founder's Cape Emblem
+
+```text
+Create a 1024x1024 square heraldic emblem for a HermesWorld Founder's Cape, centered on a dark midnight blue (#0F1622) background with a subtle parchment scroll texture behind. Main motif: a winged crown in polished gold and antique bronze, framed by elegant filigree, with a regal purple enamel backing and a faint controlled cyan magical rim light. Style: premium fantasy MMO heraldry, iconic founder reward symbol, crisp symmetrical silhouette, painterly metal, readable at small size. No text, no UI, no logo, no watermark, no cluttered background.
+```
+
+Note for Eric: Save the result as: founders-cape-emblem.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+### C6: Trader's Guild Seal
+
+```text
+Create a 1024x1024 square heraldic seal for the HermesWorld Trader's Guild, centered on a dark midnight blue (#0F1622) background with a subtle parchment scroll texture behind. Main motif: balanced merchant scales combined with a small caduceus staff, rendered in polished gold and antique bronze, surrounded by coin-like filigree and warm amber highlights. Add restrained cyan glow to the caduceus centerline only. Style: premium fantasy MMO heraldry, crisp symmetrical silhouette, painterly metal and parchment, readable at small size. No text, no UI, no logo, no watermark, no cluttered background.
+```
+
+Note for Eric: Save the result as: traders-guild-seal.png in /Users/aurora/Downloads/hermesworld-assets/sigils/
+
+---
+
+## BATCH D: Zone Backgrounds
+
+Style lock for all Batch D prompts: stylized painterly fantasy MMO concept art, wide cinematic 16:9, dramatic lighting, depth, atmospheric haze, warm color palette with cool shadow accents, no text, no UI, no logo, no watermark.
+
+### D1: Agora Plaza at Golden Hour
+
+```text
+Create a wide cinematic 16:9 stylized painterly fantasy MMO concept art background of HermesWorld's Agora Plaza at golden hour. Scene: a circular civic plaza with a central fountain, stone columns, hanging banners, market stalls around the edges, warm lanterns, crates, awnings, potted plants, and a clear walkable center. Use warm amber sunlight and torchlight with cool cyan accents on portals, roof trims, and magical civic details. Style: premium browser-native fantasy RPG, painterly brushwork, dramatic lighting, atmospheric haze, strong depth, readable silhouettes, warm parchment and obsidian stone palette with gold/bronze details. Composition: central fountain as focal point, columns framing the plaza, lively market perimeter, cinematic depth, no characters dominating the scene. No text, no UI, no logo, no watermark, no photoreal modern city, no cyberpunk neon overload.
+```
+
+Note for Eric: Save the result as: agora-plaza-golden-hour.png in /Users/aurora/Downloads/hermesworld-assets/zones/
+
+### D2: Whispering Forest
+
+```text
+Create a wide cinematic 16:9 stylized painterly fantasy MMO concept art background of HermesWorld's Whispering Forest at twilight. Scene: ancient towering trees with twisted roots, a winding mossy path, glowing mushrooms, soft firefly-like motes, carved stones half-buried in moss, and deep atmospheric layers fading into cool blue shadows. Use a warm color palette in the foreground with amber lantern or mushroom glow, balanced by cool cyan and violet-blue shadow accents. Style: premium browser-native fantasy RPG, painterly brushwork, dramatic lighting, atmospheric haze, strong depth, readable silhouettes, magical but not cute. Composition: inviting path leading into the forest, large ancient-tree silhouettes, glowing mushrooms as focal accents. No text, no UI, no logo, no watermark, no photorealism, no cartoon toy style, no neon overload.
+```
+
+Note for Eric: Save the result as: whispering-forest-twilight.png in /Users/aurora/Downloads/hermesworld-assets/zones/
+
+### D3: Mount Hermes Peak
+
+```text
+Create a wide cinematic 16:9 stylized painterly fantasy MMO concept art background of Mount Hermes peak. Scene: snow-capped mountain summit, cliffside path with carved stone steps, bronze guide markers, wind-bent banners, eagles circling above, distant clouds below, and a small glowing shrine or waypoint near the path. Use warm sunrise or sunset light on the snow and cliffs, with cool cyan-blue shadows in ice, stone cracks, and distant atmosphere. Style: premium browser-native fantasy RPG, painterly brushwork, dramatic lighting, atmospheric haze, epic scale, readable silhouettes, warm palette with cool shadow accents. Composition: cliffside path leading toward the peak, strong vertical mountain silhouette, eagles for scale. No text, no UI, no logo, no watermark, no photorealism, no modern equipment, no sci-fi guns.
+```
+
+Note for Eric: Save the result as: mount-hermes-peak.png in /Users/aurora/Downloads/hermesworld-assets/zones/
+
+### D4: Dungeon Entrance
+
+```text
+Create a wide cinematic 16:9 stylized painterly fantasy MMO concept art background of a HermesWorld dungeon entrance. Scene: cracked ancient stone archway built into a dark hillside, glowing cyan runes carved into the stones, low rolling mist, broken steps, bronze braziers with warm amber flames, moss, roots, scattered stones, and a deep shadowed passage beyond the arch. Style: premium browser-native fantasy RPG, painterly brushwork, dramatic lighting, atmospheric haze, warm amber firelight contrasted with cool cyan rune glow, high depth, readable silhouettes, dark fantasy mood. Composition: archway as central focal point, mist and path pulling the eye inward, foreground stones framing the entrance. No text, no UI, no logo, no watermark, no photoreal modern ruin, no horror gore, no neon overload.
+```
+
+Note for Eric: Save the result as: dungeon-entrance-runes.png in /Users/aurora/Downloads/hermesworld-assets/zones/


### PR DESCRIPTION
## Summary
- Adds ChatGPT-ready HermesWorld prompt batch 001
- Covers NPC portraits, item icons, heraldic sigils, and zone backgrounds
- Includes copy-paste prompt blocks plus exact save filenames/folders for Eric

## Verification
- Validated 30 prompt headings, 30 prompt code blocks, and 30 save notes
- Batch counts: A=8, B=12, C=6, D=4

No image assets generated; manifest logging not applicable.