### PR TITLE
docs: update swarm orchestrator references

### DIFF
--- a/docs/swarm/ARCHITECTURE.md
+++ b/docs/swarm/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Swarm Mode is built around a durable loop: intent enters through Aurora, dispatc
     │ translates intent into SwarmBrief
     ▼
 ┌────────────────────────────┐
-│ swarm3 / Orchestrator      │
+│ Orchestrator                │
 │ routing, drift, escalation │
 └───┬────────────────────────┘
     │ dispatches by role + standing mission
@@ -109,8 +109,8 @@ The notification router lives in `src/server/swarm-notifications.ts`.
 Current behavior:
 
 - Checkpoints route to the orchestrator worker by default.
-- The default orchestrator worker is `swarm3`.
-- The tmux target is `swarm-swarm3`.
+- The default orchestrator worker is `orchestrator`.
+- The tmux target is `swarm-orchestrator`.
 - Duplicate raw checkpoints are suppressed via `runtime.json`.
 - `NEEDS_INPUT` escalates to the main session.
 - If the orchestrator tmux session is unreachable, the checkpoint escalates to the main session.

--- a/docs/swarm/README.md
+++ b/docs/swarm/README.md
@@ -25,7 +25,7 @@ This is not a chat wrapper with tabs. It is the operating surface for a local ag
 Eric talks to Aurora. Aurora turns intent into a brief. The orchestrator routes that brief to the right Hermes Agent. Workers execute inside persistent tmux sessions, checkpoint with proof, and the orchestrator decides whether to continue, repair, escalate, or put a card in the Inbox.
 
 ```text
-Eric -> Aurora -> swarm3/orchestrator -> role workers -> checkpoints -> reports/inbox -> review/escalation
+Eric -> Aurora -> orchestrator -> role workers -> checkpoints -> reports/inbox -> review/escalation
 ```
 
 The important move is that dispatch becomes a system, not a vibe. The worker is not just "another model call." It is a named lane with memory, runtime state, default skills, a profile, and a job.

--- a/docs/swarm/ROLES.md
+++ b/docs/swarm/ROLES.md
@@ -60,7 +60,7 @@ When to use:
 Canonical spec:
 
 ```text
-/swarm-specs/projects/swarm3.md
+/swarm-specs/projects/orchestrator.md
 ```
 
 Good checkpoint:


### PR DESCRIPTION
## Summary
- updates stale `swarm3` references in swarm docs to the semantic `orchestrator` lane
- aligns documented tmux target with `swarm-orchestrator`
- records this as the first bounded autoresearch pilot: fixed metric, docs-only scope, mechanical guard

## Autoresearch pilot
- Goal: reduce stale legacy `swarm3` mentions in `docs/swarm` orchestrator docs
- Scope/mutable target: `docs/swarm/README.md`, `docs/swarm/ROLES.md`, `docs/swarm/ARCHITECTURE.md`
- Locked eval: literal `swarm3` count across those files
- Metric: lower is better; baseline 5, final 0
- Results log: `/tmp/autoresearch-results/semantic-swarm-docs.tsv` on the runner host

## Test Plan
- `git diff --check`
- `pnpm vitest run src/server/swarm-notifications.test.ts src/routes/api/-swarm-health.test.ts`
