### PR TITLE
feat: add Kanban store provider contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Start here: [docs/swarm/](./docs/swarm/)
 - **Orchestrator Chat** — ask the control plane for one task, a decomposed mission, or a full broadcast.
 - **Multi-Agent Control Plane** — see persistent Hermes Agents, roles, state, runtime, and routing wires in one surface.
 - **Kanban TaskBoard** — plan backlog, ready, running, review, blocked, and done lanes without leaving the workspace.
+  The server-side Kanban layer uses a store/provider contract so SQLite remains the default while future backends can be tested behind a conformance suite.
 - **Reports + Inbox** — review checkpoints, blockers, handoffs, and ready-for-human decisions.
 - **TUI View built in** — attach to tmux-backed workers or fall back to a live shell/log stream.
 
@@ -76,6 +77,14 @@ Start here: [docs/swarm/](./docs/swarm/)
 |                  Tasks                  |                 Jobs                 |
 | :--------------------------------------: | :----------------------------------: |
 | ![Tasks](./docs/screenshots/tasks.png) | ![Jobs](./docs/screenshots/jobs.png) |
+
+---
+
+## Kanban store contract
+
+The TaskBoard backend is split behind a small store/provider contract. The default provider is SQLite and should stay the compatibility oracle for local installs. New providers must satisfy the shared conformance suite before they are exposed to the UI.
+
+For operator rollouts, keep provider changes server-scoped and reversible: back up the existing SQLite data, test against a disposable board, then canary one recurring board before considering broader use. The UI should treat provider-backed task data as a board source, not as an instruction to globally migrate every board.
 
 ---
 

--- a/docs/swarm/QUICKSTART.md
+++ b/docs/swarm/QUICKSTART.md
@@ -157,6 +157,8 @@ The Inbox is where the swarm asks for judgment instead of trying to be brave in 
 
 Switch to Kanban view for planning. The board is useful when you want a visual queue but still want dispatch to happen through the orchestrator.
 
+Storage note: the TaskBoard defaults to SQLite. Provider-backed boards should be treated as explicit canaries: back up SQLite, test a disposable board first, then promote one recurring board at a time.
+
 Recommended lane meanings:
 
 | Lane | Meaning |

--- a/scripts/seed-runtime.mjs
+++ b/scripts/seed-runtime.mjs
@@ -4,15 +4,17 @@ import os from 'node:os'
 
 const PROFILES = path.join(os.homedir(), '.claude', 'profiles')
 const NOW = Date.now()
+const WORKSPACE_ROOT = process.env.HERMES_WORKSPACE_ROOT ?? process.cwd()
+const OPS_WORKSPACE_ROOT = process.env.HERMES_OPS_WORKSPACE_ROOT ?? WORKSPACE_ROOT
 const LANES = {
-  swarm1:  ['PR / Issues', 'Triage open PRs and surface review-ready items for the orchestrator', 'Standing by on PR/issues lane; tmux session live and wrapper wired.', '/Users/aurora/hermes-workspace'],
-  swarm6:  ['Reviewer', 'Review pending diffs and gate merges with checklist + tests', 'Reviewer lane initialized; awaiting first dispatch.', '/Users/aurora/hermes-workspace'],
-  swarm7:  ['Docs', 'Maintain handoffs, README updates, and skill documentation', 'Docs lane initialized; runtime contract adopted.', '/Users/aurora/hermes-workspace'],
-  swarm8:  ['Ops', 'Track infra, gateways, schedulers, and operational health', 'Ops lane initialized; ready to monitor swarm health.', '/Users/aurora/.ocplatform/workspace'],
-  swarm9:  ['Hackathon', 'Prototype experimental flows and one-off agent missions', 'Hackathon lane initialized; sandbox ready.', '/Users/aurora/hermes-workspace'],
-  swarm10: ['Builder', 'Implement feature work assigned by the orchestrator', 'Builder lane initialized; ready for next ticket.', '/Users/aurora/hermes-workspace'],
-  swarm11: ['Reviewer', 'Secondary review lane for high-throughput periods', 'Reviewer lane initialized; ready for parallel review.', '/Users/aurora/hermes-workspace'],
-  swarm12: ['PR / Issues', 'Backup PR/issues lane for parallel triage', 'PR/issues secondary lane initialized.', '/Users/aurora/hermes-workspace'],
+  swarm1:  ['PR / Issues', 'Triage open PRs and surface review-ready items for the orchestrator', 'Standing by on PR/issues lane; tmux session live and wrapper wired.', WORKSPACE_ROOT],
+  swarm6:  ['Reviewer', 'Review pending diffs and gate merges with checklist + tests', 'Reviewer lane initialized; awaiting first dispatch.', WORKSPACE_ROOT],
+  swarm7:  ['Docs', 'Maintain handoffs, README updates, and skill documentation', 'Docs lane initialized; runtime contract adopted.', WORKSPACE_ROOT],
+  swarm8:  ['Ops', 'Track infra, gateways, schedulers, and operational health', 'Ops lane initialized; ready to monitor swarm health.', OPS_WORKSPACE_ROOT],
+  swarm9:  ['Hackathon', 'Prototype experimental flows and one-off agent missions', 'Hackathon lane initialized; sandbox ready.', WORKSPACE_ROOT],
+  swarm10: ['Builder', 'Implement feature work assigned by the orchestrator', 'Builder lane initialized; ready for next ticket.', WORKSPACE_ROOT],
+  swarm11: ['Reviewer', 'Secondary review lane for high-throughput periods', 'Reviewer lane initialized; ready for parallel review.', WORKSPACE_ROOT],
+  swarm12: ['PR / Issues', 'Backup PR/issues lane for parallel triage', 'PR/issues secondary lane initialized.', WORKSPACE_ROOT],
   swarm1_existing: null,
 }
 for (const [wid, v] of Object.entries(LANES)) {

--- a/scripts/swarm-env-check.sh
+++ b/scripts/swarm-env-check.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CANONICAL_REPO="/Users/aurora/hermes-workspace"
-FORBIDDEN_REPO="/Users/aurora/hermes-workspace"
+CANONICAL_REPO="${HERMES_WORKSPACE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}"
+FORBIDDEN_REPO="${HERMES_FORBIDDEN_REPO:-}"
 
 CURRENT_DIR="$(pwd -P)"
 
-if [[ "$CURRENT_DIR" == "$FORBIDDEN_REPO" ]] || [[ "$CURRENT_DIR" == "$FORBIDDEN_REPO"/* ]]; then
+if [[ -n "$FORBIDDEN_REPO" ]] && { [[ "$CURRENT_DIR" == "$FORBIDDEN_REPO" ]] || [[ "$CURRENT_DIR" == "$FORBIDDEN_REPO"/* ]]; }; then
   echo "ERROR: wrong repo: $CURRENT_DIR"
   echo "Use: $CANONICAL_REPO"
   exit 1
@@ -23,10 +23,11 @@ if [[ ! -f "$CANONICAL_REPO/package.json" ]]; then
   exit 1
 fi
 
-REPO_NAME="$(python3 - <<'PY'
+REPO_NAME="$(CANONICAL_REPO="$CANONICAL_REPO" python3 - <<'PY'
 import json
+import os
 from pathlib import Path
-pkg = json.loads(Path('/Users/aurora/hermes-workspace/package.json').read_text())
+pkg = json.loads((Path(os.environ['CANONICAL_REPO']) / 'package.json').read_text())
 print(pkg.get('name', ''))
 PY
 )"

--- a/src/routes/api/swarm-kanban.ts
+++ b/src/routes/api/swarm-kanban.ts
@@ -2,11 +2,17 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { z } from 'zod'
 import { createKanbanCard, getKanbanBackendMeta, listKanbanCards, updateKanbanCard } from '../../server/kanban-backend'
+import { isAuthenticated } from '../../server/auth-middleware'
 
 const CreateCardSchema = z.object({
   title: z.string().trim().min(1).max(200),
   spec: z.string().trim().max(5000).optional().default(''),
-  acceptanceCriteria: z.string().trim().max(5000).optional().default(''),
+  acceptanceCriteria: z.preprocess(
+    (value) => typeof value === 'string'
+      ? value.split('\n').map((line) => line.trim()).filter(Boolean)
+      : value,
+    z.array(z.string().trim().min(1).max(1000)).max(50),
+  ).optional().default([]),
   assignedWorker: z.string().trim().max(120).optional().nullable(),
   reviewer: z.string().trim().max(120).optional().nullable(),
   status: z.enum(['backlog', 'ready', 'running', 'review', 'blocked', 'done']).optional().default('backlog'),
@@ -22,7 +28,10 @@ const UpdateCardSchema = CreateCardSchema.partial().extend({
 export const Route = createFileRoute('/api/swarm-kanban')({
   server: {
     handlers: {
-      GET: async () => {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
         return json({
           ok: true,
           cards: await listKanbanCards(),
@@ -30,6 +39,9 @@ export const Route = createFileRoute('/api/swarm-kanban')({
         })
       },
       POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
         let body: unknown
         try {
           body = await request.json()
@@ -44,6 +56,9 @@ export const Route = createFileRoute('/api/swarm-kanban')({
         return json({ ok: true, card, backend: getKanbanBackendMeta() })
       },
       PATCH: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
         let body: unknown
         try {
           body = await request.json()

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { KANBAN_STORE_API_VERSION } from './kanban-store-contract'
 
 afterEach(() => {
   vi.resetModules()
@@ -8,6 +9,7 @@ afterEach(() => {
 
 async function loadKanbanBackend(options?: {
   existsSync?: (path: string) => boolean
+  readFileSync?: (path: string) => string
   execFileSync?: (command: string, args?: string[]) => string
 }) {
   vi.doMock('./swarm-kanban-store', () => ({
@@ -26,20 +28,22 @@ async function loadKanbanBackend(options?: {
       createdAt: 1,
       updatedAt: 1,
     })),
-    listSwarmKanbanCards: vi.fn(() => [{
-      id: 'local-1',
-      title: 'Local task',
-      spec: '',
-      acceptanceCriteria: [],
-      assignedWorker: null,
-      reviewer: null,
-      status: 'backlog',
-      missionId: null,
-      reportPath: null,
-      createdBy: 'local',
-      createdAt: 1,
-      updatedAt: 1,
-    }]),
+    listSwarmKanbanCards: vi.fn(() => [
+      {
+        id: 'local-1',
+        title: 'Local task',
+        spec: '',
+        acceptanceCriteria: [],
+        assignedWorker: null,
+        reviewer: null,
+        status: 'backlog',
+        missionId: null,
+        reportPath: null,
+        createdBy: 'local',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]),
     updateSwarmKanbanCard: vi.fn((cardId, updates) => ({
       id: cardId,
       title: updates.title ?? 'Local task',
@@ -58,10 +62,14 @@ async function loadKanbanBackend(options?: {
 
   vi.doMock('node:fs', () => ({
     existsSync: vi.fn((path: string) => options?.existsSync?.(path) ?? false),
+    readFileSync: vi.fn((path: string) => options?.readFileSync?.(path) ?? ''),
   }))
 
   vi.doMock('node:child_process', () => ({
-    execFileSync: vi.fn((command: string, args?: string[]) => options?.execFileSync?.(command, args) ?? ''),
+    execFileSync: vi.fn(
+      (command: string, args?: string[]) =>
+        options?.execFileSync?.(command, args) ?? '',
+    ),
   }))
 
   return import('./kanban-backend')
@@ -70,12 +78,20 @@ async function loadKanbanBackend(options?: {
 describe('kanban-backend', () => {
   it('auto-detect prefers Hermes backend when Hermes CLI and canonical storage are present', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: Array<{ command: string; args?: string[] }> = []
     const mod = await loadKanbanBackend({
-      existsSync: (target) => target === '/Users/aurora/.claude/kanban.db' || target === '/Users/aurora/.claude/kanban',
+      existsSync: (target) =>
+        target === '/Users/aurora/.claude/kanban.db' ||
+        target === '/Users/aurora/.claude/kanban',
       execFileSync: (command, args = []) => {
-        if (command === 'which' && args[0] === 'claude') return '/Users/aurora/.local/bin/claude\n'
-        if (command === '/Users/aurora/.local/bin/claude' && args[0] === '--version') return 'claude 1.0.0\n'
+        if (command === 'which' && args[0] === 'claude')
+          return '/Users/aurora/.local/bin/claude\n'
+        if (
+          command === '/Users/aurora/.local/bin/claude' &&
+          args[0] === '--version'
+        )
+          return 'claude 1.0.0\n'
         if (command === 'sqlite3') {
           sqliteCalls.push({ command, args })
           return JSON.stringify([
@@ -99,6 +115,14 @@ describe('kanban-backend', () => {
       detected: true,
       writable: true,
       path: '/Users/aurora/.claude/kanban.db',
+      apiVersion: KANBAN_STORE_API_VERSION,
+      capabilities: {
+        tasks: true,
+        runs: true,
+        claims: true,
+        dispatcher: true,
+        completionCreatedCardsGuard: true,
+      },
     })
 
     const cards = await mod.listKanbanCards()
@@ -115,10 +139,12 @@ describe('kanban-backend', () => {
 
   it('auto-detect uses Hermes storage directly when the CLI is unavailable', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
       existsSync: (target) => target === '/Users/aurora/.claude/kanban.db',
       execFileSync: (command, args = []) => {
-        if (command === 'which' && args[0] === 'claude') throw new Error('not found')
+        if (command === 'which' && args[0] === 'claude')
+          throw new Error('not found')
         if (command === 'sqlite3') {
           return JSON.stringify([
             {
@@ -142,16 +168,23 @@ describe('kanban-backend', () => {
       writable: true,
       path: '/Users/aurora/.claude/kanban.db',
     })
-    expect(mod.getKanbanBackendMeta().details).toContain('direct local storage access')
-    expect((await mod.listKanbanCards())[0]).toMatchObject({ id: 't_direct', status: 'ready' })
+    expect(mod.getKanbanBackendMeta().details).toContain(
+      'direct local storage access',
+    )
+    expect((await mod.listKanbanCards())[0]).toMatchObject({
+      id: 't_direct',
+      status: 'ready',
+    })
   })
 
   it('resolves canonical Kanban paths from legacy profile-home env fallback too', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
     const mod = await loadKanbanBackend({
       existsSync: (target) => target === '/Users/aurora/.claude/kanban.db',
       execFileSync: (command, args = []) => {
-        if (command === 'which' && args[0] === 'claude') throw new Error('not found')
+        if (command === 'which' && args[0] === 'claude')
+          throw new Error('not found')
         if (command === 'sqlite3') return '[]'
         throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
       },
@@ -166,11 +199,17 @@ describe('kanban-backend', () => {
 
   it('auto-detect falls back to local when canonical Hermes storage is missing', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
       existsSync: () => false,
       execFileSync: (command, args = []) => {
-        if (command === 'which' && args[0] === 'claude') return '/Users/aurora/.local/bin/claude\n'
-        if (command === '/Users/aurora/.local/bin/claude' && args[0] === '--version') return 'claude 1.0.0\n'
+        if (command === 'which' && args[0] === 'claude')
+          return '/Users/aurora/.local/bin/claude\n'
+        if (
+          command === '/Users/aurora/.local/bin/claude' &&
+          args[0] === '--version'
+        )
+          return 'claude 1.0.0\n'
         throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
       },
     })
@@ -180,19 +219,99 @@ describe('kanban-backend', () => {
       detected: true,
       writable: true,
       path: '/tmp/swarm2-kanban.json',
+      apiVersion: KANBAN_STORE_API_VERSION,
+      capabilities: {
+        tasks: true,
+        runs: false,
+        claims: false,
+      },
     })
     expect((await mod.listKanbanCards())[0]?.id).toBe('local-1')
   })
 
+  it('uses env provider selection and keeps sqlite as the default provider', async () => {
+    vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'local')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) =>
+        target === '/Users/aurora/.claude/kanban.db' ||
+        target === '/Users/aurora/.claude/kanban',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'claude')
+          return '/Users/aurora/.local/bin/claude\n'
+        if (
+          command === '/Users/aurora/.local/bin/claude' &&
+          args[0] === '--version'
+        )
+          return 'claude 1.0.0\n'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'local',
+      path: '/tmp/swarm2-kanban.json',
+    })
+  })
+
+  it('uses config provider selection when env does not override it', async () => {
+    vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) =>
+        target === '/Users/aurora/.claude/config.yaml' ||
+        target === '/Users/aurora/.claude/kanban.db',
+      readFileSync: (target) => {
+        expect(target).toBe('/Users/aurora/.claude/config.yaml')
+        return 'kanban:\n  provider: local\n  api_version: kanban-store.v1\n'
+      },
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'claude')
+          throw new Error('not found')
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'local',
+      path: '/tmp/swarm2-kanban.json',
+    })
+  })
+
+  it('fails loudly for unsupported env providers and API versions', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'postgres')
+    const unsupportedProvider = await loadKanbanBackend()
+    expect(() => unsupportedProvider.getKanbanBackendMeta()).toThrow(
+      /Unsupported Kanban provider/,
+    )
+
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('HERMES_KANBAN_STORE_API_VERSION', 'kanban-store.v2')
+    const unsupportedApi = await loadKanbanBackend()
+    expect(() => unsupportedApi.getKanbanBackendMeta()).toThrow(
+      /Unsupported Kanban store API version/,
+    )
+  })
+
   it('creates and updates Hermes tasks through canonical kanban.db path', async () => {
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: string[] = []
     let readCount = 0
     const mod = await loadKanbanBackend({
-      existsSync: (target) => target === '/Users/aurora/.claude/kanban.db' || target === '/Users/aurora/.claude/kanban',
+      existsSync: (target) =>
+        target === '/Users/aurora/.claude/kanban.db' ||
+        target === '/Users/aurora/.claude/kanban',
       execFileSync: (command, args = []) => {
-        if (command === 'which' && args[0] === 'claude') return '/Users/aurora/.local/bin/claude\n'
-        if (command === '/Users/aurora/.local/bin/claude' && args[0] === '--version') return 'claude 1.0.0\n'
+        if (command === 'which' && args[0] === 'claude')
+          return '/Users/aurora/.local/bin/claude\n'
+        if (
+          command === '/Users/aurora/.local/bin/claude' &&
+          args[0] === '--version'
+        )
+          return 'claude 1.0.0\n'
         if (command === 'sqlite3') {
           sqliteCalls.push(args.join(' '))
           const sql = args[2] ?? ''
@@ -201,7 +320,10 @@ describe('kanban-backend', () => {
             return JSON.stringify([
               {
                 id: 't_deadbeef',
-                title: readCount === 1 ? 'Created Hermes task' : 'Updated Hermes task',
+                title:
+                  readCount === 1
+                    ? 'Created Hermes task'
+                    : 'Updated Hermes task',
                 body: 'Task body',
                 status: readCount === 1 ? 'queued' : 'done',
                 assignee: 'swarm6',
@@ -216,13 +338,41 @@ describe('kanban-backend', () => {
       },
     })
 
-    const created = await mod.createKanbanCard({ title: 'Created Hermes task', spec: 'Task body', assignedWorker: 'swarm6', status: 'backlog' })
-    const updated = await mod.updateKanbanCard('t_deadbeef', { title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
+    const created = await mod.createKanbanCard({
+      title: 'Created Hermes task',
+      spec: 'Task body',
+      assignedWorker: 'swarm6',
+      status: 'backlog',
+    })
+    const updated = await mod.updateKanbanCard('t_deadbeef', {
+      title: 'Updated Hermes task',
+      status: 'done',
+      assignedWorker: 'swarm6',
+    })
 
-    expect(created).toMatchObject({ id: 't_deadbeef', title: 'Created Hermes task', status: 'backlog', assignedWorker: 'swarm6', createdBy: 'claude-kanban' })
-    expect(updated).toMatchObject({ id: 't_deadbeef', title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
-    expect(sqliteCalls.every((call) => call.startsWith('/Users/aurora/.claude/kanban.db '))).toBe(true)
-    expect(sqliteCalls.some((call) => call.includes('insert into tasks'))).toBe(true)
-    expect(sqliteCalls.some((call) => call.includes('update tasks set'))).toBe(true)
+    expect(created).toMatchObject({
+      id: 't_deadbeef',
+      title: 'Created Hermes task',
+      status: 'backlog',
+      assignedWorker: 'swarm6',
+      createdBy: 'claude-kanban',
+    })
+    expect(updated).toMatchObject({
+      id: 't_deadbeef',
+      title: 'Updated Hermes task',
+      status: 'done',
+      assignedWorker: 'swarm6',
+    })
+    expect(
+      sqliteCalls.every((call) =>
+        call.startsWith('/Users/aurora/.claude/kanban.db '),
+      ),
+    ).toBe(true)
+    expect(sqliteCalls.some((call) => call.includes('insert into tasks'))).toBe(
+      true,
+    )
+    expect(sqliteCalls.some((call) => call.includes('update tasks set'))).toBe(
+      true,
+    )
   })
 })

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -119,10 +119,10 @@ describe('kanban-backend', () => {
       apiVersion: KANBAN_STORE_API_VERSION,
       capabilities: {
         tasks: true,
-        runs: true,
-        claims: true,
-        dispatcher: true,
-        completionCreatedCardsGuard: true,
+        runs: false,
+        claims: false,
+        dispatcher: false,
+        completionCreatedCardsGuard: false,
       },
     })
 
@@ -331,6 +331,20 @@ describe('kanban-backend', () => {
       detected: true,
       writable: false,
       path: 'crosscut work visual-board',
+      capabilities: {
+        boards: true,
+        tasks: true,
+        taskLinks: false,
+        comments: false,
+        events: false,
+        runs: false,
+        claims: false,
+        dispatcher: false,
+        notifications: false,
+        idempotentCreate: false,
+        skillValidation: false,
+        completionCreatedCardsGuard: false,
+      },
     })
     const cards = await mod.listKanbanCards()
     expect(cards[0]).toMatchObject({

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -77,6 +77,7 @@ async function loadKanbanBackend(options?: {
 
 describe('kanban-backend', () => {
   it('auto-detect prefers Hermes backend when Hermes CLI and canonical storage are present', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'sqlite')
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
     vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: Array<{ command: string; args?: string[] }> = []
@@ -138,6 +139,7 @@ describe('kanban-backend', () => {
   })
 
   it('auto-detect uses Hermes storage directly when the CLI is unavailable', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'sqlite')
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
     vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
@@ -178,6 +180,7 @@ describe('kanban-backend', () => {
   })
 
   it('resolves canonical Kanban paths from legacy profile-home env fallback too', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'sqlite')
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
     vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm5/home')
     const mod = await loadKanbanBackend({
@@ -198,6 +201,7 @@ describe('kanban-backend', () => {
   })
 
   it('auto-detect falls back to local when canonical Hermes storage is missing', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'sqlite')
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
     vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const mod = await loadKanbanBackend({
@@ -279,6 +283,88 @@ describe('kanban-backend', () => {
     })
   })
 
+  it('uses CrossCut Postgres visual-board projection as a read-only provider', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'crosscut-postgres')
+    const crosscutCalls: string[][] = []
+    const mod = await loadKanbanBackend({
+      execFileSync: (command, args = []) => {
+        if (command === 'crosscut') {
+          crosscutCalls.push(args)
+          if (args.includes('boards')) {
+            return JSON.stringify({
+              provider_id: 'crosscut-postgres',
+              read_only: true,
+              boards: [
+                {
+                  id: 'hermes-local:work-graph-execution',
+                  backend_id: 'hermes-local',
+                  external_board: 'work-graph-execution',
+                  task_count: 1,
+                },
+              ],
+            })
+          }
+          if (args.includes('tasks')) {
+            return JSON.stringify({
+              provider_id: 'crosscut-postgres',
+              read_only: true,
+              tasks: [
+                {
+                  id: 'map-1',
+                  title: 'CrossCut Work Item',
+                  body: 'Durable planning body',
+                  work_status: 'delegated',
+                  external_status: 'running',
+                  assignee_hint: 'crosscut-coder',
+                  priority: 7,
+                },
+              ],
+            })
+          }
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'crosscut-postgres',
+      detected: true,
+      writable: false,
+      path: 'crosscut work visual-board',
+    })
+    const cards = await mod.listKanbanCards()
+    expect(cards[0]).toMatchObject({
+      id: 'map-1',
+      title: 'CrossCut Work Item',
+      spec: expect.stringContaining('Durable planning body'),
+      assignedWorker: 'crosscut-coder',
+      status: 'ready',
+      createdBy: 'crosscut-postgres',
+    })
+    await expect(
+      mod.createKanbanCard({ title: 'nope', spec: '', status: 'ready' }),
+    ).rejects.toThrow(/read-only/)
+    expect(crosscutCalls.some((args) => args.includes('boards'))).toBe(true)
+    expect(crosscutCalls.some((args) => args.includes('tasks'))).toBe(true)
+  })
+
+  it('falls back when CrossCut Postgres provider is selected but unavailable', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'crosscut-postgres')
+    const mod = await loadKanbanBackend({
+      execFileSync: (command, args = []) => {
+        if (command === 'crosscut') throw new Error('database unavailable')
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'local',
+      detected: true,
+      writable: true,
+    })
+    expect((await mod.listKanbanCards())[0]?.id).toBe('local-1')
+  })
+
   it('fails loudly for unsupported env providers and API versions', async () => {
     vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'postgres')
     const unsupportedProvider = await loadKanbanBackend()
@@ -296,6 +382,7 @@ describe('kanban-backend', () => {
   })
 
   it('creates and updates Hermes tasks through canonical kanban.db path', async () => {
+    vi.stubEnv('HERMES_KANBAN_STORE_PROVIDER', 'sqlite')
     vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.claude/profiles/swarm2')
     vi.stubEnv('HERMES_HOME', '/Users/aurora/.claude/profiles/swarm2')
     const sqliteCalls: string[] = []

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -31,9 +31,9 @@ import {
   type KanbanTaskRecord,
 } from './kanban-store-contract'
 
-export type KanbanBackendId = 'local' | 'claude' | 'hermes-proxy'
+export type KanbanBackendId = 'local' | 'claude' | 'hermes-proxy' | 'crosscut-postgres'
 
-type KanbanProviderPreference = 'local' | 'sqlite' | 'hermes-proxy' | 'auto'
+type KanbanProviderPreference = 'local' | 'sqlite' | 'hermes-proxy' | 'crosscut-postgres' | 'auto'
 
 type KanbanProviderSelection = {
   provider: KanbanProviderPreference
@@ -176,6 +176,96 @@ function dashboardTaskToCard(task: DashboardKanbanTask): SwarmKanbanCard {
   }
 }
 
+type CrossCutVisualTask = {
+  id?: string
+  mapping_id?: string
+  title?: string
+  body?: string | null
+  body_preview?: string | null
+  work_status?: string | null
+  external_status?: string | null
+  assignee_hint?: string | null
+  priority?: number | null
+}
+
+type CrossCutVisualTaskList = {
+  tasks?: CrossCutVisualTask[]
+}
+
+type CrossCutVisualBoardList = {
+  boards?: unknown[]
+}
+
+function runCrossCutVisualBoard(command: 'boards' | 'tasks'): unknown {
+  const output = execFileSync(
+    'crosscut',
+    ['work', 'visual-board', command],
+    {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: process.env,
+    },
+  )
+  return JSON.parse(output)
+}
+
+function detectCrossCutPostgres(): { available: boolean; reason?: string } {
+  try {
+    const boardList = runCrossCutVisualBoard('boards') as CrossCutVisualBoardList
+    return { available: Array.isArray(boardList.boards) }
+  } catch (error) {
+    return {
+      available: false,
+      reason: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function mapCrossCutStatusToLane(status: string | null | undefined): SwarmKanbanCard['status'] {
+  switch ((status ?? '').toLowerCase()) {
+    case 'running':
+      return 'running'
+    case 'blocked':
+      return 'blocked'
+    case 'done':
+      return 'done'
+    case 'delegated':
+    case 'ready':
+      return 'ready'
+    case 'planned':
+    case 'backlog':
+    case 'closed':
+    default:
+      return 'backlog'
+  }
+}
+
+function crossCutTaskToCard(task: CrossCutVisualTask): SwarmKanbanCard {
+  const body = task.body ?? task.body_preview ?? ''
+  const externalStatus = task.external_status ? `\n\nExternal status: ${task.external_status}` : ''
+  return {
+    id: task.id ?? task.mapping_id ?? '',
+    title: task.title ?? task.id ?? task.mapping_id ?? 'CrossCut Work Item',
+    spec: `${body}${externalStatus}`,
+    acceptanceCriteria: [],
+    assignedWorker: task.assignee_hint ?? null,
+    reviewer: null,
+    status: mapCrossCutStatusToLane(task.work_status),
+    missionId: null,
+    reportPath: null,
+    createdBy: 'crosscut-postgres',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+function listCrossCutVisualCards(): SwarmKanbanCard[] {
+  const taskList = runCrossCutVisualBoard('tasks') as CrossCutVisualTaskList
+  return (Array.isArray(taskList.tasks) ? taskList.tasks : [])
+    .map(crossCutTaskToCard)
+    .sort((a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title))
+}
+
 type ClaudeDetection = {
   available: boolean
   cliPath?: string | null
@@ -242,11 +332,14 @@ function normalizeKanbanProviderPreference(
     case 'proxy':
     case 'dashboard-proxy':
       return 'hermes-proxy'
+    case 'crosscut-postgres':
+    case 'crosscut':
+      return 'crosscut-postgres'
     case 'auto':
       return 'auto'
     default:
       throw new Error(
-        `Unsupported Kanban provider ${JSON.stringify(value)}. Supported providers: sqlite, local, hermes-proxy, auto.`,
+        `Unsupported Kanban provider ${JSON.stringify(value)}. Supported providers: sqlite, local, hermes-proxy, crosscut-postgres, auto.`,
       )
   }
 }
@@ -545,6 +638,42 @@ const claudeBackend: KanbanBackend = {
   },
 }
 
+const crossCutPostgresBackend: KanbanBackend = {
+  meta() {
+    const detection = detectCrossCutPostgres()
+    return withKanbanStoreContract(
+      {
+        id: 'crosscut-postgres',
+        label: 'CrossCut PostgreSQL visual board',
+        detected: detection.available,
+        writable: false,
+        path: 'crosscut work visual-board',
+        details: detection.available
+          ? 'Read-only projection from CrossCut PostgreSQL work records; execution writes remain gated through CrossCut/Hermes paths.'
+          : `CrossCut visual-board projection not detected${detection.reason ? `: ${detection.reason}` : '.'}`,
+      },
+      kanbanStoreCapabilities({
+        boards: true,
+        tasks: true,
+        taskLinks: true,
+        comments: true,
+        events: true,
+        runs: true,
+        diagnostics: true,
+      }),
+    )
+  },
+  list() {
+    return listCrossCutVisualCards()
+  },
+  create() {
+    throw new Error('CrossCut PostgreSQL visual board provider is read-only')
+  },
+  update() {
+    throw new Error('CrossCut PostgreSQL visual board provider is read-only')
+  },
+}
+
 // Hermes Dashboard kanban plugin backend (HTTP proxy).
 //
 // Used when the upstream Hermes Agent dashboard exposes the kanban plugin
@@ -623,7 +752,7 @@ const dashboardProxyBackend: KanbanBackend = {
  *
  * Precedence (highest first):
  *   1. Env: HERMES_KANBAN_STORE_PROVIDER / KANBAN_STORE_PROVIDER / legacy
- *      CLAUDE_KANBAN_BACKEND (sqlite | local | hermes-proxy | auto)
+ *      CLAUDE_KANBAN_BACKEND (sqlite | local | hermes-proxy | crosscut-postgres | auto)
  *   2. Config: config.yaml kanban.provider or kanban_store.provider
  *   3. Default: sqlite (direct ~/.hermes/kanban.db when detected, local JSON
  *      fallback only when storage is absent)
@@ -638,6 +767,13 @@ export function resolveKanbanBackend(): KanbanBackend {
   if (selection.provider === 'local') return localBackend
   if (selection.provider === 'hermes-proxy') {
     return getCapabilities().kanban ? dashboardProxyBackend : localBackend
+  }
+  if (selection.provider === 'crosscut-postgres') {
+    const crossCutMeta = crossCutPostgresBackend.meta()
+    if (crossCutMeta.detected) return crossCutPostgresBackend
+    if (getCapabilities().kanban) return dashboardProxyBackend
+    const claudeMeta = claudeBackend.meta()
+    return claudeMeta.detected ? claudeBackend : localBackend
   }
   if (selection.provider === 'sqlite') {
     const claudeMeta = claudeBackend.meta()

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { randomUUID } from 'node:crypto'
+import YAML from 'yaml'
 import { getClaudeRoot, getWorkspaceClaudeHome } from './claude-paths'
 import {
   SWARM_KANBAN_FILE,
@@ -19,14 +19,34 @@ import {
   updateDashboardKanbanTask,
   type DashboardKanbanTask,
 } from './kanban-dashboard-proxy'
+import {
+  HERMES_SQLITE_KANBAN_CAPABILITIES,
+  SqliteKanbanStoreProvider,
+} from './kanban-sqlite-provider'
+import {
+  KANBAN_STORE_API_VERSION,
+  kanbanStoreCapabilities,
+  type KanbanStoreApiVersion,
+  type KanbanStoreCapabilityMap,
+  type KanbanTaskRecord,
+} from './kanban-store-contract'
 
 export type KanbanBackendId = 'local' | 'claude' | 'hermes-proxy'
+
+type KanbanProviderPreference = 'local' | 'sqlite' | 'hermes-proxy' | 'auto'
+
+type KanbanProviderSelection = {
+  provider: KanbanProviderPreference
+  apiVersion: KanbanStoreApiVersion
+}
 
 export type KanbanBackendMeta = {
   id: KanbanBackendId
   label: string
   detected: boolean
   writable: boolean
+  apiVersion: KanbanStoreApiVersion
+  capabilities: KanbanStoreCapabilityMap
   details?: string | null
   path?: string | null
 }
@@ -34,12 +54,49 @@ export type KanbanBackendMeta = {
 type KanbanBackend = {
   meta(): KanbanBackendMeta
   list(): SwarmKanbanCard[] | Promise<SwarmKanbanCard[]>
-  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard | Promise<SwarmKanbanCard>
+  create(
+    input: CreateSwarmKanbanCardInput,
+  ): SwarmKanbanCard | Promise<SwarmKanbanCard>
   update(
     cardId: string,
     updates: UpdateSwarmKanbanCardInput,
   ): SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
 }
+
+const BASIC_CARD_CAPABILITIES = kanbanStoreCapabilities({
+  tasks: true,
+})
+
+const HERMES_KANBAN_CAPABILITIES = kanbanStoreCapabilities({
+  boards: true,
+  tasks: true,
+  taskLinks: true,
+  comments: true,
+  events: true,
+  runs: true,
+  claims: true,
+  dispatcher: true,
+  workspaces: true,
+  notifications: true,
+  stats: true,
+  diagnostics: true,
+  idempotentCreate: true,
+  skillValidation: true,
+  completionCreatedCardsGuard: true,
+})
+
+function withKanbanStoreContract(
+  meta: Omit<KanbanBackendMeta, 'apiVersion' | 'capabilities'>,
+  capabilities: KanbanCapabilityPreset = BASIC_CARD_CAPABILITIES,
+): KanbanBackendMeta {
+  return {
+    ...meta,
+    apiVersion: KANBAN_STORE_API_VERSION,
+    capabilities,
+  }
+}
+
+type KanbanCapabilityPreset = KanbanStoreCapabilityMap
 
 // Map upstream Hermes kanban statuses (triage/todo/ready/running/done/blocked
 // and any custom user statuses) into our internal lane vocabulary. Mirrors
@@ -119,16 +176,6 @@ function dashboardTaskToCard(task: DashboardKanbanTask): SwarmKanbanCard {
   }
 }
 
-type ClaudeTaskRow = {
-  id: string
-  title: string
-  body?: string | null
-  status?: string | null
-  assignee?: string | null
-  created_at?: number | string | null
-  updated_at?: number | string | null
-}
-
 type ClaudeDetection = {
   available: boolean
   cliPath?: string | null
@@ -140,6 +187,113 @@ type ClaudeDetection = {
 function env(name: string): string | null {
   const value = process.env[name]
   return value && value.trim() ? value.trim() : null
+}
+
+function firstEnv(names: string[]): string | null {
+  for (const name of names) {
+    const value = env(name)
+    if (value) return value
+  }
+  return null
+}
+
+function configString(pathSegments: string[][]): string | null {
+  const configPath = path.join(getClaudeRoot(), 'config.yaml')
+  if (!fs.existsSync(configPath)) return null
+
+  let parsed: unknown
+  try {
+    parsed = YAML.parse(fs.readFileSync(configPath, 'utf8'))
+  } catch (error) {
+    throw new Error(
+      `Failed to read Kanban provider config from ${configPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+
+  for (const segments of pathSegments) {
+    let value: unknown = parsed
+    for (const segment of segments) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        value = undefined
+        break
+      }
+      value = (value as Record<string, unknown>)[segment]
+    }
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function normalizeKanbanProviderPreference(
+  value: string | null,
+): KanbanProviderPreference {
+  const normalized = (value ?? 'sqlite').trim().toLowerCase()
+  switch (normalized) {
+    case 'sqlite':
+    case 'claude':
+    case 'hermes-sqlite':
+      return 'sqlite'
+    case 'local':
+    case 'json':
+      return 'local'
+    case 'hermes-proxy':
+    case 'proxy':
+    case 'dashboard-proxy':
+      return 'hermes-proxy'
+    case 'auto':
+      return 'auto'
+    default:
+      throw new Error(
+        `Unsupported Kanban provider ${JSON.stringify(value)}. Supported providers: sqlite, local, hermes-proxy, auto.`,
+      )
+  }
+}
+
+function normalizeKanbanApiVersion(
+  value: string | null,
+): KanbanStoreApiVersion {
+  const normalized = (value ?? KANBAN_STORE_API_VERSION).trim()
+  if (normalized === KANBAN_STORE_API_VERSION) return KANBAN_STORE_API_VERSION
+  throw new Error(
+    `Unsupported Kanban store API version ${JSON.stringify(
+      value,
+    )}. Supported API version: ${KANBAN_STORE_API_VERSION}.`,
+  )
+}
+
+function resolveKanbanProviderSelection(): KanbanProviderSelection {
+  const envProvider = firstEnv([
+    'HERMES_KANBAN_STORE_PROVIDER',
+    'KANBAN_STORE_PROVIDER',
+    'CLAUDE_KANBAN_BACKEND',
+  ])
+  const envApiVersion = firstEnv([
+    'HERMES_KANBAN_STORE_API_VERSION',
+    'KANBAN_STORE_API_VERSION',
+  ])
+
+  const configProvider = envProvider
+    ? null
+    : configString([
+        ['kanban', 'provider'],
+        ['kanban', 'store_provider'],
+        ['kanban_store', 'provider'],
+      ])
+  const configApiVersion = envApiVersion
+    ? null
+    : configString([
+        ['kanban', 'api_version'],
+        ['kanban', 'apiVersion'],
+        ['kanban_store', 'api_version'],
+        ['kanban_store', 'apiVersion'],
+      ])
+
+  return {
+    provider: normalizeKanbanProviderPreference(envProvider ?? configProvider),
+    apiVersion: normalizeKanbanApiVersion(envApiVersion ?? configApiVersion),
+  }
 }
 
 function claudeProfileRoot(): string {
@@ -156,21 +310,36 @@ function claudeWorkspacePath(): string {
 
 function claudeCliPath(): string | null {
   try {
-    const output = execFileSync('which', ['claude'], { encoding: 'utf8', timeout: 5_000 }).trim()
+    const output = execFileSync('which', ['claude'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim()
     return output || null
   } catch {
     return null
   }
 }
 
-function checkClaudeCli(): { ok: boolean; path?: string | null; reason?: string } {
+function checkClaudeCli(): {
+  ok: boolean
+  path?: string | null
+  reason?: string
+} {
   const cli = claudeCliPath()
   if (!cli) return { ok: false, reason: 'claude CLI not found on PATH' }
   try {
-    execFileSync(cli, ['--version'], { encoding: 'utf8', timeout: 10_000, env: { ...process.env, CLAUDE_HOME: claudeProfileRoot() } })
+    execFileSync(cli, ['--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: { ...process.env, CLAUDE_HOME: claudeProfileRoot() },
+    })
     return { ok: true, path: cli }
   } catch (error) {
-    return { ok: false, path: cli, reason: error instanceof Error ? error.message : String(error) }
+    return {
+      ok: false,
+      path: cli,
+      reason: error instanceof Error ? error.message : String(error),
+    }
   }
 }
 
@@ -186,60 +355,39 @@ function detectClaudeKanban(): ClaudeDetection {
       cliPath: null,
       dbPath,
       workspacePath,
-      reason: 'Hermes Kanban storage not found; using the local Swarm Board fallback.',
+      reason:
+        'Hermes Kanban storage not found; using the local Swarm Board fallback.',
     }
   }
 
   const cli = checkClaudeCli()
   return {
     available: true,
-    cliPath: cli.ok ? cli.path ?? null : null,
+    cliPath: cli.ok ? (cli.path ?? null) : null,
     dbPath,
     workspacePath,
-    reason: cli.ok ? undefined : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
+    reason: cli.ok
+      ? undefined
+      : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
   }
 }
 
-function sqliteQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`
-}
-
-function runSqlite(dbPath: string, sql: string): string {
-  return execFileSync('sqlite3', [dbPath, '-json', sql], {
-    encoding: 'utf8',
-    timeout: 15_000,
-  }).trim()
-}
-
-function readClaudeTasks(): ClaudeTaskRow[] {
+function createClaudeSqliteProvider(): SqliteKanbanStoreProvider {
   const detection = detectClaudeKanban()
-  if (!detection.available) return []
-  const query = [
-    'select',
-    'id,',
-    'title,',
-    'body,',
-    'status,',
-    'assignee,',
-    'created_at,',
-    'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
-    'from tasks',
-    'order by created_at desc, id desc;',
-  ].join(' ')
-  const raw = runSqlite(detection.dbPath, query)
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
-  return Array.isArray(parsed) ? parsed : []
-}
-
-function readClaudeTask(taskId: string): ClaudeTaskRow | null {
-  const detection = detectClaudeKanban()
-  if (!detection.available) return null
-  const raw = runSqlite(
-    detection.dbPath,
-    `select id, title, body, status, assignee, created_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
-  )
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
-  return Array.isArray(parsed) && parsed[0] ? parsed[0] : null
+  return new SqliteKanbanStoreProvider({
+    providerId: 'claude',
+    label: 'Hermes Kanban',
+    detected: detection.available,
+    writable: detection.available,
+    dbPath: detection.dbPath,
+    workspacePath: detection.workspacePath,
+    cliPath: detection.cliPath ?? null,
+    details: detection.available
+      ? (detection.reason ??
+        `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`)
+      : (detection.reason ?? 'Hermes Kanban not detected.'),
+    capabilities: HERMES_SQLITE_KANBAN_CAPABILITIES,
+  })
 }
 
 function normalizeTimestamp(value: unknown): number {
@@ -255,7 +403,9 @@ function normalizeTimestamp(value: unknown): number {
   return Date.now()
 }
 
-function mapClaudeStatus(status: string | null | undefined): SwarmKanbanCard['status'] {
+function mapClaudeStatus(
+  status: string | null | undefined,
+): SwarmKanbanCard['status'] {
   switch ((status ?? '').toLowerCase()) {
     case 'queued':
     case 'todo':
@@ -280,7 +430,9 @@ function mapClaudeStatus(status: string | null | undefined): SwarmKanbanCard['st
   }
 }
 
-function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): string {
+function mapBoardStatus(
+  status: SwarmKanbanCard['status'] | null | undefined,
+): string {
   switch (status) {
     case 'backlog':
       return 'queued'
@@ -299,9 +451,11 @@ function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): s
   }
 }
 
-function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
-  const createdAt = normalizeTimestamp(task.created_at)
-  const updatedAt = normalizeTimestamp(task.updated_at ?? task.created_at)
+function claudeTaskToCard(task: KanbanTaskRecord): SwarmKanbanCard {
+  const createdAt = normalizeTimestamp(task.createdAt)
+  const updatedAt = normalizeTimestamp(
+    task.updatedAt ?? task.completedAt ?? task.startedAt ?? task.createdAt,
+  )
   return {
     id: task.id,
     title: task.title,
@@ -312,7 +466,7 @@ function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
     status: mapClaudeStatus(task.status),
     missionId: null,
     reportPath: null,
-    createdBy: 'claude-kanban',
+    createdBy: task.createdBy ?? 'claude-kanban',
     createdAt,
     updatedAt,
   }
@@ -320,14 +474,14 @@ function claudeTaskToCard(task: ClaudeTaskRow): SwarmKanbanCard {
 
 const localBackend: KanbanBackend = {
   meta() {
-    return {
+    return withKanbanStoreContract({
       id: 'local',
       label: 'Local board',
       detected: true,
       writable: true,
       path: SWARM_KANBAN_FILE,
       details: 'Using local Swarm board JSON store.',
-    }
+    })
   },
   list() {
     return listSwarmKanbanCards()
@@ -342,70 +496,51 @@ const localBackend: KanbanBackend = {
 
 const claudeBackend: KanbanBackend = {
   meta() {
-    const detection = detectClaudeKanban()
+    const provider = createClaudeSqliteProvider()
+    const metadata = provider.metadata()
     return {
       id: 'claude',
-      label: 'Hermes Kanban',
-      detected: detection.available,
-      writable: detection.available,
-      path: fs.existsSync(detection.dbPath) ? detection.dbPath : null,
-      details: detection.available
-        ? detection.reason ?? `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`
-        : detection.reason ?? 'Hermes Kanban not detected.',
+      label: metadata.label,
+      detected: metadata.detected,
+      writable: metadata.writable,
+      path: metadata.path ?? null,
+      details: metadata.details ?? null,
+      apiVersion: metadata.apiVersion,
+      capabilities: metadata.capabilities,
     }
   },
   list() {
-    return readClaudeTasks().map(claudeTaskToCard)
+    return createClaudeSqliteProvider().listTasks().map(claudeTaskToCard)
   },
   create(input) {
-    const detection = detectClaudeKanban()
-    if (!detection.available) throw new Error(detection.reason ?? 'Hermes Kanban not detected')
-    const nowSeconds = Math.floor(Date.now() / 1000)
-    const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
-    const status = mapBoardStatus(input.status ?? 'backlog')
-    const statements = [
-      'insert into tasks (',
-      'id, title, body, assignee, status, priority, created_by, created_at, workspace_kind, workspace_path',
-      ') values (',
-      [
-        sqliteQuote(taskId),
-        sqliteQuote(input.title.trim()),
-        sqliteQuote((input.spec ?? '').trim()),
-        input.assignedWorker?.trim() ? sqliteQuote(input.assignedWorker.trim()) : 'NULL',
-        sqliteQuote(status),
-        '0',
-        sqliteQuote(input.createdBy?.trim() || 'swarm2-kanban'),
-        String(nowSeconds),
-        sqliteQuote('scratch'),
-        sqliteQuote(path.join(detection.workspacePath, 'workspaces', taskId)),
-      ].join(', '),
-      ');',
-    ].join(' ')
-    runSqlite(detection.dbPath, statements)
-    const created = readClaudeTask(taskId)
-    if (!created) throw new Error(`Created Hermes task ${taskId} but could not read it back`)
+    const provider = createClaudeSqliteProvider()
+    const metadata = provider.metadata()
+    if (!metadata.detected)
+      throw new Error(metadata.details ?? 'Hermes Kanban not detected')
+    const created = provider.createTask({
+      title: input.title,
+      body: input.spec ?? '',
+      assignee: input.assignedWorker ?? null,
+      status: mapBoardStatus(
+        input.status ?? 'backlog',
+      ) as KanbanTaskRecord['status'],
+      createdBy: input.createdBy?.trim() || 'swarm2-kanban',
+      workspaceKind: 'scratch',
+    })
     return claudeTaskToCard(created)
   },
   update(cardId, updates) {
-    const detection = detectClaudeKanban()
-    if (!detection.available) return null
-    const assignments: string[] = []
-    if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
-    if (typeof updates.spec === 'string') assignments.push(`body = ${sqliteQuote(updates.spec)}`)
-    if (updates.assignedWorker !== undefined) assignments.push(`assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`)
-    if (updates.status) {
-      const status = mapBoardStatus(updates.status)
-      assignments.push(`status = ${sqliteQuote(status)}`)
-      if (status === 'running') assignments.push(`started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`)
-      if (status === 'done') assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
-      if (status !== 'done') assignments.push('completed_at = NULL')
-    }
-    if (assignments.length === 0) {
-      const current = readClaudeTask(cardId)
-      return current ? claudeTaskToCard(current) : null
-    }
-    runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
-    const updated = readClaudeTask(cardId)
+    const provider = createClaudeSqliteProvider()
+    const metadata = provider.metadata()
+    if (!metadata.detected) return null
+    const updated = provider.updateTask(cardId, {
+      title: updates.title,
+      body: updates.spec,
+      assignee: updates.assignedWorker,
+      status: updates.status
+        ? (mapBoardStatus(updates.status) as KanbanTaskRecord['status'])
+        : undefined,
+    })
     return updated ? claudeTaskToCard(updated) : null
   },
 }
@@ -419,16 +554,19 @@ const claudeBackend: KanbanBackend = {
 const dashboardProxyBackend: KanbanBackend = {
   meta() {
     const caps = getCapabilities()
-    return {
-      id: 'hermes-proxy',
-      label: 'Hermes Dashboard kanban',
-      detected: caps.kanban,
-      writable: caps.kanban,
-      path: caps.dashboard.url || CLAUDE_DASHBOARD_URL,
-      details: caps.kanban
-        ? `Synced with the Hermes Dashboard kanban plugin at ${caps.dashboard.url}/kanban (single SQLite source of truth, dispatcher-aware).`
-        : 'Hermes Dashboard kanban plugin not detected.',
-    }
+    return withKanbanStoreContract(
+      {
+        id: 'hermes-proxy',
+        label: 'Hermes Dashboard kanban',
+        detected: caps.kanban,
+        writable: caps.kanban,
+        path: caps.dashboard.url || CLAUDE_DASHBOARD_URL,
+        details: caps.kanban
+          ? `Synced with the Hermes Dashboard kanban plugin at ${caps.dashboard.url}/kanban (single SQLite source of truth, dispatcher-aware).`
+          : 'Hermes Dashboard kanban plugin not detected.',
+      },
+      HERMES_KANBAN_CAPABILITIES,
+    )
   },
   async list() {
     const board = await fetchDashboardKanbanBoard()
@@ -484,27 +622,30 @@ const dashboardProxyBackend: KanbanBackend = {
  * Resolve which backend to use.
  *
  * Precedence (highest first):
- *   1. CLAUDE_KANBAN_BACKEND env var (local | claude | hermes-proxy | auto)
- *   2. caps.kanban (Hermes Dashboard plugin available) → hermes-proxy
- *   3. legacy claudeBackend (direct sqlite to ~/.hermes/kanban.db) when DB exists
- *   4. localBackend (file-backed swarm2-kanban.json) as last resort
+ *   1. Env: HERMES_KANBAN_STORE_PROVIDER / KANBAN_STORE_PROVIDER / legacy
+ *      CLAUDE_KANBAN_BACKEND (sqlite | local | hermes-proxy | auto)
+ *   2. Config: config.yaml kanban.provider or kanban_store.provider
+ *   3. Default: sqlite (direct ~/.hermes/kanban.db when detected, local JSON
+ *      fallback only when storage is absent)
  *
- * The 'auto' default deliberately prefers hermes-proxy over the legacy direct
- * SQLite path so dispatchers + transactional helpers stay in charge of writes.
- * Set CLAUDE_KANBAN_BACKEND=claude to force the direct-SQLite path during
- * troubleshooting.
+ * Env/config may also set HERMES_KANBAN_STORE_API_VERSION,
+ * KANBAN_STORE_API_VERSION, kanban.api_version, or kanban_store.api_version.
+ * Unsupported providers/API versions fail loudly instead of silently falling
+ * back to a different durable store.
  */
 export function resolveKanbanBackend(): KanbanBackend {
-  const preference = (env('CLAUDE_KANBAN_BACKEND') ?? 'auto').toLowerCase()
-  if (preference === 'local') return localBackend
-  if (preference === 'hermes-proxy' || preference === 'proxy') {
+  const selection = resolveKanbanProviderSelection()
+  if (selection.provider === 'local') return localBackend
+  if (selection.provider === 'hermes-proxy') {
     return getCapabilities().kanban ? dashboardProxyBackend : localBackend
   }
-  if (preference === 'claude') {
+  if (selection.provider === 'sqlite') {
     const claudeMeta = claudeBackend.meta()
     return claudeMeta.detected ? claudeBackend : localBackend
   }
-  // auto
+
+  // auto remains available for operators who want proxy-first behavior; the
+  // safe default is direct SQLite so there is only one local durable store.
   if (getCapabilities().kanban) return dashboardProxyBackend
   const claudeMeta = claudeBackend.meta()
   if (claudeMeta.detected) return claudeBackend

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -655,10 +655,6 @@ const crossCutPostgresBackend: KanbanBackend = {
       kanbanStoreCapabilities({
         boards: true,
         tasks: true,
-        taskLinks: true,
-        comments: true,
-        events: true,
-        runs: true,
         diagnostics: true,
       }),
     )

--- a/src/server/kanban-sqlite-provider.test.ts
+++ b/src/server/kanban-sqlite-provider.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { KANBAN_STORE_API_VERSION } from './kanban-store-contract'
+import { describeKanbanStoreProviderConformance } from './kanban-store-provider-conformance'
+
+const execFileSync = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  execFileSync,
+}))
+
+vi.mock('node:crypto', () => ({
+  randomUUID: () => 'deadbeef-0000-4000-8000-000000000000',
+}))
+
+afterEach(() => {
+  execFileSync.mockReset()
+})
+
+describe('SqliteKanbanStoreProvider', () => {
+  it('advertises the KanbanStore contract with sqlite storage authority', async () => {
+    const { SqliteKanbanStoreProvider } =
+      await import('./kanban-sqlite-provider')
+    const provider = new SqliteKanbanStoreProvider({
+      providerId: 'claude',
+      label: 'Hermes Kanban',
+      detected: true,
+      dbPath: '/tmp/kanban.db',
+      workspacePath: '/tmp/kanban',
+      details: 'direct sqlite',
+    })
+
+    expect(provider.metadata()).toMatchObject({
+      providerId: 'claude',
+      label: 'Hermes Kanban',
+      apiVersion: KANBAN_STORE_API_VERSION,
+      detected: true,
+      writable: true,
+      storageAuthority: 'sqlite',
+      path: '/tmp/kanban.db',
+      capabilities: {
+        tasks: true,
+        runs: true,
+        dispatcher: true,
+      },
+    })
+  })
+
+  it('routes task list/create/update through the provider sqlite adapter', async () => {
+    const { SqliteKanbanStoreProvider } =
+      await import('./kanban-sqlite-provider')
+    const sqliteCalls: string[] = []
+    let readCount = 0
+    execFileSync.mockImplementation((_command: string, args: string[]) => {
+      sqliteCalls.push(args.join(' '))
+      const sql = args[2] ?? ''
+      if (sql.includes('order by')) {
+        return JSON.stringify([
+          {
+            id: 't_existing',
+            title: 'Existing task',
+            body: 'Body',
+            status: 'running',
+            assignee: 'worker-a',
+            created_at: 1777527540,
+          },
+        ])
+      }
+      if (sql.includes('where id =')) {
+        readCount += 1
+        return JSON.stringify([
+          {
+            id: 't_deadbeef',
+            title: readCount === 1 ? 'Created task' : 'Updated task',
+            body: 'Body',
+            status: readCount === 1 ? 'queued' : 'done',
+            assignee: 'worker-b',
+            created_at: 1777527540,
+            completed_at: readCount === 1 ? null : 1777527644,
+          },
+        ])
+      }
+      return '[]'
+    })
+
+    const provider = new SqliteKanbanStoreProvider({
+      detected: true,
+      dbPath: '/tmp/kanban.db',
+      workspacePath: '/tmp/kanban',
+    })
+
+    expect(provider.listTasks()[0]).toMatchObject({
+      id: 't_existing',
+      status: 'running',
+      assignee: 'worker-a',
+    })
+    expect(
+      provider.createTask({
+        title: 'Created task',
+        body: 'Body',
+        assignee: 'worker-b',
+        status: 'todo',
+      }),
+    ).toMatchObject({ id: 't_deadbeef', status: 'todo' })
+    expect(
+      provider.updateTask('t_deadbeef', {
+        title: 'Updated task',
+        status: 'done',
+      }),
+    ).toMatchObject({ id: 't_deadbeef', status: 'done' })
+
+    expect(sqliteCalls.some((call) => call.includes('insert into tasks'))).toBe(
+      true,
+    )
+    expect(sqliteCalls.some((call) => call.includes('update tasks set'))).toBe(
+      true,
+    )
+  })
+})
+
+describeKanbanStoreProviderConformance({
+  name: 'SqliteKanbanStoreProvider',
+  createProvider: () => {
+    type Row = {
+      id: string
+      title: string
+      body: string
+      status: string
+      assignee: string | null
+      created_at: number
+      completed_at?: number | null
+      workspace_kind?: string | null
+      workspace_path?: string | null
+    }
+
+    const rows = new Map<string, Row>()
+    const taskId = 't_deadbeef'
+    execFileSync.mockImplementation((_command: string, args: string[]) => {
+      const sql = args[2] ?? ''
+      if (sql.includes('select') && sql.includes('where id =')) {
+        const row = rows.get(taskId)
+        return JSON.stringify(row ? [row] : [])
+      }
+      if (sql.includes('select') && sql.includes('order by')) {
+        return JSON.stringify(Array.from(rows.values()))
+      }
+      if (sql.includes('insert into tasks')) {
+        rows.set(taskId, {
+          id: taskId,
+          title: 'Conformance task',
+          body: 'Created by shared KanbanStore conformance tests',
+          status: 'queued',
+          assignee: 'conformance-worker',
+          created_at: 1777527540,
+        })
+        return '[]'
+      }
+      if (sql.includes('update tasks set')) {
+        const existing = rows.get(taskId)
+        if (existing) {
+          if (sql.includes("title = 'Updated conformance task'")) {
+            existing.title = 'Updated conformance task'
+          }
+          if (sql.includes("body = 'Updated body'")) {
+            existing.body = 'Updated body'
+          }
+          if (sql.includes('assignee = NULL')) {
+            existing.assignee = null
+          }
+          if (sql.includes("status = 'done'")) {
+            existing.status = 'done'
+            existing.completed_at = 1777527644
+          }
+          if (sql.includes("status = 'archived'")) {
+            existing.status = 'archived'
+            existing.completed_at = null
+          }
+        }
+        return '[]'
+      }
+      return '[]'
+    })
+
+    return import('./kanban-sqlite-provider').then(
+      ({ SqliteKanbanStoreProvider }) =>
+        new SqliteKanbanStoreProvider({
+          providerId: 'sqlite-conformance',
+          label: 'SQLite conformance provider',
+          detected: true,
+          dbPath: '/tmp/kanban.db',
+          workspacePath: '/tmp/kanban',
+        }),
+    )
+  },
+})

--- a/src/server/kanban-sqlite-provider.test.ts
+++ b/src/server/kanban-sqlite-provider.test.ts
@@ -40,8 +40,16 @@ describe('SqliteKanbanStoreProvider', () => {
       path: '/tmp/kanban.db',
       capabilities: {
         tasks: true,
-        runs: true,
-        dispatcher: true,
+        taskLinks: false,
+        comments: false,
+        events: false,
+        runs: false,
+        claims: false,
+        dispatcher: false,
+        notifications: false,
+        idempotentCreate: false,
+        skillValidation: false,
+        completionCreatedCardsGuard: false,
       },
     })
   })

--- a/src/server/kanban-sqlite-provider.ts
+++ b/src/server/kanban-sqlite-provider.ts
@@ -1,0 +1,403 @@
+import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import * as path from 'node:path'
+
+import {
+  KANBAN_STORE_API_VERSION,
+  kanbanStoreCapabilities,
+  validateKanbanStoreProviderMetadata,
+  type BlockKanbanTaskRequest,
+  type ClaimKanbanTaskRequest,
+  type CompleteKanbanTaskRequest,
+  type CreateKanbanTaskRequest,
+  type KanbanBoardRef,
+  type KanbanNotifySubscription,
+  type KanbanStoreCapabilityMap,
+  type KanbanStoreProvider,
+  type KanbanStoreProviderMetadata,
+  type KanbanTaskComment,
+  type KanbanTaskEvent,
+  type KanbanTaskLink,
+  type KanbanTaskRecord,
+  type KanbanTaskRun,
+  type UpdateKanbanTaskRequest,
+} from './kanban-store-contract'
+
+export type SqliteKanbanTaskRow = {
+  id: string
+  title: string
+  body?: string | null
+  status?: string | null
+  assignee?: string | null
+  created_at?: number | string | null
+  started_at?: number | string | null
+  completed_at?: number | string | null
+  updated_at?: number | string | null
+}
+
+export type SqliteKanbanProviderOptions = {
+  providerId?: string
+  label?: string
+  detected: boolean
+  writable?: boolean
+  dbPath: string
+  workspacePath: string
+  details?: string | null
+  cliPath?: string | null
+  capabilities?: KanbanStoreCapabilityMap
+}
+
+export const HERMES_SQLITE_KANBAN_CAPABILITIES = kanbanStoreCapabilities({
+  boards: true,
+  tasks: true,
+  taskLinks: true,
+  comments: true,
+  events: true,
+  runs: true,
+  claims: true,
+  dispatcher: true,
+  workspaces: true,
+  notifications: true,
+  stats: true,
+  diagnostics: true,
+  idempotentCreate: true,
+  skillValidation: true,
+  completionCreatedCardsGuard: true,
+})
+
+export function sqliteQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+function runSqlite(dbPath: string, sql: string): string {
+  return execFileSync('sqlite3', [dbPath, '-json', sql], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  }).trim()
+}
+
+function parseSqliteRows<T>(raw: string): T[] {
+  const parsed = raw ? (JSON.parse(raw) as T[]) : []
+  return Array.isArray(parsed) ? parsed : []
+}
+
+function normalizeStatus(
+  status: string | null | undefined,
+): KanbanTaskRecord['status'] {
+  switch ((status ?? '').toLowerCase()) {
+    case 'queued':
+      return 'todo'
+    case 'triage':
+    case 'todo':
+    case 'ready':
+    case 'running':
+    case 'blocked':
+    case 'done':
+    case 'archived':
+      return status?.toLowerCase() ?? 'todo'
+    case 'complete':
+    case 'completed':
+      return 'done'
+    default:
+      return 'todo'
+  }
+}
+
+function mapContractStatusToSqlite(status: string | null | undefined): string {
+  switch ((status ?? '').toLowerCase()) {
+    case 'todo':
+      return 'queued'
+    case 'triage':
+    case 'ready':
+    case 'running':
+    case 'blocked':
+    case 'done':
+    case 'archived':
+      return status?.toLowerCase() ?? 'queued'
+    default:
+      return 'queued'
+  }
+}
+
+function rowToTask(row: SqliteKanbanTaskRow): KanbanTaskRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body ?? '',
+    status: normalizeStatus(row.status),
+    assignee: row.assignee ?? null,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+    startedAt: row.started_at ?? null,
+    completedAt: row.completed_at ?? null,
+  }
+}
+
+function unsupported(operation: string): never {
+  throw new Error(
+    `Hermes SQLite Kanban provider does not implement ${operation}`,
+  )
+}
+
+export class SqliteKanbanStoreProvider implements KanbanStoreProvider {
+  private readonly options: Required<
+    Pick<SqliteKanbanProviderOptions, 'providerId' | 'label'>
+  > &
+    Omit<SqliteKanbanProviderOptions, 'providerId' | 'label'>
+
+  constructor(options: SqliteKanbanProviderOptions) {
+    this.options = {
+      providerId: options.providerId ?? 'hermes-sqlite',
+      label: options.label ?? 'Hermes Kanban SQLite',
+      ...options,
+    }
+  }
+
+  metadata(): KanbanStoreProviderMetadata {
+    return validateKanbanStoreProviderMetadata({
+      providerId: this.options.providerId,
+      label: this.options.label,
+      apiVersion: KANBAN_STORE_API_VERSION,
+      capabilities:
+        this.options.capabilities ?? HERMES_SQLITE_KANBAN_CAPABILITIES,
+      detected: this.options.detected,
+      writable: this.options.writable ?? this.options.detected,
+      storageAuthority: 'sqlite',
+      details: this.options.details ?? null,
+      path: this.options.detected ? this.options.dbPath : null,
+    })
+  }
+
+  listBoards(): KanbanBoardRef[] {
+    return [
+      {
+        slug: 'default',
+        path: this.options.workspacePath,
+        current: true,
+      },
+    ]
+  }
+
+  createBoard(_slug: string): KanbanBoardRef {
+    return unsupported('createBoard')
+  }
+
+  renameBoard(_oldSlug: string, _newSlug: string): KanbanBoardRef {
+    return unsupported('renameBoard')
+  }
+
+  deleteBoard(_slug: string): void {
+    unsupported('deleteBoard')
+  }
+
+  switchBoard(slug: string): KanbanBoardRef {
+    if (slug !== 'default') return unsupported('switchBoard')
+    return this.listBoards()[0]
+  }
+
+  listTasks(): KanbanTaskRecord[] {
+    if (!this.options.detected) return []
+    const raw = runSqlite(
+      this.options.dbPath,
+      [
+        'select',
+        'id,',
+        'title,',
+        'body,',
+        'status,',
+        'assignee,',
+        'created_at,',
+        'started_at,',
+        'completed_at,',
+        'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
+        'from tasks',
+        'order by created_at desc, id desc;',
+      ].join(' '),
+    )
+    return parseSqliteRows<SqliteKanbanTaskRow>(raw).map(rowToTask)
+  }
+
+  getTask(taskId: string): KanbanTaskRecord | null {
+    if (!this.options.detected) return null
+    const raw = runSqlite(
+      this.options.dbPath,
+      `select id, title, body, status, assignee, created_at, started_at, completed_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
+    )
+    return parseSqliteRows<SqliteKanbanTaskRow>(raw).map(rowToTask)[0] ?? null
+  }
+
+  createTask(input: CreateKanbanTaskRequest): KanbanTaskRecord {
+    if (!this.options.detected)
+      throw new Error('Hermes Kanban SQLite storage not detected')
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
+    const status = mapContractStatusToSqlite(input.status ?? 'todo')
+    const statements = [
+      'insert into tasks (',
+      'id, title, body, assignee, status, priority, created_by, created_at, workspace_kind, workspace_path',
+      ') values (',
+      [
+        sqliteQuote(taskId),
+        sqliteQuote(input.title.trim()),
+        sqliteQuote((input.body ?? '').trim()),
+        input.assignee?.trim() ? sqliteQuote(input.assignee.trim()) : 'NULL',
+        sqliteQuote(status),
+        String(input.priority ?? 0),
+        sqliteQuote(input.createdBy?.trim() || 'hermes-workspace'),
+        String(nowSeconds),
+        sqliteQuote(input.workspaceKind ?? 'scratch'),
+        sqliteQuote(
+          input.workspacePath?.trim() ||
+            path.join(this.options.workspacePath, 'workspaces', taskId),
+        ),
+      ].join(', '),
+      ');',
+    ].join(' ')
+    runSqlite(this.options.dbPath, statements)
+    const created = this.getTask(taskId)
+    if (!created)
+      throw new Error(
+        `Created Hermes task ${taskId} but could not read it back`,
+      )
+    return created
+  }
+
+  updateTask(
+    taskId: string,
+    updates: UpdateKanbanTaskRequest,
+  ): KanbanTaskRecord | null {
+    if (!this.options.detected) return null
+    const assignments: string[] = []
+    if (typeof updates.title === 'string' && updates.title.trim()) {
+      assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
+    }
+    if (typeof updates.body === 'string') {
+      assignments.push(`body = ${sqliteQuote(updates.body)}`)
+    }
+    if (updates.assignee !== undefined) {
+      assignments.push(
+        `assignee = ${updates.assignee?.trim() ? sqliteQuote(updates.assignee.trim()) : 'NULL'}`,
+      )
+    }
+    if (updates.status) {
+      const status = mapContractStatusToSqlite(updates.status)
+      assignments.push(`status = ${sqliteQuote(status)}`)
+      if (status === 'running') {
+        assignments.push(
+          `started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`,
+        )
+      }
+      if (status === 'done')
+        assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
+      if (status !== 'done') assignments.push('completed_at = NULL')
+    }
+    if (assignments.length === 0) return this.getTask(taskId)
+    runSqlite(
+      this.options.dbPath,
+      `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(taskId)};`,
+    )
+    return this.getTask(taskId)
+  }
+
+  archiveTask(taskId: string): KanbanTaskRecord | null {
+    return this.updateTask(taskId, { status: 'archived' })
+  }
+
+  listLinks(_taskId?: string): KanbanTaskLink[] {
+    return unsupported('listLinks')
+  }
+
+  linkTasks(_parentId: string, _childId: string): KanbanTaskLink {
+    return unsupported('linkTasks')
+  }
+
+  unlinkTasks(_parentId: string, _childId: string): void {
+    unsupported('unlinkTasks')
+  }
+
+  listComments(_taskId: string): KanbanTaskComment[] {
+    return unsupported('listComments')
+  }
+
+  addComment(_taskId: string, _body: string): KanbanTaskComment {
+    return unsupported('addComment')
+  }
+
+  listEvents(
+    _taskId?: string,
+    _afterEventId?: number | string | null,
+  ): KanbanTaskEvent[] {
+    return unsupported('listEvents')
+  }
+
+  appendEvent(
+    _taskId: string,
+    _kind: string,
+    _payload?: unknown,
+  ): KanbanTaskEvent {
+    return unsupported('appendEvent')
+  }
+
+  claimTask(_input: ClaimKanbanTaskRequest): KanbanTaskRun {
+    return unsupported('claimTask')
+  }
+
+  heartbeatTask(_taskId: string, _note?: string | null): KanbanTaskRun | null {
+    return unsupported('heartbeatTask')
+  }
+
+  completeTask(_input: CompleteKanbanTaskRequest): KanbanTaskRecord {
+    return unsupported('completeTask')
+  }
+
+  blockTask(_input: BlockKanbanTaskRequest): KanbanTaskRecord {
+    return unsupported('blockTask')
+  }
+
+  unblockTask(_taskId: string): KanbanTaskRecord {
+    return unsupported('unblockTask')
+  }
+
+  reclaimTask(_taskId: string): KanbanTaskRecord | null {
+    return unsupported('reclaimTask')
+  }
+
+  listRuns(_taskId?: string): KanbanTaskRun[] {
+    return unsupported('listRuns')
+  }
+
+  readTaskLog(_taskId: string, _offset?: number, _limit?: number): string {
+    return unsupported('readTaskLog')
+  }
+
+  listNotifySubscriptions(): KanbanNotifySubscription[] {
+    return unsupported('listNotifySubscriptions')
+  }
+
+  upsertNotifySubscription(
+    _subscription: KanbanNotifySubscription,
+  ): KanbanNotifySubscription {
+    return unsupported('upsertNotifySubscription')
+  }
+
+  deleteNotifySubscription(_subscriptionId: number | string): void {
+    unsupported('deleteNotifySubscription')
+  }
+
+  stats(): Record<string, unknown> {
+    return {
+      providerId: this.options.providerId,
+      detected: this.options.detected,
+    }
+  }
+
+  diagnostics(): Record<string, unknown> {
+    return {
+      providerId: this.options.providerId,
+      detected: this.options.detected,
+      dbPath: this.options.dbPath,
+      workspacePath: this.options.workspacePath,
+      cliPath: this.options.cliPath ?? null,
+    }
+  }
+}

--- a/src/server/kanban-sqlite-provider.ts
+++ b/src/server/kanban-sqlite-provider.ts
@@ -50,19 +50,8 @@ export type SqliteKanbanProviderOptions = {
 export const HERMES_SQLITE_KANBAN_CAPABILITIES = kanbanStoreCapabilities({
   boards: true,
   tasks: true,
-  taskLinks: true,
-  comments: true,
-  events: true,
-  runs: true,
-  claims: true,
-  dispatcher: true,
-  workspaces: true,
-  notifications: true,
   stats: true,
   diagnostics: true,
-  idempotentCreate: true,
-  skillValidation: true,
-  completionCreatedCardsGuard: true,
 })
 
 export function sqliteQuote(value: string): string {

--- a/src/server/kanban-store-contract.test.ts
+++ b/src/server/kanban-store-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KANBAN_STORE_API_VERSION,
+  KANBAN_STORE_CAPABILITIES,
+  kanbanStoreCapabilities,
+  validateKanbanStoreProviderMetadata,
+  type KanbanStoreProviderMetadata,
+} from './kanban-store-contract'
+
+describe('kanban-store-contract', () => {
+  it('declares an explicit api version and complete boolean capability map', () => {
+    const capabilities = kanbanStoreCapabilities({ tasks: true, claims: true })
+
+    expect(KANBAN_STORE_API_VERSION).toBe('kanban-store.v1')
+    expect(Object.keys(capabilities).sort()).toEqual(
+      [...KANBAN_STORE_CAPABILITIES].sort(),
+    )
+    expect(capabilities.tasks).toBe(true)
+    expect(capabilities.claims).toBe(true)
+    expect(capabilities.comments).toBe(false)
+  })
+
+  it('validates provider metadata before a backend is treated as contract-compatible', () => {
+    const metadata: KanbanStoreProviderMetadata = {
+      providerId: 'fake-provider',
+      label: 'Fake provider',
+      apiVersion: KANBAN_STORE_API_VERSION,
+      capabilities: kanbanStoreCapabilities({
+        tasks: true,
+        taskLinks: true,
+        runs: true,
+      }),
+      detected: true,
+      writable: true,
+      storageAuthority: 'memory',
+      details: 'test provider',
+    }
+
+    expect(validateKanbanStoreProviderMetadata(metadata)).toBe(metadata)
+    expect(() =>
+      validateKanbanStoreProviderMetadata({
+        ...metadata,
+        apiVersion: 'kanban-store.v0',
+      } as KanbanStoreProviderMetadata),
+    ).toThrow('Unsupported KanbanStore apiVersion')
+    expect(() =>
+      validateKanbanStoreProviderMetadata({
+        ...metadata,
+        capabilities: { tasks: true },
+      } as KanbanStoreProviderMetadata),
+    ).toThrow('capability boards must be declared')
+  })
+})

--- a/src/server/kanban-store-contract.ts
+++ b/src/server/kanban-store-contract.ts
@@ -1,0 +1,275 @@
+export const KANBAN_STORE_API_VERSION = 'kanban-store.v1' as const
+
+export type KanbanStoreApiVersion = typeof KANBAN_STORE_API_VERSION
+
+export const KANBAN_STORE_CAPABILITIES = [
+  'boards',
+  'tasks',
+  'taskLinks',
+  'comments',
+  'events',
+  'runs',
+  'claims',
+  'dispatcher',
+  'workspaces',
+  'notifications',
+  'stats',
+  'diagnostics',
+  'idempotentCreate',
+  'skillValidation',
+  'completionCreatedCardsGuard',
+] as const
+
+export type KanbanStoreCapability = (typeof KANBAN_STORE_CAPABILITIES)[number]
+export type KanbanStoreCapabilityMap = Record<KanbanStoreCapability, boolean>
+
+export type KanbanTaskStatus =
+  | 'triage'
+  | 'todo'
+  | 'ready'
+  | 'running'
+  | 'blocked'
+  | 'done'
+  | 'archived'
+export type KanbanWorkspaceKind = 'scratch' | 'dir' | 'worktree'
+
+export type KanbanBoardRef = {
+  slug: string
+  path?: string | null
+  current?: boolean
+}
+
+export type KanbanTaskRecord = {
+  id: string
+  title: string
+  body?: string | null
+  assignee?: string | null
+  status: KanbanTaskStatus | string
+  priority?: number | null
+  createdBy?: string | null
+  createdAt?: number | string | null
+  updatedAt?: number | string | null
+  startedAt?: number | string | null
+  completedAt?: number | string | null
+  workspaceKind?: KanbanWorkspaceKind | string | null
+  workspacePath?: string | null
+  tenant?: string | null
+  result?: string | null
+  idempotencyKey?: string | null
+  currentRunId?: number | string | null
+  skills?: string[] | null
+  maxRetries?: number | null
+  maxRuntimeSeconds?: number | null
+}
+
+export type KanbanTaskLink = {
+  parentId: string
+  childId: string
+}
+
+export type KanbanTaskComment = {
+  id?: number | string
+  taskId: string
+  body: string
+  author?: string | null
+  createdAt?: number | string | null
+}
+
+export type KanbanTaskEvent = {
+  id?: number | string
+  taskId: string
+  runId?: number | string | null
+  kind: string
+  payload?: unknown
+  createdAt?: number | string | null
+}
+
+export type KanbanTaskRun = {
+  id: number | string
+  taskId: string
+  profile?: string | null
+  status?: string | null
+  outcome?: string | null
+  summary?: string | null
+  metadata?: unknown
+  error?: string | null
+  startedAt?: number | string | null
+  endedAt?: number | string | null
+  heartbeatAt?: number | string | null
+}
+
+export type KanbanNotifySubscription = {
+  id?: number | string
+  platform: string
+  taskId?: string | null
+  board?: string | null
+  chatId?: string | null
+  threadId?: string | null
+  userId?: string | null
+  lastEventId?: number | string | null
+}
+
+export type CreateKanbanTaskRequest = {
+  title: string
+  body?: string | null
+  assignee?: string | null
+  status?: KanbanTaskStatus | null
+  priority?: number | null
+  createdBy?: string | null
+  parents?: string[]
+  tenant?: string | null
+  workspaceKind?: KanbanWorkspaceKind | null
+  workspacePath?: string | null
+  triage?: boolean
+  idempotencyKey?: string | null
+  maxRuntimeSeconds?: number | null
+  maxRetries?: number | null
+  skills?: string[]
+}
+
+export type UpdateKanbanTaskRequest = Partial<{
+  title: string
+  body: string | null
+  assignee: string | null
+  status: KanbanTaskStatus
+  priority: number
+  tenant: string | null
+  result: string | null
+  maxRuntimeSeconds: number | null
+  maxRetries: number | null
+  skills: string[]
+}>
+
+export type ClaimKanbanTaskRequest = {
+  taskId: string
+  profile: string
+  claimLock?: string | null
+  claimTtlSeconds?: number | null
+  workerPid?: number | null
+  maxRuntimeSeconds?: number | null
+}
+
+export type CompleteKanbanTaskRequest = {
+  taskId: string
+  summary?: string | null
+  result?: string | null
+  metadata?: unknown
+  createdCards?: string[]
+}
+
+export type BlockKanbanTaskRequest = {
+  taskId: string
+  reason: string
+}
+
+export type KanbanStoreProviderMetadata = {
+  providerId: string
+  label: string
+  apiVersion: KanbanStoreApiVersion
+  capabilities: KanbanStoreCapabilityMap
+  detected: boolean
+  writable: boolean
+  storageAuthority:
+    | 'local-file'
+    | 'sqlite'
+    | 'dashboard-proxy'
+    | 'postgres'
+    | 'remote'
+    | 'memory'
+    | string
+  details?: string | null
+  path?: string | null
+}
+
+export type MaybePromise<T> = T | Promise<T>
+
+export interface KanbanStoreProvider {
+  metadata(): MaybePromise<KanbanStoreProviderMetadata>
+
+  listBoards(): MaybePromise<KanbanBoardRef[]>
+  createBoard(slug: string): MaybePromise<KanbanBoardRef>
+  renameBoard(oldSlug: string, newSlug: string): MaybePromise<KanbanBoardRef>
+  deleteBoard(slug: string): MaybePromise<void>
+  switchBoard(slug: string): MaybePromise<KanbanBoardRef>
+
+  listTasks(filters?: Record<string, unknown>): MaybePromise<KanbanTaskRecord[]>
+  getTask(taskId: string): MaybePromise<KanbanTaskRecord | null>
+  createTask(input: CreateKanbanTaskRequest): MaybePromise<KanbanTaskRecord>
+  updateTask(
+    taskId: string,
+    updates: UpdateKanbanTaskRequest,
+  ): MaybePromise<KanbanTaskRecord | null>
+  archiveTask(taskId: string): MaybePromise<KanbanTaskRecord | null>
+
+  listLinks(taskId?: string): MaybePromise<KanbanTaskLink[]>
+  linkTasks(parentId: string, childId: string): MaybePromise<KanbanTaskLink>
+  unlinkTasks(parentId: string, childId: string): MaybePromise<void>
+
+  listComments(taskId: string): MaybePromise<KanbanTaskComment[]>
+  addComment(taskId: string, body: string): MaybePromise<KanbanTaskComment>
+
+  listEvents(
+    taskId?: string,
+    afterEventId?: number | string | null,
+  ): MaybePromise<KanbanTaskEvent[]>
+  appendEvent(
+    taskId: string,
+    kind: string,
+    payload?: unknown,
+  ): MaybePromise<KanbanTaskEvent>
+
+  claimTask(input: ClaimKanbanTaskRequest): MaybePromise<KanbanTaskRun>
+  heartbeatTask(
+    taskId: string,
+    note?: string | null,
+  ): MaybePromise<KanbanTaskRun | null>
+  completeTask(input: CompleteKanbanTaskRequest): MaybePromise<KanbanTaskRecord>
+  blockTask(input: BlockKanbanTaskRequest): MaybePromise<KanbanTaskRecord>
+  unblockTask(taskId: string): MaybePromise<KanbanTaskRecord>
+  reclaimTask(taskId: string): MaybePromise<KanbanTaskRecord | null>
+
+  listRuns(taskId?: string): MaybePromise<KanbanTaskRun[]>
+  readTaskLog(
+    taskId: string,
+    offset?: number,
+    limit?: number,
+  ): MaybePromise<string>
+
+  listNotifySubscriptions(): MaybePromise<KanbanNotifySubscription[]>
+  upsertNotifySubscription(
+    subscription: KanbanNotifySubscription,
+  ): MaybePromise<KanbanNotifySubscription>
+  deleteNotifySubscription(subscriptionId: number | string): MaybePromise<void>
+
+  stats(): MaybePromise<Record<string, unknown>>
+  diagnostics(): MaybePromise<Record<string, unknown>>
+}
+
+export function kanbanStoreCapabilities(
+  supported: Partial<Record<KanbanStoreCapability, boolean>> = {},
+): KanbanStoreCapabilityMap {
+  return Object.fromEntries(
+    KANBAN_STORE_CAPABILITIES.map((capability) => [
+      capability,
+      supported[capability] === true,
+    ]),
+  ) as KanbanStoreCapabilityMap
+}
+
+export function validateKanbanStoreProviderMetadata(
+  metadata: KanbanStoreProviderMetadata,
+): KanbanStoreProviderMetadata {
+  if (metadata.apiVersion !== KANBAN_STORE_API_VERSION) {
+    throw new Error(
+      `Unsupported KanbanStore apiVersion: ${metadata.apiVersion}`,
+    )
+  }
+  for (const capability of KANBAN_STORE_CAPABILITIES) {
+    if (typeof metadata.capabilities[capability] !== 'boolean') {
+      throw new Error(
+        `KanbanStore capability ${capability} must be declared as a boolean`,
+      )
+    }
+  }
+  return metadata
+}

--- a/src/server/kanban-store-provider-conformance.ts
+++ b/src/server/kanban-store-provider-conformance.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KANBAN_STORE_API_VERSION,
+  KANBAN_STORE_CAPABILITIES,
+  validateKanbanStoreProviderMetadata,
+  type KanbanStoreProvider,
+  type KanbanTaskRecord,
+  type MaybePromise,
+} from './kanban-store-contract'
+
+export type KanbanStoreProviderConformanceOptions = {
+  name: string
+  createProvider: () => MaybePromise<KanbanStoreProvider>
+}
+
+function expectTaskShape(task: KanbanTaskRecord): void {
+  expect(task.id).toMatch(/^t_[A-Za-z0-9_-]+$/)
+  expect(task.title.trim()).not.toBe('')
+  expect(typeof task.status).toBe('string')
+}
+
+export function describeKanbanStoreProviderConformance(
+  options: KanbanStoreProviderConformanceOptions,
+): void {
+  describe(`${options.name} KanbanStore provider conformance`, () => {
+    it('returns valid v1 provider metadata with an explicit capability map', async () => {
+      const provider = await options.createProvider()
+      const metadata = validateKanbanStoreProviderMetadata(
+        await provider.metadata(),
+      )
+
+      expect(metadata.apiVersion).toBe(KANBAN_STORE_API_VERSION)
+      expect(metadata.providerId.trim()).not.toBe('')
+      expect(metadata.label.trim()).not.toBe('')
+      expect(typeof metadata.detected).toBe('boolean')
+      expect(typeof metadata.writable).toBe('boolean')
+      expect(Object.keys(metadata.capabilities).sort()).toEqual(
+        [...KANBAN_STORE_CAPABILITIES].sort(),
+      )
+    })
+
+    it('exposes a current board and can resolve that board by slug', async () => {
+      const provider = await options.createProvider()
+      const boards = await provider.listBoards()
+      const current = boards.find((board) => board.current) ?? boards[0]
+
+      expect(current).toBeTruthy()
+      expect(current.slug.trim()).not.toBe('')
+      expect(await provider.switchBoard(current.slug)).toMatchObject({
+        slug: current.slug,
+      })
+    })
+
+    it('supports the task create/read/list/update/archive lifecycle', async () => {
+      const provider = await options.createProvider()
+      const before = await provider.listTasks()
+      expect(Array.isArray(before)).toBe(true)
+
+      const created = await provider.createTask({
+        title: 'Conformance task',
+        body: 'Created by shared KanbanStore conformance tests',
+        assignee: 'conformance-worker',
+        status: 'todo',
+        priority: 7,
+        createdBy: 'kanban-store-conformance',
+        workspaceKind: 'scratch',
+      })
+
+      expectTaskShape(created)
+      expect(created).toMatchObject({
+        title: 'Conformance task',
+        body: 'Created by shared KanbanStore conformance tests',
+        assignee: 'conformance-worker',
+        status: 'todo',
+      })
+
+      expect(await provider.getTask(created.id)).toMatchObject({
+        id: created.id,
+        title: 'Conformance task',
+      })
+      expect(await provider.listTasks()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: created.id })]),
+      )
+
+      const updated = await provider.updateTask(created.id, {
+        title: 'Updated conformance task',
+        body: 'Updated body',
+        assignee: null,
+        status: 'done',
+      })
+      expect(updated).toMatchObject({
+        id: created.id,
+        title: 'Updated conformance task',
+        body: 'Updated body',
+        assignee: null,
+        status: 'done',
+      })
+
+      expect(await provider.archiveTask(created.id)).toMatchObject({
+        id: created.id,
+        status: 'archived',
+      })
+    })
+
+    it('reports stats and diagnostics as serializable objects', async () => {
+      const provider = await options.createProvider()
+
+      expect(await provider.stats()).toEqual(expect.any(Object))
+      expect(await provider.diagnostics()).toEqual(expect.any(Object))
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- add a shared Kanban store provider contract/capability shape
- expose Hermes Dashboard proxy and read-only CrossCut Postgres provider paths behind provider selection
- keep local board fallback behavior when selected providers are unavailable

## Validation
- npm test -- --run src/server/kanban-backend.test.ts

## Notes
- CrossCut Postgres provider is read-only in this slice.
- Local live DB smoke was not run here because the approval layer blocked the direct CrossCut/Postgres command; fallback and provider behavior are covered by the focused Vitest suite.