### PR TITLE
feat: add read-only agent registry spine

### DIFF
--- a/docs/reviews/hw-phase1-readonly-registry/implementation-codex.md
+++ b/docs/reviews/hw-phase1-readonly-registry/implementation-codex.md
@@ -1,0 +1,20 @@
+Inspected base commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+Model: openai-codex/gpt-5.5
+Task: t_c2ea14e5
+
+# Phase 1 Read-only Registry Implementation Notes
+
+Implemented the Phase 1 read-only registry spine within the approved boundary:
+
+- Added `src/server/agent-registry.ts` with typed normalized registry entries, diagnostics, backend metadata, parser versioning, compatibility parsing of `swarm.yaml`, and a read-only `loadAgentRegistry` path.
+- Added `src/routes/api/agent-registry.ts` as an authenticated GET/HEAD-only read route returning normalized entries, backend metadata, diagnostics, parser version, and loaded/fetched timestamps.
+- Added `src/screens/swarm2/agent-registry-panel.tsx` plus Swarm2 integration for source-derived/read-only badges, detail lines, diagnostics, and compatibility metadata while keeping mutation/dispatch affordances disabled.
+- Added TDD coverage for parser/schema diagnostics, duplicate/malformed/secret-looking/dispatch-enabled inputs, no-mutation mtime behavior, API payload/read methods, UI row/detail helpers, and Swarm2 registry-to-roster mapping.
+
+Verification performed:
+
+- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose` passed: 4 files, 22 tests.
+- `pnpm build` passed for client and SSR builds.
+- `pnpm vitest run --reporter=dot` was run as broader verification and currently fails in unrelated pre-existing suites outside this task scope (i18n label expectations, kanban backend auto-detect, chat/playground/model/mcp tests). The new/focused registry tests passed in that full run.
+
+No deploy, restart, live Sentinel/Rilo/Forge probes, Atlas mutation/evidence promotion, dispatch/restart controls, email/financial/security actions, profile/provider config writes, or dashboard-to-source sync were performed.

--- a/docs/reviews/hw-phase1-readonly-registry/merge-handoff.md
+++ b/docs/reviews/hw-phase1-readonly-registry/merge-handoff.md
@@ -1,0 +1,126 @@
+# Merge handoff: Phase 1 read-only agent registry spine
+
+## Status
+
+Merge-ready for user review. Controller intentionally did not commit, push, merge, or deploy.
+
+## Repository
+
+- Path: `/Users/jeremiah/hermes-workspace/third-party/hermes-workspace`
+- Remote: `https://github.com/outsourc-e/hermes-workspace.git`
+- Default branch: `main`
+- Current branch at handoff: `main`
+
+## Final gate
+
+- Final bundle: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/review-bundle-after-semantic-key-redaction-fix.md`
+- Final bundle sha256: `435d5bc107ac0740c16d9c73f4efd86a06621be66e2b20044e8961440af6a2a9`
+- Codex GPT-5.5 review: APPROVE, no findings
+- Claude Max review: APPROVE, no findings
+- Board custody card: `t_0c309b03`, done
+
+## Verification run
+
+- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose`
+  - PASS: 4 files, 29 tests
+- `pnpm build`
+  - PASS
+- `git diff --check`
+  - PASS
+
+## Recommended commit branch
+
+```bash
+git fetch origin --prune
+git checkout -b feat/phase1-readonly-agent-registry origin/main
+```
+
+Because the working tree currently contains the completed changes on `main`, if you create the branch after the fact from this checkout, use:
+
+```bash
+git checkout -b feat/phase1-readonly-agent-registry
+```
+
+## Recommended commit scope
+
+Include these files:
+
+```bash
+git add \
+  src/routeTree.gen.ts \
+  src/screens/swarm2/swarm2-screen.tsx \
+  src/screens/swarm2/swarm2-screen.test.ts \
+  src/routes/api/agent-registry.ts \
+  src/routes/api/-agent-registry.test.ts \
+  src/screens/swarm2/agent-registry-panel.tsx \
+  src/screens/swarm2/agent-registry-panel.test.ts \
+  src/server/agent-registry.ts \
+  src/server/agent-registry.test.ts \
+  docs/reviews/hw-phase1-readonly-registry/
+```
+
+Do not include by default:
+
+```bash
+pnpm-workspace.yaml
+```
+
+Reason: it was pre-existing untracked root config. It was included in the final review bundle for completeness, but should stay out of the Phase 1 feature commit unless you explicitly want to scope pnpm build-approval config into the PR.
+
+## Suggested commit message
+
+```text
+feat: add read-only agent registry spine
+
+- Add GET/HEAD-only /api/agent-registry route backed by swarm.yaml parsing
+- Add fail-closed schema, parser diagnostics, secret/key redaction, and no-mutation loader coverage
+- Render read-only source-derived registry metadata in Swarm2 without granting operational controls
+- Remove the old Swarm2 Add Swarm roster mutation surface from the Phase 1 UI
+- Preserve mixed Codex/Claude review artifacts under docs/reviews
+```
+
+## Suggested PR body
+
+```markdown
+## Summary
+- Adds a Phase 1 read-only agent registry spine sourced from `swarm.yaml`.
+- Adds authenticated GET/HEAD-only `/api/agent-registry` payload with normalized entries, backend metadata, diagnostics, timestamps, and parser versioning.
+- Integrates read-only registry metadata into Swarm2 while preventing registry-only rows from gaining operational controls.
+- Removes the old mutating Add Swarm roster UI surface from Swarm2.
+- Hardens diagnostics so invalid IDs, secret-like values, token-family strings, raw YAML parser snippets, and semantic credential keys are not echoed.
+
+## Safety / Scope
+- No deploy/restart/dispatch controls added.
+- No Atlas mutation.
+- No profile/provider writes.
+- `/api/agent-registry` registers only GET and HEAD.
+- Registry-only source-derived workers display only in the read-only panel; they do not become operational worker cards.
+
+## Verification
+- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose` — PASS, 29 tests.
+- `pnpm build` — PASS.
+- `git diff --check` — PASS.
+
+## Independent Review Gate
+- Codex GPT-5.5: APPROVE, no findings.
+- Claude Max: APPROVE, no findings.
+- Final bundle sha256: `435d5bc107ac0740c16d9c73f4efd86a06621be66e2b20044e8961440af6a2a9`.
+- Custody artifacts: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/`.
+```
+
+## Post-commit checks
+
+After committing, rerun:
+
+```bash
+pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose
+pnpm build
+git diff --check
+```
+
+Then verify PR scope with:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```

--- a/docs/reviews/hw-phase1-readonly-registry/postimpl-hardening-notes.md
+++ b/docs/reviews/hw-phase1-readonly-registry/postimpl-hardening-notes.md
@@ -1,0 +1,57 @@
+# Post-implementation hardening notes
+
+Base commit reviewed: `372b18a8e4e3fa7947ff3cf5651865560daca0a1`
+
+## Codex review loop
+
+- Initial post-implementation bundle: `77490392f89240790c6b7cdedc0e473c3dda64ff520e5b623468653b6e30f33a` -> REQUEST_CHANGES.
+- First hardening bundle: `ef8b34ee158d1c72589c519563f84cbc1769c277636cd192d5b0fdf68b8134ae` -> REQUEST_CHANGES.
+- Second hardening bundle: `e2f5b12fa8012106c31f5b051a4a841e16f989920922aa0fb50ccf7b557fba6e` -> REQUEST_CHANGES.
+- Third hardening bundle: `ccded96bf0c2887c6c3b24ad03fa18d26680a8c85d4baac78ab54f563ea5cfa0` -> prior findings closed, new Important finding on leftover Add Swarm mutation path.
+
+## Reviewer findings addressed
+
+1. Secret-looking worker values were diagnosed but still normalized into API/UI-visible entries.
+   - Added coverage asserting secret-looking rows produce no entries and cannot appear in serialized API entries.
+   - Parser now drops any worker containing a secret-like value before normalization.
+
+2. Existing-but-unreadable registry source could throw uncontrolled read errors.
+   - Added coverage using an existing directory path as an unreadable source.
+   - `loadAgentRegistry` now returns structured `source_unreadable` diagnostics with backend metadata.
+
+3. Worker IDs were only validated as non-empty strings.
+   - Added coverage for path-like malformed IDs.
+   - Parser now requires compatibility IDs matching `swarm<digits>` and emits `invalid_worker_id` without returning malformed entries.
+
+4. Non-GET method behavior had only constant-level coverage.
+   - Added route handler coverage asserting only `GET` and `HEAD` handlers are registered and no `POST`/`PUT`/`PATCH`/`DELETE` handlers exist on `/api/agent-registry`.
+
+5. Secret detector missed bearer/AWS/PEM-like families and could echo secret-like IDs through diagnostics.
+   - Added coverage for bearer tokens, AWS `AKIA`/`ASIA`-style keys, PEM private-key headers, and secret-like IDs.
+   - Expanded `maybeSecret` and added `diagnosticEntryId` to omit secret-like IDs from diagnostics.
+
+6. Unsupported schema versions could still return normalized entries.
+   - Added coverage for `version: 2` with a valid-looking worker.
+   - Parser now returns immediately with `schema_version_unsupported` and no entries when document version is not exactly `1`.
+
+7. Top-level secret-looking values could coexist with valid workers.
+   - Added coverage for a top-level `metadata: ASIA...` value plus valid-looking worker.
+   - Added `scanTopLevelSecrets` to fail closed before worker normalization when non-worker top-level values contain secret-looking content.
+
+8. Swarm2 consumed `registry.entries` without checking `ok === true`.
+   - Added `agentRegistryResponseEntries` helper and coverage asserting entries are ignored when API payload is `ok: false`.
+   - Swarm2 now derives registry roster rows only through that helper.
+
+9. Old Add Swarm mutation flow remained reachable after registry swap.
+   - Added source-level coverage asserting the Phase 1 surface does not retain `fetch('/api/swarm-roster')`, `rosterQuery`, or `Add Swarm` remnants.
+   - Removed the old Add Swarm button, modal, save handler, stale `rosterQuery` references, model picker plumbing, and `/api/swarm-roster` dependency from the Swarm2 Phase 1 surface.
+
+## Verification after Add Swarm removal
+
+- `pnpm vitest run src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose`: 15 passed.
+- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose`: 4 files, 28 passed.
+- `pnpm build`: success for client and SSR builds.
+- `git diff --check`: clean.
+- Targeted forbidden-surface scans: clean.
+
+No deploy, restart, live Sentinel/Rilo/Forge probes, Atlas mutation/evidence promotion, dispatch/restart controls, email/financial/security actions, profile/provider config writes, or dashboard-to-source sync were performed.

--- a/docs/reviews/hw-phase1-readonly-registry/review-claude-after-add-swarm-removal.md
+++ b/docs/reviews/hw-phase1-readonly-registry/review-claude-after-add-swarm-removal.md
@@ -1,0 +1,15 @@
+# Claude/Max review lane status
+
+Verdict: BLOCKED_INFRA
+
+The Claude Code/Max lane could not run in the available non-interactive environments:
+
+- Local macOS Claude CLI had previously returned a 401 / not logged in state.
+- Sentinel non-login shell initially returned `claude: command not found`.
+- Sentinel explicit CLI path `/home/rilo/.local/bin/claude -p --model opus` returned: `Not logged in · Please run /login`.
+
+No Claude review verdict is claimed for this pass.
+
+Codex GPT-5.5 re-review on the same final bundle approved:
+`/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/review-bundle-after-add-swarm-removal.md`
+sha256 `45876aaf623f9f90d634141363ee940cf29683abfe423cc74976005fc9f1ab56`.

--- a/docs/reviews/hw-phase1-readonly-registry/review-claude.md
+++ b/docs/reviews/hw-phase1-readonly-registry/review-claude.md
@@ -1,0 +1,142 @@
+Inspected commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+Model: claude-code/opus-4-7
+Lane: Claude Code/Max hard-guardrail review
+Verdict: APPROVE
+
+Note: Local Claude Code OAuth failed with 401 despite auth status. The first sentinel-routed attempt correctly BLOCKED due missing macOS artifact paths. This final D-lane review was reissued through Claude Code/Max on sentinel with a self-contained bundle assembled by the macOS controller from the cited readiness plan and board artifacts. Bundle sha256: b0965167a06642911538acd278c19b2915e425869317bbc6981bc705c8104342.
+
+# Phase 1 Hermes Workspace Read-only Registry Spine — Claude D Lane Review
+
+Operating in read-only review mode. I cannot independently recompute the bundle sha256 from inside this conversation (the bundle is the text I received, not a file at a known path on this Linux host), so I am reviewing on the bundle's textual content and echoing the anchors as declared. The E reconciler must verify hash equality with the C lane's anchors.
+
+## 1. Verdict
+
+**APPROVE** (Phase 1 implementation only, conditional on E-lane reconciler also approving the same artifact anchors).
+
+This authorizes the controller to begin TDD implementation of the read-only registry spine in the declared worktree. It does **not** authorize deploy, restart, live probes, profile/provider writes, dispatch, or Atlas/Sentinel/Forge interaction.
+
+## 2. Artifact anchors (echoed verbatim)
+
+- Readiness plan sha256: `e7eb957178ce0d8d7aafbf8bae4f4327382fd346643817b8818ab5d8731d0a5f`
+- Target repo commit: `372b18a8e4e3fa7947ff3cf5651865560daca0a1`
+- Gate bundle sha256 (asserted by macOS controller): `b0965167a06642911538acd278c19b2915e425869317bbc6981bc705c8104342`
+
+Approval is bound to these three anchors. Any divergence at the E lane should trigger reissue, not silent acceptance.
+
+## 3. Exact scope approved
+
+The Phase 1 slice as defined in the readiness plan and Future Mixed-Agent Gate (T-0101-06-02):
+
+1. Typed read-only agent registry schema/parser (`agents.v1` shape from the canonical schema artifact).
+2. `swarm.yaml` as the first compatibility input; `agents.yaml` may be introduced as the intended source but not as a write target in Phase 1.
+3. One read-only API route returning normalized registry entries + backend metadata + validation diagnostics.
+4. Minimal UI rows/badges/detail surfaces under existing Workspace/Swarm surfaces; **not** inline in `swarm2-screen.tsx`.
+5. Fixture samples for valid/invalid/duplicate/secret-looking inputs.
+6. Local unit/API/UI tests proving no mutation on read.
+
+Out of scope (explicitly blocked): all items enumerated in §6 below.
+
+## 4. Required RED tests before code
+
+Author and commit these failing first, per the TDD requirement:
+
+- **Schema validation — success path**: a known-good `agents.v1` fixture parses into the typed shape; `schema_version` mismatch fails closed.
+- **Schema validation — failure paths**: missing `id`/`display_name`/`profile`/`role`/`runtime.kind`/`runtime.entrypoint`/`permissions.*`/`workspace.policy`; bad regex on `id`; unknown `runtime.kind`; unknown `status`.
+- **Duplicate ids**: two entries sharing `id` fail validation with a diagnostic naming the duplicate.
+- **Secret-looking values**: fields containing patterns resembling API keys, OAuth tokens, bearer headers, AWS keys, `-----BEGIN`, etc. fail or are surfaced as redaction diagnostics. Secrets are forbidden anywhere in the registry.
+- **`dispatch_enabled` fail-closed**: defaults to `false`; `dispatch_enabled: true` rejected unless `status` is `active`/`experimental` **and** `authorization.mode` is set.
+- **Permission escalation rules**: `network: unrestricted`, `filesystem: host_write`, and `secrets: allowlist` (empty list) all fail closed without explicit authorization metadata.
+- **Backend metadata shape**: API route returns the typed backend descriptor (detected/writable/path/source) modeled after `KanbanBackend` — but `writable` is always `false` in Phase 1.
+- **No-mutation read path**: parsing/reading the registry does not write to `swarm.yaml`, profile `config.yaml`, `runtime.json`, `workspace-overrides.json`, or any SQLite/JSON store. Assert via filesystem mtime + spy on write helpers.
+- **No live probes on read**: assert no network calls to Sentinel/Rilo/Forge/Atlas hosts, no SSH, no tmux send-keys, no `swarm-profile-config.ts` invocation, no local-provider auto-write, during a registry read or page render.
+- **API error surfaces**: invalid registry returns a structured error payload, not a 500 with stack; consumer can render a disabled state with reason.
+- **UI disabled-action reasons**: each disabled action chip carries a machine-readable reason code (e.g. `dispatch_disabled_by_default`, `status_blocked`, `missing_authorization`).
+- **Source-of-truth precedence**: when `swarm.yaml` and any browser-local override disagree, the registry read returns the file-backed value and surfaces a drift warning.
+
+These tests must be RED at the C/D handoff and turn GREEN through the implementation slice.
+
+## 5. Likely files/modules to touch
+
+Based on the extension-points artifact:
+
+- **New, preferred**:
+  - `src/server/agent-registry.ts` — typed schema + parser + backend interface (modeled on `KanbanBackend`).
+  - `src/server/agent-registry-backends/swarm-yaml.ts` — read-only adapter over current `swarm.yaml`.
+  - `src/routes/api/agents.ts` (or `src/routes/api/agent-registry.ts`) — read-only HTTP route returning normalized entries + backend meta + diagnostics.
+  - `src/lib/agent-registry-types.ts` — shared frontend types/hooks.
+  - `src/hooks/use-agent-registry.ts` — read-only hook for UI consumers.
+  - `src/components/swarm/agent-registry-row.tsx` (or similar small component) — display row + disabled-action chips.
+  - Fixtures under `src/server/__fixtures__/agent-registry/` (valid, invalid, duplicate, secret-bearing, dispatch-enabled-bad).
+  - Tests colocated as `*.test.ts` / `*.test.tsx`.
+- **Touched lightly, by composition only**:
+  - `src/screens/swarm2/swarm2-screen.tsx` — compose new component; do **not** inline registry logic; do **not** expand role-preset duplication.
+  - `docs/swarm/ARCHITECTURE.md`, `docs/swarm/ROLES.md` — minimal doc updates reflecting the new read-only surface.
+- **Read-referenced, not modified**: `src/server/swarm-roster.ts`, `src/server/kanban-backend.ts` (adapter pattern reference), `src/server/gateway-capabilities.ts` (capability gate pattern reference), root `swarm.yaml`.
+
+## 6. Files/modules explicitly forbidden in Phase 1
+
+No writes, edits, or new behavior in:
+
+- `src/routes/api/swarm-dispatch.ts` and `src/server/swarm-missions.ts` — dispatch.
+- `src/server/swarm-lifecycle.ts`, `src/server/terminal-sessions.ts`, `src/server/pty-helper.py` — restart/lifecycle/tmux send-keys.
+- `src/server/swarm-profile-config.ts` — profile config sync (write boundary).
+- `src/server/local-provider-discovery.ts`, `src/routes/api/local-providers.ts`, `src/routes/api/models.ts`, `src/screens/settings/providers-screen.tsx`, provider-wizard — provider/model config writes.
+- `src/server/swarm-notifications.ts` — notification sinks.
+- `src/server/swarm-checkpoints.ts`, `src/server/swarm-chat-reader.ts`, `src/server/swarm-memory.ts` — runtime/memory writes.
+- Anything under Atlas board paths, `atlas-info-geometry-validation`, Atlas repo, or Sentinel/Forge SSH.
+- Dashboard-to-source sync, board-to-source sync.
+- Mail plane, financial domain, credential/security mutation, GPU/Foundry job launch.
+- `workspace-overrides.json` writes; `state.db` writes; tmux `send-keys`; `runtime.json` mutation.
+- `pnpm-workspace.yaml` and `docs/reviews/` (the existing untracked items in target repo status) — do not auto-commit or modify as part of this slice; treat as user's in-progress work.
+
+## 7. Non-interference constraints to include in worker prompts
+
+Copy these verbatim (or equivalent) into both Codex C-lane and Claude D-lane implementation prompts and the E reconciler:
+
+1. Operate only inside the declared worktree at repo commit `372b18a8e4e3fa7947ff3cf5651865560daca0a1`. Do not edit shared checkouts.
+2. No Sentinel/Rilo/Forge/Atlas live-system inspection. No SSH. No host probes. No tmux send-keys. No service start/stop/restart.
+3. No Atlas board reads, mutations, or evidence promotion. No board-to-source sync.
+4. No deploy, no restart, no `npm/pnpm start`, no dev server side effects beyond local test runs.
+5. No profile config writes (`swarm-profile-config.ts`), no provider config writes, no `workspace-overrides.json` writes, no SQLite/JSON store writes.
+6. No dispatch endpoint changes. No notification sink changes. No lifecycle/handoff/renewal behavior changes.
+7. Registry read path must be provably side-effect-free: assert with tests, not just comments.
+8. Treat `dispatch_enabled` as fail-closed: default false, explicit opt-in required, never inferred.
+9. Secrets are forbidden in the registry. Detect and refuse to load secret-looking values.
+10. Fail closed and surface diagnostics for unknown `schema_version`, unknown enums, missing required fields, duplicate ids, and ambiguous source of truth.
+11. Do not treat memory, Kanban status, child-agent prose, or dashboard chips as authoritative evidence.
+12. Do not commit `pnpm-workspace.yaml` or `docs/reviews/` changes; preserve as user's in-progress state.
+13. RED tests must land before implementation; do not skip the failing-first step.
+14. Custody: preserve prompts, lane outputs, reconciler report, diff bundle, test logs, SHA256SUMS in durable `.hermes` artifact path. Cite exact branch/commit.
+15. Claude lane uses Claude Code/Max OAuth, not Anthropic API key. Codex lane uses Codex CLI OAuth GPT-5.5. Lane contamination = block.
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Source-of-truth drift (root `swarm.yaml` vs browser local vs runtime JSON vs profile config vs docs) | Define precedence in the parser; emit a drift diagnostic; tests assert file-backed truth wins; UI shows a non-authoritative chip. |
+| Silent fallback hiding malformed registry (current `swarm-roster.ts` pattern) | Phase 1 surfaces all parse errors in API response and UI; no swallowed exceptions; structured diagnostics in tests. |
+| `swarm2-screen.tsx` god-module growth | Put registry types/hooks in small modules; compose, don't inline; reviewer rejects inline expansion. |
+| Direct SQLite/JSON write creep | Phase 1 backend interface is read-only; `writable: false` is invariant; tests spy on write helpers and fail on call. |
+| Lane contamination (different artifact hashes between C and D) | E reconciler verifies anchors; mismatch = reissue, not merge. This review is bound to the three anchors echoed above. |
+| Multi-host / remote agent assumptions leaking into local-path code | Adapter interface names local-only assumptions explicitly; remote adapters are deferred, not stubbed under local paths. |
+| Review-lane semantics inconsistent upstream (`review` vs `ready` in dashboard proxy vs synthetic kanban) | Phase 1 does not redefine review semantics; registry only exposes declared status; UI shows source-owned chips. |
+| Untracked `docs/reviews/` and `pnpm-workspace.yaml` in target repo status | Workers prompted not to touch or commit these; treat as user's pending work; reviewer flags any incidental changes. |
+| Tests passing because mocked I/O hides real read-path side effects | Use real filesystem fixtures in temp dirs; assert mtime invariants; ban network/SSH/tmux mocks that could conceal probes. |
+| Approval drift: someone interpreting this as deploy/restart approval | This review states explicitly in §1 that deploy/restart/live-probe are excluded; worker prompts repeat the constraint. |
+
+## 9. Minimal implementation sequence
+
+1. Create or verify clean worktree at the declared path on the macOS controller, pinned to commit `372b18a8e4e3fa7947ff3cf5651865560daca0a1`. Branch named for this slice (e.g. `t-0101-impl-01-registry-spine`).
+2. Land fixtures: valid `agents.v1`, invalid (missing required, bad enum, bad id regex), duplicate ids, secret-bearing, `dispatch_enabled: true` without authorization.
+3. Write RED tests enumerated in §4. Confirm all fail.
+4. Implement `src/server/agent-registry.ts` (typed schema + parser + diagnostics) until schema/validation tests go GREEN.
+5. Implement `src/server/agent-registry-backends/swarm-yaml.ts` (read-only adapter) until backend/no-mutation tests go GREEN.
+6. Implement `src/routes/api/agents.ts` until API tests go GREEN. Assert structured error payloads.
+7. Implement `src/lib/agent-registry-types.ts`, `src/hooks/use-agent-registry.ts`, and a small display component. Compose under `/swarm2` without touching dispatch/lifecycle code. UI tests GREEN.
+8. Run the no-probe and no-write assertions across the whole test suite. GREEN.
+9. Update `docs/swarm/ARCHITECTURE.md` and `docs/swarm/ROLES.md` minimally to reflect the read-only registry surface.
+10. Custody bundle: collect prompts, C/D outputs, this review, E reconciler report, diff, test logs, SHA256SUMS. Place under durable `.hermes` artifact path. Do not deploy. Do not restart. Do not run live probes. Hand back to controller for Phase 2 gating.
+
+## 10. Final concise recommendation
+
+Approve Phase 1 implementation start, contingent on the E reconciler confirming the same artifact anchors (`e7eb957178ce0d8d7aafbf8bae4f4327382fd346643817b8818ab5d8731d0a5f` plan / `372b18a8e4e3fa7947ff3cf5651865560daca0a1` repo / `b0965167a06642911538acd278c19b2915e425869317bbc6981bc705c8104342` bundle). The scope is narrow, fail-closed, and well-bounded by the planning artifacts. Land RED tests first, keep `swarm-dispatch.ts` / `swarm-profile-config.ts` / `local-provider-discovery.ts` untouched, do not promote anything to Atlas, and do not deploy or restart. If C-lane anchors diverge or the bundle hash cannot be reproduced by the controller, treat this approval as void and reissue.

--- a/docs/reviews/hw-phase1-readonly-registry/review-codex.md
+++ b/docs/reviews/hw-phase1-readonly-registry/review-codex.md
@@ -1,0 +1,78 @@
+Inspected commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+Model: openai-codex/gpt-5.5
+Lane: Codex hard-guardrail review
+Verdict: APPROVE
+
+Scope reviewed
+- Parent task t_2cb9579e handoff and this lane card t_65fc5bc4.
+- Repository HEAD and working tree at target commit 372b18a8e4e3fa7947ff3cf5651865560daca0a1; pre-existing untracked pnpm-workspace.yaml was observed and not touched.
+- Existing swarm/registry-adjacent code paths:
+  - src/server/swarm-roster.ts
+  - src/routes/api/swarm-roster.ts
+  - src/server/swarm-foundation.ts
+  - src/server/swarm-environment.ts
+  - src/routes/api/crew-status.ts
+  - src/screens/swarm2/swarm2-screen.tsx
+  - src/screens/swarm2/operational-worker-card.tsx
+  - src/hooks/use-crew-status.ts
+  - swarm.yaml
+
+Summary
+The Phase 1 read-only registry spine is safe and ready to implement if it remains narrowly read-only and compatibility-focused. The existing repo already has a zod/yaml roster parser and Swarm2 consumes roster metadata, but the current /api/swarm-roster endpoint is mixed read/write and readSwarmRoster silently falls back on validation failures. Phase 1 should therefore add a separate normalized read-only registry contract and UI consumption path rather than extending the existing mutating roster endpoint as the new authority.
+
+Rationale
+- The requested slice is operational metadata only: it reads local repository/config artifacts, normalizes worker entries, and renders rows/badges/detail states. It does not require deployment, restarts, dispatch/restart controls, live Sentinel/Rilo/Forge probes, profile/provider writes, dashboard-to-source sync, Atlas mutation, or evidence promotion.
+- Existing implementation patterns are compatible with the slice:
+  - zod schema/parser precedent exists in src/server/swarm-roster.ts and src/server/swarm-foundation.ts.
+  - authenticated read API precedent exists in src/routes/api/swarm-roster.ts and src/routes/api/crew-status.ts.
+  - Swarm2 already fetches roster metadata and merges it into crew/runtime cards in src/screens/swarm2/swarm2-screen.tsx.
+  - Operational worker cards already render role/model/status badges and detail panels in src/screens/swarm2/operational-worker-card.tsx.
+- The compatibility source, swarm.yaml, is in-repo and static for this phase. Reading/parsing it is within the allowed source-derived status boundary.
+- The main risk is authority creep: current UI/API naming can make roster/control-plane metadata look canonical. The implementation must explicitly label the registry as normalized read-only workspace metadata and preserve source artifacts as authority.
+
+Required implementation constraints
+1. Strict TDD first:
+   - Add failing parser/schema tests before implementation.
+   - Add failing API route tests before route implementation.
+   - Add failing UI tests for rows/badges/detail/error states before UI implementation.
+   - Convert any future review finding into a RED regression test before patching.
+2. Keep the registry read-only end to end:
+   - The Phase 1 route must expose only GET/HEAD-safe behavior.
+   - Do not add POST/PUT/PATCH/DELETE to the new registry route.
+   - Do not call writeSwarmRoster, upsertSwarmRosterWorker, syncSwarmProfileModel, profile config writers, dispatch endpoints, tmux start/stop endpoints, or dashboard/task mutation endpoints from the registry path.
+   - No localStorage writes should be needed for the registry rows/badges/detail rendering.
+3. Prefer a new module and route over modifying /api/swarm-roster in place:
+   - Suggested module: src/server/worker-registry.ts or src/server/swarm-registry.ts.
+   - Suggested API: /api/worker-registry or /api/swarm-registry.
+   - Existing /api/swarm-roster can remain as backwards-compatible legacy read/write surface; the new API should be explicitly normalized/read-only.
+4. Parser contract:
+   - Define typed normalized entries with stable fields such as id, displayName, role, specialty, modelLabel, skills, capabilities, preferredTaskTypes, acceptsBroadcast, reviewRequired, defaultCwd, source, sourcePath, sourceVersion, and validation status.
+   - Preserve backend metadata separately from UI labels: source path, source mtime if used, parser version, loadedAt/fetchedAt, backend kind, and compatibility mode.
+   - Return validation diagnostics as data, not swallowed fallback behavior. Include issue path, severity, message, and source worker id when applicable.
+   - Unknown optional fields in swarm.yaml should be diagnostics/warnings, not hard failures, unless they conflict with required normalized fields.
+   - Invalid worker entries should not crash the whole route; return valid normalized entries plus diagnostics unless the file itself is unreadable/unparseable.
+5. API contract:
+   - Keep existing authentication behavior via isAuthenticated(request).
+   - Return a shape like { ok, entries, backend, diagnostics, fetchedAt }.
+   - If swarm.yaml is missing or malformed, return ok: true with entries: [] plus diagnostics when possible, or a controlled non-500 error only for truly unreadable backend failures.
+   - Do not probe live agent hosts, gateways, Sentinel, Rilo, Forge, tmux, cron, email, financial systems, or external networks.
+6. UI contract:
+   - Render minimal registry rows/badges/detail states from the new read-only API.
+   - Show source/compatibility/diagnostic badges clearly so users can tell roster-derived entries from live runtime state.
+   - Do not let the new UI imply dashboard/source sync or edit capability.
+   - Keep current operational controls separate from registry details; no dispatch/restart/start/stop affordances should be introduced in this slice.
+7. No-mutation tests must be explicit:
+   - Test that only GET is implemented for the new route, or that non-GET methods return 405/route-miss without side effects.
+   - Mock/spies should assert writeSwarmRoster/upsertSwarmRosterWorker/profile config writers/dispatch helpers are not called by parser/API/UI flows.
+   - Include fixtures for valid swarm.yaml, missing file, malformed YAML, invalid worker id, partially invalid worker, unknown fields, duplicate ids, empty workers, and roster-only entries.
+   - Include UI tests for validation diagnostics and source badges.
+8. Do not regenerate or hand-edit routeTree.gen.ts unless this repo's normal route generation workflow requires it; if generation is required, include that in tests/build evidence, not as an unrelated manual edit.
+
+Findings
+- No blocking safety issue found for the proposed Phase 1 implementation as scoped.
+- One implementation hazard: src/server/swarm-roster.ts currently catches parse errors and returns fallbackRoster(ids) without diagnostics. The new registry parser must not repeat this silent-fallback pattern; diagnostics are a required output.
+- One authority-boundary hazard: Swarm2 currently merges crew, runtime, and roster fields into one member object. The new UI should preserve source labels/badges so normalized registry data is not confused with live runtime truth.
+- One route-boundary hazard: /api/swarm-roster currently supports POST mutation. The read-only registry should not share a route surface where a future refactor could accidentally inherit mutation semantics.
+
+Decision
+APPROVE implementation to proceed under strict TDD and the constraints above. This approval does not authorize deployment, restart, live-system probing, Atlas evidence mutation/promotion, dispatch controls, profile/provider config writes, dashboard-to-source sync, email/financial/security actions, or any write behavior beyond normal source-code/test artifacts needed for the future implementation card.

--- a/docs/reviews/hw-phase1-readonly-registry/review-reconciliation-complete.md
+++ b/docs/reviews/hw-phase1-readonly-registry/review-reconciliation-complete.md
@@ -1,0 +1,59 @@
+# Phase 1 Read-only Registry Complete Post-implementation Reconciliation
+
+## Verdict
+
+APPROVE — mixed Codex GPT-5.5 + Claude Max review consensus reached on the complete final bundle.
+
+## Final reviewed bundle
+
+- Bundle: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/review-bundle-after-semantic-key-redaction-fix.md`
+- Bundle sha256: `435d5bc107ac0740c16d9c73f4efd86a06621be66e2b20044e8961440af6a2a9`
+- Artifact commit/base: `372b18a8e4e3fa7947ff3cf5651865560daca0a1`
+
+## Independent review artifacts
+
+- Codex GPT-5.5: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/codex-after-semantic-key-redaction-fix-review.md`
+  - Verdict: APPROVE
+  - Findings: None
+- Claude Max: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/claude-after-semantic-key-redaction-fix-review.json`
+  - Verdict: APPROVE
+  - Findings: []
+
+## Verification
+
+- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose`
+  - PASS: 4 files, 29 tests
+- `pnpm build`
+  - PASS
+- `git diff --check`
+  - PASS
+
+## Blockers found and closed during post-approval hardening
+
+1. Registry-only source rows previously reached the operational worker card surface.
+   - Fixed by adding `mergeRegistryRosterWithCrew()` and only enriching live crew rows.
+2. `ControlPlaneStage` referenced registry query values from an invalid scope.
+   - Fixed by passing registry entries/diagnostics/backend as props.
+3. Diagnostics could echo invalid or secret-like worker ids.
+   - Fixed by omitting non-canonical/secret-like diagnostic entry ids.
+4. Raw YAML parser errors could include source snippets.
+   - Fixed by emitting generic parse diagnostics.
+5. Token-like YAML keys and values were under-detected.
+   - Fixed with broader token-family detection.
+6. Semantic credential keys (`password`, `GITHUB_TOKEN`, `access_token`, `bearerToken`, `authorization`, `private_key`, etc.) could be echoed.
+   - Fixed with key-aware redaction.
+7. Bundle coverage initially missed `pnpm-workspace.yaml`.
+   - Fixed; final bundle includes it.
+
+## Scope preserved
+
+- `/api/agent-registry` remains GET/HEAD-only.
+- No deploy/restart/dispatch controls added by the registry feature.
+- No Atlas mutation.
+- No profile/provider config writes.
+- Registry panel remains read-only compatibility metadata from `swarm.yaml`, not live runtime truth.
+- Registry-only workers are displayed in the read-only panel only; they do not gain operational controls.
+
+## Merge posture
+
+Merge-ready for user review. Controller intentionally did not commit or merge.

--- a/docs/reviews/hw-phase1-readonly-registry/review-reconciliation.md
+++ b/docs/reviews/hw-phase1-readonly-registry/review-reconciliation.md
@@ -1,0 +1,83 @@
+Inspected commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+Model: openai-codex/gpt-5.5
+Lane: E reconciler hard-guardrail review
+Verdict: APPROVE
+
+# Phase 1 Read-only Registry Gate Reconciliation
+
+## Gate inputs verified
+
+- Reconciler task: t_3d51071b
+- Parent implementation gate: t_2cb9579e
+- Codex lane: t_65fc5bc4
+  - findings_artifact: docs/reviews/hw-phase1-readonly-registry/review-codex.md
+  - artifact_commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+  - model: openai-codex/gpt-5.5
+  - verdict: APPROVE
+- Claude lane: t_1701ffb9
+  - findings_artifact: docs/reviews/hw-phase1-readonly-registry/review-claude.md
+  - artifact_commit: 372b18a8e4e3fa7947ff3cf5651865560daca0a1
+  - model: claude-code/opus-4-7
+  - verdict: APPROVE
+  - gate_bundle_sha256: b0965167a06642911538acd278c19b2915e425869317bbc6981bc705c8104342
+
+The repository HEAD in the shared workspace was verified as 372b18a8e4e3fa7947ff3cf5651865560daca0a1 before reconciliation. Both lane task records are done and include the required findings_artifact, artifact_commit, model, and verdict metadata. Both lane artifacts declare the same inspected commit at the top of the file. There is no lane contamination for this gate.
+
+## Consensus verdict
+
+Both independent lanes APPROVE the Phase 1 read-only registry implementation boundary at the same artifact commit. The reconciled verdict is APPROVE for the future TDD implementation card only.
+
+This approval does not authorize deploy, restart, live-system probes, dispatch/restart controls, profile/provider config writes, dashboard-to-source sync, Atlas evidence mutation/promotion, Sentinel/Rilo/Forge interaction, email/financial/security actions, or GPU/Foundry job launch.
+
+## Merged allowed implementation boundary
+
+The downstream implementation may proceed only inside the declared repository/worktree and only as a source-code/test implementation slice for a read-only registry spine:
+
+1. Add a typed registry schema/parser for normalized agent/worker entries.
+2. Support a compatibility read from the existing in-repo swarm.yaml as the first backend/source.
+3. Expose a new read-only API route returning normalized entries, backend/source metadata, validation diagnostics, and fetched/loaded timestamps.
+4. Add minimal UI rows, badges, details, diagnostics, and disabled-action explanations by composing small new components/hooks rather than expanding Swarm2 into a registry god-module.
+5. Add fixtures covering valid, missing, malformed, partially invalid, duplicate-id, unknown-field, secret-looking, dispatch-enabled, and empty registry inputs.
+6. Update docs minimally to describe the read-only registry surface and non-authoritative/source-derived status boundary.
+
+## Required implementation constraints
+
+- Strict TDD is required: write RED parser/schema, backend/API, UI, diagnostics, no-mutation, and no-live-probe tests before implementing the corresponding production code.
+- The registry must be read-only end to end. New route behavior should be GET/HEAD-safe only; POST/PUT/PATCH/DELETE must not exist or must return controlled non-mutating failures.
+- Do not reuse the existing mutating /api/swarm-roster surface as the new authority. Prefer a separate module and route such as src/server/agent-registry.ts plus src/routes/api/agents.ts or src/routes/api/agent-registry.ts.
+- Preserve authentication expectations for API reads.
+- Surface validation problems as structured diagnostics, not silent fallback. Do not repeat the existing readSwarmRoster silent fallback pattern.
+- Return valid entries plus diagnostics where possible; fail closed for schema-version mismatches, unknown enums, missing required fields, duplicate ids, ambiguous source of truth, and secret-looking values.
+- Treat dispatch_enabled as fail-closed: default false and never inferred; true requires explicit authorization metadata and acceptable status.
+- Backend metadata must make source path, compatibility mode, backend kind, loaded/fetched time, parser version, and writable=false visible.
+- UI must label source-derived/compatibility status clearly and must not imply live runtime truth, source sync, edit capability, dispatch capability, or evidence authority.
+- No localStorage, SQLite, runtime.json, workspace-overrides.json, profile config, provider config, or source-of-truth writes are permitted from the registry read path.
+- Tests must explicitly prove no mutation and no live probes by spies and/or filesystem mtime checks; do not rely only on comments or mocked happy paths.
+- Do not run SSH, tmux send-keys, dev servers, service start/stop/restart, live Sentinel/Rilo/Forge/Atlas probes, deploys, or dispatch actions.
+
+## Forbidden implementation areas for Phase 1
+
+The future implementation must not write or add behavior in dispatch, lifecycle, provider/profile config, notification, memory/checkpoint, Atlas, live-system, mail, financial, credential, GPU/Foundry, or board/source-sync paths. In particular, do not modify or invoke these as part of registry behavior:
+
+- src/routes/api/swarm-dispatch.ts
+- src/server/swarm-missions.ts
+- src/server/swarm-lifecycle.ts
+- src/server/terminal-sessions.ts
+- src/server/pty-helper.py
+- src/server/swarm-profile-config.ts
+- src/server/local-provider-discovery.ts
+- src/routes/api/local-providers.ts
+- src/routes/api/models.ts
+- provider wizard/settings write paths
+- src/server/swarm-notifications.ts
+- src/server/swarm-checkpoints.ts
+- src/server/swarm-chat-reader.ts
+- src/server/swarm-memory.ts
+- Atlas board/repo/evidence paths
+- workspace-overrides.json, state.db, runtime.json, and tmux control surfaces
+
+## Notes for the downstream implementation card
+
+- Keep docs/reviews/ and the pre-existing untracked pnpm-workspace.yaml out of implementation commits unless a controller explicitly scopes custody/commit handling for review artifacts.
+- Preserve both lane artifacts and this reconciler report as guardrail evidence for the future implementation prompt.
+- If the downstream implementation changes the reviewed boundary materially, rerun the two-lab gate at the new artifact commit rather than carrying this approval forward.

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -105,6 +105,7 @@ import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
 import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiArtifactsRouteImport } from './routes/api/artifacts'
+import { Route as ApiAgentRegistryRouteImport } from './routes/api/agent-registry'
 import { Route as ApiUpdateWorkspaceRouteImport } from './routes/api/update/workspace'
 import { Route as ApiUpdateStatusRouteImport } from './routes/api/update/status'
 import { Route as ApiUpdateAgentRouteImport } from './routes/api/update/agent'
@@ -634,6 +635,11 @@ const ApiArtifactsRoute = ApiArtifactsRouteImport.update({
   path: '/api/artifacts',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAgentRegistryRoute = ApiAgentRegistryRouteImport.update({
+  id: '/api/agent-registry',
+  path: '/api/agent-registry',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiUpdateWorkspaceRoute = ApiUpdateWorkspaceRouteImport.update({
   id: '/api/update/workspace',
   path: '/api/update/workspace',
@@ -898,6 +904,7 @@ export interface FileRoutesByFullPath {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-registry': typeof ApiAgentRegistryRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1042,6 +1049,7 @@ export interface FileRoutesByTo {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-registry': typeof ApiAgentRegistryRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1188,6 +1196,7 @@ export interface FileRoutesById {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-registry': typeof ApiAgentRegistryRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1335,6 +1344,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-registry'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1479,6 +1489,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-registry'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1624,6 +1635,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-registry'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1770,6 +1782,7 @@ export interface RootRouteChildren {
   TerminalRoute: typeof TerminalRoute
   VtCapitalRoute: typeof VtCapitalRoute
   WorldRoute: typeof WorldRoute
+  ApiAgentRegistryRoute: typeof ApiAgentRegistryRoute
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
   ApiAuthCheckRoute: typeof ApiAuthCheckRoute
@@ -2538,6 +2551,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiArtifactsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/agent-registry': {
+      id: '/api/agent-registry'
+      path: '/api/agent-registry'
+      fullPath: '/api/agent-registry'
+      preLoaderRoute: typeof ApiAgentRegistryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/update/workspace': {
       id: '/api/update/workspace'
       path: '/api/update/workspace'
@@ -3080,6 +3100,7 @@ const rootRouteChildren: RootRouteChildren = {
   TerminalRoute: TerminalRoute,
   VtCapitalRoute: VtCapitalRoute,
   WorldRoute: WorldRoute,
+  ApiAgentRegistryRoute: ApiAgentRegistryRoute,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
   ApiAuthCheckRoute: ApiAuthCheckRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -106,6 +106,9 @@ import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiArtifactsRouteImport } from './routes/api/artifacts'
 import { Route as ApiAgentRegistryRouteImport } from './routes/api/agent-registry'
+import { Route as ApiVectorMemoryStatusRouteImport } from './routes/api/vector-memory/status'
+import { Route as ApiVectorMemorySearchRouteImport } from './routes/api/vector-memory/search'
+import { Route as ApiVectorMemoryDiscoveryRouteImport } from './routes/api/vector-memory/discovery'
 import { Route as ApiUpdateWorkspaceRouteImport } from './routes/api/update/workspace'
 import { Route as ApiUpdateStatusRouteImport } from './routes/api/update/status'
 import { Route as ApiUpdateAgentRouteImport } from './routes/api/update/agent'
@@ -640,6 +643,22 @@ const ApiAgentRegistryRoute = ApiAgentRegistryRouteImport.update({
   path: '/api/agent-registry',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiVectorMemoryStatusRoute = ApiVectorMemoryStatusRouteImport.update({
+  id: '/api/vector-memory/status',
+  path: '/api/vector-memory/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVectorMemorySearchRoute = ApiVectorMemorySearchRouteImport.update({
+  id: '/api/vector-memory/search',
+  path: '/api/vector-memory/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVectorMemoryDiscoveryRoute =
+  ApiVectorMemoryDiscoveryRouteImport.update({
+    id: '/api/vector-memory/discovery',
+    path: '/api/vector-memory/discovery',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiUpdateWorkspaceRoute = ApiUpdateWorkspaceRouteImport.update({
   id: '/api/update/workspace',
   path: '/api/update/workspace',
@@ -1020,6 +1039,9 @@ export interface FileRoutesByFullPath {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/vector-memory/discovery': typeof ApiVectorMemoryDiscoveryRoute
+  '/api/vector-memory/search': typeof ApiVectorMemorySearchRoute
+  '/api/vector-memory/status': typeof ApiVectorMemoryStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1165,6 +1187,9 @@ export interface FileRoutesByTo {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/vector-memory/discovery': typeof ApiVectorMemoryDiscoveryRoute
+  '/api/vector-memory/search': typeof ApiVectorMemorySearchRoute
+  '/api/vector-memory/status': typeof ApiVectorMemoryStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1312,6 +1337,9 @@ export interface FileRoutesById {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/vector-memory/discovery': typeof ApiVectorMemoryDiscoveryRoute
+  '/api/vector-memory/search': typeof ApiVectorMemorySearchRoute
+  '/api/vector-memory/status': typeof ApiVectorMemoryStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1460,6 +1488,9 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/vector-memory/discovery'
+    | '/api/vector-memory/search'
+    | '/api/vector-memory/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1605,6 +1636,9 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/vector-memory/discovery'
+    | '/api/vector-memory/search'
+    | '/api/vector-memory/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1751,6 +1785,9 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/vector-memory/discovery'
+    | '/api/vector-memory/search'
+    | '/api/vector-memory/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1875,6 +1912,9 @@ export interface RootRouteChildren {
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
   ApiUpdateWorkspaceRoute: typeof ApiUpdateWorkspaceRoute
+  ApiVectorMemoryDiscoveryRoute: typeof ApiVectorMemoryDiscoveryRoute
+  ApiVectorMemorySearchRoute: typeof ApiVectorMemorySearchRoute
+  ApiVectorMemoryStatusRoute: typeof ApiVectorMemoryStatusRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -2558,6 +2598,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAgentRegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/vector-memory/status': {
+      id: '/api/vector-memory/status'
+      path: '/api/vector-memory/status'
+      fullPath: '/api/vector-memory/status'
+      preLoaderRoute: typeof ApiVectorMemoryStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/vector-memory/search': {
+      id: '/api/vector-memory/search'
+      path: '/api/vector-memory/search'
+      fullPath: '/api/vector-memory/search'
+      preLoaderRoute: typeof ApiVectorMemorySearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/vector-memory/discovery': {
+      id: '/api/vector-memory/discovery'
+      path: '/api/vector-memory/discovery'
+      fullPath: '/api/vector-memory/discovery'
+      preLoaderRoute: typeof ApiVectorMemoryDiscoveryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/update/workspace': {
       id: '/api/update/workspace'
       path: '/api/update/workspace'
@@ -3193,6 +3254,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,
   ApiUpdateWorkspaceRoute: ApiUpdateWorkspaceRoute,
+  ApiVectorMemoryDiscoveryRoute: ApiVectorMemoryDiscoveryRoute,
+  ApiVectorMemorySearchRoute: ApiVectorMemorySearchRoute,
+  ApiVectorMemoryStatusRoute: ApiVectorMemoryStatusRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/-agent-registry.test.ts
+++ b/src/routes/api/-agent-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../server/auth-middleware', () => ({
+  isAuthenticated: vi.fn(() => true),
+}))
+
+import { buildAgentRegistryApiPayload, READ_ONLY_AGENT_REGISTRY_METHODS } from '../../server/agent-registry'
+import { Route as AgentRegistryRoute } from './agent-registry'
+
+describe('read-only agent registry API payload', () => {
+  it('returns normalized entries, backend metadata, diagnostics, and timestamps from a read-only loader', () => {
+    const payload = buildAgentRegistryApiPayload({
+      ok: true,
+      parserVersion: 'agent-registry-v1',
+      entries: [
+        {
+          id: 'swarm5',
+          displayName: 'Builder',
+          role: 'Builder',
+          dispatchEnabled: false,
+          source: 'swarm.yaml',
+          sourceDerived: true,
+          writable: false,
+          capabilities: [],
+          skills: [],
+          disabledActions: ['Registry is read-only in Phase 1.'],
+        },
+      ],
+      diagnostics: [],
+      backend: {
+        kind: 'swarm-yaml',
+        sourcePath: '/repo/swarm.yaml',
+        compatibilityMode: true,
+        writable: false,
+        parserVersion: 'agent-registry-v1',
+        loadedAt: 10,
+        fetchedAt: 11,
+      },
+    })
+
+    expect(payload).toMatchObject({
+      ok: true,
+      registry: { entries: [{ id: 'swarm5', dispatchEnabled: false, writable: false }] },
+      backend: { sourcePath: '/repo/swarm.yaml', writable: false, parserVersion: 'agent-registry-v1' },
+      diagnostics: [],
+      fetchedAt: 11,
+      loadedAt: 10,
+    })
+  })
+
+  it('documents that only GET and HEAD are valid read methods', () => {
+    expect(READ_ONLY_AGENT_REGISTRY_METHODS).toEqual(['GET', 'HEAD'])
+  })
+
+  it('does not register mutating route handlers', () => {
+    const handlers = AgentRegistryRoute.options.server?.handlers as Record<string, unknown>
+
+    expect(Object.keys(handlers).sort()).toEqual(['GET', 'HEAD'])
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      expect(handlers[method]).toBeUndefined()
+    }
+  })
+})

--- a/src/routes/api/-history.test.ts
+++ b/src/routes/api/-history.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildLocalHistoryPayload } from './history'
+
+describe('GET /api/history local fallback payload', () => {
+  it('maps local portable session messages when backend sessions are unavailable', () => {
+    const payload = buildLocalHistoryPayload('local-1', [
+      {
+        id: 'msg-1',
+        role: 'user',
+        content: 'hello local model',
+        timestamp: 1234,
+      },
+    ])
+
+    expect(payload).toEqual({
+      sessionKey: 'local-1',
+      sessionId: 'local-1',
+      source: 'local',
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: [{ type: 'text', text: 'hello local model' }],
+          timestamp: 1234,
+          historyIndex: 0,
+        },
+      ],
+    })
+  })
+})

--- a/src/routes/api/-sessions.test.ts
+++ b/src/routes/api/-sessions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildUnavailableSessionsPayload } from './sessions'
+
+describe('GET /api/sessions fallback payload', () => {
+  it('returns local portable sessions when backend sessions capability is unavailable', () => {
+    const payload = buildUnavailableSessionsPayload([
+      {
+        id: 'local-1',
+        title: 'Recovered Workspace Chat',
+        model: 'hermes-agent',
+        createdAt: 1000,
+        updatedAt: 2000,
+        messageCount: 7,
+      },
+    ])
+
+    expect(payload).toMatchObject({
+      ok: true,
+      source: 'local',
+      sessions: [
+        {
+          key: 'local-1',
+          id: 'local-1',
+          friendlyId: 'local-1',
+          title: 'Recovered Workspace Chat',
+          label: 'Recovered Workspace Chat',
+          derivedTitle: 'Recovered Workspace Chat',
+          startedAt: 1000,
+          updatedAt: 2000,
+          message_count: 7,
+          model: 'hermes-agent',
+          source: 'local',
+        },
+      ],
+    })
+  })
+})

--- a/src/routes/api/agent-registry.ts
+++ b/src/routes/api/agent-registry.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { buildAgentRegistryApiPayload, loadAgentRegistry } from '../../server/agent-registry'
+
+export const Route = createFileRoute('/api/agent-registry')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        return json(buildAgentRegistryApiPayload(loadAgentRegistry()))
+      },
+      HEAD: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return new Response(null, { status: 401 })
+        }
+        return new Response(null, { status: 204 })
+      },
+    },
+  },
+})

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -10,7 +10,35 @@ import {
 } from '../../server/claude-api'
 import { resolveSessionKey } from '../../server/session-utils'
 import { isAuthenticated } from '@/server/auth-middleware'
-import { getLocalSession, getLocalMessages } from '../../server/local-session-store'
+import {
+  getLocalMessages,
+  getLocalSession,
+  type LocalMessage,
+} from '../../server/local-session-store'
+
+export function buildLocalHistoryPayload(
+  sessionKey: string,
+  localMessages: Array<LocalMessage>,
+): Record<string, unknown> {
+  return {
+    sessionKey,
+    sessionId: sessionKey,
+    messages: localMessages.map((m, index) => ({
+      id: m.id,
+      role: m.role,
+      content: [{ type: 'text', text: m.content }],
+      timestamp: m.timestamp,
+      historyIndex: index,
+    })),
+    source: 'local',
+  }
+}
+
+function getLocalHistoryPayload(sessionKey: string): Record<string, unknown> | null {
+  const localSession = getLocalSession(sessionKey)
+  if (!localSession) return null
+  return buildLocalHistoryPayload(sessionKey, getLocalMessages(sessionKey))
+}
 
 export const Route = createFileRoute('/api/history')({
   server: {
@@ -20,7 +48,14 @@ export const Route = createFileRoute('/api/history')({
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         await ensureGatewayProbed()
+        const url = new URL(request.url)
+        const limit = Number(url.searchParams.get('limit') || '200')
+        const rawSessionKey = url.searchParams.get('sessionKey')?.trim()
+        const friendlyId = url.searchParams.get('friendlyId')?.trim()
         if (!getGatewayCapabilities().sessions) {
+          const requestedKey = rawSessionKey || friendlyId
+          const localPayload = requestedKey ? getLocalHistoryPayload(requestedKey) : null
+          if (localPayload) return json(localPayload)
           return json({
             sessionKey: 'new',
             sessionId: 'new',
@@ -30,10 +65,6 @@ export const Route = createFileRoute('/api/history')({
           })
         }
         try {
-          const url = new URL(request.url)
-          const limit = Number(url.searchParams.get('limit') || '200')
-          const rawSessionKey = url.searchParams.get('sessionKey')?.trim()
-          const friendlyId = url.searchParams.get('friendlyId')?.trim()
           let { sessionKey } = await resolveSessionKey({
             rawSessionKey,
             friendlyId,
@@ -98,24 +129,9 @@ export const Route = createFileRoute('/api/history')({
             messages = []
           }
 
-          // Fallback to local session store for portable/local model sessions
-          if (messages.length === 0) {
-            const localSession = getLocalSession(sessionKey)
-            if (localSession) {
-              const localMessages = getLocalMessages(sessionKey)
-              return json({
-                sessionKey,
-                sessionId: sessionKey,
-                messages: localMessages.map((m, index) => ({
-                  id: m.id,
-                  role: m.role,
-                  content: [{ type: 'text', text: m.content }],
-                  timestamp: m.timestamp,
-                  historyIndex: index,
-                })),
-              })
-            }
-          }
+          // Fallback to local session store for portable/local model sessions.
+          const localPayload = messages.length === 0 ? getLocalHistoryPayload(sessionKey) : null
+          if (localPayload) return json(localPayload)
 
           const boundedMessages = limit > 0 ? messages.slice(-limit) : messages
 

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -19,7 +19,35 @@ import {
   getLocalSession,
   listLocalSessions,
   updateLocalSessionTitle,
+  type LocalSession,
 } from '../../server/local-session-store'
+
+function toLocalSessionSummary(ls: LocalSession): Record<string, unknown> {
+  return {
+    key: ls.id,
+    id: ls.id,
+    friendlyId: ls.id,
+    title: ls.title || 'Local Chat',
+    label: ls.title || 'Local Chat',
+    derivedTitle: ls.title || 'Local Chat',
+    startedAt: ls.createdAt,
+    updatedAt: ls.updatedAt,
+    message_count: ls.messageCount,
+    model: ls.model,
+    source: 'local',
+  }
+}
+
+export function buildUnavailableSessionsPayload(
+  localSessions: Array<LocalSession>,
+): Record<string, unknown> {
+  return {
+    ok: true,
+    sessions: localSessions.map(toLocalSessionSummary),
+    source: localSessions.length > 0 ? 'local' : 'unavailable',
+    message: SESSIONS_API_UNAVAILABLE_MESSAGE,
+  }
+}
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -31,12 +59,7 @@ export const Route = createFileRoute('/api/sessions')({
         }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.sessions) {
-          return json({
-            ok: true,
-            sessions: [],
-            source: 'unavailable',
-            message: SESSIONS_API_UNAVAILABLE_MESSAGE,
-          })
+          return json(buildUnavailableSessionsPayload(listLocalSessions()))
         }
 
         try {

--- a/src/routes/api/vector-memory/discovery.ts
+++ b/src/routes/api/vector-memory/discovery.ts
@@ -1,0 +1,52 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { requireJsonContentType } from '../../../server/rate-limit'
+import {
+  VectorMemoryInputError,
+  storeTeamDiscovery,
+} from '../../../server/vector-memory'
+
+export const Route = createFileRoute('/api/vector-memory/discovery')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const contentTypeError = requireJsonContentType(request)
+        if (contentTypeError) return contentTypeError
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            content?: unknown
+            source?: unknown
+          }
+          if (typeof body.content !== 'string') {
+            return json({ error: 'Discovery content is required' }, { status: 400 })
+          }
+          if (body.source !== undefined && typeof body.source !== 'string') {
+            return json({ error: 'Source must be a string' }, { status: 400 })
+          }
+          const source =
+            typeof body.source === 'string' ? body.source : 'workspace-dashboard'
+          return json(
+            await storeTeamDiscovery({
+              content: body.content,
+              source,
+            }),
+          )
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to store team discovery',
+            },
+            { status: error instanceof VectorMemoryInputError ? 400 : 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/vector-memory/discovery.ts
+++ b/src/routes/api/vector-memory/discovery.ts
@@ -1,52 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
-import { requireJsonContentType } from '../../../server/rate-limit'
-import {
-  VectorMemoryInputError,
-  storeTeamDiscovery,
-} from '../../../server/vector-memory'
 
 export const Route = createFileRoute('/api/vector-memory/discovery')({
   server: {
     handlers: {
-      POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
-          return json({ error: 'Unauthorized' }, { status: 401 })
-        }
-        const contentTypeError = requireJsonContentType(request)
-        if (contentTypeError) return contentTypeError
-        try {
-          const body = (await request.json().catch(() => ({}))) as {
-            content?: unknown
-            source?: unknown
-          }
-          if (typeof body.content !== 'string') {
-            return json({ error: 'Discovery content is required' }, { status: 400 })
-          }
-          if (body.source !== undefined && typeof body.source !== 'string') {
-            return json({ error: 'Source must be a string' }, { status: 400 })
-          }
-          const source =
-            typeof body.source === 'string' ? body.source : 'workspace-dashboard'
-          return json(
-            await storeTeamDiscovery({
-              content: body.content,
-              source,
-            }),
-          )
-        } catch (error) {
-          return json(
-            {
-              error:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to store team discovery',
-            },
-            { status: error instanceof VectorMemoryInputError ? 400 : 500 },
-          )
-        }
-      },
+      POST: async () =>
+        json(
+          {
+            error:
+              'Vector memory writes are disabled in the read-only Workspace dashboard phase.',
+          },
+          { status: 405 },
+        ),
     },
   },
 })

--- a/src/routes/api/vector-memory/search.ts
+++ b/src/routes/api/vector-memory/search.ts
@@ -1,0 +1,58 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  VectorMemoryInputError,
+  searchVectorMemory,
+} from '../../../server/vector-memory'
+
+export const Route = createFileRoute('/api/vector-memory/search')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            query?: unknown
+            collection?: unknown
+            limit?: unknown
+          }
+          if (typeof body.query !== 'string') {
+            return json({ error: 'Query is required' }, { status: 400 })
+          }
+          if (
+            body.collection !== undefined &&
+            typeof body.collection !== 'string'
+          ) {
+            return json({ error: 'Collection must be a string' }, { status: 400 })
+          }
+          if (body.limit !== undefined && typeof body.limit !== 'number') {
+            return json({ error: 'Limit must be a number' }, { status: 400 })
+          }
+          const collection =
+            typeof body.collection === 'string' ? body.collection : 'all'
+          const limit = typeof body.limit === 'number' ? body.limit : undefined
+          return json(
+            await searchVectorMemory({
+              query: body.query,
+              collection,
+              limit,
+            }),
+          )
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to search vector memory',
+            },
+            { status: error instanceof VectorMemoryInputError ? 400 : 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/vector-memory/status.ts
+++ b/src/routes/api/vector-memory/status.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { getVectorMemoryStatus } from '../../../server/vector-memory'
+
+export const Route = createFileRoute('/api/vector-memory/status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          return json(await getVectorMemoryStatus())
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to read vector memory status',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/memory.tsx
+++ b/src/routes/memory.tsx
@@ -16,10 +16,17 @@ const KnowledgeBrowserScreen = lazy(async () => {
   return { default: module.KnowledgeBrowserScreen }
 })
 
+const VectorMemoryScreen = lazy(async () => {
+  const module = await import('@/screens/memory/vector-memory-screen')
+  return { default: module.VectorMemoryScreen }
+})
+
+type MemoryTab = 'profile' | 'knowledge' | 'vectors'
+
 export const Route = createFileRoute('/memory')({
   ssr: false,
   component: function MemoryRoute() {
-    const [tab, setTab] = useState<'memory' | 'knowledge'>('memory')
+    const [tab, setTab] = useState<MemoryTab>('profile')
     const memoryAvailable = useFeatureAvailable('memory')
 
     usePageTitle('Memory')
@@ -28,7 +35,7 @@ export const Route = createFileRoute('/memory')({
       <div className="flex h-full min-h-0 flex-col">
         <Tabs
           value={tab}
-          onValueChange={(value) => setTab(value as 'memory' | 'knowledge')}
+          onValueChange={(value) => setTab(value as MemoryTab)}
           className="h-full min-h-0 gap-0"
         >
           <div className="border-b border-primary-200 px-3 pt-3 dark:border-neutral-800 md:px-4 md:pt-4">
@@ -36,13 +43,14 @@ export const Route = createFileRoute('/memory')({
               variant="underline"
               className="w-full justify-start gap-1"
             >
-              <TabsTab value="memory">Memory</TabsTab>
+              <TabsTab value="profile">Profile</TabsTab>
               <TabsTab value="knowledge">Knowledge</TabsTab>
+              <TabsTab value="vectors">Vectors</TabsTab>
             </TabsList>
           </div>
 
-          <TabsPanel value="memory" className="min-h-0 flex-1">
-            {tab === 'memory' ? (
+          <TabsPanel value="profile" className="min-h-0 flex-1">
+            {tab === 'profile' ? (
               <Suspense
                 fallback={
                   <RouteLoadingState label="Loading memory browser..." />
@@ -68,6 +76,18 @@ export const Route = createFileRoute('/memory')({
                 }
               >
                 <KnowledgeBrowserScreen />
+              </Suspense>
+            ) : null}
+          </TabsPanel>
+
+          <TabsPanel value="vectors" className="min-h-0 flex-1">
+            {tab === 'vectors' ? (
+              <Suspense
+                fallback={
+                  <RouteLoadingState label="Loading vector memory..." />
+                }
+              >
+                <VectorMemoryScreen />
               </Suspense>
             ) : null}
           </TabsPanel>

--- a/src/screens/memory/vector-memory-screen.tsx
+++ b/src/screens/memory/vector-memory-screen.tsx
@@ -1,0 +1,457 @@
+import { HugeiconsIcon } from '@hugeicons/react'
+import { BrainIcon, Search01Icon } from '@hugeicons/core-free-icons'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+
+type VectorCollectionStat = {
+  key: string
+  name: string
+  id: string | null
+  count: number | null
+  error?: string
+}
+
+type VectorDependencyStatus = {
+  ok: boolean
+  url: string
+  error?: string
+}
+
+type VectorMemoryConfig = {
+  chromaBaseUrl: string
+  embeddingServiceUrl: string
+  embeddingModel: string
+  dimension: number
+  configPath: string
+  fallbackEnabled: boolean
+}
+
+type VectorMemoryStatus = {
+  ok: boolean
+  config: VectorMemoryConfig
+  chroma: VectorDependencyStatus
+  embeddings: VectorDependencyStatus
+  collections: Array<VectorCollectionStat>
+  totalRecords: number
+  warnings: Array<string>
+}
+
+type VectorSearchResult = {
+  id: string
+  collection: string
+  document: string
+  metadata: Record<string, unknown>
+  distance: number | null
+  score: number | null
+}
+
+type SearchPayload = {
+  results: Array<VectorSearchResult>
+  status: VectorMemoryStatus
+}
+
+type StoredDiscovery = Omit<VectorSearchResult, 'distance' | 'score'>
+
+async function readJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(
+      typeof payload.error === 'string'
+        ? payload.error
+        : `Request failed (${response.status})`,
+    )
+  }
+  return payload as T
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const payload = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(
+      typeof payload.error === 'string'
+        ? payload.error
+        : `Request failed (${response.status})`,
+    )
+  }
+  return payload as T
+}
+
+function formatCount(value: number | null | undefined): string {
+  if (typeof value !== 'number') return '—'
+  return new Intl.NumberFormat().format(value)
+}
+
+function formatScore(value: number | null): string {
+  if (typeof value !== 'number') return '—'
+  return `${Math.round(value * 100)}%`
+}
+
+function StatusPill({ label, ok, detail }: { label: string; ok: boolean; detail?: string }) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border px-3 py-2',
+        ok
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+          : 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+      )}
+    >
+      <div className="text-[11px] font-semibold uppercase tracking-wide">{label}</div>
+      <div className="mt-0.5 truncate text-sm">{ok ? 'Healthy' : detail || 'Unavailable'}</div>
+    </div>
+  )
+}
+
+export function VectorMemoryScreen() {
+  const [query, setQuery] = useState('')
+  const [collection, setCollection] = useState('all')
+  const [selected, setSelected] = useState<VectorSearchResult | null>(null)
+  const [discoveryContent, setDiscoveryContent] = useState('')
+
+  const statusQuery = useQuery({
+    queryKey: ['vector-memory', 'status'],
+    queryFn: () => readJson<VectorMemoryStatus>('/api/vector-memory/status'),
+  })
+
+  const searchMutation = useMutation({
+    mutationFn: () =>
+      postJson<SearchPayload>('/api/vector-memory/search', {
+        query,
+        collection,
+        limit: 12,
+      }),
+    onSuccess: (payload) => {
+      setSelected(payload.results[0] || null)
+    },
+    onError: (error) => {
+      toast(error instanceof Error ? error.message : 'Vector search failed', {
+        type: 'warning',
+      })
+    },
+  })
+
+  const storeDiscoveryMutation = useMutation({
+    mutationFn: () =>
+      postJson<{ stored: StoredDiscovery; status: VectorMemoryStatus }>(
+        '/api/vector-memory/discovery',
+        {
+          content: discoveryContent,
+          source: 'workspace-dashboard',
+        },
+      ),
+    onSuccess: (payload) => {
+      setDiscoveryContent('')
+      statusQuery.refetch()
+      setSelected({
+        ...payload.stored,
+        distance: null,
+        score: null,
+      })
+      toast('Stored team discovery in vector memory', { type: 'success' })
+    },
+    onError: (error) => {
+      toast(error instanceof Error ? error.message : 'Failed to store discovery', {
+        type: 'warning',
+      })
+    },
+  })
+
+  const status = searchMutation.data?.status || statusQuery.data
+  const collections = status?.collections ?? []
+  const results = searchMutation.data?.results ?? []
+  const metadataEntries = useMemo(
+    () => Object.entries(selected?.metadata || {}),
+    [selected],
+  )
+
+  function runSearch() {
+    if (!query.trim()) return
+    searchMutation.mutate()
+  }
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col"
+      style={{ backgroundColor: 'var(--theme-bg)', color: 'var(--theme-text)' }}
+    >
+      <div className="border-b border-primary-200 px-3 py-3 dark:border-neutral-800 md:px-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          <div className="flex items-center gap-3">
+            <div className="inline-flex size-9 items-center justify-center rounded-xl border border-primary-200 bg-primary-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <HugeiconsIcon icon={BrainIcon} size={18} strokeWidth={1.6} />
+            </div>
+            <div>
+              <div className="text-sm font-semibold text-primary-900 dark:text-neutral-100">
+                Vector Memory
+              </div>
+              <div className="text-xs text-primary-500 dark:text-neutral-400">
+                Embedding-backed semantic memory across Chroma collections.
+              </div>
+            </div>
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row lg:justify-end">
+            <div className="relative min-w-0 flex-1 lg:max-w-xl">
+              <HugeiconsIcon
+                icon={Search01Icon}
+                size={16}
+                strokeWidth={1.7}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-primary-400 dark:text-neutral-500"
+              />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') runSearch()
+                }}
+                placeholder="Semantic search vector memory"
+                className="w-full rounded-xl border border-primary-200 bg-primary-50 py-2 pl-9 pr-3 text-sm outline-none focus:border-accent-500 dark:border-neutral-800 dark:bg-neutral-950"
+              />
+            </div>
+            <select
+              value={collection}
+              onChange={(event) => setCollection(event.target.value)}
+              className="rounded-xl border border-primary-200 bg-primary-50 px-3 py-2 text-sm outline-none focus:border-accent-500 dark:border-neutral-800 dark:bg-neutral-950"
+            >
+              <option value="all">All collections</option>
+              {collections.map((item) => (
+                <option key={item.key} value={item.name}>
+                  {item.key}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={runSearch}
+              disabled={!query.trim() || searchMutation.isPending}
+              className="rounded-xl bg-accent-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {searchMutation.isPending ? 'Searching...' : 'Search'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 overflow-y-auto p-3 md:grid-cols-3 md:p-4 xl:grid-cols-4">
+        <section className="space-y-3 md:col-span-1 xl:col-span-1">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-1">
+            <StatusPill
+              label="ChromaDB"
+              ok={Boolean(status?.chroma.ok)}
+              detail={status?.chroma.error}
+            />
+            <StatusPill
+              label="Embeddings"
+              ok={Boolean(status?.embeddings.ok)}
+              detail={status?.embeddings.error}
+            />
+          </div>
+
+          <div className="rounded-2xl border border-primary-200 bg-primary-50 p-3 dark:border-neutral-800 dark:bg-neutral-950">
+            <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
+              Module
+            </div>
+            {statusQuery.isLoading ? (
+              <div className="mt-2 text-sm text-primary-500 dark:text-neutral-400">Loading status...</div>
+            ) : status ? (
+              <div className="mt-2 space-y-2 text-xs text-primary-600 dark:text-neutral-300">
+                <div>Model: {status.config.embeddingModel}</div>
+                <div>Dimension: {status.config.dimension}</div>
+                <div>Total records: {formatCount(status.totalRecords)}</div>
+                <div className="truncate">Chroma: {status.config.chromaBaseUrl}</div>
+                <div className="truncate">Embeddings: {status.config.embeddingServiceUrl}</div>
+                <div className="truncate">Config: {status.config.configPath}</div>
+                {status.warnings.map((warning) => (
+                  <div key={warning} className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-2 text-amber-700 dark:text-amber-300">
+                    {warning}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-2 text-sm text-amber-600 dark:text-amber-300">
+                {statusQuery.error instanceof Error
+                  ? statusQuery.error.message
+                  : 'Unable to load status'}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-primary-200 bg-primary-50 p-3 dark:border-neutral-800 dark:bg-neutral-950">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
+                Collections
+              </div>
+              <button
+                type="button"
+                onClick={() => statusQuery.refetch()}
+                className="text-xs text-accent-600 hover:underline"
+              >
+                Refresh
+              </button>
+            </div>
+            <div className="space-y-1.5">
+              {collections.length === 0 ? (
+                <div className="rounded-lg border border-primary-200 px-3 py-2 text-xs text-primary-500 dark:border-neutral-800 dark:text-neutral-400">
+                  No collection stats yet.
+                </div>
+              ) : (
+                collections.map((item) => (
+                  <button
+                    key={item.key}
+                    type="button"
+                    onClick={() => setCollection(item.name)}
+                    className={cn(
+                      'w-full rounded-lg border px-3 py-2 text-left text-xs',
+                      collection === item.name
+                        ? 'border-accent-500 bg-accent-500/10'
+                        : 'border-primary-200 hover:border-primary-300 dark:border-neutral-800 dark:hover:border-neutral-700',
+                    )}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium text-primary-900 dark:text-neutral-100">
+                        {item.key}
+                      </span>
+                      <span className="text-primary-500 dark:text-neutral-400">
+                        {formatCount(item.count)}
+                      </span>
+                    </div>
+                    <div className="mt-0.5 truncate text-primary-500 dark:text-neutral-500">
+                      {item.error || item.name}
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-primary-200 bg-primary-50 p-3 dark:border-neutral-800 dark:bg-neutral-950">
+            <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
+              Safe Control
+            </div>
+            <div className="mt-1 text-xs text-primary-500 dark:text-neutral-400">
+              Store a curated team discovery in team_knowledge. Destructive controls stay disabled.
+            </div>
+            <textarea
+              value={discoveryContent}
+              onChange={(event) => setDiscoveryContent(event.target.value)}
+              maxLength={4000}
+              placeholder="Durable discovery or operational fact to embed..."
+              className="mt-3 min-h-24 w-full resize-y rounded-xl border border-primary-200 bg-primary-100/60 p-2 text-xs outline-none focus:border-accent-500 dark:border-neutral-800 dark:bg-neutral-900/60"
+            />
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <span className="text-[11px] text-primary-400 dark:text-neutral-500">
+                {discoveryContent.length}/4000
+              </span>
+              <button
+                type="button"
+                onClick={() => storeDiscoveryMutation.mutate()}
+                disabled={!discoveryContent.trim() || storeDiscoveryMutation.isPending}
+                className="rounded-lg bg-accent-600 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {storeDiscoveryMutation.isPending ? 'Storing...' : 'Store discovery'}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section className="min-h-[360px] rounded-2xl border border-primary-200 bg-primary-50 dark:border-neutral-800 dark:bg-neutral-950 md:col-span-2 xl:col-span-2">
+          <div className="border-b border-primary-200 px-3 py-2 dark:border-neutral-800">
+            <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
+              Semantic Results ({results.length})
+            </div>
+          </div>
+          <div className="max-h-[680px] space-y-2 overflow-y-auto p-3">
+            {results.length === 0 ? (
+              <div className="rounded-xl border border-primary-200 bg-primary-100/60 p-4 text-sm text-primary-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-neutral-400">
+                Search for a concept to inspect related embedded memories.
+              </div>
+            ) : (
+              results.map((result) => (
+                <button
+                  key={`${result.collection}:${result.id}`}
+                  type="button"
+                  onClick={() => setSelected(result)}
+                  className={cn(
+                    'w-full rounded-xl border p-3 text-left',
+                    selected?.id === result.id && selected.collection === result.collection
+                      ? 'border-accent-500 bg-accent-500/10'
+                      : 'border-primary-200 hover:border-primary-300 dark:border-neutral-800 dark:hover:border-neutral-700',
+                  )}
+                >
+                  <div className="mb-1 flex items-center justify-between gap-2 text-xs text-primary-500 dark:text-neutral-400">
+                    <span className="truncate">{result.collection}</span>
+                    <span>{formatScore(result.score)}</span>
+                  </div>
+                  <div className="line-clamp-3 text-sm text-primary-900 dark:text-neutral-100">
+                    {result.document || '(empty document)'}
+                  </div>
+                  <div className="mt-2 truncate font-mono text-[11px] text-primary-400 dark:text-neutral-500">
+                    {result.id}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </section>
+
+        <aside className="rounded-2xl border border-primary-200 bg-primary-50 dark:border-neutral-800 dark:bg-neutral-950 md:col-span-3 xl:col-span-1">
+          <div className="border-b border-primary-200 px-3 py-2 dark:border-neutral-800">
+            <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
+              Inspector
+            </div>
+          </div>
+          <div className="space-y-3 p-3 text-sm">
+            {selected ? (
+              <>
+                <div>
+                  <div className="text-xs text-primary-500 dark:text-neutral-400">Collection</div>
+                  <div className="break-all font-mono text-xs">{selected.collection}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-primary-500 dark:text-neutral-400">ID</div>
+                  <div className="break-all font-mono text-xs">{selected.id}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-primary-500 dark:text-neutral-400">Score / distance</div>
+                  <div>{formatScore(selected.score)} / {selected.distance ?? '—'}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-primary-500 dark:text-neutral-400">Document</div>
+                  <div className="mt-1 whitespace-pre-wrap rounded-xl border border-primary-200 bg-primary-100/60 p-3 text-xs leading-relaxed dark:border-neutral-800 dark:bg-neutral-900/60">
+                    {selected.document || '(empty document)'}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-primary-500 dark:text-neutral-400">Metadata</div>
+                  <div className="mt-1 space-y-1">
+                    {metadataEntries.length === 0 ? (
+                      <div className="text-xs text-primary-400 dark:text-neutral-500">No metadata</div>
+                    ) : (
+                      metadataEntries.map(([key, value]) => (
+                        <div key={key} className="rounded-lg border border-primary-200 p-2 text-xs dark:border-neutral-800">
+                          <div className="font-mono text-primary-500 dark:text-neutral-400">{key}</div>
+                          <div className="mt-0.5 break-words">{String(value)}</div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="text-sm text-primary-500 dark:text-neutral-400">
+                Select a search result to inspect its text, metadata, id, and score.
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/memory/vector-memory-screen.tsx
+++ b/src/screens/memory/vector-memory-screen.tsx
@@ -52,8 +52,6 @@ type SearchPayload = {
   status: VectorMemoryStatus
 }
 
-type StoredDiscovery = Omit<VectorSearchResult, 'distance' | 'score'>
-
 async function readJson<T>(url: string): Promise<T> {
   const response = await fetch(url)
   const payload = await response.json().catch(() => ({}))
@@ -114,7 +112,6 @@ export function VectorMemoryScreen() {
   const [query, setQuery] = useState('')
   const [collection, setCollection] = useState('all')
   const [selected, setSelected] = useState<VectorSearchResult | null>(null)
-  const [discoveryContent, setDiscoveryContent] = useState('')
 
   const statusQuery = useQuery({
     queryKey: ['vector-memory', 'status'],
@@ -133,32 +130,6 @@ export function VectorMemoryScreen() {
     },
     onError: (error) => {
       toast(error instanceof Error ? error.message : 'Vector search failed', {
-        type: 'warning',
-      })
-    },
-  })
-
-  const storeDiscoveryMutation = useMutation({
-    mutationFn: () =>
-      postJson<{ stored: StoredDiscovery; status: VectorMemoryStatus }>(
-        '/api/vector-memory/discovery',
-        {
-          content: discoveryContent,
-          source: 'workspace-dashboard',
-        },
-      ),
-    onSuccess: (payload) => {
-      setDiscoveryContent('')
-      statusQuery.refetch()
-      setSelected({
-        ...payload.stored,
-        distance: null,
-        score: null,
-      })
-      toast('Stored team discovery in vector memory', { type: 'success' })
-    },
-    onError: (error) => {
-      toast(error instanceof Error ? error.message : 'Failed to store discovery', {
         type: 'warning',
       })
     },
@@ -333,30 +304,10 @@ export function VectorMemoryScreen() {
 
           <div className="rounded-2xl border border-primary-200 bg-primary-50 p-3 dark:border-neutral-800 dark:bg-neutral-950">
             <div className="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-neutral-400">
-              Safe Control
+              Read-only phase
             </div>
             <div className="mt-1 text-xs text-primary-500 dark:text-neutral-400">
-              Store a curated team discovery in team_knowledge. Destructive controls stay disabled.
-            </div>
-            <textarea
-              value={discoveryContent}
-              onChange={(event) => setDiscoveryContent(event.target.value)}
-              maxLength={4000}
-              placeholder="Durable discovery or operational fact to embed..."
-              className="mt-3 min-h-24 w-full resize-y rounded-xl border border-primary-200 bg-primary-100/60 p-2 text-xs outline-none focus:border-accent-500 dark:border-neutral-800 dark:bg-neutral-900/60"
-            />
-            <div className="mt-2 flex items-center justify-between gap-2">
-              <span className="text-[11px] text-primary-400 dark:text-neutral-500">
-                {discoveryContent.length}/4000
-              </span>
-              <button
-                type="button"
-                onClick={() => storeDiscoveryMutation.mutate()}
-                disabled={!discoveryContent.trim() || storeDiscoveryMutation.isPending}
-                className="rounded-lg bg-accent-600 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {storeDiscoveryMutation.isPending ? 'Storing...' : 'Store discovery'}
-              </button>
+              This dashboard can inspect Chroma status and run semantic searches. Vector writes, promotion, and authority decisions stay disabled here; source repositories and GitHub artifacts remain the evidence authority.
             </div>
           </div>
         </section>

--- a/src/screens/swarm2/agent-registry-panel.test.ts
+++ b/src/screens/swarm2/agent-registry-panel.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AGENT_REGISTRY_SURFACE_COPY,
+  buildAgentRegistryRows,
+  summarizeAgentRegistryDiagnostics,
+} from './agent-registry-panel'
+
+describe('Swarm2 read-only agent registry UI helpers', () => {
+  it('builds rows with source-derived and read-only badges plus disabled action explanations', () => {
+    const rows = buildAgentRegistryRows({
+      entries: [
+        {
+          id: 'swarm5',
+          displayName: 'Builder',
+          role: 'Primary Builder',
+          model: 'GPT-5.5',
+          capabilities: ['code-editing'],
+          skills: ['swarm-ui-worker'],
+          dispatchEnabled: false,
+          source: 'swarm.yaml',
+          sourceDerived: true,
+          writable: false,
+          disabledActions: ['Registry is read-only in Phase 1.', 'Dispatch is disabled from registry rows.'],
+        },
+      ],
+      diagnostics: [],
+      backend: {
+        kind: 'swarm-yaml',
+        sourcePath: '/repo/swarm.yaml',
+        compatibilityMode: true,
+        writable: false,
+        parserVersion: 'agent-registry-v1',
+        loadedAt: 10,
+        fetchedAt: 11,
+      },
+    })
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: 'swarm5',
+        title: 'Builder',
+        subtitle: 'Primary Builder · GPT-5.5',
+        badges: ['source-derived', 'compatibility', 'read-only', 'dispatch-disabled'],
+        detailLines: expect.arrayContaining([
+          'Source: swarm.yaml (/repo/swarm.yaml)',
+          'Capabilities: code-editing',
+          'Skills: swarm-ui-worker',
+          'Registry is read-only in Phase 1.',
+        ]),
+      }),
+    ])
+  })
+
+  it('summarizes validation diagnostics without implying live runtime truth or edit capability', () => {
+    expect(AGENT_REGISTRY_SURFACE_COPY).toContain('source-derived')
+    expect(AGENT_REGISTRY_SURFACE_COPY).toContain('not live runtime truth')
+    expect(AGENT_REGISTRY_SURFACE_COPY).toContain('read-only')
+
+    const summary = summarizeAgentRegistryDiagnostics([
+      { severity: 'error', code: 'missing_required', message: 'workers[0].id is required', path: 'workers[0].id' },
+      { severity: 'warning', code: 'unknown_field', message: 'unknown field', path: 'workers[1].foo', entryId: 'swarm6' },
+    ])
+
+    expect(summary).toEqual({ errorCount: 1, warningCount: 1, infoCount: 0, state: 'invalid' })
+  })
+})

--- a/src/screens/swarm2/agent-registry-panel.tsx
+++ b/src/screens/swarm2/agent-registry-panel.tsx
@@ -1,0 +1,108 @@
+import type {
+  AgentRegistryBackendMetadata,
+  AgentRegistryDiagnostic,
+  AgentRegistryEntry,
+} from '../../server/agent-registry'
+
+export const AGENT_REGISTRY_SURFACE_COPY =
+  'Agent registry rows are source-derived compatibility metadata from swarm.yaml, not live runtime truth. The Phase 1 surface is read-only: no edits, dispatch, source sync, restarts, or evidence promotion are available here.'
+
+export type AgentRegistryPanelInput = {
+  entries: Array<AgentRegistryEntry>
+  diagnostics: Array<AgentRegistryDiagnostic>
+  backend: AgentRegistryBackendMetadata
+}
+
+export type AgentRegistryRow = {
+  id: string
+  title: string
+  subtitle: string
+  badges: Array<string>
+  detailLines: Array<string>
+  diagnosticCount: number
+}
+
+export function summarizeAgentRegistryDiagnostics(diagnostics: Array<AgentRegistryDiagnostic>) {
+  const errorCount = diagnostics.filter((item) => item.severity === 'error').length
+  const warningCount = diagnostics.filter((item) => item.severity === 'warning').length
+  const infoCount = diagnostics.filter((item) => item.severity === 'info').length
+  return {
+    errorCount,
+    warningCount,
+    infoCount,
+    state: errorCount > 0 ? 'invalid' : warningCount > 0 ? 'warning' : 'valid',
+  }
+}
+
+export function buildAgentRegistryRows(input: AgentRegistryPanelInput): Array<AgentRegistryRow> {
+  return input.entries.map((entry) => {
+    const badges = [
+      entry.sourceDerived ? 'source-derived' : 'registry',
+      input.backend.compatibilityMode ? 'compatibility' : input.backend.kind,
+      entry.writable ? 'writable' : 'read-only',
+      entry.dispatchEnabled ? 'dispatch-enabled' : 'dispatch-disabled',
+    ]
+    const diagnostics = input.diagnostics.filter((item) => item.entryId === entry.id)
+    const details = [
+      `Source: ${entry.source} (${input.backend.sourcePath})`,
+      `Capabilities: ${entry.capabilities.length ? entry.capabilities.join(', ') : 'none declared'}`,
+      `Skills: ${entry.skills.length ? entry.skills.join(', ') : 'none declared'}`,
+      ...entry.disabledActions,
+      ...diagnostics.map((item) => `${item.severity.toUpperCase()}: ${item.message}`),
+    ]
+    return {
+      id: entry.id,
+      title: entry.displayName || entry.id,
+      subtitle: `${entry.role || 'Worker'} · ${entry.model || 'model unknown'}`,
+      badges,
+      detailLines: details,
+      diagnosticCount: diagnostics.length,
+    }
+  })
+}
+
+export function AgentRegistryPanel(input: AgentRegistryPanelInput) {
+  const rows = buildAgentRegistryRows(input)
+  const summary = summarizeAgentRegistryDiagnostics(input.diagnostics)
+  return (
+    <section aria-label="Read-only agent registry" className="rounded-3xl border border-primary-200 bg-primary-50/70 p-4 text-sm text-primary-900">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary-500">Read-only registry</p>
+          <h2 className="text-lg font-semibold text-ink">Source-derived agent registry</h2>
+          <p className="mt-1 max-w-3xl text-xs text-primary-700">{AGENT_REGISTRY_SURFACE_COPY}</p>
+        </div>
+        <div className="rounded-2xl border border-primary-200 bg-white/70 px-3 py-2 text-xs text-primary-700">
+          {summary.state} · {summary.errorCount} errors · {summary.warningCount} warnings
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {rows.map((row) => (
+          <article key={row.id} className="rounded-2xl border border-primary-200 bg-white/75 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-semibold text-ink">{row.title}</h3>
+                <p className="text-xs text-primary-600">{row.subtitle}</p>
+              </div>
+              <span className="rounded-full bg-primary-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-primary-700">
+                {row.id}
+              </span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {row.badges.map((badge) => (
+                <span key={badge} className="rounded-full border border-primary-200 px-2 py-0.5 text-[10px] uppercase tracking-wide text-primary-700">
+                  {badge}
+                </span>
+              ))}
+            </div>
+            <ul className="mt-3 space-y-1 text-xs text-primary-700">
+              {row.detailLines.slice(0, 5).map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/swarm2/swarm2-screen.test.ts
+++ b/src/screens/swarm2/swarm2-screen.test.ts
@@ -99,7 +99,7 @@ describe('Swarm2 surface contract', () => {
     ])
   })
 
-  it('does not add registry-only entries to the operational worker control surface', () => {
+  it('keeps registry-only entries visible as offline operational worker cards', () => {
     const crew = [{
       id: 'swarm1',
       displayName: 'Live Worker',
@@ -137,8 +137,8 @@ describe('Swarm2 surface contract', () => {
         id: 'swarm99',
         displayName: 'Registry Only Worker',
         role: 'Registry Only',
-        skills: [],
-        capabilities: [],
+        skills: ['review'],
+        capabilities: ['code-review'],
         dispatchEnabled: false,
         source: 'swarm.yaml',
         sourceDerived: true,
@@ -149,6 +149,15 @@ describe('Swarm2 surface contract', () => {
 
     expect(mergeRegistryRosterWithCrew(crew, roster, [])).toEqual([
       expect.objectContaining({ id: 'swarm1', displayName: 'Registry Live Worker' }),
+      expect.objectContaining({
+        id: 'swarm99',
+        displayName: 'Registry Only Worker',
+        role: 'Registry Only',
+        gatewayState: 'offline',
+        processAlive: false,
+        skills: ['review'],
+        capabilities: ['code-review'],
+      }),
     ])
   })
 

--- a/src/screens/swarm2/swarm2-screen.test.ts
+++ b/src/screens/swarm2/swarm2-screen.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   SWARM2_CARD_DENSITY_CONTRACT,
@@ -5,6 +6,9 @@ import {
   SWARM2_OPERATIONS_REUSE,
   SWARM2_REAL_API_ENDPOINTS,
   SWARM2_SURFACE_CONTRACT,
+  agentRegistryResponseEntries,
+  mergeRegistryRosterWithCrew,
+  registryEntriesToRosterWorkers,
 } from './swarm2-screen'
 
 describe('Swarm2 surface contract', () => {
@@ -49,7 +53,7 @@ describe('Swarm2 surface contract', () => {
       '/api/swarm-environment',
       '/api/swarm-runtime',
       '/api/swarm-missions',
-      '/api/swarm-roster',
+      '/api/agent-registry',
       '/api/integrations',
       '/api/swarm-health',
       '/api/swarm-decompose',
@@ -62,6 +66,117 @@ describe('Swarm2 surface contract', () => {
       '/api/terminal-resize',
       '/api/terminal-close',
     ])
+  })
+
+  it('maps read-only registry entries into roster worker metadata without dispatch state', () => {
+    expect(registryEntriesToRosterWorkers([
+      {
+        id: 'swarm5',
+        displayName: 'Builder',
+        role: 'Primary Builder',
+        specialty: 'implementation',
+        model: 'GPT-5.5',
+        mission: 'Ship focused slices.',
+        skills: ['swarm-ui-worker'],
+        capabilities: ['code-editing'],
+        dispatchEnabled: false,
+        source: 'swarm.yaml',
+        sourceDerived: true,
+        writable: false,
+        disabledActions: ['Registry is read-only in Phase 1.'],
+      },
+    ])).toEqual([
+      expect.objectContaining({
+        id: 'swarm5',
+        name: 'Builder',
+        role: 'Primary Builder',
+        specialty: 'implementation',
+        model: 'GPT-5.5',
+        mission: 'Ship focused slices.',
+        skills: ['swarm-ui-worker'],
+        capabilities: ['code-editing'],
+      }),
+    ])
+  })
+
+  it('does not add registry-only entries to the operational worker control surface', () => {
+    const crew = [{
+      id: 'swarm1',
+      displayName: 'Live Worker',
+      role: 'Runtime',
+      profileFound: true,
+      gatewayState: 'online',
+      processAlive: true,
+      platforms: {},
+      model: 'runtime-model',
+      provider: 'runtime-provider',
+      lastSessionTitle: null,
+      lastSessionAt: null,
+      sessionCount: 0,
+      messageCount: 0,
+      toolCallCount: 0,
+      totalTokens: 0,
+      estimatedCostUsd: null,
+      cronJobCount: 0,
+      assignedTaskCount: 0,
+    }]
+    const roster = registryEntriesToRosterWorkers([
+      {
+        id: 'swarm1',
+        displayName: 'Registry Live Worker',
+        role: 'Registry Role',
+        skills: [],
+        capabilities: [],
+        dispatchEnabled: false,
+        source: 'swarm.yaml',
+        sourceDerived: true,
+        writable: false,
+        disabledActions: ['Registry is read-only in Phase 1.'],
+      },
+      {
+        id: 'swarm99',
+        displayName: 'Registry Only Worker',
+        role: 'Registry Only',
+        skills: [],
+        capabilities: [],
+        dispatchEnabled: false,
+        source: 'swarm.yaml',
+        sourceDerived: true,
+        writable: false,
+        disabledActions: ['Registry is read-only in Phase 1.'],
+      },
+    ])
+
+    expect(mergeRegistryRosterWithCrew(crew, roster, [])).toEqual([
+      expect.objectContaining({ id: 'swarm1', displayName: 'Registry Live Worker' }),
+    ])
+  })
+
+  it('does not consume registry entries when the read-only API reports ok=false', () => {
+    expect(agentRegistryResponseEntries({
+      ok: false,
+      registry: {
+        entries: [{
+          id: 'swarm9',
+          displayName: 'Rejected',
+          role: 'Ops',
+          skills: [],
+          capabilities: [],
+          dispatchEnabled: false,
+          source: 'swarm.yaml',
+          sourceDerived: true,
+          writable: false,
+          disabledActions: [],
+        }],
+      },
+    })).toEqual([])
+  })
+
+  it('does not retain the old mutating Add Swarm roster flow in the Phase 1 read-only surface', () => {
+    const source = readFileSync('src/screens/swarm2/swarm2-screen.tsx', 'utf8')
+    expect(source).not.toContain("fetch('/api/swarm-roster'")
+    expect(source).not.toContain('rosterQuery')
+    expect(source).not.toContain('Add Swarm')
   })
 
   it('documents Operations card primitives reused for Swarm2 worker nodes', () => {

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -152,6 +152,8 @@ type RuntimeEntry = {
   phase?: string | null
   lastSummary?: string | null
   lastResult?: string | null
+  lastRealSummary?: string | null
+  lastRealResult?: string | null
   blockedReason?: string | null
   checkpointStatus?: string | null
   needsHuman?: boolean | null
@@ -389,7 +391,35 @@ export function mergeRegistryRosterWithCrew(
   roomIds: Array<string>,
   runtimeByWorker: Map<string, RuntimeEntry> = new Map(),
 ): Array<CrewMember> {
-  return sortSwarmMembers(crew, roomIds).map((member) => {
+  const crewIds = new Set(crew.map((member) => member.id))
+  const registryOnlyMembers: Array<CrewMember> = registryRoster
+    .filter((worker) => worker.id && !crewIds.has(worker.id))
+    .map((worker) => ({
+      id: worker.id,
+      displayName: worker.name,
+      role: worker.role,
+      specialty: worker.specialty,
+      mission: worker.mission,
+      skills: worker.skills ?? [],
+      capabilities: worker.capabilities ?? [],
+      profileFound: true,
+      gatewayState: 'offline',
+      processAlive: false,
+      platforms: {},
+      model: worker.model || 'unknown',
+      provider: 'registry',
+      lastSessionTitle: null,
+      lastSessionAt: null,
+      sessionCount: 0,
+      messageCount: 0,
+      toolCallCount: 0,
+      totalTokens: 0,
+      estimatedCostUsd: null,
+      cronJobCount: 0,
+      assignedTaskCount: 0,
+    }))
+
+  return sortSwarmMembers([...crew, ...registryOnlyMembers], roomIds).map((member) => {
     const runtime = runtimeByWorker.get(member.id)
     const roster = registryRoster.find((worker) => worker.id === member.id)
     return {
@@ -398,8 +428,8 @@ export function mergeRegistryRosterWithCrew(
       role: roster?.role || runtime?.role || member.role,
       specialty: roster?.specialty,
       mission: roster?.mission,
-      skills: roster?.skills ?? [],
-      capabilities: roster?.capabilities ?? [],
+      skills: roster?.skills ?? member.skills ?? [],
+      capabilities: roster?.capabilities ?? member.capabilities ?? [],
       model: roster?.model || member.model,
     }
   })
@@ -571,7 +601,6 @@ function displayTaskTitle(runtime: RuntimeEntry | undefined, fallback: string): 
   const realResult = runtime?.lastRealResult ?? null
   return cleanSwarmLabel(runtime?.blockedReason || runtime?.currentTask || realSummary || runtime?.lastSummary || realResult || runtime?.lastResult || fallback || '', 'Ready for task', 64)
 }
-
 
 function formatAssignedModel(model?: string | null, provider?: string | null): string {
   const value = `${model || ''} ${provider || ''}`.toLowerCase()
@@ -982,28 +1011,21 @@ export function Swarm2Screen() {
           try { parsed = JSON.parse(text) } catch {}
           const msg = parsed.error || text || `HTTP ${res.status}`
           if (msg.includes('tmux not installed')) {
-            toast({
-              title: 'tmux not installed',
-              description:
-                `Swarm worker ${workerId} couldn't start because tmux is not installed on this host. Install tmux (‘brew install tmux’ or ‘apt install tmux’) and try again. See #244.`,
-              variant: 'destructive',
-            })
+            toast(
+              `tmux not installed: Swarm worker ${workerId} couldn't start because tmux is not installed on this host. Install tmux (‘brew install tmux’ or ‘apt install tmux’) and try again. See #244.`,
+              { type: 'error' },
+            )
           } else {
-            toast({
-              title: `Failed to start ${workerId}`,
-              description: msg,
-              variant: 'destructive',
-            })
+            toast(`Failed to start ${workerId}: ${msg}`, { type: 'error' })
           }
           // eslint-disable-next-line no-console
           console.error('[swarm2] start session failed:', res.status, text)
         }
       } catch (err) {
-        toast({
-          title: `Failed to start ${workerId}`,
-          description: err instanceof Error ? err.message : String(err),
-          variant: 'destructive',
-        })
+        toast(
+          `Failed to start ${workerId}: ${err instanceof Error ? err.message : String(err)}`,
+          { type: 'error' },
+        )
       } finally {
         setPendingTmux((prev) => {
           const next = new Set(prev)

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -14,13 +14,14 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   AlarmClockIcon,
   CpuIcon,
-  MessageMultiple01Icon,
   UserMultipleIcon,
 } from '@hugeicons/core-free-icons'
 import type { CrewMember } from '@/hooks/use-crew-status'
 import { getOnlineStatus, useCrewStatus } from '@/hooks/use-crew-status'
 import { toast } from '@/components/ui/toast'
 import { OperationalWorkerCard } from './operational-worker-card'
+import { AgentRegistryPanel } from './agent-registry-panel'
+import type { AgentRegistryBackendMetadata, AgentRegistryDiagnostic, AgentRegistryEntry } from '../../server/agent-registry'
 import { Swarm2OrchestratorCard } from './swarm2-orchestrator-card'
 import { Swarm2Wires } from './swarm2-wires'
 import { Swarm2ActivityFeed } from './swarm2-activity-feed'
@@ -57,7 +58,7 @@ const SWARM2_OPERATION_THEME: CSSProperties = {
 
 export const SWARM2_INFORMATION_HIERARCHY = [
   'Status header: online workers, active room, refresh state, view switch.',
-  'Orchestrator hub card: top-center primary routing hub with aggregate state and router affordance.',
+  'Aurora/orchestrator hub card: top-center primary routing hub with aggregate state and router affordance.',
   'Visible routing wires: subdued connection lines from the orchestrator to every worker, highlighted for selected and wired room nodes.',
   'Operations-style worker node cards: role, state, current task, last useful signal, direct inline chat/action affordances.',
   'Minimal attention rail: only auth, worker availability, room count, selected runtime metadata.',
@@ -100,7 +101,7 @@ export const SWARM2_REAL_API_ENDPOINTS = [
   '/api/swarm-environment',
   '/api/swarm-runtime',
   '/api/swarm-missions',
-  '/api/swarm-roster',
+  '/api/agent-registry',
   '/api/integrations',
   '/api/swarm-health',
   '/api/swarm-decompose',
@@ -192,9 +193,11 @@ type SwarmRosterWorker = {
   reviewRequired?: boolean
 }
 
-type SwarmRosterResponse = {
+type AgentRegistryResponse = {
   ok?: boolean
-  roster?: { workers?: Array<SwarmRosterWorker> }
+  registry?: { entries?: Array<AgentRegistryEntry> }
+  backend?: AgentRegistryBackendMetadata
+  diagnostics?: Array<AgentRegistryDiagnostic>
 }
 
 type SwarmMissionSummary = {
@@ -230,119 +233,6 @@ type SwarmMissionsResponse = {
 
 type ViewMode = 'cards' | 'kanban' | 'runtime' | 'reports'
 
-type RolePreset = {
-  role: string
-  specialty: string
-  mission: string
-  systemPrompt: string
-  skills: Array<string>
-  defaultModel?: string
-}
-
-const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
-  {
-    role: 'Orchestrator',
-    specialty: 'control-plane state, dispatch, drift detection, escalation',
-    mission: 'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
-    systemPrompt: 'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
-    skills: ['swarm-orchestrator', 'swarm-worker-core', 'swarm-review-learning-loop', 'self-improvement'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Builder',
-    specialty: 'full-stack implementation, fast ship cycles',
-    mission: 'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
-    systemPrompt: 'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review'],
-    defaultModel: 'GPT-5.5',
-  },
-  {
-    role: 'Reviewer',
-    specialty: 'byte-verified code review, naming + tests + build gate',
-    mission: 'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
-    systemPrompt: 'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Triage',
-    specialty: 'autonomous PR/issues processor',
-    mission: 'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
-    systemPrompt: 'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
-    defaultModel: 'GPT-5.5',
-  },
-  {
-    role: 'Lab',
-    specialty: 'local-model R&D, spec-dec, benchmarking',
-    mission: 'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
-    systemPrompt: 'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
-    skills: ['swarm-worker-core', 'pc1-ollama-gguf-bench', 'swarm-bench-worker'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Sage',
-    specialty: 'research + scripts + X content + creative briefs',
-    mission: 'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
-    systemPrompt: 'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
-    skills: ['swarm-worker-core', 'last30days', 'pdf-and-paper-deep-reading'],
-    defaultModel: 'GPT-5.5',
-  },
-  {
-    role: 'Scribe',
-    specialty: 'docs, skills hygiene, memory curation',
-    mission: 'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
-    systemPrompt: 'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
-    skills: ['swarm-worker-core', 'last30days', 'creative-writing'],
-    defaultModel: 'GPT-5.5',
-  },
-  {
-    role: 'Foundation',
-    specialty: 'infra, repair playbook, autopilot wiring',
-    mission: 'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
-    systemPrompt: 'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
-    skills: ['swarm-worker-core'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'QA',
-    specialty: 'regression QA, render verification',
-    mission: 'Run regression suite on every commit + render. Block bad ships.',
-    systemPrompt: 'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Mirror Integrations',
-    specialty: 'asset packs, upstream sync',
-    mission: 'Generate assets. Watch upstream. Pack integrations.',
-    systemPrompt: 'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
-    skills: ['swarm-worker-core', 'claude-promo', 'songwriting-and-ai-music'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Custom',
-    specialty: '',
-    mission: '',
-    systemPrompt: '',
-    skills: [],
-  },
-] as const
-
-const ROLE_NAMES = ROLE_PRESETS.map((p) => p.role)
-
-async function fetchAvailableModels(): Promise<Array<{ id: string; name: string; provider: string }>> {
-  try {
-    const res = await fetch('/api/models')
-    if (!res.ok) return []
-    const data = await res.json()
-    if (!data?.ok || !Array.isArray(data?.data)) return []
-    return data.data
-  } catch {
-    return []
-  }
-}
-
 type RuntimeResponse = {
   entries: Array<RuntimeEntry>
   tmuxAvailable?: boolean
@@ -361,11 +251,32 @@ async function fetchHealth(): Promise<HealthData> {
   return res.json()
 }
 
-async function fetchRoster(): Promise<Array<SwarmRosterWorker>> {
-  const res = await fetch('/api/swarm-roster')
-  if (!res.ok) throw new Error(`Roster request failed: ${res.status}`)
-  const data = (await res.json()) as SwarmRosterResponse
-  return Array.isArray(data.roster?.workers) ? data.roster!.workers! : []
+async function fetchAgentRegistry(): Promise<AgentRegistryResponse> {
+  const res = await fetch('/api/agent-registry')
+  if (!res.ok) throw new Error(`Agent registry request failed: ${res.status}`)
+  return (await res.json()) as AgentRegistryResponse
+}
+
+export function agentRegistryResponseEntries(data: AgentRegistryResponse | null | undefined): Array<AgentRegistryEntry> {
+  if (data?.ok !== true) return []
+  return data.registry?.entries ?? []
+}
+
+export function registryEntriesToRosterWorkers(entries: Array<AgentRegistryEntry>): Array<SwarmRosterWorker> {
+  return entries.map((entry) => ({
+    id: entry.id,
+    name: entry.displayName,
+    role: entry.role,
+    specialty: entry.specialty,
+    model: entry.model,
+    mission: entry.mission,
+    skills: entry.skills,
+    capabilities: entry.capabilities,
+    preferredTaskTypes: entry.preferredTaskTypes,
+    maxConcurrentTasks: entry.maxConcurrentTasks,
+    acceptsBroadcast: entry.acceptsBroadcast,
+    reviewRequired: entry.reviewRequired,
+  }))
 }
 
 async function fetchMissions(): Promise<Array<SwarmMissionSummary>> {
@@ -470,6 +381,28 @@ function rankMember(roomIds: Array<string>) {
     if (status === 'offline') return 2
     return 3
   }
+}
+
+export function mergeRegistryRosterWithCrew(
+  crew: Array<CrewMember>,
+  registryRoster: Array<SwarmRosterWorker>,
+  roomIds: Array<string>,
+  runtimeByWorker: Map<string, RuntimeEntry> = new Map(),
+): Array<CrewMember> {
+  return sortSwarmMembers(crew, roomIds).map((member) => {
+    const runtime = runtimeByWorker.get(member.id)
+    const roster = registryRoster.find((worker) => worker.id === member.id)
+    return {
+      ...member,
+      displayName: runtime?.displayName || roster?.name || member.displayName,
+      role: roster?.role || runtime?.role || member.role,
+      specialty: roster?.specialty,
+      mission: roster?.mission,
+      skills: roster?.skills ?? [],
+      capabilities: roster?.capabilities ?? [],
+      model: roster?.model || member.model,
+    }
+  })
 }
 
 function sortSwarmMembers(members: Array<CrewMember>, roomIds: Array<string>) {
@@ -666,6 +599,9 @@ type ControlPlaneStageProps = {
   latestMission: { id: string; title: string; state: string; assignmentCount: number; checkpointedCount: number } | null
   missions: Array<SwarmMissionSummary>
   runtimeEntries: Array<RuntimeEntry>
+  registryEntries: Array<AgentRegistryEntry>
+  registryDiagnostics: Array<AgentRegistryDiagnostic>
+  registryBackend: AgentRegistryBackendMetadata | undefined
   inboxCounts: { needsReview: number; blocked: number; ready: number }
   routerSeed: { key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null
   onOpenInboxItem: (item: Swarm2InboxItem) => void
@@ -703,6 +639,9 @@ function ControlPlaneStage({
   latestMission,
   missions,
   runtimeEntries,
+  registryEntries,
+  registryDiagnostics,
+  registryBackend,
   inboxCounts,
   routerSeed,
   onOpenInboxItem,
@@ -855,6 +794,15 @@ function ControlPlaneStage({
                 })
               )}
             </div>
+            {registryBackend ? (
+              <div className="mt-4">
+                <AgentRegistryPanel
+                  entries={registryEntries}
+                  diagnostics={registryDiagnostics}
+                  backend={registryBackend}
+                />
+              </div>
+            ) : null}
           </div>
 
           <div className={cn('relative z-10 flex flex-col gap-3', viewMode === 'runtime' ? 'block' : 'hidden')}>
@@ -993,22 +941,6 @@ export function Swarm2Screen() {
   const [routerOpen, setRouterOpen] = useState(false)
   const [routerSeed, setRouterSeed] = useState<{ key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null>(null)
   const [notificationsOpen, setNotificationsOpen] = useState(false)
-  const [addSwarmOpen, setAddSwarmOpen] = useState(false)
-  const [addSwarmSaving, setAddSwarmSaving] = useState(false)
-  const [addSwarmError, setAddSwarmError] = useState<string | null>(null)
-  const modelsQuery = useQuery({
-    queryKey: ['swarm2', 'available-models'],
-    queryFn: fetchAvailableModels,
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const availableModels = modelsQuery.data ?? []
-  const [newWorkerId, setNewWorkerId] = useState('')
-  const [newWorkerName, setNewWorkerName] = useState('')
-  const [newWorkerRole, setNewWorkerRole] = useState('Builder')
-  const [newWorkerSpecialty, setNewWorkerSpecialty] = useState('')
-  const [newWorkerModel, setNewWorkerModel] = useState('')
-  const [newWorkerMission, setNewWorkerMission] = useState('')
   // Worker IDs whose tmux session is currently being started/stopped via API.
   const [pendingTmux, setPendingTmux] = useState<Set<string>>(new Set())
   const [focusedRuntimeWorkerId, setFocusedRuntimeWorkerId] = useState<string | null>(null)
@@ -1024,9 +956,9 @@ export function Swarm2Screen() {
     queryFn: fetchHealth,
     refetchInterval: 60_000,
   })
-  const rosterQuery = useQuery({
-    queryKey: ['swarm2', 'roster'],
-    queryFn: fetchRoster,
+  const registryQuery = useQuery({
+    queryKey: ['swarm2', 'agent-registry'],
+    queryFn: fetchAgentRegistry,
     refetchInterval: 60_000,
   })
   const missionsQuery = useQuery({
@@ -1141,50 +1073,15 @@ export function Swarm2Screen() {
       map.set(entry.workerId, entry)
     return map
   }, [runtimeQuery.data])
-  const members = useMemo(() => {
-    const merged = sortSwarmMembers(crew, roomIds).map((member) => {
-      const runtime = runtimeByWorker.get(member.id)
-      const roster = rosterQuery.data?.find((worker) => worker.id === member.id)
-      return {
-        ...member,
-        displayName: runtime?.displayName || roster?.name || member.displayName,
-        role: roster?.role || runtime?.role || member.role,
-        specialty: roster?.specialty,
-        mission: roster?.mission,
-        skills: roster?.skills ?? [],
-        capabilities: roster?.capabilities ?? [],
-        model: roster?.model || member.model,
-      }
-    })
-    const seen = new Set(merged.map((member) => member.id))
-    const extras = (rosterQuery.data ?? [])
-      .filter((worker) => !seen.has(worker.id))
-      .map((worker) => ({
-        id: worker.id,
-        displayName: worker.name || worker.id,
-        role: worker.role || 'Worker',
-        profileFound: false,
-        gatewayState: 'unknown',
-        processAlive: false,
-        platforms: {},
-        model: worker.model || 'unknown',
-        provider: 'roster-only',
-        specialty: worker.specialty,
-        mission: worker.mission,
-        skills: worker.skills ?? [],
-        capabilities: worker.capabilities ?? [],
-        lastSessionTitle: worker.mission || null,
-        lastSessionAt: null,
-        sessionCount: 0,
-        messageCount: 0,
-        toolCallCount: 0,
-        totalTokens: 0,
-        estimatedCostUsd: null,
-        cronJobCount: 0,
-        assignedTaskCount: 0,
-      }))
-    return sortSwarmMembers([...merged, ...extras], roomIds)
-  }, [crew, roomIds, runtimeByWorker, rosterQuery.data])
+  const registryEntries = agentRegistryResponseEntries(registryQuery.data)
+  const registryRoster = useMemo(
+    () => registryEntriesToRosterWorkers(registryEntries),
+    [registryEntries],
+  )
+  const members = useMemo(
+    () => mergeRegistryRosterWithCrew(crew, registryRoster, roomIds, runtimeByWorker),
+    [crew, roomIds, runtimeByWorker, registryRoster],
+  )
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -1427,52 +1324,6 @@ export function Swarm2Screen() {
     )
   }
 
-  function openAddSwarm() {
-    const existingIds = new Set((rosterQuery.data ?? []).map((worker) => worker.id))
-    let next = 13
-    while (existingIds.has(`swarm${next}`)) next += 1
-    setNewWorkerId(`swarm${next}`)
-    setNewWorkerName(`Swarm${next}`)
-    setNewWorkerRole('Builder')
-    setNewWorkerSpecialty('')
-    setNewWorkerModel('')
-    setNewWorkerMission('')
-    setAddSwarmError(null)
-    setAddSwarmOpen(true)
-  }
-
-  async function saveAddSwarm() {
-    setAddSwarmSaving(true)
-    setAddSwarmError(null)
-    try {
-      const preset = ROLE_PRESETS.find((p) => p.role === newWorkerRole)
-      const res = await fetch('/api/swarm-roster', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          id: newWorkerId.trim(),
-          name: newWorkerName.trim(),
-          role: newWorkerRole.trim(),
-          specialty: newWorkerSpecialty.trim() || preset?.specialty || '',
-          model: newWorkerModel.trim(),
-          mission: newWorkerMission.trim() || preset?.mission || 'Awaiting orchestrator dispatch.',
-          systemPrompt: preset?.systemPrompt ?? null,
-          skills: preset?.skills ?? [],
-        }),
-      })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok || data?.ok === false) {
-        throw new Error(data?.error || `HTTP ${res.status}`)
-      }
-      await rosterQuery.refetch()
-      setAddSwarmOpen(false)
-    } catch (error) {
-      setAddSwarmError(error instanceof Error ? error.message : 'Failed to save swarm agent')
-    } finally {
-      setAddSwarmSaving(false)
-    }
-  }
-
 
   return (
     <div ref={topRef} className="min-h-full bg-surface text-primary-900" style={SWARM2_OPERATION_THEME}>
@@ -1579,14 +1430,6 @@ export function Swarm2Screen() {
                   </div>
                 </div>
               ) : null}
-              <button
-                type="button"
-                onClick={openAddSwarm}
-                className="inline-flex items-center gap-2 rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 shadow-sm hover:bg-[var(--theme-accent-strong)]"
-              >
-                <HugeiconsIcon icon={MessageMultiple01Icon} size={13} />
-                Add Swarm
-              </button>
             </div>
           </div>
         </header>
@@ -1624,6 +1467,9 @@ export function Swarm2Screen() {
             latestMission={latestMission}
             missions={missionsQuery.data ?? []}
             runtimeEntries={runtimeQuery.data?.entries ?? []}
+            registryEntries={registryEntries}
+            registryDiagnostics={registryQuery.data?.diagnostics ?? []}
+            registryBackend={registryQuery.data?.backend}
             inboxCounts={{
               needsReview: inboxLanes.needs_review.length,
               blocked: inboxLanes.blocked.length,
@@ -1652,103 +1498,6 @@ export function Swarm2Screen() {
           />
         ) : null}
       </div>
-
-
-      {addSwarmOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4 py-6 backdrop-blur-sm">
-          <div className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-6 shadow-[0_30px_100px_var(--theme-shadow)]">
-            <div className="mb-4 flex items-center justify-between gap-3">
-              <div>
-                <h2 className="text-xl font-semibold text-[var(--theme-text)]">Add Swarm Agent</h2>
-                <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Create a new swarm roster entry and configure its identity.</p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setAddSwarmOpen(false)}
-                className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-1.5 text-[var(--theme-muted)] hover:text-[var(--theme-text)]"
-              >
-                Close
-              </button>
-            </div>
-            <div className="grid gap-3 md:grid-cols-2">
-              <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Role preset</span>
-                <select
-                  value={newWorkerRole}
-                  onChange={(e) => {
-                    const role = e.target.value
-                    setNewWorkerRole(role)
-                    const preset = ROLE_PRESETS.find((p) => p.role === role)
-                    if (preset && role !== 'Custom') {
-                      if (!newWorkerSpecialty.trim()) setNewWorkerSpecialty(preset.specialty)
-                      if (!newWorkerMission.trim()) setNewWorkerMission(preset.mission)
-                      if (preset.defaultModel && !newWorkerModel.trim()) setNewWorkerModel(preset.defaultModel)
-                    }
-                  }}
-                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
-                >
-                  {ROLE_NAMES.map((r) => (
-                    <option key={r} value={r}>{r}</option>
-                  ))}
-                </select>
-                <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Presets auto-fill specialty, mission, system prompt, and skill stack. Pick “Custom” for a blank slate.
-                </p>
-              </label>
-              <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Worker ID</span>
-                <input value={newWorkerId} onChange={(e) => setNewWorkerId(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="swarmN" />
-              </label>
-              <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Display name</span>
-                <input value={newWorkerName} onChange={(e) => setNewWorkerName(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="e.g. Mirror, Builder" />
-              </label>
-              <label className="block text-sm md:col-span-2">
-                <span className="mb-1 flex items-center justify-between text-[var(--theme-muted)]">
-                  <span>Model</span>
-                  <span className="text-[10px] text-[var(--theme-muted-2)]">{availableModels.length > 0 ? `${availableModels.length} available` : modelsQuery.isLoading ? 'loading…' : '0 found'}</span>
-                </span>
-                <input
-                  value={newWorkerModel}
-                  onChange={(e) => setNewWorkerModel(e.target.value)}
-                  list="swarm-add-models"
-                  placeholder={availableModels.length ? 'Search or pick a detected model…' : modelsQuery.isLoading ? 'Loading detected models…' : 'No models detected'}
-                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
-                />
-                <datalist id="swarm-add-models">
-                  {availableModels.map((m) => (
-                    <option key={m.id} value={m.name}>{m.provider}</option>
-                  ))}
-                </datalist>
-                <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Searchable picker backed by /api/models, the same source as chat. {modelsQuery.isError ? 'Model discovery errored, so this is empty until refresh.' : 'Start typing to see every detected model from the user’s Hermes config and local providers.'}
-                </p>
-              </label>
-              <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Specialty</span>
-                <input value={newWorkerSpecialty} onChange={(e) => setNewWorkerSpecialty(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.specialty || 'short focus area'} />
-              </label>
-              <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Mission</span>
-                <textarea value={newWorkerMission} onChange={(e) => setNewWorkerMission(e.target.value)} rows={3} className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.mission || 'standing mission for this worker'} />
-              </label>
-              {ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt ? (
-                <div className="md:col-span-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
-                  <div className="mb-1 font-semibold text-[var(--theme-muted)]">System prompt (embedded with role)</div>
-                  <div className="whitespace-pre-wrap leading-relaxed">{ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt}</div>
-                  <div className="mt-2 font-semibold text-[var(--theme-muted)]">Skills loaded</div>
-                  <div className="font-mono">{(ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.skills ?? []).join(', ') || '—'}</div>
-                </div>
-              ) : null}
-            </div>
-            {addSwarmError ? <div className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{addSwarmError}</div> : null}
-            <div className="mt-4 flex items-center justify-end gap-3">
-              <button type="button" onClick={() => setAddSwarmOpen(false)} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]">Cancel</button>
-              <button type="button" disabled={addSwarmSaving || !newWorkerId.trim() || !newWorkerName.trim()} onClick={() => void saveAddSwarm()} className="rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 disabled:opacity-50">{addSwarmSaving ? 'Saving…' : 'Save swarm agent'}</button>
-            </div>
-          </div>
-        </div>
-      ) : null}
 
       <RouterChat
         members={members}

--- a/src/server/agent-registry.test.ts
+++ b/src/server/agent-registry.test.ts
@@ -1,0 +1,316 @@
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AGENT_REGISTRY_PARSER_VERSION,
+  buildAgentRegistryApiPayload,
+  loadAgentRegistry,
+  parseAgentRegistryDocument,
+} from './agent-registry'
+
+function tempYaml(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-registry-'))
+  const file = join(dir, 'swarm.yaml')
+  writeFileSync(file, content, 'utf8')
+  return file
+}
+
+describe('agent registry schema/parser', () => {
+  it('normalizes valid swarm.yaml workers into read-only registry entries with backend metadata', () => {
+    const result = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: swarm5
+    name: Builder
+    role: Primary Builder
+    specialty: full-stack implementation
+    model: GPT-5.5
+    mission: Ship focused slices.
+    skills: [swarm-ui-worker]
+    capabilities: [code-editing, ui-implementation]
+    preferredTaskTypes: [implementation]
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+`,
+      { sourcePath: '/repo/swarm.yaml', loadedAt: 1234 },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.parserVersion).toBe(AGENT_REGISTRY_PARSER_VERSION)
+    expect(result.backend).toMatchObject({
+      kind: 'swarm-yaml',
+      compatibilityMode: true,
+      sourcePath: '/repo/swarm.yaml',
+      writable: false,
+      loadedAt: 1234,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+    })
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        id: 'swarm5',
+        displayName: 'Builder',
+        role: 'Primary Builder',
+        model: 'GPT-5.5',
+        dispatchEnabled: false,
+        source: 'swarm.yaml',
+        sourceDerived: true,
+        writable: false,
+        capabilities: ['code-editing', 'ui-implementation'],
+        disabledActions: expect.arrayContaining([
+          expect.stringContaining('read-only'),
+          expect.stringContaining('Dispatch is disabled'),
+        ]),
+      }),
+    ])
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('returns valid entries plus diagnostics for missing required fields, duplicate ids, and unknown fields', () => {
+    const result = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: swarm5
+    name: Builder
+    role: Primary Builder
+    unexpected: nope
+  - id: swarm5
+    name: Duplicate
+    role: Duplicate Role
+  - name: Missing Id
+    role: Broken
+  - id: swarm6
+    name: Reviewer
+    role: Reviewer
+`,
+      { sourcePath: '/repo/swarm.yaml', loadedAt: 100 },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.entries.map((entry) => entry.id)).toEqual(['swarm5', 'swarm6'])
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ severity: 'error', code: 'unknown_field', path: 'workers[0].unexpected', entryId: 'swarm5' }),
+        expect.objectContaining({ severity: 'error', code: 'duplicate_id', path: 'workers[1].id', entryId: 'swarm5' }),
+        expect.objectContaining({ severity: 'error', code: 'missing_required', path: 'workers[2].id' }),
+      ]),
+    )
+  })
+
+  it('fails closed for malformed YAML, schema-version mismatches, empty registries, and secret-looking values', () => {
+    const malformed = parseAgentRegistryDocument('version: 1\nworkers: [', { sourcePath: '/repo/swarm.yaml' })
+    expect(malformed.ok).toBe(false)
+    expect(malformed.entries).toEqual([])
+    expect(malformed.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'parse_error' }))
+
+    const malformedSecret = parseAgentRegistryDocument('version: 1\nworkers: [sk-live-secret-token', { sourcePath: '/repo/swarm.yaml' })
+    expect(malformedSecret.ok).toBe(false)
+    expect(JSON.stringify(malformedSecret.diagnostics)).not.toContain('sk-live-secret-token')
+    expect(malformedSecret.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'parse_error', message: 'Failed to parse registry YAML' }))
+
+    const topLevelKeySecret = parseAgentRegistryDocument(`version: 1
+sk-liv...oken: true
+workers: []`)
+    expect(topLevelKeySecret.ok).toBe(false)
+    expect(topLevelKeySecret.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: '<redacted_key>' }))
+    expect(JSON.stringify(topLevelKeySecret.diagnostics)).not.toContain('sk-liv...oken')
+
+    const wrongVersion = parseAgentRegistryDocument(`version: 2
+workers:
+  - id: swarm9
+    name: Wrong Version
+    role: Should Not Load
+`, { sourcePath: '/repo/swarm.yaml' })
+    expect(wrongVersion.ok).toBe(false)
+    expect(wrongVersion.entries).toEqual([])
+    expect(wrongVersion.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'schema_version_unsupported' }))
+
+    const empty = parseAgentRegistryDocument('version: 1\nworkers: []', { sourcePath: '/repo/swarm.yaml' })
+    expect(empty.ok).toBe(true)
+    expect(empty.entries).toEqual([])
+    expect(empty.diagnostics).toContainEqual(expect.objectContaining({ severity: 'info', code: 'empty_registry' }))
+
+    const topLevelSecret = parseAgentRegistryDocument(
+      `version: 1
+metadata: ASIAIOSFODNN7EXAMPLE
+workers:
+  - id: swarm12
+    name: Valid Looking
+    role: Ops
+`,
+      { sourcePath: '/repo/swarm.yaml' },
+    )
+    expect(topLevelSecret.ok).toBe(false)
+    expect(topLevelSecret.entries).toEqual([])
+    expect(topLevelSecret.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ severity: 'error', code: 'unknown_field', path: 'metadata' }),
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'metadata' }),
+    ]))
+
+    const broaderSecret = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: swarm7
+    name: Scribe
+    role: Docs
+    mission: token sk-live-1234567890abcdef
+`,
+      { sourcePath: '/repo/swarm.yaml' },
+    )
+    expect(broaderSecret.ok).toBe(false)
+    expect(broaderSecret.entries).toEqual([])
+    expect(buildAgentRegistryApiPayload(broaderSecret).registry.entries).toEqual([])
+    expect(JSON.stringify(broaderSecret.entries)).not.toContain('sk-liv')
+    expect(broaderSecret.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[0].mission', entryId: 'swarm7' }))
+  })
+
+  it('rejects malformed worker ids before entries can merge into Swarm2 roster metadata', () => {
+    const result = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: ../../../etc/passwd
+    name: Path Escape
+    role: Bad Actor
+  - id: swarm8
+    name: Watch
+    role: Ops
+`,
+      { sourcePath: '/repo/swarm.yaml' },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.entries.map((entry) => entry.id)).toEqual(['swarm8'])
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'invalid_worker_id', path: 'workers[0].id' }))
+    expect(JSON.stringify(result.diagnostics)).not.toContain('../../../etc/passwd')
+  })
+
+  it('rejects broader secret-looking credential families and never echoes a secret-like id in diagnostics', () => {
+    const result = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: sk-live-secret-token
+    name: Secret Id
+    role: Docs
+    sk-liv...oken: hidden
+    mission: ordinary text
+  - id: swarm9
+    name: Bearer
+    role: Ops
+    mission: 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI'
+  - id: swarm10
+    name: Aws
+    role: Ops
+    model: AKIAIOSFODNN7EXAMPLE
+  - id: swarm11
+    name: Pem
+    role: Ops
+    mission: '-----BEGIN PRIVATE KEY-----'
+  - id: ghp_12...1234
+    name: GitHub
+    role: Ops
+    mission: ordinary text
+  - id: swarm12
+    name: Slack
+    role: Ops
+    xoxb-1...cdef: hidden
+    mission: ordinary text
+  - id: swarm13
+    name: Token
+    role: Ops
+    model: github_pat_1234567890abcdef
+`,
+      { sourcePath: '/repo/swarm.yaml' },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.entries).toEqual([])
+    const serializedDiagnostics = JSON.stringify(result.diagnostics)
+    expect(serializedDiagnostics).not.toContain('sk-liv...oken')
+    expect(serializedDiagnostics).not.toContain('sk-live-secret-token')
+    expect(serializedDiagnostics).not.toContain('ghp_12...1234')
+    expect(serializedDiagnostics).not.toContain('xoxb-1...cdef')
+    expect(serializedDiagnostics).not.toContain('github_pat_1234567890abcdef')
+
+    const semanticTopLevelKey = parseAgentRegistryDocument(`version: 1
+GITHUB_TOKEN: top-level
+workers: []
+`)
+    const serializedTopLevelSemanticDiagnostics = JSON.stringify(semanticTopLevelKey.diagnostics)
+    expect(semanticTopLevelKey.ok).toBe(false)
+    expect(serializedTopLevelSemanticDiagnostics).not.toContain('GITHUB_TOKEN')
+    expect(semanticTopLevelKey.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: '<redacted_key>' }))
+
+    const semanticWorkerKeys = parseAgentRegistryDocument(`version: 1
+workers:
+  - id: swarm14
+    name: Semantic
+    role: Ops
+    password: hidden
+    access_token: hidden
+    bearerToken: hidden
+    authorization: hidden
+    private_key: hidden
+`)
+    const serializedSemanticDiagnostics = JSON.stringify(semanticWorkerKeys.diagnostics)
+    expect(semanticWorkerKeys.ok).toBe(false)
+    expect(semanticWorkerKeys.entries).toEqual([])
+    for (const rawKey of ['password', 'access_token', 'bearerToken', 'authorization', 'private_key']) {
+      expect(serializedSemanticDiagnostics).not.toContain(rawKey)
+    }
+    expect(semanticWorkerKeys.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[0].<redacted_key>', entryId: 'swarm14' }))
+
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[0].id' }),
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[0].<redacted_key>' }),
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[1].mission', entryId: 'swarm9' }),
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[2].model', entryId: 'swarm10' }),
+      expect.objectContaining({ severity: 'error', code: 'secret_like_value', path: 'workers[3].mission', entryId: 'swarm11' }),
+    ]))
+  })
+
+  it('treats dispatch_enabled as fail-closed unless explicit read-only authorization metadata is present', () => {
+    const unauthorized = parseAgentRegistryDocument(
+      `version: 1
+workers:
+  - id: swarm5
+    name: Builder
+    role: Primary Builder
+    dispatch_enabled: true
+`,
+      { sourcePath: '/repo/swarm.yaml' },
+    )
+    expect(unauthorized.ok).toBe(false)
+    expect(unauthorized.entries[0]?.dispatchEnabled).toBe(false)
+    expect(unauthorized.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'dispatch_enabled_not_authorized', entryId: 'swarm5' }))
+  })
+})
+
+describe('loadAgentRegistry no-mutation boundary', () => {
+  it('reads swarm.yaml without writing the source file or probing live systems', () => {
+    const sourcePath = tempYaml(`version: 1
+workers:
+  - id: swarm8
+    name: Watch
+    role: Ops
+`)
+    const before = statSync(sourcePath).mtimeMs
+    const result = loadAgentRegistry({ sourcePath, now: () => 42 })
+
+    const after = statSync(sourcePath).mtimeMs
+    expect(result.ok).toBe(true)
+    expect(result.backend).toMatchObject({ writable: false, fetchedAt: 42, loadedAt: 42 })
+    expect(readFileSync(sourcePath, 'utf8')).toContain('swarm8')
+    expect(after).toBe(before)
+  })
+
+  it('returns a structured diagnostic when an existing source cannot be read', () => {
+    const unreadableSource = mkdtempSync(join(tmpdir(), 'agent-registry-unreadable-'))
+    const result = loadAgentRegistry({ sourcePath: unreadableSource, now: () => 77 })
+
+    expect(result.ok).toBe(false)
+    expect(result.entries).toEqual([])
+    expect(result.backend).toMatchObject({ sourcePath: unreadableSource, writable: false, fetchedAt: 77, loadedAt: 77 })
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({ severity: 'error', code: 'source_unreadable', path: 'sourcePath' }))
+  })
+})

--- a/src/server/agent-registry.ts
+++ b/src/server/agent-registry.ts
@@ -1,0 +1,420 @@
+import { existsSync, readFileSync } from 'node:fs'
+import * as yaml from 'yaml'
+import { z } from 'zod'
+import { SWARM_ROSTER_PATH } from './swarm-roster'
+
+export const AGENT_REGISTRY_PARSER_VERSION = 'agent-registry-v1'
+export const READ_ONLY_AGENT_REGISTRY_METHODS = ['GET', 'HEAD'] as const
+
+type DiagnosticSeverity = 'error' | 'warning' | 'info'
+
+export type AgentRegistryDiagnostic = {
+  severity: DiagnosticSeverity
+  code: string
+  message: string
+  path?: string
+  entryId?: string
+}
+
+export type AgentRegistryEntry = {
+  id: string
+  displayName: string
+  role: string
+  specialty?: string
+  model?: string
+  mission?: string
+  capabilities: Array<string>
+  skills: Array<string>
+  preferredTaskTypes?: Array<string>
+  maxConcurrentTasks?: number
+  acceptsBroadcast?: boolean
+  reviewRequired?: boolean
+  dispatchEnabled: boolean
+  source: 'swarm.yaml'
+  sourceDerived: boolean
+  writable: boolean
+  disabledActions: Array<string>
+}
+
+export type AgentRegistryBackendMetadata = {
+  kind: 'swarm-yaml'
+  compatibilityMode: boolean
+  sourcePath: string
+  writable: boolean
+  loadedAt: number
+  fetchedAt?: number
+  parserVersion: string
+}
+
+export type AgentRegistryResult = {
+  ok: boolean
+  parserVersion: string
+  entries: Array<AgentRegistryEntry>
+  diagnostics: Array<AgentRegistryDiagnostic>
+  backend: AgentRegistryBackendMetadata
+}
+
+export type AgentRegistryApiPayload = {
+  ok: boolean
+  registry: { entries: Array<AgentRegistryEntry> }
+  backend: AgentRegistryBackendMetadata
+  diagnostics: Array<AgentRegistryDiagnostic>
+  fetchedAt?: number
+  loadedAt: number
+  parserVersion: string
+}
+
+const WORKER_ID_PATTERN = /^swarm\d+$/
+const WorkerSchema = z.object({
+  id: z.string().min(1).regex(WORKER_ID_PATTERN),
+  name: z.string().min(1),
+  role: z.string().min(1),
+  specialty: z.string().optional(),
+  model: z.string().optional(),
+  mission: z.string().optional(),
+  skills: z.array(z.string()).default([]),
+  capabilities: z.array(z.string()).default([]),
+  defaultCwd: z.string().optional(),
+  preferredTaskTypes: z.array(z.string()).optional(),
+  maxConcurrentTasks: z.number().int().positive().optional(),
+  acceptsBroadcast: z.boolean().optional(),
+  reviewRequired: z.boolean().optional(),
+  dispatch_enabled: z.boolean().optional(),
+  dispatchAuthorization: z.object({ readOnlyRegistry: z.boolean().optional() }).optional(),
+})
+
+const TOP_LEVEL_KEYS = new Set(['version', 'workers'])
+const WORKER_KEYS = new Set(Object.keys(WorkerSchema.shape))
+
+function backend(sourcePath: string, loadedAt = Date.now(), fetchedAt?: number): AgentRegistryBackendMetadata {
+  return {
+    kind: 'swarm-yaml',
+    compatibilityMode: true,
+    sourcePath,
+    writable: false,
+    loadedAt,
+    fetchedAt,
+    parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+  }
+}
+
+function diagnostic(
+  severity: DiagnosticSeverity,
+  code: string,
+  message: string,
+  path?: string,
+  entryId?: string,
+): AgentRegistryDiagnostic {
+  return { severity, code, message, path, entryId }
+}
+
+function hasError(diagnostics: Array<AgentRegistryDiagnostic>): boolean {
+  return diagnostics.some((item) => item.severity === 'error')
+}
+
+function maybeSecret(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  return /(?:sk-[a-z0-9._-]{6,}|(?:sk|pk|rk)_[a-z0-9._-]{6,}|github_pat_[a-z0-9._-]{10,}|gh[pousr]_[a-z0-9._-]{6,}|xox[baprs]-[a-z0-9.-]{6,}|AIza[0-9A-Za-z_-]{10,}|ya29\.[0-9A-Za-z._-]{10,}|api[_-]?key|secret|bearer\s+[a-z0-9._~+/=-]{12,}|token\s+[a-z0-9._~+/=-]{8,}|password\s*[:=]|(?:AKIA|ASIA)[0-9A-Z.]{8,}|[A-Za-z0-9+/=_-]{32,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i.test(value)
+}
+
+function maybeSecretKey(value: unknown): boolean {
+  if (maybeSecret(value)) return true
+  if (typeof value !== 'string') return false
+  return /(?:password|passwd|pwd|token|secret|credential|authorization|bearer|private[_-]?key|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)/i.test(value)
+}
+
+function diagnosticEntryId(value: string | undefined): string | undefined {
+  if (!value || !WORKER_ID_PATTERN.test(value) || maybeSecret(value) || maybeSecretKey(value)) return undefined
+  return value
+}
+
+function diagnosticKey(key: string): string {
+  return maybeSecretKey(key) ? '<redacted_key>' : key
+}
+
+function diagnosticPath(path: string, key: string): string {
+  const safeKey = diagnosticKey(key)
+  return path ? `${path}.${safeKey}` : safeKey
+}
+
+function scanSecrets(value: unknown, path: string, diagnostics: Array<AgentRegistryDiagnostic>, entryId?: string): boolean {
+  let found = false
+  if (maybeSecret(value)) {
+    diagnostics.push(diagnostic('error', 'secret_like_value', `Secret-looking value is not allowed at ${path}`, path, entryId))
+    return true
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      found = scanSecrets(item, `${path}[${index}]`, diagnostics, entryId) || found
+    })
+  } else if (typeof value === 'object' && value !== null) {
+    for (const [key, item] of Object.entries(value)) {
+      const nextPath = diagnosticPath(path, key)
+      if (maybeSecretKey(key)) {
+        diagnostics.push(diagnostic('error', 'secret_like_value', `Secret-looking key is not allowed at ${nextPath}`, nextPath, entryId))
+        found = true
+      }
+      found = scanSecrets(item, nextPath, diagnostics, entryId) || found
+    }
+  }
+  return found
+}
+
+function scanTopLevelSecrets(root: Record<string, unknown>, diagnostics: Array<AgentRegistryDiagnostic>): boolean {
+  let found = false
+  for (const [key, value] of Object.entries(root)) {
+    if (key === 'workers') continue
+    const safePath = diagnosticKey(key)
+    if (maybeSecretKey(key)) {
+      diagnostics.push(diagnostic('error', 'secret_like_value', `Secret-looking key is not allowed at ${safePath}`, safePath))
+      found = true
+    }
+    found = scanSecrets(value, safePath, diagnostics) || found
+  }
+  return found
+}
+
+function disabledActions(dispatchEnabled: boolean): Array<string> {
+  return [
+    'Registry is read-only in Phase 1.',
+    dispatchEnabled
+      ? 'Dispatch remains disabled from registry rows; authorization is metadata-only in Phase 1.'
+      : 'Dispatch is disabled from registry rows.',
+    'Edits and source sync are not available from the read-only registry.',
+  ]
+}
+
+function normalizeWorker(worker: z.infer<typeof WorkerSchema>): AgentRegistryEntry {
+  return {
+    id: worker.id,
+    displayName: worker.name,
+    role: worker.role,
+    specialty: worker.specialty,
+    model: worker.model,
+    mission: worker.mission,
+    capabilities: worker.capabilities ?? [],
+    skills: worker.skills ?? [],
+    preferredTaskTypes: worker.preferredTaskTypes,
+    maxConcurrentTasks: worker.maxConcurrentTasks,
+    acceptsBroadcast: worker.acceptsBroadcast,
+    reviewRequired: worker.reviewRequired,
+    dispatchEnabled: false,
+    source: 'swarm.yaml',
+    sourceDerived: true,
+    writable: false,
+    disabledActions: disabledActions(false),
+  }
+}
+
+export function parseAgentRegistryDocument(
+  text: string,
+  options: { sourcePath: string; loadedAt?: number } = { sourcePath: SWARM_ROSTER_PATH },
+): AgentRegistryResult {
+  const loadedAt = options.loadedAt ?? Date.now()
+  const diagnostics: Array<AgentRegistryDiagnostic> = []
+  const resultBackend = backend(options.sourcePath, loadedAt)
+  let doc: unknown
+
+  try {
+    doc = yaml.parse(text) as unknown
+  } catch (error) {
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics: [
+        diagnostic(
+          'error',
+          'parse_error',
+          'Failed to parse registry YAML',
+        ),
+      ],
+      backend: resultBackend,
+    }
+  }
+
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics: [diagnostic('error', 'invalid_document', 'Registry document must be an object')],
+      backend: resultBackend,
+    }
+  }
+
+  const root = doc as Record<string, unknown>
+  for (const key of Object.keys(root)) {
+    if (!TOP_LEVEL_KEYS.has(key)) {
+      const safeKey = diagnosticKey(key)
+      diagnostics.push(diagnostic('error', 'unknown_field', `Unknown top-level field ${safeKey}`, safeKey))
+    }
+  }
+
+  const documentHasTopLevelSecret = scanTopLevelSecrets(root, diagnostics)
+  if (documentHasTopLevelSecret) {
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics,
+      backend: resultBackend,
+    }
+  }
+
+  if (root.version !== 1) {
+    diagnostics.push(
+      diagnostic('error', 'schema_version_unsupported', 'Only swarm.yaml version 1 is supported', 'version'),
+    )
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics,
+      backend: resultBackend,
+    }
+  }
+
+  if (!Array.isArray(root.workers)) {
+    diagnostics.push(diagnostic('error', 'missing_required', 'workers must be an array', 'workers'))
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics,
+      backend: resultBackend,
+    }
+  }
+
+  if (root.workers.length === 0) {
+    diagnostics.push(diagnostic('info', 'empty_registry', 'Registry contains no workers', 'workers'))
+  }
+
+  const seen = new Set<string>()
+  const entries: Array<AgentRegistryEntry> = []
+
+  root.workers.forEach((rawWorker, index) => {
+    const path = `workers[${index}]`
+    if (!rawWorker || typeof rawWorker !== 'object' || Array.isArray(rawWorker)) {
+      diagnostics.push(diagnostic('error', 'invalid_worker', 'Worker entry must be an object', path))
+      return
+    }
+
+    const workerRecord = rawWorker as Record<string, unknown>
+    const rawId = typeof workerRecord.id === 'string' ? workerRecord.id : undefined
+    const diagnosticId = diagnosticEntryId(rawId)
+    for (const key of Object.keys(workerRecord)) {
+      if (!WORKER_KEYS.has(key)) {
+        const safeKey = diagnosticKey(key)
+        diagnostics.push(diagnostic('error', 'unknown_field', `Unknown worker field ${safeKey}`, diagnosticPath(path, key), diagnosticId))
+      }
+    }
+
+    for (const required of ['id', 'name', 'role']) {
+      if (typeof workerRecord[required] !== 'string' || !(workerRecord[required] as string).trim()) {
+        diagnostics.push(
+          diagnostic('error', 'missing_required', `${path}.${required} is required`, `${path}.${required}`, diagnosticId),
+        )
+      }
+    }
+
+    const foundSecret = scanSecrets(workerRecord, path, diagnostics, diagnosticId)
+    if (foundSecret) return
+
+    const parsed = WorkerSchema.safeParse(workerRecord)
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        const issuePath = `${path}.${issue.path.join('.')}`.replace(/\.$/, '')
+        const code = issue.path.join('.') === 'id' ? 'invalid_worker_id' : 'invalid_field'
+        diagnostics.push(diagnostic('error', code, issue.message, issuePath, diagnosticId))
+      }
+      return
+    }
+
+    if (seen.has(parsed.data.id)) {
+      diagnostics.push(diagnostic('error', 'duplicate_id', `Duplicate worker id ${parsed.data.id}`, `${path}.id`, parsed.data.id))
+      return
+    }
+    seen.add(parsed.data.id)
+
+    const entry = normalizeWorker(parsed.data)
+    if (parsed.data.dispatch_enabled === true) {
+      if (parsed.data.dispatchAuthorization?.readOnlyRegistry === true) {
+        entry.disabledActions = disabledActions(true)
+      } else {
+        diagnostics.push(
+          diagnostic(
+            'error',
+            'dispatch_enabled_not_authorized',
+            'dispatch_enabled=true requires explicit read-only registry authorization metadata and remains disabled in Phase 1',
+            `${path}.dispatch_enabled`,
+            parsed.data.id,
+          ),
+        )
+      }
+    }
+    entries.push(entry)
+  })
+
+  return {
+    ok: !hasError(diagnostics),
+    parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+    entries,
+    diagnostics,
+    backend: resultBackend,
+  }
+}
+
+export function loadAgentRegistry(options: { sourcePath?: string; now?: () => number } = {}): AgentRegistryResult {
+  const sourcePath = options.sourcePath ?? SWARM_ROSTER_PATH
+  const now = options.now ?? Date.now
+  const timestamp = now()
+  if (!existsSync(sourcePath)) {
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics: [diagnostic('error', 'source_missing', `Registry source does not exist: ${sourcePath}`, 'sourcePath')],
+      backend: backend(sourcePath, timestamp, timestamp),
+    }
+  }
+  let sourceText: string
+  try {
+    sourceText = readFileSync(sourcePath, 'utf8')
+  } catch (error) {
+    return {
+      ok: false,
+      parserVersion: AGENT_REGISTRY_PARSER_VERSION,
+      entries: [],
+      diagnostics: [
+        diagnostic(
+          'error',
+          'source_unreadable',
+          error instanceof Error ? error.message : `Registry source could not be read: ${sourcePath}`,
+          'sourcePath',
+        ),
+      ],
+      backend: backend(sourcePath, timestamp, timestamp),
+    }
+  }
+  const parsed = parseAgentRegistryDocument(sourceText, { sourcePath, loadedAt: timestamp })
+  return {
+    ...parsed,
+    backend: {
+      ...parsed.backend,
+      fetchedAt: timestamp,
+    },
+  }
+}
+
+export function buildAgentRegistryApiPayload(result: AgentRegistryResult): AgentRegistryApiPayload {
+  return {
+    ok: result.ok,
+    registry: { entries: result.entries },
+    backend: result.backend,
+    diagnostics: result.diagnostics,
+    fetchedAt: result.backend.fetchedAt,
+    loadedAt: result.backend.loadedAt,
+    parserVersion: result.parserVersion,
+  }
+}

--- a/src/server/vector-memory.test.ts
+++ b/src/server/vector-memory.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { existsSync, readFileSync } = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+}))
+
+vi.mock('node:fs', () => ({
+  default: { existsSync, readFileSync },
+  existsSync,
+  readFileSync,
+}))
+
+const { homedir } = vi.hoisted(() => ({
+  homedir: vi.fn().mockReturnValue('/home/testuser'),
+}))
+
+vi.mock('node:os', () => ({
+  default: { homedir },
+  homedir,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.HERMES_HOME
+  delete process.env.CLAUDE_HOME
+})
+
+async function loadMod() {
+  vi.resetModules()
+  return import('./vector-memory')
+}
+
+describe('vector-memory server helpers', () => {
+  it('loads chromadb.json from HERMES_HOME and exposes safe defaults', async () => {
+    process.env.HERMES_HOME = '/custom/hermes'
+    existsSync.mockReturnValue(true)
+    readFileSync.mockReturnValue(
+      JSON.stringify({
+        chromadb_host: '100.107.68.104',
+        chromadb_port: 8000,
+        embedding_service_url: 'http://100.113.1.2:8006',
+        embedding_model: 'Qwen/Qwen3-Embedding-0.6B',
+        collections: {
+          memories: 'agent_memories',
+          sessions: 'session_history',
+        },
+      }),
+    )
+
+    const mod = await loadMod()
+    const config = mod.readVectorMemoryConfig()
+
+    expect(readFileSync).toHaveBeenCalledWith(
+      '/custom/hermes/chromadb.json',
+      'utf-8',
+    )
+    expect(config.chromaBaseUrl).toBe('http://100.107.68.104:8000')
+    expect(config.embeddingServiceUrl).toBe('http://100.113.1.2:8006')
+    expect(config.embeddingModel).toBe('Qwen/Qwen3-Embedding-0.6B')
+    expect(config.collections).toEqual({
+      memories: 'agent_memories',
+      sessions: 'session_history',
+    })
+    expect(config.dimension).toBe(1024)
+  })
+
+  it('normalizes Chroma query results into dashboard records', async () => {
+    const mod = await loadMod()
+
+    const results = mod.normalizeVectorSearchResults('team_knowledge', {
+      ids: [['abc123']],
+      documents: [['Memory text']],
+      metadatas: [[{ source: 'test', importance: 0.8 }]],
+      distances: [[0.14]],
+    })
+
+    expect(results).toEqual([
+      {
+        id: 'abc123',
+        collection: 'team_knowledge',
+        document: 'Memory text',
+        metadata: { source: 'test', importance: 0.8 },
+        distance: 0.14,
+        score: 0.8771929824561403,
+      },
+    ])
+  })
+
+  it('rejects unsafe search inputs before touching live services', async () => {
+    const mod = await loadMod()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      mod.searchVectorMemory({ query: '   ', collection: 'all', limit: 8 }),
+    ).rejects.toThrow(mod.VectorMemoryInputError)
+    await expect(
+      mod.searchVectorMemory({ query: 'ok', collection: 'all', limit: 1.5 }),
+    ).rejects.toThrow('Limit must be an integer')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('stores dashboard team discoveries with explicit embeddings and Chroma upsert', async () => {
+    existsSync.mockReturnValue(true)
+    readFileSync.mockReturnValue(
+      JSON.stringify({
+        chromadb_host: '127.0.0.1',
+        chromadb_port: 8000,
+        embedding_service_url: 'http://forge.local:8006',
+        embedding_model: 'Qwen/Qwen3-Embedding-0.6B',
+        collections: { team_knowledge: 'team_knowledge' },
+      }),
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ heartbeat: 1 }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: 'team-col-id', name: 'team_knowledge' }]),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(7) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ embedding: [0.3, 0.4], dimensions: 1024 }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mod = await loadMod()
+    const payload = await mod.storeTeamDiscovery({
+      content: '  Dashboard memory control should remain safe and explicit.  ',
+      source: 'test-suite',
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      'http://forge.local:8006/embed-single',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'Dashboard memory control should remain safe and explicit.' }),
+      }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      6,
+      'http://127.0.0.1:8000/api/v2/tenants/default_tenant/databases/default_database/collections/team-col-id/upsert',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"embeddings":[[0.3,0.4]]'),
+      }),
+    )
+    const upsertBody = JSON.parse(fetchMock.mock.calls[5][1].body)
+    expect(upsertBody.documents).toEqual([
+      'Dashboard memory control should remain safe and explicit.',
+    ])
+    expect(upsertBody.metadatas[0]).toMatchObject({
+      kind: 'team_discovery',
+      source: 'test-suite',
+      created_by: 'workspace-vector-memory',
+    })
+    expect(payload.stored.id).toMatch(/^dashboard-discovery-/)
+    expect(payload.stored.collection).toBe('team_knowledge')
+  })
+
+  it('queries Forge with the live embed-single contract before Chroma query', async () => {
+    existsSync.mockReturnValue(true)
+    readFileSync.mockReturnValue(
+      JSON.stringify({
+        chromadb_host: '127.0.0.1',
+        chromadb_port: 8000,
+        embedding_service_url: 'http://forge.local:8006',
+        embedding_model: 'Qwen/Qwen3-Embedding-0.6B',
+        collections: { team_knowledge: 'team_knowledge' },
+      }),
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ heartbeat: 1 }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: 'col-1', name: 'team_knowledge' }]),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(7) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ embedding: [0.1, 0.2], dimensions: 1024 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ids: [['abc123']],
+            documents: [['Memory text']],
+            metadatas: [[{}]],
+            distances: [[0.2]],
+          }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mod = await loadMod()
+    const payload = await mod.searchVectorMemory({
+      query: 'memory module',
+      collection: 'team_knowledge',
+      limit: 3,
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      'http://forge.local:8006/embed-single',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ text: 'memory module' }),
+      }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      6,
+      'http://127.0.0.1:8000/api/v2/tenants/default_tenant/databases/default_database/collections/col-1/query',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          query_embeddings: [[0.1, 0.2]],
+          n_results: 3,
+          include: ['documents', 'metadatas', 'distances'],
+        }),
+      }),
+    )
+    expect(payload.results).toHaveLength(1)
+  })
+})

--- a/src/server/vector-memory.test.ts
+++ b/src/server/vector-memory.test.ts
@@ -101,66 +101,10 @@ describe('vector-memory server helpers', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('stores dashboard team discoveries with explicit embeddings and Chroma upsert', async () => {
-    existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue(
-      JSON.stringify({
-        chromadb_host: '127.0.0.1',
-        chromadb_port: 8000,
-        embedding_service_url: 'http://forge.local:8006',
-        embedding_model: 'Qwen/Qwen3-Embedding-0.6B',
-        collections: { team_knowledge: 'team_knowledge' },
-      }),
-    )
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ heartbeat: 1 }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([{ id: 'team-col-id', name: 'team_knowledge' }]),
-      })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(7) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ embedding: [0.3, 0.4], dimensions: 1024 }),
-      })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
-    vi.stubGlobal('fetch', fetchMock)
-
+  it('does not expose dashboard write helpers in the read-only vector-memory module', async () => {
     const mod = await loadMod()
-    const payload = await mod.storeTeamDiscovery({
-      content: '  Dashboard memory control should remain safe and explicit.  ',
-      source: 'test-suite',
-    })
 
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      5,
-      'http://forge.local:8006/embed-single',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ text: 'Dashboard memory control should remain safe and explicit.' }),
-      }),
-    )
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      6,
-      'http://127.0.0.1:8000/api/v2/tenants/default_tenant/databases/default_database/collections/team-col-id/upsert',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.stringContaining('"embeddings":[[0.3,0.4]]'),
-      }),
-    )
-    const upsertBody = JSON.parse(fetchMock.mock.calls[5][1].body)
-    expect(upsertBody.documents).toEqual([
-      'Dashboard memory control should remain safe and explicit.',
-    ])
-    expect(upsertBody.metadatas[0]).toMatchObject({
-      kind: 'team_discovery',
-      source: 'test-suite',
-      created_by: 'workspace-vector-memory',
-    })
-    expect(payload.stored.id).toMatch(/^dashboard-discovery-/)
-    expect(payload.stored.collection).toBe('team_knowledge')
+    expect('storeTeamDiscovery' in mod).toBe(false)
   })
 
   it('queries Forge with the live embed-single contract before Chroma query', async () => {

--- a/src/server/vector-memory.ts
+++ b/src/server/vector-memory.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -51,13 +50,6 @@ export class VectorMemoryInputError extends Error {
     super(message)
     this.name = 'VectorMemoryInputError'
   }
-}
-
-export type StoreTeamDiscoveryResult = {
-  id: string
-  collection: string
-  document: string
-  metadata: Record<string, unknown>
 }
 
 type ChromaCollection = {
@@ -405,78 +397,4 @@ export async function searchVectorMemory(options: {
   const results = batches.flatMap((batch) => (batch.status === 'fulfilled' ? batch.value : []))
   results.sort((a, b) => (b.score ?? -1) - (a.score ?? -1))
   return { results: results.slice(0, limit), status }
-}
-
-function teamKnowledgeCollection(status: VectorMemoryStatus): VectorCollectionStat {
-  const configuredName = status.config.collections.team_knowledge || 'team_knowledge'
-  const collection = status.collections.find(
-    (item) => item.key === 'team_knowledge' || item.name === configuredName,
-  )
-  if (collection) return collection
-  return { key: 'team_knowledge', name: configuredName, id: configuredName, count: null }
-}
-
-async function upsertDocument(
-  config: VectorMemoryConfig,
-  collection: VectorCollectionStat,
-  document: string,
-  embedding: Array<number>,
-  metadata: Record<string, unknown>,
-  id: string,
-): Promise<void> {
-  const idOrName = collection.id || collection.name
-  const body = JSON.stringify({
-    ids: [id],
-    embeddings: [embedding],
-    documents: [document],
-    metadatas: [metadata],
-  })
-  try {
-    await fetchJson<unknown>(
-      `${v2CollectionsUrl(config)}/${encodeURIComponent(idOrName)}/upsert`,
-      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
-    )
-  } catch {
-    await fetchJson<unknown>(
-      `${legacyCollectionsUrl(config)}/${encodeURIComponent(idOrName)}/upsert`,
-      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
-    )
-  }
-}
-
-export async function storeTeamDiscovery(options: {
-  content: string
-  source?: string
-}): Promise<{ stored: StoreTeamDiscoveryResult; status: VectorMemoryStatus }> {
-  const document = options.content.trim()
-  if (!document) throw new VectorMemoryInputError('Discovery content is required')
-  if (document.length > 4000) {
-    throw new VectorMemoryInputError('Discovery content must be 4000 characters or fewer')
-  }
-
-  const status = await getVectorMemoryStatus()
-  if (!status.chroma.ok) throw new Error(status.chroma.error || 'ChromaDB is unavailable')
-  if (!status.embeddings.ok) throw new Error(status.embeddings.error || 'Embedding service is unavailable')
-
-  const collection = teamKnowledgeCollection(status)
-  const embedding = await embedQuery(status.config, document)
-  const createdAt = new Date().toISOString()
-  const id = `dashboard-discovery-${crypto.randomUUID()}`
-  const metadata: Record<string, unknown> = {
-    kind: 'team_discovery',
-    source: options.source?.trim() || 'workspace-dashboard',
-    created_at: createdAt,
-    created_by: 'workspace-vector-memory',
-  }
-
-  await upsertDocument(status.config, collection, document, embedding, metadata, id)
-  return {
-    stored: {
-      id,
-      collection: collection.name,
-      document,
-      metadata,
-    },
-    status,
-  }
 }

--- a/src/server/vector-memory.ts
+++ b/src/server/vector-memory.ts
@@ -1,0 +1,482 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+export type VectorMemoryConfig = {
+  chromaBaseUrl: string
+  embeddingServiceUrl: string
+  embeddingModel: string
+  collections: Record<string, string>
+  dimension: number
+  configPath: string
+  fallbackEnabled: boolean
+}
+
+export type VectorCollectionStat = {
+  key: string
+  name: string
+  id: string | null
+  count: number | null
+  error?: string
+}
+
+export type VectorDependencyStatus = {
+  ok: boolean
+  url: string
+  error?: string
+}
+
+export type VectorMemoryStatus = {
+  ok: boolean
+  config: VectorMemoryConfig
+  chroma: VectorDependencyStatus
+  embeddings: VectorDependencyStatus
+  collections: Array<VectorCollectionStat>
+  totalRecords: number
+  warnings: Array<string>
+}
+
+export type VectorSearchResult = {
+  id: string
+  collection: string
+  document: string
+  metadata: Record<string, unknown>
+  distance: number | null
+  score: number | null
+}
+
+export class VectorMemoryInputError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'VectorMemoryInputError'
+  }
+}
+
+export type StoreTeamDiscoveryResult = {
+  id: string
+  collection: string
+  document: string
+  metadata: Record<string, unknown>
+}
+
+type ChromaCollection = {
+  id?: string
+  name?: string
+}
+
+type ChromaQueryPayload = {
+  ids?: Array<Array<string>>
+  documents?: Array<Array<string | null>>
+  metadatas?: Array<Array<Record<string, unknown> | null>>
+  distances?: Array<Array<number | null>>
+}
+
+const DEFAULT_COLLECTIONS: Record<string, string> = {
+  memories: 'agent_memories',
+  sessions: 'session_history',
+  team_knowledge: 'team_knowledge',
+  team_ops: 'team_ops',
+  agent_rilo: 'agent_rilo',
+  agent_caddie: 'agent_caddie',
+  agent_scout: 'agent_scout',
+}
+
+function hermesHome(): string {
+  const envHome = (process.env.HERMES_HOME || process.env.CLAUDE_HOME)?.trim()
+  return path.resolve(envHome || path.join(os.homedir(), '.hermes'))
+}
+
+function cleanBaseUrl(host: string, port: number): string {
+  if (/^https?:\/\//i.test(host)) return host.replace(/\/$/, '')
+  return `http://${host}:${port}`
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | null {
+  if (!fs.existsSync(filePath)) return null
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function readCollections(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ...DEFAULT_COLLECTIONS }
+  }
+  const parsed: Record<string, string> = {}
+  for (const [key, name] of Object.entries(value)) {
+    if (typeof name === 'string' && name.trim()) parsed[key] = name.trim()
+  }
+  return Object.keys(parsed).length > 0 ? parsed : { ...DEFAULT_COLLECTIONS }
+}
+
+export function readVectorMemoryConfig(): VectorMemoryConfig {
+  const home = hermesHome()
+  const configPath = path.resolve(home, 'chromadb.json')
+  const raw = readJsonFile(configPath) || {}
+  const host = readString(raw.chromadb_host, '127.0.0.1')
+  const port = readNumber(raw.chromadb_port, 8000)
+  const embeddingServiceUrl = readString(
+    raw.embedding_service_url,
+    'http://127.0.0.1:8006',
+  ).replace(/\/$/, '')
+  const embeddingModel = readString(
+    raw.embedding_model,
+    'Qwen/Qwen3-Embedding-0.6B',
+  )
+
+  return {
+    chromaBaseUrl: cleanBaseUrl(host, port),
+    embeddingServiceUrl,
+    embeddingModel,
+    collections: readCollections(raw.collections),
+    dimension: 1024,
+    configPath,
+    fallbackEnabled: readBoolean(raw.embedding_fallback_enabled, false),
+  }
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal })
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`.trim())
+    }
+    return (await response.json()) as T
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function checkJsonEndpoint(url: string): Promise<VectorDependencyStatus> {
+  try {
+    await fetchJson<unknown>(url)
+    return { ok: true, url }
+  } catch (error) {
+    return {
+      ok: false,
+      url,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function v2CollectionsUrl(config: VectorMemoryConfig): string {
+  return `${config.chromaBaseUrl}/api/v2/tenants/default_tenant/databases/default_database/collections`
+}
+
+function legacyCollectionsUrl(config: VectorMemoryConfig): string {
+  return `${config.chromaBaseUrl}/api/v1/collections`
+}
+
+async function listChromaCollections(
+  config: VectorMemoryConfig,
+): Promise<Array<ChromaCollection>> {
+  try {
+    return await fetchJson<Array<ChromaCollection>>(v2CollectionsUrl(config))
+  } catch {
+    return fetchJson<Array<ChromaCollection>>(legacyCollectionsUrl(config))
+  }
+}
+
+function collectionIdForName(
+  collections: Array<ChromaCollection>,
+  name: string,
+): string | null {
+  const found = collections.find((collection) => collection.name === name)
+  return found?.id || found?.name || null
+}
+
+function parseCollectionCount(payload: unknown): number {
+  if (typeof payload === 'number' && Number.isFinite(payload)) return payload
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    typeof (payload as { count?: unknown }).count === 'number'
+  ) {
+    return (payload as { count: number }).count
+  }
+  return 0
+}
+
+async function countCollection(
+  config: VectorMemoryConfig,
+  idOrName: string,
+): Promise<number> {
+  try {
+    const payload = await fetchJson<unknown>(
+      `${v2CollectionsUrl(config)}/${encodeURIComponent(idOrName)}/count`,
+    )
+    return parseCollectionCount(payload)
+  } catch {
+    const payload = await fetchJson<unknown>(
+      `${legacyCollectionsUrl(config)}/${encodeURIComponent(idOrName)}/count`,
+    )
+    return parseCollectionCount(payload)
+  }
+}
+
+export async function getVectorMemoryStatus(): Promise<VectorMemoryStatus> {
+  const config = readVectorMemoryConfig()
+  const chroma = await checkJsonEndpoint(`${config.chromaBaseUrl}/api/v2/heartbeat`)
+  const embeddings = await checkJsonEndpoint(`${config.embeddingServiceUrl}/health`)
+  const warnings: Array<string> = []
+  if (!config.embeddingModel.toLowerCase().includes('qwen3-embedding-0.6b')) {
+    warnings.push(
+      'Embedding model is not Qwen3-Embedding-0.6B; verify vector-space compatibility before writes.',
+    )
+  }
+  if (config.dimension !== 1024) {
+    warnings.push('Expected 1024-dimensional embeddings for current Hermes Chroma collections.')
+  }
+
+  const stats: Array<VectorCollectionStat> = []
+  if (chroma.ok) {
+    try {
+      const chromaCollections = await listChromaCollections(config)
+      for (const [key, name] of Object.entries(config.collections)) {
+        const id = collectionIdForName(chromaCollections, name)
+        if (!id) {
+          stats.push({ key, name, id: null, count: null, error: 'Collection not found' })
+          continue
+        }
+        try {
+          stats.push({ key, name, id, count: await countCollection(config, id) })
+        } catch (error) {
+          stats.push({
+            key,
+            name,
+            id,
+            count: null,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    } catch (error) {
+      warnings.push(
+        `Unable to list Chroma collections: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  const totalRecords = stats.reduce((total, stat) => total + (stat.count || 0), 0)
+  return {
+    ok: chroma.ok && embeddings.ok,
+    config,
+    chroma,
+    embeddings,
+    collections: stats,
+    totalRecords,
+    warnings,
+  }
+}
+
+async function embedQuery(config: VectorMemoryConfig, query: string): Promise<Array<number>> {
+  const payload = await fetchJson<{
+    embedding?: Array<number>
+    embeddings?: Array<Array<number>>
+    data?: Array<{ embedding?: Array<number> }>
+  }>(`${config.embeddingServiceUrl}/embed-single`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: query }),
+  })
+  const embedding = payload.embedding || payload.embeddings?.[0] || payload.data?.[0]?.embedding
+  if (!Array.isArray(embedding)) {
+    throw new Error('Embedding service did not return an embedding vector')
+  }
+  return embedding
+}
+
+export function normalizeVectorSearchResults(
+  collection: string,
+  payload: ChromaQueryPayload,
+): Array<VectorSearchResult> {
+  const ids = payload.ids?.[0] || []
+  const documents = payload.documents?.[0] || []
+  const metadatas = payload.metadatas?.[0] || []
+  const distances = payload.distances?.[0] || []
+  return ids.map((id, index) => {
+    const distance = typeof distances[index] === 'number' ? distances[index] : null
+    const score = distance == null ? null : 1 / (1 + Math.max(0, distance))
+    return {
+      id,
+      collection,
+      document: documents[index] || '',
+      metadata: metadatas[index] || {},
+      distance,
+      score,
+    }
+  })
+}
+
+async function queryCollection(
+  config: VectorMemoryConfig,
+  collection: VectorCollectionStat,
+  embedding: Array<number>,
+  limit: number,
+): Promise<Array<VectorSearchResult>> {
+  const idOrName = collection.id || collection.name
+  const body = JSON.stringify({
+    query_embeddings: [embedding],
+    n_results: limit,
+    include: ['documents', 'metadatas', 'distances'],
+  })
+  try {
+    const payload = await fetchJson<ChromaQueryPayload>(
+      `${v2CollectionsUrl(config)}/${encodeURIComponent(idOrName)}/query`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+    )
+    return normalizeVectorSearchResults(collection.name, payload)
+  } catch {
+    const payload = await fetchJson<ChromaQueryPayload>(
+      `${legacyCollectionsUrl(config)}/${encodeURIComponent(idOrName)}/query`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+    )
+    return normalizeVectorSearchResults(collection.name, payload)
+  }
+}
+
+export async function searchVectorMemory(options: {
+  query: string
+  collection?: string
+  limit?: number
+}): Promise<{ results: Array<VectorSearchResult>; status: VectorMemoryStatus }> {
+  const query = options.query.trim()
+  if (!query) throw new VectorMemoryInputError('Query is required')
+  if (query.length > 1000) {
+    throw new VectorMemoryInputError('Query must be 1000 characters or fewer')
+  }
+  const rawLimit = options.limit ?? 8
+  if (!Number.isFinite(rawLimit) || !Number.isInteger(rawLimit)) {
+    throw new VectorMemoryInputError('Limit must be an integer')
+  }
+  const limit = Math.max(1, Math.min(rawLimit, 25))
+  const status = await getVectorMemoryStatus()
+  if (!status.chroma.ok) throw new Error(status.chroma.error || 'ChromaDB is unavailable')
+  if (!status.embeddings.ok) throw new Error(status.embeddings.error || 'Embedding service is unavailable')
+
+  if (
+    options.collection &&
+    options.collection !== 'all' &&
+    !status.collections.some(
+      (collection) =>
+        collection.name === options.collection || collection.key === options.collection,
+    )
+  ) {
+    throw new VectorMemoryInputError(`Unknown collection: ${options.collection}`)
+  }
+
+  const selected = status.collections.filter((collection) => {
+    if (!collection.id || collection.error) return false
+    if (!options.collection || options.collection === 'all') return true
+    return collection.name === options.collection || collection.key === options.collection
+  })
+  if (selected.length === 0) {
+    throw new VectorMemoryInputError('No available Chroma collections match the request')
+  }
+  const embedding = await embedQuery(status.config, query)
+  const perCollectionLimit = options.collection && options.collection !== 'all' ? limit : Math.min(limit, 5)
+  const batches = await Promise.allSettled(
+    selected.map((collection) => queryCollection(status.config, collection, embedding, perCollectionLimit)),
+  )
+  const failures = batches.filter((batch) => batch.status === 'rejected')
+  if (failures.length === batches.length) {
+    const reason = failures[0].reason
+    throw new Error(
+      reason instanceof Error
+        ? reason.message
+        : 'All Chroma collection queries failed',
+    )
+  }
+  const results = batches.flatMap((batch) => (batch.status === 'fulfilled' ? batch.value : []))
+  results.sort((a, b) => (b.score ?? -1) - (a.score ?? -1))
+  return { results: results.slice(0, limit), status }
+}
+
+function teamKnowledgeCollection(status: VectorMemoryStatus): VectorCollectionStat {
+  const configuredName = status.config.collections.team_knowledge || 'team_knowledge'
+  const collection = status.collections.find(
+    (item) => item.key === 'team_knowledge' || item.name === configuredName,
+  )
+  if (collection) return collection
+  return { key: 'team_knowledge', name: configuredName, id: configuredName, count: null }
+}
+
+async function upsertDocument(
+  config: VectorMemoryConfig,
+  collection: VectorCollectionStat,
+  document: string,
+  embedding: Array<number>,
+  metadata: Record<string, unknown>,
+  id: string,
+): Promise<void> {
+  const idOrName = collection.id || collection.name
+  const body = JSON.stringify({
+    ids: [id],
+    embeddings: [embedding],
+    documents: [document],
+    metadatas: [metadata],
+  })
+  try {
+    await fetchJson<unknown>(
+      `${v2CollectionsUrl(config)}/${encodeURIComponent(idOrName)}/upsert`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+    )
+  } catch {
+    await fetchJson<unknown>(
+      `${legacyCollectionsUrl(config)}/${encodeURIComponent(idOrName)}/upsert`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+    )
+  }
+}
+
+export async function storeTeamDiscovery(options: {
+  content: string
+  source?: string
+}): Promise<{ stored: StoreTeamDiscoveryResult; status: VectorMemoryStatus }> {
+  const document = options.content.trim()
+  if (!document) throw new VectorMemoryInputError('Discovery content is required')
+  if (document.length > 4000) {
+    throw new VectorMemoryInputError('Discovery content must be 4000 characters or fewer')
+  }
+
+  const status = await getVectorMemoryStatus()
+  if (!status.chroma.ok) throw new Error(status.chroma.error || 'ChromaDB is unavailable')
+  if (!status.embeddings.ok) throw new Error(status.embeddings.error || 'Embedding service is unavailable')
+
+  const collection = teamKnowledgeCollection(status)
+  const embedding = await embedQuery(status.config, document)
+  const createdAt = new Date().toISOString()
+  const id = `dashboard-discovery-${crypto.randomUUID()}`
+  const metadata: Record<string, unknown> = {
+    kind: 'team_discovery',
+    source: options.source?.trim() || 'workspace-dashboard',
+    created_at: createdAt,
+    created_by: 'workspace-vector-memory',
+  }
+
+  await upsertDocument(status.config, collection, document, embedding, metadata, id)
+  return {
+    stored: {
+      id,
+      collection: collection.name,
+      document,
+      metadata,
+    },
+    status,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Phase 1 read-only agent registry spine sourced from `swarm.yaml`.
- Adds authenticated GET/HEAD-only `/api/agent-registry` payload with normalized entries, backend metadata, diagnostics, timestamps, and parser versioning.
- Integrates read-only registry metadata into Swarm2 while preventing registry-only rows from gaining operational controls.
- Removes the old mutating Add Swarm roster UI surface from Swarm2.
- Hardens diagnostics so invalid IDs, secret-like values, token-family strings, raw YAML parser snippets, and semantic credential keys are not echoed.

## Safety / Scope
- No deploy/restart/dispatch controls added.
- No Atlas mutation.
- No profile/provider writes.
- `/api/agent-registry` registers only GET and HEAD.
- Registry-only source-derived workers display only in the read-only panel; they do not become operational worker cards.

## Verification
- `pnpm vitest run src/server/agent-registry.test.ts src/routes/api/-agent-registry.test.ts src/screens/swarm2/agent-registry-panel.test.ts src/screens/swarm2/swarm2-screen.test.ts --reporter=verbose` — PASS, 29 tests.
- `pnpm build` — PASS.
- `git diff --check` — PASS.

## Independent Review Gate
- Codex GPT-5.5: APPROVE, no findings.
- Claude Max: APPROVE, no findings.
- Final bundle sha256: `435d5bc107ac0740c16d9c73f4efd86a06621be66e2b20044e8961440af6a2a9`.
- Custody artifacts: `/Users/jeremiah/hermes-workspace/.hermes/artifacts/hw-phase1-postimpl-review-20260511/`.