### PR TITLE
feat: make Conductor use native Swarm fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # container needs the key for whichever provider you configured in
 # ~/.hermes/config.yaml. Common options:
 #
-#   Anthropic (Claude):      https://console.anthropic.com/settings/keys
+#   OpenAI Codex / OpenAI-compatible: configure through `hermes setup` / `hermes model`
 #   OpenAI (GPT / o-series): https://platform.openai.com/api-keys
 #   OpenRouter (many models, free tier available): https://openrouter.ai/keys
 #   Google (Gemini):         https://aistudio.google.com/app/apikey
@@ -18,7 +18,6 @@
 #
 # Uncomment ONLY the key(s) for the providers you actually use.
 
-# ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # OPENROUTER_API_KEY=sk-or-v1-...
 # GOOGLE_API_KEY=AIza...
@@ -51,8 +50,8 @@
 # Set this if hermes-agent is installed elsewhere
 # HERMES_AGENT_PATH=/path/to/hermes-agent
 
-# Server port (default: 3002)
-# PORT=3002
+# Server port (default: 3000)
+# PORT=3000
 
 # ══════════════════════════════════════════════════════════════
 # Security

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 > Not a chat wrapper. A complete workspace — orchestrate agents, browse memory, manage skills, and control everything from one interface.
 
-> **v2 — zero-fork.** Clone, don't fork. Runs on vanilla [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) installed via Nous's own installer. Chat, sessions, memory, skills, jobs, MCP, terminal, dashboard, Agent View, and Operations are all in vanilla parity. **Conductor** currently requires an additional dashboard plugin not in upstream yet — the UI shows a clear placeholder when that endpoint isn't available ([#262](https://github.com/outsourc-e/hermes-workspace/issues/262)). Everything else works with zero patches.
+> **v2 — zero-fork.** Clone, don't fork. Runs on vanilla [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) installed via Nous's own installer. Chat, sessions, memory, skills, jobs, MCP, terminal, dashboard, Agent View, and Operations are all in vanilla parity. **Conductor** uses the dashboard mission API when available and falls back to Workspace-native Swarm dispatch (`mode: native-swarm`) when the dashboard endpoint is absent, preserving zero-fork behavior ([#262](https://github.com/outsourc-e/hermes-workspace/issues/262)).
 
 ![Hermes Workspace](./docs/screenshots/splash.png)
 
@@ -48,7 +48,7 @@ Start here: [docs/swarm/](./docs/swarm/)
 - 🔌 **MCP** — Full /mcp page (catalog + marketplace + sources), or fallback to local config CRUD
 - 📁 **Files + Terminal** — Full workspace file browser with Monaco; cross-platform PTY terminal
 - 🎮 **Operations** — Multi-agent dashboard with profile presets (Sage/Trader/Builder/Scribe/Ops) and 'Needs setup' detection
-- 📡 **Conductor** — Mission dispatch + decomposition (requires upstream dashboard plugin, see [#262](https://github.com/outsourc-e/hermes-workspace/issues/262))
+- 📡 **Conductor** — Mission dispatch + decomposition with dashboard-backed missions when available and Workspace-native Swarm fallback otherwise
 - 👥 **Agent View** — Live agent panel in chat with avatar, queue, history, usage meter
 - 🐝 **Swarm Mode** — Persistent tmux-backed Hermes Agent workers with role-based dispatch
 - 🗄️ **Dashboard** — Aggregated overview: sessions, model mix, cost ledger, attention card, ops strip
@@ -213,8 +213,7 @@ HERMES_API_URL=http://127.0.0.1:8642
 
 # Optional: provider keys the Hermes Agent gateway can read at runtime.
 # You only need the key(s) for whichever provider(s) you actually use.
-# ANTHROPIC_API_KEY=***         # Anthropic
-# OPENAI_API_KEY=sk-...                # GPT / o-series
+# OPENAI_API_KEY=sk-...                # GPT / o-series / OpenAI-compatible
 # OPENROUTER_API_KEY=sk-or-v1-...      # OpenRouter (incl. free models)
 # GOOGLE_API_KEY=AIza...               # Gemini
 # (Ollama / LM Studio / local servers don't need a key)
@@ -320,7 +319,7 @@ The Docker setup runs both the **Hermes Agent gateway** and **Hermes Workspace**
 
 - **Docker**
 - **Docker Compose**
-- **Anthropic API Key** — [Get one here](https://console.anthropic.com/settings/keys) (required for the agent gateway)
+- **A configured Hermes Agent model provider** — run `hermes setup` / `hermes model`, or provide a key for whichever provider you use. This workspace does not require Anthropic.
 
 ### Step 1: Configure Environment
 
@@ -334,8 +333,7 @@ Edit `.env` and add **at least one** LLM provider key — whichever provider you
 
 ```env
 # Pick one (or more). You do NOT need all of these.
-# ANTHROPIC_API_KEY=***         # Anthropic
-# OPENAI_API_KEY=sk-...                # GPT / o-series
+# OPENAI_API_KEY=sk-...                # GPT / o-series / OpenAI-compatible
 # OPENROUTER_API_KEY=sk-or-v1-...      # OpenRouter (free models available)
 # GOOGLE_API_KEY=AIza...               # Gemini
 ```
@@ -586,7 +584,7 @@ Verify: `curl http://localhost:8642/health` should return `{"status": "ok"}`.
 
 v2+ runs on vanilla `hermes-agent`. **No fork required.** The upstream ships every endpoint the workspace needs for chat, sessions, memory, skills, config, jobs, MCP, terminal, and Agent View.
 
-**One known exception:** **Conductor** uses a dashboard plugin that hasn't landed upstream yet. When the workspace detects the missing endpoint, the Conductor screen shows a clear "Upstream not ready" placeholder with a link to [issue #262](https://github.com/outsourc-e/hermes-workspace/issues/262) instead of failing mid-action. Everything else works.
+**Conductor note:** when the dashboard mission API is available, Workspace uses it directly. When that endpoint is absent, Workspace uses its native Swarm fallback and returns `mode: native-swarm`. The fallback dispatches through Workspace Swarm workers, keeps status available through `/api/conductor-spawn?missionId=...`, and cancels through `/api/conductor-stop`.
 
 If you're pinned to an older `hermes-agent` version and missing core endpoints, the workspace will degrade gracefully to **portable mode** with basic chat — upgrade upstream to restore full features.
 
@@ -598,7 +596,7 @@ If using Docker Compose and getting auth errors:
 
    ```bash
    grep -E '_API_KEY' .env
-   # Should show one of: ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, GOOGLE_API_KEY, ...
+   # Should show one of: OPENAI_API_KEY, OPENROUTER_API_KEY, GOOGLE_API_KEY, or another provider key you intentionally use.
    ```
 
    (hermes-agent reads whichever key matches the provider configured in `~/.hermes/config.yaml`.)
@@ -661,13 +659,13 @@ The Docker setup runs both automatically — no action needed if using `docker c
 | Mobile PWA + Tailscale | Install as native-feeling app on any device |
 | Themes | Hermes / Nous / Bronze / Slate / Mono (light + dark) |
 | Capability gates | Graceful 'upstream not ready' placeholders |
-| Multi-provider | Anthropic, OpenAI, OpenRouter, Google, Ollama, LM Studio, vLLM, Atomic Chat |
+| Multi-provider | OpenAI/OpenAI-compatible, OpenRouter, Google, Ollama, LM Studio, vLLM, Atomic Chat, and other Hermes-supported providers |
 
 ### In progress 🔨
 
 | Feature | Status |
 |---|---|
-| Conductor missions | Workspace UI is shipped; awaiting upstream dashboard plugin (see [#262](https://github.com/outsourc-e/hermes-workspace/issues/262)) |
+| Conductor missions | Workspace UI is shipped; uses dashboard mission API when available and Workspace-native Swarm fallback otherwise (see [#262](https://github.com/outsourc-e/hermes-workspace/issues/262)) |
 | Native Desktop App (Electron) | Spec'd; PWA install path works today |
 
 ### Coming 🔜

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,8 +13,8 @@ Common setup issues and how to fix them.
 **Fix:**
 
 ```bash
-# Find your claude env file
-claude config env-path
+# Find your Hermes env file
+hermes config env-path
 # Usually: ~/.hermes/.env
 
 # Check for the key
@@ -43,7 +43,7 @@ After fixing, restart the gateway: `hermes gateway run --replace`
 
 **Checklist (in order):**
 
-1. Is the gateway running? `pgrep -af "claude.*gateway"`
+1. Is the gateway running? `hermes gateway status` or `pgrep -af "hermes.*gateway"`
 2. Is port 8642 bound? `curl -sf http://127.0.0.1:8642/health`
 3. Is Workspace `.env` correct? `grep HERMES_API_URL ~/hermes-workspace/.env`
    - Should be: `HERMES_API_URL=http://127.0.0.1:8642`
@@ -122,10 +122,10 @@ This means the Vite SSR server tried `GET /api/gateway-status` which internally 
 If nothing above helps, run this and share the output:
 
 ```bash
-echo "=== claude version ===" && claude --version 2>&1
-echo "=== claude env path ===" && claude config env-path 2>&1
-echo "=== claude env (redacted) ===" && grep -E "^(API_SERVER|CLAUDE_)" "$(claude config env-path 2>/dev/null || echo ~/.hermes/.env)" 2>&1
-echo "=== gateway process ===" && pgrep -af "claude.*gateway" 2>&1 || echo "not running"
+echo "=== hermes version ===" && hermes --version 2>&1
+echo "=== hermes env path ===" && hermes config env-path 2>&1
+echo "=== hermes env (redacted) ===" && grep -E "^(API_SERVER|HERMES_|CLAUDE_)" "$(hermes config env-path 2>/dev/null || echo ~/.hermes/.env)" 2>&1
+echo "=== gateway process ===" && pgrep -af "hermes.*gateway" 2>&1 || echo "not running"
 echo "=== port 8642 ===" && (ss -tlnp 2>/dev/null || lsof -iTCP:8642 -sTCP:LISTEN 2>/dev/null) | grep 8642 || echo "not bound"
 echo "=== health check ===" && curl -sf http://127.0.0.1:8642/health 2>&1 || echo "not reachable"
 echo "=== workspace .env ===" && grep CLAUDE ~/hermes-workspace/.env 2>&1 || echo "no .env"

--- a/src/components/swarm/swarm-health-strip.tsx
+++ b/src/components/swarm/swarm-health-strip.tsx
@@ -19,8 +19,16 @@ type WorkerHealth = {
   model: string
   provider: string
   recentAuthErrors: number
+  recentFallbacks: number
   lastErrorAt: string | null
   lastErrorMessage: string | null
+  lastFallbackAt: string | null
+  lastFallbackMessage: string | null
+  modelAuthStatus: 'ready' | 'primary-auth-failed' | 'fallback-active' | 'not-configured' | 'unknown'
+  primaryAuthOk: boolean | null
+  fallbackActive: boolean
+  fallbackProvider: string | null
+  fallbackModel: string | null
 }
 
 type HealthResponse = {
@@ -33,6 +41,11 @@ type HealthResponse = {
     totalWorkers: number
     wrappersConfigured: number
     totalAuthErrors24h: number
+    totalFallbacks24h: number
+    workersUsingFallback: number
+    workersPrimaryAuthFailed: number
+    degraded: boolean
+    warnings: string[]
     distinctModels: string[]
     distinctProviders: string[]
   }
@@ -110,6 +123,9 @@ export function SwarmHealthStrip({ targetWorkerId }: { targetWorkerId?: string |
   const workspaceModel = data?.workspaceModel ?? '—'
   const apiUrl = data?.agentApiUrl ?? data?.claudeApiUrl ?? '—'
   const totalAuthErrors = data?.summary.totalAuthErrors24h ?? 0
+  const totalFallbacks = data?.summary.totalFallbacks24h ?? 0
+  const degraded = data?.summary.degraded ?? false
+  const warnings = data?.summary.warnings ?? []
   const wrappersConfigured = data?.summary.wrappersConfigured ?? 0
   const totalWorkers = data?.summary.totalWorkers ?? 0
   const distinctModels = data?.summary.distinctModels ?? []
@@ -120,7 +136,7 @@ export function SwarmHealthStrip({ targetWorkerId }: { targetWorkerId?: string |
     <div className="rounded-2xl border border-emerald-400/15 bg-[#08110d] p-4 text-emerald-50/85">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <HugeiconsIcon icon={CheckmarkCircle02Icon} size={14} className="text-emerald-300" />
+          <HugeiconsIcon icon={degraded ? AlertCircleIcon : CheckmarkCircle02Icon} size={14} className={degraded ? 'text-amber-300' : 'text-emerald-300'} />
           <span className="text-[11px] uppercase tracking-[0.18em] text-emerald-200/80">Swarm health</span>
         </div>
         <div className="flex items-center gap-2 text-[11px] text-emerald-100/55">
@@ -148,12 +164,22 @@ export function SwarmHealthStrip({ targetWorkerId }: { targetWorkerId?: string |
         <HealthTile icon={FlashIcon} label="Provider" value={provider} />
         <HealthTile icon={FlashIcon} label="Wrappers" value={`${wrappersConfigured}/${totalWorkers}`} />
         <HealthTile
-          icon={totalAuthErrors === 0 ? CheckmarkCircle02Icon : AlertCircleIcon}
-          label="Auth errors 24h"
-          value={String(totalAuthErrors)}
-          tone={totalAuthErrors === 0 ? 'good' : 'warn'}
+          icon={totalFallbacks === 0 ? CheckmarkCircle02Icon : AlertCircleIcon}
+          label="Fallbacks 24h"
+          value={String(totalFallbacks)}
+          tone={totalFallbacks === 0 ? 'good' : 'warn'}
         />
       </div>
+
+      {degraded ? (
+        <div className="mt-3 rounded-lg border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          <div className="font-semibold">Primary model readiness degraded.</div>
+          <div className="mt-1 text-amber-100/80">
+            Auth errors: {totalAuthErrors}. Fallbacks: {totalFallbacks}. Reply smoke tests can pass on fallback; fix primary auth before production swarm work.
+          </div>
+          {warnings.length > 0 ? <div className="mt-1 text-amber-100/70">{warnings.join(' ')}</div> : null}
+        </div>
+      ) : null}
 
       <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-emerald-100/55">
         <span>Gateway: <span className="text-emerald-50">{apiUrl}</span></span>
@@ -164,8 +190,8 @@ export function SwarmHealthStrip({ targetWorkerId }: { targetWorkerId?: string |
 
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-emerald-400/15 bg-emerald-500/5 px-3 py-2">
         <div className="text-[11px] text-emerald-100/70">
-          Smoke test: dispatch a tiny prompt to{' '}
-          <span className="font-semibold text-emerald-100">{pingTarget ?? 'no worker'}</span> and confirm a real reply.
+          Reply smoke test: dispatch a tiny prompt to{' '}
+          <span className="font-semibold text-emerald-100">{pingTarget ?? 'no worker'}</span>. This confirms a reply, not primary-model readiness.
         </div>
         <button
           type="button"

--- a/src/hooks/use-crew-status.ts
+++ b/src/hooks/use-crew-status.ts
@@ -9,6 +9,7 @@ export type CrewPlatformInfo = {
 export type CrewMember = {
   id: string
   displayName: string
+  humanLabel?: string
   role: string
   specialty?: string
   mission?: string

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-provid
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
+import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
@@ -487,6 +488,11 @@ const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   path: '/api/gateway-status',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiGatewayReprobeRoute = ApiGatewayReprobeRouteImport.update({
+  id: '/api/gateway-reprobe',
+  path: '/api/gateway-reprobe',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiFilesRoute = ApiFilesRouteImport.update({
   id: '/api/files',
   path: '/api/files',
@@ -836,6 +842,7 @@ export interface FileRoutesByFullPath {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -968,6 +975,7 @@ export interface FileRoutesByTo {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -1102,6 +1110,7 @@ export interface FileRoutesById {
   '/api/crew-status': typeof ApiCrewStatusRoute
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
+  '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
@@ -1237,6 +1246,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1369,6 +1379,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1502,6 +1513,7 @@ export interface FileRouteTypes {
     | '/api/crew-status'
     | '/api/events'
     | '/api/files'
+    | '/api/gateway-reprobe'
     | '/api/gateway-status'
     | '/api/history'
     | '/api/integrations'
@@ -1636,6 +1648,7 @@ export interface RootRouteChildren {
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
+  ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
@@ -2191,6 +2204,13 @@ declare module '@tanstack/react-router' {
       path: '/api/gateway-status'
       fullPath: '/api/gateway-status'
       preLoaderRoute: typeof ApiGatewayStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/gateway-reprobe': {
+      id: '/api/gateway-reprobe'
+      path: '/api/gateway-reprobe'
+      fullPath: '/api/gateway-reprobe'
+      preLoaderRoute: typeof ApiGatewayReprobeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/files': {
@@ -2826,6 +2846,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewStatusRoute: ApiCrewStatusRoute,
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
+  ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,

--- a/src/routes/api/-conductor-spawn.test.ts
+++ b/src/routes/api/-conductor-spawn.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { NATIVE_CONDUCTOR_MODE_NOTE, buildNativeConductorAssignments, toNativeConductorMissionRecord } from './conductor-spawn'
+import type { SwarmMission } from '../../server/swarm-missions'
+
+describe('native Conductor fallback', () => {
+  it('labels native-swarm as the official OOTB fallback when dashboard Conductor is unavailable', () => {
+    expect(NATIVE_CONDUCTOR_MODE_NOTE).toContain('official Workspace-native Swarm fallback')
+    expect(NATIVE_CONDUCTOR_MODE_NOTE).toContain('dashboard Conductor API')
+  })
+
+  it('decomposes production missions onto named Workspace Swarm lanes', () => {
+    const assignments = buildNativeConductorAssignments('Fix conductor and make it production ready', {
+      maxParallel: 4,
+      supervised: false,
+    })
+
+    expect(assignments.map((assignment) => assignment.workerId)).toEqual(['swarm2', 'swarm5', 'swarm6', 'swarm11'])
+    expect(assignments[0].task).toContain('Conductor mission: Fix conductor')
+    expect(assignments.every((assignment) => assignment.direct === true)).toBe(true)
+    expect(assignments.every((assignment) => assignment.reviewRequired === false)).toBe(true)
+  })
+
+  it('uses Scribe when the mission asks for documentation even with a smaller lane count', () => {
+    const assignments = buildNativeConductorAssignments('Write docs and handoff for the release', {
+      maxParallel: 3,
+      supervised: true,
+    })
+
+    expect(assignments.map((assignment) => assignment.workerId)).toContain('swarm7')
+    expect(assignments.some((assignment) => assignment.task.includes('Supervised mode'))).toBe(true)
+  })
+
+  it('normalizes native swarm missions into the Conductor mission status contract', () => {
+    const mission: SwarmMission = {
+      id: 'conductor-test',
+      title: 'Conductor: smoke',
+      state: 'executing',
+      createdAt: 1,
+      updatedAt: 2,
+      assignments: [
+        {
+          id: 'a1',
+          workerId: 'swarm2',
+          task: 'Run smoke',
+          rationale: 'Foundation',
+          dependsOn: [],
+          reviewRequired: false,
+          state: 'dispatched',
+          dispatchedAt: 1,
+          completedAt: null,
+          reviewedAt: null,
+          reviewedBy: null,
+          checkpoint: null,
+        },
+      ],
+      events: [
+        { id: 'e1', type: 'created', at: 1, message: 'Mission created' },
+      ],
+    }
+
+    const record = toNativeConductorMissionRecord(mission)
+    expect(record.id).toBe('conductor-test')
+    expect(record.status).toBe('running')
+    expect(record.nativeSwarm).toBe(true)
+    expect(record.modeOfficialOotb).toBe(true)
+    expect(record.modeNote).toBe(NATIVE_CONDUCTOR_MODE_NOTE)
+    expect(record.lines.join('\n')).toContain('swarm2 dispatched')
+  })
+})

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildWorkerPrompt,
   checkpointFromRuntimeSnapshot,
   runtimeCheckpointSignature,
   runtimeSnapshotIsFresh,
@@ -71,5 +72,62 @@ describe('runtimeSnapshotIsFresh', () => {
     }
 
     expect(runtimeSnapshotIsFresh(updated, runtimeCheckpointSignature(baseline), dispatchedAt)).toBe(true)
+  })
+})
+
+describe('buildWorkerPrompt', () => {
+  const roster = {
+    id: 'swarm5',
+    name: 'Builder',
+    role: 'Primary Builder',
+    specialty: 'full-stack implementation across Hermes Workspace and Swarm2',
+    model: 'GPT-5.5',
+    mission: 'Ship focused product slices with tests and clean diffs.',
+    skills: ['swarm-ui-worker', 'swarm-worker-core'],
+    capabilities: ['code-editing', 'ui-implementation', 'build-verification'],
+    preferredTaskTypes: ['implementation'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  }
+
+  it('uses Name — Role as the human-facing label while preserving swarmN as machine ID', () => {
+    const prompt = buildWorkerPrompt({
+      workerId: 'swarm5',
+      task: 'Patch the conductor card copy.',
+      rationale: 'Builder executes implementation work.',
+      roster,
+    })
+
+    expect(prompt).toContain('Worker: Builder — Primary Builder')
+    expect(prompt).toContain('Machine ID: swarm5')
+    expect(prompt).toContain('Mission: Ship focused product slices with tests and clean diffs.')
+    expect(prompt).toContain('Capabilities: code-editing, ui-implementation, build-verification')
+    expect(prompt).toContain('Skills: swarm-ui-worker, swarm-worker-core')
+  })
+
+  it('still injects role context for direct one-shot dispatch unless raw mode is explicit', () => {
+    const prompt = buildWorkerPrompt({
+      workerId: 'swarm5',
+      task: 'Reply with exactly: BUILDER_OK',
+      roster,
+      direct: true,
+    })
+
+    expect(prompt).toContain('Worker: Builder — Primary Builder')
+    expect(prompt).toContain('## Assigned Task')
+    expect(prompt).toContain('Reply with exactly: BUILDER_OK')
+  })
+
+  it('keeps explicit raw/smoke dispatch unwrapped for minimal probes', () => {
+    const prompt = buildWorkerPrompt({
+      workerId: 'swarm5',
+      task: 'RAW_PING_ONLY',
+      roster,
+      direct: true,
+      raw: true,
+    })
+
+    expect(prompt).toBe('RAW_PING_ONLY')
   })
 })

--- a/src/routes/api/-swarm-health.test.ts
+++ b/src/routes/api/-swarm-health.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { parseModelAuthEventsFromText, summarizeSwarmHealth } from './swarm-health'
+
+describe('swarm-health model/auth readiness', () => {
+  it('detects primary auth failure and fallback provider from Hermes logs', () => {
+    const events = parseModelAuthEventsFromText(`
+2026-05-04 18:37:56,770 WARNING cli: Primary provider auth failed (No Codex credentials stored. Run \`hermes auth\` to authenticate.). Falling through to fallback: minimax/MiniMax-M2.7
+2026-05-04 18:37:56,771 WARNING provider: resolve_provider_client: openai-codex requested but no Codex OAuth token found
+`)
+
+    expect(events.authErrorCount).toBe(2)
+    expect(events.fallbackCount).toBe(1)
+    expect(events.fallbackProvider).toBe('minimax')
+    expect(events.fallbackModel).toBe('MiniMax-M2.7')
+    expect(events.modelAuthStatus).toBe('fallback-active')
+    expect(events.primaryAuthOk).toBe(false)
+  })
+
+  it('detects Copilot classic PAT validation failures as primary auth failures', () => {
+    const events = parseModelAuthEventsFromText('2026-05-04 18:38:04,950 WARNING cli: Copilot token validation failed: Token from `gh auth token` is a classic PAT (ghp_*). Classic PATs are not supported by the Copilot API.')
+
+    expect(events.authErrorCount).toBe(1)
+    expect(events.modelAuthStatus).toBe('primary-auth-failed')
+    expect(events.primaryAuthOk).toBe(false)
+  })
+
+  it('marks summary degraded when any worker is falling back', () => {
+    const workerBase = {
+      displayName: 'Worker',
+      humanLabel: 'Worker — Role',
+      role: 'Role',
+      specialty: null,
+      mission: null,
+      skills: [],
+      capabilities: [],
+      profileFound: true,
+      wrapperFound: false,
+      model: 'gpt-5.5',
+      provider: 'openai-codex',
+      recentAuthErrors: 0,
+      recentFallbacks: 0,
+      lastErrorAt: null,
+      lastErrorMessage: null,
+      lastFallbackAt: null,
+      lastFallbackMessage: null,
+      modelAuthStatus: 'unknown' as const,
+      primaryAuthOk: null,
+      fallbackActive: false,
+      fallbackProvider: null,
+      fallbackModel: null,
+    }
+    const summary = summarizeSwarmHealth([
+      { ...workerBase, workerId: 'swarm2', recentAuthErrors: 1, recentFallbacks: 1, modelAuthStatus: 'fallback-active', primaryAuthOk: false, fallbackActive: true, fallbackProvider: 'minimax', fallbackModel: 'MiniMax-M2.7' },
+      { ...workerBase, workerId: 'swarm5' },
+    ])
+
+    expect(summary.workersUsingFallback).toBe(1)
+    expect(summary.workersPrimaryAuthFailed).toBe(1)
+    expect(summary.degraded).toBe(true)
+    expect(summary.warnings.join('\n')).toContain('fallback')
+  })
+})

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -6,8 +6,13 @@ import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { dashboardFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { getSwarmMission } from '../../server/swarm-missions'
+import { dispatchSwarmAssignments } from './swarm-dispatch'
+import type { SwarmMission } from '../../server/swarm-missions'
 
 let cachedSkill: string | null = null
+
+export const NATIVE_CONDUCTOR_MODE_NOTE = 'Native-swarm is the official Workspace-native Swarm fallback when the dashboard Conductor API is unavailable.'
 
 type ConductorSpawnBody = {
   goal?: unknown
@@ -122,6 +127,186 @@ async function createDashboardConductorMission(payload: { name: string; prompt: 
   return { id: data.id, name: data.name, sessionKey: data.session_id }
 }
 
+type NativeConductorAssignment = {
+  workerId: string
+  task: string
+  rationale: string
+  reviewRequired?: boolean
+  direct?: boolean
+  raw?: boolean
+}
+
+function clipText(value: string, max = 8000): string {
+  return value.length <= max ? value : `${value.slice(0, max - 20)}\n...[truncated]`
+}
+
+export function buildNativeConductorAssignments(goal: string, options: { maxParallel: number; supervised: boolean }): Array<NativeConductorAssignment> {
+  const maxParallel = Math.min(5, Math.max(1, options.maxParallel || 1))
+  const normalizedGoal = goal.toLowerCase()
+  const wantsProduction = /production|ready|harden|audit|clean|fix|bug|test|build|release|deploy|operational/.test(normalizedGoal)
+  const wantsDocs = /doc|handoff|readme|spec|plan|summary/.test(normalizedGoal)
+  const assignments: Array<NativeConductorAssignment> = []
+
+  assignments.push({
+    workerId: wantsProduction ? 'swarm2' : 'swarm5',
+    rationale: wantsProduction ? 'Foundation owns runtime contracts and production blockers.' : 'Builder owns the primary implementation lane.',
+    reviewRequired: false,
+    direct: true,
+    task: [
+      `Conductor mission: ${goal}`,
+      '',
+      'Lane: Foundation / primary implementation.',
+      'Find the smallest safe execution plan, make concrete progress, and produce a checkpoint. If code changes are required, keep them scoped and testable.',
+      options.supervised ? 'Supervised mode: stop before destructive writes or commits and report the exact approval needed.' : 'Do not ask for confirmation unless blocked; start immediately.',
+    ].join('\n'),
+  })
+
+  if (maxParallel >= 2) {
+    assignments.push({
+      workerId: 'swarm5',
+      rationale: 'Builder executes implementation or patch work in parallel with foundation analysis.',
+      reviewRequired: false,
+      direct: true,
+      task: [
+        `Conductor mission: ${goal}`,
+        '',
+        'Lane: Builder.',
+        'Implement or prototype the concrete fix/feature path. Avoid broad refactors. Report files changed, tests run, and remaining risks.',
+        options.supervised ? 'Supervised mode: prepare patches but stop before destructive writes or commits if approval is needed.' : 'Proceed without asking unless blocked.',
+      ].join('\n'),
+    })
+  }
+
+  if (maxParallel >= 3) {
+    assignments.push({
+      workerId: 'swarm6',
+      rationale: 'Reviewer independently checks correctness, regressions, and merge risk.',
+      reviewRequired: false,
+      direct: true,
+      task: [
+        `Conductor mission: ${goal}`,
+        '',
+        'Lane: Reviewer / merge gate.',
+        'Review the implementation plan and any changes from Foundation/Builder. Look for regressions, missing tests, unsafe assumptions, and production-readiness gaps. Do not make broad edits unless needed to unblock correctness.',
+      ].join('\n'),
+    })
+  }
+
+  if (maxParallel >= 4) {
+    assignments.push({
+      workerId: 'swarm11',
+      rationale: 'QA validates behavior with targeted tests and smoke checks.',
+      reviewRequired: false,
+      direct: true,
+      task: [
+        `Conductor mission: ${goal}`,
+        '',
+        'Lane: QA.',
+        'Run or design focused verification. Prefer targeted tests/build/smoke checks. Report exact commands and results. If tests are missing, identify the minimal regression coverage needed.',
+      ].join('\n'),
+    })
+  }
+
+  if (maxParallel >= 5 || wantsDocs) {
+    assignments.push({
+      workerId: 'swarm7',
+      rationale: 'Scribe captures handoff, docs, and operational notes.',
+      reviewRequired: false,
+      direct: true,
+      task: [
+        `Conductor mission: ${goal}`,
+        '',
+        'Lane: Scribe.',
+        'Create a concise handoff/status note: what changed, how to operate it, verification, caveats, and next actions. Do not expose secrets.',
+      ].join('\n'),
+    })
+  }
+
+  const selected = assignments.slice(0, maxParallel)
+  if (wantsDocs && !selected.some((assignment) => assignment.workerId === 'swarm7')) {
+    selected[selected.length - 1] = {
+      workerId: 'swarm7',
+      rationale: 'Scribe captures handoff, docs, and operational notes.',
+      reviewRequired: false,
+      direct: true,
+      task: [
+        `Conductor mission: ${goal}`,
+        '',
+        'Lane: Scribe.',
+        'Create a concise handoff/status note: what changed, how to operate it, verification, caveats, and next actions. Do not expose secrets.',
+        options.supervised ? 'Supervised mode: stop before destructive writes or commits and report the exact approval needed.' : 'Proceed without asking unless blocked.',
+      ].join('\n'),
+    }
+  }
+
+  return selected
+}
+
+function swarmMissionStatus(mission: SwarmMission): string {
+  if (mission.state === 'cancelled') return 'cancelled'
+  if (mission.state === 'complete') return 'completed'
+  if (mission.state === 'blocked') return 'failed'
+  return 'running'
+}
+
+function nativeMissionLines(mission: SwarmMission, maxLines: number): Array<string> {
+  const lines = [
+    `Native Workspace Swarm mission: ${mission.title}`,
+    `mission_id: ${mission.id}`,
+    `state: ${mission.state}`,
+    ...mission.assignments.map((assignment) => {
+      const result = assignment.checkpoint?.result ? ` — ${assignment.checkpoint.result}` : ''
+      const blocker = assignment.checkpoint?.blocker ? ` — blocker: ${assignment.checkpoint.blocker}` : ''
+      return `${assignment.workerId} ${assignment.state}: ${assignment.task.slice(0, 160)}${result}${blocker}`
+    }),
+    ...mission.events.slice(-20).map((event) => `${new Date(event.at).toISOString()} ${event.type}: ${event.message}`),
+  ]
+  return lines.slice(-maxLines)
+}
+
+export function toNativeConductorMissionRecord(mission: SwarmMission, maxLines = 400) {
+  return {
+    id: mission.id,
+    name: mission.title,
+    status: swarmMissionStatus(mission),
+    error: mission.state === 'blocked' ? 'Native Workspace Swarm mission blocked' : null,
+    session_id: null,
+    lines: nativeMissionLines(mission, maxLines),
+    exit_code: mission.state === 'blocked' || mission.state === 'cancelled' ? 1 : mission.state === 'complete' ? 0 : null,
+    nativeSwarm: true,
+    modeOfficialOotb: true,
+    modeNote: NATIVE_CONDUCTOR_MODE_NOTE,
+    assignments: mission.assignments,
+    updatedAt: mission.updatedAt,
+  }
+}
+
+function createNativeConductorMission(input: {
+  goal: string
+  missionName: string
+  maxParallel: number
+  supervised: boolean
+}) {
+  const assignments = buildNativeConductorAssignments(input.goal, {
+    maxParallel: input.maxParallel,
+    supervised: input.supervised,
+  })
+  const missionTitle = `Conductor: ${clipText(input.goal, 120)}`
+  void dispatchSwarmAssignments({
+    assignments,
+    missionId: input.missionName,
+    missionTitle,
+    allowAsync: true,
+    waitForCheckpoint: false,
+    timeoutSeconds: 600,
+    checkpointPollSeconds: 10,
+    notifySessionKey: 'main',
+  }).catch((error) => {
+    console.error('[conductor] native swarm dispatch failed:', error instanceof Error ? error.message : String(error))
+  })
+  return { missionId: input.missionName, missionTitle, assignments }
+}
+
 export const Route = createFileRoute('/api/conductor-spawn')({
   server: {
     handlers: {
@@ -133,9 +318,14 @@ export const Route = createFileRoute('/api/conductor-spawn')({
         const lines = Number.isFinite(requestedLines) ? Math.min(2000, Math.max(1, requestedLines)) : 200
         if (!missionId) return json({ ok: false, error: 'missionId required' }, { status: 400 })
 
+        const nativeMission = getSwarmMission(missionId)
+        if (nativeMission) {
+          return json({ ok: true, mode: 'native-swarm', mission: toNativeConductorMissionRecord(nativeMission, lines) })
+        }
+
         const capabilities = await ensureGatewayProbed()
-        if (!capabilities.dashboard.available) {
-          return json({ ok: false, error: 'Hermes dashboard API is unavailable' }, { status: 503 })
+        if (!capabilities.dashboard.available || !capabilities.conductor) {
+          return json({ ok: false, error: 'Conductor mission not found in native swarm store and dashboard Conductor API is unavailable' }, { status: 404 })
         }
 
         const res = await dashboardFetch(`/api/conductor/missions/${encodeURIComponent(missionId)}?lines=${lines}`)
@@ -177,17 +367,27 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           const missionName = `conductor-${Date.now()}`
           const capabilities = await ensureGatewayProbed()
 
-          if (!capabilities.dashboard.available) {
+          if (!capabilities.dashboard.available || !capabilities.conductor) {
+            const native = createNativeConductorMission({
+              goal,
+              missionName,
+              maxParallel,
+              supervised,
+            })
             return json({
               ok: true,
-              mode: 'portable',
-              prompt,
-              missionId: null,
-              sessionKey: missionName,
+              mode: 'native-swarm',
+              modeOfficialOotb: true,
+              modeNote: NATIVE_CONDUCTOR_MODE_NOTE,
+              prompt: null,
+              missionId: native.missionId,
+              sessionKey: null,
               sessionKeyPrefix: null,
-              jobId: null,
-              jobName: missionName,
+              jobId: native.missionId,
+              jobName: native.missionTitle,
               runId: null,
+              assignments: native.assignments,
+              results: null,
             })
           }
 

--- a/src/routes/api/conductor-stop.ts
+++ b/src/routes/api/conductor-stop.ts
@@ -1,12 +1,42 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { deleteSession } from '../../server/claude-api'
-import {
-  dashboardFetch,
-  ensureGatewayProbed,
-} from '../../server/gateway-capabilities'
+import { dashboardFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { cancelSwarmMission } from '../../server/swarm-missions'
+import { getProfilesDir } from '../../server/claude-paths'
+
+function resetNativeWorkerRuntime(workerId: string, missionId: string): boolean {
+  const runtimePath = join(getProfilesDir(), workerId, 'runtime.json')
+  let current: Record<string, unknown> = {}
+  if (existsSync(runtimePath)) {
+    try {
+      current = JSON.parse(readFileSync(runtimePath, 'utf8')) as Record<string, unknown>
+    } catch {
+      current = {}
+    }
+  }
+  const now = new Date().toISOString()
+  writeFileSync(runtimePath, JSON.stringify({
+    ...current,
+    workerId,
+    state: 'idle',
+    phase: 'cancelled',
+    currentTask: null,
+    currentMissionId: null,
+    currentAssignmentId: null,
+    checkpointStatus: 'none',
+    needsHuman: false,
+    blockedReason: null,
+    lastCheckIn: now,
+    lastSummary: `Cancelled native Conductor mission ${missionId}`,
+    nextAction: 'Idle; ready for next Conductor or Swarm dispatch.',
+  }, null, 2) + '\n')
+  return true
+}
 
 export const Route = createFileRoute('/api/conductor-stop')({
   server: {
@@ -35,9 +65,31 @@ export const Route = createFileRoute('/api/conductor-stop')({
 
           let deleted = 0
           let stoppedMissions = 0
+          let cancelledNativeMissions = 0
           const capabilities = await ensureGatewayProbed()
-          if (capabilities.dashboard.available) {
-            for (const missionId of missionIds) {
+          for (const missionId of missionIds) {
+            try {
+              const cancelled = cancelSwarmMission({
+                missionId,
+                actor: 'conductor-stop',
+                reason: 'Conductor mission stopped by user',
+              })
+              if (cancelled) {
+                cancelledNativeMissions += 1
+                for (const workerId of Array.from(new Set(cancelled.mission.assignments.map((assignment) => assignment.workerId)))) {
+                  try {
+                    resetNativeWorkerRuntime(workerId, missionId)
+                  } catch {
+                    // Runtime reset is best-effort; cancellation state is still durable.
+                  }
+                }
+                continue
+              }
+            } catch {
+              // Fall through to dashboard cleanup.
+            }
+
+            if (capabilities.dashboard.available && capabilities.conductor) {
               try {
                 const res = await dashboardFetch(
                   `/api/conductor/missions/${encodeURIComponent(missionId)}`,
@@ -59,7 +111,7 @@ export const Route = createFileRoute('/api/conductor-stop')({
             }
           }
 
-          return json({ ok: true, deleted, stoppedMissions })
+          return json({ ok: true, deleted, stoppedMissions, cancelledNativeMissions })
         } catch (error) {
           return json(
             {

--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -7,11 +7,17 @@ import { join } from 'node:path'
 import * as yaml from 'yaml'
 import { BEARER_TOKEN, CLAUDE_API, ensureGatewayProbed } from '../../server/gateway-capabilities'
 import { getClaudeRoot, getProfileClaudeHome, getWorkspaceClaudeHome } from '../../server/claude-paths'
+import { formatSwarmWorkerLabel, rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
 
 type CrewDefinition = {
   id: string
   displayName: string
+  humanLabel: string
   role: string
+  specialty?: string
+  mission?: string
+  skills?: Array<string>
+  capabilities?: Array<string>
   profilePath: string | null
 }
 
@@ -33,6 +39,22 @@ function titleCase(value: string): string {
     .join(' ')
 }
 
+function buildCrewDefinitionFromRoster(profile: string, worker: SwarmRosterWorker | null | undefined): CrewDefinition {
+  const displayName = worker?.name || titleCase(profile)
+  const role = worker?.role || 'Profile'
+  return {
+    id: profile,
+    displayName,
+    humanLabel: formatSwarmWorkerLabel(profile, worker),
+    role,
+    specialty: worker?.specialty || undefined,
+    mission: worker?.mission || undefined,
+    skills: worker?.skills?.length ? worker.skills : undefined,
+    capabilities: worker?.capabilities?.length ? worker.capabilities : undefined,
+    profilePath: profile,
+  }
+}
+
 function buildCrewDefinitions(): CrewDefinition[] {
   const profilesDir = join(getClaudeRoot(), 'profiles')
   const dynamicProfiles = existsSync(profilesDir)
@@ -51,14 +73,10 @@ function buildCrewDefinitions(): CrewDefinition[] {
         .sort()
     : []
 
+  const roster = rosterByWorkerId(dynamicProfiles)
   return [
-    { id: 'workspace', displayName: 'Workspace', role: 'Primary profile', profilePath: null },
-    ...dynamicProfiles.map((profile) => ({
-      id: profile,
-      displayName: titleCase(profile),
-      role: 'Profile',
-      profilePath: profile,
-    })),
+    { id: 'workspace', displayName: 'Workspace', humanLabel: 'Workspace — Primary profile', role: 'Primary profile', profilePath: null },
+    ...dynamicProfiles.map((profile) => buildCrewDefinitionFromRoster(profile, /^swarm\d+$/i.test(profile) ? roster.get(profile) : null)),
   ]
 }
 
@@ -246,7 +264,12 @@ export const Route = createFileRoute('/api/crew-status')({
             return {
               id: member.id,
               displayName: member.displayName,
+              humanLabel: member.humanLabel,
               role: member.role,
+              specialty: member.specialty,
+              mission: member.mission,
+              skills: member.skills,
+              capabilities: member.capabilities,
               profileFound: false,
               gatewayState: 'unknown',
               processAlive: false,
@@ -272,7 +295,12 @@ export const Route = createFileRoute('/api/crew-status')({
           return {
             id: member.id,
             displayName: member.displayName,
+            humanLabel: member.humanLabel,
             role: member.role,
+            specialty: member.specialty,
+            mission: member.mission,
+            skills: member.skills,
+            capabilities: member.capabilities,
             profileFound: true,
             gatewayState: gatewayInfo.gatewayState,
             processAlive: checkProcessAlive(gatewayInfo.pid),

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -1,16 +1,20 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { json } from '@tanstack/react-start'
+import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { newestCheckpointFromMessages, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import {  newestCheckpointFromMessages, parseSwarmCheckpoint } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
-import { createOrUpdateMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
-import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
-import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
+import { createOrUpdateMission, getSwarmMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
+import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
+import {  rosterByWorkerId } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
+import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
+import { ensureSwarmProfileConfig, syncSwarmProfileIdentity, syncSwarmProfileModel } from '../../server/swarm-profile-config'
+import type {SwarmRosterWorker} from '../../server/swarm-roster';
+import type {ParsedSwarmCheckpoint} from '../../server/swarm-checkpoints';
 
 const HERMES_BIN_CANDIDATES = [
   process.env.HERMES_CLI_BIN,
@@ -38,6 +42,7 @@ type AssignmentRequest = {
   dependsOn?: Array<string>
   reviewRequired?: boolean
   direct?: boolean
+  raw?: boolean
 }
 
 type DispatchRequest = {
@@ -51,6 +56,8 @@ type DispatchRequest = {
   missionId?: unknown
   missionTitle?: unknown
   direct?: unknown
+  raw?: unknown
+  smoke?: unknown
   notifySessionKey?: unknown
 }
 
@@ -161,7 +168,7 @@ function execFileAsync(
   return new Promise((resolve) => {
     const child = execFile(cmd, args, { timeout, maxBuffer: MAX_OUTPUT_CHARS }, (error, stdout, stderr) => {
       if (error) {
-        resolve({ ok: false, error: stderr?.toString().trim() || error.message })
+        resolve({ ok: false, error: stderr.toString().trim() || error.message })
         return
       }
       resolve({
@@ -203,11 +210,12 @@ function parseAssignments(value: unknown): Array<AssignmentRequest> {
     const workerId = typeof obj.workerId === 'string' ? obj.workerId.trim() : ''
     const task = typeof obj.task === 'string' ? obj.task.trim() : ''
     const rationale = typeof obj.rationale === 'string' ? obj.rationale.trim() : undefined
-    const dependsOn = Array.isArray(obj.dependsOn) ? obj.dependsOn.filter((value): value is string => typeof value === 'string' && value.trim().length > 0) : undefined
+    const dependsOn = Array.isArray(obj.dependsOn) ? obj.dependsOn.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : undefined
     const reviewRequired = typeof obj.reviewRequired === 'boolean' ? obj.reviewRequired : undefined
     const direct = typeof obj.direct === 'boolean' ? obj.direct : undefined
+    const raw = typeof obj.raw === 'boolean' ? obj.raw : typeof obj.smoke === 'boolean' ? obj.smoke : undefined
     if (!workerId || !task || !validateWorkerId(workerId)) continue
-    assignments.push({ workerId, task, rationale, dependsOn, reviewRequired, direct })
+    assignments.push({ workerId, task, rationale, dependsOn, reviewRequired, direct, raw })
   }
   return assignments
 }
@@ -371,22 +379,24 @@ export function checkpointFromRuntimeSnapshot(snapshot: RuntimeCheckpointSnapsho
   return checkpoint
 }
 
-function buildWorkerPrompt(input: {
+export function buildWorkerPrompt(input: {
   workerId: string
   task: string
   rationale?: string
   roster?: SwarmRosterWorker
   direct?: boolean
+  raw?: boolean
   missionId?: string | null
   taskTitle?: string | null
 }): string {
-  if (input.direct) return input.task
+  if (input.raw) return input.task
   const roster = input.roster
-  const role = roster?.role || 'Worker'
-  const skills = roster?.skills?.length ? roster.skills.join(', ') : 'swarm-worker-core'
-  const capabilities = roster?.capabilities?.length ? roster.capabilities.join(', ') : 'not declared'
-  const mission = roster?.mission || 'Execute assigned swarm tasks and checkpoint progress.'
-  const specialty = roster?.specialty || 'General execution'
+  const name = roster && roster.name.trim() ? roster.name.trim() : input.workerId
+  const role = roster ? roster.role : 'Worker'
+  const skills = roster && roster.skills.length > 0 ? roster.skills.join(', ') : 'swarm-worker-core'
+  const capabilities = roster && roster.capabilities.length > 0 ? roster.capabilities.join(', ') : 'not declared'
+  const mission = roster ? roster.mission : 'Execute assigned swarm tasks and checkpoint progress.'
+  const specialty = roster ? roster.specialty : 'General execution'
 
   let snapshotSection = ''
   try {
@@ -405,12 +415,14 @@ function buildWorkerPrompt(input: {
 
   const lines: Array<string> = [
     '## Swarm Orchestrator Dispatch',
-    `Worker: ${input.workerId} — ${role}`,
+    `Worker: ${name} — ${role}`,
+    `Machine ID: ${input.workerId}`,
     `Specialty: ${specialty}`,
     `Mission: ${mission}`,
     `Skills: ${skills}`,
     `Capabilities: ${capabilities}`,
     input.rationale ? `Routing rationale: ${input.rationale}` : '',
+    `Workspace repo: ${process.env.HERMES_WORKSPACE_ROOT || process.cwd()}`,
     '',
   ]
   if (snapshotSection) {
@@ -423,7 +435,8 @@ function buildWorkerPrompt(input: {
     '',
     '## Operating Rules',
     '- Work in your persistent Hermes worker session and preserve your profile context.',
-    `- The Worker Startup Memory Snapshot above is your authoritative starting context. If you have filesystem tools, also read \`~/.\u0068\u0065\u0072\u006d\u0065\u0073/profiles/${input.workerId}/MEMORY.md\`, \`SOUL.md\`, \`USER.md\`, and \`memory/IDENTITY.md\` for full detail.`,
+    `- Canonical Workspace repo is \`${process.env.HERMES_WORKSPACE_ROOT || process.cwd()}\`. Use this absolute path for repo file reads, searches, edits, terminal workdir, tests, and build commands unless the assigned task names a different repo.`,
+    `- The Worker Startup Memory Snapshot above is your authoritative starting context. If you have filesystem tools, read any present profile files under \`~/.hermes/profiles/${input.workerId}/\` (especially \`SOUL.md\`, \`memory/IDENTITY.md\`, and, when present, \`MEMORY.md\` / \`USER.md\`) for full detail. Do not treat missing optional profile files as a blocker.`,
     `- Search your own memory before starting if relevant: GET /api/swarm-memory/search?workerId=${input.workerId}&q=<term>.`,
     '- Do not blame a generic sandbox for missing access. Assume repo/filesystem/network are available unless a command proves otherwise. If auth or tools fail, report the exact failing command and exact missing token/tool/env.',
     '- Produce concrete artifacts or a concrete checkpoint; avoid vague status updates.',
@@ -474,6 +487,11 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
     blockedReason: result.ok ? null : result.error,
     lastCheckIn: new Date().toISOString(),
   })
+}
+
+function markDispatchResultUnlessMissionCancelled(workerId: string, result: WorkerResult, missionId?: string | null): void {
+  if (missionId && getSwarmMission(missionId)?.state === 'cancelled') return
+  markDispatchResult(workerId, result)
 }
 
 function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoint, notifySessionKey?: string | null): void {
@@ -538,7 +556,7 @@ function resolveWorkerCwd(workerId: string): string {
       /* noop */
     }
   }
-  return homedir()
+  return process.env.HERMES_WORKSPACE_ROOT || process.cwd() || homedir()
 }
 
 async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmuxBin: string; sessionName: string } | { ok: false; error: string }> {
@@ -671,26 +689,48 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   }
 }
 
-function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: SwarmRosterWorker | undefined, options?: { waitForCheckpoint?: boolean; checkpointPollMs?: number; missionId?: string | null; notifySessionKey?: string | null }): Promise<WorkerResult> {
-  return new Promise(async (resolve) => {
-    const workerId = assignment.workerId
+async function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: SwarmRosterWorker | undefined, options?: { waitForCheckpoint?: boolean; checkpointPollMs?: number; missionId?: string | null; notifySessionKey?: string | null }): Promise<WorkerResult> {
+  const opts = options ?? {}
+  const workerId = assignment.workerId
     const prompt = buildWorkerPrompt({
       workerId,
       task: assignment.task,
       rationale: assignment.rationale,
       roster,
       direct: assignment.direct,
-      missionId: options?.missionId ?? null,
+      raw: assignment.raw,
+      missionId: opts.missionId ?? null,
       taskTitle: assignment.task.slice(0, 120),
     })
     const profilePath = getProfilePath(workerId)
+    const bootstrap = ensureSwarmProfileConfig(profilePath)
+    if (!bootstrap.ok) {
+      const result: WorkerResult = {
+        workerId,
+        ok: false,
+        output: '',
+        error: bootstrap.error ?? `Unable to bootstrap profile at ${profilePath}`,
+        durationMs: 0,
+        exitCode: null,
+        delivery: 'oneshot',
+      }
+      markDispatchResultUnlessMissionCancelled(workerId, result, opts.missionId ?? null)
+      return result
+    }
+    if (roster) {
+      syncSwarmProfileIdentity(profilePath, { ...roster, id: workerId })
+    }
+    const resolvedModel = resolveSwarmModelLabel(roster?.model ?? null)
+    if (resolvedModel) {
+      syncSwarmProfileModel(profilePath, resolvedModel)
+    }
     const runtimeBeforeDispatch = readRuntimeCheckpointSnapshot(profilePath)
     const previousRaw = runtimeBeforeDispatch.checkpointRaw
     const baselineRuntimeSignature = runtimeCheckpointSignature(runtimeBeforeDispatch)
-    markDispatchStarted(workerId, assignment.task, options?.missionId ?? null, assignment.assignmentId ?? null, options?.notifySessionKey ?? 'main')
-    if (options?.missionId) {
+    markDispatchStarted(workerId, assignment.task, opts.missionId ?? null, assignment.assignmentId ?? null, opts.notifySessionKey ?? 'main')
+    if (opts.missionId) {
       markMissionAssignmentDispatched({
-        missionId: options.missionId,
+        missionId: opts.missionId,
         workerId,
         task: assignment.task,
         source: 'swarm-dispatch',
@@ -699,7 +739,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
     }
     appendSwarmMemoryEvent({
       workerId,
-      missionId: options?.missionId ?? null,
+      missionId: opts.missionId ?? null,
       assignmentId: assignment.assignmentId ?? null,
       type: 'dispatch',
       summary: `Dispatched task: ${assignment.task.slice(0, 240)}`,
@@ -707,28 +747,33 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         task: assignment.task,
         rationale: assignment.rationale ?? null,
         direct: assignment.direct ?? false,
+        raw: assignment.raw ?? false,
         deliveryTarget: 'tmux',
       },
     })
     const startedAt = Date.now()
     const wrapperPath = getWrapperPath(workerId)
 
-    // Prefer the persistent live agent session when available/startable.
-    const liveResult = await sendPromptToLiveSession(workerId, prompt)
+    // Prefer the persistent live agent session when available/startable, unless
+    // the assignment explicitly asks for a direct one-shot worker run. Direct
+    // lanes are important for smoke tests and automation packets because a live
+    // TUI can accept the paste but sit in a long deliberation loop, leaving the
+    // mission stuck on the synthetic IN_PROGRESS dispatch checkpoint.
+    const liveResult = assignment.direct ? null : await sendPromptToLiveSession(workerId, prompt)
     if (liveResult) {
-      markDispatchResult(workerId, liveResult)
-      if (options?.waitForCheckpoint && liveResult.ok) {
+      markDispatchResultUnlessMissionCancelled(workerId, liveResult, opts.missionId ?? null)
+      if (opts.waitForCheckpoint && liveResult.ok) {
         const checkpoint = await waitForFreshCheckpoint(
           workerId,
           previousRaw,
           baselineRuntimeSignature,
           startedAt,
-          options.checkpointPollMs ?? 90_000,
+          opts.checkpointPollMs ?? 90_000,
         )
         if (checkpoint) {
-          markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
+          markCheckpointResult(workerId, checkpoint, opts.notifySessionKey ?? 'main')
           const updatedMission = recordMissionCheckpoint({
-            missionId: options?.missionId,
+            missionId: opts.missionId,
             assignmentId: assignment.assignmentId ?? null,
             workerId,
             checkpoint,
@@ -749,7 +794,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           }
           appendSwarmMemoryEvent({
             workerId,
-            missionId: options?.missionId ?? null,
+            missionId: opts.missionId ?? null,
             assignmentId: assignment.assignmentId ?? null,
             type: 'checkpoint',
             summary: checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
@@ -764,10 +809,10 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           })
           publishSwarmCheckpointNotification({
             workerId,
-            missionId: options?.missionId ?? null,
+            missionId: opts.missionId ?? null,
             assignmentId: assignment.assignmentId ?? null,
             checkpoint,
-            notifySessionKey: options?.notifySessionKey ?? 'main',
+            notifySessionKey: opts.notifySessionKey ?? 'main',
           })
           liveResult.checkpoint = checkpoint
           liveResult.checkpointStatus = 'checkpointed'
@@ -780,8 +825,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
       } else {
         liveResult.checkpointStatus = 'not-requested'
       }
-      resolve(liveResult)
-      return
+      return liveResult
     }
 
     if (!existsSync(profilePath)) {
@@ -794,9 +838,8 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         exitCode: null,
         delivery: 'oneshot',
       }
-      markDispatchResult(workerId, result)
-      resolve(result)
-      return
+      markDispatchResultUnlessMissionCancelled(workerId, result, opts.missionId ?? null)
+      return result
     }
 
     const useWrapper = existsSync(wrapperPath)
@@ -812,12 +855,13 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
       env.GITHUB_TOKEN = ghToken
     }
 
-    const proc = execFile(
+    return await new Promise<WorkerResult>((resolve) => {
+      const proc = execFile(
       cmd,
       args,
       {
         env,
-        cwd: homedir(),
+        cwd: resolveWorkerCwd(workerId),
         timeout: timeoutMs,
         maxBuffer: MAX_OUTPUT_CHARS,
         killSignal: 'SIGTERM',
@@ -839,7 +883,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
             exitCode: typeof code === 'number' ? code : null,
             delivery: 'oneshot',
           }
-          markDispatchResult(workerId, result)
+          markDispatchResultUnlessMissionCancelled(workerId, result, opts.missionId ?? null)
           resolve(result)
           return
         }
@@ -853,12 +897,27 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           exitCode: 0,
           delivery: 'oneshot',
         }
-        markDispatchResult(workerId, result)
+        const checkpoint = parseSwarmCheckpoint(out)
+        if (checkpoint) {
+          result.checkpoint = checkpoint
+          result.checkpointStatus = 'checkpointed'
+          markCheckpointResult(workerId, checkpoint, opts.notifySessionKey ?? 'main')
+          recordMissionCheckpoint({
+            missionId: opts.missionId,
+            assignmentId: assignment.assignmentId ?? null,
+            workerId,
+            checkpoint,
+            source: 'swarm-dispatch',
+          })
+        } else {
+          result.checkpointStatus = 'not-requested'
+          markDispatchResultUnlessMissionCancelled(workerId, result, opts.missionId ?? null)
+        }
         resolve(result)
       },
     )
 
-    proc.on('error', (error) => {
+      proc.on('error', (error) => {
       const result: WorkerResult = {
         workerId,
         ok: false,
@@ -868,10 +927,120 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         exitCode: null,
         delivery: 'oneshot',
       }
-      markDispatchResult(workerId, result)
+      markDispatchResultUnlessMissionCancelled(workerId, result, opts.missionId ?? null)
       resolve(result)
+      })
     })
+}
+
+export class SwarmDispatchError extends Error {
+  status: number
+
+  constructor(message: string, status = 400) {
+    super(message)
+    this.name = 'SwarmDispatchError'
+    this.status = status
+  }
+}
+
+export async function dispatchSwarmAssignments(body: DispatchRequest) {
+  let assignments = parseAssignments(body.assignments)
+  const promptRaw = typeof body.prompt === 'string' ? body.prompt : ''
+  const prompt = promptRaw.trim()
+  if (assignments.length === 0) {
+    const workerIdsRaw = Array.isArray(body.workerIds) ? body.workerIds : []
+    const workerIds = workerIdsRaw
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0 && validateWorkerId(value))
+    assignments = workerIds.map((workerId) => ({
+      workerId,
+      task: prompt,
+      rationale: 'Legacy broadcast dispatch.',
+      direct: body.direct === true,
+      raw: body.raw === true || body.smoke === true,
+    }))
+  }
+
+  if (assignments.length === 0) {
+    throw new SwarmDispatchError('assignments[] or workerIds[] required')
+  }
+  if (assignments.length > 12) {
+    throw new SwarmDispatchError('Maximum 12 workers per dispatch')
+  }
+  if (assignments.some((assignment) => assignment.task.length === 0)) {
+    throw new SwarmDispatchError('assignment task required')
+  }
+  if (assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)) {
+    throw new SwarmDispatchError(`assignment task exceeds ${MAX_PROMPT_CHARS} characters`)
+  }
+
+  const timeoutRaw = typeof body.timeoutSeconds === 'number' ? body.timeoutSeconds : DEFAULT_TIMEOUT_S
+  const timeoutSeconds = Math.max(10, Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)))
+  const timeoutMs = timeoutSeconds * 1000
+  // Swarm2 control-plane dispatches should be observable by default:
+  // wait for a fresh checkpoint so completion/blocker notifications can
+  // be published and worker progress cards can resolve. Callers that
+  // intentionally want fire-and-forget delivery must opt out with both
+  // waitForCheckpoint:false and allowAsync:true.
+  const waitForCheckpoint = !(body.waitForCheckpoint === false && body.allowAsync === true)
+  const pollRaw = typeof body.checkpointPollSeconds === 'number' ? body.checkpointPollSeconds : 90
+  const checkpointPollSeconds = Math.max(5, Math.min(300, Math.floor(pollRaw)))
+  const notifySessionKey = typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim() ? body.notifySessionKey.trim() : 'main'
+
+  const requestedMissionId = typeof body.missionId === 'string' ? body.missionId.trim() : ''
+  const hasExplicitMissionTitle = typeof body.missionTitle === 'string' && body.missionTitle.trim()
+  const missionTitle = hasExplicitMissionTitle
+    ? (body.missionTitle as string).trim()
+    : requestedMissionId ? '' : assignments.length === 1 ? assignments[0].task.slice(0, 120) : `${assignments.length} assigned tasks`
+  const mission = createOrUpdateMission({
+    missionId: requestedMissionId || null,
+    title: missionTitle,
+    assignments,
   })
+  if (mission._created) {
+    for (const workerId of new Set(assignments.map((a) => a.workerId))) {
+      try {
+        appendSwarmMemoryEvent({
+          workerId,
+          missionId: mission.id,
+          type: 'mission-start',
+          title: mission.title,
+          summary: `Mission started: ${mission.title}`,
+          event: { workers: [...new Set(assignments.map((a) => a.workerId))] },
+        })
+      } catch { /* memory write best-effort */ }
+    }
+  }
+
+  const assignmentIdByKey = new Map(mission.assignments.map((item) => [`${item.workerId}\n${item.task}`, item.id]))
+  assignments = assignments.map((assignment) => ({
+    ...assignment,
+    assignmentId: assignmentIdByKey.get(`${assignment.workerId}\n${assignment.task}`),
+  }))
+
+  const dispatchedAt = Date.now()
+  const roster = rosterByWorkerId(assignments.map((assignment) => assignment.workerId))
+  const results = await Promise.all(assignments.map((assignment) => runWorker(
+    assignment,
+    timeoutMs,
+    roster.get(assignment.workerId),
+    { waitForCheckpoint, checkpointPollMs: checkpointPollSeconds * 1000, missionId: mission.id, notifySessionKey },
+  )))
+
+  return {
+    dispatchedAt,
+    completedAt: Date.now(),
+    missionId: mission.id,
+    mission,
+    prompt: assignments.length === 1 ? assignments[0].task : `${assignments.length} assigned tasks`,
+    assignments,
+    timeoutSeconds,
+    waitForCheckpoint,
+    checkpointPollSeconds,
+    notifySessionKey,
+    results,
+  }
 }
 
 export const Route = createFileRoute('/api/swarm-dispatch')({
@@ -889,97 +1058,14 @@ export const Route = createFileRoute('/api/swarm-dispatch')({
           return json({ error: 'Invalid JSON body' }, { status: 400 })
         }
 
-        let assignments = parseAssignments(body.assignments)
-        const promptRaw = typeof body.prompt === 'string' ? body.prompt : ''
-        const prompt = promptRaw.trim()
-        if (assignments.length === 0) {
-          const workerIdsRaw = Array.isArray(body.workerIds) ? body.workerIds : []
-          const workerIds = workerIdsRaw
-            .filter((value): value is string => typeof value === 'string')
-            .map((value) => value.trim())
-            .filter((value) => value.length > 0 && validateWorkerId(value))
-          assignments = workerIds.map((workerId) => ({ workerId, task: prompt, rationale: 'Legacy broadcast dispatch.', direct: body.direct === true }))
-        }
-
-        if (assignments.length === 0) {
-          return json({ error: 'assignments[] or workerIds[] required' }, { status: 400 })
-        }
-        if (assignments.length > 12) {
-          return json({ error: 'Maximum 12 workers per dispatch' }, { status: 400 })
-        }
-        if (assignments.some((assignment) => assignment.task.length === 0)) {
-          return json({ error: 'assignment task required' }, { status: 400 })
-        }
-        if (assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)) {
-          return json({ error: `assignment task exceeds ${MAX_PROMPT_CHARS} characters` }, { status: 400 })
-        }
-
-        const timeoutRaw = typeof body.timeoutSeconds === 'number' ? body.timeoutSeconds : DEFAULT_TIMEOUT_S
-        const timeoutSeconds = Math.max(10, Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)))
-        const timeoutMs = timeoutSeconds * 1000
-        // Swarm2 control-plane dispatches should be observable by default:
-        // wait for a fresh checkpoint so completion/blocker notifications can
-        // be published and worker progress cards can resolve. Callers that
-        // intentionally want fire-and-forget delivery must opt out with both
-        // waitForCheckpoint:false and allowAsync:true.
-        const waitForCheckpoint = !(body.waitForCheckpoint === false && body.allowAsync === true)
-        const pollRaw = typeof body.checkpointPollSeconds === 'number' ? body.checkpointPollSeconds : 90
-        const checkpointPollSeconds = Math.max(5, Math.min(300, Math.floor(pollRaw)))
-        const notifySessionKey = typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim() ? body.notifySessionKey.trim() : 'main'
-
-        const requestedMissionId = typeof body.missionId === 'string' ? body.missionId.trim() : ''
-        const hasExplicitMissionTitle = typeof body.missionTitle === 'string' && body.missionTitle.trim()
-        const missionTitle = hasExplicitMissionTitle
-          ? (body.missionTitle as string).trim()
-          : requestedMissionId ? '' : assignments.length === 1 ? assignments[0].task.slice(0, 120) : `${assignments.length} assigned tasks` 
-        const mission = createOrUpdateMission({
-          missionId: requestedMissionId || null,
-          title: missionTitle,
-          assignments,
-        })
-        if (mission._created) {
-          for (const workerId of new Set(assignments.map((a) => a.workerId))) {
-            try {
-              appendSwarmMemoryEvent({
-                workerId,
-                missionId: mission.id,
-                type: 'mission-start',
-                title: mission.title,
-                summary: `Mission started: ${mission.title}`,
-                event: { workers: [...new Set(assignments.map((a) => a.workerId))] },
-              })
-            } catch { /* memory write best-effort */ }
+        try {
+          return json(await dispatchSwarmAssignments(body))
+        } catch (error) {
+          if (error instanceof SwarmDispatchError) {
+            return json({ error: error.message }, { status: error.status })
           }
+          return json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 })
         }
-
-        const assignmentIdByKey = new Map(mission.assignments.map((item) => [`${item.workerId}\n${item.task}`, item.id]))
-        assignments = assignments.map((assignment) => ({
-          ...assignment,
-          assignmentId: assignmentIdByKey.get(`${assignment.workerId}\n${assignment.task}`),
-        }))
-
-        const dispatchedAt = Date.now()
-        const roster = rosterByWorkerId(assignments.map((assignment) => assignment.workerId))
-        const results = await Promise.all(assignments.map((assignment) => runWorker(
-          assignment,
-          timeoutMs,
-          roster.get(assignment.workerId),
-          { waitForCheckpoint, checkpointPollMs: checkpointPollSeconds * 1000, missionId: mission.id, notifySessionKey },
-        )))
-
-        return json({
-          dispatchedAt,
-          completedAt: Date.now(),
-          missionId: mission.id,
-          mission,
-          prompt: assignments.length === 1 ? assignments[0].task : `${assignments.length} assigned tasks`,
-          assignments,
-          timeoutSeconds,
-          waitForCheckpoint,
-          checkpointPollSeconds,
-          notifySessionKey,
-          results,
-        })
       },
     },
   },

--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -1,23 +1,54 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
 import * as yaml from 'yaml'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getLocalBinDir, getProfilesDir } from '../../server/claude-paths'
+import { formatSwarmWorkerLabel, resolveSwarmWorkerDisplayName, rosterByWorkerId } from '../../server/swarm-roster'
 
-type WorkerHealth = {
+export type WorkerModelAuthStatus = 'ready' | 'primary-auth-failed' | 'fallback-active' | 'not-configured' | 'unknown'
+
+export type WorkerHealth = {
   workerId: string
+  displayName: string
+  humanLabel: string
+  role: string
+  specialty: string | null
+  mission: string | null
+  skills: Array<string>
+  capabilities: Array<string>
   profileFound: boolean
   wrapperFound: boolean
   model: string
   provider: string
   recentAuthErrors: number
+  recentFallbacks: number
   lastErrorAt: string | null
   lastErrorMessage: string | null
+  lastFallbackAt: string | null
+  lastFallbackMessage: string | null
+  modelAuthStatus: WorkerModelAuthStatus
+  primaryAuthOk: boolean | null
+  fallbackActive: boolean
+  fallbackProvider: string | null
+  fallbackModel: string | null
 }
 
-function listSwarmIds(): string[] {
+export type SwarmHealthSummary = {
+  totalWorkers: number
+  wrappersConfigured: number
+  totalAuthErrors24h: number
+  totalFallbacks24h: number
+  workersUsingFallback: number
+  workersPrimaryAuthFailed: number
+  distinctModels: Array<string>
+  distinctProviders: Array<string>
+  degraded: boolean
+  warnings: Array<string>
+}
+
+function listSwarmIds(): Array<string> {
   const dir = getProfilesDir()
   if (!existsSync(dir)) return []
   return readdirSync(dir, { withFileTypes: true })
@@ -68,41 +99,126 @@ function formatProviderDisplay(provider: string): string {
   return provider.replace(/^custom:/, '').replace(/[-_]/g, ' ')
 }
 
-function scanRecentAuthErrors(profilePath: string): {
-  count: number
-  lastAt: string | null
-  lastMessage: string | null
+export function parseModelAuthEventsFromText(text: string): {
+  authErrorCount: number
+  fallbackCount: number
+  lastAuthErrorAt: string | null
+  lastAuthErrorMessage: string | null
+  lastFallbackAt: string | null
+  lastFallbackMessage: string | null
+  fallbackProvider: string | null
+  fallbackModel: string | null
+  modelAuthStatus: WorkerModelAuthStatus
+  primaryAuthOk: boolean | null
 } {
+  const authPatterns = [
+    /primary provider auth failed/i,
+    /no codex credentials/i,
+    /no .*oauth token found/i,
+    /copilot token validation failed/i,
+    /classic pat|classic personal access token/i,
+    /\b401\b/i,
+    /\bunauthorized\b/i,
+    /\bauthentication\b/i,
+  ]
+  const fallbackPatterns = [
+    /falling through to fallback:\s*([^/\s]+)\/([^\s]+)/i,
+    /fallback:\s*([^/\s]+)\/([^\s]+)/i,
+  ]
+  let authErrorCount = 0
+  let fallbackCount = 0
+  let lastAuthErrorAt: string | null = null
+  let lastAuthErrorMessage: string | null = null
+  let lastFallbackAt: string | null = null
+  let lastFallbackMessage: string | null = null
+  let fallbackProvider: string | null = null
+  let fallbackModel: string | null = null
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:,\d{3})?/)
+    const ts = tsMatch?.[1] ?? null
+    if (authPatterns.some((pattern) => pattern.test(line))) {
+      authErrorCount += 1
+      lastAuthErrorAt = ts
+      lastAuthErrorMessage = line.slice(0, 320)
+    }
+    for (const pattern of fallbackPatterns) {
+      const match = line.match(pattern)
+      if (!match) continue
+      fallbackCount += 1
+      fallbackProvider = match[1]
+      fallbackModel = match[2]
+      lastFallbackAt = ts
+      lastFallbackMessage = line.slice(0, 320)
+      break
+    }
+  }
+  const fallbackActive = fallbackCount > 0
+  const authFailed = authErrorCount > 0
+  return {
+    authErrorCount,
+    fallbackCount,
+    lastAuthErrorAt,
+    lastAuthErrorMessage,
+    lastFallbackAt,
+    lastFallbackMessage,
+    fallbackProvider,
+    fallbackModel,
+    modelAuthStatus: fallbackActive ? 'fallback-active' : authFailed ? 'primary-auth-failed' : 'unknown',
+    primaryAuthOk: authFailed || fallbackActive ? false : null,
+  }
+}
+
+function scanRecentAuthErrors(profilePath: string): ReturnType<typeof parseModelAuthEventsFromText> {
   const errorsLog = join(profilePath, 'logs', 'errors.log')
-  if (!existsSync(errorsLog)) return { count: 0, lastAt: null, lastMessage: null }
+  if (!existsSync(errorsLog)) {
+    return parseModelAuthEventsFromText('')
+  }
   try {
-    const stat = statSync(errorsLog)
     const buffer = readFileSync(errorsLog, 'utf-8')
     const tail = buffer.length > 64_000 ? buffer.slice(-64_000) : buffer
-    const lines = tail.split('\n')
-    const cutoffMs = Date.now() - 24 * 60 * 60 * 1000
-    let count = 0
-    let lastAt: string | null = null
-    let lastMessage: string | null = null
-    for (const line of lines) {
-      if (!line.includes('401') && !line.toLowerCase().includes('authentication')) continue
-      const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/)
-      if (!tsMatch) continue
-      const ts = new Date(tsMatch[1].replace(' ', 'T') + 'Z')
-      if (Number.isFinite(ts.getTime()) && ts.getTime() < cutoffMs) continue
-      count += 1
-      lastAt = tsMatch[1]
-      lastMessage = line.slice(0, 320)
-    }
-    if (count === 0) {
-      // Honor last-modified file timestamp as a hint if no parseable lines but file changed recently.
-      if (Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000) {
-        // Leave count 0; UI shows fresh log activity separately if needed.
-      }
-    }
-    return { count, lastAt, lastMessage }
+    return parseModelAuthEventsFromText(tail)
   } catch {
-    return { count: 0, lastAt: null, lastMessage: null }
+    return parseModelAuthEventsFromText('')
+  }
+}
+
+export function summarizeSwarmHealth(workers: Array<WorkerHealth>): SwarmHealthSummary {
+  const totalAuthErrors = workers.reduce((sum, worker) => sum + worker.recentAuthErrors, 0)
+  const totalFallbacks = workers.reduce((sum, worker) => sum + worker.recentFallbacks, 0)
+  const workersUsingFallback = workers.filter((worker) => worker.fallbackActive).length
+  const workersPrimaryAuthFailed = workers.filter((worker) => worker.primaryAuthOk === false || worker.modelAuthStatus === 'primary-auth-failed' || worker.modelAuthStatus === 'fallback-active').length
+  const distinctModels = Array.from(new Set(workers.map((w) => formatModelDisplay(w.model, w.provider)))).filter((value) => value !== 'unknown')
+  const distinctProviders = Array.from(new Set(workers.map((w) => formatProviderDisplay(w.provider)))).filter((value) => value !== 'unknown')
+  const warnings: Array<string> = []
+  if (workersUsingFallback > 0) warnings.push(`${workersUsingFallback} worker(s) used fallback model; primary model auth is degraded.`)
+  if (workersPrimaryAuthFailed > 0) warnings.push(`${workersPrimaryAuthFailed} worker(s) have primary auth failures.`)
+  return {
+    totalWorkers: workers.length,
+    wrappersConfigured: workers.filter((w) => w.wrapperFound).length,
+    totalAuthErrors24h: totalAuthErrors,
+    totalFallbacks24h: totalFallbacks,
+    workersUsingFallback,
+    workersPrimaryAuthFailed,
+    distinctModels,
+    distinctProviders,
+    degraded: totalAuthErrors > 0 || totalFallbacks > 0 || workersPrimaryAuthFailed > 0,
+    warnings,
+  }
+}
+
+function hasOpenAiCodexAuth(profilePath: string): boolean {
+  const authPath = join(profilePath, 'auth.json')
+  if (!existsSync(authPath)) return false
+  try {
+    const raw = JSON.parse(readFileSync(authPath, 'utf-8')) as Record<string, unknown>
+    const providers = raw.providers && typeof raw.providers === 'object' ? raw.providers as Record<string, unknown> : raw
+    const codex = providers['openai-codex']
+    if (!codex || typeof codex !== 'object') return false
+    const tokens = (codex as Record<string, unknown>).tokens
+    return Boolean(tokens && typeof tokens === 'object' && (tokens as Record<string, unknown>).access_token && (tokens as Record<string, unknown>).refresh_token)
+  } catch {
+    return false
   }
 }
 
@@ -119,27 +235,43 @@ export const Route = createFileRoute('/api/swarm-health')({
         const profilesBase = getProfilesDir()
         const swarmIds = listSwarmIds()
         const wrapperBase = getLocalBinDir()
+        const roster = rosterByWorkerId(swarmIds)
 
-        const workers: WorkerHealth[] = swarmIds.map((id) => {
+        const workers: Array<WorkerHealth> = swarmIds.map((id) => {
+          const worker = roster.get(id)
           const profilePath = join(profilesBase, id)
           const wrapperPath = join(wrapperBase, id)
           const config = readWorkerConfig(profilePath)
           const errs = scanRecentAuthErrors(profilePath)
+          const primaryReady = errs.authErrorCount === 0 && errs.fallbackCount === 0 && (config.provider !== 'openai-codex' || hasOpenAiCodexAuth(profilePath))
           return {
             workerId: id,
+            displayName: resolveSwarmWorkerDisplayName(id, worker),
+            humanLabel: formatSwarmWorkerLabel(id, worker),
+            role: worker.role.trim() || 'Worker',
+            specialty: worker.specialty.trim() || null,
+            mission: worker.mission.trim() || null,
+            skills: worker.skills.length ? worker.skills : [],
+            capabilities: worker.capabilities.length ? worker.capabilities : [],
             profileFound: existsSync(profilePath),
             wrapperFound: existsSync(wrapperPath),
             model: config.model,
             provider: config.provider,
-            recentAuthErrors: errs.count,
-            lastErrorAt: errs.lastAt,
-            lastErrorMessage: errs.lastMessage,
+            recentAuthErrors: errs.authErrorCount,
+            recentFallbacks: errs.fallbackCount,
+            lastErrorAt: errs.lastAuthErrorAt,
+            lastErrorMessage: errs.lastAuthErrorMessage,
+            lastFallbackAt: errs.lastFallbackAt,
+            lastFallbackMessage: errs.lastFallbackMessage,
+            modelAuthStatus: primaryReady ? 'ready' : errs.modelAuthStatus,
+            primaryAuthOk: primaryReady ? true : errs.primaryAuthOk,
+            fallbackActive: errs.fallbackCount > 0,
+            fallbackProvider: errs.fallbackProvider,
+            fallbackModel: errs.fallbackModel,
           }
         })
 
-        const totalAuthErrors = workers.reduce((sum, worker) => sum + worker.recentAuthErrors, 0)
-        const distinctModels = Array.from(new Set(workers.map((w) => formatModelDisplay(w.model, w.provider)))).filter((value) => value !== 'unknown')
-        const distinctProviders = Array.from(new Set(workers.map((w) => formatProviderDisplay(w.provider)))).filter((value) => value !== 'unknown')
+        const summary = summarizeSwarmHealth(workers)
 
         return json({
           checkedAt: Date.now(),
@@ -147,13 +279,7 @@ export const Route = createFileRoute('/api/swarm-health')({
           agentApiUrl: apiUrl,
           claudeApiUrl: apiUrl,
           workers,
-          summary: {
-            totalWorkers: workers.length,
-            wrappersConfigured: workers.filter((w) => w.wrapperFound).length,
-            totalAuthErrors24h: totalAuthErrors,
-            distinctModels,
-            distinctProviders,
-          },
+          summary,
         })
       },
     },

--- a/src/routes/api/swarm-missions.ts
+++ b/src/routes/api/swarm-missions.ts
@@ -1,7 +1,59 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { getSwarmMission, listSwarmMissions, listSwarmReports, SWARM_MISSIONS_PATH } from '../../server/swarm-missions'
+import { SWARM_MISSIONS_PATH, cancelSwarmAssignment, cancelSwarmMission, getSwarmMission, listSwarmMissions, listSwarmReports } from '../../server/swarm-missions'
+import { getProfilesDir } from '../../server/claude-paths'
+
+type CancelPostBody = {
+  action?: unknown
+  missionId?: unknown
+  assignmentId?: unknown
+  workerId?: unknown
+  reason?: unknown
+  actor?: unknown
+  resetWorkers?: unknown
+}
+
+function cleanString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function resetWorkerRuntime(workerId: string, reason: string, actor: string): { workerId: string; ok: boolean; error?: string } {
+  if (!/^swarm\d+$/i.test(workerId)) return { workerId, ok: false, error: 'invalid worker id' }
+  const runtimePath = join(getProfilesDir(), workerId, 'runtime.json')
+  if (!existsSync(runtimePath)) return { workerId, ok: true }
+  try {
+    const raw = JSON.parse(readFileSync(runtimePath, 'utf-8')) as Record<string, unknown>
+    const next = {
+      ...raw,
+      state: 'idle',
+      phase: 'cancelled',
+      currentTask: null,
+      currentMissionId: null,
+      currentAssignmentId: null,
+      checkpointStatus: 'none',
+      needsHuman: false,
+      blockedReason: null,
+      activeTool: null,
+      checkpointRaw: null,
+      orchestratorProcessedRaw: null,
+      lastSummary: `Cancelled by ${actor}: ${reason}`,
+      lastControlMessage: `Cancelled by ${actor}: ${reason}`,
+      nextAction: 'Idle. Do not continue cancelled Workspace swarm work unless explicitly re-dispatched.',
+      cancelledAt: new Date().toISOString(),
+      cancellationReason: reason,
+      cancelledBy: actor,
+    }
+    const tmp = `${runtimePath}.${process.pid}.${Date.now()}.tmp`
+    writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n')
+    renameSync(tmp, runtimePath)
+    return { workerId, ok: true }
+  } catch (err) {
+    return { workerId, ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
 
 export const Route = createFileRoute('/api/swarm-missions')({
   server: {
@@ -21,6 +73,50 @@ export const Route = createFileRoute('/api/swarm-missions')({
           missions: id ? [] : listSwarmMissions(limit),
           reports: id ? listSwarmReports({ missionId: id, limit }) : [],
           fetchedAt: Date.now(),
+        })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        let body: CancelPostBody
+        try {
+          body = await request.json() as CancelPostBody
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 })
+        }
+        const action = cleanString(body.action)
+        if (action !== 'cancel') return json({ ok: false, error: 'Unsupported action' }, { status: 400 })
+        const missionId = cleanString(body.missionId)
+        if (!missionId) return json({ ok: false, error: 'missionId required' }, { status: 400 })
+        const actor = cleanString(body.actor) ?? 'workspace-cancel'
+        const reason = cleanString(body.reason) ?? 'Cancelled from Workspace Swarm'
+        const assignmentId = cleanString(body.assignmentId)
+        const workerId = cleanString(body.workerId)
+        const result = assignmentId || workerId
+          ? cancelSwarmAssignment({ missionId, assignmentId, workerId, actor, reason })
+          : cancelSwarmMission({ missionId, actor, reason })
+        if (!result) return json({ ok: false, error: 'Mission or assignment not found' }, { status: 404 })
+
+        const workerIds = new Set<string>()
+        if ('assignment' in result) workerIds.add(result.assignment.workerId)
+        if ('cancelledAssignmentIds' in result) {
+          const cancelledIds = new Set(result.cancelledAssignmentIds)
+          for (const assignment of result.mission.assignments) {
+            if (cancelledIds.has(assignment.id)) workerIds.add(assignment.workerId)
+          }
+        }
+        if (workerId && /^swarm\d+$/i.test(workerId)) workerIds.add(workerId)
+        const runtimeResets = body.resetWorkers !== false
+          ? Array.from(workerIds).map((id) => resetWorkerRuntime(id, reason, actor))
+          : []
+
+        return json({
+          ok: true,
+          action,
+          result,
+          runtimeResets,
+          cancelledAt: Date.now(),
         })
       },
     },

--- a/src/routes/api/swarm-runtime.ts
+++ b/src/routes/api/swarm-runtime.ts
@@ -1,36 +1,42 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { json } from '@tanstack/react-start'
+import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfilesDir } from '../../server/claude-paths'
 import {
+
+
+
+
+
+
+
+
+
+
+
   buildSwarmDispatchMetadata,
   buildSwarmSessionMetadata,
   getSwarmTmuxSessionName,
   getSwarmWrapperPath,
   listSwarmWorkerIds,
-  readSwarmRuntimeFile,
-  type SwarmArtifactMetadata,
-  type SwarmBoundary,
-  type SwarmCheckpointStatus,
-  type SwarmDispatchMetadata,
-  type SwarmLifecycleMetadata,
-  type SwarmPreviewMetadata,
-  type SwarmRuntimeSource,
-  type SwarmSessionMetadata,
-  type SwarmTaskMetadata,
-  type SwarmTerminalKind,
-  type SwarmWorkerState,
+  readSwarmRuntimeFile
 } from '../../server/swarm-foundation'
-import { rosterByWorkerId } from '../../server/swarm-roster'
+import { formatSwarmWorkerLabel, resolveSwarmWorkerDisplayName, rosterByWorkerId } from '../../server/swarm-roster'
 import { readSwarmMode, writeSwarmMode } from '../../server/swarm-mode'
+import type {SwarmArtifactMetadata, SwarmBoundary, SwarmCheckpointStatus, SwarmDispatchMetadata, SwarmLifecycleMetadata, SwarmPreviewMetadata, SwarmRuntimeSource, SwarmSessionMetadata, SwarmTaskMetadata, SwarmTerminalKind, SwarmWorkerState} from '../../server/swarm-foundation';
 
 type RuntimeEntry = {
   workerId: string
   displayName: string
+  humanLabel: string
   role: string
+  specialty: string | null
+  mission: string | null
+  skills: Array<string>
+  capabilities: Array<string>
   source: SwarmRuntimeSource
   pid: number | null
   startedAt: number | null
@@ -66,15 +72,7 @@ type RuntimeEntry = {
   previews: Array<SwarmPreviewMetadata>
 }
 
-function titleCase(value: string): string {
-  return value
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ')
-}
-
-function listWorkerIds(): string[] {
+function listWorkerIds(): Array<string> {
   return listSwarmWorkerIds()
 }
 
@@ -188,8 +186,13 @@ async function buildEntry(
 
   return {
     workerId,
-    displayName: roster?.name || titleCase(workerId),
+    displayName: resolveSwarmWorkerDisplayName(workerId, roster),
+    humanLabel: formatSwarmWorkerLabel(workerId, roster),
     role: roster?.role || runtime.role,
+    specialty: roster?.specialty || null,
+    mission: roster?.mission || null,
+    skills: roster.skills.length ? roster.skills : [],
+    capabilities: roster.capabilities.length ? roster.capabilities : [],
     source,
     pid: lifecycle.pid,
     startedAt: runtime.startedAt,

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -89,7 +89,7 @@ type StreamEvent =
 
 type ConductorSpawnResponse = {
   ok?: boolean
-  mode?: 'dashboard' | 'portable'
+  mode?: 'dashboard' | 'portable' | 'native-swarm'
   prompt?: string | null
   missionId?: string | null
   sessionKey?: string | null
@@ -594,6 +594,10 @@ function isFailedMissionStatus(status: string | null): boolean {
   return status === 'failed' || status === 'error' || status === 'errored' || status === 'cancelled' || status === 'canceled'
 }
 
+function isCompletedMissionStatus(status: string | null): boolean {
+  return status === 'completed' || status === 'complete' || status === 'done' || status === 'success'
+}
+
 async function fetchConductorMission(missionId: string): Promise<ConductorMissionRecord> {
   const response = await fetch(`/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`)
   const payload = (await response.json().catch(() => ({}))) as ConductorMissionResponse
@@ -1041,6 +1045,13 @@ export function useConductorGateway() {
       setStreamText((current) => (current === missionLog ? current : missionLog))
       lastActivityAtRef.current = Date.now()
       setTimeoutWarning(false)
+    }
+
+    if (isCompletedMissionStatus(status)) {
+      doneRef.current = true
+      setCompletedAt((value) => value ?? new Date().toISOString())
+      setPhase('complete')
+      return
     }
 
     if (isFailedMissionStatus(status)) {

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -27,9 +27,20 @@ vi.mock('node:os', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.unstubAllGlobals()
   delete process.env.CLAUDE_HOME
+  delete process.env.HERMES_HOME
   delete process.env.CLAUDE_API_URL
+  delete process.env.HERMES_API_URL
   delete process.env.CLAUDE_DASHBOARD_URL
+  delete process.env.HERMES_DASHBOARD_URL
+  delete process.env.CLAUDE_DASHBOARD_TOKEN
+  delete process.env.HERMES_DASHBOARD_TOKEN
+  delete process.env.HOST
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 async function loadMod() {
@@ -64,6 +75,107 @@ describe('gateway-capabilities', () => {
     const resolved = mod.getResolvedUrls()
     expect(resolved.gateway).toBe('http://127.0.0.1:8642')
     expect(resolved.source).toBe('default')
+  })
+
+  it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {
+    process.env.HERMES_API_URL = 'http://gateway.test'
+    process.env.CLAUDE_DASHBOARD_URL = 'http://dashboard.test'
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === 'http://dashboard.test/api/status') {
+        return new Response(JSON.stringify({ version: '0.12.0' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://dashboard.test/') {
+        return new Response("<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>", {
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/conductor/missions') {
+        return new Response('<!doctype html><div id="root"></div>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/plugins/kanban/board') {
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/mcp') {
+        return new Response('not found', { status: 404 })
+      }
+      if (url === 'http://dashboard.test/api/config') {
+        return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://gateway.test/v1/chat/completions') {
+        return new Response('', { status: 405 })
+      }
+      if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') {
+        return new Response('', { status: 404 })
+      }
+      if (url === 'http://gateway.test/api/mcp') {
+        return new Response('', { status: 404 })
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mod = await loadMod()
+    const caps = await mod.probeGateway({ force: true })
+
+    expect(caps.dashboard.available).toBe(true)
+    expect(caps.conductor).toBe(false)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://dashboard.test/api/conductor/missions',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
+  it('marks Conductor available when dashboard returns JSON from missions API', async () => {
+    process.env.HERMES_API_URL = 'http://gateway.test'
+    process.env.CLAUDE_DASHBOARD_URL = 'http://dashboard.test'
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === 'http://dashboard.test/api/status') {
+        return new Response(JSON.stringify({ version: '0.12.0' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://dashboard.test/') {
+        return new Response("<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>", {
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/conductor/missions') {
+        return new Response(JSON.stringify({ missions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/config') {
+        return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://gateway.test/v1/chat/completions') return new Response('', { status: 405 })
+      if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') return new Response('', { status: 404 })
+      if (url.endsWith('/api/mcp')) return new Response('', { status: 404 })
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }))
+
+    const mod = await loadMod()
+    const caps = await mod.probeGateway({ force: true })
+
+    expect(caps.conductor).toBe(true)
   })
 
   describe('isLocalhostDeployment', () => {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -36,8 +36,8 @@ function overridesPath(): string {
 function readOverrides(): WorkspaceOverrides {
   try {
     const raw = fs.readFileSync(overridesPath(), 'utf-8')
-    const parsed = JSON.parse(raw) as WorkspaceOverrides
-    return parsed && typeof parsed === 'object' ? parsed : {}
+    const parsed = JSON.parse(raw) as unknown
+    return parsed !== null && typeof parsed === 'object' ? (parsed as WorkspaceOverrides) : {}
   } catch {
     return {}
   }
@@ -289,8 +289,8 @@ let loggedHtmlScrapeFallback = false
  * Resolve a bearer token for dashboard API calls.
  *
  * Lookup order:
- *   1.  CLAUDE_DASHBOARD_TOKEN / CLAUDE_API_TOKEN env (preferred)
- *   2.  Inline token injected into the dashboard's root HTML (legacy
+ *   1. CLAUDE_DASHBOARD_TOKEN / CLAUDE_API_TOKEN env (preferred)
+ *   2. Inline token injected into the dashboard's root HTML (legacy
  *      fallback — logs a deprecation warning; to be removed once all
  *      supported dashboards expose a first-class token endpoint). See #124.
  */
@@ -621,7 +621,15 @@ async function probeConductor(dashboardAvailable: boolean): Promise<boolean> {
     if (res.status === 404 || res.status === 405) return false
     // 401 means the path exists but the auth token isn't accepted yet —
     // treat as available so token-gated setups don't hide the feature.
-    return true
+    if (res.status === 401) return true
+
+    const contentType = res.headers.get('content-type') ?? ''
+    // Vite/TanStack's SPA fallback returns HTTP 200 + text/html for missing
+    // API routes. Do not mark Conductor available unless the dashboard gives
+    // us a JSON API response; otherwise /api/conductor-spawn tries to POST to
+    // the dashboard and the user sees "Method Not Allowed".
+    if (!contentType.toLowerCase().includes('application/json')) return false
+    return res.ok
   } catch {
     return false
   }
@@ -896,6 +904,8 @@ export function getEnhancedCapabilities(): EnhancedCapabilities {
     jobs: capabilities.jobs,
     mcp: capabilities.mcp,
     mcpFallback: capabilities.mcpFallback,
+    conductor: capabilities.conductor,
+    kanban: capabilities.kanban,
   }
 }
 

--- a/src/server/swarm-environment.ts
+++ b/src/server/swarm-environment.ts
@@ -4,11 +4,9 @@ import { homedir } from 'node:os'
 import { getHermesRoot, getProfilesDir, getLocalBinDir } from './claude-paths'
 
 export const SWARM_CANONICAL_REPO = resolve(process.cwd())
-export const SWARM_MEMORY_ROOT = join(homedir(), '.openclaw', 'workspace')
+export const SWARM_MEMORY_ROOT = process.env.HERMES_SWARM_MEMORY_ROOT || join(homedir(), 'hermes-workspace')
 export const SWARM_MEMORY_HANDOFFS = join(SWARM_MEMORY_ROOT, 'memory')
-export const SWARM_FORBIDDEN_PATHS = [
-  join(homedir(), 'hermes-workspace'),
-]
+export const SWARM_FORBIDDEN_PATHS: string[] = []
 
 export type SwarmEnvironment = {
   canonicalRepo: string

--- a/src/server/swarm-memory.ts
+++ b/src/server/swarm-memory.ts
@@ -2,8 +2,8 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renam
 import { homedir } from 'node:os'
 import { basename, dirname, join, relative, resolve } from 'node:path'
 import YAML from 'yaml'
+import { SWARM_CANONICAL_REPO, SWARM_MEMORY_HANDOFFS } from './swarm-environment'
 import type { ParsedSwarmCheckpoint } from './swarm-checkpoints'
-import { SWARM_CANONICAL_REPO } from './swarm-environment'
 
 export type SwarmMemoryKind = 'profile' | 'mission' | 'episodic' | 'handoff' | 'shared'
 
@@ -51,8 +51,8 @@ export type SwarmMemorySearchResult = {
   snippet: string
 }
 
-export const SWARM_SHARED_MEMORY_ROOT = join(homedir(), '.openclaw', 'workspace', 'memory', 'swarm')
-export const SWARM_SHARED_HANDOFF_ROOT = join(homedir(), '.openclaw', 'workspace', 'memory', 'handoffs', 'swarm')
+export const SWARM_SHARED_MEMORY_ROOT = join(SWARM_MEMORY_HANDOFFS, 'swarm')
+export const SWARM_SHARED_HANDOFF_ROOT = join(SWARM_MEMORY_HANDOFFS, 'handoffs', 'swarm')
 export const SWARM_RUNTIME_ROOT = join(SWARM_CANONICAL_REPO, '.runtime')
 export const SWARM_PROJECT_CONTEXT_PATH = join(SWARM_SHARED_MEMORY_ROOT, 'PROJECT.md')
 
@@ -329,8 +329,7 @@ function memoryRootFor(input: { workerId?: string | null; kind: SwarmMemoryKind;
     return swarmWorkerMissionMemoryRoot(workerId, missionId)
   }
   if (input.kind === 'episodic') return swarmWorkerEpisodesRoot(workerId)
-  if (input.kind === 'handoff') return swarmWorkerHandoffsRoot(workerId)
-  return swarmWorkerMemoryRoot(workerId)
+  return swarmWorkerHandoffsRoot(workerId)
 }
 
 function listFiles(root: string, maxDepth = 2): Array<string> {
@@ -574,8 +573,8 @@ export function buildSwarmStartupSnapshot(input: SwarmStartupSnapshotInput): Swa
   renderedSections.push('### Memory locations')
   renderedSections.push(
     [
-      `Profile root: ~/.hermes/profiles/${workerId}/  (MEMORY.md, SOUL.md, USER.md cloned from main)`,
-      `Swarm memory: ~/.ocplatform/profiles/${workerId}/memory/  (IDENTITY.md, missions/, episodes/, handoffs/)`,
+      `Profile root: ~/.hermes/profiles/${workerId}/  (SOUL.md plus optional MEMORY.md / USER.md when cloned from main)`,
+      `Swarm memory: ~/.hermes/profiles/${workerId}/memory/  (IDENTITY.md, missions/, episodes/, handoffs/)`,
       `Shared handoff: ${sharedHandoffPath}`,
       `Shared swarm memory: ${SWARM_SHARED_MEMORY_ROOT}`,
       `Project context: ${SWARM_PROJECT_CONTEXT_PATH}`,

--- a/src/server/swarm-missions.test.ts
+++ b/src/server/swarm-missions.test.ts
@@ -155,6 +155,78 @@ describe('swarm-missions', () => {
     expect(mod.readyQueuedAssignments(mission.id).map((assignment) => assignment.id)).toEqual([finalAction.id])
   })
 
+  it('cancels active missions without accepting stale checkpoints afterward', async () => {
+    const mod = await loadModule()
+    const mission = mod.createOrUpdateMission({
+      missionId: 'mission-cancel-1',
+      title: 'Cancel test',
+      assignments: [
+        { workerId: 'swarm2', task: 'Active backend task', reviewRequired: false },
+        { workerId: 'swarm5', task: 'Queued builder task', reviewRequired: false },
+      ],
+    })
+    mod.markMissionAssignmentDispatched({ missionId: mission.id, workerId: 'swarm2', task: 'Active backend task' })
+
+    const cancelled = mod.cancelSwarmMission({
+      missionId: mission.id,
+      actor: 'test',
+      reason: 'User cancelled bad swarm run',
+    })
+
+    expect(cancelled?.mission.state).toBe('cancelled')
+    expect(cancelled?.cancelledAssignmentIds).toHaveLength(2)
+    expect(cancelled?.mission.assignments.map((assignment) => assignment.state)).toEqual(['cancelled', 'cancelled'])
+    expect(cancelled?.mission.events.at(-1)?.type).toBe('mission_cancelled')
+
+    const staleCheckpoint = mod.recordMissionCheckpoint({
+      missionId: mission.id,
+      assignmentId: mission.assignments[0]?.id,
+      workerId: 'swarm2',
+      checkpoint: {
+        stateLabel: 'DONE',
+        runtimeState: 'idle',
+        checkpointStatus: 'done',
+        filesChanged: 'none',
+        commandsRun: 'none',
+        result: 'Stale checkpoint after cancel',
+        blocker: null,
+        nextAction: 'none',
+        raw: 'STATE: DONE\nRESULT: stale',
+      },
+      source: 'stale-worker',
+    })
+
+    expect(staleCheckpoint?._ignoredReason).toContain('cancelled')
+    const persisted = mod.getSwarmMission(mission.id)
+    expect(persisted?.state).toBe('cancelled')
+    expect(persisted?.assignments[0]?.state).toBe('cancelled')
+    expect(persisted?.events.filter((event) => event.type === 'checkpoint')).toHaveLength(0)
+  })
+
+  it('cancels a single assignment and leaves unaffected work active', async () => {
+    const mod = await loadModule()
+    const mission = mod.createOrUpdateMission({
+      missionId: 'mission-cancel-assignment',
+      title: 'Assignment cancel test',
+      assignments: [
+        { workerId: 'swarm2', task: 'Cancel this', reviewRequired: false },
+        { workerId: 'swarm5', task: 'Keep this queued', reviewRequired: false },
+      ],
+    })
+
+    const cancelled = mod.cancelSwarmAssignment({
+      missionId: mission.id,
+      assignmentId: mission.assignments[0]?.id,
+      actor: 'test',
+      reason: 'Only one bad lane',
+    })
+
+    expect(cancelled?.assignment?.state).toBe('cancelled')
+    expect(cancelled?.mission.state).toBe('planning')
+    expect(cancelled?.mission.assignments.map((assignment) => assignment.state)).toEqual(['cancelled', 'queued'])
+    expect(cancelled?.mission.events.at(-1)?.type).toBe('assignment_cancelled')
+  })
+
   it('archives stale executing missions when all assignments are terminal', async () => {
     const mod = await loadModule()
     const staleMission = {

--- a/src/server/swarm-missions.ts
+++ b/src/server/swarm-missions.ts
@@ -3,8 +3,8 @@ import { dirname, join } from 'node:path'
 import { SWARM_CANONICAL_REPO } from './swarm-environment'
 import type { ParsedSwarmCheckpoint } from './swarm-checkpoints'
 
-export type SwarmMissionAssignmentState = 'queued' | 'dispatched' | 'checkpointed' | 'blocked' | 'needs_input' | 'reviewing' | 'done'
-export type SwarmMissionState = 'planning' | 'dispatching' | 'executing' | 'reviewing' | 'blocked' | 'complete'
+export type SwarmMissionAssignmentState = 'queued' | 'dispatched' | 'checkpointed' | 'blocked' | 'needs_input' | 'reviewing' | 'done' | 'cancelled'
+export type SwarmMissionState = 'planning' | 'dispatching' | 'executing' | 'reviewing' | 'blocked' | 'complete' | 'cancelled'
 
 export type SwarmMissionAssignment = {
   id: string
@@ -23,7 +23,7 @@ export type SwarmMissionAssignment = {
 
 export type SwarmMissionEvent = {
   id: string
-  type: 'created' | 'assignment_dispatched' | 'checkpoint' | 'continuation' | 'review' | 'blocked'
+  type: 'created' | 'assignment_dispatched' | 'checkpoint' | 'continuation' | 'review' | 'blocked' | 'assignment_cancelled' | 'mission_cancelled'
   at: number
   workerId?: string
   assignmentId?: string
@@ -118,11 +118,18 @@ function reportFromCheckpoint(input: {
 }
 
 function deriveMissionState(assignments: Array<SwarmMissionAssignment>): SwarmMissionState {
+  if (assignments.length > 0 && assignments.every((item) => item.state === 'cancelled')) return 'cancelled'
   if (assignments.some((item) => item.state === 'blocked' || item.state === 'needs_input')) return 'blocked'
-  if (assignments.length > 0 && assignments.every((item) => item.state === 'done' || (item.state === 'checkpointed' && !item.reviewRequired))) return 'complete'
+  if (assignments.length > 0 && assignments.every((item) => item.state === 'done' || item.state === 'cancelled' || (item.state === 'checkpointed' && !item.reviewRequired))) return 'complete'
   if (assignments.some((item) => item.state === 'reviewing' || (item.state === 'checkpointed' && item.reviewRequired))) return 'reviewing'
   if (assignments.some((item) => item.state === 'dispatched' || item.state === 'checkpointed')) return 'executing'
   return 'planning'
+}
+
+const TERMINAL_ASSIGNMENT_STATES = new Set<SwarmMissionAssignmentState>(['done', 'cancelled'])
+
+function isTerminalAssignment(assignment: SwarmMissionAssignment): boolean {
+  return TERMINAL_ASSIGNMENT_STATES.has(assignment.state)
 }
 
 export function listSwarmMissions(limit = 20): Array<SwarmMission> {
@@ -135,10 +142,10 @@ export function getSwarmMission(missionId: string): SwarmMission | null {
   return readStore().missions.find((mission) => mission.id === missionId) ?? null
 }
 
-export function archiveStaleMissions(staleMs: number = 6 * 60 * 60 * 1000): { archivedIds: string[]; count: number } {
+export function archiveStaleMissions(staleMs: number = 6 * 60 * 60 * 1000): { archivedIds: Array<string>; count: number } {
   const store = readStore()
   const now = Date.now()
-  const archivedIds: string[] = []
+  const archivedIds: Array<string> = []
   for (const mission of store.missions) {
     if (mission.state !== 'executing' && mission.state !== 'planning') continue
     if ((now - mission.updatedAt) < staleMs) continue
@@ -215,8 +222,10 @@ export function markMissionAssignmentDispatched(input: {
   const store = readStore()
   const mission = store.missions.find((item) => item.id === input.missionId)
   if (!mission) return null
+  if (mission.state === 'cancelled' || mission.state === 'complete') return mission
   const assignment = mission.assignments.find((item) => item.workerId === input.workerId && item.task === input.task)
   if (!assignment) return null
+  if (isTerminalAssignment(assignment)) return mission
   assignment.state = 'dispatched'
   assignment.dispatchedAt = now()
   mission.events.push(event('assignment_dispatched', `Dispatched ${assignment.id} to ${input.workerId}`, {
@@ -234,7 +243,7 @@ export function markMissionAssignmentDispatched(input: {
   return mission
 }
 
-export type RecordCheckpointResult = (SwarmMission & { _completed?: boolean }) | null
+export type RecordCheckpointResult = (SwarmMission & { _completed?: boolean; _ignoredReason?: string }) | null
 
 export function recordMissionCheckpoint(input: {
   missionId?: string | null
@@ -247,12 +256,15 @@ export function recordMissionCheckpoint(input: {
   const store = readStore()
   const mission = store.missions.find((item) => item.id === input.missionId)
   if (!mission) return null
+  if (mission.state === 'cancelled') return Object.assign(mission, { _ignoredReason: 'mission cancelled' })
   const assignment = (input.assignmentId
     ? mission.assignments.find((item) => item.id === input.assignmentId)
     : null)
     ?? [...mission.assignments].reverse().find((item) => item.workerId === input.workerId && item.state !== 'done')
     ?? [...mission.assignments].reverse().find((item) => item.workerId === input.workerId)
   if (!assignment) return null
+  if (assignment.state === 'cancelled') return Object.assign(mission, { _ignoredReason: 'assignment cancelled' })
+  if (assignment.state === 'done') return Object.assign(mission, { _ignoredReason: 'assignment done' })
   if (assignment.checkpoint?.raw === input.checkpoint.raw) {
     return Object.assign(mission, { _completed: mission.state === 'complete' })
   }
@@ -295,6 +307,7 @@ export function appendMissionContinuation(input: {
   const store = readStore()
   const mission = store.missions.find((item) => item.id === input.missionId)
   if (!mission) return null
+  if (mission.state === 'cancelled') return null
   const id = shortId('assign')
   mission.assignments.push({
     id,
@@ -322,6 +335,75 @@ export function readyQueuedAssignments(missionId: string): Array<SwarmMissionAss
   if (!mission) return []
   const doneIds = new Set(mission.assignments.filter((item) => ['checkpointed', 'done'].includes(item.state)).map((item) => item.id))
   return mission.assignments.filter((item) => item.state === 'queued' && item.dependsOn.every((id) => doneIds.has(id)))
+}
+
+export function cancelSwarmAssignment(input: {
+  missionId?: string | null
+  assignmentId?: string | null
+  workerId?: string | null
+  actor?: string | null
+  reason?: string | null
+}): { mission: SwarmMission; assignment: SwarmMissionAssignment; changed: boolean } | null {
+  if (!input.missionId) return null
+  const store = readStore()
+  const mission = store.missions.find((item) => item.id === input.missionId)
+  if (!mission) return null
+  const assignment = (input.assignmentId
+    ? mission.assignments.find((item) => item.id === input.assignmentId)
+    : null)
+    ?? (input.workerId ? [...mission.assignments].reverse().find((item) => item.workerId === input.workerId && !isTerminalAssignment(item)) : null)
+    ?? null
+  if (!assignment) return null
+  if (assignment.state === 'cancelled') return { mission, assignment, changed: false }
+  const cancelledAt = now()
+  assignment.state = 'cancelled'
+  assignment.completedAt = cancelledAt
+  assignment.reviewedAt = cancelledAt
+  assignment.reviewedBy = input.actor?.trim() || 'system-cancel'
+  mission.events.push(event('assignment_cancelled', `Cancelled ${assignment.id}${input.reason ? `: ${input.reason}` : ''}`, {
+    workerId: assignment.workerId,
+    assignmentId: assignment.id,
+    data: {
+      actor: input.actor?.trim() || 'system-cancel',
+      reason: input.reason?.trim() || null,
+    },
+  }))
+  mission.updatedAt = cancelledAt
+  mission.state = deriveMissionState(mission.assignments)
+  writeStore(store)
+  return { mission, assignment, changed: true }
+}
+
+export function cancelSwarmMission(input: {
+  missionId?: string | null
+  actor?: string | null
+  reason?: string | null
+}): { mission: SwarmMission; cancelledAssignmentIds: Array<string>; changed: boolean } | null {
+  if (!input.missionId) return null
+  const store = readStore()
+  const mission = store.missions.find((item) => item.id === input.missionId)
+  if (!mission) return null
+  const cancelledAt = now()
+  const cancelledAssignmentIds: Array<string> = []
+  for (const assignment of mission.assignments) {
+    if (isTerminalAssignment(assignment)) continue
+    assignment.state = 'cancelled'
+    assignment.completedAt = cancelledAt
+    assignment.reviewedAt = cancelledAt
+    assignment.reviewedBy = input.actor?.trim() || 'system-cancel'
+    cancelledAssignmentIds.push(assignment.id)
+  }
+  mission.state = 'cancelled'
+  mission.updatedAt = cancelledAt
+  mission.events.push(event('mission_cancelled', `Cancelled mission${input.reason ? `: ${input.reason}` : ''}`, {
+    data: {
+      actor: input.actor?.trim() || 'system-cancel',
+      reason: input.reason?.trim() || null,
+      cancelledAssignmentIds,
+    },
+  }))
+  writeStore(store)
+  return { mission, cancelledAssignmentIds, changed: cancelledAssignmentIds.length > 0 }
 }
 
 export function markMissionAssignmentReviewed(input: { missionId?: string | null; assignmentId: string; reviewerId?: string }): SwarmMission | null {

--- a/src/server/swarm-profile-config.test.ts
+++ b/src/server/swarm-profile-config.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
-import { syncSwarmProfileModel } from './swarm-profile-config'
+import { syncSwarmProfileIdentity, syncSwarmProfileModel } from './swarm-profile-config'
 
 function makeProfile(initial: Record<string, unknown>): string {
   const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-cfg-'))
@@ -141,6 +141,37 @@ describe('syncSwarmProfileModel', () => {
         default: 'gpt-5.5',
       })
       expect(result.ok).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+
+describe('syncSwarmProfileIdentity', () => {
+  it('writes profile-local identity with name, role, mission, capabilities, and stable machine ID', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-id-'))
+    try {
+      const result = syncSwarmProfileIdentity(dir, {
+        id: 'swarm5',
+        name: 'Builder',
+        role: 'Primary Builder',
+        specialty: 'full-stack implementation across Hermes Workspace and Swarm2',
+        model: 'GPT-5.5',
+        mission: 'Ship focused product slices with tests and clean diffs.',
+        skills: ['swarm-ui-worker', 'swarm-worker-core'],
+        capabilities: ['code-editing', 'ui-implementation'],
+      })
+
+      expect(result.ok).toBe(true)
+      const identity = readFileSync(join(dir, 'memory', 'IDENTITY.md'), 'utf8')
+      expect(identity).toContain('# IDENTITY.md — Builder')
+      expect(identity).toContain('- Name: Builder')
+      expect(identity).toContain('- Worker ID: swarm5')
+      expect(identity).toContain('- Role: Primary Builder')
+      expect(identity).toContain('- Mission: Ship focused product slices with tests and clean diffs.')
+      expect(identity).toContain('- Capabilities: code-editing, ui-implementation')
+      expect(identity).toContain('The worker ID is a stable machine identifier only')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/src/server/swarm-profile-config.ts
+++ b/src/server/swarm-profile-config.ts
@@ -14,13 +14,150 @@
  * matches, so re-running on a healthy profile is free.
  */
 
-import { existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
 
 export type ConfigSyncResult =
   | { ok: true; changed: boolean; previous?: { provider: string; default: string } }
   | { ok: false; error: string }
+
+export type ProfileBootstrapResult = {
+  ok: boolean
+  configCreated: boolean
+  envLinked: boolean
+  authLinked: boolean
+  error?: string
+}
+
+export type SwarmWorkerIdentity = {
+  id: string
+  name?: string
+  role?: string
+  specialty?: string
+  model?: string
+  mission?: string
+  skills?: Array<string>
+  capabilities?: Array<string>
+}
+
+/**
+ * Ensure a worker HERMES_HOME has enough runtime config to boot Hermes.
+ *
+ * Swarm dispatch runs workers with HERMES_HOME=~/.hermes/profiles/<workerId>.
+ * A brand-new profile only has memory/runtime files, so `hermes chat -q` exits
+ * with first-run setup before the worker can do any work. Bootstrap by copying
+ * the operator's non-secret config.yaml and linking the private .env locally.
+ * The config is copied (not symlinked) because per-worker model sync edits it.
+ */
+export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapResult {
+  const result: ProfileBootstrapResult = { ok: true, configCreated: false, envLinked: false, authLinked: false }
+  try {
+    mkdirSync(profilePath, { recursive: true })
+
+    const configPath = join(profilePath, 'config.yaml')
+    const sourceConfig = join(homedir(), '.hermes', 'config.yaml')
+    if (!existsSync(configPath) && existsSync(sourceConfig)) {
+      copyFileSync(sourceConfig, configPath)
+      result.configCreated = true
+    }
+
+    const envPath = join(profilePath, '.env')
+    const sourceEnv = join(homedir(), '.hermes', '.env')
+    if (existsSync(sourceEnv)) {
+      let shouldLink = !existsSync(envPath)
+      if (!shouldLink) {
+        try {
+          const stat = lstatSync(envPath)
+          shouldLink = stat.isSymbolicLink()
+          if (shouldLink) unlinkSync(envPath)
+        } catch {
+          shouldLink = false
+        }
+      }
+      if (shouldLink) {
+        symlinkSync(sourceEnv, envPath)
+        result.envLinked = true
+      }
+    }
+
+    const authPath = join(profilePath, 'auth.json')
+    const sourceAuth = join(homedir(), '.hermes', 'auth.json')
+    if (existsSync(sourceAuth)) {
+      let shouldLink = !existsSync(authPath)
+      if (!shouldLink) {
+        try {
+          const stat = lstatSync(authPath)
+          shouldLink = stat.isSymbolicLink()
+          if (shouldLink) unlinkSync(authPath)
+        } catch {
+          shouldLink = false
+        }
+      }
+      if (shouldLink) {
+        symlinkSync(sourceAuth, authPath)
+        result.authLinked = true
+      }
+    }
+
+    if (!existsSync(configPath)) {
+      return { ...result, ok: false, error: `config.yaml missing at ${configPath}` }
+    }
+    return result
+  } catch (err) {
+    return { ...result, ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+export function renderSwarmWorkerIdentity(worker: SwarmWorkerIdentity): string {
+  const name = worker.name?.trim() || worker.id
+  const role = worker.role?.trim() || 'Worker'
+  const specialty = worker.specialty?.trim() || 'General execution'
+  const model = worker.model?.trim() || 'Unspecified'
+  const mission = worker.mission?.trim() || 'Execute assigned swarm work and checkpoint progress.'
+  const skills = worker.skills && worker.skills.length > 0 ? worker.skills.join(', ') : 'swarm-worker-core'
+  const capabilities = worker.capabilities && worker.capabilities.length > 0 ? worker.capabilities.join(', ') : 'not declared'
+
+  return [
+    `# IDENTITY.md — ${name}`,
+    '',
+    `- Name: ${name}`,
+    `- Worker ID: ${worker.id}`,
+    `- Role: ${role}`,
+    `- Specialty: ${specialty}`,
+    `- Mission: ${mission}`,
+    `- Skills: ${skills}`,
+    `- Capabilities: ${capabilities}`,
+    `- Model: ${model}`,
+    '',
+    '## Job description',
+    `${name} is the ${role} lane. ${mission}`,
+    '',
+    'The worker ID is a stable machine identifier only; user-facing surfaces should prefer `Name — Role`.',
+    '',
+  ].join('\n')
+}
+
+export function syncSwarmProfileIdentity(profilePath: string, worker: SwarmWorkerIdentity): ConfigSyncResult {
+  if (!existsSync(profilePath)) {
+    return { ok: false, error: `profile path missing: ${profilePath}` }
+  }
+  const identityDir = join(profilePath, 'memory')
+  const identityPath = join(identityDir, 'IDENTITY.md')
+  const next = renderSwarmWorkerIdentity(worker)
+  try {
+    mkdirSync(identityDir, { recursive: true })
+    const current = existsSync(identityPath) ? readFileSync(identityPath, 'utf8') : ''
+    if (current === next) return { ok: true, changed: false }
+    const tmpPath = `${identityPath}.tmp-${process.pid}-${Date.now()}`
+    writeFileSync(tmpPath, next, 'utf8')
+    renameSync(tmpPath, identityPath)
+    return { ok: true, changed: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
 
 export function syncSwarmProfileModel(
   profilePath: string,

--- a/src/server/swarm-roster.test.ts
+++ b/src/server/swarm-roster.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatSwarmWorkerLabel, resolveSwarmWorkerDisplayName } from './swarm-roster'
+
+describe('swarm roster presentation helpers', () => {
+  it('prefers roster names for human-facing display labels', () => {
+    expect(resolveSwarmWorkerDisplayName('swarm2', { name: 'Backend Foundation' })).toBe('Backend Foundation')
+    expect(formatSwarmWorkerLabel('swarm2', { name: 'Backend Foundation', role: 'Runtime Contracts' })).toBe(
+      'Backend Foundation — Runtime Contracts',
+    )
+  })
+
+  it('falls back to title-cased machine ids and default roles when roster data is missing', () => {
+    expect(resolveSwarmWorkerDisplayName('swarm2')).toBe('Swarm2')
+    expect(formatSwarmWorkerLabel('swarm2')).toBe('Swarm2 — Backend Foundation')
+  })
+})

--- a/src/server/swarm-roster.ts
+++ b/src/server/swarm-roster.ts
@@ -36,6 +36,14 @@ export const SwarmRosterUpsertSchema = SwarmRosterWorkerSchema.extend({
 
 export type SwarmRosterUpsert = z.infer<typeof SwarmRosterUpsertSchema>
 
+function titleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
 function defaultRoleFromId(id: string): string {
   const n = id.match(/(\d+)/)?.[1] ?? ''
   switch (n) {
@@ -76,6 +84,12 @@ export function fallbackRoster(ids: Array<string> = []): SwarmRoster {
       model: 'Worker',
       mission: 'Awaiting orchestrator dispatch.',
       skills: [],
+      capabilities: [],
+      defaultCwd: undefined,
+      preferredTaskTypes: [],
+      maxConcurrentTasks: 1,
+      acceptsBroadcast: true,
+      reviewRequired: false,
     })),
   }
 }
@@ -120,4 +134,17 @@ export function upsertSwarmRosterWorker(input: SwarmRosterUpsert, ids: Array<str
 
 export function rosterByWorkerId(ids: Array<string> = []): Map<string, SwarmRosterWorker> {
   return new Map(readSwarmRoster(ids).workers.map((worker) => [worker.id, worker]))
+}
+
+export function resolveSwarmWorkerDisplayName(workerId: string, worker?: Pick<SwarmRosterWorker, 'name'> | null): string {
+  return worker ? worker.name.trim() || titleCase(workerId) : titleCase(workerId)
+}
+
+export function formatSwarmWorkerLabel(
+  workerId: string,
+  worker?: Pick<SwarmRosterWorker, 'name' | 'role'> | null,
+): string {
+  const displayName = resolveSwarmWorkerDisplayName(workerId, worker)
+  const role = worker ? worker.role.trim() || defaultRoleFromId(workerId) : defaultRoleFromId(workerId)
+  return `${displayName} — ${role}`
 }

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -4,8 +4,8 @@ workers:
     name: Reviewer
     role: Reviewer / Merge Gate
     specialty: code review, regression detection, test coverage, merge readiness
-    model: Opus 4.7
-    mission: Catch breakage before it reaches Eric. Be the final quality gate.
+    model: GPT-5.5
+    mission: Catch breakage before it reaches Mena. Be the final quality gate.
     skills:
       - swarm-pr-worker
       - swarm-worker-core
@@ -74,7 +74,7 @@ workers:
     role: Research / AI Intelligence / X Content
     specialty: AI/model/runtime research, technical synthesis, X post drafting
     model: GPT-5.5
-    mission: Produce decision-grade research and copy so builders and Eric stay unblocked.
+    mission: Produce decision-grade research and copy so Mena, Henry, and builders stay unblocked.
     skills:
       - swarm-worker-core
     capabilities:
@@ -117,7 +117,7 @@ workers:
   - id: swarm2
     name: Foundation
     role: Backend Foundation / Runtime Contracts
-    specialty: ClaudeSwarm runtime contracts, API design, plugin foundations, state
+    specialty: Workspace Swarm runtime contracts, API design, plugin foundations, state
     model: GPT-5.4
     mission: Build the backend substrate that keeps swarm state, dispatch, sessions, and plugins coherent.
     skills:


### PR DESCRIPTION
## Summary
- preserves dashboard-first Conductor dispatch when the dashboard mission API is available
- adds Workspace-native Swarm fallback for missing dashboard Conductor API with `mode: native-swarm` and `modeOfficialOotb: true`
- adds native mission status/cancel/readback handling and UI completion handling
- updates setup docs to provider-neutral / zero-fork native fallback wording
- adds regression coverage for native Conductor, Swarm dispatch/health/roster/profile, and gateway Conductor capability detection

## Verification
- `git diff --cached --check`
- `pnpm vitest run src/routes/api/-conductor-spawn.test.ts src/routes/api/-swarm-dispatch.test.ts src/routes/api/-swarm-health.test.ts src/server/swarm-memory.test.ts src/server/swarm-missions.test.ts src/server/swarm-profile-config.test.ts src/server/swarm-roster.test.ts src/server/__tests__/gateway-capabilities.test.ts` — 44 passed
- `pnpm exec eslint src/routes/api/conductor-spawn.ts src/routes/api/-conductor-spawn.test.ts src/routes/api/swarm-dispatch.ts src/routes/api/swarm-health.ts src/routes/api/swarm-missions.ts src/routes/api/swarm-runtime.ts src/routes/api/conductor-stop.ts src/server/swarm-memory.ts src/server/swarm-missions.ts src/server/swarm-profile-config.ts src/server/swarm-roster.ts src/server/gateway-capabilities.ts` — 0 errors, 9 existing warnings
- `pnpm build` — passed
