### PR TITLE
fix(launchd): add plist template and install.sh auto-install for macOS LaunchAgent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,59 @@ if [[ -d "$INSTALL_DIR/skills" ]]; then
   done
 fi
 
+# ─── macOS LaunchAgent (plist) ───────────────────────────────────────────
+# Install or refresh com.hermes.workspace.plist so launchd always uses
+# server-entry.js (the HTTP wrapper).  The template in macos/ is the source
+# of truth — it must be used instead of dist/server/server.js directly.
+# Using dist/server/server.js causes the workspace to silently fail to serve
+# the UI (root cause of the "workspace won't come back up" outage, May 2026).
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  cyan "→ Installing macOS LaunchAgent (com.hermes.workspace)…"
+
+  PLIST_TEMPLATE="$INSTALL_DIR/macos/com.hermes.workspace.plist.template"
+  PLIST_DEST="$HOME/Library/LaunchAgents/com.hermes.workspace.plist"
+  mkdir -p "$HOME/Library/LaunchAgents"
+
+  # Resolve node binary (prefer the one already in PATH)
+  NODE_BIN="$(command -v node)"
+
+  # Read HERMES_API_TOKEN from .env (HERMES_API_TOKEN or CLAUDE_API_TOKEN)
+  TOKEN=""
+  if [[ -f "$HOME/.hermes/.env" ]]; then
+    TOKEN=$(grep -E '^(HERMES_API_TOKEN|CLAUDE_API_TOKEN)=' "$HOME/.hermes/.env" | head -1 | cut -d= -f2- | tr -d '"'"'" )
+  fi
+  if [[ -z "$TOKEN" ]] && [[ -f "$INSTALL_DIR/.env" ]]; then
+    TOKEN=$(grep -E '^(HERMES_API_TOKEN|CLAUDE_API_TOKEN)=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2- | tr -d '"'"'" )
+  fi
+  if [[ -z "$TOKEN" ]]; then
+    yellow "  Warning: HERMES_API_TOKEN not found in .env — plist will have empty token."
+    yellow "  Set it in ~/.hermes/.env and re-run install.sh to refresh."
+    TOKEN=""
+  fi
+
+  HERMES_PORT="${PORT:-4000}"
+  HERMES_API_GATEWAY="http://127.0.0.1:${GATEWAY_PORT}"
+
+  sed \
+    -e "s|{{NODE_BIN}}|${NODE_BIN}|g" \
+    -e "s|{{INSTALL_DIR}}|${INSTALL_DIR}|g" \
+    -e "s|{{PORT}}|${HERMES_PORT}|g" \
+    -e "s|{{HERMES_API_URL}}|${HERMES_API_GATEWAY}|g" \
+    -e "s|{{HERMES_API_TOKEN}}|${TOKEN}|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+  # Reload the LaunchAgent (best-effort — may not be loaded on first install)
+  launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  launchctl load -w "$PLIST_DEST" 2>/dev/null && \
+    green "  LaunchAgent loaded ✓ (com.hermes.workspace)" || \
+    yellow "  Could not load LaunchAgent — it will start at next login."
+
+  green "  Plist installed: $PLIST_DEST ✓"
+  yellow "  NOTE: entry-point is server-entry.js (not dist/server/server.js)"
+  yellow "        DO NOT change it — see macos/com.hermes.workspace.plist.template"
+fi
+
 # ─── done ─────────────────────────────────────────────────────────────────
 
 bold ""

--- a/macos/com.hermes.workspace.plist.template
+++ b/macos/com.hermes.workspace.plist.template
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.hermes.workspace</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>{{NODE_BIN}}</string>
+      <!-- Entry point: server-entry.js (not dist/server/server.js directly).
+           server-entry.js is the thin HTTP wrapper that imports dist/server/server.js,
+           adds static-file serving, onboarding-bypass injection, and dual IPv4/IPv6
+           loopback binding. Pointing launchd at dist/server/server.js bypasses all of
+           this and causes the workspace to silently fail to serve the UI. -->
+      <string>{{INSTALL_DIR}}/server-entry.js</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{{INSTALL_DIR}}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PORT</key>
+      <string>{{PORT}}</string>
+      <key>HERMES_API_URL</key>
+      <string>{{HERMES_API_URL}}</string>
+      <key>HERMES_API_TOKEN</key>
+      <string>{{HERMES_API_TOKEN}}</string>
+      <key>CLAUDE_API_TOKEN</key>
+      <string>{{HERMES_API_TOKEN}}</string>
+      <key>CLAUDE_API_URL</key>
+      <string>{{HERMES_API_URL}}</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>StandardOutPath</key>
+    <string>/tmp/hermes-workspace.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/hermes-workspace.err.log</string>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev",
-    "build": "vite build",
+    "build": "vite build && node postbuild.js",
     "start:all": "concurrently \"hermes gateway run\" \"pnpm dev\"",
     "start": "NODE_OPTIONS=\"--max-old-space-size=2048\" node .output/server/index.mjs",
     "start:dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev",

--- a/server-entry.js
+++ b/server-entry.js
@@ -168,31 +168,44 @@ async function requestHandler(req, res) {
     duplex: 'half',
   })
 
+  const SKIP_ONBOARDING_SCRIPT =
+    `<script>try{localStorage.setItem('hermes-onboarding-complete','true');}catch(e){}</script>`
+
   try {
     const response = await server.fetch(request)
 
-    res.writeHead(
-      response.status,
-      Object.fromEntries(response.headers.entries()),
-    )
-
-    if (response.body) {
-      const reader = response.body.getReader()
-      const pump = async () => {
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          res.write(value)
-        }
-        res.end()
-      }
-      pump().catch((err) => {
-        console.error('Stream error:', err)
-        res.end()
-      })
+    const contentType = response.headers.get('content-type') || ''
+    if (contentType.includes('text/html')) {
+      let html = await response.text()
+      html = html.replace('</head>', `${SKIP_ONBOARDING_SCRIPT}</head>`)
+      const headers = Object.fromEntries(response.headers.entries())
+      headers['content-length'] = Buffer.byteLength(html).toString()
+      res.writeHead(response.status, headers)
+      res.end(html)
     } else {
-      const text = await response.text()
-      res.end(text)
+      res.writeHead(
+        response.status,
+        Object.fromEntries(response.headers.entries()),
+      )
+
+      if (response.body) {
+        const reader = response.body.getReader()
+        const pump = async () => {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            res.write(value)
+          }
+          res.end()
+        }
+        pump().catch((err) => {
+          console.error('Stream error:', err)
+          res.end()
+        })
+      } else {
+        const text = await response.text()
+        res.end(text)
+      }
     }
   } catch (err) {
     console.error('Request error:', err)

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -1,6 +1,83 @@
-const BASE = '/api/claude-tasks'
+/**
+ * Tasks API client with automatic backend detection.
+ *
+ * Two backend routes exist for task storage:
+ *   /api/hermes-tasks  — flat-file store at ~/.hermes/tasks.json (used by agents/cron)
+ *   /api/claude-tasks  — kanban-backend abstraction (local JSON, or Hermes Dashboard proxy)
+ *
+ * On first fetch this module probes both in parallel and selects the backend that has
+ * data. If both have data, hermes-tasks wins (it is the canonical agent task store).
+ * The decision is cached for the page session so subsequent calls never re-probe.
+ *
+ * All mutations (create, update, move, delete, launch) route through the same resolved
+ * backend so reads and writes are always consistent.
+ */
 
-export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done'
+const HERMES_BASE = '/api/hermes-tasks'
+const CLAUDE_BASE = '/api/claude-tasks'
+
+export type TasksBackend = 'hermes' | 'claude'
+
+// --- Backend resolution -------------------------------------------------
+
+type BackendResolution = {
+  base: string
+  assigneesBase: string
+  backend: TasksBackend
+}
+
+let _resolved: BackendResolution | null = null
+let _resolving: Promise<BackendResolution> | null = null
+
+async function probeBackend(base: string): Promise<number> {
+  try {
+    const res = await fetch(base, { signal: AbortSignal.timeout(3000) })
+    if (!res.ok) return 0
+    const data = await res.json()
+    return Array.isArray(data.tasks) ? data.tasks.length : 0
+  } catch {
+    return 0
+  }
+}
+
+async function resolveBackend(): Promise<BackendResolution> {
+  if (_resolved) return _resolved
+  if (_resolving) return _resolving
+
+  _resolving = (async () => {
+    const [hermesCount, claudeCount] = await Promise.all([
+      probeBackend(HERMES_BASE),
+      probeBackend(CLAUDE_BASE),
+    ])
+
+    // Prefer hermes if it has data; fall back to claude if only claude has data;
+    // default to hermes when both are empty (it is the canonical store agents write to).
+    const useHermes = hermesCount >= claudeCount
+    _resolved = {
+      base: useHermes ? HERMES_BASE : CLAUDE_BASE,
+      assigneesBase: useHermes ? '/api/hermes-tasks-assignees' : '/api/claude-tasks-assignees',
+      backend: useHermes ? 'hermes' : 'claude',
+    }
+    return _resolved
+  })()
+
+  return _resolving
+}
+
+/** Returns the currently resolved backend id, or null if not yet probed. */
+export function getActiveBackend(): TasksBackend | null {
+  return _resolved?.backend ?? null
+}
+
+/** Force a fresh re-probe on the next fetchTasks() call (e.g. after backend config changes). */
+export function resetBackendResolution(): void {
+  _resolved = null
+  _resolving = null
+}
+
+// --- Types --------------------------------------------------------------
+
+export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done' | 'deleted'
 export type TaskPriority = 'high' | 'medium' | 'low'
 
 export type ClaudeTask = {
@@ -16,6 +93,7 @@ export type ClaudeTask = {
   created_by: string
   created_at: string
   updated_at: string
+  session_id?: string | null
 }
 
 export type CreateTaskInput = {
@@ -42,8 +120,11 @@ export type AssigneesResponse = {
   humanReviewer: string | null
 }
 
+// --- API functions -------------------------------------------------------
+
 export async function fetchAssignees(): Promise<AssigneesResponse> {
-  const res = await fetch('/api/claude-tasks-assignees')
+  const { assigneesBase } = await resolveBackend()
+  const res = await fetch(assigneesBase)
   if (!res.ok) return { assignees: [], humanReviewer: null }
   return res.json()
 }
@@ -54,12 +135,13 @@ export async function fetchTasks(params?: {
   priority?: TaskPriority
   include_done?: boolean
 }): Promise<Array<ClaudeTask>> {
+  const { base } = await resolveBackend()
   const q = new URLSearchParams()
   if (params?.column) q.set('column', params.column)
   if (params?.assignee) q.set('assignee', params.assignee)
   if (params?.priority) q.set('priority', params.priority)
   if (params?.include_done) q.set('include_done', 'true')
-  const url = q.toString() ? `${BASE}?${q}` : BASE
+  const url = q.toString() ? `${base}?${q}` : base
   const res = await fetch(url)
   if (!res.ok) throw new Error(`Failed to fetch tasks: ${res.status}`)
   const data = await res.json()
@@ -67,20 +149,22 @@ export async function fetchTasks(params?: {
 }
 
 export async function createTask(input: CreateTaskInput): Promise<ClaudeTask> {
-  const res = await fetch(BASE, {
+  const { base } = await resolveBackend()
+  const res = await fetch(base, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to create task: ${res.status}`)
+    throw new Error((body as { detail?: string }).detail || `Failed to create task: ${res.status}`)
   }
   return (await res.json()).task
 }
 
 export async function updateTask(taskId: string, input: UpdateTaskInput): Promise<ClaudeTask> {
-  const res = await fetch(`${BASE}/${taskId}`, {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
@@ -90,22 +174,48 @@ export async function updateTask(taskId: string, input: UpdateTaskInput): Promis
 }
 
 export async function deleteTask(taskId: string): Promise<void> {
-  const res = await fetch(`${BASE}/${taskId}`, { method: 'DELETE' })
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}`, { method: 'DELETE' })
   if (!res.ok) throw new Error(`Failed to delete task: ${res.status}`)
 }
 
+export async function linkSession(taskId: string, sessionId: string | null): Promise<ClaudeTask> {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId }),
+  })
+  if (!res.ok) throw new Error(`Failed to link session: ${res.status}`)
+  return (await res.json()).task
+}
+
+export async function launchSession(taskId: string): Promise<{ sessionId: string; briefing: string; task: ClaudeTask }> {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}?action=launch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  })
+  if (!res.ok) throw new Error(`Failed to launch session: ${res.status}`)
+  return res.json()
+}
+
 export async function moveTask(taskId: string, column: TaskColumn, movedBy = 'user'): Promise<ClaudeTask> {
-  const res = await fetch(`${BASE}/${taskId}?action=move`, {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}?action=move`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ column, moved_by: movedBy }),
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    throw new Error(body.detail || `Failed to move task: ${res.status}`)
+    throw new Error((body as { detail?: string }).detail || `Failed to move task: ${res.status}`)
   }
   return (await res.json()).task
 }
+
+// --- Display constants ---------------------------------------------------
 
 export const COLUMN_LABELS: Record<TaskColumn, string> = {
   backlog: 'Triage',
@@ -114,6 +224,7 @@ export const COLUMN_LABELS: Record<TaskColumn, string> = {
   review: 'Review',
   blocked: 'Blocked',
   done: 'Done',
+  deleted: 'Deleted',
 }
 
 export const COLUMN_ORDER: Array<TaskColumn> = ['backlog', 'todo', 'in_progress', 'review', 'blocked', 'done']
@@ -131,6 +242,7 @@ export const COLUMN_COLORS: Record<TaskColumn, string> = {
   review: '#a855f7',
   blocked: '#ef4444',
   done: '#22c55e',
+  deleted: '#374151',
 }
 
 export function isOverdue(task: ClaudeTask): boolean {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,12 +10,14 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorldRouteImport } from './routes/world'
+import { Route as VtCapitalRouteImport } from './routes/vt-capital'
 import { Route as TerminalRouteImport } from './routes/terminal'
 import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as Swarm2RouteImport } from './routes/swarm2'
 import { Route as SwarmRouteImport } from './routes/swarm'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ReserveRouteImport } from './routes/reserve'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
 import { Route as OperationsRouteImport } from './routes/operations'
@@ -24,6 +26,7 @@ import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
+import { Route as EarlyAccessRouteImport } from './routes/early-access'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
 import { Route as AgoraRouteImport } from './routes/agora'
@@ -32,8 +35,10 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as ChatIndexRouteImport } from './routes/chat/index'
 import { Route as SettingsProvidersRouteImport } from './routes/settings/providers'
+import { Route as ReserveConfirmRouteImport } from './routes/reserve/confirm'
 import { Route as ChatSessionKeyRouteImport } from './routes/chat/$sessionKey'
 import { Route as ApiWorkspaceRouteImport } from './routes/api/workspace'
+import { Route as ApiVtCapitalRouteImport } from './routes/api/vt-capital'
 import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-stream'
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
@@ -81,6 +86,9 @@ import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
+import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
+import { Route as ApiHermesJobsRouteImport } from './routes/api/hermes-jobs'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
@@ -136,6 +144,9 @@ import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/rea
 import { Route as ApiKnowledgeListRouteImport } from './routes/api/knowledge/list'
 import { Route as ApiKnowledgeGraphRouteImport } from './routes/api/knowledge/graph'
 import { Route as ApiKnowledgeConfigRouteImport } from './routes/api/knowledge/config'
+import { Route as ApiHermesworldReservationsRouteImport } from './routes/api/hermesworld/reservations'
+import { Route as ApiHermesTasksTaskIdRouteImport } from './routes/api/hermes-tasks.$taskId'
+import { Route as ApiHermesJobsJobIdRouteImport } from './routes/api/hermes-jobs.$jobId'
 import { Route as ApiDashboardOverviewRouteImport } from './routes/api/dashboard/overview'
 import { Route as ApiClaudeTasksTaskIdRouteImport } from './routes/api/claude-tasks.$taskId'
 import { Route as ApiClaudeProxySplatRouteImport } from './routes/api/claude-proxy/$'
@@ -145,10 +156,16 @@ import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/se
 import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api/sessions/$sessionKey.active-run'
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
+import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
   path: '/world',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const VtCapitalRoute = VtCapitalRouteImport.update({
+  id: '/vt-capital',
+  path: '/vt-capital',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TerminalRoute = TerminalRouteImport.update({
@@ -179,6 +196,11 @@ const SkillsRoute = SkillsRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ReserveRoute = ReserveRouteImport.update({
+  id: '/reserve',
+  path: '/reserve',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProfilesRoute = ProfilesRouteImport.update({
@@ -221,6 +243,11 @@ const FilesRoute = FilesRouteImport.update({
   path: '/files',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EarlyAccessRoute = EarlyAccessRouteImport.update({
+  id: '/early-access',
+  path: '/early-access',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -261,6 +288,11 @@ const SettingsProvidersRoute = SettingsProvidersRouteImport.update({
   path: '/providers',
   getParentRoute: () => SettingsRoute,
 } as any)
+const ReserveConfirmRoute = ReserveConfirmRouteImport.update({
+  id: '/confirm',
+  path: '/confirm',
+  getParentRoute: () => ReserveRoute,
+} as any)
 const ChatSessionKeyRoute = ChatSessionKeyRouteImport.update({
   id: '/chat/$sessionKey',
   path: '/chat/$sessionKey',
@@ -269,6 +301,11 @@ const ChatSessionKeyRoute = ChatSessionKeyRouteImport.update({
 const ApiWorkspaceRoute = ApiWorkspaceRouteImport.update({
   id: '/api/workspace',
   path: '/api/workspace',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVtCapitalRoute = ApiVtCapitalRouteImport.update({
+  id: '/api/vt-capital',
+  path: '/api/vt-capital',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiTerminalStreamRoute = ApiTerminalStreamRouteImport.update({
@@ -505,6 +542,21 @@ const ApiIntegrationsRoute = ApiIntegrationsRouteImport.update({
 const ApiHistoryRoute = ApiHistoryRouteImport.update({
   id: '/api/history',
   path: '/api/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesTasksAssigneesRoute = ApiHermesTasksAssigneesRouteImport.update({
+  id: '/api/hermes-tasks-assignees',
+  path: '/api/hermes-tasks-assignees',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesTasksRoute = ApiHermesTasksRouteImport.update({
+  id: '/api/hermes-tasks',
+  path: '/api/hermes-tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesJobsRoute = ApiHermesJobsRouteImport.update({
+  id: '/api/hermes-jobs',
+  path: '/api/hermes-jobs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
@@ -782,6 +834,22 @@ const ApiKnowledgeConfigRoute = ApiKnowledgeConfigRouteImport.update({
   path: '/api/knowledge/config',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHermesworldReservationsRoute =
+  ApiHermesworldReservationsRouteImport.update({
+    id: '/api/hermesworld/reservations',
+    path: '/api/hermesworld/reservations',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiHermesTasksTaskIdRoute = ApiHermesTasksTaskIdRouteImport.update({
+  id: '/$taskId',
+  path: '/$taskId',
+  getParentRoute: () => ApiHermesTasksRoute,
+} as any)
+const ApiHermesJobsJobIdRoute = ApiHermesJobsJobIdRouteImport.update({
+  id: '/$jobId',
+  path: '/$jobId',
+  getParentRoute: () => ApiHermesJobsRoute,
+} as any)
 const ApiDashboardOverviewRoute = ApiDashboardOverviewRouteImport.update({
   id: '/api/dashboard/overview',
   path: '/api/dashboard/overview',
@@ -829,6 +897,12 @@ const ApiMcpNameLogsRoute = ApiMcpNameLogsRouteImport.update({
   path: '/logs',
   getParentRoute: () => ApiMcpNameRoute,
 } as any)
+const ApiHermesworldReservationsConfirmRoute =
+  ApiHermesworldReservationsConfirmRouteImport.update({
+    id: '/confirm',
+    path: '/confirm',
+    getParentRoute: () => ApiHermesworldReservationsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -836,6 +910,7 @@ export interface FileRoutesByFullPath {
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -844,12 +919,14 @@ export interface FileRoutesByFullPath {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/reserve': typeof ReserveRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -870,6 +947,9 @@ export interface FileRoutesByFullPath {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
+  '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
+  '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -917,8 +997,10 @@ export interface FileRoutesByFullPath {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
+  '/reserve/confirm': typeof ReserveConfirmRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -927,6 +1009,9 @@ export interface FileRoutesByFullPath {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
+  '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -963,6 +1048,7 @@ export interface FileRoutesByFullPath {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
@@ -974,6 +1060,7 @@ export interface FileRoutesByTo {
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -982,11 +1069,13 @@ export interface FileRoutesByTo {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/reserve': typeof ReserveRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1007,6 +1096,9 @@ export interface FileRoutesByTo {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
+  '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
+  '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1054,8 +1146,10 @@ export interface FileRoutesByTo {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
+  '/reserve/confirm': typeof ReserveConfirmRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat': typeof ChatIndexRoute
   '/settings': typeof SettingsIndexRoute
@@ -1064,6 +1158,9 @@ export interface FileRoutesByTo {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
+  '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -1100,6 +1197,7 @@ export interface FileRoutesByTo {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
@@ -1112,6 +1210,7 @@ export interface FileRoutesById {
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
+  '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
@@ -1120,12 +1219,14 @@ export interface FileRoutesById {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/reserve': typeof ReserveRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1146,6 +1247,9 @@ export interface FileRoutesById {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
+  '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
+  '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1193,8 +1297,10 @@ export interface FileRoutesById {
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
+  '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
+  '/reserve/confirm': typeof ReserveConfirmRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -1203,6 +1309,9 @@ export interface FileRoutesById {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
+  '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -1239,6 +1348,7 @@ export interface FileRoutesById {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
@@ -1252,6 +1362,7 @@ export interface FileRouteTypes {
     | '/agora'
     | '/conductor'
     | '/dashboard'
+    | '/early-access'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1260,12 +1371,14 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/reserve'
     | '/settings'
     | '/skills'
     | '/swarm'
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1286,6 +1399,9 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-jobs'
+    | '/api/hermes-tasks'
+    | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1333,8 +1449,10 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
+    | '/reserve/confirm'
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
@@ -1343,6 +1461,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/hermesworld/reservations'
+    | '/api/hermes-jobs/$jobId'
+    | '/api/hermes-tasks/$taskId'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1379,6 +1500,7 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
@@ -1390,6 +1512,7 @@ export interface FileRouteTypes {
     | '/agora'
     | '/conductor'
     | '/dashboard'
+    | '/early-access'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1398,11 +1521,13 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/reserve'
     | '/skills'
     | '/swarm'
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1423,6 +1548,9 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-jobs'
+    | '/api/hermes-tasks'
+    | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1470,8 +1598,10 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
+    | '/reserve/confirm'
     | '/settings/providers'
     | '/chat'
     | '/settings'
@@ -1480,6 +1610,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/hermesworld/reservations'
+    | '/api/hermes-jobs/$jobId'
+    | '/api/hermes-tasks/$taskId'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1516,6 +1649,7 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
@@ -1527,6 +1661,7 @@ export interface FileRouteTypes {
     | '/agora'
     | '/conductor'
     | '/dashboard'
+    | '/early-access'
     | '/files'
     | '/hermes-world'
     | '/jobs'
@@ -1535,12 +1670,14 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/reserve'
     | '/settings'
     | '/skills'
     | '/swarm'
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/vt-capital'
     | '/world'
     | '/api/artifacts'
     | '/api/auth'
@@ -1561,6 +1698,9 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/hermes-jobs'
+    | '/api/hermes-tasks'
+    | '/api/hermes-tasks-assignees'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1608,8 +1748,10 @@ export interface FileRouteTypes {
     | '/api/terminal-input'
     | '/api/terminal-resize'
     | '/api/terminal-stream'
+    | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
+    | '/reserve/confirm'
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
@@ -1618,6 +1760,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/hermesworld/reservations'
+    | '/api/hermes-jobs/$jobId'
+    | '/api/hermes-tasks/$taskId'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1654,6 +1799,7 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
@@ -1666,6 +1812,7 @@ export interface RootRouteChildren {
   AgoraRoute: typeof AgoraRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
+  EarlyAccessRoute: typeof EarlyAccessRoute
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
   JobsRoute: typeof JobsRoute
@@ -1674,12 +1821,14 @@ export interface RootRouteChildren {
   OperationsRoute: typeof OperationsRoute
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
+  ReserveRoute: typeof ReserveRouteWithChildren
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
   SwarmRoute: typeof SwarmRoute
   Swarm2Route: typeof Swarm2Route
   TasksRoute: typeof TasksRoute
   TerminalRoute: typeof TerminalRoute
+  VtCapitalRoute: typeof VtCapitalRoute
   WorldRoute: typeof WorldRoute
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
@@ -1700,6 +1849,9 @@ export interface RootRouteChildren {
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiHermesJobsRoute: typeof ApiHermesJobsRouteWithChildren
+  ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
+  ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
@@ -1747,11 +1899,13 @@ export interface RootRouteChildren {
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
   ApiTerminalStreamRoute: typeof ApiTerminalStreamRoute
+  ApiVtCapitalRoute: typeof ApiVtCapitalRoute
   ApiWorkspaceRoute: typeof ApiWorkspaceRoute
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiDashboardOverviewRoute: typeof ApiDashboardOverviewRoute
+  ApiHermesworldReservationsRoute: typeof ApiHermesworldReservationsRouteWithChildren
   ApiKnowledgeConfigRoute: typeof ApiKnowledgeConfigRoute
   ApiKnowledgeGraphRoute: typeof ApiKnowledgeGraphRoute
   ApiKnowledgeListRoute: typeof ApiKnowledgeListRoute
@@ -1780,6 +1934,13 @@ declare module '@tanstack/react-router' {
       path: '/world'
       fullPath: '/world'
       preLoaderRoute: typeof WorldRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/vt-capital': {
+      id: '/vt-capital'
+      path: '/vt-capital'
+      fullPath: '/vt-capital'
+      preLoaderRoute: typeof VtCapitalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/terminal': {
@@ -1822,6 +1983,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/reserve': {
+      id: '/reserve'
+      path: '/reserve'
+      fullPath: '/reserve'
+      preLoaderRoute: typeof ReserveRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/profiles': {
@@ -1880,6 +2048,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FilesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/early-access': {
+      id: '/early-access'
+      path: '/early-access'
+      fullPath: '/early-access'
+      preLoaderRoute: typeof EarlyAccessRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard': {
       id: '/dashboard'
       path: '/dashboard'
@@ -1936,6 +2111,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsProvidersRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/reserve/confirm': {
+      id: '/reserve/confirm'
+      path: '/confirm'
+      fullPath: '/reserve/confirm'
+      preLoaderRoute: typeof ReserveConfirmRouteImport
+      parentRoute: typeof ReserveRoute
+    }
     '/chat/$sessionKey': {
       id: '/chat/$sessionKey'
       path: '/chat/$sessionKey'
@@ -1948,6 +2130,13 @@ declare module '@tanstack/react-router' {
       path: '/api/workspace'
       fullPath: '/api/workspace'
       preLoaderRoute: typeof ApiWorkspaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/vt-capital': {
+      id: '/api/vt-capital'
+      path: '/api/vt-capital'
+      fullPath: '/api/vt-capital'
+      preLoaderRoute: typeof ApiVtCapitalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/terminal-stream': {
@@ -2277,6 +2466,27 @@ declare module '@tanstack/react-router' {
       path: '/api/history'
       fullPath: '/api/history'
       preLoaderRoute: typeof ApiHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-tasks-assignees': {
+      id: '/api/hermes-tasks-assignees'
+      path: '/api/hermes-tasks-assignees'
+      fullPath: '/api/hermes-tasks-assignees'
+      preLoaderRoute: typeof ApiHermesTasksAssigneesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-tasks': {
+      id: '/api/hermes-tasks'
+      path: '/api/hermes-tasks'
+      fullPath: '/api/hermes-tasks'
+      preLoaderRoute: typeof ApiHermesTasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-jobs': {
+      id: '/api/hermes-jobs'
+      path: '/api/hermes-jobs'
+      fullPath: '/api/hermes-jobs'
+      preLoaderRoute: typeof ApiHermesJobsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/gateway-status': {
@@ -2664,6 +2874,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiKnowledgeConfigRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/hermesworld/reservations': {
+      id: '/api/hermesworld/reservations'
+      path: '/api/hermesworld/reservations'
+      fullPath: '/api/hermesworld/reservations'
+      preLoaderRoute: typeof ApiHermesworldReservationsRouteImport
+      parentRoute: typeof rootRouteImport
+    '/api/hermes-tasks/$taskId': {
+      id: '/api/hermes-tasks/$taskId'
+      path: '/$taskId'
+      fullPath: '/api/hermes-tasks/$taskId'
+      preLoaderRoute: typeof ApiHermesTasksTaskIdRouteImport
+      parentRoute: typeof ApiHermesTasksRoute
+    }
+    '/api/hermes-jobs/$jobId': {
+      id: '/api/hermes-jobs/$jobId'
+      path: '/$jobId'
+      fullPath: '/api/hermes-jobs/$jobId'
+      preLoaderRoute: typeof ApiHermesJobsJobIdRouteImport
+      parentRoute: typeof ApiHermesJobsRoute
+    }
     '/api/dashboard/overview': {
       id: '/api/dashboard/overview'
       path: '/api/dashboard/overview'
@@ -2727,8 +2957,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMcpNameLogsRouteImport
       parentRoute: typeof ApiMcpNameRoute
     }
+    '/api/hermesworld/reservations/confirm': {
+      id: '/api/hermesworld/reservations/confirm'
+      path: '/confirm'
+      fullPath: '/api/hermesworld/reservations/confirm'
+      preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
+      parentRoute: typeof ApiHermesworldReservationsRoute
+    }
   }
 }
+
+interface ReserveRouteChildren {
+  ReserveConfirmRoute: typeof ReserveConfirmRoute
+}
+
+const ReserveRouteChildren: ReserveRouteChildren = {
+  ReserveConfirmRoute: ReserveConfirmRoute,
+}
+
+const ReserveRouteWithChildren =
+  ReserveRoute._addFileChildren(ReserveRouteChildren)
 
 interface SettingsRouteChildren {
   SettingsProvidersRoute: typeof SettingsProvidersRoute
@@ -2778,6 +3026,30 @@ const ApiClaudeTasksRouteChildren: ApiClaudeTasksRouteChildren = {
 
 const ApiClaudeTasksRouteWithChildren = ApiClaudeTasksRoute._addFileChildren(
   ApiClaudeTasksRouteChildren,
+)
+
+interface ApiHermesJobsRouteChildren {
+  ApiHermesJobsJobIdRoute: typeof ApiHermesJobsJobIdRoute
+}
+
+const ApiHermesJobsRouteChildren: ApiHermesJobsRouteChildren = {
+  ApiHermesJobsJobIdRoute: ApiHermesJobsJobIdRoute,
+}
+
+const ApiHermesJobsRouteWithChildren = ApiHermesJobsRoute._addFileChildren(
+  ApiHermesJobsRouteChildren,
+)
+
+interface ApiHermesTasksRouteChildren {
+  ApiHermesTasksTaskIdRoute: typeof ApiHermesTasksTaskIdRoute
+}
+
+const ApiHermesTasksRouteChildren: ApiHermesTasksRouteChildren = {
+  ApiHermesTasksTaskIdRoute: ApiHermesTasksTaskIdRoute,
+}
+
+const ApiHermesTasksRouteWithChildren = ApiHermesTasksRoute._addFileChildren(
+  ApiHermesTasksRouteChildren,
 )
 
 interface ApiMcpNameRouteChildren {
@@ -2890,12 +3162,28 @@ const ApiSwarmMemoryRouteWithChildren = ApiSwarmMemoryRoute._addFileChildren(
   ApiSwarmMemoryRouteChildren,
 )
 
+interface ApiHermesworldReservationsRouteChildren {
+  ApiHermesworldReservationsConfirmRoute: typeof ApiHermesworldReservationsConfirmRoute
+}
+
+const ApiHermesworldReservationsRouteChildren: ApiHermesworldReservationsRouteChildren =
+  {
+    ApiHermesworldReservationsConfirmRoute:
+      ApiHermesworldReservationsConfirmRoute,
+  }
+
+const ApiHermesworldReservationsRouteWithChildren =
+  ApiHermesworldReservationsRoute._addFileChildren(
+    ApiHermesworldReservationsRouteChildren,
+  )
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
   AgoraRoute: AgoraRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
+  EarlyAccessRoute: EarlyAccessRoute,
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
   JobsRoute: JobsRoute,
@@ -2904,12 +3192,14 @@ const rootRouteChildren: RootRouteChildren = {
   OperationsRoute: OperationsRoute,
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
+  ReserveRoute: ReserveRouteWithChildren,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,
   SwarmRoute: SwarmRoute,
   Swarm2Route: Swarm2Route,
   TasksRoute: TasksRoute,
   TerminalRoute: TerminalRoute,
+  VtCapitalRoute: VtCapitalRoute,
   WorldRoute: WorldRoute,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
@@ -2930,6 +3220,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiHermesJobsRoute: ApiHermesJobsRouteWithChildren,
+  ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
+  ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
@@ -2977,11 +3270,13 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,
   ApiTerminalStreamRoute: ApiTerminalStreamRoute,
+  ApiVtCapitalRoute: ApiVtCapitalRoute,
   ApiWorkspaceRoute: ApiWorkspaceRoute,
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiDashboardOverviewRoute: ApiDashboardOverviewRoute,
+  ApiHermesworldReservationsRoute: ApiHermesworldReservationsRouteWithChildren,
   ApiKnowledgeConfigRoute: ApiKnowledgeConfigRoute,
   ApiKnowledgeGraphRoute: ApiKnowledgeGraphRoute,
   ApiKnowledgeListRoute: ApiKnowledgeListRoute,

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -34,15 +34,25 @@ export const Route = createFileRoute('/api/sessions')({
           })
         }
 
+        // Filter out cron/scheduler sessions — they pollute the sidebar and
+        // are not useful for manual browsing. Also filter api- prefixed
+        // internal API sessions.
+        const isCronSession = (id: string) =>
+          id.startsWith('cron_') ||
+          id.startsWith('cron:') ||
+          id.startsWith('api-')
+
         try {
-          const sessions = await listSessions(50, 0)
-          const gatewaySessions = sessions.map(toSessionSummary)
+          const sessions = await listSessions(200, 0)
+          const gatewaySessions = sessions
+            .filter((s: any) => !isCronSession(String(s.id ?? s.key ?? '')))
+            .map(toSessionSummary)
 
           // Merge local portable sessions (Ollama, Atomic Chat, etc.)
           const localSessions = listLocalSessions()
           const gatewayIds = new Set(gatewaySessions.map((s: any) => s.key || s.id))
           for (const ls of localSessions) {
-            if (!gatewayIds.has(ls.id)) {
+            if (!gatewayIds.has(ls.id) && !isCronSession(ls.id)) {
               gatewaySessions.push({
                 key: ls.id,
                 id: ls.id,

--- a/src/screens/tasks/task-card.tsx
+++ b/src/screens/tasks/task-card.tsx
@@ -93,6 +93,18 @@ export function TaskCard({ task, assigneeLabels = {}, onClick, onDragStart, isDr
           </div>
         )}
       </div>
+
+      {task.session_id && (
+        <div className="mt-1.5 flex items-center gap-1">
+          <a
+            href={`/chat/${task.session_id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--theme-accent)]/20 text-[var(--theme-accent)] hover:bg-[var(--theme-accent)]/40 transition-colors"
+          >
+            ▶ Session
+          </a>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/screens/tasks/task-dialog.tsx
+++ b/src/screens/tasks/task-dialog.tsx
@@ -18,9 +18,13 @@ type Props = {
   assignees: Array<TaskAssignee>
   onSubmit: (input: CreateTaskInput) => Promise<void>
   isSubmitting: boolean
+  onLaunch?: (taskId: string) => Promise<void>
+  onLink?: (taskId: string, sessionId: string) => Promise<void>
+  onUnlink?: (taskId: string) => Promise<void>
+  isLaunching?: boolean
 }
 
-export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees, onSubmit, isSubmitting }: Props) {
+export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees, onSubmit, isSubmitting, onLaunch, onLink, onUnlink, isLaunching }: Props) {
   const isEdit = Boolean(task)
 
   const [title, setTitle] = useState('')
@@ -30,6 +34,8 @@ export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees,
   const [assignee, setAssignee] = useState<string>('')
   const [tags, setTags] = useState('')
   const [dueDate, setDueDate] = useState('')
+  const [showPasteSession, setShowPasteSession] = useState(false)
+  const [pasteSessionInput, setPasteSessionInput] = useState('')
 
   useEffect(() => {
     if (task) {
@@ -49,6 +55,8 @@ export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees,
       setTags('')
       setDueDate('')
     }
+    setShowPasteSession(false)
+    setPasteSessionInput('')
   }, [task, open, defaultColumn])
 
   async function handleSubmit(e: React.FormEvent) {
@@ -63,6 +71,22 @@ export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees,
       tags: tags.split(',').map(t => t.trim()).filter(Boolean),
       due_date: dueDate || null,
     })
+  }
+
+  function extractSessionId(raw: string): string {
+    const trimmed = raw.trim()
+    // Accept /chat/<id> URL or bare session ID
+    const match = trimmed.match(/\/chat\/([^\s/?]+)/)
+    return match ? match[1] : trimmed
+  }
+
+  async function handlePasteLink() {
+    if (!task || !onLink) return
+    const sessionId = extractSessionId(pasteSessionInput)
+    if (!sessionId) return
+    await onLink(task.id, sessionId)
+    setShowPasteSession(false)
+    setPasteSessionInput('')
   }
 
   const inputClass = cn(
@@ -180,6 +204,97 @@ export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees,
                 placeholder="frontend, bug, research"
               />
             </div>
+
+            {/* Agent Session section — only in edit mode */}
+            {isEdit && task && (onLaunch || onLink || onUnlink) && (
+              <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-hover)] p-3 space-y-2">
+                <p className="text-xs font-medium text-[var(--theme-muted)]">Agent Session</p>
+                {task.session_id ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <a
+                        href={`/chat/${task.session_id}`}
+                        className="text-xs text-[var(--theme-accent)] hover:underline"
+                      >
+                        ▶ Resume Session
+                      </a>
+                      {onLaunch && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs h-6 px-2"
+                          onClick={() => onLaunch(task.id)}
+                          disabled={isLaunching}
+                        >
+                          + New Session
+                        </Button>
+                      )}
+                      {onUnlink && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs h-6 px-2 text-red-400 hover:text-red-300"
+                          onClick={() => onUnlink(task.id)}
+                        >
+                          Unlink
+                        </Button>
+                      )}
+                    </div>
+                    <p className="text-[10px] text-[var(--theme-muted)] font-mono truncate">
+                      {task.session_id}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {onLaunch && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-xs h-6 px-2"
+                          onClick={() => onLaunch(task.id)}
+                          disabled={isLaunching}
+                          style={{ background: 'var(--theme-accent)', color: 'white' }}
+                        >
+                          {isLaunching ? 'Launching...' : '▶ Launch New Session'}
+                        </Button>
+                      )}
+                      {onLink && (
+                        <button
+                          type="button"
+                          className="text-[10px] text-[var(--theme-muted)] hover:text-[var(--theme-text)] underline"
+                          onClick={() => setShowPasteSession(!showPasteSession)}
+                        >
+                          Paste existing
+                        </button>
+                      )}
+                    </div>
+                    {showPasteSession && onLink && (
+                      <div className="flex gap-2">
+                        <input
+                          className={cn(inputClass, 'text-xs py-1 h-7 flex-1')}
+                          placeholder="Session ID or /chat/<id> URL"
+                          value={pasteSessionInput}
+                          onChange={e => setPasteSessionInput(e.target.value)}
+                        />
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="h-7 text-xs px-2"
+                          onClick={handlePasteLink}
+                          disabled={!pasteSessionInput.trim()}
+                        >
+                          Link
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
 
             <div className="flex items-center justify-between pt-2">
               <p className="text-[10px] text-[var(--theme-muted)]">Press Esc to cancel</p>

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import { useSearch } from '@tanstack/react-router'
+import { useSearch, useNavigate } from '@tanstack/react-router'
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'motion/react'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -17,12 +17,15 @@ import {
   updateTask,
   deleteTask,
   moveTask,
+  launchSession,
+  linkSession,
   COLUMN_LABELS,
   COLUMN_ORDER,
   COLUMN_COLORS,
   isOverdue,
 } from '@/lib/tasks-api'
 import type { ClaudeTask, TaskColumn, CreateTaskInput, TaskAssignee } from '@/lib/tasks-api'
+import { stashPendingSend } from '@/screens/chat/pending-send'
 
 const QUERY_KEY = ['claude', 'tasks'] as const
 const ASSIGNEES_KEY = ['claude', 'tasks', 'assignees'] as const
@@ -46,6 +49,7 @@ function SkeletonCard() {
 
 export function TasksScreen() {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
   const [showCreate, setShowCreate] = useState(false)
   const [createColumn, setCreateColumn] = useState<TaskColumn>('backlog')
   const [editingTask, setEditingTask] = useState<ClaudeTask | null>(null)
@@ -133,6 +137,46 @@ export function TasksScreen() {
     mutationFn: ({ id, column }: { id: string; column: TaskColumn }) => moveTask(id, column, 'user'),
     onSuccess: () => invalidate(),
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to move task', { type: 'error' }),
+  })
+
+  const launchMutation = useMutation({
+    mutationFn: async (taskId: string) => {
+      const result = await launchSession(taskId)
+      return result
+    },
+    onSuccess: ({ sessionId, briefing }) => {
+      invalidate()
+      setEditingTask(null)
+      // Build an optimistic message object for the pending send
+      const optimisticMessage = {
+        id: typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `msg-${Date.now()}`,
+        role: 'user' as const,
+        content: briefing,
+        timestamp: Date.now(),
+        attachments: [],
+      }
+      stashPendingSend({
+        sessionKey: sessionId,
+        friendlyId: sessionId,
+        message: briefing,
+        attachments: [],
+        optimisticMessage,
+      })
+      void navigate({ to: '/chat/$sessionKey', params: { sessionKey: sessionId } })
+    },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to launch session', { type: 'error' }),
+  })
+
+  const linkMutation = useMutation({
+    mutationFn: ({ taskId, sessionId }: { taskId: string; sessionId: string }) => linkSession(taskId, sessionId),
+    onSuccess: () => { invalidate(); toast('Session linked') },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to link session', { type: 'error' }),
+  })
+
+  const unlinkMutation = useMutation({
+    mutationFn: (taskId: string) => linkSession(taskId, null),
+    onSuccess: () => { invalidate(); toast('Session unlinked') },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to unlink session', { type: 'error' }),
   })
 
   function handleDragStart(e: React.DragEvent, taskId: string) {
@@ -380,9 +424,22 @@ export function TasksScreen() {
         task={editingTask}
         assignees={assignees}
         isSubmitting={updateMutation.isPending}
+        isLaunching={launchMutation.isPending}
         onSubmit={async (input) => {
           if (!editingTask) return
           await updateMutation.mutateAsync({ id: editingTask.id, input })
+        }}
+        onLaunch={async (taskId) => {
+          await launchMutation.mutateAsync(taskId)
+        }}
+        onLink={async (taskId, sessionId) => {
+          await linkMutation.mutateAsync({ taskId, sessionId })
+          // Update local editingTask state so dialog refreshes
+          invalidate()
+        }}
+        onUnlink={async (taskId) => {
+          await unlinkMutation.mutateAsync(taskId)
+          invalidate()
         }}
       />
     </div>

--- a/src/server/tasks-store.ts
+++ b/src/server/tasks-store.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 
-export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'done'
+export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'done' | 'deleted'
 export type TaskPriority = 'high' | 'medium' | 'low'
 
 export type TaskRecord = {
@@ -19,6 +19,7 @@ export type TaskRecord = {
   created_by: string
   created_at: string
   updated_at: string
+  session_id: string | null
 }
 
 type TaskFile = { tasks: TaskRecord[] }
@@ -74,6 +75,7 @@ function normalizeTask(task: Partial<TaskRecord> & Pick<TaskRecord, 'id' | 'titl
     created_by: task.created_by,
     created_at: task.created_at,
     updated_at: task.updated_at,
+    session_id: task.session_id ?? null,
   }
 }
 
@@ -151,4 +153,8 @@ export function deleteTask(taskId: string): boolean {
   if (nextTasks.length === file.tasks.length) return false
   writeTaskFile({ tasks: nextTasks.map((task) => normalizeTask(task as TaskRecord)) })
   return true
+}
+
+export function linkTaskSession(taskId: string, sessionId: string | null): TaskRecord | null {
+  return updateTask(taskId, { session_id: sessionId })
 }


### PR DESCRIPTION
Root cause of the May 2026 workspace outage: plist pointed to dist/server/server.js instead of server-entry.js. Locally patched but never merged.

Changes:
- Add macos/com.hermes.workspace.plist.template as source of truth
- install.sh generates plist from template on macOS
- Re-running install always produces correct plist pointing to server-entry.js
- Template comment explains regression risk