### PR TITLE
fix(swarm): worker card shows stale state after task completes

### DIFF
--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -502,10 +502,17 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
 }
 
 function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoint, notifySessionKey?: string | null): void {
+  // When the checkpoint reaches any terminal status (anything other than
+  // 'in_progress' — i.e. done/blocked/needs_input/handoff) the worker is no
+  // longer running this task, so clear currentTask the same way conductor-stop
+  // resets it. While still in_progress we omit the key entirely so
+  // writeRuntimePatch keeps the existing currentTask untouched.
+  const clearCurrentTask = checkpoint.checkpointStatus !== 'in_progress'
   writeRuntimePatch(workerId, {
     state: checkpoint.runtimeState,
     phase: checkpoint.stateLabel.toLowerCase(),
     checkpointStatus: checkpoint.checkpointStatus,
+    ...(clearCurrentTask ? { currentTask: null } : {}),
     lastCheckIn: new Date().toISOString(),
     lastOutputAt: Date.now(),
     lastSummary: checkpoint.result,

--- a/src/screens/swarm2/operational-worker-card.tsx
+++ b/src/screens/swarm2/operational-worker-card.tsx
@@ -72,10 +72,32 @@ function roleFromId(id: string): string {
   }
 }
 
-function deriveWorkerState(member: CrewMember, currentTask: string | null): WorkerState {
+function deriveWorkerState(
+  member: CrewMember,
+  currentTask: string | null,
+  checkpointStatus?: string | null,
+  runtimeState?: string | null,
+): WorkerState {
   const status = getOnlineStatus(member)
   if (status === 'offline') return 'offline'
+
+  // Authoritative runtime state takes precedence over the title heuristic.
+  // SwarmCheckpointStatus: 'none' | 'in_progress' | 'done' | 'blocked' | 'handoff' | 'needs_input'
+  // SwarmWorkerState: 'idle' | 'executing' | 'thinking' | 'writing' | 'waiting' | 'blocked' | 'syncing' | 'reviewing' | 'offline'
+  const cs = checkpointStatus ?? null
+  const rs = runtimeState ?? null
+
+  // Terminal-done: a finished worker renders as Idle (there is no 'done' WorkerState).
+  if (cs === 'done' || cs === 'handoff' || rs === 'idle') return 'idle'
+  // Blocked from either authoritative source.
+  if (cs === 'blocked' || rs === 'blocked') return 'error'
+  // Needs human input / waiting.
+  if (cs === 'needs_input' || rs === 'waiting') return 'waiting'
+
   if (!currentTask) return 'idle'
+
+  // Safety: a set, non-in-progress checkpoint must never render as active.
+  if (cs && cs !== 'none' && cs !== 'in_progress') return 'idle'
 
   const lc = currentTask.toLowerCase()
   if (lc.includes('review')) return 'reviewing'
@@ -191,6 +213,8 @@ const AVATAR_OPTIONS = ['','🤖','🧠','🛠️','📊','🧪','📝','⚙️'
 export type OperationalWorkerCardProps = {
   member: CrewMember
   currentTask?: string | null
+  checkpointStatus?: string | null
+  runtimeState?: string | null
   recentLines?: Array<string>
   recentOutputAt?: number | null
   recentSummary?: string | null
@@ -208,6 +232,8 @@ export type OperationalWorkerCardProps = {
 export function OperationalWorkerCard({
   member,
   currentTask = null,
+  checkpointStatus = null,
+  runtimeState = null,
   recentOutputAt = null,
   recentSummary = null,
   artifacts = [],
@@ -228,7 +254,7 @@ export function OperationalWorkerCard({
   const [draftModel, setDraftModel] = useState('')
   const [draftAvatar, setDraftAvatar] = useState('')
   const [taskComposerOpen, setTaskComposerOpen] = useState(false)
-  const state = deriveWorkerState(member, currentTask)
+  const state = deriveWorkerState(member, currentTask, checkpointStatus, runtimeState)
   const status = statusStyles(state)
   const role = settings.role || member.role || roleFromId(member.id)
   const displayName = settings.displayName || member.displayName || member.id

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -153,6 +153,7 @@ type RuntimeEntry = {
   lastResult?: string | null
   blockedReason?: string | null
   checkpointStatus?: string | null
+  state?: string | null
   needsHuman?: boolean | null
   assignedTaskCount?: number | null
   cronJobCount?: number | null
@@ -839,6 +840,8 @@ function ControlPlaneStage({
                       cardRef={setWorkerRef(member.id)}
                       member={member}
                       currentTask={runtime?.currentTask ?? null}
+                      checkpointStatus={runtime?.checkpointStatus ?? null}
+                      runtimeState={runtime?.state ?? null}
                       recentLines={recentLines(runtime)}
                       recentOutputAt={runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? null}
                       recentSummary={runtime?.lastRealSummary ?? runtime?.lastRealResult ?? runtime?.lastSummary ?? runtime?.lastResult ?? runtime?.blockedReason ?? null}


### PR DESCRIPTION
## Problem

In the Swarm tab, a worker card stays on a "working"-type badge (Reviewing / Active / etc.) after the worker has actually finished. The card never returns to **Idle** even though the worker's runtime checkpoint is `done`, so the Control view disagrees with Swarm Reports and the worker's real state.

## Root cause

Two compounding issues:

1. **`deriveWorkerState` (`operational-worker-card.tsx`)** derives the badge purely by substring-matching the raw `currentTask` title text (`.includes('review')` → `reviewing`, etc.). It never consults the authoritative runtime state, so a task titled "review …" renders as `reviewing` regardless of whether the worker is still on it.

2. **`markCheckpointResult` (`swarm-dispatch.ts`)** writes the terminal `state` / `phase` / `checkpointStatus` on completion but never clears `currentTask`. The stale title therefore keeps feeding the heuristic in (1) forever, so the card is permanently "working".

## Fix

- **`swarm-dispatch.ts`**: on a terminal checkpoint (`checkpointStatus !== 'in_progress'`) clear `currentTask` to `null` — the same reset `conductor-stop` already performs. While still `in_progress` the key is omitted so `writeRuntimePatch` leaves the existing value untouched.
- **`operational-worker-card.tsx`**: `deriveWorkerState` now reads the authoritative `checkpointStatus` / runtime `state` first (`done`/`handoff`/`idle` → Idle, `blocked` → Error, `needs_input` → Waiting, plus a guard so any set non-`in_progress` checkpoint never renders active), and only falls back to the existing title heuristic while genuinely in progress.
- **`swarm2-screen.tsx`**: pass `checkpointStatus` and runtime `state` (already returned by `/api/swarm-runtime`) into the card.

Defense in depth: either change alone resolves the stale badge; together they also stop the stale `currentTask` from lingering.

## Scope / relation to other work

- Distinct from #235 / #238 (which fixed the `/api/swarm-tmux-stop` path leaving runtime stale) — this is the **normal terminal-checkpoint completion path** plus the card's own heuristic.
- Distinct from #451 (Conductor native-swarm "Spawning…" state + dispatch bugs + mobile CSS) — that PR touches the same files but different functions; no overlap with `deriveWorkerState` / `markCheckpointResult`.

## Testing

- `tsc --noEmit`: clean.
- `vite build`: succeeds.
- All 39 tests across the swarm-related suites (`-swarm-dispatch`, `swarm-checkpoints`, `swarm2-screen`, `swarm2-reports-view`, `swarm2-kanban-board`, `swarm-routes`, `-swarm-health`) pass.
- Lint: introduces zero new issues (pre-existing repo lint state unchanged with vs. without this patch).
- Pre-existing unrelated failures in `playground-settings.test.tsx` exist on `main` independent of this change (verified by stashing this patch).
- Manual: with a worker whose runtime is `checkpointStatus=done` but `currentTask` still set (the exact bug fixture), the card now renders **Idle** instead of the stale working badge; all worker cards match backend state.
