### PR TITLE
Document ways to obtain HERMES_DASHBOARD_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,9 @@
 #
 # Preferred over the legacy HTML-scrape token flow. Set this to a dashboard
 # bearer and the workspace uses it directly for dashboard API calls (see #124).
+#
+# To obtain your dashboard token, visit your dashboard in a browser and inspect the source code or use:  
+# curl -s <HERMES_DASHBOARD_URL> | grep -oP 'window\.__HERMES_SESSION_TOKEN__\s*=\s*["'\'']\K[^"'\'';]+'
 # HERMES_DASHBOARD_TOKEN=
 
 # Bypass fail-closed startup guard (NOT recommended)


### PR DESCRIPTION
**Why?**
At some point, setting this variable will become required and obtaining it is not currently documented.

**How?**
A valid session token can be obtained right from the source code of your dashboard, so we document a simple `curl` command to extract it directly inside of the `.env` file where it needs to be set.