### PR TITLE
fix(chat): clear stale thinking runs reliably

### DIFF
--- a/src/screens/chat/chat-screen-utils.test.ts
+++ b/src/screens/chat/chat-screen-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { advanceStickyStreamingText } from './chat-screen-utils'
+import {
+  advanceStickyStreamingText,
+  createResponseWaitSnapshot,
+  isTerminalActiveRunStatus,
+  shouldClearWaitingForAssistantMessage,
+} from './chat-screen-utils'
 
 describe('advanceStickyStreamingText', () => {
   it('preserves the last non-empty streaming text when a tool phase temporarily reports empty text', () => {
@@ -48,5 +53,43 @@ describe('advanceStickyStreamingText', () => {
     })
 
     expect(next).toEqual({ runId: null, text: '' })
+  })
+})
+
+describe('response wait detection', () => {
+  it('treats persisted complete runs as terminal', () => {
+    expect(isTerminalActiveRunStatus('complete')).toBe(true)
+    expect(isTerminalActiveRunStatus('completed')).toBe(true)
+    expect(isTerminalActiveRunStatus('active')).toBe(false)
+  })
+
+  it('clears waiting when a new assistant message appears after the send snapshot', () => {
+    const snapshot = createResponseWaitSnapshot([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'remember that i like cheesecake' }],
+      },
+    ])
+
+    expect(
+      shouldClearWaitingForAssistantMessage(
+        [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'remember that i like cheesecake' },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Remembered: you like cheesecake.' },
+            ],
+            id: 'assistant-1',
+          },
+        ],
+        snapshot,
+      ),
+    ).toBe(true)
   })
 })

--- a/src/screens/chat/chat-screen-utils.ts
+++ b/src/screens/chat/chat-screen-utils.ts
@@ -5,6 +5,57 @@ export type StickyStreamingTextState = {
   text: string
 }
 
+export type ResponseWaitSnapshot = {
+  messageCount: number
+  lastAssistantId: string | null
+}
+
+export function isTerminalActiveRunStatus(status: unknown): boolean {
+  return (
+    typeof status === 'string' &&
+    ['complete', 'completed', 'failed', 'cancelled', 'error'].includes(status)
+  )
+}
+
+function assistantMessageIdentity(message: ChatMessage): string {
+  return String(
+    message.__optimisticId ??
+      message.id ??
+      message.messageId ??
+      message.__realtimeSequence ??
+      '',
+  )
+}
+
+export function createResponseWaitSnapshot(
+  messages: Array<ChatMessage>,
+): ResponseWaitSnapshot {
+  const last = messages[messages.length - 1]
+  return {
+    messageCount: messages.length,
+    lastAssistantId:
+      last?.role === 'assistant' ? assistantMessageIdentity(last) : null,
+  }
+}
+
+export function shouldClearWaitingForAssistantMessage(
+  messages: Array<ChatMessage>,
+  snapshot: ResponseWaitSnapshot,
+): boolean {
+  const last = messages[messages.length - 1]
+  if (!last || last.role !== 'assistant') return false
+  if (last.__streamingStatus === 'streaming') return false
+
+  if (messages.length > snapshot.messageCount) return true
+
+  const currentId = assistantMessageIdentity(last)
+  if (currentId.length > 0 && currentId !== (snapshot.lastAssistantId ?? '')) {
+    return true
+  }
+
+  return snapshot.lastAssistantId === null
+}
+
 export function advanceStickyStreamingText(params: {
   isStreaming: boolean
   runId: string | null

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -22,7 +22,11 @@ import {
 } from './utils'
 import {
   advanceStickyStreamingText,
+  createResponseWaitSnapshot,
   createOptimisticMessage,
+  isTerminalActiveRunStatus,
+  shouldClearWaitingForAssistantMessage,
+  type ResponseWaitSnapshot,
 } from './chat-screen-utils'
 import {
   appendHistoryMessage,
@@ -910,10 +914,8 @@ export function ChatScreen({
         if (!data.ok) return
         // Run not yet registered (gateway lag during silent processing) → keep waiting
         if (!data.run) return
-        const status = data.run.status
         // Treat unknown / transient statuses as still-active to avoid premature teardown
-        const terminalStatuses = ['completed', 'failed', 'cancelled', 'error']
-        if (terminalStatuses.includes(status)) {
+        if (isTerminalActiveRunStatus(data.run.status)) {
           streamFinish()
           refreshHistoryRef.current()
         }
@@ -1398,8 +1400,7 @@ export function ChatScreen({
     localStreamingMessageId,
   ])
 
-  const messageCountAtSendRef = useRef(0)
-  const lastAssistantIdAtSendRef = useRef<string | null>(null)
+  const responseWaitSnapshotRef = useRef<ResponseWaitSnapshot | null>(null)
   const prevIsRealtimeStreamingRef = useRef(activeIsRealtimeStreaming)
   const activeRealtimeStreamingRef = useRef(activeIsRealtimeStreaming)
 
@@ -1408,22 +1409,13 @@ export function ChatScreen({
   }, [activeIsRealtimeStreaming])
 
   useEffect(() => {
-    if (waitingForResponse) {
-      messageCountAtSendRef.current = finalDisplayMessages.length
-      const lastMsg = finalDisplayMessages[finalDisplayMessages.length - 1]
-      if (lastMsg?.role === 'assistant') {
-        const raw = lastMsg as Record<string, unknown>
-        lastAssistantIdAtSendRef.current = String(
-          raw.__optimisticId ??
-            raw.id ??
-            raw.messageId ??
-            raw.__realtimeSequence ??
-            '',
-        )
-      } else {
-        lastAssistantIdAtSendRef.current = null
-      }
+    if (!waitingForResponse) {
+      responseWaitSnapshotRef.current = null
+      return
     }
+    if (responseWaitSnapshotRef.current) return
+    responseWaitSnapshotRef.current =
+      createResponseWaitSnapshot(finalDisplayMessages)
   }, [waitingForResponse, finalDisplayMessages])
 
   useEffect(() => {
@@ -1434,24 +1426,9 @@ export function ChatScreen({
       }
       return
     }
-    const last = finalDisplayMessages[finalDisplayMessages.length - 1]
-    if (!last || last.role !== 'assistant') return
-    if ((last as any).__streamingStatus === 'streaming') return
-    const countGrew =
-      finalDisplayMessages.length > messageCountAtSendRef.current
-    const raw = last as Record<string, unknown>
-    const currentId = String(
-      raw.__optimisticId ??
-        raw.id ??
-        raw.messageId ??
-        raw.__realtimeSequence ??
-        '',
-    )
-    const identityChanged =
-      currentId.length > 0 &&
-      currentId !== (lastAssistantIdAtSendRef.current ?? '')
-    const noAssistantAtSend = lastAssistantIdAtSendRef.current === null
-    if (countGrew || identityChanged || noAssistantAtSend) {
+    const snapshot = responseWaitSnapshotRef.current
+    if (!snapshot) return
+    if (shouldClearWaitingForAssistantMessage(finalDisplayMessages, snapshot)) {
       if (clearTimerRef.current) return
       clearTimerRef.current = window.setTimeout(() => {
         clearTimerRef.current = null

--- a/src/server/run-store.test.ts
+++ b/src/server/run-store.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const originalHermesHome = process.env.HERMES_HOME
+
+let tempHome: string | null = null
+
+beforeEach(() => {
+  vi.resetModules()
+  tempHome = mkdtempSync(join(tmpdir(), 'hermes-run-store-'))
+  process.env.HERMES_HOME = tempHome
+})
+
+afterEach(() => {
+  if (tempHome) rmSync(tempHome, { recursive: true, force: true })
+  tempHome = null
+  if (originalHermesHome === undefined) delete process.env.HERMES_HOME
+  else process.env.HERMES_HOME = originalHermesHome
+  vi.resetModules()
+})
+
+describe('run-store persistence', () => {
+  it('preserves concurrent updates to the same run', async () => {
+    const { addRunLifecycleEvent, createPersistedRun, getPersistedRun } =
+      await import('./run-store')
+
+    await createPersistedRun({ runId: 'run-1', sessionKey: 'session-1' })
+
+    const events = Array.from({ length: 24 }, (_, index) => ({
+      text: `event-${index}`,
+      emoji: '',
+      timestamp: index,
+      isError: false,
+    }))
+
+    await Promise.all(
+      events.map((event) => addRunLifecycleEvent('session-1', 'run-1', event)),
+    )
+
+    const stored = await getPersistedRun('session-1', 'run-1')
+    expect(stored?.lifecycleEvents.map((event) => event.text).sort()).toEqual(
+      events.map((event) => event.text).sort(),
+    )
+  })
+})

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { getHermesRoot } from './claude-paths'
@@ -35,6 +35,7 @@ export type PersistedRunState = {
 }
 
 const RUNS_ROOT = path.join(getHermesRoot(), 'webui-mvp', 'runs')
+const runUpdateQueues = new Map<string, Promise<void>>()
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')
@@ -55,11 +56,34 @@ async function ensureDir(dir: string): Promise<void> {
 async function writeRun(run: PersistedRunState): Promise<void> {
   const dir = sessionDir(run.sessionKey)
   await ensureDir(dir)
-  await writeFile(
-    runPath(run.sessionKey, run.runId),
-    `${JSON.stringify(run, null, 2)}\n`,
-    'utf8',
+  const targetPath = runPath(run.sessionKey, run.runId)
+  const tempPath = `${targetPath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(36)
+    .slice(2)}.tmp`
+  await writeFile(tempPath, `${JSON.stringify(run, null, 2)}\n`, 'utf8')
+  await rename(tempPath, targetPath)
+}
+
+async function enqueueRunUpdate<T>(
+  sessionKey: string,
+  runId: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const key = `${encodeSessionKey(sessionKey)}:${runId}`
+  const previous = runUpdateQueues.get(key) ?? Promise.resolve()
+  const current = previous.catch(() => undefined).then(work)
+  const marker = current.then(
+    () => undefined,
+    () => undefined,
   )
+  runUpdateQueues.set(key, marker)
+  try {
+    return await current
+  } finally {
+    if (runUpdateQueues.get(key) === marker) {
+      runUpdateQueues.delete(key)
+    }
+  }
 }
 
 export async function createPersistedRun(input: {
@@ -102,12 +126,14 @@ export async function updatePersistedRun(
   runId: string,
   updater: (run: PersistedRunState) => PersistedRunState,
 ): Promise<PersistedRunState | null> {
-  const current = await getPersistedRun(sessionKey, runId)
-  if (!current) return null
-  const next = updater(current)
-  next.updatedAt = Date.now()
-  await writeRun(next)
-  return next
+  return enqueueRunUpdate(sessionKey, runId, async () => {
+    const current = await getPersistedRun(sessionKey, runId)
+    if (!current) return null
+    const next = updater(current)
+    next.updatedAt = Date.now()
+    await writeRun(next)
+    return next
+  })
 }
 
 export async function appendRunText(


### PR DESCRIPTION
## Summary
- Snapshot the chat message list once when a response wait starts, so a completed assistant message can clear the Thinking indicator instead of moving the baseline forward.
- Treat persisted `complete` run statuses as terminal in the active-run polling fallback.
- Serialize persisted run updates per run and write through a temp file + rename to avoid lost updates or malformed JSON from concurrent writes.

## Tests
- `pnpm test src/screens/chat/chat-screen-utils.test.ts src/server/run-store.test.ts`
- `pnpm build`

Note: I also ran the full `pnpm test` locally; it currently fails in unrelated existing suites on current main (MCP hub search expectations, gateway env resolution, i18n label text, context usage helper export, composer/context copy checks, chat-message-list helpers, and playground localStorage setup). This patch-specific coverage passes.