### PR TITLE
fix(usage-meter): reposition menu trigger for better alignment

### DIFF
--- a/src/components/chat-panel-toggle.tsx
+++ b/src/components/chat-panel-toggle.tsx
@@ -26,7 +26,7 @@ export function ChatPanelToggle() {
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.8 }}
           transition={{ duration: 0.15 }}
-          className="fixed bottom-6 right-6 z-50"
+          className="fixed bottom-12 right-4 z-50"
         >
           <TooltipProvider>
             <TooltipRoot>

--- a/src/components/usage-meter/usage-meter.tsx
+++ b/src/components/usage-meter/usage-meter.tsx
@@ -842,6 +842,7 @@ export function UsageMeter() {
       <MenuRoot>
         <MenuTrigger
           className={cn(
+            "absolute bottom-2 right-2",
             'ml-auto rounded-full border px-3 py-1 text-xs font-medium',
             'flex items-center gap-3 transition hover:bg-primary-100 cursor-pointer',
             alertTone,


### PR DESCRIPTION
The UsageComponent was being rendered under the fold, below the appshell. I set it to an absolute position so that it's shown and moved the chat-panel-toggle component up a bit to make room.

<img width="2018" height="1393" alt="image" src="https://github.com/user-attachments/assets/e0e02bf2-bbd1-4f09-9419-52371480682e" />


