### PR TITLE
Fix Kanban dashboard loopback link

### DIFF
--- a/src/screens/swarm2/swarm2-kanban-board.test.ts
+++ b/src/screens/swarm2/swarm2-kanban-board.test.ts
@@ -42,4 +42,34 @@ describe('Swarm2 Kanban backend presentation', () => {
       toastBody: 'Using local Swarm board JSON store.',
     })
   })
+
+  it('does not deep-link remote users to a loopback Hermes Dashboard URL', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'hermes-proxy',
+      label: 'Hermes Dashboard kanban',
+      detected: true,
+      writable: true,
+      details: 'Synced through Workspace proxy',
+      path: 'http://127.0.0.1:9119',
+    })).toMatchObject({
+      badgeLabel: 'Synced • Hermes',
+      badgeTone: 'hermes-proxy',
+      dashboardUrl: undefined,
+    })
+  })
+
+  it('deep-links to Hermes Dashboard only when the configured URL is remotely reachable', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'hermes-proxy',
+      label: 'Hermes Dashboard kanban',
+      detected: true,
+      writable: true,
+      details: 'Synced through Workspace proxy',
+      path: 'http://100.113.68.47:9119',
+    })).toMatchObject({
+      badgeLabel: 'Synced • Hermes',
+      badgeTone: 'hermes-proxy',
+      dashboardUrl: 'http://100.113.68.47:9119/kanban',
+    })
+  })
 })

--- a/src/screens/swarm2/swarm2-kanban-board.tsx
+++ b/src/screens/swarm2/swarm2-kanban-board.tsx
@@ -28,7 +28,7 @@ type KanbanWorker = {
 }
 
 type KanbanBackendMeta = {
-  id: 'local' | 'claude'
+  id: 'local' | 'claude' | 'hermes-proxy'
   label: string
   detected: boolean
   writable: boolean
@@ -56,8 +56,18 @@ type KanbanBackendPresentation = {
   toastTitle: string
   toastBody: string
   title: string | undefined
-  /** When set, the badge becomes a deep-link to the dashboard kanban tab. */
+  /** When set, the badge becomes a deep-link to a dashboard that is safe/reachable from the current browser. */
   dashboardUrl?: string
+}
+
+function isLoopbackDashboardUrl(value: string | null | undefined): boolean {
+  if (!value) return false
+  try {
+    const url = new URL(value)
+    return ['127.0.0.1', 'localhost', '::1'].includes(url.hostname)
+  } catch {
+    return false
+  }
 }
 
 export function getKanbanBackendPresentation(backend: KanbanBackendMeta | null | undefined): KanbanBackendPresentation {
@@ -71,9 +81,14 @@ export function getKanbanBackendPresentation(backend: KanbanBackendMeta | null |
     }
   }
   if (backend.id === 'hermes-proxy' && backend.detected) {
-    // Backend.path is the dashboard origin (e.g. http://127.0.0.1:9119).
+    // Backend.path is the dashboard origin. Do not deep-link to loopback
+    // origins (127.0.0.1/localhost): in a remote browser that points at the
+    // user's own device, not the VPS. The board still syncs via Workspace's
+    // server-side proxy, so the safe UI is to show a non-clickable status.
     const dashboardUrl =
-      typeof backend.path === 'string' && backend.path.startsWith('http')
+      typeof backend.path === 'string' &&
+      backend.path.startsWith('http') &&
+      !isLoopbackDashboardUrl(backend.path)
         ? `${backend.path.replace(/\/+$/, '')}/kanban`
         : undefined
     return {


### PR DESCRIPTION
## Summary
- Prevent the Swarm/Kanban “Synced • Hermes” badge from exposing raw `127.0.0.1:9119` dashboard links to remote browsers
- Keep local loopback dashboard URLs internal while allowing safe non-loopback dashboard links

## Test Plan
- `pnpm test src/screens/swarm2/swarm2-kanban-board.test.ts`
