### PR TITLE
fix: functionalize Hermes dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@
 # Without it, the gateway serves messaging platforms but not port 8642.
 # HERMES_API_URL=http://127.0.0.1:8642
 
+# Optional: Hermes dashboard companion API URL.
+# When available, this unlocks dashboard-backed sessions, skills, config,
+# cron, analytics, and toolset data. The workspace still opens without it.
+# HERMES_DASHBOARD_URL=http://127.0.0.1:9119
+
 # Project Agent API token — required when the gateway is authenticated
 # (e.g. Docker deployments exposing API_SERVER_HOST=0.0.0.0).
 #
@@ -46,6 +51,12 @@
 #
 # Leave unset for local loopback gateways that don't set API_SERVER_KEY.
 # HERMES_API_TOKEN=your-gateway-secret
+
+# Optional: colon-separated env files loaded into workspace terminal PTY
+# sessions. Values are injected into the spawned terminal process only and
+# are never printed by the workspace. Defaults:
+# /home/lucas/.hermes/.env.shared:~/.hermes/.env.shared:~/.hermes/.env
+# HERMES_TERMINAL_ENV_FILES=/home/lucas/.hermes/.env.shared:/home/lucas/.hermes/agents/atlas/.env
 
 # Project Agent directory (auto-detected if sibling to workspace)
 # Set this if hermes-agent is installed elsewhere

--- a/README.md
+++ b/README.md
@@ -100,6 +100,35 @@ Verify: `curl http://127.0.0.1:8642/health` should return ok. Then start the wor
 
 ---
 
+## Dashboard
+
+Hermes Workspace has two dashboard surfaces:
+
+- `/dashboard` — general Hermes workspace overview with quick navigation, session metrics, model/config status, skills, and recent sessions.
+- `/ll-ops` — LL Empire Hermes-only operating cockpit for briefing, pipeline, agents, clients, performance placeholders, and integration gates.
+
+Both routes open even when the Hermes gateway or dashboard companion API is offline. In that state the UI shows safe fixture/fallback data and explicit unavailable states instead of blocking the whole app behind setup. Live data is enabled by these optional env vars:
+
+```bash
+HERMES_API_URL=http://127.0.0.1:8645
+HERMES_DASHBOARD_URL=http://127.0.0.1:9119
+HERMES_API_TOKEN=<same value as API_SERVER_KEY when gateway auth is enabled>
+```
+
+The terminal route uses a real PTY. If the CLI needs Hermes credentials, configure `HERMES_TERMINAL_ENV_FILES` or keep the default env file locations documented in `.env.example`; secret values are loaded into the terminal process without being printed by the workspace.
+
+Useful checks:
+
+```bash
+npm run test
+npm run build
+./node_modules/.bin/eslint src/screens/ll-ops/ll-ops-dashboard-screen.tsx src/screens/dashboard/dashboard-screen.tsx src/components/workspace-shell.tsx src/server/terminal-sessions.ts src/routes/api/auth-check.ts src/routes/api/debug-analyze.ts
+```
+
+See [`docs/dashboard.md`](./docs/dashboard.md) for the operating tutorial and current limitations.
+
+---
+
 ### Manual install
 
 Hermes Workspace works with any OpenAI-compatible backend. If your backend also exposes Hermes gateway APIs, enhanced features like sessions, memory, skills, and jobs unlock automatically.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,90 @@
+# Dashboard Operating Guide
+
+## Purpose
+
+Hermes Workspace exposes two dashboard routes:
+
+- `/dashboard`: general Hermes workspace control surface for sessions, model status, skills, terminal, and settings.
+- `/ll-ops`: LL Empire Hermes-only ops cockpit for briefing, content pipeline, agent state, client placeholders, performance placeholders, and integration gates.
+
+The dashboard is designed to remain usable without external credentials. When Hermes gateway or dashboard companion APIs are unavailable, the UI renders fixture/fallback data and clear unavailable states instead of blocking access.
+
+## Local Run
+
+```bash
+npx pnpm@10 install --frozen-lockfile
+npm run dev
+```
+
+Open `http://localhost:3000/dashboard` or `http://localhost:3000/ll-ops`.
+
+This repo also supports:
+
+```bash
+npm run test
+npm run build
+npm run start
+```
+
+`npm run start` intentionally runs the TanStack Start/Vite server because this workspace is deployed in service mode with `vite dev`, not `vite preview`.
+
+## Required And Optional Env Vars
+
+Core chat backend:
+
+```bash
+HERMES_API_URL=http://127.0.0.1:8645
+HERMES_API_TOKEN=<same value as API_SERVER_KEY when gateway auth is enabled>
+```
+
+Optional dashboard companion API:
+
+```bash
+HERMES_DASHBOARD_URL=http://127.0.0.1:9119
+```
+
+Optional terminal env loading:
+
+```bash
+HERMES_TERMINAL_ENV_FILES=/home/lucas/.hermes/.env.shared:/home/lucas/.hermes/agents/atlas/.env
+```
+
+Do not place secrets in client code. Keep them in env files or server-side process env only.
+
+## Step-by-Step Usage
+
+1. Open `/dashboard`.
+2. Use `New Chat`, `Terminal`, `Skills`, and `Settings` to move to real routes. Buttons route even when enhanced APIs are unavailable.
+3. Read unavailable widgets as capability status, not app failure. Missing sessions/config/skills means the gateway or dashboard API is not exposing those endpoints yet.
+4. Open `/ll-ops`.
+5. Use the section buttons to filter the cockpit: Overview, Research, Pipeline, Performance, Agents, Clients, Settings.
+6. Use search to filter pipeline, agents, clients, integrations, and briefing rows.
+7. Click `Review` on a briefing row to mark the selected review item in the dashboard.
+8. Click `Refresh and reset` to clear search/review state and refetch read-only status.
+9. Open `/terminal` to use the persistent PTY workspace.
+10. Click the terminal debug button after a failing command to call `/api/debug-analyze`; it returns structured, safe diagnostics and suggested commands without exposing secret values.
+
+## Data Sources
+
+`/ll-ops` reads these sources when available:
+
+- `systemctl is-active` for Hermes service status.
+- `/home/lucas/llempire/SHARED_STATE.md`.
+- `/home/lucas/llempire/ACTIVE_STATE.md`.
+- `/home/lucas/llempire/ops/status.json`.
+
+When those paths are missing, the route returns safe missing-file/status metadata and the UI falls back to fixture content.
+
+`/dashboard` reads:
+
+- `/api/sessions` for session metrics.
+- `/api/hermes-config` for model/provider status.
+- `/api/skills` for skills summary.
+- `/api/gateway-status` for capability gates.
+
+## Known Limitations
+
+- Live chat still requires a reachable OpenAI-compatible backend.
+- Enhanced session, skill, config, job, and dashboard data require Hermes gateway/dashboard APIs.
+- External business integrations such as Google Ads, YouTube, Instagram, TikTok, Apify, and ScrapeGraphAI remain disabled until credentials and write policy are approved.
+- Full-project `npm run lint` currently fails on pre-existing lint debt outside the dashboard changes. Targeted lint on changed dashboard files passes.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --port 3000",
     "build": "vite build",
-    "start": "NODE_OPTIONS=\"--max-old-space-size=2048\" node .output/server/index.mjs",
+    "start": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --host 0.0.0.0 --port ${PORT:-3000}",
     "start:dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --port 3000",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -39,6 +39,13 @@ const NAV_ITEMS = [
     match: (p: string) => p.startsWith('/dashboard'),
   },
   {
+    id: 'll-ops',
+    label: 'LL Ops',
+    icon: DashboardSquare01Icon,
+    to: '/ll-ops',
+    match: (p: string) => p.startsWith('/ll-ops'),
+  },
+  {
     id: 'terminal',
     label: 'Terminal',
     icon: CommandLineIcon,
@@ -236,9 +243,13 @@ export function MobileHamburgerMenu() {
                     ? {
                         background:
                           'var(--theme-accent-subtle, color-mix(in srgb, var(--theme-accent, #6366f1) 12%, transparent))',
-                        color: 'var(--theme-accent, var(--color-accent, #6366f1))',
+                        color:
+                          'var(--theme-accent, var(--color-accent, #6366f1))',
                       }
-                    : { color: 'var(--theme-muted, var(--color-ink-muted, #555))' }
+                    : {
+                        color:
+                          'var(--theme-muted, var(--color-ink-muted, #555))',
+                      }
                 }
               >
                 <HugeiconsIcon
@@ -275,7 +286,9 @@ export function MobileHamburgerMenu() {
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                style={{ color: 'var(--theme-accent, var(--color-accent, #6366f1))' }}
+                style={{
+                  color: 'var(--theme-accent, var(--color-accent, #6366f1))',
+                }}
               >
                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
                 <circle cx="12" cy="7" r="4" />

--- a/src/components/mobile-prompt/MobilePromptTrigger.tsx
+++ b/src/components/mobile-prompt/MobilePromptTrigger.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Cancel01Icon } from '@hugeicons/core-free-icons'
@@ -10,12 +10,8 @@ export function MobilePromptTrigger() {
   const [showPrompt, setShowPrompt] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [dontShowAgain, setDontShowAgain] = useState(false)
-  const [isDismissedForSession, setIsDismissedForSession] = useState(false)
-  const mountTimeRef = useRef<number | null>(null)
 
   useEffect(() => {
-    mountTimeRef.current = Date.now()
-
     // ?mobile-preview forces modal open immediately (dev/review only)
     // Strip the param from URL so navigation doesn't re-trigger it
     if (
@@ -28,33 +24,7 @@ export function MobilePromptTrigger() {
       return
     }
 
-    const isDismissed =
-      localStorage.getItem('hermes-mobile-access-dismissed') === 'true' ||
-      localStorage.getItem('hermes-mobile-prompt-dismissed') === 'true'
-    const isSetup = localStorage.getItem('hermes-mobile-setup-seen') === 'true'
-
-    if (isDismissed || isSetup) {
-      return
-    }
-
-    const checkPrompt = () => {
-      if (!mountTimeRef.current) {
-        return
-      }
-
-      const elapsedTime = Date.now() - mountTimeRef.current
-      const isDesktop = window.innerWidth > 768
-      const hasBeenOnPageLongEnough = elapsedTime >= 45_000
-
-      if (isDesktop && hasBeenOnPageLongEnough && !isDismissedForSession) {
-        setShowPrompt(true)
-      }
-    }
-
-    checkPrompt()
-    const interval = window.setInterval(checkPrompt, 5_000)
-    return () => window.clearInterval(interval)
-  }, [isDismissedForSession])
+  }, [])
 
   const persistDismissalPreference = () => {
     if (dontShowAgain) {
@@ -64,13 +34,11 @@ export function MobilePromptTrigger() {
 
   const dismissPrompt = () => {
     persistDismissalPreference()
-    setIsDismissedForSession(true)
     setShowPrompt(false)
   }
 
   const openSetup = () => {
     persistDismissalPreference()
-    setIsDismissedForSession(true)
     setShowPrompt(false)
     setIsModalOpen(true)
   }

--- a/src/components/terminal/debug-panel.tsx
+++ b/src/components/terminal/debug-panel.tsx
@@ -31,7 +31,7 @@ export function DebugPanel({
       animate={{ x: 0, opacity: 1 }}
       transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'absolute inset-y-0 right-0 z-40 flex h-full w-[400px] max-w-full translate-x-0 flex-col border-l border-primary-700/40 bg-[#0d0d0d] text-primary-100 shadow-2xl transition-transform duration-200',
+        'absolute bottom-0 right-0 top-8 z-40 flex w-[400px] max-w-full translate-x-0 flex-col border-l border-primary-700/40 bg-[#0d0d0d] text-primary-100 shadow-2xl transition-transform duration-200',
       )}
       role="complementary"
       aria-label="Debug analyzer"

--- a/src/components/terminal/terminal-workspace.tsx
+++ b/src/components/terminal/terminal-workspace.tsx
@@ -15,6 +15,7 @@ import type * as FitAddonModule from 'xterm-addon-fit'
 import type { Terminal } from 'xterm'
 import type * as XtermModule from 'xterm'
 import type * as WebLinksAddonModule from 'xterm-addon-web-links'
+import 'xterm/css/xterm.css'
 import type { DebugAnalysis } from '@/components/terminal/debug-panel'
 import type { TerminalTab } from '@/stores/terminal-panel-store'
 import { DebugPanel } from '@/components/terminal/debug-panel'
@@ -35,8 +36,6 @@ async function ensureXterm() {
     import('xterm-addon-fit'),
     import('xterm-addon-web-links'),
   ])
-  // Load CSS on client only
-  await import('xterm/css/xterm.css')
   TerminalCtor = xtermMod.Terminal
   FitAddonCtor = fitMod.FitAddon
   WebLinksAddonCtor = linksMod.WebLinksAddon

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,14 +11,20 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
-import { ConnectionStartupScreen } from '@/components/connection-startup-screen'
 import { ChatSidebar } from '@/screens/chat/components/chat-sidebar'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -37,6 +43,7 @@ import { useMobileKeyboard } from '@/hooks/use-mobile-keyboard'
 // System metrics footer removed — not used in Hermes Workspace
 import { CommandPalette } from '@/components/command-palette'
 import { useSettings } from '@/hooks/use-settings'
+import { fetchHermesAuthStatus } from '@/lib/hermes-auth'
 // ActivityTicker moved to dashboard-only (too noisy for global header)
 
 const TerminalWorkspace = lazy(() =>
@@ -98,6 +105,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   // Map pathname to tab index (mirrors TABS order in mobile-tab-bar)
   const getTabIndex = useCallback((path: string): number => {
     if (path === '/dashboard') return 0
+    if (path.startsWith('/ll-ops')) return 1
     if (path.startsWith('/chat') || path === '/new' || path === '/') return 1
     if (path.startsWith('/files')) return 2
     if (path.startsWith('/terminal')) return 3
@@ -112,10 +120,8 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   }, [])
 
   const isClient = typeof window !== 'undefined'
-  // Both SSR and client start with the same value to avoid hydration mismatch.
-  // The ConnectionStartupScreen overlay verifies the real status on mount.
   const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
-  const [connectionVerified, setConnectionVerified] = useState(false)
+  const [connectionVerified, setConnectionVerified] = useState(true)
 
   const authState = {
     checked: !isClient || connectionVerified,
@@ -123,14 +129,29 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     authRequired: authStatus?.authRequired ?? false,
   }
 
-  const handleStartupConnected = useCallback((status: AuthStatus) => {
-    setAuthStatus(status)
-    setConnectionVerified(true)
+  useEffect(() => {
+    let cancelled = false
+
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (cancelled) return
+        setAuthStatus(status)
+        setConnectionVerified(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setConnectionVerified(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   // Derive active session from URL
   const mobilePageTitle = (() => {
     if (pathname.startsWith('/terminal')) return 'Terminal'
+    if (pathname.startsWith('/ll-ops')) return 'LL Ops'
     if (pathname.startsWith('/files')) return 'Files'
     if (pathname.startsWith('/jobs')) return 'Jobs'
     if (pathname.startsWith('/conductor')) return 'Conductor'
@@ -175,7 +196,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const startNewChat = useCallback(() => {
     setCreatingSession(true)
-    navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'new' } }).then(
+    navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'main' } }).then(
       () => {
         setCreatingSession(false)
       },
@@ -401,9 +422,6 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
           />
         ) : null}
 
-        {!authState.checked ? (
-          <ConnectionStartupScreen onConnected={handleStartupConnected} />
-        ) : null}
       </div>
 
       <MobileHamburgerMenu />

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
+import { Route as LlOpsRouteImport } from './routes/ll-ops'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as DashboardRouteImport } from './routes/dashboard'
@@ -47,6 +48,7 @@ import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
+import { Route as ApiLlOpsStatusRouteImport } from './routes/api/ll-ops-status'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
 import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
@@ -55,6 +57,7 @@ import { Route as ApiHermesConfigRouteImport } from './routes/api/hermes-config'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
+import { Route as ApiDebugAnalyzeRouteImport } from './routes/api/debug-analyze'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
 import { Route as ApiContextUsageRouteImport } from './routes/api/context-usage'
 import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection-status'
@@ -129,6 +132,11 @@ const OperationsRoute = OperationsRouteImport.update({
 const MemoryRoute = MemoryRouteImport.update({
   id: '/memory',
   path: '/memory',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlOpsRoute = LlOpsRouteImport.update({
+  id: '/ll-ops',
+  path: '/ll-ops',
   getParentRoute: () => rootRouteImport,
 } as any)
 const JobsRoute = JobsRouteImport.update({
@@ -286,6 +294,11 @@ const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
   path: '/api/local-providers',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiLlOpsStatusRoute = ApiLlOpsStatusRouteImport.update({
+  id: '/api/ll-ops-status',
+  path: '/api/ll-ops-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHistoryRoute = ApiHistoryRouteImport.update({
   id: '/api/history',
   path: '/api/history',
@@ -324,6 +337,11 @@ const ApiFilesRoute = ApiFilesRouteImport.update({
 const ApiEventsRoute = ApiEventsRouteImport.update({
   id: '/api/events',
   path: '/api/events',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDebugAnalyzeRoute = ApiDebugAnalyzeRouteImport.update({
+  id: '/api/debug-analyze',
+  path: '/api/debug-analyze',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiCrewStatusRoute = ApiCrewStatusRouteImport.update({
@@ -536,6 +554,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/ll-ops': typeof LlOpsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -551,6 +570,7 @@ export interface FileRoutesByFullPath {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/debug-analyze': typeof ApiDebugAnalyzeRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -559,6 +579,7 @@ export interface FileRoutesByFullPath {
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/ll-ops-status': typeof ApiLlOpsStatusRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -624,6 +645,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/ll-ops': typeof LlOpsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -638,6 +660,7 @@ export interface FileRoutesByTo {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/debug-analyze': typeof ApiDebugAnalyzeRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -646,6 +669,7 @@ export interface FileRoutesByTo {
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/ll-ops-status': typeof ApiLlOpsStatusRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -712,6 +736,7 @@ export interface FileRoutesById {
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
   '/jobs': typeof JobsRoute
+  '/ll-ops': typeof LlOpsRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
   '/profiles': typeof ProfilesRoute
@@ -727,6 +752,7 @@ export interface FileRoutesById {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/debug-analyze': typeof ApiDebugAnalyzeRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -735,6 +761,7 @@ export interface FileRoutesById {
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/ll-ops-status': typeof ApiLlOpsStatusRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -802,6 +829,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/ll-ops'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -817,6 +845,7 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/debug-analyze'
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
@@ -825,6 +854,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
     | '/api/history'
+    | '/api/ll-ops-status'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -890,6 +920,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/ll-ops'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -904,6 +935,7 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/debug-analyze'
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
@@ -912,6 +944,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
     | '/api/history'
+    | '/api/ll-ops-status'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -977,6 +1010,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/files'
     | '/jobs'
+    | '/ll-ops'
     | '/memory'
     | '/operations'
     | '/profiles'
@@ -992,6 +1026,7 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/debug-analyze'
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
@@ -1000,6 +1035,7 @@ export interface FileRouteTypes {
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
     | '/api/history'
+    | '/api/ll-ops-status'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1066,6 +1102,7 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRoute
   FilesRoute: typeof FilesRoute
   JobsRoute: typeof JobsRoute
+  LlOpsRoute: typeof LlOpsRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
   ProfilesRoute: typeof ProfilesRoute
@@ -1081,6 +1118,7 @@ export interface RootRouteChildren {
   ApiConnectionStatusRoute: typeof ApiConnectionStatusRoute
   ApiContextUsageRoute: typeof ApiContextUsageRoute
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
+  ApiDebugAnalyzeRoute: typeof ApiDebugAnalyzeRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
@@ -1089,6 +1127,7 @@ export interface RootRouteChildren {
   ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
   ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
+  ApiLlOpsStatusRoute: typeof ApiLlOpsStatusRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
@@ -1181,6 +1220,13 @@ declare module '@tanstack/react-router' {
       path: '/memory'
       fullPath: '/memory'
       preLoaderRoute: typeof MemoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ll-ops': {
+      id: '/ll-ops'
+      path: '/ll-ops'
+      fullPath: '/ll-ops'
+      preLoaderRoute: typeof LlOpsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jobs': {
@@ -1400,6 +1446,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiLocalProvidersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/ll-ops-status': {
+      id: '/api/ll-ops-status'
+      path: '/api/ll-ops-status'
+      fullPath: '/api/ll-ops-status'
+      preLoaderRoute: typeof ApiLlOpsStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/history': {
       id: '/api/history'
       path: '/api/history'
@@ -1454,6 +1507,13 @@ declare module '@tanstack/react-router' {
       path: '/api/events'
       fullPath: '/api/events'
       preLoaderRoute: typeof ApiEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/debug-analyze': {
+      id: '/api/debug-analyze'
+      path: '/api/debug-analyze'
+      fullPath: '/api/debug-analyze'
+      preLoaderRoute: typeof ApiDebugAnalyzeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/crew-status': {
@@ -1838,6 +1898,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardRoute: DashboardRoute,
   FilesRoute: FilesRoute,
   JobsRoute: JobsRoute,
+  LlOpsRoute: LlOpsRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
   ProfilesRoute: ProfilesRoute,
@@ -1853,6 +1914,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiConnectionStatusRoute: ApiConnectionStatusRoute,
   ApiContextUsageRoute: ApiContextUsageRoute,
   ApiCrewStatusRoute: ApiCrewStatusRoute,
+  ApiDebugAnalyzeRoute: ApiDebugAnalyzeRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
@@ -1861,6 +1923,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
   ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
   ApiHistoryRoute: ApiHistoryRoute,
+  ApiLlOpsStatusRoute: ApiLlOpsStatusRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,

--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { getRootSurfaceState } from './-root-layout-state'
 
 describe('root layout surface state', () => {
-  it('shows fullscreen onboarding until onboarding is complete', () => {
+  it('opens the workspace shell even before onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
-      showOnboarding: true,
-      showWorkspaceShell: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
-      showOnboarding: true,
-      showWorkspaceShell: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
       showPostOnboardingOverlays: false,
     })
   })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -9,8 +9,8 @@ export function getRootSurfaceState(
 ): RootSurfaceState {
   if (onboardingComplete !== true) {
     return {
-      showOnboarding: true,
-      showWorkspaceShell: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
       showPostOnboardingOverlays: false,
     }
   }

--- a/src/routes/-root-layout-utils.test.ts
+++ b/src/routes/-root-layout-utils.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getRootLayoutMode } from './__root'
 
 describe('getRootLayoutMode', () => {
-  it('shows fullscreen onboarding until onboarding is complete', () => {
-    expect(getRootLayoutMode(null)).toBe('onboarding')
-    expect(getRootLayoutMode('')).toBe('onboarding')
+  it('shows fullscreen onboarding only when explicitly requested', () => {
+    expect(getRootLayoutMode('false')).toBe('onboarding')
+  })
+
+  it('shows the workspace shell by default', () => {
+    expect(getRootLayoutMode(null)).toBe('workspace')
+    expect(getRootLayoutMode('')).toBe('workspace')
   })
 
   it('shows the workspace shell after onboarding is complete', () => {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -24,13 +24,11 @@ import {
 import { ErrorBoundary } from '@/components/error-boundary'
 import { getRootSurfaceState } from './-root-layout-state'
 
-
 const APP_CSP = [
   "default-src 'self'",
   "base-uri 'self'",
   "object-src 'none'",
   "form-action 'self'",
-  "frame-ancestors 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
@@ -205,8 +203,10 @@ export const Route = createRootRoute({
 
 const queryClient = new QueryClient()
 
-export function getRootLayoutMode(onboardingComplete: string | null): 'onboarding' | 'workspace' {
-  return onboardingComplete === 'true' ? 'workspace' : 'onboarding'
+export function getRootLayoutMode(
+  onboardingComplete: string | null,
+): 'onboarding' | 'workspace' {
+  return onboardingComplete === 'false' ? 'onboarding' : 'workspace'
 }
 
 export function wrapInlineScript(source: string): string {
@@ -214,7 +214,11 @@ export function wrapInlineScript(source: string): string {
 }
 
 type ServiceWorkerLike = {
-  getRegistrations: () => Promise<ReadonlyArray<{ unregister: () => boolean | Promise<boolean> | void | Promise<void> }>>
+  getRegistrations: () => Promise<
+    ReadonlyArray<{
+      unregister: () => boolean | Promise<boolean> | void | Promise<void>
+    }>
+  >
 }
 
 type CachesLike = {
@@ -240,7 +244,9 @@ export async function unregisterServiceWorkers({
 
   await cachesApi
     ?.keys()
-    .then((names) => Promise.allSettled(names.map((name) => cachesApi.delete(name))))
+    .then((names) =>
+      Promise.allSettled(names.map((name) => cachesApi.delete(name))),
+    )
     .catch(() => undefined)
 }
 
@@ -254,9 +260,9 @@ function RootLayout() {
 
     const syncOnboardingCompletion = () => {
       try {
-        setOnboardingComplete(localStorage.getItem(ONBOARDING_KEY) === 'true')
+        setOnboardingComplete(localStorage.getItem(ONBOARDING_KEY) !== 'false')
       } catch {
-        setOnboardingComplete(false)
+        setOnboardingComplete(true)
       }
     }
 
@@ -282,7 +288,8 @@ function RootLayout() {
     )
 
     void unregisterServiceWorkers({
-      serviceWorker: 'serviceWorker' in navigator ? navigator.serviceWorker : undefined,
+      serviceWorker:
+        'serviceWorker' in navigator ? navigator.serviceWorker : undefined,
       cachesApi: 'caches' in window ? caches : undefined,
     })
 
@@ -347,120 +354,19 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         `),
           }}
         />
-        <script dangerouslySetInnerHTML={{ __html: wrapInlineScript(themeScript) }} />
+        <script
+          dangerouslySetInnerHTML={{ __html: wrapInlineScript(themeScript) }}
+        />
         <HeadContent />
         <script
-          dangerouslySetInnerHTML={{ __html: wrapInlineScript(themeColorScript) }}
+          dangerouslySetInnerHTML={{
+            __html: wrapInlineScript(themeColorScript),
+          }}
         />
       </head>
       <body>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: wrapInlineScript(`
-          (function(){
-            if (document.getElementById('splash-screen')) return;
-            var bg = '#031A1A', txt = '#F8F1E3', muted = '#9CB2AE', accent = '#FFAC02';
-            try {
-              var theme = localStorage.getItem('${THEME_STORAGE_KEY}') || '${DEFAULT_THEME}';
-              if (theme === 'hermes-nous') {
-                bg = '#031A1A';
-                txt = '#F8F1E3';
-                muted = '#9CB2AE';
-                accent = '#FFAC02';
-              } else if (theme === 'hermes-nous-light') {
-                bg = '#F8FAF8';
-                txt = '#16315F';
-                muted = '#6F7D96';
-                accent = '#2557B7';
-              } else if (theme === 'hermes-classic') {
-                bg = '#0d0f12';
-                txt = '#eceff4';
-                muted = '#7f8a96';
-                accent = '#b98a44';
-              } else if (theme === 'hermes-official-light') {
-                bg = '#F7F7F1';
-                txt = '#16315F';
-                muted = '#6F7D96';
-                accent = '#2557B7';
-              } else if (theme === 'hermes-classic-light') {
-                bg = '#F5F2ED';
-                txt = '#1a1f26';
-                muted = '#6F675E';
-                accent = '#b98a44';
-              } else if (theme === 'hermes-slate') {
-                bg = '#0d1117';
-                txt = '#c9d1d9';
-                muted = '#8b949e';
-                accent = '#7eb8f6';
-              } else if (theme === 'hermes-slate-light') {
-                bg = '#F6F8FA';
-                txt = '#24292f';
-                muted = '#57606A';
-                accent = '#3b82f6';
-              }
-            } catch(e){}
-
-            var isDark = !['hermes-nous-light','hermes-official-light','hermes-classic-light','hermes-slate-light'].includes(theme);
-            var quips = ["Consulting the oracle...","Loading ancient knowledge...","Warming up the messenger...","Calibrating tool chain...","Summoning Hermes...","Preparing the workspace...","Bridging realms...","Initializing agent runtime..."];
-            var quip = quips[Math.floor(Math.random() * quips.length)];
-
-            var d = document.createElement('div');
-            d.id = 'splash-screen';
-            d.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;align-items:center;justify-content:center;background:'+bg+';transition:opacity 0.5s ease;';
-            d.innerHTML = '<img src="/hermes-avatar.webp" alt="Hermes" style="width:80px;height:80px;margin-bottom:20px;border-radius:16px;filter:drop-shadow(0 8px 32px color-mix(in srgb,'+accent+' 45%, transparent))" />'
-              + '<img src="'+(isDark ? '/hermes-banner.png' : '/hermes-banner-light.png')+'" alt="Hermes Workspace" style="width:280px;height:auto;margin-bottom:8px;filter:drop-shadow(0 4px 16px '+(isDark ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.1)')+')" />'
-              + '<div style="font:400 14px/1 system-ui,-apple-system,sans-serif;letter-spacing:0.04em;color:'+muted+'">Workspace</div>'
-              + '<div style="margin-top:28px;width:140px;height:3px;background:'+(isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)')+';border-radius:3px;overflow:hidden;position:relative"><div id=splash-bar style="width:0%;height:100%;background:'+accent+';border-radius:3px;transition:width 0.4s ease"></div></div>';
-            document.body.prepend(d);
-
-            var bar = document.getElementById('splash-bar');
-            if (bar) {
-              setTimeout(function(){ bar.style.width='15%' }, 300);
-              setTimeout(function(){ bar.style.width='40%' }, 800);
-              setTimeout(function(){ bar.style.width='65%' }, 1500);
-              setTimeout(function(){ bar.style.width='85%' }, 2500);
-              setTimeout(function(){ bar.style.width='92%' }, 3200);
-            }
-
-            window.__dismissSplash = function() {
-              var el = document.getElementById('splash-screen');
-              if (!el) return;
-              if (bar) bar.style.width = '100%';
-              setTimeout(function(){
-                el.style.opacity = '0';
-                setTimeout(function(){ el.remove(); }, 500);
-              }, 300);
-            };
-            // Fallback: always dismiss after 5s
-            setTimeout(function(){ window.__dismissSplash && window.__dismissSplash(); }, 5000);
-            // Fast dismiss: returning users skip quickly
-            try {
-              if (localStorage.getItem('hermes-hermes-url') || localStorage.getItem('hermes-url')) {
-                setTimeout(function(){ window.__dismissSplash && window.__dismissSplash(); }, 600);
-              }
-            } catch(e) {}
-          })()
-        `),
-          }}
-        />
         <div className="root">{children}</div>
         <Scripts />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: wrapInlineScript(`
-          (function(){
-            var start = Date.now();
-            function check() {
-              var el = document.querySelector('nav, aside, .workspace-shell, [data-testid]');
-              var elapsed = Date.now() - start;
-              if (el && elapsed > 2500) { window.__dismissSplash && window.__dismissSplash(); }
-              else { setTimeout(check, 200); }
-            }
-            setTimeout(check, 2500);
-          })()
-        `),
-          }}
-        />
       </body>
     </html>
   )

--- a/src/routes/api/auth-check.ts
+++ b/src/routes/api/auth-check.ts
@@ -10,6 +10,9 @@ export const Route = createFileRoute('/api/auth-check')({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        const authRequired = isPasswordProtectionEnabled()
+        const authenticated = isAuthenticated(request)
+
         try {
           // Use ensureGatewayProbed() which handles auto-detection across
           // multiple ports (8642, 8643) instead of checking a single
@@ -20,31 +23,22 @@ export const Route = createFileRoute('/api/auth-check')({
           const reachable = caps.health || caps.chatCompletions || caps.models
 
           if (!reachable) {
-            return json(
-              {
-                authenticated: false,
-                authRequired: false,
-                error: 'hermes_agent_unreachable',
-              },
-              { status: 503 },
-            )
+            return json({
+              authenticated,
+              authRequired,
+              error: 'hermes_agent_unreachable',
+            })
           }
         } catch (error) {
-          return json(
-            {
-              authenticated: false,
-              authRequired: false,
-              error:
-                error instanceof DOMException && error.name === 'AbortError'
-                  ? 'hermes_agent_timeout'
-                  : 'hermes_agent_unreachable',
-            },
-            { status: 503 },
-          )
+          return json({
+            authenticated,
+            authRequired,
+            error:
+              error instanceof DOMException && error.name === 'AbortError'
+                ? 'hermes_agent_timeout'
+                : 'hermes_agent_unreachable',
+          })
         }
-
-        const authRequired = isPasswordProtectionEnabled()
-        const authenticated = isAuthenticated(request)
 
         return json({
           authenticated,

--- a/src/routes/api/connection-status.ts
+++ b/src/routes/api/connection-status.ts
@@ -24,7 +24,7 @@ function readActiveModel(): string {
     if (typeof modelField === 'string') return modelField
     if (modelField && typeof modelField === 'object') {
       const obj = modelField as Record<string, unknown>
-      return (obj.default as string) || ''
+      return (obj.default as string) || (obj.name as string) || ''
     }
   } catch {
     // config missing or unreadable
@@ -33,6 +33,9 @@ function readActiveModel(): string {
 }
 
 type ConnectionStatus = {
+  ok: boolean
+  mode: 'enhanced' | 'portable' | 'disconnected'
+  backend: string
   status: 'connected' | 'enhanced' | 'partial' | 'disconnected'
   label: 'Connected' | 'Enhanced' | 'Partial' | 'Disconnected'
   detail: string
@@ -100,6 +103,14 @@ export const Route = createFileRoute('/api/connection-status')({
         }
 
         const body: ConnectionStatus = {
+          ok: status !== 'disconnected',
+          mode:
+            status === 'enhanced'
+              ? 'enhanced'
+              : status === 'disconnected'
+                ? 'disconnected'
+                : 'portable',
+          backend: HERMES_API,
           status,
           label,
           detail,

--- a/src/routes/api/debug-analyze.ts
+++ b/src/routes/api/debug-analyze.ts
@@ -1,0 +1,178 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  getClientIp,
+  rateLimit,
+  rateLimitResponse,
+  requireJsonContentType,
+} from '../../server/rate-limit'
+
+type SuggestedCommand = {
+  command: string
+  description: string
+}
+
+type DebugAnalysis = {
+  summary: string
+  rootCause: string
+  suggestedCommands: Array<SuggestedCommand>
+  docsLink?: string
+}
+
+const COMMAND_LIMIT = 5
+const MAX_OUTPUT_CHARS = 12_000
+
+function has(text: string, pattern: RegExp): boolean {
+  return pattern.test(text)
+}
+
+function clip(text: string): string {
+  return text.length > MAX_OUTPUT_CHARS
+    ? text.slice(text.length - MAX_OUTPUT_CHARS)
+    : text
+}
+
+function buildAnalysis(rawOutput: string): DebugAnalysis {
+  const output = clip(rawOutput)
+  const lower = output.toLowerCase()
+  const suggestedCommands: Array<SuggestedCommand> = []
+
+  let summary = 'No known failure pattern was detected in the recent terminal output.'
+  let rootCause =
+    'The terminal is reachable, but the captured output does not include enough signal for a specific diagnosis. Run the failing command again, then click Debug.'
+  const docsLink = '/docs/troubleshooting.md'
+
+  if (has(lower, /command not found:?\s+hermes|hermes:\s+command not found/)) {
+    summary = 'Hermes CLI is not available in this shell.'
+    rootCause =
+      'The PTY started successfully, but PATH does not include the Hermes executable for the active user/session.'
+    suggestedCommands.push(
+      {
+        command: 'which hermes',
+        description: 'Confirm whether the shell can resolve the Hermes CLI.',
+      },
+      {
+        command: 'python3 -m pip show hermes-agent',
+        description: 'Check whether hermes-agent is installed for Python.',
+      },
+    )
+  } else if (has(lower, /unauthorized|401|api_server_key|invalid api key/)) {
+    summary = 'Hermes API authentication failed.'
+    rootCause =
+      'The workspace terminal likely started without the gateway token expected by the Hermes backend.'
+    suggestedCommands.push(
+      {
+        command:
+          'python3 - <<\'PY\'\nimport os\nprint("HERMES_API_TOKEN configured:", bool(os.getenv("HERMES_API_TOKEN")))\nprint("API_SERVER_KEY configured:", bool(os.getenv("API_SERVER_KEY")))\nPY',
+        description:
+          'Check token presence without printing secret values.',
+      },
+      {
+        command: 'curl -sS http://127.0.0.1:8645/health',
+        description: 'Verify whether the local Hermes gateway is reachable.',
+      },
+    )
+  } else if (has(lower, /connection refused|econnrefused|failed to connect/)) {
+    summary = 'The target backend is not accepting connections.'
+    rootCause =
+      'The command reached the network layer, but no service is listening at the requested host/port.'
+    suggestedCommands.push(
+      {
+        command: 'curl -sS http://127.0.0.1:8645/health',
+        description: 'Probe the default Hermes gateway health endpoint.',
+      },
+      {
+        command: 'lsof -nP -iTCP -sTCP:LISTEN | grep -E "8645|8642|9119|3000"',
+        description:
+          'List local listeners for Hermes gateway, dashboard, and workspace ports.',
+      },
+    )
+  } else if (has(lower, /unknown model|model.*unknown|no model|model not found/)) {
+    summary = 'The active model could not be resolved by the backend.'
+    rootCause =
+      'Hermes is reachable, but the configured provider/model pair is missing, misspelled, or not available to the configured credentials.'
+    suggestedCommands.push(
+      {
+        command: 'hermes models list',
+        description:
+          'Ask Hermes which models are available in the active provider context.',
+      },
+      {
+        command:
+          'python3 - <<\'PY\'\nimport os\nprint("GOOGLE_API_KEY configured:", bool(os.getenv("GOOGLE_API_KEY")))\nprint("OPENAI_API_KEY configured:", bool(os.getenv("OPENAI_API_KEY")))\nPY',
+        description:
+          'Verify provider credential presence without exposing values.',
+      },
+    )
+  } else if (has(lower, /permission denied|eacces|operation not permitted/)) {
+    summary = 'The command failed because of filesystem or process permissions.'
+    rootCause =
+      'The active user does not have permission for the requested path, socket, or executable.'
+    suggestedCommands.push(
+      {
+        command: 'pwd && whoami && ls -la',
+        description:
+          'Confirm current directory ownership and active terminal user.',
+      },
+    )
+  } else if (output.trim().length > 0) {
+    summary = 'Terminal output captured successfully.'
+    rootCause =
+      'No built-in rule matched the captured output. Use the safe inspection commands below to gather more context.'
+    suggestedCommands.push(
+      {
+        command: 'pwd && whoami && date',
+        description:
+          'Confirm the terminal working directory, user, and wall-clock context.',
+      },
+      {
+        command: 'curl -sS http://127.0.0.1:8645/health || true',
+        description:
+          'Check the default Hermes gateway without mutating state.',
+      },
+    )
+  }
+
+  if (suggestedCommands.length === 0) {
+    suggestedCommands.push({
+      command: 'pwd && whoami && env | grep -E "^(HERMES_|API_SERVER_|GOOGLE_|OPENAI_)" | sed "s/=.*$/=<configured>/"',
+      description:
+        'List relevant environment variable names without printing secret values.',
+    })
+  }
+
+  return {
+    summary,
+    rootCause,
+    suggestedCommands: suggestedCommands.slice(0, COMMAND_LIMIT),
+    docsLink,
+  }
+}
+
+export const Route = createFileRoute('/api/debug-analyze')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return Response.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        const ip = getClientIp(request)
+        if (!rateLimit(`debug-analyze:${ip}`, 30, 60_000)) {
+          return rateLimitResponse()
+        }
+
+        const body = (await request.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >
+        const terminalOutput =
+          typeof body.terminalOutput === 'string' ? body.terminalOutput : ''
+
+        return Response.json(buildAnalysis(terminalOutput))
+      },
+    },
+  },
+})

--- a/src/routes/api/hermes-config.ts
+++ b/src/routes/api/hermes-config.ts
@@ -19,6 +19,7 @@ type AuthResult = Response | true
 const HERMES_HOME = path.join(os.homedir(), '.hermes')
 const CONFIG_PATH = path.join(HERMES_HOME, 'config.yaml')
 const ENV_PATH = path.join(HERMES_HOME, '.env')
+const SHARED_ENV_PATH = path.join(HERMES_HOME, '.env.shared')
 
 // Known Hermes providers
 const PROVIDERS = [
@@ -29,6 +30,12 @@ const PROVIDERS = [
     name: 'Anthropic',
     authType: 'api_key',
     envKeys: ['ANTHROPIC_API_KEY'],
+  },
+  {
+    id: 'google',
+    name: 'Google Gemini',
+    authType: 'api_key',
+    envKeys: ['GOOGLE_API_KEY'],
   },
   {
     id: 'openrouter',
@@ -98,9 +105,9 @@ function writeConfig(config: Record<string, unknown>): void {
   fs.writeFileSync(CONFIG_PATH, YAML.stringify(config), 'utf-8')
 }
 
-function readEnv(): Record<string, string> {
+function readEnvFile(envPath: string): Record<string, string> {
   try {
-    const raw = fs.readFileSync(ENV_PATH, 'utf-8')
+    const raw = fs.readFileSync(envPath, 'utf-8')
     const env: Record<string, string> = {}
     for (const line of raw.split('\n')) {
       const trimmed = line.trim()
@@ -122,6 +129,13 @@ function readEnv(): Record<string, string> {
     return env
   } catch {
     return {}
+  }
+}
+
+function readEnv(): Record<string, string> {
+  return {
+    ...readEnvFile(SHARED_ENV_PATH),
+    ...readEnvFile(ENV_PATH),
   }
 }
 
@@ -181,16 +195,7 @@ export const Route = createFileRoute('/api/hermes-config')({
         const authResult = isAuthenticated(request) as AuthResult
         if (authResult !== true) return authResult
         await ensureGatewayProbed()
-        if (!getCapabilities().config) {
-          return Response.json({
-            ...createCapabilityUnavailablePayload('config'),
-            config: {},
-            providers: [],
-            activeProvider: '',
-            activeModel: '',
-            hermesHome: HERMES_HOME,
-          })
-        }
+        const configWritable = getCapabilities().config
 
         const config = readConfig()
         const env = readEnv()
@@ -232,13 +237,20 @@ export const Route = createFileRoute('/api/hermes-config')({
           activeProvider = (config.provider as string) || ''
         } else if (modelField && typeof modelField === 'object') {
           const modelObj = modelField as Record<string, unknown>
-          activeModel = (modelObj.default as string) || ''
+          activeModel =
+            (modelObj.name as string) || (modelObj.default as string) || ''
           activeProvider =
             (modelObj.provider as string) || (config.provider as string) || ''
         }
 
         return Response.json({
+          ok: true,
           config,
+          configWritable,
+          capability:
+            configWritable === true
+              ? undefined
+              : createCapabilityUnavailablePayload('config'),
           providers: providerStatus,
           activeProvider,
           activeModel,

--- a/src/routes/api/ll-ops-status.ts
+++ b/src/routes/api/ll-ops-status.ts
@@ -1,0 +1,167 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+
+type ServiceId =
+  | 'hermes-workspace'
+  | 'hermes-seven'
+  | 'hermes-atlas'
+  | 'hermes-neo'
+
+const SERVICES: Array<{ id: ServiceId; label: string; role: string }> = [
+  {
+    id: 'hermes-workspace',
+    label: 'Workspace',
+    role: 'TanStack Start dashboard',
+  },
+  { id: 'hermes-seven', label: 'Seven', role: 'Chief of Staff' },
+  { id: 'hermes-atlas', label: 'Atlas', role: 'Infra and Security' },
+  { id: 'hermes-neo', label: 'Neo', role: 'Finance and Market Intel' },
+]
+
+const STATE_FILES = [
+  {
+    id: 'active-state',
+    label: 'LL Empire active state',
+    path: '/home/lucas/llempire/ACTIVE_STATE.md',
+  },
+  {
+    id: 'shared-state',
+    label: 'Shared state handoff',
+    path: '/home/lucas/llempire/SHARED_STATE.md',
+  },
+  {
+    id: 'ops-status',
+    label: 'Ops status snapshot',
+    path: '/home/lucas/llempire/ops/status.json',
+  },
+]
+
+function readServiceStatus(service: ServiceId) {
+  try {
+    const status = execFileSync('systemctl', ['is-active', service], {
+      encoding: 'utf-8',
+      timeout: 2_000,
+    }).trim()
+
+    return {
+      id: service,
+      active: status === 'active',
+      status,
+    }
+  } catch {
+    return {
+      id: service,
+      active: false,
+      status: 'unknown',
+    }
+  }
+}
+
+function readFileMeta(path: string) {
+  if (!existsSync(path)) {
+    return {
+      exists: false,
+      modifiedAt: null,
+      size: 0,
+    }
+  }
+
+  const stats = statSync(path)
+  return {
+    exists: true,
+    modifiedAt: stats.mtime.toISOString(),
+    size: stats.size,
+  }
+}
+
+function readTextTail(path: string, maxChars: number) {
+  if (!existsSync(path)) return ''
+  const text = readFileSync(path, 'utf-8')
+  return text.length > maxChars ? text.slice(text.length - maxChars) : text
+}
+
+function extractRecentSharedEntries(text: string) {
+  const matches = Array.from(text.matchAll(/^## \[([^\]]+)\]\s+(.+)$/gm))
+  return matches
+    .slice(-4)
+    .reverse()
+    .map((match) => ({
+      timestamp: match[1],
+      title: match[2],
+    }))
+}
+
+function extractActiveWorkspaces(text: string) {
+  const rows = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('|') && line.includes('`~/Projects/'))
+
+  return rows.map((row) => {
+    const cells = row
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter(Boolean)
+    return {
+      workspace: cells[0] ?? 'Unknown',
+      path: (cells[1] ?? '').replace(/`/g, ''),
+      state: cells[2] ?? 'unknown',
+    }
+  })
+}
+
+function readOpsStatus(path: string) {
+  if (!existsSync(path)) return null
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Record<
+      string,
+      unknown
+    >
+    return {
+      generatedAt: raw.generated_at ?? raw.generatedAt ?? raw.timestamp ?? null,
+      summary: raw.summary ?? raw.status ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export const Route = createFileRoute('/api/ll-ops-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const services = SERVICES.map((service) => ({
+          ...service,
+          ...readServiceStatus(service.id),
+        }))
+        const sharedStateText = readTextTail(
+          '/home/lucas/llempire/SHARED_STATE.md',
+          16_000,
+        )
+        const activeStateText = readTextTail(
+          '/home/lucas/llempire/ACTIVE_STATE.md',
+          24_000,
+        )
+
+        return json({
+          fetchedAt: new Date().toISOString(),
+          services,
+          stateFiles: STATE_FILES.map((file) => ({
+            ...file,
+            ...readFileMeta(file.path),
+          })),
+          recentSharedEntries: extractRecentSharedEntries(sharedStateText),
+          activeWorkspaces: extractActiveWorkspaces(activeStateText),
+          opsStatus: readOpsStatus('/home/lucas/llempire/ops/status.json'),
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -91,19 +91,17 @@ function readHermesModelsJson(): Array<ModelEntry> {
   }
 }
 
-/**
- * Read the default model from ~/.hermes/config.yaml without a YAML parser.
- * Looks for "default: <model-id>" under the "model:" section.
- */
 function readHermesDefaultModel(): ModelEntry | null {
   const configPath = path.join(os.homedir(), '.hermes', 'config.yaml')
   try {
     if (!fs.existsSync(configPath)) return null
     const raw = fs.readFileSync(configPath, 'utf-8')
-    const defaultMatch = raw.match(/^\s*default:\s*(.+)$/m)
-    const providerMatch = raw.match(/^\s*provider:\s*(.+)$/m)
-    if (!defaultMatch) return null
-    const modelId = defaultMatch[1].trim()
+    const modelBlock = raw.match(/^model:\s*\n((?:\s{2,}.+\n?)*)/m)
+    const block = modelBlock?.[1] ?? ''
+    const nameMatch = block.match(/^\s+name:\s*(.+)$/m)
+    const providerMatch = block.match(/^\s+provider:\s*(.+)$/m)
+    if (!nameMatch) return null
+    const modelId = nameMatch[1].trim()
     const provider = providerMatch ? providerMatch[1].trim() : 'unknown'
     return { id: modelId, name: modelId, provider }
   } catch {
@@ -143,7 +141,7 @@ export const Route = createFileRoute('/api/models')({
         try {
           // Primary: read user-configured models from ~/.hermes/models.json
           let models = readHermesModelsJson()
-          let source = 'models.json'
+          let source = models.length > 0 ? 'models.json' : 'config.yaml'
 
           // Ensure the default model from config.yaml is always included
           const defaultModel = readHermesDefaultModel()

--- a/src/routes/api/terminal-input.ts
+++ b/src/routes/api/terminal-input.ts
@@ -23,7 +23,7 @@ export const Route = createFileRoute('/api/terminal-input')({
         if (csrfCheck) return csrfCheck
 
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal:${ip}`, 10, 60_000)) {
+        if (!rateLimit(`terminal:${ip}`, 1_800, 60_000)) {
           return rateLimitResponse()
         }
 

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,10 +40,12 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return new Response(
+            JSON.stringify({ ok: false, error: 'Not found' }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
         }
         session.resize(cols, rows)
         return new Response(JSON.stringify({ ok: true }), {

--- a/src/routes/api/terminal-stream.ts
+++ b/src/routes/api/terminal-stream.ts
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/api/terminal-stream')({
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal-stream:${ip}`, 10, 60_000)) {
+        if (!rateLimit(`terminal-stream:${ip}`, 120, 60_000)) {
           return rateLimitResponse()
         }
 

--- a/src/routes/chat/$sessionKey.tsx
+++ b/src/routes/chat/$sessionKey.tsx
@@ -75,8 +75,13 @@ function ChatRoute() {
   useEffect(() => {
     if (isNewChat) {
       queryClient.removeQueries({ queryKey: ['chat', 'history', 'new', 'new'] })
+      navigate({
+        to: '/chat/$sessionKey',
+        params: { sessionKey: 'main' },
+        replace: true,
+      })
     }
-  }, [isNewChat, queryClient])
+  }, [isNewChat, navigate, queryClient])
 
   const handleSessionResolved = useCallback(
     function handleSessionResolved(payload: {
@@ -114,6 +119,14 @@ function ChatRoute() {
     return (
       <div className="flex h-full items-center justify-center text-primary-400">
         Loading chat…
+      </div>
+    )
+  }
+
+  if (isNewChat) {
+    return (
+      <div className="flex h-full items-center justify-center text-primary-400">
+        Redirecting chat…
       </div>
     )
   }

--- a/src/routes/chat/index.tsx
+++ b/src/routes/chat/index.tsx
@@ -4,13 +4,13 @@ export const Route = createFileRoute('/chat/')({
   ssr: false,
   beforeLoad: () => {
     // Try to restore last active session from localStorage
-    let lastSession = 'new'
+    let lastSession = 'main'
     try {
       const stored =
         typeof window !== 'undefined'
           ? localStorage.getItem('hermes-last-session')
           : null
-      if (stored && stored !== 'main') lastSession = stored
+      if (stored && stored !== 'main' && stored !== 'new') lastSession = stored
     } catch {}
     throw redirect({
       to: '/chat/$sessionKey',

--- a/src/routes/ll-ops.tsx
+++ b/src/routes/ll-ops.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { LlOpsDashboardScreen } from '@/screens/ll-ops/ll-ops-dashboard-screen'
+
+export const Route = createFileRoute('/ll-ops')({
+  ssr: false,
+  component: LlOpsRoute,
+})
+
+function LlOpsRoute() {
+  usePageTitle('LL Empire Ops')
+  return <LlOpsDashboardScreen />
+}

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1,7 +1,9 @@
 // Module-level local model override — set by composer when user picks a local model
 // Avoids prop threading. Reset when switching back to cloud models.
 export let _localModelOverride = ''
-export function setLocalModelOverride(model: string) { _localModelOverride = model }
+export function setLocalModelOverride(model: string) {
+  _localModelOverride = model
+}
 
 import {
   useCallback,
@@ -594,7 +596,8 @@ export function ChatScreen({
   // If so, re-set waitingForResponse in the store so the UI shows the spinner.
   useActiveRunCheck({
     sessionKey: resolvedSessionKey ?? '',
-    enabled: !isNewChat && Boolean(resolvedSessionKey) && historyQuery.isSuccess,
+    enabled:
+      !isNewChat && Boolean(resolvedSessionKey) && historyQuery.isSuccess,
   })
 
   // Wire SSE realtime stream for instant message delivery
@@ -617,9 +620,9 @@ export function ChatScreen({
       : isNewChat
         ? 'new'
         : resolvedSessionKey ||
-        sessionKeyForHistory ||
-        activeCanonicalKey ||
-        'main',
+          sessionKeyForHistory ||
+          activeCanonicalKey ||
+          'main',
     friendlyId: portableChatFriendlyId,
     historyMessages,
     portableMode: isPortableMode,
@@ -906,7 +909,11 @@ export function ChatScreen({
         )
         if (!res.ok) return
         const data = await res.json()
-        if (!data.ok || !data.run || !['accepted', 'active', 'handoff'].includes(data.run.status)) {
+        if (
+          !data.ok ||
+          !data.run ||
+          !['accepted', 'active', 'handoff'].includes(data.run.status)
+        ) {
           streamFinish()
           refreshHistoryRef.current()
         }
@@ -1162,10 +1169,12 @@ export function ChatScreen({
     activeRealtimeStreamingText,
     activeIsRealtimeStreaming,
   )
-  const stickyStreamingTextRef = useRef<{ runId: string | null; text: string }>({
-    runId: null,
-    text: '',
-  })
+  const stickyStreamingTextRef = useRef<{ runId: string | null; text: string }>(
+    {
+      runId: null,
+      text: '',
+    },
+  )
   stickyStreamingTextRef.current = advanceStickyStreamingText({
     isStreaming: activeIsRealtimeStreaming,
     runId: streamingRunId ?? null,
@@ -2759,7 +2768,7 @@ export function ChatScreen({
             setSessionsOpen(false)
             void navigate({
               to: '/chat/$sessionKey',
-              params: { sessionKey: 'new' },
+              params: { sessionKey: 'main' },
             })
           }}
         />

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -14,18 +14,18 @@ import {
   Moon02Icon,
   PencilEdit02Icon,
   PuzzleIcon,
-
   Rocket01Icon,
-  Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
+  Search01Icon,
+  Settings01Icon,
+  Sun02Icon,
+  UserGroupIcon,
+  UserMultipleIcon,
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
 import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,7 +33,7 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
@@ -67,9 +67,10 @@ function ThemeToggleMini() {
   const updateSettings = useSettingsStore((state) => state.updateSettings)
   void _theme
   // Detect dark/light from actual data-theme attribute
-  const currentDataTheme = typeof document !== 'undefined'
-    ? document.documentElement.getAttribute('data-theme') || 'hermes-nous'
-    : 'hermes-nous'
+  const currentDataTheme =
+    typeof document !== 'undefined'
+      ? document.documentElement.getAttribute('data-theme') || 'hermes-nous'
+      : 'hermes-nous'
   const isDark = !currentDataTheme.endsWith('-light')
 
   // Map between dark and light counterparts — must include all theme families
@@ -89,7 +90,11 @@ function ThemeToggleMini() {
       type="button"
       onClick={() => {
         // Fall back to current family rather than dropping the user into hermes-official
-        const nextDataTheme = LIGHT_DARK_PAIRS[currentDataTheme] || (isDark ? `${currentDataTheme}-light` : currentDataTheme.replace(/-light$/, ''))
+        const nextDataTheme =
+          LIGHT_DARK_PAIRS[currentDataTheme] ||
+          (isDark
+            ? `${currentDataTheme}-light`
+            : currentDataTheme.replace(/-light$/, ''))
         // Import and call setTheme to persist and apply
         import('@/lib/theme').then(({ setTheme }) => {
           setTheme(nextDataTheme as any)
@@ -103,7 +108,11 @@ function ThemeToggleMini() {
       style={{ color: 'var(--theme-muted)' }}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      <HugeiconsIcon icon={isDark ? Sun02Icon : Moon02Icon} size={16} strokeWidth={1.5} />
+      <HugeiconsIcon
+        icon={isDark ? Sun02Icon : Moon02Icon}
+        size={16}
+        strokeWidth={1.5}
+      />
     </button>
   )
 }
@@ -122,8 +131,6 @@ type ChatSidebarProps = {
   sessionsError: string | null
   onRetrySessions: () => void
 }
-
-
 
 // ── Reusable nav item ───────────────────────────────────────────────────
 
@@ -205,7 +212,9 @@ function NavItem({
           transition={transition}
           className="flex min-w-0 items-center gap-2"
         >
-          <span className="overflow-hidden whitespace-nowrap">{item.label}</span>
+          <span className="overflow-hidden whitespace-nowrap">
+            {item.label}
+          </span>
           {item.badge && item.badge !== 'error-dot' ? (
             <span className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full border border-primary-700 bg-primary-900 px-2 py-0.5 text-[10px] font-semibold leading-none text-primary-300">
               {item.badge}
@@ -503,12 +512,8 @@ function ChatSidebarComponent({
   sessionsError,
   onRetrySessions,
 }: ChatSidebarProps) {
-  const {
-    settingsOpen,
-    settingsSection,
-    setSettingsOpen,
-    handleOpenSettings,
-  } = useSidebarSettings()
+  const { settingsOpen, settingsSection, setSettingsOpen, handleOpenSettings } =
+    useSidebarSettings()
   const profileDisplayName = useChatSettingsStore(selectChatProfileDisplayName)
   const profileAvatarDataUrl = useChatSettingsStore(
     selectChatProfileAvatarDataUrl,
@@ -526,7 +531,9 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -562,6 +569,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
+  const isLlOpsActive = pathname === '/ll-ops'
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -580,8 +588,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -671,7 +677,6 @@ function ChatSidebarComponent({
 
   const isVisuallyCollapsed = isCollapsed && !isHoverExpanded
   const isHoverPreviewExpanded = !isMobile && isCollapsed && isHoverExpanded
-
 
   function handleSidebarToggle() {
     if (isHoverPreviewExpanded) {
@@ -764,6 +769,13 @@ function ChatSidebarComponent({
     },
     {
       kind: 'link',
+      to: '/ll-ops',
+      icon: DashboardSquare01Icon,
+      label: 'LL Ops',
+      active: isLlOpsActive,
+    },
+    {
+      kind: 'link',
       to: '/chat',
       icon: MessageMultiple01Icon,
       label: t('nav.chat'),
@@ -847,10 +859,19 @@ function ChatSidebarComponent({
       }}
       initial={false}
       animate={{
-        width: isVisuallyCollapsed ? (isMobile ? 0 : 48) : isMobile ? '85vw' : 300,
+        width: isVisuallyCollapsed
+          ? isMobile
+            ? 0
+            : 48
+          : isMobile
+            ? '85vw'
+            : 300,
       }}
       transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-      className={cn(asideProps.className, isMobile && isCollapsed && 'pointer-events-none overflow-hidden')}
+      className={cn(
+        asideProps.className,
+        isMobile && isCollapsed && 'pointer-events-none overflow-hidden',
+      )}
       data-tour="sidebar-container"
       style={isMobile ? { maxWidth: 360 } : undefined}
       onMouseEnter={() => {
@@ -883,8 +904,17 @@ function ChatSidebarComponent({
                   'w-full pl-1.5 justify-start gap-2',
                 )}
               >
-                <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
-                <span className="text-sm font-semibold tracking-tight" style={{ color: 'var(--theme-text)' }}>Hermes Workspace</span>
+                <img
+                  src="/hermes-avatar.webp"
+                  alt="Hermes"
+                  className="size-6 rounded-lg"
+                />
+                <span
+                  className="text-sm font-semibold tracking-tight"
+                  style={{ color: 'var(--theme-text)' }}
+                >
+                  Hermes Workspace
+                </span>
               </Link>
             </motion.div>
           ) : null}
@@ -897,7 +927,9 @@ function ChatSidebarComponent({
                 <Button
                   size="icon-sm"
                   variant="ghost"
-                  aria-label={isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'}
+                  aria-label={
+                    isVisuallyCollapsed ? 'Open Sidebar' : 'Close Sidebar'
+                  }
                   className="absolute right-2 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100"
                   data-tour="sidebar-collapse-toggle"
                 >
@@ -945,7 +977,7 @@ function ChatSidebarComponent({
         <div className="px-2 pb-1">
           <Link
             to="/chat/$sessionKey"
-            params={{ sessionKey: 'new' }}
+            params={{ sessionKey: 'main' }}
             onClick={() => {
               onSelectSession?.()
             }}
@@ -1017,12 +1049,7 @@ function ChatSidebarComponent({
         </div>
 
         {/* Sessions list */}
-        <div
-          className={cn(
-            'shrink-0 mt-1',
-            isMobile && 'order-1',
-          )}
-        >
+        <div className={cn('shrink-0 mt-1', isMobile && 'order-1')}>
           <AnimatePresence initial={false}>
             {!isVisuallyCollapsed && (
               <motion.div
@@ -1056,10 +1083,12 @@ function ChatSidebarComponent({
       {/* ── Footer with User Menu ─────────────────────────────────── */}
       <div className="px-2 py-2.5 border-t shrink-0 theme-border theme-panel">
         {/* User card + actions */}
-        <div className={cn(
-          'flex items-center rounded-lg transition-colors',
-          isVisuallyCollapsed ? 'flex-col gap-2 py-2' : 'gap-2.5 px-2 py-1.5',
-        )}>
+        <div
+          className={cn(
+            'flex items-center rounded-lg transition-colors',
+            isVisuallyCollapsed ? 'flex-col gap-2 py-2' : 'gap-2.5 px-2 py-1.5',
+          )}
+        >
           {/* User menu trigger */}
           <MenuRoot>
             <MenuTrigger
@@ -1119,7 +1148,11 @@ function ChatSidebarComponent({
                 className="shrink-0 rounded-lg p-1.5 text-primary-400 hover:bg-primary-200 dark:hover:bg-neutral-800 hover:text-primary-600 dark:hover:text-neutral-300 transition-colors"
                 aria-label="Settings"
               >
-                <HugeiconsIcon icon={Settings01Icon} size={16} strokeWidth={1.5} />
+                <HugeiconsIcon
+                  icon={Settings01Icon}
+                  size={16}
+                  strokeWidth={1.5}
+                />
               </button>
               <ThemeToggleMini />
             </div>

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -1,5 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
+import {
+  Moon02Icon,
+  Sun02Icon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useMemo, useState } from 'react'
 import {
   Area,
@@ -12,14 +17,11 @@ import {
 } from 'recharts'
 import type { ReactNode } from 'react'
 import type { HermesSession } from '@/server/hermes-api'
-import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { getUnavailableReason } from '@/lib/feature-gates'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
 import { openHamburgerMenu } from '@/components/mobile-hamburger-menu'
 import { applyTheme, useSettingsStore } from '@/hooks/use-settings'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { Moon02Icon, Sun02Icon } from '@hugeicons/core-free-icons'
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -473,7 +475,7 @@ function ModelCard({ palette }: { palette: ReturnType<typeof readDashboardPalett
                 {fallbackModel}
               </div>
               <div className="text-[10px] text-muted font-mono truncate">
-                {(fallbackBlock?.provider as string) ?? ''}
+                {String(fallbackBlock.provider ?? '')}
               </div>
             </div>
           </div>
@@ -700,7 +702,7 @@ export function DashboardScreen() {
     enabled: sessionsAvailable,
   })
 
-  const sessions = (sessionsQuery.data ?? []) as HermesSession[]
+  const sessions = sessionsQuery.data ?? []
 
   const stats = useMemo(() => {
     let totalMessages = 0,
@@ -808,7 +810,7 @@ export function DashboardScreen() {
             onClick={() =>
               navigate({
                 to: '/chat/$sessionKey',
-                params: { sessionKey: 'new' },
+                params: { sessionKey: 'main' },
               })
             }
           />
@@ -823,7 +825,6 @@ export function DashboardScreen() {
             icon="🧩"
             accentColor={palette.warning}
             onClick={() => navigate({ to: '/skills' })}
-            disabled={!skillsAvailable}
             badge={!skillsAvailable ? 'Enhanced' : undefined}
           />
           <QuickAction

--- a/src/screens/ll-ops/ll-ops-dashboard-screen.tsx
+++ b/src/screens/ll-ops/ll-ops-dashboard-screen.tsx
@@ -1,0 +1,930 @@
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Analytics01Icon,
+  ArrowRight01Icon,
+  CheckListIcon,
+  DashboardSquare01Icon,
+  Database01Icon,
+  Rocket01Icon,
+  Settings01Icon,
+  Shield01Icon,
+  UserGroupIcon,
+} from '@hugeicons/core-free-icons'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type StatusTone = 'good' | 'warn' | 'blocked' | 'idle'
+
+type Metric = {
+  label: string
+  value: string
+  detail: string
+  tone: StatusTone
+}
+
+type BriefItem = {
+  title: string
+  detail: string
+  owner: string
+  tone: StatusTone
+}
+
+type PipelineItem = {
+  title: string
+  platform: string
+  stage:
+    | 'Idea'
+    | 'Researching'
+    | 'Script'
+    | 'Production'
+    | 'Scheduled'
+    | 'Published'
+  owner: string
+  blocker?: string
+}
+
+type AgentItem = {
+  name: string
+  role: string
+  model: string
+  status: string
+  tone: StatusTone
+  lastSignal: string
+}
+
+type IntegrationItem = {
+  name: string
+  mode: 'read-only' | 'disabled' | 'fixture' | 'live'
+  status: string
+  tone: StatusTone
+}
+
+type LlOpsStatus = {
+  fetchedAt: string
+  services: Array<{
+    id: string
+    label: string
+    role: string
+    active: boolean
+    status: string
+  }>
+  stateFiles: Array<{
+    id: string
+    label: string
+    path: string
+    exists: boolean
+    modifiedAt: string | null
+    size: number
+  }>
+  recentSharedEntries: Array<{
+    timestamp: string
+    title: string
+  }>
+  activeWorkspaces: Array<{
+    workspace: string
+    path: string
+    state: string
+  }>
+  opsStatus: {
+    generatedAt: unknown
+    summary: unknown
+  } | null
+}
+
+const metrics: Array<Metric> = [
+  {
+    label: 'MRR target',
+    value: '$33K',
+    detail: 'Strategic target, not live revenue',
+    tone: 'idle',
+  },
+  {
+    label: 'Pipeline',
+    value: '18',
+    detail: 'Fixture content items across six stages',
+    tone: 'good',
+  },
+  {
+    label: 'Credential gates',
+    value: '5',
+    detail: 'Apify, YouTube, TikTok, Instagram, Google Ads',
+    tone: 'warn',
+  },
+  {
+    label: 'Unsafe actions',
+    value: '0',
+    detail: 'No infra or Hermes mutations in this MVP',
+    tone: 'good',
+  },
+]
+
+function buildMetrics(status: LlOpsStatus | undefined): Array<Metric> {
+  if (!status) return metrics
+  const activeServices = status.services.filter((service) => service.active).length
+  const readyStateFiles = status.stateFiles.filter((file) => file.exists).length
+
+  return [
+    {
+      label: 'Hermes services',
+      value: `${activeServices}/${status.services.length}`,
+      detail: 'Live read-only systemd status',
+      tone: activeServices === status.services.length ? 'good' : 'warn',
+    },
+    {
+      label: 'Active workspaces',
+      value: String(status.activeWorkspaces.length),
+      detail: 'Parsed from ACTIVE_STATE.md',
+      tone: status.activeWorkspaces.length > 0 ? 'good' : 'warn',
+    },
+    {
+      label: 'State files',
+      value: `${readyStateFiles}/${status.stateFiles.length}`,
+      detail: 'Read-only local ops sources',
+      tone: readyStateFiles === status.stateFiles.length ? 'good' : 'warn',
+    },
+    {
+      label: 'Unsafe actions',
+      value: '0',
+      detail: 'No infra or Hermes mutations in the dashboard',
+      tone: 'good',
+    },
+  ]
+}
+
+const briefing: Array<BriefItem> = [
+  {
+    title: 'Build the ops cockpit before data integrations',
+    detail:
+      'Static MVP proves layout, density, and navigation before touching API keys.',
+    owner: 'Codex',
+    tone: 'good',
+  },
+  {
+    title: 'Google Ads remains credential-gated',
+    detail:
+      'Read-only MCP path exists, but activation waits for real credentials.',
+    owner: 'Lucas',
+    tone: 'warn',
+  },
+  {
+    title: 'Hermes actions stay approval-gated',
+    detail:
+      'Restart, config edits, trading, and external writes require a Chairman Brief.',
+    owner: 'Atlas',
+    tone: 'blocked',
+  },
+]
+
+function buildBriefing(status: LlOpsStatus | undefined): Array<BriefItem> {
+  if (!status || status.recentSharedEntries.length === 0) return briefing
+  return status.recentSharedEntries.slice(0, 3).map((entry) => ({
+    title: entry.title,
+    detail: `Latest shared-state entry at ${entry.timestamp}. Source: /home/lucas/llempire/SHARED_STATE.md`,
+    owner: 'Live',
+    tone: 'good',
+  }))
+}
+
+const pipeline: Array<PipelineItem> = [
+  {
+    title: 'Tenfold dashboard teardown',
+    platform: 'Research',
+    stage: 'Researching',
+    owner: 'Codex',
+  },
+  {
+    title: 'AI Ops dashboard static MVP',
+    platform: 'Hermes Workspace',
+    stage: 'Production',
+    owner: 'Codex',
+  },
+  {
+    title: 'YouTube performance import',
+    platform: 'YouTube',
+    stage: 'Idea',
+    owner: 'Lucas',
+    blocker: 'API key not confirmed',
+  },
+  {
+    title: 'TikTok/Instagram trend pulls',
+    platform: 'Apify',
+    stage: 'Idea',
+    owner: 'Seven',
+    blocker: 'Apify credential not confirmed',
+  },
+  {
+    title: 'Client launch reporting',
+    platform: 'Clients',
+    stage: 'Script',
+    owner: 'Lucas',
+  },
+  {
+    title: 'ScrapeGraph structured extract pilot',
+    platform: 'ScrapeGraphAI',
+    stage: 'Idea',
+    owner: 'Codex',
+    blocker: 'Sandbox test pending',
+  },
+]
+
+const agents: Array<AgentItem> = [
+  {
+    name: 'Seven',
+    role: 'Chief of Staff',
+    model: 'gemini-2.5-flash',
+    status: 'Active',
+    tone: 'good',
+    lastSignal: 'Workspace/briefing context available',
+  },
+  {
+    name: 'Atlas',
+    role: 'Infra and Security',
+    model: 'gemini-2.5-flash',
+    status: 'Approval gate',
+    tone: 'warn',
+    lastSignal: 'Hermes Workspace changes require visible event log',
+  },
+  {
+    name: 'Neo',
+    role: 'Finance and Market Intel',
+    model: 'gemini-2.5-flash',
+    status: 'Read-only safe',
+    tone: 'good',
+    lastSignal: 'Trading/write actions are excluded from MVP',
+  },
+  {
+    name: 'Codex',
+    role: 'Builder and operator',
+    model: 'GPT-5',
+    status: 'Building',
+    tone: 'good',
+    lastSignal: 'Static route only; no external writes',
+  },
+]
+
+function buildAgents(status: LlOpsStatus | undefined): Array<AgentItem> {
+  if (!status) return agents
+  return status.services.map((service) => ({
+    name: service.label,
+    role: service.role,
+    model:
+      service.id === 'hermes-workspace'
+        ? 'vite dev / TanStack Start'
+        : 'Hermes v0.11 runtime',
+    status: service.status,
+    tone: service.active ? 'good' : 'blocked',
+    lastSignal: `Live read-only check from systemctl is-active ${service.id}`,
+  }))
+}
+
+const integrations: Array<IntegrationItem> = [
+  {
+    name: 'Hermes Workspace',
+    mode: 'read-only',
+    status: 'UI shell connected',
+    tone: 'good',
+  },
+  {
+    name: 'LL Empire state files',
+    mode: 'fixture',
+    status: 'Planned read-only source',
+    tone: 'idle',
+  },
+  {
+    name: 'Obsidian summaries',
+    mode: 'fixture',
+    status: 'Planned read-only source',
+    tone: 'idle',
+  },
+  {
+    name: 'Apify',
+    mode: 'disabled',
+    status: 'Credential not confirmed',
+    tone: 'warn',
+  },
+  {
+    name: 'YouTube Data API',
+    mode: 'disabled',
+    status: 'Credential not confirmed',
+    tone: 'warn',
+  },
+  {
+    name: 'Instagram Graph',
+    mode: 'disabled',
+    status: 'Account/token readiness not proven',
+    tone: 'warn',
+  },
+  {
+    name: 'Google Ads',
+    mode: 'disabled',
+    status: 'MCP pilot credential-gated',
+    tone: 'blocked',
+  },
+  {
+    name: 'ScrapeGraphAI',
+    mode: 'disabled',
+    status: 'Optional sandbox pilot',
+    tone: 'idle',
+  },
+]
+
+function buildIntegrations(status: LlOpsStatus | undefined): Array<IntegrationItem> {
+  if (!status) return integrations
+  const stateFiles = status.stateFiles.map((file) => ({
+    name: file.label,
+    mode: 'live' as const,
+    status: file.exists
+      ? `Modified ${file.modifiedAt ?? 'unknown'} (${file.size} bytes)`
+      : `Missing: ${file.path}`,
+    tone: file.exists ? ('good' as const) : ('warn' as const),
+  }))
+
+  return [
+    {
+      name: 'Hermes services',
+      mode: 'live',
+      status: `${status.services.filter((service) => service.active).length}/${status.services.length} active`,
+      tone: status.services.every((service) => service.active) ? 'good' : 'warn',
+    },
+    ...stateFiles,
+    {
+      name: 'Apify',
+      mode: 'disabled',
+      status: 'Credential not confirmed',
+      tone: 'warn',
+    },
+    {
+      name: 'YouTube Data API',
+      mode: 'disabled',
+      status: 'Credential not confirmed',
+      tone: 'warn',
+    },
+    {
+      name: 'Instagram Graph',
+      mode: 'disabled',
+      status: 'Account/token readiness not proven',
+      tone: 'warn',
+    },
+    {
+      name: 'Google Ads',
+      mode: 'disabled',
+      status: 'MCP pilot credential-gated',
+      tone: 'blocked',
+    },
+    {
+      name: 'ScrapeGraphAI',
+      mode: 'disabled',
+      status: 'Optional sandbox pilot',
+      tone: 'idle',
+    },
+  ]
+}
+
+async function fetchLlOpsStatus(): Promise<LlOpsStatus> {
+  const response = await fetch('/api/ll-ops-status')
+  if (!response.ok) {
+    throw new Error(`Failed to load LL Ops status: ${response.status}`)
+  }
+  return response.json() as Promise<LlOpsStatus>
+}
+
+type SectionId =
+  | 'overview'
+  | 'research'
+  | 'pipeline'
+  | 'performance'
+  | 'agents'
+  | 'clients'
+  | 'settings'
+
+const sections: Array<{ id: SectionId; label: string }> = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'research', label: 'Research' },
+  { id: 'pipeline', label: 'Pipeline' },
+  { id: 'performance', label: 'Performance' },
+  { id: 'agents', label: 'Agents' },
+  { id: 'clients', label: 'Clients' },
+  { id: 'settings', label: 'Settings' },
+]
+
+const performanceSources = ['YouTube', 'TikTok', 'Instagram', 'Campaigns']
+const clientRows = ['LL Empire core', 'Paid traffic pilot', 'Content factory']
+
+function matchesSearch(values: Array<string | undefined>, query: string) {
+  if (!query) return true
+  return values.some((value) => value?.toLowerCase().includes(query))
+}
+
+function toneClasses(tone: StatusTone): string {
+  if (tone === 'good')
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+  if (tone === 'warn')
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+  if (tone === 'blocked')
+    return 'border-rose-500/30 bg-rose-500/10 text-rose-300'
+  return 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)]'
+}
+
+function Panel({
+  title,
+  icon,
+  right,
+  children,
+  className,
+}: {
+  title: string
+  icon: typeof DashboardSquare01Icon
+  right?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <section
+      className={cn(
+        'rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-sm',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--theme-border)] px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <HugeiconsIcon
+            icon={icon}
+            size={18}
+            strokeWidth={1.7}
+            className="shrink-0 text-[var(--theme-accent)]"
+          />
+          <h2 className="truncate text-sm font-semibold text-[var(--theme-text)]">
+            {title}
+          </h2>
+        </div>
+        {right}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function StatusPill({
+  tone,
+  children,
+}: {
+  tone: StatusTone
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-1 text-[11px] font-semibold leading-none',
+        toneClasses(tone),
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+export function LlOpsDashboardScreen() {
+  const [activeSection, setActiveSection] = useState<SectionId>('overview')
+  const [query, setQuery] = useState('')
+  const [reviewedItemTitle, setReviewedItemTitle] = useState<string | null>(null)
+  const statusQuery = useQuery({
+    queryKey: ['ll-ops-status'],
+    queryFn: fetchLlOpsStatus,
+    staleTime: 20_000,
+    refetchInterval: 60_000,
+  })
+  const liveStatus = statusQuery.data
+  const visibleMetrics = buildMetrics(liveStatus)
+  const visibleBriefing = buildBriefing(liveStatus)
+  const visibleAgents = buildAgents(liveStatus)
+  const visibleIntegrations = buildIntegrations(liveStatus)
+  const normalizedQuery = query.trim().toLowerCase()
+  const sectionVisible = (section: SectionId) =>
+    activeSection === 'overview' || activeSection === section
+  const filteredPipeline = useMemo(
+    () =>
+      pipeline.filter((item) =>
+        matchesSearch(
+          [item.title, item.platform, item.stage, item.owner, item.blocker],
+          normalizedQuery,
+        ),
+      ),
+    [normalizedQuery],
+  )
+  const filteredAgents = useMemo(
+    () =>
+      visibleAgents.filter((agent) =>
+        matchesSearch(
+          [agent.name, agent.role, agent.model, agent.status, agent.lastSignal],
+          normalizedQuery,
+        ),
+      ),
+    [normalizedQuery, visibleAgents],
+  )
+  const filteredIntegrations = useMemo(
+    () =>
+      visibleIntegrations.filter((integration) =>
+        matchesSearch(
+          [integration.name, integration.mode, integration.status],
+          normalizedQuery,
+        ),
+      ),
+    [normalizedQuery, visibleIntegrations],
+  )
+  const filteredBriefing = useMemo(
+    () =>
+      visibleBriefing.filter((item) =>
+        matchesSearch([item.title, item.detail, item.owner], normalizedQuery),
+      ),
+    [normalizedQuery, visibleBriefing],
+  )
+  const filteredPerformanceSources = useMemo(
+    () =>
+      performanceSources.filter((source) =>
+        matchesSearch([source], normalizedQuery),
+      ),
+    [normalizedQuery],
+  )
+  const filteredClientRows = useMemo(
+    () =>
+      clientRows.filter((client) => matchesSearch([client], normalizedQuery)),
+    [normalizedQuery],
+  )
+
+  return (
+    <main className="min-h-full bg-[var(--theme-bg)] px-4 pb-28 pt-14 text-[var(--theme-text)] md:px-8 md:py-6 lg:px-10">
+      <div className="mx-auto flex max-w-[1500px] flex-col gap-5">
+        <header className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-5 py-5 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="min-w-0">
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <StatusPill tone="good">Phase 3 read-only</StatusPill>
+                <StatusPill tone={liveStatus ? 'good' : 'warn'}>
+                  {liveStatus ? 'Live local data' : 'Fixture fallback'}
+                </StatusPill>
+                <StatusPill tone="blocked">No browser secrets</StatusPill>
+              </div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                LL Empire
+              </p>
+              <h1 className="mt-1 text-3xl font-bold tracking-normal text-[var(--theme-text)] md:text-4xl">
+                AI Ops Dashboard
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--theme-muted)]">
+                Founder-operator cockpit for briefing, content pipeline, agent
+                state, clients, and integration gates. Live cards use read-only
+                local ops sources and keep external integrations disabled until
+                credentials are approved.
+              </p>
+              <p className="mt-3 text-xs leading-5 text-[var(--theme-muted)]">
+                Last refresh:{' '}
+                {liveStatus?.fetchedAt ?? (statusQuery.isError ? 'failed' : 'loading')}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:justify-end">
+              {sections.map((section) => (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => setActiveSection(section.id)}
+                  className={cn(
+                    'rounded-lg border px-3 py-2 text-xs font-semibold transition-colors',
+                    activeSection === section.id
+                      ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)] text-black'
+                      : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-text)]',
+                  )}
+                >
+                  {section.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto] md:items-center">
+            <label className="sr-only" htmlFor="ll-ops-search">
+              Search dashboard
+            </label>
+            <input
+              id="ll-ops-search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search pipeline, agents, clients, integrations..."
+              className="min-h-10 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 text-sm text-[var(--theme-text)] outline-none transition-colors placeholder:text-[var(--theme-muted)] focus:border-[var(--theme-accent)]"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('')
+                setReviewedItemTitle(null)
+                setActiveSection('overview')
+                void statusQuery.refetch()
+              }}
+              className="min-h-10 rounded-lg border border-[var(--theme-border)] px-3 text-xs font-semibold text-[var(--theme-text)] transition-colors hover:border-[var(--theme-accent)]"
+            >
+              Refresh and reset
+            </button>
+          </div>
+          {statusQuery.isError ? (
+            <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+              Live LL Ops status is unavailable. The dashboard is using safe
+              fixture data until the read-only API can reach the configured
+              local ops files and services.
+            </div>
+          ) : null}
+          {reviewedItemTitle ? (
+            <div className="mt-4 rounded-lg border border-[var(--theme-accent)] bg-[var(--theme-card2)] px-4 py-3 text-sm text-[var(--theme-text)]">
+              Review selected: <strong>{reviewedItemTitle}</strong>
+            </div>
+          ) : null}
+        </header>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {visibleMetrics.map((metric) => (
+            <article
+              key={metric.label}
+              className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                    {metric.label}
+                  </p>
+                  <p className="mt-2 text-3xl font-bold tabular-nums text-[var(--theme-text)]">
+                    {metric.value}
+                  </p>
+                </div>
+                <StatusPill tone={metric.tone}>
+                  {liveStatus ? 'Live' : 'Fixture'}
+                </StatusPill>
+              </div>
+              <p className="mt-3 text-xs leading-5 text-[var(--theme-muted)]">
+                {metric.detail}
+              </p>
+            </article>
+          ))}
+        </div>
+
+        {sectionVisible('research') ? (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+          <Panel title="Today's Briefing" icon={DashboardSquare01Icon}>
+            <div className="divide-y divide-[var(--theme-border)]">
+              {filteredBriefing.map((item) => (
+                <div
+                  key={item.title}
+                  className="grid gap-3 px-4 py-4 md:grid-cols-[1fr_auto] md:items-center"
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+                        {item.title}
+                      </h3>
+                      <StatusPill tone={item.tone}>{item.owner}</StatusPill>
+                    </div>
+                    <p className="mt-1 text-sm leading-6 text-[var(--theme-muted)]">
+                      {item.detail}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setReviewedItemTitle(item.title)
+                      setActiveSection('research')
+                    }}
+                    className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-[var(--theme-border)] px-3 text-xs font-semibold text-[var(--theme-text)] hover:border-[var(--theme-accent)]"
+                  >
+                    Review
+                    <HugeiconsIcon
+                      icon={ArrowRight01Icon}
+                      size={14}
+                      strokeWidth={1.8}
+                    />
+                  </button>
+                </div>
+              ))}
+              {filteredBriefing.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-[var(--theme-muted)]">
+                  No briefing rows match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+
+          <Panel title="Integration Gates" icon={Database01Icon}>
+            <div className="grid grid-cols-1 gap-2 p-4 sm:grid-cols-2 xl:grid-cols-1">
+              {filteredIntegrations.map((item) => (
+                <div
+                  key={item.name}
+                  className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="truncate text-sm font-semibold text-[var(--theme-text)]">
+                      {item.name}
+                    </p>
+                    <StatusPill tone={item.tone}>{item.mode}</StatusPill>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+                    {item.status}
+                  </p>
+                </div>
+              ))}
+              {filteredIntegrations.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--theme-border)] p-4 text-center text-sm text-[var(--theme-muted)]">
+                  No integrations match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+        </div>
+        ) : null}
+
+        {sectionVisible('pipeline') || sectionVisible('agents') ? (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-[1.25fr_0.75fr]">
+          {sectionVisible('pipeline') ? (
+          <Panel
+            title="Content Pipeline"
+            icon={CheckListIcon}
+            right={
+              <span className="text-xs text-[var(--theme-muted)]">
+                Six guarded stages
+              </span>
+            }
+          >
+            <div className="grid grid-cols-1 gap-3 p-4 md:grid-cols-2 2xl:grid-cols-3">
+              {filteredPipeline.map((item) => (
+                <article
+                  key={item.title}
+                  className="flex min-h-36 flex-col justify-between rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-4"
+                >
+                  <div>
+                    <div className="mb-3 flex items-center justify-between gap-2">
+                      <StatusPill tone={item.blocker ? 'warn' : 'good'}>
+                        {item.stage}
+                      </StatusPill>
+                      <span className="truncate text-xs font-semibold text-[var(--theme-muted)]">
+                        {item.platform}
+                      </span>
+                    </div>
+                    <h3 className="text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                      {item.title}
+                    </h3>
+                  </div>
+                  <div className="mt-4 flex items-end justify-between gap-3">
+                    <p className="text-xs text-[var(--theme-muted)]">
+                      Owner: {item.owner}
+                    </p>
+                    {item.blocker ? (
+                      <span className="max-w-[55%] text-right text-[11px] font-semibold leading-4 text-amber-300">
+                        {item.blocker}
+                      </span>
+                    ) : null}
+                  </div>
+                </article>
+              ))}
+              {filteredPipeline.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--theme-border)] p-6 text-center text-sm text-[var(--theme-muted)] md:col-span-2 2xl:col-span-3">
+                  No pipeline items match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+          ) : null}
+
+          {sectionVisible('agents') ? (
+          <Panel title="Agent State" icon={UserGroupIcon}>
+            <div className="divide-y divide-[var(--theme-border)]">
+              {filteredAgents.map((agent) => (
+                <div key={agent.name} className="px-4 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+                        {agent.name}
+                      </h3>
+                      <p className="text-xs text-[var(--theme-muted)]">
+                        {agent.role}
+                      </p>
+                    </div>
+                    <StatusPill tone={agent.tone}>{agent.status}</StatusPill>
+                  </div>
+                  <p className="mt-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 font-mono text-[11px] text-[var(--theme-muted)]">
+                    {agent.model}
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+                    {agent.lastSignal}
+                  </p>
+                </div>
+              ))}
+              {filteredAgents.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-[var(--theme-muted)]">
+                  No agents match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+          ) : null}
+        </div>
+        ) : null}
+
+        {sectionVisible('performance') ||
+        sectionVisible('clients') ||
+        sectionVisible('settings') ? (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+          {sectionVisible('performance') ? (
+          <Panel
+            title="Performance"
+            icon={Analytics01Icon}
+            className="xl:col-span-1"
+          >
+            <div className="space-y-3 p-4">
+              {filteredPerformanceSources.map((source) => (
+                <div
+                  key={source}
+                  className="rounded-lg border border-dashed border-[var(--theme-border)] bg-[var(--theme-card2)] p-4"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[var(--theme-text)]">
+                      {source}
+                    </p>
+                    <StatusPill tone="idle">No live data</StatusPill>
+                  </div>
+                  <div className="mt-4 h-2 overflow-hidden rounded-full bg-[var(--theme-border)]">
+                    <div className="h-full w-1/3 rounded-full bg-[var(--theme-accent)] opacity-40" />
+                  </div>
+                </div>
+              ))}
+              {filteredPerformanceSources.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--theme-border)] p-6 text-center text-sm text-[var(--theme-muted)]">
+                  No performance sources match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+          ) : null}
+
+          {sectionVisible('clients') ? (
+          <Panel title="Clients" icon={Rocket01Icon} className="xl:col-span-1">
+            <div className="space-y-3 p-4">
+              {filteredClientRows.map((client, index) => (
+                <div
+                  key={client}
+                  className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-4"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[var(--theme-text)]">
+                      {client}
+                    </p>
+                    <span className="text-xs font-semibold tabular-nums text-[var(--theme-muted)]">
+                      0{index + 1}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+                    Fixture account row. Replace with CRM or LL Empire state
+                    source after data approval.
+                  </p>
+                </div>
+              ))}
+              {filteredClientRows.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-[var(--theme-border)] p-6 text-center text-sm text-[var(--theme-muted)]">
+                  No clients match this search.
+                </div>
+              ) : null}
+            </div>
+          </Panel>
+          ) : null}
+
+          {sectionVisible('settings') ? (
+          <Panel
+            title="Safety Contract"
+            icon={Shield01Icon}
+            className="xl:col-span-1"
+          >
+            <div className="space-y-3 p-4">
+              {[
+                'Secrets stay server-side.',
+                'Every live metric gets source and timestamp.',
+                'Infra and Hermes mutations require Chairman Brief.',
+                'Fixture metrics cannot be reported as real performance.',
+              ].map((rule) => (
+                <div
+                  key={rule}
+                  className="flex items-start gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+                >
+                  <HugeiconsIcon
+                    icon={Settings01Icon}
+                    size={16}
+                    strokeWidth={1.7}
+                    className="mt-0.5 shrink-0 text-[var(--theme-accent)]"
+                  />
+                  <p className="text-xs leading-5 text-[var(--theme-muted)]">
+                    {rule}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Panel>
+          ) : null}
+        </div>
+        ) : null}
+      </div>
+    </main>
+  )
+}

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -50,8 +50,7 @@ export type DashboardCapabilities = {
 }
 
 /** Full capabilities — backward compat with existing code */
-export type GatewayCapabilities =
-  CoreCapabilities &
+export type GatewayCapabilities = CoreCapabilities &
   EnhancedCapabilities &
   DashboardCapabilities
 
@@ -96,7 +95,11 @@ let dashboardTokenPromise: Promise<string> | null = null
 let dashboardTokenCache = ''
 
 /** Optional bearer token for authenticated gateway endpoints. */
-export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
+export const BEARER_TOKEN =
+  process.env.HERMES_API_TOKEN ||
+  process.env.API_SERVER_KEY ||
+  process.env.HERMES_GATEWAY_TOKEN ||
+  ''
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -319,7 +322,9 @@ async function autoDetectGatewayUrl(): Promise<void> {
     }
   }
 
-  console.warn('[gateway] Could not reach Hermes gateway on 8645, 8642, or 8643')
+  console.warn(
+    '[gateway] Could not reach Hermes gateway on 8645, 8642, or 8643',
+  )
 }
 
 async function autoDetectDashboardUrl(): Promise<void> {

--- a/src/server/openai-compat-api.ts
+++ b/src/server/openai-compat-api.ts
@@ -1,7 +1,4 @@
-import { HERMES_API } from './gateway-capabilities'
-
-/** Optional bearer token for authenticated OpenAI-compatible endpoints (e.g. Codex OAuth). */
-const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
+import { BEARER_TOKEN, HERMES_API } from './gateway-capabilities'
 
 /** Cached first available model from /v1/models — used as fallback when no model is specified. */
 let _cachedDefaultModel: string | null = null
@@ -108,8 +105,7 @@ function parseHermesToolProgressChunk(payload: string): StreamChunkType | null {
     const parsed = JSON.parse(payload) as unknown
     const record = readRecord(parsed)
     if (!record) return null
-    const name =
-      readString(record.tool) || readString(record.name) || 'tool'
+    const name = readString(record.tool) || readString(record.name) || 'tool'
     const emoji = readString(record.emoji)
     const labelText = readString(record.label)
     const label = [emoji, labelText].filter(Boolean).join(' ').trim()

--- a/src/server/terminal-sessions.ts
+++ b/src/server/terminal-sessions.ts
@@ -4,6 +4,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
@@ -33,6 +34,64 @@ const __dirname_resolved =
     : dirname(fileURLToPath(import.meta.url))
 const PTY_HELPER = resolve(__dirname_resolved, 'pty-helper.py')
 
+const TERMINAL_ENV_FILE_LIST = [
+  '/home/lucas/.hermes/.env.shared',
+  '~/.hermes/.env.shared',
+  '~/.hermes/.env',
+]
+
+function parseEnvFile(path: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  if (!existsSync(path)) return env
+
+  const raw = readFileSync(path, 'utf-8')
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    const exportPrefix = 'export '
+    const normalized = trimmed.startsWith(exportPrefix)
+      ? trimmed.slice(exportPrefix.length).trim()
+      : trimmed
+    const equalsIndex = normalized.indexOf('=')
+    if (equalsIndex <= 0) continue
+
+    const key = normalized.slice(0, equalsIndex).trim()
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue
+
+    let value = normalized.slice(equalsIndex + 1).trim()
+    const quote = value[0]
+    if (
+      (quote === '"' || quote === "'") &&
+      value.endsWith(quote) &&
+      value.length >= 2
+    ) {
+      value = value.slice(1, -1)
+    }
+    env[key] = value
+  }
+
+  return env
+}
+
+function expandHome(path: string, home: string): string {
+  return path.startsWith('~') ? path.replace('~', home) : path
+}
+
+function loadTerminalEnv(home: string): Record<string, string> {
+  const configured = process.env.HERMES_TERMINAL_ENV_FILES
+  const paths = configured
+    ? configured.split(':').map((item) => item.trim()).filter(Boolean)
+    : TERMINAL_ENV_FILE_LIST
+
+  return paths.reduce<Record<string, string>>((acc, item) => {
+    return {
+      ...acc,
+      ...parseEnvFile(expandHome(item, home)),
+    }
+  }, {})
+}
+
 export function createTerminalSession(params: {
   command?: Array<string>
   cwd?: string
@@ -43,7 +102,7 @@ export function createTerminalSession(params: {
   const emitter = new EventEmitter()
   const sessionId = randomUUID()
 
-  const home = process.env.HOME ?? homedir() ?? '/tmp'
+  const home = process.env.HOME || homedir()
   const defaultShell =
     process.platform === 'win32'
       ? 'powershell.exe'
@@ -58,6 +117,7 @@ export function createTerminalSession(params: {
 
   const cols = params.cols ?? 80
   const rows = params.rows ?? 24
+  const terminalEnv = loadTerminalEnv(home)
 
   // Buffer early output before any listener registers
   const earlyBuffer: Array<TerminalSessionEvent> = []
@@ -90,6 +150,7 @@ export function createTerminalSession(params: {
     {
       env: {
         ...process.env,
+        ...terminalEnv,
         ...params.env,
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=EB+Garamond:opsz,wght@8..120,400..800&family=JetBrains+Mono:wght@400;500&display=swap');
 @import 'tailwindcss';
 
 /* Tailwind v4 — enable dark: variant on .dark class (set by __root.tsx) */
@@ -976,7 +975,6 @@ code {
   --theme-input: #ffffff;
 }
 
-
 /* ============================================================
    Hermes Nous — matches nousresearch.com/hermes-agent chrome
    Dark:  deep teal #041C1C background, cream #ffe6cb accent
@@ -1255,7 +1253,9 @@ code {
 [data-theme$='-light'] .shadow-lg,
 [data-theme$='-light'] .shadow-xl,
 [data-theme$='-light'] .shadow-2xl {
-  box-shadow: 0 1px 0 rgba(22, 49, 95, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.7) !important;
+  box-shadow:
+    0 1px 0 rgba(22, 49, 95, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7) !important;
 }
 [data-theme$='-light'] .shadow-md {
   box-shadow: 0 1px 0 rgba(22, 49, 95, 0.04) !important;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { URL, fileURLToPath } from 'node:url'
 import { execSync, spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import net from 'node:net'
 import { resolve, dirname } from 'node:path'
 import os from 'node:os'
+import YAML from 'yaml'
 
 // devtools removed
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
@@ -85,6 +86,96 @@ async function isHermesAgentHealthy(port = 8642): Promise<boolean> {
 const config = defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const hermesApiUrl = env.HERMES_API_URL?.trim() || 'http://127.0.0.1:8642'
+  const hermesApiToken =
+    env.HERMES_API_TOKEN ||
+    env.API_SERVER_KEY ||
+    env.HERMES_GATEWAY_TOKEN ||
+    process.env.HERMES_API_TOKEN ||
+    process.env.API_SERVER_KEY ||
+    process.env.HERMES_GATEWAY_TOKEN ||
+    ''
+
+  function hermesAuthHeaders(): Record<string, string> {
+    return hermesApiToken ? { Authorization: `Bearer ${hermesApiToken}` } : {}
+  }
+
+  function readActiveModel(): string {
+    try {
+      const raw = readFileSync(resolve(os.homedir(), '.hermes', 'config.yaml'), 'utf-8')
+      const config = (YAML.parse(raw) as Record<string, unknown>) || {}
+      const modelField = config.model
+      if (typeof modelField === 'string') return modelField
+      if (modelField && typeof modelField === 'object') {
+        const model = modelField as Record<string, unknown>
+        return (model.default as string) || (model.name as string) || ''
+      }
+    } catch {
+      // The API still reports backend reachability when the config file is missing.
+    }
+    return ''
+  }
+
+  function writeConnectionStatus(
+    res: {
+      statusCode: number
+      setHeader: (name: string, value: string) => void
+      end: (chunk?: string) => void
+    },
+    input: {
+      httpStatus: number
+      status: 'connected' | 'enhanced' | 'partial' | 'disconnected'
+      detail: string
+      hasModels: boolean
+      hasSessions: boolean
+      health: boolean
+    },
+  ) {
+    const activeModel = readActiveModel()
+    const ok = input.status !== 'disconnected'
+    const mode =
+      input.status === 'enhanced'
+        ? 'enhanced'
+        : input.status === 'disconnected'
+          ? 'disconnected'
+          : 'portable'
+    res.statusCode = input.httpStatus
+    res.setHeader('content-type', 'application/json')
+    res.end(
+      JSON.stringify({
+        ok,
+        mode,
+        backend: hermesApiUrl,
+        status: input.status,
+        label:
+          input.status === 'enhanced'
+            ? 'Enhanced'
+            : input.status === 'connected'
+              ? 'Connected'
+              : input.status === 'partial'
+                ? 'Partial'
+                : 'Disconnected',
+        detail: input.detail,
+        health: input.health,
+        chatReady: input.hasModels,
+        modelConfigured: Boolean(activeModel),
+        activeModel,
+        chatMode: mode === 'enhanced' ? 'enhanced-hermes' : mode,
+        capabilities: {
+          health: input.health,
+          chatCompletions: input.hasModels,
+          models: input.hasModels,
+          streaming: input.hasModels,
+          sessions: input.hasSessions,
+          skills: false,
+          memory: true,
+          config: false,
+          jobs: true,
+          dashboard: false,
+        },
+        hermesUrl: hermesApiUrl,
+      }),
+    )
+  }
 
   // Hermes Agent auto-start state
   let hermesAgentChild: ChildProcess | null = null
@@ -519,61 +610,62 @@ const config = defineConfig(({ mode, command }) => {
                 // Check for enhanced Hermes gateway first (has /api/sessions)
                 const [modelsRes, sessionsRes] = await Promise.all([
                   fetch(`${hermesApiUrl}/v1/models`, {
+                    headers: hermesAuthHeaders(),
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                   fetch(`${hermesApiUrl}/api/sessions?limit=1`, {
+                    headers: hermesAuthHeaders(),
                     signal: AbortSignal.timeout(3000),
                   }).catch(() => null),
                 ])
                 const hasModels = modelsRes?.ok ?? false
                 const hasSessions = sessionsRes?.ok ?? false
                 if (hasModels && hasSessions) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
-                      ok: true,
-                      mode: 'enhanced',
-                      backend: hermesApiUrl,
-                    }),
-                  )
+                  writeConnectionStatus(res, {
+                    httpStatus: 200,
+                    status: 'enhanced',
+                    detail:
+                      'Core chat works and Hermes gateway sessions are available.',
+                    hasModels,
+                    hasSessions,
+                    health: true,
+                  })
                   return
                 }
                 if (hasModels) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
-                      ok: true,
-                      mode: 'portable',
-                      backend: hermesApiUrl,
-                    }),
-                  )
+                  writeConnectionStatus(res, {
+                    httpStatus: 200,
+                    status: 'connected',
+                    detail: 'Core chat is ready on this backend.',
+                    hasModels,
+                    hasSessions,
+                    health: true,
+                  })
                   return
                 }
                 // Fall back to /health for full Hermes backends
                 const healthRes = await fetch(`${hermesApiUrl}/health`, {
                   signal: AbortSignal.timeout(3000),
                 })
-                res.statusCode = healthRes.ok ? 200 : 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
-                    ok: healthRes.ok,
-                    mode: 'enhanced',
-                    backend: hermesApiUrl,
-                  }),
-                )
+                writeConnectionStatus(res, {
+                  httpStatus: healthRes.ok ? 200 : 502,
+                  status: healthRes.ok ? 'partial' : 'disconnected',
+                  detail: healthRes.ok
+                    ? 'Backend is reachable, but chat API is not ready yet.'
+                    : 'No compatible backend detected.',
+                  hasModels: false,
+                  hasSessions: false,
+                  health: healthRes.ok,
+                })
               } catch {
-                res.statusCode = 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
-                    ok: false,
-                    mode: 'disconnected',
-                    backend: hermesApiUrl,
-                  }),
-                )
+                writeConnectionStatus(res, {
+                  httpStatus: 502,
+                  status: 'disconnected',
+                  detail: 'No compatible backend detected.',
+                  hasModels: false,
+                  hasSessions: false,
+                  health: false,
+                })
               }
               return
             }


### PR DESCRIPTION
## Summary
- unlock dashboard/workspace routes from blocking onboarding and backend availability states
- add Hermes-only LL Ops cockpit, terminal debug analyzer, and safe terminal env loading
- make dashboard/chat/terminal navigation usable with clear fallback states
- document dashboard usage and env requirements

## Verification
- targeted ESLint passed with one warning in ll-ops-status async handler and existing .eslintignore deprecation notice
- focused Vitest passed: 2 files / 3 tests
- npm run build passed
- live VPS smoke passed for /dashboard, /ll-ops, /terminal, /api/debug-analyze, and /api/connection-status

## Notes
- no secrets included; commit secret-pattern scan returned 0 hits
- public/neo-pnl.json was intentionally not committed because it is local financial data
- no Hermes agent config, SOUL, cron, firewall, auth file, model routing, or trading script was changed