### PR TITLE
feat: add external memory provider browser

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -145,6 +145,9 @@ import { Route as ApiKnowledgeGraphRouteImport } from './routes/api/knowledge/gr
 import { Route as ApiKnowledgeConfigRouteImport } from './routes/api/knowledge/config'
 import { Route as ApiHermesworldReservationsRouteImport } from './routes/api/hermesworld/reservations'
 import { Route as ApiHermesTasksTaskIdRouteImport } from './routes/api/hermes-tasks.$taskId'
+import { Route as ApiExternalMemorySearchRouteImport } from './routes/api/external-memory/search'
+import { Route as ApiExternalMemoryProvidersRouteImport } from './routes/api/external-memory/providers'
+import { Route as ApiExternalMemoryCandidatesRouteImport } from './routes/api/external-memory/candidates'
 import { Route as ApiDashboardOverviewRouteImport } from './routes/api/dashboard/overview'
 import { Route as ApiClaudeTasksTaskIdRouteImport } from './routes/api/claude-tasks.$taskId'
 import { Route as ApiClaudeProxySplatRouteImport } from './routes/api/claude-proxy/$'
@@ -838,6 +841,23 @@ const ApiHermesTasksTaskIdRoute = ApiHermesTasksTaskIdRouteImport.update({
   path: '/$taskId',
   getParentRoute: () => ApiHermesTasksRoute,
 } as any)
+const ApiExternalMemorySearchRoute = ApiExternalMemorySearchRouteImport.update({
+  id: '/api/external-memory/search',
+  path: '/api/external-memory/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiExternalMemoryProvidersRoute =
+  ApiExternalMemoryProvidersRouteImport.update({
+    id: '/api/external-memory/providers',
+    path: '/api/external-memory/providers',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiExternalMemoryCandidatesRoute =
+  ApiExternalMemoryCandidatesRouteImport.update({
+    id: '/api/external-memory/candidates',
+    path: '/api/external-memory/candidates',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiDashboardOverviewRoute = ApiDashboardOverviewRouteImport.update({
   id: '/api/dashboard/overview',
   path: '/api/dashboard/overview',
@@ -996,6 +1016,9 @@ export interface FileRoutesByFullPath {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/external-memory/candidates': typeof ApiExternalMemoryCandidatesRoute
+  '/api/external-memory/providers': typeof ApiExternalMemoryProvidersRoute
+  '/api/external-memory/search': typeof ApiExternalMemorySearchRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
@@ -1143,6 +1166,9 @@ export interface FileRoutesByTo {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/external-memory/candidates': typeof ApiExternalMemoryCandidatesRoute
+  '/api/external-memory/providers': typeof ApiExternalMemoryProvidersRoute
+  '/api/external-memory/search': typeof ApiExternalMemorySearchRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
@@ -1292,6 +1318,9 @@ export interface FileRoutesById {
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
   '/api/claude-tasks/$taskId': typeof ApiClaudeTasksTaskIdRoute
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
+  '/api/external-memory/candidates': typeof ApiExternalMemoryCandidatesRoute
+  '/api/external-memory/providers': typeof ApiExternalMemoryProvidersRoute
+  '/api/external-memory/search': typeof ApiExternalMemorySearchRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
@@ -1442,6 +1471,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/external-memory/candidates'
+    | '/api/external-memory/providers'
+    | '/api/external-memory/search'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
     | '/api/knowledge/config'
@@ -1589,6 +1621,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/external-memory/candidates'
+    | '/api/external-memory/providers'
+    | '/api/external-memory/search'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
     | '/api/knowledge/config'
@@ -1737,6 +1772,9 @@ export interface FileRouteTypes {
     | '/api/claude-proxy/$'
     | '/api/claude-tasks/$taskId'
     | '/api/dashboard/overview'
+    | '/api/external-memory/candidates'
+    | '/api/external-memory/providers'
+    | '/api/external-memory/search'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
     | '/api/knowledge/config'
@@ -1880,6 +1918,9 @@ export interface RootRouteChildren {
   ChatIndexRoute: typeof ChatIndexRoute
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiDashboardOverviewRoute: typeof ApiDashboardOverviewRoute
+  ApiExternalMemoryCandidatesRoute: typeof ApiExternalMemoryCandidatesRoute
+  ApiExternalMemoryProvidersRoute: typeof ApiExternalMemoryProvidersRoute
+  ApiExternalMemorySearchRoute: typeof ApiExternalMemorySearchRoute
   ApiHermesworldReservationsRoute: typeof ApiHermesworldReservationsRouteWithChildren
   ApiKnowledgeConfigRoute: typeof ApiKnowledgeConfigRoute
   ApiKnowledgeGraphRoute: typeof ApiKnowledgeGraphRoute
@@ -2856,6 +2897,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHermesTasksTaskIdRouteImport
       parentRoute: typeof ApiHermesTasksRoute
     }
+    '/api/external-memory/search': {
+      id: '/api/external-memory/search'
+      path: '/api/external-memory/search'
+      fullPath: '/api/external-memory/search'
+      preLoaderRoute: typeof ApiExternalMemorySearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/external-memory/providers': {
+      id: '/api/external-memory/providers'
+      path: '/api/external-memory/providers'
+      fullPath: '/api/external-memory/providers'
+      preLoaderRoute: typeof ApiExternalMemoryProvidersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/external-memory/candidates': {
+      id: '/api/external-memory/candidates'
+      path: '/api/external-memory/candidates'
+      fullPath: '/api/external-memory/candidates'
+      preLoaderRoute: typeof ApiExternalMemoryCandidatesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/dashboard/overview': {
       id: '/api/dashboard/overview'
       path: '/api/dashboard/overview'
@@ -3225,6 +3287,9 @@ const rootRouteChildren: RootRouteChildren = {
   ChatIndexRoute: ChatIndexRoute,
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiDashboardOverviewRoute: ApiDashboardOverviewRoute,
+  ApiExternalMemoryCandidatesRoute: ApiExternalMemoryCandidatesRoute,
+  ApiExternalMemoryProvidersRoute: ApiExternalMemoryProvidersRoute,
+  ApiExternalMemorySearchRoute: ApiExternalMemorySearchRoute,
   ApiHermesworldReservationsRoute: ApiHermesworldReservationsRouteWithChildren,
   ApiKnowledgeConfigRoute: ApiKnowledgeConfigRoute,
   ApiKnowledgeGraphRoute: ApiKnowledgeGraphRoute,

--- a/src/routes/api/external-memory/candidates.ts
+++ b/src/routes/api/external-memory/candidates.ts
@@ -1,0 +1,118 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  listExternalMemoryCandidates,
+  editExternalMemoryCandidate,
+  approveExternalMemoryCandidate,
+  rejectExternalMemoryCandidate,
+  deleteExternalMemoryCandidate,
+} from '../../../server/external-memory-browser'
+
+export const Route = createFileRoute('/api/external-memory/candidates')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const url = new URL(request.url)
+          return json(
+            listExternalMemoryCandidates({
+              provider: url.searchParams.get('provider') || undefined,
+              state: url.searchParams.get('state') || undefined,
+              limit: url.searchParams.get('limit') || undefined,
+              offset: url.searchParams.get('offset') || undefined,
+            }),
+          )
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to list external memory candidates',
+            },
+            { status: 500 },
+          )
+        }
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            provider?: string
+            id?: string
+            action?: string
+            text?: string
+            reason?: string
+          }
+          if (body.action === 'edit') {
+            return json(
+              editExternalMemoryCandidate({
+                provider: body.provider,
+                id: body.id || '',
+                text: body.text || '',
+              }),
+            )
+          }
+          if (body.action === 'approve') {
+            return json(
+              approveExternalMemoryCandidate({
+                provider: body.provider,
+                id: body.id || '',
+              }),
+            )
+          }
+          if (body.action === 'reject') {
+            return json(
+              rejectExternalMemoryCandidate({
+                provider: body.provider,
+                id: body.id || '',
+                reason: body.reason || '',
+              }),
+            )
+          }
+          return json({ error: 'Unsupported action' }, { status: 400 })
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to update external memory candidate',
+            },
+            { status: 500 },
+          )
+        }
+      },
+      DELETE: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const url = new URL(request.url)
+          const id = url.searchParams.get('id') || ''
+          const provider = url.searchParams.get('provider') || undefined
+          return json(deleteExternalMemoryCandidate({ provider, id }))
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to delete external memory candidate',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/external-memory/providers.ts
+++ b/src/routes/api/external-memory/providers.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { listExternalMemoryProviders } from '../../../server/external-memory-browser'
+
+export const Route = createFileRoute('/api/external-memory/providers')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          return json(listExternalMemoryProviders())
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to list external memory providers',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/external-memory/search.ts
+++ b/src/routes/api/external-memory/search.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { searchExternalMemoryCandidates } from '../../../server/external-memory-browser'
+
+export const Route = createFileRoute('/api/external-memory/search')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const url = new URL(request.url)
+          return json(
+            searchExternalMemoryCandidates({
+              provider: url.searchParams.get('provider') || undefined,
+              query: url.searchParams.get('q') || '',
+              limit: url.searchParams.get('limit') || undefined,
+            }),
+          )
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to search external memory candidates',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/memory.tsx
+++ b/src/routes/memory.tsx
@@ -16,10 +16,17 @@ const KnowledgeBrowserScreen = lazy(async () => {
   return { default: module.KnowledgeBrowserScreen }
 })
 
+const ExternalMemoryBrowserScreen = lazy(async () => {
+  const module = await import('@/screens/memory/external-memory-browser-screen')
+  return { default: module.ExternalMemoryBrowserScreen }
+})
+
 export const Route = createFileRoute('/memory')({
   ssr: false,
   component: function MemoryRoute() {
-    const [tab, setTab] = useState<'memory' | 'knowledge'>('memory')
+    const [tab, setTab] = useState<'memory' | 'knowledge' | 'external'>(
+      'memory',
+    )
     const memoryAvailable = useFeatureAvailable('memory')
 
     usePageTitle('Memory')
@@ -28,7 +35,9 @@ export const Route = createFileRoute('/memory')({
       <div className="flex h-full min-h-0 flex-col">
         <Tabs
           value={tab}
-          onValueChange={(value) => setTab(value as 'memory' | 'knowledge')}
+          onValueChange={(value) =>
+            setTab(value as 'memory' | 'knowledge' | 'external')
+          }
           className="h-full min-h-0 gap-0"
         >
           <div className="border-b border-primary-200 px-3 pt-3 dark:border-neutral-800 md:px-4 md:pt-4">
@@ -38,6 +47,7 @@ export const Route = createFileRoute('/memory')({
             >
               <TabsTab value="memory">Memory</TabsTab>
               <TabsTab value="knowledge">Knowledge</TabsTab>
+              <TabsTab value="external">External providers</TabsTab>
             </TabsList>
           </div>
 
@@ -68,6 +78,18 @@ export const Route = createFileRoute('/memory')({
                 }
               >
                 <KnowledgeBrowserScreen />
+              </Suspense>
+            ) : null}
+          </TabsPanel>
+
+          <TabsPanel value="external" className="min-h-0 flex-1">
+            {tab === 'external' ? (
+              <Suspense
+                fallback={
+                  <RouteLoadingState label="Loading external memory providers..." />
+                }
+              >
+                <ExternalMemoryBrowserScreen />
               </Suspense>
             ) : null}
           </TabsPanel>

--- a/src/screens/memory/external-memory-browser-screen.test.tsx
+++ b/src/screens/memory/external-memory-browser-screen.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  candidateActionLabels,
+  formatStateFilterLabel,
+} from './external-memory-browser-screen'
+
+describe('formatStateFilterLabel', () => {
+  it('appends state totals in parentheses when counts are available', () => {
+    const totals = {
+      candidate: 3,
+      approved: 2,
+      rejected: 1,
+      all: 6,
+    }
+
+    expect(formatStateFilterLabel('candidate', totals)).toBe('candidate (3)')
+    expect(formatStateFilterLabel('approved', totals)).toBe('approved (2)')
+    expect(formatStateFilterLabel('rejected', totals)).toBe('rejected (1)')
+    expect(formatStateFilterLabel('all', totals)).toBe('all (6)')
+  })
+
+  it('keeps zero totals visible in filter labels', () => {
+    expect(formatStateFilterLabel('rejected', { rejected: 0 })).toBe(
+      'rejected (0)',
+    )
+  })
+})
+
+describe('candidateActionLabels', () => {
+  it('shows edit, approve, reject, and delete actions for review candidates', () => {
+    expect(candidateActionLabels({ state: 'candidate' })).toEqual([
+      'Edit',
+      'Approve',
+      'Reject',
+      'Delete',
+    ])
+  })
+
+  it('hides redundant approve or reject actions for final states', () => {
+    expect(candidateActionLabels({ state: 'approved' })).toEqual([
+      'Edit',
+      'Reject',
+      'Delete',
+    ])
+    expect(candidateActionLabels({ state: 'rejected' })).toEqual([
+      'Edit',
+      'Approve',
+      'Delete',
+    ])
+  })
+})

--- a/src/screens/memory/external-memory-browser-screen.tsx
+++ b/src/screens/memory/external-memory-browser-screen.tsx
@@ -1,0 +1,471 @@
+import { HugeiconsIcon } from '@hugeicons/react'
+import { BrainIcon, Search01Icon } from '@hugeicons/core-free-icons'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useDeferredValue, useEffect, useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type ExternalMemoryProvider = {
+  id: string
+  label: string
+  capabilities: Array<string>
+  dbPath: string
+  configPath: string
+  available: boolean
+}
+
+type MemoryState = 'candidate' | 'approved' | 'rejected' | 'all'
+
+type StateCounts = Partial<Record<MemoryState, number>>
+
+const MEMORY_STATES: ReadonlyArray<MemoryState> = [
+  'candidate',
+  'approved',
+  'rejected',
+  'all',
+]
+
+type ExternalMemoryCandidate = {
+  provider: string
+  id: string
+  text: string
+  source: string
+  metadata: Record<string, unknown>
+  state: string
+  contentSha256: string
+  createdAt: number
+  updatedAt: number
+}
+
+type ProviderResponse = {
+  active: string
+  providers: Array<ExternalMemoryProvider>
+}
+
+type CandidateResponse = {
+  provider: string
+  state: string
+  count: number
+  total: number
+  counts?: StateCounts
+  candidates?: Array<ExternalMemoryCandidate>
+}
+
+type SearchResponse = {
+  provider: string
+  query: string
+  count: number
+  results?: Array<ExternalMemoryCandidate>
+}
+
+type CandidateAction = 'edit' | 'approve' | 'reject' | 'delete'
+
+async function mutateCandidate(options: {
+  action: CandidateAction
+  provider: string
+  id: string
+  text?: string
+  reason?: string
+}): Promise<void> {
+  const response =
+    options.action === 'delete'
+      ? await fetch(
+          `/api/external-memory/candidates?provider=${encodeURIComponent(options.provider)}&id=${encodeURIComponent(options.id)}`,
+          { method: 'DELETE' },
+        )
+      : await fetch('/api/external-memory/candidates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(options),
+        })
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null)
+    throw new Error(payload?.error || `Action failed (${response.status})`)
+  }
+}
+
+async function readJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(text || `Request failed (${response.status})`)
+  }
+  return (await response.json()) as T
+}
+
+function formatTimestamp(value: number): string {
+  if (!value) return 'Unknown'
+  const millis = value < 10_000_000_000 ? value * 1000 : value
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(millis))
+}
+
+function stateClasses(state: string): string {
+  if (state === 'approved')
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  if (state === 'rejected')
+    return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300'
+  return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+}
+
+function metadataPreview(metadata: Record<string, unknown>): string {
+  const entries = Object.entries(metadata).slice(0, 4)
+  if (entries.length === 0) return 'No metadata'
+  return entries.map(([key, value]) => `${key}: ${String(value)}`).join(' · ')
+}
+
+export function formatStateFilterLabel(
+  state: MemoryState,
+  counts: StateCounts,
+): string {
+  const count = counts[state]
+  return typeof count === 'number' ? `${state} (${count})` : state
+}
+
+export function candidateActionLabels(
+  candidate: Pick<ExternalMemoryCandidate, 'state'>,
+): Array<string> {
+  const labels = ['Edit']
+  if (candidate.state !== 'approved') labels.push('Approve')
+  if (candidate.state !== 'rejected') labels.push('Reject')
+  labels.push('Delete')
+  return labels
+}
+
+async function readStateCounts(providerId: string): Promise<StateCounts> {
+  const entries = await Promise.all(
+    MEMORY_STATES.map(async (state) => {
+      const response = await readJson<CandidateResponse>(
+        `/api/external-memory/candidates?provider=${encodeURIComponent(providerId)}&state=${encodeURIComponent(state)}&limit=1`,
+      )
+      return [state, response.total] as const
+    }),
+  )
+  return Object.fromEntries(entries) as StateCounts
+}
+
+export function ExternalMemoryBrowserScreen() {
+  const queryClient = useQueryClient()
+  const [providerId, setProviderId] = useState('')
+  const [state, setState] = useState<MemoryState>('candidate')
+  const [searchInput, setSearchInput] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const deferredSearch = useDeferredValue(searchInput)
+  const searchTerm = deferredSearch.trim()
+
+  const providersQuery = useQuery({
+    queryKey: ['external-memory', 'providers'],
+    queryFn: () => readJson<ProviderResponse>('/api/external-memory/providers'),
+  })
+
+  const providers = providersQuery.data?.providers ?? []
+  useEffect(() => {
+    if (providerId || providers.length === 0) return
+    setProviderId(providersQuery.data?.active || providers[0]?.id || '')
+  }, [providerId, providers, providersQuery.data?.active])
+
+  const listQuery = useQuery({
+    queryKey: ['external-memory', 'candidates', providerId, state],
+    queryFn: () =>
+      readJson<CandidateResponse>(
+        `/api/external-memory/candidates?provider=${encodeURIComponent(providerId)}&state=${encodeURIComponent(state)}`,
+      ),
+    enabled: Boolean(providerId) && !searchTerm,
+  })
+
+  const countsQuery = useQuery({
+    queryKey: ['external-memory', 'candidate-counts', providerId],
+    queryFn: () => readStateCounts(providerId),
+    enabled: Boolean(providerId) && !searchTerm,
+  })
+
+  const searchQuery = useQuery({
+    queryKey: ['external-memory', 'search', providerId, searchTerm],
+    queryFn: () =>
+      readJson<SearchResponse>(
+        `/api/external-memory/search?provider=${encodeURIComponent(providerId)}&q=${encodeURIComponent(searchTerm)}`,
+      ),
+    enabled: Boolean(providerId) && Boolean(searchTerm),
+  })
+
+  const candidates = searchTerm
+    ? (searchQuery.data?.results ?? [])
+    : (listQuery.data?.candidates ?? [])
+  const stateCounts = listQuery.data?.counts ?? countsQuery.data ?? {}
+
+  useEffect(() => {
+    if (
+      selectedId &&
+      candidates.some((candidate) => candidate.id === selectedId)
+    )
+      return
+    setSelectedId(candidates[0]?.id ?? null)
+  }, [candidates, selectedId])
+
+  const selected = useMemo(
+    () => candidates.find((candidate) => candidate.id === selectedId) ?? null,
+    [candidates, selectedId],
+  )
+  const activeProvider =
+    providers.find((provider) => provider.id === providerId) ?? null
+  const isLoading =
+    providersQuery.isLoading || listQuery.isLoading || searchQuery.isLoading
+  const error = providersQuery.error || listQuery.error || searchQuery.error
+
+  async function refreshCandidates() {
+    await queryClient.invalidateQueries({ queryKey: ['external-memory'] })
+  }
+
+  async function runAction(action: CandidateAction) {
+    if (!selected) return
+    let text: string | undefined
+    let reason: string | undefined
+    if (action === 'edit') {
+      text = window.prompt('Edit memory candidate', selected.text) || ''
+      if (!text.trim() || text === selected.text) return
+    }
+    if (action === 'reject') {
+      reason = window.prompt('Reason for rejection', '') || ''
+    }
+    if (
+      action === 'delete' &&
+      !window.confirm('Delete this external memory row?')
+    ) {
+      return
+    }
+    await mutateCandidate({
+      action,
+      provider: selected.provider,
+      id: selected.id,
+      text,
+      reason,
+    })
+    if (action === 'delete') setSelectedId(null)
+    await refreshCandidates()
+  }
+
+  if (!providersQuery.isLoading && providers.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4">
+        <div className="max-w-xl rounded-2xl border border-primary-200 bg-primary-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-950">
+          <HugeiconsIcon
+            icon={BrainIcon}
+            className="mx-auto mb-3 size-8 text-primary-500"
+          />
+          <h2 className="text-lg font-semibold text-primary-900 dark:text-neutral-100">
+            No external memory providers
+          </h2>
+          <p className="mt-2 text-sm text-primary-600 dark:text-neutral-400">
+            Register providers in $HERMES_HOME/external_memory_providers.json to
+            inspect external memory review queues here.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid h-full min-h-0 grid-cols-1 gap-0 lg:grid-cols-[380px_minmax(0,1fr)]">
+      <aside className="flex min-h-0 flex-col border-b border-primary-200 bg-white dark:border-neutral-800 dark:bg-neutral-950 lg:border-r lg:border-b-0">
+        <div className="space-y-3 border-b border-primary-200 p-4 dark:border-neutral-800">
+          <div>
+            <h2 className="text-sm font-semibold text-primary-900 dark:text-neutral-100">
+              External memory
+            </h2>
+            <p className="text-xs text-primary-500 dark:text-neutral-400">
+              Review queues backed by custom providers.
+            </p>
+          </div>
+
+          <select
+            value={providerId}
+            onChange={(event) => setProviderId(event.target.value)}
+            className="w-full rounded-xl border border-primary-200 bg-white px-3 py-2 text-sm text-primary-900 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100"
+          >
+            {providers.map((provider) => (
+              <option key={provider.id} value={provider.id}>
+                {provider.label}
+              </option>
+            ))}
+          </select>
+
+          <div className="relative">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              className="pointer-events-none absolute top-2.5 left-3 size-4 text-primary-400"
+            />
+            <input
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="Search text, metadata, source..."
+              className="w-full rounded-xl border border-primary-200 bg-white py-2 pr-3 pl-9 text-sm text-primary-900 outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100"
+            />
+          </div>
+
+          <div className="grid grid-cols-4 gap-1 text-xs">
+            {MEMORY_STATES.map((item) => (
+              <button
+                key={item}
+                type="button"
+                onClick={() => setState(item)}
+                disabled={Boolean(searchTerm)}
+                className={cn(
+                  'rounded-lg border px-2 py-1.5 capitalize transition disabled:opacity-40',
+                  state === item
+                    ? 'border-primary-500 bg-primary-100 text-primary-900 dark:border-blue-500 dark:bg-blue-500/15 dark:text-blue-100'
+                    : 'border-primary-200 text-primary-600 hover:bg-primary-50 dark:border-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-900',
+                )}
+              >
+                {formatStateFilterLabel(item, stateCounts)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          {isLoading ? (
+            <p className="p-3 text-sm text-primary-500 dark:text-neutral-400">
+              Loading...
+            </p>
+          ) : null}
+          {error ? (
+            <p className="p-3 text-sm text-rose-600">
+              {error instanceof Error ? error.message : String(error)}
+            </p>
+          ) : null}
+          {!isLoading && candidates.length === 0 ? (
+            <p className="p-3 text-sm text-primary-500 dark:text-neutral-400">
+              No memory rows found.
+            </p>
+          ) : null}
+          <div className="space-y-2">
+            {candidates.map((candidate) => (
+              <button
+                key={candidate.id}
+                type="button"
+                onClick={() => setSelectedId(candidate.id)}
+                className={cn(
+                  'w-full rounded-xl border p-3 text-left transition',
+                  selectedId === candidate.id
+                    ? 'border-primary-500 bg-primary-50 dark:border-blue-500 dark:bg-blue-500/10'
+                    : 'border-primary-200 bg-white hover:bg-primary-50 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-900',
+                )}
+              >
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <span className="truncate font-mono text-xs text-primary-500 dark:text-neutral-400">
+                    {candidate.id}
+                  </span>
+                  <span
+                    className={cn(
+                      'rounded-full border px-2 py-0.5 text-[11px] capitalize',
+                      stateClasses(candidate.state),
+                    )}
+                  >
+                    {candidate.state}
+                  </span>
+                </div>
+                <p className="line-clamp-3 text-sm text-primary-900 dark:text-neutral-100">
+                  {candidate.text}
+                </p>
+                <p className="mt-2 text-xs text-primary-500 dark:text-neutral-500">
+                  {formatTimestamp(candidate.updatedAt)}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      </aside>
+
+      <main className="min-h-0 overflow-y-auto bg-primary-50 p-4 dark:bg-neutral-950/80">
+        {selected ? (
+          <article className="mx-auto max-w-4xl space-y-4 rounded-2xl border border-primary-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-950">
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b border-primary-100 pb-4 dark:border-neutral-800">
+              <div>
+                <p className="font-mono text-xs text-primary-500 dark:text-neutral-400">
+                  {selected.id}
+                </p>
+                <h1 className="mt-1 text-xl font-semibold text-primary-950 dark:text-neutral-50">
+                  {activeProvider?.label || selected.provider}
+                </h1>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={cn(
+                    'rounded-full border px-3 py-1 text-xs capitalize',
+                    stateClasses(selected.state),
+                  )}
+                >
+                  {selected.state}
+                </span>
+                {candidateActionLabels(selected).map((label) => (
+                  <button
+                    key={label}
+                    type="button"
+                    onClick={() =>
+                      runAction(label.toLowerCase() as CandidateAction)
+                    }
+                    className={cn(
+                      'rounded-lg border px-3 py-1 text-xs transition',
+                      label === 'Delete'
+                        ? 'border-rose-500/40 text-rose-600 hover:bg-rose-500/10 dark:text-rose-300'
+                        : 'border-primary-200 text-primary-700 hover:bg-primary-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-900',
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-primary-100 bg-primary-50 p-4 text-sm leading-7 whitespace-pre-wrap text-primary-950 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100">
+              {selected.text}
+            </div>
+
+            <dl className="grid gap-3 text-sm md:grid-cols-2">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-primary-400 dark:text-neutral-500">
+                  Source
+                </dt>
+                <dd className="mt-1 text-primary-900 dark:text-neutral-100">
+                  {selected.source}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-primary-400 dark:text-neutral-500">
+                  Updated
+                </dt>
+                <dd className="mt-1 text-primary-900 dark:text-neutral-100">
+                  {formatTimestamp(selected.updatedAt)}
+                </dd>
+              </div>
+              <div className="md:col-span-2">
+                <dt className="text-xs uppercase tracking-wide text-primary-400 dark:text-neutral-500">
+                  Metadata
+                </dt>
+                <dd className="mt-1 text-primary-900 dark:text-neutral-100">
+                  {metadataPreview(selected.metadata)}
+                </dd>
+              </div>
+              <div className="md:col-span-2">
+                <dt className="text-xs uppercase tracking-wide text-primary-400 dark:text-neutral-500">
+                  SHA-256
+                </dt>
+                <dd className="mt-1 break-all font-mono text-xs text-primary-700 dark:text-neutral-300">
+                  {selected.contentSha256}
+                </dd>
+              </div>
+            </dl>
+          </article>
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-primary-500 dark:text-neutral-400">
+            Select a memory row.
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/server/external-memory-browser.test.ts
+++ b/src/server/external-memory-browser.test.ts
@@ -1,0 +1,189 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+let tempRoot = ''
+
+function makeProviderConfig() {
+  fs.writeFileSync(
+    path.join(tempRoot, 'external_memory_providers.json'),
+    JSON.stringify({
+      providers: [
+        {
+          id: 'custom_provider',
+          label: 'Custom Provider',
+          db_path: 'custom_provider/knowledge.sqlite',
+          config_path: 'custom_provider.json',
+        },
+      ],
+    }),
+  )
+  fs.mkdirSync(path.join(tempRoot, 'custom_provider'), { recursive: true })
+  fs.writeFileSync(
+    path.join(tempRoot, 'custom_provider.json'),
+    JSON.stringify({ vector_collection: 'external_memory_collection' }),
+  )
+}
+
+function seedCandidateDb() {
+  const dbPath = path.join(tempRoot, 'custom_provider/knowledge.sqlite')
+  execFileSync('python3', [
+    '-c',
+    `import sqlite3, sys, json
+con = sqlite3.connect(sys.argv[1])
+con.execute('create table candidates(id text primary key, text text not null, source text not null default "agent", metadata_json text not null default "{}", state text not null default "candidate", content_sha256 text not null, created_at real not null, updated_at real not null)')
+con.execute('insert into candidates values(?,?,?,?,?,?,?,?)', ('mem-1', 'External providers should expose reviewable memory', 'agent', json.dumps({'domain':'ops'}), 'candidate', 'abc', 1000.0, 1001.0))
+con.execute('insert into candidates values(?,?,?,?,?,?,?,?)', ('mem-2', 'Approved strategic note', 'manual', '{}', 'approved', 'def', 900.0, 950.0))
+con.execute('insert into candidates values(?,?,?,?,?,?,?,?)', ('mem-3', 'Rejected transient note', 'manual', '{}', 'rejected', 'ghi', 800.0, 850.0))
+con.commit()
+con.close()
+`,
+    dbPath,
+  ])
+}
+
+beforeEach(() => {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-external-memory-'))
+  process.env.HERMES_HOME = tempRoot
+})
+
+afterEach(() => {
+  delete process.env.HERMES_HOME
+  fs.rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('external-memory-browser', () => {
+  it('discovers registered external memory providers from HERMES_HOME', async () => {
+    makeProviderConfig()
+    const mod = await import('./external-memory-browser')
+
+    const result = mod.listExternalMemoryProviders()
+
+    expect(result.active).toBe('custom_provider')
+    expect(result.providers).toEqual([
+      expect.objectContaining({
+        id: 'custom_provider',
+        label: 'Custom Provider',
+        kind: 'custom',
+        available: true,
+      }),
+    ])
+  })
+
+  it('lists provider candidates from the review queue sqlite database', async () => {
+    makeProviderConfig()
+    seedCandidateDb()
+    const mod = await import('./external-memory-browser')
+
+    const result = mod.listExternalMemoryCandidates({
+      provider: 'custom_provider',
+      state: 'candidate',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      provider: 'custom_provider',
+      state: 'candidate',
+      count: 1,
+      total: 1,
+    })
+    expect(result.candidates[0]).toMatchObject({
+      id: 'mem-1',
+      text: 'External providers should expose reviewable memory',
+      source: 'agent',
+      state: 'candidate',
+      metadata: { domain: 'ops' },
+    })
+  })
+
+  it('returns per-state totals with candidate lists for filter badges', async () => {
+    makeProviderConfig()
+    seedCandidateDb()
+    const mod = await import('./external-memory-browser')
+
+    const result = mod.listExternalMemoryCandidates({
+      provider: 'custom_provider',
+      state: 'all',
+    })
+
+    expect(result.counts).toEqual({
+      candidate: 1,
+      approved: 1,
+      rejected: 1,
+      all: 3,
+    })
+  })
+
+  it('searches candidate text and metadata for a registered provider', async () => {
+    makeProviderConfig()
+    seedCandidateDb()
+    const mod = await import('./external-memory-browser')
+
+    const result = mod.searchExternalMemoryCandidates({
+      provider: 'custom_provider',
+      query: 'strategic',
+    })
+
+    expect(result.count).toBe(1)
+    expect(result.results[0]).toMatchObject({ id: 'mem-2', state: 'approved' })
+  })
+
+  it('edits candidate text and refreshes its content hash', async () => {
+    makeProviderConfig()
+    seedCandidateDb()
+    const mod = await import('./external-memory-browser')
+
+    const result = mod.editExternalMemoryCandidate({
+      provider: 'custom_provider',
+      id: 'mem-1',
+      text: 'External providers should expose curated memory.',
+    })
+
+    expect(result.candidate).toMatchObject({
+      id: 'mem-1',
+      text: 'External providers should expose curated memory.',
+      state: 'candidate',
+    })
+    expect(result.candidate.contentSha256).toHaveLength(64)
+    expect(result.candidate.contentSha256).not.toBe('abc')
+    expect(result.candidate.metadata.edited_at).toEqual(expect.any(Number))
+  })
+
+  it('approves, rejects, and deletes candidates from the review queue', async () => {
+    makeProviderConfig()
+    seedCandidateDb()
+    const mod = await import('./external-memory-browser')
+
+    const approved = mod.approveExternalMemoryCandidate({
+      provider: 'custom_provider',
+      id: 'mem-1',
+    })
+    const rejected = mod.rejectExternalMemoryCandidate({
+      provider: 'custom_provider',
+      id: 'mem-2',
+      reason: 'not durable',
+    })
+    const deleted = mod.deleteExternalMemoryCandidate({
+      provider: 'custom_provider',
+      id: 'mem-3',
+    })
+
+    expect(approved.candidate).toMatchObject({ id: 'mem-1', state: 'approved' })
+    expect(approved.candidate.metadata.approved_at).toEqual(expect.any(Number))
+    expect(rejected.candidate).toMatchObject({ id: 'mem-2', state: 'rejected' })
+    expect(rejected.candidate.metadata.review_reason).toBe('not durable')
+    expect(deleted).toEqual({
+      ok: true,
+      provider: 'custom_provider',
+      deleted: 'mem-3',
+    })
+    expect(
+      mod.listExternalMemoryCandidates({
+        provider: 'custom_provider',
+        state: 'all',
+      }).total,
+    ).toBe(2)
+  })
+})

--- a/src/server/external-memory-browser.ts
+++ b/src/server/external-memory-browser.ts
@@ -1,0 +1,404 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const VALID_STATES = new Set(['candidate', 'approved', 'rejected'])
+
+export type ExternalMemoryProvider = {
+  id: string
+  label: string
+  kind: 'custom'
+  capabilities: Array<string>
+  dbPath: string
+  configPath: string
+  available: boolean
+}
+
+export type ExternalMemoryCandidate = {
+  provider: string
+  id: string
+  text: string
+  source: string
+  metadata: Record<string, unknown>
+  state: string
+  contentSha256: string
+  createdAt: number
+  updatedAt: number
+}
+
+export type ExternalMemoryListResult = {
+  ok: true
+  provider: string
+  state: string
+  limit: number
+  offset: number
+  count: number
+  total: number
+  counts: Record<'candidate' | 'approved' | 'rejected' | 'all', number>
+  candidates: Array<ExternalMemoryCandidate>
+}
+
+export type ExternalMemorySearchResult = {
+  ok: true
+  provider: string
+  query: string
+  limit: number
+  count: number
+  results: Array<ExternalMemoryCandidate>
+}
+
+export type ExternalMemoryCandidateResult = {
+  ok: true
+  provider: string
+  candidate: ExternalMemoryCandidate
+}
+
+export type ExternalMemoryDeleteResult = {
+  ok: true
+  provider: string
+  deleted: string
+}
+
+type RawProviderConfig = {
+  id?: unknown
+  name?: unknown
+  label?: unknown
+  db_path?: unknown
+  config_path?: unknown
+}
+
+function getHermesHome(): string {
+  const envHome = (process.env.HERMES_HOME || process.env.CLAUDE_HOME)?.trim()
+  return path.resolve(envHome || path.join(os.homedir(), '.hermes'))
+}
+
+function safeProviderId(value: unknown): string | null {
+  const provider = String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, '_')
+  if (!provider || !/^[a-z0-9_]+$/.test(provider)) return null
+  return provider
+}
+
+function resolveUnderHermesHome(hermesHome: string, input: unknown): string {
+  const raw = String(input || '').trim()
+  if (!raw) return ''
+  const expanded = raw.startsWith('~/')
+    ? path.join(os.homedir(), raw.slice(2))
+    : raw
+  return path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(hermesHome, expanded)
+}
+
+function readProviderRegistry(): Array<RawProviderConfig> {
+  const registryPath = path.join(
+    getHermesHome(),
+    'external_memory_providers.json',
+  )
+  if (!fs.existsSync(registryPath)) return []
+  try {
+    const parsed = JSON.parse(fs.readFileSync(registryPath, 'utf-8')) as unknown
+    if (Array.isArray(parsed)) return parsed as Array<RawProviderConfig>
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray((parsed as { providers?: unknown }).providers)
+    ) {
+      return (parsed as { providers: Array<RawProviderConfig> }).providers
+    }
+  } catch {
+    return []
+  }
+  return []
+}
+
+export function listExternalMemoryProviders(): {
+  ok: true
+  active: string
+  providers: Array<ExternalMemoryProvider>
+} {
+  const hermesHome = getHermesHome()
+  const seen = new Set<string>()
+  const providers: Array<ExternalMemoryProvider> = []
+
+  for (const item of readProviderRegistry()) {
+    const id = safeProviderId(item.id ?? item.name)
+    if (!id || seen.has(id)) continue
+    const dbPath = resolveUnderHermesHome(hermesHome, item.db_path)
+    if (!dbPath) continue
+    const configPath = resolveUnderHermesHome(hermesHome, item.config_path)
+    seen.add(id)
+    providers.push({
+      id,
+      label: String(
+        item.label ||
+          id.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase()),
+      ),
+      kind: 'custom',
+      capabilities: ['review', 'search'],
+      dbPath,
+      configPath,
+      available: fs.existsSync(dbPath) || fs.existsSync(path.dirname(dbPath)),
+    })
+  }
+
+  return { ok: true, active: providers[0]?.id || '', providers }
+}
+
+function getProvider(provider?: string): ExternalMemoryProvider {
+  const providers = listExternalMemoryProviders().providers
+  if (providers.length === 0)
+    throw new Error('No external memory providers configured')
+  const providerId = provider ? safeProviderId(provider) : providers[0]?.id
+  const match = providers.find((item) => item.id === providerId)
+  if (!match)
+    throw new Error(`External memory provider not found: ${providerId || ''}`)
+  return match
+}
+
+function coerceLimit(
+  value: number | string | undefined,
+  defaultValue: number,
+  maximum: number,
+): number {
+  const parsed = Number.parseInt(String(value ?? defaultValue), 10)
+  if (!Number.isFinite(parsed)) return defaultValue
+  return Math.max(1, Math.min(parsed, maximum))
+}
+
+function coerceOffset(value: number | string | undefined): number {
+  const parsed = Number.parseInt(String(value ?? 0), 10)
+  if (!Number.isFinite(parsed)) return 0
+  return Math.max(0, parsed)
+}
+
+const PYTHON_SCRIPT = String.raw`import hashlib, json, sqlite3, sys, time
+
+db_path, provider, mode = sys.argv[1], sys.argv[2], sys.argv[3]
+state = sys.argv[4]
+limit = int(sys.argv[5])
+offset = int(sys.argv[6])
+query = sys.argv[7] if len(sys.argv) > 7 else ""
+
+conn = sqlite3.connect("file:" + db_path + ("?mode=ro" if mode in ("list", "search") else ""), uri=True)
+conn.row_factory = sqlite3.Row
+cur = conn.cursor()
+
+def row_to_candidate(row):
+    try:
+        metadata = json.loads(row["metadata_json"] or "{}")
+        if not isinstance(metadata, dict):
+            metadata = {}
+    except Exception:
+        metadata = {}
+    return {
+        "provider": provider,
+        "id": row["id"],
+        "text": row["text"],
+        "source": row["source"],
+        "metadata": metadata,
+        "state": row["state"],
+        "contentSha256": row["content_sha256"],
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+    }
+
+if mode == "search":
+    pattern = "%" + query + "%"
+    rows = cur.execute(
+        """
+        select * from candidates
+        where text like ? or metadata_json like ? or source like ?
+        order by case when state='approved' then 0 when state='candidate' then 1 else 2 end,
+                 updated_at desc
+        limit ?
+        """,
+        (pattern, pattern, pattern, limit),
+    ).fetchall()
+    result = {"ok": True, "provider": provider, "query": query, "limit": limit, "count": len(rows), "results": [row_to_candidate(row) for row in rows]}
+elif mode in ("edit", "approve", "reject", "delete"):
+    candidate_id = state
+    row = cur.execute("select * from candidates where id=?", (candidate_id,)).fetchone()
+    if not row:
+        raise RuntimeError("candidate not found: " + candidate_id)
+    now = time.time()
+    if mode == "delete":
+        cur.execute("delete from candidates where id=?", (candidate_id,))
+        conn.commit()
+        result = {"ok": True, "provider": provider, "deleted": candidate_id}
+    else:
+        candidate = row_to_candidate(row)
+        metadata = dict(candidate.get("metadata") or {})
+        if mode == "edit":
+            next_text = query.strip()
+            if not next_text:
+                raise RuntimeError("text is required")
+            if candidate.get("state") == "approved":
+                raise RuntimeError("approved external memory cannot be edited; create a new candidate instead")
+            metadata["edited_at"] = now
+            cur.execute(
+                "update candidates set text=?, content_sha256=?, metadata_json=?, updated_at=? where id=?",
+                (next_text, hashlib.sha256(next_text.encode("utf-8")).hexdigest(), json.dumps(metadata, ensure_ascii=False, sort_keys=True), now, candidate_id),
+            )
+        elif mode == "approve":
+            metadata["approved_at"] = now
+            cur.execute("update candidates set state=?, metadata_json=?, updated_at=? where id=?", ("approved", json.dumps(metadata, ensure_ascii=False, sort_keys=True), now, candidate_id))
+        else:
+            metadata["review_reason"] = query or ""
+            metadata["reviewed_at"] = now
+            cur.execute("update candidates set state=?, metadata_json=?, updated_at=? where id=?", ("rejected", json.dumps(metadata, ensure_ascii=False, sort_keys=True), now, candidate_id))
+        conn.commit()
+        updated = cur.execute("select * from candidates where id=?", (candidate_id,)).fetchone()
+        result = {"ok": True, "provider": provider, "candidate": row_to_candidate(updated)}
+else:
+    state_counts = dict(cur.execute("select state, count(*) from candidates group by state").fetchall())
+    counts = {
+        "candidate": int(state_counts.get("candidate", 0)),
+        "approved": int(state_counts.get("approved", 0)),
+        "rejected": int(state_counts.get("rejected", 0)),
+    }
+    counts["all"] = counts["candidate"] + counts["approved"] + counts["rejected"]
+    if state == "all":
+        rows = cur.execute("select * from candidates order by created_at desc limit ? offset ?", (limit, offset)).fetchall()
+        total = counts["all"]
+    else:
+        rows = cur.execute("select * from candidates where state=? order by created_at desc limit ? offset ?", (state, limit, offset)).fetchall()
+        total = counts[state]
+    result = {"ok": True, "provider": provider, "state": state, "limit": limit, "offset": offset, "count": len(rows), "total": total, "counts": counts, "candidates": [row_to_candidate(row) for row in rows]}
+
+conn.close()
+print(json.dumps(result))
+`
+
+function runSqliteQuery<T>(
+  provider: ExternalMemoryProvider,
+  args: Array<string>,
+): T {
+  if (!fs.existsSync(provider.dbPath)) {
+    throw new Error(`External memory database not found: ${provider.dbPath}`)
+  }
+  const raw = execFileSync(
+    'python3',
+    ['-c', PYTHON_SCRIPT, provider.dbPath, provider.id, ...args],
+    {
+      encoding: 'utf-8',
+      timeout: 5_000,
+      maxBuffer: 1024 * 1024,
+    },
+  )
+  return JSON.parse(raw) as T
+}
+
+export function listExternalMemoryCandidates(options: {
+  provider?: string
+  state?: string
+  limit?: number | string
+  offset?: number | string
+}): ExternalMemoryListResult {
+  const provider = getProvider(options.provider)
+  const requestedState = String(options.state || 'all')
+    .trim()
+    .toLowerCase()
+  const state =
+    !requestedState || requestedState === 'all' ? 'all' : requestedState
+  if (state !== 'all' && !VALID_STATES.has(state)) {
+    throw new Error('state must be one of: candidate, approved, rejected, all')
+  }
+  const limit = coerceLimit(options.limit, 100, 500)
+  const offset = coerceOffset(options.offset)
+  return runSqliteQuery<ExternalMemoryListResult>(provider, [
+    'list',
+    state,
+    String(limit),
+    String(offset),
+  ])
+}
+
+export function searchExternalMemoryCandidates(options: {
+  provider?: string
+  query: string
+  limit?: number | string
+}): ExternalMemorySearchResult {
+  const provider = getProvider(options.provider)
+  const query = options.query.trim()
+  if (!query) throw new Error('query is required')
+  const limit = coerceLimit(options.limit, 25, 100)
+  return runSqliteQuery<ExternalMemorySearchResult>(provider, [
+    'search',
+    'all',
+    String(limit),
+    '0',
+    query,
+  ])
+}
+
+function runExternalMemoryMutation<T>(options: {
+  provider?: string
+  id: string
+  mode: 'edit' | 'approve' | 'reject' | 'delete'
+  value?: string
+}): T {
+  const provider = getProvider(options.provider)
+  const id = String(options.id || '').trim()
+  if (!id) throw new Error('candidate id is required')
+  return runSqliteQuery<T>(provider, [
+    options.mode,
+    id,
+    '1',
+    '0',
+    options.value || '',
+  ])
+}
+
+export function editExternalMemoryCandidate(options: {
+  provider?: string
+  id: string
+  text: string
+}): ExternalMemoryCandidateResult {
+  const text = String(options.text || '').trim()
+  if (!text) throw new Error('text is required')
+  return runExternalMemoryMutation<ExternalMemoryCandidateResult>({
+    provider: options.provider,
+    id: options.id,
+    mode: 'edit',
+    value: text,
+  })
+}
+
+export function approveExternalMemoryCandidate(options: {
+  provider?: string
+  id: string
+}): ExternalMemoryCandidateResult {
+  return runExternalMemoryMutation<ExternalMemoryCandidateResult>({
+    provider: options.provider,
+    id: options.id,
+    mode: 'approve',
+  })
+}
+
+export function rejectExternalMemoryCandidate(options: {
+  provider?: string
+  id: string
+  reason?: string
+}): ExternalMemoryCandidateResult {
+  return runExternalMemoryMutation<ExternalMemoryCandidateResult>({
+    provider: options.provider,
+    id: options.id,
+    mode: 'reject',
+    value: options.reason || '',
+  })
+}
+
+export function deleteExternalMemoryCandidate(options: {
+  provider?: string
+  id: string
+}): ExternalMemoryDeleteResult {
+  return runExternalMemoryMutation<ExternalMemoryDeleteResult>({
+    provider: options.provider,
+    id: options.id,
+    mode: 'delete',
+  })
+}


### PR DESCRIPTION
## Summary

Adds a provider-agnostic external memory provider surface to the Memory page. The new tab lets Workspace discover registered external memory integrations, inspect provider-backed review queues, search records, and perform basic review actions without coupling the UI to any specific backend implementation.

## What changed

- Adds an “External providers” tab under Memory.
- Adds authenticated API routes for external memory provider discovery, candidate listing, search, and review actions.
- Adds a provider-neutral server adapter that reads registered providers from `external_memory_providers.json` under the Hermes home directory.
- Adds a lazy-loaded browser UI for provider selection, state filters, search, record details, metadata preview, and review actions.
- Adds focused tests for provider discovery, queue reads, search, mutations, filter labels, and action visibility.

## Provider contract

External memory integrations can register a provider entry with:

- `id` or `name`: stable provider identifier.
- `label`: human-readable display name.
- `db_path`: provider-owned SQLite review queue path, relative to Hermes home or absolute.
- `config_path`: optional provider configuration path, relative to Hermes home or absolute.

The browser expects a provider-owned `candidates` table with these fields:

- `id`
- `text`
- `source`
- `metadata_json`
- `state`
- `content_sha256`
- `created_at`
- `updated_at`

This keeps Workspace generic: providers own ingestion, persistence, indexing, and sync semantics; Workspace only presents the registered provider and its review queue.

## Test plan

- [x] `pnpm test src/server/external-memory-browser.test.ts src/screens/memory/external-memory-browser-screen.test.tsx`
- [x] `pnpm build`
- [x] Scanned the staged diff and PR body for provider-specific names, private paths, infrastructure details, tokens, and local network addresses.
