### PR TITLE
fix(tasks-api): guard against HTML catch-all responses

### DIFF
--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -33,6 +33,9 @@ async function probeBackend(base: string): Promise<number> {
   try {
     const res = await fetch(base, { signal: AbortSignal.timeout(3000) })
     if (!res.ok) return 0
+    // Guard against HTML catch-all responses (route not found returns 200 HTML)
+    const contentType = res.headers.get('content-type') ?? ''
+    if (!contentType.includes('application/json')) return -1
     const data = await res.json()
     return Array.isArray(data.tasks) ? data.tasks.length : 0
   } catch {
@@ -50,9 +53,11 @@ async function resolveBackend(): Promise<BackendResolution> {
       probeBackend(CLAUDE_BASE),
     ])
 
-    // Prefer hermes if it has data; fall back to claude if only claude has data;
-    // default to hermes when both are empty (it is the canonical store agents write to).
-    const useHermes = hermesCount >= claudeCount
+    // Prefer hermes if it has real data (> 0); fall back to claude if hermes is
+    // missing (returns -1 for non-JSON / route-not-found) or empty.
+    // Default to claude when both are empty — it is the active backend after the
+    // hermes-tasks → claude-tasks route rename (commit efcb7d14).
+    const useHermes = hermesCount > 0 && hermesCount >= claudeCount
     _resolved = {
       base: useHermes ? HERMES_BASE : CLAUDE_BASE,
       assigneesBase: useHermes ? '/api/hermes-tasks-assignees' : '/api/claude-tasks-assignees',


### PR DESCRIPTION
## Problem

After commit `efcb7d14` renamed `/api/hermes-tasks` → `/api/claude-tasks`, the task board showed **"Failed to load tasks"** in all columns despite the backend being healthy.

### Root cause

`probeBackend()` in `tasks-api.ts` still probed the old `/api/hermes-tasks` route. Since the SPA catch-all returns `200 OK` with an HTML body (not a 404), `probeBackend()` saw a successful response and didn't treat it as a dead route. Then `resolveBackend()` selected `hermes-tasks` as the winner (both counts were 0, and the old logic defaulted to hermes when equal), and the actual task fetch to that dead route threw — causing the board to fail entirely.

## Fix

Two changes to `src/lib/tasks-api.ts`:

1. **`probeBackend()`** — check `Content-Type: application/json` after a 200 response. Return `-1` for non-JSON (HTML catch-all) instead of treating it as a valid empty backend.

2. **`resolveBackend()`** — only prefer `hermes-tasks` when `hermesCount > 0`. When hermes is absent or returns non-JSON, default to `claude-tasks` (the active backend post-rename).

## How to reproduce (before fix)

1. Run hermes-workspace against a server that only has `/api/claude-tasks` (post-rename)
2. Open the Tasks board
3. All columns show "Failed to load tasks"

## After fix

Tasks board loads correctly via `/api/claude-tasks`. If `/api/hermes-tasks` is ever restored and has data, it will still be preferred automatically.