### PR TITLE
Fix noisy startup update/context modals

### DIFF
--- a/src/components/update-center-notifier.tsx
+++ b/src/components/update-center-notifier.tsx
@@ -75,7 +75,7 @@ function shortSha(value: string | null | undefined): string {
 }
 
 function productDismissKey(product: ProductUpdateStatus): string {
-  return `${product.id}:${product.latestHead ?? product.version ?? 'unknown'}`
+  return `${product.id}:${product.latestHead ?? product.version}`
 }
 
 function notesId(sections: Array<ReleaseNoteSection>): string {
@@ -98,8 +98,8 @@ function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
   try {
     const raw = localStorage.getItem(NOTES_KEY)
     if (raw) {
-      const parsed = JSON.parse(raw) as Notes
-      existingId = parsed?.id ?? null
+      const parsed = JSON.parse(raw) as Partial<Notes>
+      existingId = typeof parsed.id === 'string' ? parsed.id : null
     }
   } catch {
     existingId = null
@@ -109,19 +109,6 @@ function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
   }
   localStorage.setItem(NOTES_KEY, JSON.stringify(notes))
   return notes
-}
-
-function readNotes(): Notes | null {
-  try {
-    const raw = localStorage.getItem(NOTES_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as Notes
-    if (!parsed?.id || !Array.isArray(parsed.sections)) return null
-    if (localStorage.getItem(NOTES_SEEN_KEY) === parsed.id) return null
-    return parsed
-  } catch {
-    return null
-  }
 }
 
 export function UpdateCenterNotifier() {
@@ -144,7 +131,9 @@ export function UpdateCenterNotifier() {
         values.add(localStorage.getItem(key) || '')
     }
     setDismissed(values)
-    setNotes(readNotes())
+    // Do not open historical release notes on startup. Successful in-app
+    // updates still call setNotes immediately after apply, but a routine
+    // status poll should not interrupt users with stale "what changed" copy.
   }, [])
 
   const { data } = useQuery({

--- a/src/components/update-center-notifier.tsx
+++ b/src/components/update-center-notifier.tsx
@@ -161,8 +161,11 @@ export function UpdateCenterNotifier() {
 
   useEffect(() => {
     if (!data?.pendingReleaseNotes?.length) return
-    const stored = storeNotes(data.pendingReleaseNotes)
-    if (stored) setNotes((current) => current ?? stored)
+    // Do not interrupt startup with release notes from a previously detected
+    // update. Store them so they can still be shown after an explicit update
+    // flow, but avoid opening the modal just because the status poll returned
+    // historical pending notes.
+    storeNotes(data.pendingReleaseNotes)
   }, [data?.pendingReleaseNotes])
 
   const visibleProducts = useMemo(() => {

--- a/src/components/usage-meter/usage-meter.tsx
+++ b/src/components/usage-meter/usage-meter.tsx
@@ -458,6 +458,7 @@ export function UsageMeter() {
     threshold: number
   }>({ open: false, threshold: 0 })
   const alertStateRef = useRef(getAlertState())
+  const lastContextPercentRef = useRef<number | null>(null)
 
   const refresh = useCallback(async () => {
     try {
@@ -554,7 +555,15 @@ export function UsageMeter() {
       state.date = getTodayKey()
       state.sent = {}
     }
-    const eligible = THRESHOLDS.filter((threshold) => current >= threshold)
+    const previous = lastContextPercentRef.current
+    lastContextPercentRef.current = current
+    // Avoid a startup modal for existing usage from another/restored session.
+    // Only alert when this mounted app instance crosses a threshold.
+    if (previous === null) return
+
+    const eligible = THRESHOLDS.filter(
+      (threshold) => previous < threshold && current >= threshold,
+    )
     if (eligible.length === 0) return
     for (const threshold of eligible) {
       if (state.sent[threshold]) continue

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -521,8 +521,9 @@ export function ChatScreen({
       return stored
     return 'low'
   })
+  const contextAlertSessionId = isNewChat ? 'new' : portableChatFriendlyId
   const { alertOpen, alertThreshold, alertPercent, dismissAlert } =
-    useContextAlert()
+    useContextAlert(contextAlertSessionId)
 
   const pendingStartRef = useRef(false)
   const composerHandleRef = useRef<ChatComposerHandle | null>(null)

--- a/src/screens/chat/hooks/use-context-alert.ts
+++ b/src/screens/chat/hooks/use-context-alert.ts
@@ -64,13 +64,14 @@ function readPercent(value: unknown): number {
   return 0
 }
 
-export function useContextAlert(): {
+export function useContextAlert(sessionId?: string): {
   alertOpen: boolean
   alertThreshold: number
   alertPercent: number
   dismissAlert: () => void
 } {
   const storedRef = useRef<StoredState | null>(null)
+  const lastPercentRef = useRef<number | null>(null)
   const [alertOpen, setAlertOpen] = useState(false)
   const [alertThreshold, setAlertThreshold] = useState<number>(0)
   const [alertPercent, setAlertPercent] = useState<number>(0)
@@ -81,13 +82,16 @@ export function useContextAlert(): {
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch('/api/context-usage')
+      const params = new URLSearchParams()
+      if (sessionId?.trim()) params.set('sessionId', sessionId.trim())
+      const query = params.toString()
+      const res = await fetch(`/api/context-usage${query ? `?${query}` : ''}`)
       if (!res.ok) return
       const data = (await res.json()) as {
         ok?: boolean
         contextPercent?: unknown
       }
-      if (!data?.ok) return
+      if (!data.ok) return
 
       const currentPercent = readPercent(data.contextPercent)
       setAlertPercent(currentPercent)
@@ -102,10 +106,18 @@ export function useContextAlert(): {
       }
       storedRef.current = stored
 
-      if (alertOpen) return
+      const previousPercent = lastPercentRef.current
+      lastPercentRef.current = currentPercent
+
+      // Do not pop a warning on first render/page load. A fresh/empty chat can
+      // briefly receive stale/global usage from the gateway before the session
+      // id resolves; warnings should only appear after this chat crosses a
+      // threshold while the user is actually in it.
+      if (previousPercent === null || alertOpen) return
 
       const candidate = THRESHOLDS.find((threshold) => {
-        if (currentPercent < threshold) return false
+        if (previousPercent >= threshold || currentPercent < threshold)
+          return false
         return !stored.sent[String(threshold) as keyof StoredState['sent']]
       })
       if (!candidate) return
@@ -118,17 +130,18 @@ export function useContextAlert(): {
     } catch {
       /* ignore */
     }
-  }, [alertOpen])
+  }, [alertOpen, sessionId])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
     storedRef.current = loadStoredState()
+    lastPercentRef.current = null
     void refresh()
     const id = window.setInterval(() => {
       void refresh()
     }, POLL_MS)
     return () => window.clearInterval(id)
-  }, [refresh])
+  }, [refresh, sessionId])
 
   return { alertOpen, alertThreshold, alertPercent, dismissAlert }
 }

--- a/src/server/update-system.ts
+++ b/src/server/update-system.ts
@@ -217,6 +217,23 @@ function canFastForward(repoPath: string, remoteRef: string): boolean {
   )
 }
 
+function containsRemoteRef(repoPath: string, remoteRef: string): boolean {
+  return (
+    exec('git', ['merge-base', '--is-ancestor', remoteRef, 'HEAD'], {
+      cwd: repoPath,
+      stdio: 'ignore',
+    }) !== null
+  )
+}
+
+function remoteBehindCount(repoPath: string, remoteRef: string): number | null {
+  const raw = git(['rev-list', '--left-right', '--count', `HEAD...${remoteRef}`], repoPath)
+  if (!raw) return null
+  const [, behind] = raw.split(/\s+/)
+  const parsed = Number(behind)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 function canResetToRemote(repoPath: string, remoteRef: string): boolean {
   return Boolean(git(['rev-parse', '--verify', remoteRef], repoPath, 10_000))
 }
@@ -338,10 +355,16 @@ export function readWorkspaceUpdateStatus(
   const latestHead =
     repoMatches && supportedBranch ? remoteHead(gitRepo, 'origin') : null
   const dirty = isDirty(gitRepo)
-  const updateAvailable = Boolean(
-    supportedBranch && currentHead && latestHead && currentHead !== latestHead,
-  )
   const remoteRef = `origin/${branch || 'main'}`
+  const behindCount = remoteBehindCount(gitRepo, remoteRef)
+  const updateAvailable = Boolean(
+    supportedBranch &&
+      currentHead &&
+      latestHead &&
+      currentHead !== latestHead &&
+      behindCount !== 0 &&
+      !containsRemoteRef(gitRepo, remoteRef),
+  )
   const canSync = updateAvailable ? canResetToRemote(gitRepo, remoteRef) : true
   const ff = updateAvailable ? canFastForward(gitRepo, remoteRef) : true
   const canUpdate = Boolean(
@@ -443,8 +466,14 @@ export function readAgentUpdateStatus(): ProductUpdateStatus {
   const latestHead = repoMatches ? remoteHead(repoPath, 'origin') : null
   const remoteRef = repoMatches ? `origin/${branch || 'main'}` : null
   const dirty = isDirty(repoPath)
+  const behindCount = remoteRef ? remoteBehindCount(repoPath, remoteRef) : null
   const updateAvailable = Boolean(
-    currentHead && latestHead && currentHead !== latestHead && remoteRef,
+    currentHead &&
+      latestHead &&
+      currentHead !== latestHead &&
+      remoteRef &&
+      behindCount !== 0 &&
+      !containsRemoteRef(repoPath, remoteRef),
   )
   const canSync = remoteRef ? canResetToRemote(repoPath, remoteRef) : false
   const ff = remoteRef ? canFastForward(repoPath, remoteRef) : false


### PR DESCRIPTION
## Summary

This PR reduces noisy startup interruptions in the workspace UI while keeping real update notifications intact.

Changes:
- Scope chat context alerts to the active/new session so a fresh chat does not inherit stale/global context usage.
- Avoid showing context warning modals immediately on app mount; warn only after the mounted app instance crosses a threshold.
- Treat a local checkout that is ahead of `origin/main` as current, not as an available Workspace update.
- Do not auto-open historical release notes from routine status polling on startup; release notes still open after an explicit in-app update apply.

## Why

When running the workspace daily from a git checkout, a clean-but-local-ahead branch can otherwise trigger false "Workspace update available" UI. Separately, startup polling can stack several modals/toasts before the user has taken any action, including context warnings for a fresh chat and historical release notes.

## Validation

- `pnpm exec vitest run src/server/update-system.test.ts src/routes/api/-claude-update.test.ts`
- `pnpm exec eslint src/screens/chat/hooks/use-context-alert.ts src/components/usage-meter/usage-meter.tsx src/server/update-system.ts src/components/update-center-notifier.tsx`

Notes:
- Existing unrelated lint warning about `.eslintignore` deprecation is emitted by the repo tooling.
- Existing Hermes Agent update availability is intentionally not suppressed; this PR only suppresses false/noisy startup UI.
