### PR TITLE
fix(docker): add -m flag to useradd so workspace home dir is created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
+    && groupadd -r workspace && useradd -r -g workspace -u 10010 -m workspace
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

When running in Docker, the server logs:

    [auth] Failed to persist session store to /home/workspace/.hermes/workspace-sessions.json
    Error: Internal Server Error

The `workspace` user is created with `useradd -r` (system account) **without** the `-m` flag,
so `/home/workspace/` is never created. The auth middleware resolves the session store path via
`homedir()` → `/home/workspace/.hermes/workspace-sessions.json`, then calls `mkdirSync` to
create the directory. This fails with EACCES because `/home/` is root-owned (755) and the
`workspace` process cannot create subdirectories inside it.

On some code paths the missing home directory causes a module-load-time ENOENT, resulting in
500 responses on all authenticated routes.

## Fix

Add `-m` to the `useradd` invocation in the runtime stage so `/home/workspace/` is created
with correct `workspace:workspace` ownership.

- Before: `useradd -r -g workspace -u 10010 workspace`
- After:  `useradd -r -g workspace -u 10010 -m workspace`