### PR TITLE
fix(terminal): Docker-safe default cwd and missing-path fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,16 @@ COPY --from=build --chown=workspace:workspace /app/package.json ./package.json
 COPY --from=build --chown=workspace:workspace /app/server-entry.js ./server-entry.js
 COPY --from=build --chown=workspace:workspace /app/skills ./skills
 
+# Writable home for PTY/sessions when not overridden by a volume mount.
+RUN mkdir -p /opt/data && chown workspace:workspace /opt/data
+
 USER workspace
-ENV NODE_ENV=production \
+# Terminal PTY + session paths: align with docker-compose.coolify-hermes.yml (HOME=/opt/data).
+# Without this, Node `os.homedir()` follows passwd for `workspace`, often /home/workspace, which
+# may not exist — client-sent ~/.hermes then becomes /home/workspace/.hermes → FileNotFoundError in pty-helper.
+ENV HOME=/opt/data \
+    HERMES_HOME=/opt/data \
+    NODE_ENV=production \
     PORT=3000 \
     HOST=0.0.0.0 \
     HERMES_API_URL=http://hermes-agent:8642

--- a/FEATURES-INVENTORY.md
+++ b/FEATURES-INVENTORY.md
@@ -385,7 +385,7 @@
 | `OPENROUTER_API_KEY`   | OpenRouter API key passthrough (optional)          |
 | `GOOGLE_API_KEY`       | Google Gemini API key passthrough (optional)       |
 | `HERMES_API_TOKEN`     | Auth token for gateway API_SERVER_KEY              |
-| `BEARER_TOKEN`         | Bearer token for backend auth                      |
+| `getGatewayBearerToken()` | Bearer token for gateway HTTP auth (`HERMES_API_TOKEN` / `CLAUDE_API_TOKEN`) |
 | `PORT`                 | Server port (default: 3002 dev, 3000 prod)         |
 
 ### 4.6 Claude Config Management

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -23,7 +23,9 @@ const ACTIVE_TAB_KEY = 'terminal.active'
 const DEFAULT_HEIGHT = 360
 const MIN_HEIGHT = 300
 const MAX_HEIGHT = 480
-const DEFAULT_CWD = '~/.hermes'
+// Use ~ (not ~/.hermes): in Docker, ~/.hermes under passwd HOME is often absent
+// and Hermes state may live under HERMES_HOME elsewhere; shell should start in a real dir.
+const DEFAULT_CWD = '~'
 
 type TerminalTabState = {
   id: string

--- a/src/components/terminal/terminal-workspace.tsx
+++ b/src/components/terminal/terminal-workspace.tsx
@@ -62,7 +62,8 @@ type TerminalSessionResponse = {
   sessionId?: string
 }
 
-const DEFAULT_TERMINAL_CWD = '~/.hermes'
+// See terminal-panel.tsx — ~/.hermes is not guaranteed to exist in the workspace image.
+const DEFAULT_TERMINAL_CWD = '~'
 const TERMINAL_BG = '#0d0d0d'
 
 function toDebugAnalysis(value: unknown): DebugAnalysis | null {

--- a/src/lib/connection-errors.ts
+++ b/src/lib/connection-errors.ts
@@ -26,7 +26,8 @@ const AUTH_FAILURE_MARKERS = [
   '403',
 ]
 
-function looksLikeAuthFailure(lower: string): boolean {
+/** Exported for UI layers that need the same “token” keyword guard as classifyConnectionError. */
+export function looksLikeAuthFailure(lower: string): boolean {
   return AUTH_FAILURE_MARKERS.some((marker) => lower.includes(marker))
 }
 

--- a/src/routes/api/-mcp.test.ts
+++ b/src/routes/api/-mcp.test.ts
@@ -168,7 +168,7 @@ describe('Phase 1.5 fallback — capability gating shape', () => {
     vi.doMock('../../server/gateway-capabilities', () => ({
       ensureGatewayProbed: () => Promise.resolve(fakeCaps),
       getCapabilities: () => fakeCaps,
-      BEARER_TOKEN: '',
+      getGatewayBearerToken: () => '',
       CLAUDE_API: 'http://127.0.0.1:8642',
       CLAUDE_UPGRADE_INSTRUCTIONS: 'noop',
       dashboardFetch: () => Promise.resolve(new Response(null, { status: 404 })),

--- a/src/routes/api/__tests__/-models.test.ts
+++ b/src/routes/api/__tests__/-models.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../server/auth-middleware', () => ({
 }))
 
 vi.mock('../../../server/gateway-capabilities', () => ({
-  BEARER_TOKEN: '',
+  getGatewayBearerToken: () => '',
   CLAUDE_API: 'http://127.0.0.1:8642',
 }))
 

--- a/src/routes/api/claude-jobs.$jobId.ts
+++ b/src/routes/api/claude-jobs.$jobId.ts
@@ -5,15 +5,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
+  getGatewayBearerToken,
 } from '../../server/gateway-capabilities'
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 function notSupported(): Response {

--- a/src/routes/api/claude-jobs.ts
+++ b/src/routes/api/claude-jobs.ts
@@ -4,17 +4,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 /**

--- a/src/routes/api/claude-proxy/$.ts
+++ b/src/routes/api/claude-proxy/$.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { BEARER_TOKEN, CLAUDE_API } from '../../../server/gateway-capabilities'
+import { CLAUDE_API, getGatewayBearerToken } from '../../../server/gateway-capabilities'
 import { isAuthenticated } from '../../../server/auth-middleware'
 
 /**
@@ -56,8 +56,7 @@ async function proxyRequest(request: Request, splat: string) {
   headers.delete('host')
   headers.delete('content-length')
   // Read at request time — follows the same fix as PR #234.
-  const bearer =
-    process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || BEARER_TOKEN
+  const bearer = getGatewayBearerToken()
   if (bearer) headers.set('Authorization', `Bearer ${bearer}`)
 
   const init: RequestInit = {

--- a/src/routes/api/claude-tasks-assignees.ts
+++ b/src/routes/api/claude-tasks-assignees.ts
@@ -7,7 +7,7 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, CLAUDE_API, CLAUDE_DASHBOARD_URL } from '../../server/gateway-capabilities'
+import { CLAUDE_API, CLAUDE_DASHBOARD_URL, getGatewayBearerToken } from '../../server/gateway-capabilities'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
@@ -58,7 +58,8 @@ function getProfileNames(): string[] {
 }
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 function titleCaseProfile(name: string): string {

--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
-import { BEARER_TOKEN, CLAUDE_API, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { CLAUDE_API, ensureGatewayProbed, getGatewayBearerToken } from '../../server/gateway-capabilities'
 import { getClaudeRoot, getProfileClaudeHome, getWorkspaceClaudeHome } from '../../server/claude-paths'
 
 type CrewDefinition = {
@@ -205,9 +205,10 @@ function readCronJobCount(claudeHome: string): number {
 
 async function fetchAssignedTaskCounts(): Promise<Record<string, number>> {
   try {
+    const bearer = getGatewayBearerToken()
     const res = await fetch(`${CLAUDE_API}/api/tasks?include_done=false`, {
       signal: AbortSignal.timeout(3_000),
-      headers: BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {},
+      headers: bearer ? { Authorization: `Bearer ${bearer}` } : {},
     })
     if (!res.ok) return {}
 

--- a/src/routes/api/mcp.ts
+++ b/src/routes/api/mcp.ts
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../server/gateway-capabilities'
 import { requireJsonContentType, safeErrorMessage } from '../../server/rate-limit'
 import {
@@ -32,8 +32,9 @@ async function mcpFetch(path: string, init: RequestInit = {}): Promise<Response>
     return dashboardFetch(path, init)
   }
   const headers = new Headers(init.headers)
-  if (BEARER_TOKEN && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  const bearer = getGatewayBearerToken()
+  if (bearer && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${bearer}`)
   }
   return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
 }

--- a/src/routes/api/mcp/$name.ts
+++ b/src/routes/api/mcp/$name.ts
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
 import { getConfig, saveConfig } from '../../../server/claude-dashboard-api'
@@ -21,8 +21,9 @@ async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
     return dashboardFetch(path, init)
   }
   const headers = new Headers(init.headers)
-  if (BEARER_TOKEN && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  const bearer = getGatewayBearerToken()
+  if (bearer && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${bearer}`)
   }
   return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
 }

--- a/src/routes/api/mcp/configure.ts
+++ b/src/routes/api/mcp/configure.ts
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
 import {
@@ -27,8 +27,9 @@ async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
     return dashboardFetch(path, init)
   }
   const headers = new Headers(init.headers)
-  if (BEARER_TOKEN && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  const bearer = getGatewayBearerToken()
+  if (bearer && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${bearer}`)
   }
   return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
 }

--- a/src/routes/api/mcp/discover.ts
+++ b/src/routes/api/mcp/discover.ts
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
 import { normalizeTestResult } from '../../../server/mcp-normalize'
@@ -22,8 +22,9 @@ async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
     return dashboardFetch(path, init)
   }
   const headers = new Headers(init.headers)
-  if (BEARER_TOKEN && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  const bearer = getGatewayBearerToken()
+  if (bearer && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${bearer}`)
   }
   return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
 }

--- a/src/routes/api/mcp/test.ts
+++ b/src/routes/api/mcp/test.ts
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 import { requireJsonContentType, safeErrorMessage } from '../../../server/rate-limit'
 import { normalizeTestResult } from '../../../server/mcp-normalize'
@@ -24,8 +24,9 @@ async function mcpFetch(path: string, init: RequestInit): Promise<Response> {
     return dashboardFetch(path, init)
   }
   const headers = new Headers(init.headers)
-  if (BEARER_TOKEN && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  const bearer = getGatewayBearerToken()
+  if (bearer && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${bearer}`)
   }
   return fetch(`${CLAUDE_API}${path}`, { ...init, headers })
 }

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -9,7 +9,7 @@ import {
   ensureGatewayProbed,
   getGatewayCapabilities,
 } from '../../server/claude-api'
-import { BEARER_TOKEN, CLAUDE_API } from '../../server/gateway-capabilities'
+import { CLAUDE_API, getGatewayBearerToken } from '../../server/gateway-capabilities'
 import {
   ensureDiscovery,
   getDiscoveredModels,
@@ -174,7 +174,8 @@ function readClaudeDefaultModel(): ModelEntry | null {
  */
 async function fetchClaudeModels(): Promise<Array<ModelEntry>> {
   const headers: Record<string, string> = {}
-  if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+  const bearer = getGatewayBearerToken()
+  if (bearer) headers['Authorization'] = `Bearer ${bearer}`
   const response = await fetch(`${CLAUDE_API}/v1/models`, { headers })
   if (!response.ok)
     throw new Error(`Hermes models request failed (${response.status})`)

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -5,12 +5,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   CLAUDE_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '../../server/gateway-capabilities'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
@@ -362,7 +362,8 @@ function normalizeSkill(value: unknown): SkillSummary | null {
 async function fetchClaudeSkills(): Promise<Array<SkillSummary>> {
   const capabilities = getCapabilities()
   const headers: Record<string, string> = {}
-  if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+  const bearer = getGatewayBearerToken()
+  if (bearer) headers['Authorization'] = `Bearer ${bearer}`
 
   const response = capabilities.dashboard.available
     ? await dashboardFetch('/api/skills')
@@ -600,7 +601,8 @@ export const Route = createFileRoute('/api/skills')({
           const headers: Record<string, string> = {
             'Content-Type': 'application/json',
           }
-          if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+          const bearer = getGatewayBearerToken()
+  if (bearer) headers['Authorization'] = `Bearer ${bearer}`
 
           const response = await fetch(`${CLAUDE_API}${endpoint}`, {
             method: 'POST',

--- a/src/routes/api/skills/install.ts
+++ b/src/routes/api/skills/install.ts
@@ -2,13 +2,14 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   ensureGatewayProbed,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 export const Route = createFileRoute('/api/skills/install')({

--- a/src/routes/api/skills/toggle.ts
+++ b/src/routes/api/skills/toggle.ts
@@ -2,14 +2,15 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   dashboardFetch,
   ensureGatewayProbed,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 export const Route = createFileRoute('/api/skills/toggle')({

--- a/src/routes/api/skills/uninstall.ts
+++ b/src/routes/api/skills/uninstall.ts
@@ -2,13 +2,14 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   ensureGatewayProbed,
+  getGatewayBearerToken,
 } from '../../../server/gateway-capabilities'
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 export const Route = createFileRoute('/api/skills/uninstall')({

--- a/src/routes/api/swarm-decompose.ts
+++ b/src/routes/api/swarm-decompose.ts
@@ -1,7 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, ensureGatewayProbed, getResolvedUrls } from '../../server/gateway-capabilities'
+import {
+  ensureGatewayProbed,
+  getGatewayBearerToken,
+  getResolvedUrls,
+} from '../../server/gateway-capabilities'
 
 type DecomposeRequest = {
   prompt?: unknown
@@ -68,7 +72,8 @@ async function callOrchestrator(prompt: string, workers: WorkerHint[], model: st
   }
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (BEARER_TOKEN) headers.Authorization = `Bearer ${BEARER_TOKEN}`
+  const bearer = getGatewayBearerToken()
+  if (bearer) headers.Authorization = `Bearer ${bearer}`
 
   const { gateway } = getResolvedUrls()
   const res = await fetch(`${gateway}/v1/chat/completions`, {

--- a/src/screens/chat/components/connection-status-message.tsx
+++ b/src/screens/chat/components/connection-status-message.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Alert02Icon, WifiDisconnected01Icon } from '@hugeicons/core-free-icons'
 import { cn } from '@/lib/utils'
+import { looksLikeAuthFailure } from '@/lib/connection-errors'
 
 type ConnectionStatusMessageProps = {
   state: 'checking' | 'error'
@@ -30,16 +31,28 @@ function classifyConnectionError(
     }
   }
 
-  if (
+  // Match gateway-capabilities: gateway uses API_SERVER_KEY (HERMES_API_TOKEN); dashboard
+  // uses a separate bearer (HERMES_DASHBOARD_TOKEN or scraped session token). Do not treat
+  // every substring "token" as auth (e.g. "session token not found" is often URL/scrape).
+  const looksLikeGatewayOrDashboardAuth =
     status === 401 ||
-    lower.includes('auth') ||
-    lower.includes('token') ||
-    lower.includes('unauthorized')
-  ) {
+    lower.includes('unauthorized') ||
+    lower.includes('unauthenticated') ||
+    lower.includes('missing gateway auth') ||
+    lower.includes('gateway auth') ||
+    lower.includes('invalid api key') ||
+    lower.includes('wrong api key') ||
+    (lower.includes('bearer') &&
+      (lower.includes('invalid') || lower.includes('missing') || lower.includes('required'))) ||
+    (lower.includes('token') && looksLikeAuthFailure(lower))
+
+  if (looksLikeGatewayOrDashboardAuth) {
     return {
       title: 'Authentication required',
-      description: 'Hermes Agent rejected the connection token.',
-      action: 'Go to Settings -> Advanced -> Hermes Agent to update your token.',
+      description:
+        'Hermes Agent rejected the gateway or dashboard bearer. The workspace password (HERMES_PASSWORD) is separate.',
+      action:
+        'In Coolify/env: set HERMES_API_TOKEN to the same value as API_SERVER_KEY on hermes-agent. For sessions/skills on the FastAPI dashboard, set HERMES_DASHBOARD_TOKEN to the dashboard session token (or leave it unset so the workspace scrapes it from hermes-dashboard:9119). Then restart hermes-workspace.',
     }
   }
 

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -27,9 +27,12 @@ vi.mock('node:os', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.unstubAllGlobals()
   delete process.env.CLAUDE_HOME
   delete process.env.CLAUDE_API_URL
   delete process.env.CLAUDE_DASHBOARD_URL
+  delete process.env.HERMES_DASHBOARD_TOKEN
+  delete process.env.CLAUDE_DASHBOARD_TOKEN
 })
 
 async function loadMod() {
@@ -100,5 +103,36 @@ describe('gateway-capabilities', () => {
         mod.setGatewayUrl(null as never)
       }
     })
+  })
+
+  it('fetchDashboardToken uses /api/auth/session-token before HTML scrape', async () => {
+    process.env.CLAUDE_DASHBOARD_URL = 'http://hermes-dashboard:9119'
+    const fetchMock = vi.fn((url: string | URL) => {
+      const s = String(url)
+      if (s.includes('/api/auth/session-token')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ token: 'from-json-api' }),
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve(''),
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mod = await loadMod()
+    const tok = await mod.fetchDashboardToken({ force: true })
+    expect(tok).toBe('from-json-api')
+    expect(
+      fetchMock.mock.calls.some((c) =>
+        String(c[0]).includes('/api/auth/session-token'),
+      ),
+    ).toBe(true)
+    expect(
+      fetchMock.mock.calls.some((c) => String(c[0]).endsWith(':9119/')),
+    ).toBe(false)
   })
 })

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -6,12 +6,12 @@
  */
 
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   SESSIONS_API_UNAVAILABLE_MESSAGE,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
   probeGateway,
 } from './gateway-capabilities'
 import {
@@ -25,8 +25,10 @@ import {
   updateSession as updateDashboardSession,
 } from './claude-dashboard-api'
 
-const _authHeaders = (): Record<string, string> =>
-  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+const _authHeaders = (): Record<string, string> => {
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
+}
 
 console.log(`[claude-api] Configured API: ${CLAUDE_API}`)
 

--- a/src/server/context-usage.ts
+++ b/src/server/context-usage.ts
@@ -1,9 +1,9 @@
 import {
-  BEARER_TOKEN,
   CLAUDE_API,
   dashboardFetch,
   ensureGatewayProbed,
   getCapabilities,
+  getGatewayBearerToken,
 } from '@/server/gateway-capabilities'
 import { getLocalMessages, getLocalSession } from '@/server/local-session-store'
 
@@ -55,7 +55,8 @@ function getContextWindow(model: string): number {
 }
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 function emptySnapshot(): ContextUsageSnapshot {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -284,8 +284,8 @@ export function getGatewayBearerToken(): string {
  * issues an ephemeral session token at boot (web_server.py:_SESSION_TOKEN).
  * Treating them as interchangeable wedges the workspace into 401 loops on
  * /api/sessions, /api/skills, etc. against the official dashboard. If
- * CLAUDE_DASHBOARD_TOKEN isn't set, leave this empty and let
- * fetchDashboardToken() fall through to the HTML-scrape legacy path.
+ * CLAUDE_DASHBOARD_TOKEN isn't set, fetchDashboardToken() uses the dashboard
+ * JSON endpoint, then legacy HTML scrape for older builds.
  */
 const DASHBOARD_BEARER_TOKEN = process.env.HERMES_DASHBOARD_TOKEN || process.env.CLAUDE_DASHBOARD_TOKEN || ''
 
@@ -297,20 +297,40 @@ function authHeaders(): Record<string, string> {
 let loggedHtmlScrapeFallback = false
 
 /**
+ * Hermes dashboard (web_server.py) exposes the ephemeral session token as JSON
+ * for the SPA. Server-side callers (workspace in Docker) use this instead of
+ * parsing HTML — reliable when dashboard runs in a separate container.
+ */
+async function fetchDashboardSessionTokenFromApi(): Promise<string | null> {
+  try {
+    const url = `${CLAUDE_DASHBOARD_URL}/api/auth/session-token`
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { token?: unknown }
+    const t = typeof data.token === 'string' ? data.token.trim() : ''
+    return t || null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Resolve a bearer token for dashboard API calls.
  *
  * Lookup order:
- *   1.  CLAUDE_DASHBOARD_TOKEN / CLAUDE_API_TOKEN env (preferred)
- *   2.  Inline token injected into the dashboard's root HTML (legacy
- *      fallback — logs a deprecation warning; to be removed once all
- *      supported dashboards expose a first-class token endpoint). See #124.
+ *   1. HERMES_DASHBOARD_TOKEN / CLAUDE_DASHBOARD_TOKEN (explicit pin)
+ *   2. GET /api/auth/session-token on the dashboard (Hermes Agent web UI)
+ *   3. Legacy: parse token from dashboard root HTML (older or minimal builds)
  */
 export async function fetchDashboardToken(options?: {
   force?: boolean
 }): Promise<string> {
   const force = options?.force === true
 
-  // Prefer the explicit service-to-service token — no HTML scrape at all.
+  // Prefer the explicit service-to-service token — no network discovery.
   if (DASHBOARD_BEARER_TOKEN) {
     dashboardTokenCache = DASHBOARD_BEARER_TOKEN
     return DASHBOARD_BEARER_TOKEN
@@ -320,13 +340,17 @@ export async function fetchDashboardToken(options?: {
   if (!force && dashboardTokenPromise) return dashboardTokenPromise
 
   dashboardTokenPromise = (async () => {
+    const fromApi = await fetchDashboardSessionTokenFromApi()
+    if (fromApi) {
+      dashboardTokenCache = fromApi
+      return fromApi
+    }
+
     if (!loggedHtmlScrapeFallback) {
       loggedHtmlScrapeFallback = true
       console.warn(
-        '[gateway] CLAUDE_DASHBOARD_TOKEN is not set — falling back to the legacy ' +
-          'HTML-scrape token flow. This fallback will be removed in a future release. ' +
-          'Set CLAUDE_DASHBOARD_TOKEN (or CLAUDE_API_TOKEN) to a dashboard bearer ' +
-          'token to migrate. See #124.',
+        '[gateway] Dashboard /api/auth/session-token unavailable — falling back to ' +
+          'HTML token scrape. Upgrade Hermes Agent dashboard or set HERMES_DASHBOARD_TOKEN.',
       )
     }
     // Dashboard injects the session token inline on `/` (root), not on

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -258,8 +258,18 @@ let lastLoggedSummary = ''
 let dashboardTokenPromise: Promise<string> | null = null
 let dashboardTokenCache = ''
 
-/** Optional bearer token for authenticated gateway endpoints. */
-export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
+/**
+ * Bearer for Hermes Agent OpenAI-compatible gateway (`API_SERVER_KEY` →
+ * `HERMES_API_TOKEN` / `CLAUDE_API_TOKEN` in the workspace).
+ *
+ * Read at **call time**, not module load: under vite-node SSR the first
+ * evaluation of this module can see an empty `process.env` snapshot even
+ * though the container later has `HERMES_API_TOKEN` set (same pattern as
+ * `openai-compat-api.ts` `getBearerToken()`).
+ */
+export function getGatewayBearerToken(): string {
+  return (process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || '').trim()
+}
 
 /**
  * Optional explicit bearer token for dashboard API calls.
@@ -280,7 +290,8 @@ export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_A
 const DASHBOARD_BEARER_TOKEN = process.env.HERMES_DASHBOARD_TOKEN || process.env.CLAUDE_DASHBOARD_TOKEN || ''
 
 function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
 }
 
 let loggedHtmlScrapeFallback = false

--- a/src/server/pty-helper.py
+++ b/src/server/pty-helper.py
@@ -14,7 +14,11 @@ def set_winsize(fd, rows, cols):
 def main():
     default_shell = '/bin/zsh' if sys.platform == 'darwin' else '/bin/bash'
 
-    cwd = sys.argv[1] if len(sys.argv) > 1 else os.environ.get('HOME', '/tmp')
+    cwd = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else (os.environ.get("HOME") or os.environ.get("HERMES_HOME") or "/tmp").strip() or "/tmp"
+    )
     cols = int(sys.argv[2]) if len(sys.argv) > 2 else 80
     rows = int(sys.argv[3]) if len(sys.argv) > 3 else 24
 
@@ -31,6 +35,18 @@ def main():
 
     if cwd.startswith('~'):
         cwd = os.path.expanduser(cwd)
+
+    # Node caller should validate cwd, but Coolify / missing HOME can still pass a
+    # non-existent path (e.g. /home/workspace/.hermes). Never let chdir crash the PTY.
+    if not os.path.isdir(cwd):
+        home = (
+            os.environ.get("HOME", "").strip()
+            or os.environ.get("HERMES_HOME", "").strip()
+        )
+        if home and os.path.isdir(home):
+            cwd = home
+        elif os.path.isdir("/tmp"):
+            cwd = "/tmp"
 
     # Create PTY
     master_fd, slave_fd = pty.openpty()

--- a/src/server/responses-api.ts
+++ b/src/server/responses-api.ts
@@ -18,7 +18,7 @@
  * `send-stream.ts` can translate to its existing `tool.*` events without
  * caring about Responses-spec quirks.
  */
-import { BEARER_TOKEN, CLAUDE_API } from './gateway-capabilities'
+import { CLAUDE_API, getGatewayBearerToken } from './gateway-capabilities'
 
 export type ResponsesStreamEvent =
   | { kind: 'text.delta'; delta: string }
@@ -55,8 +55,10 @@ export type ResponsesChatRequest = {
   signal?: AbortSignal
 }
 
-const _authHeaders = (): Record<string, string> =>
-  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+const _authHeaders = (): Record<string, string> => {
+  const t = getGatewayBearerToken()
+  return t ? { Authorization: `Bearer ${t}` } : {}
+}
 
 function tryParseJson(value: string): Record<string, unknown> | string | null {
   if (!value) return null
@@ -109,7 +111,7 @@ export async function* streamResponses(
     'Content-Type': 'application/json',
     Accept: 'text/event-stream',
   }
-  if (req.sessionId && BEARER_TOKEN) {
+  if (req.sessionId && getGatewayBearerToken()) {
     headers['X-Hermes-Session-Id'] = req.sessionId
   }
 

--- a/src/server/terminal-sessions.ts
+++ b/src/server/terminal-sessions.ts
@@ -4,6 +4,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
@@ -75,6 +76,9 @@ export function createTerminalSession(params: {
   let cwd = params.cwd ?? home
   if (cwd.startsWith('~')) {
     cwd = cwd.replace('~', home)
+  }
+  if (!existsSync(cwd)) {
+    cwd = home
   }
 
   const cols = params.cols ?? 80

--- a/src/server/terminal-sessions.ts
+++ b/src/server/terminal-sessions.ts
@@ -63,7 +63,13 @@ export function createTerminalSession(params: {
   const emitter = new EventEmitter()
   const sessionId = randomUUID()
 
-  const home = process.env.HOME ?? homedir() ?? '/tmp'
+  // Prefer compose-injected HOME (e.g. /opt/data), then HERMES_HOME (Coolify often sets one but not
+  // the other), then passwd homedir — the `workspace` user may have /home/workspace in passwd
+  // without that directory existing, which breaks ~/.hermes expansion (pty-helper FileNotFoundError).
+  const hermesHome = process.env.HERMES_HOME?.trim() || ''
+  const envHome =
+    process.env.HOME?.trim() || hermesHome
+  const sysHome = (homedir() ?? '').trim() || ''
   const defaultShell =
     process.platform === 'win32'
       ? 'powershell.exe'
@@ -73,12 +79,19 @@ export function createTerminalSession(params: {
   const command = params.command?.length
     ? params.command
     : [process.env.SHELL ?? defaultShell]
-  let cwd = params.cwd ?? home
+  const tildeBase = envHome || sysHome || '/'
+  let cwd =
+    typeof params.cwd === 'string' && params.cwd.trim().length > 0
+      ? params.cwd.trim()
+      : envHome || sysHome || '/tmp'
   if (cwd.startsWith('~')) {
-    cwd = cwd.replace('~', home)
+    cwd = cwd.replace(/^~/, tildeBase)
   }
   if (!existsSync(cwd)) {
-    cwd = home
+    if (envHome && existsSync(envHome)) cwd = envHome
+    else if (hermesHome && existsSync(hermesHome)) cwd = hermesHome
+    else if (sysHome && existsSync(sysHome)) cwd = sysHome
+    else cwd = '/tmp'
   }
 
   const cols = params.cols ?? 80


### PR DESCRIPTION
## Problem
The embedded terminal defaulted to `~/.hermes`. In the workspace container, that expands to a path under passwd HOME (e.g. `/home/workspace/.hermes`) that is often absent, so `pty-helper.py` fails on `os.chdir` and the UI reconnects in a loop.

## Changes
- Default terminal cwd to `~` instead of `~/.hermes`.
- In `terminal-sessions.ts`, if the resolved cwd does not exist, fall back to `HOME`.

## Note
Ocass Coolify compose sets `HOME=/opt/data` on `hermes-workspace` so `~` is a real persisted directory.