### PR TITLE
feat: align semantic Hermes swarm agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Hermes Workspace Agent Contract
+
+This workspace uses semantic Hermes swarm workers, not numbered-only lanes. The source of truth for routing is `swarm.yaml`; each worker also has a matching profile under `~/.hermes/profiles/<worker-id>/`, a role skill `<worker-id>-core`, and a wrapper in `~/.local/bin/`.
+
+## Current semantic roster
+
+| Worker | Wrapper | Tools | Skills | MCP | Plugins |
+|---|---|---|---|---|---|
+| `orchestrator` | `orchestrator:plan` | todo, kanban, delegation, terminal, file, gbrain, session_search, cronjob, skills, clarify, web | orchestrator-core, gstack-for-hermes, gbrain, kanban-orchestrator, subagent-driven-development, writing-plans, requesting-code-review, workspace-dispatch | gbrain | none |
+| `km-agent` | `km:health` | gbrain, file, terminal, session_search, skills, todo, cronjob, web | km-agent-core, gbrain, obsidian-markdown, obsidian-cli, obsidian-bases, json-canvas, gstack-for-hermes | gbrain | none |
+| `builder` | `builder:task` | terminal, file, browser, web, gbrain, session_search, skills, todo | builder-core, gstack-for-hermes, test-driven-development, systematic-debugging, github-pr-workflow, requesting-code-review, codebase-inspection | gbrain | none |
+| `reviewer` | `reviewer:gate` | terminal, file, web, gbrain, session_search, skills | reviewer-core, requesting-code-review, github-code-review, systematic-debugging, gstack-for-hermes, gbrain, codebase-inspection | gbrain | none |
+| `qa` | `qa:smoke` | browser, terminal, file, vision, gbrain, session_search, skills, web | qa-core, browser-harness-power-use, dogfood, gstack-for-hermes | gbrain | none |
+| `researcher` | `researcher:quick` | gbrain, web, browser, terminal, file, vision, session_search, skills, todo | researcher-core, gbrain, autoresearch, browser-harness-power-use, gstack-for-hermes, researcher-quick, researcher-autoresearch, arxiv, youtube-content, polymarket | gbrain | none |
+| `ops-watch` | `ops:health` | terminal, cronjob, file, gbrain, skills, session_search, web | ops-watch-core, gbrain, hermes-agent, systematic-debugging, webhook-subscriptions | gbrain | none |
+| `maintainer` | `maintainer:check` | terminal, file, web, browser, gbrain, session_search, skills | maintainer-core, github-repo-management, github-pr-workflow, github-issues, github-code-review, gbrain, gstack-for-hermes, hermes-agent | gbrain | none |
+| `strategist` | `strategist:review` | gbrain, web, session_search, file, skills, todo, clarify | strategist-core, gstack-for-hermes, gbrain, writing-plans, polymarket | gbrain | none |
+| `inbox-triage` | `inbox:triage` | gbrain, web, file, session_search, todo, skills, terminal | inbox-triage-core, gbrain, obsidian-markdown, gstack-for-hermes, defuddle, youtube-content | gbrain | none |
+
+## Operating rules
+
+- Keep `swarm.yaml`, profile `config.yaml`, profile core skills, and wrappers aligned when changing a worker.
+- Prefer GBrain-first lookup for context-sensitive RAZSOC/Hermes/workflow decisions.
+- Builder implements; Reviewer gates; QA verifies behavior; Orchestrator routes and enforces greenlight.
+- Do not enable optional Hermes plugins globally unless the task explicitly needs them; record plugin/toolset alignment in `swarm.yaml` first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,4 +22,7 @@ This workspace uses semantic Hermes swarm workers, not numbered-only lanes. The 
 - Keep `swarm.yaml`, profile `config.yaml`, profile core skills, and wrappers aligned when changing a worker.
 - Prefer GBrain-first lookup for context-sensitive RAZSOC/Hermes/workflow decisions.
 - Builder implements; Reviewer gates; QA verifies behavior; Orchestrator routes and enforces greenlight.
+- Durable named-role work should route through Kanban/profile dispatch when profile state, dependencies, retries, logs, or audit trail matter; use `delegate_task` only for short synchronous throwaway subtasks where named profile identity is irrelevant.
+- If a named worker stalls, reclaim, reassign, split, or block the card and report the status; do not silently finish that worker's role in the parent context.
+- Reuse stable boards and scope with tenants/workspaces/task titles; avoid timestamped or per-turn boards unless isolation truly requires a new board.
 - Do not enable optional Hermes plugins globally unless the task explicitly needs them; record plugin/toolset alignment in `swarm.yaml` first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,10 @@ This workspace uses semantic Hermes swarm workers, not numbered-only lanes. The 
 - Keep `swarm.yaml`, profile `config.yaml`, profile core skills, and wrappers aligned when changing a worker.
 - Prefer GBrain-first lookup for context-sensitive RAZSOC/Hermes/workflow decisions.
 - Builder implements; Reviewer gates; QA verifies behavior; Orchestrator routes and enforces greenlight.
-- Durable named-role work should route through Kanban/profile dispatch when profile state, dependencies, retries, logs, or audit trail matter; use `delegate_task` only for short synchronous throwaway subtasks where named profile identity is irrelevant.
-- If a named worker stalls, reclaim, reassign, split, or block the card and report the status; do not silently finish that worker's role in the parent context.
+- Runtime ownership: `ops-watch` owns local agent-stack health (gateway, MCP, cron, workspace services, process/port/log checks); `km-agent` owns RAZSOC/GBrain knowledge integrity and graph/drift audits; `maintainer` owns upstream dependency and local patch hygiene; `orchestrator` owns cross-role routing and greenlight gates.
+- Durable named-role work should route through Kanban/profile dispatch when profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter; use `delegate_task` only for short synchronous throwaway subtasks where named profile identity is irrelevant; root/default Hermes may execute small verified work directly.
+- Before dispatch, split only genuinely independent lanes and link real dependencies. Avoid fake parallelism where workers have no fan-in contract.
+- During execution, avoid long silent polling; checkpoint after meaningful batches or blockers; use one deliberate expensive review gate by default unless the user explicitly approves deeper review.
+- If a named worker stalls, inspect logs/status, reclaim or retry, reassign if profile/tooling is broken, narrow scope, or block the card and report the status; do not silently finish that worker's role in the parent context.
 - Reuse stable boards and scope with tenants/workspaces/task titles; avoid timestamped or per-turn boards unless isolation truly requires a new board.
 - Do not enable optional Hermes plugins globally unless the task explicitly needs them; record plugin/toolset alignment in `swarm.yaml` first.

--- a/agents/builder/README.md
+++ b/agents/builder/README.md
@@ -1,0 +1,19 @@
+# Builder
+
+Profile: `builder`
+Wrapper: `builder:task`
+Modes: task
+
+## Tools
+terminal, file, browser, web, gbrain, session_search, skills, todo
+
+## Skills
+builder-core, gstack-for-hermes, test-driven-development, systematic-debugging, github-pr-workflow, requesting-code-review, codebase-inspection
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/builder/`.

--- a/agents/inbox-triage/README.md
+++ b/agents/inbox-triage/README.md
@@ -1,0 +1,19 @@
+# Inbox Triage
+
+Profile: `inbox-triage`
+Wrapper: `inbox:triage`
+Modes: triage
+
+## Tools
+gbrain, web, file, session_search, todo, skills, terminal
+
+## Skills
+inbox-triage-core, gbrain, obsidian-markdown, gstack-for-hermes, defuddle, youtube-content
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/inbox-triage/`.

--- a/agents/km-agent/README.md
+++ b/agents/km-agent/README.md
@@ -1,0 +1,19 @@
+# KM Agent
+
+Profile: `km-agent`
+Wrapper: `km:health`
+Modes: health, curate
+
+## Tools
+gbrain, file, terminal, session_search, skills, todo, cronjob, web
+
+## Skills
+km-agent-core, gbrain, obsidian-markdown, obsidian-cli, obsidian-bases, json-canvas, gstack-for-hermes
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/km-agent/`.

--- a/agents/maintainer/README.md
+++ b/agents/maintainer/README.md
@@ -1,0 +1,19 @@
+# Maintainer
+
+Profile: `maintainer`
+Wrapper: `maintainer:check`
+Modes: check
+
+## Tools
+terminal, file, web, browser, gbrain, session_search, skills
+
+## Skills
+maintainer-core, github-repo-management, github-pr-workflow, github-issues, github-code-review, gbrain, gstack-for-hermes, hermes-agent
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/maintainer/`.

--- a/agents/ops-watch/README.md
+++ b/agents/ops-watch/README.md
@@ -1,0 +1,19 @@
+# Ops Watch
+
+Profile: `ops-watch`
+Wrapper: `ops:health`
+Modes: health
+
+## Tools
+terminal, cronjob, file, gbrain, skills, session_search, web
+
+## Skills
+ops-watch-core, gbrain, hermes-agent, systematic-debugging, webhook-subscriptions
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/ops-watch/`.

--- a/agents/orchestrator/README.md
+++ b/agents/orchestrator/README.md
@@ -1,0 +1,19 @@
+# Orchestrator
+
+Profile: `orchestrator`
+Wrapper: `orchestrator:plan`
+Modes: plan
+
+## Tools
+todo, kanban, delegation, terminal, file, gbrain, session_search, cronjob, skills, clarify, web
+
+## Skills
+orchestrator-core, gstack-for-hermes, gbrain, kanban-orchestrator, subagent-driven-development, writing-plans, requesting-code-review, workspace-dispatch
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/orchestrator/`.

--- a/agents/qa/README.md
+++ b/agents/qa/README.md
@@ -1,0 +1,19 @@
+# QA
+
+Profile: `qa`
+Wrapper: `qa:smoke`
+Modes: smoke
+
+## Tools
+browser, terminal, file, vision, gbrain, session_search, skills, web
+
+## Skills
+qa-core, browser-harness-power-use, dogfood, gstack-for-hermes
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/qa/`.

--- a/agents/researcher/README.md
+++ b/agents/researcher/README.md
@@ -1,0 +1,19 @@
+# Researcher
+
+Profile: `researcher`
+Wrapper: `researcher:quick`
+Modes: quick, autoresearch
+
+## Tools
+gbrain, web, browser, terminal, file, vision, session_search, skills, todo
+
+## Skills
+researcher-core, gbrain, autoresearch, browser-harness-power-use, gstack-for-hermes, researcher-quick, researcher-autoresearch, arxiv, youtube-content, polymarket
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/researcher/`.

--- a/agents/reviewer/README.md
+++ b/agents/reviewer/README.md
@@ -1,0 +1,19 @@
+# Reviewer
+
+Profile: `reviewer`
+Wrapper: `reviewer:gate`
+Modes: gate
+
+## Tools
+terminal, file, web, gbrain, session_search, skills
+
+## Skills
+reviewer-core, requesting-code-review, github-code-review, systematic-debugging, gstack-for-hermes, gbrain, codebase-inspection
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/reviewer/`.

--- a/agents/strategist/README.md
+++ b/agents/strategist/README.md
@@ -1,0 +1,19 @@
+# Strategist
+
+Profile: `strategist`
+Wrapper: `strategist:review`
+Modes: review
+
+## Tools
+gbrain, web, session_search, file, skills, todo, clarify
+
+## Skills
+strategist-core, gstack-for-hermes, gbrain, writing-plans, polymarket
+
+## MCP servers
+gbrain
+
+## Plugins
+none
+
+This file mirrors `swarm.yaml` and the profile config under `~/.hermes/profiles/strategist/`.

--- a/docs/swarm/ALIGNMENT_HEALTH.md
+++ b/docs/swarm/ALIGNMENT_HEALTH.md
@@ -16,7 +16,7 @@ Examples where `worker.id` and `worker.wrapper` intentionally differ:
 
 - `builder` -> `builder:task`
 - `reviewer` -> `reviewer:gate`
-- `qa` -> `qa:verify`
+- `qa` -> `qa:smoke`
 - `ops-watch` -> `ops:health`
 - `inbox-triage` -> `inbox:triage`
 

--- a/docs/swarm/ALIGNMENT_HEALTH.md
+++ b/docs/swarm/ALIGNMENT_HEALTH.md
@@ -1,0 +1,101 @@
+# Agent / Skill / Tool / Plugin Alignment Health
+
+Use this SOP when changing semantic agents, `swarm.yaml`, profile wrappers, toolsets, plugin toolsets, or Workspace Swarm health surfaces.
+
+## Invariants
+
+- `swarm.yaml` is the Workspace roster source for semantic workers.
+- Each worker should have a matching Hermes profile under `~/.hermes/profiles/<profile>`.
+- Each worker should have a profile-local `<agent>-core` skill.
+- `tools` in `swarm.yaml` should match profile `toolsets` and `platform_toolsets.cli`.
+- `pluginToolsets` in `swarm.yaml` should match profile `known_plugin_toolsets.cli`.
+- `plugins: []` and `pluginToolsets: []` means no accidental plugin enablement.
+- `wrapper` is authoritative for executable health. Do not assume wrapper executable names equal worker ids.
+
+Examples where `worker.id` and `worker.wrapper` intentionally differ:
+
+- `builder` -> `builder:task`
+- `reviewer` -> `reviewer:gate`
+- `qa` -> `qa:verify`
+- `ops-watch` -> `ops:health`
+- `inbox-triage` -> `inbox:triage`
+
+Health code should derive:
+
+- `profilePath` from `worker.profile || worker.id`
+- `wrapperPath` from `worker.wrapper || worker.id`
+
+## Quick local metadata check
+
+```bash
+cd /home/aleks/src/hermes-workspace
+python3 - <<'PY'
+from pathlib import Path
+import yaml, subprocess
+root = Path('.').resolve()
+roster = yaml.safe_load((root / 'swarm.yaml').read_text())
+workers = roster.get('workers', [])
+print('workers', len(workers))
+for w in workers:
+    wid = w['id']
+    profile = w.get('profile') or wid
+    wrapper = w.get('wrapper') or wid
+    pdir = Path.home() / '.hermes' / 'profiles' / profile
+    wpath = Path.home() / '.local' / 'bin' / wrapper
+    cfg = yaml.safe_load((pdir / 'config.yaml').read_text()) if (pdir / 'config.yaml').exists() else {}
+    print(wid, {
+        'profile': pdir.exists(),
+        'soul': (pdir / 'SOUL.md').exists(),
+        'core_skill': (pdir / 'skills' / f'{wid}-core' / 'SKILL.md').exists(),
+        'wrapper': wpath.exists(),
+        'tools_match': sorted(w.get('tools', [])) == sorted(cfg.get('toolsets', [])) == sorted(cfg.get('platform_toolsets', {}).get('cli', [])),
+        'plugin_toolsets_match': sorted(w.get('pluginToolsets', [])) == sorted(cfg.get('known_plugin_toolsets', {}).get('cli', [])),
+    })
+PY
+```
+
+## API health smoke
+
+Start Workspace, then verify:
+
+```bash
+cd /home/aleks/src/hermes-workspace
+pnpm dev
+```
+
+In another shell:
+
+```bash
+python3 - <<'PY'
+import json, urllib.request
+base = 'http://127.0.0.1:3000'
+with urllib.request.urlopen(base + '/api/swarm-roster', timeout=20) as r:
+    roster = json.load(r)
+workers = roster['roster']['workers']
+assert len(workers) >= 10, len(workers)
+with urllib.request.urlopen(base + '/api/swarm-health', timeout=20) as r:
+    health = json.load(r)
+summary = health['summary']
+assert summary['totalWorkers'] == len(workers), summary
+assert summary['wrappersConfigured'] == summary['totalWorkers'], summary
+assert all(w['wrapperFound'] for w in health['workers']), health['workers']
+print('SWARM_ALIGNMENT_HEALTH_OK', summary)
+PY
+```
+
+## Browser smoke
+
+- Open `/swarm`.
+- Confirm all semantic workers render.
+- Confirm no browser console errors.
+- Confirm the health API reports all wrappers configured.
+
+## Durable dispatch discipline
+
+Use Swarm/Kanban/Profile dispatch for durable named-role work: profile state, dependencies, retries, logs, audit trail, or cross-turn execution. Use short synchronous subagents for generic bounded subtasks. Let root/default Hermes execute small, obvious, low-risk work directly when it can verify quickly.
+
+Before dispatch, split only genuinely independent lanes and link real dependencies. During execution, checkpoint after meaningful batches or blockers, avoid silent polling, and use one deliberate expensive review gate by default unless deeper review is explicitly approved. If a worker stalls, inspect logs/status, reclaim or retry, reassign, narrow scope, or block with the exact decision needed; do not silently absorb another worker's role into root context.
+
+## Regression test expectation
+
+The route-level health behavior should be protected by a focused test proving that semantic wrapper names are respected. A worker with `id: builder` and `wrapper: builder:task` must report `wrapperFound: true` when `/bin/builder:task` exists, even though `/bin/builder` does not.

--- a/docs/swarm/ARCHITECTURE.md
+++ b/docs/swarm/ARCHITECTURE.md
@@ -53,6 +53,12 @@ The key rule: workers do not free-style message Eric. They checkpoint. The orche
 7. The orchestrator decides whether to continue, repair, hand off, review, or escalate.
 8. Reports and Inbox make the state inspectable.
 
+## Durable routing discipline
+
+Swarm/Kanban/Profile dispatch is for named persistent work, not for every tiny thought. Use durable dispatch when profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter. Use `delegate_task`/short synchronous subagents for disposable checks, and let the root operator execute small verified work directly.
+
+The orchestrator must split only genuinely independent lanes, link real dependencies, checkpoint after meaningful batches or blockers, avoid silent polling, and use one deliberate expensive review gate by default. When a worker stalls, recover by inspecting logs/status, reclaiming or retrying, reassigning, narrowing scope, or blocking for a real decision; do not silently absorb the stalled role.
+
 ## SwarmBrief shape
 
 The canonical YAML lives in `SWARM_SPEC.md` section 3. This is the public shape:
@@ -261,7 +267,9 @@ Important endpoints:
 | `POST /api/swarm-tmux-start` | Start a tmux-backed worker session. |
 | `POST /api/swarm-tmux-stop` | Stop a worker tmux session. |
 | `POST /api/swarm-tmux-scroll` | Scroll a tmux session from the UI. |
-| `GET /api/swarm-health` | Summarize local swarm health. |
+| `GET /api/swarm-health` | Summarize local swarm health, including profile/wrapper/auth status. |
+
+Health must resolve profile and wrapper paths from the roster, not by assuming executable names equal worker IDs. Semantic workers commonly use `wrapper` values such as `builder:task`, `reviewer:gate`, `ops:health`, and `inbox:triage`; `/api/swarm-health` should derive `profilePath` from `worker.profile || worker.id` and `wrapperPath` from `worker.wrapper || worker.id`. Otherwise the UI reports false missing wrappers even when all wrappers are installed and executable.
 
 ## Failure philosophy
 

--- a/docs/swarm/ARCHITECTURE.md
+++ b/docs/swarm/ARCHITECTURE.md
@@ -17,16 +17,16 @@ Swarm Mode is built around a durable loop: intent enters through Aurora, dispatc
     │ translates intent into SwarmBrief
     ▼
 ┌────────────────────────────┐
-│ swarm3 / Orchestrator      │
+│ orchestrator               │
 │ routing, drift, escalation │
 └───┬────────────────────────┘
     │ dispatches by role + standing mission
     ▼
 ┌────────────────────────────────────────────────────┐
 │ Hermes Agents                                      │
-│ swarm4 research  swarm5 build  swarm6 review        │
-│ swarm7 docs      swarm8 ops    swarm9 lab           │
-│ swarm10 patches  swarm11 QA    swarm12 triage       │
+│ researcher     builder     reviewer                │
+│ km-agent       ops-watch   maintainer               │
+│ strategist     qa          inbox-triage             │
 └───┬────────────────────────────────────────────────┘
     │ proof-bearing checkpoint
     ▼
@@ -65,7 +65,7 @@ The canonical YAML lives in `SWARM_SPEC.md` section 3. This is the public shape:
 
 ```yaml
 brief_id: brief-<timestamp>-<slug>
-worker: swarm<N>
+worker: <semantic-worker-id>
 project: <project-name>
 goal: <one-sentence end state>
 why_now: <trigger>
@@ -115,8 +115,8 @@ The notification router lives in `src/server/swarm-notifications.ts`.
 Current behavior:
 
 - Checkpoints route to the orchestrator worker by default.
-- The default orchestrator worker is `swarm3`.
-- The tmux target is `swarm-swarm3`.
+- The default orchestrator worker is `orchestrator`.
+- The tmux target is `swarm-orchestrator`.
 - Duplicate raw checkpoints are suppressed via `runtime.json`.
 - `NEEDS_INPUT` escalates to the main session.
 - If the orchestrator tmux session is unreachable, the checkpoint escalates to the main session.
@@ -131,11 +131,11 @@ That split matters. Without it, the main chat becomes a trash fire of worker tri
 
 A standing mission is a worker's permanent responsibility. Examples:
 
-- Scribe maintains docs and handoffs.
-- Reviewer owns the byte-verified review gate.
-- Triage works the PR/issues lane.
-- Lab runs model/runtime experiments.
-- Foundation maintains health and repair infrastructure.
+- `km-agent` maintains RAZSOC/GBrain/docs/source-of-truth integrity.
+- `reviewer` owns the independent quality/security/regression gate.
+- `inbox-triage` works inbound classification and routing.
+- `researcher` handles bounded research and discovery lanes.
+- `ops-watch` maintains runtime health and repair infrastructure.
 
 Standing missions are how idle workers stay useful without waiting for Eric to invent busywork.
 
@@ -160,10 +160,10 @@ Purpose: ship coordinated launch artifacts, demos, media, and release-facing ass
 Typical owners:
 
 - Builder for implementation
-- Mirror Integrations for assets
-- Sage for narrative and research
-- QA for smoke checks
-- Scribe for README/showcase copy
+- `maintainer` for upstream/dependency hygiene
+- `researcher` for narrative/research inputs
+- `qa` for smoke checks
+- `km-agent` for README/showcase/source-of-truth copy
 
 ### Lane B — Issues + PR autopilot
 
@@ -171,10 +171,10 @@ Purpose: keep open GitHub issues and PRs moving.
 
 Typical owners:
 
-- Triage as primary processor
-- Overflow for backup
-- Reviewer for gatekeeping
-- QA for regression proof
+- `inbox-triage` as primary processor
+- `builder` or `maintainer` for implementation backup
+- `reviewer` for gatekeeping
+- `qa` for regression proof
 
 Core loop:
 
@@ -182,13 +182,13 @@ Core loop:
 scan -> score -> reproduce -> patch -> test -> PR -> review -> human approval
 ```
 
-### Lane C — Lab / experiments
+### Lane C — Research / experiments
 
-Purpose: run experiments without destabilizing the product lane.
+Purpose: run research or experiments without destabilizing the product lane.
 
 Typical owner:
 
-- Lab
+- `researcher`
 
 Examples:
 
@@ -197,7 +197,7 @@ Examples:
 - speculative performance experiments
 - prototype loops
 
-Lab gets autonomy because isolation lowers risk. The product lane gets evidence when Lab finds something real.
+Research lanes get autonomy because isolation lowers risk. The product lane gets evidence when research finds something real.
 
 ## Greenlight Gate
 

--- a/docs/swarm/QUICKSTART.md
+++ b/docs/swarm/QUICKSTART.md
@@ -80,6 +80,12 @@ In the workspace:
 
 The role presets fill the important defaults: role, specialty, mission, system prompt, skills, and default model. You can edit them before saving.
 
+## 5.5 Durable dispatch discipline
+
+Use Swarm/Kanban/Profile dispatch for durable named-role work: profile state, dependencies, retries, logs, audit trail, or cross-turn execution. For short generic checks, use `delegate_task`/a synchronous subtask instead; for small obvious work, the root operator can execute and verify directly.
+
+Before dispatching multiple workers, split only independent lanes and link real dependencies. Avoid silent polling; checkpoint after meaningful batches or blockers. If a worker stalls, inspect logs/status, reclaim/retry, reassign, narrow, or block the work rather than silently taking over that role.
+
 ## 6. Dispatch the first task
 
 The dispatch API is:

--- a/docs/swarm/QUICKSTART.md
+++ b/docs/swarm/QUICKSTART.md
@@ -98,7 +98,7 @@ Minimal single-worker example:
 
 ```bash
 curl -X POST http://localhost:3000/api/swarm-dispatch   -H 'Content-Type: application/json'   -d '{
-    "workerIds": ["swarm7"],
+    "workerIds": ["km-agent"],
     "prompt": "Write a short checkpoint explaining what you can see in your current workspace. Do not modify files.",
     "timeoutSeconds": 240,
     "waitForCheckpoint": true
@@ -112,9 +112,9 @@ curl -X POST http://localhost:3000/api/swarm-dispatch   -H 'Content-Type: applic
     "missionTitle": "Docs smoke test",
     "assignments": [
       {
-        "workerId": "swarm7",
+        "workerId": "km-agent",
         "task": "Review docs/swarm/README.md and return a checkpoint with one improvement suggestion.",
-        "rationale": "Scribe owns docs and handoff quality."
+        "rationale": "km-agent owns docs, RAZSOC, GBrain, and handoff quality."
       }
     ],
     "waitForCheckpoint": true,
@@ -128,11 +128,11 @@ Expected response shape:
 {
   "missionId": "mission-...",
   "assignments": [
-    { "workerId": "swarm7", "task": "..." }
+    { "workerId": "km-agent", "task": "..." }
   ],
   "results": [
     {
-      "workerId": "swarm7",
+      "workerId": "km-agent",
       "ok": true,
       "delivery": "tmux",
       "checkpointStatus": "checkpointed"
@@ -181,13 +181,13 @@ The Add Swarm dialog includes these presets:
 - Orchestrator
 - Builder
 - Reviewer
-- Triage
-- Lab
-- Sage
-- Scribe
-- Foundation
+- Inbox Triage
+- Researcher
+- KM Agent
+- Ops Watch
 - QA
-- Mirror Integrations
+- Maintainer
+- Strategist
 - Custom
 
 Pick the closest role first, then tune. Avoid starting from Custom unless you are intentionally creating a new lane. Presets encode the operating contract so the worker knows whether it is allowed to build, review, triage, research, or just report.

--- a/docs/swarm/README.md
+++ b/docs/swarm/README.md
@@ -25,7 +25,7 @@ This is not a chat wrapper with tabs. It is the operating surface for a local ag
 Eric talks to Aurora. Aurora turns intent into a brief. The orchestrator routes that brief to the right Hermes Agent. Workers execute inside persistent tmux sessions, checkpoint with proof, and the orchestrator decides whether to continue, repair, escalate, or put a card in the Inbox.
 
 ```text
-Eric -> Aurora -> swarm3/orchestrator -> role workers -> checkpoints -> reports/inbox -> review/escalation
+Eric -> Aurora -> orchestrator -> semantic workers -> checkpoints -> reports/inbox -> review/escalation
 ```
 
 The important move is that dispatch becomes a system, not a vibe. The worker is not just "another model call." It is a named lane with memory, runtime state, default skills, a profile, and a job.

--- a/docs/swarm/README.md
+++ b/docs/swarm/README.md
@@ -16,6 +16,7 @@ This is not a chat wrapper with tabs. It is the operating surface for a local ag
 
 - [QUICKSTART.md](./QUICKSTART.md) — clone, run, detect profiles, spawn workers, dispatch the first task.
 - [ARCHITECTURE.md](./ARCHITECTURE.md) — loop, SwarmBrief shape, notification routing, lanes, review, repair.
+- [ALIGNMENT_HEALTH.md](./ALIGNMENT_HEALTH.md) — agent/profile/wrapper/tool/plugin invariants and smoke checks.
 - [SKILLS.md](./SKILLS.md) — bundled swarm skills, auto-loading, and custom skill conventions.
 - [ROLES.md](./ROLES.md) — role presets used by the Add Swarm dialog and the canonical project specs.
 
@@ -102,8 +103,9 @@ Read these in order if you are testing the v1 release:
 
 1. [QUICKSTART.md](./QUICKSTART.md)
 2. [ARCHITECTURE.md](./ARCHITECTURE.md)
-3. [ROLES.md](./ROLES.md)
-4. [SKILLS.md](./SKILLS.md)
+3. [ALIGNMENT_HEALTH.md](./ALIGNMENT_HEALTH.md)
+4. [ROLES.md](./ROLES.md)
+5. [SKILLS.md](./SKILLS.md)
 
 ## Canonical spec
 

--- a/docs/swarm/README.md
+++ b/docs/swarm/README.md
@@ -29,6 +29,12 @@ Eric -> Aurora -> swarm3/orchestrator -> role workers -> checkpoints -> reports/
 
 The important move is that dispatch becomes a system, not a vibe. The worker is not just "another model call." It is a named lane with memory, runtime state, default skills, a profile, and a job.
 
+## Durable dispatch discipline
+
+Use Swarm/Kanban/Profile dispatch for durable named-role work: profile state, dependencies, retries, logs, audit trail, or work that may outlive one chat turn. Use `delegate_task`/synchronous subagents only for short generic subtasks, and let the root operator handle small verified work directly.
+
+Before dispatch, split only genuinely independent lanes and link real dependencies. During execution, avoid silent polling, checkpoint after meaningful batches or blockers, and use one deliberate expensive review gate by default. If a worker stalls, inspect, reclaim/retry, reassign, narrow, or block; do not silently absorb its role into the parent context.
+
 ## What ships in v1
 
 ### Orchestrator Chat

--- a/docs/swarm/ROLES.md
+++ b/docs/swarm/ROLES.md
@@ -34,6 +34,12 @@ Use those specs as the source of truth for standing missions. The role preset is
 | Mirror Integrations | GPT-5.4 | You need upstream sync, integrations, or asset packs. |
 | Custom | user-selected | You are creating a lane that does not fit an existing preset. |
 
+## Role routing discipline
+
+Role presets are routing aids, not a reason to spawn every role. Use durable Swarm/Kanban/Profile dispatch only when named profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter. Keep short generic checks on `delegate_task`/synchronous subagents and let the root operator handle small verified work directly.
+
+Split only genuinely independent lanes, link real dependencies, checkpoint after batches/blockers, and use one deliberate expensive review gate by default unless deeper review is explicitly approved. If a worker stalls, inspect, reclaim/retry, reassign, narrow, or block with evidence; do not silently absorb the role into the parent context.
+
 ## Orchestrator
 
 Specialty: control-plane state, dispatch, drift detection, escalation.

--- a/docs/swarm/ROLES.md
+++ b/docs/swarm/ROLES.md
@@ -1,137 +1,65 @@
 # Swarm Role Presets
 
-The Add Swarm dialog ships with role presets so new Hermes Agents start with a real operating contract instead of a blank textarea and optimism. Pick the closest preset, tune the mission, then start the worker.
+The canonical Swarm roster uses semantic Hermes worker IDs from `swarm.yaml`. Role presets are routing aids, not a reason to spawn every role. Pick the closest semantic worker, tune the mission, then start durable work only when profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter.
 
-Each role has:
-
-- specialty
-- default skills
-- default model
-- when to use it
-- canonical spec reference
-
-Canonical project specs live in the swarm specs directory at:
+Canonical project specs live at:
 
 ```text
-/swarm-specs/projects/<worker>.md
+/swarm-specs/projects/<semantic-worker-id>.md
 ```
-
-Use those specs as the source of truth for standing missions. The role preset is the fast-start shape; the project spec is the durable contract.
 
 ## Preset summary
 
-| Preset | Default model | Use when |
+| Worker ID | Role intent | Use when |
 | --- | --- | --- |
-| Orchestrator | GPT-5.4 | You need dispatch, routing, drift detection, and escalation. |
-| Builder | GPT-5.5 | You need product code shipped with tests/build proof. |
-| Reviewer | GPT-5.4 | You need byte-verified review and merge readiness. |
-| Triage | GPT-5.5 | You need issues/PRs scored, reproduced, patched, or prepared. |
-| Lab | GPT-5.4 | You need isolated experiments or local-model benchmarking. |
-| Sage | GPT-5.5 | You need research, synthesis, scripts, or launch copy. |
-| Scribe | GPT-5.5 | You need docs, specs, handoffs, skills hygiene, memory curation. |
-| Foundation | GPT-5.4 | You need runtime, repair, infra, health, or lifecycle work. |
-| QA | GPT-5.4 | You need regression, smoke, expected-vs-actual verification. |
-| Mirror Integrations | GPT-5.4 | You need upstream sync, integrations, or asset packs. |
-| Custom | user-selected | You are creating a lane that does not fit an existing preset. |
+| `orchestrator` | Mission decomposition, routing, greenlight gates | Work needs durable coordination, dependency management, or escalation. |
+| `km-agent` | RAZSOC/GBrain/source-of-truth stewardship | Docs, knowledge graph, Obsidian, drift, or handoff quality matter. |
+| `builder` | Scoped implementation with tests and small diffs | Product code or repo changes need to ship. |
+| `reviewer` | Independent quality/security/regression gate | Merge readiness, adversarial review, or risk assessment is needed. |
+| `qa` | Browser/manual/test/workflow verification | Smoke checks, expected-vs-actual validation, screenshots, or console checks matter. |
+| `researcher` | Bounded research and discovery | Web/source research, synthesis, or evidence gathering is needed. |
+| `ops-watch` | Local runtime health and reliability | Gateway, Workspace, cron, MCP, ports, logs, processes, or service health matter. |
+| `maintainer` | Upstream/dependency/release hygiene | Patches, releases, dependency drift, or workaround hygiene matter. |
+| `strategist` | Wedges, kill criteria, tradeoffs | Planning, bets, sequencing, or decision review is needed. |
+| `inbox-triage` | Inbound classification/capture/routing | Issues, PRs, messages, or incoming material need routing. |
 
 ## Role routing discipline
 
-Role presets are routing aids, not a reason to spawn every role. Use durable Swarm/Kanban/Profile dispatch only when named profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter. Keep short generic checks on `delegate_task`/synchronous subagents and let the root operator handle small verified work directly.
+Use durable Swarm/Kanban/Profile dispatch only when named profile state, dependencies, retries, logs, audit trail, or cross-turn execution matter. Keep short generic checks on `delegate_task`/synchronous subagents and let the root operator handle small verified work directly.
 
 Split only genuinely independent lanes, link real dependencies, checkpoint after batches/blockers, and use one deliberate expensive review gate by default unless deeper review is explicitly approved. If a worker stalls, inspect, reclaim/retry, reassign, narrow, or block with evidence; do not silently absorb the role into the parent context.
 
-## Orchestrator
+## Worker contracts
+
+### `orchestrator`
 
 Specialty: control-plane state, dispatch, drift detection, escalation.
 
-Default skills:
-
-- `swarm-orchestrator`
-- `swarm-worker-core`
-- `swarm-review-learning-loop`
-- `self-improvement`
-
-Default model: GPT-5.4
-
-When to use:
-
-- routing multi-worker missions
-- translating intent into SwarmBriefs
-- interpreting checkpoints
-- detecting drift
-- re-prompting workers
-- escalating blockers
-- managing standing missions
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm3.md
-```
+Use for multi-worker missions, SwarmBrief framing, checkpoint interpretation, dependency routing, greenlight gates, and stalled-worker recovery.
 
 Good checkpoint:
 
 ```text
 STATE: HANDOFF
-RESULT: Routed docs release to swarm7 and review gate to swarm6 after docs checkpoint.
-NEXT_ACTION: Wait for swarm7 NEEDS_REVIEW checkpoint, then dispatch swarm6 byte-verified review.
+RESULT: Routed docs release to km-agent and review gate to reviewer after docs checkpoint.
+NEXT_ACTION: Wait for km-agent NEEDS_REVIEW checkpoint, then dispatch reviewer merge-readiness review.
 ```
 
-## Builder
+### `km-agent`
 
-Specialty: full-stack implementation, fast ship cycles.
+Specialty: RAZSOC, GBrain, Obsidian/source-of-truth, docs, skills hygiene, memory curation.
 
-Default skills:
+Use for README/docs trees, runbooks, handoffs, skill documentation, graph/source drift checks, and knowledge integrity.
 
-- `swarm-worker-core`
-- `byte-verified-code-review`
+### `builder`
 
-Default model: GPT-5.5
+Specialty: implementation, bug fixes, integrations, focused refactors.
 
-When to use:
+Use for narrow code diffs with tests/build proof. Builder should ship small slices, not opportunistic rewrites.
 
-- product UI
-- backend endpoints
-- integrations
-- bug fixes
-- feature slices
-- focused refactors
+### `reviewer`
 
-Canonical spec examples:
-
-```text
-/swarm-specs/projects/swarm5.md
-/swarm-specs/projects/swarm10.md
-```
-
-Builder should ship narrow diffs, not renovate the cathedral because a button looked lonely.
-
-## Reviewer
-
-Specialty: byte-verified code review, naming, tests, build gate.
-
-Default skills:
-
-- `swarm-worker-core`
-- `byte-verified-code-review`
-- `swarm-review-learning-loop`
-
-Default model: GPT-5.4
-
-When to use:
-
-- PR readiness
-- release branch gates
-- generated-file sanity checks
-- fragile naming changes
-- regression review
-- build/test verification
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm6.md
-```
+Specialty: independent code/security/regression review and merge readiness.
 
 Reviewer verdicts should be one of:
 
@@ -139,268 +67,51 @@ Reviewer verdicts should be one of:
 - CHANGES_REQUESTED
 - BLOCKED
 
-## Triage
+### `qa`
 
-Specialty: autonomous PR/issues processor.
-
-Default skills:
-
-- `swarm-worker-core`
-- `byte-verified-code-review`
-- `swarm-review-learning-loop`
-
-Default model: GPT-5.5
-
-When to use:
-
-- issue backlog scan
-- PR feedback triage
-- reproduction notes
-- minimal failing tests
-- small fix branches
-- issue ranking
-
-Canonical spec examples:
-
-```text
-/swarm-specs/projects/swarm12.md
-/swarm-specs/projects/swarm1.md
-```
-
-Triage should never silently merge or close. It prepares the work and asks for the gate.
-
-## Lab
-
-Specialty: local-model R&D, spec-dec, benchmarking.
-
-Default skills:
-
-- `swarm-worker-core`
-- `pc1-ollama-gguf-bench`
-- `swarm-bench-worker`
-
-Default model: GPT-5.4
-
-When to use:
-
-- local model testing
-- throughput comparisons
-- speculative runtime improvements
-- isolated prototypes
-- experiment logs
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm9.md
-```
-
-Lab is allowed to be weird because it is isolated. Product lanes are not.
-
-## Sage
-
-Specialty: research, scripts, X content, creative briefs.
-
-Default skills:
-
-- `swarm-worker-core`
-- `last30days`
-- `pdf-and-paper-deep-reading`
-
-Default model: GPT-5.5
-
-When to use:
-
-- technical research
-- market/model scan
-- launch angles
-- thread drafts
-- creative briefs
-- citations
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm4.md
-```
-
-Sage drafts; humans approve public posting.
-
-## Scribe
-
-Specialty: docs, skills hygiene, memory curation.
-
-Default skills:
-
-- `swarm-worker-core`
-- `last30days`
-- `creative-writing`
-
-Default model: GPT-5.5
-
-When to use:
-
-- README updates
-- docs trees
-- release notes
-- handoffs
-- specs
-- runbooks
-- skill documentation
-- memory hygiene reports
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm7.md
-```
-
-Scribe makes the system legible. This is less glamorous than building the system and usually more responsible for whether anyone can use it.
-
-## Foundation
-
-Specialty: infra, repair playbook, autopilot wiring.
-
-Default skills:
-
-- `swarm-worker-core`
-
-Default model: GPT-5.4
-
-When to use:
-
-- runtime APIs
-- health checks
-- tmux lifecycle
-- profile detection
-- repair playbook updates
-- orchestrator loop wiring
-- backend contracts
-
-Canonical spec examples:
-
-```text
-/swarm-specs/projects/swarm8.md
-/swarm-specs/projects/swarm2.md
-```
-
-Foundation keeps the floor from turning into soup.
-
-## QA
-
-Specialty: regression QA, render verification, expected-vs-actual checks.
-
-Default skills:
-
-- `swarm-worker-core`
-- `byte-verified-code-review`
-
-Default model: GPT-5.4
-
-When to use:
-
-- smoke tests
-- regression checks
-- UI expected-vs-actual passes
-- artifact verification
-- post-build confidence
-- release sanity
-
-Canonical spec:
-
-```text
-/swarm-specs/projects/swarm11.md
-```
+Specialty: regression QA, render verification, browser/manual/test workflow checks.
 
 QA should say exactly what was checked, exactly what failed, and exactly how to reproduce it.
 
-## Mirror Integrations
+### `researcher`
 
-Specialty: asset packs, upstream sync, integrations.
+Specialty: bounded research, discovery, citations, market/model scans, experiment notes.
 
-Default skills:
+Researcher drafts evidence and options; humans approve public posting or strategic commitments.
 
-- `swarm-worker-core`
-- `claude-promo`
-- `songwriting-and-ai-music`
+### `ops-watch`
 
-Default model: GPT-5.4
+Specialty: local runtime health, gateway/MCP/cron/process/log checks, repair playbook updates.
 
-When to use:
+Ops-watch keeps the runtime floor stable and boring.
 
-- upstream diff watching
-- integration packaging
-- asset collection
-- creative asset generation
-- cross-lane support
+### `maintainer`
 
-Canonical spec:
+Specialty: upstream sync, dependency hygiene, releases, local patches, workaround cleanup.
 
-```text
-/swarm-specs/projects/swarm10.md
-```
+Use when the main risk is drift against external sources or package/release health.
 
-Mirror Integrations is the lane for portable useful things, not random shiny distractions. There will be random shiny distractions. They are sneaky.
+### `strategist`
 
-## Custom
+Specialty: operating plans, wedges, bets, kill criteria, tradeoff reviews.
 
-Specialty: user-defined.
+Use when sequencing and decision quality matter more than immediate execution.
 
-Default skills: none.
+### `inbox-triage`
 
-Default model: user-selected.
+Specialty: issues/PRs/messages classification, capture, discard, research, or route.
 
-When to use:
+Inbox-triage should never silently merge, close, or publish. It prepares the work and asks for the gate.
 
-- the worker does not fit an existing role
-- you are testing a new lane
-- you need temporary specialization
-- a future preset is being prototyped
+## Custom workers
 
-Canonical spec:
+Use a custom worker only when none of the semantic workers fit. Document:
 
-```text
-/swarm-specs/projects/<new-worker>.md
-```
+- standing mission
+- profile name
+- wrapper name
+- toolsets/plugin toolsets
+- greenlight boundaries
+- checkpoint contract
 
-Custom workers should still get:
-
-- `swarm-worker-core`
-- a role description
-- a specialty
-- a mission
-- a checkpoint contract
-- a clear approval boundary
-
-Blank custom workers become expensive autocomplete. Add structure first.
-
-## Choosing the right role
-
-Use this routing rule:
-
-| If the work is mostly... | Send it to... |
-| --- | --- |
-| deciding who should do what | Orchestrator |
-| changing product code | Builder |
-| proving a branch is safe | Reviewer |
-| chewing through issues/PRs | Triage |
-| experimenting away from release | Lab |
-| researching or drafting narrative | Sage |
-| explaining, documenting, preserving context | Scribe |
-| runtime/health/repair infrastructure | Foundation |
-| checking behavior and regressions | QA |
-| upstream/integration/assets | Mirror Integrations |
-| none of the above | Custom |
-
-## Adding a new role preset
-
-1. Define the role in the UI preset list.
-2. Give it a one-line specialty.
-3. Give it a standing mission.
-4. Choose default skills.
-5. Choose default model.
-6. Create a canonical project spec.
-7. Add it to this document.
-8. Dispatch a tiny smoke task and verify a checkpoint.
-
-If step 6 feels like too much work, the role probably is not real yet.
+If the custom role becomes durable, add it to `swarm.yaml`, profile config, wrapper, and `docs/swarm/ALIGNMENT_HEALTH.md` invariants together.

--- a/docs/swarm/SKILLS.md
+++ b/docs/swarm/SKILLS.md
@@ -40,18 +40,18 @@ The important rule is that the worker's runtime must be able to resolve the skil
 
 ## Role-to-skill defaults
 
-| Role | Default skills |
+| Worker | Default skills |
 | --- | --- |
-| Orchestrator | `swarm-orchestrator`, `swarm-worker-core`, `swarm-review-learning-loop`, `self-improvement` |
-| Builder | `swarm-worker-core`, `byte-verified-code-review` |
-| Reviewer | `swarm-worker-core`, `byte-verified-code-review`, `swarm-review-learning-loop` |
-| Triage | `swarm-worker-core`, `byte-verified-code-review`, `swarm-review-learning-loop` |
-| Lab | `swarm-worker-core`, `pc1-ollama-gguf-bench`, `swarm-bench-worker` |
-| Sage | `swarm-worker-core`, `last30days`, `pdf-and-paper-deep-reading` |
-| Scribe | `swarm-worker-core`, `last30days`, `creative-writing` |
-| Foundation | `swarm-worker-core` |
-| QA | `swarm-worker-core`, `byte-verified-code-review` |
-| Mirror Integrations | `swarm-worker-core`, `claude-promo`, `songwriting-and-ai-music` |
+| `orchestrator` | `orchestrator-core`, `swarm-orchestrator`, `swarm-worker-core` |
+| `km-agent` | `km-agent-core`, `swarm-worker-core` |
+| `builder` | `builder-core`, `swarm-worker-core`, `byte-verified-code-review` |
+| `reviewer` | `reviewer-core`, `swarm-worker-core`, `byte-verified-code-review`, `swarm-review-learning-loop` |
+| `qa` | `qa-core`, `swarm-worker-core`, `byte-verified-code-review` |
+| `researcher` | `researcher-core`, `swarm-worker-core`, `last30days`, `pdf-and-paper-deep-reading` |
+| `ops-watch` | `ops-watch-core`, `swarm-worker-core`, `swarm-dev-runtime` |
+| `maintainer` | `maintainer-core`, `swarm-worker-core`, `swarm-pr-worker` |
+| `strategist` | `strategist-core`, `swarm-worker-core` |
+| `inbox-triage` | `inbox-triage-core`, `swarm-worker-core`, `swarm-pr-worker` |
 | Custom | no default skills |
 
 ## What each core skill contributes
@@ -100,7 +100,7 @@ Used for review gates. It forces proof instead of "looks fine":
 
 ### swarm-bench-worker
 
-Used by Lab for local-model and runtime experiments:
+Used by researcher/experiments lanes for local-model and runtime experiments:
 
 - benchmark plan
 - controlled run
@@ -131,7 +131,7 @@ Used by UI builders:
 
 ### swarm-dev-runtime
 
-Used by Foundation/runtime lanes:
+Used by ops-watch/runtime lanes:
 
 - API contracts
 - profile/runtime state

--- a/skills/workspace-dispatch/SKILL.md
+++ b/skills/workspace-dispatch/SKILL.md
@@ -8,6 +8,13 @@ description: |
 
 You are an autonomous mission orchestrator. Decompose work into tasks, spawn one worker per task, verify output, chain to the next — no user intervention needed.
 
+
+## Dispatch Boundary
+
+Use this skill for bounded mission decomposition where one orchestrator can verify machine-checkable exit criteria. For durable named-profile work that needs profile state, dependencies, retries, logs, audit trail, or cross-turn execution, route through Kanban/Profile dispatch instead. For short generic checks, use `delegate_task`/a synchronous subtask; for small obvious work, execute directly and verify.
+
+Before spawning workers, split only genuinely independent lanes and state the fan-in contract. Avoid silent polling: checkpoint after meaningful batches or blockers. If a worker stalls, inspect status/logs, retry with narrower scope, reassign if tooling/profile is broken, or block with the exact decision needed; do not silently absorb the worker's role.
+
 ## Flow
 
 1. **Decompose** the goal into 2-6 tasks with machine-checkable exit criteria

--- a/src/components/update-center-notifier.tsx
+++ b/src/components/update-center-notifier.tsx
@@ -69,13 +69,14 @@ const CHECK_INTERVAL_MS = 30 * 60 * 1000
 const DISMISS_PREFIX = 'hermes-update-v2-dismissed:'
 const NOTES_KEY = 'hermes-update-v2-release-notes'
 const NOTES_SEEN_KEY = 'hermes-update-v2-release-notes-seen'
+const NOTES_DISABLED_KEY = 'hermes-update-v2-release-notes-disabled'
 
 function shortSha(value: string | null | undefined): string {
   return value ? value.slice(0, 7) : 'unknown'
 }
 
 function productDismissKey(product: ProductUpdateStatus): string {
-  return `${product.id}:${product.latestHead ?? product.version ?? 'unknown'}`
+  return `${product.id}:${product.latestHead ?? product.version}`
 }
 
 function notesId(sections: Array<ReleaseNoteSection>): string {
@@ -99,7 +100,7 @@ function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
     const raw = localStorage.getItem(NOTES_KEY)
     if (raw) {
       const parsed = JSON.parse(raw) as Notes
-      existingId = parsed?.id ?? null
+      existingId = parsed.id
     }
   } catch {
     existingId = null
@@ -113,10 +114,11 @@ function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
 
 function readNotes(): Notes | null {
   try {
+    if (localStorage.getItem(NOTES_DISABLED_KEY) === '1') return null
     const raw = localStorage.getItem(NOTES_KEY)
     if (!raw) return null
     const parsed = JSON.parse(raw) as Notes
-    if (!parsed?.id || !Array.isArray(parsed.sections)) return null
+    if (!parsed.id || !Array.isArray(parsed.sections)) return null
     if (localStorage.getItem(NOTES_SEEN_KEY) === parsed.id) return null
     return parsed
   } catch {
@@ -160,6 +162,7 @@ export function UpdateCenterNotifier() {
   })
 
   useEffect(() => {
+    if (localStorage.getItem(NOTES_DISABLED_KEY) === '1') return
     if (!data?.pendingReleaseNotes?.length) return
     const stored = storeNotes(data.pendingReleaseNotes)
     if (stored) setNotes((current) => current ?? stored)

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -179,6 +179,23 @@ export async function deleteTask(taskId: string): Promise<void> {
   if (!res.ok) throw new Error(`Failed to delete task: ${res.status}`)
 }
 
+export async function archiveTask(taskId: string): Promise<void> {
+  const { base } = await resolveBackend()
+  const res = await fetch(`${base}/${taskId}?action=archive`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(
+      (body as { detail?: string; error?: string }).detail
+      || (body as { error?: string }).error
+      || `Failed to archive task: ${res.status}`,
+    )
+  }
+}
+
 export async function linkSession(taskId: string, sessionId: string | null): Promise<ClaudeTask> {
   const { base } = await resolveBackend()
   const res = await fetch(`${base}/${taskId}`, {

--- a/src/routes/api/claude-tasks.$taskId.ts
+++ b/src/routes/api/claude-tasks.$taskId.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { getClaudeTask, moveClaudeTask, updateClaudeTask } from '../../server/claude-tasks-backend'
+import { archiveClaudeTask, deleteClaudeTask, getClaudeTask, moveClaudeTask, updateClaudeTask } from '../../server/claude-tasks-backend'
 import type { TaskColumn, TaskPriority } from '../../server/claude-tasks-backend'
 
 function jsonResponse(data: unknown, status = 200) {
@@ -62,12 +62,14 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
         }
       },
 
-      DELETE: async ({ request }) => {
+      DELETE: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
           return jsonResponse({ error: 'Unauthorized' }, 401)
         }
 
-        return jsonResponse({ error: 'Delete is not supported by the shared Agent Kanban backend' }, 405)
+        const deleted = await deleteClaudeTask(params.taskId)
+        if (!deleted) return jsonResponse({ error: 'Task not found or delete unsupported' }, 404)
+        return jsonResponse({ ok: true })
       },
 
       POST: async ({ request, params }) => {
@@ -77,6 +79,11 @@ export const Route = createFileRoute('/api/claude-tasks/$taskId')({
 
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || 'move'
+        if (action === 'archive') {
+          const task = await archiveClaudeTask(params.taskId)
+          if (!task) return jsonResponse({ error: 'Task not found' }, 404)
+          return jsonResponse({ task })
+        }
         if (action !== 'move') {
           return jsonResponse({ error: `Unsupported action: ${action}` }, 400)
         }

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -273,8 +273,24 @@ export const Route = createFileRoute('/api/conductor-spawn')({
             name: missionName,
             prompt,
           })
-          if (result.error)
-            return json({ ok: false, error: result.error }, { status: 502 })
+          if (result.error) {
+            // Some Hermes dashboard builds advertise conductor endpoints but reject
+            // mission creation (for example HTTP 405 Method Not Allowed). Fall back
+            // to the portable Workspace conductor path instead of failing the smoke
+            // mission before the orchestrator can run.
+            return json({
+              ok: true,
+              mode: 'portable',
+              prompt,
+              missionId: null,
+              sessionKey: missionName,
+              sessionKeyPrefix: null,
+              jobId: null,
+              jobName: missionName,
+              runId: null,
+              warnings: [...goalSanitization.warnings, result.error],
+            })
+          }
           const missionId = result.id ?? missionName
           return json({
             ok: true,

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -64,8 +64,8 @@ function readOptionalString(value: unknown): string {
 }
 
 function readMaxParallel(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 1
-  return Math.min(5, Math.max(1, Math.round(value)))
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 6
+  return Math.min(10, Math.max(1, Math.round(value)))
 }
 
 function buildOrchestratorPrompt(
@@ -105,6 +105,7 @@ function buildOrchestratorPrompt(
       ? [
           '',
           `Run up to ${options.maxParallel} workers in parallel when tasks are independent`,
+          'If the goal names specific worker/agent roles, create one worker per named role and preserve those role names in the worker labels and result lines.',
         ]
       : [
           '',
@@ -117,7 +118,9 @@ function buildOrchestratorPrompt(
     '## Critical Rules',
     '- Use create_task / delegate_task to create worker agents for each task',
     '- Do NOT do the work yourself — spawn workers',
-    '- For simple tasks (single file, quick mockup), use ONLY 1 task with 1 worker — do not over-decompose',
+    ...(options.maxParallel > 1
+      ? ['- For multi-role missions, create distinct workers for the independent roles instead of collapsing them into one worker']
+      : ['- For simple tasks (single file, quick mockup), use ONLY 1 task with 1 worker — do not over-decompose']),
     '- Do NOT ask for confirmation — start immediately',
     '- Label workers as "worker-<task-slug>" so the UI can track them',
     '- Each worker gets a self-contained prompt with the task + exit criteria',

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -1454,13 +1454,24 @@ export const Route = createFileRoute('/api/send-stream')({
                 }
               }
 
-              // Set a timeout to close the stream if no completion event
-              streamTimeoutTimer = setTimeout(() => {
-                if (!streamClosed) {
-                  sendEvent('error', { message: 'Stream timeout' })
-                  closeStream()
+              // Some Hermes Agent builds finish the upstream stream after
+              // `assistant.completed` without emitting a separate `run.completed`.
+              // In that case we have already sent the final assistant text above,
+              // so emit a terminal done event now instead of leaving the Workspace
+              // UI stuck in "Thinking…" until the send-stream timeout fires.
+              if (!streamClosed) {
+                const translated = {
+                  state: 'complete',
+                  sessionKey,
+                  runId: activeRunId ?? undefined,
                 }
-              }, SEND_STREAM_RUN_TIMEOUT_MS)
+                persistActiveRun((runSessionKey, activeId) =>
+                  markRunStatus(runSessionKey, activeId, 'complete'),
+                )
+                sendEvent('done', translated)
+                skipPublish || publishChatEvent('done', translated)
+                closeStream()
+              }
             } catch (err) {
               // Only send error if stream hasn't already completed successfully
               if (!streamClosed) {

--- a/src/routes/api/swarm-checkpoint.ts
+++ b/src/routes/api/swarm-checkpoint.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { z } from 'zod'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getSwarmProfilePath } from '../../server/swarm-foundation'
+import { isSwarmWorkerId } from '../../server/swarm-roster'
 import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
 import { checkpointFromRuntimeSnapshot, readRuntimeCheckpointSnapshot } from './swarm-dispatch'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
@@ -26,7 +27,7 @@ type CheckpointRequest = {
 }
 
 const CheckpointBodySchema = z.object({
-  workerId: z.string().regex(/^swarm\d+$/i),
+  workerId: z.string().trim().refine(isSwarmWorkerId, 'worker id must look like swarm13 or a semantic profile id'),
   state: z.enum(['idle', 'executing', 'thinking', 'writing', 'waiting', 'blocked', 'syncing', 'reviewing', 'offline']).optional(),
   phase: z.string().trim().max(200).nullable().optional(),
   currentTask: z.string().trim().max(16_000).nullable().optional(),
@@ -45,7 +46,7 @@ const ALLOWED_STATES = new Set(['idle', 'executing', 'thinking', 'writing', 'wai
 const ALLOWED_CHECKPOINTS = new Set(['none', 'in_progress', 'done', 'blocked', 'handoff', 'needs_input'])
 
 function validateWorkerId(value: string): boolean {
-  return /^swarm\d+$/i.test(value)
+  return isSwarmWorkerId(value)
 }
 
 function cleanString(value: unknown): string | null | undefined {

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { newestCheckpointFromMessages, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import { newestCheckpointFromMessages, parseSwarmCheckpoint, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
 import { createOrUpdateMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
@@ -920,6 +920,48 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           durationMs,
           exitCode: 0,
           delivery: 'oneshot',
+        }
+        if (options?.waitForCheckpoint) {
+          const checkpoint = parseSwarmCheckpoint(out)
+          if (checkpoint) {
+            markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
+            recordMissionCheckpoint({
+              missionId: options?.missionId,
+              assignmentId: assignment.assignmentId ?? null,
+              workerId,
+              checkpoint,
+              source: 'swarm-dispatch',
+            })
+            appendSwarmMemoryEvent({
+              workerId,
+              missionId: options?.missionId ?? null,
+              assignmentId: assignment.assignmentId ?? null,
+              type: 'checkpoint',
+              summary: checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
+              checkpoint,
+              event: {
+                stateLabel: checkpoint.stateLabel,
+                filesChanged: checkpoint.filesChanged,
+                commandsRun: checkpoint.commandsRun,
+                blocker: checkpoint.blocker,
+                nextAction: checkpoint.nextAction,
+              },
+            })
+            publishSwarmCheckpointNotification({
+              workerId,
+              missionId: options?.missionId ?? null,
+              assignmentId: assignment.assignmentId ?? null,
+              checkpoint,
+              notifySessionKey: options?.notifySessionKey ?? 'main',
+            })
+            result.checkpoint = checkpoint
+            result.checkpointStatus = 'checkpointed'
+          } else {
+            result.checkpoint = null
+            result.checkpointStatus = 'timeout'
+          }
+        } else {
+          result.checkpointStatus = 'not-requested'
         }
         markDispatchResult(workerId, result)
         resolve(result)

--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -1,24 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
 import * as yaml from 'yaml'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getLocalBinDir, getProfilesDir } from '../../server/claude-paths'
-import { isSwarmWorkerId } from '../../server/swarm-roster'
+import { buildWorkerHealth } from '../../server/swarm-health'
+import { isSwarmWorkerId, readSwarmRoster } from '../../server/swarm-roster'
 
-type WorkerHealth = {
-  workerId: string
-  profileFound: boolean
-  wrapperFound: boolean
-  model: string
-  provider: string
-  recentAuthErrors: number
-  lastErrorAt: string | null
-  lastErrorMessage: string | null
-}
-
-function listSwarmIds(): string[] {
+function listSwarmIds(): Array<string> {
   const dir = getProfilesDir()
   if (!existsSync(dir)) return []
   return readdirSync(dir, { withFileTypes: true })
@@ -110,7 +100,7 @@ function scanRecentAuthErrors(profilePath: string): {
 export const Route = createFileRoute('/api/swarm-health')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
+      GET: ({ request }) => {
         if (!isAuthenticated(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
@@ -119,24 +109,15 @@ export const Route = createFileRoute('/api/swarm-health')({
         const apiUrl = process.env.HERMES_API_URL ?? process.env.CLAUDE_API_URL ?? null
         const profilesBase = getProfilesDir()
         const swarmIds = listSwarmIds()
+        const rosterWorkers = readSwarmRoster(swarmIds).workers
         const wrapperBase = getLocalBinDir()
 
-        const workers: WorkerHealth[] = swarmIds.map((id) => {
-          const profilePath = join(profilesBase, id)
-          const wrapperPath = join(wrapperBase, id)
-          const config = readWorkerConfig(profilePath)
-          const errs = scanRecentAuthErrors(profilePath)
-          return {
-            workerId: id,
-            profileFound: existsSync(profilePath),
-            wrapperFound: existsSync(wrapperPath),
-            model: config.model,
-            provider: config.provider,
-            recentAuthErrors: errs.count,
-            lastErrorAt: errs.lastAt,
-            lastErrorMessage: errs.lastMessage,
-          }
-        })
+        const workers = rosterWorkers.map((worker) => buildWorkerHealth(worker, {
+          profilesBase,
+          wrapperBase,
+          readWorkerConfig,
+          scanRecentAuthErrors,
+        }))
 
         const totalAuthErrors = workers.reduce((sum, worker) => sum + worker.recentAuthErrors, 0)
         const distinctModels = Array.from(new Set(workers.map((w) => formatModelDisplay(w.model, w.provider)))).filter((value) => value !== 'unknown')

--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import * as yaml from 'yaml'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getLocalBinDir, getProfilesDir } from '../../server/claude-paths'
+import { isSwarmWorkerId } from '../../server/swarm-roster'
 
 type WorkerHealth = {
   workerId: string
@@ -23,7 +24,7 @@ function listSwarmIds(): string[] {
   return readdirSync(dir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter((name) => /^swarm\d+$/i.test(name))
+    .filter((name) => isSwarmWorkerId(name))
     .sort()
 }
 

--- a/src/routes/api/swarm-lifecycle.ts
+++ b/src/routes/api/swarm-lifecycle.ts
@@ -9,6 +9,7 @@ import {
   requestWorkerHandoff,
 } from '../../server/swarm-lifecycle'
 import { listSwarmWorkerIds } from '../../server/swarm-foundation'
+import { isSwarmWorkerId } from '../../server/swarm-roster'
 
 type LifecyclePost = {
   action?: unknown
@@ -16,7 +17,7 @@ type LifecyclePost = {
 }
 
 function validWorkerId(value: unknown): string | null {
-  return typeof value === 'string' && /^swarm\d+$/i.test(value.trim()) ? value.trim() : null
+  return isSwarmWorkerId(value) ? value.trim() : null
 }
 
 export const Route = createFileRoute('/api/swarm-lifecycle')({

--- a/src/routes/api/swarm-orchestrator-loop.ts
+++ b/src/routes/api/swarm-orchestrator-loop.ts
@@ -11,7 +11,7 @@ import { appendMissionContinuation, markMissionAssignmentsReviewedByWorker, reco
 import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
 import { publishSwarmActionPrompt, publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { applySwarmModeToLoopFlags, readSwarmMode } from '../../server/swarm-mode'
-import { readSwarmRoster } from '../../server/swarm-roster'
+import { isSwarmWorkerId, readSwarmRoster } from '../../server/swarm-roster'
 
 type LoopRequest = {
   workerIds?: unknown
@@ -38,7 +38,7 @@ function validWorkerIds(value: unknown): Array<string> {
   return value
     .filter((item): item is string => typeof item === 'string')
     .map((item) => item.trim())
-    .filter((item) => /^swarm\d+$/i.test(item))
+    .filter((item) => isSwarmWorkerId(item))
 }
 
 function timestampFromRuntime(value: unknown): number | null {
@@ -230,7 +230,8 @@ function chooseByRole(workerIds: Array<string>, pattern: RegExp): string | null 
 }
 
 function chooseReviewer(workerIds: Array<string>, requested: unknown): string | null {
-  if (typeof requested === 'string' && /^swarm\d+$/i.test(requested.trim())) return requested.trim()
+  if (typeof requested === 'string' && isSwarmWorkerId(requested)) return requested.trim()
+  if (workerIds.includes('reviewer')) return 'reviewer'
   if (workerIds.includes('swarm6')) return 'swarm6'
   return chooseByRole(workerIds, /review|qa|critic/i)
 }

--- a/src/routes/api/swarm-runtime.ts
+++ b/src/routes/api/swarm-runtime.ts
@@ -1,8 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfilesDir } from '../../server/claude-paths'
 import {
@@ -12,20 +12,22 @@ import {
   getSwarmWrapperPath,
   listSwarmWorkerIds,
   readSwarmRuntimeFile,
-  type SwarmArtifactMetadata,
-  type SwarmBoundary,
-  type SwarmCheckpointStatus,
-  type SwarmDispatchMetadata,
-  type SwarmLifecycleMetadata,
-  type SwarmPreviewMetadata,
-  type SwarmRuntimeSource,
-  type SwarmSessionMetadata,
-  type SwarmTaskMetadata,
-  type SwarmTerminalKind,
-  type SwarmWorkerState,
 } from '../../server/swarm-foundation'
-import { rosterByWorkerId } from '../../server/swarm-roster'
 import { readSwarmMode, writeSwarmMode } from '../../server/swarm-mode'
+import { rosterByWorkerId } from '../../server/swarm-roster'
+import type {
+  SwarmArtifactMetadata,
+  SwarmBoundary,
+  SwarmCheckpointStatus,
+  SwarmDispatchMetadata,
+  SwarmLifecycleMetadata,
+  SwarmPreviewMetadata,
+  SwarmRuntimeSource,
+  SwarmSessionMetadata,
+  SwarmTaskMetadata,
+  SwarmTerminalKind,
+  SwarmWorkerState,
+} from '../../server/swarm-foundation'
 
 type RuntimeEntry = {
   workerId: string
@@ -74,7 +76,7 @@ function titleCase(value: string): string {
     .join(' ')
 }
 
-function listWorkerIds(): string[] {
+function listWorkerIds(): Array<string> {
   return listSwarmWorkerIds()
 }
 
@@ -136,11 +138,11 @@ async function buildEntry(
   workerId: string,
   tmuxAvailable: boolean,
 ): Promise<RuntimeEntry> {
-  const profilePath = join(getProfilesDir(), workerId)
+  const roster = rosterByWorkerId([workerId]).get(workerId)
+  const profilePath = join(getProfilesDir(), roster?.profile || workerId)
   const { source, runtime } = readSwarmRuntimeFile(profilePath, workerId, {
     workspaceRoot: process.cwd(),
   })
-  const roster = rosterByWorkerId([workerId]).get(workerId)
   const { tail, lastSessionStartedAt, logPath } = lastLogTail(profilePath)
   const matched = tmuxAvailable
     ? await probeTmuxName(workerId, getSwarmTmuxSessionName(workerId))
@@ -151,7 +153,7 @@ async function buildEntry(
   else if (runtime.cwd) terminalKind = 'shell'
   else if (logPath) terminalKind = 'log-tail'
 
-  const wrapperPath = getSwarmWrapperPath(workerId)
+  const wrapperPath = getSwarmWrapperPath(workerId, roster)
   const resolvedWrapperPath = existsSync(wrapperPath) ? wrapperPath : null
   const session = buildSwarmSessionMetadata({
     workerId,

--- a/src/screens/gateway/conductor.tsx
+++ b/src/screens/gateway/conductor.tsx
@@ -98,6 +98,19 @@ const QUICK_ACTIONS: Array<{
 
 const AGENT_NAMES = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
 const AGENT_EMOJIS = ['🤖', '⚡', '🔥', '🌊', '🌿', '💫', '🔮', '⭐']
+const SEMANTIC_AGENT_IDS = ['orchestrator', 'km-agent', 'builder', 'reviewer', 'qa', 'researcher', 'ops-watch', 'maintainer', 'strategist', 'inbox-triage']
+const SEMANTIC_AGENT_LABELS: Record<string, string> = {
+  'ops-watch': 'ops-watch',
+  qa: 'qa',
+  reviewer: 'reviewer',
+  builder: 'builder',
+  'km-agent': 'km-agent',
+  maintainer: 'maintainer',
+  orchestrator: 'orchestrator',
+  researcher: 'researcher',
+  strategist: 'strategist',
+  'inbox-triage': 'inbox-triage',
+}
 const BLENDED_COST_PER_MILLION_TOKENS = 5
 const CONDUCTOR_GOAL_DRAFT_STORAGE_KEY = 'conductor:goal-draft'
 
@@ -126,6 +139,23 @@ function getAgentPersona(index: number) {
     name: AGENT_NAMES[index % AGENT_NAMES.length],
     emoji: AGENT_EMOJIS[index % AGENT_EMOJIS.length],
   }
+}
+
+function extractSemanticAgentIds(text: string): Array<string> {
+  const lower = text.toLowerCase()
+  return SEMANTIC_AGENT_IDS.filter((id) => lower.includes(id))
+}
+
+function semanticResultLineStatus(text: string, agentId: string): 'complete' | 'failed' | 'running' {
+  const escaped = agentId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const line = text.match(new RegExp(`^${escaped}:\\s*(PASS|FAIL)\\b.*$`, 'im'))?.[0]
+  if (!line) return 'running'
+  return /:\s*FAIL\b/i.test(line) ? 'failed' : 'complete'
+}
+
+function semanticResultLine(text: string, agentId: string): string | null {
+  const escaped = agentId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return text.match(new RegExp(`^${escaped}:\\s*(?:PASS|FAIL)\\b.*$`, 'im'))?.[0] ?? null
 }
 
 function estimateTokenCost(totalTokens: number): number {
@@ -960,7 +990,31 @@ export function Conductor() {
     })
   }, [conductor.recentSessions])
 
+  const requestedSemanticAgentIds = useMemo(() => extractSemanticAgentIds(conductor.goal), [conductor.goal])
+
   const officeAgentRows = useMemo<AgentWorkingRow[]>(() => {
+    if (requestedSemanticAgentIds.length > 1) {
+      const streamText = conductor.streamText || ''
+      return requestedSemanticAgentIds.map((agentId) => {
+        const resultStatus = semanticResultLineStatus(streamText, agentId)
+        const resultLine = semanticResultLine(streamText, agentId)
+        const existingWorker = conductor.workers.find((worker) => worker.label.toLowerCase().includes(agentId) || worker.displayName.toLowerCase().includes(agentId))
+        const isPaused = conductor.isPaused && resultStatus === 'running'
+        return {
+          id: `semantic-${agentId}`,
+          name: SEMANTIC_AGENT_LABELS[agentId] ?? agentId,
+          modelId: existingWorker?.model || conductor.conductorSettings.workerModel || 'auto',
+          roleDescription: existingWorker?.displayName || 'Semantic worker',
+          status: isPaused ? 'paused' : resultStatus === 'complete' ? 'idle' : resultStatus === 'failed' ? 'error' : 'active',
+          lastLine: isPaused ? 'Paused' : resultLine || `Assigned ${agentId} QC lane`,
+          lastAt: existingWorker?.updatedAt ? new Date(existingWorker.updatedAt).getTime() : undefined,
+          taskCount: conductor.tasks.filter((task) => task.title.toLowerCase().includes(agentId) || task.workerKey === existingWorker?.key).length,
+          currentTask: resultLine ? undefined : `Running ${agentId}`,
+          sessionKey: existingWorker?.key ?? `semantic-${agentId}`,
+        }
+      })
+    }
+
     if (conductor.workers.length > 0) {
       return conductor.workers.map((worker, index) => {
         const persona = getAgentPersona(index)
@@ -996,7 +1050,7 @@ export function Conductor() {
         sessionKey: 'conductor-placeholder-agent',
       },
     ]
-  }, [conductor.conductorSettings.workerModel, conductor.goal, conductor.isPaused, conductor.tasks, conductor.workerOutputs, conductor.workers])
+  }, [conductor.conductorSettings.workerModel, conductor.goal, conductor.isPaused, conductor.streamText, conductor.tasks, conductor.workerOutputs, conductor.workers, requestedSemanticAgentIds])
 
   const completePhaseProjectPath = useMemo(() => {
     const workerOutputTexts = [...Object.values(conductor.workerOutputs), ...conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -51,8 +51,15 @@ const DEFAULT_CONDUCTOR_SETTINGS: ConductorSettings = {
   orchestratorModel: '',
   workerModel: '',
   projectsDir: '',
-  maxParallel: 1,
+  maxParallel: 6,
   supervised: false,
+}
+
+const SEMANTIC_AGENT_IDS = ['orchestrator', 'km-agent', 'builder', 'reviewer', 'qa', 'researcher', 'ops-watch', 'maintainer', 'strategist', 'inbox-triage']
+
+function countNamedSemanticAgents(text: string): number {
+  const lower = text.toLowerCase()
+  return SEMANTIC_AGENT_IDS.filter((id) => lower.includes(id)).length
 }
 
 type PersistedMission = {
@@ -352,7 +359,7 @@ function loadConductorSettings(): ConductorSettings {
       orchestratorModel: typeof parsed.orchestratorModel === 'string' ? parsed.orchestratorModel : DEFAULT_CONDUCTOR_SETTINGS.orchestratorModel,
       workerModel: typeof parsed.workerModel === 'string' ? parsed.workerModel : DEFAULT_CONDUCTOR_SETTINGS.workerModel,
       projectsDir: typeof parsed.projectsDir === 'string' ? parsed.projectsDir : DEFAULT_CONDUCTOR_SETTINGS.projectsDir,
-      maxParallel: Math.min(5, Math.max(1, typeof parsed.maxParallel === 'number' && Number.isFinite(parsed.maxParallel) ? Math.round(parsed.maxParallel) : DEFAULT_CONDUCTOR_SETTINGS.maxParallel)),
+      maxParallel: Math.min(10, Math.max(1, typeof parsed.maxParallel === 'number' && Number.isFinite(parsed.maxParallel) ? Math.round(parsed.maxParallel) : DEFAULT_CONDUCTOR_SETTINGS.maxParallel)),
       supervised: typeof parsed.supervised === 'boolean' ? parsed.supervised : DEFAULT_CONDUCTOR_SETTINGS.supervised,
     }
   } catch {
@@ -1415,6 +1422,11 @@ export function useConductorGateway() {
       seenToolCallRef.current = false
       historySavedRef.current = false
       const startedAt = new Date().toISOString()
+      const namedSemanticAgentCount = countNamedSemanticAgents(trimmed)
+      const effectiveSettings: ConductorSettings = {
+        ...settings,
+        maxParallel: Math.max(settings.maxParallel, namedSemanticAgentCount, DEFAULT_CONDUCTOR_SETTINGS.maxParallel),
+      }
       setMissionStartedAt(startedAt)
       setPhase('decomposing')
       persistMission({
@@ -1440,7 +1452,7 @@ export function useConductorGateway() {
       const response = await fetch('/api/conductor-spawn', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ goal: trimmed, ...settings }),
+        body: JSON.stringify({ goal: trimmed, ...effectiveSettings }),
       })
 
       if (!response.ok) {

--- a/src/screens/swarm/swarm-screen.tsx
+++ b/src/screens/swarm/swarm-screen.tsx
@@ -26,6 +26,8 @@ import { SwarmTerminal } from '@/components/swarm/swarm-terminal'
 import { useQuery } from '@tanstack/react-query'
 
 const SWARM_ROOM_STORAGE_KEY = 'claude-swarm-room-v1'
+const WORKER_ID_PATTERN = /^(swarm\d+|[a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/i
+const isWorkerId = (id: string) => WORKER_ID_PATTERN.test(id)
 
 type WorkerHealth = { workerId: string; recentAuthErrors: number }
 type HealthData = { workspaceModel: string | null; workers: WorkerHealth[]; summary: { totalWorkers: number; totalAuthErrors24h: number; distinctProviders: string[] } }
@@ -121,7 +123,7 @@ export function SwarmScreen() {
 
   const swarmMembers = useMemo(() => {
     return [...crew]
-      .filter((member) => /^swarm\d+$/i.test(member.id))
+      .filter((member) => isWorkerId(member.id))
       .sort((a, b) => {
         const aSwarm = /^swarm\d+$/i.test(a.id)
         const bSwarm = /^swarm\d+$/i.test(b.id)
@@ -266,6 +268,15 @@ export function SwarmScreen() {
           >
             <HugeiconsIcon icon={RefreshIcon} size={11} className={isFetching ? 'animate-spin' : ''} />
             Refresh
+          </button>
+          <button
+            type="button"
+            onClick={() => setMissionOpen(true)}
+            disabled={!selectedId}
+            className="inline-flex items-center gap-2 rounded-full border border-emerald-400/35 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100 hover:bg-emerald-400/20 disabled:opacity-50"
+          >
+            <HugeiconsIcon icon={ComputerTerminal01Icon} size={12} />
+            Route to {selectedId ?? 'agent'}
           </button>
           <button
             type="button"

--- a/src/screens/swarm2/operational-worker-card.tsx
+++ b/src/screens/swarm2/operational-worker-card.tsx
@@ -551,10 +551,11 @@ export function OperationalWorkerCard({
         <button
           type="button"
           onClick={onOpenTasks}
+          title={`Route work to ${member.displayName || member.id}`}
           className="inline-flex items-center gap-1 rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2.5 py-1 text-[var(--theme-muted)] transition-colors hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
         >
           <HugeiconsIcon icon={CheckListIcon} size={11} />
-          Route work
+          Route to agent
         </button>
         <button
           type="button"

--- a/src/screens/tasks/task-dialog.tsx
+++ b/src/screens/tasks/task-dialog.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
+import type { ClaudeTask, CreateTaskInput, TaskAssignee, TaskColumn, TaskPriority } from '@/lib/tasks-api'
 import {
   DialogContent,
+  DialogDescription,
   DialogRoot,
   DialogTitle,
-  DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import type { ClaudeTask, CreateTaskInput, TaskColumn, TaskPriority, TaskAssignee } from '@/lib/tasks-api'
 import { COLUMN_LABELS, COLUMN_ORDER } from '@/lib/tasks-api'
 
 type Props = {
@@ -17,11 +17,19 @@ type Props = {
   defaultColumn?: TaskColumn
   assignees: Array<TaskAssignee>
   onSubmit: (input: CreateTaskInput) => Promise<void>
+  onArchive?: () => Promise<void>
+  onDelete?: () => Promise<void>
   isSubmitting: boolean
+  isArchiving?: boolean
+  isDeleting?: boolean
 }
 
-export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees, onSubmit, isSubmitting }: Props) {
+export const ARCHIVE_TASK_BUTTON_LABEL = 'Archive'
+export const DELETE_TASK_BUTTON_LABEL = 'Delete'
+
+export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees, onSubmit, onArchive, onDelete, isSubmitting, isArchiving = false, isDeleting = false }: Props) {
   const isEdit = Boolean(task)
+  const isBusy = isSubmitting || isArchiving || isDeleting
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -181,22 +189,46 @@ export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees,
               />
             </div>
 
-            <div className="flex items-center justify-between pt-2">
-              <p className="text-[10px] text-[var(--theme-muted)]">Press Esc to cancel</p>
+            <div className="flex items-center justify-between gap-3 pt-2">
+              <div className="flex items-center gap-2">
+                {isEdit && onArchive && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => { void onArchive() }}
+                    disabled={isBusy}
+                  >
+                    {isArchiving ? 'Archiving...' : ARCHIVE_TASK_BUTTON_LABEL}
+                  </Button>
+                )}
+                {isEdit && onDelete && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => { void onDelete() }}
+                    disabled={isBusy}
+                    className="text-red-400 hover:text-red-300"
+                  >
+                    {isDeleting ? 'Deleting...' : DELETE_TASK_BUTTON_LABEL}
+                  </Button>
+                )}
+              </div>
               <div className="flex gap-2">
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
                   onClick={() => onOpenChange(false)}
-                  disabled={isSubmitting}
+                  disabled={isBusy}
                 >
                   Cancel
                 </Button>
                 <Button
                   type="submit"
                   size="sm"
-                  disabled={isSubmitting || !title.trim()}
+                  disabled={isBusy || !title.trim()}
                   style={{ background: 'var(--theme-accent)', color: 'white' }}
                 >
                   {isSubmitting ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Task'}

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -8,21 +8,22 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, CheckListIcon, RefreshIcon } from '@hugeicons/core-free-icons'
 import { TaskCard } from './task-card'
 import { TaskDialog } from './task-dialog'
+import type { ClaudeTask, CreateTaskInput, TaskAssignee, TaskColumn } from '@/lib/tasks-api'
 import { toast } from '@/components/ui/toast'
 import { cn } from '@/lib/utils'
 import {
-  fetchTasks,
-  fetchAssignees,
-  createTask,
-  updateTask,
-  deleteTask,
-  moveTask,
+  COLUMN_COLORS,
   COLUMN_LABELS,
   COLUMN_ORDER,
-  COLUMN_COLORS,
+  archiveTask,
+  createTask,
+  deleteTask,
+  fetchAssignees,
+  fetchTasks,
   isOverdue,
+  moveTask,
+  updateTask,
 } from '@/lib/tasks-api'
-import type { ClaudeTask, TaskColumn, CreateTaskInput, TaskAssignee } from '@/lib/tasks-api'
 
 const QUERY_KEY = ['claude', 'tasks'] as const
 const ASSIGNEES_KEY = ['claude', 'tasks', 'assignees'] as const
@@ -89,7 +90,8 @@ export function TasksScreen() {
     }
     for (const t of tasks) {
       if (assigneeFilter && t.assignee !== assigneeFilter) continue
-      if (map[t.column]) map[t.column].push(t)
+      if (t.column === 'deleted') continue
+      map[t.column].push(t)
     }
     for (const col of COLUMN_ORDER) {
       map[col].sort((a, b) => a.position - b.position)
@@ -125,8 +127,14 @@ export function TasksScreen() {
 
   const deleteMutation = useMutation({
     mutationFn: deleteTask,
-    onSuccess: () => { invalidate(); toast('Task deleted') },
+    onSuccess: () => { invalidate(); toast('Task deleted'); setEditingTask(null) },
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to delete task', { type: 'error' }),
+  })
+
+  const archiveMutation = useMutation({
+    mutationFn: archiveTask,
+    onSuccess: () => { invalidate(); toast('Task archived'); setEditingTask(null) },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to archive task', { type: 'error' }),
   })
 
   const moveMutation = useMutation({
@@ -380,6 +388,17 @@ export function TasksScreen() {
         task={editingTask}
         assignees={assignees}
         isSubmitting={updateMutation.isPending}
+        isArchiving={archiveMutation.isPending}
+        isDeleting={deleteMutation.isPending}
+        onArchive={async () => {
+          if (!editingTask) return
+          await archiveMutation.mutateAsync(editingTask.id)
+        }}
+        onDelete={async () => {
+          if (!editingTask) return
+          if (!window.confirm(`Delete task "${editingTask.title}"?`)) return
+          await deleteMutation.mutateAsync(editingTask.id)
+        }}
         onSubmit={async (input) => {
           if (!editingTask) return
           await updateMutation.mutateAsync({ id: editingTask.id, input })

--- a/src/screens/tasks/tasks-ux.test.ts
+++ b/src/screens/tasks/tasks-ux.test.ts
@@ -10,6 +10,13 @@ describe('tasks UX copy', () => {
     )
   })
 
+  it('labels visible destructive task actions distinctly', async () => {
+    const dialog = await import('./task-dialog')
+
+    expect(dialog.ARCHIVE_TASK_BUTTON_LABEL).toBe('Archive')
+    expect(dialog.DELETE_TASK_BUTTON_LABEL).toBe('Delete')
+  })
+
   it('formats assignee labels explicitly for assigned and unassigned tasks', () => {
     expect(formatTaskAssigneeLabel('jarvis', { jarvis: 'Jarvis' })).toBe(
       'Assignee: Jarvis',

--- a/src/server/claude-tasks-backend.ts
+++ b/src/server/claude-tasks-backend.ts
@@ -1,10 +1,12 @@
 import {
+  archiveKanbanCard,
   createKanbanCard,
-  listKanbanCards,
-  type KanbanBackendMeta,
+  deleteKanbanCard,
   getKanbanBackendMeta,
+  listKanbanCards,
   updateKanbanCard,
 } from './kanban-backend'
+import type { KanbanBackendMeta } from './kanban-backend'
 
 export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done'
 export type TaskPriority = 'high' | 'medium' | 'low'
@@ -16,7 +18,7 @@ export type ClaudeTaskRecord = {
   column: TaskColumn
   priority: TaskPriority
   assignee: string | null
-  tags: string[]
+  tags: Array<string>
   due_date: string | null
   position: number
   created_by: string
@@ -37,7 +39,7 @@ type CreateTaskInput = {
   column?: TaskColumn
   priority?: TaskPriority
   assignee?: string | null
-  tags?: string[]
+  tags?: Array<string>
   due_date?: string | null
   created_by?: string
 }
@@ -114,7 +116,7 @@ export function getClaudeTasksBackendMeta(): KanbanBackendMeta {
   return getKanbanBackendMeta()
 }
 
-export async function listClaudeTasks(filters: TaskFilters = {}): Promise<ClaudeTaskRecord[]> {
+export async function listClaudeTasks(filters: TaskFilters = {}): Promise<Array<ClaudeTaskRecord>> {
   let tasks = (await listKanbanCards()).map(mapCardToTask)
   if (!filters.includeDone) {
     tasks = tasks.filter((task) => task.column !== 'done')
@@ -163,4 +165,13 @@ export async function updateClaudeTask(taskId: string, updates: UpdateTaskInput)
 
 export async function moveClaudeTask(taskId: string, column: TaskColumn): Promise<ClaudeTaskRecord | null> {
   return updateClaudeTask(taskId, { column })
+}
+
+export async function archiveClaudeTask(taskId: string): Promise<ClaudeTaskRecord | null> {
+  const card = await archiveKanbanCard(taskId)
+  return card ? mapCardToTask(card) : null
+}
+
+export async function deleteClaudeTask(taskId: string): Promise<boolean> {
+  return deleteKanbanCard(taskId)
 }

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -5,20 +5,19 @@ import { randomUUID } from 'node:crypto'
 import { getClaudeRoot, getWorkspaceClaudeHome } from './claude-paths'
 import {
   SWARM_KANBAN_FILE,
-  type CreateSwarmKanbanCardInput,
   createSwarmKanbanCard,
+  deleteSwarmKanbanCard,
   listSwarmKanbanCards,
-  type SwarmKanbanCard,
   updateSwarmKanbanCard,
-  type UpdateSwarmKanbanCardInput,
 } from './swarm-kanban-store'
 import { CLAUDE_DASHBOARD_URL, getCapabilities } from './gateway-capabilities'
 import {
-  fetchDashboardKanbanBoard,
   createDashboardKanbanTask,
+  fetchDashboardKanbanBoard,
   updateDashboardKanbanTask,
-  type DashboardKanbanTask,
 } from './kanban-dashboard-proxy'
+import type { CreateSwarmKanbanCardInput, SwarmKanbanCard, UpdateSwarmKanbanCardInput } from './swarm-kanban-store'
+import type { DashboardKanbanTask } from './kanban-dashboard-proxy'
 
 export type KanbanBackendId = 'local' | 'claude' | 'hermes-proxy'
 
@@ -32,13 +31,15 @@ export type KanbanBackendMeta = {
 }
 
 type KanbanBackend = {
-  meta(): KanbanBackendMeta
-  list(): SwarmKanbanCard[] | Promise<SwarmKanbanCard[]>
-  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard | Promise<SwarmKanbanCard>
-  update(
+  meta: () => KanbanBackendMeta
+  list: () => Array<SwarmKanbanCard> | Promise<Array<SwarmKanbanCard>>
+  create: (input: CreateSwarmKanbanCardInput) => SwarmKanbanCard | Promise<SwarmKanbanCard>
+  update: (
     cardId: string,
     updates: UpdateSwarmKanbanCardInput,
-  ): SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
+  ) => SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
+  archive?: (cardId: string) => SwarmKanbanCard | null | Promise<SwarmKanbanCard | null>
+  delete?: (cardId: string) => boolean | Promise<boolean>
 }
 
 // Map upstream Hermes kanban statuses (triage/todo/ready/running/done/blocked
@@ -205,13 +206,36 @@ function sqliteQuote(value: string): string {
 }
 
 function runSqlite(dbPath: string, sql: string): string {
-  return execFileSync('sqlite3', [dbPath, '-json', sql], {
-    encoding: 'utf8',
-    timeout: 15_000,
-  }).trim()
+  try {
+    return execFileSync('sqlite3', [dbPath, '-json', sql], {
+      encoding: 'utf8',
+      timeout: 15_000,
+    }).trim()
+  } catch (err) {
+    if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) {
+      throw err
+    }
+    const script = [
+      'import json, sqlite3, sys',
+      'db_path, sql = sys.argv[1], sys.argv[2]',
+      'conn = sqlite3.connect(db_path)',
+      'conn.row_factory = sqlite3.Row',
+      'cur = conn.cursor()',
+      'if sql.lstrip().lower().startswith("select"):',
+      '    cur.execute(sql)',
+      '    print(json.dumps([dict(row) for row in cur.fetchall()]))',
+      'else:',
+      '    cur.executescript(sql)',
+      '    conn.commit()',
+    ].join('\n')
+    return execFileSync('python3', ['-c', script, dbPath, sql], {
+      encoding: 'utf8',
+      timeout: 15_000,
+    }).trim()
+  }
 }
 
-function readClaudeTasks(): ClaudeTaskRow[] {
+function readClaudeTasks(): Array<ClaudeTaskRow> {
   const detection = detectClaudeKanban()
   if (!detection.available) return []
   const query = [
@@ -224,10 +248,11 @@ function readClaudeTasks(): ClaudeTaskRow[] {
     'created_at,',
     'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
     'from tasks',
+    "where status not in ('archived', 'deleted')",
     'order by created_at desc, id desc;',
   ].join(' ')
   const raw = runSqlite(detection.dbPath, query)
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
+  const parsed = raw ? (JSON.parse(raw) as Array<ClaudeTaskRow>) : []
   return Array.isArray(parsed) ? parsed : []
 }
 
@@ -238,7 +263,7 @@ function readClaudeTask(taskId: string): ClaudeTaskRow | null {
     detection.dbPath,
     `select id, title, body, status, assignee, created_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
   )
-  const parsed = raw ? (JSON.parse(raw) as ClaudeTaskRow[]) : []
+  const parsed = raw ? (JSON.parse(raw) as Array<ClaudeTaskRow>) : []
   return Array.isArray(parsed) && parsed[0] ? parsed[0] : null
 }
 
@@ -338,6 +363,12 @@ const localBackend: KanbanBackend = {
   update(cardId, updates) {
     return updateSwarmKanbanCard(cardId, updates)
   },
+  archive(cardId) {
+    return updateSwarmKanbanCard(cardId, { status: 'done' })
+  },
+  delete(cardId) {
+    return deleteSwarmKanbanCard(cardId)
+  },
 }
 
 const claudeBackend: KanbanBackend = {
@@ -389,7 +420,7 @@ const claudeBackend: KanbanBackend = {
   update(cardId, updates) {
     const detection = detectClaudeKanban()
     if (!detection.available) return null
-    const assignments: string[] = []
+    const assignments: Array<string> = []
     if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
     if (typeof updates.spec === 'string') assignments.push(`body = ${sqliteQuote(updates.spec)}`)
     if (updates.assignedWorker !== undefined) assignments.push(`assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`)
@@ -407,6 +438,25 @@ const claudeBackend: KanbanBackend = {
     runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
     const updated = readClaudeTask(cardId)
     return updated ? claudeTaskToCard(updated) : null
+  },
+  archive(cardId) {
+    const detection = detectClaudeKanban()
+    if (!detection.available) return null
+    const current = readClaudeTask(cardId)
+    if (!current) return null
+    runSqlite(
+      detection.dbPath,
+      `update tasks set status = 'archived', claim_lock = NULL, claim_expires = NULL, worker_pid = NULL where id = ${sqliteQuote(cardId)} and status != 'archived';`,
+    )
+    return claudeTaskToCard({ ...current, status: 'archived', updated_at: Date.now() })
+  },
+  delete(cardId) {
+    const detection = detectClaudeKanban()
+    if (!detection.available) return false
+    const current = readClaudeTask(cardId)
+    if (!current) return false
+    runSqlite(detection.dbPath, `update tasks set status = 'deleted', claim_lock = NULL, claim_expires = NULL, worker_pid = NULL where id = ${sqliteQuote(cardId)};`)
+    return true
   },
 }
 
@@ -432,9 +482,10 @@ const dashboardProxyBackend: KanbanBackend = {
   },
   async list() {
     const board = await fetchDashboardKanbanBoard()
-    const cards: SwarmKanbanCard[] = []
+    const cards: Array<SwarmKanbanCard> = []
     for (const column of board.columns) {
       for (const task of column.tasks) {
+        if (task.status === 'archived' || task.status === 'deleted') continue
         cards.push(dashboardTaskToCard(task))
       }
     }
@@ -478,6 +529,21 @@ const dashboardProxyBackend: KanbanBackend = {
       throw err
     }
   },
+  async archive(cardId) {
+    try {
+      const archived = await updateDashboardKanbanTask(cardId, { status: 'archived' })
+      return dashboardTaskToCard(archived)
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('→ 404')) return null
+      throw err
+    }
+  },
+  delete(cardId) {
+    // The dashboard plugin exposes archive but not hard-delete for tasks.
+    // On local installs, use the same SQLite store directly so Delete and
+    // Archive remain distinct actions in the Workspace UI.
+    return claudeBackend.delete?.(cardId) ?? false
+  },
 }
 
 /**
@@ -515,7 +581,7 @@ export function getKanbanBackendMeta(): KanbanBackendMeta {
   return resolveKanbanBackend().meta()
 }
 
-export async function listKanbanCards(): Promise<SwarmKanbanCard[]> {
+export async function listKanbanCards(): Promise<Array<SwarmKanbanCard>> {
   return Promise.resolve(resolveKanbanBackend().list())
 }
 
@@ -530,4 +596,18 @@ export async function updateKanbanCard(
   updates: UpdateSwarmKanbanCardInput,
 ): Promise<SwarmKanbanCard | null> {
   return Promise.resolve(resolveKanbanBackend().update(cardId, updates))
+}
+
+export async function archiveKanbanCard(
+  cardId: string,
+): Promise<SwarmKanbanCard | null> {
+  const backend = resolveKanbanBackend()
+  if (backend.archive) return Promise.resolve(backend.archive(cardId))
+  return Promise.resolve(backend.update(cardId, { status: 'done' }))
+}
+
+export async function deleteKanbanCard(cardId: string): Promise<boolean> {
+  const backend = resolveKanbanBackend()
+  if (backend.delete) return Promise.resolve(backend.delete(cardId))
+  return false
 }

--- a/src/server/swarm-foundation.test.ts
+++ b/src/server/swarm-foundation.test.ts
@@ -1,15 +1,19 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   buildSwarmDispatchMetadata,
   buildSwarmSessionMetadata,
   classifySwarmPluginBoundary,
   deriveSwarmBoundary,
+  getSwarmProfilePath,
+  getSwarmWrapperPath,
   normalizeSwarmRuntime,
   parseSwarmPluginManifest,
+  patchSwarmRuntimeFile,
+  readSwarmRuntimeFile,
 } from './swarm-foundation'
-import * as fs from 'node:fs'
-import * as os from 'node:os'
-import * as path from 'node:path'
 
 describe('normalizeSwarmRuntime', () => {
   it('fills legacy or sparse runtime.json values with stable defaults', () => {
@@ -119,6 +123,13 @@ describe('buildSwarmDispatchMetadata', () => {
   })
 })
 
+describe('semantic swarm paths', () => {
+  it('resolves profile and wrapper paths from roster metadata when ids differ from executable names', () => {
+    expect(getSwarmProfilePath('builder', { profile: 'builder' })).toMatch(/profiles[/\\]builder$/)
+    expect(getSwarmWrapperPath('builder', { wrapper: 'builder:task' })).toMatch(/bin[/\\]builder:task$/)
+  })
+})
+
 describe('parseSwarmPluginManifest', () => {
   it('parses plugin boundary and scopes from manifest yaml', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-plugin-'))
@@ -155,8 +166,6 @@ describe('parseSwarmPluginManifest', () => {
     }
   })
 })
-
-import { patchSwarmRuntimeFile, readSwarmRuntimeFile } from './swarm-foundation'
 
 describe('patchSwarmRuntimeFile', () => {
   it('returns ok=false when the profile path does not exist', () => {

--- a/src/server/swarm-foundation.ts
+++ b/src/server/swarm-foundation.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import * as YAML from 'yaml'
 import { z } from 'zod'
 import { getLocalBinDir, getProfilesDir } from './claude-paths'
+import { isSwarmWorkerId } from './swarm-roster'
 
 export const SwarmWorkerStateSchema = z.enum([
   'idle',
@@ -456,7 +457,7 @@ export function listSwarmWorkerIds(options?: { swarmOnly?: boolean }): Array<str
   return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter((name) => (options?.swarmOnly ?? false ? /^swarm\d+$/i.test(name) : true))
+    .filter((name) => (options?.swarmOnly ?? false ? isSwarmWorkerId(name) : true))
     .sort()
 }
 

--- a/src/server/swarm-foundation.ts
+++ b/src/server/swarm-foundation.ts
@@ -461,12 +461,12 @@ export function listSwarmWorkerIds(options?: { swarmOnly?: boolean }): Array<str
     .sort()
 }
 
-export function getSwarmProfilePath(workerId: string): string {
-  return path.join(getProfilesDir(), workerId)
+export function getSwarmProfilePath(workerId: string, roster?: { profile?: string | null }): string {
+  return path.join(getProfilesDir(), roster?.profile || workerId)
 }
 
-export function getSwarmWrapperPath(workerId: string): string {
-  return path.join(getLocalBinDir(), workerId)
+export function getSwarmWrapperPath(workerId: string, roster?: { wrapper?: string | null }): string {
+  return path.join(getLocalBinDir(), roster?.wrapper || workerId)
 }
 
 export function getSwarmTmuxSessionName(workerId: string): string {

--- a/src/server/swarm-health.test.ts
+++ b/src/server/swarm-health.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildWorkerHealth } from './swarm-health'
+
+describe('swarm health semantic wrappers', () => {
+  it('resolves wrapperFound from roster wrapper field instead of worker id', () => {
+    const health = buildWorkerHealth(
+      {
+        id: 'builder',
+        profile: 'builder',
+        wrapper: 'builder:task',
+      },
+      {
+        profilesBase: '/profiles',
+        wrapperBase: '/bin',
+        exists: (path) => path === '/profiles/builder' || path === '/bin/builder:task',
+        readWorkerConfig: () => ({ model: 'gpt-5.5', provider: 'openai-codex' }),
+        scanRecentAuthErrors: () => ({ count: 0, lastAt: null, lastMessage: null }),
+      },
+    )
+
+    expect(health).toMatchObject({
+      workerId: 'builder',
+      profileFound: true,
+      wrapperFound: true,
+      model: 'gpt-5.5',
+      provider: 'openai-codex',
+      recentAuthErrors: 0,
+    })
+  })
+})

--- a/src/server/swarm-health.ts
+++ b/src/server/swarm-health.ts
@@ -1,0 +1,48 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { SwarmRosterWorker } from './swarm-roster'
+
+export type WorkerHealth = {
+  workerId: string
+  profileFound: boolean
+  wrapperFound: boolean
+  model: string
+  provider: string
+  recentAuthErrors: number
+  lastErrorAt: string | null
+  lastErrorMessage: string | null
+}
+
+type WorkerHealthDeps = {
+  profilesBase: string
+  wrapperBase: string
+  exists?: (path: string) => boolean
+  readWorkerConfig: (profilePath: string) => { model: string; provider: string }
+  scanRecentAuthErrors: (profilePath: string) => {
+    count: number
+    lastAt: string | null
+    lastMessage: string | null
+  }
+}
+
+export function buildWorkerHealth(worker: Pick<SwarmRosterWorker, 'id' | 'profile' | 'wrapper'>, deps: WorkerHealthDeps): WorkerHealth {
+  const exists = deps.exists ?? existsSync
+  const id = worker.id
+  const profileId = worker.profile || id
+  const wrapperId = worker.wrapper || id
+  const profilePath = join(deps.profilesBase, profileId)
+  const wrapperPath = join(deps.wrapperBase, wrapperId)
+  const config = deps.readWorkerConfig(profilePath)
+  const errs = deps.scanRecentAuthErrors(profilePath)
+
+  return {
+    workerId: id,
+    profileFound: exists(profilePath),
+    wrapperFound: exists(wrapperPath),
+    model: config.model,
+    provider: config.provider,
+    recentAuthErrors: errs.count,
+    lastErrorAt: errs.lastAt,
+    lastErrorMessage: errs.lastMessage,
+  }
+}

--- a/src/server/swarm-kanban-store.ts
+++ b/src/server/swarm-kanban-store.ts
@@ -10,7 +10,7 @@ export type SwarmKanbanCard = {
   id: string
   title: string
   spec: string
-  acceptanceCriteria: string[]
+  acceptanceCriteria: Array<string>
   assignedWorker: string | null
   reviewer: string | null
   status: SwarmKanbanLane
@@ -21,7 +21,7 @@ export type SwarmKanbanCard = {
   updatedAt: number
 }
 
-type SwarmKanbanFile = { cards: SwarmKanbanCard[] }
+type SwarmKanbanFile = { cards: Array<SwarmKanbanCard> }
 
 type ListFilters = {
   status?: string | null
@@ -33,7 +33,7 @@ type ListFilters = {
 export type CreateSwarmKanbanCardInput = {
   title: string
   spec?: string
-  acceptanceCriteria?: string[]
+  acceptanceCriteria?: Array<string>
   assignedWorker?: string | null
   reviewer?: string | null
   status?: SwarmKanbanLane | null
@@ -77,7 +77,7 @@ function normalizeStatus(value: unknown): SwarmKanbanLane {
   return SWARM_KANBAN_LANES.includes(value as SwarmKanbanLane) ? (value as SwarmKanbanLane) : 'backlog'
 }
 
-function normalizeCriteria(value: unknown): string[] {
+function normalizeCriteria(value: unknown): Array<string> {
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
   if (typeof value === 'string') return value.split('\n').map((item) => item.trim()).filter(Boolean)
   return []
@@ -105,7 +105,7 @@ function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: 
   }
 }
 
-export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard[] {
+export function listSwarmKanbanCards(filters: ListFilters = {}): Array<SwarmKanbanCard> {
   let cards = readKanbanFile().cards
   if (filters.status) cards = cards.filter((card) => card.status === normalizeStatus(filters.status))
   if (filters.assignedWorker) cards = cards.filter((card) => card.assignedWorker === filters.assignedWorker)
@@ -153,4 +153,12 @@ export function updateSwarmKanbanCard(cardId: string, updates: UpdateSwarmKanban
   file.cards[index] = next
   writeKanbanFile(file)
   return next
+}
+
+export function deleteSwarmKanbanCard(cardId: string): boolean {
+  const file = readKanbanFile()
+  const nextCards = file.cards.filter((card) => card.id !== cardId)
+  if (nextCards.length === file.cards.length) return false
+  writeKanbanFile({ cards: nextCards })
+  return true
 }

--- a/src/server/swarm-notifications.test.ts
+++ b/src/server/swarm-notifications.test.ts
@@ -75,9 +75,9 @@ describe('swarm-notifications', () => {
       notifySessionKey: 'qa-main',
     })
 
-    // DONE checkpoints route to the orchestrator (swarm3 tmux), not main.
+    // DONE checkpoints route to the semantic orchestrator tmux session, not main.
     expect(first).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'orchestrator' })
-    expect(first.orchestrator).toMatchObject({ sent: true, session: 'swarm-swarm3' })
+    expect(first.orchestrator).toMatchObject({ sent: true, session: 'swarm-orchestrator' })
     // Same raw is deduped on the second call.
     expect(second).toMatchObject({ published: false, sessionKey: 'qa-main', route: 'noop' })
     // No chat event was published — DONE goes to orchestrator only.
@@ -159,7 +159,7 @@ describe('swarm-notifications', () => {
     })
 
     expect(result).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'main' })
-    expect(result.orchestrator).toMatchObject({ sent: true, session: 'swarm-swarm3' })
+    expect(result.orchestrator).toMatchObject({ sent: true, session: 'swarm-orchestrator' })
     // Both the orchestrator AND main were notified.
     expect(publishChatEvent).toHaveBeenCalledTimes(2)
     expect(publishChatEvent).toHaveBeenNthCalledWith(
@@ -201,7 +201,7 @@ describe('swarm-notifications', () => {
     })
 
     expect(result).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'main' })
-    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-swarm3' })
+    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-orchestrator' })
     expect(publishChatEvent).toHaveBeenCalled()
   })
 
@@ -218,15 +218,15 @@ describe('swarm-notifications', () => {
       nextAction: 'Continue loop',
       raw: 'STATE: DONE\nRESULT: Orchestrator self-report\nNEXT_ACTION: Continue loop',
     }
-    mkdirSync(join(tempRoot, 'swarm3'), { recursive: true })
+    mkdirSync(join(tempRoot, 'orchestrator'), { recursive: true })
 
     const result = mod.publishSwarmCheckpointNotification({
-      workerId: 'swarm3',
+      workerId: 'orchestrator',
       checkpoint,
       notifySessionKey: 'qa-main',
     })
 
     // skippedSelf -> orchestrator route is treated as 'orchestrator' (self-report doesn't escalate either).
-    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-swarm3', skippedSelf: true })
+    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-orchestrator', skippedSelf: true })
   })
 })

--- a/src/server/swarm-notifications.ts
+++ b/src/server/swarm-notifications.ts
@@ -1,11 +1,11 @@
 import { join } from 'node:path'
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
-import type { ParsedSwarmCheckpoint } from './swarm-checkpoints'
 import { getSwarmProfilePath } from './swarm-foundation'
 import { publishChatEvent } from './chat-event-bus'
+import type { ParsedSwarmCheckpoint } from './swarm-checkpoints'
 
-const ORCHESTRATOR_WORKER_ID = process.env.SWARM_ORCHESTRATOR_WORKER_ID?.trim() || 'swarm3'
+const ORCHESTRATOR_WORKER_ID = process.env.SWARM_ORCHESTRATOR_WORKER_ID?.trim() || 'orchestrator'
 const ORCHESTRATOR_TMUX_SESSION = `swarm-${ORCHESTRATOR_WORKER_ID}`
 const MAIN_SESSION_KEY = process.env.SWARM_MAIN_SESSION_KEY?.trim() || 'main'
 
@@ -155,7 +155,7 @@ export function publishSwarmCheckpointNotification(input: {
   const current = readRuntime(runtimePath)
   const currentRaw = typeof current.lastNotifiedCheckpointRaw === 'string' ? current.lastNotifiedCheckpointRaw : null
   const currentSig = typeof current.lastNotifiedCheckpointSignature === 'string' ? current.lastNotifiedCheckpointSignature : null
-  const checkpointRaw = input.checkpoint.raw?.trim() || ''
+  const checkpointRaw = input.checkpoint.raw.trim() || ''
   const sessionKey = input.notifySessionKey?.trim() || (typeof current.notifySessionKey === 'string' && current.notifySessionKey.trim()) || MAIN_SESSION_KEY
 
   // Build a checkpoint signature that includes state + status + raw + result, so dedupe
@@ -163,7 +163,7 @@ export function publishSwarmCheckpointNotification(input: {
   // state actually changed (e.g. worker went executing -> done with same scraped raw).
   const checkpointSignature = [
     input.checkpoint.stateLabel,
-    input.checkpoint.checkpointStatus ?? '',
+    input.checkpoint.checkpointStatus,
     input.checkpoint.result ?? '',
     input.checkpoint.blocker ?? '',
     input.checkpoint.nextAction ?? '',
@@ -176,7 +176,7 @@ export function publishSwarmCheckpointNotification(input: {
   // Backwards-compat: if no signature was ever stored but raw matches AND nothing else
   // could have changed (raw is non-empty + state matches a 'no progress' shape), still skip.
   // Otherwise, fall through and publish.
-  if (!currentSig && checkpointRaw && currentRaw === checkpointRaw && (input.checkpoint.stateLabel === 'IN_PROGRESS' || !input.checkpoint.stateLabel)) {
+  if (!currentSig && checkpointRaw && currentRaw === checkpointRaw && input.checkpoint.stateLabel === 'IN_PROGRESS') {
     return { published: false, sessionKey, route: 'noop' }
   }
 
@@ -187,7 +187,7 @@ export function publishSwarmCheckpointNotification(input: {
     checkpointSummary(input.checkpoint),
   ].filter(Boolean).join(' — ')
 
-  // 1. Route to orchestrator (swarm3) by default.
+  // 1. Route to the semantic orchestrator by default.
   const orchestratorResult = publishCheckpointToOrchestrator({
     workerId: input.workerId,
     checkpoint: input.checkpoint,

--- a/src/server/swarm-roster.test.ts
+++ b/src/server/swarm-roster.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { SwarmRosterSchema, SwarmRosterUpsertSchema, isSwarmWorkerId } from './swarm-roster'
+
+describe('swarm roster semantic workers', () => {
+  it('accepts both legacy swarm ids and semantic profile ids for upsert', () => {
+    const baseWorker = {
+      name: 'Builder',
+      role: 'Builder',
+      specialty: '',
+      model: 'Worker',
+      mission: 'Ship focused changes.',
+      skills: [],
+      capabilities: [],
+      preferredTaskTypes: [],
+      maxConcurrentTasks: 1,
+    }
+
+    expect(SwarmRosterUpsertSchema.parse({ ...baseWorker, id: ' builder ' }).id).toBe('builder')
+    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'swarm13' }).success).toBe(true)
+    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'builder' }).success).toBe(true)
+    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'km-agent' }).success).toBe(true)
+    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'ops-watch' }).success).toBe(true)
+    expect(isSwarmWorkerId('builder')).toBe(true)
+    expect(isSwarmWorkerId('km-agent')).toBe(true)
+    expect(isSwarmWorkerId('../bad')).toBe(false)
+  })
+
+  it('preserves semantic roster metadata through parse', () => {
+    const parsed = SwarmRosterSchema.parse({
+      version: 1,
+      workers: [
+        {
+          id: 'km-agent',
+          name: 'KM Agent',
+          role: 'Knowledge steward',
+          specialty: 'RAZSOC and GBrain stewardship',
+          model: 'GPT-5.5',
+          mission: 'Keep the operating brain coherent.',
+          profile: 'km-agent',
+          modes: ['health', 'curate'],
+          tools: ['gbrain', 'terminal', 'file'],
+          skills: ['km-agent-core'],
+          plugins: ['disk-cleanup'],
+          pluginToolsets: ['spotify'],
+          mcpServers: ['gbrain'],
+          wrapper: 'km:health',
+          capabilities: ['gbrain', 'obsidian', 'drift-audit'],
+          preferredTaskTypes: ['knowledge', 'curation'],
+          greenlightRequiredFor: ['delete', 'purge', 'publish'],
+          maxConcurrentTasks: 1,
+        },
+      ],
+    })
+
+    expect(parsed.workers[0]).toMatchObject({
+      id: 'km-agent',
+      profile: 'km-agent',
+      modes: ['health', 'curate'],
+      tools: ['gbrain', 'terminal', 'file'],
+      skills: ['km-agent-core'],
+      plugins: ['disk-cleanup'],
+      pluginToolsets: ['spotify'],
+      mcpServers: ['gbrain'],
+      wrapper: 'km:health',
+      greenlightRequiredFor: ['delete', 'purge', 'publish'],
+    })
+  })
+})

--- a/src/server/swarm-roster.ts
+++ b/src/server/swarm-roster.ts
@@ -6,17 +6,36 @@ import { SWARM_CANONICAL_REPO } from './swarm-environment'
 
 export const SWARM_ROSTER_PATH = join(SWARM_CANONICAL_REPO, 'swarm.yaml')
 
+const WORKER_ID_PATTERN = /^(swarm\d+|[a-z][a-z0-9]*(?:-[a-z0-9]+)*)$/i
+
+export function isSwarmWorkerId(value: unknown): value is string {
+  return typeof value === 'string' && WORKER_ID_PATTERN.test(value.trim())
+}
+
+const WorkerIdSchema = z
+  .string()
+  .trim()
+  .regex(WORKER_ID_PATTERN, 'worker id must look like swarm13 or a semantic profile id')
+
 export const SwarmRosterWorkerSchema = z.object({
-  id: z.string(),
+  id: WorkerIdSchema,
   name: z.string().default(''),
   role: z.string().default('Worker'),
   specialty: z.string().default(''),
   model: z.string().default('Worker'),
   mission: z.string().default('Awaiting orchestrator dispatch.'),
+  profile: WorkerIdSchema.optional(),
+  modes: z.array(z.string()).default([]),
+  tools: z.array(z.string()).default([]),
   skills: z.array(z.string()).default([]),
+  plugins: z.array(z.string()).default([]),
+  pluginToolsets: z.array(z.string()).default([]),
+  mcpServers: z.array(z.string()).default([]),
+  wrapper: z.string().optional(),
   capabilities: z.array(z.string()).default([]),
   defaultCwd: z.string().optional(),
   preferredTaskTypes: z.array(z.string()).default([]),
+  greenlightRequiredFor: z.array(z.string()).default([]),
   maxConcurrentTasks: z.number().int().positive().default(1),
   acceptsBroadcast: z.boolean().default(true),
   reviewRequired: z.boolean().default(false),
@@ -31,7 +50,7 @@ export type SwarmRosterWorker = z.infer<typeof SwarmRosterWorkerSchema>
 export type SwarmRoster = z.infer<typeof SwarmRosterSchema>
 
 export const SwarmRosterUpsertSchema = SwarmRosterWorkerSchema.extend({
-  id: z.string().regex(/^swarm\d+$/i, 'worker id must look like swarm13'),
+  id: WorkerIdSchema,
 })
 
 export type SwarmRosterUpsert = z.infer<typeof SwarmRosterUpsertSchema>

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -1,263 +1,498 @@
 version: 1
 workers:
-  - id: swarm6
-    name: Reviewer
-    role: Reviewer / Merge Gate
-    specialty: code review, regression detection, test coverage, merge readiness
-    model: Opus 4.7
-    mission: Catch breakage before it reaches Eric. Be the final quality gate.
-    skills:
-      - swarm-pr-worker
-      - swarm-worker-core
-    capabilities:
-      - code-review
-      - regression-analysis
-      - test-planning
-      - quality-gate
-      - merge-readiness
-    preferredTaskTypes:
-      - review
-      - qa
-      - regression
-      - verification
-      - merge-gate
-    reviewRequired: false
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm12
-    name: Triage
-    role: PR / Issues Primary
-    specialty: GitHub triage, issue reproduction, PR review prep, focused fixes
-    model: GPT-5.5
-    mission: Turn repo issues and review feedback into reproductions, plans, and tested PRs.
-    skills:
-      - swarm-pr-worker
-      - swarm-worker-core
-    capabilities:
-      - github-triage
-      - issue-reproduction
-      - pr-patching
-      - review-feedback
-      - gh-cli
-    preferredTaskTypes:
-      - pr
-      - issue
-      - bugfix
-      - github
-      - triage
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm5
-    name: Builder
-    role: Primary Builder
-    specialty: full-stack implementation across Hermes Workspace and Swarm2
-    model: GPT-5.5
-    mission: Ship focused product slices with tests and clean diffs.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - code-editing
-      - ui-implementation
-      - full-stack-integration
-      - build-verification
-    preferredTaskTypes:
-      - implementation
-      - ui
-      - frontend
-      - integration
-      - feature
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm4
-    name: Sage
-    role: Research / AI Intelligence / X Content
-    specialty: AI/model/runtime research, technical synthesis, X post drafting
-    model: GPT-5.5
-    mission: Produce decision-grade research and copy so builders and Eric stay unblocked.
-    skills:
-      - swarm-worker-core
-    capabilities:
-      - research
-      - benchmark-planning
-      - model-analysis
-      - technical-synthesis
-      - x-content
-    preferredTaskTypes:
-      - research
-      - benchmark
-      - analysis
-      - options
-      - x-post
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm10
-    name: Sidekick
-    role: Secondary Builder / Fast Patch Lane
-    specialty: parallel implementation slices, refactors, focused bug fixes
-    model: GPT-5.5
-    mission: Take decomposed tasks and produce clean patches quickly.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - code-editing
-      - refactor
-      - parallel-implementation
-      - bug-fix
-      - build-verification
-    preferredTaskTypes:
-      - implementation
-      - refactor
-      - backend
-      - frontend
-      - patch
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm2
-    name: Foundation
-    role: Backend Foundation / Runtime Contracts
-    specialty: ClaudeSwarm runtime contracts, API design, plugin foundations, state
-    model: GPT-5.4
-    mission: Build the backend substrate that keeps swarm state, dispatch, sessions, and plugins coherent.
-    skills:
-      - swarm-dev-runtime
-      - swarm-worker-core
-    capabilities:
-      - api-design
-      - runtime-contracts
-      - plugin-foundation
-      - state-management
-    preferredTaskTypes:
-      - backend
-      - runtime
-      - api
-      - infrastructure
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm3
-    name: Mirror
-    role: Swarm Control Plane / Main-Session Mirror
-    specialty: control-plane state, card parity, main-agent continuity
-    model: GPT-5.4
-    mission: Keep the swarm control plane operationally useful and visually canonical.
-    skills:
-      - swarm-orchestrator
-      - swarm-worker-core
-    capabilities:
-      - orchestration
-      - main-session-continuity
-      - control-plane-state
-    preferredTaskTypes:
-      - orchestration
-      - coordination
-      - handoff
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm8
-    name: Watch
-    role: Ops / Health / Lifecycle
-    specialty: gateway health, cron, runtime/process status, lifecycle sweeps
-    model: GPT-5.4
-    mission: Keep the local swarm/gateway environment stable and observable.
-    skills:
-      - swarm-dev-runtime
-      - swarm-worker-core
-    capabilities:
-      - ops-health
-      - gateway-status
-      - runtime-monitoring
-      - cron
-      - lifecycle-sweep
-    preferredTaskTypes:
-      - ops
-      - health
-      - monitoring
-      - lifecycle
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm7
-    name: Scribe
-    role: Docs / Specs / Handoffs / Memory Hygiene
-    specialty: handoffs, specs, README/docs, skill documentation, memory curation
-    model: GPT-5.5
-    mission: Preserve context and make the swarm understandable across sessions.
-    skills:
-      - swarm-worker-core
-    capabilities:
-      - documentation
-      - handoffs
-      - spec-writing
-      - runbooks
-      - memory-curation
-    preferredTaskTypes:
-      - docs
-      - handoff
-      - spec
-      - runbook
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm9
-    name: Lab
-    role: PC1 Experiments / Local-Model R&D / BenchLoop
-    specialty: PC1 experiments, local model testing, model runtime comparisons
-    model: GPT-5.5
-    mission: Explore fast without destabilizing canonical paths.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - prototype
-      - experiment
-      - local-model
-      - benchmark-experiment
-      - rapid-build
-    preferredTaskTypes:
-      - prototype
-      - experiment
-      - hackathon
-      - benchmark
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm11
-    name: QA
-    role: Secondary QA / Reviewer Support
-    specialty: secondary review, smoke verification, expected-vs-actual checks
-    model: GPT-5.4
-    mission: Review parallel outputs and protect quality gates.
-    skills:
-      - swarm-pr-worker
-      - swarm-worker-core
-    capabilities:
-      - secondary-review
-      - quality-gate
-      - regression-analysis
-      - smoke-verification
-    preferredTaskTypes:
-      - review
-      - qa
-      - verification
-      - smoke
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm1
-    name: Overflow
-    role: PR / Issues Overflow / Clawsuite (offline for now)
-    specialty: parked broken lane, keep out of rotation until worker runtime is repaired
-    model: GPT-5.5
-    mission: Stay out of active rotation until the swarm1 worker runtime is repaired, then absorb overflow from PR/issues lanes and cover Clawsuite.
-    skills:
-      - swarm-pr-worker
-      - swarm-worker-core
-    capabilities:
-      - github-triage
-      - small-patches
-      - issue-reproduction
-      - clawsuite
-    preferredTaskTypes:
-      - pr
-      - issue
-      - small-fix
-      - clawsuite
-    maxConcurrentTasks: 1
-    acceptsBroadcast: false
+- id: orchestrator
+  name: Orchestrator
+  role: Swarm Orchestrator / Greenlight Gate
+  specialty: mission routing, task decomposition, handoffs, proof contracts, human approval gates
+  model: GPT-5.5
+  mission: Decompose missions into safe, proof-bearing work and route to the right specialist while preserving human greenlight control.
+  profile: orchestrator
+  modes:
+  - plan
+  tools:
+  - todo
+  - kanban
+  - delegation
+  - terminal
+  - file
+  - gbrain
+  - session_search
+  - cronjob
+  - skills
+  - clarify
+  - web
+  skills:
+  - orchestrator-core
+  - gstack-for-hermes
+  - gbrain
+  - kanban-orchestrator
+  - subagent-driven-development
+  - writing-plans
+  - requesting-code-review
+  - workspace-dispatch
+  capabilities:
+  - orchestration
+  - decomposition
+  - routing
+  - proof-contracts
+  - greenlight-gate
+  preferredTaskTypes:
+  - orchestration
+  - planning
+  - routing
+  - coordination
+  - handoff
+  greenlightRequiredFor:
+  - merge
+  - publish
+  - destructive
+  - external-send
+  - credential-change
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: orchestrator:plan
+- id: km-agent
+  name: KM Agent
+  role: RAZSOC / GBrain Knowledge Steward
+  specialty: RAZSOC, GBrain, Obsidian, TaskNotes, graph health, durable knowledge capture, drift audits
+  model: GPT-5.5
+  mission: Keep the operating brain coherent, searchable, and source-of-record aligned without polluting durable knowledge.
+  profile: km-agent
+  modes:
+  - health
+  - curate
+  tools:
+  - gbrain
+  - file
+  - terminal
+  - session_search
+  - skills
+  - todo
+  - cronjob
+  - web
+  skills:
+  - km-agent-core
+  - gbrain
+  - obsidian-markdown
+  - obsidian-cli
+  - obsidian-bases
+  - json-canvas
+  - gstack-for-hermes
+  capabilities:
+  - gbrain
+  - razsoc
+  - obsidian
+  - tasknotes
+  - drift-audit
+  - knowledge-curation
+  preferredTaskTypes:
+  - knowledge
+  - curation
+  - brain-health
+  - drift
+  - documentation
+  greenlightRequiredFor:
+  - delete
+  - purge
+  - bulk-edit
+  - source-of-record-change
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: km:health
+- id: builder
+  name: Builder
+  role: Scoped Implementation Agent
+  specialty: focused implementation, tests, small diffs, integration fixes
+  model: GPT-5.5
+  mission: Ship scoped product/code slices with tests, minimal diffs, and clear verification evidence.
+  profile: builder
+  modes:
+  - task
+  tools:
+  - terminal
+  - file
+  - browser
+  - web
+  - gbrain
+  - session_search
+  - skills
+  - todo
+  skills:
+  - builder-core
+  - gstack-for-hermes
+  - test-driven-development
+  - systematic-debugging
+  - github-pr-workflow
+  - requesting-code-review
+  - codebase-inspection
+  capabilities:
+  - implementation
+  - code-editing
+  - tests
+  - integration
+  - build-verification
+  preferredTaskTypes:
+  - implementation
+  - bugfix
+  - feature
+  - refactor
+  - integration
+  greenlightRequiredFor:
+  - merge
+  - push
+  - destructive
+  - external-write
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: builder:task
+- id: reviewer
+  name: Reviewer
+  role: Independent Review / Merge Gate
+  specialty: security review, logic review, regression detection, quality gates
+  model: GPT-5.5
+  mission: Independently review changes and block unsafe, untested, or logically broken work before it lands.
+  profile: reviewer
+  modes:
+  - gate
+  tools:
+  - terminal
+  - file
+  - web
+  - gbrain
+  - session_search
+  - skills
+  skills:
+  - reviewer-core
+  - requesting-code-review
+  - github-code-review
+  - systematic-debugging
+  - gstack-for-hermes
+  - gbrain
+  - codebase-inspection
+  capabilities:
+  - code-review
+  - security-review
+  - regression-analysis
+  - quality-gate
+  - merge-readiness
+  preferredTaskTypes:
+  - review
+  - qa
+  - regression
+  - verification
+  - merge-gate
+  greenlightRequiredFor:
+  - approve-merge
+  - external-comment
+  - destructive
+  reviewRequired: false
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: reviewer:gate
+- id: qa
+  name: QA
+  role: Browser / Workflow / CLI Smoke Verification
+  specialty: browser QA, workflow smoke tests, expected-vs-actual checks, regression reproduction
+  model: GPT-5.5
+  mission: Verify user-visible behavior with concrete smoke evidence and concise bug reports.
+  profile: qa
+  modes:
+  - smoke
+  tools:
+  - browser
+  - terminal
+  - file
+  - vision
+  - gbrain
+  - session_search
+  - skills
+  - web
+  skills:
+  - qa-core
+  - browser-harness-power-use
+  - dogfood
+  - gstack-for-hermes
+  capabilities:
+  - browser-qa
+  - smoke-verification
+  - regression-reproduction
+  - cli-verification
+  - evidence-capture
+  preferredTaskTypes:
+  - qa
+  - smoke
+  - browser
+  - verification
+  - regression
+  greenlightRequiredFor:
+  - destructive
+  - external-write
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: qa:smoke
+- id: researcher
+  name: Researcher
+  role: Brain-first Research / Bounded Autoresearch
+  specialty: GBrain-first lookup, external research, synthesis, source trails, bounded research loops
+  model: GPT-5.5
+  mission: Produce decision-grade research with brain-first context, external verification, and explicit uncertainty.
+  profile: researcher
+  modes:
+  - quick
+  - autoresearch
+  tools:
+  - gbrain
+  - web
+  - browser
+  - terminal
+  - file
+  - vision
+  - session_search
+  - skills
+  - todo
+  skills:
+  - researcher-core
+  - gbrain
+  - autoresearch
+  - browser-harness-power-use
+  - gstack-for-hermes
+  - researcher-quick
+  - researcher-autoresearch
+  - arxiv
+  - youtube-content
+  - polymarket
+  capabilities:
+  - research
+  - synthesis
+  - source-verification
+  - gbrain-query
+  - autoresearch
+  preferredTaskTypes:
+  - research
+  - analysis
+  - options
+  - source-review
+  - market-map
+  greenlightRequiredFor:
+  - publish
+  - external-send
+  - long-running-loop
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: researcher:quick
+- id: ops-watch
+  name: Ops Watch
+  role: Local Infra / Runtime Health Watch
+  specialty: gateway health, cron, MCP, workspace services, local process status, boring reliability
+  model: GPT-5.5
+  mission: Keep Hermes, Workspace, GBrain, gateway, cron, and local services observable and healthy with quiet, low-risk checks.
+  profile: ops-watch
+  modes:
+  - health
+  tools:
+  - terminal
+  - cronjob
+  - file
+  - gbrain
+  - skills
+  - session_search
+  - web
+  skills:
+  - ops-watch-core
+  - gbrain
+  - hermes-agent
+  - systematic-debugging
+  - webhook-subscriptions
+  capabilities:
+  - ops-health
+  - gateway-status
+  - runtime-monitoring
+  - cron
+  - mcp-health
+  - lifecycle-sweep
+  preferredTaskTypes:
+  - ops
+  - health
+  - monitoring
+  - lifecycle
+  - incident-triage
+  greenlightRequiredFor:
+  - restart-service
+  - destructive
+  - config-change
+  - credential-change
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: ops:health
+- id: maintainer
+  name: Maintainer
+  role: Upstream Dependency / Patch Hygiene
+  specialty: upstream tracking, local patch hygiene, dependency updates, PR/issue follow-through
+  model: GPT-5.5
+  mission: Keep local forks and upstream dependencies healthy without losing local patches or dirty-worktree context.
+  profile: maintainer
+  modes:
+  - check
+  tools:
+  - terminal
+  - file
+  - web
+  - browser
+  - gbrain
+  - session_search
+  - skills
+  skills:
+  - maintainer-core
+  - github-repo-management
+  - github-pr-workflow
+  - github-issues
+  - github-code-review
+  - gbrain
+  - gstack-for-hermes
+  - hermes-agent
+  capabilities:
+  - upstream-tracking
+  - dependency-maintenance
+  - patch-hygiene
+  - git-review
+  - issue-tracking
+  preferredTaskTypes:
+  - maintenance
+  - upstream
+  - dependency
+  - patch
+  - release-notes
+  greenlightRequiredFor:
+  - merge
+  - push
+  - destructive
+  - fork-reset
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: maintainer:check
+- id: strategist
+  name: Strategist
+  role: Wedges / Bets / Kill Criteria
+  specialty: operating plans, gstack-style wedges, strategy reviews, decision framing, kill criteria
+  model: GPT-5.5
+  mission: Turn ambiguity into crisp wedges, bets, constraints, and kill criteria without over-planning.
+  profile: strategist
+  modes:
+  - review
+  tools:
+  - gbrain
+  - web
+  - session_search
+  - file
+  - skills
+  - todo
+  - clarify
+  skills:
+  - strategist-core
+  - gstack-for-hermes
+  - gbrain
+  - writing-plans
+  - polymarket
+  capabilities:
+  - strategy
+  - planning
+  - ideation
+  - decision-framing
+  - kill-criteria
+  preferredTaskTypes:
+  - strategy
+  - planning
+  - review
+  - ideation
+  - prioritization
+  greenlightRequiredFor:
+  - publish
+  - external-send
+  - irreversible-decision
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: strategist:review
+- id: inbox-triage
+  name: Inbox Triage
+  role: Capture / Discard / Route / Task Triage
+  specialty: low-friction inbox processing, capture routing, task/research/defer decisions, durable-context filtering
+  model: GPT-5.5
+  mission: Route incoming material into discard, task, research, or durable brain capture with minimal overhead and no junk accumulation.
+  profile: inbox-triage
+  modes:
+  - triage
+  tools:
+  - gbrain
+  - web
+  - file
+  - session_search
+  - todo
+  - skills
+  - terminal
+  skills:
+  - inbox-triage-core
+  - gbrain
+  - obsidian-markdown
+  - gstack-for-hermes
+  - defuddle
+  - youtube-content
+  capabilities:
+  - inbox-triage
+  - capture-routing
+  - task-routing
+  - knowledge-filtering
+  - source-review
+  preferredTaskTypes:
+  - triage
+  - inbox
+  - capture
+  - task-routing
+  - reading-queue
+  greenlightRequiredFor:
+  - delete
+  - purge
+  - publish
+  - external-send
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: inbox:triage


### PR DESCRIPTION
## Summary
- Replace legacy numbered swarm assumptions with semantic worker IDs while retaining legacy-compatible validation.
- Add the 10-agent semantic roster: orchestrator, km-agent, builder, reviewer, qa, researcher, ops-watch, maintainer, strategist, inbox-triage.
- Document each semantic agent and align swarm metadata, route affordances, lifecycle/health/checkpoint routes, and one-shot checkpoint parsing.
- Fix `/api/swarm-health` and `/api/swarm-runtime` to resolve semantic worker wrappers from `swarm.yaml.wrapper` instead of assuming executable names equal worker ids.
- Route worker checkpoints to the semantic `orchestrator` by default instead of legacy `swarm3`.
- Add regression coverage for semantic wrapper names such as `builder:task` and semantic orchestrator notification routing.
- Add durable dispatch / alignment-health guidance to Workspace docs and SOP surfaces, including `docs/swarm/ALIGNMENT_HEALTH.md` as the source-owned SOP.
- Refresh Swarm docs to use semantic worker names instead of stale numbered/legacy role examples.

## Test Plan
- [x] `pnpm exec vitest run src/server/swarm-roster.test.ts`
- [x] `pnpm exec vitest run src/server/swarm-roster.test.ts src/server/swarm-health.test.ts`
- [x] `pnpm exec vitest run src/server/swarm-notifications.test.ts src/server/swarm-foundation.test.ts src/server/swarm-health.test.ts src/server/swarm-roster.test.ts`
- [x] `pnpm exec eslint src/routes/api/swarm-health.ts src/server/swarm-health.ts src/server/swarm-health.test.ts`
- [x] `pnpm exec eslint src/server/swarm-notifications.ts src/server/swarm-notifications.test.ts src/server/swarm-foundation.ts src/server/swarm-foundation.test.ts src/routes/api/swarm-runtime.ts src/routes/api/swarm-health.ts src/server/swarm-health.ts src/server/swarm-health.test.ts src/server/swarm-roster.ts src/server/swarm-roster.test.ts`
- [x] `git diff --check`
- [x] Local roster API returned all 10 semantic workers.
- [x] Local health API returned `wrappersConfigured: 10` and all workers `wrapperFound: true`.
- [x] Local runtime API returned builder wrapper path ending in `/builder:task` and `supportsOneShotDispatch: true`.
- [x] Local one-shot dispatch smoke to `qa` returned `checkpointStatus: checkpointed`.
- [x] Browser checked `/swarm`: semantic cards visible, `Route to agent` buttons render, no console errors.
- [x] Alignment SOP doc smoke: verified `worker.wrapper || worker.id`, `builder:task`, `wrappersConfigured`, and durable dispatch guidance are present.
- [x] Swarm docs stale-term scan: no `swarm-swarm3`, `qa:verify`, or `GPT-5.4` remains in `docs/swarm/*.md`.

## Notes
- This PR intentionally keeps legacy worker ID compatibility while enabling semantic profile IDs.
- Runtime-only local profile/SOUL/wrapper changes are not included in this repository PR.
- Full repo `pnpm exec vitest run` and `pnpm exec eslint .` still have unrelated pre-existing failures; changed-file tests and lint are green.
- I reviewed whether to split this PR. Recommendation for now is to keep it as one semantic-swarm PR because the docs, roster, route affordances, and health/runtime fixes now describe one coherent migration. If maintainers want smaller diffs, the task/Kanban UX work is the separable slice.
