### PR TITLE
fix(conductor): pass through sessionKeyPrefix from portable spawn result

### DIFF
--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -282,7 +282,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
             prompt: null,
             missionId,
             sessionKey: result.sessionKey ?? null,
-            sessionKeyPrefix: null,
+            sessionKeyPrefix: (result as Record<string, unknown>).sessionKeyPrefix ?? null,
             jobId: missionId,
             jobName: result.name ?? missionName,
             runId: null,


### PR DESCRIPTION
## Summary

Fixes a bug where `sessionKeyPrefix` was hardcoded to `null` in `conductor-spawn.ts`, breaking async session resolution when the dashboard backend returns a prefix value from the spawn result.

## Change

- `conductor-spawn.ts`: Changed `sessionKeyPrefix: null` to read the value from the spawn result: `(result as Record<string, unknown>).sessionKeyPrefix ?? null`

This mirrors the existing `sessionKey` pattern and ensures the downstream job/session routing can correctly resolve sessions when the backend provides a prefix.

## How it was found

After getting the Conductor page working locally with a dashboard-backed backend, missions were spawning but the async session resolver could not find them because the hardcoded `null` blocked prefix-based lookups.

Co-authored-by: Hermes Agent