### PR TITLE
fix(docker): start Hermes Agent gateway in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
   # Provides the backend API that the workspace connects to
   hermes-agent:
     image: nousresearch/hermes-agent:latest
+    # The Hermes Agent image entrypoint defaults to the interactive CLI which exits
+    # immediately under `docker compose up -d`. We override here to start the
+    # gateway, which is the long-running API/health server the Workspace needs.
+    # See #360.
+    command: ["gateway", "run"]
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary

The `hermes-agent` image's default entrypoint is the interactive CLI, which exits immediately under `docker compose up -d`. That makes the gateway appear absent and the Workspace healthcheck/connection fail with `Could not reach Hermes gateway`.

This adds an explicit `command: [gateway, run]` to the `hermes-agent` service so the long-running API/health server starts on `up -d`.

Closes #360.

## Reproduction without this fix

Fresh `docker compose up -d` against upstream main fails with the symptoms reported across several users on #360. The only working remedy was for users to manually patch their compose with `command: gateway run` (confirmed by @CipherFrame, @nazeshinjite, @nixbin-engineering in the issue thread).

## Test plan

- `docker compose down -v && docker compose up -d --force-recreate`
- `curl http://localhost:8642/health` → `{"status":"ok","platform":"hermes-agent"}`
- Open `http://localhost:3000` and confirm Workspace connects without "Could not reach Hermes gateway" error.
