### PR TITLE
feat(skills): per-profile skills toggle in Skills screen

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -115,6 +115,8 @@ import { Route as ApiSkillsInstallRouteImport } from './routes/api/skills/instal
 import { Route as ApiSkillsHubSearchRouteImport } from './routes/api/skills/hub-search'
 import { Route as ApiSessionsSendRouteImport } from './routes/api/sessions/send'
 import { Route as ApiProfilesUpdateRouteImport } from './routes/api/profiles/update'
+import { Route as ApiProfilesToggleSkillRouteImport } from './routes/api/profiles/toggle-skill'
+import { Route as ApiProfilesSkillsRouteImport } from './routes/api/profiles/skills'
 import { Route as ApiProfilesRenameRouteImport } from './routes/api/profiles/rename'
 import { Route as ApiProfilesReadRouteImport } from './routes/api/profiles/read'
 import { Route as ApiProfilesListRouteImport } from './routes/api/profiles/list'
@@ -684,6 +686,16 @@ const ApiProfilesUpdateRoute = ApiProfilesUpdateRouteImport.update({
   path: '/api/profiles/update',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiProfilesToggleSkillRoute = ApiProfilesToggleSkillRouteImport.update({
+  id: '/api/profiles/toggle-skill',
+  path: '/api/profiles/toggle-skill',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProfilesSkillsRoute = ApiProfilesSkillsRouteImport.update({
+  id: '/api/profiles/skills',
+  path: '/api/profiles/skills',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiProfilesRenameRoute = ApiProfilesRenameRouteImport.update({
   id: '/api/profiles/rename',
   path: '/api/profiles/rename',
@@ -1003,6 +1015,8 @@ export interface FileRoutesByFullPath {
   '/api/profiles/list': typeof ApiProfilesListRoute
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
+  '/api/profiles/skills': typeof ApiProfilesSkillsRoute
+  '/api/profiles/toggle-skill': typeof ApiProfilesToggleSkillRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
@@ -1147,6 +1161,8 @@ export interface FileRoutesByTo {
   '/api/profiles/list': typeof ApiProfilesListRoute
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
+  '/api/profiles/skills': typeof ApiProfilesSkillsRoute
+  '/api/profiles/toggle-skill': typeof ApiProfilesToggleSkillRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
@@ -1293,6 +1309,8 @@ export interface FileRoutesById {
   '/api/profiles/list': typeof ApiProfilesListRoute
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
+  '/api/profiles/skills': typeof ApiProfilesSkillsRoute
+  '/api/profiles/toggle-skill': typeof ApiProfilesToggleSkillRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
@@ -1440,6 +1458,8 @@ export interface FileRouteTypes {
     | '/api/profiles/list'
     | '/api/profiles/read'
     | '/api/profiles/rename'
+    | '/api/profiles/skills'
+    | '/api/profiles/toggle-skill'
     | '/api/profiles/update'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
@@ -1584,6 +1604,8 @@ export interface FileRouteTypes {
     | '/api/profiles/list'
     | '/api/profiles/read'
     | '/api/profiles/rename'
+    | '/api/profiles/skills'
+    | '/api/profiles/toggle-skill'
     | '/api/profiles/update'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
@@ -1729,6 +1751,8 @@ export interface FileRouteTypes {
     | '/api/profiles/list'
     | '/api/profiles/read'
     | '/api/profiles/rename'
+    | '/api/profiles/skills'
+    | '/api/profiles/toggle-skill'
     | '/api/profiles/update'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
@@ -1858,6 +1882,8 @@ export interface RootRouteChildren {
   ApiProfilesListRoute: typeof ApiProfilesListRoute
   ApiProfilesReadRoute: typeof ApiProfilesReadRoute
   ApiProfilesRenameRoute: typeof ApiProfilesRenameRoute
+  ApiProfilesSkillsRoute: typeof ApiProfilesSkillsRoute
+  ApiProfilesToggleSkillRoute: typeof ApiProfilesToggleSkillRoute
   ApiProfilesUpdateRoute: typeof ApiProfilesUpdateRoute
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
@@ -2608,6 +2634,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiProfilesUpdateRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/profiles/toggle-skill': {
+      id: '/api/profiles/toggle-skill'
+      path: '/api/profiles/toggle-skill'
+      fullPath: '/api/profiles/toggle-skill'
+      preLoaderRoute: typeof ApiProfilesToggleSkillRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/profiles/skills': {
+      id: '/api/profiles/skills'
+      path: '/api/profiles/skills'
+      fullPath: '/api/profiles/skills'
+      preLoaderRoute: typeof ApiProfilesSkillsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/profiles/rename': {
       id: '/api/profiles/rename'
       path: '/api/profiles/rename'
@@ -3168,6 +3208,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiProfilesListRoute: ApiProfilesListRoute,
   ApiProfilesReadRoute: ApiProfilesReadRoute,
   ApiProfilesRenameRoute: ApiProfilesRenameRoute,
+  ApiProfilesSkillsRoute: ApiProfilesSkillsRoute,
+  ApiProfilesToggleSkillRoute: ApiProfilesToggleSkillRoute,
   ApiProfilesUpdateRoute: ApiProfilesUpdateRoute,
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,

--- a/src/routes/api/profiles/skills.ts
+++ b/src/routes/api/profiles/skills.ts
@@ -1,0 +1,96 @@
+/**
+ * Proxy for the dashboard's per-profile skills endpoint.
+ *
+ *   GET /api/profiles/skills?name=<profile>
+ *     → dashboard GET /api/profiles/<profile>/skills
+ *
+ * Pairs with NousResearch/hermes-agent#25116, which lets one dashboard
+ * daemon edit `skills.disabled` across every installed profile. Without
+ * this proxy the workspace can only manage the dashboard's currently
+ * bound profile (whichever HERMES_HOME the daemon launched against),
+ * matching the old single-profile constraint.
+ *
+ * The dashboard returns a lighter payload than `/api/skills` — just
+ * `{name, description, category, path, enabled}` per entry, scoped to
+ * the profile's own `skills/` directory. The frontend normalizes these
+ * entries into the workspace's richer `SkillSummary` shape with safe
+ * defaults for fields the dashboard doesn't supply at the profile scope.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  dashboardFetch,
+  ensureGatewayProbed,
+} from '../../../server/gateway-capabilities'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const PROFILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+
+export const Route = createFileRoute('/api/profiles/skills')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.skills || !capabilities.dashboard.available) {
+          return json(
+            {
+              ...createCapabilityUnavailablePayload('skills'),
+              items: [],
+            },
+            { status: 503 },
+          )
+        }
+
+        try {
+          const url = new URL(request.url)
+          const profile = (url.searchParams.get('name') || '').trim()
+          if (!profile || !PROFILE_NAME_RE.test(profile)) {
+            return json(
+              { error: 'A valid profile name is required' },
+              { status: 400 },
+            )
+          }
+
+          const response = await dashboardFetch(
+            `/api/profiles/${encodeURIComponent(profile)}/skills`,
+            { signal: AbortSignal.timeout(30_000) },
+          )
+          const body = await response.text()
+          if (!response.ok) {
+            // 404 from dashboard means the profile doesn't exist or doesn't
+            // expose the endpoint (older dashboard without PR #25116).
+            return json(
+              {
+                error:
+                  body ||
+                  `Dashboard profile skills request failed (${response.status})`,
+              },
+              { status: response.status },
+            )
+          }
+
+          let parsed: unknown
+          try {
+            parsed = JSON.parse(body)
+          } catch {
+            return json(
+              { error: 'Dashboard returned malformed JSON for profile skills' },
+              { status: 502 },
+            )
+          }
+          const items = Array.isArray(parsed) ? parsed : []
+          return json({ profile, items })
+        } catch (err) {
+          return json(
+            { error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/profiles/toggle-skill.ts
+++ b/src/routes/api/profiles/toggle-skill.ts
@@ -1,0 +1,95 @@
+/**
+ * Proxy for the dashboard's per-profile skills toggle endpoint.
+ *
+ *   PUT /api/profiles/toggle-skill
+ *     body: { profile: string, name: string, enabled: boolean }
+ *     → dashboard PUT /api/profiles/<profile>/skills/toggle
+ *
+ * Writes `skills.disabled` in the *target profile's* config.yaml, not the
+ * active profile's. Pairs with the per-profile skills GET proxy and
+ * NousResearch/hermes-agent#25116.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  dashboardFetch,
+  ensureGatewayProbed,
+} from '../../../server/gateway-capabilities'
+import { requireJsonContentType } from '../../../server/rate-limit'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+const PROFILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
+
+export const Route = createFileRoute('/api/profiles/toggle-skill')({
+  server: {
+    handlers: {
+      PUT: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const capabilities = await ensureGatewayProbed()
+        if (!capabilities.skills || !capabilities.dashboard.available) {
+          return json(
+            {
+              ok: false,
+              ...createCapabilityUnavailablePayload('skills'),
+            },
+            { status: 503 },
+          )
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        try {
+          const body = (await request.json()) as {
+            profile?: string
+            name?: string
+            enabled?: boolean
+          }
+          const profile = (body.profile || '').trim()
+          const name = (body.name || '').trim()
+          const enabled = Boolean(body.enabled)
+          if (!profile || !PROFILE_NAME_RE.test(profile)) {
+            return json(
+              { ok: false, error: 'A valid profile name is required' },
+              { status: 400 },
+            )
+          }
+          if (!name) {
+            return json(
+              { ok: false, error: 'A skill name is required' },
+              { status: 400 },
+            )
+          }
+
+          const response = await dashboardFetch(
+            `/api/profiles/${encodeURIComponent(profile)}/skills/toggle`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name, enabled }),
+              signal: AbortSignal.timeout(30_000),
+            },
+          )
+          const text = await response.text()
+          let payload: unknown = null
+          try {
+            payload = text ? JSON.parse(text) : null
+          } catch {
+            payload = { ok: false, error: text }
+          }
+          return json(payload, { status: response.status })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/screens/skills/skills-screen.tsx
+++ b/src/screens/skills/skills-screen.tsx
@@ -30,6 +30,70 @@ type SecurityRisk = {
   score: number
 }
 
+type ProfileSummary = {
+  name: string
+  path?: string
+  active?: boolean
+  is_active?: boolean
+  is_default?: boolean
+}
+
+type ProfileListResponse = {
+  profiles: Array<ProfileSummary>
+  activeProfile?: string
+  error?: string
+}
+
+type ProfileSkillRaw = {
+  name: string
+  description?: string
+  category?: string | null
+  path?: string
+  enabled?: boolean
+}
+
+type ProfileSkillsResponse = {
+  profile: string
+  items: Array<ProfileSkillRaw>
+  error?: string
+}
+
+function titleCaseCategory(raw: string | null | undefined): string {
+  const value = (raw || '').trim()
+  if (!value) return 'Productivity'
+  return value
+    .split(/[-_/]/)
+    .map((word) =>
+      word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : '',
+    )
+    .filter(Boolean)
+    .join(' ')
+}
+
+function normalizeProfileSkill(raw: ProfileSkillRaw): SkillSummary {
+  const name = (raw.name || '').trim()
+  return {
+    id: name,
+    slug: name,
+    name,
+    description: raw.description || '',
+    author: '',
+    triggers: [],
+    tags: [],
+    homepage: null,
+    category: titleCaseCategory(raw.category),
+    icon: '✨',
+    content: '',
+    fileCount: 0,
+    sourcePath: raw.path || '',
+    installed: true,
+    enabled: raw.enabled !== false,
+    featuredGroup: undefined,
+    security: { level: 'safe', flags: [], score: 0 },
+    origin: 'marketplace',
+  }
+}
+
 type SkillSummary = {
   id: string
   slug: string
@@ -140,6 +204,43 @@ export function SkillsScreen() {
   const [actionSkillId, setActionSkillId] = useState<string | null>(null)
   const [selectedSkill, setSelectedSkill] = useState<SkillSummary | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [selectedProfile, setSelectedProfile] = useState<string>('')
+
+  const profilesQuery = useQuery({
+    queryKey: ['skills-profiles-list'],
+    queryFn: async function fetchProfiles(): Promise<ProfileListResponse> {
+      const response = await fetch('/api/profiles/list')
+      const payload = (await response.json()) as ProfileListResponse
+      if (!response.ok) {
+        throw new Error(payload.error || 'Failed to load profiles')
+      }
+      return payload
+    },
+    staleTime: 60_000,
+  })
+
+  const profiles = profilesQuery.data?.profiles ?? []
+  // Treat the profile that the workspace is bound to (active_profile file) as
+  // the dashboard's `is_active`. They derive from the same on-disk source.
+  const activeProfileName = useMemo(() => {
+    const fromActiveFlag = profiles.find((p) => p.active || p.is_active)
+    if (fromActiveFlag) return fromActiveFlag.name
+    const explicit = profilesQuery.data?.activeProfile
+    if (explicit) return explicit
+    const defaultProfile = profiles.find((p) => p.is_default)
+    return defaultProfile?.name ?? profiles[0]?.name ?? ''
+  }, [profiles, profilesQuery.data?.activeProfile])
+
+  // Pick a sensible default once profiles arrive — match the dashboard's
+  // pattern (active first, then default, then any).
+  useEffect(() => {
+    if (!profiles.length || selectedProfile) return
+    setSelectedProfile(activeProfileName || profiles[0]!.name)
+  }, [profiles, activeProfileName, selectedProfile])
+
+  const effectiveProfile = selectedProfile || activeProfileName
+  const isOnActiveProfile =
+    !effectiveProfile || effectiveProfile === activeProfileName
 
   useEffect(() => {
     if (tab !== 'marketplace') return
@@ -153,9 +254,66 @@ export function SkillsScreen() {
     }
   }, [searchInput, tab])
 
+  // When viewing a non-active profile, the marketplace/featured tabs don't
+  // apply — the dashboard's per-profile endpoint only enumerates installed
+  // skills inside that profile's own skills/ dir. Snap back to 'installed'
+  // so the page stays consistent when the user changes profile.
+  useEffect(() => {
+    if (!isOnActiveProfile && tab !== 'installed') {
+      setTab('installed')
+      setPage(1)
+    }
+  }, [isOnActiveProfile, tab])
+
   const skillsQuery = useQuery({
-    queryKey: ['skills-browser', tab, searchInput, category, origin, page, sort],
+    queryKey: [
+      'skills-browser',
+      tab,
+      searchInput,
+      category,
+      origin,
+      page,
+      sort,
+      isOnActiveProfile ? '__active__' : effectiveProfile,
+    ],
+    enabled: isOnActiveProfile || Boolean(effectiveProfile),
     queryFn: async function fetchSkills(): Promise<SkillsApiResponse> {
+      if (!isOnActiveProfile) {
+        const response = await fetch(
+          `/api/profiles/skills?name=${encodeURIComponent(effectiveProfile)}`,
+        )
+        const payload = (await response.json()) as ProfileSkillsResponse & {
+          error?: string
+        }
+        if (!response.ok) {
+          throw new Error(payload.error || 'Failed to fetch profile skills')
+        }
+        const normalized = (payload.items || []).map(normalizeProfileSkill)
+        const lowered = searchInput.trim().toLowerCase()
+        const filtered = normalized.filter((skill) => {
+          if (category !== 'All' && skill.category !== category) return false
+          if (!lowered) return true
+          return [skill.name, skill.description, skill.category]
+            .join('\n')
+            .toLowerCase()
+            .includes(lowered)
+        })
+        const sorted = [...filtered].sort((a, b) => {
+          if (sort === 'category') {
+            const compare = a.category.localeCompare(b.category)
+            if (compare !== 0) return compare
+          }
+          return a.name.localeCompare(b.name)
+        })
+        const total = sorted.length
+        const start = (page - 1) * PAGE_LIMIT
+        const skills = sorted.slice(start, start + PAGE_LIMIT)
+        const categorySet = Array.from(
+          new Set(['All', ...normalized.map((skill) => skill.category)]),
+        )
+        return { skills, total, page, categories: categorySet }
+      }
+
       const params = new URLSearchParams()
       params.set('tab', tab)
       params.set('search', searchInput)
@@ -341,25 +499,48 @@ export function SkillsScreen() {
     setActionError(null)
     setActionSkillId(payload.skillId)
 
+    // Install/uninstall on a non-active profile would silently target the
+    // dashboard's bound profile (the only one the legacy /api/skills routes
+    // can edit). The dashboard's per-profile endpoint only supports toggle.
+    if (action !== 'toggle' && !isOnActiveProfile) {
+      setActionError(
+        `Install/uninstall is only available on the active profile. Switch the profile dropdown to "${activeProfileName || 'default'}" to manage installs.`,
+      )
+      setActionSkillId(null)
+      return
+    }
+
     try {
-      const endpoint =
-        action === 'install'
+      const routeProfileToggle =
+        action === 'toggle' && !isOnActiveProfile && Boolean(effectiveProfile)
+
+      const endpoint = routeProfileToggle
+        ? '/api/profiles/toggle-skill'
+        : action === 'install'
           ? '/api/skills/install'
           : action === 'uninstall'
             ? '/api/skills/uninstall'
             : '/api/skills/toggle'
 
       const response = await fetch(endpoint, {
-        method: 'POST',
+        method: routeProfileToggle ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action,
-          skillId: payload.skillId,
-          name: payload.skillId,
-          identifier: payload.skillId,
-          enabled: payload.enabled,
-          source: payload.source,
-        }),
+        body: JSON.stringify(
+          routeProfileToggle
+            ? {
+                profile: effectiveProfile,
+                name: payload.skillId,
+                enabled: payload.enabled,
+              }
+            : {
+                action,
+                skillId: payload.skillId,
+                name: payload.skillId,
+                identifier: payload.skillId,
+                enabled: payload.enabled,
+                source: payload.source,
+              },
+        ),
       })
 
       const data = (await response.json()) as {
@@ -478,6 +659,31 @@ export function SkillsScreen() {
         <section className="rounded-2xl border border-primary-200 bg-primary-50/80 p-3 backdrop-blur-xl sm:p-4">
           <Tabs value={tab} onValueChange={handleTabChange}>
             <div className="flex flex-wrap items-center gap-2">
+              {profiles.length > 1 ? (
+                <label className="flex h-9 items-center gap-2 rounded-lg border border-primary-200 bg-primary-100/60 px-3 text-xs text-primary-500">
+                  <span className="font-medium uppercase tracking-wider text-[10px]">
+                    Profile
+                  </span>
+                  <select
+                    value={effectiveProfile}
+                    onChange={(event) => {
+                      setSelectedProfile(event.target.value)
+                      setPage(1)
+                    }}
+                    className="h-7 rounded-md border border-primary-200 bg-primary-50/70 px-2 text-xs text-ink outline-none"
+                    aria-label="Profile"
+                  >
+                    {profiles.map((profile) => (
+                      <option key={profile.name} value={profile.name}>
+                        {profile.name === activeProfileName
+                          ? `${profile.name} (active)`
+                          : profile.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+
               <input
                 value={searchInput}
                 onChange={(event) => handleSearchChange(event.target.value)}
@@ -505,7 +711,7 @@ export function SkillsScreen() {
                 </select>
               ) : null}
 
-              {tab === 'installed' ? (
+              {tab === 'installed' && isOnActiveProfile ? (
                 <select
                   value={origin}
                   onChange={(event) => handleOriginChange(event.target.value)}
@@ -540,9 +746,11 @@ export function SkillsScreen() {
                 <TabsTab value="installed" className="min-w-[110px]">
                   Installed
                 </TabsTab>
-                <TabsTab value="marketplace" className="min-w-[120px]">
-                  Marketplace
-                </TabsTab>
+                {isOnActiveProfile ? (
+                  <TabsTab value="marketplace" className="min-w-[120px]">
+                    Marketplace
+                  </TabsTab>
+                ) : null}
               </TabsList>
             </div>
 


### PR DESCRIPTION
## Summary

Adds a **Profile** dropdown to the Skills screen so one workspace process can manage `skills.disabled` across every installed Hermes profile. Today the screen only edits the profile the dashboard daemon is bound to; toggling a sub-profile (`scratch-worker`, `writer`, `emailtriage`, …) requires running a second daemon.

Pairs with [NousResearch/hermes-agent#25116](https://github.com/NousResearch/hermes-agent/pull/25116), which adds the matching server-side endpoints on the dashboard:

- `GET  /api/profiles/{name}/skills`
- `PUT  /api/profiles/{name}/skills/toggle`
- `is_active` flag on `/api/profiles`

## What changes

### Backend

Two thin proxy routes that forward to the new dashboard endpoints:

| Workspace route | Dashboard route |
| --- | --- |
| `GET  /api/profiles/skills?name=<profile>` | `GET  /api/profiles/<profile>/skills` |
| `PUT  /api/profiles/toggle-skill` body `{profile,name,enabled}` | `PUT  /api/profiles/<profile>/skills/toggle` |

Both go through the existing `dashboardFetch` helper, so auth is transparent. They early-return when `capabilities.dashboard.available` is false, so older zero-fork/managed-gateway setups don't get spurious 5xxs.

I did **not** add a new `/api/profiles` proxy — the existing `/api/profiles/list` already surfaces which profile the workspace is bound to (`active`/`activeProfile`), which is the same source-of-truth the dashboard uses to compute `is_active`. Reusing it avoids a redundant network hop on every Skills mount.

### Frontend (`src/screens/skills/skills-screen.tsx`)

- New **Profile** `<select>` in the Skills toolbar. Hidden when only one profile is installed (single-profile parity with the dashboard's sidebar). Defaults to the active profile, falls back to `is_default`, then any.
- The active profile is suffixed `(active)` so the user always knows which profile the daemon is currently bound to — mirrors the dashboard PR's affordance.
- When the user picks a non-active profile:
  - The screen fetches `/api/profiles/skills?name=<profile>` instead of `/api/skills`.
  - The lighter per-profile payload is normalized into `SkillSummary` so existing rows/dialogs render unchanged.
  - The `Marketplace` tab and `Origin` filter are hidden — both depend on workspace-side enrichment (Skills Hub, bundled manifest, agent-created flags) that the dashboard's per-profile endpoint deliberately omits.
  - Toggle writes go through `PUT /api/profiles/toggle-skill` so `skills.disabled` is mutated in the **target** profile's `config.yaml`, not the active one.
  - Install/uninstall on a non-active profile is intentionally blocked with a friendly error pointing the user back to the active profile — the dashboard's per-profile endpoint only supports toggle today.

## How to test

1. Run a dashboard daemon with at least one sub-profile in `~/.hermes/profiles/` (e.g. `scratch-worker`, `writer`).
2. Start the workspace and open the Skills screen. The Profile dropdown appears in the toolbar, defaulted to the active profile with `(active)` suffix.
3. Switch to a non-active profile. The list refreshes from that profile's `skills/` directory; Marketplace tab and Origin filter disappear.
4. Toggle any skill. Reload the page and verify `skills.disabled` in `~/.hermes/profiles/<name>/config.yaml` reflects the change, and the active profile's `config.yaml` is untouched.

I smoke-tested this against two co-located Hermes installs:

- **Iris** (default + `emailtriage` + `hivemind-community-manager`) — toggling `ascii-art` off on `emailtriage` from the workspace UI added `ascii-art` to `~/.hermes/profiles/emailtriage/config.yaml` only; `~/.hermes/config.yaml` was unchanged.
- **Artemis** (default + `scratch-worker` + `writer` + `analyst` + `creative` + `researcher` + `shopify-admin`) — toggling `airtable` on `scratch-worker` removed `airtable` from `scratch-worker/config.yaml` only; default's disabled list was unchanged.

## Known limitations

- The per-profile list excludes skills loaded via `skills.external_dirs` — same scope as the dashboard's endpoint.
- Install/uninstall on a non-active profile requires either a follow-up to dashboard PR #25116 or running a daemon bound to that profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)