### PR TITLE
fix(updates): show "Hermes updated" modal only once per release

### DIFF
--- a/src/components/update-center-notifier.tsx
+++ b/src/components/update-center-notifier.tsx
@@ -87,9 +87,27 @@ function notesId(sections: Array<ReleaseNoteSection>): string {
 
 function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
   if (!sections.length) return null
-  const notes = { id: notesId(sections), sections, updatedAt: Date.now() }
+  const id = notesId(sections)
+  const notes = { id, sections, updatedAt: Date.now() }
+  // Only clear the "seen" marker when the release-notes payload actually
+  // changed. Without this guard the modal pops up on every page refresh
+  // because /api/update/status returns the same pendingReleaseNotes on every
+  // poll, useEffect fires, and we used to drop the seen marker every time.
+  // See #356.
+  let existingId: string | null = null
+  try {
+    const raw = localStorage.getItem(NOTES_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as Notes
+      existingId = parsed?.id ?? null
+    }
+  } catch {
+    existingId = null
+  }
+  if (existingId !== id) {
+    localStorage.removeItem(NOTES_SEEN_KEY)
+  }
   localStorage.setItem(NOTES_KEY, JSON.stringify(notes))
-  localStorage.removeItem(NOTES_SEEN_KEY)
   return notes
 }
 


### PR DESCRIPTION
## Summary

The 'Hermes updated' modal was popping on every page refresh.

Closes #356.

## Root cause

`storeNotes()` ran inside a `useEffect` keyed on `data?.pendingReleaseNotes`. Every `/api/update/status` poll returns the same notes payload, so the effect re-fired, and `storeNotes()` *unconditionally* cleared `NOTES_SEEN_KEY`. That made `readNotes()` consider the same notes 'unseen' again on the next refresh, and the modal popped.

## Fix

Only clear the seen marker when the notes ID actually changed (i.e. a new release with different content). Identical payloads keep the seen marker intact across refreshes and polls.

## Verification

Manually:

1. Refresh the page after acknowledging the modal — modal does not reappear ✅
2. Bump a release notes section in the agent — modal reappears once on the next refresh ✅
3. Acknowledge again — modal stays dismissed across further refreshes ✅
