### PR TITLE
feat(tasks): add TaskSheet component for detailed task history and management

### DIFF
--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -55,7 +55,9 @@ async function resolveBackend(): Promise<BackendResolution> {
     const useHermes = hermesCount >= claudeCount
     _resolved = {
       base: useHermes ? HERMES_BASE : CLAUDE_BASE,
-      assigneesBase: useHermes ? '/api/hermes-tasks-assignees' : '/api/claude-tasks-assignees',
+      assigneesBase: useHermes
+        ? '/api/hermes-tasks-assignees'
+        : '/api/claude-tasks-assignees',
       backend: useHermes ? 'hermes' : 'claude',
     }
     return _resolved
@@ -77,7 +79,14 @@ export function resetBackendResolution(): void {
 
 // --- Types --------------------------------------------------------------
 
-export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done' | 'deleted'
+export type TaskColumn =
+  | 'backlog'
+  | 'todo'
+  | 'in_progress'
+  | 'review'
+  | 'blocked'
+  | 'done'
+  | 'deleted'
 export type TaskPriority = 'high' | 'medium' | 'low'
 
 export type ClaudeTask = {
@@ -94,6 +103,58 @@ export type ClaudeTask = {
   created_at: string
   updated_at: string
   session_id?: string | null
+}
+
+export type TaskEventPayload =
+  | Record<string, unknown>
+  | Array<unknown>
+  | string
+  | number
+  | boolean
+  | null
+
+export type TaskComment = {
+  id: number | string
+  task_id: string
+  author: string
+  body: string
+  created_at: number | string
+}
+
+export type TaskEvent = {
+  id: number | string
+  task_id: string
+  kind: string
+  payload?: TaskEventPayload
+  created_at: number | string
+  run_id?: number | null
+}
+
+export type TaskRun = {
+  id: number | string
+  task_id: string
+  profile?: string | null
+  step_key?: string | null
+  status: string
+  claim_lock?: string | null
+  claim_expires?: number | null
+  worker_pid?: number | null
+  max_runtime_seconds?: number | null
+  last_heartbeat_at?: number | null
+  started_at: number | string
+  ended_at?: number | string | null
+  outcome?: string | null
+  summary?: string | null
+  metadata?: Record<string, unknown> | null
+  error?: string | null
+}
+
+export type TaskDetail = {
+  task: ClaudeTask
+  comments: Array<TaskComment>
+  events: Array<TaskEvent>
+  links: { parents: Array<string>; children: Array<string> }
+  runs: Array<TaskRun>
 }
 
 export type CreateTaskInput = {
@@ -148,6 +209,35 @@ export async function fetchTasks(params?: {
   return data.tasks ?? []
 }
 
+function emptyTaskDetail(task: ClaudeTask): TaskDetail {
+  return {
+    task,
+    comments: [],
+    events: [],
+    links: { parents: [], children: [] },
+    runs: [],
+  }
+}
+
+export async function fetchTaskDetail(taskId: string): Promise<TaskDetail> {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${encodeURIComponent(taskId)}`)
+  if (!res.ok) throw new Error(`Failed to fetch task detail: ${res.status}`)
+  const data = await res.json()
+  const task = data.task as ClaudeTask | undefined
+  if (!task) throw new Error('Task detail response did not include a task')
+  return {
+    ...emptyTaskDetail(task),
+    comments: Array.isArray(data.comments) ? data.comments : [],
+    events: Array.isArray(data.events) ? data.events : [],
+    links: {
+      parents: Array.isArray(data.links?.parents) ? data.links.parents : [],
+      children: Array.isArray(data.links?.children) ? data.links.children : [],
+    },
+    runs: Array.isArray(data.runs) ? data.runs : [],
+  }
+}
+
 export async function createTask(input: CreateTaskInput): Promise<ClaudeTask> {
   const { base } = await resolveBackend()
   const res = await fetch(base, {
@@ -157,12 +247,18 @@ export async function createTask(input: CreateTaskInput): Promise<ClaudeTask> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error((body as { detail?: string }).detail || `Failed to create task: ${res.status}`)
+    throw new Error(
+      (body as { detail?: string }).detail ||
+        `Failed to create task: ${res.status}`,
+    )
   }
   return (await res.json()).task
 }
 
-export async function updateTask(taskId: string, input: UpdateTaskInput): Promise<ClaudeTask> {
+export async function updateTask(
+  taskId: string,
+  input: UpdateTaskInput,
+): Promise<ClaudeTask> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${taskId}`, {
     method: 'PATCH',
@@ -179,7 +275,10 @@ export async function deleteTask(taskId: string): Promise<void> {
   if (!res.ok) throw new Error(`Failed to delete task: ${res.status}`)
 }
 
-export async function linkSession(taskId: string, sessionId: string | null): Promise<ClaudeTask> {
+export async function linkSession(
+  taskId: string,
+  sessionId: string | null,
+): Promise<ClaudeTask> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${taskId}`, {
     method: 'PATCH',
@@ -190,7 +289,9 @@ export async function linkSession(taskId: string, sessionId: string | null): Pro
   return (await res.json()).task
 }
 
-export async function launchSession(taskId: string): Promise<{ sessionId: string; briefing: string; task: ClaudeTask }> {
+export async function launchSession(
+  taskId: string,
+): Promise<{ sessionId: string; briefing: string; task: ClaudeTask }> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${taskId}?action=launch`, {
     method: 'POST',
@@ -201,7 +302,11 @@ export async function launchSession(taskId: string): Promise<{ sessionId: string
   return res.json()
 }
 
-export async function moveTask(taskId: string, column: TaskColumn, movedBy = 'user'): Promise<ClaudeTask> {
+export async function moveTask(
+  taskId: string,
+  column: TaskColumn,
+  movedBy = 'user',
+): Promise<ClaudeTask> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${taskId}?action=move`, {
     method: 'POST',
@@ -210,7 +315,10 @@ export async function moveTask(taskId: string, column: TaskColumn, movedBy = 'us
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error((body as { detail?: string }).detail || `Failed to move task: ${res.status}`)
+    throw new Error(
+      (body as { detail?: string }).detail ||
+        `Failed to move task: ${res.status}`,
+    )
   }
   return (await res.json()).task
 }
@@ -227,7 +335,14 @@ export const COLUMN_LABELS: Record<TaskColumn, string> = {
   deleted: 'Deleted',
 }
 
-export const COLUMN_ORDER: Array<TaskColumn> = ['backlog', 'todo', 'in_progress', 'review', 'blocked', 'done']
+export const COLUMN_ORDER: Array<TaskColumn> = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'review',
+  'blocked',
+  'done',
+]
 
 export const PRIORITY_COLORS: Record<TaskPriority, string> = {
   high: '#ef4444',

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -149,11 +149,22 @@ export type TaskRun = {
   error?: string | null
 }
 
+export type TaskRelationLink = {
+  id: string
+  title?: string | null
+  column?: TaskColumn | null
+  priority?: TaskPriority | null
+  assignee?: string | null
+}
+
 export type TaskDetail = {
   task: ClaudeTask
   comments: Array<TaskComment>
   events: Array<TaskEvent>
-  links: { parents: Array<string>; children: Array<string> }
+  links: {
+    parents: Array<TaskRelationLink>
+    children: Array<TaskRelationLink>
+  }
   runs: Array<TaskRun>
 }
 
@@ -219,6 +230,52 @@ function emptyTaskDetail(task: ClaudeTask): TaskDetail {
   }
 }
 
+function normalizeTaskColumn(value: unknown): TaskColumn | null {
+  return value === 'backlog' ||
+    value === 'todo' ||
+    value === 'in_progress' ||
+    value === 'review' ||
+    value === 'blocked' ||
+    value === 'done' ||
+    value === 'deleted'
+    ? value
+    : null
+}
+
+function normalizeTaskPriority(value: unknown): TaskPriority | null {
+  return value === 'high' || value === 'medium' || value === 'low'
+    ? value
+    : null
+}
+
+function normalizeTaskRelationLink(value: unknown): TaskRelationLink | null {
+  if (typeof value === 'string') {
+    const id = value.trim()
+    return id ? { id } : null
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const record = value as Record<string, unknown>
+  const id = typeof record.id === 'string' ? record.id.trim() : ''
+  if (!id) return null
+
+  return {
+    id,
+    title: typeof record.title === 'string' ? record.title : null,
+    column: normalizeTaskColumn(record.column),
+    priority: normalizeTaskPriority(record.priority),
+    assignee: typeof record.assignee === 'string' ? record.assignee : null,
+  }
+}
+
+function normalizeTaskRelationLinks(value: unknown): Array<TaskRelationLink> {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry) => {
+    const normalized = normalizeTaskRelationLink(entry)
+    return normalized ? [normalized] : []
+  })
+}
+
 export async function fetchTaskDetail(taskId: string): Promise<TaskDetail> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${encodeURIComponent(taskId)}`)
@@ -231,8 +288,8 @@ export async function fetchTaskDetail(taskId: string): Promise<TaskDetail> {
     comments: Array.isArray(data.comments) ? data.comments : [],
     events: Array.isArray(data.events) ? data.events : [],
     links: {
-      parents: Array.isArray(data.links?.parents) ? data.links.parents : [],
-      children: Array.isArray(data.links?.children) ? data.links.children : [],
+      parents: normalizeTaskRelationLinks(data.links?.parents),
+      children: normalizeTaskRelationLinks(data.links?.children),
     },
     runs: Array.isArray(data.runs) ? data.runs : [],
   }

--- a/src/routes/api/claude-tasks.$taskId.ts
+++ b/src/routes/api/claude-tasks.$taskId.ts
@@ -1,7 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { getClaudeTask, moveClaudeTask, updateClaudeTask } from '../../server/claude-tasks-backend'
-import type { TaskColumn, TaskPriority } from '../../server/claude-tasks-backend'
+import {
+  getClaudeTaskDetail,
+  moveClaudeTask,
+  updateClaudeTask,
+} from '../../server/claude-tasks-backend'
+import type {
+  TaskColumn,
+  TaskPriority,
+} from '../../server/claude-tasks-backend'
 
 function jsonResponse(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -33,9 +40,9 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
           return jsonResponse({ error: 'Unauthorized' }, 401)
         }
 
-        const task = await getClaudeTask(params.taskId)
-        if (!task) return jsonResponse({ error: 'Task not found' }, 404)
-        return jsonResponse({ task })
+        const detail = await getClaudeTaskDetail(params.taskId)
+        if (!detail) return jsonResponse({ error: 'Task not found' }, 404)
+        return jsonResponse(detail)
       },
 
       PATCH: async ({ request, params }) => {
@@ -47,12 +54,25 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
           const body = (await request.json()) as Record<string, unknown>
           const task = await updateClaudeTask(params.taskId, {
             title: typeof body.title === 'string' ? body.title : undefined,
-            description: typeof body.description === 'string' ? body.description : undefined,
+            description:
+              typeof body.description === 'string'
+                ? body.description
+                : undefined,
             column: isTaskColumn(body.column) ? body.column : undefined,
             priority: isTaskPriority(body.priority) ? body.priority : undefined,
-            assignee: body.assignee === null || typeof body.assignee === 'string' ? body.assignee : undefined,
-            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : undefined,
-            due_date: body.due_date === null || typeof body.due_date === 'string' ? body.due_date : undefined,
+            assignee:
+              body.assignee === null || typeof body.assignee === 'string'
+                ? body.assignee
+                : undefined,
+            tags: Array.isArray(body.tags)
+              ? body.tags.filter(
+                  (tag): tag is string => typeof tag === 'string',
+                )
+              : undefined,
+            due_date:
+              body.due_date === null || typeof body.due_date === 'string'
+                ? body.due_date
+                : undefined,
           })
 
           if (!task) return jsonResponse({ error: 'Task not found' }, 404)
@@ -62,12 +82,17 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
         }
       },
 
-      DELETE: async ({ request }) => {
+      DELETE: ({ request }) => {
         if (!isAuthenticated(request)) {
           return jsonResponse({ error: 'Unauthorized' }, 401)
         }
 
-        return jsonResponse({ error: 'Delete is not supported by the shared Agent Kanban backend' }, 405)
+        return jsonResponse(
+          {
+            error: 'Delete is not supported by the shared Agent Kanban backend',
+          },
+          405,
+        )
       },
 
       POST: async ({ request, params }) => {

--- a/src/screens/tasks/task-sheet.tsx
+++ b/src/screens/tasks/task-sheet.tsx
@@ -1,0 +1,614 @@
+'use client'
+
+import { Dialog } from '@base-ui/react/dialog'
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import type {
+  ClaudeTask,
+  TaskAssignee,
+  TaskColumn,
+  TaskComment,
+  TaskDetail,
+  TaskEvent,
+  TaskPriority,
+  TaskRun,
+  UpdateTaskInput,
+} from '@/lib/tasks-api'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { COLUMN_LABELS, COLUMN_ORDER } from '@/lib/tasks-api'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  task: ClaudeTask | null
+  detail?: TaskDetail | null
+  isLoadingDetail?: boolean
+  detailError?: Error | null
+  assignees: Array<TaskAssignee>
+  onSubmit: (input: UpdateTaskInput) => Promise<void>
+  isSubmitting: boolean
+}
+
+export type TaskHistoryEntry = {
+  id: string
+  timestamp: number
+  source: 'event' | 'comment' | 'run' | 'synthetic'
+  title: string
+  subtitle?: string
+  body?: string
+  payloadText?: string
+  tone?: 'default' | 'success' | 'warning' | 'danger'
+}
+
+function toTimestamp(value: number | string | null | undefined): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : value * 1000
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value)
+    if (Number.isFinite(numeric)) return toTimestamp(numeric)
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+function formatTimestamp(timestamp: number): string {
+  if (!timestamp) return 'Unknown time'
+  return new Date(timestamp).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function titleCase(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function compactPayload(
+  payload: TaskEvent['payload'] | undefined,
+): string | undefined {
+  if (payload === undefined || payload === null) return undefined
+  if (typeof payload !== 'object') return String(payload)
+  if (Array.isArray(payload)) return JSON.stringify(payload, null, 2)
+
+  const parts: Array<string> = []
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === null || value === undefined || value === '') continue
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      parts.push(`${titleCase(key)}: ${String(value)}`)
+    }
+  }
+  if (parts.length > 0) return parts.join(' · ')
+  return JSON.stringify(payload, null, 2)
+}
+
+function eventTitle(event: TaskEvent): string {
+  const payload =
+    event.payload &&
+    typeof event.payload === 'object' &&
+    !Array.isArray(event.payload)
+      ? event.payload
+      : {}
+
+  switch (event.kind) {
+    case 'created':
+      return 'Task created'
+    case 'edited':
+      return 'Fields edited'
+    case 'assigned':
+      return payload.assignee
+        ? `Assigned to ${String(payload.assignee)}`
+        : 'Unassigned'
+    case 'status':
+      return payload.status
+        ? `Moved to ${titleCase(String(payload.status))}`
+        : 'Status changed'
+    case 'blocked':
+      return 'Blocked'
+    case 'unblocked':
+      return 'Unblocked'
+    case 'completed':
+    case 'done':
+      return 'Completed'
+    case 'claimed':
+      return payload.profile
+        ? `Claimed by ${String(payload.profile)}`
+        : 'Claimed'
+    case 'reclaimed':
+      return 'Claim reclaimed'
+    case 'reprioritized':
+      return payload.priority !== undefined
+        ? `Priority set to ${String(payload.priority)}`
+        : 'Priority changed'
+    case 'linked':
+      return 'Dependency linked'
+    case 'unlinked':
+      return 'Dependency removed'
+    case 'updated':
+      return 'Task updated'
+    default:
+      return titleCase(event.kind)
+  }
+}
+
+function eventTone(kind: string): TaskHistoryEntry['tone'] {
+  if (kind === 'completed' || kind === 'done' || kind === 'unblocked')
+    return 'success'
+  if (kind === 'blocked' || kind === 'spawn_auto_blocked' || kind === 'gave_up')
+    return 'danger'
+  if (
+    kind.includes('warning') ||
+    kind.includes('hallucination') ||
+    kind === 'reprioritized'
+  )
+    return 'warning'
+  return 'default'
+}
+
+function runTitle(run: TaskRun): string {
+  const status = run.outcome || run.status
+  const prefix = `Run ${run.id}`
+  return status ? `${prefix} ${titleCase(status)}` : prefix
+}
+
+function runTone(run: TaskRun): TaskHistoryEntry['tone'] {
+  const status = (run.outcome || run.status || '').toLowerCase()
+  if (status === 'completed' || status === 'done') return 'success'
+  if (
+    status === 'blocked' ||
+    status === 'crashed' ||
+    status === 'timed_out' ||
+    status === 'failed' ||
+    status === 'gave_up'
+  )
+    return 'danger'
+  if (status === 'running') return 'warning'
+  return 'default'
+}
+
+export function buildTaskHistoryEntries(
+  detail: TaskDetail | null | undefined,
+  fallbackTask: ClaudeTask | null | undefined,
+): Array<TaskHistoryEntry> {
+  const task = detail?.task ?? fallbackTask ?? null
+  const entries: Array<TaskHistoryEntry> = []
+  let hasCreatedEvent = false
+
+  for (const event of detail?.events ?? []) {
+    if (event.kind === 'created') hasCreatedEvent = true
+    if (event.kind === 'commented') continue
+    entries.push({
+      id: `event:${event.id}`,
+      timestamp: toTimestamp(event.created_at),
+      source: 'event',
+      title: eventTitle(event),
+      subtitle: event.run_id ? `Event · Run ${event.run_id}` : 'Event',
+      payloadText: compactPayload(event.payload),
+      tone: eventTone(event.kind),
+    })
+  }
+
+  for (const comment of detail?.comments ?? []) {
+    entries.push({
+      id: `comment:${comment.id}`,
+      timestamp: toTimestamp(comment.created_at),
+      source: 'comment',
+      title: `Comment from ${comment.author}`,
+      subtitle: 'Comment',
+      body: comment.body,
+    })
+  }
+
+  for (const run of detail?.runs ?? []) {
+    const endedAt = toTimestamp(run.ended_at ?? undefined)
+    const startedAt = toTimestamp(run.started_at)
+    const profile = run.profile ? ` · ${run.profile}` : ''
+    entries.push({
+      id: `run:${run.id}`,
+      timestamp: endedAt || startedAt,
+      source: 'run',
+      title: runTitle(run),
+      subtitle: `Run attempt${profile}`,
+      body: run.summary || run.error || undefined,
+      payloadText: run.metadata
+        ? JSON.stringify(run.metadata, null, 2)
+        : undefined,
+      tone: runTone(run),
+    })
+  }
+
+  if (task && entries.length === 0) {
+    entries.push({
+      id: `synthetic:updated:${task.id}`,
+      timestamp: toTimestamp(task.updated_at),
+      source: 'synthetic',
+      title: 'Last updated',
+      subtitle: 'Task record',
+      tone: 'default',
+    })
+  }
+
+  if (task && !hasCreatedEvent) {
+    entries.push({
+      id: `synthetic:created:${task.id}`,
+      timestamp: toTimestamp(task.created_at),
+      source: 'synthetic',
+      title: 'Task created',
+      subtitle: `Created by ${task.created_by}`,
+      tone: 'default',
+    })
+  }
+
+  return entries.sort(
+    (a, b) => b.timestamp - a.timestamp || b.id.localeCompare(a.id),
+  )
+}
+
+function statusLabel(column: TaskColumn): string {
+  return COLUMN_LABELS[column]
+}
+
+function inputBaseClass() {
+  return cn(
+    'w-full rounded-lg border px-3 py-2 text-sm',
+    'bg-[var(--theme-input)] border-[var(--theme-border)] text-[var(--theme-text)]',
+    'focus:outline-none focus:ring-1 focus:ring-[var(--theme-accent)]',
+    'placeholder:text-[var(--theme-muted)]',
+  )
+}
+
+function toneClasses(tone: TaskHistoryEntry['tone']) {
+  switch (tone) {
+    case 'success':
+      return 'border-emerald-400/60 bg-emerald-400/15'
+    case 'warning':
+      return 'border-amber-400/60 bg-amber-400/15'
+    case 'danger':
+      return 'border-red-400/60 bg-red-400/15'
+    default:
+      return 'border-[var(--theme-border)] bg-[var(--theme-hover)]'
+  }
+}
+
+function HistoryList({ entries }: { entries: Array<TaskHistoryEntry> }) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-4 text-sm text-[var(--theme-muted)]">
+        No history has been recorded for this task yet.
+      </div>
+    )
+  }
+
+  return (
+    <ol className="min-w-0 space-y-3">
+      {entries.map((entry) => (
+        <li
+          key={entry.id}
+          className="grid min-w-0 grid-cols-[12px_minmax(0,1fr)] gap-3"
+        >
+          <div className="flex flex-col items-center pt-1.5">
+            <span
+              className={cn(
+                'h-2.5 w-2.5 rounded-full border',
+                toneClasses(entry.tone),
+              )}
+            />
+            <span className="mt-1 h-full min-h-8 w-px bg-[var(--theme-border)]" />
+          </div>
+          <article className="min-w-0 max-w-full overflow-hidden rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+            <div className="flex min-w-0 items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h4 className="break-words text-sm font-medium text-[var(--theme-text)] [overflow-wrap:anywhere]">
+                  {entry.title}
+                </h4>
+                {entry.subtitle && (
+                  <p className="mt-0.5 break-words text-[11px] text-[var(--theme-muted)] [overflow-wrap:anywhere]">
+                    {entry.subtitle}
+                  </p>
+                )}
+              </div>
+              <time className="shrink-0 text-right text-[10px] leading-snug text-[var(--theme-muted)]">
+                {formatTimestamp(entry.timestamp)}
+              </time>
+            </div>
+            {entry.body && (
+              <p className="mt-3 whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--theme-text)] [overflow-wrap:anywhere]">
+                {entry.body}
+              </p>
+            )}
+            {entry.payloadText && (
+              <pre className="mt-3 max-h-60 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-2 text-[11px] leading-relaxed text-[var(--theme-muted)] [overflow-wrap:anywhere]">
+                {entry.payloadText}
+              </pre>
+            )}
+          </article>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export function TaskSheet({
+  open,
+  onOpenChange,
+  task,
+  detail,
+  isLoadingDetail = false,
+  detailError = null,
+  assignees,
+  onSubmit,
+  isSubmitting,
+}: Props) {
+  const activeTask = detail?.task ?? task
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [column, setColumn] = useState<TaskColumn>('backlog')
+  const [priority, setPriority] = useState<TaskPriority>('medium')
+  const [assignee, setAssignee] = useState<string>('')
+  const [tags, setTags] = useState('')
+  const [dueDate, setDueDate] = useState('')
+
+  useEffect(() => {
+    if (!activeTask) return
+    setTitle(activeTask.title)
+    setDescription(activeTask.description)
+    setColumn(activeTask.column)
+    setPriority(activeTask.priority)
+    setAssignee(activeTask.assignee ?? '')
+    setTags(activeTask.tags.join(', '))
+    setDueDate(activeTask.due_date ?? '')
+  }, [activeTask?.id, activeTask?.updated_at, activeTask])
+
+  const historyEntries = useMemo(
+    () => buildTaskHistoryEntries(detail, activeTask),
+    [detail, activeTask],
+  )
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!title.trim()) return
+    await onSubmit({
+      title: title.trim(),
+      description: description.trim(),
+      column,
+      priority,
+      assignee: assignee || null,
+      tags: tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      due_date: dueDate || null,
+    })
+  }
+
+  const inputClass = inputBaseClass()
+  const labelClass = 'block text-xs font-medium text-[var(--theme-muted)] mb-1'
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/55 backdrop-blur-sm transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100" />
+        <Dialog.Popup
+          className={cn(
+            'fixed right-0 top-0 z-50 flex h-dvh w-[min(920px,100vw)] flex-col overflow-hidden',
+            'border-l border-[var(--theme-border)] bg-[var(--theme-panel)] text-[var(--theme-text)] shadow-[0_24px_120px_rgba(0,0,0,0.45)]',
+            'transition-transform duration-200 ease-out data-[state=closed]:translate-x-full data-[state=open]:translate-x-0',
+          )}
+        >
+          <div className="flex shrink-0 items-start justify-between gap-4 border-b border-[var(--theme-border)] p-5">
+            <div className="min-w-0">
+              <Dialog.Title className="text-lg font-semibold text-[var(--theme-text)]">
+                {activeTask?.title || 'Task'}
+              </Dialog.Title>
+              <Dialog.Description className="mt-1 text-xs text-[var(--theme-muted)]">
+                {activeTask
+                  ? `${activeTask.id} · ${statusLabel(activeTask.column)} · newest history first`
+                  : 'Task detail'}
+              </Dialog.Description>
+            </div>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-sm text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-accent)] hover:text-[var(--theme-text)]"
+              aria-label="Close task detail"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-5">
+            {!activeTask ? (
+              <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-6 text-sm text-[var(--theme-muted)]">
+                Select a task to open its detail view.
+              </div>
+            ) : (
+              <div className="min-w-0 space-y-5">
+                <section className="min-w-0 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+                        Fields
+                      </h3>
+                      <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                        Edit the task record without leaving the board.
+                      </p>
+                    </div>
+                    <span className="text-[11px] text-[var(--theme-muted)]">
+                      Updated{' '}
+                      {formatTimestamp(toTimestamp(activeTask.updated_at))}
+                    </span>
+                  </div>
+
+                  <form onSubmit={handleSubmit} className="space-y-4">
+                    <div>
+                      <label className={labelClass}>Title *</label>
+                      <input
+                        className={inputClass}
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        placeholder="What needs to be done?"
+                        required
+                      />
+                    </div>
+
+                    <div>
+                      <label className={labelClass}>Description</label>
+                      <textarea
+                        className={cn(inputClass, 'min-h-40 resize-y')}
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="Optional details..."
+                      />
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <label className={labelClass}>Column</label>
+                        <select
+                          className={inputClass}
+                          style={{ colorScheme: 'dark' }}
+                          value={column}
+                          onChange={(e) =>
+                            setColumn(e.target.value as TaskColumn)
+                          }
+                        >
+                          {COLUMN_ORDER.map((col) => (
+                            <option key={col} value={col}>
+                              {COLUMN_LABELS[col]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className={labelClass}>Priority</label>
+                        <select
+                          className={inputClass}
+                          style={{ colorScheme: 'dark' }}
+                          value={priority}
+                          onChange={(e) =>
+                            setPriority(e.target.value as TaskPriority)
+                          }
+                        >
+                          <option value="high">High</option>
+                          <option value="medium">Medium</option>
+                          <option value="low">Low</option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <label className={labelClass}>Assignee</label>
+                        <select
+                          className={inputClass}
+                          style={{ colorScheme: 'dark' }}
+                          value={assignee}
+                          onChange={(e) => setAssignee(e.target.value)}
+                        >
+                          <option value="">Unassigned</option>
+                          {assignees.map(({ id, label }) => (
+                            <option key={id} value={id}>
+                              {label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className={labelClass}>Due date</label>
+                        <input
+                          type="date"
+                          className={inputClass}
+                          style={{ colorScheme: 'dark' }}
+                          value={dueDate}
+                          onChange={(e) => setDueDate(e.target.value)}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className={labelClass}>
+                        Tags (comma-separated)
+                      </label>
+                      <input
+                        className={inputClass}
+                        value={tags}
+                        onChange={(e) => setTags(e.target.value)}
+                        placeholder="frontend, bug, research"
+                      />
+                    </div>
+
+                    <div className="flex items-center justify-end gap-2 border-t border-[var(--theme-border)] pt-4">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isSubmitting}
+                      >
+                        Close
+                      </Button>
+                      <Button
+                        type="submit"
+                        size="sm"
+                        disabled={isSubmitting || !title.trim()}
+                        style={{
+                          background: 'var(--theme-accent)',
+                          color: 'white',
+                        }}
+                      >
+                        {isSubmitting ? 'Saving...' : 'Save changes'}
+                      </Button>
+                    </div>
+                  </form>
+                </section>
+
+                <section className="min-w-0 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+                  <div className="mb-4 flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+                        History
+                      </h3>
+                      <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                        Full card activity in reverse chronological order.
+                      </p>
+                    </div>
+                    <span className="text-[11px] text-[var(--theme-muted)]">
+                      {historyEntries.length} entries
+                    </span>
+                  </div>
+
+                  {isLoadingDetail && (
+                    <div className="mb-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-hover)] p-3 text-xs text-[var(--theme-muted)]">
+                      Loading full history...
+                    </div>
+                  )}
+
+                  {detailError && (
+                    <div className="mb-3 rounded-lg border border-red-400/40 bg-red-400/10 p-3 text-xs text-red-300">
+                      Could not load full history: {detailError.message}
+                    </div>
+                  )}
+
+                  <HistoryList entries={historyEntries} />
+                </section>
+              </div>
+            )}
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/screens/tasks/task-sheet.tsx
+++ b/src/screens/tasks/task-sheet.tsx
@@ -11,6 +11,7 @@ import type {
   TaskDetail,
   TaskEvent,
   TaskPriority,
+  TaskRelationLink,
   TaskRun,
   UpdateTaskInput,
 } from '@/lib/tasks-api'
@@ -21,11 +22,14 @@ import { COLUMN_LABELS, COLUMN_ORDER } from '@/lib/tasks-api'
 type Props = {
   open: boolean
   onOpenChange: (open: boolean) => void
+  taskId?: string | null
   task: ClaudeTask | null
   detail?: TaskDetail | null
   isLoadingDetail?: boolean
   detailError?: Error | null
   assignees: Array<TaskAssignee>
+  allTasks?: Array<ClaudeTask>
+  onOpenTask?: (taskId: string) => void
   onSubmit: (input: UpdateTaskInput) => Promise<void>
   isSubmitting: boolean
 }
@@ -341,14 +345,144 @@ function HistoryList({ entries }: { entries: Array<TaskHistoryEntry> }) {
   )
 }
 
+function resolveRelatedTask(
+  link: TaskRelationLink,
+  allTasks: Array<ClaudeTask>,
+): TaskRelationLink {
+  const knownTask = allTasks.find((task) => task.id === link.id)
+  if (!knownTask) return link
+  return {
+    id: link.id,
+    title: link.title ?? knownTask.title,
+    column: link.column ?? knownTask.column,
+    priority: link.priority ?? knownTask.priority,
+    assignee: link.assignee ?? knownTask.assignee,
+  }
+}
+
+function relatedTaskMeta(relation: TaskRelationLink): string {
+  const parts = [relation.id]
+  if (relation.column) parts.push(statusLabel(relation.column))
+  if (relation.assignee) parts.push(`Assigned to ${relation.assignee}`)
+  return parts.join(' · ')
+}
+
+function RelatedTaskGroup({
+  title,
+  links,
+  allTasks,
+  currentTaskId,
+  onOpenTask,
+}: {
+  title: string
+  links: Array<TaskRelationLink>
+  allTasks: Array<ClaudeTask>
+  currentTaskId: string
+  onOpenTask?: (taskId: string) => void
+}) {
+  return (
+    <div className="min-w-0 space-y-2">
+      <h4 className="text-xs font-medium text-[var(--theme-muted)]">{title}</h4>
+      {links.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-[var(--theme-border)] px-3 py-2 text-xs text-[var(--theme-muted)]">
+          None
+        </p>
+      ) : (
+        <div className="min-w-0 space-y-2">
+          {links.map((link) => {
+            const relation = resolveRelatedTask(link, allTasks)
+            const isCurrentTask = relation.id === currentTaskId
+            const canOpen = Boolean(onOpenTask) && !isCurrentTask
+            return (
+              <button
+                key={relation.id}
+                type="button"
+                disabled={!canOpen}
+                onClick={() => onOpenTask?.(relation.id)}
+                className={cn(
+                  'group flex min-w-0 w-full items-start justify-between gap-3 rounded-lg border px-3 py-2 text-left transition-colors',
+                  'border-[var(--theme-border)] bg-[var(--theme-panel)] hover:border-[var(--theme-accent)] hover:bg-[var(--theme-hover)]',
+                  isCurrentTask && 'cursor-default opacity-70',
+                )}
+              >
+                <span className="min-w-0">
+                  <span className="block break-words text-sm font-medium text-[var(--theme-text)] [overflow-wrap:anywhere]">
+                    {relation.title || relation.id}
+                  </span>
+                  <span className="mt-0.5 block break-words text-[11px] text-[var(--theme-muted)] [overflow-wrap:anywhere]">
+                    {relatedTaskMeta(relation)}
+                  </span>
+                </span>
+                {canOpen && (
+                  <span className="shrink-0 text-xs text-[var(--theme-muted)] transition-colors group-hover:text-[var(--theme-accent)]">
+                    Open
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RelatedTasksSection({
+  detail,
+  allTasks,
+  currentTaskId,
+  onOpenTask,
+}: {
+  detail: TaskDetail | null | undefined
+  allTasks: Array<ClaudeTask>
+  currentTaskId: string
+  onOpenTask?: (taskId: string) => void
+}) {
+  const parents = detail?.links.parents ?? []
+  const children = detail?.links.children ?? []
+  if (parents.length === 0 && children.length === 0) return null
+
+  return (
+    <section className="min-w-0 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+          Related tasks
+        </h3>
+        <p className="mt-1 text-xs text-[var(--theme-muted)]">
+          Parent and child tasks open in this sheet.
+        </p>
+      </div>
+      <div className="min-w-0 space-y-4">
+        <RelatedTaskGroup
+          title="Parent tasks"
+          links={parents}
+          allTasks={allTasks}
+          currentTaskId={currentTaskId}
+          onOpenTask={onOpenTask}
+        />
+        <RelatedTaskGroup
+          title="Child tasks"
+          links={children}
+          allTasks={allTasks}
+          currentTaskId={currentTaskId}
+          onOpenTask={onOpenTask}
+        />
+      </div>
+    </section>
+  )
+}
+
 export function TaskSheet({
   open,
   onOpenChange,
+  taskId = null,
   task,
   detail,
   isLoadingDetail = false,
   detailError = null,
   assignees,
+  allTasks = [],
+  onOpenTask,
   onSubmit,
   isSubmitting,
 }: Props) {
@@ -432,7 +566,9 @@ export function TaskSheet({
           <div className="min-h-0 flex-1 overflow-y-auto p-5">
             {!activeTask ? (
               <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-6 text-sm text-[var(--theme-muted)]">
-                Select a task to open its detail view.
+                {taskId
+                  ? `Loading task ${taskId}...`
+                  : 'Select a task to open its detail view.'}
               </div>
             ) : (
               <div className="min-w-0 space-y-5">
@@ -574,6 +710,13 @@ export function TaskSheet({
                     </div>
                   </form>
                 </section>
+
+                <RelatedTasksSection
+                  detail={detail}
+                  allTasks={allTasks}
+                  currentTaskId={activeTask.id}
+                  onOpenTask={onOpenTask}
+                />
 
                 <section className="min-w-0 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
                   <div className="mb-4 flex items-start justify-between gap-3">

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -2,27 +2,44 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useSearch } from '@tanstack/react-router'
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Add01Icon, CheckListIcon, RefreshIcon } from '@hugeicons/core-free-icons'
+import {
+  Add01Icon,
+  CheckListIcon,
+  RefreshIcon,
+} from '@hugeicons/core-free-icons'
 import { TaskCard } from './task-card'
 import { TaskDialog } from './task-dialog'
+import { TaskSheet } from './task-sheet'
+import type {
+  ClaudeTask,
+  CreateTaskInput,
+  TaskAssignee,
+  TaskColumn,
+  UpdateTaskInput,
+} from '@/lib/tasks-api'
 import { toast } from '@/components/ui/toast'
 import { cn } from '@/lib/utils'
 import {
-  fetchTasks,
-  fetchAssignees,
-  createTask,
-  updateTask,
-  deleteTask,
-  moveTask,
+  COLUMN_COLORS,
   COLUMN_LABELS,
   COLUMN_ORDER,
-  COLUMN_COLORS,
+  createTask,
+  deleteTask,
+  fetchAssignees,
+  fetchTaskDetail,
+  fetchTasks,
   isOverdue,
+  moveTask,
+  updateTask,
 } from '@/lib/tasks-api'
-import type { ClaudeTask, TaskColumn, CreateTaskInput, TaskAssignee } from '@/lib/tasks-api'
 
 const QUERY_KEY = ['claude', 'tasks'] as const
 const ASSIGNEES_KEY = ['claude', 'tasks', 'assignees'] as const
@@ -48,14 +65,17 @@ export function TasksScreen() {
   const queryClient = useQueryClient()
   const [showCreate, setShowCreate] = useState(false)
   const [createColumn, setCreateColumn] = useState<TaskColumn>('backlog')
-  const [editingTask, setEditingTask] = useState<ClaudeTask | null>(null)
+  const [selectedTask, setSelectedTask] = useState<ClaudeTask | null>(null)
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [dragOverColumn, setDragOverColumn] = useState<TaskColumn | null>(null)
   const [showDone, setShowDone] = useState(false)
 
   const search = useSearch({ from: '/tasks' })
-  const initialAssignee = typeof search.assignee === 'string' ? search.assignee : null
-  const [assigneeFilter, setAssigneeFilter] = useState<string | null>(initialAssignee)
+  const initialAssignee =
+    typeof search.assignee === 'string' ? search.assignee : null
+  const [assigneeFilter, setAssigneeFilter] = useState<string | null>(
+    initialAssignee,
+  )
 
   const tasksQuery = useQuery({
     queryKey: [...QUERY_KEY, showDone],
@@ -82,14 +102,34 @@ export function TasksScreen() {
   }, [assignees])
 
   const tasks = tasksQuery.data ?? []
+  const selectedTaskId = selectedTask?.id ?? null
+  const activeTask = selectedTaskId
+    ? (tasks.find((task) => task.id === selectedTaskId) ?? selectedTask)
+    : null
+
+  const taskDetailQuery = useQuery({
+    queryKey: [...QUERY_KEY, 'detail', selectedTaskId],
+    queryFn: () => fetchTaskDetail(selectedTaskId!),
+    enabled: selectedTaskId !== null,
+    staleTime: 5_000,
+  })
+
+  const taskDetailError =
+    taskDetailQuery.error instanceof Error ? taskDetailQuery.error : null
 
   const tasksByColumn = useMemo(() => {
     const map: Record<TaskColumn, Array<ClaudeTask>> = {
-      backlog: [], todo: [], in_progress: [], review: [], blocked: [], done: [],
+      backlog: [],
+      todo: [],
+      in_progress: [],
+      review: [],
+      blocked: [],
+      done: [],
+      deleted: [],
     }
     for (const t of tasks) {
       if (assigneeFilter && t.assignee !== assigneeFilter) continue
-      if (map[t.column]) map[t.column].push(t)
+      map[t.column].push(t)
     }
     for (const col of COLUMN_ORDER) {
       map[col].sort((a, b) => a.position - b.position)
@@ -99,10 +139,12 @@ export function TasksScreen() {
 
   const stats = useMemo(() => {
     const total = tasks.length
-    const running = tasks.filter(t => t.column === 'in_progress').length
-    const blocked = tasks.filter(t => t.column === 'blocked').length
-    const done = tasks.filter(t => t.column === 'done').length
-    const overdue = tasks.filter(t => isOverdue(t) && t.column !== 'done').length
+    const running = tasks.filter((t) => t.column === 'in_progress').length
+    const blocked = tasks.filter((t) => t.column === 'blocked').length
+    const done = tasks.filter((t) => t.column === 'done').length
+    const overdue = tasks.filter(
+      (t) => isOverdue(t) && t.column !== 'done',
+    ).length
     const completion = total > 0 ? Math.round((done / total) * 100) : 0
     return { total, running, blocked, done, overdue, completion }
   }, [tasks])
@@ -113,26 +155,54 @@ export function TasksScreen() {
 
   const createMutation = useMutation({
     mutationFn: createTask,
-    onSuccess: () => { invalidate(); toast('Task created'); setShowCreate(false) },
-    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to create task', { type: 'error' }),
+    onSuccess: () => {
+      invalidate()
+      toast('Task created')
+      setShowCreate(false)
+    },
+    onError: (e) =>
+      toast(e instanceof Error ? e.message : 'Failed to create task', {
+        type: 'error',
+      }),
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: CreateTaskInput }) => updateTask(id, input),
-    onSuccess: () => { invalidate(); toast('Task updated'); setEditingTask(null) },
-    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to update task', { type: 'error' }),
+    mutationFn: ({ id, input }: { id: string; input: UpdateTaskInput }) =>
+      updateTask(id, input),
+    onSuccess: (task) => {
+      setSelectedTask(task)
+      invalidate()
+      void queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEY, 'detail', task.id],
+      })
+      toast('Task updated')
+    },
+    onError: (e) =>
+      toast(e instanceof Error ? e.message : 'Failed to update task', {
+        type: 'error',
+      }),
   })
 
   const deleteMutation = useMutation({
     mutationFn: deleteTask,
-    onSuccess: () => { invalidate(); toast('Task deleted') },
-    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to delete task', { type: 'error' }),
+    onSuccess: () => {
+      invalidate()
+      toast('Task deleted')
+    },
+    onError: (e) =>
+      toast(e instanceof Error ? e.message : 'Failed to delete task', {
+        type: 'error',
+      }),
   })
 
   const moveMutation = useMutation({
-    mutationFn: ({ id, column }: { id: string; column: TaskColumn }) => moveTask(id, column, 'user'),
+    mutationFn: ({ id, column }: { id: string; column: TaskColumn }) =>
+      moveTask(id, column, 'user'),
     onSuccess: () => invalidate(),
-    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to move task', { type: 'error' }),
+    onError: (e) =>
+      toast(e instanceof Error ? e.message : 'Failed to move task', {
+        type: 'error',
+      }),
   })
 
   function handleDragStart(e: React.DragEvent, taskId: string) {
@@ -148,7 +218,7 @@ export function TasksScreen() {
   function handleDrop(e: React.DragEvent, targetColumn: TaskColumn) {
     e.preventDefault()
     const taskId = e.dataTransfer.getData('text/plain')
-    const task = tasks.find(t => t.id === taskId)
+    const task = tasks.find((t) => t.id === taskId)
     if (!task || task.column === targetColumn) {
       setDraggingId(null)
       setDragOverColumn(null)
@@ -172,220 +242,274 @@ export function TasksScreen() {
     setDragOverColumn(null)
   }
 
-  const visibleColumns = showDone ? COLUMN_ORDER : COLUMN_ORDER.filter(c => c !== 'done')
+  const visibleColumns = showDone
+    ? COLUMN_ORDER
+    : COLUMN_ORDER.filter((c) => c !== 'done')
   const colMaxWidth = Math.floor(1200 / visibleColumns.length)
 
   return (
     <div className="min-h-full overflow-y-auto bg-surface text-ink">
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
-      {/* Header */}
-      <header className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
-        <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <h1 className="text-2xl font-medium text-ink">Tasks</h1>
-          {assigneeFilter && (
-            <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
-              <span>Filtered by: <span className="capitalize" style={{ color: '#f59e0b' }}>{assigneeFilter}</span></span>
+        {/* Header */}
+        <header className="rounded-2xl border border-primary-200 bg-primary-50/85 p-4 backdrop-blur-xl">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              <h1 className="text-2xl font-medium text-ink">Tasks</h1>
+              {assigneeFilter && (
+                <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
+                  <span>
+                    Filtered by:{' '}
+                    <span className="capitalize" style={{ color: '#f59e0b' }}>
+                      {assigneeFilter}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setAssigneeFilter(null)}
+                    className="text-[var(--theme-muted)] hover:text-[var(--theme-text)] transition-colors"
+                  >
+                    ✕ Clear
+                  </button>
+                </div>
+              )}
+              {/* Stats */}
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)] flex-wrap">
+                <span>{stats.total} total</span>
+                <span className="hidden sm:inline">·</span>
+                <span className="hidden sm:inline">
+                  {stats.running} running
+                </span>
+                {stats.blocked > 0 && (
+                  <>
+                    <span className="hidden sm:inline">·</span>
+                    <span className="text-red-400">
+                      {stats.blocked} blocked
+                    </span>
+                  </>
+                )}
+                {stats.overdue > 0 && (
+                  <>
+                    <span>·</span>
+                    <span className="text-red-400">
+                      {stats.overdue} overdue
+                    </span>
+                  </>
+                )}
+                <span className="hidden sm:inline">·</span>
+                <span className="hidden sm:inline">
+                  {stats.completion}% done
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 shrink-0">
               <button
-                type="button"
-                onClick={() => setAssigneeFilter(null)}
-                className="text-[var(--theme-muted)] hover:text-[var(--theme-text)] transition-colors"
+                onClick={() => setShowDone((v) => !v)}
+                className={cn(
+                  'text-xs px-2.5 py-1 rounded-lg border transition-colors',
+                  showDone
+                    ? 'border-[var(--theme-accent)] text-[var(--theme-accent)] bg-[var(--theme-hover)]'
+                    : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-[var(--theme-text)] hover:border-[var(--theme-accent)]',
+                )}
               >
-                ✕ Clear
+                {showDone ? 'Hide Done' : 'Show Done'}
+              </button>
+              <button
+                onClick={invalidate}
+                className="rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-hover)]"
+                title="Refresh"
+              >
+                <HugeiconsIcon
+                  icon={RefreshIcon}
+                  size={16}
+                  className="text-[var(--theme-muted)]"
+                />
+              </button>
+              <button
+                onClick={() => {
+                  setCreateColumn('backlog')
+                  setShowCreate(true)
+                }}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                style={{ background: 'var(--theme-accent)' }}
+              >
+                <HugeiconsIcon icon={Add01Icon} size={14} />
+                New Task
               </button>
             </div>
-          )}
-          {/* Stats */}
-          <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)] flex-wrap">
-            <span>{stats.total} total</span>
-            <span className="hidden sm:inline">·</span>
-            <span className="hidden sm:inline">{stats.running} running</span>
-            {stats.blocked > 0 && (
-              <>
-                <span className="hidden sm:inline">·</span>
-                <span className="text-red-400">{stats.blocked} blocked</span>
-              </>
-            )}
-            {stats.overdue > 0 && (
-              <>
-                <span>·</span>
-                <span className="text-red-400">{stats.overdue} overdue</span>
-              </>
-            )}
-            <span className="hidden sm:inline">·</span>
-            <span className="hidden sm:inline">{stats.completion}% done</span>
           </div>
-        </div>
+          <p className="mt-3 text-xs text-[var(--theme-muted)]">
+            {TASKS_BOARD_HELP_TEXT}
+          </p>
+        </header>
 
-        <div className="flex items-center gap-2 shrink-0">
-          <button
-            onClick={() => setShowDone(v => !v)}
-            className={cn(
-              'text-xs px-2.5 py-1 rounded-lg border transition-colors',
-              showDone
-                ? 'border-[var(--theme-accent)] text-[var(--theme-accent)] bg-[var(--theme-hover)]'
-                : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-[var(--theme-text)] hover:border-[var(--theme-accent)]',
-            )}
-          >
-            {showDone ? 'Hide Done' : 'Show Done'}
-          </button>
-          <button
-            onClick={invalidate}
-            className="rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-hover)]"
-            title="Refresh"
-          >
-            <HugeiconsIcon icon={RefreshIcon} size={16} className="text-[var(--theme-muted)]" />
-          </button>
-          <button
-            onClick={() => { setCreateColumn('backlog'); setShowCreate(true) }}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-            style={{ background: 'var(--theme-accent)' }}
-          >
-            <HugeiconsIcon icon={Add01Icon} size={14} />
-            New Task
-          </button>
-        </div>
-      </div>
-        <p className="mt-3 text-xs text-[var(--theme-muted)]">
-          {TASKS_BOARD_HELP_TEXT}
-        </p>
-      </header>
+        {/* Board */}
+        <div
+          className="mx-auto flex w-full max-w-[1200px] flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
+          style={{ boxShadow: 'inset 0 8px 24px rgba(0,0,0,0.2)' }}
+        >
+          {visibleColumns.map((col) => {
+            const colTasks = tasksByColumn[col]
+            const colColor = COLUMN_COLORS[col]
+            const isDragOver = dragOverColumn === col
 
-      {/* Board */}
-      <div
-        className="mx-auto flex w-full max-w-[1200px] flex-1 gap-3 overflow-x-auto overflow-y-hidden p-4 min-h-0"
-        style={{ boxShadow: 'inset 0 8px 24px rgba(0,0,0,0.2)' }}
-      >
-        {visibleColumns.map((col) => {
-          const colTasks = tasksByColumn[col]
-          const colColor = COLUMN_COLORS[col]
-          const isDragOver = dragOverColumn === col
-
-          return (
-            <div
-              key={col}
-              className={cn(
-                'flex flex-col rounded-xl border min-w-[180px] w-full shrink-0 flex-1',
-                'bg-[var(--theme-card)] border-[var(--theme-border)]',
-                'transition-colors shadow-[0_2px_12px_rgba(0,0,0,0.25)]',
-                isDragOver && 'border-[var(--theme-accent)] bg-[var(--theme-hover)]',
-              )}
-              style={{ maxWidth: colMaxWidth }}
-              onDragOver={e => handleDragOver(e, col)}
-              onDrop={e => handleDrop(e, col)}
-              onDragLeave={() => setDragOverColumn(null)}
-            >
-              {/* Column header */}
+            return (
               <div
-                className="flex items-center justify-between px-3 py-2.5 border-b border-[var(--theme-border)] rounded-t-xl"
-                style={{ borderTopWidth: 2, borderTopColor: colColor, borderTopStyle: 'solid' }}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full shrink-0" style={{ background: colColor }} />
-                  <span className="text-xs font-semibold text-[var(--theme-text)]">
-                    {COLUMN_LABELS[col]}
-                  </span>
-                  <span className="text-xs text-[var(--theme-muted)]">
-                    ({tasksQuery.isFetching && tasksQuery.data === undefined ? '…' : colTasks.length})
-                  </span>
-                </div>
-                <button
-                  onClick={() => { setCreateColumn(col); setShowCreate(true) }}
-                  className="rounded p-0.5 hover:bg-[var(--theme-hover)] transition-colors"
-                  title={`Add to ${COLUMN_LABELS[col]}`}
-                >
-                  <HugeiconsIcon icon={Add01Icon} size={14} className="text-[var(--theme-muted)]" />
-                </button>
-              </div>
-
-              {/* Cards */}
-              <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto">
-                {tasksQuery.isError ? (
-                  <motion.div
-                    key="error"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    className="flex flex-col items-center justify-center py-8 gap-2 text-red-400"
-                  >
-                    <p className="text-xs font-medium">Failed to load tasks</p>
-                    <button
-                      onClick={() => tasksQuery.refetch()}
-                      className="text-xs text-[var(--theme-accent)] hover:underline"
-                    >
-                      Retry
-                    </button>
-                  </motion.div>
-                ) : tasksQuery.isLoading ? (
-                  <>
-                    <SkeletonCard />
-                    <SkeletonCard />
-                    <SkeletonCard />
-                  </>
-                ) : (
-                  <AnimatePresence initial={false}>
-                    {colTasks.length === 0 ? (
-                      <motion.div
-                        key="empty"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        className="flex flex-col items-center justify-center py-8 gap-2 text-[var(--theme-muted)] opacity-60"
-                      >
-                        <HugeiconsIcon icon={CheckListIcon} size={22} />
-                        <p className="text-xs font-medium">No tasks</p>
-                        <p className="text-[10px]">Drop here or click + to add</p>
-                      </motion.div>
-                    ) : (
-                      colTasks.map(task => (
-                        <motion.div
-                          key={task.id}
-                          layout
-                          initial={{ opacity: 0, y: 6 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={{ opacity: 0, y: -6 }}
-                          onDragEnd={handleDragEnd}
-                        >
-                          <TaskCard
-                            task={task}
-                            assigneeLabels={assigneeLabels}
-                            isDragging={draggingId === task.id}
-                            onDragStart={e => handleDragStart(e, task.id)}
-                            onClick={() => setEditingTask(task)}
-                          />
-                        </motion.div>
-                      ))
-                    )}
-                  </AnimatePresence>
+                key={col}
+                className={cn(
+                  'flex flex-col rounded-xl border min-w-[180px] w-full shrink-0 flex-1',
+                  'bg-[var(--theme-card)] border-[var(--theme-border)]',
+                  'transition-colors shadow-[0_2px_12px_rgba(0,0,0,0.25)]',
+                  isDragOver &&
+                    'border-[var(--theme-accent)] bg-[var(--theme-hover)]',
                 )}
+                style={{ maxWidth: colMaxWidth }}
+                onDragOver={(e) => handleDragOver(e, col)}
+                onDrop={(e) => handleDrop(e, col)}
+                onDragLeave={() => setDragOverColumn(null)}
+              >
+                {/* Column header */}
+                <div
+                  className="flex items-center justify-between px-3 py-2.5 border-b border-[var(--theme-border)] rounded-t-xl"
+                  style={{
+                    borderTopWidth: 2,
+                    borderTopColor: colColor,
+                    borderTopStyle: 'solid',
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="w-2 h-2 rounded-full shrink-0"
+                      style={{ background: colColor }}
+                    />
+                    <span className="text-xs font-semibold text-[var(--theme-text)]">
+                      {COLUMN_LABELS[col]}
+                    </span>
+                    <span className="text-xs text-[var(--theme-muted)]">
+                      (
+                      {tasksQuery.isFetching && tasksQuery.data === undefined
+                        ? '…'
+                        : colTasks.length}
+                      )
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => {
+                      setCreateColumn(col)
+                      setShowCreate(true)
+                    }}
+                    className="rounded p-0.5 hover:bg-[var(--theme-hover)] transition-colors"
+                    title={`Add to ${COLUMN_LABELS[col]}`}
+                  >
+                    <HugeiconsIcon
+                      icon={Add01Icon}
+                      size={14}
+                      className="text-[var(--theme-muted)]"
+                    />
+                  </button>
+                </div>
+
+                {/* Cards */}
+                <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto">
+                  {tasksQuery.isError ? (
+                    <motion.div
+                      key="error"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      className="flex flex-col items-center justify-center py-8 gap-2 text-red-400"
+                    >
+                      <p className="text-xs font-medium">
+                        Failed to load tasks
+                      </p>
+                      <button
+                        onClick={() => tasksQuery.refetch()}
+                        className="text-xs text-[var(--theme-accent)] hover:underline"
+                      >
+                        Retry
+                      </button>
+                    </motion.div>
+                  ) : tasksQuery.isLoading ? (
+                    <>
+                      <SkeletonCard />
+                      <SkeletonCard />
+                      <SkeletonCard />
+                    </>
+                  ) : (
+                    <AnimatePresence initial={false}>
+                      {colTasks.length === 0 ? (
+                        <motion.div
+                          key="empty"
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          exit={{ opacity: 0 }}
+                          className="flex flex-col items-center justify-center py-8 gap-2 text-[var(--theme-muted)] opacity-60"
+                        >
+                          <HugeiconsIcon icon={CheckListIcon} size={22} />
+                          <p className="text-xs font-medium">No tasks</p>
+                          <p className="text-[10px]">
+                            Drop here or click + to add
+                          </p>
+                        </motion.div>
+                      ) : (
+                        colTasks.map((task) => (
+                          <motion.div
+                            key={task.id}
+                            layout
+                            initial={{ opacity: 0, y: 6 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -6 }}
+                            onDragEnd={handleDragEnd}
+                          >
+                            <TaskCard
+                              task={task}
+                              assigneeLabels={assigneeLabels}
+                              isDragging={draggingId === task.id}
+                              onDragStart={(e) => handleDragStart(e, task.id)}
+                              onClick={() => setSelectedTask(task)}
+                            />
+                          </motion.div>
+                        ))
+                      )}
+                    </AnimatePresence>
+                  )}
+                </div>
               </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
+
+        {/* Create dialog */}
+        <TaskDialog
+          open={showCreate}
+          onOpenChange={setShowCreate}
+          defaultColumn={createColumn}
+          assignees={assignees}
+          isSubmitting={createMutation.isPending}
+          onSubmit={async (input) => {
+            await createMutation.mutateAsync(input)
+          }}
+        />
+
+        {/* Task detail sheet */}
+        <TaskSheet
+          open={selectedTask !== null}
+          onOpenChange={(open) => {
+            if (!open) setSelectedTask(null)
+          }}
+          task={activeTask}
+          detail={taskDetailQuery.data ?? null}
+          isLoadingDetail={
+            taskDetailQuery.isFetching && taskDetailQuery.data === undefined
+          }
+          detailError={taskDetailError}
+          assignees={assignees}
+          isSubmitting={updateMutation.isPending}
+          onSubmit={async (input) => {
+            if (!activeTask) return
+            await updateMutation.mutateAsync({ id: activeTask.id, input })
+          }}
+        />
       </div>
-
-      {/* Create dialog */}
-      <TaskDialog
-        open={showCreate}
-        onOpenChange={setShowCreate}
-        defaultColumn={createColumn}
-        assignees={assignees}
-        isSubmitting={createMutation.isPending}
-        onSubmit={async (input) => { await createMutation.mutateAsync(input) }}
-      />
-
-      {/* Edit dialog */}
-      <TaskDialog
-        open={editingTask !== null}
-        onOpenChange={(open) => { if (!open) setEditingTask(null) }}
-        task={editingTask}
-        assignees={assignees}
-        isSubmitting={updateMutation.isPending}
-        onSubmit={async (input) => {
-          if (!editingTask) return
-          await updateMutation.mutateAsync({ id: editingTask.id, input })
-        }}
-      />
-    </div>
     </div>
   )
 }

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -65,6 +65,7 @@ export function TasksScreen() {
   const queryClient = useQueryClient()
   const [showCreate, setShowCreate] = useState(false)
   const [createColumn, setCreateColumn] = useState<TaskColumn>('backlog')
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [selectedTask, setSelectedTask] = useState<ClaudeTask | null>(null)
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [dragOverColumn, setDragOverColumn] = useState<TaskColumn | null>(null)
@@ -102,9 +103,8 @@ export function TasksScreen() {
   }, [assignees])
 
   const tasks = tasksQuery.data ?? []
-  const selectedTaskId = selectedTask?.id ?? null
-  const activeTask = selectedTaskId
-    ? (tasks.find((task) => task.id === selectedTaskId) ?? selectedTask)
+  const selectedListTask = selectedTaskId
+    ? (tasks.find((task) => task.id === selectedTaskId) ?? null)
     : null
 
   const taskDetailQuery = useQuery({
@@ -116,6 +116,11 @@ export function TasksScreen() {
 
   const taskDetailError =
     taskDetailQuery.error instanceof Error ? taskDetailQuery.error : null
+  const selectedSeedTask =
+    selectedTask?.id === selectedTaskId ? selectedTask : null
+  const activeTask = selectedTaskId
+    ? (selectedListTask ?? taskDetailQuery.data?.task ?? selectedSeedTask)
+    : null
 
   const tasksByColumn = useMemo(() => {
     const map: Record<TaskColumn, Array<ClaudeTask>> = {
@@ -153,6 +158,24 @@ export function TasksScreen() {
     void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
   }, [queryClient])
 
+  const openTaskSheet = useCallback(
+    (taskOrId: ClaudeTask | string) => {
+      const taskId = typeof taskOrId === 'string' ? taskOrId : taskOrId.id
+      const knownTask =
+        typeof taskOrId === 'string'
+          ? (tasks.find((task) => task.id === taskId) ?? null)
+          : taskOrId
+      setSelectedTaskId(taskId)
+      setSelectedTask(knownTask)
+    },
+    [tasks],
+  )
+
+  const closeTaskSheet = useCallback(() => {
+    setSelectedTaskId(null)
+    setSelectedTask(null)
+  }, [])
+
   const createMutation = useMutation({
     mutationFn: createTask,
     onSuccess: () => {
@@ -170,6 +193,7 @@ export function TasksScreen() {
     mutationFn: ({ id, input }: { id: string; input: UpdateTaskInput }) =>
       updateTask(id, input),
     onSuccess: (task) => {
+      setSelectedTaskId(task.id)
       setSelectedTask(task)
       invalidate()
       void queryClient.invalidateQueries({
@@ -465,7 +489,7 @@ export function TasksScreen() {
                               assigneeLabels={assigneeLabels}
                               isDragging={draggingId === task.id}
                               onDragStart={(e) => handleDragStart(e, task.id)}
-                              onClick={() => setSelectedTask(task)}
+                              onClick={() => openTaskSheet(task)}
                             />
                           </motion.div>
                         ))
@@ -492,10 +516,11 @@ export function TasksScreen() {
 
         {/* Task detail sheet */}
         <TaskSheet
-          open={selectedTask !== null}
+          open={selectedTaskId !== null}
           onOpenChange={(open) => {
-            if (!open) setSelectedTask(null)
+            if (!open) closeTaskSheet()
           }}
+          taskId={selectedTaskId}
           task={activeTask}
           detail={taskDetailQuery.data ?? null}
           isLoadingDetail={
@@ -503,6 +528,8 @@ export function TasksScreen() {
           }
           detailError={taskDetailError}
           assignees={assignees}
+          allTasks={tasks}
+          onOpenTask={openTaskSheet}
           isSubmitting={updateMutation.isPending}
           onSubmit={async (input) => {
             if (!activeTask) return

--- a/src/screens/tasks/tasks-ux.test.ts
+++ b/src/screens/tasks/tasks-ux.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import { formatTaskAssigneeLabel } from './task-card'
+import { buildTaskHistoryEntries } from './task-sheet'
 import { TASKS_BOARD_HELP_TEXT } from './tasks-screen'
+import type { ClaudeTask, TaskDetail } from '@/lib/tasks-api'
 
 describe('tasks UX copy', () => {
   it('exposes helper copy that explains drag and assignment behavior', () => {
@@ -15,5 +17,70 @@ describe('tasks UX copy', () => {
       'Assignee: Jarvis',
     )
     expect(formatTaskAssigneeLabel(null, {})).toBe('Assignee: Unassigned')
+  })
+
+  it('builds card history with comments, events, and runs newest first', () => {
+    const task: ClaudeTask = {
+      id: 'task-1',
+      title: 'History task',
+      description: 'Check timeline ordering',
+      column: 'todo',
+      priority: 'medium',
+      assignee: null,
+      tags: [],
+      due_date: null,
+      position: 1,
+      created_by: 'user',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    }
+    const detail: TaskDetail = {
+      task,
+      comments: [
+        {
+          id: 'comment-1',
+          task_id: 'task-1',
+          author: 'aurora',
+          body: 'middle note',
+          created_at: '2026-01-01T00:05:00.000Z',
+        },
+      ],
+      events: [
+        {
+          id: 'event-1',
+          task_id: 'task-1',
+          kind: 'created',
+          created_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'event-2',
+          task_id: 'task-1',
+          kind: 'status',
+          payload: { status: 'review' },
+          created_at: '2026-01-01T00:10:00.000Z',
+        },
+      ],
+      links: { parents: [], children: [] },
+      runs: [
+        {
+          id: 'run-1',
+          task_id: 'task-1',
+          status: 'completed',
+          started_at: '2026-01-01T00:02:00.000Z',
+          ended_at: '2026-01-01T00:20:00.000Z',
+          outcome: 'completed',
+          summary: 'done',
+        },
+      ],
+    }
+
+    expect(
+      buildTaskHistoryEntries(detail, task).map((entry) => entry.id),
+    ).toEqual([
+      'run:run-1',
+      'event:event-2',
+      'comment:comment-1',
+      'event:event-1',
+    ])
   })
 })

--- a/src/server/claude-tasks-backend.test.ts
+++ b/src/server/claude-tasks-backend.test.ts
@@ -9,22 +9,38 @@ async function loadBackend(options?: {
   cards?: Array<Record<string, unknown>>
   updatedCard?: Record<string, unknown> | null
 }) {
-  const listKanbanCards = vi.fn(async () => options?.cards ?? [])
-  const createKanbanCard = vi.fn(async (input) => ({
-    id: 'card-created',
-    title: input.title,
-    spec: input.spec ?? '',
-    acceptanceCriteria: [],
-    assignedWorker: input.assignedWorker ?? null,
-    reviewer: null,
-    status: input.status ?? 'backlog',
-    missionId: null,
-    reportPath: null,
-    createdBy: input.createdBy ?? 'user',
-    createdAt: 1_700_000_000_000,
-    updatedAt: 1_700_000_000_000,
-  }))
-  const updateKanbanCard = vi.fn(async (_taskId, _updates) => options?.updatedCard ?? null)
+  const listKanbanCards = vi.fn(() => Promise.resolve(options?.cards ?? []))
+  const createKanbanCard = vi.fn((input) =>
+    Promise.resolve({
+      id: 'card-created',
+      title: input.title,
+      spec: input.spec ?? '',
+      acceptanceCriteria: [],
+      assignedWorker: input.assignedWorker ?? null,
+      reviewer: null,
+      status: input.status ?? 'backlog',
+      missionId: null,
+      reportPath: null,
+      createdBy: input.createdBy ?? 'user',
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    }),
+  )
+  const updateKanbanCard = vi.fn((_taskId, _updates) =>
+    Promise.resolve(options?.updatedCard ?? null),
+  )
+  const getKanbanCardDetail = vi.fn((taskId: string) => {
+    const card = (options?.cards ?? []).find((entry) => entry.id === taskId)
+    return card
+      ? {
+          card,
+          comments: [],
+          events: [],
+          links: { parents: [], children: [] },
+          runs: [],
+        }
+      : null
+  })
   const getKanbanBackendMeta = vi.fn(() => ({
     id: 'hermes-proxy',
     label: 'Hermes Dashboard kanban',
@@ -36,11 +52,18 @@ async function loadBackend(options?: {
     listKanbanCards,
     createKanbanCard,
     updateKanbanCard,
+    getKanbanCardDetail,
     getKanbanBackendMeta,
   }))
 
   const mod = await import('./claude-tasks-backend')
-  return { mod, listKanbanCards, createKanbanCard, updateKanbanCard, getKanbanBackendMeta }
+  return {
+    mod,
+    listKanbanCards,
+    createKanbanCard,
+    updateKanbanCard,
+    getKanbanBackendMeta,
+  }
 }
 
 describe('claude-tasks-backend', () => {
@@ -87,14 +110,20 @@ describe('claude-tasks-backend', () => {
       created_by: 'user',
     })
 
-    expect(createKanbanCard).toHaveBeenCalledWith(expect.objectContaining({
-      title: 'Wire workspace board to shared kanban',
-      spec: 'Proxy through Agent API',
-      assignedWorker: 'swarm3',
-      status: 'ready',
-      createdBy: 'user',
-    }))
-    expect(task).toMatchObject({ id: 'card-created', column: 'todo', assignee: 'swarm3' })
+    expect(createKanbanCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Wire workspace board to shared kanban',
+        spec: 'Proxy through Agent API',
+        assignedWorker: 'swarm3',
+        status: 'ready',
+        createdBy: 'user',
+      }),
+    )
+    expect(task).toMatchObject({
+      id: 'card-created',
+      column: 'todo',
+      assignee: 'swarm3',
+    })
   })
 
   it('moves running and blocked cards through kanban status updates', async () => {
@@ -116,7 +145,10 @@ describe('claude-tasks-backend', () => {
     })
 
     const task = await mod.moveClaudeTask('card-2', 'blocked')
-    expect(updateKanbanCard).toHaveBeenCalledWith('card-2', expect.objectContaining({ status: 'blocked' }))
+    expect(updateKanbanCard).toHaveBeenCalledWith(
+      'card-2',
+      expect.objectContaining({ status: 'blocked' }),
+    )
     expect(task).toMatchObject({ id: 'card-2', column: 'blocked' })
   })
 })

--- a/src/server/claude-tasks-backend.test.ts
+++ b/src/server/claude-tasks-backend.test.ts
@@ -8,6 +8,7 @@ afterEach(() => {
 async function loadBackend(options?: {
   cards?: Array<Record<string, unknown>>
   updatedCard?: Record<string, unknown> | null
+  detailLinks?: { parents: Array<string>; children: Array<string> }
 }) {
   const listKanbanCards = vi.fn(() => Promise.resolve(options?.cards ?? []))
   const createKanbanCard = vi.fn((input) =>
@@ -36,7 +37,7 @@ async function loadBackend(options?: {
           card,
           comments: [],
           events: [],
-          links: { parents: [], children: [] },
+          links: options?.detailLinks ?? { parents: [], children: [] },
           runs: [],
         }
       : null
@@ -150,5 +151,72 @@ describe('claude-tasks-backend', () => {
       expect.objectContaining({ status: 'blocked' }),
     )
     expect(task).toMatchObject({ id: 'card-2', column: 'blocked' })
+  })
+
+  it('hydrates parent and child links with related task labels for the sheet', async () => {
+    const baseCard = {
+      spec: '',
+      acceptanceCriteria: [],
+      assignedWorker: null,
+      reviewer: null,
+      missionId: null,
+      reportPath: null,
+      createdBy: 'aurora',
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_010_000,
+    }
+    const { mod } = await loadBackend({
+      detailLinks: {
+        parents: ['parent-1'],
+        children: ['child-1', 'missing-child'],
+      },
+      cards: [
+        {
+          ...baseCard,
+          id: 'task-1',
+          title: 'Main task',
+          status: 'ready',
+          priority: 0,
+        },
+        {
+          ...baseCard,
+          id: 'parent-1',
+          title: 'Parent task',
+          status: 'blocked',
+          priority: 1,
+          assignedWorker: 'swarm1',
+        },
+        {
+          ...baseCard,
+          id: 'child-1',
+          title: 'Child task',
+          status: 'done',
+          priority: -1,
+          assignedWorker: 'swarm2',
+        },
+      ],
+    })
+
+    const detail = await mod.getClaudeTaskDetail('task-1')
+
+    expect(detail?.links.parents).toEqual([
+      {
+        id: 'parent-1',
+        title: 'Parent task',
+        column: 'blocked',
+        priority: 'high',
+        assignee: 'swarm1',
+      },
+    ])
+    expect(detail?.links.children).toEqual([
+      {
+        id: 'child-1',
+        title: 'Child task',
+        column: 'done',
+        priority: 'low',
+        assignee: 'swarm2',
+      },
+      { id: 'missing-child' },
+    ])
   })
 })

--- a/src/server/claude-tasks-backend.ts
+++ b/src/server/claude-tasks-backend.ts
@@ -1,12 +1,25 @@
 import {
   createKanbanCard,
-  listKanbanCards,
-  type KanbanBackendMeta,
   getKanbanBackendMeta,
+  getKanbanCardDetail,
+  listKanbanCards,
   updateKanbanCard,
 } from './kanban-backend'
+import type {
+  KanbanBackendMeta,
+  KanbanCardDetail,
+  KanbanTaskComment,
+  KanbanTaskEvent,
+  KanbanTaskRun,
+} from './kanban-backend'
 
-export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done'
+export type TaskColumn =
+  | 'backlog'
+  | 'todo'
+  | 'in_progress'
+  | 'review'
+  | 'blocked'
+  | 'done'
 export type TaskPriority = 'high' | 'medium' | 'low'
 
 export type ClaudeTaskRecord = {
@@ -16,12 +29,20 @@ export type ClaudeTaskRecord = {
   column: TaskColumn
   priority: TaskPriority
   assignee: string | null
-  tags: string[]
+  tags: Array<string>
   due_date: string | null
   position: number
   created_by: string
   created_at: string
   updated_at: string
+}
+
+export type ClaudeTaskDetail = {
+  task: ClaudeTaskRecord
+  comments: Array<KanbanTaskComment>
+  events: Array<KanbanTaskEvent>
+  links: { parents: Array<string>; children: Array<string> }
+  runs: Array<KanbanTaskRun>
 }
 
 type TaskFilters = {
@@ -37,7 +58,7 @@ type CreateTaskInput = {
   column?: TaskColumn
   priority?: TaskPriority
   assignee?: string | null
-  tags?: string[]
+  tags?: Array<string>
   due_date?: string | null
   created_by?: string
 }
@@ -46,6 +67,28 @@ type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'created_by'>>
 
 function toIso(timestamp: number): string {
   return new Date(timestamp).toISOString()
+}
+
+function mapTaskPriorityToKanbanPriority(
+  priority: TaskPriority | undefined,
+): number {
+  switch (priority) {
+    case 'high':
+      return 1
+    case 'low':
+      return -1
+    case 'medium':
+    default:
+      return 0
+  }
+}
+
+function mapKanbanPriorityToTaskPriority(priority: unknown): TaskPriority {
+  const numeric =
+    typeof priority === 'number' && Number.isFinite(priority) ? priority : 0
+  if (numeric > 0) return 'high'
+  if (numeric < 0) return 'low'
+  return 'medium'
 }
 
 function mapKanbanStatusToTaskColumn(status: string): TaskColumn {
@@ -66,7 +109,9 @@ function mapKanbanStatusToTaskColumn(status: string): TaskColumn {
   }
 }
 
-function mapTaskColumnToKanbanStatus(column: TaskColumn): 'backlog' | 'ready' | 'running' | 'review' | 'blocked' | 'done' {
+function mapTaskColumnToKanbanStatus(
+  column: TaskColumn,
+): 'backlog' | 'ready' | 'running' | 'review' | 'blocked' | 'done' {
   switch (column) {
     case 'todo':
       return 'ready'
@@ -90,6 +135,7 @@ function mapCardToTask(card: {
   spec: string
   assignedWorker: string | null
   status: string
+  priority?: number | null
   createdBy: string
   createdAt: number
   updatedAt: number
@@ -99,7 +145,7 @@ function mapCardToTask(card: {
     title: card.title,
     description: card.spec,
     column: mapKanbanStatusToTaskColumn(card.status),
-    priority: 'medium',
+    priority: mapKanbanPriorityToTaskPriority(card.priority),
     assignee: card.assignedWorker,
     tags: [],
     due_date: null,
@@ -110,11 +156,23 @@ function mapCardToTask(card: {
   }
 }
 
+function mapCardDetailToTaskDetail(detail: KanbanCardDetail): ClaudeTaskDetail {
+  return {
+    task: mapCardToTask(detail.card),
+    comments: detail.comments,
+    events: detail.events,
+    links: detail.links,
+    runs: detail.runs,
+  }
+}
+
 export function getClaudeTasksBackendMeta(): KanbanBackendMeta {
   return getKanbanBackendMeta()
 }
 
-export async function listClaudeTasks(filters: TaskFilters = {}): Promise<ClaudeTaskRecord[]> {
+export async function listClaudeTasks(
+  filters: TaskFilters = {},
+): Promise<Array<ClaudeTaskRecord>> {
   let tasks = (await listKanbanCards()).map(mapCardToTask)
   if (!filters.includeDone) {
     tasks = tasks.filter((task) => task.column !== 'done')
@@ -128,39 +186,65 @@ export async function listClaudeTasks(filters: TaskFilters = {}): Promise<Claude
   if (filters.priority) {
     tasks = tasks.filter((task) => task.priority === filters.priority)
   }
-  return tasks.sort((a, b) => b.position - a.position || a.title.localeCompare(b.title))
+  return tasks.sort(
+    (a, b) => b.position - a.position || a.title.localeCompare(b.title),
+  )
 }
 
-export async function getClaudeTask(taskId: string): Promise<ClaudeTaskRecord | null> {
+export async function getClaudeTask(
+  taskId: string,
+): Promise<ClaudeTaskRecord | null> {
   const tasks = await listKanbanCards()
   const card = tasks.find((entry) => entry.id === taskId)
   return card ? mapCardToTask(card) : null
 }
 
-export async function createClaudeTask(input: CreateTaskInput): Promise<ClaudeTaskRecord> {
+export async function getClaudeTaskDetail(
+  taskId: string,
+): Promise<ClaudeTaskDetail | null> {
+  const detail = await getKanbanCardDetail(taskId)
+  return detail ? mapCardDetailToTaskDetail(detail) : null
+}
+
+export async function createClaudeTask(
+  input: CreateTaskInput,
+): Promise<ClaudeTaskRecord> {
   const card = await createKanbanCard({
     title: input.title,
     spec: input.description ?? '',
     assignedWorker: input.assignee ?? null,
     status: mapTaskColumnToKanbanStatus(input.column ?? 'backlog'),
+    priority: mapTaskPriorityToKanbanPriority(input.priority),
     createdBy: input.created_by ?? 'user',
   })
   return mapCardToTask(card)
 }
 
-export async function updateClaudeTask(taskId: string, updates: UpdateTaskInput): Promise<ClaudeTaskRecord | null> {
+export async function updateClaudeTask(
+  taskId: string,
+  updates: UpdateTaskInput,
+): Promise<ClaudeTaskRecord | null> {
   const card = await updateKanbanCard(taskId, {
     title: typeof updates.title === 'string' ? updates.title : undefined,
-    spec: typeof updates.description === 'string' ? updates.description : undefined,
+    spec:
+      typeof updates.description === 'string' ? updates.description : undefined,
     assignedWorker:
       updates.assignee === null || typeof updates.assignee === 'string'
         ? updates.assignee
         : undefined,
-    status: updates.column ? mapTaskColumnToKanbanStatus(updates.column) : undefined,
+    priority: updates.priority
+      ? mapTaskPriorityToKanbanPriority(updates.priority)
+      : undefined,
+    status: updates.column
+      ? mapTaskColumnToKanbanStatus(updates.column)
+      : undefined,
   })
   return card ? mapCardToTask(card) : null
 }
 
-export async function moveClaudeTask(taskId: string, column: TaskColumn): Promise<ClaudeTaskRecord | null> {
+export async function moveClaudeTask(
+  taskId: string,
+  column: TaskColumn,
+): Promise<ClaudeTaskRecord | null> {
   return updateClaudeTask(taskId, { column })
 }

--- a/src/server/claude-tasks-backend.ts
+++ b/src/server/claude-tasks-backend.ts
@@ -37,11 +37,22 @@ export type ClaudeTaskRecord = {
   updated_at: string
 }
 
+export type ClaudeTaskRelationLink = {
+  id: string
+  title?: string | null
+  column?: TaskColumn | null
+  priority?: TaskPriority | null
+  assignee?: string | null
+}
+
 export type ClaudeTaskDetail = {
   task: ClaudeTaskRecord
   comments: Array<KanbanTaskComment>
   events: Array<KanbanTaskEvent>
-  links: { parents: Array<string>; children: Array<string> }
+  links: {
+    parents: Array<ClaudeTaskRelationLink>
+    children: Array<ClaudeTaskRelationLink>
+  }
   runs: Array<KanbanTaskRun>
 }
 
@@ -156,12 +167,47 @@ function mapCardToTask(card: {
   }
 }
 
-function mapCardDetailToTaskDetail(detail: KanbanCardDetail): ClaudeTaskDetail {
+function taskToRelationLink(task: ClaudeTaskRecord): ClaudeTaskRelationLink {
+  return {
+    id: task.id,
+    title: task.title,
+    column: task.column,
+    priority: task.priority,
+    assignee: task.assignee,
+  }
+}
+
+function fallbackRelationLink(taskId: string): ClaudeTaskRelationLink {
+  return { id: taskId }
+}
+
+async function mapCardDetailToTaskDetail(
+  detail: KanbanCardDetail,
+): Promise<ClaudeTaskDetail> {
+  const relationIds = new Set([
+    ...detail.links.parents,
+    ...detail.links.children,
+  ])
+  const relatedById = new Map<string, ClaudeTaskRelationLink>()
+  if (relationIds.size > 0) {
+    for (const card of await listKanbanCards()) {
+      if (!relationIds.has(card.id)) continue
+      relatedById.set(card.id, taskToRelationLink(mapCardToTask(card)))
+    }
+  }
+
   return {
     task: mapCardToTask(detail.card),
     comments: detail.comments,
     events: detail.events,
-    links: detail.links,
+    links: {
+      parents: detail.links.parents.map(
+        (taskId) => relatedById.get(taskId) ?? fallbackRelationLink(taskId),
+      ),
+      children: detail.links.children.map(
+        (taskId) => relatedById.get(taskId) ?? fallbackRelationLink(taskId),
+      ),
+    },
     runs: detail.runs,
   }
 }

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -5,19 +5,25 @@ import { randomUUID } from 'node:crypto'
 import { getClaudeRoot, getWorkspaceClaudeHome } from './claude-paths'
 import {
   SWARM_KANBAN_FILE,
-  type CreateSwarmKanbanCardInput,
   createSwarmKanbanCard,
   listSwarmKanbanCards,
-  type SwarmKanbanCard,
   updateSwarmKanbanCard,
-  type UpdateSwarmKanbanCardInput,
 } from './swarm-kanban-store'
 import { CLAUDE_DASHBOARD_URL, getCapabilities } from './gateway-capabilities'
 import {
-  fetchDashboardKanbanBoard,
   createDashboardKanbanTask,
+  fetchDashboardKanbanBoard,
+  fetchDashboardKanbanTaskDetail,
   updateDashboardKanbanTask,
-  type DashboardKanbanTask,
+} from './kanban-dashboard-proxy'
+import type {
+  CreateSwarmKanbanCardInput,
+  SwarmKanbanCard,
+  UpdateSwarmKanbanCardInput,
+} from './swarm-kanban-store'
+import type {
+  DashboardKanbanTask,
+  DashboardKanbanTaskDetailResponse,
 } from './kanban-dashboard-proxy'
 
 export type KanbanBackendId = 'local' | 'claude' | 'hermes-proxy'
@@ -31,14 +37,63 @@ export type KanbanBackendMeta = {
   path?: string | null
 }
 
+export type KanbanTaskComment = {
+  id: number | string
+  task_id: string
+  author: string
+  body: string
+  created_at: number | string
+}
+
+export type KanbanTaskEvent = {
+  id: number | string
+  task_id: string
+  kind: string
+  payload?: unknown
+  created_at: number | string
+  run_id?: number | null
+}
+
+export type KanbanTaskRun = {
+  id: number | string
+  task_id: string
+  profile?: string | null
+  step_key?: string | null
+  status: string
+  claim_lock?: string | null
+  claim_expires?: number | null
+  worker_pid?: number | null
+  max_runtime_seconds?: number | null
+  last_heartbeat_at?: number | null
+  started_at: number | string
+  ended_at?: number | string | null
+  outcome?: string | null
+  summary?: string | null
+  metadata?: Record<string, unknown> | null
+  error?: string | null
+}
+
+export type KanbanCardDetail = {
+  card: SwarmKanbanCard
+  comments: Array<KanbanTaskComment>
+  events: Array<KanbanTaskEvent>
+  links: { parents: Array<string>; children: Array<string> }
+  runs: Array<KanbanTaskRun>
+}
+
 type KanbanBackend = {
-  meta(): KanbanBackendMeta
-  list(): SwarmKanbanCard[] | Promise<SwarmKanbanCard[]>
-  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard | Promise<SwarmKanbanCard>
-  update(
+  meta: () => KanbanBackendMeta
+  list: () => Array<SwarmKanbanCard> | Promise<Array<SwarmKanbanCard>>
+  create: (
+    input: CreateSwarmKanbanCardInput,
+  ) => SwarmKanbanCard | Promise<SwarmKanbanCard>
+  update: (
     cardId: string,
     updates: UpdateSwarmKanbanCardInput,
-  ): SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
+  ) => SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
+  detail: (
+    cardId: string,
+  ) => KanbanCardDetail | null | Promise<KanbanCardDetail | null>
 }
 
 // Map upstream Hermes kanban statuses (triage/todo/ready/running/done/blocked
@@ -111,6 +166,7 @@ function dashboardTaskToCard(task: DashboardKanbanTask): SwarmKanbanCard {
     assignedWorker: task.assignee ?? null,
     reviewer: null,
     status: mapDashboardStatusToLane(task.status),
+    priority: typeof task.priority === 'number' ? task.priority : 0,
     missionId: null,
     reportPath: null,
     createdBy: task.created_by ?? 'hermes-kanban',
@@ -125,6 +181,7 @@ type ClaudeTaskRow = {
   body?: string | null
   status?: string | null
   assignee?: string | null
+  priority?: number | string | null
   created_at?: number | string | null
   updated_at?: number | string | null
 }
@@ -156,21 +213,36 @@ function claudeWorkspacePath(): string {
 
 function claudeCliPath(): string | null {
   try {
-    const output = execFileSync('which', ['claude'], { encoding: 'utf8', timeout: 5_000 }).trim()
+    const output = execFileSync('which', ['claude'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim()
     return output || null
   } catch {
     return null
   }
 }
 
-function checkClaudeCli(): { ok: boolean; path?: string | null; reason?: string } {
+function checkClaudeCli(): {
+  ok: boolean
+  path?: string | null
+  reason?: string
+} {
   const cli = claudeCliPath()
   if (!cli) return { ok: false, reason: 'claude CLI not found on PATH' }
   try {
-    execFileSync(cli, ['--version'], { encoding: 'utf8', timeout: 10_000, env: { ...process.env, CLAUDE_HOME: claudeProfileRoot() } })
+    execFileSync(cli, ['--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: { ...process.env, CLAUDE_HOME: claudeProfileRoot() },
+    })
     return { ok: true, path: cli }
   } catch (error) {
-    return { ok: false, path: cli, reason: error instanceof Error ? error.message : String(error) }
+    return {
+      ok: false,
+      path: cli,
+      reason: error instanceof Error ? error.message : String(error),
+    }
   }
 }
 
@@ -186,17 +258,20 @@ function detectClaudeKanban(): ClaudeDetection {
       cliPath: null,
       dbPath,
       workspacePath,
-      reason: 'Hermes Kanban storage not found; using the local Swarm Board fallback.',
+      reason:
+        'Hermes Kanban storage not found; using the local Swarm Board fallback.',
     }
   }
 
   const cli = checkClaudeCli()
   return {
     available: true,
-    cliPath: cli.ok ? cli.path ?? null : null,
+    cliPath: cli.ok ? (cli.path ?? null) : null,
     dbPath,
     workspacePath,
-    reason: cli.ok ? undefined : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
+    reason: cli.ok
+      ? undefined
+      : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
   }
 }
 
@@ -211,7 +286,10 @@ function runSqlite(dbPath: string, sql: string): string {
   }).trim()
 }
 
-function readClaudeTasks(): ClaudeTaskRow[] {
+const CLAUDE_TASK_UPDATED_AT_SQL =
+  'max(coalesce(last_heartbeat_at, 0), coalesce(completed_at, 0), coalesce(started_at, 0), created_at, coalesce((select max(created_at) from task_events where task_id = tasks.id), 0)) as updated_at'
+
+function readClaudeTasks(): Array<ClaudeTaskRow> {
   const detection = detectClaudeKanban()
   if (!detection.available) return []
   const query = [
@@ -221,13 +299,14 @@ function readClaudeTasks(): ClaudeTaskRow[] {
     'body,',
     'status,',
     'assignee,',
+    'priority,',
     'created_at,',
-    'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
+    CLAUDE_TASK_UPDATED_AT_SQL,
     'from tasks',
     'order by created_at desc, id desc;',
   ].join(' ')
   const raw = runSqlite(detection.dbPath, query)
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
+  const parsed = raw ? (JSON.parse(raw) as Array<ClaudeTaskRow>) : []
   return Array.isArray(parsed) ? parsed : []
 }
 
@@ -236,9 +315,9 @@ function readClaudeTask(taskId: string): ClaudeTaskRow | null {
   if (!detection.available) return null
   const raw = runSqlite(
     detection.dbPath,
-    `select id, title, body, status, assignee, created_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
+    `select id, title, body, status, assignee, priority, created_at, ${CLAUDE_TASK_UPDATED_AT_SQL} from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
   )
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
+  const parsed = raw ? (JSON.parse(raw) as Array<ClaudeTaskRow>) : []
   return Array.isArray(parsed) && parsed[0] ? parsed[0] : null
 }
 
@@ -255,7 +334,18 @@ function normalizeTimestamp(value: unknown): number {
   return Date.now()
 }
 
-function mapClaudeStatus(status: string | null | undefined): SwarmKanbanCard['status'] {
+function normalizePriority(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+function mapClaudeStatus(
+  status: string | null | undefined,
+): SwarmKanbanCard['status'] {
   switch ((status ?? '').toLowerCase()) {
     case 'queued':
     case 'todo':
@@ -280,7 +370,9 @@ function mapClaudeStatus(status: string | null | undefined): SwarmKanbanCard['st
   }
 }
 
-function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): string {
+function mapBoardStatus(
+  status: SwarmKanbanCard['status'] | null | undefined,
+): string {
   switch (status) {
     case 'backlog':
       return 'queued'
@@ -310,11 +402,177 @@ function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
     assignedWorker: task.assignee ?? null,
     reviewer: null,
     status: mapClaudeStatus(task.status),
+    priority: normalizePriority(task.priority),
     missionId: null,
     reportPath: null,
     createdBy: 'claude-kanban',
     createdAt,
     updatedAt,
+  }
+}
+
+function parseJsonArray<T>(raw: string): Array<T> {
+  const parsed = raw ? (JSON.parse(raw) as unknown) : []
+  return Array.isArray(parsed) ? (parsed as Array<T>) : []
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? null
+  if (!value.trim()) return null
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return value
+  }
+}
+
+function insertClaudeTaskEvent(
+  dbPath: string,
+  taskId: string,
+  kind: string,
+  payload: Record<string, unknown>,
+): void {
+  try {
+    runSqlite(
+      dbPath,
+      `insert into task_events (task_id, run_id, kind, payload, created_at) values (${sqliteQuote(taskId)}, NULL, ${sqliteQuote(kind)}, ${sqliteQuote(JSON.stringify(payload))}, ${Math.floor(Date.now() / 1000)});`,
+    )
+  } catch {
+    // Older or partially initialized kanban databases may not have event
+    // tables. Keep the task write successful and let detail reads fall back to
+    // synthetic timestamps.
+  }
+}
+
+function claudeUpdateEventKind(
+  updates: UpdateSwarmKanbanCardInput,
+): 'assigned' | 'edited' | 'reprioritized' | 'status' | 'updated' {
+  const changedKeys = [
+    updates.title !== undefined,
+    updates.spec !== undefined,
+    updates.assignedWorker !== undefined,
+    updates.priority !== undefined,
+    updates.status !== undefined,
+  ].filter(Boolean).length
+
+  if (changedKeys > 1) return 'updated'
+  if (updates.status !== undefined) return 'status'
+  if (updates.assignedWorker !== undefined) return 'assigned'
+  if (updates.priority !== undefined) return 'reprioritized'
+  return 'edited'
+}
+
+function claudeUpdateEventPayload(
+  updates: UpdateSwarmKanbanCardInput,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {}
+  if (typeof updates.title === 'string') payload.title = updates.title.trim()
+  if (typeof updates.spec === 'string') payload.body = updates.spec
+  if (updates.assignedWorker !== undefined)
+    payload.assignee = updates.assignedWorker?.trim() || null
+  if (updates.priority !== undefined)
+    payload.priority = normalizePriority(updates.priority)
+  if (updates.status !== undefined)
+    payload.status = mapBoardStatus(updates.status)
+  return payload
+}
+
+function localCardDetail(card: SwarmKanbanCard): KanbanCardDetail {
+  return {
+    card,
+    comments: [],
+    events: [
+      {
+        id: `${card.id}:created`,
+        task_id: card.id,
+        kind: 'created',
+        payload: { status: card.status, assignee: card.assignedWorker },
+        created_at: Math.round(card.createdAt / 1000),
+      },
+      ...(card.updatedAt !== card.createdAt
+        ? [
+            {
+              id: `${card.id}:updated`,
+              task_id: card.id,
+              kind: 'updated',
+              payload: { status: card.status, assignee: card.assignedWorker },
+              created_at: Math.round(card.updatedAt / 1000),
+            },
+          ]
+        : []),
+    ],
+    links: { parents: [], children: [] },
+    runs: [],
+  }
+}
+
+function readClaudeTaskDetail(taskId: string): KanbanCardDetail | null {
+  const task = readClaudeTask(taskId)
+  if (!task) return null
+  const detection = detectClaudeKanban()
+  if (!detection.available) return null
+
+  const comments = parseJsonArray<KanbanTaskComment>(
+    runSqlite(
+      detection.dbPath,
+      `select id, task_id, author, body, created_at from task_comments where task_id = ${sqliteQuote(taskId)} order by created_at asc, id asc;`,
+    ),
+  )
+  const rawEvents = parseJsonArray<KanbanTaskEvent & { payload?: unknown }>(
+    runSqlite(
+      detection.dbPath,
+      `select id, task_id, run_id, kind, payload, created_at from task_events where task_id = ${sqliteQuote(taskId)} order by created_at asc, id asc;`,
+    ),
+  )
+  const events = rawEvents.map((event) => ({
+    ...event,
+    payload: parseJsonValue(event.payload),
+  }))
+  const rawRuns = parseJsonArray<KanbanTaskRun & { metadata?: unknown }>(
+    runSqlite(
+      detection.dbPath,
+      `select id, task_id, profile, step_key, status, claim_lock, claim_expires, worker_pid, max_runtime_seconds, last_heartbeat_at, started_at, ended_at, outcome, summary, metadata, error from task_runs where task_id = ${sqliteQuote(taskId)} order by started_at asc, id asc;`,
+    ),
+  )
+  const runs = rawRuns.map((run) => ({
+    ...run,
+    metadata: parseJsonValue(run.metadata) as Record<string, unknown> | null,
+  }))
+  const parents = parseJsonArray<{ parent_id: string }>(
+    runSqlite(
+      detection.dbPath,
+      `select parent_id from task_links where child_id = ${sqliteQuote(taskId)} order by parent_id;`,
+    ),
+  ).map((row) => row.parent_id)
+  const children = parseJsonArray<{ child_id: string }>(
+    runSqlite(
+      detection.dbPath,
+      `select child_id from task_links where parent_id = ${sqliteQuote(taskId)} order by child_id;`,
+    ),
+  ).map((row) => row.child_id)
+
+  return {
+    card: claudeTaskToCard(task),
+    comments,
+    events,
+    links: { parents, children },
+    runs,
+  }
+}
+
+function dashboardDetailToCardDetail(
+  detail: DashboardKanbanTaskDetailResponse | null,
+): KanbanCardDetail | null {
+  if (!detail?.task) return null
+  return {
+    card: dashboardTaskToCard(detail.task),
+    comments: detail.comments ?? [],
+    events: detail.events ?? [],
+    links: {
+      parents: detail.links?.parents ?? [],
+      children: detail.links?.children ?? [],
+    },
+    runs: detail.runs ?? [],
   }
 }
 
@@ -338,6 +596,10 @@ const localBackend: KanbanBackend = {
   update(cardId, updates) {
     return updateSwarmKanbanCard(cardId, updates)
   },
+  detail(cardId) {
+    const card = listSwarmKanbanCards({}).find((entry) => entry.id === cardId)
+    return card ? localCardDetail(card) : null
+  },
 }
 
 const claudeBackend: KanbanBackend = {
@@ -350,8 +612,9 @@ const claudeBackend: KanbanBackend = {
       writable: detection.available,
       path: fs.existsSync(detection.dbPath) ? detection.dbPath : null,
       details: detection.available
-        ? detection.reason ?? `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`
-        : detection.reason ?? 'Hermes Kanban not detected.',
+        ? (detection.reason ??
+          `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`)
+        : (detection.reason ?? 'Hermes Kanban not detected.'),
     }
   },
   list() {
@@ -359,7 +622,8 @@ const claudeBackend: KanbanBackend = {
   },
   create(input) {
     const detection = detectClaudeKanban()
-    if (!detection.available) throw new Error(detection.reason ?? 'Hermes Kanban not detected')
+    if (!detection.available)
+      throw new Error(detection.reason ?? 'Hermes Kanban not detected')
     const nowSeconds = Math.floor(Date.now() / 1000)
     const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
     const status = mapBoardStatus(input.status ?? 'backlog')
@@ -371,9 +635,11 @@ const claudeBackend: KanbanBackend = {
         sqliteQuote(taskId),
         sqliteQuote(input.title.trim()),
         sqliteQuote((input.spec ?? '').trim()),
-        input.assignedWorker?.trim() ? sqliteQuote(input.assignedWorker.trim()) : 'NULL',
+        input.assignedWorker?.trim()
+          ? sqliteQuote(input.assignedWorker.trim())
+          : 'NULL',
         sqliteQuote(status),
-        '0',
+        String(normalizePriority(input.priority)),
         sqliteQuote(input.createdBy?.trim() || 'swarm2-kanban'),
         String(nowSeconds),
         sqliteQuote('scratch'),
@@ -382,31 +648,62 @@ const claudeBackend: KanbanBackend = {
       ');',
     ].join(' ')
     runSqlite(detection.dbPath, statements)
+    insertClaudeTaskEvent(detection.dbPath, taskId, 'created', {
+      status,
+      assignee: input.assignedWorker?.trim() || null,
+      created_by: input.createdBy?.trim() || 'swarm2-kanban',
+    })
     const created = readClaudeTask(taskId)
-    if (!created) throw new Error(`Created Hermes task ${taskId} but could not read it back`)
+    if (!created)
+      throw new Error(
+        `Created Hermes task ${taskId} but could not read it back`,
+      )
     return claudeTaskToCard(created)
   },
   update(cardId, updates) {
     const detection = detectClaudeKanban()
     if (!detection.available) return null
-    const assignments: string[] = []
-    if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
-    if (typeof updates.spec === 'string') assignments.push(`body = ${sqliteQuote(updates.spec)}`)
-    if (updates.assignedWorker !== undefined) assignments.push(`assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`)
+    const assignments: Array<string> = []
+    if (typeof updates.title === 'string' && updates.title.trim())
+      assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
+    if (typeof updates.spec === 'string')
+      assignments.push(`body = ${sqliteQuote(updates.spec)}`)
+    if (updates.assignedWorker !== undefined)
+      assignments.push(
+        `assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`,
+      )
+    if (updates.priority !== undefined)
+      assignments.push(`priority = ${normalizePriority(updates.priority)}`)
     if (updates.status) {
       const status = mapBoardStatus(updates.status)
       assignments.push(`status = ${sqliteQuote(status)}`)
-      if (status === 'running') assignments.push(`started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`)
-      if (status === 'done') assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
+      if (status === 'running')
+        assignments.push(
+          `started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`,
+        )
+      if (status === 'done')
+        assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
       if (status !== 'done') assignments.push('completed_at = NULL')
     }
     if (assignments.length === 0) {
       const current = readClaudeTask(cardId)
       return current ? claudeTaskToCard(current) : null
     }
-    runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
+    runSqlite(
+      detection.dbPath,
+      `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`,
+    )
+    insertClaudeTaskEvent(
+      detection.dbPath,
+      cardId,
+      claudeUpdateEventKind(updates),
+      claudeUpdateEventPayload(updates),
+    )
     const updated = readClaudeTask(cardId)
     return updated ? claudeTaskToCard(updated) : null
+  },
+  detail(cardId) {
+    return readClaudeTaskDetail(cardId)
   },
 }
 
@@ -432,7 +729,7 @@ const dashboardProxyBackend: KanbanBackend = {
   },
   async list() {
     const board = await fetchDashboardKanbanBoard()
-    const cards: SwarmKanbanCard[] = []
+    const cards: Array<SwarmKanbanCard> = []
     for (const column of board.columns) {
       for (const task of column.tasks) {
         cards.push(dashboardTaskToCard(task))
@@ -448,6 +745,7 @@ const dashboardProxyBackend: KanbanBackend = {
       body: (input.spec ?? '').trim() || undefined,
       assignee: input.assignedWorker?.trim() || undefined,
       status: mapLaneToDashboardStatus(input.status ?? 'backlog'),
+      priority: normalizePriority(input.priority),
       created_by: input.createdBy?.trim() || 'hermes-workspace',
     })
     return dashboardTaskToCard(task)
@@ -459,6 +757,8 @@ const dashboardProxyBackend: KanbanBackend = {
     if (typeof updates.spec === 'string') patch.body = updates.spec
     if (updates.assignedWorker !== undefined)
       patch.assignee = updates.assignedWorker?.trim() || null
+    if (updates.priority !== undefined)
+      patch.priority = normalizePriority(updates.priority)
     if (updates.status) patch.status = mapLaneToDashboardStatus(updates.status)
     if (Object.keys(patch).length === 0) {
       // No-op patches: just refetch.
@@ -477,6 +777,11 @@ const dashboardProxyBackend: KanbanBackend = {
       if (err instanceof Error && err.message.includes('→ 404')) return null
       throw err
     }
+  },
+  async detail(cardId) {
+    return dashboardDetailToCardDetail(
+      await fetchDashboardKanbanTaskDetail(cardId),
+    )
   },
 }
 
@@ -515,7 +820,7 @@ export function getKanbanBackendMeta(): KanbanBackendMeta {
   return resolveKanbanBackend().meta()
 }
 
-export async function listKanbanCards(): Promise<SwarmKanbanCard[]> {
+export async function listKanbanCards(): Promise<Array<SwarmKanbanCard>> {
   return Promise.resolve(resolveKanbanBackend().list())
 }
 
@@ -530,4 +835,10 @@ export async function updateKanbanCard(
   updates: UpdateSwarmKanbanCardInput,
 ): Promise<SwarmKanbanCard | null> {
   return Promise.resolve(resolveKanbanBackend().update(cardId, updates))
+}
+
+export async function getKanbanCardDetail(
+  cardId: string,
+): Promise<KanbanCardDetail | null> {
+  return Promise.resolve(resolveKanbanBackend().detail(cardId))
 }

--- a/src/server/kanban-dashboard-proxy.ts
+++ b/src/server/kanban-dashboard-proxy.ts
@@ -46,6 +46,50 @@ export type DashboardKanbanTask = {
   workspace_path?: string | null
 }
 
+export type DashboardKanbanComment = {
+  id: number
+  task_id: string
+  author: string
+  body: string
+  created_at: number
+}
+
+export type DashboardKanbanEvent = {
+  id: number
+  task_id: string
+  kind: string
+  payload?: unknown
+  created_at: number
+  run_id?: number | null
+}
+
+export type DashboardKanbanRun = {
+  id: number
+  task_id: string
+  profile?: string | null
+  step_key?: string | null
+  status: string
+  claim_lock?: string | null
+  claim_expires?: number | null
+  worker_pid?: number | null
+  max_runtime_seconds?: number | null
+  last_heartbeat_at?: number | null
+  started_at: number
+  ended_at?: number | null
+  outcome?: string | null
+  summary?: string | null
+  metadata?: Record<string, unknown> | null
+  error?: string | null
+}
+
+export type DashboardKanbanTaskDetailResponse = {
+  task?: DashboardKanbanTask | null
+  comments?: Array<DashboardKanbanComment>
+  events?: Array<DashboardKanbanEvent>
+  links?: { parents?: Array<string>; children?: Array<string> }
+  runs?: Array<DashboardKanbanRun>
+}
+
 export type DashboardKanbanBoardResponse = {
   columns: Array<{
     name: string
@@ -73,7 +117,10 @@ async function buildHeaders(): Promise<Record<string, string>> {
   return headers
 }
 
-function dashboardUrl(path: string, params: Record<string, string | undefined> = {}): string {
+function dashboardUrl(
+  path: string,
+  params: Record<string, string | undefined> = {},
+): string {
   const base = CLAUDE_DASHBOARD_URL.replace(/\/+$/, '')
   const url = new URL(`${base}${path}`)
   for (const [key, value] of Object.entries(params)) {
@@ -113,22 +160,30 @@ export function fetchDashboardKanbanBoard(
   )
 }
 
+/** Fetch one task and its full drawer detail by id. Returns null task on 404. */
+export async function fetchDashboardKanbanTaskDetail(
+  taskId: string,
+  board?: string,
+): Promise<DashboardKanbanTaskDetailResponse | null> {
+  try {
+    return await dashboardFetch<DashboardKanbanTaskDetailResponse>(
+      `/api/plugins/kanban/tasks/${encodeURIComponent(taskId)}`,
+      {},
+      board ? { board } : {},
+    )
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('→ 404')) return null
+    throw err
+  }
+}
+
 /** Fetch one task by id. Returns null on 404. */
 export async function fetchDashboardKanbanTask(
   taskId: string,
   board?: string,
 ): Promise<DashboardKanbanTask | null> {
-  try {
-    const wrapped = await dashboardFetch<{ task?: DashboardKanbanTask }>(
-      `/api/plugins/kanban/tasks/${encodeURIComponent(taskId)}`,
-      {},
-      board ? { board } : {},
-    )
-    return wrapped.task ?? null
-  } catch (err) {
-    if (err instanceof Error && err.message.includes('→ 404')) return null
-    throw err
-  }
+  const detail = await fetchDashboardKanbanTaskDetail(taskId, board)
+  return detail?.task ?? null
 }
 
 export type CreateDashboardKanbanTaskInput = {

--- a/src/server/swarm-kanban-store.ts
+++ b/src/server/swarm-kanban-store.ts
@@ -3,17 +3,25 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { randomUUID } from 'node:crypto'
 
-export const SWARM_KANBAN_LANES = ['backlog', 'ready', 'running', 'review', 'blocked', 'done'] as const
+export const SWARM_KANBAN_LANES = [
+  'backlog',
+  'ready',
+  'running',
+  'review',
+  'blocked',
+  'done',
+] as const
 export type SwarmKanbanLane = (typeof SWARM_KANBAN_LANES)[number]
 
 export type SwarmKanbanCard = {
   id: string
   title: string
   spec: string
-  acceptanceCriteria: string[]
+  acceptanceCriteria: Array<string>
   assignedWorker: string | null
   reviewer: string | null
   status: SwarmKanbanLane
+  priority: number
   missionId: string | null
   reportPath: string | null
   createdBy: string
@@ -21,7 +29,7 @@ export type SwarmKanbanCard = {
   updatedAt: number
 }
 
-type SwarmKanbanFile = { cards: SwarmKanbanCard[] }
+type SwarmKanbanFile = { cards: Array<SwarmKanbanCard> }
 
 type ListFilters = {
   status?: string | null
@@ -33,24 +41,34 @@ type ListFilters = {
 export type CreateSwarmKanbanCardInput = {
   title: string
   spec?: string
-  acceptanceCriteria?: string[]
+  acceptanceCriteria?: Array<string>
   assignedWorker?: string | null
   reviewer?: string | null
   status?: SwarmKanbanLane | null
+  priority?: number | null
   missionId?: string | null
   reportPath?: string | null
   createdBy?: string | null
 }
 
-export type UpdateSwarmKanbanCardInput = Partial<Omit<CreateSwarmKanbanCardInput, 'createdBy'>>
+export type UpdateSwarmKanbanCardInput = Partial<
+  Omit<CreateSwarmKanbanCardInput, 'createdBy'>
+>
 
-const HERMES_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
+const HERMES_HOME =
+  process.env.HERMES_HOME ??
+  process.env.CLAUDE_HOME ??
+  path.join(os.homedir(), '.hermes')
 export const SWARM_KANBAN_FILE = path.join(HERMES_HOME, 'swarm2-kanban.json')
 
 function ensureKanbanFile(): void {
   fs.mkdirSync(HERMES_HOME, { recursive: true })
   if (!fs.existsSync(SWARM_KANBAN_FILE)) {
-    fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: [] }, null, 2) + '\n', 'utf-8')
+    fs.writeFileSync(
+      SWARM_KANBAN_FILE,
+      JSON.stringify({ cards: [] }, null, 2) + '\n',
+      'utf-8',
+    )
   }
 }
 
@@ -60,7 +78,9 @@ function readKanbanFile(): SwarmKanbanFile {
     const raw = fs.readFileSync(SWARM_KANBAN_FILE, 'utf-8').trim()
     if (!raw) return { cards: [] }
     const parsed = JSON.parse(raw) as Partial<SwarmKanbanFile>
-    return { cards: Array.isArray(parsed.cards) ? parsed.cards.map(normalizeCard) : [] }
+    return {
+      cards: Array.isArray(parsed.cards) ? parsed.cards.map(normalizeCard) : [],
+    }
   } catch {
     return { cards: [] }
   }
@@ -68,53 +88,104 @@ function readKanbanFile(): SwarmKanbanFile {
 
 function writeKanbanFile(data: SwarmKanbanFile): void {
   ensureKanbanFile()
-  fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: data.cards.map(normalizeCard) }, null, 2) + '\n', 'utf-8')
+  fs.writeFileSync(
+    SWARM_KANBAN_FILE,
+    JSON.stringify({ cards: data.cards.map(normalizeCard) }, null, 2) + '\n',
+    'utf-8',
+  )
 }
 
 function normalizeStatus(value: unknown): SwarmKanbanLane {
   if (value === 'todo') return 'ready'
   if (value === 'in_progress' || value === 'doing') return 'running'
-  return SWARM_KANBAN_LANES.includes(value as SwarmKanbanLane) ? (value as SwarmKanbanLane) : 'backlog'
+  return SWARM_KANBAN_LANES.includes(value as SwarmKanbanLane)
+    ? (value as SwarmKanbanLane)
+    : 'backlog'
 }
 
-function normalizeCriteria(value: unknown): string[] {
-  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
-  if (typeof value === 'string') return value.split('\n').map((item) => item.trim()).filter(Boolean)
+function normalizeCriteria(value: unknown): Array<string> {
+  if (Array.isArray(value))
+    return value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  if (typeof value === 'string')
+    return value
+      .split('\n')
+      .map((item) => item.trim())
+      .filter(Boolean)
   return []
+}
+
+function normalizePriority(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
 }
 
 function optionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: string; title?: string; status?: SwarmKanbanLane | string | null })): SwarmKanbanCard {
+function normalizeCard(
+  card: Partial<Omit<SwarmKanbanCard, 'priority' | 'status'>> & {
+    id?: string
+    priority?: unknown
+    status?: SwarmKanbanLane | string | null
+    title?: string
+  },
+): SwarmKanbanCard {
   const now = Date.now()
   return {
     id: typeof card.id === 'string' && card.id ? card.id : randomUUID(),
-    title: typeof card.title === 'string' && card.title.trim() ? card.title.trim() : 'Untitled task',
+    title:
+      typeof card.title === 'string' && card.title.trim()
+        ? card.title.trim()
+        : 'Untitled task',
     spec: typeof card.spec === 'string' ? card.spec : '',
     acceptanceCriteria: normalizeCriteria(card.acceptanceCriteria),
     assignedWorker: optionalString(card.assignedWorker),
     reviewer: optionalString(card.reviewer),
     status: normalizeStatus(card.status),
+    priority: normalizePriority(card.priority),
     missionId: optionalString(card.missionId),
     reportPath: optionalString(card.reportPath),
-    createdBy: typeof card.createdBy === 'string' && card.createdBy ? card.createdBy : 'swarm2-kanban',
+    createdBy:
+      typeof card.createdBy === 'string' && card.createdBy
+        ? card.createdBy
+        : 'swarm2-kanban',
     createdAt: typeof card.createdAt === 'number' ? card.createdAt : now,
     updatedAt: typeof card.updatedAt === 'number' ? card.updatedAt : now,
   }
 }
 
-export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard[] {
+export function listSwarmKanbanCards(
+  filters: ListFilters = {},
+): Array<SwarmKanbanCard> {
   let cards = readKanbanFile().cards
-  if (filters.status) cards = cards.filter((card) => card.status === normalizeStatus(filters.status))
-  if (filters.assignedWorker) cards = cards.filter((card) => card.assignedWorker === filters.assignedWorker)
-  if (filters.reviewer) cards = cards.filter((card) => card.reviewer === filters.reviewer)
-  if (filters.missionId) cards = cards.filter((card) => card.missionId === filters.missionId)
-  return [...cards].sort((a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title))
+  if (filters.status)
+    cards = cards.filter(
+      (card) => card.status === normalizeStatus(filters.status),
+    )
+  if (filters.assignedWorker)
+    cards = cards.filter(
+      (card) => card.assignedWorker === filters.assignedWorker,
+    )
+  if (filters.reviewer)
+    cards = cards.filter((card) => card.reviewer === filters.reviewer)
+  if (filters.missionId)
+    cards = cards.filter((card) => card.missionId === filters.missionId)
+  return [...cards].sort(
+    (a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title),
+  )
 }
 
-export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
+export function createSwarmKanbanCard(
+  input: CreateSwarmKanbanCardInput,
+): SwarmKanbanCard {
   const file = readKanbanFile()
   const now = Date.now()
   const card = normalizeCard({
@@ -125,6 +196,7 @@ export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmK
     assignedWorker: input.assignedWorker,
     reviewer: input.reviewer,
     status: input.status ?? 'backlog',
+    priority: input.priority,
     missionId: input.missionId,
     reportPath: input.reportPath,
     createdBy: input.createdBy ?? 'swarm2-kanban',
@@ -136,7 +208,10 @@ export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmK
   return card
 }
 
-export function updateSwarmKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
+export function updateSwarmKanbanCard(
+  cardId: string,
+  updates: UpdateSwarmKanbanCardInput,
+): SwarmKanbanCard | null {
   const file = readKanbanFile()
   const index = file.cards.findIndex((card) => card.id === cardId)
   if (index === -1) return null


### PR DESCRIPTION
- Introduced a new TaskSheet component to display task history entries, including events, comments, and runs.
- Implemented utility functions for timestamp formatting, payload compacting, and event title generation.
- Enhanced TasksScreen to manage task selection and detail fetching, integrating the new TaskSheet for improved task management.
- Added unit tests for task history entry building to ensure correct ordering and structure.

<img width="2432" height="1419" alt="image" src="https://github.com/user-attachments/assets/7747b9e7-7205-48d8-bebe-be3137e19c14" />


unrelated note: That UsageMeter component in the screenshot is below the fold. That was like that before I touched it.