### PR TITLE
fix: align swarm runtime with semantic wrappers

### DIFF
--- a/src/routes/api/-swarm-health.test.ts
+++ b/src/routes/api/-swarm-health.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { parseModelAuthEventsFromText, summarizeSwarmHealth } from './swarm-health'
+import { parseModelAuthEventsFromText, resolveWorkerWrapperName, summarizeSwarmHealth } from './swarm-health'
 
 describe('swarm-health model/auth readiness', () => {
+  it('uses roster wrapper aliases when resolving semantic worker wrappers', () => {
+    expect(resolveWorkerWrapperName('builder', { wrapper: 'builder:task' })).toBe('builder:task')
+    expect(resolveWorkerWrapperName('builder', { wrapper: '  ' })).toBe('builder')
+    expect(resolveWorkerWrapperName('swarm5', null)).toBe('swarm5')
+  })
+
   it('detects primary auth failure and fallback provider from Hermes logs', () => {
     const events = parseModelAuthEventsFromText(`
 2026-05-04 18:37:56,770 WARNING cli: Primary provider auth failed (No Codex credentials stored. Run \`hermes auth\` to authenticate.). Falling through to fallback: minimax/MiniMax-M2.7

--- a/src/routes/api/swarm-direct-chat.ts
+++ b/src/routes/api/swarm-direct-chat.ts
@@ -6,6 +6,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { readWorkerMessages, type SwarmChatMessage } from '../../server/swarm-chat-reader'
+import { rosterByWorkerId } from '../../server/swarm-roster'
 
 type DirectChatRequest = {
   workerId?: unknown
@@ -60,7 +61,9 @@ function getProfilePath(workerId: string): string {
 }
 
 function getWrapperPath(workerId: string): string {
-  return join(homedir(), '.local', 'bin', workerId)
+  const worker = rosterByWorkerId([workerId]).get(workerId)
+  const wrapperName = worker?.wrapper?.trim() || workerId
+  return join(homedir(), '.local', 'bin', wrapperName)
 }
 
 function resolveWorkerCwd(workerId: string): string {

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -96,7 +96,9 @@ function getProfilesDir(): string {
 }
 
 function getWrapperPath(workerId: string): string {
-  return join(homedir(), '.local', 'bin', workerId)
+  const worker = rosterByWorkerId([workerId]).get(workerId)
+  const wrapperName = worker?.wrapper?.trim() || workerId
+  return join(homedir(), '.local', 'bin', wrapperName)
 }
 
 function getProfilePath(workerId: string): string {

--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -6,6 +6,7 @@ import * as yaml from 'yaml'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getLocalBinDir, getProfilesDir } from '../../server/claude-paths'
 import { formatSwarmWorkerLabel, isSwarmWorkerId, resolveSwarmWorkerDisplayName, rosterByWorkerId } from '../../server/swarm-roster'
+import type { SwarmRosterWorker } from '../../server/swarm-roster'
 
 export type WorkerModelAuthStatus = 'ready' | 'primary-auth-failed' | 'fallback-active' | 'not-configured' | 'unknown'
 
@@ -46,6 +47,10 @@ export type SwarmHealthSummary = {
   distinctProviders: Array<string>
   degraded: boolean
   warnings: Array<string>
+}
+
+export function resolveWorkerWrapperName(workerId: string, worker?: Pick<SwarmRosterWorker, 'wrapper'> | null): string {
+  return worker?.wrapper?.trim() || workerId
 }
 
 function listSwarmIds(): Array<string> {
@@ -239,7 +244,8 @@ export const Route = createFileRoute('/api/swarm-health')({
         const workers: Array<WorkerHealth> = swarmIds.map((id) => {
           const worker = roster.get(id)
           const profilePath = join(profilesBase, id)
-          const wrapperPath = join(wrapperBase, id)
+          const wrapperName = resolveWorkerWrapperName(id, worker)
+          const wrapperPath = join(wrapperBase, wrapperName)
           const config = readWorkerConfig(profilePath)
           const errs = scanRecentAuthErrors(profilePath)
           const primaryReady = errs.authErrorCount === 0 && errs.fallbackCount === 0 && (config.provider !== 'openai-codex' || hasOpenAiCodexAuth(profilePath))

--- a/src/routes/api/swarm-tmux-start.ts
+++ b/src/routes/api/swarm-tmux-start.ts
@@ -135,7 +135,9 @@ function startSession(
 }
 
 function resolveWorkerCwd(workerId: string): string {
-  const wrapperPath = join(homedir(), '.local', 'bin', workerId)
+  const worker = rosterByWorkerId([workerId]).get(workerId)
+  const wrapperName = worker?.wrapper?.trim() || workerId
+  const wrapperPath = join(homedir(), '.local', 'bin', wrapperName)
   if (existsSync(wrapperPath)) {
     try {
       const text = readFileSync(wrapperPath, 'utf8')
@@ -178,7 +180,9 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
         // path is bogus, and the sandbox quirks on this host make existsSync
         // unreliable for parent dirs even when leaf paths work.
         // We still verify the wrapper exists as a sanity check.
-        const wrapper = join(homedir(), '.local', 'bin', workerId)
+        const worker = rosterByWorkerId([workerId]).get(workerId)
+        const wrapperName = worker?.wrapper?.trim() || workerId
+        const wrapper = join(homedir(), '.local', 'bin', wrapperName)
         if (!existsSync(wrapper)) {
           return json(
             { error: `No wrapper for ${workerId} at ${wrapper}` },

--- a/src/server/swarm-foundation.test.ts
+++ b/src/server/swarm-foundation.test.ts
@@ -4,6 +4,7 @@ import {
   buildSwarmSessionMetadata,
   classifySwarmPluginBoundary,
   deriveSwarmBoundary,
+  getSwarmWrapperPath,
   normalizeSwarmRuntime,
   parseSwarmPluginManifest,
 } from './swarm-foundation'
@@ -12,6 +13,11 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 
 describe('normalizeSwarmRuntime', () => {
+  it('resolves semantic wrapper aliases from the roster', () => {
+    expect(getSwarmWrapperPath('builder')).toMatch(/\/builder:task$/)
+    expect(getSwarmWrapperPath('swarm5')).toMatch(/\/swarm5$/)
+  })
+
   it('fills legacy or sparse runtime.json values with stable defaults', () => {
     const runtime = normalizeSwarmRuntime(
       'swarm7',

--- a/src/server/swarm-foundation.ts
+++ b/src/server/swarm-foundation.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path'
 import * as YAML from 'yaml'
 import { z } from 'zod'
 import { getLocalBinDir, getProfilesDir } from './claude-paths'
-import { isSwarmWorkerId } from './swarm-roster'
+import { isSwarmWorkerId, rosterByWorkerId } from './swarm-roster'
 
 export const SwarmWorkerStateSchema = z.enum([
   'idle',
@@ -466,7 +466,9 @@ export function getSwarmProfilePath(workerId: string): string {
 }
 
 export function getSwarmWrapperPath(workerId: string): string {
-  return path.join(getLocalBinDir(), workerId)
+  const worker = rosterByWorkerId([workerId]).get(workerId)
+  const wrapperName = worker?.wrapper?.trim() || workerId
+  return path.join(getLocalBinDir(), wrapperName)
 }
 
 export function getSwarmTmuxSessionName(workerId: string): string {

--- a/src/server/swarm-notifications.test.ts
+++ b/src/server/swarm-notifications.test.ts
@@ -75,9 +75,9 @@ describe('swarm-notifications', () => {
       notifySessionKey: 'qa-main',
     })
 
-    // DONE checkpoints route to the orchestrator (swarm3 tmux), not main.
+    // DONE checkpoints route to the orchestrator tmux session, not main.
     expect(first).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'orchestrator' })
-    expect(first.orchestrator).toMatchObject({ sent: true, session: 'swarm-swarm3' })
+    expect(first.orchestrator).toMatchObject({ sent: true, session: 'swarm-orchestrator' })
     // Same raw is deduped on the second call.
     expect(second).toMatchObject({ published: false, sessionKey: 'qa-main', route: 'noop' })
     // No chat event was published — DONE goes to orchestrator only.
@@ -159,7 +159,7 @@ describe('swarm-notifications', () => {
     })
 
     expect(result).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'main' })
-    expect(result.orchestrator).toMatchObject({ sent: true, session: 'swarm-swarm3' })
+    expect(result.orchestrator).toMatchObject({ sent: true, session: 'swarm-orchestrator' })
     // Both the orchestrator AND main were notified.
     expect(publishChatEvent).toHaveBeenCalledTimes(2)
     expect(publishChatEvent).toHaveBeenNthCalledWith(
@@ -201,7 +201,7 @@ describe('swarm-notifications', () => {
     })
 
     expect(result).toMatchObject({ published: true, sessionKey: 'qa-main', route: 'main' })
-    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-swarm3' })
+    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-orchestrator' })
     expect(publishChatEvent).toHaveBeenCalled()
   })
 
@@ -218,15 +218,15 @@ describe('swarm-notifications', () => {
       nextAction: 'Continue loop',
       raw: 'STATE: DONE\nRESULT: Orchestrator self-report\nNEXT_ACTION: Continue loop',
     }
-    mkdirSync(join(tempRoot, 'swarm3'), { recursive: true })
+    mkdirSync(join(tempRoot, 'orchestrator'), { recursive: true })
 
     const result = mod.publishSwarmCheckpointNotification({
-      workerId: 'swarm3',
+      workerId: 'orchestrator',
       checkpoint,
       notifySessionKey: 'qa-main',
     })
 
     // skippedSelf -> orchestrator route is treated as 'orchestrator' (self-report doesn't escalate either).
-    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-swarm3', skippedSelf: true })
+    expect(result.orchestrator).toMatchObject({ sent: false, session: 'swarm-orchestrator', skippedSelf: true })
   })
 })

--- a/src/server/swarm-notifications.ts
+++ b/src/server/swarm-notifications.ts
@@ -5,7 +5,7 @@ import type { ParsedSwarmCheckpoint } from './swarm-checkpoints'
 import { getSwarmProfilePath } from './swarm-foundation'
 import { publishChatEvent } from './chat-event-bus'
 
-const ORCHESTRATOR_WORKER_ID = process.env.SWARM_ORCHESTRATOR_WORKER_ID?.trim() || 'swarm3'
+const ORCHESTRATOR_WORKER_ID = process.env.SWARM_ORCHESTRATOR_WORKER_ID?.trim() || 'orchestrator'
 const ORCHESTRATOR_TMUX_SESSION = `swarm-${ORCHESTRATOR_WORKER_ID}`
 const MAIN_SESSION_KEY = process.env.SWARM_MAIN_SESSION_KEY?.trim() || 'main'
 
@@ -187,7 +187,7 @@ export function publishSwarmCheckpointNotification(input: {
     checkpointSummary(input.checkpoint),
   ].filter(Boolean).join(' — ')
 
-  // 1. Route to orchestrator (swarm3) by default.
+  // 1. Route to orchestrator by default.
   const orchestratorResult = publishCheckpointToOrchestrator({
     workerId: input.workerId,
     checkpoint: input.checkpoint,


### PR DESCRIPTION
## Summary
- resolves semantic swarm wrapper aliases from `swarm.yaml` instead of assuming wrapper binary == worker id
- applies wrapper alias resolution across health/runtime/dispatch/direct-chat/tmux-start surfaces
- changes checkpoint routing default from legacy `swarm3` to semantic `orchestrator`
- adds focused regression coverage for `builder:task` wrapper aliases and orchestrator routing

## Test Plan
- `pnpm vitest run src/routes/api/-swarm-health.test.ts src/server/swarm-notifications.test.ts src/server/swarm-foundation.test.ts src/routes/api/-swarm-dispatch.test.ts`
