### PR TITLE
fix: keep seen update notes dismissed

### DIFF
--- a/src/components/update-center-notifier.test.tsx
+++ b/src/components/update-center-notifier.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { __updateReleaseNotesStorageForTests } from './update-center-notifier'
+
+const { NOTES_SEEN_KEY, storeNotes } = __updateReleaseNotesStorageForTests
+
+const agentReleaseNotes = [
+  {
+    product: 'agent' as const,
+    label: 'Hermes Agent',
+    from: 'c23a87bc163b188abc7e40fbdccf07a9739231c3',
+    to: '4fdfdf67499c33015ed56e6e5910d8bdc00aa901',
+    commits: ['Merge pull request #25045 (4fdfdf674)'],
+  },
+]
+
+function installLocalStorage() {
+  const store = new Map<string, string>()
+  const storage = {
+    get length() {
+      return store.size
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value)
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    clear() {
+      store.clear()
+    },
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+}
+
+beforeEach(() => {
+  installLocalStorage()
+})
+
+describe('update center release notes storage', () => {
+  it('does not reopen release notes already marked seen when status returns the same payload', () => {
+    const firstStored = storeNotes(agentReleaseNotes)
+
+    expect(firstStored).not.toBeNull()
+    localStorage.setItem(NOTES_SEEN_KEY, firstStored!.id)
+
+    expect(storeNotes(agentReleaseNotes)).toBeNull()
+  })
+})

--- a/src/components/update-center-notifier.tsx
+++ b/src/components/update-center-notifier.tsx
@@ -108,6 +108,7 @@ function storeNotes(sections: Array<ReleaseNoteSection>): Notes | null {
     localStorage.removeItem(NOTES_SEEN_KEY)
   }
   localStorage.setItem(NOTES_KEY, JSON.stringify(notes))
+  if (localStorage.getItem(NOTES_SEEN_KEY) === id) return null
   return notes
 }
 
@@ -519,4 +520,9 @@ function ReleaseNotes({
       </motion.div>
     </AnimatePresence>
   )
+}
+
+export const __updateReleaseNotesStorageForTests = {
+  NOTES_SEEN_KEY,
+  storeNotes,
 }


### PR DESCRIPTION
## Summary
- Keep pending update release notes closed once the current notes id has been marked seen.
- Prevent the same "Hermes updated" modal from reopening when `/api/update/status` returns the same pending notes after refresh.
- Add a regression test for the repeated status-payload path.

Refs #356.

## Testing
- `env CLAUDE_API_URL=http://127.0.0.1:9 pnpm --dir /Users/jonathannew/Active-Work/Code/third-party/hermes-workspace exec vitest run src/components/update-center-notifier.test.tsx`
- `pnpm --dir /Users/jonathannew/Active-Work/Code/third-party/hermes-workspace exec eslint src/components/update-center-notifier.tsx src/components/update-center-notifier.test.tsx`
- `git diff --cached --check`
- `env CLAUDE_API_URL=http://127.0.0.1:9 pnpm --dir /Users/jonathannew/Active-Work/Code/third-party/hermes-workspace build`

## Known Existing Check Failure
- `pnpm --dir /Users/jonathannew/Active-Work/Code/third-party/hermes-workspace exec tsc --noEmit` currently fails in untouched upstream code at `src/screens/playground/components/playground-hud.tsx` with JSX syntax errors. This PR does not modify that file.