### PR TITLE
fix(ci): pin pnpm 10 for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #
 # ─── build stage ─────────────────────────────────────────────────────────
 FROM node:22-slim AS build
-RUN corepack enable && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 # Install deps (cache-friendly: copy only manifests first)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hermes-workspace",
   "version": "2.3.0",
+  "packageManager": "pnpm@10.24.0",
   "description": "Desktop workspace for Hermes Agent — chat, orchestration, and multi-agent coding pipelines",
   "author": "Eric (https://github.com/outsourc-e)",
   "license": "MIT",


### PR DESCRIPTION
El build de Docker estaba fallando en Lockfile is up to date, resolution step is skipped
Already up to date

╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: electron, electron-winstaller, esbuild,             │
│   unrs-resolver.                                                             │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

Done in 1.1s using pnpm v10.24.0 por el nuevo bloqueo de build scripts de pnpm 11.\n\nEste cambio fija pnpm 10.24.0 en el repo y en el Dockerfile, lo que deja el build no interactivo y mantiene el build de la imagen pasando.\n\nVerificación local:\n- CI=true pnpm install --frozen-lockfile\n- CI=true pnpm build