### PR TITLE
fix: restore hermes-config and config-patch API routes

### DIFF
--- a/src/routes/api/config-patch.ts
+++ b/src/routes/api/config-patch.ts
@@ -1,0 +1,16 @@
+/**
+ * Config Patch API — handles provider/settings saves from the providers screen
+ * and provider wizard. Delegates to the same hermes-config-route handler.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  handleHermesConfigPatch,
+} from '../../server/hermes-config-route'
+
+export const Route = createFileRoute('/api/config-patch')({
+  server: {
+    handlers: {
+      POST: handleHermesConfigPatch,
+    },
+  },
+})

--- a/src/routes/api/hermes-config.ts
+++ b/src/routes/api/hermes-config.ts
@@ -1,0 +1,19 @@
+/**
+ * Hermes Config API — proxy route for hermes-config-route handlers.
+ * Maps GET and PATCH/POST to the server-side config read/write logic.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  handleHermesConfigGet,
+  handleHermesConfigPatch,
+} from '../../server/hermes-config-route'
+
+export const Route = createFileRoute('/api/hermes-config')({
+  server: {
+    handlers: {
+      GET: handleHermesConfigGet,
+      PATCH: handleHermesConfigPatch,
+      POST: handleHermesConfigPatch,
+    },
+  },
+})


### PR DESCRIPTION
## fix: restore hermes-config and config-patch API routes

### Problem

The Aurora rename migration (`efcb7d14`, May 1) renamed `hermes-config.ts` → `claude-config.ts` under `src/routes/api/`. However, the frontend code and `routeTree.gen.ts` still reference the original paths:

- **`/api/hermes-config`** — used by `settings-dialog.tsx` (GET for reading config, PATCH for saving provider settings, API keys, model defaults)
- **`/api/config-patch`** — used by `providers-screen.tsx` and `provider-wizard.tsx` (POST for saving provider API keys and custom endpoint config)

Since the route files no longer exist, all requests to these endpoints fall through to the SPA HTML fallback (HTTP 200 with HTML content). The frontend's `response.json()` fails to parse HTML, resulting in the **"Failed to save"** error toast.

### Evidence

- `routeTree.gen.ts` contains 20+ references to `/api/hermes-config` and `/api/config-patch`
- `-hermes-config.test.ts` imports from `'./hermes-config'` (the original file name)
- `src/server/hermes-config-route.ts` (6697 bytes) has the handler code (`handleHermesConfigGet`, `handleHermesConfigPatch`) but no route file to mount it
- `claude-config.ts` exists as the renamed file but serves `/api/claude-config`, not `/api/hermes-config`

### Fix

Created two thin route files that delegate to the existing handlers:

**`src/routes/api/hermes-config.ts`** — wires GET/PATCH/POST to `handleHermesConfigGet`/`handleHermesConfigPatch`

**`src/routes/api/config-patch.ts`** — wires POST to `handleHermesConfigPatch`

Both files import from `../../server/hermes-config-route` which already handles:
- Action-based patches (`set-api-key`, `set-default-model`, `set-custom-provider`, etc.)
- Legacy patches (`{ config: {...}, env: {...} }`)
- Auth and capability checks

### Testing

Verified locally:
- `GET /api/hermes-config` returns proper JSON with provider status (12 providers)
- `PATCH /api/hermes-config` with legacy format succeeds
- `POST /api/config-patch` succeeds
- Config file integrity preserved after writes

### Related

- #399 — Original PR that added the canonical hermes-config API with action-based patches
- #85 — Settings save silently destroys user config sections