### PR TITLE
feat: add multi-agent control plane MVP

### DIFF
--- a/docs/multi-agent-mvp.md
+++ b/docs/multi-agent-mvp.md
@@ -1,0 +1,355 @@
+# Hermes Multi-Agent Control Plane MVP
+
+Hermes Multi-Agent Control Plane is a local, single-user workflow for running Hermes Agent workers against isolated git worktrees from the Hermes Workspace UI.
+
+The MVP flow is:
+
+```text
+Configure project → Create task → Start isolated worktree + worker → Watch events/diff → Run validation → Approve PR action → Create GitHub PR → Save final summary
+```
+
+## Scope
+
+This MVP is intentionally local-first:
+
+- one local user;
+- Hermes Agent runtime only;
+- web UI first, Electron shell smoke-tested separately;
+- file-backed local state under `.runtime/multi-agent/` by default;
+- explicit approvals for risky/external actions.
+
+Out of scope for this MVP: team accounts, multi-tenant auth, remote worker fleets, automatic deploys, and non-Hermes runtimes such as Claude/Codex/OpenCode workers.
+
+## Start the workspace
+
+1. Install dependencies if needed:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Configure at least one git project for the Agent Board.
+
+   Single-project setup:
+
+   ```bash
+   export HERMES_MA_PROJECT_PATH=/absolute/path/to/git/repo
+   ```
+
+   Multi-project setup:
+
+   ```bash
+   export HERMES_MA_PROJECTS_JSON='[
+     {
+       "id": "workspace",
+       "name": "Hermes Workspace",
+       "repoPath": "/absolute/path/to/git/repo",
+       "defaultBranch": "main",
+       "validation": {
+         "test": "pnpm test",
+         "build": "pnpm build"
+       }
+     }
+   ]'
+   ```
+
+   Project paths must exist and must be git repositories. If `worktreeRoot` is omitted, the default is:
+
+   ```text
+   <repoPath>/.hermes-worktrees/
+   ```
+
+3. Start Hermes Workspace:
+
+   ```bash
+   pnpm dev
+   ```
+
+4. Open the workspace in the browser and go to the Conductor / Agent Board area. The board loads projects from `GET /api/ma/projects`, profiles from `GET /api/ma/profiles`, and tasks from `GET /api/ma/tasks`.
+
+### Useful environment variables
+
+| Variable | Purpose |
+|---|---|
+| `HERMES_MA_PROJECT_PATH` | Configure one local git project. |
+| `HERMES_MA_PROJECTS_JSON` | Configure multiple projects and validation commands. |
+| `HERMES_MA_STATE_FILE` | Override the local state file path. Defaults to `.runtime/multi-agent/state.json`. |
+| `HERMES_MA_EVENT_LOG` | Override the task event JSONL log path. |
+| `HERMES_MA_WORKER_COMMAND` | Test/development override for worker command. Default runtime uses Hermes Agent. |
+| `HERMES_MA_WORKER_ARGS_JSON` | Test/development override for worker args as a JSON string array. |
+| `HERMES_MA_OBSIDIAN_RUNS_DIR` | Override where final summaries are saved as Markdown notes. |
+| `HERMES_MA_GH_MOCK=1` | Test-only mock for GitHub PR route. Do not use for real PR creation. |
+
+## Create a task
+
+1. Click **Create task** on the Agent Board.
+2. Choose a configured project and worker profile.
+3. Fill in:
+   - title;
+   - priority;
+   - description;
+   - work packet;
+   - acceptance criteria, one per line.
+4. Submit the form.
+
+The UI posts to `POST /api/ma/tasks`. The task is stored in local state and appears in the board column matching its status.
+
+Task fields that matter operationally:
+
+- `projectId` — must match a configured project;
+- `assigneeProfileId` — selects the worker profile;
+- `workPacket` — primary instructions passed to the worker;
+- `acceptanceCriteria` — checklist used for review/validation;
+- `branchName` and `worktreePath` — filled after start;
+- `latestRunId` and `finalSummary` — filled by worker/memory hooks.
+
+## Start a task and worktree layout
+
+Click **Start** on a task card. The start route:
+
+```text
+POST /api/ma/tasks/:taskId/start
+```
+
+performs this sequence:
+
+1. resolves the configured project;
+2. creates an isolated git worktree if the task does not already have one;
+3. creates a run record;
+4. launches a Hermes Agent worker for the task;
+5. appends task events to the event log.
+
+Default branch name format:
+
+```text
+hermes/task-<task-id>-<slugified-task-title>
+```
+
+Default worktree path format:
+
+```text
+<project.worktreeRoot>/task-<task-id>-<slugified-task-title>/
+```
+
+Example:
+
+```text
+repoPath:      /home/me/projects/app
+worktreeRoot: /home/me/projects/app/.hermes-worktrees
+branch:       hermes/task-task-abc123-add-validation-ui
+worktree:     /home/me/projects/app/.hermes-worktrees/task-task-abc123-add-validation-ui
+```
+
+Safety behavior:
+
+- the worktree path must stay inside `project.worktreeRoot`;
+- the repository root is never used as the task worktree;
+- an existing path that is not the registered worktree for the branch returns a conflict;
+- worktree removal is not an automatic MVP action and should require explicit approval when added.
+
+## Events, diff, and validation
+
+The task detail panel shows:
+
+- **Events / Live Log** from `GET /api/ma/tasks/:taskId/events`;
+- **Diff** from `GET /api/ma/tasks/:taskId/diff`;
+- **Validation** history from `GET /api/ma/tasks/:taskId/validate`.
+
+Validation is started from the task detail panel:
+
+```text
+POST /api/ma/tasks/:taskId/validate
+```
+
+Supported validation types:
+
+- `lint`
+- `typecheck`
+- `test`
+- `build`
+- `custom` — intentionally approval-gated/rejected in the MVP unless approval support is extended.
+
+Validation commands are resolved from the selected project's `validation` config. Example:
+
+```json
+{
+  "validation": {
+    "lint": "pnpm lint",
+    "test": "pnpm exec vitest run src/server/multi-agent/store.test.ts",
+    "build": "pnpm build"
+  }
+}
+```
+
+Non-zero validation command exits are represented as `validation.status: "failed"`; they are not treated as HTTP transport failures. Full validation output is written under `.runtime/multi-agent/artifacts/validation-output/`, and the validation record stores an output artifact id.
+
+## Approval behavior
+
+The MVP uses an explicit approval queue for risky actions. Approval records are listed by:
+
+```text
+GET /api/ma/approvals
+```
+
+and resolved by:
+
+```text
+POST /api/ma/approvals/:approvalId/resolve
+```
+
+with:
+
+```json
+{ "decision": "approved" }
+```
+
+or:
+
+```json
+{ "decision": "denied" }
+```
+
+Always require approval for:
+
+- `git push`;
+- `gh pr create`;
+- worktree removal;
+- deploy commands;
+- edits to environment files or secrets detected in diff.
+
+Allowed without approval in the MVP:
+
+- creating a task;
+- creating a local git worktree;
+- reading local diff;
+- running configured validation commands from project settings;
+- local commit after an explicit UI action, when implemented.
+
+The current PR flow creates a `github.pr_create` approval before pushing or calling `gh pr create`.
+
+## GitHub PR requirements
+
+The PR panel calls:
+
+```text
+POST /api/ma/tasks/:taskId/pr
+```
+
+Before a PR can be created, the preflight checks require:
+
+1. the task has `worktreePath` and `branchName`;
+2. the `gh` CLI is installed (`gh --version`);
+3. `gh auth status` succeeds;
+4. the worktree has an `origin` remote;
+5. the current worktree branch matches the task branch;
+6. at least one validation for the task has `status: "passed"`;
+7. a `github.pr_create` approval has been approved.
+
+When approved, the route runs:
+
+```bash
+git push -u origin <task.branchName>
+gh pr create --title <title> --body <body> --base <baseBranch> --head <task.branchName>
+```
+
+The created PR URL is saved as a `github-pr` artifact and the task moves to `review`.
+
+## Memory hooks and final summaries
+
+Task summaries can be saved through:
+
+```text
+POST /api/ma/tasks/:taskId/save-summary
+```
+
+The summary is persisted in both:
+
+- latest run: `run.summary`;
+- task: `task.finalSummary`.
+
+If `saveToObsidian: true` is sent, the server writes a Markdown note. Default path:
+
+```text
+~/ai-workspace/knowledge/obsidian-vault/Hermes/Multi-Agent Runs/
+```
+
+Override it with:
+
+```bash
+export HERMES_MA_OBSIDIAN_RUNS_DIR=/absolute/path/to/Obsidian/Multi-Agent\ Runs
+```
+
+Notes include task/run metadata, summary, work packet, and acceptance criteria. Do not store credentials, API keys, or secrets in summaries.
+
+## Local state and artifacts
+
+Default state layout:
+
+```text
+.runtime/multi-agent/
+  state.json
+  events.jsonl
+  artifacts/
+    validation-output/
+      <validation-id>.log
+```
+
+The state file stores projects, profiles, tasks, runs, approvals, validations, and artifact metadata. Large command output should stay in artifact files instead of `state.json`.
+
+## Electron smoke
+
+The web flow is primary for the MVP. Electron shell smoke is available to ensure the desktop wrapper can still open after web changes:
+
+```bash
+pnpm build
+pnpm electron:bundle-server
+pnpm smoke:electron
+```
+
+`pnpm smoke:electron` sets `HERMES_ELECTRON_SMOKE=1`, loads the local production shell, and exits after the app shell loads.
+
+If Electron fails with `Electron failed to install correctly`, repair the local binary:
+
+```bash
+node node_modules/.pnpm/electron@40.9.3/node_modules/electron/install.js
+pnpm exec electron --version
+```
+
+## Known limitations
+
+- Single-user local app; no team accounts or multi-tenant auth.
+- Hermes Agent is the only worker runtime in the MVP.
+- The app uses file-backed local state, not a database.
+- Approval coverage is focused on push/PR/custom risky actions; deeper policy automation is future work.
+- Worktree cleanup is intentionally not automatic.
+- Validation command safety depends on project configuration; avoid placing destructive commands in configured validation slots.
+- PR creation depends on local `git`, `gh`, remotes, and authentication.
+- Final summaries are manually saved; the MVP does not auto-write every run to Obsidian.
+- Browser web UI is the primary supported surface; Electron is smoke-tested but not the primary implementation surface.
+
+## Quick verification checklist
+
+Use this checklist when validating the MVP locally:
+
+```bash
+# Build web app and generated routes
+pnpm build
+
+# Multi-agent targeted tests, if changing code
+pnpm exec vitest run src/server/multi-agent/*.test.ts src/routes/api/ma/*.test.ts --pool forks --no-file-parallelism
+
+# Electron shell smoke, if touching desktop wrapper
+pnpm electron:bundle-server
+pnpm smoke:electron
+```
+
+Manual flow:
+
+1. Start `pnpm dev` with `HERMES_MA_PROJECT_PATH` or `HERMES_MA_PROJECTS_JSON` set.
+2. Create a task from the Agent Board.
+3. Start the task and confirm branch/worktree appear in task detail.
+4. Watch events and diff update.
+5. Run at least one configured validation.
+6. Request PR creation and approve the generated approval.
+7. Create the PR and confirm the PR artifact appears.
+8. Save a final summary, optionally to Obsidian.

--- a/docs/multi-agent-mvp.md
+++ b/docs/multi-agent-mvp.md
@@ -88,6 +88,8 @@ Out of scope for this MVP: team accounts, multi-tenant auth, remote worker fleet
    - title;
    - priority;
    - description;
+   - product goal and user story;
+   - success metrics and non-goals, one per line;
    - work packet;
    - acceptance criteria, one per line.
 4. Submit the form.
@@ -98,10 +100,28 @@ Task fields that matter operationally:
 
 - `projectId` — must match a configured project;
 - `assigneeProfileId` — selects the worker profile;
-- `workPacket` — primary instructions passed to the worker;
+- `productBrief` — product goal, user story, success metrics, and non-goals shown in task detail and passed to the worker;
+- `workPacket` — implementation instructions passed to the worker;
 - `acceptanceCriteria` — checklist used for review/validation;
 - `branchName` and `worktreePath` — filled after start;
 - `latestRunId` and `finalSummary` — filled by worker/memory hooks.
+
+## Contextual skill autoloading
+
+When a worker run starts, Hermes builds the worker skill list from three sources, in stable order with duplicates removed:
+
+1. explicit skills already configured on the selected profile;
+2. role defaults from the multi-agent role map;
+3. contextual matches from the task title, description, product brief, work packet, and acceptance criteria.
+
+Examples:
+
+- backend work loads `test-driven-development` and `systematic-debugging` by default;
+- frontend/UI task text can add `frontend-design`;
+- review/validation task text can add `review-gate`;
+- docs task text can add `document-release`.
+
+The selected skills are passed to Hermes Agent with `--skills`, embedded in the worker prompt under **Skills loaded for this run**, and stored in the `run.started` event payload as `loadedSkills` for UI debugging. The worker prompt also includes the task **Product brief** so implementation decisions stay tied to the product goal, user story, success metrics, and explicit non-goals.
 
 ## Start a task and worktree layout
 
@@ -151,7 +171,10 @@ Safety behavior:
 
 The task detail panel shows:
 
+- product brief: goal, user story, success metrics, and non-goals;
+
 - **Events / Live Log** from `GET /api/ma/tasks/:taskId/events`;
+- **Skills loaded for this run** from the latest `run.started` event payload;
 - **Diff** from `GET /api/ma/tasks/:taskId/diff`;
 - **Validation** history from `GET /api/ma/tasks/:taskId/validate`.
 
@@ -325,6 +348,7 @@ pnpm exec electron --version
 - Validation command safety depends on project configuration; avoid placing destructive commands in configured validation slots.
 - PR creation depends on local `git`, `gh`, remotes, and authentication.
 - Final summaries are manually saved; the MVP does not auto-write every run to Obsidian.
+- Contextual skill matching is keyword-based; profile configuration remains the source of explicit project-specific skills.
 - Browser web UI is the primary supported surface; Electron is smoke-tested but not the primary implementation surface.
 
 ## Quick verification checklist

--- a/docs/plans/hermes-multi-agent-control-plane-mvp.md
+++ b/docs/plans/hermes-multi-agent-control-plane-mvp.md
@@ -1,0 +1,1762 @@
+# Hermes Multi-Agent Control Plane MVP Implementation Plan
+
+> **For Hermes:** Use `protocol-driven-orchestrator`, `agent-team-operating-manual`, `best-of-n-planning`, `test-driven-development`, and `review-gate` when executing this plan. Implement slice-by-slice with tests first where practical.
+
+**Goal:** Turn Hermes Workspace into a local personal multi-agent control plane for Hermes Agent workers: board → isolated worktree → live run → approvals → diff/review → validation → GitHub PR.
+
+**Current repo:** `/home/rab/ai-workspace/apps/hermes-workspace`
+
+**Primary runtime:** Hermes Agent only. No Claude/Codex/OpenCode runtimes in MVP.
+
+**Primary UI:** Web UI first, packaged through existing Electron shell scripts after core web flow is stable.
+
+**User model:** Single-user local app for Ярослав; no team/multi-tenant auth in MVP.
+
+---
+
+## 1. Context and constraints
+
+### 1.1 Existing repo facts
+
+`hermes-workspace` already contains useful surfaces:
+
+- Electron scripts in `package.json`:
+  - `electron:dev`
+  - `electron:build`
+  - `electron:build:mac`
+  - `electron:build:win`
+- Existing route/API area:
+  - `src/routes/api/conductor-spawn.ts`
+  - `src/routes/api/projects.ts`
+  - `src/routes/api/swarm-*`
+  - `src/routes/api/workspace.ts`
+  - `src/routes/api/start-agent.ts`
+  - `src/routes/api/sessions/*`
+- Existing UI areas:
+  - `src/screens/gateway/conductor.tsx`
+  - `src/screens/gateway/components/task-board.tsx`
+  - `src/screens/gateway/components/kanban-board.tsx`
+  - `src/screens/gateway/components/approvals-panel.tsx`
+  - `src/screens/gateway/components/approvals-page.tsx`
+  - `src/screens/gateway/components/mission-event-log.tsx`
+  - `src/screens/gateway/components/agent-output-panel.tsx`
+  - `src/screens/swarm2/*`
+  - `src/screens/tasks/*`
+- Existing stores/helpers:
+  - `src/lib/workspace-agents.ts`
+  - `src/lib/workspace-checkpoints.ts`
+  - `src/server/project-registry.ts`
+  - `src/server/tool-artifacts-store.ts`
+
+### 1.2 Dirty state warning
+
+There are already uncommitted changes in this repo. Before implementing, preserve them.
+
+Current observed dirty state includes:
+
+```text
+M src/routes/api/-conductor-spawn.test.ts
+M src/routes/api/conductor-spawn.ts
+M src/routes/api/projects.ts
+M src/routes/conductor.tsx
+M src/screens/gateway/conductor-launch-intent.test.ts
+M src/screens/gateway/conductor-launch-intent.ts
+M src/screens/gateway/conductor.tsx
+M src/screens/gateway/hooks/use-conductor-gateway.test.ts
+M src/screens/gateway/hooks/use-conductor-gateway.ts
+M src/screens/projects/projects-screen.tsx
+M src/server/project-registry.test.ts
+M src/server/project-registry.ts
+?? src/screens/gateway/conductor-preflight-summary.test.ts
+?? src/screens/gateway/conductor-preflight-summary.ts
+?? src/screens/gateway/conductor-trace-hydration.test.ts
+?? src/screens/gateway/conductor-trace-hydration.ts
+?? src/screens/gateway/hooks/mission-history.test.ts
+?? src/screens/gateway/hooks/mission-history.ts
+?? src/screens/projects/project-mission-trace.test.ts
+?? src/screens/projects/project-mission-trace.ts
+```
+
+Execution rule:
+
+1. Do not overwrite this work.
+2. Before coding, create a checkpoint branch or patch.
+3. Keep multi-agent MVP commits separate from existing conductor/project work.
+
+### 1.3 Hermes Agent dirty state dependency
+
+`hermes-agent` also has relevant uncommitted sandbox/project-context work:
+
+```text
+M gateway/platforms/base.py
+M gateway/platforms/telegram.py
+M gateway/run.py
+M gateway/session_context.py
+M tools/delegate_tool.py
+M tools/file_tools.py
+M tools/terminal_tool.py
+?? gateway/project_context.py
+?? tests/gateway/test_project_sandbox_context.py
+?? tests/tools/test_project_sandbox.py
+?? tools/project_sandbox.py
+```
+
+This appears relevant for project sandbox/workdir safety. Do not assume it is merged. Treat it as either:
+
+- a dependency to stabilize before worker isolation; or
+- a parallel branch to preserve and integrate later.
+
+---
+
+## 2. References to borrow from
+
+### 2.1 Emdash
+
+Borrow:
+
+- desktop-first agentic development environment feel;
+- multiple isolated worktrees;
+- remote/dev workflow patterns;
+- MCP/tools settings UX;
+- port isolation concept via env var.
+
+Do not copy:
+
+- multi-provider complexity in MVP.
+
+### 2.2 Vibe Kanban / AI Agent Board
+
+Borrow:
+
+- Kanban board for agent tasks;
+- task detail drawer/page;
+- task groups later;
+- parallelism slider later;
+- diff review + inline comments later.
+
+MVP starts with simple task cards and task detail.
+
+### 2.3 Composio Agent Orchestrator
+
+Borrow later:
+
+- CI failure reaction loop;
+- review-comment routing;
+- PR lifecycle automation.
+
+MVP only needs `commit → push → gh pr create`.
+
+### 2.4 OpenCastle
+
+Borrow:
+
+- Team Lead Orchestrator vocabulary;
+- specialist roles;
+- work packets;
+- quality gates;
+- deterministic task graph.
+
+MVP implements the data model and manual flow first; autonomous decomposition can come after the first end-to-end path works.
+
+### 2.5 Claude Squad
+
+Borrow:
+
+- simple task/worktree lifecycle;
+- local terminal/process control;
+- review-before-merge mindset.
+
+---
+
+## 3. MVP scope
+
+### 3.1 In scope
+
+1. Local Agent Board in Hermes Workspace.
+2. Hermes Agent worker runtime only.
+3. One git worktree + branch per coding task.
+4. Live events/logs for each run.
+5. Basic approval queue for risky operations.
+6. Diff view for task worktree.
+7. Validation command runner.
+8. GitHub PR creation via `gh`.
+9. Web UI flow.
+10. Electron smoke after web flow is stable.
+11. Single-user local storage.
+
+### 3.2 Out of scope for MVP
+
+- Claude/Codex/OpenCode providers.
+- Multi-user/team auth.
+- Full autonomous conflict resolver.
+- Full CI/review-comment reaction loop.
+- Auto-merge.
+- Remote SSH.
+- Advanced inline diff comments.
+- Marketplace/provider registry.
+- Perfect unified tool-guardrail integration if it delays MVP.
+
+---
+
+## 4. Product flow
+
+### 4.1 Happy path
+
+```text
+User opens /conductor or /agents board
+→ creates task with project + description + agent profile
+→ task appears in Backlog/Ready
+→ user clicks Start
+→ system creates worktree + branch
+→ system launches Hermes Agent worker inside worktree
+→ events stream into task detail
+→ worker finishes or requests approval
+→ system collects changed files and diff
+→ user runs validation commands
+→ user approves result
+→ system commits, pushes branch, creates GitHub PR
+→ task moves Done
+→ result summary/artifacts persist
+```
+
+### 4.2 First implementation slice
+
+```text
+Create Task → Create Worktree → Show Task on Board
+```
+
+No worker yet. This validates:
+
+- storage;
+- project selection;
+- task model;
+- git branch/worktree creation;
+- UI board.
+
+### 4.3 Second implementation slice
+
+```text
+Start Hermes Worker → Stream Events → Complete Task
+```
+
+### 4.4 Third implementation slice
+
+```text
+Diff → Validation → Commit/Push/PR
+```
+
+### 4.5 Fourth implementation slice
+
+```text
+Approval Queue
+```
+
+---
+
+## 5. Data model
+
+Use TypeScript domain types in a new module first. Persist to JSON file or SQLite based on existing repo patterns after audit. Because the repo already uses local JSON stores such as `.runtime/tool-artifacts`, MVP can start with file-backed JSON under `.runtime/multi-agent/` and migrate later if needed.
+
+Recommended MVP path:
+
+```text
+.runtime/multi-agent/state.json
+.runtime/multi-agent/events/*.jsonl
+.runtime/multi-agent/artifacts/<task-id>/...
+```
+
+### 5.1 Project
+
+```ts
+export type MultiAgentProject = {
+  id: string
+  name: string
+  repoPath: string
+  defaultBranch: string
+  worktreeRoot: string
+  githubRemote?: string | null
+  graphifyGraphPath?: string | null
+  obsidianPath?: string | null
+  validation?: {
+    lint?: string | null
+    typecheck?: string | null
+    test?: string | null
+    build?: string | null
+  }
+  createdAt: string
+  updatedAt: string
+}
+```
+
+Notes:
+
+- `repoPath` should come from existing `project-registry.ts` where possible.
+- `worktreeRoot` default:
+  - `<repoPath>/.hermes-worktrees`
+- `defaultBranch` should be detected by:
+  - `git symbolic-ref refs/remotes/origin/HEAD`
+  - fallback `main`
+  - fallback current branch.
+
+### 5.2 Agent profile
+
+```ts
+export type MultiAgentProfile = {
+  id: string
+  name: string
+  role:
+    | 'orchestrator'
+    | 'frontend-engineer'
+    | 'backend-engineer'
+    | 'qa-validator'
+    | 'reviewer'
+    | 'docs-writer'
+  runtime: 'hermes-agent'
+  model?: string | null
+  skills: string[]
+  enabledToolsets?: string[]
+  permissionPolicy: 'safe-default' | 'ask-risky' | 'read-only'
+  createdAt: string
+  updatedAt: string
+}
+```
+
+MVP default profiles:
+
+```text
+orchestrator
+frontend-engineer
+backend-engineer
+qa-validator
+reviewer
+docs-writer
+```
+
+All profiles use Hermes Agent. Differences are prompt/work packet and allowed toolsets.
+
+### 5.3 Task
+
+```ts
+export type MultiAgentTaskStatus =
+  | 'backlog'
+  | 'ready'
+  | 'running'
+  | 'needs_approval'
+  | 'review'
+  | 'blocked'
+  | 'done'
+  | 'failed'
+  | 'cancelled'
+
+export type MultiAgentTask = {
+  id: string
+  projectId: string
+  title: string
+  description: string
+  status: MultiAgentTaskStatus
+  priority: 'low' | 'medium' | 'high' | 'urgent'
+  assigneeProfileId: string
+  parentIds: string[]
+  childIds: string[]
+  workPacket: string
+  acceptanceCriteria: string[]
+  branchName?: string | null
+  worktreePath?: string | null
+  latestRunId?: string | null
+  createdAt: string
+  updatedAt: string
+}
+```
+
+### 5.4 Run
+
+```ts
+export type MultiAgentRun = {
+  id: string
+  taskId: string
+  profileId: string
+  status: 'queued' | 'starting' | 'running' | 'waiting_approval' | 'completed' | 'failed' | 'cancelled'
+  pid?: number | null
+  sessionId?: string | null
+  startedAt?: string | null
+  finishedAt?: string | null
+  tokenIn?: number | null
+  tokenOut?: number | null
+  costUsd?: number | null
+  summary?: string | null
+  error?: string | null
+}
+```
+
+### 5.5 Event
+
+```ts
+export type MultiAgentEvent = {
+  id: string
+  taskId: string
+  runId?: string | null
+  type:
+    | 'task.created'
+    | 'worktree.created'
+    | 'run.started'
+    | 'run.log'
+    | 'run.tool_call'
+    | 'approval.requested'
+    | 'approval.resolved'
+    | 'validation.started'
+    | 'validation.completed'
+    | 'diff.updated'
+    | 'pr.created'
+    | 'task.completed'
+    | 'task.failed'
+  message: string
+  payload?: unknown
+  createdAt: string
+}
+```
+
+### 5.6 Approval
+
+```ts
+export type MultiAgentApproval = {
+  id: string
+  taskId: string
+  runId?: string | null
+  riskLevel: 'low' | 'medium' | 'high' | 'critical'
+  actionType:
+    | 'git.push'
+    | 'github.pr_create'
+    | 'file.delete'
+    | 'shell.risky'
+    | 'external.message'
+    | 'deploy'
+    | 'secret_or_env'
+  title: string
+  description: string
+  payload: unknown
+  status: 'pending' | 'approved' | 'denied' | 'expired'
+  createdAt: string
+  resolvedAt?: string | null
+}
+```
+
+### 5.7 Validation
+
+```ts
+export type MultiAgentValidation = {
+  id: string
+  taskId: string
+  type: 'lint' | 'typecheck' | 'test' | 'build' | 'custom'
+  command: string
+  status: 'queued' | 'running' | 'passed' | 'failed' | 'cancelled'
+  exitCode?: number | null
+  outputSummary?: string | null
+  outputArtifactId?: string | null
+  startedAt?: string | null
+  finishedAt?: string | null
+}
+```
+
+### 5.8 Artifact
+
+```ts
+export type MultiAgentArtifact = {
+  id: string
+  taskId: string
+  type: 'diff' | 'log' | 'pr' | 'screenshot' | 'report' | 'validation-output'
+  pathOrUrl: string
+  title: string
+  metadata?: Record<string, unknown>
+  createdAt: string
+}
+```
+
+---
+
+## 6. Backend modules
+
+Create new modules under `src/server/multi-agent/`.
+
+```text
+src/server/multi-agent/types.ts
+src/server/multi-agent/store.ts
+src/server/multi-agent/events.ts
+src/server/multi-agent/project-resolver.ts
+src/server/multi-agent/worktree-manager.ts
+src/server/multi-agent/hermes-worker-runtime.ts
+src/server/multi-agent/diff-manager.ts
+src/server/multi-agent/validation-runner.ts
+src/server/multi-agent/github-pr-manager.ts
+src/server/multi-agent/approval-store.ts
+```
+
+### 6.1 `types.ts`
+
+Contains all domain types.
+
+### 6.2 `store.ts`
+
+Responsibilities:
+
+- load/save `.runtime/multi-agent/state.json`;
+- CRUD projects/tasks/profiles/runs/approvals/validations/artifacts;
+- atomic-ish writes via temp file + rename;
+- no large logs inside state file.
+
+Test cases:
+
+- creates empty state if missing;
+- preserves malformed state by writing `.corrupt-<timestamp>.json` and returning empty state;
+- creates task;
+- updates task status;
+- appends run/artifact/approval.
+
+### 6.3 `events.ts`
+
+Responsibilities:
+
+- append JSONL event files under `.runtime/multi-agent/events/<task-id>.jsonl`;
+- read events by task;
+- summarize latest event for cards.
+
+Test cases:
+
+- append/read events in order;
+- rejects invalid task IDs/path traversal;
+- handles missing event file.
+
+### 6.4 `project-resolver.ts`
+
+Responsibilities:
+
+- integrate with existing `src/server/project-registry.ts`;
+- validate `repoPath` exists;
+- verify git repo;
+- detect default branch;
+- detect GitHub remote;
+- derive worktree root.
+
+Test cases:
+
+- detects git repo;
+- rejects non-existent path;
+- detects default branch fallback;
+- derives `.hermes-worktrees`.
+
+### 6.5 `worktree-manager.ts`
+
+Responsibilities:
+
+- create branch and worktree;
+- ensure branch name safe;
+- inspect worktree status;
+- remove worktree only with explicit call;
+- prevent path traversal;
+- never delete repo root.
+
+Core functions:
+
+```ts
+createTaskWorktree(project, task): Promise<{ branchName: string; worktreePath: string }>
+getWorktreeStatus(worktreePath): Promise<WorktreeStatus>
+removeTaskWorktree(worktreePath, branchName, options): Promise<void>
+```
+
+Implementation detail:
+
+```bash
+git -C <repo> fetch --all --prune
+git -C <repo> worktree add <worktreePath> -b <branchName> <baseRef>
+```
+
+Branch format:
+
+```text
+hermes/task-<task-id>-<slug>
+```
+
+Worktree path:
+
+```text
+<repo>/.hermes-worktrees/task-<task-id>-<slug>
+```
+
+Test cases with temp git repo:
+
+- creates worktree;
+- branch exists;
+- worktree path under expected root;
+- duplicate creation is idempotent or returns useful error;
+- refuses unsafe branch slug;
+- refuses removal outside worktree root.
+
+### 6.6 `hermes-worker-runtime.ts`
+
+Responsibilities:
+
+- launch Hermes Agent worker in the task worktree;
+- inject env vars;
+- stream stdout/stderr into events;
+- handle cancel;
+- mark run completed/failed.
+
+MVP command strategy:
+
+1. First try a stable Hermes CLI non-interactive entrypoint if available.
+2. If not available, add a tiny wrapper script later in `hermes-agent`.
+
+Proposed env:
+
+```text
+HERMES_TASK_ID=<task-id>
+HERMES_RUN_ID=<run-id>
+HERMES_PROJECT_PATH=<repoPath>
+HERMES_WORKTREE_PATH=<worktreePath>
+HERMES_TASK_PORT=<allocated-port>
+HERMES_WORKER_PROFILE=<profile-id>
+```
+
+Work packet prompt template:
+
+```markdown
+You are a Hermes Agent worker running under Hermes Workspace Multi-Agent Control Plane.
+
+Role: <profile role>
+Task: <title>
+Project: <project name>
+Worktree: <worktree path>
+
+Work packet:
+<workPacket>
+
+Acceptance criteria:
+- ...
+
+Rules:
+- Work only inside the worktree unless explicitly approved.
+- Do not push, deploy, send external messages, or edit secrets without approval.
+- Run relevant validation if practical.
+- End with structured result: summary, files changed, validation, risks, blockers.
+```
+
+Test cases:
+
+- builds prompt correctly;
+- emits `run.started` and `run.log` events;
+- handles process exit 0;
+- handles process exit non-zero;
+- cancel kills child process.
+
+### 6.7 `diff-manager.ts`
+
+Responsibilities:
+
+- list changed files;
+- produce unified diff;
+- stage/unstage if needed;
+- create diff artifact.
+
+Commands:
+
+```bash
+git -C <worktree> status --porcelain
+git -C <worktree> diff --stat
+git -C <worktree> diff -- <path>
+```
+
+Test cases:
+
+- no changes;
+- modified file diff;
+- untracked file appears;
+- path filter safe.
+
+### 6.8 `validation-runner.ts`
+
+Responsibilities:
+
+- run project validation commands in worktree;
+- stream output to artifact;
+- store pass/fail.
+
+Validation source:
+
+- project config if set;
+- detected package manager shortcuts later.
+
+MVP commands:
+
+```text
+lint
+typecheck
+test
+build
+custom
+```
+
+Test cases:
+
+- command pass;
+- command fail;
+- timeout;
+- output artifact saved.
+
+### 6.9 `github-pr-manager.ts`
+
+Responsibilities:
+
+- verify `gh` exists;
+- verify `gh auth status`;
+- commit staged/all task changes;
+- push branch;
+- create PR;
+- store PR artifact.
+
+Commands:
+
+```bash
+git -C <worktree> add -A
+git -C <worktree> commit -m <message>
+git -C <worktree> push -u origin <branch>
+gh pr create --repo <owner/repo> --title <title> --body <body> --head <branch> --base <base>
+```
+
+Approval requirement:
+
+- `git push` and `gh pr create` require approval unless user globally configures allow for local-only repo.
+
+Test cases:
+
+- missing gh returns setup error;
+- unauthenticated gh returns setup error;
+- dry-run PR body generation;
+- command construction does not shell-inject branch/title.
+
+### 6.10 `approval-store.ts`
+
+Responsibilities:
+
+- create approval;
+- resolve approval;
+- list pending approvals;
+- attach approvals to task/run.
+
+MVP may not fully pause/resume the Hermes worker for all tool calls. It must at least gate built-in workspace actions:
+
+- push branch;
+- create PR;
+- remove worktree;
+- run custom shell validation if marked risky.
+
+---
+
+## 7. API routes
+
+Create routes under `src/routes/api/ma/`.
+
+```text
+src/routes/api/ma/projects.ts
+src/routes/api/ma/profiles.ts
+src/routes/api/ma/tasks.ts
+src/routes/api/ma/tasks/$taskId.ts
+src/routes/api/ma/tasks/$taskId/start.ts
+src/routes/api/ma/tasks/$taskId/events.ts
+src/routes/api/ma/tasks/$taskId/diff.ts
+src/routes/api/ma/tasks/$taskId/validate.ts
+src/routes/api/ma/tasks/$taskId/commit.ts
+src/routes/api/ma/tasks/$taskId/pr.ts
+src/routes/api/ma/approvals.ts
+src/routes/api/ma/approvals/$approvalId.resolve.ts
+```
+
+If TanStack file route syntax makes `$taskId` paths awkward, follow the existing project route conventions.
+
+### 7.1 `GET /api/ma/projects`
+
+Returns configured/detected projects.
+
+### 7.2 `GET /api/ma/profiles`
+
+Returns default Hermes Agent profiles.
+
+### 7.3 `GET /api/ma/tasks`
+
+Query params:
+
+```text
+project_id?
+status?
+```
+
+### 7.4 `POST /api/ma/tasks`
+
+Input:
+
+```json
+{
+  "projectId": "...",
+  "title": "...",
+  "description": "...",
+  "assigneeProfileId": "backend-engineer",
+  "priority": "medium",
+  "acceptanceCriteria": ["..."],
+  "workPacket": "..."
+}
+```
+
+Behavior:
+
+- validates project;
+- creates task in `backlog` or `ready`;
+- emits `task.created`.
+
+### 7.5 `POST /api/ma/tasks/:taskId/start`
+
+Behavior:
+
+- if no worktree, create worktree;
+- create run;
+- launch Hermes worker;
+- task status `running`;
+- emits `worktree.created`, `run.started`.
+
+For first slice, implement only worktree creation and status transition; runtime can return `501 not implemented` until slice 2.
+
+### 7.6 `GET /api/ma/tasks/:taskId/events`
+
+Returns events. For live updates, start with polling; add SSE/WebSocket later if existing infra is easy.
+
+### 7.7 `GET /api/ma/tasks/:taskId/diff`
+
+Returns:
+
+```json
+{
+  "changedFiles": [...],
+  "stat": "...",
+  "diff": "..."
+}
+```
+
+### 7.8 `POST /api/ma/tasks/:taskId/validate`
+
+Input:
+
+```json
+{ "type": "test" }
+```
+
+or
+
+```json
+{ "type": "custom", "command": "pnpm test" }
+```
+
+### 7.9 `POST /api/ma/tasks/:taskId/commit`
+
+Requires approval if policy says so.
+
+Input:
+
+```json
+{ "message": "feat: ..." }
+```
+
+### 7.10 `POST /api/ma/tasks/:taskId/pr`
+
+Requires approval.
+
+Input:
+
+```json
+{ "title": "...", "body": "...", "base": "main" }
+```
+
+### 7.11 `GET /api/ma/approvals`
+
+Returns pending approvals.
+
+### 7.12 `POST /api/ma/approvals/:approvalId/resolve`
+
+Input:
+
+```json
+{ "decision": "approved" }
+```
+
+or
+
+```json
+{ "decision": "denied", "reason": "..." }
+```
+
+---
+
+## 8. UI implementation
+
+### 8.1 Route choice
+
+Prefer extending existing conductor area instead of creating a separate product concept.
+
+Recommended route:
+
+```text
+/conductor
+```
+
+Add a tab or primary mode:
+
+```text
+Agent Board
+```
+
+If existing conductor code is too entangled, create a temporary route:
+
+```text
+/agents
+```
+
+and link it from conductor later.
+
+### 8.2 Components
+
+Create or adapt:
+
+```text
+src/screens/gateway/components/multi-agent-board.tsx
+src/screens/gateway/components/multi-agent-task-card.tsx
+src/screens/gateway/components/multi-agent-task-detail.tsx
+src/screens/gateway/components/multi-agent-create-task-dialog.tsx
+src/screens/gateway/components/multi-agent-approvals-panel.tsx
+src/screens/gateway/components/multi-agent-diff-view.tsx
+src/screens/gateway/components/multi-agent-validation-panel.tsx
+src/screens/gateway/components/multi-agent-pr-panel.tsx
+```
+
+Reuse existing components where possible:
+
+- `task-board.tsx`
+- `kanban-board.tsx`
+- `approvals-panel.tsx`
+- `approvals-page.tsx`
+- `mission-event-log.tsx`
+- `agent-output-panel.tsx`
+- `task-card.tsx`
+
+### 8.3 Board columns
+
+```text
+Backlog
+Ready
+Running
+Needs Approval
+Review
+Blocked
+Done
+Failed
+```
+
+Column mapping:
+
+```ts
+const COLUMNS = [
+  ['backlog', 'Backlog'],
+  ['ready', 'Ready'],
+  ['running', 'Running'],
+  ['needs_approval', 'Needs Approval'],
+  ['review', 'Review'],
+  ['blocked', 'Blocked'],
+  ['done', 'Done'],
+  ['failed', 'Failed'],
+]
+```
+
+### 8.4 Task card contents
+
+Show:
+
+- title;
+- project;
+- profile;
+- status;
+- branch name;
+- latest event summary;
+- approval count;
+- changed files count;
+- validation status.
+
+### 8.5 Task detail tabs
+
+```text
+Overview
+Work Packet
+Events / Live Log
+Approvals
+Diff
+Validation
+PR
+Artifacts
+```
+
+### 8.6 Create task dialog
+
+Fields:
+
+- project select;
+- title;
+- description;
+- profile;
+- priority;
+- acceptance criteria textarea;
+- work packet textarea;
+- checkbox: create worktree immediately.
+
+---
+
+## 9. Worker prompt contracts
+
+### 9.1 Work packet template
+
+```markdown
+### Work Packet
+Role: <profile role>
+Goal: <task title>
+Context:
+<task description>
+
+Project:
+- Name: <project name>
+- Repo: <repo path>
+- Worktree: <worktree path>
+- Branch: <branch>
+
+Constraints:
+- Work only inside the task worktree.
+- Do not push, create PRs, deploy, send external messages, or edit secrets without approval.
+- Keep changes scoped to the task.
+- Prefer TDD when practical.
+
+Acceptance criteria:
+- ...
+
+Expected output:
+- Summary
+- Files changed
+- Tests/validation run
+- Risks/blockers
+```
+
+### 9.2 Worker result contract
+
+Worker final answer must include:
+
+```markdown
+### Specialist Result
+Role:
+Summary:
+Files changed:
+Validation:
+Risks:
+Blockers:
+Recommended next action:
+```
+
+`hermes-worker-runtime.ts` should parse this lightly later. MVP can store it as raw summary.
+
+---
+
+## 10. Approval policy
+
+### 10.1 MVP gated actions
+
+Always require approval:
+
+- `git push`
+- `gh pr create`
+- worktree removal
+- deploy commands
+- env/secrets file edits detected in diff
+
+Ask/flag:
+
+- delete files;
+- custom shell validation command;
+- large diff over threshold.
+
+Allowed without approval:
+
+- create task;
+- create local worktree;
+- local diff read;
+- local validation commands from project settings;
+- local commit after explicit UI click.
+
+### 10.2 Approval UI behavior
+
+Approval card shows:
+
+- task title;
+- action;
+- risk;
+- command/payload preview;
+- approve;
+- deny;
+- reason.
+
+---
+
+## 11. GitHub PR flow
+
+### 11.1 Preflight checks
+
+Before PR:
+
+1. `git status --porcelain` has changes or commits ahead.
+2. `gh --version` works.
+3. `gh auth status` works.
+4. remote GitHub repo detected.
+5. validation status displayed; failed validation requires override.
+
+### 11.2 PR body template
+
+```markdown
+## Summary
+<task summary>
+
+## Task
+- Task ID: <id>
+- Agent profile: <profile>
+- Worktree: <path>
+
+## Validation
+- lint: pass/fail/not run
+- typecheck: pass/fail/not run
+- test: pass/fail/not run
+- build: pass/fail/not run
+
+## Risks / Notes
+<risks>
+```
+
+---
+
+## 12. Tests
+
+### 12.1 Unit tests
+
+Add tests near modules:
+
+```text
+src/server/multi-agent/store.test.ts
+src/server/multi-agent/events.test.ts
+src/server/multi-agent/project-resolver.test.ts
+src/server/multi-agent/worktree-manager.test.ts
+src/server/multi-agent/diff-manager.test.ts
+src/server/multi-agent/validation-runner.test.ts
+src/server/multi-agent/github-pr-manager.test.ts
+src/server/multi-agent/approval-store.test.ts
+```
+
+### 12.2 Route tests
+
+```text
+src/routes/api/ma/-tasks.test.ts
+src/routes/api/ma/-worktree-start.test.ts
+src/routes/api/ma/-approvals.test.ts
+src/routes/api/ma/-diff.test.ts
+src/routes/api/ma/-validation.test.ts
+```
+
+Follow existing API route test patterns.
+
+### 12.3 UI tests
+
+```text
+src/screens/gateway/components/multi-agent-board.test.tsx
+src/screens/gateway/components/multi-agent-task-detail.test.tsx
+src/screens/gateway/components/multi-agent-create-task-dialog.test.tsx
+```
+
+Minimum assertions:
+
+- renders columns;
+- renders task in correct column;
+- create dialog validates required fields;
+- task detail shows tabs;
+- approvals panel shows pending approval.
+
+### 12.4 Integration smoke
+
+Manual smoke after implementation:
+
+```bash
+pnpm test -- src/server/multi-agent
+pnpm test -- src/routes/api/ma
+pnpm build
+pnpm electron:dev
+```
+
+---
+
+## 13. Step-by-step implementation tasks
+
+## Task 0: Preserve current state
+
+**Objective:** Avoid losing current user modifications.
+
+**Steps:**
+
+1. Run:
+   ```bash
+   git status --short
+   git diff --stat
+   ```
+2. Create branch:
+   ```bash
+   git switch -c feature/multi-agent-control-plane-mvp
+   ```
+   If branch already exists, use it.
+3. Save current dirty diff as patch before touching code:
+   ```bash
+   mkdir -p .runtime/patches
+   git diff > .runtime/patches/pre-multi-agent-mvp.diff
+   git status --short > .runtime/patches/pre-multi-agent-mvp.status.txt
+   ```
+4. Do not commit unrelated existing changes unless user explicitly approves.
+
+**Validation:** Patch/status files exist.
+
+---
+
+## Task 1: Add domain types
+
+**Objective:** Add multi-agent domain types without behavior.
+
+**Files:**
+
+- Create: `src/server/multi-agent/types.ts`
+
+**Steps:**
+
+1. Add types from Section 5.
+2. Export all types.
+3. Run typecheck/build if available.
+
+**Validation:**
+
+```bash
+pnpm build
+```
+
+Expected: either pass or fail only on pre-existing unrelated issues; document result.
+
+---
+
+## Task 2: Add file-backed store
+
+**Objective:** Persist tasks/profiles/runs/approvals/artifacts in `.runtime/multi-agent/state.json`.
+
+**Files:**
+
+- Create: `src/server/multi-agent/store.ts`
+- Create: `src/server/multi-agent/store.test.ts`
+
+**Implementation requirements:**
+
+- `loadState()`
+- `saveState(state)`
+- `createTask(input)`
+- `updateTask(id, patch)`
+- `listTasks(filter?)`
+- `createRun(input)`
+- `updateRun(id, patch)`
+- `createApproval(input)`
+- `resolveApproval(id, decision)`
+- `createArtifact(input)`
+
+**Tests:**
+
+- creates empty state if missing;
+- writes and reads task;
+- updates task status;
+- resolves approval;
+- handles malformed JSON safely.
+
+**Validation:**
+
+```bash
+pnpm test -- src/server/multi-agent/store.test.ts
+```
+
+---
+
+## Task 3: Add event log
+
+**Objective:** Append/read task events as JSONL.
+
+**Files:**
+
+- Create: `src/server/multi-agent/events.ts`
+- Create: `src/server/multi-agent/events.test.ts`
+
+**Implementation requirements:**
+
+- `appendTaskEvent(event)`
+- `listTaskEvents(taskId)`
+- `getLatestTaskEvent(taskId)`
+- safe task ID filename handling.
+
+**Validation:**
+
+```bash
+pnpm test -- src/server/multi-agent/events.test.ts
+```
+
+---
+
+## Task 4: Add project resolver
+
+**Objective:** Resolve existing workspace projects into multi-agent projects.
+
+**Files:**
+
+- Create: `src/server/multi-agent/project-resolver.ts`
+- Create: `src/server/multi-agent/project-resolver.test.ts`
+- Possibly modify: `src/server/project-registry.ts` only if needed.
+
+**Implementation requirements:**
+
+- `resolveProject(input)`
+- `isGitRepo(path)`
+- `detectDefaultBranch(repoPath)`
+- `detectGithubRemote(repoPath)`
+- `defaultWorktreeRoot(repoPath)`
+
+**Validation:**
+
+```bash
+pnpm test -- src/server/multi-agent/project-resolver.test.ts
+```
+
+---
+
+## Task 5: Add worktree manager
+
+**Objective:** Create isolated git worktrees for tasks.
+
+**Files:**
+
+- Create: `src/server/multi-agent/worktree-manager.ts`
+- Create: `src/server/multi-agent/worktree-manager.test.ts`
+
+**Implementation requirements:**
+
+- safe branch names;
+- safe worktree paths;
+- temp git repo tests;
+- idempotent helpful errors.
+
+**Core function:**
+
+```ts
+createTaskWorktree(project, task): Promise<{ branchName: string; worktreePath: string }>
+```
+
+**Validation:**
+
+```bash
+pnpm test -- src/server/multi-agent/worktree-manager.test.ts
+```
+
+---
+
+## Task 6: Add initial API routes for tasks/projects/profiles
+
+**Objective:** Expose project/profile/task APIs.
+
+**Files:**
+
+- Create: `src/routes/api/ma/projects.ts`
+- Create: `src/routes/api/ma/profiles.ts`
+- Create: `src/routes/api/ma/tasks.ts`
+- Create tests following existing route conventions.
+
+**Endpoints:**
+
+- `GET /api/ma/projects`
+- `GET /api/ma/profiles`
+- `GET /api/ma/tasks`
+- `POST /api/ma/tasks`
+
+**Validation:**
+
+```bash
+pnpm test -- src/routes/api/ma
+```
+
+---
+
+## Task 7: Add start task route with worktree creation only
+
+**Objective:** Implement first slice: task → worktree → board-ready status.
+
+**Files:**
+
+- Create: `src/routes/api/ma/tasks/$taskId.start.ts` or repo-conventional equivalent.
+- Modify store/events as needed.
+
+**Behavior:**
+
+- loads task;
+- resolves project;
+- creates worktree;
+- stores branch/worktree path;
+- emits event;
+- status transitions to `ready` or `running_stub` depending UI needs.
+
+For this task, do **not** launch Hermes worker yet.
+
+**Validation:**
+
+- route test creates a temp git repo and verifies worktree path.
+
+---
+
+## Task 8: Add Agent Board UI basic
+
+**Objective:** Render tasks by status and allow task creation/start.
+
+**Files:**
+
+- Create: `src/screens/gateway/components/multi-agent-board.tsx`
+- Create: `src/screens/gateway/components/multi-agent-task-card.tsx`
+- Create: `src/screens/gateway/components/multi-agent-create-task-dialog.tsx`
+- Modify: `src/screens/gateway/conductor.tsx` or add a tab/section.
+
+**UI behavior:**
+
+- fetch profiles/projects/tasks;
+- create task;
+- start task;
+- show branch/worktree after start.
+
+**Validation:**
+
+```bash
+pnpm test -- src/screens/gateway/components/multi-agent-board.test.tsx
+pnpm build
+```
+
+---
+
+## Task 9: Add Hermes worker runtime
+
+**Objective:** Launch Hermes Agent worker process in task worktree.
+
+**Files:**
+
+- Create: `src/server/multi-agent/hermes-worker-runtime.ts`
+- Create: `src/server/multi-agent/hermes-worker-runtime.test.ts`
+- Modify start route to launch worker.
+
+**Implementation note:**
+
+First inspect available Hermes CLI non-interactive options. If no clean option exists, create an internal wrapper later. For MVP plan execution, do not block earlier slices on perfect worker runtime.
+
+**Validation:**
+
+- unit test with fake command;
+- manual test with real Hermes only after API works.
+
+---
+
+## Task 10: Add event polling / live log panel
+
+**Objective:** Show worker events/logs in task detail.
+
+**Files:**
+
+- Create: `src/screens/gateway/components/multi-agent-task-detail.tsx`
+- Create: `src/screens/gateway/components/multi-agent-event-log.tsx`
+- Create route: `GET /api/ma/tasks/:taskId/events`
+
+**MVP:** Poll every 1–2 seconds. SSE/WebSocket later.
+
+---
+
+## Task 11: Add diff manager and UI
+
+**Objective:** Show changed files and unified diff for worktree.
+
+**Files:**
+
+- Create: `src/server/multi-agent/diff-manager.ts`
+- Create route: `GET /api/ma/tasks/:taskId/diff`
+- Create: `src/screens/gateway/components/multi-agent-diff-view.tsx`
+
+**Validation:**
+
+- temp git repo test;
+- UI renders no-change and changed states.
+
+---
+
+## Task 12: Add validation runner
+
+**Objective:** Run configured validation commands in task worktree.
+
+**Files:**
+
+- Create: `src/server/multi-agent/validation-runner.ts`
+- Create route: `POST /api/ma/tasks/:taskId/validate`
+- Create: `src/screens/gateway/components/multi-agent-validation-panel.tsx`
+
+**MVP commands:**
+
+- lint;
+- typecheck;
+- test;
+- build;
+- custom.
+
+**Validation:**
+
+- pass/fail command tests;
+- output artifact saved.
+
+---
+
+## Task 13: Add approval store and UI
+
+**Objective:** Basic unified approvals for workspace actions.
+
+**Files:**
+
+- Create: `src/server/multi-agent/approval-store.ts` if not folded into `store.ts`.
+- Create routes:
+  - `GET /api/ma/approvals`
+  - `POST /api/ma/approvals/:approvalId/resolve`
+- Create/modify:
+  - `src/screens/gateway/components/multi-agent-approvals-panel.tsx`
+
+**MVP gated actions:**
+
+- push;
+- PR create;
+- worktree removal;
+- risky custom shell command.
+
+---
+
+## Task 14: Add GitHub PR manager
+
+**Objective:** Commit, push, and create GitHub PR from task worktree.
+
+**Files:**
+
+- Create: `src/server/multi-agent/github-pr-manager.ts`
+- Create route: `POST /api/ma/tasks/:taskId/pr`
+- Create: `src/screens/gateway/components/multi-agent-pr-panel.tsx`
+
+**Preflight:**
+
+- `gh --version`;
+- `gh auth status`;
+- GitHub remote exists;
+- branch exists;
+- validation status visible.
+
+**Approval:**
+
+- route creates approval if not approved;
+- after approval, executes push/PR.
+
+---
+
+## Task 15: Add memory hooks MVP
+
+**Objective:** Persist useful task result context.
+
+**MVP behavior:**
+
+- task final summary stored in task/run;
+- optional button: “Save summary to Obsidian”.
+
+**Files:**
+
+- Create: `src/server/multi-agent/memory-sync.ts`
+- Create route: `POST /api/ma/tasks/:taskId/save-summary`
+
+**Obsidian path default:**
+
+```text
+~/ai-workspace/knowledge/obsidian-vault/Hermes/Multi-Agent Runs/
+```
+
+Do not auto-write too much. Keep notes concise.
+
+---
+
+## Task 16: Electron smoke
+
+**Objective:** Ensure desktop shell still opens after web flow.
+
+**Commands:**
+
+```bash
+pnpm build
+pnpm electron:dev
+```
+
+If Electron issues are unrelated to MVP, document and keep web UI working.
+
+---
+
+## Task 17: Documentation
+
+**Objective:** Document usage and architecture.
+
+**Files:**
+
+- Create: `docs/multi-agent-mvp.md`
+- Update: `docs/troubleshooting.md` if needed.
+
+Include:
+
+- how to start workspace;
+- how to create task;
+- worktree layout;
+- PR requirements;
+- approval behavior;
+- known limitations.
+
+---
+
+## 14. Execution order summary
+
+```text
+0. Preserve current state
+1. Domain types
+2. Store
+3. Events
+4. Project resolver
+5. Worktree manager
+6. Projects/profiles/tasks API
+7. Start task route creates worktree
+8. Board UI basic
+9. Hermes worker runtime
+10. Task detail + event log
+11. Diff manager + UI
+12. Validation runner + UI
+13. Approval queue
+14. GitHub PR manager + UI
+15. Memory hooks
+16. Electron smoke
+17. Docs
+```
+
+---
+
+## 15. Definition of Done
+
+MVP is complete when:
+
+- [ ] User can create a task in Hermes Workspace.
+- [ ] Task appears on Agent Board.
+- [ ] Starting task creates isolated git worktree and branch.
+- [ ] Hermes Agent worker can run in that worktree.
+- [ ] Task detail shows run events/logs.
+- [ ] Task detail shows changed files/diff.
+- [ ] User can run validation commands.
+- [ ] User can approve push/PR creation.
+- [ ] System can create GitHub PR via `gh`.
+- [ ] Task stores final summary/artifacts.
+- [ ] Web build passes or known unrelated failures are documented.
+- [ ] Electron dev shell opens or known unrelated issue is documented.
+- [ ] Docs explain the flow.
+
+---
+
+## 16. Key risks and mitigations
+
+### Risk: Hermes Agent has no stable worker CLI
+
+Mitigation:
+
+- Make `hermes-worker-runtime.ts` command configurable.
+- Use fake command in tests.
+- Add thin Hermes Agent wrapper later if needed.
+
+### Risk: Approval bridge into Hermes tools is complex
+
+Mitigation:
+
+- MVP gates workspace actions first: push, PR, delete, risky custom command.
+- Worker-level tool approval integration can be Phase 2.
+
+### Risk: Current dirty state conflicts
+
+Mitigation:
+
+- Patch/checkpoint first.
+- Use small commits/slices.
+- Avoid editing existing conductor files until board integration task.
+
+### Risk: Worktree cleanup is dangerous
+
+Mitigation:
+
+- Never auto-delete worktrees in MVP.
+- Cleanup requires explicit approval.
+- Path containment tests required.
+
+### Risk: PR flow depends on GitHub auth
+
+Mitigation:
+
+- Preflight `gh auth status`.
+- Show actionable setup error.
+
+### Risk: Electron distracts from core flow
+
+Mitigation:
+
+- Web UI is source of truth.
+- Electron only smoke-tested after core flow.
+
+---
+
+## 17. Post-MVP roadmap
+
+After MVP:
+
+1. Task groups and parallelism slider.
+2. Orchestrator-generated task graph with user approval.
+3. CI failure reaction loop.
+4. GitHub review-comment reaction loop.
+5. Inline diff comments → fix tasks.
+6. Full Hermes tool approval bridge.
+7. Graphify update button after code changes.
+8. Obsidian automatic decision logging.
+9. Remote SSH workers.
+10. Additional runtimes only if needed.
+
+---
+
+## 18. Approval request
+
+Recommended approved MVP:
+
+```text
+Hermes Workspace Multi-Agent Control Plane MVP
+= web-first Agent Board
++ Hermes Agent workers only
++ worktree isolation
++ live logs/events
++ diff and validation
++ basic unified approvals
++ GitHub PR creation
++ Electron shell smoke
+```
+
+If approved, start with Task 0 and Task 1. Do not begin implementation until current dirty state is preserved.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,46 @@ This means the Vite SSR server tried `GET /api/gateway-status` which internally 
 
 ---
 
+## 7. Agent Board shows no projects
+
+**Symptom:** The Multi-Agent Agent Board loads, but project selection is empty or `GET /api/ma/projects` returns an empty list.
+
+**Cause:** No multi-agent project was configured for the local session.
+
+**Fix:** Export one of the project configuration variables before starting Workspace:
+
+```bash
+# Single project
+export HERMES_MA_PROJECT_PATH=/absolute/path/to/git/repo
+
+# Or multiple projects with validation commands
+export HERMES_MA_PROJECTS_JSON='[{"id":"workspace","repoPath":"/absolute/path/to/git/repo","validation":{"test":"pnpm test","build":"pnpm build"}}]'
+
+pnpm dev
+```
+
+The configured path must exist and must be a git repository. See [Multi-Agent MVP](./multi-agent-mvp.md) for the full workflow.
+
+---
+
+## 8. Electron smoke fails before opening a window
+
+**Symptom:** `pnpm smoke:electron` or `pnpm exec electron --version` fails with `Electron failed to install correctly`.
+
+**Cause:** The local Electron package is present, but its downloaded binary/path metadata is missing.
+
+**Fix:** Re-run Electron's install script and verify the binary:
+
+```bash
+node node_modules/.pnpm/electron@40.9.3/node_modules/electron/install.js
+pnpm exec electron --version
+pnpm smoke:electron
+```
+
+The smoke command should start the local production server and log `Electron smoke mode loaded app shell` before exiting.
+
+---
+
 ## Diagnostic bundle
 
 If nothing above helps, run this and share the output:

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -11,6 +11,7 @@ module.exports = {
     'dist/client/**/*',
     'dist/server/**/*',
     'electron/main.cjs',
+    'electron/shell-config.cjs',
     'electron/preload.cjs',
     'electron/prod-server.cjs',
     'electron/server-bundle.cjs',

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,6 +3,7 @@ const { join } = require('path')
 const { existsSync } = require('fs')
 const { spawn, execSync } = require('child_process')
 const http = require('http')
+const { DEFAULT_APP_PORT, getAppUrl, getSmokeMode } = require('./shell-config.cjs')
 let autoUpdater = null
 try {
   ;({ autoUpdater } = require('electron-updater'))
@@ -13,7 +14,7 @@ try {
   )
 }
 
-const APP_PORT = 3847
+const APP_PORT = DEFAULT_APP_PORT
 const HERMES_GATEWAY_URL = 'http://127.0.0.1:8642/health'
 const HERMES_DASHBOARD_URL = 'http://127.0.0.1:9119/api/status'
 const HERMES_INSTALL_SCRIPT =
@@ -239,13 +240,6 @@ async function ensureHermesBackend() {
   }
 }
 
-function getAppUrl() {
-  if (process.env.NODE_ENV === 'development') {
-    return 'http://127.0.0.1:3002/?desktop=1'
-  }
-  return `http://127.0.0.1:${localServerPort}/?desktop=1`
-}
-
 function startLocalServer() {
   return new Promise((resolve, reject) => {
     let resolved = false
@@ -342,7 +336,14 @@ async function createWindow() {
     return { action: 'deny' }
   })
 
-  await mainWindow.loadURL(getAppUrl())
+  await mainWindow.loadURL(getAppUrl(process.env, localServerPort))
+
+  if (getSmokeMode(process.env)) {
+    console.log('[hermes-workspace] Electron smoke mode loaded app shell')
+    app.quit()
+    return
+  }
+
   void ensureHermesBackend()
   setTimeout(() => {
     void checkForAppUpdates()

--- a/electron/shell-config.cjs
+++ b/electron/shell-config.cjs
@@ -1,0 +1,31 @@
+const DEFAULT_APP_PORT = 3847
+const DEFAULT_DEV_SERVER_PORT = 3000
+
+function parsePort(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10)
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) return fallback
+  return parsed
+}
+
+function getDevServerPort(env = process.env) {
+  return parsePort(env.HERMES_ELECTRON_DEV_SERVER_PORT || env.PORT, DEFAULT_DEV_SERVER_PORT)
+}
+
+function getSmokeMode(env = process.env) {
+  return env.HERMES_ELECTRON_SMOKE === '1'
+}
+
+function getAppUrl(env = process.env, localServerPort = DEFAULT_APP_PORT) {
+  if (env.NODE_ENV === 'development') {
+    return `http://127.0.0.1:${getDevServerPort(env)}/?desktop=1`
+  }
+  return `http://127.0.0.1:${localServerPort}/?desktop=1`
+}
+
+module.exports = {
+  DEFAULT_APP_PORT,
+  DEFAULT_DEV_SERVER_PORT,
+  getAppUrl,
+  getDevServerPort,
+  getSmokeMode,
+}

--- a/electron/shell-config.test.mjs
+++ b/electron/shell-config.test.mjs
@@ -1,0 +1,26 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { getAppUrl, getDevServerPort, getSmokeMode } = require('./shell-config.cjs')
+
+describe('Electron shell config', () => {
+  it('points development shell at the Vite dev server default port', () => {
+    expect(getDevServerPort({})).toBe(3000)
+    expect(getAppUrl({ NODE_ENV: 'development' }, 3847)).toBe('http://127.0.0.1:3000/?desktop=1')
+  })
+
+  it('allows development shell port override for local smoke sessions', () => {
+    expect(getDevServerPort({ HERMES_ELECTRON_DEV_SERVER_PORT: '3015' })).toBe(3015)
+    expect(getAppUrl({ NODE_ENV: 'development', HERMES_ELECTRON_DEV_SERVER_PORT: '3015' }, 3847)).toBe('http://127.0.0.1:3015/?desktop=1')
+  })
+
+  it('loads the bundled local server in production mode', () => {
+    expect(getAppUrl({ NODE_ENV: 'production' }, 3847)).toBe('http://127.0.0.1:3847/?desktop=1')
+  })
+
+  it('detects opt-in smoke mode only from explicit env flag', () => {
+    expect(getSmokeMode({})).toBe(false)
+    expect(getSmokeMode({ HERMES_ELECTRON_SMOKE: '1' })).toBe(true)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "smoke:managed": "node scripts/managed-companion-smoke.mjs",
+    "smoke:electron": "HERMES_ELECTRON_SMOKE=1 NODE_ENV=production electron .",
     "playground:ws": "node scripts/playground-ws.mjs",
     "lint": "eslint",
     "format": "prettier",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run",
     "smoke:managed": "node scripts/managed-companion-smoke.mjs",
     "smoke:electron": "HERMES_ELECTRON_SMOKE=1 NODE_ENV=production electron .",
+    "smoke:multi-agent": "node scripts/multi-agent-mvp-smoke.mjs",
     "playground:ws": "node scripts/playground-ws.mjs",
     "lint": "eslint",
     "format": "prettier",

--- a/scripts/multi-agent-mvp-smoke.mjs
+++ b/scripts/multi-agent-mvp-smoke.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-mvp-smoke-'))
+const repoPath = join(tempRoot, 'repo')
+const stateRoot = join(tempRoot, 'state')
+const obsidianRoot = join(tempRoot, 'obsidian')
+const port = Number(process.env.HERMES_MA_SMOKE_PORT || 3187)
+const baseUrl = `http://127.0.0.1:${port}`
+const serverReadyPattern = /Local:\s+http:\/\/localhost:|Network:/
+let server
+let serverPid
+let taskId
+let worktreePath
+
+function log(message) {
+  process.stdout.write(`${message}\n`)
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? root,
+      env: options.env ?? process.env,
+      stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk) => { stdout += chunk.toString() })
+    child.stderr?.on('data', (chunk) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) resolve({ stdout, stderr })
+      else reject(new Error(`${command} ${args.join(' ')} failed with ${code}\n${stdout}\n${stderr}`))
+    })
+  })
+}
+
+async function waitForServer(timeoutMs = 60_000) {
+  const start = Date.now()
+  let lastError = ''
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(`${baseUrl}/api/ma/projects`, { cache: 'no-store' })
+      if (response.ok) return
+      lastError = `${response.status} ${await response.text()}`
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  throw new Error(`Workspace server did not become ready at ${baseUrl}: ${lastError}`)
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      ...(options.body ? { 'content-type': 'application/json' } : {}),
+      ...(options.headers ?? {}),
+    },
+  })
+  const text = await response.text()
+  let body = {}
+  try { body = text ? JSON.parse(text) : {} } catch { body = { raw: text } }
+  if (!response.ok) {
+    const error = new Error(`${options.method ?? 'GET'} ${path} failed: ${response.status} ${text}`)
+    error.response = response
+    error.body = body
+    throw error
+  }
+  return body
+}
+
+async function waitForTask(predicate, label, timeoutMs = 15_000) {
+  const start = Date.now()
+  let lastTask = null
+  while (Date.now() - start < timeoutMs) {
+    const tasks = await api('/api/ma/tasks')
+    lastTask = tasks.tasks?.find((task) => task.id === taskId) ?? null
+    if (lastTask && predicate(lastTask)) return lastTask
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  }
+  throw new Error(`Timed out waiting for task ${label}. Last task: ${JSON.stringify(lastTask, null, 2)}`)
+}
+
+async function stopServer() {
+  if (!serverPid) return
+  try {
+    await run('bash', ['-lc', `pkill -TERM -P ${serverPid} 2>/dev/null || true; kill -TERM ${serverPid} 2>/dev/null || true; sleep 0.3; pkill -KILL -P ${serverPid} 2>/dev/null || true; kill -KILL ${serverPid} 2>/dev/null || true`])
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+async function main() {
+  log(`Using temp root: ${tempRoot}`)
+  await run('git', ['init', '-b', 'main', repoPath])
+  await run('git', ['config', 'user.email', 'smoke@example.test'], { cwd: repoPath })
+  await run('git', ['config', 'user.name', 'Hermes Smoke'], { cwd: repoPath })
+  await run('bash', ['-lc', 'printf "# Hermes MA smoke\\n" > README.md && git add README.md && git commit -m init'], { cwd: repoPath })
+  await run('git', ['remote', 'add', 'origin', 'https://github.com/example/hermes-ma-smoke.git'], { cwd: repoPath })
+
+  const workerScript = 'const fs=require("fs"); fs.writeFileSync("worker-output.txt", "hello from smoke\\n"); console.log("worker done")'
+  const env = {
+    ...process.env,
+    PORT: String(port),
+    CLAUDE_PASSWORD: '',
+    HERMES_MA_STATE_FILE: join(stateRoot, 'state.json'),
+    HERMES_MA_EVENTS_DIR: join(stateRoot, 'events'),
+    HERMES_MA_PROJECTS_JSON: JSON.stringify([
+      {
+        id: 'smoke',
+        name: 'Smoke Temp Repo',
+        repoPath,
+        defaultBranch: 'main',
+        validation: {
+          test: 'git status --short',
+          build: 'git status --short',
+        },
+      },
+    ]),
+    HERMES_MA_WORKER_COMMAND: process.execPath,
+    HERMES_MA_WORKER_ARGS_JSON: JSON.stringify(['-e', workerScript]),
+    HERMES_MA_GH_MOCK: '1',
+    HERMES_MA_OBSIDIAN_RUNS_DIR: obsidianRoot,
+    HERMES_API_URL: 'http://127.0.0.1:8642',
+  }
+
+  log(`Starting Workspace dev server on ${baseUrl}`)
+  server = spawn('pnpm', ['dev', '--host', '127.0.0.1', '--port', String(port)], {
+    cwd: root,
+    env,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  serverPid = server.pid
+  server.unref()
+  server.stdout?.unref()
+  server.stderr?.unref()
+  server.stdout.on('data', (chunk) => {
+    const text = chunk.toString()
+    if (process.env.HERMES_MA_SMOKE_VERBOSE === '1' || serverReadyPattern.test(text)) process.stdout.write(text)
+  })
+  server.stderr.on('data', (chunk) => {
+    const text = chunk.toString()
+    if (process.env.HERMES_MA_SMOKE_VERBOSE === '1') process.stderr.write(text)
+  })
+
+  await waitForServer()
+
+  const projects = await api('/api/ma/projects')
+  if (!projects.projects?.some((project) => project.id === 'smoke')) throw new Error('Smoke project did not load')
+  log('✓ project config loaded')
+
+  const profiles = await api('/api/ma/profiles')
+  const profileId = profiles.profiles?.[0]?.id ?? 'backend-engineer'
+
+  const created = await api('/api/ma/tasks', {
+    method: 'POST',
+    body: JSON.stringify({
+      projectId: 'smoke',
+      title: 'MVP smoke task',
+      description: 'Exercise multi-agent MVP API flow',
+      assigneeProfileId: profileId,
+      priority: 'medium',
+      workPacket: 'Create worker-output.txt and finish successfully.',
+      acceptanceCriteria: ['worker-output.txt exists', 'validation passes', 'PR artifact is created'],
+    }),
+  })
+  taskId = created.task.id
+  log(`✓ task created: ${taskId}`)
+
+  const started = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/start`, { method: 'POST' })
+  worktreePath = started.task.worktreePath
+  if (!worktreePath) throw new Error('Start did not return worktreePath')
+  log(`✓ task started with worktree: ${worktreePath}`)
+
+  const completedTask = await waitForTask((task) => task.status === 'done', 'worker completion', 20_000)
+  if (!existsSync(join(completedTask.worktreePath, 'worker-output.txt'))) throw new Error('worker-output.txt was not created')
+  log('✓ worker completed and wrote output')
+
+  const events = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/events`)
+  if (!events.events?.some((event) => event.type === 'task.completed')) throw new Error('task.completed event missing')
+  log(`✓ events captured: ${events.events.length}`)
+
+  const diff = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/diff`)
+  if (!diff.diff?.changedFiles?.includes('worker-output.txt')) throw new Error(`Diff missing worker-output.txt: ${JSON.stringify(diff.diff)}`)
+  log('✓ diff includes worker-output.txt')
+
+  const validation = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/validate`, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'test' }),
+  })
+  if (validation.validation?.status !== 'passed') throw new Error(`Validation did not pass: ${JSON.stringify(validation)}`)
+  log('✓ validation passed')
+
+  const firstPr = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/pr`, {
+    method: 'POST',
+    body: JSON.stringify({ title: 'MVP smoke PR', body: 'Smoke PR body' }),
+  })
+  if (!firstPr.approval?.id) throw new Error(`Expected approval required response: ${JSON.stringify(firstPr)}`)
+  log(`✓ PR approval requested: ${firstPr.approval.id}`)
+
+  const resolved = await api(`/api/ma/approvals/${encodeURIComponent(firstPr.approval.id)}/resolve`, {
+    method: 'POST',
+    body: JSON.stringify({ decision: 'approved' }),
+  })
+  if (resolved.approval?.status !== 'approved') throw new Error(`Approval did not resolve: ${JSON.stringify(resolved)}`)
+  log('✓ PR approval approved')
+
+  const secondPr = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/pr`, {
+    method: 'POST',
+    body: JSON.stringify({ title: 'MVP smoke PR', body: 'Smoke PR body' }),
+  })
+  if (secondPr.pr?.url !== 'https://github.com/example/repo/pull/1') throw new Error(`Mock PR URL missing: ${JSON.stringify(secondPr)}`)
+  log(`✓ mock PR artifact created: ${secondPr.pr.url}`)
+
+  const summary = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/save-summary`, {
+    method: 'POST',
+    body: JSON.stringify({ summary: 'Smoke summary for Hermes multi-agent MVP.', saveToObsidian: true }),
+  })
+  if (!summary.task?.finalSummary || !summary.run?.summary || !summary.obsidian?.path) throw new Error(`Summary save incomplete: ${JSON.stringify(summary)}`)
+  if (!existsSync(summary.obsidian.path)) throw new Error(`Obsidian note missing: ${summary.obsidian.path}`)
+  if (!readFileSync(summary.obsidian.path, 'utf-8').includes('Smoke summary')) throw new Error('Obsidian note content missing summary')
+  log(`✓ summary saved to ${summary.obsidian.path}`)
+
+  log('\nPASS: Hermes Multi-Agent MVP API smoke completed successfully')
+  await stopServer()
+}
+
+try {
+  await main()
+} catch (error) {
+  process.exitCode = 1
+  console.error('\nFAIL: Hermes Multi-Agent MVP smoke failed')
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+} finally {
+  await stopServer()
+  if (process.env.HERMES_MA_SMOKE_KEEP_TEMP === '1') {
+    log(`Keeping temp root: ${tempRoot}`)
+  } else {
+    try { rmSync(tempRoot, { recursive: true, force: true }) } catch {}
+  }
+}

--- a/scripts/multi-agent-mvp-smoke.mjs
+++ b/scripts/multi-agent-mvp-smoke.mjs
@@ -9,7 +9,9 @@ const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-mvp-smoke-'))
 const repoPath = join(tempRoot, 'repo')
 const stateRoot = join(tempRoot, 'state')
 const obsidianRoot = join(tempRoot, 'obsidian')
-const port = Number(process.env.HERMES_MA_SMOKE_PORT || 3187)
+const port = process.env.HERMES_MA_SMOKE_PORT
+  ? Number(process.env.HERMES_MA_SMOKE_PORT)
+  : 3187 + Math.floor(Math.random() * 1000)
 const baseUrl = `http://127.0.0.1:${port}`
 const serverReadyPattern = /Local:\s+http:\/\/localhost:|Network:/
 let server
@@ -169,6 +171,12 @@ async function main() {
       assigneeProfileId: profileId,
       priority: 'medium',
       workPacket: 'Create worker-output.txt and finish successfully.',
+      productBrief: {
+        goal: 'Verify the local multi-agent product loop works end to end.',
+        userStory: 'As an operator, I can trust the Agent Board before using it for real implementation work.',
+        successMetrics: ['smoke flow exits with PASS', 'summary note includes product context'],
+        nonGoals: ['real GitHub network calls'],
+      },
       acceptanceCriteria: ['worker-output.txt exists', 'validation passes', 'PR artifact is created'],
     }),
   })
@@ -186,7 +194,15 @@ async function main() {
 
   const events = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/events`)
   if (!events.events?.some((event) => event.type === 'task.completed')) throw new Error('task.completed event missing')
-  log(`✓ events captured: ${events.events.length}`)
+  const runStarted = events.events?.find((event) => event.type === 'run.started')
+  const loadedSkills = runStarted?.payload?.loadedSkills
+  if (!Array.isArray(loadedSkills) || !loadedSkills.includes('protocol-driven-orchestrator')) {
+    throw new Error(`run.started missing contextual loadedSkills: ${JSON.stringify(runStarted)}`)
+  }
+  if (!loadedSkills.includes('review-gate')) {
+    throw new Error(`Expected contextual review-gate skill for smoke task: ${JSON.stringify(loadedSkills)}`)
+  }
+  log(`✓ events captured with loaded skills: ${loadedSkills.join(', ')}`)
 
   const diff = await api(`/api/ma/tasks/${encodeURIComponent(taskId)}/diff`)
   if (!diff.diff?.changedFiles?.includes('worker-output.txt')) throw new Error(`Diff missing worker-output.txt: ${JSON.stringify(diff.diff)}`)
@@ -226,7 +242,9 @@ async function main() {
   })
   if (!summary.task?.finalSummary || !summary.run?.summary || !summary.obsidian?.path) throw new Error(`Summary save incomplete: ${JSON.stringify(summary)}`)
   if (!existsSync(summary.obsidian.path)) throw new Error(`Obsidian note missing: ${summary.obsidian.path}`)
-  if (!readFileSync(summary.obsidian.path, 'utf-8').includes('Smoke summary')) throw new Error('Obsidian note content missing summary')
+  const note = readFileSync(summary.obsidian.path, 'utf-8')
+  if (!note.includes('Smoke summary')) throw new Error('Obsidian note content missing summary')
+  if (!note.includes('Verify the local multi-agent product loop works end to end.')) throw new Error('Obsidian note content missing product brief')
   log(`✓ summary saved to ${summary.obsidian.path}`)
 
   log('\nPASS: Hermes Multi-Agent MVP API smoke completed successfully')

--- a/src/components/mobile-tab-bar.tsx
+++ b/src/components/mobile-tab-bar.tsx
@@ -8,6 +8,7 @@ import {
   CommandLineIcon,
   DashboardSquare01Icon,
   File01Icon,
+  Folder01Icon,
   McpServerIcon,
   PuzzleIcon,
   Rocket01Icon,
@@ -73,6 +74,13 @@ export const MOBILE_NAV_TABS: Array<TabItem> = [
     icon: File01Icon,
     to: '/files',
     match: (p) => p.startsWith('/files'),
+  },
+  {
+    id: 'projects',
+    label: 'Projects',
+    icon: Folder01Icon,
+    to: '/projects',
+    match: (p) => p.startsWith('/projects'),
   },
   {
     id: 'terminal',

--- a/src/components/swarm/router-chat.tsx
+++ b/src/components/swarm/router-chat.tsx
@@ -235,21 +235,41 @@ export function RouterChat({
     setResults(null)
     setFollowUp(null)
     try {
-      const res = await fetch('/api/swarm-dispatch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          assignments: plan,
-          timeoutSeconds: 300,
-          waitForCheckpoint: true,
-          checkpointPollSeconds: 90,
-        }),
-      })
+      const res = mode === 'auto'
+        ? await fetch('/api/swarm-autopilot', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            prompt: prompt.trim(),
+            dispatch: true,
+            ensureLiveWorkers: true,
+            timeoutSeconds: 300,
+            waitForCheckpoint: true,
+            checkpointPollSeconds: 90,
+          }),
+        })
+        : await fetch('/api/swarm-dispatch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            assignments: plan,
+            timeoutSeconds: 300,
+            waitForCheckpoint: true,
+            checkpointPollSeconds: 90,
+          }),
+        })
       if (!res.ok) {
         const text = await res.text()
         throw new Error(text || `HTTP ${res.status}`)
       }
-      const data = (await res.json()) as DispatchResponse
+      const rawData = (await res.json()) as DispatchResponse | { dispatch?: DispatchResponse; plan?: { assignments?: Array<Assignment>; unassigned?: Array<string> } }
+      const data = mode === 'auto' && 'dispatch' in rawData && rawData.dispatch
+        ? rawData.dispatch
+        : rawData as DispatchResponse
+      if (mode === 'auto' && 'plan' in rawData && rawData.plan) {
+        setAssignments(rawData.plan.assignments ?? [])
+        setUnassigned(rawData.plan.unassigned ?? [])
+      }
       setResults(data)
       onResults(data)
       if (plan.length > 1 && data.results.some((result) => result.checkpointStatus === 'checkpointed')) {

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -96,14 +96,15 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (path === '/dashboard') return 0
     if (path.startsWith('/chat') || path === '/new' || path === '/') return 1
     if (path.startsWith('/files')) return 2
-    if (path.startsWith('/terminal')) return 3
-    if (path.startsWith('/jobs')) return 4
-    if (path === '/swarm' || path.startsWith('/swarm2')) return 5
-    if (path.startsWith('/memory')) return 6
-    if (path.startsWith('/skills')) return 7
-    if (path.startsWith('/mcp')) return 8
-    if (path.startsWith('/profiles')) return 9
-    if (path.startsWith('/settings')) return 10
+    if (path.startsWith('/projects')) return 3
+    if (path.startsWith('/terminal')) return 4
+    if (path.startsWith('/jobs')) return 5
+    if (path === '/swarm' || path.startsWith('/swarm2')) return 6
+    if (path.startsWith('/memory')) return 7
+    if (path.startsWith('/skills')) return 8
+    if (path.startsWith('/mcp')) return 9
+    if (path.startsWith('/profiles')) return 10
+    if (path.startsWith('/settings')) return 11
     return -1
   }, [])
 
@@ -169,6 +170,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const mobilePageTitle = (() => {
     if (pathname.startsWith('/terminal')) return 'Terminal'
     if (pathname.startsWith('/files')) return 'Files'
+    if (pathname.startsWith('/projects')) return 'Projects'
     if (pathname.startsWith('/jobs')) return 'Jobs'
     if (pathname.startsWith('/conductor')) return 'Conductor'
     if (pathname.startsWith('/operations')) return 'Operations'
@@ -187,10 +189,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const activeFriendlyId = chatMatch ? chatMatch[1] : 'main'
   const isOnChatRoute = Boolean(chatMatch) || pathname === '/new'
   const isOnTerminalRoute = pathname.startsWith('/terminal')
-  const isOnPlaygroundRoute = pathname === '/playground' || pathname.startsWith('/playground/')
-  const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
+  const isOnPlaygroundRoute =
+    pathname === '/playground' || pathname.startsWith('/playground/')
+  const isOnHermesWorldLandingRoute =
+    pathname === '/hermes-world' ||
+    pathname.startsWith('/hermes-world/') ||
+    pathname === '/world' ||
+    pathname.startsWith('/world/')
   const isEmbeddedSurface =
-    search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
+    search?.embed === '1' ||
+    search?.embed === 'true' ||
+    search?.mode === 'embed'
   const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
@@ -342,7 +351,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
         <div
           className={cn(
             'grid h-full grid-cols-1 grid-rows-[minmax(0,1fr)] overflow-hidden',
-            hideChatSidebar || isChromeFreeSurface ? 'md:grid-cols-1' : 'md:grid-cols-[auto_1fr]',
+            hideChatSidebar || isChromeFreeSurface
+              ? 'md:grid-cols-1'
+              : 'md:grid-cols-[auto_1fr]',
           )}
         >
           {/* Activity ticker bar */}
@@ -433,11 +444,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
           </main>
 
           {/* Chat panel — visible on non-chat routes (but not in HermesWorld, which has its own in-game chat) */}
-          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && <ChatPanel />}
+          {!isOnChatRoute &&
+            !isOnPlaygroundRoute &&
+            !isChromeFreeSurface &&
+            !isMobile && <ChatPanel />}
         </div>
 
         {/* Floating chat toggle — visible on non-chat routes (but not in HermesWorld) */}
-        {!isChromeFreeSurface && !isOnChatRoute && !isOnPlaygroundRoute && !isMobile && <ChatPanelToggle />}
+        {!isChromeFreeSurface &&
+          !isOnChatRoute &&
+          !isOnPlaygroundRoute &&
+          !isMobile && <ChatPanelToggle />}
 
         {showDesktopSidebarBackdrop ? (
           <button
@@ -454,10 +471,15 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
       </div>
 
       {!isChromeFreeSurface ? <MobileHamburgerMenu /> : null}
-      {!isChromeFreeSurface && !isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
+      {!isChromeFreeSurface &&
+      !isMobile &&
+      !isOnChatRoute &&
+      settings.showSystemMetricsFooter ? (
         <SystemMetricsFooter leftOffsetPx={sidebarCollapsed ? 48 : 300} />
       ) : null}
-      {!isChromeFreeSurface ? <CommandPalette pathname={pathname} sessions={sessions} /> : null}
+      {!isChromeFreeSurface ? (
+        <CommandPalette pathname={pathname} sessions={sessions} />
+      ) : null}
     </>
   )
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -137,6 +137,9 @@ import { Route as ApiMcpHubSearchRouteImport } from './routes/api/mcp/hub-search
 import { Route as ApiMcpDiscoverRouteImport } from './routes/api/mcp/discover'
 import { Route as ApiMcpConfigureRouteImport } from './routes/api/mcp/configure'
 import { Route as ApiMcpNameRouteImport } from './routes/api/mcp/$name'
+import { Route as ApiMaTasksRouteImport } from './routes/api/ma/tasks'
+import { Route as ApiMaProjectsRouteImport } from './routes/api/ma/projects'
+import { Route as ApiMaProfilesRouteImport } from './routes/api/ma/profiles'
 import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
 import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/read'
@@ -154,6 +157,7 @@ import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
+import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -796,6 +800,21 @@ const ApiMcpNameRoute = ApiMcpNameRouteImport.update({
   path: '/$name',
   getParentRoute: () => ApiMcpRoute,
 } as any)
+const ApiMaTasksRoute = ApiMaTasksRouteImport.update({
+  id: '/api/ma/tasks',
+  path: '/api/ma/tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMaProjectsRoute = ApiMaProjectsRouteImport.update({
+  id: '/api/ma/projects',
+  path: '/api/ma/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMaProfilesRoute = ApiMaProfilesRouteImport.update({
+  id: '/api/ma/profiles',
+  path: '/api/ma/profiles',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiKnowledgeSyncRoute = ApiKnowledgeSyncRouteImport.update({
   id: '/api/knowledge/sync',
   path: '/api/knowledge/sync',
@@ -885,6 +904,11 @@ const ApiHermesworldReservationsConfirmRoute =
     path: '/confirm',
     getParentRoute: () => ApiHermesworldReservationsRoute,
   } as any)
+const ApiMaTasksTaskIdStartRoute = ApiMaTasksTaskIdStartRouteImport.update({
+  id: '/$taskId/start',
+  path: '/$taskId/start',
+  getParentRoute: () => ApiMaTasksRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -997,6 +1021,9 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/profiles': typeof ApiMaProfilesRoute
+  '/api/ma/projects': typeof ApiMaProjectsRoute
+  '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1032,6 +1059,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -1143,6 +1171,9 @@ export interface FileRoutesByTo {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/profiles': typeof ApiMaProfilesRoute
+  '/api/ma/projects': typeof ApiMaProjectsRoute
+  '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1178,6 +1209,7 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -1291,6 +1323,9 @@ export interface FileRoutesById {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/profiles': typeof ApiMaProfilesRoute
+  '/api/ma/projects': typeof ApiMaProjectsRoute
+  '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1326,6 +1361,7 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -1440,6 +1476,9 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/profiles'
+    | '/api/ma/projects'
+    | '/api/ma/tasks'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1475,6 +1514,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/start'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1586,6 +1626,9 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/profiles'
+    | '/api/ma/projects'
+    | '/api/ma/tasks'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1621,6 +1664,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/start'
   id:
     | '__root__'
     | '/'
@@ -1733,6 +1777,9 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/profiles'
+    | '/api/ma/projects'
+    | '/api/ma/tasks'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1768,6 +1815,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/start'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1875,6 +1923,9 @@ export interface RootRouteChildren {
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
+  ApiMaProfilesRoute: typeof ApiMaProfilesRoute
+  ApiMaProjectsRoute: typeof ApiMaProjectsRoute
+  ApiMaTasksRoute: typeof ApiMaTasksRouteWithChildren
   ApiModelInfoRoute: typeof ApiModelInfoRoute
   ApiOauthDeviceCodeRoute: typeof ApiOauthDeviceCodeRoute
   ApiOauthPollTokenRoute: typeof ApiOauthPollTokenRoute
@@ -2788,6 +2839,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMcpNameRouteImport
       parentRoute: typeof ApiMcpRoute
     }
+    '/api/ma/tasks': {
+      id: '/api/ma/tasks'
+      path: '/api/ma/tasks'
+      fullPath: '/api/ma/tasks'
+      preLoaderRoute: typeof ApiMaTasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/ma/projects': {
+      id: '/api/ma/projects'
+      path: '/api/ma/projects'
+      fullPath: '/api/ma/projects'
+      preLoaderRoute: typeof ApiMaProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/ma/profiles': {
+      id: '/api/ma/profiles'
+      path: '/api/ma/profiles'
+      fullPath: '/api/ma/profiles'
+      preLoaderRoute: typeof ApiMaProfilesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/knowledge/sync': {
       id: '/api/knowledge/sync'
       path: '/api/knowledge/sync'
@@ -2906,6 +2978,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/hermesworld/reservations/confirm'
       preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
       parentRoute: typeof ApiHermesworldReservationsRoute
+    }
+    '/api/ma/tasks/$taskId/start': {
+      id: '/api/ma/tasks/$taskId/start'
+      path: '/$taskId/start'
+      fullPath: '/api/ma/tasks/$taskId/start'
+      preLoaderRoute: typeof ApiMaTasksTaskIdStartRouteImport
+      parentRoute: typeof ApiMaTasksRoute
     }
   }
 }
@@ -3096,6 +3175,18 @@ const ApiHermesworldReservationsRouteWithChildren =
     ApiHermesworldReservationsRouteChildren,
   )
 
+interface ApiMaTasksRouteChildren {
+  ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
+}
+
+const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
+  ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
+}
+
+const ApiMaTasksRouteWithChildren = ApiMaTasksRoute._addFileChildren(
+  ApiMaTasksRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
@@ -3201,6 +3292,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
+  ApiMaProfilesRoute: ApiMaProfilesRoute,
+  ApiMaProjectsRoute: ApiMaProjectsRoute,
+  ApiMaTasksRoute: ApiMaTasksRouteWithChildren,
   ApiModelInfoRoute: ApiModelInfoRoute,
   ApiOauthDeviceCodeRoute: ApiOauthDeviceCodeRoute,
   ApiOauthPollTokenRoute: ApiOauthPollTokenRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -140,6 +140,7 @@ import { Route as ApiMcpNameRouteImport } from './routes/api/mcp/$name'
 import { Route as ApiMaTasksRouteImport } from './routes/api/ma/tasks'
 import { Route as ApiMaProjectsRouteImport } from './routes/api/ma/projects'
 import { Route as ApiMaProfilesRouteImport } from './routes/api/ma/profiles'
+import { Route as ApiMaApprovalsRouteImport } from './routes/api/ma/approvals'
 import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
 import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/read'
@@ -157,9 +158,11 @@ import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
+import { Route as ApiMaTasksTaskIdValidateRouteImport } from './routes/api/ma/tasks.$taskId.validate'
 import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
 import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
 import { Route as ApiMaTasksTaskIdDiffRouteImport } from './routes/api/ma/tasks.$taskId.diff'
+import { Route as ApiMaApprovalsApprovalIdResolveRouteImport } from './routes/api/ma/approvals.$approvalId.resolve'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -817,6 +820,11 @@ const ApiMaProfilesRoute = ApiMaProfilesRouteImport.update({
   path: '/api/ma/profiles',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMaApprovalsRoute = ApiMaApprovalsRouteImport.update({
+  id: '/api/ma/approvals',
+  path: '/api/ma/approvals',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiKnowledgeSyncRoute = ApiKnowledgeSyncRouteImport.update({
   id: '/api/knowledge/sync',
   path: '/api/knowledge/sync',
@@ -906,6 +914,12 @@ const ApiHermesworldReservationsConfirmRoute =
     path: '/confirm',
     getParentRoute: () => ApiHermesworldReservationsRoute,
   } as any)
+const ApiMaTasksTaskIdValidateRoute =
+  ApiMaTasksTaskIdValidateRouteImport.update({
+    id: '/$taskId/validate',
+    path: '/$taskId/validate',
+    getParentRoute: () => ApiMaTasksRoute,
+  } as any)
 const ApiMaTasksTaskIdStartRoute = ApiMaTasksTaskIdStartRouteImport.update({
   id: '/$taskId/start',
   path: '/$taskId/start',
@@ -921,6 +935,12 @@ const ApiMaTasksTaskIdDiffRoute = ApiMaTasksTaskIdDiffRouteImport.update({
   path: '/$taskId/diff',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaApprovalsApprovalIdResolveRoute =
+  ApiMaApprovalsApprovalIdResolveRouteImport.update({
+    id: '/$approvalId/resolve',
+    path: '/$approvalId/resolve',
+    getParentRoute: () => ApiMaApprovalsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -1033,6 +1053,7 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1071,9 +1092,11 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
+  '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -1185,6 +1208,7 @@ export interface FileRoutesByTo {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1223,9 +1247,11 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
+  '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -1339,6 +1365,7 @@ export interface FileRoutesById {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1377,9 +1404,11 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
+  '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -1494,6 +1523,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/approvals'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -1532,9 +1562,11 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
+    | '/api/ma/tasks/$taskId/validate'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1646,6 +1678,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/approvals'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -1684,9 +1717,11 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
+    | '/api/ma/tasks/$taskId/validate'
   id:
     | '__root__'
     | '/'
@@ -1799,6 +1834,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/ma/approvals'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -1837,9 +1873,11 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
+    | '/api/ma/tasks/$taskId/validate'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1947,6 +1985,7 @@ export interface RootRouteChildren {
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
+  ApiMaApprovalsRoute: typeof ApiMaApprovalsRouteWithChildren
   ApiMaProfilesRoute: typeof ApiMaProfilesRoute
   ApiMaProjectsRoute: typeof ApiMaProjectsRoute
   ApiMaTasksRoute: typeof ApiMaTasksRouteWithChildren
@@ -2884,6 +2923,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaProfilesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/ma/approvals': {
+      id: '/api/ma/approvals'
+      path: '/api/ma/approvals'
+      fullPath: '/api/ma/approvals'
+      preLoaderRoute: typeof ApiMaApprovalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/knowledge/sync': {
       id: '/api/knowledge/sync'
       path: '/api/knowledge/sync'
@@ -3003,6 +3049,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
       parentRoute: typeof ApiHermesworldReservationsRoute
     }
+    '/api/ma/tasks/$taskId/validate': {
+      id: '/api/ma/tasks/$taskId/validate'
+      path: '/$taskId/validate'
+      fullPath: '/api/ma/tasks/$taskId/validate'
+      preLoaderRoute: typeof ApiMaTasksTaskIdValidateRouteImport
+      parentRoute: typeof ApiMaTasksRoute
+    }
     '/api/ma/tasks/$taskId/start': {
       id: '/api/ma/tasks/$taskId/start'
       path: '/$taskId/start'
@@ -3023,6 +3076,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/ma/tasks/$taskId/diff'
       preLoaderRoute: typeof ApiMaTasksTaskIdDiffRouteImport
       parentRoute: typeof ApiMaTasksRoute
+    }
+    '/api/ma/approvals/$approvalId/resolve': {
+      id: '/api/ma/approvals/$approvalId/resolve'
+      path: '/$approvalId/resolve'
+      fullPath: '/api/ma/approvals/$approvalId/resolve'
+      preLoaderRoute: typeof ApiMaApprovalsApprovalIdResolveRouteImport
+      parentRoute: typeof ApiMaApprovalsRoute
     }
   }
 }
@@ -3213,16 +3273,30 @@ const ApiHermesworldReservationsRouteWithChildren =
     ApiHermesworldReservationsRouteChildren,
   )
 
+interface ApiMaApprovalsRouteChildren {
+  ApiMaApprovalsApprovalIdResolveRoute: typeof ApiMaApprovalsApprovalIdResolveRoute
+}
+
+const ApiMaApprovalsRouteChildren: ApiMaApprovalsRouteChildren = {
+  ApiMaApprovalsApprovalIdResolveRoute: ApiMaApprovalsApprovalIdResolveRoute,
+}
+
+const ApiMaApprovalsRouteWithChildren = ApiMaApprovalsRoute._addFileChildren(
+  ApiMaApprovalsRouteChildren,
+)
+
 interface ApiMaTasksRouteChildren {
   ApiMaTasksTaskIdDiffRoute: typeof ApiMaTasksTaskIdDiffRoute
   ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
   ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
+  ApiMaTasksTaskIdValidateRoute: typeof ApiMaTasksTaskIdValidateRoute
 }
 
 const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
   ApiMaTasksTaskIdDiffRoute: ApiMaTasksTaskIdDiffRoute,
   ApiMaTasksTaskIdEventsRoute: ApiMaTasksTaskIdEventsRoute,
   ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
+  ApiMaTasksTaskIdValidateRoute: ApiMaTasksTaskIdValidateRoute,
 }
 
 const ApiMaTasksRouteWithChildren = ApiMaTasksRoute._addFileChildren(
@@ -3334,6 +3408,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
+  ApiMaApprovalsRoute: ApiMaApprovalsRouteWithChildren,
   ApiMaProfilesRoute: ApiMaProfilesRoute,
   ApiMaProjectsRoute: ApiMaProjectsRoute,
   ApiMaTasksRoute: ApiMaTasksRouteWithChildren,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -167,6 +167,7 @@ import { Route as ApiMaTasksTaskIdSaveSummaryRouteImport } from './routes/api/ma
 import { Route as ApiMaTasksTaskIdPrRouteImport } from './routes/api/ma/tasks.$taskId.pr'
 import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
 import { Route as ApiMaTasksTaskIdDiffRouteImport } from './routes/api/ma/tasks.$taskId.diff'
+import { Route as ApiMaMissionsMissionIdPlanRouteImport } from './routes/api/ma/missions.$missionId.plan'
 import { Route as ApiMaApprovalsApprovalIdResolveRouteImport } from './routes/api/ma/approvals.$approvalId.resolve'
 
 const WorldRoute = WorldRouteImport.update({
@@ -966,6 +967,12 @@ const ApiMaTasksTaskIdDiffRoute = ApiMaTasksTaskIdDiffRouteImport.update({
   path: '/$taskId/diff',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaMissionsMissionIdPlanRoute =
+  ApiMaMissionsMissionIdPlanRouteImport.update({
+    id: '/$missionId/plan',
+    path: '/$missionId/plan',
+    getParentRoute: () => ApiMaMissionsRoute,
+  } as any)
 const ApiMaApprovalsApprovalIdResolveRoute =
   ApiMaApprovalsApprovalIdResolveRouteImport.update({
     id: '/$approvalId/resolve',
@@ -1087,7 +1094,7 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
-  '/api/ma/missions': typeof ApiMaMissionsRoute
+  '/api/ma/missions': typeof ApiMaMissionsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1127,6 +1134,7 @@ export interface FileRoutesByFullPath {
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
+  '/api/ma/missions/$missionId/plan': typeof ApiMaMissionsMissionIdPlanRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
@@ -1247,7 +1255,7 @@ export interface FileRoutesByTo {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
-  '/api/ma/missions': typeof ApiMaMissionsRoute
+  '/api/ma/missions': typeof ApiMaMissionsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1287,6 +1295,7 @@ export interface FileRoutesByTo {
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
+  '/api/ma/missions/$missionId/plan': typeof ApiMaMissionsMissionIdPlanRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
@@ -1409,7 +1418,7 @@ export interface FileRoutesById {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
-  '/api/ma/missions': typeof ApiMaMissionsRoute
+  '/api/ma/missions': typeof ApiMaMissionsRouteWithChildren
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1449,6 +1458,7 @@ export interface FileRoutesById {
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
+  '/api/ma/missions/$missionId/plan': typeof ApiMaMissionsMissionIdPlanRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
@@ -1612,6 +1622,7 @@ export interface FileRouteTypes {
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
     | '/api/ma/approvals/$approvalId/resolve'
+    | '/api/ma/missions/$missionId/plan'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
@@ -1772,6 +1783,7 @@ export interface FileRouteTypes {
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
     | '/api/ma/approvals/$approvalId/resolve'
+    | '/api/ma/missions/$missionId/plan'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
@@ -1933,6 +1945,7 @@ export interface FileRouteTypes {
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
     | '/api/ma/approvals/$approvalId/resolve'
+    | '/api/ma/missions/$missionId/plan'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
@@ -2049,7 +2062,7 @@ export interface RootRouteChildren {
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
   ApiMaApprovalsRoute: typeof ApiMaApprovalsRouteWithChildren
-  ApiMaMissionsRoute: typeof ApiMaMissionsRoute
+  ApiMaMissionsRoute: typeof ApiMaMissionsRouteWithChildren
   ApiMaProfilesRoute: typeof ApiMaProfilesRoute
   ApiMaProjectsRoute: typeof ApiMaProjectsRoute
   ApiMaTasksRoute: typeof ApiMaTasksRouteWithChildren
@@ -3176,6 +3189,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaTasksTaskIdDiffRouteImport
       parentRoute: typeof ApiMaTasksRoute
     }
+    '/api/ma/missions/$missionId/plan': {
+      id: '/api/ma/missions/$missionId/plan'
+      path: '/$missionId/plan'
+      fullPath: '/api/ma/missions/$missionId/plan'
+      preLoaderRoute: typeof ApiMaMissionsMissionIdPlanRouteImport
+      parentRoute: typeof ApiMaMissionsRoute
+    }
     '/api/ma/approvals/$approvalId/resolve': {
       id: '/api/ma/approvals/$approvalId/resolve'
       path: '/$approvalId/resolve'
@@ -3384,6 +3404,18 @@ const ApiMaApprovalsRouteWithChildren = ApiMaApprovalsRoute._addFileChildren(
   ApiMaApprovalsRouteChildren,
 )
 
+interface ApiMaMissionsRouteChildren {
+  ApiMaMissionsMissionIdPlanRoute: typeof ApiMaMissionsMissionIdPlanRoute
+}
+
+const ApiMaMissionsRouteChildren: ApiMaMissionsRouteChildren = {
+  ApiMaMissionsMissionIdPlanRoute: ApiMaMissionsMissionIdPlanRoute,
+}
+
+const ApiMaMissionsRouteWithChildren = ApiMaMissionsRoute._addFileChildren(
+  ApiMaMissionsRouteChildren,
+)
+
 interface ApiMaTasksRouteChildren {
   ApiMaTasksTaskIdDiffRoute: typeof ApiMaTasksTaskIdDiffRoute
   ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
@@ -3514,7 +3546,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
   ApiMaApprovalsRoute: ApiMaApprovalsRouteWithChildren,
-  ApiMaMissionsRoute: ApiMaMissionsRoute,
+  ApiMaMissionsRoute: ApiMaMissionsRouteWithChildren,
   ApiMaProfilesRoute: ApiMaProfilesRoute,
   ApiMaProjectsRoute: ApiMaProjectsRoute,
   ApiMaTasksRoute: ApiMaTasksRouteWithChildren,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as ApiSwarmProjectRouteImport } from './routes/api/swarm-project'
 import { Route as ApiSwarmOrchestratorLoopRouteImport } from './routes/api/swarm-orchestrator-loop'
 import { Route as ApiSwarmMissionsRouteImport } from './routes/api/swarm-missions'
 import { Route as ApiSwarmMemoryRouteImport } from './routes/api/swarm-memory'
+import { Route as ApiSwarmLiveWorkersRouteImport } from './routes/api/swarm-live-workers'
 import { Route as ApiSwarmLifecycleRouteImport } from './routes/api/swarm-lifecycle'
 import { Route as ApiSwarmKanbanRouteImport } from './routes/api/swarm-kanban'
 import { Route as ApiSwarmHealthRouteImport } from './routes/api/swarm-health'
@@ -64,6 +65,7 @@ import { Route as ApiSwarmDirectChatRouteImport } from './routes/api/swarm-direc
 import { Route as ApiSwarmDecomposeRouteImport } from './routes/api/swarm-decompose'
 import { Route as ApiSwarmCheckpointRouteImport } from './routes/api/swarm-checkpoint'
 import { Route as ApiSwarmChatRouteImport } from './routes/api/swarm-chat'
+import { Route as ApiSwarmAutopilotRouteImport } from './routes/api/swarm-autopilot'
 import { Route as ApiStartClaudeRouteImport } from './routes/api/start-claude'
 import { Route as ApiStartAgentRouteImport } from './routes/api/start-agent'
 import { Route as ApiSkillsRouteImport } from './routes/api/skills'
@@ -397,6 +399,11 @@ const ApiSwarmMemoryRoute = ApiSwarmMemoryRouteImport.update({
   path: '/api/swarm-memory',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSwarmLiveWorkersRoute = ApiSwarmLiveWorkersRouteImport.update({
+  id: '/api/swarm-live-workers',
+  path: '/api/swarm-live-workers',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSwarmLifecycleRoute = ApiSwarmLifecycleRouteImport.update({
   id: '/api/swarm-lifecycle',
   path: '/api/swarm-lifecycle',
@@ -440,6 +447,11 @@ const ApiSwarmCheckpointRoute = ApiSwarmCheckpointRouteImport.update({
 const ApiSwarmChatRoute = ApiSwarmChatRouteImport.update({
   id: '/api/swarm-chat',
   path: '/api/swarm-chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSwarmAutopilotRoute = ApiSwarmAutopilotRouteImport.update({
+  id: '/api/swarm-autopilot',
+  path: '/api/swarm-autopilot',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiStartClaudeRoute = ApiStartClaudeRouteImport.update({
@@ -1023,6 +1035,7 @@ export interface FileRoutesByFullPath {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
+  '/api/swarm-autopilot': typeof ApiSwarmAutopilotRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
   '/api/swarm-checkpoint': typeof ApiSwarmCheckpointRoute
   '/api/swarm-decompose': typeof ApiSwarmDecomposeRoute
@@ -1032,6 +1045,7 @@ export interface FileRoutesByFullPath {
   '/api/swarm-health': typeof ApiSwarmHealthRoute
   '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/swarm-lifecycle': typeof ApiSwarmLifecycleRoute
+  '/api/swarm-live-workers': typeof ApiSwarmLiveWorkersRoute
   '/api/swarm-memory': typeof ApiSwarmMemoryRouteWithChildren
   '/api/swarm-missions': typeof ApiSwarmMissionsRoute
   '/api/swarm-orchestrator-loop': typeof ApiSwarmOrchestratorLoopRoute
@@ -1180,6 +1194,7 @@ export interface FileRoutesByTo {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
+  '/api/swarm-autopilot': typeof ApiSwarmAutopilotRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
   '/api/swarm-checkpoint': typeof ApiSwarmCheckpointRoute
   '/api/swarm-decompose': typeof ApiSwarmDecomposeRoute
@@ -1189,6 +1204,7 @@ export interface FileRoutesByTo {
   '/api/swarm-health': typeof ApiSwarmHealthRoute
   '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/swarm-lifecycle': typeof ApiSwarmLifecycleRoute
+  '/api/swarm-live-workers': typeof ApiSwarmLiveWorkersRoute
   '/api/swarm-memory': typeof ApiSwarmMemoryRouteWithChildren
   '/api/swarm-missions': typeof ApiSwarmMissionsRoute
   '/api/swarm-orchestrator-loop': typeof ApiSwarmOrchestratorLoopRoute
@@ -1339,6 +1355,7 @@ export interface FileRoutesById {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
+  '/api/swarm-autopilot': typeof ApiSwarmAutopilotRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
   '/api/swarm-checkpoint': typeof ApiSwarmCheckpointRoute
   '/api/swarm-decompose': typeof ApiSwarmDecomposeRoute
@@ -1348,6 +1365,7 @@ export interface FileRoutesById {
   '/api/swarm-health': typeof ApiSwarmHealthRoute
   '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/swarm-lifecycle': typeof ApiSwarmLifecycleRoute
+  '/api/swarm-live-workers': typeof ApiSwarmLiveWorkersRoute
   '/api/swarm-memory': typeof ApiSwarmMemoryRouteWithChildren
   '/api/swarm-missions': typeof ApiSwarmMissionsRoute
   '/api/swarm-orchestrator-loop': typeof ApiSwarmOrchestratorLoopRoute
@@ -1499,6 +1517,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-claude'
+    | '/api/swarm-autopilot'
     | '/api/swarm-chat'
     | '/api/swarm-checkpoint'
     | '/api/swarm-decompose'
@@ -1508,6 +1527,7 @@ export interface FileRouteTypes {
     | '/api/swarm-health'
     | '/api/swarm-kanban'
     | '/api/swarm-lifecycle'
+    | '/api/swarm-live-workers'
     | '/api/swarm-memory'
     | '/api/swarm-missions'
     | '/api/swarm-orchestrator-loop'
@@ -1656,6 +1676,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-claude'
+    | '/api/swarm-autopilot'
     | '/api/swarm-chat'
     | '/api/swarm-checkpoint'
     | '/api/swarm-decompose'
@@ -1665,6 +1686,7 @@ export interface FileRouteTypes {
     | '/api/swarm-health'
     | '/api/swarm-kanban'
     | '/api/swarm-lifecycle'
+    | '/api/swarm-live-workers'
     | '/api/swarm-memory'
     | '/api/swarm-missions'
     | '/api/swarm-orchestrator-loop'
@@ -1814,6 +1836,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-claude'
+    | '/api/swarm-autopilot'
     | '/api/swarm-chat'
     | '/api/swarm-checkpoint'
     | '/api/swarm-decompose'
@@ -1823,6 +1846,7 @@ export interface FileRouteTypes {
     | '/api/swarm-health'
     | '/api/swarm-kanban'
     | '/api/swarm-lifecycle'
+    | '/api/swarm-live-workers'
     | '/api/swarm-memory'
     | '/api/swarm-missions'
     | '/api/swarm-orchestrator-loop'
@@ -1973,6 +1997,7 @@ export interface RootRouteChildren {
   ApiSkillsRoute: typeof ApiSkillsRouteWithChildren
   ApiStartAgentRoute: typeof ApiStartAgentRoute
   ApiStartClaudeRoute: typeof ApiStartClaudeRoute
+  ApiSwarmAutopilotRoute: typeof ApiSwarmAutopilotRoute
   ApiSwarmChatRoute: typeof ApiSwarmChatRoute
   ApiSwarmCheckpointRoute: typeof ApiSwarmCheckpointRoute
   ApiSwarmDecomposeRoute: typeof ApiSwarmDecomposeRoute
@@ -1982,6 +2007,7 @@ export interface RootRouteChildren {
   ApiSwarmHealthRoute: typeof ApiSwarmHealthRoute
   ApiSwarmKanbanRoute: typeof ApiSwarmKanbanRoute
   ApiSwarmLifecycleRoute: typeof ApiSwarmLifecycleRoute
+  ApiSwarmLiveWorkersRoute: typeof ApiSwarmLiveWorkersRoute
   ApiSwarmMemoryRoute: typeof ApiSwarmMemoryRouteWithChildren
   ApiSwarmMissionsRoute: typeof ApiSwarmMissionsRoute
   ApiSwarmOrchestratorLoopRoute: typeof ApiSwarmOrchestratorLoopRoute
@@ -2353,6 +2379,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSwarmMemoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/swarm-live-workers': {
+      id: '/api/swarm-live-workers'
+      path: '/api/swarm-live-workers'
+      fullPath: '/api/swarm-live-workers'
+      preLoaderRoute: typeof ApiSwarmLiveWorkersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/swarm-lifecycle': {
       id: '/api/swarm-lifecycle'
       path: '/api/swarm-lifecycle'
@@ -2414,6 +2447,13 @@ declare module '@tanstack/react-router' {
       path: '/api/swarm-chat'
       fullPath: '/api/swarm-chat'
       preLoaderRoute: typeof ApiSwarmChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/swarm-autopilot': {
+      id: '/api/swarm-autopilot'
+      path: '/api/swarm-autopilot'
+      fullPath: '/api/swarm-autopilot'
+      preLoaderRoute: typeof ApiSwarmAutopilotRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/start-claude': {
@@ -3414,6 +3454,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSkillsRoute: ApiSkillsRouteWithChildren,
   ApiStartAgentRoute: ApiStartAgentRoute,
   ApiStartClaudeRoute: ApiStartClaudeRoute,
+  ApiSwarmAutopilotRoute: ApiSwarmAutopilotRoute,
   ApiSwarmChatRoute: ApiSwarmChatRoute,
   ApiSwarmCheckpointRoute: ApiSwarmCheckpointRoute,
   ApiSwarmDecomposeRoute: ApiSwarmDecomposeRoute,
@@ -3423,6 +3464,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSwarmHealthRoute: ApiSwarmHealthRoute,
   ApiSwarmKanbanRoute: ApiSwarmKanbanRoute,
   ApiSwarmLifecycleRoute: ApiSwarmLifecycleRoute,
+  ApiSwarmLiveWorkersRoute: ApiSwarmLiveWorkersRoute,
   ApiSwarmMemoryRoute: ApiSwarmMemoryRouteWithChildren,
   ApiSwarmMissionsRoute: ApiSwarmMissionsRoute,
   ApiSwarmOrchestratorLoopRoute: ApiSwarmOrchestratorLoopRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -142,6 +142,7 @@ import { Route as ApiMcpNameRouteImport } from './routes/api/mcp/$name'
 import { Route as ApiMaTasksRouteImport } from './routes/api/ma/tasks'
 import { Route as ApiMaProjectsRouteImport } from './routes/api/ma/projects'
 import { Route as ApiMaProfilesRouteImport } from './routes/api/ma/profiles'
+import { Route as ApiMaMissionsRouteImport } from './routes/api/ma/missions'
 import { Route as ApiMaApprovalsRouteImport } from './routes/api/ma/approvals'
 import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
@@ -834,6 +835,11 @@ const ApiMaProfilesRoute = ApiMaProfilesRouteImport.update({
   path: '/api/ma/profiles',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMaMissionsRoute = ApiMaMissionsRouteImport.update({
+  id: '/api/ma/missions',
+  path: '/api/ma/missions',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiMaApprovalsRoute = ApiMaApprovalsRouteImport.update({
   id: '/api/ma/approvals',
   path: '/api/ma/approvals',
@@ -1081,6 +1087,7 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
+  '/api/ma/missions': typeof ApiMaMissionsRoute
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1240,6 +1247,7 @@ export interface FileRoutesByTo {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
+  '/api/ma/missions': typeof ApiMaMissionsRoute
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1401,6 +1409,7 @@ export interface FileRoutesById {
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
   '/api/ma/approvals': typeof ApiMaApprovalsRouteWithChildren
+  '/api/ma/missions': typeof ApiMaMissionsRoute
   '/api/ma/profiles': typeof ApiMaProfilesRoute
   '/api/ma/projects': typeof ApiMaProjectsRoute
   '/api/ma/tasks': typeof ApiMaTasksRouteWithChildren
@@ -1563,6 +1572,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
     | '/api/ma/approvals'
+    | '/api/ma/missions'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -1722,6 +1732,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
     | '/api/ma/approvals'
+    | '/api/ma/missions'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -1882,6 +1893,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
     | '/api/ma/approvals'
+    | '/api/ma/missions'
     | '/api/ma/profiles'
     | '/api/ma/projects'
     | '/api/ma/tasks'
@@ -2037,6 +2049,7 @@ export interface RootRouteChildren {
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
   ApiMaApprovalsRoute: typeof ApiMaApprovalsRouteWithChildren
+  ApiMaMissionsRoute: typeof ApiMaMissionsRoute
   ApiMaProfilesRoute: typeof ApiMaProfilesRoute
   ApiMaProjectsRoute: typeof ApiMaProjectsRoute
   ApiMaTasksRoute: typeof ApiMaTasksRouteWithChildren
@@ -2988,6 +3001,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaProfilesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/ma/missions': {
+      id: '/api/ma/missions'
+      path: '/api/ma/missions'
+      fullPath: '/api/ma/missions'
+      preLoaderRoute: typeof ApiMaMissionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/ma/approvals': {
       id: '/api/ma/approvals'
       path: '/api/ma/approvals'
@@ -3494,6 +3514,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
   ApiMaApprovalsRoute: ApiMaApprovalsRouteWithChildren,
+  ApiMaMissionsRoute: ApiMaMissionsRoute,
   ApiMaProfilesRoute: ApiMaProfilesRoute,
   ApiMaProjectsRoute: ApiMaProjectsRoute,
   ApiMaTasksRoute: ApiMaTasksRouteWithChildren,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -160,6 +160,7 @@ import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 import { Route as ApiMaTasksTaskIdValidateRouteImport } from './routes/api/ma/tasks.$taskId.validate'
 import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
+import { Route as ApiMaTasksTaskIdSaveSummaryRouteImport } from './routes/api/ma/tasks.$taskId.save-summary'
 import { Route as ApiMaTasksTaskIdPrRouteImport } from './routes/api/ma/tasks.$taskId.pr'
 import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
 import { Route as ApiMaTasksTaskIdDiffRouteImport } from './routes/api/ma/tasks.$taskId.diff'
@@ -926,6 +927,12 @@ const ApiMaTasksTaskIdStartRoute = ApiMaTasksTaskIdStartRouteImport.update({
   path: '/$taskId/start',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaTasksTaskIdSaveSummaryRoute =
+  ApiMaTasksTaskIdSaveSummaryRouteImport.update({
+    id: '/$taskId/save-summary',
+    path: '/$taskId/save-summary',
+    getParentRoute: () => ApiMaTasksRoute,
+  } as any)
 const ApiMaTasksTaskIdPrRoute = ApiMaTasksTaskIdPrRouteImport.update({
   id: '/$taskId/pr',
   path: '/$taskId/pr',
@@ -1102,6 +1109,7 @@ export interface FileRoutesByFullPath {
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
+  '/api/ma/tasks/$taskId/save-summary': typeof ApiMaTasksTaskIdSaveSummaryRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1258,6 +1266,7 @@ export interface FileRoutesByTo {
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
+  '/api/ma/tasks/$taskId/save-summary': typeof ApiMaTasksTaskIdSaveSummaryRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1416,6 +1425,7 @@ export interface FileRoutesById {
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
+  '/api/ma/tasks/$taskId/save-summary': typeof ApiMaTasksTaskIdSaveSummaryRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1575,6 +1585,7 @@ export interface FileRouteTypes {
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
+    | '/api/ma/tasks/$taskId/save-summary'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   fileRoutesByTo: FileRoutesByTo
@@ -1731,6 +1742,7 @@ export interface FileRouteTypes {
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
+    | '/api/ma/tasks/$taskId/save-summary'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   id:
@@ -1888,6 +1900,7 @@ export interface FileRouteTypes {
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/pr'
+    | '/api/ma/tasks/$taskId/save-summary'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   fileRoutesById: FileRoutesById
@@ -3075,6 +3088,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaTasksTaskIdStartRouteImport
       parentRoute: typeof ApiMaTasksRoute
     }
+    '/api/ma/tasks/$taskId/save-summary': {
+      id: '/api/ma/tasks/$taskId/save-summary'
+      path: '/$taskId/save-summary'
+      fullPath: '/api/ma/tasks/$taskId/save-summary'
+      preLoaderRoute: typeof ApiMaTasksTaskIdSaveSummaryRouteImport
+      parentRoute: typeof ApiMaTasksRoute
+    }
     '/api/ma/tasks/$taskId/pr': {
       id: '/api/ma/tasks/$taskId/pr'
       path: '/$taskId/pr'
@@ -3308,6 +3328,7 @@ interface ApiMaTasksRouteChildren {
   ApiMaTasksTaskIdDiffRoute: typeof ApiMaTasksTaskIdDiffRoute
   ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
   ApiMaTasksTaskIdPrRoute: typeof ApiMaTasksTaskIdPrRoute
+  ApiMaTasksTaskIdSaveSummaryRoute: typeof ApiMaTasksTaskIdSaveSummaryRoute
   ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
   ApiMaTasksTaskIdValidateRoute: typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -3316,6 +3337,7 @@ const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
   ApiMaTasksTaskIdDiffRoute: ApiMaTasksTaskIdDiffRoute,
   ApiMaTasksTaskIdEventsRoute: ApiMaTasksTaskIdEventsRoute,
   ApiMaTasksTaskIdPrRoute: ApiMaTasksTaskIdPrRoute,
+  ApiMaTasksTaskIdSaveSummaryRoute: ApiMaTasksTaskIdSaveSummaryRoute,
   ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
   ApiMaTasksTaskIdValidateRoute: ApiMaTasksTaskIdValidateRoute,
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -158,6 +158,7 @@ import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sou
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
+import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -909,6 +910,11 @@ const ApiMaTasksTaskIdStartRoute = ApiMaTasksTaskIdStartRouteImport.update({
   path: '/$taskId/start',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaTasksTaskIdEventsRoute = ApiMaTasksTaskIdEventsRouteImport.update({
+  id: '/$taskId/events',
+  path: '/$taskId/events',
+  getParentRoute: () => ApiMaTasksRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -1059,6 +1065,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRoutesByTo {
@@ -1209,6 +1216,7 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRoutesById {
@@ -1361,6 +1369,7 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
 export interface FileRouteTypes {
@@ -1514,6 +1523,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -1664,6 +1674,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   id:
     | '__root__'
@@ -1815,6 +1826,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   fileRoutesById: FileRoutesById
 }
@@ -2986,6 +2998,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaTasksTaskIdStartRouteImport
       parentRoute: typeof ApiMaTasksRoute
     }
+    '/api/ma/tasks/$taskId/events': {
+      id: '/api/ma/tasks/$taskId/events'
+      path: '/$taskId/events'
+      fullPath: '/api/ma/tasks/$taskId/events'
+      preLoaderRoute: typeof ApiMaTasksTaskIdEventsRouteImport
+      parentRoute: typeof ApiMaTasksRoute
+    }
   }
 }
 
@@ -3176,10 +3195,12 @@ const ApiHermesworldReservationsRouteWithChildren =
   )
 
 interface ApiMaTasksRouteChildren {
+  ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
   ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
 }
 
 const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
+  ApiMaTasksTaskIdEventsRoute: ApiMaTasksTaskIdEventsRoute,
   ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
 }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -160,6 +160,7 @@ import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 import { Route as ApiMaTasksTaskIdValidateRouteImport } from './routes/api/ma/tasks.$taskId.validate'
 import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
+import { Route as ApiMaTasksTaskIdPrRouteImport } from './routes/api/ma/tasks.$taskId.pr'
 import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
 import { Route as ApiMaTasksTaskIdDiffRouteImport } from './routes/api/ma/tasks.$taskId.diff'
 import { Route as ApiMaApprovalsApprovalIdResolveRouteImport } from './routes/api/ma/approvals.$approvalId.resolve'
@@ -925,6 +926,11 @@ const ApiMaTasksTaskIdStartRoute = ApiMaTasksTaskIdStartRouteImport.update({
   path: '/$taskId/start',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaTasksTaskIdPrRoute = ApiMaTasksTaskIdPrRouteImport.update({
+  id: '/$taskId/pr',
+  path: '/$taskId/pr',
+  getParentRoute: () => ApiMaTasksRoute,
+} as any)
 const ApiMaTasksTaskIdEventsRoute = ApiMaTasksTaskIdEventsRouteImport.update({
   id: '/$taskId/events',
   path: '/$taskId/events',
@@ -1095,6 +1101,7 @@ export interface FileRoutesByFullPath {
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
+  '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1250,6 +1257,7 @@ export interface FileRoutesByTo {
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
+  '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1407,6 +1415,7 @@ export interface FileRoutesById {
   '/api/ma/approvals/$approvalId/resolve': typeof ApiMaApprovalsApprovalIdResolveRoute
   '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
+  '/api/ma/tasks/$taskId/pr': typeof ApiMaTasksTaskIdPrRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
   '/api/ma/tasks/$taskId/validate': typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -1565,6 +1574,7 @@ export interface FileRouteTypes {
     | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
+    | '/api/ma/tasks/$taskId/pr'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   fileRoutesByTo: FileRoutesByTo
@@ -1720,6 +1730,7 @@ export interface FileRouteTypes {
     | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
+    | '/api/ma/tasks/$taskId/pr'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   id:
@@ -1876,6 +1887,7 @@ export interface FileRouteTypes {
     | '/api/ma/approvals/$approvalId/resolve'
     | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
+    | '/api/ma/tasks/$taskId/pr'
     | '/api/ma/tasks/$taskId/start'
     | '/api/ma/tasks/$taskId/validate'
   fileRoutesById: FileRoutesById
@@ -3063,6 +3075,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaTasksTaskIdStartRouteImport
       parentRoute: typeof ApiMaTasksRoute
     }
+    '/api/ma/tasks/$taskId/pr': {
+      id: '/api/ma/tasks/$taskId/pr'
+      path: '/$taskId/pr'
+      fullPath: '/api/ma/tasks/$taskId/pr'
+      preLoaderRoute: typeof ApiMaTasksTaskIdPrRouteImport
+      parentRoute: typeof ApiMaTasksRoute
+    }
     '/api/ma/tasks/$taskId/events': {
       id: '/api/ma/tasks/$taskId/events'
       path: '/$taskId/events'
@@ -3288,6 +3307,7 @@ const ApiMaApprovalsRouteWithChildren = ApiMaApprovalsRoute._addFileChildren(
 interface ApiMaTasksRouteChildren {
   ApiMaTasksTaskIdDiffRoute: typeof ApiMaTasksTaskIdDiffRoute
   ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
+  ApiMaTasksTaskIdPrRoute: typeof ApiMaTasksTaskIdPrRoute
   ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
   ApiMaTasksTaskIdValidateRoute: typeof ApiMaTasksTaskIdValidateRoute
 }
@@ -3295,6 +3315,7 @@ interface ApiMaTasksRouteChildren {
 const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
   ApiMaTasksTaskIdDiffRoute: ApiMaTasksTaskIdDiffRoute,
   ApiMaTasksTaskIdEventsRoute: ApiMaTasksTaskIdEventsRoute,
+  ApiMaTasksTaskIdPrRoute: ApiMaTasksTaskIdPrRoute,
   ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
   ApiMaTasksTaskIdValidateRoute: ApiMaTasksTaskIdValidateRoute,
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SwarmRouteImport } from './routes/swarm'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ReserveRouteImport } from './routes/reserve'
+import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
 import { Route as OperationsRouteImport } from './routes/operations'
@@ -73,6 +74,7 @@ import { Route as ApiSessionHistoryRouteImport } from './routes/api/session-hist
 import { Route as ApiSendStreamRouteImport } from './routes/api/send-stream'
 import { Route as ApiSendRouteImport } from './routes/api/send'
 import { Route as ApiProviderUsageRouteImport } from './routes/api/provider-usage'
+import { Route as ApiProjectsRouteImport } from './routes/api/projects'
 import { Route as ApiPreviewFileRouteImport } from './routes/api/preview-file'
 import { Route as ApiPluginsRouteImport } from './routes/api/plugins'
 import { Route as ApiPlaygroundNpcRouteImport } from './routes/api/playground-npc'
@@ -196,6 +198,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ReserveRoute = ReserveRouteImport.update({
   id: '/reserve',
   path: '/reserve',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectsRoute = ProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProfilesRoute = ProfilesRouteImport.update({
@@ -472,6 +479,11 @@ const ApiSendRoute = ApiSendRouteImport.update({
 const ApiProviderUsageRoute = ApiProviderUsageRouteImport.update({
   id: '/api/provider-usage',
   path: '/api/provider-usage',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProjectsRoute = ApiProjectsRouteImport.update({
+  id: '/api/projects',
+  path: '/api/projects',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiPreviewFileRoute = ApiPreviewFileRouteImport.update({
@@ -889,6 +901,7 @@ export interface FileRoutesByFullPath {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/projects': typeof ProjectsRoute
   '/reserve': typeof ReserveRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -930,6 +943,7 @@ export interface FileRoutesByFullPath {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1034,6 +1048,7 @@ export interface FileRoutesByTo {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/projects': typeof ProjectsRoute
   '/reserve': typeof ReserveRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1074,6 +1089,7 @@ export interface FileRoutesByTo {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1179,6 +1195,7 @@ export interface FileRoutesById {
   '/operations': typeof OperationsRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
+  '/projects': typeof ProjectsRoute
   '/reserve': typeof ReserveRouteWithChildren
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
@@ -1220,6 +1237,7 @@ export interface FileRoutesById {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1326,6 +1344,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/projects'
     | '/reserve'
     | '/settings'
     | '/skills'
@@ -1367,6 +1386,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1471,6 +1491,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/projects'
     | '/reserve'
     | '/skills'
     | '/swarm'
@@ -1511,6 +1532,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1615,6 +1637,7 @@ export interface FileRouteTypes {
     | '/operations'
     | '/playground'
     | '/profiles'
+    | '/projects'
     | '/reserve'
     | '/settings'
     | '/skills'
@@ -1656,6 +1679,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1761,6 +1785,7 @@ export interface RootRouteChildren {
   OperationsRoute: typeof OperationsRoute
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
+  ProjectsRoute: typeof ProjectsRoute
   ReserveRoute: typeof ReserveRouteWithChildren
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
@@ -1802,6 +1827,7 @@ export interface RootRouteChildren {
   ApiPlaygroundNpcRoute: typeof ApiPlaygroundNpcRoute
   ApiPluginsRoute: typeof ApiPluginsRoute
   ApiPreviewFileRoute: typeof ApiPreviewFileRoute
+  ApiProjectsRoute: typeof ApiProjectsRoute
   ApiProviderUsageRoute: typeof ApiProviderUsageRoute
   ApiSendRoute: typeof ApiSendRoute
   ApiSendStreamRoute: typeof ApiSendStreamRoute
@@ -1927,6 +1953,13 @@ declare module '@tanstack/react-router' {
       path: '/reserve'
       fullPath: '/reserve'
       preLoaderRoute: typeof ReserveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects': {
+      id: '/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof ProjectsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/profiles': {
@@ -2312,6 +2345,13 @@ declare module '@tanstack/react-router' {
       path: '/api/provider-usage'
       fullPath: '/api/provider-usage'
       preLoaderRoute: typeof ApiProviderUsageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/projects': {
+      id: '/api/projects'
+      path: '/api/projects'
+      fullPath: '/api/projects'
+      preLoaderRoute: typeof ApiProjectsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/preview-file': {
@@ -3071,6 +3111,7 @@ const rootRouteChildren: RootRouteChildren = {
   OperationsRoute: OperationsRoute,
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
+  ProjectsRoute: ProjectsRoute,
   ReserveRoute: ReserveRouteWithChildren,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,
@@ -3112,6 +3153,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaygroundNpcRoute: ApiPlaygroundNpcRoute,
   ApiPluginsRoute: ApiPluginsRoute,
   ApiPreviewFileRoute: ApiPreviewFileRoute,
+  ApiProjectsRoute: ApiProjectsRoute,
   ApiProviderUsageRoute: ApiProviderUsageRoute,
   ApiSendRoute: ApiSendRoute,
   ApiSendStreamRoute: ApiSendStreamRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -159,6 +159,7 @@ import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 import { Route as ApiMaTasksTaskIdStartRouteImport } from './routes/api/ma/tasks.$taskId.start'
 import { Route as ApiMaTasksTaskIdEventsRouteImport } from './routes/api/ma/tasks.$taskId.events'
+import { Route as ApiMaTasksTaskIdDiffRouteImport } from './routes/api/ma/tasks.$taskId.diff'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -915,6 +916,11 @@ const ApiMaTasksTaskIdEventsRoute = ApiMaTasksTaskIdEventsRouteImport.update({
   path: '/$taskId/events',
   getParentRoute: () => ApiMaTasksRoute,
 } as any)
+const ApiMaTasksTaskIdDiffRoute = ApiMaTasksTaskIdDiffRouteImport.update({
+  id: '/$taskId/diff',
+  path: '/$taskId/diff',
+  getParentRoute: () => ApiMaTasksRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -1065,6 +1071,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
@@ -1216,6 +1223,7 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
@@ -1369,6 +1377,7 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/ma/tasks/$taskId/diff': typeof ApiMaTasksTaskIdDiffRoute
   '/api/ma/tasks/$taskId/events': typeof ApiMaTasksTaskIdEventsRoute
   '/api/ma/tasks/$taskId/start': typeof ApiMaTasksTaskIdStartRoute
 }
@@ -1523,6 +1532,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   fileRoutesByTo: FileRoutesByTo
@@ -1674,6 +1684,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   id:
@@ -1826,6 +1837,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/ma/tasks/$taskId/diff'
     | '/api/ma/tasks/$taskId/events'
     | '/api/ma/tasks/$taskId/start'
   fileRoutesById: FileRoutesById
@@ -3005,6 +3017,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMaTasksTaskIdEventsRouteImport
       parentRoute: typeof ApiMaTasksRoute
     }
+    '/api/ma/tasks/$taskId/diff': {
+      id: '/api/ma/tasks/$taskId/diff'
+      path: '/$taskId/diff'
+      fullPath: '/api/ma/tasks/$taskId/diff'
+      preLoaderRoute: typeof ApiMaTasksTaskIdDiffRouteImport
+      parentRoute: typeof ApiMaTasksRoute
+    }
   }
 }
 
@@ -3195,11 +3214,13 @@ const ApiHermesworldReservationsRouteWithChildren =
   )
 
 interface ApiMaTasksRouteChildren {
+  ApiMaTasksTaskIdDiffRoute: typeof ApiMaTasksTaskIdDiffRoute
   ApiMaTasksTaskIdEventsRoute: typeof ApiMaTasksTaskIdEventsRoute
   ApiMaTasksTaskIdStartRoute: typeof ApiMaTasksTaskIdStartRoute
 }
 
 const ApiMaTasksRouteChildren: ApiMaTasksRouteChildren = {
+  ApiMaTasksTaskIdDiffRoute: ApiMaTasksTaskIdDiffRoute,
   ApiMaTasksTaskIdEventsRoute: ApiMaTasksTaskIdEventsRoute,
   ApiMaTasksTaskIdStartRoute: ApiMaTasksTaskIdStartRoute,
 }

--- a/src/routes/api/-conductor-spawn.test.ts
+++ b/src/routes/api/-conductor-spawn.test.ts
@@ -3,6 +3,7 @@ import {
   buildConductorWorkingDirectoryRules,
   buildMissionProjectMetadata,
   buildOrchestratorPrompt,
+  buildProjectOverridePromptBlock,
 } from './conductor-spawn'
 
 describe('buildConductorWorkingDirectoryRules', () => {
@@ -88,6 +89,54 @@ describe('buildMissionProjectMetadata', () => {
       activeProjectName: 'historical-app',
       activeProjectPath: '/workspace/historical-app',
       effectiveWorkingDirectory: '/workspace/historical-app',
+      contextPreview: null,
+      status: null,
     })
+  })
+
+  it('preserves bounded context preview and status from project override', () => {
+    const metadata = buildMissionProjectMetadata({
+      activeProject: {
+        id: 'current',
+        name: 'current-app',
+        path: '/workspace/current-app',
+      },
+      projectsDir: '',
+      override: {
+        activeProjectId: 'project-1',
+        activeProjectName: 'demo-app',
+        activeProjectPath: '/workspace/demo-app',
+        effectiveWorkingDirectory: '/workspace/demo-app',
+        contextPreview: {
+          summary: 'Project summary',
+          files: [
+            {
+              name: 'README.md',
+              path: '/workspace/demo-app/README.md',
+              chars: 900,
+            },
+          ],
+        },
+        status: {
+          gitDirty: true,
+          changedFiles: 3,
+          lastCommit: 'abc1234',
+          lastCommitAt: '2026-01-01T00:00:00Z',
+          detectedStack: ['React', 'TypeScript'],
+          packageManager: 'pnpm',
+        },
+      },
+    })
+
+    const promptBlock = buildProjectOverridePromptBlock(metadata)
+
+    expect(promptBlock).toContain('Project: demo-app')
+    expect(promptBlock).toContain('Git status: 3 changed file(s)')
+    expect(promptBlock).toContain('Stack: React, TypeScript')
+    expect(promptBlock).toContain('Package manager: pnpm')
+    expect(promptBlock).toContain('Project summary')
+    expect(promptBlock).toContain(
+      '- README.md (900 chars): /workspace/demo-app/README.md',
+    )
   })
 })

--- a/src/routes/api/-conductor-spawn.test.ts
+++ b/src/routes/api/-conductor-spawn.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConductorWorkingDirectoryRules,
+  buildMissionProjectMetadata,
+  buildOrchestratorPrompt,
+} from './conductor-spawn'
+
+describe('buildConductorWorkingDirectoryRules', () => {
+  it('uses active project as worker cwd when project directory is not configured', () => {
+    const rules = buildConductorWorkingDirectoryRules({
+      projectsDir: '/tmp/active-project',
+      activeProjectPath: '/tmp/active-project',
+      explicitProjectsDir: false,
+    })
+
+    expect(rules).toContain(
+      '- Primary working directory for every worker: /tmp/active-project',
+    )
+    expect(rules).toContain(
+      '- Every worker prompt MUST include exactly this line: "Working directory: /tmp/active-project"',
+    )
+    expect(rules.join('\n')).toContain(
+      'Project Directory was not configured explicitly',
+    )
+  })
+
+  it('keeps explicit project directory ahead of active project metadata', () => {
+    const rules = buildConductorWorkingDirectoryRules({
+      projectsDir: '/tmp/custom-output',
+      activeProjectPath: '/tmp/active-project',
+      explicitProjectsDir: true,
+    })
+
+    expect(rules).toContain(
+      '- Primary working directory for every worker: /tmp/custom-output',
+    )
+    expect(rules.join('\n')).toContain(
+      'configured Project Directory explicitly',
+    )
+    expect(rules.join('\n')).toContain('/tmp/custom-output')
+  })
+})
+
+describe('buildOrchestratorPrompt', () => {
+  it('injects project context and mandatory worker working directory rules', () => {
+    const prompt = buildOrchestratorPrompt('Ship the slice', 'dispatch skill', {
+      orchestratorModel: '',
+      workerModel: '',
+      projectsDir: '/tmp/active-project',
+      activeProjectPath: '/tmp/active-project',
+      explicitProjectsDir: false,
+      maxParallel: 1,
+      supervised: false,
+      projectContext: '## Active Project Context\nPath: /tmp/active-project',
+    })
+
+    expect(prompt).toContain('## Active Project Context')
+    expect(prompt).toContain('## Worker Working Directory')
+    expect(prompt).toContain(
+      'Primary working directory for every worker: /tmp/active-project',
+    )
+    expect(prompt).toContain('Working directory: /tmp/active-project')
+    expect(prompt).toContain(
+      'Workers should write output to /tmp/active-project/dispatch-<slug> directories',
+    )
+  })
+})
+
+describe('buildMissionProjectMetadata', () => {
+  it('uses historical project override ahead of current active project', () => {
+    const metadata = buildMissionProjectMetadata({
+      activeProject: {
+        id: 'current',
+        name: 'current-app',
+        path: '/workspace/current-app',
+      },
+      projectsDir: '',
+      override: {
+        activeProjectId: 'historical',
+        activeProjectName: 'historical-app',
+        activeProjectPath: '/workspace/historical-app',
+        effectiveWorkingDirectory: '/workspace/historical-app',
+      },
+    })
+
+    expect(metadata).toEqual({
+      activeProjectId: 'historical',
+      activeProjectName: 'historical-app',
+      activeProjectPath: '/workspace/historical-app',
+      effectiveWorkingDirectory: '/workspace/historical-app',
+    })
+  })
+})

--- a/src/routes/api/-swarm-live-workers.test.ts
+++ b/src/routes/api/-swarm-live-workers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { buildSwarmLiveWorkersStartSummary } from '../../server/swarm-live-workers'
+
+describe('buildSwarmLiveWorkersStartSummary', () => {
+  it('summarizes all 15 worker startup results for the UI/API response', () => {
+    const summary = buildSwarmLiveWorkersStartSummary([
+      { workerId: 'swarm1', started: true, alreadyRunning: false, ok: true },
+      { workerId: 'swarm2', started: false, alreadyRunning: true, ok: true },
+      { workerId: 'swarm3', started: false, alreadyRunning: false, ok: false, error: 'tmux failed' },
+    ])
+
+    expect(summary).toEqual({
+      requested: 3,
+      ok: false,
+      started: 1,
+      alreadyRunning: 1,
+      failed: 1,
+    })
+  })
+})

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -10,9 +10,19 @@ import {
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
 import { sanitizeConductorMissionGoal } from '../../server/conductor-mission-sanitize'
-import { getActiveProjectContext } from '../../server/project-registry'
+import {
+  buildProjectContextPromptBlock,
+  getActiveProjectContext,
+} from '../../server/project-registry'
+import type {
+  ProjectRegistryContextPreview,
+  ProjectRegistryStatus,
+} from '../../server/project-registry'
 
 let cachedSkill: string | null = null
+
+const MAX_CONTEXT_PREVIEW_SUMMARY_CHARS = 1200
+const MAX_CONTEXT_PREVIEW_FILES = 8
 
 type ConductorSpawnBody = {
   goal?: unknown
@@ -65,6 +75,69 @@ function readOptionalString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  return `${value.slice(0, maxChars).trimEnd()}…`
+}
+
+function readNullableBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function readNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function readOptionalStringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => readOptionalString(item))
+    .filter((item) => item.length > 0)
+    .slice(0, 12)
+}
+
+function readProjectContextPreview(
+  value: unknown,
+): ProjectRegistryContextPreview | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const summary = truncateText(
+    readOptionalString(record.summary),
+    MAX_CONTEXT_PREVIEW_SUMMARY_CHARS,
+  )
+  const rawFiles = Array.isArray(record.files) ? record.files : []
+  const files = rawFiles
+    .slice(0, MAX_CONTEXT_PREVIEW_FILES)
+    .map((file) => {
+      if (!file || typeof file !== 'object' || Array.isArray(file)) return null
+      const fileRecord = file as Record<string, unknown>
+      const name = readOptionalString(fileRecord.name)
+      const filePath = readOptionalString(fileRecord.path)
+      const chars = readNullableNumber(fileRecord.chars)
+      if (!name || !filePath || chars === null) return null
+      return { name, path: filePath, chars }
+    })
+    .filter(
+      (file): file is { name: string; path: string; chars: number } =>
+        file !== null,
+    )
+  if (!summary && files.length === 0) return null
+  return { summary, files }
+}
+
+function readProjectStatus(value: unknown): ProjectRegistryStatus | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  return {
+    gitDirty: readNullableBoolean(record.gitDirty),
+    changedFiles: readNullableNumber(record.changedFiles),
+    lastCommit: readOptionalString(record.lastCommit) || null,
+    lastCommitAt: readOptionalString(record.lastCommitAt) || null,
+    detectedStack: readOptionalStringArray(record.detectedStack),
+    packageManager: readOptionalString(record.packageManager) || null,
+  }
+}
+
 function readMaxParallel(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 1
   return Math.min(5, Math.max(1, Math.round(value)))
@@ -81,7 +154,18 @@ function readMissionProjectOverride(
     activeProjectPath: readOptionalString(record.activeProjectPath) || null,
     effectiveWorkingDirectory:
       readOptionalString(record.effectiveWorkingDirectory) || null,
+    contextPreview: readProjectContextPreview(record.contextPreview),
+    status: readProjectStatus(record.status),
   }
+}
+
+export type MissionProjectMetadata = {
+  activeProjectId: string | null
+  activeProjectName: string | null
+  activeProjectPath: string | null
+  effectiveWorkingDirectory: string | null
+  contextPreview?: ProjectRegistryContextPreview | null
+  status?: ProjectRegistryStatus | null
 }
 
 export function buildMissionProjectMetadata(params: {
@@ -104,14 +188,58 @@ export function buildMissionProjectMetadata(params: {
       override?.activeProjectName ?? params.activeProject?.name ?? null,
     activeProjectPath,
     effectiveWorkingDirectory,
+    contextPreview: override?.contextPreview ?? null,
+    status: override?.status ?? null,
   }
 }
 
-export type MissionProjectMetadata = {
-  activeProjectId: string | null
-  activeProjectName: string | null
-  activeProjectPath: string | null
-  effectiveWorkingDirectory: string | null
+export function buildProjectOverridePromptBlock(
+  project: MissionProjectMetadata | null,
+): string {
+  if (!project || !project.activeProjectPath) return ''
+  const summary = project.contextPreview?.summary.trim()
+  const files = project.contextPreview?.files ?? []
+  const status = project.status ?? null
+  return [
+    '## Active Project Context',
+    '',
+    `Project: ${project.activeProjectName ?? 'unknown'}`,
+    `Path: ${project.activeProjectPath}`,
+    project.effectiveWorkingDirectory
+      ? `Effective working directory: ${project.effectiveWorkingDirectory}`
+      : null,
+    status
+      ? `Git status: ${
+          status.gitDirty === null
+            ? 'unavailable'
+            : status.gitDirty
+              ? `${status.changedFiles ?? 0} changed file(s)`
+              : 'clean worktree'
+        }`
+      : null,
+    status?.lastCommit
+      ? `Last commit: ${status.lastCommit}${status.lastCommitAt ? ` (${status.lastCommitAt})` : ''}`
+      : null,
+    status && status.detectedStack.length > 0
+      ? `Stack: ${status.detectedStack.join(', ')}`
+      : null,
+    status?.packageManager ? `Package manager: ${status.packageManager}` : null,
+    summary ? ['', '### Auto-context preview', summary].join('\n') : null,
+    files.length > 0
+      ? [
+          '',
+          '### Context files available at project root',
+          ...files.map(
+            (file) => `- ${file.name} (${file.chars} chars): ${file.path}`,
+          ),
+        ].join('\n')
+      : null,
+    '',
+    'Use this project path as the primary working directory for spawned workers unless the user explicitly asks otherwise.',
+    'Workers must inspect the listed project instruction/readme files before editing.',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n')
 }
 
 export type ConductorPromptOptions = {
@@ -338,13 +466,16 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           const explicitProjectsDir = Boolean(
             projectsDir || projectOverride?.effectiveWorkingDirectory,
           )
+          const projectContext = projectOverride
+            ? buildProjectOverridePromptBlock(projectMetadata)
+            : buildProjectContextPromptBlock(activeProject.project)
           const prompt = buildOrchestratorPrompt(goal, loadDispatchSkill(), {
             orchestratorModel,
             workerModel,
             projectsDir: effectiveProjectsDir,
             maxParallel,
             supervised,
-            projectContext: activeProject.promptBlock,
+            projectContext,
             activeProjectPath,
             explicitProjectsDir,
           })

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -10,6 +10,7 @@ import {
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
 import { sanitizeConductorMissionGoal } from '../../server/conductor-mission-sanitize'
+import { getActiveProjectContext } from '../../server/project-registry'
 
 let cachedSkill: string | null = null
 
@@ -20,6 +21,7 @@ type ConductorSpawnBody = {
   projectsDir?: unknown
   maxParallel?: unknown
   supervised?: unknown
+  projectOverride?: unknown
 }
 
 function repoRoot(): string {
@@ -68,18 +70,91 @@ function readMaxParallel(value: unknown): number {
   return Math.min(5, Math.max(1, Math.round(value)))
 }
 
-function buildOrchestratorPrompt(
+function readMissionProjectOverride(
+  value: unknown,
+): Partial<MissionProjectMetadata> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  return {
+    activeProjectId: readOptionalString(record.activeProjectId) || null,
+    activeProjectName: readOptionalString(record.activeProjectName) || null,
+    activeProjectPath: readOptionalString(record.activeProjectPath) || null,
+    effectiveWorkingDirectory:
+      readOptionalString(record.effectiveWorkingDirectory) || null,
+  }
+}
+
+export function buildMissionProjectMetadata(params: {
+  activeProject?: { id: string; name: string; path: string } | null
+  projectsDir?: string
+  override?: Partial<MissionProjectMetadata> | null
+}): MissionProjectMetadata {
+  const override = params.override ?? null
+  const activeProjectPath =
+    override?.activeProjectPath ?? params.activeProject?.path ?? null
+  const effectiveWorkingDirectory =
+    override?.effectiveWorkingDirectory ??
+    params.projectsDir ??
+    activeProjectPath ??
+    null
+  return {
+    activeProjectId:
+      override?.activeProjectId ?? params.activeProject?.id ?? null,
+    activeProjectName:
+      override?.activeProjectName ?? params.activeProject?.name ?? null,
+    activeProjectPath,
+    effectiveWorkingDirectory,
+  }
+}
+
+export type MissionProjectMetadata = {
+  activeProjectId: string | null
+  activeProjectName: string | null
+  activeProjectPath: string | null
+  effectiveWorkingDirectory: string | null
+}
+
+export type ConductorPromptOptions = {
+  orchestratorModel: string
+  workerModel: string
+  projectsDir: string
+  maxParallel: number
+  supervised: boolean
+  projectContext: string
+  activeProjectPath?: string | null
+  explicitProjectsDir?: boolean
+}
+
+export function buildConductorWorkingDirectoryRules(
+  options: Pick<
+    ConductorPromptOptions,
+    'projectsDir' | 'activeProjectPath' | 'explicitProjectsDir'
+  >,
+): Array<string> {
+  const workingDirectory =
+    options.projectsDir || options.activeProjectPath || ''
+  if (!workingDirectory) {
+    return [
+      '- No active project directory was detected. Use /tmp/dispatch-<slug> for worker outputs unless the mission specifies a path.',
+    ]
+  }
+
+  return [
+    `- Primary working directory for every worker: ${workingDirectory}`,
+    `- Every worker prompt MUST include exactly this line: "Working directory: ${workingDirectory}"`,
+    '- Workers must inspect project instructions in that directory before editing, and must not modify files outside it unless the mission explicitly asks for an external output.',
+    options.explicitProjectsDir
+      ? `- The user configured Project Directory explicitly, so use ${workingDirectory} for worker cwd/output even if the active project metadata points somewhere else.`
+      : `- Project Directory was not configured explicitly, so the active project path ${workingDirectory} is the default worker cwd/output root.`,
+  ]
+}
+
+export function buildOrchestratorPrompt(
   goal: string,
   skill: string,
-  options: {
-    orchestratorModel: string
-    workerModel: string
-    projectsDir: string
-    maxParallel: number
-    supervised: boolean
-  },
+  options: ConductorPromptOptions,
 ): string {
-  const outputBase = options.projectsDir || '/tmp'
+  const outputBase = options.projectsDir || options.activeProjectPath || '/tmp'
   const outputPrefix =
     outputBase === '/tmp'
       ? '/tmp/dispatch-<slug>'
@@ -113,6 +188,10 @@ function buildOrchestratorPrompt(
     ...(options.supervised
       ? ['', 'Supervised mode is enabled. Require approval before each task.']
       : []),
+    ...(options.projectContext ? ['', options.projectContext] : []),
+    '',
+    '## Worker Working Directory',
+    ...buildConductorWorkingDirectoryRules(options),
     '',
     '## Critical Rules',
     '- Use create_task / delegate_task to create worker agents for each task',
@@ -244,12 +323,30 @@ export const Route = createFileRoute('/api/conductor-spawn')({
               { status: 400 },
             )
 
+          const activeProject = await getActiveProjectContext()
+          const projectOverride = readMissionProjectOverride(
+            body.projectOverride,
+          )
+          const projectMetadata = buildMissionProjectMetadata({
+            activeProject: activeProject.project,
+            projectsDir,
+            override: projectOverride,
+          })
+          const activeProjectPath = projectMetadata.activeProjectPath
+          const effectiveProjectsDir =
+            projectMetadata.effectiveWorkingDirectory || ''
+          const explicitProjectsDir = Boolean(
+            projectsDir || projectOverride?.effectiveWorkingDirectory,
+          )
           const prompt = buildOrchestratorPrompt(goal, loadDispatchSkill(), {
             orchestratorModel,
             workerModel,
-            projectsDir,
+            projectsDir: effectiveProjectsDir,
             maxParallel,
             supervised,
+            projectContext: activeProject.promptBlock,
+            activeProjectPath,
+            explicitProjectsDir,
           })
           const missionName = `conductor-${Date.now()}`
           const capabilities = await ensureGatewayProbed()
@@ -266,6 +363,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
               jobName: missionName,
               runId: null,
               warnings: goalSanitization.warnings,
+              project: projectMetadata,
             })
           }
 
@@ -287,6 +385,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
             jobName: result.name ?? missionName,
             runId: null,
             warnings: goalSanitization.warnings,
+            project: projectMetadata,
           })
         } catch (error) {
           return json(

--- a/src/routes/api/ma/-approvals.test.ts
+++ b/src/routes/api/ma/-approvals.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createApproval, createMultiAgentStore } from '../../../server/multi-agent/store'
+
+interface ApprovalsRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        GET: (ctx: { request: Request }) => Promise<Response>
+      }
+    }
+  }
+}
+
+interface ResolveRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        POST: (ctx: { request: Request; params: { approvalId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let stateFile = ''
+
+async function loadApprovalsRoute(): Promise<ApprovalsRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({ createFileRoute: () => (cfg: unknown) => cfg }))
+  return (await import('./approvals')) as unknown as ApprovalsRouteModule
+}
+
+async function loadResolveRoute(): Promise<ResolveRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({ createFileRoute: () => (cfg: unknown) => cfg }))
+  return (await import('./approvals.$approvalId.resolve')) as unknown as ResolveRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-approvals-route-'))
+  stateFile = join(tempRoot, 'state.json')
+  process.env = { ...originalEnv, HERMES_MA_STATE_FILE: stateFile }
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('multi-agent approval routes', () => {
+  it('lists pending approvals by default and supports all status filter', async () => {
+    let nextId = 1
+    const store = createMultiAgentStore({ stateFile, id: () => `approval-${nextId++}`, now: () => '2026-05-18T13:00:00.000Z' })
+    const pending = createApproval(store, {
+      taskId: 'task-1',
+      riskLevel: 'high',
+      actionType: 'github.pr_create',
+      title: 'Create PR',
+      description: 'Push branch and create PR',
+      payload: { branch: 'hermes/task-1' },
+    })
+    createApproval(store, {
+      taskId: 'task-2',
+      riskLevel: 'medium',
+      actionType: 'shell.risky',
+      title: 'Run shell command',
+      description: 'Run custom validation',
+      payload: { command: 'pnpm test' },
+    })
+    const second = Object.values((await import('../../../server/multi-agent/store')).loadState(stateFile).approvals).find((approval) => approval.taskId === 'task-2')!
+    ;(await import('../../../server/multi-agent/store')).resolveApproval(store, second.id, 'denied')
+    const mod = await loadApprovalsRoute()
+
+    const pendingRes = await mod.Route.server.handlers.GET({ request: new Request('http://localhost/api/ma/approvals') })
+    expect(pendingRes.status).toBe(200)
+    const pendingBody = await jsonBody<{ ok: boolean; approvals: Array<{ id: string; status: string }> }>(pendingRes)
+    expect(pendingBody.approvals).toEqual([expect.objectContaining({ id: pending.id, status: 'pending' })])
+
+    const allRes = await mod.Route.server.handlers.GET({ request: new Request('http://localhost/api/ma/approvals?status=all') })
+    const allBody = await jsonBody<{ approvals: Array<{ status: string }> }>(allRes)
+    expect(allBody.approvals.map((approval) => approval.status).sort()).toEqual(['denied', 'pending'])
+  })
+
+  it('resolves approvals as approved or denied and rejects unsupported decisions', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'approval', now: () => '2026-05-18T13:00:00.000Z' })
+    const approval = createApproval(store, {
+      taskId: 'task-1',
+      riskLevel: 'critical',
+      actionType: 'git.push',
+      title: 'Push branch',
+      description: 'Push to remote',
+      payload: { branch: 'hermes/task-1' },
+    })
+    const mod = await loadResolveRoute()
+
+    const bad = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/approvals/${approval.id}/resolve`, {
+        method: 'POST',
+        body: JSON.stringify({ decision: 'maybe' }),
+      }),
+      params: { approvalId: approval.id },
+    })
+    expect(bad.status).toBe(400)
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/approvals/${approval.id}/resolve`, {
+        method: 'POST',
+        body: JSON.stringify({ decision: 'approved' }),
+      }),
+      params: { approvalId: approval.id },
+    })
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; approval: { id: string; status: string; resolvedAt: string } }>(res)
+    expect(body.approval).toMatchObject({ id: approval.id, status: 'approved' })
+    expect(body.approval.resolvedAt).toBeTruthy()
+  })
+})

--- a/src/routes/api/ma/-helpers.ts
+++ b/src/routes/api/ma/-helpers.ts
@@ -1,0 +1,24 @@
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { createMultiAgentEventLog } from '../../../server/multi-agent/events'
+import { createMultiAgentStore } from '../../../server/multi-agent/store'
+
+export function unauthorized() {
+  return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+}
+
+export function requireAuthenticated(request: Request): Response | null {
+  return isAuthenticated(request) ? null : unauthorized()
+}
+
+export function getRouteStore() {
+  return createMultiAgentStore({ stateFile: process.env.HERMES_MA_STATE_FILE })
+}
+
+export function getRouteEventLog() {
+  return createMultiAgentEventLog({ eventsDir: process.env.HERMES_MA_EVENTS_DIR })
+}
+
+export function safeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/routes/api/ma/-project-config.test.ts
+++ b/src/routes/api/ma/-project-config.test.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { listConfiguredProjects, resolveConfiguredProject } from './-project-config'
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let repoPath = ''
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const path = mkdtempSync(join(tempRoot, 'repo-'))
+  git(path, ['init', '-b', 'main'])
+  git(path, ['config', 'user.email', 'test@example.com'])
+  git(path, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(path, 'README.md'), '# test repo\n', 'utf-8')
+  git(path, ['add', 'README.md'])
+  git(path, ['commit', '-m', 'initial commit'])
+  return path
+}
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-project-config-'))
+  repoPath = initRepo()
+  process.env = { ...originalEnv }
+  delete process.env.HERMES_MA_PROJECTS_JSON
+  delete process.env.HERMES_MA_PROJECT_PATH
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('multi-agent project route config', () => {
+  it('parses configured projects from shared env once for all ma routes', () => {
+    process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([{ id: 'workspace', repoPath }])
+
+    const projects = listConfiguredProjects()
+    const project = resolveConfiguredProject('workspace')
+
+    expect(projects).toHaveLength(1)
+    expect(projects[0]).toMatchObject({ id: 'workspace', repoPath, defaultBranch: 'main' })
+    expect(project).toMatchObject({ id: 'workspace', repoPath, defaultBranch: 'main' })
+  })
+
+  it('throws a typed not-found error for missing project ids', () => {
+    process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([{ id: 'workspace', repoPath }])
+
+    expect(() => resolveConfiguredProject('missing')).toThrow(
+      expect.objectContaining({ name: 'MultiAgentProjectNotFoundError', statusCode: 404 }),
+    )
+  })
+})

--- a/src/routes/api/ma/-project-config.ts
+++ b/src/routes/api/ma/-project-config.ts
@@ -1,0 +1,34 @@
+import { resolveProject, type ResolveProjectInput } from '../../../server/multi-agent/project-resolver'
+
+export class MultiAgentProjectNotFoundError extends Error {
+  readonly statusCode = 404
+
+  constructor(projectId: string) {
+    super(`Project not found: ${projectId}`)
+    this.name = 'MultiAgentProjectNotFoundError'
+  }
+}
+
+export function listConfiguredProjectInputs(): ResolveProjectInput[] {
+  const raw = process.env.HERMES_MA_PROJECTS_JSON
+  if (raw?.trim()) {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) throw new Error('HERMES_MA_PROJECTS_JSON must be an array')
+    return parsed as ResolveProjectInput[]
+  }
+
+  const singlePath = process.env.HERMES_MA_PROJECT_PATH
+  if (singlePath?.trim()) return [{ repoPath: singlePath }]
+
+  return []
+}
+
+export function listConfiguredProjects() {
+  return listConfiguredProjectInputs().map((project) => resolveProject(project))
+}
+
+export function resolveConfiguredProject(projectId: string) {
+  const project = listConfiguredProjects().find((candidate) => candidate.id === projectId)
+  if (!project) throw new MultiAgentProjectNotFoundError(projectId)
+  return project
+}

--- a/src/routes/api/ma/-routes.test.ts
+++ b/src/routes/api/ma/-routes.test.ts
@@ -99,6 +99,39 @@ describe('multi-agent API routes', () => {
     expect(body.projects[0]).toMatchObject({ id: 'workspace', repoPath, defaultBranch: 'main' })
   })
 
+  it('POST and GET /api/ma/missions persists top-level product missions', async () => {
+    const mod = await loadRoute('./missions')
+    const created = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/missions', {
+        method: 'POST',
+        body: JSON.stringify({
+          projectId: 'workspace',
+          title: 'Autonomous Hermes team',
+          productBrief: {
+            goal: 'Let one mission coordinate multiple Hermes workers.',
+            userStory: 'As an operator, I can create a mission before decomposing it into tasks.',
+            successMetrics: ['mission appears in board'],
+            nonGoals: ['remote worker fleet'],
+          },
+          constraints: ['local single-user only'],
+          desiredOutput: 'Mission ready for planning.',
+        }),
+      }),
+    })
+
+    expect(created.status).toBe(201)
+    const createdBody = await jsonBody<{ ok: boolean; mission: { id: string; title: string; status: string; taskIds: string[] } }>(created)
+    expect(createdBody.ok).toBe(true)
+    expect(createdBody.mission).toMatchObject({ title: 'Autonomous Hermes team', status: 'draft', taskIds: [] })
+
+    const listed = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/missions?project_id=workspace'),
+    })
+    expect(listed.status).toBe(200)
+    const listedBody = await jsonBody<{ ok: boolean; missions: Array<{ id: string; title: string }> }>(listed)
+    expect(listedBody.missions.map((mission) => mission.title)).toEqual(['Autonomous Hermes team'])
+  })
+
   it('GET /api/ma/tasks returns persisted tasks and supports project/status filters', async () => {
     const tasksMod = await loadRoute('./tasks')
     await tasksMod.Route.server.handlers.POST({
@@ -106,6 +139,7 @@ describe('multi-agent API routes', () => {
         method: 'POST',
         body: JSON.stringify({
           projectId: 'workspace',
+          missionId: 'mission-api',
           title: 'Build API',
           description: 'Expose routes',
           assigneeProfileId: 'backend-engineer',
@@ -122,10 +156,10 @@ describe('multi-agent API routes', () => {
     })
 
     expect(res.status).toBe(200)
-    const body = await jsonBody<{ ok: boolean; tasks: Array<{ title: string; status: string }> }>(res)
+    const body = await jsonBody<{ ok: boolean; tasks: Array<{ title: string; status: string; missionId?: string | null }> }>(res)
     expect(body.ok).toBe(true)
     expect(body.tasks).toHaveLength(1)
-    expect(body.tasks[0]).toMatchObject({ title: 'Build API', status: 'ready' })
+    expect(body.tasks[0]).toMatchObject({ title: 'Build API', status: 'ready', missionId: 'mission-api' })
   })
 
   it('POST /api/ma/tasks validates input and creates a task', async () => {
@@ -140,16 +174,31 @@ describe('multi-agent API routes', () => {
           assigneeProfileId: 'backend-engineer',
           priority: 'medium',
           workPacket: 'Add POST route',
+          productBrief: {
+            goal: 'Reduce task creation ambiguity for product work.',
+            userStory: 'As a PM, I can capture the product why before implementation starts.',
+            successMetrics: ['PM can review goal in task detail'],
+            nonGoals: ['full roadmap planner'],
+          },
           acceptanceCriteria: ['Task persisted'],
         }),
       }),
     })
 
     expect(res.status).toBe(201)
-    const body = await jsonBody<{ ok: boolean; task: { id: string; status: string; title: string } }>(res)
+    const body = await jsonBody<{ ok: boolean; task: { id: string; status: string; title: string; productBrief?: { goal: string; userStory: string; successMetrics: string[]; nonGoals: string[] } } }>(res)
     expect(body.ok).toBe(true)
     expect(body.task.id).toMatch(/^task-/)
-    expect(body.task).toMatchObject({ title: 'Create task route', status: 'backlog' })
+    expect(body.task).toMatchObject({
+      title: 'Create task route',
+      status: 'backlog',
+      productBrief: {
+        goal: 'Reduce task creation ambiguity for product work.',
+        userStory: 'As a PM, I can capture the product why before implementation starts.',
+        successMetrics: ['PM can review goal in task detail'],
+        nonGoals: ['full roadmap planner'],
+      },
+    })
   })
 
   it('POST /api/ma/tasks returns 400 for missing title', async () => {

--- a/src/routes/api/ma/-routes.test.ts
+++ b/src/routes/api/ma/-routes.test.ts
@@ -79,6 +79,7 @@ describe('multi-agent API routes', () => {
       'orchestrator',
       'frontend-engineer',
       'backend-engineer',
+      'architect',
       'qa-validator',
       'reviewer',
       'docs-writer',
@@ -130,6 +131,45 @@ describe('multi-agent API routes', () => {
     expect(listed.status).toBe(200)
     const listedBody = await jsonBody<{ ok: boolean; missions: Array<{ id: string; title: string }> }>(listed)
     expect(listedBody.missions.map((mission) => mission.title)).toEqual(['Autonomous Hermes team'])
+  })
+
+  it('POST /api/ma/missions/$missionId/plan creates a deterministic linked task graph', async () => {
+    const missionsMod = await loadRoute('./missions')
+    const planMod = await loadRoute('./missions.$missionId.plan') as unknown as {
+      Route: { server: { handlers: Record<string, (ctx: { request: Request; params: { missionId: string } }) => Promise<Response>> } }
+    }
+    const created = await missionsMod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/missions', {
+        method: 'POST',
+        body: JSON.stringify({
+          projectId: 'workspace',
+          title: 'Autonomous Hermes team',
+          productBrief: {
+            goal: 'Let one mission coordinate multiple Hermes workers.',
+            userStory: 'As an operator, I can generate a task graph from the mission.',
+            successMetrics: ['planner creates tasks'],
+            nonGoals: ['remote worker fleet'],
+          },
+          constraints: ['local single-user only'],
+          desiredOutput: 'Planned task graph ready for execution.',
+        }),
+      }),
+    })
+    const createdBody = await jsonBody<{ mission: { id: string } }>(created)
+
+    const planned = await planMod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/missions/${createdBody.mission.id}/plan`, { method: 'POST' }),
+      params: { missionId: createdBody.mission.id },
+    })
+
+    expect(planned.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; mission: { status: string; taskIds: string[] }; tasks: Array<{ missionId: string; title: string; assigneeProfileId: string }> }>(planned)
+    expect(body.ok).toBe(true)
+    expect(body.mission.status).toBe('planned')
+    expect(body.tasks).toHaveLength(3)
+    expect(body.tasks.map((task) => task.missionId)).toEqual([createdBody.mission.id, createdBody.mission.id, createdBody.mission.id])
+    expect(body.tasks.map((task) => task.assigneeProfileId)).toEqual(['architect', 'backend-engineer', 'qa-validator'])
+    expect(body.mission.taskIds).toEqual(body.tasks.map((task) => expect.stringMatching(/^task-/)))
   })
 
   it('GET /api/ma/tasks returns persisted tasks and supports project/status filters', async () => {

--- a/src/routes/api/ma/-routes.test.ts
+++ b/src/routes/api/ma/-routes.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+interface ApiRouteModule {
+  Route: {
+    server: {
+      handlers: Record<string, (ctx: { request: Request }) => Promise<Response>>
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let stateFile = ''
+let repoPath = ''
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const path = mkdtempSync(join(tempRoot, 'repo-'))
+  git(path, ['init', '-b', 'main'])
+  git(path, ['config', 'user.email', 'test@example.com'])
+  git(path, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(path, 'README.md'), '# test repo\n', 'utf-8')
+  git(path, ['add', 'README.md'])
+  git(path, ['commit', '-m', 'initial commit'])
+  return path
+}
+
+async function loadRoute(relativePath: string): Promise<ApiRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({
+    createFileRoute: () => (cfg: unknown) => cfg,
+  }))
+  return (await import(relativePath)) as unknown as ApiRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-routes-'))
+  stateFile = join(tempRoot, 'state.json')
+  repoPath = initRepo()
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([
+    { id: 'workspace', name: 'Workspace', repoPath, validation: { test: 'pnpm test' } },
+  ])
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('multi-agent API routes', () => {
+  it('GET /api/ma/profiles returns default Hermes Agent profiles', async () => {
+    const mod = await loadRoute('./profiles')
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/profiles'),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; profiles: Array<{ id: string; runtime: string }> }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.profiles.map((profile) => profile.id)).toEqual([
+      'orchestrator',
+      'frontend-engineer',
+      'backend-engineer',
+      'qa-validator',
+      'reviewer',
+      'docs-writer',
+    ])
+    expect(new Set(body.profiles.map((profile) => profile.runtime))).toEqual(new Set(['hermes-agent']))
+  })
+
+  it('GET /api/ma/projects resolves configured projects', async () => {
+    const mod = await loadRoute('./projects')
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/projects'),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; projects: Array<{ id: string; repoPath: string; defaultBranch: string }> }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.projects).toHaveLength(1)
+    expect(body.projects[0]).toMatchObject({ id: 'workspace', repoPath, defaultBranch: 'main' })
+  })
+
+  it('GET /api/ma/tasks returns persisted tasks and supports project/status filters', async () => {
+    const tasksMod = await loadRoute('./tasks')
+    await tasksMod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks', {
+        method: 'POST',
+        body: JSON.stringify({
+          projectId: 'workspace',
+          title: 'Build API',
+          description: 'Expose routes',
+          assigneeProfileId: 'backend-engineer',
+          priority: 'high',
+          workPacket: 'Implement initial routes',
+          acceptanceCriteria: ['Can create task'],
+          status: 'ready',
+        }),
+      }),
+    })
+
+    const res = await tasksMod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/tasks?project_id=workspace&status=ready'),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; tasks: Array<{ title: string; status: string }> }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.tasks).toHaveLength(1)
+    expect(body.tasks[0]).toMatchObject({ title: 'Build API', status: 'ready' })
+  })
+
+  it('POST /api/ma/tasks validates input and creates a task', async () => {
+    const mod = await loadRoute('./tasks')
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks', {
+        method: 'POST',
+        body: JSON.stringify({
+          projectId: 'workspace',
+          title: 'Create task route',
+          description: 'Persist task from route',
+          assigneeProfileId: 'backend-engineer',
+          priority: 'medium',
+          workPacket: 'Add POST route',
+          acceptanceCriteria: ['Task persisted'],
+        }),
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await jsonBody<{ ok: boolean; task: { id: string; status: string; title: string } }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.task.id).toMatch(/^task-/)
+    expect(body.task).toMatchObject({ title: 'Create task route', status: 'backlog' })
+  })
+
+  it('POST /api/ma/tasks returns 400 for missing title', async () => {
+    const mod = await loadRoute('./tasks')
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks', {
+        method: 'POST',
+        body: JSON.stringify({ projectId: 'workspace', assigneeProfileId: 'backend-engineer' }),
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('title is required')
+  })
+
+  it('routes return 401 when password protection is enabled and no auth cookie is present', async () => {
+    process.env.CLAUDE_PASSWORD = 'guard'
+    const mod = await loadRoute('./profiles')
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/profiles'),
+    })
+
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/api/ma/-task-diff.test.ts
+++ b/src/routes/api/ma/-task-diff.test.ts
@@ -1,0 +1,138 @@
+import { execFileSync } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMultiAgentStore, createTask, updateTask } from '../../../server/multi-agent/store'
+
+interface TaskDiffRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        GET: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let repoPath = ''
+let stateFile = ''
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const path = mkdtempSync(join(tempRoot, 'repo-'))
+  git(path, ['init', '-b', 'main'])
+  git(path, ['config', 'user.email', 'test@example.com'])
+  git(path, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(path, 'README.md'), '# test repo\n', 'utf-8')
+  git(path, ['add', 'README.md'])
+  git(path, ['commit', '-m', 'initial commit'])
+  return path
+}
+
+async function loadRoute(): Promise<TaskDiffRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({
+    createFileRoute: () => (cfg: unknown) => cfg,
+  }))
+  return (await import('./tasks.$taskId.diff')) as unknown as TaskDiffRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-diff-route-'))
+  repoPath = initRepo()
+  stateFile = join(tempRoot, 'state.json')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('GET /api/ma/tasks/:taskId/diff', () => {
+  it('returns changed files, stat, and unified diff for a task worktree', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'diff' })
+    const task = updateTask(
+      store,
+      createTask(store, {
+        projectId: 'workspace',
+        title: 'Show diff',
+        description: 'Expose diff',
+        assigneeProfileId: 'backend-engineer',
+      }).id,
+      { worktreePath: repoPath, branchName: 'hermes/task-diff', status: 'review' },
+    )
+    writeFileSync(join(repoPath, 'README.md'), '# changed repo\n', 'utf-8')
+    writeFileSync(join(repoPath, 'new-file.txt'), 'new file\n', 'utf-8')
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/diff`),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{
+      ok: boolean
+      diff: { clean: boolean; changedFiles: string[]; stat: string; diff: string }
+    }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.diff.clean).toBe(false)
+    expect(body.diff.changedFiles).toEqual(['README.md', 'new-file.txt'])
+    expect(body.diff.stat).toContain('README.md')
+    expect(body.diff.stat).toContain('new-file.txt')
+    expect(body.diff.diff).toContain('diff --git a/README.md b/README.md')
+    expect(body.diff.diff).toContain('diff --git a/new-file.txt b/new-file.txt')
+  })
+
+  it('returns 404 for unknown tasks', async () => {
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/tasks/task-missing/diff'),
+      params: { taskId: 'task-missing' },
+    })
+
+    expect(res.status).toBe(404)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('Task not found')
+  })
+
+  it('returns 409 when the task has no worktree yet', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'no-worktree' })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'No worktree',
+      description: 'Cannot diff yet',
+      assigneeProfileId: 'backend-engineer',
+    })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/diff`),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(409)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('has no worktree')
+  })
+})

--- a/src/routes/api/ma/-task-events.test.ts
+++ b/src/routes/api/ma/-task-events.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { appendTaskEvent, createMultiAgentEventLog } from '../../../server/multi-agent/events'
+import { createMultiAgentStore, createTask } from '../../../server/multi-agent/store'
+
+interface TaskEventsRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        GET: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let stateFile = ''
+let eventsDir = ''
+
+async function loadRoute(): Promise<TaskEventsRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({
+    createFileRoute: () => (cfg: unknown) => cfg,
+  }))
+  return (await import('./tasks.$taskId.events')) as unknown as TaskEventsRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-events-route-'))
+  stateFile = join(tempRoot, 'state.json')
+  eventsDir = join(tempRoot, 'events')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_EVENTS_DIR = eventsDir
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('GET /api/ma/tasks/:taskId/events', () => {
+  it('returns events for an existing task in order', async () => {
+    const store = createMultiAgentStore({ stateFile, now: () => '2026-05-18T12:00:00.000Z', id: () => '1' })
+    const eventLog = createMultiAgentEventLog({ eventsDir })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'Stream events',
+      description: 'Expose events',
+      assigneeProfileId: 'backend-engineer',
+    })
+    appendTaskEvent(eventLog, {
+      id: 'event-1',
+      taskId: task.id,
+      type: 'run.started',
+      message: 'started',
+      createdAt: '2026-05-18T12:00:01.000Z',
+    })
+    appendTaskEvent(eventLog, {
+      id: 'event-2',
+      taskId: task.id,
+      type: 'run.log',
+      message: 'hello',
+      createdAt: '2026-05-18T12:00:02.000Z',
+    })
+
+    const mod = await loadRoute()
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/events`),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; events: Array<{ id: string; message: string }> }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.events.map((event) => event.message)).toEqual(['started', 'hello'])
+  })
+
+  it('returns 404 for unknown tasks before reading event files', async () => {
+    const mod = await loadRoute()
+    const res = await mod.Route.server.handlers.GET({
+      request: new Request('http://localhost/api/ma/tasks/task-missing/events'),
+      params: { taskId: 'task-missing' },
+    })
+
+    expect(res.status).toBe(404)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('Task not found')
+  })
+})

--- a/src/routes/api/ma/-task-pr.test.ts
+++ b/src/routes/api/ma/-task-pr.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMultiAgentStore, createTask, listApprovals, resolveApproval, updateTask, saveValidation } from '../../../server/multi-agent/store'
+
+interface TaskPrRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        POST: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let repoPath = ''
+let stateFile = ''
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], { encoding: 'utf-8' }).trim()
+}
+
+function setupRepo(): string {
+  const path = mkdtempSync(join(tempRoot, 'repo-'))
+  git(path, ['init', '-b', 'main'])
+  git(path, ['config', 'user.email', 'test@example.com'])
+  git(path, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(path, 'README.md'), '# repo\n', 'utf-8')
+  git(path, ['add', 'README.md'])
+  git(path, ['commit', '-m', 'initial'])
+  git(path, ['checkout', '-b', 'hermes/task-1-demo'])
+  git(path, ['remote', 'add', 'origin', 'https://github.com/example/repo.git'])
+  return path
+}
+
+async function loadRoute(): Promise<TaskPrRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({ createFileRoute: () => (cfg: unknown) => cfg }))
+  return (await import('./tasks.$taskId.pr')) as unknown as TaskPrRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-pr-route-'))
+  repoPath = setupRepo()
+  stateFile = join(tempRoot, 'state.json')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([{ id: 'workspace', name: 'Workspace', repoPath }])
+  process.env.HERMES_MA_GH_MOCK = '1'
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('POST /api/ma/tasks/:taskId/pr', () => {
+  it('creates a pending approval before executing PR creation', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'id' })
+    const created = createTask(store, { projectId: 'workspace', title: 'Demo PR', description: 'Create PR', assigneeProfileId: 'backend-engineer' })
+    const task = updateTask(store, created.id, { worktreePath: repoPath, branchName: 'hermes/task-1-demo', status: 'review' })
+    saveValidation(store, { id: 'validation-1', taskId: task.id, type: 'test', command: 'pnpm test', status: 'passed', exitCode: 0 })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/pr`, { method: 'POST', body: JSON.stringify({ title: 'Demo PR', body: 'Summary' }) }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(202)
+    const body = await jsonBody<{ ok: boolean; approval: { status: string; actionType: string } }>(res)
+    expect(body.approval).toMatchObject({ status: 'pending', actionType: 'github.pr_create' })
+    expect(listApprovals(store, { taskId: task.id, status: 'pending' })).toHaveLength(1)
+  })
+
+  it('creates a PR artifact after approval is resolved', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'id' })
+    const created = createTask(store, { projectId: 'workspace', title: 'Demo PR', description: 'Create PR', assigneeProfileId: 'backend-engineer' })
+    const task = updateTask(store, created.id, { worktreePath: repoPath, branchName: 'hermes/task-1-demo', status: 'review' })
+    saveValidation(store, { id: 'validation-1', taskId: task.id, type: 'test', command: 'pnpm test', status: 'passed', exitCode: 0 })
+    const approval = (await loadRoute(), listApprovals(store, { taskId: task.id }))[0]
+    // create approval through the first route call to preserve production flow
+    const mod = await loadRoute()
+    await mod.Route.server.handlers.POST({ request: new Request(`http://localhost/api/ma/tasks/${task.id}/pr`, { method: 'POST', body: JSON.stringify({ title: 'Demo PR', body: 'Summary' }) }), params: { taskId: task.id } })
+    const pending = listApprovals(store, { taskId: task.id, status: 'pending' })[0]
+    resolveApproval(store, pending.id, 'approved')
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/pr`, { method: 'POST', body: JSON.stringify({ title: 'Demo PR', body: 'Summary' }) }),
+      params: { taskId: task.id },
+    })
+
+    expect(approval).toBeUndefined()
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; pr: { url: string; artifactId: string } }>(res)
+    expect(body.pr.url).toBe('https://github.com/example/repo/pull/1')
+    expect(body.pr.artifactId).toMatch(/^artifact-/)
+  })
+
+  it('returns conflict when preflight fails', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'id' })
+    const created = createTask(store, { projectId: 'workspace', title: 'No validation', description: 'Create PR', assigneeProfileId: 'backend-engineer' })
+    const task = updateTask(store, created.id, { worktreePath: repoPath, branchName: 'hermes/task-1-demo', status: 'review' })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/pr`, { method: 'POST', body: JSON.stringify({ title: 'Demo PR', body: 'Summary' }) }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(409)
+    const body = await jsonBody<{ ok: boolean; preflight: { ok: boolean } }>(res)
+    expect(body.preflight.ok).toBe(false)
+  })
+})

--- a/src/routes/api/ma/-task-save-summary.test.ts
+++ b/src/routes/api/ma/-task-save-summary.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMultiAgentStore, createRun, createTask, loadState } from '../../../server/multi-agent/store'
+
+interface SaveSummaryRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        POST: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let stateFile = ''
+let obsidianRoot = ''
+
+async function loadRoute(): Promise<SaveSummaryRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({ createFileRoute: () => (cfg: unknown) => cfg }))
+  return (await import('./tasks.$taskId.save-summary')) as unknown as SaveSummaryRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-save-summary-route-'))
+  stateFile = join(tempRoot, 'state.json')
+  obsidianRoot = join(tempRoot, 'Obsidian Runs')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_OBSIDIAN_RUNS_DIR = obsidianRoot
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('POST /api/ma/tasks/:taskId/save-summary', () => {
+  it('stores a final summary on the task latest run and writes optional Obsidian note', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'id', now: () => '2026-05-18T12:00:00.000Z' })
+    const task = createTask(store, { projectId: 'workspace', title: 'Memory hooks', description: 'Persist summary', assigneeProfileId: 'backend-engineer' })
+    const run = createRun(store, { taskId: task.id, profileId: 'backend-engineer', status: 'completed' })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/save-summary`, {
+        method: 'POST',
+        body: JSON.stringify({ summary: 'Final context for future sessions.', saveToObsidian: true }),
+      }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; task: { id: string }; run: { id: string; summary: string }; obsidian?: { path: string } }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.run).toMatchObject({ id: run.id, summary: 'Final context for future sessions.' })
+    expect(body.task).toMatchObject({ id: task.id, finalSummary: 'Final context for future sessions.' })
+    expect(body.obsidian?.path).toMatch(/memory-hooks\.md$/)
+    expect(readFileSync(body.obsidian!.path, 'utf-8')).toContain('Final context for future sessions.')
+    const persistedState = loadState(stateFile)
+    expect(persistedState.runs[run.id]?.summary).toBe('Final context for future sessions.')
+    expect(persistedState.tasks[task.id]?.finalSummary).toBe('Final context for future sessions.')
+  })
+
+  it('returns bad request for empty summary and not found for missing tasks', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'id' })
+    const task = createTask(store, { projectId: 'workspace', title: 'Memory hooks', description: 'Persist summary', assigneeProfileId: 'backend-engineer' })
+    createRun(store, { taskId: task.id, profileId: 'backend-engineer', status: 'completed' })
+    const mod = await loadRoute()
+
+    const empty = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/save-summary`, { method: 'POST', body: JSON.stringify({ summary: '  ' }) }),
+      params: { taskId: task.id },
+    })
+    const missing = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks/missing/save-summary', { method: 'POST', body: JSON.stringify({ summary: 'hello' }) }),
+      params: { taskId: 'missing' },
+    })
+
+    expect(empty.status).toBe(400)
+    expect(missing.status).toBe(404)
+  })
+})

--- a/src/routes/api/ma/-task-start.test.ts
+++ b/src/routes/api/ma/-task-start.test.ts
@@ -61,6 +61,8 @@ beforeEach(() => {
   process.env.HERMES_MA_STATE_FILE = stateFile
   process.env.HERMES_MA_EVENTS_DIR = eventsDir
   process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([{ id: 'workspace', name: 'Workspace', repoPath }])
+  process.env.HERMES_MA_WORKER_COMMAND = process.execPath
+  process.env.HERMES_MA_WORKER_ARGS_JSON = JSON.stringify(['-e', "console.log('route worker done')"])
   delete process.env.CLAUDE_PASSWORD
 })
 
@@ -71,7 +73,7 @@ afterEach(() => {
 })
 
 describe('POST /api/ma/tasks/:taskId/start', () => {
-  it('creates a task worktree, stores branch metadata, and emits an event', async () => {
+  it('creates a task worktree, starts a worker run, stores branch metadata, and emits events', async () => {
     const store = createMultiAgentStore({ stateFile, id: () => '123' })
     const task = createTask(store, {
       projectId: 'workspace',
@@ -89,21 +91,21 @@ describe('POST /api/ma/tasks/:taskId/start', () => {
     expect(res.status).toBe(200)
     const body = await jsonBody<{
       ok: boolean
-      task: { id: string; status: string; branchName: string; worktreePath: string }
-      event: { type: string; message: string }
+      task: { id: string; status: string; branchName: string; worktreePath: string; latestRunId: string }
+      run: { id: string; status: string; profileId: string }
     }>(res)
     expect(body.ok).toBe(true)
     expect(body.task).toMatchObject({
       id: task.id,
-      status: 'ready',
+      status: 'running',
       branchName: 'hermes/task-task-123-build-start-route',
     })
+    expect(body.task.latestRunId).toMatch(/^run-/)
+    expect(body.run).toMatchObject({ id: body.task.latestRunId, status: 'starting', profileId: 'backend-engineer' })
     expect(body.task.worktreePath).toContain('.hermes-worktrees/task-task-123-build-start-route')
     expect(git(body.task.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe(
       'hermes/task-task-123-build-start-route',
     )
-    expect(body.event).toMatchObject({ type: 'worktree.created' })
-
     const eventFile = await readFile(join(eventsDir, `${task.id}.jsonl`), 'utf-8')
     expect(eventFile).toContain('worktree.created')
     expect(eventFile).toContain(body.task.worktreePath)

--- a/src/routes/api/ma/-task-start.test.ts
+++ b/src/routes/api/ma/-task-start.test.ts
@@ -1,0 +1,172 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMultiAgentStore, createTask } from '../../../server/multi-agent/store'
+
+interface StartRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        POST: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let repoPath = ''
+let stateFile = ''
+let eventsDir = ''
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const path = mkdtempSync(join(tempRoot, 'repo-'))
+  git(path, ['init', '-b', 'main'])
+  git(path, ['config', 'user.email', 'test@example.com'])
+  git(path, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(path, 'README.md'), '# test repo\n', 'utf-8')
+  git(path, ['add', 'README.md'])
+  git(path, ['commit', '-m', 'initial commit'])
+  return path
+}
+
+async function loadRoute(): Promise<StartRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({
+    createFileRoute: () => (cfg: unknown) => cfg,
+  }))
+  return (await import('./tasks.$taskId.start')) as unknown as StartRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-start-route-'))
+  repoPath = initRepo()
+  stateFile = join(tempRoot, 'state.json')
+  eventsDir = join(tempRoot, 'events')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_EVENTS_DIR = eventsDir
+  process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([{ id: 'workspace', name: 'Workspace', repoPath }])
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('POST /api/ma/tasks/:taskId/start', () => {
+  it('creates a task worktree, stores branch metadata, and emits an event', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => '123' })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'Build Start Route',
+      description: 'Create worktree only',
+      assigneeProfileId: 'backend-engineer',
+    })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/start`, { method: 'POST' }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{
+      ok: boolean
+      task: { id: string; status: string; branchName: string; worktreePath: string }
+      event: { type: string; message: string }
+    }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.task).toMatchObject({
+      id: task.id,
+      status: 'ready',
+      branchName: 'hermes/task-task-123-build-start-route',
+    })
+    expect(body.task.worktreePath).toContain('.hermes-worktrees/task-task-123-build-start-route')
+    expect(git(body.task.worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe(
+      'hermes/task-task-123-build-start-route',
+    )
+    expect(body.event).toMatchObject({ type: 'worktree.created' })
+
+    const eventFile = await readFile(join(eventsDir, `${task.id}.jsonl`), 'utf-8')
+    expect(eventFile).toContain('worktree.created')
+    expect(eventFile).toContain(body.task.worktreePath)
+  })
+
+  it('returns 404 for an unknown task id', async () => {
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks/task-missing/start', { method: 'POST' }),
+      params: { taskId: 'task-missing' },
+    })
+
+    expect(res.status).toBe(404)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('Task not found')
+  })
+
+  it('returns 404 when the task project is not configured', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'missing-project' })
+    const task = createTask(store, {
+      projectId: 'missing-project',
+      title: 'Missing Project',
+      description: 'No configured project matches',
+      assigneeProfileId: 'backend-engineer',
+    })
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/start`, { method: 'POST' }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(404)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('Project not found')
+  })
+
+  it('returns 409 when the worktree path already exists but is unmanaged', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'conflict' })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'Conflict Path',
+      description: 'Pre-existing unmanaged worktree directory',
+      assigneeProfileId: 'backend-engineer',
+    })
+    const mod = await loadRoute()
+
+    mkdirSync(join(repoPath, '.hermes-worktrees', 'task-task-conflict-conflict-path'), {
+      recursive: true,
+    })
+
+    // Pre-create the generated path outside git's worktree registry.
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/start`, { method: 'POST' }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(409)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.ok).toBe(false)
+    expect(body.error).toContain('Worktree path already exists')
+  })
+})

--- a/src/routes/api/ma/-task-validation.test.ts
+++ b/src/routes/api/ma/-task-validation.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMultiAgentStore, createTask, loadState, updateTask } from '../../../server/multi-agent/store'
+
+interface TaskValidationRouteModule {
+  Route: {
+    server: {
+      handlers: {
+        GET: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+        POST: (ctx: { request: Request; params: { taskId: string } }) => Promise<Response>
+      }
+    }
+  }
+}
+
+const originalEnv = { ...process.env }
+let tempRoot = ''
+let worktreePath = ''
+let stateFile = ''
+
+async function loadRoute(): Promise<TaskValidationRouteModule> {
+  vi.doMock('@tanstack/react-router', () => ({
+    createFileRoute: () => (cfg: unknown) => cfg,
+  }))
+  return (await import('./tasks.$taskId.validate')) as unknown as TaskValidationRouteModule
+}
+
+async function jsonBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  tempRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-validation-route-'))
+  worktreePath = mkdtempSync(join(tempRoot, 'worktree-'))
+  execFileSync('git', ['init', '-b', 'main'], { cwd: worktreePath, stdio: 'ignore' })
+  stateFile = join(tempRoot, 'state.json')
+  process.env = { ...originalEnv }
+  process.env.HERMES_MA_STATE_FILE = stateFile
+  process.env.HERMES_MA_PROJECTS_JSON = JSON.stringify([
+    {
+      id: 'workspace',
+      name: 'Workspace',
+      repoPath: worktreePath,
+      validation: {
+        test: `${process.execPath} -e "console.log('test ok')"`,
+        build: `${process.execPath} -e "console.error('build bad'); process.exit(5)"`,
+      },
+    },
+  ])
+  delete process.env.CLAUDE_PASSWORD
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('POST /api/ma/tasks/:taskId/validate', () => {
+  it('runs configured validation in the task worktree and persists the result', async () => {
+    writeFileSync(join(worktreePath, 'marker.txt'), 'ok\n', 'utf-8')
+    const store = createMultiAgentStore({ stateFile, id: () => 'validation' })
+    const task = updateTask(
+      store,
+      createTask(store, {
+        projectId: 'workspace',
+        title: 'Validate me',
+        description: 'Run test command',
+        assigneeProfileId: 'backend-engineer',
+      }).id,
+      { worktreePath, branchName: 'hermes/task-validate', status: 'review' },
+    )
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/validate`, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'test' }),
+      }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; validation: { id: string; status: string; outputSummary: string; outputArtifactId: string } }>(res)
+    expect(body.ok).toBe(true)
+    expect(body.validation).toMatchObject({ status: 'passed' })
+    expect(body.validation.outputSummary).toContain('test ok')
+    const state = loadState(stateFile)
+    expect(state.validations[body.validation.id]).toMatchObject({ status: 'passed' })
+    const artifact = state.artifacts[body.validation.outputArtifactId]
+    expect(artifact).toMatchObject({ taskId: task.id, type: 'validation-output', title: 'test validation output' })
+    expect(existsSync(artifact.pathOrUrl)).toBe(true)
+    expect(readFileSync(artifact.pathOrUrl, 'utf-8')).toContain('test ok')
+
+    const listRes = await mod.Route.server.handlers.GET({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/validate`, { method: 'GET' }),
+      params: { taskId: task.id },
+    })
+    expect(listRes.status).toBe(200)
+    const listBody = await jsonBody<{ ok: boolean; validations: Array<{ id: string; status: string }> }>(listRes)
+    expect(listBody.validations).toEqual([expect.objectContaining({ id: body.validation.id, status: 'passed' })])
+  })
+
+  it('returns failed validation for non-zero configured commands', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'fail' })
+    const task = updateTask(
+      store,
+      createTask(store, {
+        projectId: 'workspace',
+        title: 'Fail validation',
+        description: 'Run build command',
+        assigneeProfileId: 'backend-engineer',
+      }).id,
+      { worktreePath, branchName: 'hermes/task-fail-validation', status: 'review' },
+    )
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/validate`, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'build' }),
+      }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await jsonBody<{ ok: boolean; validation: { status: string; exitCode: number; outputSummary: string } }>(res)
+    expect(body.validation.status).toBe('failed')
+    expect(body.validation.exitCode).toBe(5)
+    expect(body.validation.outputSummary).toContain('build bad')
+  })
+
+  it('returns 404 for unknown tasks and 409 for tasks without worktrees', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'no-worktree' })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'No worktree',
+      description: 'Cannot validate yet',
+      assigneeProfileId: 'backend-engineer',
+    })
+    const mod = await loadRoute()
+
+    const missing = await mod.Route.server.handlers.POST({
+      request: new Request('http://localhost/api/ma/tasks/task-missing/validate', { method: 'POST' }),
+      params: { taskId: 'task-missing' },
+    })
+    expect(missing.status).toBe(404)
+
+    const noWorktree = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/validate`, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'test' }),
+      }),
+      params: { taskId: task.id },
+    })
+    expect(noWorktree.status).toBe(409)
+  })
+
+  it('rejects custom validation commands until approvals are implemented', async () => {
+    const store = createMultiAgentStore({ stateFile, id: () => 'custom' })
+    const task = updateTask(
+      store,
+      createTask(store, {
+        projectId: 'workspace',
+        title: 'Custom validation',
+        description: 'Needs approval',
+        assigneeProfileId: 'backend-engineer',
+      }).id,
+      { worktreePath, branchName: 'hermes/task-custom-validation', status: 'review' },
+    )
+    const mod = await loadRoute()
+
+    const res = await mod.Route.server.handlers.POST({
+      request: new Request(`http://localhost/api/ma/tasks/${task.id}/validate`, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'custom', command: 'echo unsafe' }),
+      }),
+      params: { taskId: task.id },
+    })
+
+    expect(res.status).toBe(403)
+    const body = await jsonBody<{ ok: boolean; error: string }>(res)
+    expect(body.error).toContain('Custom validation commands require approval')
+  })
+})

--- a/src/routes/api/ma/approvals.$approvalId.resolve.ts
+++ b/src/routes/api/ma/approvals.$approvalId.resolve.ts
@@ -1,0 +1,34 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { resolveApproval } from '../../../server/multi-agent/store'
+import type { MultiAgentApprovalStatus } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+function parseDecision(value: unknown): Extract<MultiAgentApprovalStatus, 'approved' | 'denied'> {
+  if (value === 'approved' || value === 'denied') return value
+  if (value === 'approve') return 'approved'
+  if (value === 'deny') return 'denied'
+  throw new Error('decision must be approved or denied')
+}
+
+export const Route = createFileRoute('/api/ma/approvals/$approvalId/resolve')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const decision = parseDecision(body.decision ?? body.action)
+          const approval = resolveApproval(getRouteStore(), params.approvalId, decision)
+          return json({ ok: true, approval })
+        } catch (err) {
+          const message = safeError(err)
+          const status = message.startsWith('Approval not found') ? 404 : 400
+          return json({ ok: false, error: message }, { status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/approvals.ts
+++ b/src/routes/api/ma/approvals.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { listApprovals } from '../../../server/multi-agent/store'
+import type { MultiAgentApprovalStatus } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+const APPROVAL_STATUSES = new Set<MultiAgentApprovalStatus>(['pending', 'approved', 'denied', 'expired'])
+
+function parseApprovalStatus(value: string | null): MultiAgentApprovalStatus | undefined {
+  if (!value || value === 'pending') return 'pending'
+  if (value === 'all') return undefined
+  if (!APPROVAL_STATUSES.has(value as MultiAgentApprovalStatus)) {
+    throw new Error(`Unsupported approval status: ${value}`)
+  }
+  return value as MultiAgentApprovalStatus
+}
+
+export const Route = createFileRoute('/api/ma/approvals')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const url = new URL(request.url)
+          const status = parseApprovalStatus(url.searchParams.get('status'))
+          const taskId = url.searchParams.get('taskId') ?? url.searchParams.get('task_id') ?? undefined
+          const approvals = listApprovals(getRouteStore(), { status, taskId })
+          return json({ ok: true, approvals })
+        } catch (err) {
+          return json({ ok: false, approvals: [], error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/missions.$missionId.plan.ts
+++ b/src/routes/api/ma/missions.$missionId.plan.ts
@@ -1,0 +1,78 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { loadState, planMissionTasks } from '../../../server/multi-agent/store'
+import type { MultiAgentMission } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+function deterministicMissionPlan(mission: MultiAgentMission) {
+  return [
+    {
+      title: `Architect plan for ${mission.title}`,
+      description: 'Define the task graph, dependencies, risks, and execution boundaries for the mission.',
+      assigneeProfileId: 'architect',
+      priority: 'high' as const,
+      workPacket: [
+        `Mission goal: ${mission.productBrief.goal}`,
+        `User story: ${mission.productBrief.userStory}`,
+        `Constraints: ${mission.constraints.join('; ') || 'none'}`,
+        'Produce an implementation graph and dependency notes.',
+      ].join('\n'),
+      acceptanceCriteria: [
+        'Task graph boundaries are explicit',
+        'Dependencies and approval risks are identified',
+      ],
+    },
+    {
+      title: `Implement core flow for ${mission.title}`,
+      description: 'Build the backend/control-plane changes needed for the mission.',
+      assigneeProfileId: 'backend-engineer',
+      priority: 'medium' as const,
+      workPacket: [
+        `Implement the core flow for: ${mission.productBrief.goal}`,
+        `Desired output: ${mission.desiredOutput || 'working mission slice'}`,
+      ].join('\n'),
+      acceptanceCriteria: [
+        'Core behavior is persisted and observable',
+        'Generated work remains linked to the mission',
+      ],
+    },
+    {
+      title: `Validate mission output for ${mission.title}`,
+      description: 'Run QA/review validation for the mission output and summarize readiness.',
+      assigneeProfileId: 'qa-validator',
+      priority: 'medium' as const,
+      workPacket: [
+        'Validate mission output against success metrics:',
+        ...mission.productBrief.successMetrics.map((metric) => `- ${metric}`),
+      ].join('\n'),
+      acceptanceCriteria: [
+        'Validation evidence is attached to the mission tasks',
+        'Remaining risks are documented before approval',
+      ],
+    },
+  ]
+}
+
+export const Route = createFileRoute('/api/ma/missions/$missionId/plan')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const store = getRouteStore()
+          const state = loadState(store.stateFile, { now: store.now })
+          const mission = state.missions[params.missionId]
+          if (!mission) return json({ ok: false, error: 'Mission not found' }, { status: 404 })
+
+          const tasks = planMissionTasks(store, mission.id, deterministicMissionPlan(mission))
+          const updatedMission = loadState(store.stateFile, { now: store.now }).missions[mission.id]
+          return json({ ok: true, mission: updatedMission, tasks })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/missions.ts
+++ b/src/routes/api/ma/missions.ts
@@ -1,0 +1,97 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { createMission, listMissions } from '../../../server/multi-agent/store'
+import type { MultiAgentMissionStatus, MultiAgentProductBrief } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+const MISSION_STATUSES = new Set<MultiAgentMissionStatus>([
+  'draft',
+  'planned',
+  'running',
+  'waiting_approval',
+  'reviewing',
+  'blocked',
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+function trimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function stringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`${fieldName} must be an array`)
+  return value.map((item) => trimmedString(item)).filter(Boolean)
+}
+
+function parseStatus(value: unknown): MultiAgentMissionStatus | undefined {
+  const status = trimmedString(value)
+  if (!status) return undefined
+  if (!MISSION_STATUSES.has(status as MultiAgentMissionStatus)) {
+    throw new Error(`Unsupported mission status: ${status}`)
+  }
+  return status as MultiAgentMissionStatus
+}
+
+function parseProductBrief(value: unknown): MultiAgentProductBrief {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('productBrief is required')
+  }
+  const brief = value as Record<string, unknown>
+  const productBrief = {
+    goal: trimmedString(brief.goal),
+    userStory: trimmedString(brief.userStory ?? brief.user_story),
+    successMetrics: stringArray(brief.successMetrics ?? brief.success_metrics, 'successMetrics'),
+    nonGoals: stringArray(brief.nonGoals ?? brief.non_goals, 'nonGoals'),
+  }
+  if (!productBrief.goal) throw new Error('productBrief.goal is required')
+  return productBrief
+}
+
+export const Route = createFileRoute('/api/ma/missions')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const url = new URL(request.url)
+          const projectId = url.searchParams.get('project_id') ?? url.searchParams.get('projectId') ?? undefined
+          const status = parseStatus(url.searchParams.get('status'))
+          const missions = listMissions(getRouteStore(), { projectId, status })
+          return json({ ok: true, missions })
+        } catch (err) {
+          return json({ ok: false, missions: [], error: safeError(err) }, { status: 400 })
+        }
+      },
+      POST: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const projectId = trimmedString(body.projectId ?? body.project_id)
+          const title = trimmedString(body.title)
+          if (!projectId) throw new Error('projectId is required')
+          if (!title) throw new Error('title is required')
+
+          const mission = createMission(getRouteStore(), {
+            projectId,
+            title,
+            status: parseStatus(body.status),
+            productBrief: parseProductBrief(body.productBrief ?? body.product_brief),
+            constraints: stringArray(body.constraints, 'constraints'),
+            desiredOutput: trimmedString(body.desiredOutput ?? body.desired_output),
+          })
+
+          return json({ ok: true, mission }, { status: 201 })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/profiles.ts
+++ b/src/routes/api/ma/profiles.ts
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { defaultMultiAgentProfiles } from '../../../server/multi-agent/profiles'
+import { requireAuthenticated, safeError } from './-helpers'
+
+export const Route = createFileRoute('/api/ma/profiles')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          return json({ ok: true, profiles: defaultMultiAgentProfiles() })
+        } catch (err) {
+          return json({ ok: false, profiles: [], error: safeError(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/projects.ts
+++ b/src/routes/api/ma/projects.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { listConfiguredProjects } from './-project-config'
+import { requireAuthenticated, safeError } from './-helpers'
+
+export const Route = createFileRoute('/api/ma/projects')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const projects = listConfiguredProjects()
+          return json({ ok: true, projects })
+        } catch (err) {
+          return json({ ok: false, projects: [], error: safeError(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.diff.ts
+++ b/src/routes/api/ma/tasks.$taskId.diff.ts
@@ -1,0 +1,32 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { getTaskDiff } from '../../../server/multi-agent/diff-manager'
+import { getTask } from '../../../server/multi-agent/store'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/diff')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const store = getRouteStore()
+          const task = getTask(store, params.taskId)
+          if (!task) {
+            return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+          }
+          if (!task.worktreePath) {
+            return json({ ok: false, error: `Task has no worktree yet: ${params.taskId}` }, { status: 409 })
+          }
+
+          const diff = getTaskDiff(task.worktreePath)
+          return json({ ok: true, diff })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.events.ts
+++ b/src/routes/api/ma/tasks.$taskId.events.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { listTaskEvents } from '../../../server/multi-agent/events'
+import { getTask } from '../../../server/multi-agent/store'
+import { getRouteEventLog, getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/events')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const store = getRouteStore()
+          const task = getTask(store, params.taskId)
+          if (!task) {
+            return json({ ok: false, events: [], error: `Task not found: ${params.taskId}` }, { status: 404 })
+          }
+
+          const events = listTaskEvents(getRouteEventLog(), params.taskId)
+          return json({ ok: true, events })
+        } catch (err) {
+          return json({ ok: false, events: [], error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.pr.ts
+++ b/src/routes/api/ma/tasks.$taskId.pr.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from 'node:child_process'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import {
+  buildGitHubPrCommand,
+  getGitHubPrPreflight,
+  type ExecFile,
+} from '../../../server/multi-agent/github-pr-manager'
+import {
+  createApproval,
+  createArtifact,
+  getTask,
+  listApprovals,
+  listTaskValidations,
+  updateTask,
+} from '../../../server/multi-agent/store'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+import { resolveConfiguredProject } from './-project-config'
+
+function prExecFile(): ExecFile {
+  if (process.env.HERMES_MA_GH_MOCK === '1') {
+    return (command, args, options) => {
+      if (command === 'gh' && args.join(' ') === '--version') return 'gh version 2.0.0'
+      if (command === 'gh' && args.join(' ') === 'auth status') return 'Logged in to github.com'
+      if (command === 'gh' && args[0] === 'pr' && args[1] === 'create') return 'https://github.com/example/repo/pull/1'
+      if (command === 'git' && args[0] === 'push') return 'mock push ok'
+      return execFileSync(command, args, { cwd: options?.cwd, encoding: 'utf-8' }).trim()
+    }
+  }
+  return (command, args, options) => execFileSync(command, args, {
+    cwd: options?.cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+  }).trim()
+}
+
+function text(value: unknown, fallback = ''): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function approvalPayload(taskId: string, title: string, body: string, branchName: string, baseBranch: string) {
+  return { taskId, title, body, branchName, baseBranch }
+}
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/pr')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const store = getRouteStore()
+          const task = getTask(store, params.taskId)
+          if (!task) return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+          if (!task.worktreePath || !task.branchName) {
+            return json({ ok: false, error: `Task has no worktree/branch yet: ${params.taskId}` }, { status: 409 })
+          }
+
+          const project = resolveConfiguredProject(task.projectId)
+          const validations = listTaskValidations(store, task.id)
+          const execFile = prExecFile()
+          const preflight = getGitHubPrPreflight({
+            worktreePath: task.worktreePath,
+            branchName: task.branchName,
+            validations,
+            execFile,
+          })
+          if (!preflight.ok) {
+            return json({ ok: false, preflight, error: 'PR preflight failed' }, { status: 409 })
+          }
+
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const title = text(body.title, task.title)
+          const prBody = text(body.body, task.workPacket || task.description || 'Created by Hermes multi-agent control plane.')
+          const baseBranch = text(body.baseBranch ?? body.base_branch, project.defaultBranch)
+          const payload = approvalPayload(task.id, title, prBody, task.branchName, baseBranch)
+
+          const approved = listApprovals(store, { taskId: task.id })
+            .find((approval) => approval.actionType === 'github.pr_create' && approval.status === 'approved')
+          if (!approved) {
+            const existingPending = listApprovals(store, { taskId: task.id })
+              .find((approval) => approval.actionType === 'github.pr_create' && approval.status === 'pending')
+            const approval = existingPending ?? createApproval(store, {
+              taskId: task.id,
+              riskLevel: 'high',
+              actionType: 'github.pr_create',
+              title: `Create PR for ${task.title}`,
+              description: `Push ${task.branchName} and create a GitHub pull request.`,
+              payload,
+            })
+            return json({ ok: false, approval, preflight, error: 'Approval required' }, { status: 202 })
+          }
+
+          execFile('git', ['push', '-u', 'origin', task.branchName], { cwd: task.worktreePath })
+          const prUrl = execFile('gh', buildGitHubPrCommand({
+            title,
+            body: prBody,
+            baseBranch,
+            headBranch: task.branchName,
+            draft: Boolean(body.draft),
+          }), { cwd: task.worktreePath }).split('\n').find(Boolean) ?? ''
+
+          const artifact = createArtifact(store, {
+            taskId: task.id,
+            type: 'github-pr',
+            pathOrUrl: prUrl,
+            title,
+            metadata: { approvalId: approved.id, branchName: task.branchName, baseBranch },
+          })
+          const updatedTask = updateTask(store, task.id, { status: 'review' })
+          return json({ ok: true, pr: { url: prUrl, artifactId: artifact.id }, artifact, task: updatedTask })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.save-summary.ts
+++ b/src/routes/api/ma/tasks.$taskId.save-summary.ts
@@ -1,0 +1,72 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import {
+  getTask,
+  updateRun,
+  updateTask,
+} from '../../../server/multi-agent/store'
+import { saveTaskSummaryToObsidian } from '../../../server/multi-agent/memory-sync'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+function envObsidianRunsDir(): string | undefined {
+  const value = process.env.HERMES_MA_OBSIDIAN_RUNS_DIR?.trim()
+  return value || undefined
+}
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/save-summary')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const summary = typeof body.summary === 'string' ? body.summary.trim() : ''
+          if (!summary) {
+            return json({ ok: false, error: 'Task final summary is required' }, { status: 400 })
+          }
+
+          const store = getRouteStore()
+          const task = getTask(store, params.taskId)
+          if (!task) {
+            return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+          }
+          if (!task.latestRunId) {
+            return json({ ok: false, error: `Task has no run yet: ${params.taskId}` }, { status: 409 })
+          }
+
+          let run
+          try {
+            run = updateRun(store, task.latestRunId, { summary })
+          } catch {
+            return json({ ok: false, error: `Run not found: ${task.latestRunId}` }, { status: 404 })
+          }
+
+          const updatedTask = updateTask(store, task.id, { finalSummary: summary })
+
+          const response: {
+            ok: true
+            task: typeof updatedTask
+            run: typeof run
+            obsidian?: { path: string }
+          } = { ok: true, task: updatedTask, run }
+
+          if (body.saveToObsidian === true) {
+            response.obsidian = saveTaskSummaryToObsidian({
+              obsidianRoot: envObsidianRunsDir(),
+              task: updatedTask,
+              run,
+              summary,
+              savedAt: store.now(),
+            })
+          }
+
+          return json(response)
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.start.ts
+++ b/src/routes/api/ma/tasks.$taskId.start.ts
@@ -1,7 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { appendTaskEvent } from '../../../server/multi-agent/events'
-import { getTask, markTaskWorktreeReady } from '../../../server/multi-agent/store'
+import { defaultMultiAgentProfiles } from '../../../server/multi-agent/profiles'
+import { createRun, getTask, markTaskWorktreeReady } from '../../../server/multi-agent/store'
+import { launchHermesWorker } from '../../../server/multi-agent/hermes-worker-runtime'
 import { createTaskWorktree } from '../../../server/multi-agent/worktree-manager'
 import { getRouteEventLog, getRouteStore, requireAuthenticated, safeError } from './-helpers'
 import { MultiAgentProjectNotFoundError, resolveConfiguredProject } from './-project-config'
@@ -20,6 +22,7 @@ export const Route = createFileRoute('/api/ma/tasks/$taskId/start')({
         if (authFailure) return authFailure
 
         const store = getRouteStore()
+        const eventLog = getRouteEventLog()
         const task = getTask(store, params.taskId)
         if (!task) {
           return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
@@ -27,19 +30,47 @@ export const Route = createFileRoute('/api/ma/tasks/$taskId/start')({
 
         try {
           const project = resolveConfiguredProject(task.projectId)
-          const worktree = await createTaskWorktree(project, task)
-          const updatedTask = markTaskWorktreeReady(store, task.id, worktree)
-          const event = {
-            id: `event-${store.id()}`,
-            taskId: task.id,
-            type: 'worktree.created' as const,
-            message: `Created worktree for ${task.title}`,
-            payload: worktree,
-            createdAt: store.now(),
+          const worktree = task.worktreePath && task.branchName
+            ? { worktreePath: task.worktreePath, branchName: task.branchName }
+            : await createTaskWorktree(project, task)
+          const readyTask = markTaskWorktreeReady(store, task.id, worktree)
+          if (!task.worktreePath || !task.branchName) {
+            appendTaskEvent(eventLog, {
+              id: `event-${store.id()}`,
+              taskId: task.id,
+              type: 'worktree.created' as const,
+              message: `Created worktree for ${task.title}`,
+              payload: worktree,
+              createdAt: store.now(),
+            })
           }
-          appendTaskEvent(getRouteEventLog(), event)
 
-          return json({ ok: true, task: updatedTask, event })
+          const profile =
+            defaultMultiAgentProfiles(store.now()).find(
+              (candidate) => candidate.id === readyTask.assigneeProfileId,
+            ) ?? defaultMultiAgentProfiles(store.now())[0]
+          const run = createRun(store, {
+            taskId: readyTask.id,
+            profileId: profile.id,
+            status: 'starting',
+          })
+          const runningTask = getTask(store, readyTask.id) ?? readyTask
+          const workerCommand = process.env.HERMES_MA_WORKER_COMMAND || undefined
+          const workerArgs = process.env.HERMES_MA_WORKER_ARGS_JSON
+            ? (JSON.parse(process.env.HERMES_MA_WORKER_ARGS_JSON) as string[])
+            : undefined
+          launchHermesWorker({
+            store,
+            eventLog,
+            task: runningTask,
+            run,
+            project,
+            profile,
+            command: workerCommand,
+            args: workerArgs,
+          })
+
+          return json({ ok: true, task: getTask(store, task.id) ?? runningTask, run })
         } catch (err) {
           return json({ ok: false, error: safeError(err) }, { status: statusForStartTaskError(err) })
         }

--- a/src/routes/api/ma/tasks.$taskId.start.ts
+++ b/src/routes/api/ma/tasks.$taskId.start.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { appendTaskEvent } from '../../../server/multi-agent/events'
+import { getTask, markTaskWorktreeReady } from '../../../server/multi-agent/store'
+import { createTaskWorktree } from '../../../server/multi-agent/worktree-manager'
+import { getRouteEventLog, getRouteStore, requireAuthenticated, safeError } from './-helpers'
+import { MultiAgentProjectNotFoundError, resolveConfiguredProject } from './-project-config'
+
+function statusForStartTaskError(err: unknown): number {
+  if (err instanceof MultiAgentProjectNotFoundError) return 404
+  if (err instanceof Error && err.message.includes('Worktree path already exists')) return 409
+  return 500
+}
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/start')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        const store = getRouteStore()
+        const task = getTask(store, params.taskId)
+        if (!task) {
+          return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+        }
+
+        try {
+          const project = resolveConfiguredProject(task.projectId)
+          const worktree = await createTaskWorktree(project, task)
+          const updatedTask = markTaskWorktreeReady(store, task.id, worktree)
+          const event = {
+            id: `event-${store.id()}`,
+            taskId: task.id,
+            type: 'worktree.created' as const,
+            message: `Created worktree for ${task.title}`,
+            payload: worktree,
+            createdAt: store.now(),
+          }
+          appendTaskEvent(getRouteEventLog(), event)
+
+          return json({ ok: true, task: updatedTask, event })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: statusForStartTaskError(err) })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.$taskId.validate.ts
+++ b/src/routes/api/ma/tasks.$taskId.validate.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { runTaskValidation } from '../../../server/multi-agent/validation-runner'
+import { createArtifact, getTask, listTaskValidations, saveValidation } from '../../../server/multi-agent/store'
+import type { MultiAgentValidationType } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+import { MultiAgentProjectNotFoundError, resolveConfiguredProject } from './-project-config'
+
+const VALIDATION_TYPES = new Set<MultiAgentValidationType>(['lint', 'typecheck', 'test', 'build', 'custom'])
+
+function parseValidationType(value: unknown): MultiAgentValidationType {
+  const type = typeof value === 'string' ? value.trim() : ''
+  if (!VALIDATION_TYPES.has(type as MultiAgentValidationType)) {
+    throw new Error(`Unsupported validation type: ${type || '(missing)'}`)
+  }
+  return type as MultiAgentValidationType
+}
+
+function statusForValidationError(err: unknown): number {
+  if (err instanceof MultiAgentProjectNotFoundError) return 404
+  if (err instanceof Error && err.message.includes('Custom validation commands require approval')) return 403
+  return 400
+}
+
+function validationArtifactsDir(stateFile: string): string {
+  return join(dirname(stateFile), 'artifacts', 'validation-output')
+}
+
+function safeValidationFileName(value: string): string {
+  return value.replace(/[^0-9A-Za-z_.-]/g, '-')
+}
+
+export const Route = createFileRoute('/api/ma/tasks/$taskId/validate')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        const store = getRouteStore()
+        const task = getTask(store, params.taskId)
+        if (!task) {
+          return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+        }
+        return json({ ok: true, validations: listTaskValidations(store, task.id) })
+      },
+      POST: async ({ request, params }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const store = getRouteStore()
+          const task = getTask(store, params.taskId)
+          if (!task) {
+            return json({ ok: false, error: `Task not found: ${params.taskId}` }, { status: 404 })
+          }
+          if (!task.worktreePath) {
+            return json({ ok: false, error: `Task has no worktree yet: ${params.taskId}` }, { status: 409 })
+          }
+
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const type = parseValidationType(body.type)
+          const command = typeof body.command === 'string' ? body.command : undefined
+          const project = resolveConfiguredProject(task.projectId)
+          const result = runTaskValidation({
+            taskId: task.id,
+            type,
+            command,
+            validationConfig: project.validation,
+            worktreePath: task.worktreePath,
+            now: store.now,
+            id: store.id,
+          })
+          const outputDir = validationArtifactsDir(store.stateFile)
+          mkdirSync(outputDir, { recursive: true })
+          const outputPath = join(outputDir, `${safeValidationFileName(result.validation.id)}.log`)
+          writeFileSync(outputPath, result.output, 'utf-8')
+          const artifact = createArtifact(store, {
+            taskId: task.id,
+            type: 'validation-output',
+            pathOrUrl: outputPath,
+            title: `${type} validation output`,
+            metadata: {
+              validationId: result.validation.id,
+              status: result.validation.status,
+              exitCode: result.validation.exitCode,
+            },
+          })
+          const validation = saveValidation(store, { ...result.validation, outputArtifactId: artifact.id })
+          return json({ ok: true, validation })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: statusForValidationError(err) })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.ts
+++ b/src/routes/api/ma/tasks.ts
@@ -1,0 +1,101 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { createTask, listTasks } from '../../../server/multi-agent/store'
+import type { MultiAgentPriority, MultiAgentTaskStatus } from '../../../server/multi-agent/types'
+import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
+
+const TASK_STATUSES = new Set<MultiAgentTaskStatus>([
+  'backlog',
+  'ready',
+  'running',
+  'needs_approval',
+  'review',
+  'blocked',
+  'done',
+  'failed',
+  'cancelled',
+])
+
+const TASK_PRIORITIES = new Set<MultiAgentPriority>(['low', 'medium', 'high', 'urgent'])
+
+function trimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) throw new Error('acceptanceCriteria must be an array')
+  return value.map((item) => trimmedString(item)).filter(Boolean)
+}
+
+function parseStatus(value: unknown): MultiAgentTaskStatus | undefined {
+  const status = trimmedString(value)
+  if (!status) return undefined
+  if (!TASK_STATUSES.has(status as MultiAgentTaskStatus)) {
+    throw new Error(`Unsupported task status: ${status}`)
+  }
+  return status as MultiAgentTaskStatus
+}
+
+function parsePriority(value: unknown): MultiAgentPriority | undefined {
+  const priority = trimmedString(value)
+  if (!priority) return undefined
+  if (!TASK_PRIORITIES.has(priority as MultiAgentPriority)) {
+    throw new Error(`Unsupported task priority: ${priority}`)
+  }
+  return priority as MultiAgentPriority
+}
+
+export const Route = createFileRoute('/api/ma/tasks')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const url = new URL(request.url)
+          const status = parseStatus(url.searchParams.get('status'))
+          const projectId = url.searchParams.get('project_id') ?? url.searchParams.get('projectId') ?? undefined
+          const tasks = listTasks(getRouteStore(), { projectId, status })
+          return json({ ok: true, tasks })
+        } catch (err) {
+          return json({ ok: false, tasks: [], error: safeError(err) }, { status: 400 })
+        }
+      },
+      POST: async ({ request }) => {
+        const authFailure = requireAuthenticated(request)
+        if (authFailure) return authFailure
+
+        try {
+          const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const projectId = trimmedString(body.projectId ?? body.project_id)
+          const title = trimmedString(body.title)
+          const description = trimmedString(body.description)
+          const assigneeProfileId = trimmedString(body.assigneeProfileId ?? body.assignee_profile_id)
+
+          if (!projectId) throw new Error('projectId is required')
+          if (!title) throw new Error('title is required')
+          if (!assigneeProfileId) throw new Error('assigneeProfileId is required')
+
+          const task = createTask(getRouteStore(), {
+            projectId,
+            title,
+            description,
+            assigneeProfileId,
+            priority: parsePriority(body.priority),
+            status: parseStatus(body.status),
+            workPacket: trimmedString(body.workPacket ?? body.work_packet),
+            acceptanceCriteria: optionalStringArray(
+              body.acceptanceCriteria ?? body.acceptance_criteria,
+            ),
+          })
+
+          return json({ ok: true, task }, { status: 201 })
+        } catch (err) {
+          return json({ ok: false, error: safeError(err) }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/ma/tasks.ts
+++ b/src/routes/api/ma/tasks.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { createTask, listTasks } from '../../../server/multi-agent/store'
-import type { MultiAgentPriority, MultiAgentTaskStatus } from '../../../server/multi-agent/types'
+import type { MultiAgentPriority, MultiAgentProductBrief, MultiAgentTaskStatus } from '../../../server/multi-agent/types'
 import { getRouteStore, requireAuthenticated, safeError } from './-helpers'
 
 const TASK_STATUSES = new Set<MultiAgentTaskStatus>([
@@ -22,10 +22,22 @@ function trimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function optionalStringArray(value: unknown): string[] | undefined {
+function optionalStringArray(value: unknown, fieldName = 'acceptanceCriteria'): string[] | undefined {
   if (value === undefined) return undefined
-  if (!Array.isArray(value)) throw new Error('acceptanceCriteria must be an array')
+  if (!Array.isArray(value)) throw new Error(`${fieldName} must be an array`)
   return value.map((item) => trimmedString(item)).filter(Boolean)
+}
+
+function optionalProductBrief(value: unknown): MultiAgentProductBrief | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'object' || Array.isArray(value)) throw new Error('productBrief must be an object')
+  const brief = value as Record<string, unknown>
+  const goal = trimmedString(brief.goal)
+  const userStory = trimmedString(brief.userStory ?? brief.user_story)
+  const successMetrics = optionalStringArray(brief.successMetrics ?? brief.success_metrics, 'successMetrics') ?? []
+  const nonGoals = optionalStringArray(brief.nonGoals ?? brief.non_goals, 'nonGoals') ?? []
+  if (!goal && !userStory && !successMetrics.length && !nonGoals.length) return undefined
+  return { goal, userStory, successMetrics, nonGoals }
 }
 
 function parseStatus(value: unknown): MultiAgentTaskStatus | undefined {
@@ -78,14 +90,17 @@ export const Route = createFileRoute('/api/ma/tasks')({
           if (!title) throw new Error('title is required')
           if (!assigneeProfileId) throw new Error('assigneeProfileId is required')
 
+          const missionId = trimmedString(body.missionId ?? body.mission_id)
           const task = createTask(getRouteStore(), {
             projectId,
+            missionId: missionId || undefined,
             title,
             description,
             assigneeProfileId,
             priority: parsePriority(body.priority),
             status: parseStatus(body.status),
             workPacket: trimmedString(body.workPacket ?? body.work_packet),
+            productBrief: optionalProductBrief(body.productBrief ?? body.product_brief),
             acceptanceCriteria: optionalStringArray(
               body.acceptanceCriteria ?? body.acceptance_criteria,
             ),

--- a/src/routes/api/projects.ts
+++ b/src/routes/api/projects.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { buildProjectRegistry } from '../../server/project-registry'
+
+export const Route = createFileRoute('/api/projects')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          return json(await buildProjectRegistry())
+        } catch (err) {
+          return json(
+            {
+              activeProjectId: null,
+              projects: [],
+              fetchedAt: Date.now(),
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/projects.ts
+++ b/src/routes/api/projects.ts
@@ -1,7 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { buildProjectRegistry } from '../../server/project-registry'
+import {
+  buildProjectRegistry,
+  setActiveProjectById,
+} from '../../server/project-registry'
 
 export const Route = createFileRoute('/api/projects')({
   server: {
@@ -21,6 +24,38 @@ export const Route = createFileRoute('/api/projects')({
               error: err instanceof Error ? err.message : String(err),
             },
             { status: 500 },
+          )
+        }
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            activeProjectId?: unknown
+          }
+          const activeProjectId =
+            typeof body.activeProjectId === 'string'
+              ? body.activeProjectId.trim()
+              : ''
+          if (!activeProjectId) {
+            return json(
+              { ok: false, error: 'activeProjectId is required' },
+              { status: 400 },
+            )
+          }
+          return json(await setActiveProjectById(activeProjectId))
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          return json(
+            {
+              activeProjectId: null,
+              projects: [],
+              fetchedAt: Date.now(),
+              error: message,
+            },
+            { status: message === 'Project not found' ? 404 : 500 },
           )
         }
       },

--- a/src/routes/api/swarm-autopilot.ts
+++ b/src/routes/api/swarm-autopilot.ts
@@ -1,0 +1,93 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { buildAutopilotDispatchPlan } from '../../server/swarm-autopilot'
+import { ensureDefaultSwarmLiveWorkers } from '../../server/swarm-live-workers'
+import { DEFAULT_SWARM_AGENT_TEAM } from '../../server/swarm-roster'
+
+type AutopilotRequest = {
+  prompt?: unknown
+  missionTitle?: unknown
+  maxWorkers?: unknown
+  dispatch?: unknown
+  ensureLiveWorkers?: unknown
+  waitForCheckpoint?: unknown
+  checkpointPollSeconds?: unknown
+  timeoutSeconds?: unknown
+}
+
+function numberInRange(value: unknown, fallback: number, min: number, max: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(min, Math.min(max, value))
+    : fallback
+}
+
+export const Route = createFileRoute('/api/swarm-autopilot')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        let body: AutopilotRequest
+        try {
+          body = (await request.json()) as AutopilotRequest
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 })
+        }
+
+        const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+        if (!prompt) return json({ ok: false, error: 'prompt required' }, { status: 400 })
+        if (prompt.length > 32_000) return json({ ok: false, error: 'prompt too long' }, { status: 400 })
+
+        const missionTitle = typeof body.missionTitle === 'string' && body.missionTitle.trim()
+          ? body.missionTitle.trim()
+          : undefined
+        const maxWorkers = numberInRange(body.maxWorkers, 8, 1, DEFAULT_SWARM_AGENT_TEAM.length)
+        const plan = buildAutopilotDispatchPlan({
+          prompt,
+          missionTitle,
+          workers: DEFAULT_SWARM_AGENT_TEAM,
+          maxWorkers,
+        })
+
+        const setup = body.ensureLiveWorkers === false ? null : ensureDefaultSwarmLiveWorkers()
+        if (body.dispatch !== true) {
+          return json({
+            ok: true,
+            dryRun: true,
+            plannedAt: Date.now(),
+            setup,
+            plan,
+          })
+        }
+
+        const res = await fetch(new URL('/api/swarm-dispatch', request.url), {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(request.headers.get('cookie') ? { cookie: request.headers.get('cookie') as string } : {}),
+          },
+          body: JSON.stringify({
+            assignments: plan.assignments,
+            missionTitle: plan.missionTitle,
+            timeoutSeconds: numberInRange(body.timeoutSeconds, 300, 10, 600),
+            waitForCheckpoint: body.waitForCheckpoint !== false,
+            checkpointPollSeconds: numberInRange(body.checkpointPollSeconds, 90, 5, 240),
+            allowAsync: true,
+          }),
+        })
+        const dispatch = await res.json().catch(() => null)
+        return json({
+          ok: res.ok,
+          dryRun: false,
+          plannedAt: Date.now(),
+          setup,
+          plan,
+          dispatch,
+        }, { status: res.ok ? 200 : 502 })
+      },
+    },
+  },
+})

--- a/src/routes/api/swarm-live-workers.ts
+++ b/src/routes/api/swarm-live-workers.ts
@@ -1,0 +1,71 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  buildSwarmLiveWorkersStartSummary,
+  ensureDefaultSwarmLiveWorkers,
+  planDefaultSwarmLiveWorkers,
+  type SwarmWorkerStartResult,
+} from '../../server/swarm-live-workers'
+
+export const Route = createFileRoute('/api/swarm-live-workers')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        return json({ ok: true, workers: planDefaultSwarmLiveWorkers() })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const setup = ensureDefaultSwarmLiveWorkers()
+        const origin = new URL(request.url).origin
+        const cookie = request.headers.get('cookie') ?? ''
+        const results: Array<SwarmWorkerStartResult> = []
+
+        for (const worker of setup.workers) {
+          try {
+            const res = await fetch(`${origin}/api/swarm-tmux-start`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(cookie ? { cookie } : {}),
+              },
+              body: JSON.stringify({ workerId: worker.id }),
+            })
+            const body = await res.json().catch(() => ({})) as Record<string, unknown>
+            results.push({
+              workerId: worker.id,
+              ok: res.ok,
+              started: body.started === true,
+              alreadyRunning: body.alreadyRunning === true,
+              error: res.ok ? undefined : String(body.error ?? `HTTP ${res.status}`),
+            })
+          } catch (error) {
+            results.push({
+              workerId: worker.id,
+              ok: false,
+              started: false,
+              alreadyRunning: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+
+        const summary = buildSwarmLiveWorkersStartSummary(results)
+        return json({
+          ok: summary.ok,
+          setup,
+          start: {
+            summary,
+            results,
+          },
+        }, { status: summary.ok ? 200 : 207 })
+      },
+    },
+  },
+})

--- a/src/routes/conductor.tsx
+++ b/src/routes/conductor.tsx
@@ -1,10 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Conductor } from '@/screens/gateway/conductor'
+import { readConductorTraceSessionKey } from '@/screens/gateway/conductor-trace-hydration'
 
 function ConductorRoute() {
-  return <Conductor />
+  const { traceSessionKey } = Route.useSearch()
+  return <Conductor traceSessionKey={traceSessionKey} />
 }
 
 export const Route = createFileRoute('/conductor')({
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { traceSessionKey?: string } => {
+    const traceSessionKey = readConductorTraceSessionKey(search)
+    return traceSessionKey ? { traceSessionKey } : {}
+  },
   component: ConductorRoute,
 })

--- a/src/routes/projects.tsx
+++ b/src/routes/projects.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { ProjectsScreen } from '@/screens/projects/projects-screen'
+
+function ProjectsRoute() {
+  return <ProjectsScreen />
+}
+
+export const Route = createFileRoute('/projects')({
+  component: ProjectsRoute,
+})

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   ComputerTerminal01Icon,
   DashboardSquare01Icon,
   File01Icon,
+  Folder01Icon,
   McpServerIcon,
   MessageMultiple01Icon,
   Moon02Icon,
@@ -225,7 +226,8 @@ function NavItem({
               style={
                 item.badge === 'NEW'
                   ? {
-                      background: 'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                      background:
+                        'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
                       color: '#0b1320',
                       boxShadow: '0 0 8px rgba(250,204,21,0.4)',
                       letterSpacing: '0.08em',
@@ -547,7 +549,9 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail.section === 'appearance' ? 'appearance' : 'claude')
+      handleOpenSettings(
+        detail.section === 'appearance' ? 'appearance' : 'claude',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -578,6 +582,7 @@ function ChatSidebarComponent({
   const isSkillsActive = pathname === '/skills'
   const isMcpActive = pathname === '/mcp'
   const isFilesActive = pathname === '/files'
+  const isProjectsActive = pathname === '/projects'
   const isPlaygroundActive = pathname === '/playground'
   const isAgoraActive = pathname === '/agora'
   const isTerminalActive = pathname === '/terminal'
@@ -805,6 +810,13 @@ function ChatSidebarComponent({
     },
     {
       kind: 'link',
+      to: '/projects',
+      icon: Folder01Icon,
+      label: 'Projects',
+      active: isProjectsActive,
+    },
+    {
+      kind: 'link',
       to: '/terminal',
       icon: ComputerTerminal01Icon,
       label: t('nav.terminal'),
@@ -845,7 +857,6 @@ function ChatSidebarComponent({
       label: 'Swarm',
       active: isSwarmActive,
     },
-
   ]
 
   const knowledgeItems: Array<NavItemDef> = [
@@ -1036,41 +1047,41 @@ function ChatSidebarComponent({
       {/* Hide when VITE_HERMESWORLD_ENABLED is explicitly '0' */}
       {!isVisuallyCollapsed &&
         (import.meta as any).env?.VITE_HERMESWORLD_ENABLED !== '0' && (
-        <div className="px-2 pb-2">
-          <Link
-            to="/playground"
-            onClick={() => onSelectSession?.()}
-            className={cn(
-              buttonVariants({ variant: 'ghost', size: 'sm' }),
-              'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
-              isPlaygroundActive &&
-                'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
-            )}
-            data-tour="hermesworld"
-          >
-            <HugeiconsIcon
-              icon={Castle02Icon}
-              size={20}
-              strokeWidth={1.5}
-              className="size-5 shrink-0"
-              style={{ color: '#facc15' }}
-            />
-            <span>HermesWorld</span>
-            <span
-              className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
-              style={{
-                background:
-                  'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
-                color: '#0b1320',
-                boxShadow: '0 0 8px rgba(250,204,21,0.4)',
-                letterSpacing: '0.08em',
-              }}
+          <div className="px-2 pb-2">
+            <Link
+              to="/playground"
+              onClick={() => onSelectSession?.()}
+              className={cn(
+                buttonVariants({ variant: 'ghost', size: 'sm' }),
+                'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
+                isPlaygroundActive &&
+                  'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
+              )}
+              data-tour="hermesworld"
             >
-              NEW
-            </span>
-          </Link>
-        </div>
-      )}
+              <HugeiconsIcon
+                icon={Castle02Icon}
+                size={20}
+                strokeWidth={1.5}
+                className="size-5 shrink-0"
+                style={{ color: '#facc15' }}
+              />
+              <span>HermesWorld</span>
+              <span
+                className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
+                style={{
+                  background:
+                    'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                  color: '#0b1320',
+                  boxShadow: '0 0 8px rgba(250,204,21,0.4)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                NEW
+              </span>
+            </Link>
+          </div>
+        )}
 
       {/* ── Scrollable body: nav + sessions ─────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin flex flex-col">

--- a/src/screens/gateway/components/multi-agent-approvals-panel.test.tsx
+++ b/src/screens/gateway/components/multi-agent-approvals-panel.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentApproval } from '../../../server/multi-agent/types'
+import { MultiAgentApprovalsPanel } from './multi-agent-approvals-panel'
+
+const now = '2026-05-18T13:00:00.000Z'
+
+function approval(overrides: Partial<MultiAgentApproval> = {}): MultiAgentApproval {
+  return {
+    id: 'approval-1',
+    taskId: 'task-1',
+    runId: null,
+    riskLevel: 'high',
+    actionType: 'github.pr_create',
+    title: 'Create pull request',
+    description: 'Push branch and open PR',
+    payload: { branch: 'hermes/task-1' },
+    status: 'pending',
+    createdAt: now,
+    resolvedAt: null,
+    ...overrides,
+  }
+}
+
+describe('MultiAgentApprovalsPanel', () => {
+  it('renders pending approvals with approve and deny controls', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentApprovalsPanel
+        approvals={[approval()]}
+        resolvingApprovalId={null}
+        error={null}
+        onResolve={() => undefined}
+      />,
+    )
+
+    expect(html).toContain('Approval Queue')
+    expect(html).toContain('Create pull request')
+    expect(html).toContain('github.pr_create')
+    expect(html).toContain('high')
+    expect(html).toContain('Push branch and open PR')
+    expect(html).toContain('Approve')
+    expect(html).toContain('Deny')
+  })
+
+  it('renders empty, error, and resolving states', () => {
+    const empty = renderToStaticMarkup(<MultiAgentApprovalsPanel approvals={[]} resolvingApprovalId={null} error={null} onResolve={() => undefined} />)
+    const error = renderToStaticMarkup(<MultiAgentApprovalsPanel approvals={[]} resolvingApprovalId={null} error="approval API down" onResolve={() => undefined} />)
+    const resolving = renderToStaticMarkup(<MultiAgentApprovalsPanel approvals={[approval()]} resolvingApprovalId="approval-1" error={null} onResolve={() => undefined} />)
+
+    expect(empty).toContain('No pending approvals')
+    expect(error).toContain('approval API down')
+    expect(resolving).toContain('Resolving')
+  })
+})

--- a/src/screens/gateway/components/multi-agent-approvals-panel.tsx
+++ b/src/screens/gateway/components/multi-agent-approvals-panel.tsx
@@ -1,0 +1,73 @@
+import type { MultiAgentApproval, MultiAgentApprovalStatus } from '../../../server/multi-agent/types'
+
+type ApprovalDecision = Extract<MultiAgentApprovalStatus, 'approved' | 'denied'>
+
+export function MultiAgentApprovalsPanel({
+  approvals,
+  resolvingApprovalId,
+  error,
+  onResolve,
+}: {
+  approvals: MultiAgentApproval[]
+  resolvingApprovalId: string | null
+  error: string | null
+  onResolve: (approvalId: string, decision: ApprovalDecision) => void
+}) {
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Approval Queue</p>
+          <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Pending workspace approvals</h3>
+        </div>
+        <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2.5 py-1 text-xs text-[var(--theme-muted)]">{approvals.length}</span>
+      </div>
+
+      {error ? <p className="mt-3 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
+
+      {approvals.length ? (
+        <ol className="mt-3 space-y-2">
+          {approvals.map((approval) => {
+            const resolving = resolvingApprovalId === approval.id
+            return (
+              <li key={approval.id} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="flex flex-wrap gap-1.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                      <span>{approval.actionType}</span>
+                      <span>·</span>
+                      <span>{approval.riskLevel}</span>
+                    </div>
+                    <h4 className="mt-1 text-sm font-semibold text-[var(--theme-text)]">{approval.title}</h4>
+                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{approval.description}</p>
+                    <p className="mt-2 font-mono text-[10px] text-[var(--theme-muted)]">{approval.taskId}</p>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap justify-end gap-2">
+                  <button
+                    type="button"
+                    disabled={resolving}
+                    onClick={() => onResolve(approval.id, 'denied')}
+                    className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs font-semibold text-[var(--theme-text)] disabled:opacity-40"
+                  >
+                    {resolving ? 'Resolving…' : 'Deny'}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={resolving}
+                    onClick={() => onResolve(approval.id, 'approved')}
+                    className="rounded-lg bg-[var(--theme-accent)] px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40"
+                  >
+                    {resolving ? 'Resolving…' : 'Approve'}
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+      ) : (
+        <p className="mt-3 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No pending approvals.</p>
+      )}
+    </section>
+  )
+}

--- a/src/screens/gateway/components/multi-agent-board-model.test.ts
+++ b/src/screens/gateway/components/multi-agent-board-model.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentTask } from '../../../server/multi-agent/types'
+import {
+  MULTI_AGENT_BOARD_COLUMNS,
+  buildMultiAgentBoardColumns,
+  buildMultiAgentTaskMeta,
+  parseAcceptanceCriteriaDraft,
+} from './multi-agent-board-model'
+
+function task(overrides: Partial<MultiAgentTask>): MultiAgentTask {
+  const now = '2026-05-18T00:00:00.000Z'
+  return {
+    id: overrides.id ?? 'task-1',
+    projectId: overrides.projectId ?? 'project-1',
+    title: overrides.title ?? 'Implement board',
+    description: overrides.description ?? 'Create the agent board UI',
+    status: overrides.status ?? 'backlog',
+    priority: overrides.priority ?? 'medium',
+    assigneeProfileId: overrides.assigneeProfileId ?? 'backend-engineer',
+    parentIds: [],
+    childIds: [],
+    workPacket: overrides.workPacket ?? 'Build the slice',
+    acceptanceCriteria: overrides.acceptanceCriteria ?? ['Shows tasks'],
+    branchName: overrides.branchName ?? null,
+    worktreePath: overrides.worktreePath ?? null,
+    latestRunId: overrides.latestRunId ?? null,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  }
+}
+
+describe('multi-agent board model', () => {
+  it('keeps every MVP task status visible as a board column', () => {
+    expect(MULTI_AGENT_BOARD_COLUMNS.map((column) => column.status)).toEqual([
+      'backlog',
+      'ready',
+      'running',
+      'needs_approval',
+      'review',
+      'blocked',
+      'done',
+      'failed',
+    ])
+  })
+
+  it('groups tasks by status and omits cancelled tasks from active board columns', () => {
+    const columns = buildMultiAgentBoardColumns([
+      task({ id: 'ready-1', status: 'ready' }),
+      task({ id: 'done-1', status: 'done' }),
+      task({ id: 'cancelled-1', status: 'cancelled' }),
+    ])
+
+    expect(columns.find((column) => column.status === 'ready')?.tasks.map((item) => item.id)).toEqual(['ready-1'])
+    expect(columns.find((column) => column.status === 'done')?.tasks.map((item) => item.id)).toEqual(['done-1'])
+    expect(columns.flatMap((column) => column.tasks.map((item) => item.id))).not.toContain('cancelled-1')
+  })
+
+  it('summarizes task branch and worktree readiness for cards', () => {
+    expect(
+      buildMultiAgentTaskMeta(
+        task({
+          status: 'ready',
+          branchName: 'hermes/task-123-board',
+          worktreePath: '/repo/.hermes-worktrees/task-123-board',
+        }),
+      ),
+    ).toMatchObject({
+      statusLabel: 'Ready',
+      priorityLabel: 'Medium',
+      branchLabel: 'hermes/task-123-board',
+      worktreeLabel: 'task-123-board',
+      canStart: true,
+    })
+
+    expect(buildMultiAgentTaskMeta(task({ status: 'running' })).canStart).toBe(false)
+  })
+
+  it('parses acceptance criteria drafts into clean bullet items', () => {
+    expect(parseAcceptanceCriteriaDraft(' - renders board\n\nstarts worktree\n* refreshes tasks ')).toEqual([
+      'renders board',
+      'starts worktree',
+      'refreshes tasks',
+    ])
+  })
+})

--- a/src/screens/gateway/components/multi-agent-board-model.ts
+++ b/src/screens/gateway/components/multi-agent-board-model.ts
@@ -1,0 +1,81 @@
+import type {
+  MultiAgentPriority,
+  MultiAgentTask,
+  MultiAgentTaskStatus,
+} from '../../../server/multi-agent/types'
+
+export type MultiAgentBoardColumnStatus = Exclude<MultiAgentTaskStatus, 'cancelled'>
+
+export type MultiAgentBoardColumnDefinition = {
+  status: MultiAgentBoardColumnStatus
+  label: string
+  hint: string
+}
+
+export const MULTI_AGENT_BOARD_COLUMNS: MultiAgentBoardColumnDefinition[] = [
+  { status: 'backlog', label: 'Backlog', hint: 'Captured work packets' },
+  { status: 'ready', label: 'Ready', hint: 'Worktree-ready tasks' },
+  { status: 'running', label: 'Running', hint: 'Active workers' },
+  { status: 'needs_approval', label: 'Needs Approval', hint: 'Waiting on a human gate' },
+  { status: 'review', label: 'Review', hint: 'Diff and validation pass' },
+  { status: 'blocked', label: 'Blocked', hint: 'Needs intervention' },
+  { status: 'done', label: 'Done', hint: 'Completed slices' },
+  { status: 'failed', label: 'Failed', hint: 'Needs retry or diagnosis' },
+]
+
+const STATUS_LABELS: Record<MultiAgentTaskStatus, string> = {
+  backlog: 'Backlog',
+  ready: 'Ready',
+  running: 'Running',
+  needs_approval: 'Needs Approval',
+  review: 'Review',
+  blocked: 'Blocked',
+  done: 'Done',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+}
+
+const PRIORITY_LABELS: Record<MultiAgentPriority, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  urgent: 'Urgent',
+}
+
+export type MultiAgentBoardColumn = MultiAgentBoardColumnDefinition & {
+  tasks: MultiAgentTask[]
+}
+
+export type MultiAgentTaskMeta = {
+  statusLabel: string
+  priorityLabel: string
+  branchLabel: string
+  worktreeLabel: string
+  canStart: boolean
+}
+
+export function buildMultiAgentBoardColumns(tasks: MultiAgentTask[]): MultiAgentBoardColumn[] {
+  return MULTI_AGENT_BOARD_COLUMNS.map((column) => ({
+    ...column,
+    tasks: tasks
+      .filter((task) => task.status === column.status)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+  }))
+}
+
+export function buildMultiAgentTaskMeta(task: MultiAgentTask): MultiAgentTaskMeta {
+  return {
+    statusLabel: STATUS_LABELS[task.status],
+    priorityLabel: PRIORITY_LABELS[task.priority],
+    branchLabel: task.branchName?.trim() || 'No branch yet',
+    worktreeLabel: task.worktreePath?.split('/').filter(Boolean).pop() || 'No worktree yet',
+    canStart: task.status === 'backlog' || task.status === 'ready',
+  }
+}
+
+export function parseAcceptanceCriteriaDraft(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim().replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+}

--- a/src/screens/gateway/components/multi-agent-board.test.tsx
+++ b/src/screens/gateway/components/multi-agent-board.test.tsx
@@ -45,6 +45,8 @@ describe('MultiAgent mission UI', () => {
         error={null}
         onSelect={() => undefined}
         onCreateMission={() => undefined}
+        onPlanMission={() => undefined}
+        planningMissionId={null}
       />,
     )
 
@@ -53,6 +55,25 @@ describe('MultiAgent mission UI', () => {
     expect(html).toContain('Coordinate several Hermes workers from one mission.')
     expect(html).toContain('2 tasks')
     expect(html).toContain('Workspace')
+    expect(html).toContain('Plan mission')
+  })
+
+  it('renders mission planning state', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentMissionPanel
+        missions={[mission]}
+        projects={[project]}
+        selectedMissionId="mission-1"
+        loading={false}
+        error={null}
+        onSelect={() => undefined}
+        onCreateMission={() => undefined}
+        onPlanMission={() => undefined}
+        planningMissionId="mission-1"
+      />,
+    )
+
+    expect(html).toContain('Planning…')
   })
 
   it('renders create mission dialog fields', () => {

--- a/src/screens/gateway/components/multi-agent-board.test.tsx
+++ b/src/screens/gateway/components/multi-agent-board.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { MultiAgentMission, MultiAgentProject } from '../../../server/multi-agent/types'
+import { MultiAgentCreateMissionDialog, MultiAgentMissionPanel } from './multi-agent-board'
+
+const now = '2026-05-19T10:00:00.000Z'
+
+const project: MultiAgentProject = {
+  id: 'workspace',
+  name: 'Workspace',
+  repoPath: '/repo',
+  defaultBranch: 'main',
+  worktreeRoot: '/repo/.hermes-worktrees',
+  githubRemote: null,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const mission: MultiAgentMission = {
+  id: 'mission-1',
+  projectId: 'workspace',
+  title: 'Real multi-agent team',
+  status: 'draft',
+  productBrief: {
+    goal: 'Coordinate several Hermes workers from one mission.',
+    userStory: 'As an operator, I create one mission before planning tasks.',
+    successMetrics: ['planner creates task graph'],
+    nonGoals: ['remote worker fleet'],
+  },
+  constraints: ['single-user local'],
+  desiredOutput: 'Mission ready for planning.',
+  taskIds: ['task-1', 'task-2'],
+  createdAt: now,
+  updatedAt: now,
+}
+
+describe('MultiAgent mission UI', () => {
+  it('renders mission list and selected mission context', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentMissionPanel
+        missions={[mission]}
+        projects={[project]}
+        selectedMissionId="mission-1"
+        loading={false}
+        error={null}
+        onSelect={() => undefined}
+        onCreateMission={() => undefined}
+      />,
+    )
+
+    expect(html).toContain('Mission Control')
+    expect(html).toContain('Real multi-agent team')
+    expect(html).toContain('Coordinate several Hermes workers from one mission.')
+    expect(html).toContain('2 tasks')
+    expect(html).toContain('Workspace')
+  })
+
+  it('renders create mission dialog fields', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentCreateMissionDialog
+        projects={[project]}
+        creating={false}
+        error={null}
+        onCancel={() => undefined}
+        onCreate={vi.fn()}
+      />,
+    )
+
+    expect(html).toContain('Create Mission')
+    expect(html).toContain('Mission Title')
+    expect(html).toContain('Product Goal')
+    expect(html).toContain('User Story')
+    expect(html).toContain('Success Metrics')
+    expect(html).toContain('Constraints')
+    expect(html).toContain('Desired Output')
+  })
+})

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -14,6 +14,7 @@ import type {
   MultiAgentProfile,
   MultiAgentProject,
   MultiAgentTask,
+  type MultiAgentEvent,
 } from '../../../server/multi-agent/types'
 import {
   buildMultiAgentBoardColumns,
@@ -25,6 +26,7 @@ type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: 
 type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: string }
 type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
 type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
+type TaskEventsResponse = { ok?: boolean; events?: MultiAgentEvent[]; error?: string }
 
 type CreateTaskDraft = {
   projectId: string
@@ -95,6 +97,13 @@ async function startMultiAgentTask(taskId: string): Promise<MultiAgentTask> {
   )
   if (!data.task) throw new Error('Updated task was not returned')
   return data.task
+}
+
+async function fetchMultiAgentTaskEvents(taskId: string): Promise<MultiAgentEvent[]> {
+  const data = await readJson<TaskEventsResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(taskId)}/events`, { cache: 'no-store' }),
+  )
+  return data.events ?? []
 }
 
 function projectLabel(projects: MultiAgentProject[], id: string): string {
@@ -174,10 +183,12 @@ function MultiAgentTaskDetail({
   task,
   projects,
   profiles,
+  events,
 }: {
   task: MultiAgentTask | null
   projects: MultiAgentProject[]
   profiles: MultiAgentProfile[]
+  events: MultiAgentEvent[]
 }) {
   if (!task) {
     return (
@@ -218,6 +229,24 @@ function MultiAgentTaskDetail({
             </ul>
           ) : (
             <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
+          )}
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>
+          {events.length ? (
+            <ol className="mt-2 max-h-72 space-y-2 overflow-auto pr-1">
+              {events.slice(-12).map((event) => (
+                <li key={event.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+                  <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                    <span>{event.type}</span>
+                    <span>{new Date(event.createdAt).toLocaleTimeString()}</span>
+                  </div>
+                  <p className="mt-1 whitespace-pre-wrap text-xs text-[var(--theme-text)]">{event.message}</p>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="mt-2 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No events captured yet.</p>
           )}
         </section>
       </div>
@@ -322,6 +351,14 @@ export function MultiAgentBoard() {
   const tasks = tasksQuery.data ?? []
   const columns = useMemo(() => buildMultiAgentBoardColumns(tasks), [tasks])
   const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? tasks[0] ?? null
+  const selectedTaskEventsQuery = useQuery({
+    queryKey: ['ma', 'tasks', selectedTask?.id, 'events'],
+    queryFn: () => fetchMultiAgentTaskEvents(selectedTask?.id ?? ''),
+    enabled: Boolean(selectedTask?.id),
+    refetchInterval: selectedTask?.status === 'running' ? 2_000 : false,
+    staleTime: 1_000,
+  })
+  const selectedTaskEvents = selectedTaskEventsQuery.data ?? []
 
   const createMutation = useMutation({
     mutationFn: createMultiAgentTask,
@@ -330,6 +367,7 @@ export function MultiAgentBoard() {
       setSelectedTaskId(task.id)
       setMutationError(null)
       void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', task.id, 'events'] })
     },
     onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to create task'),
   })
@@ -341,6 +379,7 @@ export function MultiAgentBoard() {
       setSelectedTaskId(task.id)
       setMutationError(null)
       void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', task.id, 'events'] })
     },
     onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to start task'),
     onSettled: () => setStartingTaskId(null),
@@ -403,7 +442,7 @@ export function MultiAgentBoard() {
             ))}
           </div>
         </div>
-        <MultiAgentTaskDetail task={selectedTask} projects={projects} profiles={profiles} />
+        <MultiAgentTaskDetail task={selectedTask} projects={projects} profiles={profiles} events={selectedTaskEvents} />
       </div>
 
       <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -21,6 +21,7 @@ import {
   buildMultiAgentTaskMeta,
   parseAcceptanceCriteriaDraft,
 } from './multi-agent-board-model'
+import { MultiAgentTaskDetail } from './multi-agent-task-detail'
 
 type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: string }
 type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: string }
@@ -106,14 +107,6 @@ async function fetchMultiAgentTaskEvents(taskId: string): Promise<MultiAgentEven
   return data.events ?? []
 }
 
-function projectLabel(projects: MultiAgentProject[], id: string): string {
-  return projects.find((project) => project.id === id)?.name ?? id
-}
-
-function profileLabel(profiles: MultiAgentProfile[], id: string): string {
-  return profiles.find((profile) => profile.id === id)?.name ?? id
-}
-
 function priorityClass(priority: MultiAgentPriority): string {
   if (priority === 'urgent') return 'border-red-400/40 bg-red-500/10 text-red-300'
   if (priority === 'high') return 'border-amber-400/40 bg-amber-500/10 text-amber-300'
@@ -155,8 +148,8 @@ function MultiAgentTaskCard({
         </div>
         <p className="mt-2 line-clamp-2 text-xs text-[var(--theme-muted-2)]">{task.description || task.workPacket || 'No description yet.'}</p>
         <div className="mt-3 flex flex-wrap gap-1.5 text-[10px] text-[var(--theme-muted)]">
-          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{projectLabel(projects, task.projectId)}</span>
-          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{profileLabel(profiles, task.assigneeProfileId)}</span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{projects.find((project) => project.id === task.projectId)?.name ?? task.projectId}</span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{profiles.find((profile) => profile.id === task.assigneeProfileId)?.name ?? task.assigneeProfileId}</span>
         </div>
         <div className="mt-3 flex min-w-0 items-center gap-1.5 text-[11px] text-[var(--theme-muted-2)]">
           <HugeiconsIcon icon={GitBranchIcon} size={13} strokeWidth={1.7} />
@@ -176,81 +169,6 @@ function MultiAgentTaskCard({
         </button>
       </div>
     </article>
-  )
-}
-
-function MultiAgentTaskDetail({
-  task,
-  projects,
-  profiles,
-  events,
-}: {
-  task: MultiAgentTask | null
-  projects: MultiAgentProject[]
-  profiles: MultiAgentProfile[]
-  events: MultiAgentEvent[]
-}) {
-  if (!task) {
-    return (
-      <aside className="rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-[var(--theme-muted)]">
-        Select a task to inspect its work packet, acceptance criteria, branch, and worktree.
-      </aside>
-    )
-  }
-
-  const meta = buildMultiAgentTaskMeta(task)
-  return (
-    <aside className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Task Detail</p>
-          <h3 className="mt-2 text-lg font-semibold text-[var(--theme-text)]">{task.title}</h3>
-        </div>
-        <span className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--theme-accent-strong)]">
-          {meta.statusLabel}
-        </span>
-      </div>
-      <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-        <div><dt className="text-xs text-[var(--theme-muted)]">Project</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{projectLabel(projects, task.projectId)}</dd></div>
-        <div><dt className="text-xs text-[var(--theme-muted)]">Profile</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{profileLabel(profiles, task.assigneeProfileId)}</dd></div>
-        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Branch</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{meta.branchLabel}</dd></div>
-        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Worktree</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{task.worktreePath || 'No worktree yet'}</dd></div>
-      </dl>
-      <div className="mt-5 space-y-4">
-        <section>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Work Packet</h4>
-          <p className="mt-2 whitespace-pre-wrap rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">{task.workPacket || task.description || 'No work packet provided.'}</p>
-        </section>
-        <section>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Acceptance Criteria</h4>
-          {task.acceptanceCriteria.length ? (
-            <ul className="mt-2 space-y-1 text-sm text-[var(--theme-text)]">
-              {task.acceptanceCriteria.map((criterion) => <li key={criterion} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">• {criterion}</li>)}
-            </ul>
-          ) : (
-            <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
-          )}
-        </section>
-        <section>
-          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>
-          {events.length ? (
-            <ol className="mt-2 max-h-72 space-y-2 overflow-auto pr-1">
-              {events.slice(-12).map((event) => (
-                <li key={event.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
-                  <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
-                    <span>{event.type}</span>
-                    <span>{new Date(event.createdAt).toLocaleTimeString()}</span>
-                  </div>
-                  <p className="mt-1 whitespace-pre-wrap text-xs text-[var(--theme-text)]">{event.message}</p>
-                </li>
-              ))}
-            </ol>
-          ) : (
-            <p className="mt-2 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No events captured yet.</p>
-          )}
-        </section>
-      </div>
-    </aside>
   )
 }
 

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from '@/lib/utils'
 import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
 import type {
+  MultiAgentMission,
   MultiAgentPriority,
   MultiAgentProfile,
   MultiAgentProject,
@@ -34,6 +35,8 @@ import { MultiAgentTaskDetail } from './multi-agent-task-detail'
 
 type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: string }
 type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: string }
+type MissionsResponse = { ok?: boolean; missions?: MultiAgentMission[]; error?: string }
+type MissionResponse = { ok?: boolean; mission?: MultiAgentMission; error?: string }
 type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
 type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
 type TaskEventsResponse = { ok?: boolean; events?: MultiAgentEvent[]; error?: string }
@@ -45,23 +48,55 @@ type ApprovalResponse = { ok?: boolean; approval?: MultiAgentApproval; error?: s
 type TaskPrResponse = { ok?: boolean; pr?: { url: string; artifactId: string }; approval?: MultiAgentApproval; artifact?: MultiAgentArtifact; error?: string }
 type SaveSummaryResponse = { ok?: boolean; task?: MultiAgentTask; run?: MultiAgentRun; obsidian?: { path: string }; error?: string }
 
+type CreateMissionDraft = {
+  projectId: string
+  title: string
+  productGoal: string
+  userStory: string
+  successMetrics: string
+  nonGoals: string
+  constraints: string
+  desiredOutput: string
+}
+
 type CreateTaskDraft = {
   projectId: string
+  missionId: string
   title: string
   description: string
   assigneeProfileId: string
   priority: MultiAgentPriority
   workPacket: string
+  productGoal: string
+  userStory: string
+  successMetrics: string
+  nonGoals: string
   acceptanceCriteria: string
+}
+
+const emptyMissionDraft: CreateMissionDraft = {
+  projectId: '',
+  title: '',
+  productGoal: '',
+  userStory: '',
+  successMetrics: '',
+  nonGoals: '',
+  constraints: '',
+  desiredOutput: '',
 }
 
 const emptyDraft: CreateTaskDraft = {
   projectId: '',
+  missionId: '',
   title: '',
   description: '',
   assigneeProfileId: 'backend-engineer',
   priority: 'medium',
   workPacket: '',
+  productGoal: '',
+  userStory: '',
+  successMetrics: '',
+  nonGoals: '',
   acceptanceCriteria: '',
 }
 
@@ -83,6 +118,34 @@ async function fetchMultiAgentProfiles(): Promise<MultiAgentProfile[]> {
   return data.profiles ?? []
 }
 
+async function fetchMultiAgentMissions(): Promise<MultiAgentMission[]> {
+  const data = await readJson<MissionsResponse>(await fetch('/api/ma/missions', { cache: 'no-store' }))
+  return data.missions ?? []
+}
+
+async function createMultiAgentMission(draft: CreateMissionDraft): Promise<MultiAgentMission> {
+  const data = await readJson<MissionResponse>(
+    await fetch('/api/ma/missions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: draft.projectId,
+        title: draft.title,
+        productBrief: {
+          goal: draft.productGoal.trim(),
+          userStory: draft.userStory.trim(),
+          successMetrics: parseAcceptanceCriteriaDraft(draft.successMetrics),
+          nonGoals: parseAcceptanceCriteriaDraft(draft.nonGoals),
+        },
+        constraints: parseAcceptanceCriteriaDraft(draft.constraints),
+        desiredOutput: draft.desiredOutput,
+      }),
+    }),
+  )
+  if (!data.mission) throw new Error('Mission was not returned')
+  return data.mission
+}
+
 async function fetchMultiAgentTasks(): Promise<MultiAgentTask[]> {
   const data = await readJson<TasksResponse>(await fetch('/api/ma/tasks', { cache: 'no-store' }))
   return data.tasks ?? []
@@ -95,11 +158,18 @@ async function createMultiAgentTask(draft: CreateTaskDraft): Promise<MultiAgentT
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         projectId: draft.projectId,
+        missionId: draft.missionId || undefined,
         title: draft.title,
         description: draft.description,
         assigneeProfileId: draft.assigneeProfileId,
         priority: draft.priority,
         workPacket: draft.workPacket,
+        productBrief: {
+          goal: draft.productGoal.trim(),
+          userStory: draft.userStory.trim(),
+          successMetrics: parseAcceptanceCriteriaDraft(draft.successMetrics),
+          nonGoals: parseAcceptanceCriteriaDraft(draft.nonGoals),
+        },
         acceptanceCriteria: parseAcceptanceCriteriaDraft(draft.acceptanceCriteria),
       }),
     }),
@@ -197,6 +267,168 @@ function priorityClass(priority: MultiAgentPriority): string {
   return 'border-sky-400/35 bg-sky-500/10 text-sky-300'
 }
 
+function loadedSkillsFromEvents(events: MultiAgentEvent[]): string[] {
+  const started = [...events].reverse().find((event) => event.type === 'run.started')
+  const payload = started?.payload
+  if (!payload || typeof payload !== 'object' || !('loadedSkills' in payload)) return []
+  const loadedSkills = (payload as { loadedSkills?: unknown }).loadedSkills
+  return Array.isArray(loadedSkills) ? loadedSkills.filter((skill): skill is string => typeof skill === 'string') : []
+}
+
+export function MultiAgentMissionPanel({
+  missions,
+  projects,
+  selectedMissionId,
+  loading,
+  error,
+  onSelect,
+  onCreateMission,
+}: {
+  missions: MultiAgentMission[]
+  projects: MultiAgentProject[]
+  selectedMissionId: string | null
+  loading: boolean
+  error: string | null
+  onSelect: (missionId: string | null) => void
+  onCreateMission: () => void
+}) {
+  return (
+    <aside className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Mission Control</p>
+          <h3 className="mt-1 text-sm font-semibold text-[var(--theme-text)]">Missions</h3>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateMission}
+          className="inline-flex items-center gap-1 rounded-xl bg-[var(--theme-accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white hover:bg-[var(--theme-accent-strong)]"
+        >
+          <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={1.8} /> Create Mission
+        </button>
+      </div>
+      {error ? <p className="mt-3 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</p> : null}
+      {loading ? <p className="mt-3 text-xs text-[var(--theme-muted)]">Loading missions…</p> : null}
+      <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+        <button
+          type="button"
+          onClick={() => onSelect(null)}
+          className={cn(
+            'min-w-[150px] rounded-xl border px-3 py-2 text-left text-xs transition-colors',
+            selectedMissionId === null ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-text)]' : 'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-muted-2)]',
+          )}
+        >
+          <span className="block font-semibold">All tasks</span>
+          <span className="mt-1 block text-[10px] text-[var(--theme-muted)]">Show every mission/task</span>
+        </button>
+        {missions.length ? missions.map((mission) => {
+          const projectName = projects.find((project) => project.id === mission.projectId)?.name ?? mission.projectId
+          return (
+            <button
+              key={mission.id}
+              type="button"
+              onClick={() => onSelect(mission.id)}
+              className={cn(
+                'min-w-[240px] rounded-xl border px-3 py-2 text-left text-xs transition-colors hover:border-[var(--theme-accent)]',
+                selectedMissionId === mission.id ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)]' : 'border-[var(--theme-border)] bg-[var(--theme-card)]',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <span className="line-clamp-1 font-semibold text-[var(--theme-text)]">{mission.title}</span>
+                <span className="shrink-0 rounded-full border border-[var(--theme-border)] px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">{mission.status}</span>
+              </div>
+              <p className="mt-1 line-clamp-2 text-[11px] text-[var(--theme-muted-2)]">{mission.productBrief.goal}</p>
+              <div className="mt-2 flex flex-wrap gap-1.5 text-[10px] text-[var(--theme-muted)]">
+                <span className="rounded-full border border-[var(--theme-border)] px-2 py-0.5">{projectName}</span>
+                <span className="rounded-full border border-[var(--theme-border)] px-2 py-0.5">{mission.taskIds.length} tasks</span>
+              </div>
+            </button>
+          )
+        }) : (
+          <div className="min-w-[240px] rounded-xl border border-dashed border-[var(--theme-border)] px-3 py-4 text-xs text-[var(--theme-muted)]">No missions yet. Create one to group autonomous work.</div>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+export function MultiAgentCreateMissionDialog({
+  projects,
+  creating,
+  error,
+  onCancel,
+  onCreate,
+}: {
+  projects: MultiAgentProject[]
+  creating: boolean
+  error: string | null
+  onCancel: () => void
+  onCreate: (draft: CreateMissionDraft) => void
+}) {
+  const [draft, setDraft] = useState<CreateMissionDraft>(() => ({
+    ...emptyMissionDraft,
+    projectId: projects[0]?.id ?? '',
+  }))
+  const canSubmit = draft.projectId && draft.title.trim() && draft.productGoal.trim()
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[color-mix(in_srgb,var(--theme-bg)_48%,transparent)] px-4 py-6 backdrop-blur-md sm:items-center" onClick={onCancel}>
+      <form
+        className="my-auto max-h-[calc(100dvh-3rem)] w-full max-w-2xl overflow-y-auto rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
+        onClick={(event) => event.stopPropagation()}
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (canSubmit) onCreate(draft)
+        }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Control</p>
+            <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Create Mission</h3>
+            <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Define a product goal before splitting work across Hermes agents.</p>
+          </div>
+          <button type="button" onClick={onCancel} className="rounded-xl border border-[var(--theme-border)] px-3 py-1.5 text-sm text-[var(--theme-muted)]">×</button>
+        </div>
+        <div className="mt-5 grid gap-4 sm:grid-cols-2">
+          <label className="text-sm font-medium text-[var(--theme-text)]">Project
+            <select value={draft.projectId} onChange={(event) => setDraft({ ...draft, projectId: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm">
+              {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Mission Title
+            <input value={draft.title} onChange={(event) => setDraft({ ...draft, title: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="Ship autonomous planning loop" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Product Goal
+            <input value={draft.productGoal} onChange={(event) => setDraft({ ...draft, productGoal: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="What outcome should this mission deliver?" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">User Story
+            <input value={draft.userStory} onChange={(event) => setDraft({ ...draft, userStory: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="As an operator, I can..." />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Success Metrics
+            <textarea value={draft.successMetrics} onChange={(event) => setDraft({ ...draft, successMetrics: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One metric per line" />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Non-goals
+            <textarea value={draft.nonGoals} onChange={(event) => setDraft({ ...draft, nonGoals: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One non-goal per line" />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Constraints
+            <textarea value={draft.constraints} onChange={(event) => setDraft({ ...draft, constraints: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One constraint per line" />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Desired Output
+            <textarea value={draft.desiredOutput} onChange={(event) => setDraft({ ...draft, desiredOutput: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="Definition of mission output" />
+          </label>
+        </div>
+        {error ? <p className="mt-4 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-xl border border-[var(--theme-border)] px-4 py-2 text-sm font-medium text-[var(--theme-text)]">Cancel</button>
+          <button type="submit" disabled={!canSubmit || creating} className="rounded-xl bg-[var(--theme-accent)] px-4 py-2 text-sm font-semibold text-white hover:bg-[var(--theme-accent-strong)] disabled:opacity-40">
+            {creating ? 'Creating…' : 'Create mission'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
 function MultiAgentTaskCard({
   task,
   projects,
@@ -258,6 +490,8 @@ function MultiAgentTaskCard({
 function MultiAgentCreateTaskDialog({
   projects,
   profiles,
+  missions,
+  selectedMission,
   creating,
   error,
   onCancel,
@@ -265,6 +499,8 @@ function MultiAgentCreateTaskDialog({
 }: {
   projects: MultiAgentProject[]
   profiles: MultiAgentProfile[]
+  missions: MultiAgentMission[]
+  selectedMission: MultiAgentMission | null
   creating: boolean
   error: string | null
   onCancel: () => void
@@ -272,7 +508,8 @@ function MultiAgentCreateTaskDialog({
 }) {
   const [draft, setDraft] = useState<CreateTaskDraft>(() => ({
     ...emptyDraft,
-    projectId: projects[0]?.id ?? '',
+    projectId: selectedMission?.projectId ?? projects[0]?.id ?? '',
+    missionId: selectedMission?.id ?? '',
     assigneeProfileId: profiles[0]?.id ?? 'backend-engineer',
   }))
   const canSubmit = draft.projectId && draft.assigneeProfileId && draft.title.trim()
@@ -301,6 +538,20 @@ function MultiAgentCreateTaskDialog({
               {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
             </select>
           </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Mission
+            <select
+              value={draft.missionId}
+              onChange={(event) => {
+                const missionId = event.target.value
+                const mission = missions.find((item) => item.id === missionId)
+                setDraft({ ...draft, missionId, projectId: mission?.projectId ?? draft.projectId })
+              }}
+              className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm"
+            >
+              <option value="">No mission</option>
+              {missions.map((mission) => <option key={mission.id} value={mission.id}>{mission.title}</option>)}
+            </select>
+          </label>
           <label className="text-sm font-medium text-[var(--theme-text)]">Profile
             <select value={draft.assigneeProfileId} onChange={(event) => setDraft({ ...draft, assigneeProfileId: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm">
               {profiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.name}</option>)}
@@ -316,6 +567,18 @@ function MultiAgentCreateTaskDialog({
           </label>
           <label className="text-sm font-medium text-[var(--theme-text)]">Description
             <input value={draft.description} onChange={(event) => setDraft({ ...draft, description: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Product Goal
+            <input value={draft.productGoal} onChange={(event) => setDraft({ ...draft, productGoal: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="What product outcome should this task unlock?" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">User Story
+            <input value={draft.userStory} onChange={(event) => setDraft({ ...draft, userStory: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="As a user/operator, I can..." />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Success Metrics
+            <textarea value={draft.successMetrics} onChange={(event) => setDraft({ ...draft, successMetrics: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One success metric per line" />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Non-goals
+            <textarea value={draft.nonGoals} onChange={(event) => setDraft({ ...draft, nonGoals: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One explicit non-goal per line" />
           </label>
           <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Work Packet
             <textarea value={draft.workPacket} onChange={(event) => setDraft({ ...draft, workPacket: event.target.value })} rows={4} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" />
@@ -339,6 +602,8 @@ function MultiAgentCreateTaskDialog({
 export function MultiAgentBoard() {
   const queryClient = useQueryClient()
   const [createOpen, setCreateOpen] = useState(false)
+  const [createMissionOpen, setCreateMissionOpen] = useState(false)
+  const [selectedMissionId, setSelectedMissionId] = useState<string | null>(null)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [startingTaskId, setStartingTaskId] = useState<string | null>(null)
   const [validationRunningType, setValidationRunningType] = useState<MultiAgentValidationType | null>(null)
@@ -356,15 +621,19 @@ export function MultiAgentBoard() {
 
   const projectsQuery = useQuery({ queryKey: ['ma', 'projects'], queryFn: fetchMultiAgentProjects, staleTime: 30_000 })
   const profilesQuery = useQuery({ queryKey: ['ma', 'profiles'], queryFn: fetchMultiAgentProfiles, staleTime: 60_000 })
+  const missionsQuery = useQuery({ queryKey: ['ma', 'missions'], queryFn: fetchMultiAgentMissions, staleTime: 5_000 })
   const tasksQuery = useQuery({ queryKey: ['ma', 'tasks'], queryFn: fetchMultiAgentTasks, staleTime: 5_000 })
   const approvalsQuery = useQuery({ queryKey: ['ma', 'approvals'], queryFn: fetchMultiAgentApprovals, staleTime: 2_000, refetchInterval: 5_000 })
 
   const projects = projectsQuery.data ?? []
   const profiles = profilesQuery.data ?? []
+  const missions = missionsQuery.data ?? []
   const tasks = tasksQuery.data ?? []
+  const visibleTasks = selectedMissionId ? tasks.filter((task) => task.missionId === selectedMissionId) : tasks
   const approvals = approvalsQuery.data ?? []
-  const columns = useMemo(() => buildMultiAgentBoardColumns(tasks), [tasks])
-  const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? tasks[0] ?? null
+  const columns = useMemo(() => buildMultiAgentBoardColumns(visibleTasks), [visibleTasks])
+  const selectedMission = selectedMissionId ? missions.find((mission) => mission.id === selectedMissionId) ?? null : null
+  const selectedTask = visibleTasks.find((task) => task.id === selectedTaskId) ?? visibleTasks[0] ?? null
   const selectedTaskEventsQuery = useQuery({
     queryKey: ['ma', 'tasks', selectedTask?.id, 'events'],
     queryFn: () => fetchMultiAgentTaskEvents(selectedTask?.id ?? ''),
@@ -388,6 +657,7 @@ export function MultiAgentBoard() {
     retry: false,
   })
   const selectedTaskEvents = selectedTaskEventsQuery.data ?? []
+  const selectedTaskLoadedSkills = loadedSkillsFromEvents(selectedTaskEvents)
   const selectedTaskValidations = selectedTaskValidationsQuery.data ?? []
   const selectedTaskPrArtifacts = selectedTask ? (prArtifactsByTaskId[selectedTask.id] ?? []) : []
   const selectedTaskFinalSummary = selectedTask
@@ -395,13 +665,27 @@ export function MultiAgentBoard() {
     : null
   const selectedTaskSummarySavedPath = selectedTask ? (summarySavedPathByTaskId[selectedTask.id] ?? null) : null
 
+  const createMissionMutation = useMutation({
+    mutationFn: createMultiAgentMission,
+    onSuccess: (mission) => {
+      setCreateMissionOpen(false)
+      setSelectedMissionId(mission.id)
+      setSelectedTaskId(null)
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'missions'] })
+    },
+    onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to create mission'),
+  })
+
   const createMutation = useMutation({
     mutationFn: createMultiAgentTask,
     onSuccess: (task) => {
       setCreateOpen(false)
       setSelectedTaskId(task.id)
+      if (task.missionId) setSelectedMissionId(task.missionId)
       setMutationError(null)
       void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'missions'] })
       void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', task.id, 'events'] })
     },
     onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to create task'),
@@ -493,8 +777,8 @@ export function MultiAgentBoard() {
     onSettled: () => setSummarySaving(false),
   })
 
-  const loading = projectsQuery.isLoading || profilesQuery.isLoading || tasksQuery.isLoading
-  const loadError = projectsQuery.error ?? profilesQuery.error ?? tasksQuery.error
+  const loading = projectsQuery.isLoading || profilesQuery.isLoading || missionsQuery.isLoading || tasksQuery.isLoading
+  const loadError = projectsQuery.error ?? profilesQuery.error ?? missionsQuery.error ?? tasksQuery.error
 
   return (
     <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-5">
@@ -517,6 +801,18 @@ export function MultiAgentBoard() {
       {loadError ? <p className="mt-4 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-sm text-red-300">{loadError instanceof Error ? loadError.message : 'Failed to load Agent Board data'}</p> : null}
       {mutationError ? <p className="mt-4 rounded-xl border border-amber-400/35 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">{mutationError}</p> : null}
       {loading ? <p className="mt-6 text-sm text-[var(--theme-muted)]">Loading Agent Board…</p> : null}
+
+      <div className="mt-5">
+        <MultiAgentMissionPanel
+          missions={missions}
+          projects={projects}
+          selectedMissionId={selectedMissionId}
+          loading={missionsQuery.isLoading || missionsQuery.isFetching}
+          error={missionsQuery.error instanceof Error ? missionsQuery.error.message : null}
+          onSelect={(missionId) => { setSelectedMissionId(missionId); setSelectedTaskId(null) }}
+          onCreateMission={() => { setMutationError(null); setCreateMissionOpen(true) }}
+        />
+      </div>
 
       <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
         <div className="space-y-4">
@@ -585,22 +881,35 @@ export function MultiAgentBoard() {
           summarySaveError={summarySaveError}
           summarySavedPath={selectedTaskSummarySavedPath}
           onSaveSummary={() => selectedTask && selectedTaskFinalSummary ? summaryMutation.mutate({ taskId: selectedTask.id, summary: selectedTaskFinalSummary, saveToObsidian: true }) : undefined}
+          loadedSkills={selectedTaskLoadedSkills}
         />
       </div>
 
       <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
         <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.7} />
-        Task 13 scope: review and resolve risky workspace approvals before push/PR/custom shell slices.
+        Mission scope: select a mission to focus the board; new tasks are linked to the selected mission automatically.
       </div>
 
       {createOpen ? (
         <MultiAgentCreateTaskDialog
           projects={projects}
           profiles={profiles}
+          missions={missions}
+          selectedMission={selectedMission}
           creating={createMutation.isPending}
           error={mutationError}
           onCancel={() => setCreateOpen(false)}
           onCreate={(draft) => createMutation.mutate(draft)}
+        />
+      ) : null}
+
+      {createMissionOpen ? (
+        <MultiAgentCreateMissionDialog
+          projects={projects}
+          creating={createMissionMutation.isPending}
+          error={mutationError}
+          onCancel={() => setCreateMissionOpen(false)}
+          onCreate={(draft) => createMissionMutation.mutate(draft)}
         />
       ) : null}
     </section>

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -1,0 +1,426 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Add01Icon,
+  ArrowRight01Icon,
+  GitBranchIcon,
+  PlayIcon,
+  RefreshIcon,
+} from '@hugeicons/core-free-icons'
+import { cn } from '@/lib/utils'
+import type {
+  MultiAgentPriority,
+  MultiAgentProfile,
+  MultiAgentProject,
+  MultiAgentTask,
+} from '../../../server/multi-agent/types'
+import {
+  buildMultiAgentBoardColumns,
+  buildMultiAgentTaskMeta,
+  parseAcceptanceCriteriaDraft,
+} from './multi-agent-board-model'
+
+type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: string }
+type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: string }
+type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
+type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
+
+type CreateTaskDraft = {
+  projectId: string
+  title: string
+  description: string
+  assigneeProfileId: string
+  priority: MultiAgentPriority
+  workPacket: string
+  acceptanceCriteria: string
+}
+
+const emptyDraft: CreateTaskDraft = {
+  projectId: '',
+  title: '',
+  description: '',
+  assigneeProfileId: 'backend-engineer',
+  priority: 'medium',
+  workPacket: '',
+  acceptanceCriteria: '',
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const data = (await response.json().catch(() => ({}))) as T & { error?: string }
+  if (!response.ok) {
+    throw new Error(data.error || `Request failed: ${response.status}`)
+  }
+  return data
+}
+
+async function fetchMultiAgentProjects(): Promise<MultiAgentProject[]> {
+  const data = await readJson<ProjectsResponse>(await fetch('/api/ma/projects', { cache: 'no-store' }))
+  return data.projects ?? []
+}
+
+async function fetchMultiAgentProfiles(): Promise<MultiAgentProfile[]> {
+  const data = await readJson<ProfilesResponse>(await fetch('/api/ma/profiles', { cache: 'no-store' }))
+  return data.profiles ?? []
+}
+
+async function fetchMultiAgentTasks(): Promise<MultiAgentTask[]> {
+  const data = await readJson<TasksResponse>(await fetch('/api/ma/tasks', { cache: 'no-store' }))
+  return data.tasks ?? []
+}
+
+async function createMultiAgentTask(draft: CreateTaskDraft): Promise<MultiAgentTask> {
+  const data = await readJson<TaskResponse>(
+    await fetch('/api/ma/tasks', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: draft.projectId,
+        title: draft.title,
+        description: draft.description,
+        assigneeProfileId: draft.assigneeProfileId,
+        priority: draft.priority,
+        workPacket: draft.workPacket,
+        acceptanceCriteria: parseAcceptanceCriteriaDraft(draft.acceptanceCriteria),
+      }),
+    }),
+  )
+  if (!data.task) throw new Error('Task was not returned')
+  return data.task
+}
+
+async function startMultiAgentTask(taskId: string): Promise<MultiAgentTask> {
+  const data = await readJson<TaskResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(taskId)}/start`, { method: 'POST' }),
+  )
+  if (!data.task) throw new Error('Updated task was not returned')
+  return data.task
+}
+
+function projectLabel(projects: MultiAgentProject[], id: string): string {
+  return projects.find((project) => project.id === id)?.name ?? id
+}
+
+function profileLabel(profiles: MultiAgentProfile[], id: string): string {
+  return profiles.find((profile) => profile.id === id)?.name ?? id
+}
+
+function priorityClass(priority: MultiAgentPriority): string {
+  if (priority === 'urgent') return 'border-red-400/40 bg-red-500/10 text-red-300'
+  if (priority === 'high') return 'border-amber-400/40 bg-amber-500/10 text-amber-300'
+  if (priority === 'low') return 'border-slate-400/30 bg-slate-500/10 text-slate-300'
+  return 'border-sky-400/35 bg-sky-500/10 text-sky-300'
+}
+
+function MultiAgentTaskCard({
+  task,
+  projects,
+  profiles,
+  selected,
+  starting,
+  onSelect,
+  onStart,
+}: {
+  task: MultiAgentTask
+  projects: MultiAgentProject[]
+  profiles: MultiAgentProfile[]
+  selected: boolean
+  starting: boolean
+  onSelect: () => void
+  onStart: () => void
+}) {
+  const meta = buildMultiAgentTaskMeta(task)
+  return (
+    <article
+      className={cn(
+        'group rounded-2xl border bg-[var(--theme-card)] p-3 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-[var(--theme-accent)] hover:shadow-md',
+        selected ? 'border-[var(--theme-accent)] ring-2 ring-[var(--theme-accent-soft)]' : 'border-[var(--theme-border)]',
+      )}
+    >
+      <button type="button" onClick={onSelect} className="block w-full text-left">
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="line-clamp-2 text-sm font-semibold text-[var(--theme-text)]">{task.title}</h4>
+          <span className={cn('shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]', priorityClass(task.priority))}>
+            {meta.priorityLabel}
+          </span>
+        </div>
+        <p className="mt-2 line-clamp-2 text-xs text-[var(--theme-muted-2)]">{task.description || task.workPacket || 'No description yet.'}</p>
+        <div className="mt-3 flex flex-wrap gap-1.5 text-[10px] text-[var(--theme-muted)]">
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{projectLabel(projects, task.projectId)}</span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5">{profileLabel(profiles, task.assigneeProfileId)}</span>
+        </div>
+        <div className="mt-3 flex min-w-0 items-center gap-1.5 text-[11px] text-[var(--theme-muted-2)]">
+          <HugeiconsIcon icon={GitBranchIcon} size={13} strokeWidth={1.7} />
+          <span className="truncate">{meta.branchLabel}</span>
+        </div>
+      </button>
+      <div className="mt-3 flex items-center justify-between gap-2 border-t border-[var(--theme-border)] pt-3">
+        <span className="truncate text-[10px] text-[var(--theme-muted)]">{meta.worktreeLabel}</span>
+        <button
+          type="button"
+          disabled={!meta.canStart || starting}
+          onClick={onStart}
+          className="inline-flex items-center gap-1 rounded-lg bg-[var(--theme-accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-[var(--theme-accent-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <HugeiconsIcon icon={PlayIcon} size={12} strokeWidth={1.8} />
+          {starting ? 'Starting…' : 'Start'}
+        </button>
+      </div>
+    </article>
+  )
+}
+
+function MultiAgentTaskDetail({
+  task,
+  projects,
+  profiles,
+}: {
+  task: MultiAgentTask | null
+  projects: MultiAgentProject[]
+  profiles: MultiAgentProfile[]
+}) {
+  if (!task) {
+    return (
+      <aside className="rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-[var(--theme-muted)]">
+        Select a task to inspect its work packet, acceptance criteria, branch, and worktree.
+      </aside>
+    )
+  }
+
+  const meta = buildMultiAgentTaskMeta(task)
+  return (
+    <aside className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Task Detail</p>
+          <h3 className="mt-2 text-lg font-semibold text-[var(--theme-text)]">{task.title}</h3>
+        </div>
+        <span className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--theme-accent-strong)]">
+          {meta.statusLabel}
+        </span>
+      </div>
+      <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+        <div><dt className="text-xs text-[var(--theme-muted)]">Project</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{projectLabel(projects, task.projectId)}</dd></div>
+        <div><dt className="text-xs text-[var(--theme-muted)]">Profile</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{profileLabel(profiles, task.assigneeProfileId)}</dd></div>
+        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Branch</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{meta.branchLabel}</dd></div>
+        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Worktree</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{task.worktreePath || 'No worktree yet'}</dd></div>
+      </dl>
+      <div className="mt-5 space-y-4">
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Work Packet</h4>
+          <p className="mt-2 whitespace-pre-wrap rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">{task.workPacket || task.description || 'No work packet provided.'}</p>
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Acceptance Criteria</h4>
+          {task.acceptanceCriteria.length ? (
+            <ul className="mt-2 space-y-1 text-sm text-[var(--theme-text)]">
+              {task.acceptanceCriteria.map((criterion) => <li key={criterion} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">• {criterion}</li>)}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
+          )}
+        </section>
+      </div>
+    </aside>
+  )
+}
+
+function MultiAgentCreateTaskDialog({
+  projects,
+  profiles,
+  creating,
+  error,
+  onCancel,
+  onCreate,
+}: {
+  projects: MultiAgentProject[]
+  profiles: MultiAgentProfile[]
+  creating: boolean
+  error: string | null
+  onCancel: () => void
+  onCreate: (draft: CreateTaskDraft) => void
+}) {
+  const [draft, setDraft] = useState<CreateTaskDraft>(() => ({
+    ...emptyDraft,
+    projectId: projects[0]?.id ?? '',
+    assigneeProfileId: profiles[0]?.id ?? 'backend-engineer',
+  }))
+  const canSubmit = draft.projectId && draft.assigneeProfileId && draft.title.trim()
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_48%,transparent)] px-4 py-6 backdrop-blur-md" onClick={onCancel}>
+      <form
+        className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
+        onClick={(event) => event.stopPropagation()}
+        onSubmit={(event) => {
+          event.preventDefault()
+          if (canSubmit) onCreate(draft)
+        }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Board</p>
+            <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Create Task</h3>
+            <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Capture a work packet before creating an isolated worktree.</p>
+          </div>
+          <button type="button" onClick={onCancel} className="rounded-xl border border-[var(--theme-border)] px-3 py-1.5 text-sm text-[var(--theme-muted)]">×</button>
+        </div>
+        <div className="mt-5 grid gap-4 sm:grid-cols-2">
+          <label className="text-sm font-medium text-[var(--theme-text)]">Project
+            <select value={draft.projectId} onChange={(event) => setDraft({ ...draft, projectId: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm">
+              {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+            </select>
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Profile
+            <select value={draft.assigneeProfileId} onChange={(event) => setDraft({ ...draft, assigneeProfileId: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm">
+              {profiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.name}</option>)}
+            </select>
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Title
+            <input value={draft.title} onChange={(event) => setDraft({ ...draft, title: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="Add validation runner UI" />
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Priority
+            <select value={draft.priority} onChange={(event) => setDraft({ ...draft, priority: event.target.value as MultiAgentPriority })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm">
+              <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="urgent">Urgent</option>
+            </select>
+          </label>
+          <label className="text-sm font-medium text-[var(--theme-text)]">Description
+            <input value={draft.description} onChange={(event) => setDraft({ ...draft, description: event.target.value })} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Work Packet
+            <textarea value={draft.workPacket} onChange={(event) => setDraft({ ...draft, workPacket: event.target.value })} rows={4} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" />
+          </label>
+          <label className="sm:col-span-2 text-sm font-medium text-[var(--theme-text)]">Acceptance Criteria
+            <textarea value={draft.acceptanceCriteria} onChange={(event) => setDraft({ ...draft, acceptanceCriteria: event.target.value })} rows={3} className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm" placeholder="One criterion per line" />
+          </label>
+        </div>
+        {error ? <p className="mt-4 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
+        <div className="mt-5 flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="rounded-xl border border-[var(--theme-border)] px-4 py-2 text-sm font-medium text-[var(--theme-text)]">Cancel</button>
+          <button type="submit" disabled={!canSubmit || creating} className="rounded-xl bg-[var(--theme-accent)] px-4 py-2 text-sm font-semibold text-white hover:bg-[var(--theme-accent-strong)] disabled:opacity-40">
+            {creating ? 'Creating…' : 'Create task'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export function MultiAgentBoard() {
+  const queryClient = useQueryClient()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const [startingTaskId, setStartingTaskId] = useState<string | null>(null)
+  const [mutationError, setMutationError] = useState<string | null>(null)
+
+  const projectsQuery = useQuery({ queryKey: ['ma', 'projects'], queryFn: fetchMultiAgentProjects, staleTime: 30_000 })
+  const profilesQuery = useQuery({ queryKey: ['ma', 'profiles'], queryFn: fetchMultiAgentProfiles, staleTime: 60_000 })
+  const tasksQuery = useQuery({ queryKey: ['ma', 'tasks'], queryFn: fetchMultiAgentTasks, staleTime: 5_000 })
+
+  const projects = projectsQuery.data ?? []
+  const profiles = profilesQuery.data ?? []
+  const tasks = tasksQuery.data ?? []
+  const columns = useMemo(() => buildMultiAgentBoardColumns(tasks), [tasks])
+  const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? tasks[0] ?? null
+
+  const createMutation = useMutation({
+    mutationFn: createMultiAgentTask,
+    onSuccess: (task) => {
+      setCreateOpen(false)
+      setSelectedTaskId(task.id)
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+    },
+    onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to create task'),
+  })
+
+  const startMutation = useMutation({
+    mutationFn: startMultiAgentTask,
+    onMutate: (taskId) => setStartingTaskId(taskId),
+    onSuccess: (task) => {
+      setSelectedTaskId(task.id)
+      setMutationError(null)
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+    },
+    onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to start task'),
+    onSettled: () => setStartingTaskId(null),
+  })
+
+  const loading = projectsQuery.isLoading || profilesQuery.isLoading || tasksQuery.isLoading
+  const loadError = projectsQuery.error ?? profilesQuery.error ?? tasksQuery.error
+
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Board</p>
+          <h2 className="mt-1 text-xl font-semibold text-[var(--theme-text)]">Multi-Agent Control Plane</h2>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--theme-muted-2)]">Create a task, mint an isolated worktree, and keep the first MVP slice visible from one board.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={() => void tasksQuery.refetch()} className="inline-flex items-center gap-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]">
+            <HugeiconsIcon icon={RefreshIcon} size={14} strokeWidth={1.7} /> Refresh
+          </button>
+          <button type="button" onClick={() => { setMutationError(null); setCreateOpen(true) }} className="inline-flex items-center gap-2 rounded-xl bg-[var(--theme-accent)] px-3 py-2 text-xs font-semibold text-white hover:bg-[var(--theme-accent-strong)]">
+            <HugeiconsIcon icon={Add01Icon} size={14} strokeWidth={1.8} /> Create task
+          </button>
+        </div>
+      </div>
+
+      {loadError ? <p className="mt-4 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-sm text-red-300">{loadError instanceof Error ? loadError.message : 'Failed to load Agent Board data'}</p> : null}
+      {mutationError ? <p className="mt-4 rounded-xl border border-amber-400/35 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">{mutationError}</p> : null}
+      {loading ? <p className="mt-6 text-sm text-[var(--theme-muted)]">Loading Agent Board…</p> : null}
+
+      <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="overflow-x-auto pb-2">
+          <div className="grid min-w-[1120px] grid-cols-8 gap-3">
+            {columns.map((column) => (
+              <div key={column.status} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-2">
+                <div className="mb-2 px-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-text)]">{column.label}</h3>
+                    <span className="rounded-full bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] text-[var(--theme-muted)]">{column.tasks.length}</span>
+                  </div>
+                  <p className="mt-1 text-[10px] text-[var(--theme-muted-2)]">{column.hint}</p>
+                </div>
+                <div className="space-y-2">
+                  {column.tasks.length ? column.tasks.map((task) => (
+                    <MultiAgentTaskCard
+                      key={task.id}
+                      task={task}
+                      projects={projects}
+                      profiles={profiles}
+                      selected={selectedTask?.id === task.id}
+                      starting={startingTaskId === task.id}
+                      onSelect={() => setSelectedTaskId(task.id)}
+                      onStart={() => startMutation.mutate(task.id)}
+                    />
+                  )) : (
+                    <div className="rounded-xl border border-dashed border-[var(--theme-border)] px-2 py-5 text-center text-[11px] text-[var(--theme-muted)]">No tasks</div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <MultiAgentTaskDetail task={selectedTask} projects={projects} profiles={profiles} />
+      </div>
+
+      <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
+        <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.7} />
+        Task 8 scope: create tasks, start worktrees, and refresh board state. Worker streaming comes next.
+      </div>
+
+      {createOpen ? (
+        <MultiAgentCreateTaskDialog
+          projects={projects}
+          profiles={profiles}
+          creating={createMutation.isPending}
+          error={mutationError}
+          onCancel={() => setCreateOpen(false)}
+          onCreate={(draft) => createMutation.mutate(draft)}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -19,6 +19,7 @@ import type {
   type MultiAgentValidation,
   type MultiAgentApproval,
   type MultiAgentApprovalStatus,
+  type MultiAgentArtifact,
   type MultiAgentValidationType,
 } from '../../../server/multi-agent/types'
 import {
@@ -27,6 +28,7 @@ import {
   parseAcceptanceCriteriaDraft,
 } from './multi-agent-board-model'
 import { MultiAgentApprovalsPanel } from './multi-agent-approvals-panel'
+import { MultiAgentPrPanel } from './multi-agent-pr-panel'
 import { MultiAgentTaskDetail } from './multi-agent-task-detail'
 
 type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: string }
@@ -39,6 +41,7 @@ type TaskValidationsResponse = { ok?: boolean; validations?: MultiAgentValidatio
 type TaskValidationResponse = { ok?: boolean; validation?: MultiAgentValidation; error?: string }
 type ApprovalsResponse = { ok?: boolean; approvals?: MultiAgentApproval[]; error?: string }
 type ApprovalResponse = { ok?: boolean; approval?: MultiAgentApproval; error?: string }
+type TaskPrResponse = { ok?: boolean; pr?: { url: string; artifactId: string }; approval?: MultiAgentApproval; artifact?: MultiAgentArtifact; error?: string }
 
 type CreateTaskDraft = {
   projectId: string
@@ -163,6 +166,16 @@ async function resolveMultiAgentApproval(input: {
   )
   if (!data.approval) throw new Error('Approval was not returned')
   return data.approval
+}
+
+async function createMultiAgentTaskPr(input: { taskId: string; title: string; body: string }): Promise<TaskPrResponse> {
+  return readJson<TaskPrResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(input.taskId)}/pr`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: input.title, body: input.body }),
+    }),
+  )
 }
 
 function priorityClass(priority: MultiAgentPriority): string {
@@ -320,6 +333,9 @@ export function MultiAgentBoard() {
   const [validationError, setValidationError] = useState<string | null>(null)
   const [resolvingApprovalId, setResolvingApprovalId] = useState<string | null>(null)
   const [approvalError, setApprovalError] = useState<string | null>(null)
+  const [creatingPr, setCreatingPr] = useState(false)
+  const [prError, setPrError] = useState<string | null>(null)
+  const [prArtifactsByTaskId, setPrArtifactsByTaskId] = useState<Record<string, MultiAgentArtifact[]>>({})
   const [mutationError, setMutationError] = useState<string | null>(null)
 
   const projectsQuery = useQuery({ queryKey: ['ma', 'projects'], queryFn: fetchMultiAgentProjects, staleTime: 30_000 })
@@ -356,6 +372,8 @@ export function MultiAgentBoard() {
     retry: false,
   })
   const selectedTaskEvents = selectedTaskEventsQuery.data ?? []
+  const selectedTaskValidations = selectedTaskValidationsQuery.data ?? []
+  const selectedTaskPrArtifacts = selectedTask ? (prArtifactsByTaskId[selectedTask.id] ?? []) : []
 
   const createMutation = useMutation({
     mutationFn: createMultiAgentTask,
@@ -409,6 +427,31 @@ export function MultiAgentBoard() {
     onSettled: () => setResolvingApprovalId(null),
   })
 
+
+  const prMutation = useMutation({
+    mutationFn: createMultiAgentTaskPr,
+    onMutate: () => {
+      setCreatingPr(true)
+      setPrError(null)
+    },
+    onSuccess: (response, input) => {
+      if (response.error) setPrError(response.error)
+      if (response.approval) setPrError('Approval required before push/PR. Review it in the approvals queue.')
+      if (response.artifact) {
+        setPrError(null)
+        setPrArtifactsByTaskId((prev) => ({
+          ...prev,
+          [input.taskId]: [response.artifact!, ...(prev[input.taskId] ?? [])],
+        }))
+      }
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'approvals'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', input.taskId, 'validations'] })
+    },
+    onError: (error) => setPrError(error instanceof Error ? error.message : 'Failed to create PR'),
+    onSettled: () => setCreatingPr(false),
+  })
+
   const loading = projectsQuery.isLoading || profilesQuery.isLoading || tasksQuery.isLoading
   const loadError = projectsQuery.error ?? profilesQuery.error ?? tasksQuery.error
 
@@ -442,6 +485,16 @@ export function MultiAgentBoard() {
             error={approvalError ?? (approvalsQuery.error instanceof Error ? approvalsQuery.error.message : null)}
             onResolve={(approvalId, decision) => approvalMutation.mutate({ approvalId, decision })}
           />
+          {selectedTask ? (
+            <MultiAgentPrPanel
+              task={selectedTask}
+              validations={selectedTaskValidations}
+              prArtifacts={selectedTaskPrArtifacts}
+              creating={creatingPr}
+              error={prError}
+              onCreatePr={() => prMutation.mutate({ taskId: selectedTask.id, title: selectedTask.title, body: selectedTask.workPacket || selectedTask.description })}
+            />
+          ) : null}
           <div className="overflow-x-auto pb-2">
             <div className="grid min-w-[1120px] grid-cols-8 gap-3">
             {columns.map((column) => (
@@ -482,7 +535,7 @@ export function MultiAgentBoard() {
           diff={selectedTaskDiffQuery.data ?? null}
           diffLoading={selectedTaskDiffQuery.isLoading || selectedTaskDiffQuery.isFetching}
           diffError={selectedTaskDiffQuery.error instanceof Error ? selectedTaskDiffQuery.error.message : null}
-          validations={selectedTaskValidationsQuery.data ?? []}
+          validations={selectedTaskValidations}
           validationRunningType={validationRunningType}
           validationError={validationError ?? (selectedTaskValidationsQuery.error instanceof Error ? selectedTaskValidationsQuery.error.message : null)}
           onValidate={(type) => selectedTask ? validationMutation.mutate({ taskId: selectedTask.id, type }) : undefined}

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -37,6 +37,7 @@ type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: 
 type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: string }
 type MissionsResponse = { ok?: boolean; missions?: MultiAgentMission[]; error?: string }
 type MissionResponse = { ok?: boolean; mission?: MultiAgentMission; error?: string }
+type MissionPlanResponse = { ok?: boolean; mission?: MultiAgentMission; tasks?: MultiAgentTask[]; error?: string }
 type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
 type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
 type TaskEventsResponse = { ok?: boolean; events?: MultiAgentEvent[]; error?: string }
@@ -144,6 +145,12 @@ async function createMultiAgentMission(draft: CreateMissionDraft): Promise<Multi
   )
   if (!data.mission) throw new Error('Mission was not returned')
   return data.mission
+}
+
+async function planMultiAgentMission(missionId: string): Promise<MissionPlanResponse> {
+  return readJson<MissionPlanResponse>(
+    await fetch(`/api/ma/missions/${encodeURIComponent(missionId)}/plan`, { method: 'POST' }),
+  )
 }
 
 async function fetchMultiAgentTasks(): Promise<MultiAgentTask[]> {
@@ -283,6 +290,8 @@ export function MultiAgentMissionPanel({
   error,
   onSelect,
   onCreateMission,
+  onPlanMission,
+  planningMissionId,
 }: {
   missions: MultiAgentMission[]
   projects: MultiAgentProject[]
@@ -291,6 +300,8 @@ export function MultiAgentMissionPanel({
   error: string | null
   onSelect: (missionId: string | null) => void
   onCreateMission: () => void
+  onPlanMission: (missionId: string) => void
+  planningMissionId: string | null
 }) {
   return (
     <aside className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
@@ -342,6 +353,21 @@ export function MultiAgentMissionPanel({
                 <span className="rounded-full border border-[var(--theme-border)] px-2 py-0.5">{projectName}</span>
                 <span className="rounded-full border border-[var(--theme-border)] px-2 py-0.5">{mission.taskIds.length} tasks</span>
               </div>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(event) => { event.stopPropagation(); onPlanMission(mission.id) }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    onPlanMission(mission.id)
+                  }
+                }}
+                className="mt-3 inline-flex rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2.5 py-1.5 text-[10px] font-semibold text-[var(--theme-text)] hover:border-[var(--theme-accent)]"
+              >
+                {planningMissionId === mission.id ? 'Planning…' : 'Plan mission'}
+              </span>
             </button>
           )
         }) : (
@@ -604,6 +630,7 @@ export function MultiAgentBoard() {
   const [createOpen, setCreateOpen] = useState(false)
   const [createMissionOpen, setCreateMissionOpen] = useState(false)
   const [selectedMissionId, setSelectedMissionId] = useState<string | null>(null)
+  const [planningMissionId, setPlanningMissionId] = useState<string | null>(null)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [startingTaskId, setStartingTaskId] = useState<string | null>(null)
   const [validationRunningType, setValidationRunningType] = useState<MultiAgentValidationType | null>(null)
@@ -675,6 +702,22 @@ export function MultiAgentBoard() {
       void queryClient.invalidateQueries({ queryKey: ['ma', 'missions'] })
     },
     onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to create mission'),
+  })
+
+  const planMissionMutation = useMutation({
+    mutationFn: planMultiAgentMission,
+    onMutate: (missionId) => {
+      setPlanningMissionId(missionId)
+      setMutationError(null)
+    },
+    onSuccess: (response, missionId) => {
+      setSelectedMissionId(missionId)
+      setSelectedTaskId(response.tasks?.[0]?.id ?? null)
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'missions'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+    },
+    onError: (error) => setMutationError(error instanceof Error ? error.message : 'Failed to plan mission'),
+    onSettled: () => setPlanningMissionId(null),
   })
 
   const createMutation = useMutation({
@@ -811,6 +854,8 @@ export function MultiAgentBoard() {
           error={missionsQuery.error instanceof Error ? missionsQuery.error.message : null}
           onSelect={(missionId) => { setSelectedMissionId(missionId); setSelectedTaskId(null) }}
           onCreateMission={() => { setMutationError(null); setCreateMissionOpen(true) }}
+          onPlanMission={(missionId) => planMissionMutation.mutate(missionId)}
+          planningMissionId={planningMissionId}
         />
       </div>
 

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -278,9 +278,9 @@ function MultiAgentCreateTaskDialog({
   const canSubmit = draft.projectId && draft.assigneeProfileId && draft.title.trim()
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_48%,transparent)] px-4 py-6 backdrop-blur-md" onClick={onCancel}>
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[color-mix(in_srgb,var(--theme-bg)_48%,transparent)] px-4 py-6 backdrop-blur-md sm:items-center" onClick={onCancel}>
       <form
-        className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
+        className="my-auto max-h-[calc(100dvh-3rem)] w-full max-w-2xl overflow-y-auto rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
         onClick={(event) => event.stopPropagation()}
         onSubmit={(event) => {
           event.preventDefault()

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -15,12 +15,13 @@ import type {
   MultiAgentProfile,
   MultiAgentProject,
   MultiAgentTask,
-  type MultiAgentEvent,
-  type MultiAgentValidation,
-  type MultiAgentApproval,
-  type MultiAgentApprovalStatus,
-  type MultiAgentArtifact,
-  type MultiAgentValidationType,
+  MultiAgentRun,
+  MultiAgentEvent,
+  MultiAgentValidation,
+  MultiAgentApproval,
+  MultiAgentApprovalStatus,
+  MultiAgentArtifact,
+  MultiAgentValidationType,
 } from '../../../server/multi-agent/types'
 import {
   buildMultiAgentBoardColumns,
@@ -42,6 +43,7 @@ type TaskValidationResponse = { ok?: boolean; validation?: MultiAgentValidation;
 type ApprovalsResponse = { ok?: boolean; approvals?: MultiAgentApproval[]; error?: string }
 type ApprovalResponse = { ok?: boolean; approval?: MultiAgentApproval; error?: string }
 type TaskPrResponse = { ok?: boolean; pr?: { url: string; artifactId: string }; approval?: MultiAgentApproval; artifact?: MultiAgentArtifact; error?: string }
+type SaveSummaryResponse = { ok?: boolean; task?: MultiAgentTask; run?: MultiAgentRun; obsidian?: { path: string }; error?: string }
 
 type CreateTaskDraft = {
   projectId: string
@@ -174,6 +176,16 @@ async function createMultiAgentTaskPr(input: { taskId: string; title: string; bo
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ title: input.title, body: input.body }),
+    }),
+  )
+}
+
+async function saveMultiAgentTaskSummary(input: { taskId: string; summary: string; saveToObsidian: boolean }): Promise<SaveSummaryResponse> {
+  return readJson<SaveSummaryResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(input.taskId)}/save-summary`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ summary: input.summary, saveToObsidian: input.saveToObsidian }),
     }),
   )
 }
@@ -336,6 +348,10 @@ export function MultiAgentBoard() {
   const [creatingPr, setCreatingPr] = useState(false)
   const [prError, setPrError] = useState<string | null>(null)
   const [prArtifactsByTaskId, setPrArtifactsByTaskId] = useState<Record<string, MultiAgentArtifact[]>>({})
+  const [summarySaving, setSummarySaving] = useState(false)
+  const [summarySaveError, setSummarySaveError] = useState<string | null>(null)
+  const [summarySavedPathByTaskId, setSummarySavedPathByTaskId] = useState<Record<string, string>>({})
+  const [runSummariesByTaskId, setRunSummariesByTaskId] = useState<Record<string, string>>({})
   const [mutationError, setMutationError] = useState<string | null>(null)
 
   const projectsQuery = useQuery({ queryKey: ['ma', 'projects'], queryFn: fetchMultiAgentProjects, staleTime: 30_000 })
@@ -374,6 +390,10 @@ export function MultiAgentBoard() {
   const selectedTaskEvents = selectedTaskEventsQuery.data ?? []
   const selectedTaskValidations = selectedTaskValidationsQuery.data ?? []
   const selectedTaskPrArtifacts = selectedTask ? (prArtifactsByTaskId[selectedTask.id] ?? []) : []
+  const selectedTaskFinalSummary = selectedTask
+    ? (runSummariesByTaskId[selectedTask.id] ?? selectedTask.finalSummary ?? null)
+    : null
+  const selectedTaskSummarySavedPath = selectedTask ? (summarySavedPathByTaskId[selectedTask.id] ?? null) : null
 
   const createMutation = useMutation({
     mutationFn: createMultiAgentTask,
@@ -450,6 +470,27 @@ export function MultiAgentBoard() {
     },
     onError: (error) => setPrError(error instanceof Error ? error.message : 'Failed to create PR'),
     onSettled: () => setCreatingPr(false),
+  })
+
+  const summaryMutation = useMutation({
+    mutationFn: saveMultiAgentTaskSummary,
+    onMutate: () => {
+      setSummarySaving(true)
+      setSummarySaveError(null)
+    },
+    onSuccess: (response, input) => {
+      if (response.error) setSummarySaveError(response.error)
+      if (response.run?.summary) {
+        setRunSummariesByTaskId((prev) => ({ ...prev, [input.taskId]: response.run!.summary ?? input.summary }))
+      }
+      if (response.obsidian?.path) {
+        setSummarySavedPathByTaskId((prev) => ({ ...prev, [input.taskId]: response.obsidian!.path }))
+      }
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', input.taskId, 'events'] })
+    },
+    onError: (error) => setSummarySaveError(error instanceof Error ? error.message : 'Failed to save summary'),
+    onSettled: () => setSummarySaving(false),
   })
 
   const loading = projectsQuery.isLoading || profilesQuery.isLoading || tasksQuery.isLoading
@@ -539,6 +580,11 @@ export function MultiAgentBoard() {
           validationRunningType={validationRunningType}
           validationError={validationError ?? (selectedTaskValidationsQuery.error instanceof Error ? selectedTaskValidationsQuery.error.message : null)}
           onValidate={(type) => selectedTask ? validationMutation.mutate({ taskId: selectedTask.id, type }) : undefined}
+          finalSummary={selectedTaskFinalSummary}
+          summarySaving={summarySaving}
+          summarySaveError={summarySaveError}
+          summarySavedPath={selectedTaskSummarySavedPath}
+          onSaveSummary={() => selectedTask && selectedTaskFinalSummary ? summaryMutation.mutate({ taskId: selectedTask.id, summary: selectedTaskFinalSummary, saveToObsidian: true }) : undefined}
         />
       </div>
 

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -16,12 +16,17 @@ import type {
   MultiAgentProject,
   MultiAgentTask,
   type MultiAgentEvent,
+  type MultiAgentValidation,
+  type MultiAgentApproval,
+  type MultiAgentApprovalStatus,
+  type MultiAgentValidationType,
 } from '../../../server/multi-agent/types'
 import {
   buildMultiAgentBoardColumns,
   buildMultiAgentTaskMeta,
   parseAcceptanceCriteriaDraft,
 } from './multi-agent-board-model'
+import { MultiAgentApprovalsPanel } from './multi-agent-approvals-panel'
 import { MultiAgentTaskDetail } from './multi-agent-task-detail'
 
 type ProjectsResponse = { ok?: boolean; projects?: MultiAgentProject[]; error?: string }
@@ -30,6 +35,10 @@ type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
 type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
 type TaskEventsResponse = { ok?: boolean; events?: MultiAgentEvent[]; error?: string }
 type TaskDiffResponse = { ok?: boolean; diff?: TaskDiffResult; error?: string }
+type TaskValidationsResponse = { ok?: boolean; validations?: MultiAgentValidation[]; error?: string }
+type TaskValidationResponse = { ok?: boolean; validation?: MultiAgentValidation; error?: string }
+type ApprovalsResponse = { ok?: boolean; approvals?: MultiAgentApproval[]; error?: string }
+type ApprovalResponse = { ok?: boolean; approval?: MultiAgentApproval; error?: string }
 
 type CreateTaskDraft = {
   projectId: string
@@ -115,6 +124,45 @@ async function fetchMultiAgentTaskDiff(taskId: string): Promise<TaskDiffResult> 
   )
   if (!data.diff) throw new Error('Task diff was not returned')
   return data.diff
+}
+
+async function fetchMultiAgentTaskValidations(taskId: string): Promise<MultiAgentValidation[]> {
+  const data = await readJson<TaskValidationsResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(taskId)}/validate`, { cache: 'no-store' }),
+  )
+  return data.validations ?? []
+}
+
+async function runMultiAgentTaskValidation(input: { taskId: string; type: MultiAgentValidationType }): Promise<MultiAgentValidation> {
+  const data = await readJson<TaskValidationResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(input.taskId)}/validate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: input.type }),
+    }),
+  )
+  if (!data.validation) throw new Error('Task validation was not returned')
+  return data.validation
+}
+
+async function fetchMultiAgentApprovals(): Promise<MultiAgentApproval[]> {
+  const data = await readJson<ApprovalsResponse>(await fetch('/api/ma/approvals', { cache: 'no-store' }))
+  return data.approvals ?? []
+}
+
+async function resolveMultiAgentApproval(input: {
+  approvalId: string
+  decision: Extract<MultiAgentApprovalStatus, 'approved' | 'denied'>
+}): Promise<MultiAgentApproval> {
+  const data = await readJson<ApprovalResponse>(
+    await fetch(`/api/ma/approvals/${encodeURIComponent(input.approvalId)}/resolve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ decision: input.decision }),
+    }),
+  )
+  if (!data.approval) throw new Error('Approval was not returned')
+  return data.approval
 }
 
 function priorityClass(priority: MultiAgentPriority): string {
@@ -268,15 +316,21 @@ export function MultiAgentBoard() {
   const [createOpen, setCreateOpen] = useState(false)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
   const [startingTaskId, setStartingTaskId] = useState<string | null>(null)
+  const [validationRunningType, setValidationRunningType] = useState<MultiAgentValidationType | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [resolvingApprovalId, setResolvingApprovalId] = useState<string | null>(null)
+  const [approvalError, setApprovalError] = useState<string | null>(null)
   const [mutationError, setMutationError] = useState<string | null>(null)
 
   const projectsQuery = useQuery({ queryKey: ['ma', 'projects'], queryFn: fetchMultiAgentProjects, staleTime: 30_000 })
   const profilesQuery = useQuery({ queryKey: ['ma', 'profiles'], queryFn: fetchMultiAgentProfiles, staleTime: 60_000 })
   const tasksQuery = useQuery({ queryKey: ['ma', 'tasks'], queryFn: fetchMultiAgentTasks, staleTime: 5_000 })
+  const approvalsQuery = useQuery({ queryKey: ['ma', 'approvals'], queryFn: fetchMultiAgentApprovals, staleTime: 2_000, refetchInterval: 5_000 })
 
   const projects = projectsQuery.data ?? []
   const profiles = profilesQuery.data ?? []
   const tasks = tasksQuery.data ?? []
+  const approvals = approvalsQuery.data ?? []
   const columns = useMemo(() => buildMultiAgentBoardColumns(tasks), [tasks])
   const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? tasks[0] ?? null
   const selectedTaskEventsQuery = useQuery({
@@ -291,6 +345,13 @@ export function MultiAgentBoard() {
     queryFn: () => fetchMultiAgentTaskDiff(selectedTask?.id ?? ''),
     enabled: Boolean(selectedTask?.id && selectedTask?.worktreePath),
     refetchInterval: selectedTask?.status === 'running' ? 3_000 : false,
+    staleTime: 1_000,
+    retry: false,
+  })
+  const selectedTaskValidationsQuery = useQuery({
+    queryKey: ['ma', 'tasks', selectedTask?.id, 'validations'],
+    queryFn: () => fetchMultiAgentTaskValidations(selectedTask?.id ?? ''),
+    enabled: Boolean(selectedTask?.id),
     staleTime: 1_000,
     retry: false,
   })
@@ -321,6 +382,33 @@ export function MultiAgentBoard() {
     onSettled: () => setStartingTaskId(null),
   })
 
+  const validationMutation = useMutation({
+    mutationFn: runMultiAgentTaskValidation,
+    onMutate: ({ type }) => {
+      setValidationRunningType(type)
+      setValidationError(null)
+    },
+    onSuccess: (validation) => {
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', validation.taskId, 'validations'] })
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'tasks', validation.taskId, 'events'] })
+    },
+    onError: (error) => setValidationError(error instanceof Error ? error.message : 'Failed to run validation'),
+    onSettled: () => setValidationRunningType(null),
+  })
+
+  const approvalMutation = useMutation({
+    mutationFn: resolveMultiAgentApproval,
+    onMutate: ({ approvalId }) => {
+      setResolvingApprovalId(approvalId)
+      setApprovalError(null)
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['ma', 'approvals'] })
+    },
+    onError: (error) => setApprovalError(error instanceof Error ? error.message : 'Failed to resolve approval'),
+    onSettled: () => setResolvingApprovalId(null),
+  })
+
   const loading = projectsQuery.isLoading || profilesQuery.isLoading || tasksQuery.isLoading
   const loadError = projectsQuery.error ?? profilesQuery.error ?? tasksQuery.error
 
@@ -347,8 +435,15 @@ export function MultiAgentBoard() {
       {loading ? <p className="mt-6 text-sm text-[var(--theme-muted)]">Loading Agent Board…</p> : null}
 
       <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="overflow-x-auto pb-2">
-          <div className="grid min-w-[1120px] grid-cols-8 gap-3">
+        <div className="space-y-4">
+          <MultiAgentApprovalsPanel
+            approvals={approvals}
+            resolvingApprovalId={resolvingApprovalId}
+            error={approvalError ?? (approvalsQuery.error instanceof Error ? approvalsQuery.error.message : null)}
+            onResolve={(approvalId, decision) => approvalMutation.mutate({ approvalId, decision })}
+          />
+          <div className="overflow-x-auto pb-2">
+            <div className="grid min-w-[1120px] grid-cols-8 gap-3">
             {columns.map((column) => (
               <div key={column.status} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-2">
                 <div className="mb-2 px-1">
@@ -376,6 +471,7 @@ export function MultiAgentBoard() {
                 </div>
               </div>
             ))}
+            </div>
           </div>
         </div>
         <MultiAgentTaskDetail
@@ -386,12 +482,16 @@ export function MultiAgentBoard() {
           diff={selectedTaskDiffQuery.data ?? null}
           diffLoading={selectedTaskDiffQuery.isLoading || selectedTaskDiffQuery.isFetching}
           diffError={selectedTaskDiffQuery.error instanceof Error ? selectedTaskDiffQuery.error.message : null}
+          validations={selectedTaskValidationsQuery.data ?? []}
+          validationRunningType={validationRunningType}
+          validationError={validationError ?? (selectedTaskValidationsQuery.error instanceof Error ? selectedTaskValidationsQuery.error.message : null)}
+          onValidate={(type) => selectedTask ? validationMutation.mutate({ taskId: selectedTask.id, type }) : undefined}
         />
       </div>
 
       <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
         <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.7} />
-        Task 11 scope: inspect worktree diffs alongside worker events before validation/PR slices.
+        Task 13 scope: review and resolve risky workspace approvals before push/PR/custom shell slices.
       </div>
 
       {createOpen ? (

--- a/src/screens/gateway/components/multi-agent-board.tsx
+++ b/src/screens/gateway/components/multi-agent-board.tsx
@@ -9,6 +9,7 @@ import {
   RefreshIcon,
 } from '@hugeicons/core-free-icons'
 import { cn } from '@/lib/utils'
+import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
 import type {
   MultiAgentPriority,
   MultiAgentProfile,
@@ -28,6 +29,7 @@ type ProfilesResponse = { ok?: boolean; profiles?: MultiAgentProfile[]; error?: 
 type TasksResponse = { ok?: boolean; tasks?: MultiAgentTask[]; error?: string }
 type TaskResponse = { ok?: boolean; task?: MultiAgentTask; error?: string }
 type TaskEventsResponse = { ok?: boolean; events?: MultiAgentEvent[]; error?: string }
+type TaskDiffResponse = { ok?: boolean; diff?: TaskDiffResult; error?: string }
 
 type CreateTaskDraft = {
   projectId: string
@@ -105,6 +107,14 @@ async function fetchMultiAgentTaskEvents(taskId: string): Promise<MultiAgentEven
     await fetch(`/api/ma/tasks/${encodeURIComponent(taskId)}/events`, { cache: 'no-store' }),
   )
   return data.events ?? []
+}
+
+async function fetchMultiAgentTaskDiff(taskId: string): Promise<TaskDiffResult> {
+  const data = await readJson<TaskDiffResponse>(
+    await fetch(`/api/ma/tasks/${encodeURIComponent(taskId)}/diff`, { cache: 'no-store' }),
+  )
+  if (!data.diff) throw new Error('Task diff was not returned')
+  return data.diff
 }
 
 function priorityClass(priority: MultiAgentPriority): string {
@@ -276,6 +286,14 @@ export function MultiAgentBoard() {
     refetchInterval: selectedTask?.status === 'running' ? 2_000 : false,
     staleTime: 1_000,
   })
+  const selectedTaskDiffQuery = useQuery({
+    queryKey: ['ma', 'tasks', selectedTask?.id, 'diff'],
+    queryFn: () => fetchMultiAgentTaskDiff(selectedTask?.id ?? ''),
+    enabled: Boolean(selectedTask?.id && selectedTask?.worktreePath),
+    refetchInterval: selectedTask?.status === 'running' ? 3_000 : false,
+    staleTime: 1_000,
+    retry: false,
+  })
   const selectedTaskEvents = selectedTaskEventsQuery.data ?? []
 
   const createMutation = useMutation({
@@ -360,12 +378,20 @@ export function MultiAgentBoard() {
             ))}
           </div>
         </div>
-        <MultiAgentTaskDetail task={selectedTask} projects={projects} profiles={profiles} events={selectedTaskEvents} />
+        <MultiAgentTaskDetail
+          task={selectedTask}
+          projects={projects}
+          profiles={profiles}
+          events={selectedTaskEvents}
+          diff={selectedTaskDiffQuery.data ?? null}
+          diffLoading={selectedTaskDiffQuery.isLoading || selectedTaskDiffQuery.isFetching}
+          diffError={selectedTaskDiffQuery.error instanceof Error ? selectedTaskDiffQuery.error.message : null}
+        />
       </div>
 
       <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
         <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={1.7} />
-        Task 8 scope: create tasks, start worktrees, and refresh board state. Worker streaming comes next.
+        Task 11 scope: inspect worktree diffs alongside worker events before validation/PR slices.
       </div>
 
       {createOpen ? (

--- a/src/screens/gateway/components/multi-agent-pr-panel.test.tsx
+++ b/src/screens/gateway/components/multi-agent-pr-panel.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentArtifact, MultiAgentTask, MultiAgentValidation } from '../../../server/multi-agent/types'
+import { MultiAgentPrPanel } from './multi-agent-pr-panel'
+
+const now = '2026-05-18T13:00:00.000Z'
+
+function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
+  return {
+    id: 'task-1',
+    projectId: 'workspace',
+    title: 'Create PR',
+    description: 'Open a pull request',
+    status: 'review',
+    priority: 'medium',
+    assigneeProfileId: 'backend-engineer',
+    parentIds: [],
+    childIds: [],
+    workPacket: 'Summary body',
+    acceptanceCriteria: [],
+    branchName: 'hermes/task-1-demo',
+    worktreePath: '/repo/.worktrees/task-1',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function validation(overrides: Partial<MultiAgentValidation> = {}): MultiAgentValidation {
+  return {
+    id: 'validation-1',
+    taskId: 'task-1',
+    type: 'test',
+    command: 'pnpm test',
+    status: 'passed',
+    exitCode: 0,
+    ...overrides,
+  }
+}
+
+function artifact(overrides: Partial<MultiAgentArtifact> = {}): MultiAgentArtifact {
+  return {
+    id: 'artifact-1',
+    taskId: 'task-1',
+    type: 'github-pr',
+    pathOrUrl: 'https://github.com/example/repo/pull/1',
+    title: 'Create PR',
+    createdAt: now,
+    ...overrides,
+  }
+}
+
+describe('MultiAgentPrPanel', () => {
+  it('renders PR readiness, validation status, and existing PR links', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentPrPanel task={task()} validations={[validation()]} prArtifacts={[artifact()]} creating={false} error={null} onCreatePr={() => undefined} />,
+    )
+
+    expect(html).toContain('Pull Request')
+    expect(html).toContain('hermes/task-1-demo')
+    expect(html).toContain('validation passed')
+    expect(html).toContain('Create PR')
+    expect(html).toContain('https://github.com/example/repo/pull/1')
+  })
+
+  it('disables PR creation until worktree branch and validation are ready', () => {
+    const noWorktree = renderToStaticMarkup(
+      <MultiAgentPrPanel task={task({ worktreePath: null, branchName: null })} validations={[]} prArtifacts={[]} creating={false} error={null} onCreatePr={() => undefined} />,
+    )
+    const noValidation = renderToStaticMarkup(
+      <MultiAgentPrPanel task={task()} validations={[]} prArtifacts={[]} creating error="approval required" onCreatePr={() => undefined} />,
+    )
+
+    expect(noWorktree).toContain('Worktree and branch are required')
+    expect(noWorktree).toContain('disabled')
+    expect(noValidation).toContain('No passed validation')
+    expect(noValidation).toContain('Creating PR')
+    expect(noValidation).toContain('approval required')
+  })
+})

--- a/src/screens/gateway/components/multi-agent-pr-panel.tsx
+++ b/src/screens/gateway/components/multi-agent-pr-panel.tsx
@@ -1,0 +1,61 @@
+import type { MultiAgentArtifact, MultiAgentTask, MultiAgentValidation } from '../../../server/multi-agent/types'
+
+export function MultiAgentPrPanel({
+  task,
+  validations,
+  prArtifacts,
+  creating,
+  error,
+  onCreatePr,
+}: {
+  task: MultiAgentTask
+  validations: MultiAgentValidation[]
+  prArtifacts: MultiAgentArtifact[]
+  creating: boolean
+  error: string | null
+  onCreatePr: () => void
+}) {
+  const hasWorktree = Boolean(task.worktreePath && task.branchName)
+  const hasPassedValidation = validations.some((validation) => validation.status === 'passed')
+  const canCreate = hasWorktree && hasPassedValidation && !creating
+
+  return (
+    <div className="mt-2 space-y-3">
+      <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Pull Request</p>
+            <p className="mt-1 font-mono text-[10px] text-[var(--theme-muted-2)]">{task.branchName || 'No branch yet'}</p>
+          </div>
+          <button
+            type="button"
+            disabled={!canCreate}
+            onClick={onCreatePr}
+            className="rounded-lg bg-[var(--theme-accent)] px-3 py-1.5 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {creating ? 'Creating PR…' : 'Create PR'}
+          </button>
+        </div>
+        <div className="mt-2 space-y-1 text-xs text-[var(--theme-muted-2)]">
+          <p>{hasWorktree ? 'Worktree and branch ready.' : 'Worktree and branch are required.'}</p>
+          <p>{hasPassedValidation ? 'validation passed' : 'No passed validation.'}</p>
+        </div>
+      </div>
+
+      {error ? <p className="rounded-xl border border-amber-400/35 bg-amber-500/10 px-3 py-3 text-sm text-amber-200">{error}</p> : null}
+
+      {prArtifacts.length ? (
+        <ol className="space-y-2">
+          {prArtifacts.map((artifact) => (
+            <li key={artifact.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+              <p className="text-xs font-semibold text-[var(--theme-text)]">{artifact.title}</p>
+              <a href={artifact.pathOrUrl} className="mt-1 block break-all font-mono text-[10px] text-[var(--theme-accent-strong)]">{artifact.pathOrUrl}</a>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No PR created yet.</p>
+      )}
+    </div>
+  )
+}

--- a/src/screens/gateway/components/multi-agent-task-detail.test.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.test.tsx
@@ -1,8 +1,15 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
-import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
+import type {
+  MultiAgentEvent,
+  MultiAgentProfile,
+  MultiAgentProject,
+  MultiAgentTask,
+  MultiAgentValidation,
+} from '../../../server/multi-agent/types'
 import { MultiAgentDiffPanel, MultiAgentTaskDetail } from './multi-agent-task-detail'
+import { MultiAgentValidationPanel } from './multi-agent-validation-panel'
 
 const now = '2026-05-18T00:00:00.000Z'
 
@@ -76,6 +83,59 @@ const changedDiff: TaskDiffResult = {
   stat: 'README.md | 2 +-\nnew-file.txt | untracked',
   diff: 'diff --git a/README.md b/README.md\n+# changed repo\ndiff --git a/new-file.txt b/new-file.txt\n+new file',
 }
+
+function validation(overrides: Partial<MultiAgentValidation> = {}): MultiAgentValidation {
+  return {
+    id: 'validation-1',
+    taskId: 'task-1',
+    type: 'test',
+    command: 'pnpm test',
+    status: 'passed',
+    exitCode: 0,
+    outputSummary: 'all tests passed',
+    outputArtifactId: 'artifact-1',
+    startedAt: now,
+    finishedAt: now,
+    ...overrides,
+  }
+}
+
+describe('MultiAgentValidationPanel', () => {
+  it('renders validation commands and latest validation results', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentValidationPanel
+        task={task()}
+        validations={[validation(), validation({ id: 'validation-2', type: 'build', command: 'pnpm build', status: 'failed', exitCode: 1, outputSummary: 'build failed' })]}
+        runningType={null}
+        error={null}
+        onValidate={() => undefined}
+      />,
+    )
+
+    expect(html).toContain('Run test')
+    expect(html).toContain('Run build')
+    expect(html).toContain('test')
+    expect(html).toContain('passed')
+    expect(html).toContain('all tests passed')
+    expect(html).toContain('build')
+    expect(html).toContain('failed')
+    expect(html).toContain('build failed')
+  })
+
+  it('disables validation controls until a worktree exists and shows running state', () => {
+    const noWorktree = renderToStaticMarkup(
+      <MultiAgentValidationPanel task={task({ worktreePath: null })} validations={[]} runningType={null} error={null} onValidate={() => undefined} />,
+    )
+    const running = renderToStaticMarkup(
+      <MultiAgentValidationPanel task={task()} validations={[]} runningType="test" error="validation unavailable" onValidate={() => undefined} />,
+    )
+
+    expect(noWorktree).toContain('Create or start a worktree before validation')
+    expect(noWorktree).toContain('disabled')
+    expect(running).toContain('Running test')
+    expect(running).toContain('validation unavailable')
+  })
+})
 
 describe('MultiAgentDiffPanel', () => {
   it('renders changed files, stat, and unified diff content', () => {

--- a/src/screens/gateway/components/multi-agent-task-detail.test.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.test.tsx
@@ -1,7 +1,8 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
 import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
-import { MultiAgentTaskDetail } from './multi-agent-task-detail'
+import { MultiAgentDiffPanel, MultiAgentTaskDetail } from './multi-agent-task-detail'
 
 const now = '2026-05-18T00:00:00.000Z'
 
@@ -63,6 +64,38 @@ function event(overrides: Partial<MultiAgentEvent> = {}): MultiAgentEvent {
     ...overrides,
   }
 }
+
+const changedDiff: TaskDiffResult = {
+  clean: false,
+  changedFiles: ['README.md', 'new-file.txt'],
+  files: [
+    { path: 'README.md', status: 'M' },
+    { path: 'new-file.txt', status: '??' },
+  ],
+  porcelain: ' M README.md\n?? new-file.txt',
+  stat: 'README.md | 2 +-\nnew-file.txt | untracked',
+  diff: 'diff --git a/README.md b/README.md\n+# changed repo\ndiff --git a/new-file.txt b/new-file.txt\n+new file',
+}
+
+describe('MultiAgentDiffPanel', () => {
+  it('renders changed files, stat, and unified diff content', () => {
+    const html = renderToStaticMarkup(<MultiAgentDiffPanel diff={changedDiff} loading={false} error={null} />)
+
+    expect(html).toContain('README.md')
+    expect(html).toContain('new-file.txt')
+    expect(html).toContain('README.md | 2 +-')
+    expect(html).toContain('diff --git a/README.md b/README.md')
+    expect(html).toContain('+new file')
+  })
+
+  it('renders clean and loading states', () => {
+    const cleanHtml = renderToStaticMarkup(<MultiAgentDiffPanel diff={{ ...changedDiff, clean: true, changedFiles: [], files: [], stat: '', diff: '', porcelain: '' }} loading={false} error={null} />)
+    const loadingHtml = renderToStaticMarkup(<MultiAgentDiffPanel diff={null} loading error={null} />)
+
+    expect(cleanHtml).toContain('No changes in worktree')
+    expect(loadingHtml).toContain('Loading diff')
+  })
+})
 
 describe('MultiAgentTaskDetail', () => {
   it('renders the selected task work packet, worktree, and live events from an extracted component', () => {

--- a/src/screens/gateway/components/multi-agent-task-detail.test.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
+import { MultiAgentTaskDetail } from './multi-agent-task-detail'
+
+const now = '2026-05-18T00:00:00.000Z'
+
+const project: MultiAgentProject = {
+  id: 'workspace',
+  name: 'Workspace',
+  repoPath: '/repo',
+  defaultBranch: 'main',
+  worktreeRoot: '/repo/.hermes-worktrees',
+  githubRemote: null,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const profile: MultiAgentProfile = {
+  id: 'backend-engineer',
+  name: 'Backend Engineer',
+  role: 'backend-engineer',
+  runtime: 'hermes-agent',
+  model: null,
+  skills: ['test-driven-development'],
+  enabledToolsets: ['terminal', 'file'],
+  permissionPolicy: 'ask-risky',
+  createdAt: now,
+  updatedAt: now,
+}
+
+function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
+  return {
+    id: 'task-1',
+    projectId: 'workspace',
+    title: 'Run worker',
+    description: 'Run a worker and show logs',
+    status: 'running',
+    priority: 'medium',
+    assigneeProfileId: 'backend-engineer',
+    parentIds: [],
+    childIds: [],
+    workPacket: 'Execute the work packet',
+    acceptanceCriteria: ['streams logs'],
+    branchName: 'hermes/task-1-run-worker',
+    worktreePath: '/repo/.hermes-worktrees/task-1-run-worker',
+    latestRunId: 'run-1',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function event(overrides: Partial<MultiAgentEvent> = {}): MultiAgentEvent {
+  return {
+    id: 'event-1',
+    taskId: 'task-1',
+    runId: 'run-1',
+    type: 'run.log',
+    message: 'worker says hi',
+    payload: { stream: 'stdout' },
+    createdAt: now,
+    ...overrides,
+  }
+}
+
+describe('MultiAgentTaskDetail', () => {
+  it('renders the selected task work packet, worktree, and live events from an extracted component', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentTaskDetail
+        task={task()}
+        projects={[project]}
+        profiles={[profile]}
+        events={[event()]}
+      />,
+    )
+
+    expect(html).toContain('Task Detail')
+    expect(html).toContain('Run worker')
+    expect(html).toContain('Backend Engineer')
+    expect(html).toContain('task-1-run-worker')
+    expect(html).toContain('Execute the work packet')
+    expect(html).toContain('streams logs')
+    expect(html).toContain('Events / Live Log')
+    expect(html).toContain('worker says hi')
+  })
+
+  it('renders an empty selection state without requiring board internals', () => {
+    const html = renderToStaticMarkup(
+      <MultiAgentTaskDetail task={null} projects={[project]} profiles={[profile]} events={[]} />,
+    )
+
+    expect(html).toContain('Select a task to inspect')
+  })
+})

--- a/src/screens/gateway/components/multi-agent-task-detail.test.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.test.tsx
@@ -100,6 +100,21 @@ function validation(overrides: Partial<MultiAgentValidation> = {}): MultiAgentVa
   }
 }
 
+function summaryProps(overrides: Partial<React.ComponentProps<typeof MultiAgentTaskDetail>> = {}) {
+  return {
+    task: task(),
+    projects: [project],
+    profiles: [profile],
+    events: [event()],
+    finalSummary: 'Implemented memory hooks and saved context.',
+    summarySaving: false,
+    summarySaveError: null,
+    summarySavedPath: null,
+    onSaveSummary: () => undefined,
+    ...overrides,
+  }
+}
+
 describe('MultiAgentValidationPanel', () => {
   it('renders validation commands and latest validation results', () => {
     const html = renderToStaticMarkup(
@@ -184,5 +199,23 @@ describe('MultiAgentTaskDetail', () => {
     )
 
     expect(html).toContain('Select a task to inspect')
+  })
+
+  it('renders final summary and optional Obsidian save controls', () => {
+    const html = renderToStaticMarkup(<MultiAgentTaskDetail {...summaryProps()} />)
+
+    expect(html).toContain('Final Summary')
+    expect(html).toContain('Implemented memory hooks and saved context.')
+    expect(html).toContain('Save summary to Obsidian')
+  })
+
+  it('renders summary save states and saved path', () => {
+    const saving = renderToStaticMarkup(<MultiAgentTaskDetail {...summaryProps({ summarySaving: true })} />)
+    const saved = renderToStaticMarkup(<MultiAgentTaskDetail {...summaryProps({ summarySavedPath: '/vault/Hermes/Multi-Agent Runs/task-1.md' })} />)
+    const error = renderToStaticMarkup(<MultiAgentTaskDetail {...summaryProps({ summarySaveError: 'Cannot write note' })} />)
+
+    expect(saving).toContain('Saving summary…')
+    expect(saved).toContain('/vault/Hermes/Multi-Agent Runs/task-1.md')
+    expect(error).toContain('Cannot write note')
   })
 })

--- a/src/screens/gateway/components/multi-agent-task-detail.test.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.test.tsx
@@ -49,6 +49,12 @@ function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
     parentIds: [],
     childIds: [],
     workPacket: 'Execute the work packet',
+    productBrief: {
+      goal: 'Ship a clearer operator experience',
+      userStory: 'As an operator, I understand why this task matters.',
+      successMetrics: ['activation: task accepted by PM'],
+      nonGoals: ['billing changes'],
+    },
     acceptanceCriteria: ['streams logs'],
     branchName: 'hermes/task-1-run-worker',
     worktreePath: '/repo/.hermes-worktrees/task-1-run-worker',
@@ -111,6 +117,26 @@ function summaryProps(overrides: Partial<React.ComponentProps<typeof MultiAgentT
     summarySaveError: null,
     summarySavedPath: null,
     onSaveSummary: () => undefined,
+    ...overrides,
+  }
+}
+
+function skillDebugProps(overrides: Partial<React.ComponentProps<typeof MultiAgentTaskDetail>> = {}) {
+  return {
+    task: task(),
+    projects: [project],
+    profiles: [profile],
+    events: [
+      event({
+        id: 'event-skills',
+        type: 'run.started',
+        message: 'Started Hermes worker with contextual skills',
+        payload: {
+          loadedSkills: ['test-driven-development', 'systematic-debugging', 'frontend-design'],
+        },
+      }),
+    ],
+    loadedSkills: ['test-driven-development', 'systematic-debugging', 'frontend-design'],
     ...overrides,
   }
 }
@@ -188,6 +214,11 @@ describe('MultiAgentTaskDetail', () => {
     expect(html).toContain('Backend Engineer')
     expect(html).toContain('task-1-run-worker')
     expect(html).toContain('Execute the work packet')
+    expect(html).toContain('Product Brief')
+    expect(html).toContain('Ship a clearer operator experience')
+    expect(html).toContain('As an operator, I understand why this task matters.')
+    expect(html).toContain('activation: task accepted by PM')
+    expect(html).toContain('billing changes')
     expect(html).toContain('streams logs')
     expect(html).toContain('Events / Live Log')
     expect(html).toContain('worker says hi')
@@ -217,5 +248,14 @@ describe('MultiAgentTaskDetail', () => {
     expect(saving).toContain('Saving summary…')
     expect(saved).toContain('/vault/Hermes/Multi-Agent Runs/task-1.md')
     expect(error).toContain('Cannot write note')
+  })
+
+  it('renders a debug panel for skills loaded for this run', () => {
+    const html = renderToStaticMarkup(<MultiAgentTaskDetail {...skillDebugProps()} />)
+
+    expect(html).toContain('Skills loaded for this run')
+    expect(html).toContain('test-driven-development')
+    expect(html).toContain('systematic-debugging')
+    expect(html).toContain('frontend-design')
   })
 })

--- a/src/screens/gateway/components/multi-agent-task-detail.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.tsx
@@ -1,6 +1,14 @@
 import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
-import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
+import type {
+  MultiAgentEvent,
+  MultiAgentProfile,
+  MultiAgentProject,
+  MultiAgentTask,
+  MultiAgentValidation,
+  MultiAgentValidationType,
+} from '../../../server/multi-agent/types'
 import { buildMultiAgentTaskMeta } from './multi-agent-board-model'
+import { MultiAgentValidationPanel } from './multi-agent-validation-panel'
 
 type MultiAgentTaskDetailProps = {
   task: MultiAgentTask | null
@@ -10,6 +18,10 @@ type MultiAgentTaskDetailProps = {
   diff?: TaskDiffResult | null
   diffLoading?: boolean
   diffError?: string | null
+  validations?: MultiAgentValidation[]
+  validationRunningType?: MultiAgentValidationType | null
+  validationError?: string | null
+  onValidate?: (type: MultiAgentValidationType) => void
 }
 
 function projectLabel(projects: MultiAgentProject[], id: string): string {
@@ -67,6 +79,10 @@ export function MultiAgentTaskDetail({
   diff = null,
   diffLoading = false,
   diffError = null,
+  validations = [],
+  validationRunningType = null,
+  validationError = null,
+  onValidate = () => undefined,
 }: MultiAgentTaskDetailProps) {
   if (!task) {
     return (
@@ -112,6 +128,16 @@ export function MultiAgentTaskDetail({
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Diff</h4>
           <MultiAgentDiffPanel diff={diff} loading={diffLoading} error={diffError} />
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Validation</h4>
+          <MultiAgentValidationPanel
+            task={task}
+            validations={validations}
+            runningType={validationRunningType}
+            error={validationError}
+            onValidate={onValidate}
+          />
         </section>
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>

--- a/src/screens/gateway/components/multi-agent-task-detail.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.tsx
@@ -22,6 +22,11 @@ type MultiAgentTaskDetailProps = {
   validationRunningType?: MultiAgentValidationType | null
   validationError?: string | null
   onValidate?: (type: MultiAgentValidationType) => void
+  finalSummary?: string | null
+  summarySaving?: boolean
+  summarySaveError?: string | null
+  summarySavedPath?: string | null
+  onSaveSummary?: () => void
 }
 
 function projectLabel(projects: MultiAgentProject[], id: string): string {
@@ -83,6 +88,11 @@ export function MultiAgentTaskDetail({
   validationRunningType = null,
   validationError = null,
   onValidate = () => undefined,
+  finalSummary = null,
+  summarySaving = false,
+  summarySaveError = null,
+  summarySavedPath = null,
+  onSaveSummary = () => undefined,
 }: MultiAgentTaskDetailProps) {
   if (!task) {
     return (
@@ -139,6 +149,24 @@ export function MultiAgentTaskDetail({
             onValidate={onValidate}
           />
         </section>
+        {finalSummary ? (
+          <section>
+            <div className="flex items-center justify-between gap-3">
+              <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Final Summary</h4>
+              <button
+                type="button"
+                disabled={summarySaving}
+                onClick={onSaveSummary}
+                className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2.5 py-1 text-[11px] font-semibold text-[var(--theme-text)] hover:border-[var(--theme-accent)] disabled:opacity-50"
+              >
+                {summarySaving ? 'Saving summary…' : 'Save summary to Obsidian'}
+              </button>
+            </div>
+            <p className="mt-2 whitespace-pre-wrap rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">{finalSummary}</p>
+            {summarySavedPath ? <p className="mt-2 rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-300">Saved to {summarySavedPath}</p> : null}
+            {summarySaveError ? <p className="mt-2 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-2 text-xs text-red-300">{summarySaveError}</p> : null}
+          </section>
+        ) : null}
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>
           {events.length ? (

--- a/src/screens/gateway/components/multi-agent-task-detail.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.tsx
@@ -1,3 +1,4 @@
+import type { TaskDiffResult } from '../../../server/multi-agent/diff-manager'
 import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
 import { buildMultiAgentTaskMeta } from './multi-agent-board-model'
 
@@ -6,6 +7,9 @@ type MultiAgentTaskDetailProps = {
   projects: MultiAgentProject[]
   profiles: MultiAgentProfile[]
   events: MultiAgentEvent[]
+  diff?: TaskDiffResult | null
+  diffLoading?: boolean
+  diffError?: string | null
 }
 
 function projectLabel(projects: MultiAgentProject[], id: string): string {
@@ -16,7 +20,54 @@ function profileLabel(profiles: MultiAgentProfile[], id: string): string {
   return profiles.find((profile) => profile.id === id)?.name ?? id
 }
 
-export function MultiAgentTaskDetail({ task, projects, profiles, events }: MultiAgentTaskDetailProps) {
+export function MultiAgentDiffPanel({
+  diff,
+  loading,
+  error,
+}: {
+  diff: TaskDiffResult | null
+  loading: boolean
+  error: string | null
+}) {
+  if (loading) {
+    return <p className="mt-2 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">Loading diff…</p>
+  }
+  if (error) {
+    return <p className="mt-2 rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-3 text-sm text-red-300">{error}</p>
+  }
+  if (!diff || diff.clean) {
+    return <p className="mt-2 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No changes in worktree.</p>
+  }
+
+  return (
+    <div className="mt-2 space-y-3">
+      <div>
+        <p className="text-xs font-medium text-[var(--theme-muted)]">Changed files</p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {diff.changedFiles.map((file) => (
+            <span key={file} className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5 font-mono text-[10px] text-[var(--theme-text)]">{file}</span>
+          ))}
+        </div>
+      </div>
+      {diff.stat ? (
+        <pre className="max-h-32 overflow-auto rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-xs text-[var(--theme-muted-2)]">{diff.stat}</pre>
+      ) : null}
+      {diff.diff ? (
+        <pre className="max-h-80 overflow-auto rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-xs text-[var(--theme-text)]">{diff.diff}</pre>
+      ) : null}
+    </div>
+  )
+}
+
+export function MultiAgentTaskDetail({
+  task,
+  projects,
+  profiles,
+  events,
+  diff = null,
+  diffLoading = false,
+  diffError = null,
+}: MultiAgentTaskDetailProps) {
   if (!task) {
     return (
       <aside className="rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-[var(--theme-muted)]">
@@ -57,6 +108,10 @@ export function MultiAgentTaskDetail({ task, projects, profiles, events }: Multi
           ) : (
             <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
           )}
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Diff</h4>
+          <MultiAgentDiffPanel diff={diff} loading={diffLoading} error={diffError} />
         </section>
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>

--- a/src/screens/gateway/components/multi-agent-task-detail.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.tsx
@@ -27,6 +27,7 @@ type MultiAgentTaskDetailProps = {
   summarySaveError?: string | null
   summarySavedPath?: string | null
   onSaveSummary?: () => void
+  loadedSkills?: string[]
 }
 
 function projectLabel(projects: MultiAgentProject[], id: string): string {
@@ -93,6 +94,7 @@ export function MultiAgentTaskDetail({
   summarySaveError = null,
   summarySavedPath = null,
   onSaveSummary = () => undefined,
+  loadedSkills = [],
 }: MultiAgentTaskDetailProps) {
   if (!task) {
     return (
@@ -125,6 +127,17 @@ export function MultiAgentTaskDetail({
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Work Packet</h4>
           <p className="mt-2 whitespace-pre-wrap rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">{task.workPacket || task.description || 'No work packet provided.'}</p>
         </section>
+        {task.productBrief ? (
+          <section>
+            <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Product Brief</h4>
+            <div className="mt-2 space-y-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">
+              {task.productBrief.goal ? <p><span className="font-semibold">Goal:</span> {task.productBrief.goal}</p> : null}
+              {task.productBrief.userStory ? <p><span className="font-semibold">User story:</span> {task.productBrief.userStory}</p> : null}
+              {task.productBrief.successMetrics.length ? <p><span className="font-semibold">Success metrics:</span> {task.productBrief.successMetrics.join('; ')}</p> : null}
+              {task.productBrief.nonGoals.length ? <p><span className="font-semibold">Non-goals:</span> {task.productBrief.nonGoals.join('; ')}</p> : null}
+            </div>
+          </section>
+        ) : null}
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Acceptance Criteria</h4>
           {task.acceptanceCriteria.length ? (
@@ -135,6 +148,16 @@ export function MultiAgentTaskDetail({
             <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
           )}
         </section>
+        {loadedSkills.length ? (
+          <section>
+            <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Skills loaded for this run</h4>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {loadedSkills.map((skill) => (
+                <span key={skill} className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5 font-mono text-[10px] text-[var(--theme-text)]">{skill}</span>
+              ))}
+            </div>
+          </section>
+        ) : null}
         <section>
           <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Diff</h4>
           <MultiAgentDiffPanel diff={diff} loading={diffLoading} error={diffError} />

--- a/src/screens/gateway/components/multi-agent-task-detail.tsx
+++ b/src/screens/gateway/components/multi-agent-task-detail.tsx
@@ -1,0 +1,82 @@
+import type { MultiAgentEvent, MultiAgentProfile, MultiAgentProject, MultiAgentTask } from '../../../server/multi-agent/types'
+import { buildMultiAgentTaskMeta } from './multi-agent-board-model'
+
+type MultiAgentTaskDetailProps = {
+  task: MultiAgentTask | null
+  projects: MultiAgentProject[]
+  profiles: MultiAgentProfile[]
+  events: MultiAgentEvent[]
+}
+
+function projectLabel(projects: MultiAgentProject[], id: string): string {
+  return projects.find((project) => project.id === id)?.name ?? id
+}
+
+function profileLabel(profiles: MultiAgentProfile[], id: string): string {
+  return profiles.find((profile) => profile.id === id)?.name ?? id
+}
+
+export function MultiAgentTaskDetail({ task, projects, profiles, events }: MultiAgentTaskDetailProps) {
+  if (!task) {
+    return (
+      <aside className="rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-5 text-sm text-[var(--theme-muted)]">
+        Select a task to inspect its work packet, acceptance criteria, branch, and worktree.
+      </aside>
+    )
+  }
+
+  const meta = buildMultiAgentTaskMeta(task)
+  return (
+    <aside className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Task Detail</p>
+          <h3 className="mt-2 text-lg font-semibold text-[var(--theme-text)]">{task.title}</h3>
+        </div>
+        <span className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-3 py-1 text-xs font-semibold text-[var(--theme-accent-strong)]">
+          {meta.statusLabel}
+        </span>
+      </div>
+      <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+        <div><dt className="text-xs text-[var(--theme-muted)]">Project</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{projectLabel(projects, task.projectId)}</dd></div>
+        <div><dt className="text-xs text-[var(--theme-muted)]">Profile</dt><dd className="mt-1 font-medium text-[var(--theme-text)]">{profileLabel(profiles, task.assigneeProfileId)}</dd></div>
+        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Branch</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{meta.branchLabel}</dd></div>
+        <div className="sm:col-span-2"><dt className="text-xs text-[var(--theme-muted)]">Worktree</dt><dd className="mt-1 truncate font-mono text-xs text-[var(--theme-text)]">{task.worktreePath || 'No worktree yet'}</dd></div>
+      </dl>
+      <div className="mt-5 space-y-4">
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Work Packet</h4>
+          <p className="mt-2 whitespace-pre-wrap rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm text-[var(--theme-text)]">{task.workPacket || task.description || 'No work packet provided.'}</p>
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Acceptance Criteria</h4>
+          {task.acceptanceCriteria.length ? (
+            <ul className="mt-2 space-y-1 text-sm text-[var(--theme-text)]">
+              {task.acceptanceCriteria.map((criterion) => <li key={criterion} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">• {criterion}</li>)}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-[var(--theme-muted-2)]">No criteria captured.</p>
+          )}
+        </section>
+        <section>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Events / Live Log</h4>
+          {events.length ? (
+            <ol className="mt-2 max-h-72 space-y-2 overflow-auto pr-1">
+              {events.slice(-12).map((event) => (
+                <li key={event.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+                  <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                    <span>{event.type}</span>
+                    <span>{new Date(event.createdAt).toLocaleTimeString()}</span>
+                  </div>
+                  <p className="mt-1 whitespace-pre-wrap text-xs text-[var(--theme-text)]">{event.message}</p>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="mt-2 rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No events captured yet.</p>
+          )}
+        </section>
+      </div>
+    </aside>
+  )
+}

--- a/src/screens/gateway/components/multi-agent-validation-panel.tsx
+++ b/src/screens/gateway/components/multi-agent-validation-panel.tsx
@@ -1,0 +1,65 @@
+import type {
+  MultiAgentTask,
+  MultiAgentValidation,
+  MultiAgentValidationType,
+} from '../../../server/multi-agent/types'
+
+const VALIDATION_COMMANDS: Array<{ type: MultiAgentValidationType; label: string }> = [
+  { type: 'lint', label: 'Run lint' },
+  { type: 'typecheck', label: 'Run typecheck' },
+  { type: 'test', label: 'Run test' },
+  { type: 'build', label: 'Run build' },
+]
+
+export function MultiAgentValidationPanel({
+  task,
+  validations,
+  runningType,
+  error,
+  onValidate,
+}: {
+  task: MultiAgentTask
+  validations: MultiAgentValidation[]
+  runningType: MultiAgentValidationType | null
+  error: string | null
+  onValidate: (type: MultiAgentValidationType) => void
+}) {
+  const disabled = !task.worktreePath || Boolean(runningType)
+  return (
+    <div className="mt-2 space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {VALIDATION_COMMANDS.map((command) => (
+          <button
+            key={command.type}
+            type="button"
+            disabled={disabled}
+            onClick={() => onValidate(command.type)}
+            className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2.5 py-1.5 text-[11px] font-semibold text-[var(--theme-text)] hover:border-[var(--theme-accent)] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {runningType === command.type ? `Running ${command.type}…` : command.label}
+          </button>
+        ))}
+      </div>
+      {!task.worktreePath ? (
+        <p className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">Create or start a worktree before validation.</p>
+      ) : null}
+      {error ? <p className="rounded-xl border border-red-400/35 bg-red-500/10 px-3 py-3 text-sm text-red-300">{error}</p> : null}
+      {validations.length ? (
+        <ol className="space-y-2">
+          {validations.slice(0, 5).map((validation) => (
+            <li key={validation.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+              <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                <span>{validation.type}</span>
+                <span>{validation.status}{typeof validation.exitCode === 'number' ? ` · exit ${validation.exitCode}` : ''}</span>
+              </div>
+              <p className="mt-1 font-mono text-[10px] text-[var(--theme-muted-2)]">{validation.command}</p>
+              {validation.outputSummary ? <p className="mt-1 whitespace-pre-wrap text-xs text-[var(--theme-text)]">{validation.outputSummary}</p> : null}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-sm text-[var(--theme-muted-2)]">No validations run yet.</p>
+      )}
+    </div>
+  )
+}

--- a/src/screens/gateway/conductor-launch-intent.test.ts
+++ b/src/screens/gateway/conductor-launch-intent.test.ts
@@ -34,6 +34,24 @@ describe('conductor launch intent', () => {
           activeProjectName: 'demo-app',
           activeProjectPath: '/workspace/demo-app',
           effectiveWorkingDirectory: '/workspace/demo-app',
+          contextPreview: {
+            summary: 'Path: /workspace/demo-app\nContext files: 1',
+            files: [
+              {
+                name: 'AGENTS.md',
+                path: '/workspace/demo-app/AGENTS.md',
+                chars: 640,
+              },
+            ],
+          },
+          status: {
+            gitDirty: true,
+            changedFiles: 2,
+            lastCommit: 'abc1234',
+            lastCommitAt: '2026-01-01T00:00:00Z',
+            detectedStack: ['Node/TypeScript'],
+            packageManager: 'pnpm',
+          },
         },
       },
       now,
@@ -48,6 +66,24 @@ describe('conductor launch intent', () => {
         activeProjectName: 'demo-app',
         activeProjectPath: '/workspace/demo-app',
         effectiveWorkingDirectory: '/workspace/demo-app',
+        contextPreview: {
+          summary: 'Path: /workspace/demo-app\nContext files: 1',
+          files: [
+            {
+              name: 'AGENTS.md',
+              path: '/workspace/demo-app/AGENTS.md',
+              chars: 640,
+            },
+          ],
+        },
+        status: {
+          gitDirty: true,
+          changedFiles: 2,
+          lastCommit: 'abc1234',
+          lastCommitAt: '2026-01-01T00:00:00Z',
+          detectedStack: ['Node/TypeScript'],
+          packageManager: 'pnpm',
+        },
       },
     })
   })

--- a/src/screens/gateway/conductor-launch-intent.test.ts
+++ b/src/screens/gateway/conductor-launch-intent.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY,
+  CONDUCTOR_LAUNCH_INTENT_TTL_MS,
+  consumeConductorLaunchIntent,
+  parseConductorLaunchIntent,
+  persistConductorLaunchIntent,
+} from './conductor-launch-intent'
+
+function createMemoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key)
+    }),
+    values,
+  }
+}
+
+describe('conductor launch intent', () => {
+  it('parses valid project launch intent and preserves project override', () => {
+    const now = Date.now()
+    const intent = parseConductorLaunchIntent(
+      {
+        source: 'projects',
+        createdAt: now,
+        draft: 'Build: ship slice',
+        projectOverride: {
+          activeProjectId: 'project-1',
+          activeProjectName: 'demo-app',
+          activeProjectPath: '/workspace/demo-app',
+          effectiveWorkingDirectory: '/workspace/demo-app',
+        },
+      },
+      now,
+    )
+
+    expect(intent).toEqual({
+      source: 'projects',
+      createdAt: now,
+      draft: 'Build: ship slice',
+      projectOverride: {
+        activeProjectId: 'project-1',
+        activeProjectName: 'demo-app',
+        activeProjectPath: '/workspace/demo-app',
+        effectiveWorkingDirectory: '/workspace/demo-app',
+      },
+    })
+  })
+
+  it('rejects expired or malformed intents', () => {
+    const now = Date.now()
+    expect(
+      parseConductorLaunchIntent(
+        {
+          source: 'projects',
+          createdAt: now - CONDUCTOR_LAUNCH_INTENT_TTL_MS - 1,
+          draft: 'too late',
+          projectOverride: { activeProjectPath: '/workspace/demo-app' },
+        },
+        now,
+      ),
+    ).toBeNull()
+
+    expect(
+      parseConductorLaunchIntent(
+        {
+          source: 'projects',
+          createdAt: now,
+          draft: 'missing project',
+          projectOverride: {},
+        },
+        now,
+      ),
+    ).toBeNull()
+  })
+
+  it('persists draft fallback and consumes intent once', () => {
+    const storage = createMemoryStorage()
+    persistConductorLaunchIntent(
+      {
+        source: 'projects',
+        createdAt: Date.now(),
+        draft: 'Build: from project',
+        projectOverride: {
+          activeProjectId: 'project-1',
+          activeProjectName: 'demo-app',
+          activeProjectPath: '/workspace/demo-app',
+          effectiveWorkingDirectory: '/workspace/demo-app',
+        },
+      },
+      storage,
+    )
+
+    expect(storage.values.get('conductor:goal-draft')).toBe(
+      'Build: from project',
+    )
+    expect(storage.values.has(CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY)).toBe(true)
+
+    const consumed = consumeConductorLaunchIntent(storage)
+    expect(consumed?.projectOverride.activeProjectPath).toBe(
+      '/workspace/demo-app',
+    )
+    expect(storage.values.has(CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY)).toBe(false)
+  })
+})

--- a/src/screens/gateway/conductor-launch-intent.ts
+++ b/src/screens/gateway/conductor-launch-intent.ts
@@ -5,6 +5,18 @@ export type ConductorProjectOverride = {
   activeProjectName: string | null
   activeProjectPath: string | null
   effectiveWorkingDirectory: string | null
+  contextPreview?: {
+    summary: string
+    files: Array<{ name: string; path: string; chars: number }>
+  } | null
+  status?: {
+    gitDirty: boolean | null
+    changedFiles: number | null
+    lastCommit: string | null
+    lastCommitAt: string | null
+    detectedStack: Array<string>
+    packageManager: string | null
+  } | null
 }
 
 export type ConductorLaunchIntent = {
@@ -22,6 +34,61 @@ function readString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
+function readNullableBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function readNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function readStringArray(value: unknown, maxItems: number): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => readString(item))
+    .filter((item): item is string => Boolean(item))
+    .slice(0, maxItems)
+}
+
+function readContextPreview(
+  value: unknown,
+): ConductorProjectOverride['contextPreview'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const summary = readString(record.summary) ?? ''
+  const rawFiles = Array.isArray(record.files) ? record.files : []
+  const files = rawFiles
+    .slice(0, 8)
+    .map((file) => {
+      if (!file || typeof file !== 'object' || Array.isArray(file)) return null
+      const fileRecord = file as Record<string, unknown>
+      const name = readString(fileRecord.name)
+      const filePath = readString(fileRecord.path)
+      const chars = readNullableNumber(fileRecord.chars)
+      if (!name || !filePath || chars === null) return null
+      return { name, path: filePath, chars }
+    })
+    .filter(
+      (file): file is { name: string; path: string; chars: number } =>
+        file !== null,
+    )
+  if (!summary && files.length === 0) return null
+  return { summary: summary.slice(0, 1200), files }
+}
+
+function readProjectStatus(value: unknown): ConductorProjectOverride['status'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  return {
+    gitDirty: readNullableBoolean(record.gitDirty),
+    changedFiles: readNullableNumber(record.changedFiles),
+    lastCommit: readString(record.lastCommit),
+    lastCommitAt: readString(record.lastCommitAt),
+    detectedStack: readStringArray(record.detectedStack, 12),
+    packageManager: readString(record.packageManager),
+  }
+}
+
 function readProjectOverride(value: unknown): ConductorProjectOverride | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   const record = value as Record<string, unknown>
@@ -37,6 +104,8 @@ function readProjectOverride(value: unknown): ConductorProjectOverride | null {
     activeProjectName,
     activeProjectPath,
     effectiveWorkingDirectory: effectiveWorkingDirectory ?? activeProjectPath,
+    contextPreview: readContextPreview(record.contextPreview),
+    status: readProjectStatus(record.status),
   }
 }
 
@@ -118,7 +187,10 @@ export function persistConductorLaunchIntent(
       JSON.stringify(completeIntent),
     )
     if (completeIntent.draft.trim()) {
-      targetStorage.setItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY, completeIntent.draft)
+      targetStorage.setItem(
+        CONDUCTOR_GOAL_DRAFT_STORAGE_KEY,
+        completeIntent.draft,
+      )
     } else {
       targetStorage.removeItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY)
     }

--- a/src/screens/gateway/conductor-launch-intent.ts
+++ b/src/screens/gateway/conductor-launch-intent.ts
@@ -1,0 +1,128 @@
+export type ConductorLaunchIntentSource = 'projects'
+
+export type ConductorProjectOverride = {
+  activeProjectId: string | null
+  activeProjectName: string | null
+  activeProjectPath: string | null
+  effectiveWorkingDirectory: string | null
+}
+
+export type ConductorLaunchIntent = {
+  source: ConductorLaunchIntentSource
+  createdAt: number
+  draft: string
+  projectOverride: ConductorProjectOverride
+}
+
+const CONDUCTOR_GOAL_DRAFT_STORAGE_KEY = 'conductor:goal-draft'
+export const CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY = 'conductor:launch-intent'
+export const CONDUCTOR_LAUNCH_INTENT_TTL_MS = 5 * 60_000
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function readProjectOverride(value: unknown): ConductorProjectOverride | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const activeProjectId = readString(record.activeProjectId)
+  const activeProjectName = readString(record.activeProjectName)
+  const activeProjectPath = readString(record.activeProjectPath)
+  const effectiveWorkingDirectory = readString(record.effectiveWorkingDirectory)
+
+  if (!activeProjectPath && !effectiveWorkingDirectory) return null
+
+  return {
+    activeProjectId,
+    activeProjectName,
+    activeProjectPath,
+    effectiveWorkingDirectory: effectiveWorkingDirectory ?? activeProjectPath,
+  }
+}
+
+export function parseConductorLaunchIntent(
+  value: unknown,
+  now = Date.now(),
+): ConductorLaunchIntent | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (record.source !== 'projects') return null
+
+  const createdAt =
+    typeof record.createdAt === 'number' && Number.isFinite(record.createdAt)
+      ? record.createdAt
+      : null
+  if (
+    createdAt === null ||
+    now - createdAt > CONDUCTOR_LAUNCH_INTENT_TTL_MS ||
+    createdAt - now > 10_000
+  )
+    return null
+
+  const draft = readString(record.draft)
+  const projectOverride = readProjectOverride(record.projectOverride)
+  if (!draft || !projectOverride) return null
+
+  return {
+    source: 'projects',
+    createdAt,
+    draft,
+    projectOverride,
+  }
+}
+
+export function loadConductorLaunchIntent(
+  storage?: Pick<Storage, 'getItem' | 'removeItem'>,
+): ConductorLaunchIntent | null {
+  const targetStorage = storage ?? globalThis.localStorage
+  try {
+    const raw = targetStorage.getItem(CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY)
+    if (!raw) return null
+    return parseConductorLaunchIntent(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+export function clearConductorLaunchIntent(
+  storage?: Pick<Storage, 'removeItem'>,
+): void {
+  const targetStorage = storage ?? globalThis.localStorage
+  try {
+    targetStorage.removeItem(CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY)
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function consumeConductorLaunchIntent(
+  storage?: Pick<Storage, 'getItem' | 'removeItem'>,
+): ConductorLaunchIntent | null {
+  const intent = loadConductorLaunchIntent(storage)
+  clearConductorLaunchIntent(storage)
+  return intent
+}
+
+export function persistConductorLaunchIntent(
+  intent: Omit<ConductorLaunchIntent, 'createdAt'> & { createdAt?: number },
+  storage?: Pick<Storage, 'setItem' | 'removeItem'>,
+): void {
+  const targetStorage = storage ?? globalThis.localStorage
+  try {
+    const completeIntent: ConductorLaunchIntent = {
+      ...intent,
+      createdAt: intent.createdAt ?? Date.now(),
+    }
+    targetStorage.setItem(
+      CONDUCTOR_LAUNCH_INTENT_STORAGE_KEY,
+      JSON.stringify(completeIntent),
+    )
+    if (completeIntent.draft.trim()) {
+      targetStorage.setItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY, completeIntent.draft)
+    } else {
+      targetStorage.removeItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY)
+    }
+  } catch {
+    // Ignore storage failures; direct Conductor launches still work.
+  }
+}

--- a/src/screens/gateway/conductor-preflight-summary.test.ts
+++ b/src/screens/gateway/conductor-preflight-summary.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConductorPreflightSummary,
+  shouldWarnProjectMismatch,
+} from './conductor-preflight-summary'
+import type { ConductorProjectOverride } from './conductor-launch-intent'
+
+describe('buildConductorPreflightSummary', () => {
+  it('summarizes a project launch override with status, stack, package manager, and context files', () => {
+    const override: ConductorProjectOverride = {
+      activeProjectId: 'demo',
+      activeProjectName: 'Demo App',
+      activeProjectPath: '/workspace/demo-app',
+      effectiveWorkingDirectory: '/workspace/demo-app',
+      contextPreview: {
+        summary: 'Path: /workspace/demo-app\nContext files: 2',
+        files: [
+          {
+            name: 'AGENTS.md',
+            path: '/workspace/demo-app/AGENTS.md',
+            chars: 700,
+          },
+          {
+            name: 'README.md',
+            path: '/workspace/demo-app/README.md',
+            chars: 1200,
+          },
+        ],
+      },
+      status: {
+        gitDirty: true,
+        changedFiles: 3,
+        lastCommit: 'abc1234',
+        lastCommitAt: '2026-01-01T00:00:00Z',
+        detectedStack: ['React', 'TypeScript', 'TanStack Start'],
+        packageManager: 'pnpm',
+      },
+    }
+
+    expect(buildConductorPreflightSummary(override)).toEqual({
+      projectLabel: 'Demo App',
+      workingDirectory: '/workspace/demo-app',
+      gitStatusLabel: '3 changed files',
+      gitStatusTone: 'warning',
+      stackLabel: 'React, TypeScript, TanStack Start',
+      packageManagerLabel: 'pnpm',
+      contextFilesLabel: 'AGENTS.md, README.md',
+      contextSummary: 'Path: /workspace/demo-app\nContext files: 2',
+      lastCommitLabel: 'abc1234',
+    })
+  })
+
+  it('falls back gracefully for missing optional metadata', () => {
+    expect(
+      buildConductorPreflightSummary({
+        activeProjectId: null,
+        activeProjectName: null,
+        activeProjectPath: '/workspace/simple-app',
+        effectiveWorkingDirectory: null,
+      }),
+    ).toMatchObject({
+      projectLabel: 'simple-app',
+      workingDirectory: '/workspace/simple-app',
+      gitStatusLabel: 'Git status unavailable',
+      gitStatusTone: 'muted',
+      stackLabel: 'Stack not detected',
+      packageManagerLabel: 'Package manager unavailable',
+      contextFilesLabel: 'No context files detected',
+      contextSummary: null,
+      lastCommitLabel: null,
+    })
+  })
+})
+
+describe('shouldWarnProjectMismatch', () => {
+  it('warns when a launch override targets a different project than the active Conductor project', () => {
+    expect(
+      shouldWarnProjectMismatch(
+        {
+          activeProjectId: 'project-from-projects',
+          activeProjectName: 'From Projects',
+          activeProjectPath: '/workspace/from-projects',
+          effectiveWorkingDirectory: '/workspace/from-projects',
+        },
+        { id: 'active', path: '/workspace/active' },
+      ),
+    ).toBe(true)
+  })
+
+  it('does not warn when ids or paths match', () => {
+    expect(
+      shouldWarnProjectMismatch(
+        {
+          activeProjectId: 'active',
+          activeProjectName: 'Active',
+          activeProjectPath: '/workspace/other-path',
+          effectiveWorkingDirectory: '/workspace/other-path',
+        },
+        { id: 'active', path: '/workspace/active' },
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldWarnProjectMismatch(
+        {
+          activeProjectId: null,
+          activeProjectName: 'Active',
+          activeProjectPath: '/workspace/active',
+          effectiveWorkingDirectory: '/workspace/active',
+        },
+        { id: 'active', path: '/workspace/active' },
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/screens/gateway/conductor-preflight-summary.ts
+++ b/src/screens/gateway/conductor-preflight-summary.ts
@@ -1,0 +1,77 @@
+import type { ConductorProjectOverride } from './conductor-launch-intent'
+
+export type ConductorPreflightSummary = {
+  projectLabel: string
+  workingDirectory: string
+  gitStatusLabel: string
+  gitStatusTone: 'success' | 'warning' | 'muted'
+  stackLabel: string
+  packageManagerLabel: string
+  contextFilesLabel: string
+  contextSummary: string | null
+  lastCommitLabel: string | null
+}
+
+function basename(path: string): string {
+  return path.split('/').filter(Boolean).pop() ?? path
+}
+
+export function buildConductorPreflightSummary(
+  project: ConductorProjectOverride,
+): ConductorPreflightSummary {
+  const workingDirectory =
+    project.effectiveWorkingDirectory ?? project.activeProjectPath ?? ''
+  const status = project.status ?? null
+  const contextFiles = project.contextPreview?.files ?? []
+
+  const gitStatusLabel = status
+    ? status.gitDirty === null
+      ? 'Git status unavailable'
+      : status.gitDirty
+        ? `${status.changedFiles ?? 0} changed file${status.changedFiles === 1 ? '' : 's'}`
+        : 'Clean worktree'
+    : 'Git status unavailable'
+
+  return {
+    projectLabel:
+      project.activeProjectName ??
+      (project.activeProjectPath
+        ? basename(project.activeProjectPath)
+        : null) ??
+      'Selected project',
+    workingDirectory,
+    gitStatusLabel,
+    gitStatusTone:
+      status?.gitDirty === false
+        ? 'success'
+        : status?.gitDirty
+          ? 'warning'
+          : 'muted',
+    stackLabel:
+      status && status.detectedStack.length > 0
+        ? status.detectedStack.join(', ')
+        : 'Stack not detected',
+    packageManagerLabel:
+      status?.packageManager ?? 'Package manager unavailable',
+    contextFilesLabel:
+      contextFiles.length > 0
+        ? contextFiles.map((file) => file.name).join(', ')
+        : 'No context files detected',
+    contextSummary: project.contextPreview?.summary.trim() || null,
+    lastCommitLabel: status?.lastCommit ?? null,
+  }
+}
+
+export function shouldWarnProjectMismatch(
+  project: ConductorProjectOverride | null,
+  activeProject: { id?: string | null; path?: string | null } | null,
+): boolean {
+  if (!project || !activeProject) return false
+  if (project.activeProjectId && activeProject.id) {
+    return project.activeProjectId !== activeProject.id
+  }
+  if (project.activeProjectPath && activeProject.path) {
+    return project.activeProjectPath !== activeProject.path
+  }
+  return false
+}

--- a/src/screens/gateway/conductor-trace-hydration.test.ts
+++ b/src/screens/gateway/conductor-trace-hydration.test.ts
@@ -1,0 +1,719 @@
+import { describe, expect, it } from 'vitest'
+import type { MissionHistoryEntry } from './hooks/mission-history'
+import {
+  buildFallbackMissionHistoryEntryForTrace,
+  buildMissionHistoryTraceActionViewModel,
+  buildMissionHistoryTraceInspectActionViewModel,
+  buildMissionHistoryTraceInspectContractViewModel,
+  buildMissionHistoryTraceLookupRefreshControl,
+  buildMissionHistoryTraceLookupViewModel,
+  buildMissionHistoryTraceRecoveryPanelViewModel,
+  buildMissionHistoryTraceRecoveryActionsViewModel,
+  buildMissionHistoryTraceButtonRenderViewModel,
+  buildMissionHistoryTraceRenderActionViewModel,
+  buildMissionHistoryTraceButtonClassName,
+  buildMissionHistoryTraceButtonElementViewModel,
+  buildMissionHistoryTraceRecoveryFeedbackViewModel,
+  buildMissionHistoryTraceRecoveryRenderActionViewModel,
+  buildMissionHistoryTraceRecoveryViewModel,
+  buildMissionHistoryTraceViewModel,
+  findMissionHistoryEntryByTraceSessionKey,
+  readConductorTraceSessionKey,
+} from './conductor-trace-hydration'
+
+const baseEntry: MissionHistoryEntry = {
+  id: 'mission-1',
+  goal: 'Hydrate trace from Projects',
+  startedAt: '2026-01-01T10:00:00.000Z',
+  completedAt: '2026-01-01T10:05:00.000Z',
+  workerCount: 1,
+  totalTokens: 100,
+  status: 'completed',
+  projectPath: '/workspace/demo',
+}
+
+describe('conductor trace hydration', () => {
+  it('reads a bounded trace session key from route search', () => {
+    expect(
+      readConductorTraceSessionKey({ traceSessionKey: ' session:abc ' }),
+    ).toBe('session:abc')
+    expect(readConductorTraceSessionKey({ traceSessionKey: '' })).toBeNull()
+    expect(readConductorTraceSessionKey({ traceSessionKey: 123 })).toBeNull()
+    expect(
+      readConductorTraceSessionKey({ traceSessionKey: 'x'.repeat(260) }),
+    ).toBeNull()
+  })
+
+  it('finds matching mission history by session key', () => {
+    const match = findMissionHistoryEntryByTraceSessionKey(
+      [
+        { ...baseEntry, id: 'mission-a', sessionKey: 'session-a' },
+        { ...baseEntry, id: 'mission-b', sessionKey: ' session-b ' },
+      ],
+      'session-b',
+    )
+
+    expect(match).toEqual(expect.objectContaining({ id: 'mission-b' }))
+    expect(
+      findMissionHistoryEntryByTraceSessionKey(
+        [{ ...baseEntry, id: 'mission-a', sessionKey: 'session-a' }],
+        'missing',
+      ),
+    ).toBeNull()
+  })
+
+  it('builds a safe fallback history entry when only trace session key is available', () => {
+    const entry = buildFallbackMissionHistoryEntryForTrace(
+      ' session:orphan ',
+      '2026-01-02T00:00:00.000Z',
+    )
+
+    expect(entry).toEqual({
+      id: 'trace-session-orphan',
+      goal: 'Open Conductor trace session: session:orphan',
+      startedAt: '2026-01-02T00:00:00.000Z',
+      completedAt: '2026-01-02T00:00:00.000Z',
+      workerCount: 1,
+      totalTokens: 0,
+      status: 'completed',
+      projectPath: null,
+      sessionKey: 'session:orphan',
+      completeSummary:
+        'No local mission history entry was found for this trace session. Use the session key to inspect the persisted Conductor/agent history.',
+    })
+
+    expect(buildFallbackMissionHistoryEntryForTrace('   ')).toBeNull()
+  })
+
+  it('builds a visible trace view model for a persisted history entry', () => {
+    expect(
+      buildMissionHistoryTraceViewModel({
+        ...baseEntry,
+        sessionKey: ' conductor:session:123 ',
+      }),
+    ).toEqual({
+      sessionKey: 'conductor:session:123',
+      sourceLabel: 'Persisted mission history',
+      actionLabel: 'Copy session key',
+      copyValue: 'conductor:session:123',
+      helperText:
+        'Use this key to correlate the mission with persisted Conductor/agent session history.',
+      isFallback: false,
+    })
+  })
+
+  it('marks fallback trace view models as session-key-only recoveries', () => {
+    const fallback = buildFallbackMissionHistoryEntryForTrace(
+      'orphan-session',
+      '2026-01-02T00:00:00.000Z',
+    )
+
+    expect(buildMissionHistoryTraceViewModel(fallback)).toEqual({
+      sessionKey: 'orphan-session',
+      sourceLabel: 'Trace session key only',
+      actionLabel: 'Copy session key',
+      copyValue: 'orphan-session',
+      helperText:
+        'No local mission history entry was found. Copy this key to inspect persisted Conductor/agent history.',
+      isFallback: true,
+    })
+  })
+
+  it('omits the trace view model when the entry has no session key', () => {
+    expect(buildMissionHistoryTraceViewModel(baseEntry)).toBeNull()
+  })
+
+  it('builds copy action feedback labels by status', () => {
+    expect(buildMissionHistoryTraceActionViewModel('idle')).toEqual({
+      label: 'Copy session key',
+      helperText: null,
+      tone: 'neutral',
+      disabled: false,
+    })
+    expect(buildMissionHistoryTraceActionViewModel('copied')).toEqual({
+      label: 'Copied',
+      helperText: 'Session key copied to clipboard.',
+      tone: 'success',
+      disabled: false,
+    })
+    expect(buildMissionHistoryTraceActionViewModel('failed')).toEqual({
+      label: 'Copy failed',
+      helperText: 'Clipboard is unavailable. Select and copy the session key manually.',
+      tone: 'danger',
+      disabled: false,
+    })
+  })
+
+  it('builds an inspect action that opens the persisted chat session by key', () => {
+    expect(
+      buildMissionHistoryTraceInspectActionViewModel(' conductor:session:123 '),
+    ).toEqual({
+      label: 'Inspect session',
+      helperText:
+        'Open the persisted chat session that backs this Conductor trace.',
+      to: '/chat/$sessionKey',
+      params: { sessionKey: 'conductor:session:123' },
+      disabled: false,
+    })
+  })
+
+  it('documents the inspect route MVP contract for raw trace session keys', () => {
+    expect(
+      buildMissionHistoryTraceInspectContractViewModel(' conductor:session:123 '),
+    ).toEqual({
+      route: '/chat/$sessionKey',
+      routeParamName: 'sessionKey',
+      routeParamValue: 'conductor:session:123',
+      supportedByCurrentRoute: true,
+      mode: 'raw-session-key-mvp',
+      risk:
+        'The chat route accepts the raw trace session key as its sessionKey param; a dedicated trace inspector is still deferred.',
+    })
+  })
+
+  it('disables the inspect action without a session key', () => {
+    expect(buildMissionHistoryTraceInspectActionViewModel('   ')).toEqual({
+      label: 'Inspect session',
+      helperText: 'No session key is available to inspect.',
+      to: null,
+      params: null,
+      disabled: true,
+    })
+  })
+
+  it('builds persisted session lookup status view models', () => {
+    expect(buildMissionHistoryTraceLookupViewModel('idle')).toEqual({
+      label: 'Persisted session lookup pending',
+      helperText: 'Session lookup will start when a trace key is available.',
+      tone: 'neutral',
+      isChecking: false,
+    })
+    expect(buildMissionHistoryTraceLookupViewModel('checking')).toEqual({
+      label: 'Checking persisted session…',
+      helperText: 'Looking for a chat session matching this trace key.',
+      tone: 'neutral',
+      isChecking: true,
+    })
+    expect(buildMissionHistoryTraceLookupViewModel('found')).toEqual({
+      label: 'Persisted session found',
+      helperText: 'This trace can be inspected in chat history.',
+      tone: 'success',
+      isChecking: false,
+    })
+    expect(buildMissionHistoryTraceLookupViewModel('missing')).toEqual({
+      label: 'Persisted session not found',
+      helperText:
+        'No persisted chat session was found for this key. You can still try opening it manually.',
+      tone: 'warning',
+      isChecking: false,
+    })
+    expect(buildMissionHistoryTraceLookupViewModel('error')).toEqual({
+      label: 'Unable to check persisted session',
+      helperText:
+        'Session lookup failed. You can still try opening the session manually.',
+      tone: 'warning',
+      isChecking: false,
+    })
+  })
+
+  it('builds lookup refresh controls for retryable and refreshable statuses', () => {
+    expect(
+      buildMissionHistoryTraceLookupRefreshControl({
+        status: 'error',
+        hasSessionKey: true,
+        isRefreshing: false,
+      }),
+    ).toEqual({
+      label: 'Retry lookup',
+      title: 'Retry persisted session lookup for this trace key.',
+      ariaLabel: 'Retry lookup: Retry persisted session lookup for this trace key.',
+      disabled: false,
+      isLoading: false,
+      visible: true,
+    })
+
+    expect(
+      buildMissionHistoryTraceLookupRefreshControl({
+        status: 'found',
+        hasSessionKey: true,
+        isRefreshing: false,
+      }),
+    ).toEqual({
+      label: 'Refresh status',
+      title: 'Refresh persisted session lookup status.',
+      ariaLabel: 'Refresh status: Refresh persisted session lookup status.',
+      disabled: false,
+      isLoading: false,
+      visible: true,
+    })
+
+    expect(
+      buildMissionHistoryTraceLookupRefreshControl({
+        status: 'checking',
+        hasSessionKey: true,
+        isRefreshing: true,
+      }),
+    ).toEqual({
+      label: 'Checking…',
+      title: 'Persisted session lookup is already running.',
+      ariaLabel: 'Checking persisted session lookup status.',
+      disabled: true,
+      isLoading: true,
+      visible: true,
+    })
+
+    expect(
+      buildMissionHistoryTraceLookupRefreshControl({
+        status: 'idle',
+        hasSessionKey: false,
+        isRefreshing: false,
+      }),
+    ).toEqual({
+      label: 'Refresh status',
+      title: 'No trace session key is available to refresh.',
+      ariaLabel: 'Refresh persisted session lookup status: no trace session key is available.',
+      disabled: true,
+      isLoading: false,
+      visible: false,
+    })
+  })
+
+  it('builds a trace recovery panel contract for fallback UI', () => {
+    const fallback = buildFallbackMissionHistoryEntryForTrace(
+      ' orphan-session ',
+      '2026-01-02T00:00:00.000Z',
+    )
+
+    expect(
+      buildMissionHistoryTraceRecoveryPanelViewModel({
+        entry: fallback,
+        lookupStatus: 'error',
+        copyStatus: 'idle',
+        lastAction: null,
+        isRefreshingLookup: false,
+      }),
+    ).toEqual({
+      trace: {
+        sessionKey: 'orphan-session',
+        sourceLabel: 'Trace session key only',
+        actionLabel: 'Copy session key',
+        copyValue: 'orphan-session',
+        helperText:
+          'No local mission history entry was found. Copy this key to inspect persisted Conductor/agent history.',
+        isFallback: true,
+      },
+      lookup: {
+        label: 'Unable to check persisted session',
+        helperText:
+          'Session lookup failed. You can still try opening the session manually.',
+        tone: 'warning',
+        isChecking: false,
+      },
+      lookupRefresh: {
+        label: 'Retry lookup',
+        title: 'Retry persisted session lookup for this trace key.',
+        ariaLabel: 'Retry lookup: Retry persisted session lookup for this trace key.',
+        disabled: false,
+        isLoading: false,
+        visible: true,
+      },
+      recovery: {
+        title: 'Local mission history not found',
+        description:
+          'This trace was opened from a session key, but no local Conductor mission history entry matched it.',
+        recommendation:
+          'Persisted session lookup failed. You can still inspect manually or retry later.',
+        tone: 'warning',
+        actions: [
+          'Try inspecting the session manually',
+          'Copy the session key for support/debugging',
+          'Retry lookup later',
+        ],
+      },
+      recoveryActions: {
+        primary: {
+          kind: 'copy',
+          label: 'Copy session key',
+          helperText: null,
+          disabled: false,
+          tone: 'neutral',
+        },
+        secondary: {
+          kind: 'inspect',
+          label: 'Inspect manually',
+          helperText: 'Open chat history while lookup is unavailable.',
+          disabled: false,
+        },
+        tertiary: {
+          kind: 'newMission',
+          label: 'Start new mission',
+          helperText: 'Start over if recovery is not possible.',
+          disabled: false,
+        },
+      },
+      feedback: null,
+    })
+
+    expect(
+      buildMissionHistoryTraceRecoveryPanelViewModel({
+        entry: baseEntry,
+        lookupStatus: 'idle',
+        copyStatus: 'idle',
+        lastAction: null,
+        isRefreshingLookup: false,
+      }),
+    ).toBeNull()
+  })
+
+  it('builds fallback trace recovery guidance from lookup status', () => {
+    expect(buildMissionHistoryTraceRecoveryViewModel(false, 'found')).toBeNull()
+    expect(buildMissionHistoryTraceRecoveryViewModel(true, 'found')).toEqual({
+      title: 'Local mission history not found',
+      description:
+        'This trace was opened from a session key, but no local Conductor mission history entry matched it.',
+      recommendation: 'Open the persisted session to inspect its chat history.',
+      tone: 'success',
+      actions: [
+        'Inspect the persisted session',
+        'Copy the session key for manual lookup',
+        'Start a new mission if this trace is from another environment',
+      ],
+    })
+    expect(buildMissionHistoryTraceRecoveryViewModel(true, 'missing')).toEqual({
+      title: 'Local mission history not found',
+      description:
+        'This trace was opened from a session key, but no local Conductor mission history entry matched it.',
+      recommendation:
+        'No persisted session was found here. The key may be stale or from another workspace.',
+      tone: 'warning',
+      actions: [
+        'Copy the session key for manual lookup',
+        'Try inspecting the session anyway',
+        'Start a new mission if recovery is not possible',
+      ],
+    })
+    expect(buildMissionHistoryTraceRecoveryViewModel(true, 'error')).toEqual({
+      title: 'Local mission history not found',
+      description:
+        'This trace was opened from a session key, but no local Conductor mission history entry matched it.',
+      recommendation:
+        'Persisted session lookup failed. You can still inspect manually or retry later.',
+      tone: 'warning',
+      actions: [
+        'Try inspecting the session manually',
+        'Copy the session key for support/debugging',
+        'Retry lookup later',
+      ],
+    })
+  })
+
+  it('builds fallback trace recovery action controls from lookup and copy status', () => {
+    expect(
+      buildMissionHistoryTraceRecoveryActionsViewModel({
+        isFallback: false,
+        lookupStatus: 'found',
+        copyStatus: 'idle',
+        sessionKey: 'session-1',
+      }),
+    ).toBeNull()
+
+    expect(
+      buildMissionHistoryTraceRecoveryActionsViewModel({
+        isFallback: true,
+        lookupStatus: 'found',
+        copyStatus: 'idle',
+        sessionKey: ' session-1 ',
+      }),
+    ).toEqual({
+      primary: {
+        kind: 'inspect',
+        label: 'Inspect recovered session',
+        helperText: 'Open the persisted session that matched this trace key.',
+        disabled: false,
+      },
+      secondary: {
+        kind: 'copy',
+        label: 'Copy session key',
+        helperText: null,
+        disabled: false,
+        tone: 'neutral',
+      },
+      tertiary: {
+        kind: 'newMission',
+        label: 'Start new mission',
+        helperText: 'Start over if this trace belongs to another environment.',
+        disabled: false,
+      },
+    })
+
+    expect(
+      buildMissionHistoryTraceRecoveryActionsViewModel({
+        isFallback: true,
+        lookupStatus: 'checking',
+        copyStatus: 'copied',
+        sessionKey: 'session-1',
+      }),
+    ).toEqual({
+      primary: {
+        kind: 'inspect',
+        label: 'Inspect manually',
+        helperText: 'Lookup is still running; you can inspect manually if needed.',
+        disabled: false,
+      },
+      secondary: {
+        kind: 'copy',
+        label: 'Copied',
+        helperText: 'Session key copied to clipboard.',
+        disabled: false,
+        tone: 'success',
+      },
+      tertiary: null,
+    })
+
+    expect(
+      buildMissionHistoryTraceRecoveryActionsViewModel({
+        isFallback: true,
+        lookupStatus: 'missing',
+        copyStatus: 'failed',
+        sessionKey: 'session-1',
+      }),
+    ).toEqual({
+      primary: {
+        kind: 'copy',
+        label: 'Copy failed',
+        helperText:
+          'Clipboard is unavailable. Select and copy the session key manually.',
+        disabled: false,
+        tone: 'danger',
+      },
+      secondary: {
+        kind: 'inspect',
+        label: 'Try inspect anyway',
+        helperText: 'Open chat history even though lookup did not find a match.',
+        disabled: false,
+      },
+      tertiary: {
+        kind: 'newMission',
+        label: 'Start new mission',
+        helperText: 'Start over if recovery is not possible.',
+        disabled: false,
+      },
+    })
+  })
+
+  it('builds shared render metadata for session trace buttons', () => {
+    expect(
+      buildMissionHistoryTraceRenderActionViewModel({
+        kind: 'inspect',
+        label: 'Inspect session',
+        helperText:
+          'Open the persisted chat session that backs this Conductor trace.',
+        disabled: false,
+      }),
+    ).toEqual({
+      label: 'Inspect session',
+      title: 'Open the persisted chat session that backs this Conductor trace.',
+      ariaLabel: 'Inspect session: Open the persisted chat session that backs this Conductor trace.',
+      classTone: 'accent',
+      disabled: false,
+    })
+
+    expect(
+      buildMissionHistoryTraceRenderActionViewModel({
+        kind: 'copy',
+        label: 'Copied',
+        helperText: 'Session key copied to clipboard.',
+        disabled: false,
+        tone: 'success',
+      }),
+    ).toEqual({
+      label: 'Copied',
+      title: 'Session key copied to clipboard.',
+      ariaLabel: 'Copied: Session key copied to clipboard.',
+      classTone: 'success',
+      disabled: false,
+    })
+
+    expect(
+      buildMissionHistoryTraceRenderActionViewModel({
+        kind: 'copy',
+        label: 'Copy session key',
+        helperText: null,
+        disabled: false,
+        tone: 'neutral',
+      }),
+    ).toEqual({
+      label: 'Copy session key',
+      title: 'Copy session key',
+      ariaLabel: 'Copy session key',
+      classTone: 'neutral',
+      disabled: false,
+    })
+  })
+
+  it('keeps recovery render metadata as a compatibility wrapper around shared trace buttons', () => {
+    expect(
+      buildMissionHistoryTraceRecoveryRenderActionViewModel({
+        kind: 'inspect',
+        label: 'Inspect recovered session',
+        helperText: 'Open the persisted session that matched this trace key.',
+        disabled: false,
+      }),
+    ).toEqual({
+      label: 'Inspect recovered session',
+      title: 'Open the persisted session that matched this trace key.',
+      ariaLabel: 'Inspect recovered session: Open the persisted session that matched this trace key.',
+      classTone: 'accent',
+      disabled: false,
+    })
+
+    expect(
+      buildMissionHistoryTraceRecoveryRenderActionViewModel({
+        kind: 'copy',
+        label: 'Copy failed',
+        helperText:
+          'Clipboard is unavailable. Select and copy the session key manually.',
+        disabled: false,
+        tone: 'danger',
+      }),
+    ).toEqual({
+      label: 'Copy failed',
+      title: 'Clipboard is unavailable. Select and copy the session key manually.',
+      ariaLabel: 'Copy failed: Clipboard is unavailable. Select and copy the session key manually.',
+      classTone: 'danger',
+      disabled: false,
+    })
+
+    expect(
+      buildMissionHistoryTraceRecoveryRenderActionViewModel({
+        kind: 'newMission',
+        label: 'Start new mission',
+        helperText: 'Start over if recovery is not possible.',
+        disabled: true,
+      }),
+    ).toEqual({
+      label: 'Start new mission',
+      title: 'Start over if recovery is not possible.',
+      ariaLabel: 'Start new mission: Start over if recovery is not possible.',
+      classTone: 'neutral',
+      disabled: true,
+    })
+  })
+
+  it('builds shared class names for trace action button render tones', () => {
+    expect(buildMissionHistoryTraceButtonClassName('accent', 'text-xs')).toBe(
+      'rounded-xl border px-4 text-xs border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:bg-[var(--theme-accent-soft-strong)]',
+    )
+    expect(buildMissionHistoryTraceButtonClassName('success')).toBe(
+      'rounded-xl border px-4 border-emerald-400/35 bg-emerald-500/10 text-emerald-600 hover:border-emerald-400/60',
+    )
+    expect(buildMissionHistoryTraceButtonClassName('danger')).toBe(
+      'rounded-xl border px-4 border-[var(--theme-danger-border)] bg-[var(--theme-danger-soft)] text-[var(--theme-danger)] hover:bg-[var(--theme-danger-soft-strong)]',
+    )
+    expect(buildMissionHistoryTraceButtonClassName('neutral')).toBe(
+      'rounded-xl border px-4 border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-text)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent)]',
+    )
+  })
+
+  it('builds shared button element props for recovery and session trace controls', () => {
+    expect(
+      buildMissionHistoryTraceButtonElementViewModel(
+        {
+          kind: 'inspect',
+          label: 'Inspect session',
+          helperText:
+            'Open the persisted chat session that backs this Conductor trace.',
+          disabled: false,
+        },
+        { extraClassName: 'text-xs' },
+      ),
+    ).toEqual({
+      actionKind: 'inspect',
+      key: 'inspect-Inspect session',
+      type: 'button',
+      label: 'Inspect session',
+      title: 'Open the persisted chat session that backs this Conductor trace.',
+      ariaLabel: 'Inspect session: Open the persisted chat session that backs this Conductor trace.',
+      disabled: false,
+      className:
+        'rounded-xl border px-4 text-xs border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:bg-[var(--theme-accent-soft-strong)]',
+    })
+
+    expect(
+      buildMissionHistoryTraceButtonElementViewModel({
+        kind: 'copy',
+        label: 'Copy session key',
+        helperText: null,
+        disabled: false,
+        tone: 'neutral',
+      }),
+    ).toEqual({
+      actionKind: 'copy',
+      key: 'copy-Copy session key',
+      type: 'button',
+      label: 'Copy session key',
+      title: 'Copy session key',
+      ariaLabel: 'Copy session key',
+      disabled: false,
+      className:
+        'rounded-xl border px-4 border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-text)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent)]',
+    })
+  })
+
+  it('builds visible recovery feedback after user actions', () => {
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: false,
+        lastAction: 'copy',
+        copyStatus: 'copied',
+      }),
+    ).toBeNull()
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: true,
+        lastAction: null,
+        copyStatus: 'idle',
+      }),
+    ).toBeNull()
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: true,
+        lastAction: 'copy',
+        copyStatus: 'copied',
+      }),
+    ).toEqual({
+      message: 'Session key copied for manual recovery.',
+      tone: 'success',
+    })
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: true,
+        lastAction: 'copy',
+        copyStatus: 'failed',
+      }),
+    ).toEqual({
+      message: 'Clipboard is unavailable. Select the session key and copy it manually.',
+      tone: 'danger',
+    })
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: true,
+        lastAction: 'inspect',
+        copyStatus: 'idle',
+      }),
+    ).toEqual({
+      message: 'Opening persisted chat history for this trace session…',
+      tone: 'neutral',
+    })
+    expect(
+      buildMissionHistoryTraceRecoveryFeedbackViewModel({
+        isFallback: true,
+        lastAction: 'newMission',
+        copyStatus: 'idle',
+      }),
+    ).toEqual({
+      message: 'Starting a new mission from the recovery flow…',
+      tone: 'neutral',
+    })
+  })
+})

--- a/src/screens/gateway/conductor-trace-hydration.ts
+++ b/src/screens/gateway/conductor-trace-hydration.ts
@@ -1,0 +1,686 @@
+import type { MissionHistoryEntry } from './hooks/mission-history'
+import { normalizeOptionalString } from './hooks/mission-history'
+
+const MAX_TRACE_SESSION_KEY_CHARS = 240
+
+export type MissionHistoryTraceCopyStatus = 'idle' | 'copied' | 'failed'
+export type MissionHistoryTraceLookupStatus =
+  | 'idle'
+  | 'checking'
+  | 'found'
+  | 'missing'
+  | 'error'
+
+export type MissionHistoryTraceActionViewModel = {
+  label: string
+  helperText: string | null
+  tone: 'neutral' | 'success' | 'danger'
+  disabled: boolean
+}
+
+export type MissionHistoryTraceInspectActionViewModel = {
+  label: string
+  helperText: string
+  to: '/chat/$sessionKey' | null
+  params: { sessionKey: string } | null
+  disabled: boolean
+}
+
+export type MissionHistoryTraceInspectContractViewModel = {
+  route: '/chat/$sessionKey'
+  routeParamName: 'sessionKey'
+  routeParamValue: string
+  supportedByCurrentRoute: boolean
+  mode: 'raw-session-key-mvp'
+  risk: string
+}
+
+export type MissionHistoryTraceLookupViewModel = {
+  label: string
+  helperText: string
+  tone: 'neutral' | 'success' | 'warning'
+  isChecking: boolean
+}
+
+export type MissionHistoryTraceLookupRefreshControl = {
+  label: string
+  title: string
+  ariaLabel: string
+  disabled: boolean
+  isLoading: boolean
+  visible: boolean
+}
+
+export type MissionHistoryTraceRecoveryViewModel = {
+  title: string
+  description: string
+  recommendation: string
+  tone: 'success' | 'warning'
+  actions: string[]
+}
+
+type MissionHistoryTraceInspectControl = {
+  kind: 'inspect'
+  label: string
+  helperText: string
+  disabled: boolean
+}
+
+type MissionHistoryTraceCopyControl = {
+  kind: 'copy'
+  label: string
+  helperText: string | null
+  disabled: boolean
+  tone: 'neutral' | 'success' | 'danger'
+}
+
+type MissionHistoryTraceNewMissionControl = {
+  kind: 'newMission'
+  label: string
+  helperText: string
+  disabled: boolean
+}
+
+export type MissionHistoryTraceButtonControl =
+  | MissionHistoryTraceInspectControl
+  | MissionHistoryTraceCopyControl
+  | MissionHistoryTraceNewMissionControl
+
+export type MissionHistoryTraceRecoveryControl = MissionHistoryTraceButtonControl
+
+export type MissionHistoryTraceRecoveryActionsViewModel = {
+  primary: MissionHistoryTraceRecoveryControl
+  secondary: MissionHistoryTraceRecoveryControl | null
+  tertiary: MissionHistoryTraceRecoveryControl | null
+}
+
+export type MissionHistoryTraceRecoveryPanelViewModel = {
+  trace: MissionHistoryTraceViewModel
+  lookup: MissionHistoryTraceLookupViewModel
+  lookupRefresh: MissionHistoryTraceLookupRefreshControl
+  recovery: MissionHistoryTraceRecoveryViewModel | null
+  recoveryActions: MissionHistoryTraceRecoveryActionsViewModel | null
+  feedback: MissionHistoryTraceRecoveryFeedbackViewModel | null
+}
+
+export type MissionHistoryTraceRecoveryLastAction =
+  | 'inspect'
+  | 'copy'
+  | 'newMission'
+
+export type MissionHistoryTraceRecoveryFeedbackViewModel = {
+  message: string
+  tone: 'neutral' | 'success' | 'danger'
+}
+
+export type MissionHistoryTraceButtonTone =
+  | 'accent'
+  | 'neutral'
+  | 'success'
+  | 'danger'
+
+export type MissionHistoryTraceRecoveryRenderActionViewModel = {
+  label: string
+  title: string
+  ariaLabel: string
+  classTone: MissionHistoryTraceButtonTone
+  disabled: boolean
+}
+
+export type MissionHistoryTraceButtonElementViewModel = {
+  actionKind: MissionHistoryTraceButtonControl['kind']
+  key: string
+  type: 'button'
+  label: string
+  title: string
+  ariaLabel: string
+  disabled: boolean
+  className: string
+}
+
+export type MissionHistoryTraceViewModel = {
+  sessionKey: string
+  sourceLabel: string
+  actionLabel: string
+  copyValue: string
+  helperText: string
+  isFallback: boolean
+}
+
+export function readConductorTraceSessionKey(
+  search: Record<string, unknown>,
+): string | null {
+  const value = normalizeOptionalString(search.traceSessionKey)
+  if (!value || value.length > MAX_TRACE_SESSION_KEY_CHARS) return null
+  return value
+}
+
+export function findMissionHistoryEntryByTraceSessionKey(
+  entries: MissionHistoryEntry[],
+  traceSessionKey: string | null,
+): MissionHistoryEntry | null {
+  const target = normalizeOptionalString(traceSessionKey)
+  if (!target) return null
+  return (
+    entries.find(
+      (entry) => normalizeOptionalString(entry.sessionKey) === target,
+    ) ?? null
+  )
+}
+
+function buildTraceFallbackId(sessionKey: string): string {
+  return `trace-${sessionKey.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'session'}`
+}
+
+export function buildFallbackMissionHistoryEntryForTrace(
+  traceSessionKey: string | null,
+  nowIso = new Date().toISOString(),
+): MissionHistoryEntry | null {
+  const sessionKey = normalizeOptionalString(traceSessionKey)
+  if (!sessionKey) return null
+  return {
+    id: buildTraceFallbackId(sessionKey),
+    goal: `Open Conductor trace session: ${sessionKey}`,
+    startedAt: nowIso,
+    completedAt: nowIso,
+    workerCount: 1,
+    totalTokens: 0,
+    status: 'completed',
+    projectPath: null,
+    sessionKey,
+    completeSummary:
+      'No local mission history entry was found for this trace session. Use the session key to inspect the persisted Conductor/agent history.',
+  }
+}
+
+export function buildMissionHistoryTraceViewModel(
+  entry: MissionHistoryEntry | null | undefined,
+): MissionHistoryTraceViewModel | null {
+  const sessionKey = normalizeOptionalString(entry?.sessionKey)
+  if (!sessionKey) return null
+
+  const isFallback = entry?.id === buildTraceFallbackId(sessionKey)
+  return {
+    sessionKey,
+    sourceLabel: isFallback
+      ? 'Trace session key only'
+      : 'Persisted mission history',
+    actionLabel: 'Copy session key',
+    copyValue: sessionKey,
+    helperText: isFallback
+      ? 'No local mission history entry was found. Copy this key to inspect persisted Conductor/agent history.'
+      : 'Use this key to correlate the mission with persisted Conductor/agent session history.',
+    isFallback,
+  }
+}
+
+export function buildMissionHistoryTraceActionViewModel(
+  status: MissionHistoryTraceCopyStatus,
+): MissionHistoryTraceActionViewModel {
+  if (status === 'copied') {
+    return {
+      label: 'Copied',
+      helperText: 'Session key copied to clipboard.',
+      tone: 'success',
+      disabled: false,
+    }
+  }
+
+  if (status === 'failed') {
+    return {
+      label: 'Copy failed',
+      helperText:
+        'Clipboard is unavailable. Select and copy the session key manually.',
+      tone: 'danger',
+      disabled: false,
+    }
+  }
+
+  return {
+    label: 'Copy session key',
+    helperText: null,
+    tone: 'neutral',
+    disabled: false,
+  }
+}
+
+export function buildMissionHistoryTraceInspectActionViewModel(
+  sessionKeyValue: string | null | undefined,
+): MissionHistoryTraceInspectActionViewModel {
+  const inspectContract =
+    buildMissionHistoryTraceInspectContractViewModel(sessionKeyValue)
+  if (!inspectContract) {
+    return {
+      label: 'Inspect session',
+      helperText: 'No session key is available to inspect.',
+      to: null,
+      params: null,
+      disabled: true,
+    }
+  }
+
+  return {
+    label: 'Inspect session',
+    helperText: 'Open the persisted chat session that backs this Conductor trace.',
+    to: inspectContract.route,
+    params: { sessionKey: inspectContract.routeParamValue },
+    disabled: false,
+  }
+}
+
+export function buildMissionHistoryTraceInspectContractViewModel(
+  sessionKeyValue: string | null | undefined,
+): MissionHistoryTraceInspectContractViewModel | null {
+  const sessionKey = normalizeOptionalString(sessionKeyValue)
+  if (!sessionKey) return null
+
+  return {
+    route: '/chat/$sessionKey',
+    routeParamName: 'sessionKey',
+    routeParamValue: sessionKey,
+    supportedByCurrentRoute: true,
+    mode: 'raw-session-key-mvp',
+    risk:
+      'The chat route accepts the raw trace session key as its sessionKey param; a dedicated trace inspector is still deferred.',
+  }
+}
+
+export function buildMissionHistoryTraceLookupViewModel(
+  status: MissionHistoryTraceLookupStatus,
+): MissionHistoryTraceLookupViewModel {
+  if (status === 'checking') {
+    return {
+      label: 'Checking persisted session…',
+      helperText: 'Looking for a chat session matching this trace key.',
+      tone: 'neutral',
+      isChecking: true,
+    }
+  }
+
+  if (status === 'found') {
+    return {
+      label: 'Persisted session found',
+      helperText: 'This trace can be inspected in chat history.',
+      tone: 'success',
+      isChecking: false,
+    }
+  }
+
+  if (status === 'missing') {
+    return {
+      label: 'Persisted session not found',
+      helperText:
+        'No persisted chat session was found for this key. You can still try opening it manually.',
+      tone: 'warning',
+      isChecking: false,
+    }
+  }
+
+  if (status === 'error') {
+    return {
+      label: 'Unable to check persisted session',
+      helperText:
+        'Session lookup failed. You can still try opening the session manually.',
+      tone: 'warning',
+      isChecking: false,
+    }
+  }
+
+  return {
+    label: 'Persisted session lookup pending',
+    helperText: 'Session lookup will start when a trace key is available.',
+    tone: 'neutral',
+    isChecking: false,
+  }
+}
+
+export function buildMissionHistoryTraceLookupRefreshControl({
+  status,
+  hasSessionKey,
+  isRefreshing,
+}: {
+  status: MissionHistoryTraceLookupStatus
+  hasSessionKey: boolean
+  isRefreshing: boolean
+}): MissionHistoryTraceLookupRefreshControl {
+  if (status === 'checking' || isRefreshing) {
+    return {
+      label: 'Checking…',
+      title: 'Persisted session lookup is already running.',
+      ariaLabel: 'Checking persisted session lookup status.',
+      disabled: true,
+      isLoading: true,
+      visible: true,
+    }
+  }
+
+  if (!hasSessionKey) {
+    return {
+      label: 'Refresh status',
+      title: 'No trace session key is available to refresh.',
+      ariaLabel:
+        'Refresh persisted session lookup status: no trace session key is available.',
+      disabled: true,
+      isLoading: false,
+      visible: false,
+    }
+  }
+
+  if (status === 'error') {
+    return {
+      label: 'Retry lookup',
+      title: 'Retry persisted session lookup for this trace key.',
+      ariaLabel: 'Retry lookup: Retry persisted session lookup for this trace key.',
+      disabled: false,
+      isLoading: false,
+      visible: true,
+    }
+  }
+
+  return {
+    label: 'Refresh status',
+    title: 'Refresh persisted session lookup status.',
+    ariaLabel: 'Refresh status: Refresh persisted session lookup status.',
+    disabled: false,
+    isLoading: false,
+    visible: true,
+  }
+}
+
+export function buildMissionHistoryTraceRecoveryViewModel(
+  isFallback: boolean,
+  lookupStatus: MissionHistoryTraceLookupStatus,
+): MissionHistoryTraceRecoveryViewModel | null {
+  if (!isFallback) return null
+
+  const base = {
+    title: 'Local mission history not found',
+    description:
+      'This trace was opened from a session key, but no local Conductor mission history entry matched it.',
+  }
+
+  if (lookupStatus === 'found') {
+    return {
+      ...base,
+      recommendation: 'Open the persisted session to inspect its chat history.',
+      tone: 'success',
+      actions: [
+        'Inspect the persisted session',
+        'Copy the session key for manual lookup',
+        'Start a new mission if this trace is from another environment',
+      ],
+    }
+  }
+
+  if (lookupStatus === 'missing') {
+    return {
+      ...base,
+      recommendation:
+        'No persisted session was found here. The key may be stale or from another workspace.',
+      tone: 'warning',
+      actions: [
+        'Copy the session key for manual lookup',
+        'Try inspecting the session anyway',
+        'Start a new mission if recovery is not possible',
+      ],
+    }
+  }
+
+  if (lookupStatus === 'error') {
+    return {
+      ...base,
+      recommendation:
+        'Persisted session lookup failed. You can still inspect manually or retry later.',
+      tone: 'warning',
+      actions: [
+        'Try inspecting the session manually',
+        'Copy the session key for support/debugging',
+        'Retry lookup later',
+      ],
+    }
+  }
+
+  return {
+    ...base,
+    recommendation:
+      'Wait for persisted session lookup, then inspect the session or copy the key for manual recovery.',
+    tone: 'warning',
+    actions: [
+      'Wait for lookup to complete',
+      'Copy the session key for manual lookup',
+      'Inspect the session if you recognize the key',
+    ],
+  }
+}
+
+export function buildMissionHistoryTraceRecoveryActionsViewModel({
+  isFallback,
+  lookupStatus,
+  copyStatus,
+  sessionKey,
+}: {
+  isFallback: boolean
+  lookupStatus: MissionHistoryTraceLookupStatus
+  copyStatus: MissionHistoryTraceCopyStatus
+  sessionKey: string | null | undefined
+}): MissionHistoryTraceRecoveryActionsViewModel | null {
+  if (!isFallback || !normalizeOptionalString(sessionKey)) return null
+
+  const copyAction = buildMissionHistoryTraceActionViewModel(copyStatus)
+  const copyControl: MissionHistoryTraceCopyControl = {
+    kind: 'copy',
+    label: copyAction.label,
+    helperText: copyAction.helperText,
+    disabled: copyAction.disabled,
+    tone: copyAction.tone,
+  }
+
+  if (lookupStatus === 'found') {
+    return {
+      primary: {
+        kind: 'inspect',
+        label: 'Inspect recovered session',
+        helperText: 'Open the persisted session that matched this trace key.',
+        disabled: false,
+      },
+      secondary: copyControl,
+      tertiary: {
+        kind: 'newMission',
+        label: 'Start new mission',
+        helperText: 'Start over if this trace belongs to another environment.',
+        disabled: false,
+      },
+    }
+  }
+
+  if (lookupStatus === 'checking' || lookupStatus === 'idle') {
+    return {
+      primary: {
+        kind: 'inspect',
+        label: 'Inspect manually',
+        helperText: 'Lookup is still running; you can inspect manually if needed.',
+        disabled: false,
+      },
+      secondary: copyControl,
+      tertiary: null,
+    }
+  }
+
+  return {
+    primary: copyControl,
+    secondary: {
+      kind: 'inspect',
+      label: lookupStatus === 'missing' ? 'Try inspect anyway' : 'Inspect manually',
+      helperText:
+        lookupStatus === 'missing'
+          ? 'Open chat history even though lookup did not find a match.'
+          : 'Open chat history while lookup is unavailable.',
+      disabled: false,
+    },
+    tertiary: {
+      kind: 'newMission',
+      label: 'Start new mission',
+      helperText: 'Start over if recovery is not possible.',
+      disabled: false,
+    },
+  }
+}
+
+export function buildMissionHistoryTraceRecoveryPanelViewModel({
+  entry,
+  lookupStatus,
+  copyStatus,
+  lastAction,
+  isRefreshingLookup,
+}: {
+  entry: MissionHistoryEntry | null | undefined
+  lookupStatus: MissionHistoryTraceLookupStatus
+  copyStatus: MissionHistoryTraceCopyStatus
+  lastAction: MissionHistoryTraceRecoveryLastAction | null
+  isRefreshingLookup: boolean
+}): MissionHistoryTraceRecoveryPanelViewModel | null {
+  const trace = buildMissionHistoryTraceViewModel(entry)
+  if (!trace) return null
+
+  return {
+    trace,
+    lookup: buildMissionHistoryTraceLookupViewModel(lookupStatus),
+    lookupRefresh: buildMissionHistoryTraceLookupRefreshControl({
+      status: lookupStatus,
+      hasSessionKey: Boolean(trace.sessionKey),
+      isRefreshing: isRefreshingLookup,
+    }),
+    recovery: buildMissionHistoryTraceRecoveryViewModel(
+      trace.isFallback,
+      lookupStatus,
+    ),
+    recoveryActions: buildMissionHistoryTraceRecoveryActionsViewModel({
+      isFallback: trace.isFallback,
+      lookupStatus,
+      copyStatus,
+      sessionKey: trace.sessionKey,
+    }),
+    feedback: buildMissionHistoryTraceRecoveryFeedbackViewModel({
+      isFallback: trace.isFallback,
+      lastAction,
+      copyStatus,
+    }),
+  }
+}
+
+export function buildMissionHistoryTraceRenderActionViewModel(
+  action: MissionHistoryTraceButtonControl,
+): MissionHistoryTraceRecoveryRenderActionViewModel {
+  const title = action.helperText ?? action.label
+  const classTone =
+    action.kind === 'inspect'
+      ? 'accent'
+      : action.kind === 'newMission'
+        ? 'neutral'
+        : action.tone
+  const ariaLabel = action.helperText ? `${action.label}: ${title}` : action.label
+
+  return {
+    label: action.label,
+    title,
+    ariaLabel,
+    classTone,
+    disabled: action.disabled,
+  }
+}
+
+export function buildMissionHistoryTraceButtonRenderViewModel(
+  action: MissionHistoryTraceButtonControl,
+): MissionHistoryTraceRecoveryRenderActionViewModel {
+  return buildMissionHistoryTraceRenderActionViewModel(action)
+}
+
+export function buildMissionHistoryTraceRecoveryRenderActionViewModel(
+  action: MissionHistoryTraceRecoveryControl,
+): MissionHistoryTraceRecoveryRenderActionViewModel {
+  return buildMissionHistoryTraceRenderActionViewModel(action)
+}
+
+export function buildMissionHistoryTraceButtonClassName(
+  tone: MissionHistoryTraceButtonTone,
+  extraClassName?: string,
+): string {
+  const baseClassName = ['rounded-xl', 'border', 'px-4', extraClassName]
+    .filter(Boolean)
+    .join(' ')
+
+  if (tone === 'accent') {
+    return `${baseClassName} border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:bg-[var(--theme-accent-soft-strong)]`
+  }
+
+  if (tone === 'success') {
+    return `${baseClassName} border-emerald-400/35 bg-emerald-500/10 text-emerald-600 hover:border-emerald-400/60`
+  }
+
+  if (tone === 'danger') {
+    return `${baseClassName} border-[var(--theme-danger-border)] bg-[var(--theme-danger-soft)] text-[var(--theme-danger)] hover:bg-[var(--theme-danger-soft-strong)]`
+  }
+
+  return `${baseClassName} border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-text)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent)]`
+}
+
+export function buildMissionHistoryTraceButtonElementViewModel(
+  action: MissionHistoryTraceButtonControl,
+  options: { extraClassName?: string } = {},
+): MissionHistoryTraceButtonElementViewModel {
+  const renderAction = buildMissionHistoryTraceRenderActionViewModel(action)
+  return {
+    actionKind: action.kind,
+    key: `${action.kind}-${action.label}`,
+    type: 'button',
+    label: renderAction.label,
+    title: renderAction.title,
+    ariaLabel: renderAction.ariaLabel,
+    disabled: renderAction.disabled,
+    className: buildMissionHistoryTraceButtonClassName(
+      renderAction.classTone,
+      options.extraClassName,
+    ),
+  }
+}
+
+export function buildMissionHistoryTraceRecoveryFeedbackViewModel({
+  isFallback,
+  lastAction,
+  copyStatus,
+}: {
+  isFallback: boolean
+  lastAction: MissionHistoryTraceRecoveryLastAction | null
+  copyStatus: MissionHistoryTraceCopyStatus
+}): MissionHistoryTraceRecoveryFeedbackViewModel | null {
+  if (!isFallback || !lastAction) return null
+
+  if (lastAction === 'copy') {
+    if (copyStatus === 'copied') {
+      return {
+        message: 'Session key copied for manual recovery.',
+        tone: 'success',
+      }
+    }
+    if (copyStatus === 'failed') {
+      return {
+        message:
+          'Clipboard is unavailable. Select the session key and copy it manually.',
+        tone: 'danger',
+      }
+    }
+    return null
+  }
+
+  if (lastAction === 'inspect') {
+    return {
+      message: 'Opening persisted chat history for this trace session…',
+      tone: 'neutral',
+    }
+  }
+
+  return {
+    message: 'Starting a new mission from the recovery flow…',
+    tone: 'neutral',
+  }
+}

--- a/src/screens/gateway/conductor.tsx
+++ b/src/screens/gateway/conductor.tsx
@@ -1,7 +1,19 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { ArrowDown01Icon, ArrowRight01Icon, PlayIcon, Rocket01Icon, Search01Icon, Settings01Icon, TaskDone01Icon } from '@hugeicons/core-free-icons'
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  Folder01Icon,
+  GitBranchIcon,
+  Link01Icon,
+  PlayIcon,
+  Rocket01Icon,
+  Search01Icon,
+  Settings01Icon,
+  TaskDone01Icon,
+} from '@hugeicons/core-free-icons'
 import { Button } from '@/components/ui/button'
 import { WorkflowHelpModal } from '@/components/workflow-help-modal'
 import { Markdown } from '@/components/prompt-kit/markdown'
@@ -9,7 +21,15 @@ import { OfficeView } from './components/office-view'
 import type { AgentWorkingRow } from './components/agents-working-panel'
 import { type GatewaySession } from '@/lib/gateway-api'
 import { cn } from '@/lib/utils'
-import { type MissionHistoryEntry, type MissionHistoryWorkerDetail, useConductorGateway } from './hooks/use-conductor-gateway'
+import {
+  consumeConductorLaunchIntent,
+  type ConductorProjectOverride,
+} from './conductor-launch-intent'
+import {
+  type MissionHistoryEntry,
+  type MissionHistoryWorkerDetail,
+  useConductorGateway,
+} from './hooks/use-conductor-gateway'
 
 type ConductorPhase = 'home' | 'preview' | 'active' | 'complete'
 type QuickActionId = 'research' | 'build' | 'review' | 'deploy'
@@ -33,6 +53,30 @@ type AvailableModel = {
   name?: string
 }
 
+type ProjectContextFile = {
+  name: string
+  path: string
+  excerpt: string
+}
+
+type ProjectContextEntry = {
+  id: string
+  name: string
+  path: string
+  active: boolean
+  gitRemote: string | null
+  gitBranch: string | null
+  instructionFiles: Array<ProjectContextFile>
+  readme: ProjectContextFile | null
+}
+
+type ProjectsResponse = {
+  activeProjectId: string | null
+  projects: Array<ProjectContextEntry>
+  fetchedAt: number
+  error?: string
+}
+
 type FileBrowserEntry = {
   name: string
   path: string
@@ -51,17 +95,26 @@ const THEME_STYLE: CSSProperties = {
   ['--theme-muted-2' as string]: 'var(--color-primary-600)',
   ['--theme-accent' as string]: 'var(--color-accent-500)',
   ['--theme-accent-strong' as string]: 'var(--color-accent-600)',
-  ['--theme-accent-soft' as string]: 'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
-  ['--theme-accent-soft-strong' as string]: 'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
-  ['--theme-shadow' as string]: 'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
+  ['--theme-accent-soft' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
+  ['--theme-accent-soft-strong' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
+  ['--theme-shadow' as string]:
+    'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
   ['--theme-danger' as string]: 'var(--color-red-600, #dc2626)',
-  ['--theme-danger-soft' as string]: 'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
-  ['--theme-danger-soft-strong' as string]: 'color-mix(in srgb, var(--theme-danger) 18%, transparent)',
-  ['--theme-danger-border' as string]: 'color-mix(in srgb, var(--theme-danger) 35%, white)',
+  ['--theme-danger-soft' as string]:
+    'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
+  ['--theme-danger-soft-strong' as string]:
+    'color-mix(in srgb, var(--theme-danger) 18%, transparent)',
+  ['--theme-danger-border' as string]:
+    'color-mix(in srgb, var(--theme-danger) 35%, white)',
   ['--theme-warning' as string]: 'var(--color-amber-600, #d97706)',
-  ['--theme-warning-soft' as string]: 'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
-  ['--theme-warning-soft-strong' as string]: 'color-mix(in srgb, var(--theme-warning) 18%, transparent)',
-  ['--theme-warning-border' as string]: 'color-mix(in srgb, var(--theme-warning) 35%, white)',
+  ['--theme-warning-soft' as string]:
+    'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
+  ['--theme-warning-soft-strong' as string]:
+    'color-mix(in srgb, var(--theme-warning) 18%, transparent)',
+  ['--theme-warning-border' as string]:
+    'color-mix(in srgb, var(--theme-warning) 35%, white)',
 }
 
 const QUICK_ACTIONS: Array<{
@@ -74,36 +127,68 @@ const QUICK_ACTIONS: Array<{
     id: 'research',
     label: 'Research',
     icon: Search01Icon,
-    prompt: 'Research the problem space, gather constraints, compare approaches, and propose the most viable plan.',
+    prompt:
+      'Research the problem space, gather constraints, compare approaches, and propose the most viable plan.',
   },
   {
     id: 'build',
     label: 'Build',
     icon: PlayIcon,
-    prompt: 'Build the requested feature end-to-end, including implementation, validation, and a concise delivery summary.',
+    prompt:
+      'Build the requested feature end-to-end, including implementation, validation, and a concise delivery summary.',
   },
   {
     id: 'review',
     label: 'Review',
     icon: TaskDone01Icon,
-    prompt: 'Review the current implementation for correctness, regressions, missing tests, and release risks.',
+    prompt:
+      'Review the current implementation for correctness, regressions, missing tests, and release risks.',
   },
   {
     id: 'deploy',
     label: 'Deploy',
     icon: Rocket01Icon,
-    prompt: 'Prepare the work for deployment, verify readiness, and summarize any operational follow-ups.',
+    prompt:
+      'Prepare the work for deployment, verify readiness, and summarize any operational follow-ups.',
   },
 ]
 
-const AGENT_NAMES = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
+const AGENT_NAMES = [
+  'Nova',
+  'Pixel',
+  'Blaze',
+  'Echo',
+  'Sage',
+  'Drift',
+  'Flux',
+  'Volt',
+]
 const AGENT_EMOJIS = ['🤖', '⚡', '🔥', '🌊', '🌿', '💫', '🔮', '⭐']
+
+async function fetchProjectsContext(): Promise<ProjectsResponse> {
+  const response = await fetch('/api/projects', { cache: 'no-store' })
+  const data = (await response.json().catch(() => ({}))) as ProjectsResponse
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to load project context')
+  }
+  return data
+}
+
+function shortenProjectRemote(remote: string | null): string {
+  if (!remote) return 'No git remote'
+  return remote
+    .replace(/^git@github.com:/, 'github.com/')
+    .replace(/^https:\/\/github.com\//, 'github.com/')
+    .replace(/\.git$/, '')
+}
 const BLENDED_COST_PER_MILLION_TOKENS = 5
 const CONDUCTOR_GOAL_DRAFT_STORAGE_KEY = 'conductor:goal-draft'
 
 function loadConductorGoalDraft(): string {
   try {
-    return globalThis.localStorage?.getItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY) ?? ''
+    return (
+      globalThis.localStorage?.getItem(CONDUCTOR_GOAL_DRAFT_STORAGE_KEY) ?? ''
+    )
   } catch {
     return ''
   }
@@ -129,26 +214,55 @@ function getAgentPersona(index: number) {
 }
 
 function estimateTokenCost(totalTokens: number): number {
-  return (Math.max(0, totalTokens) / 1_000_000) * BLENDED_COST_PER_MILLION_TOKENS
+  return (
+    (Math.max(0, totalTokens) / 1_000_000) * BLENDED_COST_PER_MILLION_TOKENS
+  )
 }
 
 function formatUsd(value: number): string {
   return `$${value.toFixed(value >= 0.1 ? 2 : 3)}`
 }
 
-function MissionCostSection({ totalTokens, workers, expanded, onToggle }: { totalTokens: number; workers: MissionCostWorker[]; expanded: boolean; onToggle: () => void }) {
+function MissionCostSection({
+  totalTokens,
+  workers,
+  expanded,
+  onToggle,
+}: {
+  totalTokens: number
+  workers: MissionCostWorker[]
+  expanded: boolean
+  onToggle: () => void
+}) {
   const estimatedCost = estimateTokenCost(totalTokens)
 
   return (
     <div className="overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-      <button type="button" onClick={onToggle} aria-expanded={expanded} className="flex w-full items-start justify-between gap-4 text-left">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="flex w-full items-start justify-between gap-4 text-left"
+      >
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Cost</p>
-          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Approximate at $5 / 1M tokens blended from input/output pricing.</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+            Mission Cost
+          </p>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+            Approximate at $5 / 1M tokens blended from input/output pricing.
+          </p>
         </div>
         <span className="inline-flex items-center gap-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs font-medium text-[var(--theme-text)]">
           {expanded ? 'Hide' : 'Show'}
-          <HugeiconsIcon icon={ArrowDown01Icon} size={16} strokeWidth={1.7} className={cn('transition-transform duration-200', expanded ? 'rotate-180' : 'rotate-0')} />
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            size={16}
+            strokeWidth={1.7}
+            className={cn(
+              'transition-transform duration-200',
+              expanded ? 'rotate-180' : 'rotate-0',
+            )}
+          />
         </span>
       </button>
 
@@ -156,12 +270,20 @@ function MissionCostSection({ totalTokens, workers, expanded, onToggle }: { tota
         <div className="mt-4 space-y-4">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Total Tokens</p>
-              <p className="mt-2 text-2xl font-semibold text-[var(--theme-text)]">{totalTokens.toLocaleString()}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                Total Tokens
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-[var(--theme-text)]">
+                {totalTokens.toLocaleString()}
+              </p>
             </div>
             <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Estimated Cost</p>
-              <p className="mt-2 text-2xl font-semibold text-[var(--theme-text)]">{formatUsd(estimatedCost)}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                Estimated Cost
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-[var(--theme-text)]">
+                {formatUsd(estimatedCost)}
+              </p>
             </div>
           </div>
 
@@ -173,18 +295,29 @@ function MissionCostSection({ totalTokens, workers, expanded, onToggle }: { tota
             {workers.length > 0 ? (
               <div className="divide-y divide-[var(--theme-border)]">
                 {workers.map((worker) => (
-                  <div key={worker.id} className="flex items-center gap-3 px-4 py-3 text-sm">
+                  <div
+                    key={worker.id}
+                    className="flex items-center gap-3 px-4 py-3 text-sm"
+                  >
                     <span className="font-medium text-[var(--theme-text)]">
                       {worker.personaEmoji} {worker.personaName}
                     </span>
-                    <span className="min-w-0 flex-1 truncate text-[var(--theme-muted)]">{worker.label}</span>
-                    <span className="text-xs text-[var(--theme-muted)]">{worker.totalTokens.toLocaleString()} tok</span>
-                    <span className="min-w-[4.5rem] text-right font-medium text-[var(--theme-text)]">{formatUsd(estimateTokenCost(worker.totalTokens))}</span>
+                    <span className="min-w-0 flex-1 truncate text-[var(--theme-muted)]">
+                      {worker.label}
+                    </span>
+                    <span className="text-xs text-[var(--theme-muted)]">
+                      {worker.totalTokens.toLocaleString()} tok
+                    </span>
+                    <span className="min-w-[4.5rem] text-right font-medium text-[var(--theme-text)]">
+                      {formatUsd(estimateTokenCost(worker.totalTokens))}
+                    </span>
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="px-4 py-3 text-sm text-[var(--theme-muted)]">Per-worker token details were not captured for this mission.</div>
+              <div className="px-4 py-3 text-sm text-[var(--theme-muted)]">
+                Per-worker token details were not captured for this mission.
+              </div>
             )}
           </div>
         </div>
@@ -193,7 +326,12 @@ function MissionCostSection({ totalTokens, workers, expanded, onToggle }: { tota
   )
 }
 
-const PLANNING_STEPS = ['Planning the mission…', 'Analyzing requirements…', 'Preparing agents…', 'Writing the spec…']
+const PLANNING_STEPS = [
+  'Planning the mission…',
+  'Analyzing requirements…',
+  'Preparing agents…',
+  'Writing the spec…',
+]
 const WORKING_STEPS = [
   '📋 Reviewing the brief…',
   '🔍 Scanning existing patterns…',
@@ -206,19 +344,32 @@ const WORKING_STEPS = [
   '🚀 Almost there…',
 ]
 
-function CyclingStatus({ steps, intervalMs = 3000, isPaused = false }: { steps: string[]; intervalMs?: number; isPaused?: boolean }) {
+function CyclingStatus({
+  steps,
+  intervalMs = 3000,
+  isPaused = false,
+}: {
+  steps: string[]
+  intervalMs?: number
+  isPaused?: boolean
+}) {
   const [step, setStep] = useState(0)
 
   useEffect(() => {
     if (isPaused) return
-    const timer = window.setInterval(() => setStep((current) => (current + 1) % steps.length), intervalMs)
+    const timer = window.setInterval(
+      () => setStep((current) => (current + 1) % steps.length),
+      intervalMs,
+    )
     return () => window.clearInterval(timer)
   }, [isPaused, steps.length, intervalMs])
 
   if (isPaused) {
     return (
       <div className="flex items-center gap-3 py-3">
-        <div className="flex size-3.5 items-center justify-center rounded-full border border-amber-400/60 bg-amber-500/10 text-[9px] text-amber-300">||</div>
+        <div className="flex size-3.5 items-center justify-center rounded-full border border-amber-400/60 bg-amber-500/10 text-[9px] text-amber-300">
+          ||
+        </div>
         <p className="text-sm text-[var(--theme-muted)]">Paused</p>
       </div>
     )
@@ -227,7 +378,9 @@ function CyclingStatus({ steps, intervalMs = 3000, isPaused = false }: { steps: 
   return (
     <div className="flex items-center gap-3 py-3">
       <div className="size-3.5 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
-      <p className="text-sm text-[var(--theme-muted)] transition-opacity duration-500">{steps[step]}</p>
+      <p className="text-sm text-[var(--theme-muted)] transition-opacity duration-500">
+        {steps[step]}
+      </p>
     </div>
   )
 }
@@ -241,7 +394,9 @@ function getOutputDisplayName(projectPath: string | null | undefined): string {
   return projectPath.split('/').pop() || 'index.html'
 }
 
-function formatMissionTimestamp(value: string | null | undefined): string | null {
+function formatMissionTimestamp(
+  value: string | null | undefined,
+): string | null {
   if (!value) return null
   const date = new Date(value)
   if (!Number.isFinite(date.getTime())) return null
@@ -249,7 +404,10 @@ function formatMissionTimestamp(value: string | null | undefined): string | null
   return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
 }
 
-function buildProjectPathCandidates(workers: Array<{ label: string }>, missionStartedAt: string | null | undefined): string[] {
+function buildProjectPathCandidates(
+  workers: Array<{ label: string }>,
+  missionStartedAt: string | null | undefined,
+): string[] {
   const timestamp = formatMissionTimestamp(missionStartedAt)
   const candidates = new Set<string>()
 
@@ -270,7 +428,10 @@ function buildProjectPathCandidates(workers: Array<{ label: string }>, missionSt
   return [...candidates]
 }
 
-function formatElapsedTime(startIso: string | null | undefined, now: number): string {
+function formatElapsedTime(
+  startIso: string | null | undefined,
+  now: number,
+): string {
   if (!startIso) return '0s'
   const startMs = new Date(startIso).getTime()
   if (!Number.isFinite(startMs)) return '0s'
@@ -287,13 +448,20 @@ function formatElapsedMilliseconds(durationMs: number): string {
   return `${seconds}s`
 }
 
-function formatDurationRange(startIso: string | null | undefined, endIso: string | null | undefined, now: number): string {
+function formatDurationRange(
+  startIso: string | null | undefined,
+  endIso: string | null | undefined,
+  now: number,
+): string {
   const endMs = endIso ? new Date(endIso).getTime() : now
   if (!Number.isFinite(endMs)) return formatElapsedTime(startIso, now)
   return formatElapsedTime(startIso, endMs)
 }
 
-function formatRelativeTime(value: string | null | undefined, now: number): string {
+function formatRelativeTime(
+  value: string | null | undefined,
+  now: number,
+): string {
   if (!value) return 'just now'
   const ms = new Date(value).getTime()
   if (!Number.isFinite(ms)) return 'just now'
@@ -313,13 +481,17 @@ function truncateContinuationText(text: string, limit = 500): string {
 }
 
 function getWorkerDot(status: 'running' | 'complete' | 'stale' | 'idle') {
-  if (status === 'complete') return { dotClass: 'bg-emerald-400', label: 'Complete' }
-  if (status === 'running') return { dotClass: 'bg-sky-400 animate-pulse', label: 'Running' }
+  if (status === 'complete')
+    return { dotClass: 'bg-emerald-400', label: 'Complete' }
+  if (status === 'running')
+    return { dotClass: 'bg-sky-400 animate-pulse', label: 'Running' }
   if (status === 'idle') return { dotClass: 'bg-amber-400', label: 'Idle' }
   return { dotClass: 'bg-red-400', label: 'Stale' }
 }
 
-function getWorkerBorderClass(status: 'running' | 'complete' | 'stale' | 'idle') {
+function getWorkerBorderClass(
+  status: 'running' | 'complete' | 'stale' | 'idle',
+) {
   if (status === 'complete') return 'border-l-emerald-400'
   if (status === 'running') return 'border-l-sky-400'
   if (status === 'idle') return 'border-l-amber-400'
@@ -334,27 +506,51 @@ function WorkerCard({
 }: {
   worker: ReturnType<typeof useConductorGateway>['workers'][number]
   index: number
-  conductor: Pick<ReturnType<typeof useConductorGateway>, 'workerOutputs' | 'isPaused' | 'pausedAtMs' | 'missionStartedAt'>
+  conductor: Pick<
+    ReturnType<typeof useConductorGateway>,
+    'workerOutputs' | 'isPaused' | 'pausedAtMs' | 'missionStartedAt'
+  >
   now: number
 }) {
   const dot = getWorkerDot(worker.status)
   const persona = getAgentPersona(index)
-  const workerOutput = conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
-  const workerStartedAt = typeof worker.raw.createdAt === 'string' ? worker.raw.createdAt : typeof worker.raw.startedAt === 'string' ? worker.raw.startedAt : conductor.missionStartedAt
+  const workerOutput =
+    conductor.workerOutputs[worker.key] ??
+    getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
+  const workerStartedAt =
+    typeof worker.raw.createdAt === 'string'
+      ? worker.raw.createdAt
+      : typeof worker.raw.startedAt === 'string'
+        ? worker.raw.startedAt
+        : conductor.missionStartedAt
   const workerEndTime =
-    worker.status === 'complete' || worker.status === 'stale' ? new Date(worker.updatedAt ?? new Date().toISOString()).getTime() : conductor.isPaused ? (conductor.pausedAtMs ?? now) : now
+    worker.status === 'complete' || worker.status === 'stale'
+      ? new Date(worker.updatedAt ?? new Date().toISOString()).getTime()
+      : conductor.isPaused
+        ? (conductor.pausedAtMs ?? now)
+        : now
 
   return (
-    <div key={worker.key} className={cn('overflow-hidden rounded-2xl border border-[var(--theme-border)] border-l-4 bg-[var(--theme-card)] px-4 py-3', getWorkerBorderClass(worker.status))}>
+    <div
+      key={worker.key}
+      className={cn(
+        'overflow-hidden rounded-2xl border border-[var(--theme-border)] border-l-4 bg-[var(--theme-card)] px-4 py-3',
+        getWorkerBorderClass(worker.status),
+      )}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <span className={cn('size-2.5 rounded-full', dot.dotClass)} />
             <p className="truncate text-sm font-medium text-[var(--theme-text)]">
-              {persona.emoji} {persona.name} <span className="text-[var(--theme-muted)]">·</span> {worker.label}
+              {persona.emoji} {persona.name}{' '}
+              <span className="text-[var(--theme-muted)]">·</span>{' '}
+              {worker.label}
             </p>
           </div>
-          <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{worker.displayName}</p>
+          <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+            {worker.displayName}
+          </p>
         </div>
         <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
           {dot.label}
@@ -364,27 +560,41 @@ function WorkerCard({
       <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
         <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2">
           <p className="text-[var(--theme-muted)]">Model</p>
-          <p className="mt-1 truncate text-[var(--theme-text)]">{getShortModelName(worker.model)}</p>
+          <p className="mt-1 truncate text-[var(--theme-text)]">
+            {getShortModelName(worker.model)}
+          </p>
         </div>
         <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2">
           <p className="text-[var(--theme-muted)]">Tokens</p>
-          <p className="mt-1 text-[var(--theme-text)]">{worker.tokenUsageLabel}</p>
+          <p className="mt-1 text-[var(--theme-text)]">
+            {worker.tokenUsageLabel}
+          </p>
         </div>
         <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2">
           <p className="text-[var(--theme-muted)]">Elapsed</p>
-          <p className="mt-1 text-[var(--theme-text)]">{formatElapsedTime(workerStartedAt, workerEndTime)}</p>
+          <p className="mt-1 text-[var(--theme-text)]">
+            {formatElapsedTime(workerStartedAt, workerEndTime)}
+          </p>
         </div>
         <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2">
           <p className="text-[var(--theme-muted)]">Last update</p>
-          <p className="mt-1 text-[var(--theme-text)]">{formatRelativeTime(worker.updatedAt, now)}</p>
+          <p className="mt-1 text-[var(--theme-text)]">
+            {formatRelativeTime(worker.updatedAt, now)}
+          </p>
         </div>
       </div>
 
       <div className="mt-3 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-4">
         {workerOutput ? (
-          <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{workerOutput}</Markdown>
+          <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+            {workerOutput}
+          </Markdown>
         ) : (
-          <CyclingStatus steps={WORKING_STEPS} intervalMs={3500} isPaused={conductor.isPaused} />
+          <CyclingStatus
+            steps={WORKING_STEPS}
+            intervalMs={3500}
+            isPaused={conductor.isPaused}
+          />
         )}
       </div>
     </div>
@@ -425,12 +635,19 @@ function usePreviewAvailability(previewUrl: string | null, enabled: boolean) {
     },
     enabled: enabled && !!previewUrl && !exhausted,
     retry: false,
-    refetchInterval: (query) => (query.state.data === true || exhausted ? false : 1_500),
+    refetchInterval: (query) =>
+      query.state.data === true || exhausted ? false : 1_500,
     staleTime: 5_000,
   })
 
   useEffect(() => {
-    if (!enabled || !previewUrl || probeQuery.data === true || probeQuery.dataUpdatedAt === 0) return
+    if (
+      !enabled ||
+      !previewUrl ||
+      probeQuery.data === true ||
+      probeQuery.dataUpdatedAt === 0
+    )
+      return
     if (lastProbeRef.current === probeQuery.dataUpdatedAt) return
     lastProbeRef.current = probeQuery.dataUpdatedAt
     setFailedProbes((current) => current + 1)
@@ -439,7 +656,8 @@ function usePreviewAvailability(previewUrl: string | null, enabled: boolean) {
   return {
     ready: probeQuery.data === true,
     loading: enabled && !!previewUrl && !exhausted && probeQuery.data !== true,
-    unavailable: enabled && !!previewUrl && exhausted && probeQuery.data !== true,
+    unavailable:
+      enabled && !!previewUrl && exhausted && probeQuery.data !== true,
   }
 }
 
@@ -449,7 +667,10 @@ function getShortModelName(model: string | null | undefined): string {
   return parts[parts.length - 1] || model
 }
 
-function getModelDisplayName(model: AvailableModel | undefined, modelId: string | null | undefined): string {
+function getModelDisplayName(
+  model: AvailableModel | undefined,
+  modelId: string | null | undefined,
+): string {
   if (!modelId) return 'Default (auto)'
   return model?.name?.trim() || model?.id?.trim() || modelId
 }
@@ -481,7 +702,11 @@ function groupModelsByProvider(models: AvailableModel[]) {
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([provider, providerModels]) => ({
       provider,
-      models: [...providerModels].sort((a, b) => getModelDisplayName(a, a.id).localeCompare(getModelDisplayName(b, b.id))),
+      models: [...providerModels].sort((a, b) =>
+        getModelDisplayName(a, a.id).localeCompare(
+          getModelDisplayName(b, b.id),
+        ),
+      ),
     }))
 }
 
@@ -554,7 +779,9 @@ function ModelSelectorDropdown({
 
   return (
     <div className="space-y-2">
-      <span className="text-sm font-medium text-[var(--theme-text)]">{label}</span>
+      <span className="text-sm font-medium text-[var(--theme-text)]">
+        {label}
+      </span>
       <div className="relative" ref={containerRef}>
         <button
           type="button"
@@ -564,7 +791,9 @@ function ModelSelectorDropdown({
           }}
           className={cn(
             'inline-flex min-h-[3rem] w-full items-center justify-between gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-left text-sm text-[var(--theme-text)] shadow-[0_8px_24px_color-mix(in_srgb,var(--theme-shadow)_18%,transparent)] transition-colors',
-            disabled ? 'cursor-not-allowed opacity-60' : 'hover:border-[var(--theme-accent)] focus:border-[var(--theme-accent)]',
+            disabled
+              ? 'cursor-not-allowed opacity-60'
+              : 'hover:border-[var(--theme-accent)] focus:border-[var(--theme-accent)]',
           )}
           aria-haspopup="listbox"
           aria-expanded={open}
@@ -572,11 +801,28 @@ function ModelSelectorDropdown({
         >
           <span className="inline-flex min-w-0 items-center gap-2">
             <span className="inline-flex items-center gap-2 rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-1 text-xs font-medium text-[var(--theme-text)]">
-              <span className={cn('size-2 rounded-full', value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
-              <span className="truncate">{getModelDisplayName(selectedModel, value)}</span>
+              <span
+                className={cn(
+                  'size-2 rounded-full',
+                  value
+                    ? 'bg-[var(--theme-accent)]'
+                    : 'bg-[var(--theme-border2)]',
+                )}
+              />
+              <span className="truncate">
+                {getModelDisplayName(selectedModel, value)}
+              </span>
             </span>
           </span>
-          <HugeiconsIcon icon={ArrowDown01Icon} size={16} strokeWidth={1.8} className={cn('shrink-0 text-[var(--theme-muted)] transition-transform', open && 'rotate-180')} />
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            size={16}
+            strokeWidth={1.8}
+            className={cn(
+              'shrink-0 text-[var(--theme-muted)] transition-transform',
+              open && 'rotate-180',
+            )}
+          />
         </button>
 
         {open ? (
@@ -590,19 +836,32 @@ function ModelSelectorDropdown({
                 }}
                 className={cn(
                   'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors',
-                  !value ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
+                  !value
+                    ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]'
+                    : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
                 )}
                 role="option"
                 aria-selected={!value}
               >
-                <span className={cn('size-2 rounded-full', !value ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
+                <span
+                  className={cn(
+                    'size-2 rounded-full',
+                    !value
+                      ? 'bg-[var(--theme-accent)]'
+                      : 'bg-[var(--theme-border2)]',
+                  )}
+                />
                 <span className="min-w-0 flex-1 truncate">Default (auto)</span>
-                <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">Auto</span>
+                <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                  Auto
+                </span>
               </button>
 
               {groupedModels.map((group) => (
                 <div key={group.provider} className="mt-2 first:mt-3">
-                  <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">{group.provider}</div>
+                  <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    {group.provider}
+                  </div>
                   <div className="space-y-1">
                     {group.models.map((model) => {
                       const modelId = model.id ?? ''
@@ -617,13 +876,24 @@ function ModelSelectorDropdown({
                           }}
                           className={cn(
                             'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors',
-                            active ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
+                            active
+                              ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-text)]'
+                              : 'text-[var(--theme-text)] hover:bg-[var(--theme-bg)]',
                           )}
                           role="option"
                           aria-selected={active}
                         >
-                          <span className={cn('size-2 rounded-full', active ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-border2)]')} />
-                          <span className="min-w-0 flex-1 truncate">{getModelDisplayName(model, modelId)}</span>
+                          <span
+                            className={cn(
+                              'size-2 rounded-full',
+                              active
+                                ? 'bg-[var(--theme-accent)]'
+                                : 'bg-[var(--theme-border2)]',
+                            )}
+                          />
+                          <span className="min-w-0 flex-1 truncate">
+                            {getModelDisplayName(model, modelId)}
+                          </span>
                           <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
                             {group.provider}
                           </span>
@@ -653,7 +923,9 @@ function extractMessageText(message: HistoryMessage | undefined): string {
   return ''
 }
 
-function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string {
+function getLastAssistantMessage(
+  messages: HistoryMessage[] | undefined,
+): string {
   if (!Array.isArray(messages)) return ''
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
@@ -698,27 +970,40 @@ function extractProjectPath(text: string): string | null {
   return null
 }
 
-function deriveSessionStatus(session: GatewaySession): 'running' | 'completed' | 'failed' {
+function deriveSessionStatus(
+  session: GatewaySession,
+): 'running' | 'completed' | 'failed' {
   const updatedMs = new Date(session.updatedAt as string).getTime()
   const staleness = Number.isFinite(updatedMs) ? Date.now() - updatedMs : 0
-  const tokens = typeof session.totalTokens === 'number' ? session.totalTokens : 0
-  const statusText = `${session.status ?? ''} ${session.state ?? ''}`.toLowerCase()
+  const tokens =
+    typeof session.totalTokens === 'number' ? session.totalTokens : 0
+  const statusText =
+    `${session.status ?? ''} ${session.state ?? ''}`.toLowerCase()
 
-  if (statusText.includes('error') || statusText.includes('failed')) return 'failed'
+  if (statusText.includes('error') || statusText.includes('failed'))
+    return 'failed'
   if (tokens > 0 && staleness > 30_000) return 'completed'
   if (staleness > 120_000 && tokens === 0) return 'failed'
   return 'running'
 }
 
 export function Conductor() {
+  const navigate = useNavigate()
   const conductor = useConductorGateway()
   const [goalDraft, setGoalDraft] = useState(() => loadConductorGoalDraft())
   const [missionModalOpen, setMissionModalOpen] = useState(false)
+  const [pendingProjectOverride, setPendingProjectOverride] =
+    useState<ConductorProjectOverride | null>(null)
+  const [launchIntentSource, setLaunchIntentSource] = useState<
+    'projects' | null
+  >(null)
   const [continueDraft, setContinueDraft] = useState('')
   const [continueModalOpen, setContinueModalOpen] = useState(false)
   const [selectedAction, setSelectedAction] = useState<QuickActionId>('build')
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-  const [activityFilter, setActivityFilter] = useState<'all' | 'completed' | 'failed'>('all')
+  const [activityFilter, setActivityFilter] = useState<
+    'all' | 'current-project' | 'completed' | 'failed'
+  >('all')
   const [activityPage, setActivityPage] = useState(0)
   const [completeCostExpanded, setCompleteCostExpanded] = useState(true)
   const [historyCostExpanded, setHistoryCostExpanded] = useState(false)
@@ -726,9 +1011,13 @@ export function Conductor() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [directoryBrowserOpen, setDirectoryBrowserOpen] = useState(false)
   const [directoryBrowserPath, setDirectoryBrowserPath] = useState('~')
-  const [directoryBrowserEntries, setDirectoryBrowserEntries] = useState<FileBrowserEntry[]>([])
+  const [directoryBrowserEntries, setDirectoryBrowserEntries] = useState<
+    FileBrowserEntry[]
+  >([])
   const [directoryBrowserLoading, setDirectoryBrowserLoading] = useState(false)
-  const [directoryBrowserError, setDirectoryBrowserError] = useState<string | null>(null)
+  const [directoryBrowserError, setDirectoryBrowserError] = useState<
+    string | null
+  >(null)
   const modelsQuery = useQuery({
     queryKey: ['conductor', 'models'],
     queryFn: async () => {
@@ -743,6 +1032,34 @@ export function Conductor() {
     staleTime: 60_000,
   })
   const availableModels = modelsQuery.data ?? []
+  const projectsQuery = useQuery({
+    queryKey: ['conductor', 'projects'],
+    queryFn: fetchProjectsContext,
+    staleTime: 30_000,
+  })
+  const activeProject = useMemo(() => {
+    const projects = projectsQuery.data?.projects ?? []
+    return (
+      projects.find(
+        (project) => project.id === projectsQuery.data?.activeProjectId,
+      ) ??
+      projects.find((project) => project.active) ??
+      null
+    )
+  }, [projectsQuery.data?.activeProjectId, projectsQuery.data?.projects])
+  const projectInstructionCount =
+    (activeProject?.instructionFiles.length ?? 0) +
+    (activeProject?.readme ? 1 : 0)
+  const effectiveProjectDir =
+    conductor.conductorSettings.projectsDir.trim() ||
+    pendingProjectOverride?.effectiveWorkingDirectory ||
+    activeProject?.path ||
+    ''
+  const pendingLaunchDiffersFromActiveProject = Boolean(
+    pendingProjectOverride?.activeProjectPath &&
+    activeProject?.path &&
+    pendingProjectOverride.activeProjectPath !== activeProject.path,
+  )
 
   useEffect(() => {
     if (!directoryBrowserOpen) return
@@ -754,7 +1071,9 @@ export function Conductor() {
       setDirectoryBrowserError(null)
 
       try {
-        const res = await fetch(`/api/files?path=${encodeURIComponent(directoryBrowserPath)}`)
+        const res = await fetch(
+          `/api/files?path=${encodeURIComponent(directoryBrowserPath)}`,
+        )
         const data = (await res.json().catch(() => ({}))) as {
           error?: string
           root?: string
@@ -766,12 +1085,22 @@ export function Conductor() {
         }
 
         if (cancelled) return
-        setDirectoryBrowserPath(typeof data.root === 'string' && data.root.trim() ? data.root : directoryBrowserPath)
-        setDirectoryBrowserEntries(Array.isArray(data.entries) ? data.entries.filter((entry) => entry?.type === 'folder') : [])
+        setDirectoryBrowserPath(
+          typeof data.root === 'string' && data.root.trim()
+            ? data.root
+            : directoryBrowserPath,
+        )
+        setDirectoryBrowserEntries(
+          Array.isArray(data.entries)
+            ? data.entries.filter((entry) => entry?.type === 'folder')
+            : [],
+        )
       } catch (error) {
         if (cancelled) return
         setDirectoryBrowserEntries([])
-        setDirectoryBrowserError(error instanceof Error ? error.message : 'Failed to load directory')
+        setDirectoryBrowserError(
+          error instanceof Error ? error.message : 'Failed to load directory',
+        )
       } finally {
         if (!cancelled) {
           setDirectoryBrowserLoading(false)
@@ -787,7 +1116,12 @@ export function Conductor() {
   }, [directoryBrowserOpen, directoryBrowserPath])
 
   useEffect(() => {
-    if (conductor.phase === 'idle' || conductor.phase === 'complete' || conductor.isPaused) return
+    if (
+      conductor.phase === 'idle' ||
+      conductor.phase === 'complete' ||
+      conductor.isPaused
+    )
+      return
     const timer = window.setInterval(() => setNow(Date.now()), 1000)
     return () => window.clearInterval(timer)
   }, [conductor.isPaused, conductor.phase])
@@ -795,6 +1129,16 @@ export function Conductor() {
   useEffect(() => {
     persistConductorGoalDraft(goalDraft)
   }, [goalDraft])
+
+  useEffect(() => {
+    const intent = consumeConductorLaunchIntent()
+    if (!intent) return
+    setGoalDraft(intent.draft)
+    persistConductorGoalDraft(intent.draft)
+    setPendingProjectOverride(intent.projectOverride)
+    setLaunchIntentSource(intent.source)
+    setMissionModalOpen(true)
+  }, [])
 
   useEffect(() => {
     if (!conductor.isPaused) return
@@ -822,6 +1166,8 @@ export function Conductor() {
     setGoalDraft('')
     persistConductorGoalDraft('')
     setMissionModalOpen(false)
+    setPendingProjectOverride(null)
+    setLaunchIntentSource(null)
     setContinueDraft('')
     setContinueModalOpen(false)
     setSelectedTaskId(null)
@@ -832,9 +1178,20 @@ export function Conductor() {
     if (!trimmed) return
     setMissionModalOpen(false)
     setContinueDraft('')
-    await conductor.sendMission(trimmed)
-    persistConductorGoalDraft('')
-    setGoalDraft('')
+    const projectOverride = pendingProjectOverride
+    try {
+      await conductor.sendMission(
+        trimmed,
+        projectOverride ? { projectOverride } : undefined,
+      )
+      setPendingProjectOverride(null)
+      setLaunchIntentSource(null)
+      persistConductorGoalDraft('')
+      setGoalDraft('')
+    } catch (error) {
+      setMissionModalOpen(true)
+      throw error
+    }
   }
 
   const handleQuickActionSelect = (action: (typeof QUICK_ACTIONS)[number]) => {
@@ -842,7 +1199,8 @@ export function Conductor() {
     setGoalDraft((current) => {
       const trimmed = current.trim()
       if (!trimmed) return `${action.label}: `
-      if (trimmed.toLowerCase().startsWith(`${action.label.toLowerCase()}:`)) return current
+      if (trimmed.toLowerCase().startsWith(`${action.label.toLowerCase()}:`))
+        return current
       return `${action.label}: ${trimmed}`
     })
   }
@@ -854,7 +1212,13 @@ export function Conductor() {
     const continuationSummarySource =
       completeSummary ??
       Object.values(conductor.workerOutputs).find((output) => output.trim()) ??
-      conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).find((output) => output.trim()) ??
+      conductor.workers
+        .map((worker) =>
+          getLastAssistantMessage(
+            worker.raw.messages as HistoryMessage[] | undefined,
+          ),
+        )
+        .find((output) => output.trim()) ??
       conductor.streamText
 
     const combinedPrompt = [
@@ -871,12 +1235,48 @@ export function Conductor() {
     await conductor.sendMission(combinedPrompt)
   }
 
-  const updateSettings = (patch: Partial<typeof conductor.conductorSettings>) => {
+  const handleContinueHistoryMission = async (entry: MissionHistoryEntry) => {
+    const historicalProjectPath =
+      entry.activeProjectPath ??
+      entry.effectiveWorkingDirectory ??
+      entry.projectPath ??
+      entry.outputPath ??
+      null
+    const historicalWorkdir =
+      entry.effectiveWorkingDirectory ?? historicalProjectPath
+    const previousSummary =
+      entry.completeSummary ?? entry.outputText ?? entry.streamText ?? ''
+    const combinedPrompt = [
+      'CONTINUATION OF HISTORICAL MISSION',
+      `Original goal: ${entry.goal}`,
+      `Historical project: ${entry.activeProjectName ?? historicalProjectPath ?? 'unknown'}`,
+      `Historical workdir: ${historicalWorkdir ?? 'unknown'}`,
+      `Previous output summary: ${truncateContinuationText(previousSummary)}`,
+      '',
+      'Continue this mission in the historical project/workdir above. Preserve existing work and inspect the project before editing.',
+    ].join('\n')
+
+    conductor.setSelectedHistoryEntry(null)
+    await conductor.sendMission(combinedPrompt, {
+      projectOverride: {
+        activeProjectId: entry.activeProjectId ?? null,
+        activeProjectName: entry.activeProjectName ?? null,
+        activeProjectPath: historicalProjectPath,
+        effectiveWorkingDirectory: historicalWorkdir,
+      },
+    })
+  }
+
+  const updateSettings = (
+    patch: Partial<typeof conductor.conductorSettings>,
+  ) => {
     conductor.setConductorSettings({ ...conductor.conductorSettings, ...patch })
   }
 
   const openDirectoryBrowser = () => {
-    setDirectoryBrowserPath(conductor.conductorSettings.projectsDir.trim() || '~')
+    setDirectoryBrowserPath(
+      conductor.conductorSettings.projectsDir.trim() || '~',
+    )
     setDirectoryBrowserEntries([])
     setDirectoryBrowserError(null)
     setDirectoryBrowserOpen(true)
@@ -897,10 +1297,16 @@ export function Conductor() {
   }, [directoryBrowserPath])
 
   const totalWorkers = conductor.workers.length
-  const completedWorkers = conductor.workers.filter((worker) => worker.status === 'complete').length
+  const completedWorkers = conductor.workers.filter(
+    (worker) => worker.status === 'complete',
+  ).length
   const activeWorkerCount = conductor.activeWorkers.length
-  const missionProgress = totalWorkers > 0 ? Math.round((completedWorkers / totalWorkers) * 100) : 0
-  const totalTokens = conductor.workers.reduce((sum, worker) => sum + worker.totalTokens, 0)
+  const missionProgress =
+    totalWorkers > 0 ? Math.round((completedWorkers / totalWorkers) * 100) : 0
+  const totalTokens = conductor.workers.reduce(
+    (sum, worker) => sum + worker.totalTokens,
+    0,
+  )
   const selectedHistoryEntry = conductor.selectedHistoryEntry
   const completeMissionCostWorkers = useMemo<MissionCostWorker[]>(
     () =>
@@ -943,9 +1349,20 @@ export function Conductor() {
     }
     return sessions.slice(0, 6).map((session, i) => {
       const s = session as GatewaySession
-      const updatedAt = typeof s.updatedAt === 'string' ? new Date(s.updatedAt).getTime() : typeof s.updatedAt === 'number' ? s.updatedAt : 0
+      const updatedAt =
+        typeof s.updatedAt === 'string'
+          ? new Date(s.updatedAt).getTime()
+          : typeof s.updatedAt === 'number'
+            ? s.updatedAt
+            : 0
       const statusText = `${s.status ?? ''} ${s.kind ?? ''}`.toLowerCase()
-      const status = /error|failed/.test(statusText) ? ('error' as const) : /pause/.test(statusText) ? ('paused' as const) : Date.now() - updatedAt < 120_000 ? ('active' as const) : ('idle' as const)
+      const status = /error|failed/.test(statusText)
+        ? ('error' as const)
+        : /pause/.test(statusText)
+          ? ('paused' as const)
+          : Date.now() - updatedAt < 120_000
+            ? ('active' as const)
+            : ('idle' as const)
       return {
         id: s.key ?? `session-${i}`,
         name: OFFICE_NAMES[i % OFFICE_NAMES.length],
@@ -964,19 +1381,37 @@ export function Conductor() {
     if (conductor.workers.length > 0) {
       return conductor.workers.map((worker, index) => {
         const persona = getAgentPersona(index)
-        const currentTask = conductor.tasks.find((task) => task.workerKey === worker.key && task.status === 'running')?.title
-        const lastLine = conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
-        const isWorkerPaused = conductor.isPaused && (worker.status === 'running' || worker.status === 'idle')
+        const currentTask = conductor.tasks.find(
+          (task) => task.workerKey === worker.key && task.status === 'running',
+        )?.title
+        const lastLine =
+          conductor.workerOutputs[worker.key] ??
+          getLastAssistantMessage(
+            worker.raw.messages as HistoryMessage[] | undefined,
+          )
+        const isWorkerPaused =
+          conductor.isPaused &&
+          (worker.status === 'running' || worker.status === 'idle')
 
         return {
           id: worker.key,
           name: persona.name,
           modelId: worker.model || 'auto',
           roleDescription: worker.displayName,
-          status: isWorkerPaused ? 'paused' : worker.status === 'complete' ? 'idle' : worker.status === 'stale' ? 'error' : 'active',
+          status: isWorkerPaused
+            ? 'paused'
+            : worker.status === 'complete'
+              ? 'idle'
+              : worker.status === 'stale'
+                ? 'error'
+                : 'active',
           lastLine: isWorkerPaused ? 'Paused' : lastLine,
-          lastAt: worker.updatedAt ? new Date(worker.updatedAt).getTime() : undefined,
-          taskCount: conductor.tasks.filter((task) => task.workerKey === worker.key).length,
+          lastAt: worker.updatedAt
+            ? new Date(worker.updatedAt).getTime()
+            : undefined,
+          taskCount: conductor.tasks.filter(
+            (task) => task.workerKey === worker.key,
+          ).length,
           currentTask: isWorkerPaused ? 'Paused' : currentTask,
           sessionKey: worker.key,
         }
@@ -996,12 +1431,24 @@ export function Conductor() {
         sessionKey: 'conductor-placeholder-agent',
       },
     ]
-  }, [conductor.conductorSettings.workerModel, conductor.goal, conductor.isPaused, conductor.tasks, conductor.workerOutputs, conductor.workers])
+  }, [
+    conductor.conductorSettings.workerModel,
+    conductor.goal,
+    conductor.isPaused,
+    conductor.tasks,
+    conductor.workerOutputs,
+    conductor.workers,
+  ])
 
   const completePhaseProjectPath = useMemo(() => {
-    const workerOutputTexts = [...Object.values(conductor.workerOutputs), ...conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(
-      Boolean,
-    )
+    const workerOutputTexts = [
+      ...Object.values(conductor.workerOutputs),
+      ...conductor.workers.map((worker) =>
+        getLastAssistantMessage(
+          worker.raw.messages as HistoryMessage[] | undefined,
+        ),
+      ),
+    ].filter(Boolean)
 
     for (const text of workerOutputTexts) {
       const extractedPath = extractProjectPath(text)
@@ -1017,19 +1464,35 @@ export function Conductor() {
     const streamPath = extractProjectPath(conductor.streamText)
     if (streamPath) return streamPath
 
-    const candidates = buildProjectPathCandidates(conductor.workers, conductor.missionStartedAt)
+    const candidates = buildProjectPathCandidates(
+      conductor.workers,
+      conductor.missionStartedAt,
+    )
     return candidates[0] ?? null
-  }, [conductor.tasks, conductor.streamText, conductor.workerOutputs, conductor.workers, conductor.missionStartedAt])
-  const completePhaseOutputLabel = useMemo(() => getOutputDisplayName(completePhaseProjectPath), [completePhaseProjectPath])
+  }, [
+    conductor.tasks,
+    conductor.streamText,
+    conductor.workerOutputs,
+    conductor.workers,
+    conductor.missionStartedAt,
+  ])
+  const completePhaseOutputLabel = useMemo(
+    () => getOutputDisplayName(completePhaseProjectPath),
+    [completePhaseProjectPath],
+  )
 
-  const previewUrl = completePhaseProjectPath ? `/api/preview-file?path=${encodeURIComponent(`${completePhaseProjectPath}/index.html`)}` : null
+  const previewUrl = completePhaseProjectPath
+    ? `/api/preview-file?path=${encodeURIComponent(`${completePhaseProjectPath}/index.html`)}`
+    : null
 
   const selectedHistoryOutputPath = useMemo(() => {
     const entry = conductor.selectedHistoryEntry
     if (!entry) return null
     if (entry.outputPath) return entry.outputPath
     if (entry.projectPath) return entry.projectPath
-    const extractedOutputPath = extractProjectPath(entry.outputText ?? '') ?? extractProjectPath(entry.streamText ?? '')
+    const extractedOutputPath =
+      extractProjectPath(entry.outputText ?? '') ??
+      extractProjectPath(entry.streamText ?? '')
     if (extractedOutputPath) return extractedOutputPath
     const candidates = buildProjectPathCandidates(
       (entry.workerDetails ?? []).map((worker) => ({ label: worker.label })),
@@ -1037,13 +1500,24 @@ export function Conductor() {
     )
     return candidates[0] ?? null
   }, [conductor.selectedHistoryEntry])
-  const selectedHistoryOutputLabel = useMemo(() => getOutputDisplayName(selectedHistoryOutputPath), [selectedHistoryOutputPath])
-  const selectedHistoryPreviewUrl = selectedHistoryOutputPath ? `/api/preview-file?path=${encodeURIComponent(`${selectedHistoryOutputPath}/index.html`)}` : null
+  const selectedHistoryOutputLabel = useMemo(
+    () => getOutputDisplayName(selectedHistoryOutputPath),
+    [selectedHistoryOutputPath],
+  )
+  const selectedHistoryPreviewUrl = selectedHistoryOutputPath
+    ? `/api/preview-file?path=${encodeURIComponent(`${selectedHistoryOutputPath}/index.html`)}`
+    : null
 
   // Skip preview probe for history entries — /tmp files are ephemeral and won't exist later.
   // Only probe if the mission just completed (still in complete phase with matching output path).
-  const isLiveCompletePreview = phase === 'complete' && !!completePhaseProjectPath && selectedHistoryOutputPath === completePhaseProjectPath
-  const selectedHistoryPreview = usePreviewAvailability(selectedHistoryPreviewUrl, !!conductor.selectedHistoryEntry && isLiveCompletePreview)
+  const isLiveCompletePreview =
+    phase === 'complete' &&
+    !!completePhaseProjectPath &&
+    selectedHistoryOutputPath === completePhaseProjectPath
+  const selectedHistoryPreview = usePreviewAvailability(
+    selectedHistoryPreviewUrl,
+    !!conductor.selectedHistoryEntry && isLiveCompletePreview,
+  )
   const previewState = usePreviewAvailability(previewUrl, phase === 'complete')
 
   const completedTaskOutputs = useMemo(() => {
@@ -1054,7 +1528,9 @@ export function Conductor() {
         extractedPath: extractProjectPath(task.output ?? ''),
         previewUrl: (() => {
           const extractedPath = extractProjectPath(task.output ?? '')
-          return extractedPath ? `/api/preview-file?path=${encodeURIComponent(`${extractedPath}/index.html`)}` : null
+          return extractedPath
+            ? `/api/preview-file?path=${encodeURIComponent(`${extractedPath}/index.html`)}`
+            : null
         })(),
         previewText: (task.output ?? '').trim().slice(0, 200),
       }))
@@ -1064,45 +1540,102 @@ export function Conductor() {
     if (phase !== 'complete') return null
     const isFailed = !!conductor.streamError
     const lines = [
-      isFailed ? `❌ ${conductor.streamError}` : '✅ Mission completed successfully',
+      isFailed
+        ? `❌ ${conductor.streamError}`
+        : '✅ Mission completed successfully',
       '',
       `**Goal:** ${conductor.goal}`,
       `**Duration:** ${formatElapsedTime(conductor.missionStartedAt, conductor.completedAt ? new Date(conductor.completedAt).getTime() : now)}`,
     ]
     if (totalWorkers > 0) {
-      lines.push(`**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`)
+      lines.push(
+        `**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`,
+      )
     }
     if (completePhaseProjectPath) {
       lines.push(`**Output:** ${completePhaseOutputLabel}`)
     }
     return lines.join('\n')
-  }, [phase, completePhaseProjectPath, completePhaseOutputLabel, totalWorkers, conductor.goal, totalTokens, conductor.missionStartedAt, now])
+  }, [
+    phase,
+    completePhaseProjectPath,
+    completePhaseOutputLabel,
+    totalWorkers,
+    conductor.goal,
+    totalTokens,
+    conductor.missionStartedAt,
+    now,
+  ])
   const continuationPreview = useMemo(() => {
     const summarySource =
       completeSummary ??
       Object.values(conductor.workerOutputs).find((output) => output.trim()) ??
-      conductor.workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).find((output) => output.trim()) ??
+      conductor.workers
+        .map((worker) =>
+          getLastAssistantMessage(
+            worker.raw.messages as HistoryMessage[] | undefined,
+          ),
+        )
+        .find((output) => output.trim()) ??
       conductor.streamText
     return truncateContinuationText(summarySource ?? '')
-  }, [completeSummary, conductor.streamText, conductor.workerOutputs, conductor.workers])
-  const continuationModalPreview = useMemo(() => truncateContinuationText(continuationPreview, 200), [continuationPreview])
+  }, [
+    completeSummary,
+    conductor.streamText,
+    conductor.workerOutputs,
+    conductor.workers,
+  ])
+  const continuationModalPreview = useMemo(
+    () => truncateContinuationText(continuationPreview, 200),
+    [continuationPreview],
+  )
   const hasMissionHistory = conductor.missionHistory.length > 0
   const canResetSavedState = hasMissionHistory || conductor.hasPersistedMission
+  const currentProjectHistoryCount = activeProject
+    ? conductor.missionHistory.filter(
+        (entry) =>
+          entry.activeProjectId === activeProject.id ||
+          entry.activeProjectPath === activeProject.path,
+      ).length
+    : 0
   const filteredHistory = (() => {
     const history = conductor.missionHistory
     if (activityFilter === 'all') return history
+    if (activityFilter === 'current-project') {
+      if (!activeProject) return []
+      return history.filter(
+        (entry) =>
+          entry.activeProjectId === activeProject.id ||
+          entry.activeProjectPath === activeProject.path,
+      )
+    }
     return history.filter((entry) => entry.status === activityFilter)
   })()
   const filteredSessions = (() => {
     const sessions = conductor.recentSessions
-    if (activityFilter === 'all') return sessions
-    return sessions.filter((session) => ((session.label as string) ?? '').startsWith('worker-')).filter((session) => deriveSessionStatus(session as GatewaySession) === activityFilter)
+    if (activityFilter === 'all' || activityFilter === 'current-project')
+      return sessions
+    return sessions
+      .filter((session) =>
+        ((session.label as string) ?? '').startsWith('worker-'),
+      )
+      .filter(
+        (session) =>
+          deriveSessionStatus(session as GatewaySession) === activityFilter,
+      )
   })()
-  const activityItems: Array<MissionHistoryEntry | GatewaySession> = hasMissionHistory ? filteredHistory : filteredSessions
+  const activityItems: Array<MissionHistoryEntry | GatewaySession> =
+    hasMissionHistory ? filteredHistory : filteredSessions
   const ACTIVITY_PAGE_SIZE = 3
-  const activityTotalPages = Math.max(1, Math.ceil(activityItems.length / ACTIVITY_PAGE_SIZE))
+  const activityTotalPages = Math.max(
+    1,
+    Math.ceil(activityItems.length / ACTIVITY_PAGE_SIZE),
+  )
   const safeActivityPage = Math.min(activityPage, activityTotalPages - 1)
-  const visibleActivityItems = activityItems.slice(safeActivityPage * ACTIVITY_PAGE_SIZE, (safeActivityPage + 1) * ACTIVITY_PAGE_SIZE)
+  const visibleActivityItems = activityItems.slice(
+    safeActivityPage * ACTIVITY_PAGE_SIZE,
+    (safeActivityPage + 1) * ACTIVITY_PAGE_SIZE,
+  )
 
   useEffect(() => {
     if (!selectedTaskId) return
@@ -1123,15 +1656,38 @@ export function Conductor() {
   if (phase === 'home') {
     if (selectedHistoryEntry) {
       const historyWorkerDetails = selectedHistoryEntry.workerDetails ?? []
-      const historySummary = selectedHistoryEntry.completeSummary ?? selectedHistoryEntry.streamText
-      const historyOutputText = selectedHistoryEntry.outputText?.trim() || selectedHistoryEntry.streamText?.trim() || ''
-      const showHistoryOutputFallback = !!historyOutputText && (!selectedHistoryOutputPath || selectedHistoryPreview.unavailable)
-      const historyStatusLabel = selectedHistoryEntry.status === 'completed' ? 'Complete' : 'Stopped'
+      const historySummary =
+        selectedHistoryEntry.completeSummary ?? selectedHistoryEntry.streamText
+      const historyOutputText =
+        selectedHistoryEntry.outputText?.trim() ||
+        selectedHistoryEntry.streamText?.trim() ||
+        ''
+      const showHistoryOutputFallback =
+        !!historyOutputText &&
+        (!selectedHistoryOutputPath || selectedHistoryPreview.unavailable)
+      const historyStatusLabel =
+        selectedHistoryEntry.status === 'completed' ? 'Complete' : 'Stopped'
       const historyStatusClasses =
-        selectedHistoryEntry.status === 'completed' ? 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300' : 'border border-red-400/35 bg-red-500/10 text-red-300'
+        selectedHistoryEntry.status === 'completed'
+          ? 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300'
+          : 'border border-red-400/35 bg-red-500/10 text-red-300'
+      const historicalProjectPath =
+        selectedHistoryEntry.activeProjectPath ??
+        selectedHistoryEntry.effectiveWorkingDirectory ??
+        selectedHistoryEntry.projectPath ??
+        selectedHistoryEntry.outputPath ??
+        null
+      const continuingDifferentProject = Boolean(
+        activeProject &&
+        historicalProjectPath &&
+        historicalProjectPath !== activeProject.path,
+      )
 
       return (
-        <div className="flex min-h-dvh flex-col overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
+        <div
+          className="flex min-h-dvh flex-col overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]"
+          style={THEME_STYLE}
+        >
           <main className="mx-auto flex min-h-0 w-full max-w-[720px] flex-1 flex-col px-4 py-4 pb-[calc(var(--tabbar-h,80px)+1rem)] md:px-6 md:py-8">
             <div className="space-y-6">
               <button
@@ -1145,16 +1701,69 @@ export function Conductor() {
               <div className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <p className={cn('text-xs font-semibold uppercase tracking-[0.24em]', selectedHistoryEntry.status === 'completed' ? 'text-[var(--theme-accent)]' : 'text-red-400')}>
-                      {selectedHistoryEntry.status === 'completed' ? 'Mission Complete' : 'Mission Stopped'}
+                    <p
+                      className={cn(
+                        'text-xs font-semibold uppercase tracking-[0.24em]',
+                        selectedHistoryEntry.status === 'completed'
+                          ? 'text-[var(--theme-accent)]'
+                          : 'text-red-400',
+                      )}
+                    >
+                      {selectedHistoryEntry.status === 'completed'
+                        ? 'Mission Complete'
+                        : 'Mission Stopped'}
                     </p>
-                    <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">{selectedHistoryEntry.goal}</h1>
+                    <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">
+                      {selectedHistoryEntry.goal}
+                    </h1>
                     <p className="mt-2 text-xs text-[var(--theme-muted-2)]">
-                      {selectedHistoryEntry.workerCount}/{Math.max(selectedHistoryEntry.workerCount, 1)} workers finished ·{' '}
-                      {formatDurationRange(selectedHistoryEntry.startedAt, selectedHistoryEntry.completedAt, now)} total elapsed
+                      {selectedHistoryEntry.workerCount}/
+                      {Math.max(selectedHistoryEntry.workerCount, 1)} workers
+                      finished ·{' '}
+                      {formatDurationRange(
+                        selectedHistoryEntry.startedAt,
+                        selectedHistoryEntry.completedAt,
+                        now,
+                      )}{' '}
+                      total elapsed
                     </p>
+                    {(selectedHistoryEntry.activeProjectName ||
+                      selectedHistoryEntry.activeProjectPath ||
+                      selectedHistoryEntry.effectiveWorkingDirectory) && (
+                      <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-[var(--theme-muted)]">
+                        {selectedHistoryEntry.activeProjectName ||
+                        selectedHistoryEntry.activeProjectPath ? (
+                          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">
+                            Project:{' '}
+                            {selectedHistoryEntry.activeProjectName ??
+                              selectedHistoryEntry.activeProjectPath}
+                          </span>
+                        ) : null}
+                        {selectedHistoryEntry.effectiveWorkingDirectory ? (
+                          <span className="max-w-full truncate rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">
+                            Workdir:{' '}
+                            {selectedHistoryEntry.effectiveWorkingDirectory}
+                          </span>
+                        ) : null}
+                      </div>
+                    )}
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
+                    {continuingDifferentProject ? (
+                      <span className="inline-flex items-center rounded-xl border border-amber-400/35 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-600">
+                        Continuing in historical project
+                      </span>
+                    ) : null}
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        void handleContinueHistoryMission(selectedHistoryEntry)
+                      }
+                      disabled={conductor.isSending}
+                      className="rounded-xl bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)] disabled:opacity-60"
+                    >
+                      Continue in this project
+                    </Button>
                     <Button
                       type="button"
                       onClick={() => {
@@ -1173,8 +1782,12 @@ export function Conductor() {
                 <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output Preview</p>
-                      <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{selectedHistoryOutputLabel}</p>
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                        Output Preview
+                      </p>
+                      <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                        {selectedHistoryOutputLabel}
+                      </p>
                     </div>
                     <a
                       href={selectedHistoryPreviewUrl!}
@@ -1186,105 +1799,168 @@ export function Conductor() {
                     </a>
                   </div>
                   <div className="mt-4 overflow-auto rounded-2xl border border-[var(--theme-border)] bg-white">
-                    <iframe src={selectedHistoryPreviewUrl!} className="h-[clamp(280px,55vh,520px)] w-full" sandbox="allow-scripts allow-same-origin" title="Mission history output preview" />
+                    <iframe
+                      src={selectedHistoryPreviewUrl!}
+                      className="h-[clamp(280px,55vh,520px)] w-full"
+                      sandbox="allow-scripts allow-same-origin"
+                      title="Mission history output preview"
+                    />
                   </div>
                 </section>
-              ) : selectedHistoryOutputPath && selectedHistoryPreview.loading ? (
+              ) : selectedHistoryOutputPath &&
+                selectedHistoryPreview.loading ? (
                 <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                   <div className="flex items-center gap-3 text-sm text-[var(--theme-muted)]">
                     <div className="size-4 animate-spin rounded-full border-2 border-[var(--theme-border)] border-t-[var(--theme-accent)]" />
                     Loading output preview…
                   </div>
                 </section>
-              ) : selectedHistoryOutputPath && selectedHistoryPreview.unavailable ? (
+              ) : selectedHistoryOutputPath &&
+                selectedHistoryPreview.unavailable ? (
                 showHistoryOutputFallback ? null : (
-                  <p className="px-1 text-sm text-[var(--theme-muted)]">No preview available.</p>
+                  <p className="px-1 text-sm text-[var(--theme-muted)]">
+                    No preview available.
+                  </p>
                 )
               ) : null}
 
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Summary</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      Agent Summary
+                    </p>
                   </div>
-                  <span className={cn('rounded-full px-3 py-1 text-xs font-medium', historyStatusClasses)}>{historyStatusLabel}</span>
+                  <span
+                    className={cn(
+                      'rounded-full px-3 py-1 text-xs font-medium',
+                      historyStatusClasses,
+                    )}
+                  >
+                    {historyStatusLabel}
+                  </span>
                 </div>
                 <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
                   {historySummary ? (
-                    <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{historySummary}</Markdown>
+                    <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                      {historySummary}
+                    </Markdown>
                   ) : (
-                    <p className="text-sm text-[var(--theme-muted)]">No summary captured.</p>
+                    <p className="text-sm text-[var(--theme-muted)]">
+                      No summary captured.
+                    </p>
                   )}
                 </div>
                 {historyWorkerDetails.length > 0 && (
                   <div className="mt-4 space-y-2">
-                    {historyWorkerDetails.map((worker: MissionHistoryWorkerDetail, index) => (
-                      <div key={`${selectedHistoryEntry.id}-worker-${index}`} className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm">
-                        <span className={cn('size-2 rounded-full', selectedHistoryEntry.status === 'completed' ? 'bg-emerald-400' : 'bg-red-400')} />
-                        <span className="font-medium text-[var(--theme-text)]">
-                          {worker.personaEmoji} {worker.personaName}
-                        </span>
-                        <span className="text-[var(--theme-muted)]">{worker.label}</span>
-                        <span className="ml-auto text-xs text-[var(--theme-muted)]">
-                          {getShortModelName(worker.model)} · {worker.totalTokens.toLocaleString()} tok
-                        </span>
-                      </div>
-                    ))}
+                    {historyWorkerDetails.map(
+                      (worker: MissionHistoryWorkerDetail, index) => (
+                        <div
+                          key={`${selectedHistoryEntry.id}-worker-${index}`}
+                          className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm"
+                        >
+                          <span
+                            className={cn(
+                              'size-2 rounded-full',
+                              selectedHistoryEntry.status === 'completed'
+                                ? 'bg-emerald-400'
+                                : 'bg-red-400',
+                            )}
+                          />
+                          <span className="font-medium text-[var(--theme-text)]">
+                            {worker.personaEmoji} {worker.personaName}
+                          </span>
+                          <span className="text-[var(--theme-muted)]">
+                            {worker.label}
+                          </span>
+                          <span className="ml-auto text-xs text-[var(--theme-muted)]">
+                            {getShortModelName(worker.model)} ·{' '}
+                            {worker.totalTokens.toLocaleString()} tok
+                          </span>
+                        </div>
+                      ),
+                    )}
                   </div>
                 )}
-                {(selectedHistoryEntry.totalTokens > 0 || historyMissionCostWorkers.length > 0) && (
+                {(selectedHistoryEntry.totalTokens > 0 ||
+                  historyMissionCostWorkers.length > 0) && (
                   <div className="mt-4">
                     <MissionCostSection
                       totalTokens={selectedHistoryEntry.totalTokens}
                       workers={historyMissionCostWorkers}
                       expanded={historyCostExpanded}
-                      onToggle={() => setHistoryCostExpanded((current) => !current)}
+                      onToggle={() =>
+                        setHistoryCostExpanded((current) => !current)
+                      }
                     />
                   </div>
                 )}
-                {selectedHistoryEntry.streamText && selectedHistoryEntry.completeSummary && (
-                  <details className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                    <summary className="cursor-pointer text-xs font-medium text-[var(--theme-muted)]">Raw Agent Output</summary>
-                    <div className="mt-4 border-t border-[var(--theme-border)] pt-4">
-                      <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{selectedHistoryEntry.streamText}</Markdown>
-                    </div>
-                  </details>
-                )}
+                {selectedHistoryEntry.streamText &&
+                  selectedHistoryEntry.completeSummary && (
+                    <details className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
+                      <summary className="cursor-pointer text-xs font-medium text-[var(--theme-muted)]">
+                        Raw Agent Output
+                      </summary>
+                      <div className="mt-4 border-t border-[var(--theme-border)] pt-4">
+                        <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                          {selectedHistoryEntry.streamText}
+                        </Markdown>
+                      </div>
+                    </details>
+                  )}
               </section>
 
               {showHistoryOutputFallback ? (
                 <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output</p>
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                        Output
+                      </p>
                       <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
                         Preview unavailable
-                        {selectedHistoryOutputPath ? ` for ${selectedHistoryOutputLabel}` : ''}.
+                        {selectedHistoryOutputPath
+                          ? ` for ${selectedHistoryOutputLabel}`
+                          : ''}
+                        .
                       </p>
                     </div>
                   </div>
                   <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                    <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{historyOutputText}</Markdown>
+                    <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                      {historyOutputText}
+                    </Markdown>
                   </div>
                 </section>
               ) : historyOutputText ? (
                 <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Worker Output</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Worker Output
+                  </p>
                   <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                    <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{historyOutputText}</Markdown>
+                    <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                      {historyOutputText}
+                    </Markdown>
                   </div>
                 </section>
               ) : null}
 
-              {!historySummary && historyWorkerDetails.length === 0 && !selectedHistoryOutputPath && !selectedHistoryEntry.workerSummary?.length && !historyOutputText && (
-                <section className="overflow-hidden rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
-                  <p className="text-center text-sm text-[var(--theme-muted)]">
-                    No detailed output was captured for this mission.
-                    <br />
-                    <span className="text-xs text-[var(--theme-muted-2)]">Missions run after this update will save full agent summaries and output previews.</span>
-                  </p>
-                </section>
-              )}
+              {!historySummary &&
+                historyWorkerDetails.length === 0 &&
+                !selectedHistoryOutputPath &&
+                !selectedHistoryEntry.workerSummary?.length &&
+                !historyOutputText && (
+                  <section className="overflow-hidden rounded-3xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+                    <p className="text-center text-sm text-[var(--theme-muted)]">
+                      No detailed output was captured for this mission.
+                      <br />
+                      <span className="text-xs text-[var(--theme-muted-2)]">
+                        Missions run after this update will save full agent
+                        summaries and output previews.
+                      </span>
+                    </p>
+                  </section>
+                )}
             </div>
           </main>
         </div>
@@ -1292,7 +1968,10 @@ export function Conductor() {
     }
 
     return (
-      <div className="flex min-h-dvh flex-col overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
+      <div
+        className="flex min-h-dvh flex-col overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]"
+        style={THEME_STYLE}
+      >
         <main className="mx-auto flex min-h-0 w-full max-w-[760px] flex-1 flex-col items-stretch justify-center px-4 py-4 pb-[calc(var(--tabbar-h,80px)+1rem)] md:px-6 md:py-6">
           <div className="w-full space-y-6">
             <div className="space-y-2 text-center">
@@ -1336,7 +2015,11 @@ export function Conductor() {
                     className="inline-flex items-center justify-center rounded-xl bg-[var(--theme-accent)] p-2 text-white shadow-sm transition-colors hover:bg-[var(--theme-accent-strong)]"
                     aria-label="New Mission"
                   >
-                    <HugeiconsIcon icon={Rocket01Icon} size={18} strokeWidth={1.7} />
+                    <HugeiconsIcon
+                      icon={Rocket01Icon}
+                      size={18}
+                      strokeWidth={1.7}
+                    />
                   </button>
                   <button
                     type="button"
@@ -1344,17 +2027,111 @@ export function Conductor() {
                     className="inline-flex items-center justify-center rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-2 text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent-strong)]"
                     aria-label="Open conductor settings"
                   >
-                    <HugeiconsIcon icon={Settings01Icon} size={18} strokeWidth={1.7} />
+                    <HugeiconsIcon
+                      icon={Settings01Icon}
+                      size={18}
+                      strokeWidth={1.7}
+                    />
                   </button>
                 </div>
               </div>
-              <p className="text-sm text-[var(--theme-muted-2)]">Launch a mission and watch your agent team build it live.</p>
+              <p className="text-sm text-[var(--theme-muted-2)]">
+                Launch a mission and watch your agent team build it live.
+              </p>
             </div>
+
+            <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-sm">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Active Project Context
+                  </p>
+                  {projectsQuery.isLoading ? (
+                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                      Loading project context…
+                    </p>
+                  ) : activeProject ? (
+                    <div className="mt-2 space-y-2">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <HugeiconsIcon
+                          icon={Folder01Icon}
+                          size={17}
+                          strokeWidth={1.7}
+                          className="shrink-0 text-[var(--theme-accent-strong)]"
+                        />
+                        <p className="truncate text-base font-semibold text-[var(--theme-text)]">
+                          {activeProject.name}
+                        </p>
+                      </div>
+                      <p className="truncate text-xs text-[var(--theme-muted-2)]">
+                        {activeProject.path}
+                      </p>
+                      <div className="flex flex-wrap gap-2 text-[11px] text-[var(--theme-muted)]">
+                        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">
+                          <HugeiconsIcon
+                            icon={GitBranchIcon}
+                            size={13}
+                            strokeWidth={1.7}
+                          />
+                          {activeProject.gitBranch ?? 'No branch'}
+                        </span>
+                        <span className="inline-flex min-w-0 items-center gap-1 rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">
+                          <HugeiconsIcon
+                            icon={Link01Icon}
+                            size={13}
+                            strokeWidth={1.7}
+                          />
+                          <span className="truncate">
+                            {shortenProjectRemote(activeProject.gitRemote)}
+                          </span>
+                        </span>
+                        <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">
+                          {projectInstructionCount} context file
+                          {projectInstructionCount === 1 ? '' : 's'}
+                        </span>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                      No active project detected. Choose a workspace project
+                      before launching missions.
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void projectsQuery.refetch()}
+                    className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs font-medium text-[var(--theme-text)] transition-colors hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent-strong)]"
+                  >
+                    Refresh
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void navigate({ to: '/projects' })}
+                    className="rounded-xl bg-[var(--theme-accent)] px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--theme-accent-strong)]"
+                  >
+                    Change project
+                  </button>
+                </div>
+              </div>
+              {effectiveProjectDir ? (
+                <p className="mt-3 text-xs text-[var(--theme-muted-2)]">
+                  New missions will use{' '}
+                  <span className="font-medium text-[var(--theme-text)]">
+                    {effectiveProjectDir}
+                  </span>{' '}
+                  as the project/output directory.
+                </p>
+              ) : null}
+            </section>
 
             <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_24px_80px_var(--theme-shadow)] md:h-[520px]">
               <OfficeView
                 agentRows={homeOfficeRows}
-                missionRunning={homeOfficeRows.some((a) => a.status === 'active')}
+                missionRunning={homeOfficeRows.some(
+                  (a) => a.status === 'active',
+                )}
                 onViewOutput={() => {}}
                 processType="parallel"
                 companyName=""
@@ -1366,7 +2143,9 @@ export function Conductor() {
             {hasMissionHistory || conductor.recentSessions.length > 0 ? (
               <section className="mt-6 w-full space-y-3">
                 <div className="flex items-center gap-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Recent Missions</h2>
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+                    Recent Missions
+                  </h2>
                   {activityTotalPages > 1 && (
                     <div className="ml-auto flex items-center gap-1.5">
                       <span className="text-[10px] text-[var(--theme-muted-2)]">
@@ -1375,7 +2154,9 @@ export function Conductor() {
                       <button
                         type="button"
                         disabled={safeActivityPage === 0}
-                        onClick={() => setActivityPage((p) => Math.max(0, p - 1))}
+                        onClick={() =>
+                          setActivityPage((p) => Math.max(0, p - 1))
+                        }
                         className="inline-flex size-6 items-center justify-center rounded-lg border border-[var(--theme-border)] text-xs text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-accent)] disabled:opacity-30"
                       >
                         ‹
@@ -1383,7 +2164,11 @@ export function Conductor() {
                       <button
                         type="button"
                         disabled={safeActivityPage >= activityTotalPages - 1}
-                        onClick={() => setActivityPage((p) => Math.min(activityTotalPages - 1, p + 1))}
+                        onClick={() =>
+                          setActivityPage((p) =>
+                            Math.min(activityTotalPages - 1, p + 1),
+                          )
+                        }
                         className="inline-flex size-6 items-center justify-center rounded-lg border border-[var(--theme-border)] text-xs text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-accent)] disabled:opacity-30"
                       >
                         ›
@@ -1392,24 +2177,33 @@ export function Conductor() {
                   )}
                 </div>
                 <div className="flex items-center gap-1">
-                  {(['all', 'completed', 'failed'] as const).map((filter) => (
-                    <button
-                      key={filter}
-                      type="button"
-                      onClick={() => {
-                        setActivityFilter(filter)
-                        setActivityPage(0)
-                      }}
-                      className={cn(
-                        'rounded-full border px-3 py-1 text-[11px] font-medium capitalize transition-colors',
-                        activityFilter === filter
-                          ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]'
-                          : 'border-[var(--theme-border)] text-[var(--theme-muted-2)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-text)]',
-                      )}
-                    >
-                      {filter}
-                    </button>
-                  ))}
+                  {(
+                    ['all', 'current-project', 'completed', 'failed'] as const
+                  ).map((filter) => {
+                    const disabled =
+                      filter === 'current-project' && !activeProject
+                    return (
+                      <button
+                        key={filter}
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => {
+                          setActivityFilter(filter)
+                          setActivityPage(0)
+                        }}
+                        className={cn(
+                          'rounded-full border px-3 py-1 text-[11px] font-medium capitalize transition-colors disabled:cursor-not-allowed disabled:opacity-40',
+                          activityFilter === filter
+                            ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]'
+                            : 'border-[var(--theme-border)] text-[var(--theme-muted-2)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-text)]',
+                        )}
+                      >
+                        {filter === 'current-project'
+                          ? `Current Project${currentProjectHistoryCount ? ` (${currentProjectHistoryCount})` : ''}`
+                          : filter}
+                      </button>
+                    )
+                  })}
                 </div>
                 {visibleActivityItems.length > 0 ? (
                   <div className="min-h-[140px] space-y-1.5">
@@ -1420,28 +2214,53 @@ export function Conductor() {
                             <button
                               key={entry.id}
                               type="button"
-                              onClick={() => conductor.setSelectedHistoryEntry(entry)}
+                              onClick={() =>
+                                conductor.setSelectedHistoryEntry(entry)
+                              }
                               className="flex w-full items-center gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-left text-sm transition-colors hover:border-[var(--theme-accent)]"
                             >
-                              <span className="min-w-0 flex-1 truncate font-medium text-[var(--theme-text)]">{entry.goal}</span>
+                              <span className="min-w-0 flex-1 truncate font-medium text-[var(--theme-text)]">
+                                {entry.goal}
+                              </span>
+                              {entry.activeProjectName ||
+                              entry.activeProjectPath ? (
+                                <span className="hidden max-w-[120px] shrink-0 truncate rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-0.5 text-[10px] font-medium text-[var(--theme-muted)] sm:inline">
+                                  {entry.activeProjectName ??
+                                    entry.activeProjectPath?.split('/').pop()}
+                                </span>
+                              ) : null}
                               <span
                                 className={cn(
                                   'w-[76px] shrink-0 rounded-full border px-2 py-0.5 text-center text-[10px] font-medium uppercase tracking-[0.12em]',
-                                  entry.status === 'completed' ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-300' : 'border-red-400/35 bg-red-500/10 text-red-300',
+                                  entry.status === 'completed'
+                                    ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-300'
+                                    : 'border-red-400/35 bg-red-500/10 text-red-300',
                                 )}
                               >
-                                {entry.status === 'completed' ? 'Complete' : 'Failed'}
+                                {entry.status === 'completed'
+                                  ? 'Complete'
+                                  : 'Failed'}
                               </span>
-                              <span className="w-[52px] shrink-0 text-right text-xs text-[var(--theme-muted-2)]">{formatRelativeTime(entry.completedAt, now)}</span>
-                              <span className="w-[72px] shrink-0 text-right text-xs text-[var(--theme-muted)]">{entry.totalTokens.toLocaleString()} tok</span>
+                              <span className="w-[52px] shrink-0 text-right text-xs text-[var(--theme-muted-2)]">
+                                {formatRelativeTime(entry.completedAt, now)}
+                              </span>
+                              <span className="w-[72px] shrink-0 text-right text-xs text-[var(--theme-muted)]">
+                                {entry.totalTokens.toLocaleString()} tok
+                              </span>
                             </button>
                           )
                         })
                       : visibleActivityItems.map((item) => {
                           const recentSession = item as GatewaySession
-                          const label = recentSession.label ?? recentSession.key ?? ''
-                          const displayName = label.replace(/^worker-/, '').replace(/[-_]+/g, ' ')
-                          const tokens = typeof recentSession.totalTokens === 'number' ? recentSession.totalTokens : 0
+                          const label =
+                            recentSession.label ?? recentSession.key ?? ''
+                          const displayName = label
+                            .replace(/^worker-/, '')
+                            .replace(/[-_]+/g, ' ')
+                          const tokens =
+                            typeof recentSession.totalTokens === 'number'
+                              ? recentSession.totalTokens
+                              : 0
                           const model = getShortModelName(recentSession.model)
                           const updatedAt =
                             typeof recentSession.updatedAt === 'string'
@@ -1451,12 +2270,23 @@ export function Conductor() {
                                 : typeof recentSession.createdAt === 'string'
                                   ? recentSession.createdAt
                                   : null
-                          const sessionStatus = deriveSessionStatus(recentSession)
-                          const dotClass = sessionStatus === 'completed' ? 'bg-emerald-400' : sessionStatus === 'failed' ? 'bg-red-400' : 'bg-sky-400 animate-pulse'
+                          const sessionStatus =
+                            deriveSessionStatus(recentSession)
+                          const dotClass =
+                            sessionStatus === 'completed'
+                              ? 'bg-emerald-400'
+                              : sessionStatus === 'failed'
+                                ? 'bg-red-400'
+                                : 'bg-sky-400 animate-pulse'
 
                           return (
-                            <div key={recentSession.key} className="flex items-center gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm">
-                              <span className="min-w-0 flex-1 truncate font-medium capitalize text-[var(--theme-text)]">{displayName}</span>
+                            <div
+                              key={recentSession.key}
+                              className="flex items-center gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm"
+                            >
+                              <span className="min-w-0 flex-1 truncate font-medium capitalize text-[var(--theme-text)]">
+                                {displayName}
+                              </span>
                               <span
                                 className={cn(
                                   'shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em]',
@@ -1467,12 +2297,23 @@ export function Conductor() {
                                       : 'border-sky-400/35 bg-sky-500/10 text-sky-300',
                                 )}
                               >
-                                <span className={cn('mr-1 inline-block size-1.5 rounded-full align-middle', dotClass)} />
+                                <span
+                                  className={cn(
+                                    'mr-1 inline-block size-1.5 rounded-full align-middle',
+                                    dotClass,
+                                  )}
+                                />
                                 {sessionStatus}
                               </span>
-                              <span className="shrink-0 text-xs text-[var(--theme-muted-2)]">{formatRelativeTime(updatedAt, now)}</span>
-                              <span className="shrink-0 text-xs text-[var(--theme-muted)]">{tokens.toLocaleString()} tok</span>
-                              <span className="hidden shrink-0 text-xs text-[var(--theme-muted)] sm:inline">{model}</span>
+                              <span className="shrink-0 text-xs text-[var(--theme-muted-2)]">
+                                {formatRelativeTime(updatedAt, now)}
+                              </span>
+                              <span className="shrink-0 text-xs text-[var(--theme-muted)]">
+                                {tokens.toLocaleString()} tok
+                              </span>
+                              <span className="hidden shrink-0 text-xs text-[var(--theme-muted)] sm:inline">
+                                {model}
+                              </span>
                             </div>
                           )
                         })}
@@ -1487,8 +2328,12 @@ export function Conductor() {
             ) : (
               <section className="mt-6 w-full">
                 <div className="rounded-xl border border-dashed border-[var(--theme-border)] px-4 py-8 text-center">
-                  <p className="text-sm text-[var(--theme-muted)]">No missions yet.</p>
-                  <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Launch your first mission and it will appear here.</p>
+                  <p className="text-sm text-[var(--theme-muted)]">
+                    No missions yet.
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                    Launch your first mission and it will appear here.
+                  </p>
                 </div>
               </section>
             )}
@@ -1505,8 +2350,12 @@ export function Conductor() {
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <h2 className="text-lg font-semibold tracking-tight text-[var(--theme-text)]">New Mission</h2>
-                    <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Describe the mission, constraints, and desired outcome.</p>
+                    <h2 className="text-lg font-semibold tracking-tight text-[var(--theme-text)]">
+                      New Mission
+                    </h2>
+                    <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+                      Describe the mission, constraints, and desired outcome.
+                    </p>
                   </div>
                   <button
                     type="button"
@@ -1525,6 +2374,61 @@ export function Conductor() {
                     void handleSubmit()
                   }}
                 >
+                  <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                      Project context
+                    </p>
+                    {pendingProjectOverride ? (
+                      <div className="mt-2 space-y-2 text-sm">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium text-[var(--theme-text)]">
+                            {pendingProjectOverride.activeProjectName ??
+                              pendingProjectOverride.activeProjectPath ??
+                              'Selected project'}
+                          </span>
+                          {launchIntentSource === 'projects' ? (
+                            <span className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-accent-strong)]">
+                              From Projects
+                            </span>
+                          ) : null}
+                        </div>
+                        <span className="block truncate text-xs text-[var(--theme-muted-2)]">
+                          {pendingProjectOverride.effectiveWorkingDirectory ??
+                            pendingProjectOverride.activeProjectPath}
+                        </span>
+                        {pendingLaunchDiffersFromActiveProject ? (
+                          <p className="rounded-xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-3 py-2 text-xs text-[var(--theme-warning)]">
+                            This mission will run in the project selected from
+                            Projects, not the current active project.
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : activeProject ? (
+                      <div className="mt-2 flex flex-col gap-1 text-sm">
+                        <span className="font-medium text-[var(--theme-text)]">
+                          {activeProject.name}
+                        </span>
+                        <span className="truncate text-xs text-[var(--theme-muted-2)]">
+                          {activeProject.path}
+                        </span>
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                        No active project detected.
+                      </p>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMissionModalOpen(false)
+                        void navigate({ to: '/projects' })
+                      }}
+                      className="mt-3 text-xs font-medium text-[var(--theme-accent-strong)] hover:underline"
+                    >
+                      Change project
+                    </button>
+                  </div>
+
                   <div className="flex flex-wrap gap-2">
                     {QUICK_ACTIONS.map((action) => (
                       <button
@@ -1538,7 +2442,11 @@ export function Conductor() {
                             : 'border-[var(--theme-border)] bg-transparent text-[var(--theme-muted)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent-strong)]',
                         )}
                       >
-                        <HugeiconsIcon icon={action.icon} size={14} strokeWidth={1.7} />
+                        <HugeiconsIcon
+                          icon={action.icon}
+                          size={14}
+                          strokeWidth={1.7}
+                        />
                         {action.label}
                       </button>
                     ))}
@@ -1554,9 +2462,17 @@ export function Conductor() {
                   />
 
                   <div className="flex justify-end">
-                    <Button type="submit" disabled={!goalDraft.trim() || conductor.isSending} className="rounded-full bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]">
+                    <Button
+                      type="submit"
+                      disabled={!goalDraft.trim() || conductor.isSending}
+                      className="rounded-full bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]"
+                    >
                       {conductor.isSending ? 'Launching...' : 'Launch Mission'}
-                      <HugeiconsIcon icon={ArrowRight01Icon} size={16} strokeWidth={1.7} />
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        size={16}
+                        strokeWidth={1.7}
+                      />
                     </Button>
                   </div>
                 </form>
@@ -1575,9 +2491,16 @@ export function Conductor() {
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Defaults</p>
-                    <h2 className="mt-2 text-2xl font-semibold tracking-tight text-[var(--theme-text)]">Conductor settings</h2>
-                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">Set the models and defaults every new mission should inherit.</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      Mission Defaults
+                    </p>
+                    <h2 className="mt-2 text-2xl font-semibold tracking-tight text-[var(--theme-text)]">
+                      Conductor settings
+                    </h2>
+                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                      Set the models and defaults every new mission should
+                      inherit.
+                    </p>
                   </div>
                   <button
                     type="button"
@@ -1593,24 +2516,32 @@ export function Conductor() {
                   <ModelSelectorDropdown
                     label="Orchestrator Model"
                     value={conductor.conductorSettings.orchestratorModel}
-                    onChange={(nextValue) => updateSettings({ orchestratorModel: nextValue })}
+                    onChange={(nextValue) =>
+                      updateSettings({ orchestratorModel: nextValue })
+                    }
                     models={availableModels}
                   />
 
                   <ModelSelectorDropdown
                     label="Worker Model"
                     value={conductor.conductorSettings.workerModel}
-                    onChange={(nextValue) => updateSettings({ workerModel: nextValue })}
+                    onChange={(nextValue) =>
+                      updateSettings({ workerModel: nextValue })
+                    }
                     models={availableModels}
                   />
 
                   <div className="space-y-2">
-                    <span className="text-sm font-medium text-[var(--theme-text)]">Project Directory</span>
+                    <span className="text-sm font-medium text-[var(--theme-text)]">
+                      Project Directory
+                    </span>
                     <div className="flex gap-2">
                       <input
                         type="text"
                         value={conductor.conductorSettings.projectsDir}
-                        onChange={(event) => updateSettings({ projectsDir: event.target.value })}
+                        onChange={(event) =>
+                          updateSettings({ projectsDir: event.target.value })
+                        }
                         placeholder="~/conductor-projects"
                         className="min-w-0 flex-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-text)] outline-none transition-colors placeholder:text-[var(--theme-muted-2)] focus:border-[var(--theme-accent)]"
                       />
@@ -1622,11 +2553,16 @@ export function Conductor() {
                         Browse
                       </button>
                     </div>
-                    <p className="text-xs text-[var(--theme-muted-2)]">Type a path directly or choose a directory from the browser.</p>
+                    <p className="text-xs text-[var(--theme-muted-2)]">
+                      Type a path directly or choose a directory from the
+                      browser.
+                    </p>
                   </div>
 
                   <label className="block space-y-2">
-                    <span className="text-sm font-medium text-[var(--theme-text)]">Max Parallel Workers</span>
+                    <span className="text-sm font-medium text-[var(--theme-text)]">
+                      Max Parallel Workers
+                    </span>
                     <input
                       type="number"
                       min={1}
@@ -1634,7 +2570,10 @@ export function Conductor() {
                       value={conductor.conductorSettings.maxParallel}
                       onChange={(event) =>
                         updateSettings({
-                          maxParallel: Math.min(5, Math.max(1, Number(event.target.value) || 1)),
+                          maxParallel: Math.min(
+                            5,
+                            Math.max(1, Number(event.target.value) || 1),
+                          ),
                         })
                       }
                       className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-text)] outline-none transition-colors focus:border-[var(--theme-accent)]"
@@ -1645,20 +2584,31 @@ export function Conductor() {
                     <input
                       type="checkbox"
                       checked={conductor.conductorSettings.supervised}
-                      onChange={(event) => updateSettings({ supervised: event.target.checked })}
+                      onChange={(event) =>
+                        updateSettings({ supervised: event.target.checked })
+                      }
                       className="mt-1 size-4 rounded border-[var(--theme-border2)] accent-[var(--theme-accent)]"
                     />
                     <span className="min-w-0">
-                      <span className="block text-sm font-medium text-[var(--theme-text)]">Supervised Mode</span>
-                      <span className="mt-1 block text-sm text-[var(--theme-muted-2)]">Require approval before each task</span>
+                      <span className="block text-sm font-medium text-[var(--theme-text)]">
+                        Supervised Mode
+                      </span>
+                      <span className="mt-1 block text-sm text-[var(--theme-muted-2)]">
+                        Require approval before each task
+                      </span>
                     </span>
                   </label>
 
                   {canResetSavedState ? (
                     <div className="flex items-center justify-between rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
                       <div>
-                        <p className="text-sm font-medium text-[var(--theme-text)]">Reset saved state</p>
-                        <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Clear mission history and any persisted Conductor mission state.</p>
+                        <p className="text-sm font-medium text-[var(--theme-text)]">
+                          Reset saved state
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                          Clear mission history and any persisted Conductor
+                          mission state.
+                        </p>
                       </div>
                       <button
                         type="button"
@@ -1681,16 +2631,26 @@ export function Conductor() {
           )}
 
           {directoryBrowserOpen ? (
-            <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_55%,transparent)] px-4 py-6 backdrop-blur-md" onClick={closeDirectoryBrowser}>
+            <div
+              className="fixed inset-0 z-[70] flex items-center justify-center bg-[color-mix(in_srgb,var(--theme-bg)_55%,transparent)] px-4 py-6 backdrop-blur-md"
+              onClick={closeDirectoryBrowser}
+            >
               <div
                 className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-6"
                 onClick={(event) => event.stopPropagation()}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Directory Browser</p>
-                    <h3 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)]">Choose project directory</h3>
-                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">Select the folder where Conductor should create project output.</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      Directory Browser
+                    </p>
+                    <h3 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)]">
+                      Choose project directory
+                    </h3>
+                    <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                      Select the folder where Conductor should create project
+                      output.
+                    </p>
                   </div>
                   <button
                     type="button"
@@ -1706,11 +2666,21 @@ export function Conductor() {
                   <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      onClick={() => setDirectoryBrowserPath(getParentDirectory(directoryBrowserPath))}
-                      disabled={directoryBrowserLoading || getParentDirectory(directoryBrowserPath) === directoryBrowserPath}
+                      onClick={() =>
+                        setDirectoryBrowserPath(
+                          getParentDirectory(directoryBrowserPath),
+                        )
+                      }
+                      disabled={
+                        directoryBrowserLoading ||
+                        getParentDirectory(directoryBrowserPath) ===
+                          directoryBrowserPath
+                      }
                       className={cn(
                         'rounded-xl border px-3 py-2 text-sm font-medium transition-colors',
-                        directoryBrowserLoading || getParentDirectory(directoryBrowserPath) === directoryBrowserPath
+                        directoryBrowserLoading ||
+                          getParentDirectory(directoryBrowserPath) ===
+                            directoryBrowserPath
                           ? 'cursor-not-allowed border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] opacity-60'
                           : 'border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-text)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent-strong)]',
                       )}
@@ -1720,14 +2690,25 @@ export function Conductor() {
                     <div className="min-w-0 flex-1 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
                       <div className="flex flex-wrap items-center gap-1 text-sm">
                         {directoryBreadcrumbs.map((crumb, index) => (
-                          <div key={crumb.path} className="flex items-center gap-1">
-                            {index > 0 ? <span className="text-[var(--theme-muted-2)]">/</span> : null}
+                          <div
+                            key={crumb.path}
+                            className="flex items-center gap-1"
+                          >
+                            {index > 0 ? (
+                              <span className="text-[var(--theme-muted-2)]">
+                                /
+                              </span>
+                            ) : null}
                             <button
                               type="button"
-                              onClick={() => setDirectoryBrowserPath(crumb.path)}
+                              onClick={() =>
+                                setDirectoryBrowserPath(crumb.path)
+                              }
                               className={cn(
                                 'rounded-md px-1.5 py-0.5 transition-colors',
-                                crumb.path === directoryBrowserPath ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]' : 'text-[var(--theme-text)] hover:bg-[var(--theme-card2)]',
+                                crumb.path === directoryBrowserPath
+                                  ? 'bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)]'
+                                  : 'text-[var(--theme-text)] hover:bg-[var(--theme-card2)]',
                               )}
                             >
                               {crumb.label}
@@ -1740,22 +2721,34 @@ export function Conductor() {
 
                   <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
                     <div className="flex items-center justify-between gap-3">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Current path</span>
-                      <span className="truncate text-sm text-[var(--theme-text)]">{directoryBrowserPath}</span>
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                        Current path
+                      </span>
+                      <span className="truncate text-sm text-[var(--theme-text)]">
+                        {directoryBrowserPath}
+                      </span>
                     </div>
                   </div>
 
                   {directoryBrowserError ? (
-                    <div className="rounded-2xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-4 py-3 text-sm text-[var(--theme-warning)]">{directoryBrowserError}</div>
+                    <div className="rounded-2xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-4 py-3 text-sm text-[var(--theme-warning)]">
+                      {directoryBrowserError}
+                    </div>
                   ) : null}
 
                   <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)]">
                     <div className="flex items-center justify-between border-b border-[var(--theme-border)] px-4 py-3">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Folders</span>
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                        Folders
+                      </span>
                       {directoryBrowserLoading ? (
-                        <span className="text-xs text-[var(--theme-muted-2)]">Loading…</span>
+                        <span className="text-xs text-[var(--theme-muted-2)]">
+                          Loading…
+                        </span>
                       ) : (
-                        <span className="text-xs text-[var(--theme-muted-2)]">{directoryBrowserEntries.length} visible</span>
+                        <span className="text-xs text-[var(--theme-muted-2)]">
+                          {directoryBrowserEntries.length} visible
+                        </span>
                       )}
                     </div>
                     <div className="max-h-[22rem] overflow-y-auto p-2">
@@ -1770,23 +2763,33 @@ export function Conductor() {
                             <button
                               key={entry.path}
                               type="button"
-                              onClick={() => setDirectoryBrowserPath(entry.path)}
+                              onClick={() =>
+                                setDirectoryBrowserPath(entry.path)
+                              }
                               className="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
                             >
                               <span className="inline-flex size-2 rounded-full bg-[var(--theme-accent)]" />
-                              <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-                              <span className="text-xs text-[var(--theme-muted)]">Open</span>
+                              <span className="min-w-0 flex-1 truncate">
+                                {entry.name}
+                              </span>
+                              <span className="text-xs text-[var(--theme-muted)]">
+                                Open
+                              </span>
                             </button>
                           ))}
                         </div>
                       ) : (
-                        <div className="px-4 py-10 text-center text-sm text-[var(--theme-muted)]">No folders found in this location.</div>
+                        <div className="px-4 py-10 text-center text-sm text-[var(--theme-muted)]">
+                          No folders found in this location.
+                        </div>
                       )}
                     </div>
                   </div>
 
                   <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Quick paths</p>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                      Quick paths
+                    </p>
                     <div className="mt-3 flex flex-wrap gap-2">
                       {getDirectorySuggestions().map((pathOption) => (
                         <button
@@ -1831,37 +2834,61 @@ export function Conductor() {
 
   if (phase === 'preview') {
     return (
-      <div className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
+      <div
+        className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]"
+        style={THEME_STYLE}
+      >
         <main className="mx-auto flex min-h-0 w-full max-w-[720px] flex-1 flex-col items-stretch justify-center px-4 py-4 pb-[calc(var(--tabbar-h,80px)+1rem)] md:px-6 md:py-8">
           <div className="space-y-6">
             <div className="space-y-2 text-center">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-accent)]">Mission Decomposition</p>
-              <h1 className="text-2xl font-semibold tracking-tight">{conductor.goal}</h1>
-              <p className="text-sm text-[var(--theme-muted-2)]">The agent is breaking the mission into workers. Once they spawn, this view flips into the active board.</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-accent)]">
+                Mission Decomposition
+              </p>
+              <h1 className="text-2xl font-semibold tracking-tight">
+                {conductor.goal}
+              </h1>
+              <p className="text-sm text-[var(--theme-muted-2)]">
+                The agent is breaking the mission into workers. Once they spawn,
+                this view flips into the active board.
+              </p>
             </div>
 
             <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
               <div className="flex items-center justify-between gap-3 border-b border-[var(--theme-border)] pb-4">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Mission Planning</p>
-                  <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Analyzing your request and preparing agents</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Mission Planning
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                    Analyzing your request and preparing agents
+                  </p>
                 </div>
-                <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300 animate-pulse">Working</span>
+                <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300 animate-pulse">
+                  Working
+                </span>
               </div>
               <div className="mt-4 min-h-[200px] overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
                 {conductor.planText ? (
                   <div className="space-y-4">
-                    <Markdown className="max-h-[500px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{conductor.planText.replace(/(.{20,}?)\1+/g, '$1')}</Markdown>
+                    <Markdown className="max-h-[500px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                      {conductor.planText.replace(/(.{20,}?)\1+/g, '$1')}
+                    </Markdown>
                     <PlanningIndicator />
                   </div>
                 ) : (
                   <PlanningIndicator />
                 )}
               </div>
-              {conductor.streamError && <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-600">{conductor.streamError}</div>}
+              {conductor.streamError && (
+                <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-600">
+                  {conductor.streamError}
+                </div>
+              )}
               {conductor.timeoutWarning && (
                 <div className="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-amber-400/40 bg-amber-500/10 px-5 py-3">
-                  <p className="text-sm text-amber-700">⚠️ Planning is taking longer than expected...</p>
+                  <p className="text-sm text-amber-700">
+                    ⚠️ Planning is taking longer than expected...
+                  </p>
                   <Button
                     type="button"
                     onClick={handleNewMission}
@@ -1873,11 +2900,18 @@ export function Conductor() {
               )}
               {conductor.tasks.length > 0 && (
                 <div className="mt-4 space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Identified Tasks ({conductor.tasks.length})</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Identified Tasks ({conductor.tasks.length})
+                  </p>
                   {conductor.tasks.map((task) => (
-                    <div key={task.id} className="flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm">
+                    <div
+                      key={task.id}
+                      className="flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-sm"
+                    >
                       <span className="size-2 rounded-full bg-zinc-500" />
-                      <span className="text-[var(--theme-text)]">{task.title}</span>
+                      <span className="text-[var(--theme-text)]">
+                        {task.title}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -1891,7 +2925,10 @@ export function Conductor() {
 
   if (phase === 'complete') {
     return (
-      <div className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
+      <div
+        className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]"
+        style={THEME_STYLE}
+      >
         <main className="mx-auto flex min-h-0 w-full max-w-[720px] flex-1 flex-col px-4 py-4 pb-[calc(var(--tabbar-h,80px)+1rem)] md:px-6 md:py-8">
           <div className="space-y-6">
             <div className="text-center">
@@ -1904,10 +2941,16 @@ export function Conductor() {
               <div className="rounded-2xl border border-[var(--theme-danger-border)] bg-[var(--theme-danger-soft)] px-5 py-4">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="flex items-start gap-3">
-                    <span className="pt-0.5 text-[var(--theme-danger)]">❌</span>
+                    <span className="pt-0.5 text-[var(--theme-danger)]">
+                      ❌
+                    </span>
                     <div>
-                      <p className="text-sm font-semibold text-[var(--theme-danger)]">Mission failed</p>
-                      <p className="mt-1 text-sm text-[var(--theme-danger)]/90">{conductor.streamError}</p>
+                      <p className="text-sm font-semibold text-[var(--theme-danger)]">
+                        Mission failed
+                      </p>
+                      <p className="mt-1 text-sm text-[var(--theme-danger)]/90">
+                        {conductor.streamError}
+                      </p>
                     </div>
                   </div>
                   <div className="flex flex-col gap-2 sm:flex-row">
@@ -1946,7 +2989,11 @@ export function Conductor() {
                     >
                       Retry Mission
                     </Button>
-                    <Button type="button" onClick={handleNewMission} className="rounded-xl bg-[var(--theme-accent)] px-4 text-white hover:bg-[var(--theme-accent-strong)]">
+                    <Button
+                      type="button"
+                      onClick={handleNewMission}
+                      className="rounded-xl bg-[var(--theme-accent)] px-4 text-white hover:bg-[var(--theme-accent-strong)]"
+                    >
                       New Mission
                     </Button>
                   </div>
@@ -1956,13 +3003,32 @@ export function Conductor() {
             <div className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <p className={cn('text-xs font-semibold uppercase tracking-[0.24em]', conductor.streamError ? 'text-red-400' : 'text-[var(--theme-accent)]')}>
-                    {conductor.streamError ? 'Mission Stopped' : 'Mission Complete'}
+                  <p
+                    className={cn(
+                      'text-xs font-semibold uppercase tracking-[0.24em]',
+                      conductor.streamError
+                        ? 'text-red-400'
+                        : 'text-[var(--theme-accent)]',
+                    )}
+                  >
+                    {conductor.streamError
+                      ? 'Mission Stopped'
+                      : 'Mission Complete'}
                   </p>
-                  <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">{conductor.goal}</h1>
+                  <h1 className="mt-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">
+                    {conductor.goal}
+                  </h1>
                   <p className="mt-2 text-xs text-[var(--theme-muted-2)]">
-                    {completedWorkers}/{Math.max(totalWorkers, completedWorkers)} workers finished ·{' '}
-                    {formatElapsedTime(conductor.missionStartedAt, conductor.completedAt ? new Date(conductor.completedAt).getTime() : now)} total elapsed
+                    {completedWorkers}/
+                    {Math.max(totalWorkers, completedWorkers)} workers finished
+                    ·{' '}
+                    {formatElapsedTime(
+                      conductor.missionStartedAt,
+                      conductor.completedAt
+                        ? new Date(conductor.completedAt).getTime()
+                        : now,
+                    )}{' '}
+                    total elapsed
                   </p>
                 </div>
                 <div className="flex gap-2">
@@ -1975,7 +3041,11 @@ export function Conductor() {
                       Continue
                     </Button>
                   ) : null}
-                  <Button type="button" onClick={handleNewMission} className="rounded-xl bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]">
+                  <Button
+                    type="button"
+                    onClick={handleNewMission}
+                    className="rounded-xl bg-[var(--theme-accent)] px-5 text-white hover:bg-[var(--theme-accent-strong)]"
+                  >
                     New Mission
                   </Button>
                 </div>
@@ -1986,8 +3056,13 @@ export function Conductor() {
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output Preview</p>
-                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{completePhaseProjectPath.split('/').pop() || 'index.html'}</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      Output Preview
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                      {completePhaseProjectPath.split('/').pop() ||
+                        'index.html'}
+                    </p>
                   </div>
                   <div className="flex items-center gap-2">
                     <a
@@ -2008,10 +3083,17 @@ export function Conductor() {
                   </div>
                 </div>
                 <div className="mt-4 overflow-auto rounded-2xl border border-[var(--theme-border)] bg-white">
-                  <iframe src={previewUrl!} className="h-[clamp(280px,55vh,520px)] w-full" sandbox="allow-scripts allow-same-origin" title="Mission output preview" />
+                  <iframe
+                    src={previewUrl!}
+                    className="h-[clamp(280px,55vh,520px)] w-full"
+                    sandbox="allow-scripts allow-same-origin"
+                    title="Mission output preview"
+                  />
                 </div>
               </section>
-            ) : completePhaseProjectPath && previewState.loading && !conductor.streamError ? (
+            ) : completePhaseProjectPath &&
+              previewState.loading &&
+              !conductor.streamError ? (
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                 <div className="flex items-center gap-3 text-sm text-[var(--theme-muted)]">
                   <div className="size-4 animate-spin rounded-full border-2 border-[var(--theme-border)] border-t-[var(--theme-accent)]" />
@@ -2025,7 +3107,12 @@ export function Conductor() {
               (() => {
                 const outputSections = conductor.workers
                   .map((worker, index) => {
-                    const output = (conductor.workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).trim()
+                    const output = (
+                      conductor.workerOutputs[worker.key] ??
+                      getLastAssistantMessage(
+                        worker.raw.messages as HistoryMessage[] | undefined,
+                      )
+                    ).trim()
                     if (!output) return null
                     const persona = getAgentPersona(index)
                     return {
@@ -2035,10 +3122,20 @@ export function Conductor() {
                       output,
                     }
                   })
-                  .filter((section): section is NonNullable<typeof section> => section !== null)
+                  .filter(
+                    (section): section is NonNullable<typeof section> =>
+                      section !== null,
+                  )
 
                 const fallbackText =
-                  outputSections.length > 0 ? outputSections.map((s) => `### ${s.persona.emoji} ${s.persona.name} · ${s.label}\n\n${s.output}`).join('\n\n---\n\n') : conductor.streamText.trim()
+                  outputSections.length > 0
+                    ? outputSections
+                        .map(
+                          (s) =>
+                            `### ${s.persona.emoji} ${s.persona.name} · ${s.label}\n\n${s.output}`,
+                        )
+                        .join('\n\n---\n\n')
+                    : conductor.streamText.trim()
 
                 if (!fallbackText) return null
 
@@ -2046,12 +3143,20 @@ export function Conductor() {
                   <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                     <div className="flex items-center justify-between gap-3">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Output</p>
-                        <p className="mt-1 text-xs text-[var(--theme-muted-2)]">{completePhaseProjectPath ? `Preview unavailable for ${completePhaseOutputLabel}` : 'Agent work output'}</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                          Output
+                        </p>
+                        <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                          {completePhaseProjectPath
+                            ? `Preview unavailable for ${completePhaseOutputLabel}`
+                            : 'Agent work output'}
+                        </p>
                       </div>
                     </div>
                     <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                      <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{fallbackText}</Markdown>
+                      <Markdown className="max-h-[600px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                        {fallbackText}
+                      </Markdown>
                     </div>
                   </section>
                 )
@@ -2061,18 +3166,27 @@ export function Conductor() {
               <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Task Outputs</p>
-                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Per-task output snapshots from completed workers.</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      Task Outputs
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
+                      Per-task output snapshots from completed workers.
+                    </p>
                   </div>
                 </div>
                 <div className="mt-4 space-y-3">
                   {completedTaskOutputs.map((task) => (
-                    <div key={task.id} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-4">
+                    <div
+                      key={task.id}
+                      className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-4"
+                    >
                       <div className="flex items-center justify-between gap-3">
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
                             <span className="size-2 rounded-full bg-emerald-400" />
-                            <p className="truncate text-sm font-medium text-[var(--theme-text)]">{task.title}</p>
+                            <p className="truncate text-sm font-medium text-[var(--theme-text)]">
+                              {task.title}
+                            </p>
                           </div>
                         </div>
                         {task.previewUrl && (
@@ -2099,12 +3213,16 @@ export function Conductor() {
             <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">Agent Summary</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Agent Summary
+                  </p>
                 </div>
                 <span
                   className={cn(
                     'rounded-full px-3 py-1 text-xs font-medium',
-                    conductor.streamError ? 'border border-red-400/35 bg-red-500/10 text-red-300' : 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300',
+                    conductor.streamError
+                      ? 'border border-red-400/35 bg-red-500/10 text-red-300'
+                      : 'border border-emerald-400/35 bg-emerald-500/10 text-emerald-300',
                   )}
                 >
                   {conductor.streamError ? 'Stopped' : 'Complete'}
@@ -2112,11 +3230,17 @@ export function Conductor() {
               </div>
               <div className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
                 {completeSummary ? (
-                  <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{completeSummary}</Markdown>
+                  <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                    {completeSummary}
+                  </Markdown>
                 ) : conductor.streamText ? (
-                  <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{conductor.streamText}</Markdown>
+                  <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                    {conductor.streamText}
+                  </Markdown>
                 ) : (
-                  <p className="text-sm text-[var(--theme-muted)]">No summary captured.</p>
+                  <p className="text-sm text-[var(--theme-muted)]">
+                    No summary captured.
+                  </p>
                 )}
               </div>
               {conductor.workers.length > 0 && (
@@ -2125,14 +3249,20 @@ export function Conductor() {
                     const persona = getAgentPersona(index)
                     const shortModelName = getShortModelName(worker.model)
                     return (
-                      <div key={worker.key} className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm">
+                      <div
+                        key={worker.key}
+                        className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm"
+                      >
                         <span className="size-2 rounded-full bg-emerald-400" />
                         <span className="font-medium text-[var(--theme-text)]">
                           {persona.emoji} {persona.name}
                         </span>
-                        <span className="text-[var(--theme-muted)]">{worker.label}</span>
+                        <span className="text-[var(--theme-muted)]">
+                          {worker.label}
+                        </span>
                         <span className="ml-auto text-xs text-[var(--theme-muted)]">
-                          {shortModelName} · {worker.totalTokens.toLocaleString()} tok
+                          {shortModelName} ·{' '}
+                          {worker.totalTokens.toLocaleString()} tok
                         </span>
                       </div>
                     )
@@ -2141,14 +3271,25 @@ export function Conductor() {
               )}
               {(totalTokens > 0 || completeMissionCostWorkers.length > 0) && (
                 <div className="mt-4">
-                  <MissionCostSection totalTokens={totalTokens} workers={completeMissionCostWorkers} expanded={completeCostExpanded} onToggle={() => setCompleteCostExpanded((current) => !current)} />
+                  <MissionCostSection
+                    totalTokens={totalTokens}
+                    workers={completeMissionCostWorkers}
+                    expanded={completeCostExpanded}
+                    onToggle={() =>
+                      setCompleteCostExpanded((current) => !current)
+                    }
+                  />
                 </div>
               )}
               {conductor.streamText && completeSummary && (
                 <details className="mt-4 overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-5 py-4">
-                  <summary className="cursor-pointer text-xs font-medium text-[var(--theme-muted)]">Raw Agent Output</summary>
+                  <summary className="cursor-pointer text-xs font-medium text-[var(--theme-muted)]">
+                    Raw Agent Output
+                  </summary>
                   <div className="mt-4 border-t border-[var(--theme-border)] pt-4">
-                    <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">{conductor.streamText}</Markdown>
+                    <Markdown className="max-h-[400px] max-w-none overflow-auto text-sm text-[var(--theme-text)]">
+                      {conductor.streamText}
+                    </Markdown>
                   </div>
                 </details>
               )}
@@ -2166,7 +3307,9 @@ export function Conductor() {
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
-                    <h2 className="text-lg font-semibold tracking-tight text-[var(--theme-text)]">Continue Mission</h2>
+                    <h2 className="text-lg font-semibold tracking-tight text-[var(--theme-text)]">
+                      Continue Mission
+                    </h2>
                   </div>
                   <button
                     type="button"
@@ -2180,8 +3323,12 @@ export function Conductor() {
 
                 {continuationModalPreview ? (
                   <div className="mt-4 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3">
-                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--theme-muted)]">Previous output summary</p>
-                    <p className="mt-2 text-sm text-[var(--theme-text)]">{continuationModalPreview}</p>
+                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                      Previous output summary
+                    </p>
+                    <p className="mt-2 text-sm text-[var(--theme-text)]">
+                      {continuationModalPreview}
+                    </p>
                   </div>
                 ) : null}
 
@@ -2211,7 +3358,11 @@ export function Conductor() {
                           : 'border border-[var(--theme-border)] bg-[var(--theme-accent-soft)] text-[var(--theme-text)] hover:border-[var(--theme-accent)] hover:bg-[var(--theme-accent-soft-strong)]',
                       )}
                     >
-                      <HugeiconsIcon icon={ArrowRight01Icon} size={16} strokeWidth={1.8} />
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        size={16}
+                        strokeWidth={1.8}
+                      />
                       {conductor.isSending ? 'Sending' : 'Send'}
                     </button>
                   </div>
@@ -2225,7 +3376,10 @@ export function Conductor() {
   }
 
   return (
-    <div className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]" style={THEME_STYLE}>
+    <div
+      className="flex min-h-dvh flex-col bg-[var(--theme-bg)] text-[var(--theme-text)]"
+      style={THEME_STYLE}
+    >
       <main className="mx-auto flex min-h-0 w-full max-w-[720px] flex-1 flex-col justify-center px-4 py-4 pb-[calc(var(--tabbar-h,80px)+1rem)] md:px-6 md:py-8">
         <div className="flex w-full flex-col gap-6">
           <div className="text-center">
@@ -2236,9 +3390,17 @@ export function Conductor() {
           </div>
           <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-5 py-5 shadow-[0_24px_80px_var(--theme-shadow)]">
             <div className="text-center">
-              <h1 className="line-clamp-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">{conductor.goal}</h1>
+              <h1 className="line-clamp-2 text-xl font-semibold tracking-tight text-[var(--theme-text)] sm:text-2xl">
+                {conductor.goal}
+              </h1>
               <div className="mt-2 flex items-center justify-center gap-2 text-xs text-[var(--theme-muted)]">
-                <span>{formatElapsedMilliseconds(conductor.isPaused ? conductor.pausedElapsedMs : conductor.missionElapsedMs)}</span>
+                <span>
+                  {formatElapsedMilliseconds(
+                    conductor.isPaused
+                      ? conductor.pausedElapsedMs
+                      : conductor.missionElapsedMs,
+                  )}
+                </span>
                 <span className="text-[var(--theme-border)]">·</span>
                 <span>
                   {completedWorkers}/{Math.max(totalWorkers, 1)} complete
@@ -2255,7 +3417,10 @@ export function Conductor() {
               ) : null}
             </div>
             <div className="mt-4 h-1 w-full overflow-hidden rounded-full bg-[var(--theme-border)]">
-              <div className="h-full rounded-full bg-[var(--theme-accent)] transition-[width] duration-500 ease-out" style={{ width: `${missionProgress}%` }} />
+              <div
+                className="h-full rounded-full bg-[var(--theme-accent)] transition-[width] duration-500 ease-out"
+                style={{ width: `${missionProgress}%` }}
+              />
             </div>
             <div className="mt-3 flex items-center justify-center gap-2">
               <button
@@ -2267,11 +3432,16 @@ export function Conductor() {
               </button>
               <button
                 type="button"
-                disabled={!conductor.orchestratorSessionKey || conductor.isPausing}
+                disabled={
+                  !conductor.orchestratorSessionKey || conductor.isPausing
+                }
                 onClick={async () => {
                   if (!conductor.orchestratorSessionKey) return
                   try {
-                    await conductor.pauseAgent(conductor.orchestratorSessionKey, !conductor.isPaused)
+                    await conductor.pauseAgent(
+                      conductor.orchestratorSessionKey,
+                      !conductor.isPaused,
+                    )
                   } catch {
                     // best effort
                   }
@@ -2285,7 +3455,12 @@ export function Conductor() {
                       : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] hover:border-[var(--theme-accent)] hover:text-[var(--theme-text)]',
                 )}
               >
-                <span>{conductor.isPaused ? '▶' : '⏸'}</span> {conductor.isPausing ? '...' : conductor.isPaused ? 'Resume' : 'Pause'}
+                <span>{conductor.isPaused ? '▶' : '⏸'}</span>{' '}
+                {conductor.isPausing
+                  ? '...'
+                  : conductor.isPaused
+                    ? 'Resume'
+                    : 'Pause'}
               </button>
             </div>
           </section>
@@ -2293,8 +3468,13 @@ export function Conductor() {
             <section className="rounded-2xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-5 py-4">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-sm font-semibold text-[var(--theme-warning)]">⏳ Mission appears stalled — no activity for 60 seconds</p>
-                  <p className="mt-1 text-xs text-[var(--theme-muted)]">Sometimes the workers are still alive, but the stream went quiet. Your call.</p>
+                  <p className="text-sm font-semibold text-[var(--theme-warning)]">
+                    ⏳ Mission appears stalled — no activity for 60 seconds
+                  </p>
+                  <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                    Sometimes the workers are still alive, but the stream went
+                    quiet. Your call.
+                  </p>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row">
                   <Button
@@ -2316,31 +3496,62 @@ export function Conductor() {
             </section>
           )}
           <section className="h-[360px] overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_24px_80px_var(--theme-shadow)]">
-            <OfficeView agentRows={officeAgentRows} missionRunning onViewOutput={() => {}} processType="parallel" companyName="Conductor Office" containerHeight={360} hideHeader />
+            <OfficeView
+              agentRows={officeAgentRows}
+              missionRunning
+              onViewOutput={() => {}}
+              processType="parallel"
+              companyName="Conductor Office"
+              containerHeight={360}
+              hideHeader
+            />
           </section>
 
           {conductor.tasks.length > 0 ? (
             <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
               <div className="space-y-2">
                 <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
-                  Tasks ({conductor.tasks.filter((task) => task.status === 'complete').length}/{conductor.tasks.length})
+                  Tasks (
+                  {
+                    conductor.tasks.filter((task) => task.status === 'complete')
+                      .length
+                  }
+                  /{conductor.tasks.length})
                 </h2>
                 {conductor.tasks.map((task) => {
                   const isSelected = selectedTaskId === task.id
-                  const statusDot = task.status === 'complete' ? 'bg-emerald-400' : task.status === 'running' ? 'bg-sky-400 animate-pulse' : task.status === 'failed' ? 'bg-red-400' : 'bg-zinc-500'
+                  const statusDot =
+                    task.status === 'complete'
+                      ? 'bg-emerald-400'
+                      : task.status === 'running'
+                        ? 'bg-sky-400 animate-pulse'
+                        : task.status === 'failed'
+                          ? 'bg-red-400'
+                          : 'bg-zinc-500'
                   return (
                     <button
                       key={task.id}
                       type="button"
-                      onClick={() => setSelectedTaskId(isSelected ? null : task.id)}
+                      onClick={() =>
+                        setSelectedTaskId(isSelected ? null : task.id)
+                      }
                       className={cn(
                         'w-full rounded-xl border px-3 py-2.5 text-left text-sm transition-colors',
-                        isSelected ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)]' : 'border-[var(--theme-border)] bg-[var(--theme-card)] hover:border-[var(--theme-accent)]',
+                        isSelected
+                          ? 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)]'
+                          : 'border-[var(--theme-border)] bg-[var(--theme-card)] hover:border-[var(--theme-accent)]',
                       )}
                     >
                       <div className="flex items-center gap-2">
-                        <span className={cn('size-2 shrink-0 rounded-full', statusDot)} />
-                        <span className="min-w-0 truncate font-medium text-[var(--theme-text)]">{task.title}</span>
+                        <span
+                          className={cn(
+                            'size-2 shrink-0 rounded-full',
+                            statusDot,
+                          )}
+                        />
+                        <span className="min-w-0 truncate font-medium text-[var(--theme-text)]">
+                          {task.title}
+                        </span>
                       </div>
                     </button>
                   )
@@ -2350,16 +3561,32 @@ export function Conductor() {
               <div className="space-y-3">
                 {selectedTaskId ? (
                   <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Task Output</h2>
+                    <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+                      Task Output
+                    </h2>
                   </div>
                 ) : null}
                 {(() => {
-                  const selectedTask = selectedTaskId ? conductor.tasks.find((task) => task.id === selectedTaskId) : null
-                  const displayWorkers = selectedTask?.workerKey ? conductor.workers.filter((worker) => worker.key === selectedTask.workerKey) : conductor.workers
+                  const selectedTask = selectedTaskId
+                    ? conductor.tasks.find((task) => task.id === selectedTaskId)
+                    : null
+                  const displayWorkers = selectedTask?.workerKey
+                    ? conductor.workers.filter(
+                        (worker) => worker.key === selectedTask.workerKey,
+                      )
+                    : conductor.workers
                   return (
                     <div className="grid gap-3 md:grid-cols-2">
                       {displayWorkers.map((worker, index) => {
-                        return <WorkerCard key={worker.key} worker={worker} index={index} conductor={conductor} now={now} />
+                        return (
+                          <WorkerCard
+                            key={worker.key}
+                            worker={worker}
+                            index={index}
+                            conductor={conductor}
+                            now={now}
+                          />
+                        )
                       })}
                       {displayWorkers.length === 0 && (
                         <div className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-8 text-center text-sm text-[var(--theme-muted)] md:col-span-2">
@@ -2368,7 +3595,11 @@ export function Conductor() {
                               <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
                               <span>Spawning workers...</span>
                             </div>
-                            {conductor.planText ? <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">{conductor.planText}</p> : null}
+                            {conductor.planText ? (
+                              <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">
+                                {conductor.planText}
+                              </p>
+                            ) : null}
                           </div>
                         </div>
                       )}
@@ -2381,7 +3612,15 @@ export function Conductor() {
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-2">
                 {conductor.workers.map((worker, index) => {
-                  return <WorkerCard key={worker.key} worker={worker} index={index} conductor={conductor} now={now} />
+                  return (
+                    <WorkerCard
+                      key={worker.key}
+                      worker={worker}
+                      index={index}
+                      conductor={conductor}
+                      now={now}
+                    />
+                  )
                 })}
                 {conductor.workers.length === 0 && (
                   <div className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-8 text-center text-sm text-[var(--theme-muted)] md:col-span-2">
@@ -2390,7 +3629,11 @@ export function Conductor() {
                         <div className="size-4 animate-spin rounded-full border-2 border-sky-400 border-t-transparent" />
                         <span>Spawning workers...</span>
                       </div>
-                      {conductor.planText ? <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">{conductor.planText}</p> : null}
+                      {conductor.planText ? (
+                        <p className="max-w-xl text-xs text-[var(--theme-muted-2)]">
+                          {conductor.planText}
+                        </p>
+                      ) : null}
                     </div>
                   </div>
                 )}

--- a/src/screens/gateway/conductor.tsx
+++ b/src/screens/gateway/conductor.tsx
@@ -26,10 +26,31 @@ import {
   type ConductorProjectOverride,
 } from './conductor-launch-intent'
 import {
-  type MissionHistoryEntry,
-  type MissionHistoryWorkerDetail,
-  useConductorGateway,
-} from './hooks/use-conductor-gateway'
+  buildConductorPreflightSummary,
+  shouldWarnProjectMismatch,
+} from './conductor-preflight-summary'
+import {
+  buildFallbackMissionHistoryEntryForTrace,
+  buildMissionHistoryTraceActionViewModel,
+  buildMissionHistoryTraceButtonElementViewModel,
+  buildMissionHistoryTraceInspectActionViewModel,
+  buildMissionHistoryTraceLookupRefreshControl,
+  buildMissionHistoryTraceLookupViewModel,
+  buildMissionHistoryTraceRecoveryActionsViewModel,
+  buildMissionHistoryTraceRecoveryFeedbackViewModel,
+  buildMissionHistoryTraceRecoveryViewModel,
+  buildMissionHistoryTraceViewModel,
+  findMissionHistoryEntryByTraceSessionKey,
+  type MissionHistoryTraceButtonControl,
+  type MissionHistoryTraceCopyStatus,
+  type MissionHistoryTraceLookupStatus,
+  type MissionHistoryTraceRecoveryLastAction,
+} from './conductor-trace-hydration'
+import { useConductorGateway } from './hooks/use-conductor-gateway'
+import type {
+  MissionHistoryEntry,
+  MissionHistoryWorkerDetail,
+} from './hooks/mission-history'
 
 type ConductorPhase = 'home' | 'preview' | 'active' | 'complete'
 type QuickActionId = 'research' | 'build' | 'review' | 'deploy'
@@ -987,7 +1008,11 @@ function deriveSessionStatus(
   return 'running'
 }
 
-export function Conductor() {
+export function Conductor({
+  traceSessionKey = null,
+}: {
+  traceSessionKey?: string | null
+}) {
   const navigate = useNavigate()
   const conductor = useConductorGateway()
   const [goalDraft, setGoalDraft] = useState(() => loadConductorGoalDraft())
@@ -1007,6 +1032,11 @@ export function Conductor() {
   const [activityPage, setActivityPage] = useState(0)
   const [completeCostExpanded, setCompleteCostExpanded] = useState(true)
   const [historyCostExpanded, setHistoryCostExpanded] = useState(false)
+  const [historyTraceCopyStatus, setHistoryTraceCopyStatus] =
+    useState<MissionHistoryTraceCopyStatus>('idle')
+  const [historyTraceRecoveryLastAction, setHistoryTraceRecoveryLastAction] =
+    useState<MissionHistoryTraceRecoveryLastAction | null>(null)
+  const historyTraceCopyTimerRef = useRef<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [directoryBrowserOpen, setDirectoryBrowserOpen] = useState(false)
@@ -1055,10 +1085,12 @@ export function Conductor() {
     pendingProjectOverride?.effectiveWorkingDirectory ||
     activeProject?.path ||
     ''
-  const pendingLaunchDiffersFromActiveProject = Boolean(
-    pendingProjectOverride?.activeProjectPath &&
-    activeProject?.path &&
-    pendingProjectOverride.activeProjectPath !== activeProject.path,
+  const preflightSummary = pendingProjectOverride
+    ? buildConductorPreflightSummary(pendingProjectOverride)
+    : null
+  const pendingLaunchDiffersFromActiveProject = shouldWarnProjectMismatch(
+    pendingProjectOverride,
+    activeProject,
   )
 
   useEffect(() => {
@@ -1308,6 +1340,42 @@ export function Conductor() {
     0,
   )
   const selectedHistoryEntry = conductor.selectedHistoryEntry
+  const selectedHistoryTrace = buildMissionHistoryTraceViewModel(selectedHistoryEntry)
+  const selectedHistoryTraceSessionKey = selectedHistoryTrace?.sessionKey ?? null
+  const traceSessionStatusQuery = useQuery({
+    queryKey: ['conductor', 'trace-session-status', selectedHistoryTraceSessionKey],
+    queryFn: async () => {
+      if (!selectedHistoryTraceSessionKey) return null
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(selectedHistoryTraceSessionKey)}/status`,
+      )
+      if (res.status === 404) return { ok: false, missing: true }
+      const data = (await res.json()) as { ok?: boolean; error?: string }
+      if (!res.ok || data.ok === false) {
+        throw new Error(data.error ?? 'Session lookup failed')
+      }
+      return data
+    },
+    enabled: Boolean(selectedHistoryTraceSessionKey),
+    retry: false,
+    staleTime: 30_000,
+  })
+
+  useEffect(() => {
+    if (!traceSessionKey) return
+    const entry =
+      findMissionHistoryEntryByTraceSessionKey(
+        conductor.missionHistory,
+        traceSessionKey,
+      ) ?? buildFallbackMissionHistoryEntryForTrace(traceSessionKey)
+    if (!entry || conductor.selectedHistoryEntry?.id === entry.id) return
+    conductor.setSelectedHistoryEntry(entry)
+  }, [
+    traceSessionKey,
+    conductor.missionHistory,
+    conductor.selectedHistoryEntry,
+  ])
+
   const completeMissionCostWorkers = useMemo<MissionCostWorker[]>(
     () =>
       conductor.workers.map((worker, index) => {
@@ -1651,7 +1719,40 @@ export function Conductor() {
   useEffect(() => {
     if (!selectedHistoryEntry) return
     setHistoryCostExpanded(false)
+    setHistoryTraceCopyStatus('idle')
+    setHistoryTraceRecoveryLastAction(null)
   }, [selectedHistoryEntry])
+
+  useEffect(
+    () => () => {
+      if (historyTraceCopyTimerRef.current !== null) {
+        window.clearTimeout(historyTraceCopyTimerRef.current)
+      }
+    },
+    [],
+  )
+
+  async function handleCopyHistoryTraceSessionKey(copyValue: string) {
+    if (historyTraceCopyTimerRef.current !== null) {
+      window.clearTimeout(historyTraceCopyTimerRef.current)
+      historyTraceCopyTimerRef.current = null
+    }
+
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable')
+      }
+      await navigator.clipboard.writeText(copyValue)
+      setHistoryTraceCopyStatus('copied')
+    } catch {
+      setHistoryTraceCopyStatus('failed')
+    }
+
+    historyTraceCopyTimerRef.current = window.setTimeout(() => {
+      setHistoryTraceCopyStatus('idle')
+      historyTraceCopyTimerRef.current = null
+    }, 1800)
+  }
 
   if (phase === 'home') {
     if (selectedHistoryEntry) {
@@ -1682,6 +1783,106 @@ export function Conductor() {
         historicalProjectPath &&
         historicalProjectPath !== activeProject.path,
       )
+      const historyTrace = selectedHistoryTrace
+      const historyTraceAction = buildMissionHistoryTraceActionViewModel(
+        historyTraceCopyStatus,
+      )
+      const historyTraceInspectAction =
+        buildMissionHistoryTraceInspectActionViewModel(historyTrace?.sessionKey)
+      const historyTraceLookupStatus: MissionHistoryTraceLookupStatus =
+        !historyTrace
+          ? 'idle'
+          : traceSessionStatusQuery.isFetching
+            ? 'checking'
+            : traceSessionStatusQuery.isError
+              ? 'error'
+              : traceSessionStatusQuery.data && 'missing' in traceSessionStatusQuery.data
+                ? 'missing'
+                : traceSessionStatusQuery.isSuccess
+                  ? 'found'
+                  : 'idle'
+      const historyTraceLookup = buildMissionHistoryTraceLookupViewModel(
+        historyTraceLookupStatus,
+      )
+      const historyTraceLookupRefresh =
+        buildMissionHistoryTraceLookupRefreshControl({
+          status: historyTraceLookupStatus,
+          hasSessionKey: Boolean(historyTrace?.sessionKey),
+          isRefreshing: traceSessionStatusQuery.isRefetching,
+        })
+      const historyTraceRecovery = buildMissionHistoryTraceRecoveryViewModel(
+        Boolean(historyTrace?.isFallback),
+        historyTraceLookupStatus,
+      )
+      const historyTraceRecoveryActions =
+        buildMissionHistoryTraceRecoveryActionsViewModel({
+          isFallback: Boolean(historyTrace?.isFallback),
+          lookupStatus: historyTraceLookupStatus,
+          copyStatus: historyTraceCopyStatus,
+          sessionKey: historyTrace?.sessionKey,
+        })
+      const historyTraceRecoveryFeedback =
+        buildMissionHistoryTraceRecoveryFeedbackViewModel({
+          isFallback: Boolean(historyTrace?.isFallback),
+          lastAction: historyTraceRecoveryLastAction,
+          copyStatus: historyTraceCopyStatus,
+        })
+      const handleHistoryTraceButtonAction = (
+        action: MissionHistoryTraceButtonControl,
+      ) => {
+        if (action.kind === 'inspect') {
+          if (
+            historyTraceInspectAction.disabled ||
+            !historyTraceInspectAction.to ||
+            !historyTraceInspectAction.params
+          ) {
+            return
+          }
+          if (historyTrace?.isFallback) {
+            setHistoryTraceRecoveryLastAction('inspect')
+          }
+          void navigate({
+            to: historyTraceInspectAction.to,
+            params: historyTraceInspectAction.params,
+          })
+          return
+        }
+
+        if (action.kind === 'copy') {
+          if (!historyTrace?.copyValue) return
+          if (historyTrace.isFallback) {
+            setHistoryTraceRecoveryLastAction('copy')
+          }
+          void handleCopyHistoryTraceSessionKey(historyTrace.copyValue)
+          return
+        }
+
+        setHistoryTraceRecoveryLastAction('newMission')
+        conductor.setSelectedHistoryEntry(null)
+        handleNewMission()
+      }
+      const renderHistoryTraceButton = (
+        action: MissionHistoryTraceButtonControl,
+        options: { extraClassName?: string } = {},
+      ) => {
+        const button = buildMissionHistoryTraceButtonElementViewModel(
+          action,
+          options,
+        )
+        return (
+          <Button
+            key={button.key}
+            type={button.type}
+            title={button.title}
+            aria-label={button.ariaLabel}
+            disabled={button.disabled}
+            onClick={() => handleHistoryTraceButtonAction(action)}
+            className={button.className}
+          >
+            {button.label}
+          </Button>
+        )
+      }
 
       return (
         <div
@@ -1777,6 +1978,168 @@ export function Conductor() {
                   </div>
                 </div>
               </div>
+
+              {historyTraceRecovery ? (
+                <section
+                  className={cn(
+                    'overflow-hidden rounded-3xl border p-5 shadow-[0_24px_80px_var(--theme-shadow)]',
+                    historyTraceRecovery.tone === 'success'
+                      ? 'border-emerald-400/35 bg-emerald-500/10'
+                      : 'border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)]',
+                  )}
+                >
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                    Trace Recovery
+                  </p>
+                  <h2 className="mt-2 text-base font-semibold text-[var(--theme-text)]">
+                    {historyTraceRecovery.title}
+                  </h2>
+                  <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
+                    {historyTraceRecovery.description}
+                  </p>
+                  <p className="mt-3 text-sm font-medium text-[var(--theme-text)]">
+                    {historyTraceRecovery.recommendation}
+                  </p>
+                  <ul className="mt-3 space-y-1 text-xs text-[var(--theme-muted)]">
+                    {historyTraceRecovery.actions.map((action) => (
+                      <li key={action} className="flex gap-2">
+                        <span aria-hidden="true">•</span>
+                        <span>{action}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  {historyTraceRecoveryActions ? (
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {[
+                        historyTraceRecoveryActions.primary,
+                        historyTraceRecoveryActions.secondary,
+                        historyTraceRecoveryActions.tertiary,
+                      ].map((action) =>
+                        action
+                          ? renderHistoryTraceButton(action, {
+                              extraClassName: 'text-xs',
+                            })
+                          : null,
+                      )}
+                    </div>
+                  ) : null}
+                  {historyTraceRecoveryFeedback ? (
+                    <p
+                      className={cn(
+                        'mt-3 text-xs font-medium',
+                        historyTraceRecoveryFeedback.tone === 'success'
+                          ? 'text-emerald-600'
+                          : historyTraceRecoveryFeedback.tone === 'danger'
+                            ? 'text-[var(--theme-danger)]'
+                            : 'text-[var(--theme-muted-2)]',
+                      )}
+                      role="status"
+                    >
+                      {historyTraceRecoveryFeedback.message}
+                    </p>
+                  ) : null}
+                </section>
+              ) : null}
+
+              {historyTrace ? (
+                <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                        Session Trace
+                      </p>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <span
+                          className={cn(
+                            'rounded-full border px-3 py-1 text-xs font-medium',
+                            historyTrace.isFallback
+                              ? 'border-amber-400/35 bg-amber-500/10 text-amber-600'
+                              : 'border-emerald-400/35 bg-emerald-500/10 text-emerald-500',
+                          )}
+                        >
+                          {historyTrace.sourceLabel}
+                        </span>
+                        <code className="max-w-full truncate rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-1.5 text-xs text-[var(--theme-text)]">
+                          {historyTrace.sessionKey}
+                        </code>
+                      </div>
+                      <p className="mt-3 text-xs text-[var(--theme-muted-2)]">
+                        {historyTrace.helperText}
+                      </p>
+                      <div
+                        className={cn(
+                          'mt-3 rounded-xl border px-3 py-2 text-xs',
+                          historyTraceLookup.tone === 'success'
+                            ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-700'
+                            : historyTraceLookup.tone === 'warning'
+                              ? 'border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] text-[var(--theme-warning)]'
+                              : 'border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-muted-2)]',
+                        )}
+                      >
+                        <div className="flex items-center gap-2 font-medium">
+                          {historyTraceLookup.isChecking ? (
+                            <span className="size-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                          ) : null}
+                          {historyTraceLookup.label}
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center justify-between gap-2 opacity-85">
+                          <p>{historyTraceLookup.helperText}</p>
+                          {historyTraceLookupRefresh.visible ? (
+                            <Button
+                              type="button"
+                              title={historyTraceLookupRefresh.title}
+                              aria-label={historyTraceLookupRefresh.ariaLabel}
+                              disabled={historyTraceLookupRefresh.disabled}
+                              onClick={() => {
+                                void traceSessionStatusQuery.refetch()
+                              }}
+                              className="rounded-lg border border-current/25 bg-transparent px-2 py-1 text-[11px] hover:bg-current/10"
+                            >
+                              {historyTraceLookupRefresh.isLoading ? (
+                                <span
+                                  className="mr-1 inline-block size-2.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                                  aria-hidden="true"
+                                />
+                              ) : null}
+                              {historyTraceLookupRefresh.label}
+                            </Button>
+                          ) : null}
+                        </div>
+                      </div>
+                      {historyTraceAction.helperText ? (
+                        <p
+                          className={cn(
+                            'mt-2 text-xs font-medium',
+                            historyTraceAction.tone === 'success'
+                              ? 'text-emerald-600'
+                              : historyTraceAction.tone === 'danger'
+                                ? 'text-[var(--theme-danger)]'
+                                : 'text-[var(--theme-muted-2)]',
+                          )}
+                          role="status"
+                        >
+                          {historyTraceAction.helperText}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {renderHistoryTraceButton({
+                        kind: 'inspect',
+                        label: historyTraceInspectAction.label,
+                        helperText: historyTraceInspectAction.helperText,
+                        disabled: historyTraceInspectAction.disabled,
+                      })}
+                      {renderHistoryTraceButton({
+                        kind: 'copy',
+                        label: historyTraceAction.label,
+                        helperText: historyTraceAction.helperText,
+                        disabled: historyTraceAction.disabled,
+                        tone: historyTraceAction.tone,
+                      })}
+                    </div>
+                  </div>
+                </section>
+              ) : null}
 
               {selectedHistoryOutputPath && selectedHistoryPreview.ready ? (
                 <section className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-[0_24px_80px_var(--theme-shadow)]">
@@ -2378,13 +2741,11 @@ export function Conductor() {
                     <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
                       Project context
                     </p>
-                    {pendingProjectOverride ? (
-                      <div className="mt-2 space-y-2 text-sm">
+                    {pendingProjectOverride && preflightSummary ? (
+                      <div className="mt-2 space-y-3 text-sm">
                         <div className="flex flex-wrap items-center gap-2">
                           <span className="font-medium text-[var(--theme-text)]">
-                            {pendingProjectOverride.activeProjectName ??
-                              pendingProjectOverride.activeProjectPath ??
-                              'Selected project'}
+                            {preflightSummary.projectLabel}
                           </span>
                           {launchIntentSource === 'projects' ? (
                             <span className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-accent-strong)]">
@@ -2393,13 +2754,70 @@ export function Conductor() {
                           ) : null}
                         </div>
                         <span className="block truncate text-xs text-[var(--theme-muted-2)]">
-                          {pendingProjectOverride.effectiveWorkingDirectory ??
-                            pendingProjectOverride.activeProjectPath}
+                          {preflightSummary.workingDirectory}
                         </span>
                         {pendingLaunchDiffersFromActiveProject ? (
                           <p className="rounded-xl border border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] px-3 py-2 text-xs text-[var(--theme-warning)]">
                             This mission will run in the project selected from
                             Projects, not the current active project.
+                          </p>
+                        ) : null}
+                        <div className="grid gap-2 text-xs sm:grid-cols-2">
+                          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
+                            <p className="font-semibold text-[var(--theme-muted)]">
+                              Git status
+                            </p>
+                            <p
+                              className={cn(
+                                'mt-1 font-medium',
+                                preflightSummary.gitStatusTone === 'warning'
+                                  ? 'text-[var(--theme-warning)]'
+                                  : preflightSummary.gitStatusTone === 'success'
+                                    ? 'text-emerald-700'
+                                    : 'text-[var(--theme-muted-2)]',
+                              )}
+                            >
+                              {preflightSummary.gitStatusLabel}
+                            </p>
+                          </div>
+                          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
+                            <p className="font-semibold text-[var(--theme-muted)]">
+                              Stack
+                            </p>
+                            <p className="mt-1 font-medium text-[var(--theme-text)]">
+                              {preflightSummary.stackLabel}
+                            </p>
+                          </div>
+                          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
+                            <p className="font-semibold text-[var(--theme-muted)]">
+                              Package manager
+                            </p>
+                            <p className="mt-1 font-medium text-[var(--theme-text)]">
+                              {preflightSummary.packageManagerLabel}
+                            </p>
+                          </div>
+                          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
+                            <p className="font-semibold text-[var(--theme-muted)]">
+                              Context files
+                            </p>
+                            <p className="mt-1 truncate font-medium text-[var(--theme-text)]">
+                              {preflightSummary.contextFilesLabel}
+                            </p>
+                          </div>
+                        </div>
+                        {preflightSummary.contextSummary ? (
+                          <details className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-xs">
+                            <summary className="cursor-pointer font-semibold text-[var(--theme-muted)]">
+                              Auto-context preview
+                            </summary>
+                            <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-[11px] leading-relaxed text-[var(--theme-muted-2)]">
+                              {preflightSummary.contextSummary}
+                            </pre>
+                          </details>
+                        ) : null}
+                        {preflightSummary.lastCommitLabel ? (
+                          <p className="text-xs text-[var(--theme-muted-2)]">
+                            Last commit: {preflightSummary.lastCommitLabel}
                           </p>
                         ) : null}
                       </div>

--- a/src/screens/gateway/conductor.tsx
+++ b/src/screens/gateway/conductor.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { WorkflowHelpModal } from '@/components/workflow-help-modal'
 import { Markdown } from '@/components/prompt-kit/markdown'
 import { OfficeView } from './components/office-view'
+import { MultiAgentBoard } from './components/multi-agent-board'
 import type { AgentWorkingRow } from './components/agents-working-panel'
 import { type GatewaySession } from '@/lib/gateway-api'
 import { cn } from '@/lib/utils'
@@ -2502,6 +2503,8 @@ export function Conductor({
                 hideHeader
               />
             </section>
+
+            <MultiAgentBoard />
 
             {hasMissionHistory || conductor.recentSessions.length > 0 ? (
               <section className="mt-6 w-full space-y-3">

--- a/src/screens/gateway/hooks/mission-history.test.ts
+++ b/src/screens/gateway/hooks/mission-history.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFallbackMissionProjectMetadata,
+  buildMissionHistoryEntryProjectFields,
+  filterMissionHistoryByProject,
+  summarizeProjectMissionHistory,
+  type MissionHistoryEntry,
+} from './mission-history'
+
+const baseEntry: MissionHistoryEntry = {
+  id: 'mission-1',
+  goal: 'Implement project-aware conductor history',
+  startedAt: '2026-01-01T10:00:00.000Z',
+  completedAt: '2026-01-01T10:10:00.000Z',
+  workerCount: 2,
+  totalTokens: 1234,
+  status: 'completed',
+  projectPath: null,
+}
+
+describe('mission history project attribution', () => {
+  it('stores explicit project metadata and session key on mission history entries', () => {
+    const fields = buildMissionHistoryEntryProjectFields({
+      projectMetadata: {
+        activeProjectId: 'project-alpha',
+        activeProjectName: 'Alpha',
+        activeProjectPath: '/workspace/alpha',
+        effectiveWorkingDirectory: '/workspace/alpha',
+        contextPreview: null,
+        status: null,
+      },
+      outputPath: '/workspace/alpha/dispatch-123',
+      sessionKey: ' conductor:alpha-session ',
+    })
+
+    expect(fields).toEqual({
+      projectPath: '/workspace/alpha',
+      activeProjectId: 'project-alpha',
+      activeProjectName: 'Alpha',
+      activeProjectPath: '/workspace/alpha',
+      effectiveWorkingDirectory: '/workspace/alpha',
+      outputPath: '/workspace/alpha/dispatch-123',
+      sessionKey: 'conductor:alpha-session',
+    })
+  })
+
+  it('preserves active project attribution when a mission is restored before completion', () => {
+    const metadata = buildFallbackMissionProjectMetadata({
+      configuredProjectsDir: '/fallback/projects',
+      outputPath: '/fallback/output',
+      previousMetadata: {
+        activeProjectId: 'project-beta',
+        activeProjectName: 'Beta',
+        activeProjectPath: '/workspace/beta',
+        effectiveWorkingDirectory: '/workspace/beta',
+        contextPreview: null,
+        status: null,
+      },
+    })
+
+    expect(metadata).toMatchObject({
+      activeProjectId: 'project-beta',
+      activeProjectName: 'Beta',
+      activeProjectPath: '/workspace/beta',
+      effectiveWorkingDirectory: '/workspace/beta',
+    })
+  })
+
+  it('filters mission history by project id or path for traceability', () => {
+    const entries: MissionHistoryEntry[] = [
+      {
+        ...baseEntry,
+        id: 'mission-alpha-new',
+        activeProjectId: 'project-alpha',
+        activeProjectName: 'Alpha',
+        activeProjectPath: '/workspace/alpha',
+        effectiveWorkingDirectory: '/workspace/alpha',
+        completedAt: '2026-01-01T11:00:00.000Z',
+      },
+      {
+        ...baseEntry,
+        id: 'mission-alpha-old',
+        activeProjectId: null,
+        activeProjectName: null,
+        activeProjectPath: '/workspace/alpha',
+        effectiveWorkingDirectory: '/workspace/alpha',
+        completedAt: '2026-01-01T09:00:00.000Z',
+      },
+      {
+        ...baseEntry,
+        id: 'mission-beta',
+        activeProjectId: 'project-beta',
+        activeProjectName: 'Beta',
+        activeProjectPath: '/workspace/beta',
+        effectiveWorkingDirectory: '/workspace/beta',
+      },
+    ]
+
+    expect(
+      filterMissionHistoryByProject(entries, {
+        id: 'project-alpha',
+        path: '/workspace/alpha',
+      }).map((entry) => entry.id),
+    ).toEqual(['mission-alpha-new', 'mission-alpha-old'])
+  })
+
+  it('summarizes project mission history counts and most recent mission', () => {
+    const summary = summarizeProjectMissionHistory(
+      [
+        {
+          ...baseEntry,
+          id: 'failed-latest',
+          status: 'failed',
+          activeProjectId: 'project-alpha',
+          activeProjectPath: '/workspace/alpha',
+          completedAt: '2026-01-02T10:00:00.000Z',
+        },
+        {
+          ...baseEntry,
+          id: 'completed-old',
+          status: 'completed',
+          activeProjectId: 'project-alpha',
+          activeProjectPath: '/workspace/alpha',
+          completedAt: '2026-01-01T10:00:00.000Z',
+        },
+      ],
+      { id: 'project-alpha', path: '/workspace/alpha' },
+    )
+
+    expect(summary).toEqual({
+      total: 2,
+      completed: 1,
+      failed: 1,
+      latest: expect.objectContaining({ id: 'failed-latest' }),
+    })
+  })
+})

--- a/src/screens/gateway/hooks/mission-history.ts
+++ b/src/screens/gateway/hooks/mission-history.ts
@@ -1,0 +1,261 @@
+import type { MissionProjectMetadata } from '@/routes/api/conductor-spawn'
+
+export type MissionHistoryWorkerDetail = {
+  label: string
+  model: string
+  totalTokens: number
+  personaEmoji: string
+  personaName: string
+}
+
+export type MissionHistoryEntry = {
+  id: string
+  goal: string
+  startedAt: string
+  completedAt: string
+  workerCount: number
+  totalTokens: number
+  status: 'completed' | 'failed'
+  projectPath: string | null
+  activeProjectId?: string | null
+  activeProjectName?: string | null
+  activeProjectPath?: string | null
+  effectiveWorkingDirectory?: string | null
+  outputPath?: string | null
+  sessionKey?: string | null
+  workerSummary?: Array<string>
+  outputText?: string
+  streamText?: string
+  completeSummary?: string
+  workerDetails?: Array<MissionHistoryWorkerDetail>
+  error?: string | null
+}
+
+export const HISTORY_STORAGE_KEY = 'conductor:history'
+export const MAX_HISTORY_ENTRIES = 50
+
+export function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function extractProjectPath(text: string): string | null {
+  if (!text) return null
+  const patterns = [
+    /(?:Project path|Working directory|Directory|Output path):\s*([^\n]+)/i,
+    /(\/[^\s]+(?:workspace|project|app|repo)[^\s]*)/i,
+  ]
+  for (const pattern of patterns) {
+    const match = text.match(pattern)
+    if (match?.[1]) return match[1].trim().replace(/[.,;)]$/, '')
+  }
+  return null
+}
+
+export function normalizeMissionHistoryEntry(
+  entry: MissionHistoryEntry,
+): MissionHistoryEntry {
+  const projectPath =
+    (typeof entry.projectPath === 'string' && entry.projectPath.trim()) ||
+    extractProjectPath(
+      typeof entry.projectPath === 'string' ? entry.projectPath : '',
+    ) ||
+    null
+  const outputText =
+    typeof entry.outputText === 'string' ? entry.outputText : undefined
+  const streamText =
+    typeof entry.streamText === 'string' ? entry.streamText : undefined
+  const outputPath =
+    (typeof entry.outputPath === 'string' && entry.outputPath.trim()) ||
+    extractProjectPath(
+      typeof entry.outputPath === 'string' ? entry.outputPath : '',
+    ) ||
+    projectPath ||
+    extractProjectPath(outputText ?? '') ||
+    extractProjectPath(streamText ?? '') ||
+    null
+  return {
+    ...entry,
+    projectPath,
+    activeProjectId: normalizeOptionalString(entry.activeProjectId),
+    activeProjectName: normalizeOptionalString(entry.activeProjectName),
+    activeProjectPath: normalizeOptionalString(entry.activeProjectPath),
+    effectiveWorkingDirectory:
+      normalizeOptionalString(entry.effectiveWorkingDirectory) ??
+      normalizeOptionalString(entry.activeProjectPath) ??
+      projectPath,
+    outputPath,
+    sessionKey: normalizeOptionalString(entry.sessionKey),
+    outputText,
+    streamText,
+  }
+}
+
+export function loadMissionHistory(): Array<MissionHistoryEntry> {
+  try {
+    const raw = globalThis.localStorage.getItem(HISTORY_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    const seen = new Set<string>()
+    return parsed
+      .filter((entry: unknown): entry is MissionHistoryEntry => {
+        if (!entry || typeof entry !== 'object') return false
+        const e = entry as Record<string, unknown>
+        if (
+          typeof e.id !== 'string' ||
+          typeof e.goal !== 'string' ||
+          typeof e.startedAt !== 'string'
+        )
+          return false
+        if (seen.has(e.id)) return false
+        seen.add(e.id)
+        return true
+      })
+      .map(normalizeMissionHistoryEntry)
+      .slice(0, MAX_HISTORY_ENTRIES)
+  } catch {
+    return []
+  }
+}
+
+export function appendMissionHistory(entry: MissionHistoryEntry): void {
+  try {
+    const current = loadMissionHistory()
+    // Deduplicate by id before appending
+    const filtered = current.filter((e) => e.id !== entry.id)
+    const updated = [entry, ...filtered].slice(0, MAX_HISTORY_ENTRIES)
+    globalThis.localStorage.setItem(
+      HISTORY_STORAGE_KEY,
+      JSON.stringify(updated),
+    )
+  } catch {
+    // Ignore persistence failures.
+  }
+}
+
+export function buildFallbackMissionProjectMetadata(params: {
+  configuredProjectsDir?: string
+  outputPath?: string | null
+  previousMetadata?: MissionProjectMetadata | null
+}): MissionProjectMetadata {
+  return {
+    activeProjectId: params.previousMetadata?.activeProjectId ?? null,
+    activeProjectName: params.previousMetadata?.activeProjectName ?? null,
+    activeProjectPath: params.previousMetadata?.activeProjectPath ?? null,
+    effectiveWorkingDirectory:
+      params.previousMetadata?.effectiveWorkingDirectory ??
+      normalizeOptionalString(params.configuredProjectsDir) ??
+      params.outputPath ??
+      null,
+    contextPreview: params.previousMetadata?.contextPreview ?? null,
+    status: params.previousMetadata?.status ?? null,
+  }
+}
+
+export function buildMissionHistoryEntryProjectFields(params: {
+  projectMetadata: MissionProjectMetadata
+  outputPath: string | null
+  sessionKey?: string | null
+}): Pick<
+  MissionHistoryEntry,
+  | 'projectPath'
+  | 'activeProjectId'
+  | 'activeProjectName'
+  | 'activeProjectPath'
+  | 'effectiveWorkingDirectory'
+  | 'outputPath'
+  | 'sessionKey'
+> {
+  return {
+    projectPath:
+      params.projectMetadata.activeProjectPath ??
+      params.projectMetadata.effectiveWorkingDirectory ??
+      params.outputPath,
+    activeProjectId: params.projectMetadata.activeProjectId,
+    activeProjectName: params.projectMetadata.activeProjectName,
+    activeProjectPath: params.projectMetadata.activeProjectPath,
+    effectiveWorkingDirectory: params.projectMetadata.effectiveWorkingDirectory,
+    outputPath: params.outputPath,
+    sessionKey: normalizeOptionalString(params.sessionKey),
+  }
+}
+
+type ProjectMissionHistoryTarget = {
+  id?: string | null
+  path?: string | null
+}
+
+function normalizeProjectPathForMatch(
+  value: string | null | undefined,
+): string | null {
+  const normalized = normalizeOptionalString(value)
+  return normalized ? normalized.replace(/\/+$/, '') : null
+}
+
+function missionMatchesProject(
+  entry: MissionHistoryEntry,
+  target: ProjectMissionHistoryTarget,
+): boolean {
+  const targetId = normalizeOptionalString(target.id)
+  const targetPath = normalizeProjectPathForMatch(target.path)
+  if (targetId && normalizeOptionalString(entry.activeProjectId) === targetId) {
+    return true
+  }
+  if (!targetPath) return false
+  const candidatePaths = [
+    entry.activeProjectPath,
+    entry.effectiveWorkingDirectory,
+    entry.projectPath,
+    entry.outputPath,
+  ]
+    .map(normalizeProjectPathForMatch)
+    .filter((value): value is string => value !== null)
+
+  return candidatePaths.some(
+    (candidate) =>
+      candidate === targetPath || candidate.startsWith(`${targetPath}/`),
+  )
+}
+
+function compareMissionHistoryRecency(
+  left: MissionHistoryEntry,
+  right: MissionHistoryEntry,
+): number {
+  const leftMs = new Date(left.completedAt || left.startedAt).getTime()
+  const rightMs = new Date(right.completedAt || right.startedAt).getTime()
+  return (
+    (Number.isFinite(rightMs) ? rightMs : 0) -
+    (Number.isFinite(leftMs) ? leftMs : 0)
+  )
+}
+
+export function filterMissionHistoryByProject(
+  entries: Array<MissionHistoryEntry>,
+  target: ProjectMissionHistoryTarget,
+): Array<MissionHistoryEntry> {
+  return entries
+    .map(normalizeMissionHistoryEntry)
+    .filter((entry) => missionMatchesProject(entry, target))
+    .sort(compareMissionHistoryRecency)
+}
+
+export type ProjectMissionHistorySummary = {
+  total: number
+  completed: number
+  failed: number
+  latest: MissionHistoryEntry | null
+}
+
+export function summarizeProjectMissionHistory(
+  entries: Array<MissionHistoryEntry>,
+  target: ProjectMissionHistoryTarget,
+): ProjectMissionHistorySummary {
+  const projectEntries = filterMissionHistoryByProject(entries, target)
+  return {
+    total: projectEntries.length,
+    completed: projectEntries.filter((entry) => entry.status === 'completed')
+      .length,
+    failed: projectEntries.filter((entry) => entry.status === 'failed').length,
+    latest: projectEntries[0] ?? null,
+  }
+}

--- a/src/screens/gateway/hooks/use-conductor-gateway.test.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.test.ts
@@ -23,6 +23,8 @@ describe('buildMissionProjectMetadata', () => {
       activeProjectName: 'demo-app',
       activeProjectPath: '/workspace/demo-app',
       effectiveWorkingDirectory: '/workspace/demo-app',
+      contextPreview: null,
+      status: null,
     })
   })
 
@@ -41,6 +43,8 @@ describe('buildMissionProjectMetadata', () => {
       activeProjectName: 'demo-app',
       activeProjectPath: '/workspace/demo-app',
       effectiveWorkingDirectory: '/custom/workdir',
+      contextPreview: null,
+      status: null,
     })
   })
 })

--- a/src/screens/gateway/hooks/use-conductor-gateway.test.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { buildMissionProjectMetadata } from '@/routes/api/conductor-spawn'
+
+describe('buildMissionProjectMetadata', () => {
+  it('uses explicit project override as effective working directory', () => {
+    const metadata = buildMissionProjectMetadata({
+      activeProject: {
+        id: 'current',
+        name: 'current-app',
+        path: '/workspace/current-app',
+      },
+      projectsDir: '',
+      override: {
+        activeProjectId: 'project-1',
+        activeProjectName: 'demo-app',
+        activeProjectPath: '/workspace/demo-app',
+        effectiveWorkingDirectory: '/workspace/demo-app',
+      },
+    })
+
+    expect(metadata).toEqual({
+      activeProjectId: 'project-1',
+      activeProjectName: 'demo-app',
+      activeProjectPath: '/workspace/demo-app',
+      effectiveWorkingDirectory: '/workspace/demo-app',
+    })
+  })
+
+  it('falls back from active project path to configured project directory', () => {
+    const metadata = buildMissionProjectMetadata({
+      activeProject: {
+        id: 'project-1',
+        name: 'demo-app',
+        path: '/workspace/demo-app',
+      },
+      projectsDir: '/custom/workdir',
+    })
+
+    expect(metadata).toEqual({
+      activeProjectId: 'project-1',
+      activeProjectName: 'demo-app',
+      activeProjectPath: '/workspace/demo-app',
+      effectiveWorkingDirectory: '/custom/workdir',
+    })
+  })
+})

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -4,6 +4,16 @@ import type { Dispatch, SetStateAction } from 'react'
 import type { MissionProjectMetadata } from '@/routes/api/conductor-spawn'
 import type { GatewaySession } from '@/lib/gateway-api'
 import { fetchSessions } from '@/lib/gateway-api'
+import {
+  appendMissionHistory,
+  buildFallbackMissionProjectMetadata,
+  buildMissionHistoryEntryProjectFields,
+  loadMissionHistory,
+  HISTORY_STORAGE_KEY,
+  MAX_HISTORY_ENTRIES,
+  type MissionHistoryEntry,
+  type MissionHistoryWorkerDetail,
+} from './mission-history'
 
 type HistoryMessagePart = {
   type?: string
@@ -132,39 +142,6 @@ export type ConductorTask = {
   workerKey: string | null
   output: string | null
 }
-
-export type MissionHistoryWorkerDetail = {
-  label: string
-  model: string
-  totalTokens: number
-  personaEmoji: string
-  personaName: string
-}
-
-export type MissionHistoryEntry = {
-  id: string
-  goal: string
-  startedAt: string
-  completedAt: string
-  workerCount: number
-  totalTokens: number
-  status: 'completed' | 'failed'
-  projectPath: string | null
-  activeProjectId?: string | null
-  activeProjectName?: string | null
-  activeProjectPath?: string | null
-  effectiveWorkingDirectory?: string | null
-  outputPath?: string | null
-  workerSummary?: string[]
-  outputText?: string
-  streamText?: string
-  completeSummary?: string
-  workerDetails?: MissionHistoryWorkerDetail[]
-  error?: string | null
-}
-
-const HISTORY_STORAGE_KEY = 'conductor:history'
-const MAX_HISTORY_ENTRIES = 50
 
 const AGENT_NAMES = [
   'Nova',
@@ -477,87 +454,6 @@ function persistConductorSettings(settings: ConductorSettings): void {
     globalThis.localStorage?.setItem(
       CONDUCTOR_SETTINGS_STORAGE_KEY,
       JSON.stringify(settings),
-    )
-  } catch {
-    // Ignore persistence failures.
-  }
-}
-
-function normalizeOptionalString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function loadMissionHistory(): MissionHistoryEntry[] {
-  try {
-    const raw = globalThis.localStorage?.getItem(HISTORY_STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return []
-    const seen = new Set<string>()
-    return parsed
-      .filter((entry: unknown): entry is MissionHistoryEntry => {
-        if (!entry || typeof entry !== 'object') return false
-        const e = entry as Record<string, unknown>
-        if (
-          typeof e.id !== 'string' ||
-          typeof e.goal !== 'string' ||
-          typeof e.startedAt !== 'string'
-        )
-          return false
-        if (seen.has(e.id)) return false
-        seen.add(e.id)
-        return true
-      })
-      .map((entry) => {
-        const projectPath =
-          (typeof entry.projectPath === 'string' && entry.projectPath.trim()) ||
-          extractProjectPath(
-            typeof entry.projectPath === 'string' ? entry.projectPath : '',
-          ) ||
-          null
-        const outputText =
-          typeof entry.outputText === 'string' ? entry.outputText : undefined
-        const streamText =
-          typeof entry.streamText === 'string' ? entry.streamText : undefined
-        const outputPath =
-          (typeof entry.outputPath === 'string' && entry.outputPath.trim()) ||
-          extractProjectPath(
-            typeof entry.outputPath === 'string' ? entry.outputPath : '',
-          ) ||
-          projectPath ||
-          extractProjectPath(outputText ?? '') ||
-          extractProjectPath(streamText ?? '') ||
-          null
-        return {
-          ...entry,
-          projectPath,
-          activeProjectId: normalizeOptionalString(entry.activeProjectId),
-          activeProjectName: normalizeOptionalString(entry.activeProjectName),
-          activeProjectPath: normalizeOptionalString(entry.activeProjectPath),
-          effectiveWorkingDirectory:
-            normalizeOptionalString(entry.effectiveWorkingDirectory) ??
-            normalizeOptionalString(entry.activeProjectPath) ??
-            projectPath,
-          outputPath,
-          outputText,
-          streamText,
-        }
-      })
-      .slice(0, MAX_HISTORY_ENTRIES)
-  } catch {
-    return []
-  }
-}
-
-function appendMissionHistory(entry: MissionHistoryEntry): void {
-  try {
-    const current = loadMissionHistory()
-    // Deduplicate by id before appending
-    const filtered = current.filter((e) => e.id !== entry.id)
-    const updated = [entry, ...filtered].slice(0, MAX_HISTORY_ENTRIES)
-    globalThis.localStorage?.setItem(
-      HISTORY_STORAGE_KEY,
-      JSON.stringify(updated),
     )
   } catch {
     // Ignore persistence failures.
@@ -1669,13 +1565,11 @@ export function useConductorGateway() {
         personaName: persona.name,
       }
     })
-    const projectMetadata = missionProjectMetadata ?? {
-      activeProjectId: null,
-      activeProjectName: null,
-      activeProjectPath: null,
-      effectiveWorkingDirectory:
-        normalizeOptionalString(conductorSettings.projectsDir) ?? outputPath,
-    }
+    const projectMetadata = buildFallbackMissionProjectMetadata({
+      configuredProjectsDir: conductorSettings.projectsDir,
+      outputPath,
+      previousMetadata: missionProjectMetadata,
+    })
     const entry: MissionHistoryEntry = {
       id: missionHistoryId,
       goal,
@@ -1684,12 +1578,11 @@ export function useConductorGateway() {
       workerCount: workers.length,
       totalTokens,
       status: streamError ? 'failed' : 'completed',
-      projectPath: projectMetadata.activeProjectPath ?? outputPath,
-      activeProjectId: projectMetadata.activeProjectId,
-      activeProjectName: projectMetadata.activeProjectName,
-      activeProjectPath: projectMetadata.activeProjectPath,
-      effectiveWorkingDirectory: projectMetadata.effectiveWorkingDirectory,
-      outputPath,
+      ...buildMissionHistoryEntryProjectFields({
+        projectMetadata,
+        outputPath,
+        sessionKey: orchestratorSessionKey,
+      }),
       workerSummary: workerSummary.length > 0 ? workerSummary : undefined,
       outputText: outputText || undefined,
       streamText: streamText ? streamText.slice(0, 5000) : undefined,
@@ -1726,6 +1619,7 @@ export function useConductorGateway() {
     streamText,
     missionProjectMetadata,
     conductorSettings.projectsDir,
+    orchestratorSessionKey,
   ])
 
   useEffect(() => {

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import type { Dispatch, SetStateAction } from 'react'
+import type { MissionProjectMetadata } from '@/routes/api/conductor-spawn'
 import type { GatewaySession } from '@/lib/gateway-api'
 import { fetchSessions } from '@/lib/gateway-api'
 
@@ -97,7 +98,12 @@ type ConductorSpawnResponse = {
   jobId?: string | null
   jobName?: string | null
   runId?: string | null
+  project?: MissionProjectMetadata | null
   error?: string
+}
+
+type SendMissionOptions = {
+  projectOverride?: MissionProjectMetadata | null
 }
 
 type PortableStreamResult = {
@@ -144,6 +150,10 @@ export type MissionHistoryEntry = {
   totalTokens: number
   status: 'completed' | 'failed'
   projectPath: string | null
+  activeProjectId?: string | null
+  activeProjectName?: string | null
+  activeProjectPath?: string | null
+  effectiveWorkingDirectory?: string | null
   outputPath?: string | null
   workerSummary?: string[]
   outputText?: string
@@ -156,7 +166,16 @@ export type MissionHistoryEntry = {
 const HISTORY_STORAGE_KEY = 'conductor:history'
 const MAX_HISTORY_ENTRIES = 50
 
-const AGENT_NAMES = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
+const AGENT_NAMES = [
+  'Nova',
+  'Pixel',
+  'Blaze',
+  'Echo',
+  'Sage',
+  'Drift',
+  'Flux',
+  'Volt',
+]
 const AGENT_EMOJIS = ['🤖', '⚡', '🔥', '🌊', '🌿', '💫', '🔮', '⭐']
 
 function getAgentPersona(index: number) {
@@ -168,7 +187,11 @@ function getAgentPersona(index: number) {
 
 function extractTasksFromPlan(planText: string): ConductorTask[] {
   const tasks: ConductorTask[] = []
-  const patterns = [/^\s*(\d+)\.\s+(.+)$/gm, /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm, /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm]
+  const patterns = [
+    /^\s*(\d+)\.\s+(.+)$/gm,
+    /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm,
+    /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm,
+  ]
 
   const seen = new Set<string>()
   for (const pattern of patterns) {
@@ -200,7 +223,9 @@ function extractTasksFromPlan(planText: string): ConductorTask[] {
 }
 
 function readString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null
 }
 
 function readNumber(value: unknown): number | null {
@@ -224,7 +249,11 @@ function toIso(value: unknown): string | null {
 }
 
 function normalizeMatchText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 function getSessionSearchText(session: GatewaySession): string {
@@ -252,13 +281,16 @@ function sessionMatchesMissionContext(
   missionStartMs: number,
   missionNeedles: string[],
 ): boolean {
-  const createdAt = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
+  const createdAt = toIso(
+    session.createdAt ?? session.startedAt ?? session.updatedAt,
+  )
   if (!createdAt) return false
 
   const createdMs = new Date(createdAt).getTime()
   if (!Number.isFinite(createdMs) || createdMs < missionStartMs) return false
 
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
   if (totalTokens <= 0) return false
 
   const text = normalizeMatchText(getSessionSearchText(session))
@@ -280,20 +312,56 @@ function loadPersistedMission(): PersistedMission | null {
     const missionJobId = readString(parsed.missionJobId)
     const goal = typeof parsed.goal === 'string' ? parsed.goal : null
     const phase = parsed.phase
-    const streamText = typeof parsed.streamText === 'string' ? parsed.streamText : null
-    const planText = typeof parsed.planText === 'string' ? parsed.planText : null
-    const workerKeys = Array.isArray(parsed.workerKeys) ? parsed.workerKeys.filter((value): value is string => typeof value === 'string') : null
-    const workerLabels = Array.isArray(parsed.workerLabels) ? parsed.workerLabels.filter((value): value is string => typeof value === 'string') : null
+    const streamText =
+      typeof parsed.streamText === 'string' ? parsed.streamText : null
+    const planText =
+      typeof parsed.planText === 'string' ? parsed.planText : null
+    const workerKeys = Array.isArray(parsed.workerKeys)
+      ? parsed.workerKeys.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : null
+    const workerLabels = Array.isArray(parsed.workerLabels)
+      ? parsed.workerLabels.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : null
     const workerOutputs =
-      parsed.workerOutputs && typeof parsed.workerOutputs === 'object' && !Array.isArray(parsed.workerOutputs)
-        ? Object.fromEntries(Object.entries(parsed.workerOutputs as Record<string, unknown>).filter((entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'))
+      parsed.workerOutputs &&
+      typeof parsed.workerOutputs === 'object' &&
+      !Array.isArray(parsed.workerOutputs)
+        ? Object.fromEntries(
+            Object.entries(
+              parsed.workerOutputs as Record<string, unknown>,
+            ).filter(
+              (entry): entry is [string, string] =>
+                typeof entry[0] === 'string' && typeof entry[1] === 'string',
+            ),
+          )
         : {}
-    const missionStartedAt = parsed.missionStartedAt === null || parsed.missionStartedAt === undefined ? null : toIso(parsed.missionStartedAt)
+    const missionStartedAt =
+      parsed.missionStartedAt === null || parsed.missionStartedAt === undefined
+        ? null
+        : toIso(parsed.missionStartedAt)
     const isPaused = parsed.isPaused === true
-    const pausedElapsedMs = typeof parsed.pausedElapsedMs === 'number' && Number.isFinite(parsed.pausedElapsedMs) ? Math.max(0, parsed.pausedElapsedMs) : 0
-    const accumulatedPausedMs = typeof parsed.accumulatedPausedMs === 'number' && Number.isFinite(parsed.accumulatedPausedMs) ? Math.max(0, parsed.accumulatedPausedMs) : 0
-    const pauseStartedAt = parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined ? null : toIso(parsed.pauseStartedAt)
-    const completedAt = parsed.completedAt === null || parsed.completedAt === undefined ? null : toIso(parsed.completedAt)
+    const pausedElapsedMs =
+      typeof parsed.pausedElapsedMs === 'number' &&
+      Number.isFinite(parsed.pausedElapsedMs)
+        ? Math.max(0, parsed.pausedElapsedMs)
+        : 0
+    const accumulatedPausedMs =
+      typeof parsed.accumulatedPausedMs === 'number' &&
+      Number.isFinite(parsed.accumulatedPausedMs)
+        ? Math.max(0, parsed.accumulatedPausedMs)
+        : 0
+    const pauseStartedAt =
+      parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined
+        ? null
+        : toIso(parsed.pauseStartedAt)
+    const completedAt =
+      parsed.completedAt === null || parsed.completedAt === undefined
+        ? null
+        : toIso(parsed.completedAt)
     const tasks = Array.isArray(parsed.tasks)
       ? parsed.tasks
           .map((task): ConductorTask | null => {
@@ -302,7 +370,14 @@ function loadPersistedMission(): PersistedMission | null {
             const id = readString(record.id)
             const title = readString(record.title)
             const status = record.status
-            if (!id || !title || (status !== 'pending' && status !== 'running' && status !== 'complete' && status !== 'failed')) {
+            if (
+              !id ||
+              !title ||
+              (status !== 'pending' &&
+                status !== 'running' &&
+                status !== 'complete' &&
+                status !== 'failed')
+            ) {
               return null
             }
 
@@ -310,14 +385,30 @@ function loadPersistedMission(): PersistedMission | null {
               id,
               title,
               status,
-              workerKey: record.workerKey === null || record.workerKey === undefined ? null : readString(record.workerKey),
-              output: record.output === null || record.output === undefined ? null : readString(record.output),
+              workerKey:
+                record.workerKey === null || record.workerKey === undefined
+                  ? null
+                  : readString(record.workerKey),
+              output:
+                record.output === null || record.output === undefined
+                  ? null
+                  : readString(record.output),
             }
           })
           .filter((task): task is ConductorTask => task !== null)
       : []
 
-    if (!goal || (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') || streamText === null || planText === null || !workerKeys || !workerLabels) {
+    if (
+      !goal ||
+      (phase !== 'idle' &&
+        phase !== 'decomposing' &&
+        phase !== 'running' &&
+        phase !== 'complete') ||
+      streamText === null ||
+      planText === null ||
+      !workerKeys ||
+      !workerLabels
+    ) {
       return null
     }
     return {
@@ -349,11 +440,32 @@ function loadConductorSettings(): ConductorSettings {
     if (!raw) return DEFAULT_CONDUCTOR_SETTINGS
     const parsed = JSON.parse(raw) as Record<string, unknown>
     return {
-      orchestratorModel: typeof parsed.orchestratorModel === 'string' ? parsed.orchestratorModel : DEFAULT_CONDUCTOR_SETTINGS.orchestratorModel,
-      workerModel: typeof parsed.workerModel === 'string' ? parsed.workerModel : DEFAULT_CONDUCTOR_SETTINGS.workerModel,
-      projectsDir: typeof parsed.projectsDir === 'string' ? parsed.projectsDir : DEFAULT_CONDUCTOR_SETTINGS.projectsDir,
-      maxParallel: Math.min(5, Math.max(1, typeof parsed.maxParallel === 'number' && Number.isFinite(parsed.maxParallel) ? Math.round(parsed.maxParallel) : DEFAULT_CONDUCTOR_SETTINGS.maxParallel)),
-      supervised: typeof parsed.supervised === 'boolean' ? parsed.supervised : DEFAULT_CONDUCTOR_SETTINGS.supervised,
+      orchestratorModel:
+        typeof parsed.orchestratorModel === 'string'
+          ? parsed.orchestratorModel
+          : DEFAULT_CONDUCTOR_SETTINGS.orchestratorModel,
+      workerModel:
+        typeof parsed.workerModel === 'string'
+          ? parsed.workerModel
+          : DEFAULT_CONDUCTOR_SETTINGS.workerModel,
+      projectsDir:
+        typeof parsed.projectsDir === 'string'
+          ? parsed.projectsDir
+          : DEFAULT_CONDUCTOR_SETTINGS.projectsDir,
+      maxParallel: Math.min(
+        5,
+        Math.max(
+          1,
+          typeof parsed.maxParallel === 'number' &&
+            Number.isFinite(parsed.maxParallel)
+            ? Math.round(parsed.maxParallel)
+            : DEFAULT_CONDUCTOR_SETTINGS.maxParallel,
+        ),
+      ),
+      supervised:
+        typeof parsed.supervised === 'boolean'
+          ? parsed.supervised
+          : DEFAULT_CONDUCTOR_SETTINGS.supervised,
     }
   } catch {
     return DEFAULT_CONDUCTOR_SETTINGS
@@ -362,10 +474,17 @@ function loadConductorSettings(): ConductorSettings {
 
 function persistConductorSettings(settings: ConductorSettings): void {
   try {
-    globalThis.localStorage?.setItem(CONDUCTOR_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+    globalThis.localStorage?.setItem(
+      CONDUCTOR_SETTINGS_STORAGE_KEY,
+      JSON.stringify(settings),
+    )
   } catch {
     // Ignore persistence failures.
   }
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
 function loadMissionHistory(): MissionHistoryEntry[] {
@@ -379,18 +498,32 @@ function loadMissionHistory(): MissionHistoryEntry[] {
       .filter((entry: unknown): entry is MissionHistoryEntry => {
         if (!entry || typeof entry !== 'object') return false
         const e = entry as Record<string, unknown>
-        if (typeof e.id !== 'string' || typeof e.goal !== 'string' || typeof e.startedAt !== 'string') return false
+        if (
+          typeof e.id !== 'string' ||
+          typeof e.goal !== 'string' ||
+          typeof e.startedAt !== 'string'
+        )
+          return false
         if (seen.has(e.id)) return false
         seen.add(e.id)
         return true
       })
       .map((entry) => {
-        const projectPath = (typeof entry.projectPath === 'string' && entry.projectPath.trim()) || extractProjectPath(typeof entry.projectPath === 'string' ? entry.projectPath : '') || null
-        const outputText = typeof entry.outputText === 'string' ? entry.outputText : undefined
-        const streamText = typeof entry.streamText === 'string' ? entry.streamText : undefined
+        const projectPath =
+          (typeof entry.projectPath === 'string' && entry.projectPath.trim()) ||
+          extractProjectPath(
+            typeof entry.projectPath === 'string' ? entry.projectPath : '',
+          ) ||
+          null
+        const outputText =
+          typeof entry.outputText === 'string' ? entry.outputText : undefined
+        const streamText =
+          typeof entry.streamText === 'string' ? entry.streamText : undefined
         const outputPath =
           (typeof entry.outputPath === 'string' && entry.outputPath.trim()) ||
-          extractProjectPath(typeof entry.outputPath === 'string' ? entry.outputPath : '') ||
+          extractProjectPath(
+            typeof entry.outputPath === 'string' ? entry.outputPath : '',
+          ) ||
           projectPath ||
           extractProjectPath(outputText ?? '') ||
           extractProjectPath(streamText ?? '') ||
@@ -398,6 +531,13 @@ function loadMissionHistory(): MissionHistoryEntry[] {
         return {
           ...entry,
           projectPath,
+          activeProjectId: normalizeOptionalString(entry.activeProjectId),
+          activeProjectName: normalizeOptionalString(entry.activeProjectName),
+          activeProjectPath: normalizeOptionalString(entry.activeProjectPath),
+          effectiveWorkingDirectory:
+            normalizeOptionalString(entry.effectiveWorkingDirectory) ??
+            normalizeOptionalString(entry.activeProjectPath) ??
+            projectPath,
           outputPath,
           outputText,
           streamText,
@@ -415,7 +555,10 @@ function appendMissionHistory(entry: MissionHistoryEntry): void {
     // Deduplicate by id before appending
     const filtered = current.filter((e) => e.id !== entry.id)
     const updated = [entry, ...filtered].slice(0, MAX_HISTORY_ENTRIES)
-    globalThis.localStorage?.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
+    globalThis.localStorage?.setItem(
+      HISTORY_STORAGE_KEY,
+      JSON.stringify(updated),
+    )
   } catch {
     // Ignore persistence failures.
   }
@@ -423,7 +566,10 @@ function appendMissionHistory(entry: MissionHistoryEntry): void {
 
 function persistMission(state: PersistedMission): void {
   try {
-    globalThis.localStorage?.setItem(ACTIVE_MISSION_STORAGE_KEY, JSON.stringify(state))
+    globalThis.localStorage?.setItem(
+      ACTIVE_MISSION_STORAGE_KEY,
+      JSON.stringify(state),
+    )
   } catch {
     // Ignore persistence failures.
   }
@@ -450,27 +596,48 @@ function readContextTokens(session: GatewaySession): number {
     readNumber(session.contextTokens) ??
     readNumber(session.maxTokens) ??
     readNumber(session.contextWindow) ??
-    readNumber(session.usage && typeof session.usage === 'object' ? (session.usage as Record<string, unknown>).contextTokens : null) ??
+    readNumber(
+      session.usage && typeof session.usage === 'object'
+        ? (session.usage as Record<string, unknown>).contextTokens
+        : null,
+    ) ??
     0
   )
 }
 
-function deriveWorkerStatus(session: GatewaySession, updatedAt: string | null): ConductorWorker['status'] {
+function deriveWorkerStatus(
+  session: GatewaySession,
+  updatedAt: string | null,
+): ConductorWorker['status'] {
   const status = readString(session.status)?.toLowerCase()
-  if (status && ['complete', 'completed', 'done', 'success', 'succeeded'].includes(status)) return 'complete'
+  if (
+    status &&
+    ['complete', 'completed', 'done', 'success', 'succeeded'].includes(status)
+  )
+    return 'complete'
   if (status && ['idle', 'waiting', 'sleeping'].includes(status)) return 'idle'
-  if (status && ['error', 'errored', 'failed', 'cancelled', 'canceled', 'killed'].includes(status)) return 'stale'
+  if (
+    status &&
+    ['error', 'errored', 'failed', 'cancelled', 'canceled', 'killed'].includes(
+      status,
+    )
+  )
+    return 'stale'
 
   const updatedMs = updatedAt ? new Date(updatedAt).getTime() : 0
   const staleness = updatedMs > 0 ? Date.now() - updatedMs : 0
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
 
   if (totalTokens > 0 && staleness > 10_000) return 'complete'
   if (staleness > 120_000) return 'stale'
   return 'running'
 }
 
-function workersLookComplete(workers: ConductorWorker[], staleAfterMs: number): boolean {
+function workersLookComplete(
+  workers: ConductorWorker[],
+  staleAfterMs: number,
+): boolean {
   if (workers.length === 0) return false
 
   return workers.every((worker) => {
@@ -514,7 +681,8 @@ function formatDisplayName(session: GatewaySession): string {
 }
 
 function formatTokenUsage(totalTokens: number, contextTokens: number): string {
-  if (contextTokens > 0) return `${totalTokens.toLocaleString()} / ${contextTokens.toLocaleString()} tok`
+  if (contextTokens > 0)
+    return `${totalTokens.toLocaleString()} / ${contextTokens.toLocaleString()} tok`
   return `${totalTokens.toLocaleString()} tok`
 }
 
@@ -522,8 +690,11 @@ function toWorker(session: GatewaySession): ConductorWorker | null {
   const key = readString(session.key)
   if (!key) return null
   const label = readString(session.label) ?? 'worker'
-  const updatedAt = toIso(session.updatedAt ?? session.startedAt ?? session.createdAt)
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const updatedAt = toIso(
+    session.updatedAt ?? session.startedAt ?? session.createdAt,
+  )
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
   const contextTokens = readContextTokens(session)
 
   return {
@@ -540,7 +711,9 @@ function toWorker(session: GatewaySession): ConductorWorker | null {
   }
 }
 
-function extractHistoryMessageText(message: HistoryMessage | undefined): string {
+function extractHistoryMessageText(
+  message: HistoryMessage | undefined,
+): string {
   if (!message) return ''
   if (typeof message.content === 'string') return message.content
   if (Array.isArray(message.content)) {
@@ -552,7 +725,9 @@ function extractHistoryMessageText(message: HistoryMessage | undefined): string 
   return ''
 }
 
-function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string {
+function getLastAssistantMessage(
+  messages: HistoryMessage[] | undefined,
+): string {
   if (!Array.isArray(messages)) return ''
   // Return the longest assistant message so we prefer the substantive work output.
   let best = ''
@@ -565,12 +740,18 @@ function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string
   return best
 }
 
-function readMissionLines(mission: ConductorMissionRecord | null | undefined): string[] {
+function readMissionLines(
+  mission: ConductorMissionRecord | null | undefined,
+): string[] {
   if (!Array.isArray(mission?.lines)) return []
-  return mission.lines.filter((line): line is string => typeof line === 'string')
+  return mission.lines.filter(
+    (line): line is string => typeof line === 'string',
+  )
 }
 
-function extractSessionIdFromMission(mission: ConductorMissionRecord | null | undefined): string | null {
+function extractSessionIdFromMission(
+  mission: ConductorMissionRecord | null | undefined,
+): string | null {
   const direct = readString(mission?.session_id)
   if (direct) return direct
 
@@ -591,14 +772,28 @@ function formatMissionLog(lines: string[]): string {
 }
 
 function isFailedMissionStatus(status: string | null): boolean {
-  return status === 'failed' || status === 'error' || status === 'errored' || status === 'cancelled' || status === 'canceled'
+  return (
+    status === 'failed' ||
+    status === 'error' ||
+    status === 'errored' ||
+    status === 'cancelled' ||
+    status === 'canceled'
+  )
 }
 
-async function fetchConductorMission(missionId: string): Promise<ConductorMissionRecord> {
-  const response = await fetch(`/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`)
-  const payload = (await response.json().catch(() => ({}))) as ConductorMissionResponse
+async function fetchConductorMission(
+  missionId: string,
+): Promise<ConductorMissionRecord> {
+  const response = await fetch(
+    `/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`,
+  )
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ConductorMissionResponse
   if (!response.ok || !payload.ok || !payload.mission) {
-    throw new Error(payload.error || `Failed to load conductor mission ${missionId}`)
+    throw new Error(
+      payload.error || `Failed to load conductor mission ${missionId}`,
+    )
   }
   return payload.mission
 }
@@ -637,8 +832,20 @@ function extractProjectPath(text: string): string | null {
   return null
 }
 
-function buildMissionOutputPath(workers: ConductorWorker[], workerOutputs: Record<string, string>, tasks: ConductorTask[], streamText: string): string | null {
-  const workerOutputTexts = [...Object.values(workerOutputs), ...workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(Boolean)
+function buildMissionOutputPath(
+  workers: ConductorWorker[],
+  workerOutputs: Record<string, string>,
+  tasks: ConductorTask[],
+  streamText: string,
+): string | null {
+  const workerOutputTexts = [
+    ...Object.values(workerOutputs),
+    ...workers.map((worker) =>
+      getLastAssistantMessage(
+        worker.raw.messages as HistoryMessage[] | undefined,
+      ),
+    ),
+  ].filter(Boolean)
 
   for (const text of workerOutputTexts) {
     const extractedPath = extractProjectPath(text)
@@ -659,7 +866,9 @@ function buildMissionOutputPath(workers: ConductorWorker[], workerOutputs: Recor
 
 function summarizeWorkers(workers: ConductorWorker[]): string[] {
   return workers.map((worker) => {
-    const output = getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
+    const output = getLastAssistantMessage(
+      worker.raw.messages as HistoryMessage[] | undefined,
+    )
     const firstLine = output
       .split(/\n+/)
       .map((line) => line.trim())
@@ -678,18 +887,41 @@ function buildCompleteSummary(params: {
   totalTokens: number
   outputPath: string | null
 }): string {
-  const { goal, streamError, missionStartedAt, completedAt, totalWorkers, totalTokens, outputPath } = params
-  const durationMs = Math.max(0, new Date(completedAt).getTime() - new Date(missionStartedAt).getTime())
+  const {
+    goal,
+    streamError,
+    missionStartedAt,
+    completedAt,
+    totalWorkers,
+    totalTokens,
+    outputPath,
+  } = params
+  const durationMs = Math.max(
+    0,
+    new Date(completedAt).getTime() - new Date(missionStartedAt).getTime(),
+  )
   const totalSeconds = Math.floor(durationMs / 1000)
   const hours = Math.floor(totalSeconds / 3600)
   const minutes = Math.floor((totalSeconds % 3600) / 60)
   const seconds = totalSeconds % 60
-  const duration = hours > 0 ? `${hours}h ${minutes}m ${seconds}s` : minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
+  const duration =
+    hours > 0
+      ? `${hours}h ${minutes}m ${seconds}s`
+      : minutes > 0
+        ? `${minutes}m ${seconds}s`
+        : `${seconds}s`
 
-  const lines = [streamError ? `❌ ${streamError}` : '✅ Mission completed successfully', '', `**Goal:** ${goal}`, `**Duration:** ${duration}`]
+  const lines = [
+    streamError ? `❌ ${streamError}` : '✅ Mission completed successfully',
+    '',
+    `**Goal:** ${goal}`,
+    `**Duration:** ${duration}`,
+  ]
 
   if (totalWorkers > 0) {
-    lines.push(`**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`)
+    lines.push(
+      `**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`,
+    )
   }
 
   if (outputPath) {
@@ -699,10 +931,19 @@ function buildCompleteSummary(params: {
   return lines.join('\n')
 }
 
-function buildMissionOutputText(workers: ConductorWorker[], workerOutputs: Record<string, string>, streamText: string): string {
+function buildMissionOutputText(
+  workers: ConductorWorker[],
+  workerOutputs: Record<string, string>,
+  streamText: string,
+): string {
   const workerSections = workers
     .map((worker) => {
-      const output = (workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).trim()
+      const output = (
+        workerOutputs[worker.key] ??
+        getLastAssistantMessage(
+          worker.raw.messages as HistoryMessage[] | undefined,
+        )
+      ).trim()
       if (!output) return null
       return `### ${worker.displayName}\n\n${output}`
     })
@@ -715,8 +956,13 @@ function buildMissionOutputText(workers: ConductorWorker[], workerOutputs: Recor
   return streamText.trim().slice(0, 5000)
 }
 
-async function fetchWorkerOutput(sessionKey: string, limit = 5): Promise<string> {
-  const response = await fetch(`/api/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=${limit}`)
+async function fetchWorkerOutput(
+  sessionKey: string,
+  limit = 5,
+): Promise<string> {
+  const response = await fetch(
+    `/api/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=${limit}`,
+  )
   const payload = (await response.json().catch(() => ({}))) as HistoryResponse
   if (!response.ok) {
     throw new Error(payload.error || `Failed to load history for ${sessionKey}`)
@@ -731,7 +977,11 @@ function appendStreamEvent(
   update((current) => [...current.slice(-99), event])
 }
 
-function readStreamText(event: string, payload: Record<string, unknown>, currentText: string): string | null {
+function readStreamText(
+  event: string,
+  payload: Record<string, unknown>,
+  currentText: string,
+): string | null {
   if (event !== 'chunk' && event !== 'assistant') return null
   const text =
     readString(payload.delta) ??
@@ -739,7 +989,9 @@ function readStreamText(event: string, payload: Record<string, unknown>, current
     readString(payload.content) ??
     readString(payload.chunk)
   if (!text) return null
-  return payload.fullReplace === true || event === 'assistant' ? text : currentText + text
+  return payload.fullReplace === true || event === 'assistant'
+    ? text
+    : currentText + text
 }
 
 function readDoneMessageText(payload: Record<string, unknown>): string {
@@ -767,7 +1019,10 @@ async function streamPortableConductorMission(params: {
       history: [],
       idempotencyKey: crypto.randomUUID(),
       model: params.model || undefined,
-      locale: typeof window !== 'undefined' ? localStorage.getItem('hermes-workspace-locale') || 'en' : 'en',
+      locale:
+        typeof window !== 'undefined'
+          ? localStorage.getItem('hermes-workspace-locale') || 'en'
+          : 'en',
     }),
     signal: params.signal,
   })
@@ -777,7 +1032,8 @@ async function streamPortableConductorMission(params: {
     throw new Error(text || `Conductor stream failed (${response.status})`)
   }
 
-  let sessionKey = response.headers.get('x-hermes-session-key')?.trim() || params.sessionKey
+  let sessionKey =
+    response.headers.get('x-hermes-session-key')?.trim() || params.sessionKey
   let runId: string | null = null
   let accumulated = ''
   let sawDone = false
@@ -785,7 +1041,8 @@ async function streamPortableConductorMission(params: {
   params.onSessionResolved(sessionKey, runId)
 
   const reader = response.body?.getReader()
-  if (!reader) throw new Error('Conductor stream did not include a response body')
+  if (!reader)
+    throw new Error('Conductor stream did not include a response body')
 
   const decoder = new TextDecoder()
   let buffer = ''
@@ -828,7 +1085,11 @@ async function streamPortableConductorMission(params: {
         runId = readString(payload.runId) ?? runId
         sessionKey = readString(payload.sessionKey) ?? sessionKey
         params.onSessionResolved(sessionKey, runId)
-        params.onStreamEvent({ type: 'started', runId: runId ?? undefined, sessionKey })
+        params.onStreamEvent({
+          type: 'started',
+          runId: runId ?? undefined,
+          sessionKey,
+        })
         continue
       }
 
@@ -855,7 +1116,10 @@ async function streamPortableConductorMission(params: {
       if (event === 'done' || event === 'complete') {
         sawDone = true
         const state = readString(payload.state) ?? undefined
-        const message = readString(payload.errorMessage) ?? readString(payload.message) ?? undefined
+        const message =
+          readString(payload.errorMessage) ??
+          readString(payload.message) ??
+          undefined
         const finalText = readDoneMessageText(payload)
         if (!accumulated && finalText) {
           accumulated = finalText
@@ -882,30 +1146,69 @@ async function streamPortableConductorMission(params: {
 }
 
 export function useConductorGateway() {
-  const [initialMission] = useState<PersistedMission | null>(() => loadPersistedMission())
-  const [missionId, setMissionId] = useState<string | null>(() => initialMission?.missionId ?? null)
-  const [missionJobId, setMissionJobId] = useState<string | null>(() => initialMission?.missionJobId ?? null)
-  const [phase, setPhase] = useState<MissionPhase>(() => initialMission?.phase ?? 'idle')
+  const [initialMission] = useState<PersistedMission | null>(() =>
+    loadPersistedMission(),
+  )
+  const [missionId, setMissionId] = useState<string | null>(
+    () => initialMission?.missionId ?? null,
+  )
+  const [missionJobId, setMissionJobId] = useState<string | null>(
+    () => initialMission?.missionJobId ?? null,
+  )
+  const [phase, setPhase] = useState<MissionPhase>(
+    () => initialMission?.phase ?? 'idle',
+  )
   const [goal, setGoal] = useState(() => initialMission?.goal ?? '')
-  const [orchestratorSessionKey, setOrchestratorSessionKey] = useState<string | null>(() => initialMission?.workerKeys[0] ?? null)
-  const [streamText, setStreamText] = useState(() => initialMission?.streamText ?? '')
+  const [orchestratorSessionKey, setOrchestratorSessionKey] = useState<
+    string | null
+  >(() => initialMission?.workerKeys[0] ?? null)
+  const [streamText, setStreamText] = useState(
+    () => initialMission?.streamText ?? '',
+  )
   const [planText, setPlanText] = useState(() => initialMission?.planText ?? '')
   const [streamEvents, setStreamEvents] = useState<StreamEvent[]>([])
-  const [missionStartedAt, setMissionStartedAt] = useState<string | null>(() => initialMission?.missionStartedAt ?? null)
-  const [isPaused, setIsPaused] = useState(() => initialMission?.isPaused ?? false)
-  const [pausedElapsedMs, setPausedElapsedMs] = useState(() => initialMission?.pausedElapsedMs ?? 0)
-  const [accumulatedPausedMs, setAccumulatedPausedMs] = useState(() => initialMission?.accumulatedPausedMs ?? 0)
-  const [pauseStartedAt, setPauseStartedAt] = useState<string | null>(() => initialMission?.pauseStartedAt ?? null)
-  const [completedAt, setCompletedAt] = useState<string | null>(() => initialMission?.completedAt ?? null)
+  const [missionStartedAt, setMissionStartedAt] = useState<string | null>(
+    () => initialMission?.missionStartedAt ?? null,
+  )
+  const [isPaused, setIsPaused] = useState(
+    () => initialMission?.isPaused ?? false,
+  )
+  const [pausedElapsedMs, setPausedElapsedMs] = useState(
+    () => initialMission?.pausedElapsedMs ?? 0,
+  )
+  const [accumulatedPausedMs, setAccumulatedPausedMs] = useState(
+    () => initialMission?.accumulatedPausedMs ?? 0,
+  )
+  const [pauseStartedAt, setPauseStartedAt] = useState<string | null>(
+    () => initialMission?.pauseStartedAt ?? null,
+  )
+  const [completedAt, setCompletedAt] = useState<string | null>(
+    () => initialMission?.completedAt ?? null,
+  )
   const [streamError, setStreamError] = useState<string | null>(null)
   const [timeoutWarning, setTimeoutWarning] = useState(false)
-  const [missionWorkerKeys, setMissionWorkerKeys] = useState<Set<string>>(() => new Set(initialMission?.workerKeys ?? []))
-  const [missionWorkerLabels, setMissionWorkerLabels] = useState<Set<string>>(() => new Set(initialMission?.workerLabels ?? []))
-  const [workerOutputs, setWorkerOutputs] = useState<Record<string, string>>(() => initialMission?.workerOutputs ?? {})
-  const [tasks, setTasks] = useState<ConductorTask[]>(() => initialMission?.tasks ?? [])
-  const [missionHistory, setMissionHistory] = useState<MissionHistoryEntry[]>(() => loadMissionHistory())
-  const [selectedHistoryEntry, setSelectedHistoryEntry] = useState<MissionHistoryEntry | null>(null)
-  const [conductorSettings, setConductorSettings] = useState<ConductorSettings>(() => loadConductorSettings())
+  const [missionWorkerKeys, setMissionWorkerKeys] = useState<Set<string>>(
+    () => new Set(initialMission?.workerKeys ?? []),
+  )
+  const [missionWorkerLabels, setMissionWorkerLabels] = useState<Set<string>>(
+    () => new Set(initialMission?.workerLabels ?? []),
+  )
+  const [workerOutputs, setWorkerOutputs] = useState<Record<string, string>>(
+    () => initialMission?.workerOutputs ?? {},
+  )
+  const [tasks, setTasks] = useState<ConductorTask[]>(
+    () => initialMission?.tasks ?? [],
+  )
+  const [missionHistory, setMissionHistory] = useState<MissionHistoryEntry[]>(
+    () => loadMissionHistory(),
+  )
+  const [selectedHistoryEntry, setSelectedHistoryEntry] =
+    useState<MissionHistoryEntry | null>(null)
+  const [conductorSettings, setConductorSettings] = useState<ConductorSettings>(
+    () => loadConductorSettings(),
+  )
+  const [missionProjectMetadata, setMissionProjectMetadata] =
+    useState<MissionProjectMetadata | null>(null)
   const doneRef = useRef(initialMission?.phase === 'complete')
   const seenToolCallRef = useRef(false)
   const historySavedRef = useRef(false)
@@ -918,7 +1221,9 @@ export function useConductorGateway() {
     queryFn: async () => {
       const payload = await fetchSessions()
       const sessions = Array.isArray(payload.sessions) ? payload.sessions : []
-      const missionStartMs = missionStartedAt ? new Date(missionStartedAt).getTime() : 0
+      const missionStartMs = missionStartedAt
+        ? new Date(missionStartedAt).getTime()
+        : 0
       const missionNeedles = buildMissionNeedles(goal)
       return sessions
         .filter((session) => {
@@ -932,25 +1237,47 @@ export function useConductorGateway() {
 
           // Match by worker label pattern
           if (label.startsWith('worker-') || label.startsWith('conductor-')) {
-            if (missionWorkerLabels.size > 0 && missionWorkerLabels.has(label)) {
+            if (
+              missionWorkerLabels.size > 0 &&
+              missionWorkerLabels.has(label)
+            ) {
               return true
             }
             // Match by creation time (workers spawned after mission start)
-            const createdIso = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
-            if (createdIso && missionStartMs && new Date(createdIso).getTime() >= missionStartMs) {
+            const createdIso = toIso(
+              session.createdAt ?? session.startedAt ?? session.updatedAt,
+            )
+            if (
+              createdIso &&
+              missionStartMs &&
+              new Date(createdIso).getTime() >= missionStartMs
+            ) {
               return true
             }
           }
 
           // Match subagent sessions created after mission start
           if (key.includes(':subagent:')) {
-            const createdIso = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
-            if (createdIso && missionStartMs && new Date(createdIso).getTime() >= missionStartMs) {
+            const createdIso = toIso(
+              session.createdAt ?? session.startedAt ?? session.updatedAt,
+            )
+            if (
+              createdIso &&
+              missionStartMs &&
+              new Date(createdIso).getTime() >= missionStartMs
+            ) {
               return true
             }
           }
 
-          if (missionStartMs > 0 && sessionMatchesMissionContext(session, missionStartMs, missionNeedles)) {
+          if (
+            missionStartMs > 0 &&
+            sessionMatchesMissionContext(
+              session,
+              missionStartMs,
+              missionNeedles,
+            )
+          ) {
             return true
           }
 
@@ -962,11 +1289,19 @@ export function useConductorGateway() {
           const statusRank = { running: 0, idle: 1, complete: 2, stale: 3 }
           const rankDiff = statusRank[a.status] - statusRank[b.status]
           if (rankDiff !== 0) return rankDiff
-          return new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime()
+          return (
+            new Date(b.updatedAt ?? 0).getTime() -
+            new Date(a.updatedAt ?? 0).getTime()
+          )
         })
     },
     enabled: phase !== 'idle',
-    refetchInterval: phase === 'decomposing' || phase === 'running' || (phase === 'complete' && Object.keys(workerOutputs).length === 0) ? 3_000 : false,
+    refetchInterval:
+      phase === 'decomposing' ||
+      phase === 'running' ||
+      (phase === 'complete' && Object.keys(workerOutputs).length === 0)
+        ? 3_000
+        : false,
   })
 
   const recentSessionsQuery = useQuery({
@@ -979,7 +1314,9 @@ export function useConductorGateway() {
         .filter((session) => {
           const label = readString(session.label) ?? ''
           const key = readString(session.key) ?? ''
-          const updatedAt = toIso(session.updatedAt ?? session.startedAt ?? session.createdAt)
+          const updatedAt = toIso(
+            session.updatedAt ?? session.startedAt ?? session.createdAt,
+          )
           if (!updatedAt) return false
           const isConductorSession =
             label.startsWith('worker-') ||
@@ -989,8 +1326,12 @@ export function useConductorGateway() {
           return isConductorSession && new Date(updatedAt).getTime() >= cutoff
         })
         .sort((a, b) => {
-          const updatedA = new Date(toIso(a.updatedAt ?? a.startedAt ?? a.createdAt) ?? 0).getTime()
-          const updatedB = new Date(toIso(b.updatedAt ?? b.startedAt ?? b.createdAt) ?? 0).getTime()
+          const updatedA = new Date(
+            toIso(a.updatedAt ?? a.startedAt ?? a.createdAt) ?? 0,
+          ).getTime()
+          const updatedB = new Date(
+            toIso(b.updatedAt ?? b.startedAt ?? b.createdAt) ?? 0,
+          ).getTime()
           return updatedB - updatedA
         })
         .slice(0, 20)
@@ -1006,11 +1347,18 @@ export function useConductorGateway() {
       return fetchConductorMission(missionId)
     },
     enabled: Boolean(missionId) && phase !== 'idle',
-    refetchInterval: phase === 'decomposing' || phase === 'running' ? 2_500 : false,
+    refetchInterval:
+      phase === 'decomposing' || phase === 'running' ? 2_500 : false,
   })
 
   const workers = sessionsQuery.data ?? []
-  const activeWorkers = useMemo(() => workers.filter((worker) => worker.status === 'running' || worker.status === 'idle'), [workers])
+  const activeWorkers = useMemo(
+    () =>
+      workers.filter(
+        (worker) => worker.status === 'running' || worker.status === 'idle',
+      ),
+    [workers],
+  )
   const hasPersistedMission = initialMission !== null
 
   useEffect(() => {
@@ -1030,15 +1378,25 @@ export function useConductorGateway() {
         next.add(realSessionKey)
         return next
       })
-      setPlanText((current) => (current && !current.startsWith('Conductor mission') ? current : 'Orchestrator session attached. Tracking worker activity...'))
+      setPlanText((current) =>
+        current && !current.startsWith('Conductor mission')
+          ? current
+          : 'Orchestrator session attached. Tracking worker activity...',
+      )
       lastActivityAtRef.current = Date.now()
       setTimeoutWarning(false)
     } else if (phase === 'decomposing' || phase === 'running') {
-      setPlanText((current) => current || `Conductor mission ${status ?? 'running'}. Waiting for Hermes to report the session...`)
+      setPlanText(
+        (current) =>
+          current ||
+          `Conductor mission ${status ?? 'running'}. Waiting for Hermes to report the session...`,
+      )
     }
 
     if (missionLog) {
-      setStreamText((current) => (current === missionLog ? current : missionLog))
+      setStreamText((current) =>
+        current === missionLog ? current : missionLog,
+      )
       lastActivityAtRef.current = Date.now()
       setTimeoutWarning(false)
     }
@@ -1055,14 +1413,24 @@ export function useConductorGateway() {
     if (!missionStartedAt) return 0
     const startedMs = new Date(missionStartedAt).getTime()
     if (!Number.isFinite(startedMs)) return 0
-    const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-    const inFlightPausedMs = isPaused && Number.isFinite(pauseStartedMs) ? Math.max(0, referenceTime - pauseStartedMs) : 0
-    return Math.max(0, referenceTime - startedMs - accumulatedPausedMs - inFlightPausedMs)
+    const pauseStartedMs = pauseStartedAt
+      ? new Date(pauseStartedAt).getTime()
+      : NaN
+    const inFlightPausedMs =
+      isPaused && Number.isFinite(pauseStartedMs)
+        ? Math.max(0, referenceTime - pauseStartedMs)
+        : 0
+    return Math.max(
+      0,
+      referenceTime - startedMs - accumulatedPausedMs - inFlightPausedMs,
+    )
   }
 
   useEffect(() => {
     if (missionWorkerLabels.size === 0 || workers.length === 0) return
-    const matchedKeys = workers.filter((worker) => missionWorkerLabels.has(worker.label)).map((worker) => worker.key)
+    const matchedKeys = workers
+      .filter((worker) => missionWorkerLabels.has(worker.label))
+      .map((worker) => worker.key)
 
     if (matchedKeys.length === 0) return
 
@@ -1111,7 +1479,12 @@ export function useConductorGateway() {
   useEffect(() => {
     if (phase !== 'running' && phase !== 'decomposing') return
 
-    const workerSnapshot = workers.map((worker) => `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`).join('|')
+    const workerSnapshot = workers
+      .map(
+        (worker) =>
+          `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`,
+      )
+      .join('|')
 
     if (workerSnapshot && workerSnapshot !== lastWorkerSnapshotRef.current) {
       lastWorkerSnapshotRef.current = workerSnapshot
@@ -1142,7 +1515,8 @@ export function useConductorGateway() {
   useEffect(() => {
     if (phase !== 'running') return
 
-    const shouldCompleteImmediately = doneRef.current && workersLookComplete(workers, 8_000)
+    const shouldCompleteImmediately =
+      doneRef.current && workersLookComplete(workers, 8_000)
     if (shouldCompleteImmediately) {
       setPhase('complete')
       setCompletedAt((value) => value ?? new Date().toISOString())
@@ -1181,8 +1555,12 @@ export function useConductorGateway() {
     void fetchAll()
 
     // Keep polling while workers are running, OR while we're missing outputs for complete workers
-    const hasRunningWorkers = workers.some((worker) => worker.status === 'running' || worker.status === 'idle')
-    const hasMissingOutputs = workers.some((worker) => worker.status === 'complete' && !workerOutputs[worker.key])
+    const hasRunningWorkers = workers.some(
+      (worker) => worker.status === 'running' || worker.status === 'idle',
+    )
+    const hasMissingOutputs = workers.some(
+      (worker) => worker.status === 'complete' && !workerOutputs[worker.key],
+    )
     if (!hasRunningWorkers && !hasMissingOutputs) {
       return () => {
         cancelled = true
@@ -1222,8 +1600,20 @@ export function useConductorGateway() {
         const worker = workers[index]
         if (!worker) return task
         const workerOutput = workerOutputs[worker.key] ?? null
-        const newStatus: ConductorTask['status'] = worker.status === 'complete' ? 'complete' : worker.status === 'stale' ? 'failed' : worker.status === 'running' ? 'running' : task.status
-        if (task.workerKey === worker.key && task.status === newStatus && task.output === workerOutput) return task
+        const newStatus: ConductorTask['status'] =
+          worker.status === 'complete'
+            ? 'complete'
+            : worker.status === 'stale'
+              ? 'failed'
+              : worker.status === 'running'
+                ? 'running'
+                : task.status
+        if (
+          task.workerKey === worker.key &&
+          task.status === newStatus &&
+          task.output === workerOutput
+        )
+          return task
         return {
           ...task,
           workerKey: worker.key,
@@ -1240,13 +1630,26 @@ export function useConductorGateway() {
   // so the entry gets enriched with actual worker content instead of empty text.
   const historySaveCountRef = useRef(0)
   useEffect(() => {
-    if (phase !== 'complete' || !goal || !completedAt || !missionStartedAt) return
+    if (phase !== 'complete' || !goal || !completedAt || !missionStartedAt)
+      return
 
     const missionHistoryId = `mission-${new Date(missionStartedAt).getTime()}`
-    const outputPath = buildMissionOutputPath(workers, workerOutputs, tasks, streamText)
+    const outputPath = buildMissionOutputPath(
+      workers,
+      workerOutputs,
+      tasks,
+      streamText,
+    )
     const workerSummary = summarizeWorkers(workers)
-    const outputText = buildMissionOutputText(workers, workerOutputs, streamText)
-    const totalTokens = workers.reduce((sum, worker) => sum + worker.totalTokens, 0)
+    const outputText = buildMissionOutputText(
+      workers,
+      workerOutputs,
+      streamText,
+    )
+    const totalTokens = workers.reduce(
+      (sum, worker) => sum + worker.totalTokens,
+      0,
+    )
     const completeSummary = buildCompleteSummary({
       goal,
       streamError,
@@ -1266,6 +1669,13 @@ export function useConductorGateway() {
         personaName: persona.name,
       }
     })
+    const projectMetadata = missionProjectMetadata ?? {
+      activeProjectId: null,
+      activeProjectName: null,
+      activeProjectPath: null,
+      effectiveWorkingDirectory:
+        normalizeOptionalString(conductorSettings.projectsDir) ?? outputPath,
+    }
     const entry: MissionHistoryEntry = {
       id: missionHistoryId,
       goal,
@@ -1274,7 +1684,11 @@ export function useConductorGateway() {
       workerCount: workers.length,
       totalTokens,
       status: streamError ? 'failed' : 'completed',
-      projectPath: outputPath,
+      projectPath: projectMetadata.activeProjectPath ?? outputPath,
+      activeProjectId: projectMetadata.activeProjectId,
+      activeProjectName: projectMetadata.activeProjectName,
+      activeProjectPath: projectMetadata.activeProjectPath,
+      effectiveWorkingDirectory: projectMetadata.effectiveWorkingDirectory,
       outputPath,
       workerSummary: workerSummary.length > 0 ? workerSummary : undefined,
       outputText: outputText || undefined,
@@ -1295,10 +1709,24 @@ export function useConductorGateway() {
         return [entry, ...current].slice(0, MAX_HISTORY_ENTRIES)
       })
     } else {
-      setMissionHistory((current) => current.map((e) => (e.id === missionHistoryId ? entry : e)))
+      setMissionHistory((current) =>
+        current.map((e) => (e.id === missionHistoryId ? entry : e)),
+      )
     }
     historySaveCountRef.current += 1
-  }, [phase, goal, completedAt, missionStartedAt, workers, streamError, workerOutputs, tasks, streamText])
+  }, [
+    phase,
+    goal,
+    completedAt,
+    missionStartedAt,
+    workers,
+    streamError,
+    workerOutputs,
+    tasks,
+    streamText,
+    missionProjectMetadata,
+    conductorSettings.projectsDir,
+  ])
 
   useEffect(() => {
     persistConductorSettings(conductorSettings)
@@ -1382,12 +1810,21 @@ export function useConductorGateway() {
     setWorkerOutputs({})
     setTasks([])
     setSelectedHistoryEntry(null)
+    setMissionProjectMetadata(null)
     seenToolCallRef.current = false
     historySavedRef.current = false
   }
 
   const sendMission = useMutation({
-    mutationFn: async ({ nextGoal, settings }: { nextGoal: string; settings: ConductorSettings }) => {
+    mutationFn: async ({
+      nextGoal,
+      settings,
+      options,
+    }: {
+      nextGoal: string
+      settings: ConductorSettings
+      options?: SendMissionOptions
+    }) => {
       const trimmed = nextGoal.trim()
       if (!trimmed) throw new Error('Mission goal required')
       doneRef.current = false
@@ -1412,6 +1849,7 @@ export function useConductorGateway() {
       setWorkerOutputs({})
       setTasks([])
       setSelectedHistoryEntry(null)
+      setMissionProjectMetadata(null)
       seenToolCallRef.current = false
       historySavedRef.current = false
       const startedAt = new Date().toISOString()
@@ -1440,7 +1878,11 @@ export function useConductorGateway() {
       const response = await fetch('/api/conductor-spawn', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ goal: trimmed, ...settings }),
+        body: JSON.stringify({
+          goal: trimmed,
+          ...settings,
+          projectOverride: options?.projectOverride ?? undefined,
+        }),
       })
 
       if (!response.ok) {
@@ -1452,12 +1894,19 @@ export function useConductorGateway() {
       if (!result.ok) {
         throw new Error(result.error ?? 'Failed to spawn orchestrator')
       }
+      setMissionProjectMetadata(result.project ?? null)
 
       if (result.mode === 'portable' || result.prompt) {
         const prompt = typeof result.prompt === 'string' ? result.prompt : ''
-        if (!prompt.trim()) throw new Error('Portable conductor response did not include a prompt')
+        if (!prompt.trim())
+          throw new Error(
+            'Portable conductor response did not include a prompt',
+          )
 
-        const portableSessionKey = result.sessionKey?.trim() || result.jobName?.trim() || `conductor-${Date.now()}`
+        const portableSessionKey =
+          result.sessionKey?.trim() ||
+          result.jobName?.trim() ||
+          `conductor-${Date.now()}`
         const portableFriendlyId = result.jobName?.trim() || portableSessionKey
         setMissionId(null)
         setMissionJobId(null)
@@ -1468,7 +1917,9 @@ export function useConductorGateway() {
           next.add(portableSessionKey)
           return next
         })
-        setPlanText('Conductor portable mission launched. Streaming orchestrator output...')
+        setPlanText(
+          'Conductor portable mission launched. Streaming orchestrator output...',
+        )
         setPhase('running')
 
         const abortController = new AbortController()
@@ -1523,7 +1974,12 @@ export function useConductorGateway() {
         return
       }
 
-      if (!result.sessionKey && !result.sessionKeyPrefix && !result.missionId && !result.jobId) {
+      if (
+        !result.sessionKey &&
+        !result.sessionKeyPrefix &&
+        !result.missionId &&
+        !result.jobId
+      ) {
         throw new Error(result.error ?? 'Failed to spawn orchestrator')
       }
 
@@ -1550,7 +2006,9 @@ export function useConductorGateway() {
             await new Promise((resolve) => setTimeout(resolve, 1500))
             try {
               const sessionPayload = await fetchSessions()
-              const sessions = Array.isArray(sessionPayload.sessions) ? sessionPayload.sessions : []
+              const sessions = Array.isArray(sessionPayload.sessions)
+                ? sessionPayload.sessions
+                : []
               const match = sessions.find((session) => {
                 const key = typeof session.key === 'string' ? session.key : ''
                 return key.startsWith(prefix)
@@ -1600,7 +2058,13 @@ export function useConductorGateway() {
   }
 
   const pauseAgent = useMutation({
-    mutationFn: async ({ sessionKey, pause }: { sessionKey: string; pause: boolean }) => {
+    mutationFn: async ({
+      sessionKey,
+      pause,
+    }: {
+      sessionKey: string
+      pause: boolean
+    }) => {
       const response = await fetch('/api/agent-pause', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1620,8 +2084,12 @@ export function useConductorGateway() {
         return
       }
 
-      const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-      const additionalPausedMs = Number.isFinite(pauseStartedMs) ? Math.max(0, now - pauseStartedMs) : 0
+      const pauseStartedMs = pauseStartedAt
+        ? new Date(pauseStartedAt).getTime()
+        : NaN
+      const additionalPausedMs = Number.isFinite(pauseStartedMs)
+        ? Math.max(0, now - pauseStartedMs)
+        : 0
       setAccumulatedPausedMs((current) => current + additionalPausedMs)
       setPauseStartedAt(null)
       setIsPaused(false)
@@ -1632,7 +2100,12 @@ export function useConductorGateway() {
   const stopMission = async () => {
     portableStreamAbortRef.current?.abort()
     portableStreamAbortRef.current = null
-    const sessionKeys = [...new Set([...missionWorkerKeys, ...workers.map((worker) => worker.key)])]
+    const sessionKeys = [
+      ...new Set([
+        ...missionWorkerKeys,
+        ...workers.map((worker) => worker.key),
+      ]),
+    ]
     const missionIds = missionId ? [missionId] : []
 
     try {
@@ -1692,8 +2165,14 @@ export function useConductorGateway() {
     workerOutputs,
     conductorSettings,
     setConductorSettings,
-    sendMission: (nextGoal: string) => sendMission.mutateAsync({ nextGoal, settings: conductorSettings }),
-    pauseAgent: (sessionKey: string, pause: boolean) => pauseAgent.mutateAsync({ sessionKey, pause }),
+    sendMission: (nextGoal: string, options?: SendMissionOptions) =>
+      sendMission.mutateAsync({
+        nextGoal,
+        settings: conductorSettings,
+        options,
+      }),
+    pauseAgent: (sessionKey: string, pause: boolean) =>
+      pauseAgent.mutateAsync({ sessionKey, pause }),
     isSending: sendMission.isPending,
     isPausing: pauseAgent.isPending,
     resetMission,

--- a/src/screens/projects/project-mission-trace.test.ts
+++ b/src/screens/projects/project-mission-trace.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { MissionHistoryEntry } from '@/screens/gateway/hooks/mission-history'
+import {
+  buildProjectMissionTraceIntent,
+  getMissionTraceSessionKey,
+} from './project-mission-trace'
+
+const baseEntry: MissionHistoryEntry = {
+  id: 'mission-1',
+  goal: 'Ship project trace links',
+  startedAt: '2026-01-01T10:00:00.000Z',
+  completedAt: '2026-01-01T10:05:00.000Z',
+  workerCount: 2,
+  totalTokens: 1200,
+  status: 'completed',
+  projectPath: '/workspace/demo',
+}
+
+describe('project mission trace links', () => {
+  it('exposes a trace session key only for entries with a persisted session', () => {
+    expect(
+      getMissionTraceSessionKey({
+        ...baseEntry,
+        sessionKey: ' conductor:abc123 ',
+      }),
+    ).toBe('conductor:abc123')
+
+    expect(getMissionTraceSessionKey(baseEntry)).toBeNull()
+    expect(
+      getMissionTraceSessionKey({ ...baseEntry, sessionKey: '   ' }),
+    ).toBeNull()
+  })
+
+  it('builds a conductor trace intent from mission history', () => {
+    expect(
+      buildProjectMissionTraceIntent({
+        ...baseEntry,
+        id: 'mission-alpha',
+        activeProjectId: 'project-alpha',
+        activeProjectName: 'Alpha',
+        activeProjectPath: '/workspace/alpha',
+        effectiveWorkingDirectory: '/workspace/alpha',
+        sessionKey: 'conductor:alpha-session',
+      }),
+    ).toEqual({
+      missionHistoryId: 'mission-alpha',
+      sessionKey: 'conductor:alpha-session',
+      projectId: 'project-alpha',
+      projectName: 'Alpha',
+      projectPath: '/workspace/alpha',
+    })
+  })
+})

--- a/src/screens/projects/project-mission-trace.ts
+++ b/src/screens/projects/project-mission-trace.ts
@@ -1,0 +1,34 @@
+import type { MissionHistoryEntry } from '@/screens/gateway/hooks/mission-history'
+import { normalizeOptionalString } from '@/screens/gateway/hooks/mission-history'
+
+export type ProjectMissionTraceIntent = {
+  missionHistoryId: string
+  sessionKey: string
+  projectId: string | null
+  projectName: string | null
+  projectPath: string | null
+}
+
+export function getMissionTraceSessionKey(
+  entry: Pick<MissionHistoryEntry, 'sessionKey'>,
+): string | null {
+  return normalizeOptionalString(entry.sessionKey)
+}
+
+export function buildProjectMissionTraceIntent(
+  entry: MissionHistoryEntry,
+): ProjectMissionTraceIntent | null {
+  const sessionKey = getMissionTraceSessionKey(entry)
+  if (!sessionKey) return null
+  return {
+    missionHistoryId: entry.id,
+    sessionKey,
+    projectId: normalizeOptionalString(entry.activeProjectId),
+    projectName: normalizeOptionalString(entry.activeProjectName),
+    projectPath:
+      normalizeOptionalString(entry.activeProjectPath) ??
+      normalizeOptionalString(entry.effectiveWorkingDirectory) ??
+      normalizeOptionalString(entry.projectPath) ??
+      normalizeOptionalString(entry.outputPath),
+  }
+}

--- a/src/screens/projects/projects-screen.tsx
+++ b/src/screens/projects/projects-screen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
@@ -14,8 +14,18 @@ import {
   TimeQuarterPassIcon,
 } from '@hugeicons/core-free-icons'
 
+import {
+  buildProjectMissionTraceIntent,
+  getMissionTraceSessionKey,
+} from './project-mission-trace'
+import type { MissionHistoryEntry } from '@/screens/gateway/hooks/mission-history'
 import { Button } from '@/components/ui/button'
 import { persistConductorLaunchIntent } from '@/screens/gateway/conductor-launch-intent'
+import {
+  filterMissionHistoryByProject,
+  loadMissionHistory,
+  summarizeProjectMissionHistory,
+} from '@/screens/gateway/hooks/mission-history'
 
 type ProjectFile = {
   name: string
@@ -41,6 +51,7 @@ type ProjectEntry = {
   id: string
   name: string
   path: string
+  source: 'shared' | 'discovered'
   active: boolean
   gitRemote: string | null
   gitBranch: string | null
@@ -57,23 +68,11 @@ type ProjectsResponse = {
   error?: string
 }
 
-type MissionHistoryEntry = {
-  id: string
-  goal: string
-  startedAt: string
-  completedAt: string
-  workerCount: number
-  totalTokens: number
-  status: 'completed' | 'failed'
-  projectPath: string | null
-  activeProjectId?: string | null
-  activeProjectName?: string | null
-  activeProjectPath?: string | null
-  effectiveWorkingDirectory?: string | null
-}
-
-const CONDUCTOR_HISTORY_STORAGE_KEY = 'conductor:history'
 const PROJECT_HISTORY_LIMIT = 4
+
+function getFirstProject(projects: Array<ProjectEntry>): ProjectEntry | null {
+  return projects.length > 0 ? projects[0] : null
+}
 
 async function fetchProjects(): Promise<ProjectsResponse> {
   const response = await fetch('/api/projects', { cache: 'no-store' })
@@ -84,60 +83,27 @@ async function fetchProjects(): Promise<ProjectsResponse> {
   return data
 }
 
+async function selectActiveProject(
+  projectId: string,
+): Promise<ProjectsResponse> {
+  const response = await fetch('/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ activeProjectId: projectId }),
+  })
+  const data = (await response.json().catch(() => ({}))) as ProjectsResponse
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to select project')
+  }
+  return data
+}
+
 function shortenRemote(remote: string | null): string {
   if (!remote) return 'No git remote'
   return remote
     .replace(/^git@github.com:/, 'github.com/')
     .replace(/^https:\/\/github.com\//, 'github.com/')
     .replace(/\.git$/, '')
-}
-
-function normalizeOptionalString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null
-}
-
-function loadMissionHistory(): Array<MissionHistoryEntry> {
-  try {
-    const raw = globalThis.localStorage?.getItem(CONDUCTOR_HISTORY_STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed)) return []
-    return parsed
-      .filter((entry): entry is MissionHistoryEntry => {
-        if (!entry || typeof entry !== 'object') return false
-        const e = entry as Record<string, unknown>
-        return (
-          typeof e.id === 'string' &&
-          typeof e.goal === 'string' &&
-          typeof e.startedAt === 'string' &&
-          typeof e.completedAt === 'string'
-        )
-      })
-      .map((entry) => ({
-        ...entry,
-        activeProjectId: normalizeOptionalString(entry.activeProjectId),
-        activeProjectName: normalizeOptionalString(entry.activeProjectName),
-        activeProjectPath: normalizeOptionalString(entry.activeProjectPath),
-        effectiveWorkingDirectory:
-          normalizeOptionalString(entry.effectiveWorkingDirectory) ??
-          normalizeOptionalString(entry.activeProjectPath) ??
-          normalizeOptionalString(entry.projectPath),
-      }))
-  } catch {
-    return []
-  }
-}
-
-function missionMatchesProject(
-  entry: MissionHistoryEntry,
-  project: ProjectEntry,
-): boolean {
-  return (
-    entry.activeProjectId === project.id ||
-    entry.activeProjectPath === project.path ||
-    entry.effectiveWorkingDirectory === project.path ||
-    entry.projectPath === project.path
-  )
 }
 
 function formatMissionDate(value: string): string {
@@ -209,12 +175,16 @@ function ProjectCard({
   selected,
   onSelect,
   onStartMission,
+  onMakeActive,
+  onOpenTrace,
 }: {
   project: ProjectEntry
   history: Array<MissionHistoryEntry>
   selected: boolean
   onSelect: () => void
   onStartMission: () => void
+  onMakeActive: () => void
+  onOpenTrace: (entry: MissionHistoryEntry) => void
 }) {
   const files =
     project.instructionFiles.length > 0
@@ -222,9 +192,10 @@ function ProjectCard({
       : project.readme
         ? [project.readme]
         : []
-  const recentHistory = history
-    .filter((entry) => missionMatchesProject(entry, project))
-    .slice(0, PROJECT_HISTORY_LIMIT)
+  const recentHistory = filterMissionHistoryByProject(history, {
+    id: project.id,
+    path: project.path,
+  }).slice(0, PROJECT_HISTORY_LIMIT)
 
   return (
     <article
@@ -243,6 +214,11 @@ function ProjectCard({
             {project.active ? (
               <span className="rounded-full bg-accent-500/15 px-2.5 py-1 text-xs font-semibold text-accent-700">
                 Active
+              </span>
+            ) : null}
+            {project.source === 'shared' ? (
+              <span className="rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold text-primary-700">
+                Shared
               </span>
             ) : null}
             {selected && !project.active ? (
@@ -273,14 +249,21 @@ function ProjectCard({
             </span>
           </div>
         </button>
-        <Button
-          type="button"
-          onClick={onStartMission}
-          className="shrink-0 bg-accent-500 text-primary-950 hover:bg-accent-400"
-        >
-          <HugeiconsIcon icon={PlayIcon} size={16} strokeWidth={1.7} />
-          Start mission
-        </Button>
+        <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:flex-col">
+          {!project.active ? (
+            <Button type="button" variant="outline" onClick={onMakeActive}>
+              Make active
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            onClick={onStartMission}
+            className="bg-accent-500 text-primary-950 hover:bg-accent-400"
+          >
+            <HugeiconsIcon icon={PlayIcon} size={16} strokeWidth={1.7} />
+            Open in Conductor
+          </Button>
+        </div>
       </div>
 
       {selected ? (
@@ -416,11 +399,22 @@ function ProjectCard({
                         {entry.status === 'completed' ? 'Done' : 'Failed'}
                       </span>
                     </div>
-                    <p className="mt-2 text-xs text-primary-500">
-                      {formatMissionDate(entry.completedAt)} ·{' '}
-                      {entry.workerCount} workers ·{' '}
-                      {entry.totalTokens.toLocaleString()} tok
-                    </p>
+                    <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-primary-500">
+                      <span>
+                        {formatMissionDate(entry.completedAt)} ·{' '}
+                        {entry.workerCount} workers ·{' '}
+                        {entry.totalTokens.toLocaleString()} tok
+                      </span>
+                      {getMissionTraceSessionKey(entry) ? (
+                        <button
+                          type="button"
+                          onClick={() => onOpenTrace(entry)}
+                          className="font-semibold text-accent-700 hover:text-accent-600"
+                        >
+                          Open trace
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 ))
               ) : (
@@ -439,10 +433,19 @@ function ProjectCard({
 
 export function ProjectsScreen() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const projectsQuery = useQuery({
     queryKey: ['projects', 'registry'],
     queryFn: fetchProjects,
     staleTime: 30_000,
+  })
+
+  const selectProjectMutation = useMutation({
+    mutationFn: selectActiveProject,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['projects', 'registry'], data)
+      setSelectedProjectId(data.activeProjectId)
+    },
   })
 
   const projects = projectsQuery.data?.projects ?? []
@@ -462,13 +465,17 @@ export function ProjectsScreen() {
   const selectedProject =
     projects.find((project) => project.id === selectedProjectId) ??
     activeProject ??
-    projects[0] ??
-    null
-  const totalProjectMissions = selectedProject
-    ? missionHistory.filter((entry) =>
-        missionMatchesProject(entry, selectedProject),
-      ).length
-    : 0
+    getFirstProject(projects)
+  const selectedProjectMissionSummary = selectedProject
+    ? summarizeProjectMissionHistory(missionHistory, {
+        id: selectedProject.id,
+        path: selectedProject.path,
+      })
+    : null
+  const totalProjectMissions = selectedProjectMissionSummary?.total ?? 0
+  const selectedProjectName = selectedProject?.name ?? 'Not detected'
+  const selectedProjectPath =
+    selectedProject?.path ?? 'Choose workspace in Files/Workspace first.'
 
   useEffect(() => {
     setMissionHistory(loadMissionHistory())
@@ -482,7 +489,7 @@ export function ProjectsScreen() {
     setSelectedProjectId((current) =>
       current && projects.some((project) => project.id === current)
         ? current
-        : (activeProject?.id ?? projects[0]?.id ?? null),
+        : (activeProject?.id ?? getFirstProject(projects)?.id ?? null),
     )
   }, [activeProject?.id, projects])
 
@@ -496,9 +503,20 @@ export function ProjectsScreen() {
         activeProjectName: project.name,
         activeProjectPath: project.path,
         effectiveWorkingDirectory: project.path,
+        contextPreview: project.contextPreview,
+        status: project.status,
       },
     })
     void navigate({ to: '/conductor' })
+  }
+
+  const openMissionTrace = (entry: MissionHistoryEntry) => {
+    const traceIntent = buildProjectMissionTraceIntent(entry)
+    if (!traceIntent) return
+    void navigate({
+      to: '/conductor',
+      search: { traceSessionKey: traceIntent.sessionKey },
+    })
   }
 
   return (
@@ -544,18 +562,21 @@ export function ProjectsScreen() {
               <p className="mt-2 text-2xl font-semibold text-primary-950">
                 {totalProjectMissions}
               </p>
+              <p className="mt-1 text-xs text-primary-600">
+                {selectedProjectMissionSummary
+                  ? `${selectedProjectMissionSummary.completed} done · ${selectedProjectMissionSummary.failed} failed`
+                  : 'No project selected'}
+              </p>
             </div>
             <div className="rounded-2xl border border-primary-200 bg-primary-50 p-4 sm:col-span-2">
               <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
                 Selected project
               </p>
               <p className="mt-2 truncate text-lg font-semibold text-primary-950">
-                {selectedProject?.name ?? activeProject?.name ?? 'Not detected'}
+                {selectedProjectName}
               </p>
               <p className="mt-1 truncate text-xs text-primary-600">
-                {selectedProject?.path ??
-                  activeProject?.path ??
-                  'Choose workspace in Files/Workspace first.'}
+                {selectedProjectPath}
               </p>
             </div>
           </div>
@@ -566,8 +587,8 @@ export function ProjectsScreen() {
                   Project dashboard ready
                 </p>
                 <p className="mt-1 text-xs text-primary-600">
-                  Review local context and launch Conductor with a prefilled
-                  mission draft for {selectedProject.name}.
+                  Review local context and open Conductor with a prefilled
+                  mission draft for {selectedProjectName}.
                 </p>
               </div>
               <Button
@@ -575,7 +596,7 @@ export function ProjectsScreen() {
                 onClick={() => startProjectMission(selectedProject)}
                 className="shrink-0 bg-accent-500 text-primary-950 hover:bg-accent-400"
               >
-                Start mission
+                Open in Conductor
                 <HugeiconsIcon
                   icon={ArrowRight01Icon}
                   size={16}
@@ -622,6 +643,8 @@ export function ProjectsScreen() {
                 selected={selectedProject?.id === project.id}
                 onSelect={() => setSelectedProjectId(project.id)}
                 onStartMission={() => startProjectMission(project)}
+                onMakeActive={() => selectProjectMutation.mutate(project.id)}
+                onOpenTrace={openMissionTrace}
               />
             ))}
           </div>

--- a/src/screens/projects/projects-screen.tsx
+++ b/src/screens/projects/projects-screen.tsx
@@ -1,0 +1,532 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowRight01Icon,
+  BookOpen01Icon,
+  CodeIcon,
+  Folder01Icon,
+  GitBranchIcon,
+  Link01Icon,
+  PlayIcon,
+  TaskDone01Icon,
+} from '@hugeicons/core-free-icons'
+
+import { Button } from '@/components/ui/button'
+import { persistConductorLaunchIntent } from '@/screens/gateway/conductor-launch-intent'
+
+type ProjectFile = {
+  name: string
+  path: string
+  excerpt: string
+}
+
+type ProjectEntry = {
+  id: string
+  name: string
+  path: string
+  active: boolean
+  gitRemote: string | null
+  gitBranch: string | null
+  instructionFiles: Array<ProjectFile>
+  readme: ProjectFile | null
+}
+
+type ProjectsResponse = {
+  activeProjectId: string | null
+  projects: Array<ProjectEntry>
+  fetchedAt: number
+  error?: string
+}
+
+type MissionHistoryEntry = {
+  id: string
+  goal: string
+  startedAt: string
+  completedAt: string
+  workerCount: number
+  totalTokens: number
+  status: 'completed' | 'failed'
+  projectPath: string | null
+  activeProjectId?: string | null
+  activeProjectName?: string | null
+  activeProjectPath?: string | null
+  effectiveWorkingDirectory?: string | null
+}
+
+const CONDUCTOR_HISTORY_STORAGE_KEY = 'conductor:history'
+const PROJECT_HISTORY_LIMIT = 4
+
+async function fetchProjects(): Promise<ProjectsResponse> {
+  const response = await fetch('/api/projects', { cache: 'no-store' })
+  const data = (await response.json().catch(() => ({}))) as ProjectsResponse
+  if (!response.ok) {
+    throw new Error(data.error || 'Failed to load projects')
+  }
+  return data
+}
+
+function shortenRemote(remote: string | null): string {
+  if (!remote) return 'No git remote'
+  return remote
+    .replace(/^git@github.com:/, 'github.com/')
+    .replace(/^https:\/\/github.com\//, 'github.com/')
+    .replace(/\.git$/, '')
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function loadMissionHistory(): Array<MissionHistoryEntry> {
+  try {
+    const raw = globalThis.localStorage?.getItem(CONDUCTOR_HISTORY_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter((entry): entry is MissionHistoryEntry => {
+        if (!entry || typeof entry !== 'object') return false
+        const e = entry as Record<string, unknown>
+        return (
+          typeof e.id === 'string' &&
+          typeof e.goal === 'string' &&
+          typeof e.startedAt === 'string' &&
+          typeof e.completedAt === 'string'
+        )
+      })
+      .map((entry) => ({
+        ...entry,
+        activeProjectId: normalizeOptionalString(entry.activeProjectId),
+        activeProjectName: normalizeOptionalString(entry.activeProjectName),
+        activeProjectPath: normalizeOptionalString(entry.activeProjectPath),
+        effectiveWorkingDirectory:
+          normalizeOptionalString(entry.effectiveWorkingDirectory) ??
+          normalizeOptionalString(entry.activeProjectPath) ??
+          normalizeOptionalString(entry.projectPath),
+      }))
+  } catch {
+    return []
+  }
+}
+
+function missionMatchesProject(
+  entry: MissionHistoryEntry,
+  project: ProjectEntry,
+): boolean {
+  return (
+    entry.activeProjectId === project.id ||
+    entry.activeProjectPath === project.path ||
+    entry.effectiveWorkingDirectory === project.path ||
+    entry.projectPath === project.path
+  )
+}
+
+function formatMissionDate(value: string): string {
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return 'Unknown date'
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function buildProjectMissionDraft(project: ProjectEntry): string {
+  return [
+    `Build: continue work in project ${project.name}.`,
+    '',
+    `Project path: ${project.path}`,
+    project.gitBranch ? `Current branch: ${project.gitBranch}` : null,
+    project.gitRemote
+      ? `Git remote: ${shortenRemote(project.gitRemote)}`
+      : null,
+    '',
+    'Inspect the project first, respect local instructions, then implement the requested slice. Desired outcome:',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n')
+}
+
+function ProjectFileCard({ file }: { file: ProjectFile }) {
+  return (
+    <div className="rounded-2xl border border-primary-200 bg-primary-50/80 p-4">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <HugeiconsIcon
+            icon={BookOpen01Icon}
+            size={16}
+            strokeWidth={1.7}
+            className="shrink-0 text-accent-600"
+          />
+          <p className="truncate text-sm font-semibold text-primary-900">
+            {file.name}
+          </p>
+        </div>
+        <p className="truncate text-[11px] text-primary-500">{file.path}</p>
+      </div>
+      <pre className="max-h-36 overflow-hidden whitespace-pre-wrap rounded-xl bg-primary-100/70 p-3 text-xs leading-relaxed text-primary-700">
+        {file.excerpt}
+      </pre>
+    </div>
+  )
+}
+
+function ProjectCard({
+  project,
+  history,
+  selected,
+  onSelect,
+  onStartMission,
+}: {
+  project: ProjectEntry
+  history: Array<MissionHistoryEntry>
+  selected: boolean
+  onSelect: () => void
+  onStartMission: () => void
+}) {
+  const files =
+    project.instructionFiles.length > 0
+      ? project.instructionFiles
+      : project.readme
+        ? [project.readme]
+        : []
+  const recentHistory = history
+    .filter((entry) => missionMatchesProject(entry, project))
+    .slice(0, PROJECT_HISTORY_LIMIT)
+
+  return (
+    <article
+      className={`rounded-3xl border bg-[var(--theme-card)] p-5 shadow-sm transition-colors ${selected ? 'border-accent-500 ring-2 ring-accent-500/15' : 'border-primary-200'}`}
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <button
+          type="button"
+          onClick={onSelect}
+          className="min-w-0 flex-1 space-y-2 text-left"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="truncate text-xl font-semibold text-primary-950">
+              {project.name}
+            </h2>
+            {project.active ? (
+              <span className="rounded-full bg-accent-500/15 px-2.5 py-1 text-xs font-semibold text-accent-700">
+                Active
+              </span>
+            ) : null}
+            {selected && !project.active ? (
+              <span className="rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold text-primary-700">
+                Selected
+              </span>
+            ) : null}
+          </div>
+          <div className="flex min-w-0 items-center gap-2 text-sm text-primary-600">
+            <HugeiconsIcon
+              icon={Folder01Icon}
+              size={16}
+              strokeWidth={1.7}
+              className="shrink-0"
+            />
+            <span className="truncate">{project.path}</span>
+          </div>
+          <div className="flex flex-wrap gap-3 text-xs text-primary-600">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-primary-200 bg-primary-50 px-2.5 py-1">
+              <HugeiconsIcon icon={GitBranchIcon} size={14} strokeWidth={1.7} />
+              {project.gitBranch ?? 'No branch'}
+            </span>
+            <span className="inline-flex min-w-0 items-center gap-1.5 rounded-full border border-primary-200 bg-primary-50 px-2.5 py-1">
+              <HugeiconsIcon icon={Link01Icon} size={14} strokeWidth={1.7} />
+              <span className="truncate">
+                {shortenRemote(project.gitRemote)}
+              </span>
+            </span>
+          </div>
+        </button>
+        <Button
+          type="button"
+          onClick={onStartMission}
+          className="shrink-0 bg-accent-500 text-primary-950 hover:bg-accent-400"
+        >
+          <HugeiconsIcon icon={PlayIcon} size={16} strokeWidth={1.7} />
+          Start mission
+        </Button>
+      </div>
+
+      {selected ? (
+        <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-primary-900">
+                Local context
+              </h3>
+              <span className="text-xs text-primary-500">
+                {files.length} files
+              </span>
+            </div>
+            {files.length > 0 ? (
+              files.map((file) => (
+                <ProjectFileCard
+                  key={`${project.id}-${file.name}`}
+                  file={file}
+                />
+              ))
+            ) : (
+              <div className="rounded-2xl border border-dashed border-primary-200 bg-primary-50/60 p-4 text-sm text-primary-600">
+                No AGENTS.md, CLAUDE.md, .cursorrules, or README.md found at
+                project root.
+              </div>
+            )}
+          </div>
+
+          <aside className="rounded-2xl border border-primary-200 bg-primary-50/70 p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                  Mission history
+                </p>
+                <p className="mt-1 text-sm font-semibold text-primary-900">
+                  {recentHistory.length
+                    ? `${recentHistory.length} recent`
+                    : 'No local missions'}
+                </p>
+              </div>
+              <HugeiconsIcon
+                icon={TaskDone01Icon}
+                size={20}
+                strokeWidth={1.7}
+                className="text-accent-600"
+              />
+            </div>
+            <div className="space-y-2">
+              {recentHistory.length > 0 ? (
+                recentHistory.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="rounded-xl border border-primary-200 bg-[var(--theme-card)] p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="line-clamp-2 text-sm font-medium text-primary-900">
+                        {entry.goal}
+                      </p>
+                      <span
+                        className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${entry.status === 'completed' ? 'bg-emerald-500/10 text-emerald-700' : 'bg-red-500/10 text-red-700'}`}
+                      >
+                        {entry.status === 'completed' ? 'Done' : 'Failed'}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-primary-500">
+                      {formatMissionDate(entry.completedAt)} ·{' '}
+                      {entry.workerCount} workers ·{' '}
+                      {entry.totalTokens.toLocaleString()} tok
+                    </p>
+                  </div>
+                ))
+              ) : (
+                <div className="rounded-xl border border-dashed border-primary-200 bg-[var(--theme-card)] p-4 text-sm text-primary-600">
+                  Launch a Conductor mission from this project and completed
+                  runs will appear here.
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </article>
+  )
+}
+
+export function ProjectsScreen() {
+  const navigate = useNavigate()
+  const projectsQuery = useQuery({
+    queryKey: ['projects', 'registry'],
+    queryFn: fetchProjects,
+    staleTime: 30_000,
+  })
+
+  const projects = projectsQuery.data?.projects ?? []
+  const activeProject = useMemo(
+    () =>
+      projects.find(
+        (project) => project.id === projectsQuery.data?.activeProjectId,
+      ) ?? projects.find((project) => project.active),
+    [projects, projectsQuery.data?.activeProjectId],
+  )
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+    null,
+  )
+  const [missionHistory, setMissionHistory] = useState<
+    Array<MissionHistoryEntry>
+  >([])
+  const selectedProject =
+    projects.find((project) => project.id === selectedProjectId) ??
+    activeProject ??
+    projects[0] ??
+    null
+  const totalProjectMissions = selectedProject
+    ? missionHistory.filter((entry) =>
+        missionMatchesProject(entry, selectedProject),
+      ).length
+    : 0
+
+  useEffect(() => {
+    setMissionHistory(loadMissionHistory())
+  }, [])
+
+  useEffect(() => {
+    if (!projects.length) {
+      setSelectedProjectId(null)
+      return
+    }
+    setSelectedProjectId((current) =>
+      current && projects.some((project) => project.id === current)
+        ? current
+        : (activeProject?.id ?? projects[0]?.id ?? null),
+    )
+  }, [activeProject?.id, projects])
+
+  const startProjectMission = (project: ProjectEntry) => {
+    const draft = buildProjectMissionDraft(project)
+    persistConductorLaunchIntent({
+      source: 'projects',
+      draft,
+      projectOverride: {
+        activeProjectId: project.id,
+        activeProjectName: project.name,
+        activeProjectPath: project.path,
+        effectiveWorkingDirectory: project.path,
+      },
+    })
+    void navigate({ to: '/conductor' })
+  }
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-4 py-6 text-primary-950 sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="rounded-3xl border border-primary-200 bg-[var(--theme-card)] p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-primary-500">
+                Project context
+              </p>
+              <h1 className="text-3xl font-semibold tracking-tight text-primary-950">
+                Projects
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-primary-600">
+                Read-only registry for active workspaces. Slice 1 surfaces
+                project root, git remote, branch, and local instruction files
+                for future Conductor routing.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void projectsQuery.refetch()}
+              disabled={projectsQuery.isFetching}
+            >
+              {projectsQuery.isFetching ? 'Refreshing…' : 'Refresh'}
+            </Button>
+          </div>
+          <div className="mt-5 grid gap-3 sm:grid-cols-4">
+            <div className="rounded-2xl border border-primary-200 bg-primary-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                Projects
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-primary-950">
+                {projects.length}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-primary-200 bg-primary-50 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                Project missions
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-primary-950">
+                {totalProjectMissions}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-primary-200 bg-primary-50 p-4 sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                Selected project
+              </p>
+              <p className="mt-2 truncate text-lg font-semibold text-primary-950">
+                {selectedProject?.name ?? activeProject?.name ?? 'Not detected'}
+              </p>
+              <p className="mt-1 truncate text-xs text-primary-600">
+                {selectedProject?.path ??
+                  activeProject?.path ??
+                  'Choose workspace in Files/Workspace first.'}
+              </p>
+            </div>
+          </div>
+          {selectedProject ? (
+            <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-accent-500/25 bg-accent-500/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-primary-950">
+                  Project dashboard ready
+                </p>
+                <p className="mt-1 text-xs text-primary-600">
+                  Review local context and launch Conductor with a prefilled
+                  mission draft for {selectedProject.name}.
+                </p>
+              </div>
+              <Button
+                type="button"
+                onClick={() => startProjectMission(selectedProject)}
+                className="shrink-0 bg-accent-500 text-primary-950 hover:bg-accent-400"
+              >
+                Start mission
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  size={16}
+                  strokeWidth={1.7}
+                />
+              </Button>
+            </div>
+          ) : null}
+        </header>
+
+        {projectsQuery.isLoading ? (
+          <div className="rounded-3xl border border-primary-200 bg-[var(--theme-card)] p-8 text-sm text-primary-600">
+            Loading projects…
+          </div>
+        ) : projectsQuery.error ? (
+          <div className="rounded-3xl border border-red-200 bg-red-50 p-8 text-sm text-red-700">
+            {projectsQuery.error instanceof Error
+              ? projectsQuery.error.message
+              : 'Failed to load projects'}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="rounded-3xl border border-dashed border-primary-200 bg-[var(--theme-card)] p-8 text-center">
+            <HugeiconsIcon
+              icon={CodeIcon}
+              size={28}
+              strokeWidth={1.7}
+              className="mx-auto text-primary-500"
+            />
+            <p className="mt-3 font-semibold text-primary-900">
+              No projects detected
+            </p>
+            <p className="mt-1 text-sm text-primary-600">
+              Add or select a workspace that contains git repos or files like
+              README.md / package.json.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {projects.map((project) => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                history={missionHistory}
+                selected={selectedProject?.id === project.id}
+                onSelect={() => setSelectedProjectId(project.id)}
+                onStartMission={() => startProjectMission(project)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/projects/projects-screen.tsx
+++ b/src/screens/projects/projects-screen.tsx
@@ -11,6 +11,7 @@ import {
   Link01Icon,
   PlayIcon,
   TaskDone01Icon,
+  TimeQuarterPassIcon,
 } from '@hugeicons/core-free-icons'
 
 import { Button } from '@/components/ui/button'
@@ -22,6 +23,20 @@ type ProjectFile = {
   excerpt: string
 }
 
+type ProjectStatus = {
+  gitDirty: boolean | null
+  changedFiles: number | null
+  lastCommit: string | null
+  lastCommitAt: string | null
+  detectedStack: Array<string>
+  packageManager: string | null
+}
+
+type ProjectContextPreview = {
+  summary: string
+  files: Array<{ name: string; path: string; chars: number }>
+}
+
 type ProjectEntry = {
   id: string
   name: string
@@ -29,6 +44,8 @@ type ProjectEntry = {
   active: boolean
   gitRemote: string | null
   gitBranch: string | null
+  status: ProjectStatus
+  contextPreview: ProjectContextPreview
   instructionFiles: Array<ProjectFile>
   readme: ProjectFile | null
 }
@@ -132,6 +149,18 @@ function formatMissionDate(value: string): string {
     hour: '2-digit',
     minute: '2-digit',
   }).format(date)
+}
+
+function formatProjectStatus(status: ProjectStatus): string {
+  if (status.gitDirty === null) return 'Git status unavailable'
+  if (!status.gitDirty) return 'Clean worktree'
+  return `${status.changedFiles ?? 0} changed file${status.changedFiles === 1 ? '' : 's'}`
+}
+
+function formatLastCommit(status: ProjectStatus): string {
+  if (!status.lastCommit) return 'No commits detected'
+  if (!status.lastCommitAt) return status.lastCommit
+  return `${status.lastCommit} · ${formatMissionDate(status.lastCommitAt)}`
 }
 
 function buildProjectMissionDraft(project: ProjectEntry): string {
@@ -257,6 +286,77 @@ function ProjectCard({
       {selected ? (
         <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
           <div className="grid gap-3">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-primary-200 bg-primary-50/80 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                  Status
+                </p>
+                <p
+                  className={`mt-2 text-sm font-semibold ${project.status.gitDirty ? 'text-amber-700' : 'text-emerald-700'}`}
+                >
+                  {formatProjectStatus(project.status)}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-primary-200 bg-primary-50/80 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                  Last commit
+                </p>
+                <p className="mt-2 truncate text-sm font-semibold text-primary-900">
+                  {formatLastCommit(project.status)}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-primary-200 bg-primary-50/80 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                  Stack
+                </p>
+                <p className="mt-2 truncate text-sm font-semibold text-primary-900">
+                  {project.status.detectedStack.length
+                    ? project.status.detectedStack.join(', ')
+                    : 'Not detected'}
+                </p>
+                {project.status.packageManager ? (
+                  <p className="mt-1 text-xs text-primary-500">
+                    {project.status.packageManager}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-primary-200 bg-primary-50/70 p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary-500">
+                    Auto-context preview
+                  </p>
+                  <p className="mt-1 text-sm text-primary-600">
+                    This is the bounded context Conductor will attach to
+                    project-aware launches.
+                  </p>
+                </div>
+                <HugeiconsIcon
+                  icon={TimeQuarterPassIcon}
+                  size={20}
+                  strokeWidth={1.7}
+                  className="text-accent-600"
+                />
+              </div>
+              <pre className="whitespace-pre-wrap rounded-xl bg-[var(--theme-card)] p-3 text-xs leading-relaxed text-primary-700">
+                {project.contextPreview.summary}
+              </pre>
+              {project.contextPreview.files.length > 0 ? (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {project.contextPreview.files.map((file) => (
+                    <span
+                      key={`${project.id}-${file.path}`}
+                      className="rounded-full border border-primary-200 bg-[var(--theme-card)] px-2.5 py-1 text-[11px] text-primary-600"
+                    >
+                      {file.name} · {file.chars.toLocaleString()} chars
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
             <div className="flex items-center justify-between gap-3">
               <h3 className="text-sm font-semibold text-primary-900">
                 Local context

--- a/src/screens/swarm2/swarm2-orchestrator-card.tsx
+++ b/src/screens/swarm2/swarm2-orchestrator-card.tsx
@@ -52,6 +52,8 @@ export type Swarm2OrchestratorCardProps = {
   latestMission?: { id: string; title: string; state: string; assignmentCount: number; checkpointedCount: number } | null
   inboxCounts?: { needsReview: number; blocked: number; ready: number }
   routerSeed?: { key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null
+  liveWorkersStarting?: boolean
+  onStartLiveWorkers?: () => void
   onOpenRouter: () => void
   onRouterResults?: (response: DispatchResponse) => void
   /**
@@ -85,6 +87,8 @@ export function Swarm2OrchestratorCard({
   latestMission = null,
   inboxCounts = { needsReview: 0, blocked: 0, ready: 0 },
   routerSeed = null,
+  liveWorkersStarting = false,
+  onStartLiveWorkers,
   onOpenRouter,
   onRouterResults,
   onAnchorRef,
@@ -188,6 +192,23 @@ export function Swarm2OrchestratorCard({
           </div>
 
           <div className="absolute right-0 top-0 flex shrink-0 items-center gap-1">
+            <button
+              type="button"
+              onClick={onStartLiveWorkers}
+              disabled={!onStartLiveWorkers || liveWorkersStarting}
+              className={cn(
+                'inline-flex h-9 items-center gap-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]',
+                (!onStartLiveWorkers || liveWorkersStarting) && 'cursor-not-allowed opacity-50',
+              )}
+              title="Ensure and start all 15 live Swarm workers"
+            >
+              <HugeiconsIcon
+                icon={ComputerTerminal01Icon}
+                size={13}
+                strokeWidth={1.8}
+              />
+              {liveWorkersStarting ? 'Starting…' : 'Start 15'}
+            </button>
             <button
               type="button"
               onClick={onOpenRouter}

--- a/src/screens/swarm2/swarm2-screen.test.ts
+++ b/src/screens/swarm2/swarm2-screen.test.ts
@@ -4,14 +4,15 @@ import {
   SWARM2_INFORMATION_HIERARCHY,
   SWARM2_OPERATIONS_REUSE,
   SWARM2_REAL_API_ENDPOINTS,
+  SWARM2_ROLE_PRESETS,
   SWARM2_SURFACE_CONTRACT,
 } from './swarm2-screen'
 
 describe('Swarm2 surface contract', () => {
-  it('keeps Aurora as the primary hub above wired operational worker cards', () => {
+  it('keeps the orchestrator as the primary hub above wired operational worker cards', () => {
     expect(SWARM2_INFORMATION_HIERARCHY[0]).toContain('Status header')
     expect(SWARM2_INFORMATION_HIERARCHY[1]).toContain(
-      'Aurora/orchestrator hub card',
+      'Orchestrator hub card',
     )
     expect(SWARM2_INFORMATION_HIERARCHY[2]).toContain('Visible routing wires')
     expect(SWARM2_INFORMATION_HIERARCHY[3]).toContain(
@@ -71,6 +72,27 @@ describe('Swarm2 surface contract', () => {
       'compact-operational-metadata-panel',
       'inline-direct-chat-panel',
       'bottom-card-action-row',
+    ])
+  })
+
+  it('offers the final specialist agent team as role presets', () => {
+    expect(SWARM2_ROLE_PRESETS.map((preset) => preset.role)).toEqual([
+      'CTO / Conductor',
+      'Product Manager',
+      'Architect',
+      'Backend Coder',
+      'ML Coder',
+      'Frontend Coder',
+      'Integration Agent',
+      'QA Tester',
+      'DevOps',
+      'Reviewer',
+      'Memory / Knowledge',
+      'Research',
+      'Designer / OpenDesign',
+      'CyberSecurity',
+      'Data Analyst',
+      'Custom',
     ])
   })
 

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type CSSProperties,
 } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   AlarmClockIcon,
@@ -239,86 +239,126 @@ type RolePreset = {
   defaultModel?: string
 }
 
-const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
+export const SWARM2_ROLE_PRESETS: ReadonlyArray<RolePreset> = [
   {
-    role: 'Orchestrator',
-    specialty: 'control-plane state, dispatch, drift detection, escalation',
-    mission: 'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
-    systemPrompt: 'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
-    skills: ['swarm-orchestrator', 'swarm-worker-core', 'swarm-review-learning-loop', 'self-improvement'],
-    defaultModel: 'GPT-5.4',
+    role: 'CTO / Conductor',
+    specialty: 'strategy, orchestration, task decomposition, agent routing, approval gates',
+    mission: 'Own the whole mission: clarify outcomes, decompose work, route packets to specialists, keep humans in the approval loop, and synthesize final decisions.',
+    systemPrompt: 'You are the CTO / Conductor for Hermes. Clarify outcomes, decompose work into specialist packets, route agents, enforce approval gates, track risks, and synthesize final decisions. Do not perform irreversible external actions without explicit human approval.',
+    skills: ['protocol-driven-orchestrator', 'agent-team-operating-manual', 'review-gate'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Builder',
-    specialty: 'full-stack implementation, fast ship cycles',
-    mission: 'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
-    systemPrompt: 'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review'],
-    defaultModel: 'GPT-5.5',
+    role: 'Product Manager',
+    specialty: 'requirements, PRDs, priorities, acceptance criteria, user outcomes',
+    mission: 'Turn vague ideas into scoped product requirements, acceptance criteria, non-goals, and priority calls.',
+    systemPrompt: 'You are the Product Manager. Convert ambiguous requests into clear PRDs, user stories, acceptance criteria, non-goals, priorities, and success metrics. Escalate only material product ambiguity.',
+    skills: ['cto-product-ops', 'office-hours', 'writing-plans'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'Architect',
+    specialty: 'system design, module boundaries, data flow, technical tradeoffs',
+    mission: 'Design robust architecture before code: APIs, boundaries, risk analysis, migration paths, and maintainability constraints.',
+    systemPrompt: 'You are the Architect. Design APIs, data flow, module boundaries, migration paths, and tradeoffs. Prefer simple maintainable architecture and call out risks before implementation.',
+    skills: ['plan-eng-review', 'best-of-n-planning', 'graphify'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'Backend Coder',
+    specialty: 'server APIs, business logic, storage, auth, workers, integrations backend',
+    mission: 'Implement backend slices with tests, clear contracts, safe persistence, and minimal production risk.',
+    systemPrompt: 'You are the Backend Coder. Implement server/API/storage/runtime changes with TDD, clear contracts, safe persistence, and targeted validation. Never leak secrets.',
+    skills: ['test-driven-development', 'systematic-debugging', 'github-pr-workflow'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'ML Coder',
+    specialty: 'ML pipelines, LLM features, evals, inference, embeddings, model tooling',
+    mission: 'Build and evaluate AI/ML features with reproducible metrics, cost awareness, and safety constraints.',
+    systemPrompt: 'You are the ML Coder. Build LLM/ML features with evals, reproducible metrics, cost awareness, and safety boundaries. Prefer measurable improvements over vibes.',
+    skills: ['autoresearch', 'dspy', 'evaluating-llms-harness'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'Frontend Coder',
+    specialty: 'React UI, state, accessibility, responsive layouts, browser behavior',
+    mission: 'Ship polished frontend experiences with focused tests, accessibility, responsive layout, and browser verification.',
+    systemPrompt: 'You are the Frontend Coder. Implement React UI, state, accessibility, responsive layouts, and browser behavior with focused tests and visual verification.',
+    skills: ['frontend-design', 'test-driven-development', 'browse'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'Integration Agent',
+    specialty: 'Telegram, GitHub, Google Workspace, Obsidian, MCP, webhooks, OAuth, external APIs',
+    mission: 'Connect Hermes to external systems with safe auth boundaries, retries, webhook handling, and clear operator docs.',
+    systemPrompt: 'You are the Integration Agent. Build external API/webhook/OAuth/MCP integrations with safe token handling, retries, observability, and operator docs.',
+    skills: ['native-mcp', 'github-pr-workflow', 'google-workspace'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'QA Tester',
+    specialty: 'test plans, regression suites, smoke tests, browser QA, reproducible bug reports',
+    mission: 'Prove whether work is ready: reproduce bugs, run targeted checks, write smoke tests, and report evidence.',
+    systemPrompt: 'You are the QA Tester. Reproduce bugs, design test plans, run targeted/regression/smoke/browser checks, and report pass/fail evidence concisely.',
+    skills: ['qa', 'playwright-mcp', 'test-driven-development'],
+    defaultModel: 'Hermes Agent',
+  },
+  {
+    role: 'DevOps',
+    specialty: 'runtime, CI/CD, deploy, env, monitoring, Electron, process health',
+    mission: 'Keep Hermes running locally and in production: scripts, CI, deploys, env safety, monitoring, and rollback plans.',
+    systemPrompt: 'You are DevOps. Maintain runtime, scripts, CI/CD, deploy, env safety, monitoring, Electron packaging, health checks, and rollback plans. Require approval for deploy/destructive actions.',
+    skills: ['setup-deploy', 'health', 'careful'],
+    defaultModel: 'Hermes Agent',
   },
   {
     role: 'Reviewer',
-    specialty: 'byte-verified code review, naming + tests + build gate',
-    mission: 'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
-    systemPrompt: 'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
-    defaultModel: 'GPT-5.4',
+    specialty: 'code review, product review, regression risk, merge readiness',
+    mission: 'Act as the independent review gate: inspect diffs, verify requirements, catch regressions, and request fixes before shipping.',
+    systemPrompt: 'You are the Reviewer. Independently inspect diffs against requirements, verify validation evidence, find regressions/security risks, and return APPROVED or CHANGES_REQUESTED.',
+    skills: ['review-gate', 'github-code-review', 'requesting-code-review'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Triage',
-    specialty: 'autonomous PR/issues processor',
-    mission: 'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
-    systemPrompt: 'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
-    defaultModel: 'GPT-5.5',
+    role: 'Memory / Knowledge',
+    specialty: 'Obsidian, docs, summaries, skills, decisions, knowledge hygiene',
+    mission: 'Preserve useful context: final summaries, lessons learned, docs, runbooks, skills, and knowledge-base updates.',
+    systemPrompt: 'You are Memory / Knowledge. Preserve only durable useful context: summaries, decisions, docs, runbooks, skills, Obsidian notes, and lessons learned. Do not store secrets.',
+    skills: ['obsidian', 'document-release', 'context-checkpoint'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Lab',
-    specialty: 'local-model R&D, spec-dec, benchmarking',
-    mission: 'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
-    systemPrompt: 'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
-    skills: ['swarm-worker-core', 'pc1-ollama-gguf-bench', 'swarm-bench-worker'],
-    defaultModel: 'GPT-5.4',
+    role: 'Research',
+    specialty: 'technical research, docs reading, competitor analysis, papers, decision briefs',
+    mission: 'Find decision-grade evidence quickly, cite sources, compare options, and summarize what matters for execution.',
+    systemPrompt: 'You are Research. Read primary sources, compare options, cite evidence, and produce decision-grade briefs with risks and recommended next actions.',
+    skills: ['arxiv', 'autoresearch', 'research-paper-writing'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Sage',
-    specialty: 'research + scripts + X content + creative briefs',
-    mission: 'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
-    systemPrompt: 'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
-    skills: ['swarm-worker-core', 'last30days', 'pdf-and-paper-deep-reading'],
-    defaultModel: 'GPT-5.5',
+    role: 'Designer / OpenDesign',
+    specialty: 'product design, UX flows, visual systems, OpenDesign artifacts, prototypes',
+    mission: 'Design clear product experiences, states, flows, and polished visual artifacts before frontend implementation.',
+    systemPrompt: 'You are Designer / OpenDesign. Create UX flows, design states, visual systems, prototypes, and OpenDesign artifacts that guide frontend implementation.',
+    skills: ['frontend-design', 'open-design-hermes-integration', 'design-review'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Scribe',
-    specialty: 'docs, skills hygiene, memory curation',
-    mission: 'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
-    systemPrompt: 'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
-    skills: ['swarm-worker-core', 'last30days', 'creative-writing'],
-    defaultModel: 'GPT-5.5',
+    role: 'CyberSecurity',
+    specialty: 'threat modeling, secrets, auth, abuse cases, supply chain, secure review',
+    mission: 'Protect Hermes and user data: threat-model changes, scan for secrets, review auth boundaries, and block unsafe releases.',
+    systemPrompt: 'You are CyberSecurity. Threat-model changes, review auth and trust boundaries, scan for secrets/supply-chain risks, and block unsafe releases.',
+    skills: ['cso', 'careful', 'review-gate'],
+    defaultModel: 'Hermes Agent',
   },
   {
-    role: 'Foundation',
-    specialty: 'infra, repair playbook, autopilot wiring',
-    mission: 'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
-    systemPrompt: 'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
-    skills: ['swarm-worker-core'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'QA',
-    specialty: 'regression QA, render verification',
-    mission: 'Run regression suite on every commit + render. Block bad ships.',
-    systemPrompt: 'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review'],
-    defaultModel: 'GPT-5.4',
-  },
-  {
-    role: 'Mirror Integrations',
-    specialty: 'asset packs, upstream sync',
-    mission: 'Generate assets. Watch upstream. Pack integrations.',
-    systemPrompt: 'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
-    skills: ['swarm-worker-core', 'claude-promo', 'songwriting-and-ai-music'],
-    defaultModel: 'GPT-5.4',
+    role: 'Data Analyst',
+    specialty: 'metrics, SQL, analytics events, dashboards, product insights, experiment readouts',
+    mission: 'Turn product and system activity into useful metrics, dashboards, tracking plans, and analytical decisions.',
+    systemPrompt: 'You are the Data Analyst. Define metrics, tracking plans, SQL/analysis, dashboards, experiment readouts, and product insights.',
+    skills: ['analytics-tracking', 'jupyter-live-kernel', 'xlsx'],
+    defaultModel: 'Hermes Agent',
   },
   {
     role: 'Custom',
@@ -329,6 +369,7 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
   },
 ] as const
 
+const ROLE_PRESETS = SWARM2_ROLE_PRESETS
 const ROLE_NAMES = ROLE_PRESETS.map((p) => p.role)
 
 async function fetchAvailableModels(): Promise<Array<{ id: string; name: string; provider: string }>> {
@@ -353,6 +394,31 @@ async function fetchRuntime(): Promise<RuntimeResponse> {
   const res = await fetch('/api/swarm-runtime')
   if (!res.ok) throw new Error(`Runtime request failed: ${res.status}`)
   return res.json()
+}
+
+type StartLiveWorkersResponse = {
+  ok: boolean
+  setup?: { workers?: Array<{ id: string }> }
+  start?: {
+    summary?: {
+      requested: number
+      ok: boolean
+      started: number
+      alreadyRunning: number
+      failed: number
+    }
+    results?: Array<{ workerId: string; ok: boolean; error?: string }>
+  }
+  error?: string
+}
+
+async function startLiveWorkers(): Promise<StartLiveWorkersResponse> {
+  const res = await fetch('/api/swarm-live-workers', { method: 'POST' })
+  const data = (await res.json().catch(() => ({}))) as StartLiveWorkersResponse
+  if (!res.ok && res.status !== 207) {
+    throw new Error(data.error || `Start live workers failed: ${res.status}`)
+  }
+  return data
 }
 
 async function fetchHealth(): Promise<HealthData> {
@@ -674,6 +740,8 @@ type ControlPlaneStageProps = {
   onViewModeChange: (mode: ViewMode) => void
   onOpenRouter: () => void
   onRouterResults: () => void
+  liveWorkersStarting: boolean
+  onStartLiveWorkers: () => void
   onSelect: (workerId: string) => void
   onToggleRoom: (workerId: string) => void
   onOpenTui: (workerId: string) => void
@@ -711,6 +779,8 @@ function ControlPlaneStage({
   onViewModeChange,
   onOpenRouter,
   onRouterResults,
+  liveWorkersStarting,
+  onStartLiveWorkers,
   onSelect,
   onToggleRoom,
   onOpenTui,
@@ -816,6 +886,8 @@ function ControlPlaneStage({
           roomIds={roomIds}
           selectedId={selectedId}
           routerSeed={routerSeed}
+          liveWorkersStarting={liveWorkersStarting}
+          onStartLiveWorkers={onStartLiveWorkers}
           onOpenRouter={onOpenRouter}
           onRouterResults={() => {
             void onRouterResults()
@@ -1033,6 +1105,28 @@ export function Swarm2Screen() {
     queryKey: ['swarm2', 'missions'],
     queryFn: fetchMissions,
     refetchInterval: 30_000,
+  })
+  const startLiveWorkersMutation = useMutation({
+    mutationFn: startLiveWorkers,
+    onSuccess: (data) => {
+      const summary = data.start?.summary
+      toast({
+        title: summary?.ok ? 'Swarm live workers started' : 'Swarm live workers partially started',
+        description: summary
+          ? `${summary.started} started, ${summary.alreadyRunning} already running, ${summary.failed} failed.`
+          : 'Live worker profiles and sessions were requested.',
+        variant: summary && summary.failed > 0 ? 'destructive' : 'default',
+      })
+      void runtimeQuery.refetch()
+      void rosterQuery.refetch()
+    },
+    onError: (error) => {
+      toast({
+        title: 'Failed to start live workers',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      })
+    },
   })
 
   const startAgentSession = useCallback(
@@ -1605,6 +1699,8 @@ export function Swarm2Screen() {
             viewMode={viewMode}
             onViewModeChange={setViewMode}
             onOpenRouter={() => setRouterOpen(true)}
+            liveWorkersStarting={startLiveWorkersMutation.isPending}
+            onStartLiveWorkers={() => { startLiveWorkersMutation.mutate() }}
             onRouterResults={() => {
               void runtimeQuery.refetch()
               void missionsQuery.refetch()

--- a/src/server/multi-agent/diff-manager.test.ts
+++ b/src/server/multi-agent/diff-manager.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getTaskDiff } from './diff-manager'
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'hermes-ma-diff-repo-'))
+  git(repoPath, ['init', '-b', 'main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(repoPath, 'README.md'), '# test repo\n', 'utf-8')
+  writeFileSync(join(repoPath, 'keep.txt'), 'keep\n', 'utf-8')
+  git(repoPath, ['add', 'README.md', 'keep.txt'])
+  git(repoPath, ['commit', '-m', 'initial commit'])
+  return repoPath
+}
+
+describe('multi-agent diff manager', () => {
+  it('returns clean diff state when the worktree has no changes', () => {
+    const repoPath = initRepo()
+    try {
+      const diff = getTaskDiff(repoPath)
+
+      expect(diff.clean).toBe(true)
+      expect(diff.changedFiles).toEqual([])
+      expect(diff.stat).toBe('')
+      expect(diff.diff).toBe('')
+      expect(diff.porcelain).toBe('')
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('returns modified and untracked files with stat and unified diff content', async () => {
+    const repoPath = initRepo()
+    try {
+      await writeFile(join(repoPath, 'README.md'), '# changed repo\n', 'utf-8')
+      await writeFile(join(repoPath, 'new-file.txt'), 'new file\n', 'utf-8')
+
+      const diff = getTaskDiff(repoPath)
+
+      expect(diff.clean).toBe(false)
+      expect(diff.changedFiles).toEqual(['README.md', 'new-file.txt'])
+      expect(diff.porcelain).toContain('README.md')
+      expect(diff.porcelain).toContain('new-file.txt')
+      expect(diff.stat).toContain('README.md')
+      expect(diff.stat).toContain('new-file.txt')
+      expect(diff.diff).toContain('diff --git a/README.md b/README.md')
+      expect(diff.diff).toContain('-# test repo')
+      expect(diff.diff).toContain('+# changed repo')
+      expect(diff.diff).toContain('diff --git a/new-file.txt b/new-file.txt')
+      expect(diff.diff).toContain('+new file')
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('supports safe path filters inside the worktree', async () => {
+    const repoPath = initRepo()
+    try {
+      await mkdir(join(repoPath, 'src'))
+      await writeFile(join(repoPath, 'README.md'), '# changed repo\n', 'utf-8')
+      await writeFile(join(repoPath, 'src', 'app.ts'), 'export const app = true\n', 'utf-8')
+
+      const diff = getTaskDiff(repoPath, { paths: ['src/app.ts'] })
+
+      expect(diff.changedFiles).toEqual(['src/app.ts'])
+      expect(diff.diff).toContain('diff --git a/src/app.ts b/src/app.ts')
+      expect(diff.diff).not.toContain('README.md')
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects unsafe path filters', () => {
+    const repoPath = initRepo()
+    try {
+      expect(() => getTaskDiff(repoPath, { paths: ['../secret.txt'] })).toThrow(/Unsafe diff path/)
+      expect(() => getTaskDiff(repoPath, { paths: ['/tmp/secret.txt'] })).toThrow(/Unsafe diff path/)
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/multi-agent/diff-manager.ts
+++ b/src/server/multi-agent/diff-manager.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process'
+import { relative, resolve, sep } from 'node:path'
+
+export type TaskDiffFile = {
+  path: string
+  status: string
+}
+
+export type TaskDiffResult = {
+  clean: boolean
+  changedFiles: string[]
+  files: TaskDiffFile[]
+  porcelain: string
+  stat: string
+  diff: string
+}
+
+export type GetTaskDiffOptions = {
+  paths?: string[]
+}
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  }).trim()
+}
+
+function assertSafeDiffPath(worktreePath: string, path: string): void {
+  if (!path || path.includes('\0') || path.startsWith('/') || path.split(/[\\/]+/).includes('..')) {
+    throw new Error(`Unsafe diff path: ${path}`)
+  }
+  const relativePath = relative(resolve(worktreePath), resolve(worktreePath, path))
+  if (relativePath === '' || relativePath.startsWith('..') || relativePath.startsWith(sep)) {
+    throw new Error(`Unsafe diff path: ${path}`)
+  }
+}
+
+function pathArgs(worktreePath: string, paths?: string[]): string[] {
+  if (!paths?.length) return []
+  for (const path of paths) assertSafeDiffPath(worktreePath, path)
+  return ['--', ...paths]
+}
+
+function parsePorcelainLine(line: string): TaskDiffFile | null {
+  if (!line.trim()) return null
+  const status = line.slice(0, 2)
+  const rawPath = line.slice(2).trim()
+  const path = rawPath.split(' -> ').at(-1) || rawPath
+  return { path, status: status.trim() || status }
+}
+
+function untrackedFileDiff(worktreePath: string, files: TaskDiffFile[]): string {
+  return files
+    .filter((file) => file.status === '??')
+    .map((file) => {
+      try {
+        return git(worktreePath, ['diff', '--no-index', '--', '/dev/null', file.path])
+      } catch (err) {
+        const output = (err as { stdout?: Buffer | string }).stdout
+        if (Buffer.isBuffer(output)) return output.toString('utf-8').trim()
+        if (typeof output === 'string') return output.trim()
+        throw err
+      }
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function getTaskDiff(worktreePath: string, options: GetTaskDiffOptions = {}): TaskDiffResult {
+  const scopedPathArgs = pathArgs(worktreePath, options.paths)
+  const porcelain = git(worktreePath, ['status', '--porcelain', ...scopedPathArgs])
+  const files = porcelain
+    .split('\n')
+    .map(parsePorcelainLine)
+    .filter((file): file is TaskDiffFile => Boolean(file))
+  const changedFiles = files.map((file) => file.path)
+
+  const trackedStat = files.length ? git(worktreePath, ['diff', '--stat', ...scopedPathArgs]) : ''
+  const untrackedStat = files
+    .filter((file) => file.status === '??')
+    .map((file) => `${file.path} | untracked`)
+    .join('\n')
+  const stat = [trackedStat, untrackedStat].filter(Boolean).join('\n')
+  const trackedDiff = files.length ? git(worktreePath, ['diff', ...scopedPathArgs]) : ''
+  const untrackedDiff = files.length ? untrackedFileDiff(worktreePath, files) : ''
+  const diff = [trackedDiff, untrackedDiff].filter(Boolean).join('\n')
+
+  return {
+    clean: files.length === 0,
+    changedFiles,
+    files,
+    porcelain,
+    stat,
+    diff,
+  }
+}

--- a/src/server/multi-agent/events.test.ts
+++ b/src/server/multi-agent/events.test.ts
@@ -1,0 +1,72 @@
+import { appendFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  appendTaskEvent,
+  createMultiAgentEventLog,
+  getLatestTaskEvent,
+  listTaskEvents,
+} from './events'
+import type { MultiAgentEvent } from './types'
+
+function tempEventsDir(): string {
+  return join(mkdtempSync(join(tmpdir(), 'hermes-ma-events-')), 'events')
+}
+
+function event(overrides: Partial<MultiAgentEvent> = {}): MultiAgentEvent {
+  return {
+    id: overrides.id ?? 'event-1',
+    taskId: overrides.taskId ?? 'task-123',
+    runId: overrides.runId ?? null,
+    type: overrides.type ?? 'task.created',
+    message: overrides.message ?? 'Task created',
+    payload: overrides.payload,
+    createdAt: overrides.createdAt ?? '2026-05-16T18:30:00.000Z',
+  }
+}
+
+describe('multi-agent event log', () => {
+  it('appends and reads events in order', () => {
+    const log = createMultiAgentEventLog({ eventsDir: tempEventsDir() })
+
+    appendTaskEvent(log, event({ id: 'event-1', message: 'first' }))
+    appendTaskEvent(log, event({ id: 'event-2', message: 'second' }))
+
+    expect(listTaskEvents(log, 'task-123').map((item) => item.message)).toEqual(['first', 'second'])
+  })
+
+  it('returns null as the latest event when the task has no event file', () => {
+    const log = createMultiAgentEventLog({ eventsDir: tempEventsDir() })
+
+    expect(listTaskEvents(log, 'task-123')).toEqual([])
+    expect(getLatestTaskEvent(log, 'task-123')).toBeNull()
+  })
+
+  it('returns the latest appended event', () => {
+    const log = createMultiAgentEventLog({ eventsDir: tempEventsDir() })
+
+    appendTaskEvent(log, event({ id: 'event-1', message: 'created' }))
+    appendTaskEvent(log, event({ id: 'event-2', type: 'worktree.created', message: 'worktree' }))
+
+    expect(getLatestTaskEvent(log, 'task-123')?.message).toBe('worktree')
+  })
+
+  it('rejects unsafe task ids to prevent path traversal', () => {
+    const log = createMultiAgentEventLog({ eventsDir: tempEventsDir() })
+
+    expect(() => listTaskEvents(log, '../outside')).toThrow(/Unsafe task id/)
+    expect(() => appendTaskEvent(log, event({ taskId: 'task/123' }))).toThrow(/Unsafe task id/)
+  })
+
+  it('skips malformed JSONL lines while preserving valid events', () => {
+    const eventsDir = tempEventsDir()
+    const log = createMultiAgentEventLog({ eventsDir })
+
+    appendTaskEvent(log, event({ id: 'event-1', message: 'valid' }))
+    appendFileSync(join(eventsDir, 'task-123.jsonl'), '{ not json }\n', 'utf-8')
+    appendTaskEvent(log, event({ id: 'event-2', message: 'still valid' }))
+
+    expect(listTaskEvents(log, 'task-123').map((item) => item.id)).toEqual(['event-1', 'event-2'])
+  })
+})

--- a/src/server/multi-agent/events.ts
+++ b/src/server/multi-agent/events.ts
@@ -1,0 +1,75 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { MultiAgentEvent } from './types'
+
+export const DEFAULT_MULTI_AGENT_EVENTS_DIR = join(process.cwd(), '.runtime', 'multi-agent', 'events')
+
+export type MultiAgentEventLog = {
+  eventsDir: string
+}
+
+type EventLogOptions = {
+  eventsDir?: string
+}
+
+const SAFE_TASK_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,159}$/
+
+export function createMultiAgentEventLog(options: EventLogOptions = {}): MultiAgentEventLog {
+  return {
+    eventsDir: options.eventsDir ?? DEFAULT_MULTI_AGENT_EVENTS_DIR,
+  }
+}
+
+function assertSafeTaskId(taskId: string): void {
+  if (!SAFE_TASK_ID_PATTERN.test(taskId)) {
+    throw new Error(`Unsafe task id: ${taskId}`)
+  }
+}
+
+function eventFilePath(log: MultiAgentEventLog, taskId: string): string {
+  assertSafeTaskId(taskId)
+  return join(log.eventsDir, `${taskId}.jsonl`)
+}
+
+export function appendTaskEvent(log: MultiAgentEventLog, event: MultiAgentEvent): void {
+  const filePath = eventFilePath(log, event.taskId)
+  mkdirSync(log.eventsDir, { recursive: true })
+  appendFileSync(filePath, `${JSON.stringify(event)}\n`, 'utf-8')
+}
+
+function parseEventLine(line: string): MultiAgentEvent | null {
+  try {
+    const parsed = JSON.parse(line) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    const record = parsed as Partial<MultiAgentEvent>
+    if (
+      typeof record.id !== 'string' ||
+      typeof record.taskId !== 'string' ||
+      typeof record.type !== 'string' ||
+      typeof record.message !== 'string' ||
+      typeof record.createdAt !== 'string'
+    ) {
+      return null
+    }
+    return record as MultiAgentEvent
+  } catch {
+    return null
+  }
+}
+
+export function listTaskEvents(log: MultiAgentEventLog, taskId: string): MultiAgentEvent[] {
+  const filePath = eventFilePath(log, taskId)
+  if (!existsSync(filePath)) return []
+
+  return readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseEventLine)
+    .filter((event): event is MultiAgentEvent => Boolean(event))
+}
+
+export function getLatestTaskEvent(log: MultiAgentEventLog, taskId: string): MultiAgentEvent | null {
+  const events = listTaskEvents(log, taskId)
+  return events.at(-1) ?? null
+}

--- a/src/server/multi-agent/github-pr-manager.test.ts
+++ b/src/server/multi-agent/github-pr-manager.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildGitHubPrCommand, getGitHubPrPreflight } from './github-pr-manager'
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], { encoding: 'utf-8' }).trim()
+}
+
+function tempGitRepo(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'hermes-ma-pr-repo-'))
+  git(repoPath, ['init', '-b', 'main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(repoPath, 'README.md'), '# repo\n', 'utf-8')
+  git(repoPath, ['add', 'README.md'])
+  git(repoPath, ['commit', '-m', 'initial'])
+  git(repoPath, ['checkout', '-b', 'hermes/task-1-demo'])
+  writeFileSync(join(repoPath, 'feature.txt'), 'feature\n', 'utf-8')
+  git(repoPath, ['add', 'feature.txt'])
+  git(repoPath, ['commit', '-m', 'feat: demo'])
+  git(repoPath, ['remote', 'add', 'origin', 'https://github.com/example/repo.git'])
+  return repoPath
+}
+
+describe('github PR manager', () => {
+  it('preflights git repo, branch, remote, gh version/auth, and validations', () => {
+    const repoPath = tempGitRepo()
+    try {
+      const preflight = getGitHubPrPreflight({
+        worktreePath: repoPath,
+        branchName: 'hermes/task-1-demo',
+        validations: [
+          { id: 'validation-1', taskId: 'task-1', type: 'test', command: 'pnpm test', status: 'passed', exitCode: 0 },
+        ],
+        execFile: (command, args, options) => {
+          if (command === 'gh' && args.join(' ') === '--version') return 'gh version 2.0.0'
+          if (command === 'gh' && args.join(' ') === 'auth status') return 'Logged in to github.com'
+          return execFileSync(command, args, { cwd: options?.cwd, encoding: 'utf-8' }).trim()
+        },
+      })
+
+      expect(preflight.ok).toBe(true)
+      expect(preflight.checks).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'gh.version', ok: true }),
+        expect.objectContaining({ name: 'gh.auth', ok: true }),
+        expect.objectContaining({ name: 'git.remote', ok: true }),
+        expect.objectContaining({ name: 'git.branch', ok: true }),
+        expect.objectContaining({ name: 'validation.status', ok: true }),
+      ]))
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('reports failed preflight checks without throwing', () => {
+    const repoPath = tempGitRepo()
+    try {
+      git(repoPath, ['remote', 'remove', 'origin'])
+      const preflight = getGitHubPrPreflight({
+        worktreePath: repoPath,
+        branchName: 'missing-branch',
+        validations: [],
+        execFile: (command, args, options) => {
+          if (command === 'gh') throw new Error(`gh failed: ${args.join(' ')}`)
+          return execFileSync(command, args, { cwd: options?.cwd, encoding: 'utf-8' }).trim()
+        },
+      })
+
+      expect(preflight.ok).toBe(false)
+      expect(preflight.checks).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'gh.version', ok: false }),
+        expect.objectContaining({ name: 'gh.auth', ok: false }),
+        expect.objectContaining({ name: 'git.remote', ok: false }),
+        expect.objectContaining({ name: 'git.branch', ok: false }),
+        expect.objectContaining({ name: 'validation.status', ok: false }),
+      ]))
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  it('builds a safe gh pr create command', () => {
+    expect(buildGitHubPrCommand({
+      title: 'Task 1',
+      body: 'Summary',
+      baseBranch: 'main',
+      headBranch: 'hermes/task-1-demo',
+      draft: true,
+    })).toEqual([
+      'pr', 'create',
+      '--title', 'Task 1',
+      '--body', 'Summary',
+      '--base', 'main',
+      '--head', 'hermes/task-1-demo',
+      '--draft',
+    ])
+  })
+})

--- a/src/server/multi-agent/github-pr-manager.ts
+++ b/src/server/multi-agent/github-pr-manager.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process'
+import type { MultiAgentValidation } from './types'
+
+export type GitHubPrPreflightCheckName =
+  | 'gh.version'
+  | 'gh.auth'
+  | 'git.remote'
+  | 'git.branch'
+  | 'validation.status'
+
+export type GitHubPrPreflightCheck = {
+  name: GitHubPrPreflightCheckName
+  ok: boolean
+  message: string
+}
+
+export type GitHubPrPreflight = {
+  ok: boolean
+  checks: GitHubPrPreflightCheck[]
+}
+
+export type ExecFile = (command: string, args: string[], options?: { cwd?: string }) => string
+
+export type GitHubPrPreflightInput = {
+  worktreePath: string
+  branchName: string
+  validations: MultiAgentValidation[]
+  execFile?: ExecFile
+}
+
+export type BuildGitHubPrCommandInput = {
+  title: string
+  body: string
+  baseBranch: string
+  headBranch: string
+  draft?: boolean
+}
+
+function defaultExecFile(command: string, args: string[], options: { cwd?: string } = {}): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 20_000,
+  }).trim()
+}
+
+function check(name: GitHubPrPreflightCheckName, fn: () => string, okMessage: string): GitHubPrPreflightCheck {
+  try {
+    const output = fn()
+    return { name, ok: true, message: output || okMessage }
+  } catch (err) {
+    return { name, ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+export function getGitHubPrPreflight(input: GitHubPrPreflightInput): GitHubPrPreflight {
+  const execFile = input.execFile ?? defaultExecFile
+  const checks: GitHubPrPreflightCheck[] = [
+    check('gh.version', () => execFile('gh', ['--version']), 'gh is installed'),
+    check('gh.auth', () => execFile('gh', ['auth', 'status']), 'gh is authenticated'),
+    check('git.remote', () => execFile('git', ['remote', 'get-url', 'origin'], { cwd: input.worktreePath }), 'origin remote exists'),
+    check('git.branch', () => {
+      const branch = execFile('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: input.worktreePath })
+      if (branch !== input.branchName) throw new Error(`Expected branch ${input.branchName}, got ${branch}`)
+      return branch
+    }, 'branch exists'),
+    {
+      name: 'validation.status',
+      ok: input.validations.some((validation) => validation.status === 'passed'),
+      message: input.validations.some((validation) => validation.status === 'passed')
+        ? 'At least one validation passed'
+        : 'No passed validation found',
+    },
+  ]
+
+  return { ok: checks.every((item) => item.ok), checks }
+}
+
+export function buildGitHubPrCommand(input: BuildGitHubPrCommandInput): string[] {
+  const args = [
+    'pr', 'create',
+    '--title', input.title,
+    '--body', input.body,
+    '--base', input.baseBranch,
+    '--head', input.headBranch,
+  ]
+  if (input.draft) args.push('--draft')
+  return args
+}

--- a/src/server/multi-agent/hermes-worker-runtime.test.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.test.ts
@@ -42,7 +42,7 @@ function project(repoPath: string): MultiAgentProject {
 }
 
 describe('hermes worker runtime', () => {
-  it('builds Hermes oneshot defaults with prompt, skills, toolsets, model, and no yolo bypass', () => {
+  it('builds Hermes oneshot defaults with prompt, contextual skills, toolsets, model, and no yolo bypass', () => {
     const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-defaults-'))
     try {
       const store = createMultiAgentStore({ stateFile: join(tempRoot, 'state.json'), now: () => now, id: () => 'defaults' })
@@ -51,9 +51,9 @@ describe('hermes worker runtime', () => {
         createTask(store, {
           projectId: 'workspace',
           title: 'Check defaults',
-          description: 'Launch with default Hermes args',
+          description: 'Launch with default Hermes args and review the implementation',
           assigneeProfileId: 'backend-engineer',
-          workPacket: 'Print argv',
+          workPacket: 'Print argv and update the frontend UI',
           acceptanceCriteria: ['no yolo bypass'],
         }).id,
         { worktreePath: tempRoot, branchName: 'hermes/task-defaults', status: 'ready' },
@@ -61,13 +61,16 @@ describe('hermes worker runtime', () => {
       const workerProfile = { ...profile(), model: 'test/model' }
       const prompt = buildHermesWorkerPrompt({ task, project: project(tempRoot), profile: workerProfile })
 
-      const args = buildHermesWorkerArgs(prompt, workerProfile)
+      const args = buildHermesWorkerArgs(prompt, workerProfile, task)
 
       expect(args[0]).toBe('--oneshot')
       expect(args[1]).toContain('Task: Check defaults')
+      expect(args[1]).toContain('Skills loaded for this run:')
+      expect(args[1]).toContain('- test-driven-development')
+      expect(args[1]).toContain('- frontend-design')
       expect(args).toContain('--accept-hooks')
       expect(args).toContain('--skills')
-      expect(args).toContain('test-driven-development')
+      expect(args).toContain('test-driven-development,systematic-debugging,frontend-design,review-gate')
       expect(args).toContain('--toolsets')
       expect(args).toContain('terminal,file')
       expect(args).toContain('--model')
@@ -88,6 +91,12 @@ describe('hermes worker runtime', () => {
         description: 'Expose task event stream',
         assigneeProfileId: 'backend-engineer',
         workPacket: 'Create GET /api/ma/tasks/:taskId/events',
+        productBrief: {
+          goal: 'Improve operator confidence in task event visibility',
+          userStory: 'As an operator, I can inspect live task events without leaving the board.',
+          successMetrics: ['adoption: event panel used in review'],
+          nonGoals: ['streaming transport rewrite'],
+        },
         acceptanceCriteria: ['returns events', 'stays inside worktree'],
       })
       const prompt = buildHermesWorkerPrompt({
@@ -100,6 +109,11 @@ describe('hermes worker runtime', () => {
       expect(prompt).toContain('Role: backend-engineer')
       expect(prompt).toContain('Task: Add events route')
       expect(prompt).toContain('Worktree:')
+      expect(prompt).toContain('Product brief:')
+      expect(prompt).toContain('Goal: Improve operator confidence in task event visibility')
+      expect(prompt).toContain('User story: As an operator, I can inspect live task events without leaving the board.')
+      expect(prompt).toContain('- adoption: event panel used in review')
+      expect(prompt).toContain('- streaming transport rewrite')
       expect(prompt).toContain('Create GET /api/ma/tasks/:taskId/events')
       expect(prompt).toContain('- returns events')
       expect(prompt).toContain('Do not push, deploy, send external messages, or edit secrets without approval.')

--- a/src/server/multi-agent/hermes-worker-runtime.test.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { appendTaskEvent, createMultiAgentEventLog, listTaskEvents } from './events'
+import { createMultiAgentStore, createRun, createTask, getTask, updateTask } from './store'
+import type { MultiAgentProfile, MultiAgentProject } from './types'
+import {
+  buildHermesWorkerPrompt,
+  launchHermesWorker,
+  waitForHermesWorkerRun,
+} from './hermes-worker-runtime'
+
+const now = '2026-05-18T12:00:00.000Z'
+
+function profile(): MultiAgentProfile {
+  return {
+    id: 'backend-engineer',
+    name: 'Backend Engineer',
+    role: 'backend-engineer',
+    runtime: 'hermes-agent',
+    skills: ['test-driven-development'],
+    enabledToolsets: ['terminal', 'file'],
+    permissionPolicy: 'ask-risky',
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function project(repoPath: string): MultiAgentProject {
+  return {
+    id: 'workspace',
+    name: 'Workspace',
+    repoPath,
+    defaultBranch: 'main',
+    worktreeRoot: join(repoPath, '.hermes-worktrees'),
+    githubRemote: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe('hermes worker runtime', () => {
+  it('builds a constrained work packet prompt', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-prompt-'))
+    try {
+      const store = createMultiAgentStore({ stateFile: join(tempRoot, 'state.json'), now: () => now, id: () => '1' })
+      const task = createTask(store, {
+        projectId: 'workspace',
+        title: 'Add events route',
+        description: 'Expose task event stream',
+        assigneeProfileId: 'backend-engineer',
+        workPacket: 'Create GET /api/ma/tasks/:taskId/events',
+        acceptanceCriteria: ['returns events', 'stays inside worktree'],
+      })
+      const prompt = buildHermesWorkerPrompt({
+        task: { ...task, worktreePath: join(tempRoot, 'wt'), branchName: 'hermes/task-1-events' },
+        project: project(tempRoot),
+        profile: profile(),
+      })
+
+      expect(prompt).toContain('You are a Hermes Agent worker running under Hermes Workspace Multi-Agent Control Plane.')
+      expect(prompt).toContain('Role: backend-engineer')
+      expect(prompt).toContain('Task: Add events route')
+      expect(prompt).toContain('Worktree:')
+      expect(prompt).toContain('Create GET /api/ma/tasks/:taskId/events')
+      expect(prompt).toContain('- returns events')
+      expect(prompt).toContain('Do not push, deploy, send external messages, or edit secrets without approval.')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('emits run events and marks task done on process exit 0', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-pass-'))
+    try {
+      const store = createMultiAgentStore({
+        stateFile: join(tempRoot, 'state.json'),
+        now: () => now,
+        id: (() => {
+          let next = 0
+          return () => String(++next)
+        })(),
+      })
+      const eventLog = createMultiAgentEventLog({ eventsDir: join(tempRoot, 'events') })
+      const task = updateTask(
+        store,
+        createTask(store, {
+          projectId: 'workspace',
+          title: 'Run worker',
+          description: 'Run a fake worker',
+          assigneeProfileId: 'backend-engineer',
+          workPacket: 'Print a result',
+        }).id,
+        { worktreePath: tempRoot, branchName: 'hermes/task-run-worker', status: 'ready' },
+      )
+      const run = createRun(store, { taskId: task.id, profileId: profile().id, status: 'starting' })
+
+      const handle = launchHermesWorker({
+        store,
+        eventLog,
+        task,
+        run,
+        project: project(tempRoot),
+        profile: profile(),
+        command: process.execPath,
+        args: ['-e', "console.log('worker says hi')"],
+      })
+      await waitForHermesWorkerRun(handle)
+
+      const events = listTaskEvents(eventLog, task.id)
+      expect(events.map((event) => event.type)).toEqual([
+        'run.started',
+        'run.log',
+        'task.completed',
+      ])
+      expect(events.find((event) => event.type === 'run.log')?.message).toContain('worker says hi')
+      expect(getTask(store, task.id)).toMatchObject({ status: 'done', latestRunId: run.id })
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('marks task failed on process exit non-zero', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-fail-'))
+    try {
+      const store = createMultiAgentStore({ stateFile: join(tempRoot, 'state.json'), now: () => now, id: () => 'x' })
+      const eventLog = createMultiAgentEventLog({ eventsDir: join(tempRoot, 'events') })
+      const task = updateTask(
+        store,
+        createTask(store, {
+          projectId: 'workspace',
+          title: 'Fail worker',
+          description: 'Run a failing fake worker',
+          assigneeProfileId: 'backend-engineer',
+        }).id,
+        { worktreePath: tempRoot, branchName: 'hermes/task-fail-worker', status: 'ready' },
+      )
+      const run = createRun(store, { taskId: task.id, profileId: profile().id, status: 'starting' })
+
+      const handle = launchHermesWorker({
+        store,
+        eventLog,
+        task,
+        run,
+        project: project(tempRoot),
+        profile: profile(),
+        command: process.execPath,
+        args: ['-e', "console.error('boom'); process.exit(7)"],
+      })
+      await waitForHermesWorkerRun(handle)
+
+      const events = listTaskEvents(eventLog, task.id)
+      expect(events.map((event) => event.type)).toContain('task.failed')
+      expect(getTask(store, task.id)).toMatchObject({ status: 'failed', latestRunId: run.id })
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/multi-agent/hermes-worker-runtime.test.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.test.ts
@@ -7,6 +7,7 @@ import { createMultiAgentStore, createRun, createTask, getTask, updateTask } fro
 import type { MultiAgentProfile, MultiAgentProject } from './types'
 import {
   buildHermesWorkerPrompt,
+  buildHermesWorkerArgs,
   launchHermesWorker,
   waitForHermesWorkerRun,
 } from './hermes-worker-runtime'
@@ -41,6 +42,42 @@ function project(repoPath: string): MultiAgentProject {
 }
 
 describe('hermes worker runtime', () => {
+  it('builds Hermes oneshot defaults with prompt, skills, toolsets, model, and no yolo bypass', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-defaults-'))
+    try {
+      const store = createMultiAgentStore({ stateFile: join(tempRoot, 'state.json'), now: () => now, id: () => 'defaults' })
+      const task = updateTask(
+        store,
+        createTask(store, {
+          projectId: 'workspace',
+          title: 'Check defaults',
+          description: 'Launch with default Hermes args',
+          assigneeProfileId: 'backend-engineer',
+          workPacket: 'Print argv',
+          acceptanceCriteria: ['no yolo bypass'],
+        }).id,
+        { worktreePath: tempRoot, branchName: 'hermes/task-defaults', status: 'ready' },
+      )
+      const workerProfile = { ...profile(), model: 'test/model' }
+      const prompt = buildHermesWorkerPrompt({ task, project: project(tempRoot), profile: workerProfile })
+
+      const args = buildHermesWorkerArgs(prompt, workerProfile)
+
+      expect(args[0]).toBe('--oneshot')
+      expect(args[1]).toContain('Task: Check defaults')
+      expect(args).toContain('--accept-hooks')
+      expect(args).toContain('--skills')
+      expect(args).toContain('test-driven-development')
+      expect(args).toContain('--toolsets')
+      expect(args).toContain('terminal,file')
+      expect(args).toContain('--model')
+      expect(args).toContain('test/model')
+      expect(args).not.toContain('--yolo')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
   it('builds a constrained work packet prompt', () => {
     const tempRoot = mkdtempSync(join(tmpdir(), 'hermes-runtime-prompt-'))
     try {

--- a/src/server/multi-agent/hermes-worker-runtime.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.ts
@@ -90,7 +90,7 @@ Rules:
 `
 }
 
-function defaultHermesArgs(prompt: string, profile: MultiAgentProfile): string[] {
+export function buildHermesWorkerArgs(prompt: string, profile: MultiAgentProfile): string[] {
   const args = ['--oneshot', prompt, '--accept-hooks']
   if (profile.skills.length) {
     args.push('--skills', profile.skills.join(','))
@@ -107,7 +107,7 @@ function defaultHermesArgs(prompt: string, profile: MultiAgentProfile): string[]
 export function launchHermesWorker(input: LaunchHermesWorkerInput): HermesWorkerRunHandle {
   const prompt = buildHermesWorkerPrompt(input)
   const command = input.command ?? 'hermes'
-  const args = input.args ?? defaultHermesArgs(prompt, input.profile)
+  const args = input.args ?? buildHermesWorkerArgs(prompt, input.profile)
   const worktreePath = input.task.worktreePath ?? input.project.repoPath
 
   updateRun(input.store, input.run.id, {

--- a/src/server/multi-agent/hermes-worker-runtime.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { appendTaskEvent, type MultiAgentEventLog } from './events'
+import { selectSkillsForTask } from './skill-autoload'
 import {
   updateRun,
   updateTask,
@@ -17,6 +18,7 @@ export type HermesWorkerPromptInput = {
   task: MultiAgentTask
   project: MultiAgentProject
   profile: MultiAgentProfile
+  loadedSkills?: string[]
 }
 
 export type LaunchHermesWorkerInput = HermesWorkerPromptInput & {
@@ -40,6 +42,24 @@ function eventId(store: MultiAgentStore): string {
   return `event-${store.id()}`
 }
 
+function listBlock(values: string[], fallback: string): string {
+  return values.length ? values.map((value) => `- ${value}`).join('\n') : `- ${fallback}`
+}
+
+function productBriefBlock(task: MultiAgentTask): string {
+  const brief = task.productBrief
+  if (!brief) return 'Product brief:\n- No product brief captured.'
+  return [
+    'Product brief:',
+    `Goal: ${brief.goal || 'Not captured.'}`,
+    `User story: ${brief.userStory || 'Not captured.'}`,
+    'Success metrics:',
+    listBlock(brief.successMetrics, 'No success metrics captured.'),
+    'Non-goals:',
+    listBlock(brief.nonGoals, 'No non-goals captured.'),
+  ].join('\n')
+}
+
 function appendEvent(
   store: MultiAgentStore,
   eventLog: MultiAgentEventLog,
@@ -58,10 +78,15 @@ export function buildHermesWorkerPrompt({
   task,
   project,
   profile,
+  loadedSkills,
 }: HermesWorkerPromptInput): string {
   const criteria = task.acceptanceCriteria.length
     ? task.acceptanceCriteria.map((criterion) => `- ${criterion}`).join('\n')
     : '- No explicit acceptance criteria were provided.'
+  const skills = loadedSkills ?? selectSkillsForTask({ profile, task })
+  const skillsBlock = skills.length
+    ? skills.map((skill) => `- ${skill}`).join('\n')
+    : '- No skills selected.'
 
   return `You are a Hermes Agent worker running under Hermes Workspace Multi-Agent Control Plane.
 
@@ -72,8 +97,13 @@ Repo: ${project.repoPath}
 Worktree: ${task.worktreePath ?? '(not assigned)'}
 Branch: ${task.branchName ?? '(not assigned)'}
 
+Skills loaded for this run:
+${skillsBlock}
+
 Context:
 ${task.description || '(no description)'}
+
+${productBriefBlock(task)}
 
 Work packet:
 ${task.workPacket || task.description || task.title}
@@ -90,10 +120,11 @@ Rules:
 `
 }
 
-export function buildHermesWorkerArgs(prompt: string, profile: MultiAgentProfile): string[] {
+export function buildHermesWorkerArgs(prompt: string, profile: MultiAgentProfile, task?: MultiAgentTask): string[] {
+  const loadedSkills = task ? selectSkillsForTask({ profile, task }) : profile.skills
   const args = ['--oneshot', prompt, '--accept-hooks']
-  if (profile.skills.length) {
-    args.push('--skills', profile.skills.join(','))
+  if (loadedSkills.length) {
+    args.push('--skills', loadedSkills.join(','))
   }
   if (profile.enabledToolsets?.length) {
     args.push('--toolsets', profile.enabledToolsets.join(','))
@@ -105,9 +136,10 @@ export function buildHermesWorkerArgs(prompt: string, profile: MultiAgentProfile
 }
 
 export function launchHermesWorker(input: LaunchHermesWorkerInput): HermesWorkerRunHandle {
-  const prompt = buildHermesWorkerPrompt(input)
+  const loadedSkills = input.loadedSkills ?? selectSkillsForTask({ profile: input.profile, task: input.task })
+  const prompt = buildHermesWorkerPrompt({ ...input, loadedSkills })
   const command = input.command ?? 'hermes'
-  const args = input.args ?? buildHermesWorkerArgs(prompt, input.profile)
+  const args = input.args ?? buildHermesWorkerArgs(prompt, input.profile, input.task)
   const worktreePath = input.task.worktreePath ?? input.project.repoPath
 
   updateRun(input.store, input.run.id, {
@@ -142,6 +174,7 @@ export function launchHermesWorker(input: LaunchHermesWorkerInput): HermesWorker
       command,
       worktreePath,
       profileId: input.profile.id,
+      loadedSkills,
     },
   })
 

--- a/src/server/multi-agent/hermes-worker-runtime.ts
+++ b/src/server/multi-agent/hermes-worker-runtime.ts
@@ -1,0 +1,220 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { appendTaskEvent, type MultiAgentEventLog } from './events'
+import {
+  updateRun,
+  updateTask,
+  type MultiAgentStore,
+} from './store'
+import type {
+  MultiAgentEvent,
+  MultiAgentProfile,
+  MultiAgentProject,
+  MultiAgentRun,
+  MultiAgentTask,
+} from './types'
+
+export type HermesWorkerPromptInput = {
+  task: MultiAgentTask
+  project: MultiAgentProject
+  profile: MultiAgentProfile
+}
+
+export type LaunchHermesWorkerInput = HermesWorkerPromptInput & {
+  store: MultiAgentStore
+  eventLog: MultiAgentEventLog
+  run: MultiAgentRun
+  command?: string
+  args?: string[]
+}
+
+export type HermesWorkerRunHandle = {
+  child: ChildProcessWithoutNullStreams
+  done: Promise<void>
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+function eventId(store: MultiAgentStore): string {
+  return `event-${store.id()}`
+}
+
+function appendEvent(
+  store: MultiAgentStore,
+  eventLog: MultiAgentEventLog,
+  event: Omit<MultiAgentEvent, 'id' | 'createdAt'>,
+): MultiAgentEvent {
+  const fullEvent: MultiAgentEvent = {
+    id: eventId(store),
+    createdAt: store.now(),
+    ...event,
+  }
+  appendTaskEvent(eventLog, fullEvent)
+  return fullEvent
+}
+
+export function buildHermesWorkerPrompt({
+  task,
+  project,
+  profile,
+}: HermesWorkerPromptInput): string {
+  const criteria = task.acceptanceCriteria.length
+    ? task.acceptanceCriteria.map((criterion) => `- ${criterion}`).join('\n')
+    : '- No explicit acceptance criteria were provided.'
+
+  return `You are a Hermes Agent worker running under Hermes Workspace Multi-Agent Control Plane.
+
+Role: ${profile.role}
+Task: ${task.title}
+Project: ${project.name}
+Repo: ${project.repoPath}
+Worktree: ${task.worktreePath ?? '(not assigned)'}
+Branch: ${task.branchName ?? '(not assigned)'}
+
+Context:
+${task.description || '(no description)'}
+
+Work packet:
+${task.workPacket || task.description || task.title}
+
+Acceptance criteria:
+${criteria}
+
+Rules:
+- Work only inside the worktree unless explicitly approved.
+- Do not push, deploy, send external messages, or edit secrets without approval.
+- Keep changes scoped to the task.
+- Run relevant validation if practical.
+- End with structured result: summary, files changed, validation, risks, blockers.
+`
+}
+
+function defaultHermesArgs(prompt: string, profile: MultiAgentProfile): string[] {
+  const args = ['--oneshot', prompt, '--accept-hooks']
+  if (profile.skills.length) {
+    args.push('--skills', profile.skills.join(','))
+  }
+  if (profile.enabledToolsets?.length) {
+    args.push('--toolsets', profile.enabledToolsets.join(','))
+  }
+  if (profile.model) {
+    args.push('--model', profile.model)
+  }
+  return args
+}
+
+export function launchHermesWorker(input: LaunchHermesWorkerInput): HermesWorkerRunHandle {
+  const prompt = buildHermesWorkerPrompt(input)
+  const command = input.command ?? 'hermes'
+  const args = input.args ?? defaultHermesArgs(prompt, input.profile)
+  const worktreePath = input.task.worktreePath ?? input.project.repoPath
+
+  updateRun(input.store, input.run.id, {
+    status: 'running',
+    startedAt: input.store.now(),
+  })
+  updateTask(input.store, input.task.id, {
+    status: 'running',
+    latestRunId: input.run.id,
+  })
+
+  const child = spawn(command, args, {
+    cwd: worktreePath,
+    env: {
+      ...process.env,
+      HERMES_TASK_ID: input.task.id,
+      HERMES_RUN_ID: input.run.id,
+      HERMES_PROJECT_PATH: input.project.repoPath,
+      HERMES_WORKTREE_PATH: worktreePath,
+      HERMES_WORKER_PROFILE: input.profile.id,
+      HERMES_WORKER_PROMPT: prompt,
+    },
+  })
+
+  appendEvent(input.store, input.eventLog, {
+    taskId: input.task.id,
+    runId: input.run.id,
+    type: 'run.started',
+    message: `Started Hermes worker with ${command} ${args.map(shellQuote).join(' ')}`,
+    payload: {
+      pid: child.pid ?? null,
+      command,
+      worktreePath,
+      profileId: input.profile.id,
+    },
+  })
+
+  const logChunk = (stream: 'stdout' | 'stderr', chunk: Buffer) => {
+    const text = chunk.toString('utf-8').trim()
+    if (!text) return
+    appendEvent(input.store, input.eventLog, {
+      taskId: input.task.id,
+      runId: input.run.id,
+      type: 'run.log',
+      message: text,
+      payload: { stream },
+    })
+  }
+
+  child.stdout.on('data', (chunk: Buffer) => logChunk('stdout', chunk))
+  child.stderr.on('data', (chunk: Buffer) => logChunk('stderr', chunk))
+
+  const finalizeFailure = (message: string, payload: Record<string, unknown>) => {
+    try {
+      updateRun(input.store, input.run.id, {
+        status: 'failed',
+        finishedAt: input.store.now(),
+        error: message,
+      })
+      updateTask(input.store, input.task.id, { status: 'failed' })
+      appendEvent(input.store, input.eventLog, {
+        taskId: input.task.id,
+        runId: input.run.id,
+        type: 'task.failed',
+        message,
+        payload,
+      })
+    } catch {
+      // The backing store can disappear during tests or workspace shutdown. The child
+      // process already exited; avoid surfacing late unhandled exceptions.
+    }
+  }
+
+  const done = new Promise<void>((resolve) => {
+    child.on('error', (error) => {
+      finalizeFailure(error.message, { error: error.message })
+      resolve()
+    })
+
+    child.on('close', (code, signal) => {
+      const success = code === 0
+      try {
+        updateRun(input.store, input.run.id, {
+          status: success ? 'completed' : 'failed',
+          finishedAt: input.store.now(),
+          error: success ? null : `Worker exited with code ${code ?? 'null'} signal ${signal ?? 'null'}`,
+        })
+        updateTask(input.store, input.task.id, { status: success ? 'done' : 'failed' })
+        appendEvent(input.store, input.eventLog, {
+          taskId: input.task.id,
+          runId: input.run.id,
+          type: success ? 'task.completed' : 'task.failed',
+          message: success
+            ? `Hermes worker completed ${input.task.title}`
+            : `Hermes worker failed with code ${code ?? 'null'}`,
+          payload: { code, signal },
+        })
+      } catch {
+        // See finalizeFailure note: do not turn late child exit into an unhandled error.
+      }
+      resolve()
+    })
+  })
+
+  return { child, done }
+}
+
+export async function waitForHermesWorkerRun(handle: HermesWorkerRunHandle): Promise<void> {
+  await handle.done
+}

--- a/src/server/multi-agent/memory-sync.test.ts
+++ b/src/server/multi-agent/memory-sync.test.ts
@@ -19,6 +19,12 @@ function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
     parentIds: [],
     childIds: [],
     workPacket: 'Store final summary and optionally sync to Obsidian.',
+    productBrief: {
+      goal: 'Preserve useful task outcomes for future planning.',
+      userStory: 'As an operator, I can reopen a run note and understand why the task mattered.',
+      successMetrics: ['summary reused in next planning session'],
+      nonGoals: ['global knowledge graph sync'],
+    },
     acceptanceCriteria: ['summary is stored', 'obsidian note can be written'],
     branchName: 'hermes/task-1-memory-hooks',
     worktreePath: '/repo/.hermes-worktrees/task-1-memory-hooks',
@@ -62,6 +68,10 @@ describe('multi-agent memory sync', () => {
     expect(note).toContain('Status: `done`')
     expect(note).toContain('Branch: `hermes/task-1-memory-hooks`')
     expect(note).toContain('Implemented memory hooks and tests.')
+    expect(note).toContain('## Product Brief')
+    expect(note).toContain('Goal: Preserve useful task outcomes for future planning.')
+    expect(note).toContain('- summary reused in next planning session')
+    expect(note).toContain('- global knowledge graph sync')
     expect(note).toContain('- summary is stored')
     expect(note).not.toContain('undefined')
   })

--- a/src/server/multi-agent/memory-sync.test.ts
+++ b/src/server/multi-agent/memory-sync.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentRun, MultiAgentTask } from './types'
+import { saveTaskSummaryToObsidian } from './memory-sync'
+
+const now = '2026-05-18T12:00:00.000Z'
+
+function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
+  return {
+    id: 'task-1',
+    projectId: 'workspace',
+    title: 'Add memory hooks / MVP',
+    description: 'Persist final task context',
+    status: 'done',
+    priority: 'medium',
+    assigneeProfileId: 'backend-engineer',
+    parentIds: [],
+    childIds: [],
+    workPacket: 'Store final summary and optionally sync to Obsidian.',
+    acceptanceCriteria: ['summary is stored', 'obsidian note can be written'],
+    branchName: 'hermes/task-1-memory-hooks',
+    worktreePath: '/repo/.hermes-worktrees/task-1-memory-hooks',
+    latestRunId: 'run-1',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function run(overrides: Partial<MultiAgentRun> = {}): MultiAgentRun {
+  return {
+    id: 'run-1',
+    taskId: 'task-1',
+    profileId: 'backend-engineer',
+    status: 'completed',
+    startedAt: now,
+    finishedAt: now,
+    summary: 'Implemented memory hooks and tests.',
+    ...overrides,
+  }
+}
+
+describe('multi-agent memory sync', () => {
+  it('writes a sanitized markdown note for a task final summary', () => {
+    const obsidianRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-memory-'))
+
+    const result = saveTaskSummaryToObsidian({
+      obsidianRoot,
+      task: task(),
+      run: run(),
+      summary: 'Implemented memory hooks and tests.',
+      savedAt: now,
+    })
+
+    expect(result.path).toMatch(/2026-05-18-task-1-add-memory-hooks-mvp\.md$/)
+    const note = readFileSync(result.path, 'utf-8')
+    expect(note).toContain('# Add memory hooks / MVP')
+    expect(note).toContain('Task: `task-1`')
+    expect(note).toContain('Run: `run-1`')
+    expect(note).toContain('Status: `done`')
+    expect(note).toContain('Branch: `hermes/task-1-memory-hooks`')
+    expect(note).toContain('Implemented memory hooks and tests.')
+    expect(note).toContain('- summary is stored')
+    expect(note).not.toContain('undefined')
+  })
+
+  it('rejects empty summaries before writing memory notes', () => {
+    const obsidianRoot = mkdtempSync(join(tmpdir(), 'hermes-ma-memory-'))
+
+    expect(() => saveTaskSummaryToObsidian({
+      obsidianRoot,
+      task: task(),
+      run: run({ summary: null }),
+      summary: '   ',
+      savedAt: now,
+    })).toThrow(/summary is required/i)
+  })
+})

--- a/src/server/multi-agent/memory-sync.ts
+++ b/src/server/multi-agent/memory-sync.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { MultiAgentRun, MultiAgentTask } from './types'
+
+export const DEFAULT_MULTI_AGENT_OBSIDIAN_RUNS_DIR = join(
+  process.env.HOME ?? process.cwd(),
+  'ai-workspace',
+  'knowledge',
+  'obsidian-vault',
+  'Hermes',
+  'Multi-Agent Runs',
+)
+
+type SaveTaskSummaryToObsidianInput = {
+  obsidianRoot?: string
+  task: MultiAgentTask
+  run: MultiAgentRun
+  summary: string
+  savedAt?: string
+}
+
+export type SaveTaskSummaryToObsidianResult = {
+  path: string
+}
+
+function safeSlug(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^0-9a-z]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+  return slug || 'summary'
+}
+
+function optionalLine(label: string, value: string | null | undefined): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : ''
+  return trimmed ? `${label}: \`${trimmed}\`` : null
+}
+
+function buildSummaryNote(input: Required<Pick<SaveTaskSummaryToObsidianInput, 'task' | 'run' | 'summary' | 'savedAt'>>): string {
+  const { task, run, summary, savedAt } = input
+  const metadata = [
+    `Task: \`${task.id}\``,
+    `Run: \`${run.id}\``,
+    `Status: \`${task.status}\``,
+    optionalLine('Branch', task.branchName),
+    optionalLine('Worktree', task.worktreePath),
+    `Saved: \`${savedAt}\``,
+  ].filter((line): line is string => Boolean(line))
+
+  const acceptance = task.acceptanceCriteria.length
+    ? task.acceptanceCriteria.map((criterion) => `- ${criterion}`).join('\n')
+    : '- No acceptance criteria captured.'
+
+  return [
+    `# ${task.title}`,
+    '',
+    metadata.join('\n'),
+    '',
+    '## Summary',
+    '',
+    summary,
+    '',
+    '## Work Packet',
+    '',
+    task.workPacket || task.description || 'No work packet provided.',
+    '',
+    '## Acceptance Criteria',
+    '',
+    acceptance,
+    '',
+  ].join('\n')
+}
+
+export function saveTaskSummaryToObsidian(input: SaveTaskSummaryToObsidianInput): SaveTaskSummaryToObsidianResult {
+  const summary = input.summary.trim()
+  if (!summary) throw new Error('Task final summary is required before saving an Obsidian note')
+
+  const savedAt = input.savedAt ?? new Date().toISOString()
+  const obsidianRoot = input.obsidianRoot ?? DEFAULT_MULTI_AGENT_OBSIDIAN_RUNS_DIR
+  const date = savedAt.slice(0, 10) || new Date().toISOString().slice(0, 10)
+  const fileName = `${date}-${safeSlug(input.task.id)}-${safeSlug(input.task.title)}.md`
+  const path = join(obsidianRoot, fileName)
+
+  mkdirSync(obsidianRoot, { recursive: true })
+  writeFileSync(
+    path,
+    buildSummaryNote({ task: input.task, run: input.run, summary, savedAt }),
+    'utf-8',
+  )
+
+  return { path }
+}

--- a/src/server/multi-agent/memory-sync.ts
+++ b/src/server/multi-agent/memory-sync.ts
@@ -51,6 +51,19 @@ function buildSummaryNote(input: Required<Pick<SaveTaskSummaryToObsidianInput, '
   const acceptance = task.acceptanceCriteria.length
     ? task.acceptanceCriteria.map((criterion) => `- ${criterion}`).join('\n')
     : '- No acceptance criteria captured.'
+  const brief = task.productBrief
+  const productBrief = brief
+    ? [
+      `Goal: ${brief.goal || 'Not captured.'}`,
+      `User story: ${brief.userStory || 'Not captured.'}`,
+      '',
+      'Success metrics:',
+      brief.successMetrics.length ? brief.successMetrics.map((metric) => `- ${metric}`).join('\n') : '- No success metrics captured.',
+      '',
+      'Non-goals:',
+      brief.nonGoals.length ? brief.nonGoals.map((nonGoal) => `- ${nonGoal}`).join('\n') : '- No non-goals captured.',
+    ].join('\n')
+    : 'No product brief captured.'
 
   return [
     `# ${task.title}`,
@@ -60,6 +73,10 @@ function buildSummaryNote(input: Required<Pick<SaveTaskSummaryToObsidianInput, '
     '## Summary',
     '',
     summary,
+    '',
+    '## Product Brief',
+    '',
+    productBrief,
     '',
     '## Work Packet',
     '',

--- a/src/server/multi-agent/profiles.ts
+++ b/src/server/multi-agent/profiles.ts
@@ -5,6 +5,7 @@ const DEFAULT_PROFILE_IDS: MultiAgentProfileRole[] = [
   'orchestrator',
   'frontend-engineer',
   'backend-engineer',
+  'architect',
   'qa-validator',
   'reviewer',
   'docs-writer',

--- a/src/server/multi-agent/profiles.ts
+++ b/src/server/multi-agent/profiles.ts
@@ -1,3 +1,4 @@
+import { defaultSkillsForRole } from './skill-autoload'
 import type { MultiAgentProfile, MultiAgentProfileRole } from './types'
 
 const DEFAULT_PROFILE_IDS: MultiAgentProfileRole[] = [
@@ -16,23 +17,6 @@ function titleizeProfileId(id: string): string {
     .join(' ')
 }
 
-function defaultSkillsFor(role: MultiAgentProfileRole): string[] {
-  switch (role) {
-    case 'orchestrator':
-      return ['protocol-driven-orchestrator', 'best-of-n-planning']
-    case 'frontend-engineer':
-      return ['test-driven-development', 'frontend-design']
-    case 'backend-engineer':
-      return ['test-driven-development', 'systematic-debugging']
-    case 'qa-validator':
-      return ['qa', 'superpowers-verification-before-completion']
-    case 'reviewer':
-      return ['review-gate', 'requesting-code-review']
-    case 'docs-writer':
-      return ['document-release', 'doc-coauthoring']
-  }
-}
-
 export function defaultMultiAgentProfiles(now = new Date().toISOString()): MultiAgentProfile[] {
   return DEFAULT_PROFILE_IDS.map((role) => ({
     id: role,
@@ -40,7 +24,7 @@ export function defaultMultiAgentProfiles(now = new Date().toISOString()): Multi
     role,
     runtime: 'hermes-agent',
     model: null,
-    skills: defaultSkillsFor(role),
+    skills: defaultSkillsForRole(role),
     enabledToolsets: ['terminal', 'file'],
     permissionPolicy: role === 'reviewer' || role === 'qa-validator' ? 'read-only' : 'ask-risky',
     createdAt: now,

--- a/src/server/multi-agent/profiles.ts
+++ b/src/server/multi-agent/profiles.ts
@@ -1,0 +1,49 @@
+import type { MultiAgentProfile, MultiAgentProfileRole } from './types'
+
+const DEFAULT_PROFILE_IDS: MultiAgentProfileRole[] = [
+  'orchestrator',
+  'frontend-engineer',
+  'backend-engineer',
+  'qa-validator',
+  'reviewer',
+  'docs-writer',
+]
+
+function titleizeProfileId(id: string): string {
+  return id
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function defaultSkillsFor(role: MultiAgentProfileRole): string[] {
+  switch (role) {
+    case 'orchestrator':
+      return ['protocol-driven-orchestrator', 'best-of-n-planning']
+    case 'frontend-engineer':
+      return ['test-driven-development', 'frontend-design']
+    case 'backend-engineer':
+      return ['test-driven-development', 'systematic-debugging']
+    case 'qa-validator':
+      return ['qa', 'superpowers-verification-before-completion']
+    case 'reviewer':
+      return ['review-gate', 'requesting-code-review']
+    case 'docs-writer':
+      return ['document-release', 'doc-coauthoring']
+  }
+}
+
+export function defaultMultiAgentProfiles(now = new Date().toISOString()): MultiAgentProfile[] {
+  return DEFAULT_PROFILE_IDS.map((role) => ({
+    id: role,
+    name: titleizeProfileId(role),
+    role,
+    runtime: 'hermes-agent',
+    model: null,
+    skills: defaultSkillsFor(role),
+    enabledToolsets: ['terminal', 'file'],
+    permissionPolicy: role === 'reviewer' || role === 'qa-validator' ? 'read-only' : 'ask-risky',
+    createdAt: now,
+    updatedAt: now,
+  }))
+}

--- a/src/server/multi-agent/project-resolver.test.ts
+++ b/src/server/multi-agent/project-resolver.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  defaultWorktreeRoot,
+  detectDefaultBranch,
+  detectGithubRemote,
+  isGitRepo,
+  resolveProject,
+} from './project-resolver'
+
+function tempDir(prefix = 'hermes-ma-project-'): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(branch = 'main'): string {
+  const repoPath = tempDir()
+  git(repoPath, ['init', '-b', branch])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(repoPath, 'README.md'), '# test repo\n', 'utf-8')
+  git(repoPath, ['add', 'README.md'])
+  git(repoPath, ['commit', '-m', 'initial commit'])
+  return repoPath
+}
+
+describe('multi-agent project resolver', () => {
+  it('detects git repositories and rejects non-git directories', () => {
+    const repoPath = initRepo()
+    const plainDir = tempDir()
+
+    expect(isGitRepo(repoPath)).toBe(true)
+    expect(isGitRepo(plainDir)).toBe(false)
+  })
+
+  it('rejects non-existent project paths', () => {
+    expect(() => resolveProject({ repoPath: join(tempDir(), 'missing') })).toThrow(/does not exist/)
+  })
+
+  it('detects default branch from origin HEAD when available', () => {
+    const repoPath = initRepo('main')
+    git(repoPath, ['remote', 'add', 'origin', 'git@github.com:example/repo.git'])
+    git(repoPath, ['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
+
+    expect(detectDefaultBranch(repoPath)).toBe('main')
+  })
+
+  it('falls back to current branch when origin HEAD is unavailable', () => {
+    const repoPath = initRepo('develop')
+
+    expect(detectDefaultBranch(repoPath)).toBe('develop')
+  })
+
+  it('detects GitHub remote and derives worktree root', () => {
+    const repoPath = initRepo()
+    git(repoPath, ['remote', 'add', 'origin', 'git@github.com:example/repo.git'])
+
+    expect(detectGithubRemote(repoPath)).toBe('git@github.com:example/repo.git')
+    expect(defaultWorktreeRoot(repoPath)).toBe(join(repoPath, '.hermes-worktrees'))
+  })
+
+  it('resolves a project with explicit metadata', () => {
+    const repoPath = initRepo('main')
+    git(repoPath, ['remote', 'add', 'origin', 'https://github.com/example/repo.git'])
+
+    const project = resolveProject({
+      id: 'custom-project',
+      name: 'Custom Project',
+      repoPath,
+      validation: { test: 'pnpm test' },
+      obsidianPath: '/vault/Custom Project',
+    })
+
+    expect(project).toMatchObject({
+      id: 'custom-project',
+      name: 'Custom Project',
+      repoPath,
+      defaultBranch: 'main',
+      worktreeRoot: join(repoPath, '.hermes-worktrees'),
+      githubRemote: 'https://github.com/example/repo.git',
+      validation: { test: 'pnpm test' },
+      obsidianPath: '/vault/Custom Project',
+    })
+    expect(project.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(project.updatedAt).toBe(project.createdAt)
+  })
+
+  it('resolves registry-shaped projects without mutating project-registry', () => {
+    const repoPath = initRepo()
+
+    const project = resolveProject({
+      id: 'registry-id',
+      name: 'Registry Project',
+      path: repoPath,
+      gitRemote: null,
+    })
+
+    expect(project.id).toBe('registry-id')
+    expect(project.name).toBe('Registry Project')
+    expect(project.repoPath).toBe(repoPath)
+  })
+
+  it('rejects files instead of directories', () => {
+    const root = tempDir()
+    const filePath = join(root, 'not-a-dir')
+    mkdirSync(root, { recursive: true })
+    writeFileSync(filePath, 'nope', 'utf-8')
+
+    expect(() => resolveProject({ repoPath: filePath })).toThrow(/not a directory/)
+  })
+})

--- a/src/server/multi-agent/project-resolver.ts
+++ b/src/server/multi-agent/project-resolver.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, statSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+import type { MultiAgentProject, MultiAgentProjectValidation } from './types'
+
+export type ResolveProjectInput = {
+  id?: string
+  name?: string
+  repoPath?: string
+  path?: string
+  defaultBranch?: string | null
+  worktreeRoot?: string | null
+  githubRemote?: string | null
+  gitRemote?: string | null
+  graphifyGraphPath?: string | null
+  obsidianPath?: string | null
+  validation?: MultiAgentProjectValidation
+  now?: () => string
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function gitOutput(repoPath: string, args: string[]): string | null {
+  try {
+    const output = execFileSync('git', ['-C', repoPath, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+    }).trim()
+    return output || null
+  } catch {
+    return null
+  }
+}
+
+function safeProjectId(repoPath: string): string {
+  return Buffer.from(repoPath).toString('base64url')
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export function isGitRepo(repoPath: string): boolean {
+  return gitOutput(repoPath, ['rev-parse', '--is-inside-work-tree']) === 'true'
+}
+
+export function detectDefaultBranch(repoPath: string): string {
+  const originHead = gitOutput(repoPath, ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])
+  const originBranch = originHead?.replace(/^origin\//, '')
+  if (originBranch) return originBranch
+
+  const currentBranch = gitOutput(repoPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  if (currentBranch && currentBranch !== 'HEAD') return currentBranch
+
+  const mainExists = gitOutput(repoPath, ['rev-parse', '--verify', 'main'])
+  if (mainExists) return 'main'
+
+  return 'main'
+}
+
+export function detectGithubRemote(repoPath: string): string | null {
+  const origin = gitOutput(repoPath, ['remote', 'get-url', 'origin'])
+  if (origin) return origin
+
+  const remotes = gitOutput(repoPath, ['remote', '-v'])
+  const githubLine = remotes
+    ?.split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.includes('github.com'))
+  if (!githubLine) return null
+
+  const [, remoteUrl] = githubLine.split(/\s+/)
+  return remoteUrl || null
+}
+
+export function defaultWorktreeRoot(repoPath: string): string {
+  return join(repoPath, '.hermes-worktrees')
+}
+
+export function resolveProject(input: ResolveProjectInput): MultiAgentProject {
+  const rawPath = input.repoPath ?? input.path
+  if (!rawPath?.trim()) throw new Error('Project repoPath is required')
+
+  const repoPath = resolve(rawPath)
+  if (!existsSync(repoPath)) throw new Error(`Project path does not exist: ${repoPath}`)
+  if (!isDirectory(repoPath)) throw new Error(`Project path is not a directory: ${repoPath}`)
+  if (!isGitRepo(repoPath)) throw new Error(`Project path is not a git repository: ${repoPath}`)
+
+  const timestamp = input.now?.() ?? nowIso()
+  const githubRemote = input.githubRemote ?? input.gitRemote ?? detectGithubRemote(repoPath)
+
+  return {
+    id: input.id ?? safeProjectId(repoPath),
+    name: input.name ?? basename(repoPath),
+    repoPath,
+    defaultBranch: input.defaultBranch || detectDefaultBranch(repoPath),
+    worktreeRoot: input.worktreeRoot ? resolve(input.worktreeRoot) : defaultWorktreeRoot(repoPath),
+    githubRemote,
+    graphifyGraphPath: input.graphifyGraphPath ?? null,
+    obsidianPath: input.obsidianPath ?? null,
+    validation: input.validation,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+}

--- a/src/server/multi-agent/skill-autoload.test.ts
+++ b/src/server/multi-agent/skill-autoload.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentProfile, MultiAgentTask } from './types'
+import {
+  MULTI_AGENT_SKILL_METADATA_INDEX,
+  defaultSkillsForRole,
+  selectSkillsForTask,
+} from './skill-autoload'
+
+const now = '2026-05-19T00:00:00.000Z'
+
+function profile(overrides: Partial<MultiAgentProfile> = {}): MultiAgentProfile {
+  return {
+    id: 'backend-engineer',
+    name: 'Backend Engineer',
+    role: 'backend-engineer',
+    runtime: 'hermes-agent',
+    model: null,
+    skills: [],
+    enabledToolsets: ['terminal', 'file'],
+    permissionPolicy: 'ask-risky',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
+  return {
+    id: 'task-1',
+    projectId: 'workspace',
+    title: 'Add validation runner UI',
+    description: 'Build a React panel for validation results and API state.',
+    status: 'ready',
+    priority: 'medium',
+    assigneeProfileId: 'backend-engineer',
+    parentIds: [],
+    childIds: [],
+    workPacket: 'Use TDD, implement POST /api validation wiring, show build and test results in UI.',
+    acceptanceCriteria: ['tests pass', 'review gate completed'],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
+describe('contextual skill autoloading', () => {
+  it('exposes a metadata index with role and keyword match signals', () => {
+    expect(MULTI_AGENT_SKILL_METADATA_INDEX['test-driven-development']).toMatchObject({
+      name: 'test-driven-development',
+      roles: expect.arrayContaining(['backend-engineer', 'frontend-engineer']),
+      keywords: expect.arrayContaining(['test', 'tdd']),
+    })
+    expect(MULTI_AGENT_SKILL_METADATA_INDEX['review-gate'].keywords).toContain('review')
+  })
+
+  it('returns default skills for each worker role', () => {
+    expect(defaultSkillsForRole('backend-engineer')).toEqual(
+      expect.arrayContaining(['test-driven-development', 'systematic-debugging']),
+    )
+    expect(defaultSkillsForRole('reviewer')).toEqual(expect.arrayContaining(['review-gate']))
+  })
+
+  it('selects profile, role-default, and contextual task skills with stable de-duplication', () => {
+    const selected = selectSkillsForTask({
+      profile: profile({ skills: ['custom-project-skill', 'test-driven-development'] }),
+      task: task(),
+    })
+
+    expect(selected).toEqual([
+      'custom-project-skill',
+      'test-driven-development',
+      'systematic-debugging',
+      'frontend-design',
+      'review-gate',
+    ])
+  })
+
+  it('adds docs and orchestration skills from task context without loading unrelated skills', () => {
+    const selected = selectSkillsForTask({
+      profile: profile({ role: 'orchestrator', id: 'orchestrator', skills: [] }),
+      task: task({
+        title: 'Document multi-agent architecture plan',
+        description: 'Write docs and decide the best plan for the control plane rollout.',
+        workPacket: 'Produce documentation, architecture notes, and best-of-n options.',
+        acceptanceCriteria: ['docs updated'],
+      }),
+    })
+
+    expect(selected).toEqual(
+      expect.arrayContaining(['protocol-driven-orchestrator', 'best-of-n-planning', 'document-release']),
+    )
+    expect(selected).not.toContain('frontend-design')
+  })
+})

--- a/src/server/multi-agent/skill-autoload.ts
+++ b/src/server/multi-agent/skill-autoload.ts
@@ -1,0 +1,116 @@
+import type { MultiAgentProfile, MultiAgentProfileRole, MultiAgentTask } from './types'
+
+export type MultiAgentSkillMetadata = {
+  name: string
+  description: string
+  roles: MultiAgentProfileRole[]
+  keywords: string[]
+}
+
+export const MULTI_AGENT_SKILL_METADATA_INDEX: Record<string, MultiAgentSkillMetadata> = {
+  'protocol-driven-orchestrator': {
+    name: 'protocol-driven-orchestrator',
+    description: 'Structured orchestration for multi-step implementation tasks.',
+    roles: ['orchestrator'],
+    keywords: ['orchestrate', 'orchestration', 'plan', 'architecture', 'multi-agent', 'control plane'],
+  },
+  'best-of-n-planning': {
+    name: 'best-of-n-planning',
+    description: 'Compare multiple implementation strategies before choosing one.',
+    roles: ['orchestrator', 'reviewer'],
+    keywords: ['best-of-n', 'strategy', 'options', 'tradeoff', 'plan'],
+  },
+  'test-driven-development': {
+    name: 'test-driven-development',
+    description: 'Red-green-refactor implementation workflow.',
+    roles: ['backend-engineer', 'frontend-engineer', 'qa-validator'],
+    keywords: ['test', 'tests', 'tdd', 'vitest', 'pytest', 'coverage', 'failing test'],
+  },
+  'systematic-debugging': {
+    name: 'systematic-debugging',
+    description: 'Structured debugging and regression isolation.',
+    roles: ['backend-engineer', 'qa-validator'],
+    keywords: ['bug', 'debug', 'failure', 'error', 'regression', 'fix'],
+  },
+  'frontend-design': {
+    name: 'frontend-design',
+    description: 'Frontend UI, component, and UX implementation guidance.',
+    roles: ['frontend-engineer'],
+    keywords: ['ui', 'ux', 'react', 'component', 'panel', 'button', 'screen', 'frontend'],
+  },
+  'review-gate': {
+    name: 'review-gate',
+    description: 'Pre-final review checklist for non-trivial changes.',
+    roles: ['reviewer', 'qa-validator'],
+    keywords: ['review', 'risk', 'quality', 'validate', 'validation', 'diff', 'build'],
+  },
+  'requesting-code-review': {
+    name: 'requesting-code-review',
+    description: 'Code review request and reviewer handoff guidance.',
+    roles: ['reviewer'],
+    keywords: ['pull request', 'pr handoff'],
+  },
+  'document-release': {
+    name: 'document-release',
+    description: 'Operator-facing release and implementation documentation.',
+    roles: ['docs-writer'],
+    keywords: ['docs', 'documentation', 'readme', 'guide', 'runbook'],
+  },
+  'doc-coauthoring': {
+    name: 'doc-coauthoring',
+    description: 'Collaborative documentation drafting and editing.',
+    roles: ['docs-writer'],
+    keywords: ['docs', 'documentation', 'copy', 'edit'],
+  },
+}
+
+const ROLE_DEFAULT_SKILLS: Record<MultiAgentProfileRole, string[]> = {
+  orchestrator: ['protocol-driven-orchestrator', 'best-of-n-planning'],
+  'frontend-engineer': ['test-driven-development', 'frontend-design'],
+  'backend-engineer': ['test-driven-development', 'systematic-debugging'],
+  'qa-validator': ['test-driven-development', 'review-gate'],
+  reviewer: ['review-gate', 'requesting-code-review'],
+  'docs-writer': ['document-release', 'doc-coauthoring'],
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)))
+}
+
+function taskSearchText(task: MultiAgentTask): string {
+  return [
+    task.title,
+    task.description,
+    task.workPacket,
+    task.productBrief?.goal,
+    task.productBrief?.userStory,
+    ...(task.productBrief?.successMetrics ?? []),
+    ...(task.productBrief?.nonGoals ?? []),
+    ...task.acceptanceCriteria,
+  ].filter(Boolean).join('\n').toLowerCase()
+}
+
+export function defaultSkillsForRole(role: MultiAgentProfileRole): string[] {
+  return [...ROLE_DEFAULT_SKILLS[role]]
+}
+
+export function matchContextualSkills(task: MultiAgentTask): string[] {
+  const text = taskSearchText(task)
+  return Object.values(MULTI_AGENT_SKILL_METADATA_INDEX)
+    .filter((metadata) => metadata.keywords.some((keyword) => text.includes(keyword.toLowerCase())))
+    .map((metadata) => metadata.name)
+}
+
+export function selectSkillsForTask({
+  profile,
+  task,
+}: {
+  profile: MultiAgentProfile
+  task: MultiAgentTask
+}): string[] {
+  return unique([
+    ...profile.skills,
+    ...defaultSkillsForRole(profile.role),
+    ...matchContextualSkills(task),
+  ])
+}

--- a/src/server/multi-agent/skill-autoload.ts
+++ b/src/server/multi-agent/skill-autoload.ts
@@ -11,7 +11,7 @@ export const MULTI_AGENT_SKILL_METADATA_INDEX: Record<string, MultiAgentSkillMet
   'protocol-driven-orchestrator': {
     name: 'protocol-driven-orchestrator',
     description: 'Structured orchestration for multi-step implementation tasks.',
-    roles: ['orchestrator'],
+    roles: ['orchestrator', 'architect'],
     keywords: ['orchestrate', 'orchestration', 'plan', 'architecture', 'multi-agent', 'control plane'],
   },
   'best-of-n-planning': {
@@ -66,6 +66,7 @@ export const MULTI_AGENT_SKILL_METADATA_INDEX: Record<string, MultiAgentSkillMet
 
 const ROLE_DEFAULT_SKILLS: Record<MultiAgentProfileRole, string[]> = {
   orchestrator: ['protocol-driven-orchestrator', 'best-of-n-planning'],
+  architect: ['protocol-driven-orchestrator', 'best-of-n-planning'],
   'frontend-engineer': ['test-driven-development', 'frontend-design'],
   'backend-engineer': ['test-driven-development', 'systematic-debugging'],
   'qa-validator': ['test-driven-development', 'review-gate'],

--- a/src/server/multi-agent/store.test.ts
+++ b/src/server/multi-agent/store.test.ts
@@ -12,6 +12,7 @@ import {
   listMissions,
   listTasks,
   loadState,
+  planMissionTasks,
   resolveApproval,
   saveState,
   updateTask,
@@ -45,6 +46,55 @@ describe('multi-agent file-backed store', () => {
     expect(loaded.missions[mission.id]?.taskIds).toEqual([])
     expect(loaded.missions[mission.id]?.productBrief.goal).toContain('autonomous Hermes team')
     expect(listMissions(store, { projectId: 'workspace' })).toEqual([mission])
+  })
+
+  it('plans a mission into linked backlog tasks and marks the mission planned', () => {
+    const stateFile = tempStateFile()
+    const ids = ['mission-1', 'task-1', 'task-2']
+    const store = createMultiAgentStore({
+      stateFile,
+      now: () => '2026-05-19T09:10:00.000Z',
+      id: () => ids.shift() ?? 'fallback',
+    })
+    const mission = createMission(store, {
+      projectId: 'workspace',
+      title: 'Ship autonomous planning loop',
+      productBrief: {
+        goal: 'Let Hermes plan and run coordinated worker tasks.',
+        userStory: 'As an operator, I can turn one mission into a reviewed task graph.',
+        successMetrics: ['task graph is created'],
+        nonGoals: ['remote worker fleet'],
+      },
+      constraints: ['local single-user runtime'],
+      desiredOutput: 'A ready execution graph.',
+    })
+
+    const plannedTasks = planMissionTasks(store, mission.id, [
+      {
+        title: 'Design task graph contract',
+        description: 'Define the mission task graph data contract.',
+        assigneeProfileId: 'architect',
+        priority: 'high',
+        workPacket: 'Specify task dependencies and outputs.',
+        acceptanceCriteria: ['Contract is documented'],
+      },
+      {
+        title: 'Implement task graph runner',
+        description: 'Persist planned tasks for execution.',
+        assigneeProfileId: 'backend-engineer',
+        priority: 'medium',
+        parentIds: ['task-task-1'],
+        workPacket: 'Create linked tasks from mission plan.',
+        acceptanceCriteria: ['Tasks are linked to mission'],
+      },
+    ])
+
+    const loaded = loadState(stateFile)
+    expect(plannedTasks.map((task) => task.missionId)).toEqual([mission.id, mission.id])
+    expect(plannedTasks.map((task) => task.status)).toEqual(['backlog', 'backlog'])
+    expect(loaded.missions[mission.id]?.status).toBe('planned')
+    expect(loaded.missions[mission.id]?.taskIds).toEqual(plannedTasks.map((task) => task.id))
+    expect(loaded.tasks[plannedTasks[1].id]?.parentIds).toEqual(['task-task-1'])
   })
 
   it('creates an empty state when the state file is missing', () => {

--- a/src/server/multi-agent/store.test.ts
+++ b/src/server/multi-agent/store.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  createApproval,
+  createMultiAgentStore,
+  createTask,
+  emptyMultiAgentState,
+  listTasks,
+  loadState,
+  resolveApproval,
+  saveState,
+  updateTask,
+} from './store'
+
+function tempStateFile(): string {
+  return join(mkdtempSync(join(tmpdir(), 'hermes-ma-store-')), 'state.json')
+}
+
+describe('multi-agent file-backed store', () => {
+  it('creates an empty state when the state file is missing', () => {
+    const stateFile = tempStateFile()
+    const state = loadState(stateFile)
+
+    expect(state.schemaVersion).toBe(1)
+    expect(state.tasks).toEqual({})
+    expect(state.profiles).toEqual({})
+  })
+
+  it('writes and reads tasks', () => {
+    const stateFile = tempStateFile()
+    const store = createMultiAgentStore({ stateFile, now: () => '2026-05-16T18:20:00.000Z' })
+
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'Build store',
+      description: 'Persist task data',
+      assigneeProfileId: 'backend-engineer',
+      priority: 'high',
+      workPacket: 'Implement store module',
+      acceptanceCriteria: ['Task can be listed'],
+    })
+
+    const loaded = loadState(stateFile)
+    expect(loaded.tasks[task.id]?.title).toBe('Build store')
+    expect(listTasks(store, { projectId: 'workspace' })).toHaveLength(1)
+  })
+
+  it('updates task status and timestamps', () => {
+    const stateFile = tempStateFile()
+    const store = createMultiAgentStore({ stateFile, now: () => '2026-05-16T18:21:00.000Z' })
+    const task = createTask(store, {
+      projectId: 'workspace',
+      title: 'Create worktree',
+      description: '',
+      assigneeProfileId: 'backend-engineer',
+      priority: 'medium',
+      workPacket: '',
+      acceptanceCriteria: [],
+    })
+
+    store.now = () => '2026-05-16T18:22:00.000Z'
+    const updated = updateTask(store, task.id, {
+      status: 'ready',
+      branchName: 'hermes/task-task-123-create-worktree',
+    })
+
+    expect(updated.status).toBe('ready')
+    expect(updated.updatedAt).toBe('2026-05-16T18:22:00.000Z')
+    expect(loadState(stateFile).tasks[task.id]?.branchName).toBe('hermes/task-task-123-create-worktree')
+  })
+
+  it('resolves approvals', () => {
+    const stateFile = tempStateFile()
+    const store = createMultiAgentStore({ stateFile, now: () => '2026-05-16T18:23:00.000Z' })
+    const approval = createApproval(store, {
+      taskId: 'task-123',
+      riskLevel: 'high',
+      actionType: 'github.pr_create',
+      title: 'Create PR',
+      description: 'Push and create a PR',
+      payload: { branch: 'hermes/task-123' },
+    })
+
+    store.now = () => '2026-05-16T18:24:00.000Z'
+    const resolved = resolveApproval(store, approval.id, 'approved')
+
+    expect(resolved.status).toBe('approved')
+    expect(resolved.resolvedAt).toBe('2026-05-16T18:24:00.000Z')
+    expect(loadState(stateFile).approvals[approval.id]?.status).toBe('approved')
+  })
+
+  it('preserves malformed state before returning empty state', () => {
+    const stateFile = tempStateFile()
+    writeFileSync(stateFile, '{ definitely not json', 'utf-8')
+
+    const state = loadState(stateFile, { now: () => '2026-05-16T18:25:00.000Z' })
+
+    expect(state).toEqual(emptyMultiAgentState('2026-05-16T18:25:00.000Z'))
+    const corruptCopy = readFileSync(`${stateFile}.corrupt-2026-05-16T18-25-00-000Z.json`, 'utf-8')
+    expect(corruptCopy).toContain('definitely not json')
+  })
+
+  it('saves state atomically through a temp file and rename', () => {
+    const stateFile = tempStateFile()
+    const state = emptyMultiAgentState('2026-05-16T18:26:00.000Z')
+
+    saveState(stateFile, state)
+
+    expect(JSON.parse(readFileSync(stateFile, 'utf-8'))).toMatchObject({ schemaVersion: 1 })
+  })
+})

--- a/src/server/multi-agent/store.test.ts
+++ b/src/server/multi-agent/store.test.ts
@@ -4,10 +4,12 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   createApproval,
+  createMission,
   createMultiAgentStore,
   listApprovals,
   createTask,
   emptyMultiAgentState,
+  listMissions,
   listTasks,
   loadState,
   resolveApproval,
@@ -20,6 +22,31 @@ function tempStateFile(): string {
 }
 
 describe('multi-agent file-backed store', () => {
+  it('writes and lists missions as the top-level multi-agent product unit', () => {
+    const stateFile = tempStateFile()
+    const store = createMultiAgentStore({ stateFile, now: () => '2026-05-19T09:00:00.000Z', id: () => 'mission-1' })
+
+    const mission = createMission(store, {
+      projectId: 'workspace',
+      title: 'Ship real multi-agent team',
+      productBrief: {
+        goal: 'Turn manual worker runs into an autonomous Hermes team.',
+        userStory: 'As an operator, I can define one mission and let Hermes plan coordinated agent work.',
+        successMetrics: ['mission creates a task graph'],
+        nonGoals: ['remote worker fleet'],
+      },
+      constraints: ['single-user local runtime', 'hermes-agent workers only'],
+      desiredOutput: 'Planned task graph ready for execution.',
+    })
+
+    const loaded = loadState(stateFile)
+    expect(loaded.missions[mission.id]?.title).toBe('Ship real multi-agent team')
+    expect(loaded.missions[mission.id]?.status).toBe('draft')
+    expect(loaded.missions[mission.id]?.taskIds).toEqual([])
+    expect(loaded.missions[mission.id]?.productBrief.goal).toContain('autonomous Hermes team')
+    expect(listMissions(store, { projectId: 'workspace' })).toEqual([mission])
+  })
+
   it('creates an empty state when the state file is missing', () => {
     const stateFile = tempStateFile()
     const state = loadState(stateFile)
@@ -40,11 +67,23 @@ describe('multi-agent file-backed store', () => {
       assigneeProfileId: 'backend-engineer',
       priority: 'high',
       workPacket: 'Implement store module',
+      productBrief: {
+        goal: 'Help operators trust stored task state.',
+        userStory: 'As an operator, I can reopen the board and see task context.',
+        successMetrics: ['task reload success rate'],
+        nonGoals: ['cloud sync'],
+      },
       acceptanceCriteria: ['Task can be listed'],
     })
 
     const loaded = loadState(stateFile)
     expect(loaded.tasks[task.id]?.title).toBe('Build store')
+    expect(loaded.tasks[task.id]?.productBrief).toEqual({
+      goal: 'Help operators trust stored task state.',
+      userStory: 'As an operator, I can reopen the board and see task context.',
+      successMetrics: ['task reload success rate'],
+      nonGoals: ['cloud sync'],
+    })
     expect(listTasks(store, { projectId: 'workspace' })).toHaveLength(1)
   })
 

--- a/src/server/multi-agent/store.test.ts
+++ b/src/server/multi-agent/store.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createApproval,
   createMultiAgentStore,
+  listApprovals,
   createTask,
   emptyMultiAgentState,
   listTasks,
@@ -71,7 +72,7 @@ describe('multi-agent file-backed store', () => {
     expect(loadState(stateFile).tasks[task.id]?.branchName).toBe('hermes/task-task-123-create-worktree')
   })
 
-  it('resolves approvals', () => {
+  it('lists and resolves approvals', () => {
     const stateFile = tempStateFile()
     const store = createMultiAgentStore({ stateFile, now: () => '2026-05-16T18:23:00.000Z' })
     const approval = createApproval(store, {
@@ -83,12 +84,16 @@ describe('multi-agent file-backed store', () => {
       payload: { branch: 'hermes/task-123' },
     })
 
+    expect(listApprovals(store, { status: 'pending' })).toEqual([approval])
+
     store.now = () => '2026-05-16T18:24:00.000Z'
     const resolved = resolveApproval(store, approval.id, 'approved')
 
     expect(resolved.status).toBe('approved')
     expect(resolved.resolvedAt).toBe('2026-05-16T18:24:00.000Z')
     expect(loadState(stateFile).approvals[approval.id]?.status).toBe('approved')
+    expect(listApprovals(store, { status: 'pending' })).toEqual([])
+    expect(listApprovals(store, { taskId: 'task-123' })).toEqual([resolved])
   })
 
   it('preserves malformed state before returning empty state', () => {

--- a/src/server/multi-agent/store.ts
+++ b/src/server/multi-agent/store.ts
@@ -59,7 +59,7 @@ type CreateMissionInput = {
   status?: MultiAgentMissionStatus
 }
 
-type CreateTaskInput = {
+export type CreateTaskInput = {
   projectId: string
   missionId?: string | null
   title: string
@@ -239,35 +239,70 @@ export function listMissions(store: MultiAgentStore, filter: MissionFilter = {})
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
 }
 
+function buildTask(store: MultiAgentStore, input: CreateTaskInput, now: string): MultiAgentTask {
+  return {
+    id: `task-${store.id()}`,
+    projectId: input.projectId,
+    missionId: input.missionId ?? null,
+    title: input.title,
+    description: input.description,
+    status: input.status ?? 'backlog',
+    priority: input.priority ?? 'medium',
+    assigneeProfileId: input.assigneeProfileId,
+    parentIds: input.parentIds ?? [],
+    childIds: input.childIds ?? [],
+    workPacket: input.workPacket ?? '',
+    productBrief: input.productBrief ?? null,
+    acceptanceCriteria: input.acceptanceCriteria ?? [],
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function attachTaskToMission(state: MultiAgentState, missionId: string | null | undefined, taskId: string, now: string): void {
+  if (!missionId || !state.missions[missionId]) return
+  const mission = state.missions[missionId]
+  state.missions[missionId] = {
+    ...mission,
+    taskIds: Array.from(new Set([...mission.taskIds, taskId])),
+    updatedAt: now,
+  }
+}
+
 export function createTask(store: MultiAgentStore, input: CreateTaskInput): MultiAgentTask {
   return mutateState(store, (state, now) => {
-    const task: MultiAgentTask = {
-      id: `task-${store.id()}`,
-      projectId: input.projectId,
-      missionId: input.missionId ?? null,
-      title: input.title,
-      description: input.description,
-      status: input.status ?? 'backlog',
-      priority: input.priority ?? 'medium',
-      assigneeProfileId: input.assigneeProfileId,
-      parentIds: input.parentIds ?? [],
-      childIds: input.childIds ?? [],
-      workPacket: input.workPacket ?? '',
-      productBrief: input.productBrief ?? null,
-      acceptanceCriteria: input.acceptanceCriteria ?? [],
-      createdAt: now,
+    const task = buildTask(store, input, now)
+    state.tasks[task.id] = task
+    attachTaskToMission(state, task.missionId, task.id, now)
+    return task
+  })
+}
+
+export function planMissionTasks(
+  store: MultiAgentStore,
+  missionId: string,
+  taskDrafts: Array<Omit<CreateTaskInput, 'projectId' | 'missionId' | 'status'>>,
+): MultiAgentTask[] {
+  return mutateState(store, (state, now) => {
+    const mission = state.missions[missionId]
+    if (!mission) throw new Error(`Mission not found: ${missionId}`)
+    const tasks = taskDrafts.map((draft) => buildTask(store, {
+      ...draft,
+      projectId: mission.projectId,
+      missionId,
+      status: 'backlog',
+      productBrief: draft.productBrief ?? mission.productBrief,
+    }, now))
+    for (const task of tasks) {
+      state.tasks[task.id] = task
+      attachTaskToMission(state, missionId, task.id, now)
+    }
+    state.missions[missionId] = {
+      ...state.missions[missionId],
+      status: 'planned',
       updatedAt: now,
     }
-    state.tasks[task.id] = task
-    if (task.missionId && state.missions[task.missionId]) {
-      const mission = state.missions[task.missionId]
-      state.missions[task.missionId] = {
-        ...mission,
-        taskIds: Array.from(new Set([...mission.taskIds, task.id])),
-        updatedAt: now,
-      }
-    }
-    return task
+    return tasks
   })
 }
 

--- a/src/server/multi-agent/store.ts
+++ b/src/server/multi-agent/store.ts
@@ -1,0 +1,329 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type {
+  MultiAgentApproval,
+  MultiAgentApprovalActionType,
+  MultiAgentApprovalStatus,
+  MultiAgentArtifact,
+  MultiAgentPriority,
+  MultiAgentRiskLevel,
+  MultiAgentRun,
+  MultiAgentRunStatus,
+  MultiAgentState,
+  MultiAgentTask,
+  MultiAgentTaskStatus,
+} from './types'
+
+export const DEFAULT_MULTI_AGENT_STATE_FILE = join(
+  process.cwd(),
+  '.runtime',
+  'multi-agent',
+  'state.json',
+)
+
+type Clock = () => string
+
+type StoreOptions = {
+  stateFile?: string
+  now?: Clock
+  id?: () => string
+}
+
+export type MultiAgentStore = {
+  stateFile: string
+  now: Clock
+  id: () => string
+}
+
+export type StartTaskWorktreePatch = Required<
+  Pick<MultiAgentTask, 'branchName' | 'worktreePath'>
+> & {
+  status?: MultiAgentTaskStatus
+}
+
+type LoadStateOptions = {
+  now?: Clock
+}
+
+type CreateTaskInput = {
+  projectId: string
+  title: string
+  description: string
+  assigneeProfileId: string
+  priority?: MultiAgentPriority
+  parentIds?: string[]
+  childIds?: string[]
+  workPacket?: string
+  acceptanceCriteria?: string[]
+  status?: MultiAgentTaskStatus
+}
+
+type CreateRunInput = {
+  taskId: string
+  profileId: string
+  status?: MultiAgentRunStatus
+  pid?: number | null
+  sessionId?: string | null
+}
+
+type CreateApprovalInput = {
+  taskId: string
+  runId?: string | null
+  riskLevel: MultiAgentRiskLevel
+  actionType: MultiAgentApprovalActionType
+  title: string
+  description: string
+  payload: unknown
+}
+
+type CreateArtifactInput = Omit<MultiAgentArtifact, 'id' | 'createdAt'>
+
+type TaskFilter = {
+  projectId?: string
+  status?: MultiAgentTaskStatus
+}
+
+function defaultNow(): string {
+  return new Date().toISOString()
+}
+
+function defaultId(): string {
+  return randomUUID()
+}
+
+function safeTimestamp(value: string): string {
+  return value.replace(/[^0-9A-Za-z-]/g, '-')
+}
+
+function ensureParentDir(path: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+}
+
+export function emptyMultiAgentState(now = defaultNow()): MultiAgentState {
+  return {
+    projects: {},
+    profiles: {},
+    tasks: {},
+    runs: {},
+    approvals: {},
+    validations: {},
+    artifacts: {},
+    schemaVersion: 1,
+    updatedAt: now,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function normalizeState(value: unknown, now: string): MultiAgentState {
+  if (!isRecord(value) || value.schemaVersion !== 1) return emptyMultiAgentState(now)
+
+  return {
+    projects: isRecord(value.projects) ? (value.projects as MultiAgentState['projects']) : {},
+    profiles: isRecord(value.profiles) ? (value.profiles as MultiAgentState['profiles']) : {},
+    tasks: isRecord(value.tasks) ? (value.tasks as MultiAgentState['tasks']) : {},
+    runs: isRecord(value.runs) ? (value.runs as MultiAgentState['runs']) : {},
+    approvals: isRecord(value.approvals) ? (value.approvals as MultiAgentState['approvals']) : {},
+    validations: isRecord(value.validations)
+      ? (value.validations as MultiAgentState['validations'])
+      : {},
+    artifacts: isRecord(value.artifacts) ? (value.artifacts as MultiAgentState['artifacts']) : {},
+    schemaVersion: 1,
+    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : now,
+  }
+}
+
+export function loadState(
+  stateFile = DEFAULT_MULTI_AGENT_STATE_FILE,
+  options: LoadStateOptions = {},
+): MultiAgentState {
+  const now = options.now?.() ?? defaultNow()
+  if (!existsSync(stateFile)) return emptyMultiAgentState(now)
+
+  try {
+    const raw = readFileSync(stateFile, 'utf-8')
+    return normalizeState(JSON.parse(raw), now)
+  } catch {
+    const corruptPath = `${stateFile}.corrupt-${safeTimestamp(now)}.json`
+    try {
+      writeFileSync(corruptPath, readFileSync(stateFile, 'utf-8'))
+    } catch {
+      // Best-effort preservation only. Return a usable empty state even if backup fails.
+    }
+    return emptyMultiAgentState(now)
+  }
+}
+
+export function saveState(
+  stateFile: string = DEFAULT_MULTI_AGENT_STATE_FILE,
+  state: MultiAgentState,
+): void {
+  ensureParentDir(stateFile)
+  const tempFile = `${stateFile}.tmp-${process.pid}-${Date.now()}`
+  writeFileSync(tempFile, JSON.stringify(state, null, 2))
+  renameSync(tempFile, stateFile)
+}
+
+export function createMultiAgentStore(options: StoreOptions = {}): MultiAgentStore {
+  return {
+    stateFile: options.stateFile ?? DEFAULT_MULTI_AGENT_STATE_FILE,
+    now: options.now ?? defaultNow,
+    id: options.id ?? defaultId,
+  }
+}
+
+function mutateState<T>(store: MultiAgentStore, mutator: (state: MultiAgentState, now: string) => T): T {
+  const now = store.now()
+  const state = loadState(store.stateFile, { now: store.now })
+  const result = mutator(state, now)
+  state.updatedAt = now
+  saveState(store.stateFile, state)
+  return result
+}
+
+export function createTask(store: MultiAgentStore, input: CreateTaskInput): MultiAgentTask {
+  return mutateState(store, (state, now) => {
+    const task: MultiAgentTask = {
+      id: `task-${store.id()}`,
+      projectId: input.projectId,
+      title: input.title,
+      description: input.description,
+      status: input.status ?? 'backlog',
+      priority: input.priority ?? 'medium',
+      assigneeProfileId: input.assigneeProfileId,
+      parentIds: input.parentIds ?? [],
+      childIds: input.childIds ?? [],
+      workPacket: input.workPacket ?? '',
+      acceptanceCriteria: input.acceptanceCriteria ?? [],
+      createdAt: now,
+      updatedAt: now,
+    }
+    state.tasks[task.id] = task
+    return task
+  })
+}
+
+export function updateTask(
+  store: MultiAgentStore,
+  taskId: string,
+  patch: Partial<Omit<MultiAgentTask, 'id' | 'createdAt' | 'updatedAt'>>,
+): MultiAgentTask {
+  return mutateState(store, (state, now) => {
+    const existing = state.tasks[taskId]
+    if (!existing) throw new Error(`Task not found: ${taskId}`)
+    const updated: MultiAgentTask = { ...existing, ...patch, updatedAt: now }
+    state.tasks[taskId] = updated
+    return updated
+  })
+}
+
+export function getTask(store: MultiAgentStore, taskId: string): MultiAgentTask | null {
+  const state = loadState(store.stateFile, { now: store.now })
+  return state.tasks[taskId] ?? null
+}
+
+export function listTasks(store: MultiAgentStore, filter: TaskFilter = {}): MultiAgentTask[] {
+  const state = loadState(store.stateFile, { now: store.now })
+  return Object.values(state.tasks)
+    .filter((task) => !filter.projectId || task.projectId === filter.projectId)
+    .filter((task) => !filter.status || task.status === filter.status)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+export function markTaskWorktreeReady(
+  store: MultiAgentStore,
+  taskId: string,
+  patch: StartTaskWorktreePatch,
+): MultiAgentTask {
+  return updateTask(store, taskId, {
+    branchName: patch.branchName,
+    worktreePath: patch.worktreePath,
+    status: patch.status ?? 'ready',
+  })
+}
+
+export function createRun(store: MultiAgentStore, input: CreateRunInput): MultiAgentRun {
+  return mutateState(store, (state, now) => {
+    const run: MultiAgentRun = {
+      id: `run-${store.id()}`,
+      taskId: input.taskId,
+      profileId: input.profileId,
+      status: input.status ?? 'queued',
+      pid: input.pid,
+      sessionId: input.sessionId,
+      startedAt: null,
+      finishedAt: null,
+    }
+    state.runs[run.id] = run
+    const task = state.tasks[run.taskId]
+    if (task) {
+      state.tasks[run.taskId] = { ...task, latestRunId: run.id, updatedAt: now }
+    }
+    return run
+  })
+}
+
+export function updateRun(
+  store: MultiAgentStore,
+  runId: string,
+  patch: Partial<Omit<MultiAgentRun, 'id'>>,
+): MultiAgentRun {
+  return mutateState(store, (state) => {
+    const existing = state.runs[runId]
+    if (!existing) throw new Error(`Run not found: ${runId}`)
+    const updated: MultiAgentRun = { ...existing, ...patch }
+    state.runs[runId] = updated
+    return updated
+  })
+}
+
+export function createApproval(
+  store: MultiAgentStore,
+  input: CreateApprovalInput,
+): MultiAgentApproval {
+  return mutateState(store, (state, now) => {
+    const approval: MultiAgentApproval = {
+      id: `approval-${store.id()}`,
+      taskId: input.taskId,
+      runId: input.runId,
+      riskLevel: input.riskLevel,
+      actionType: input.actionType,
+      title: input.title,
+      description: input.description,
+      payload: input.payload,
+      status: 'pending',
+      createdAt: now,
+    }
+    state.approvals[approval.id] = approval
+    return approval
+  })
+}
+
+export function resolveApproval(
+  store: MultiAgentStore,
+  approvalId: string,
+  decision: Extract<MultiAgentApprovalStatus, 'approved' | 'denied'>,
+): MultiAgentApproval {
+  return mutateState(store, (state, now) => {
+    const existing = state.approvals[approvalId]
+    if (!existing) throw new Error(`Approval not found: ${approvalId}`)
+    const resolved: MultiAgentApproval = { ...existing, status: decision, resolvedAt: now }
+    state.approvals[approvalId] = resolved
+    return resolved
+  })
+}
+
+export function createArtifact(store: MultiAgentStore, input: CreateArtifactInput): MultiAgentArtifact {
+  return mutateState(store, (state, now) => {
+    const artifact: MultiAgentArtifact = {
+      id: `artifact-${store.id()}`,
+      ...input,
+      createdAt: now,
+    }
+    state.artifacts[artifact.id] = artifact
+    return artifact
+  })
+}

--- a/src/server/multi-agent/store.ts
+++ b/src/server/multi-agent/store.ts
@@ -6,7 +6,10 @@ import type {
   MultiAgentApprovalActionType,
   MultiAgentApprovalStatus,
   MultiAgentArtifact,
+  MultiAgentMission,
+  MultiAgentMissionStatus,
   MultiAgentPriority,
+  MultiAgentProductBrief,
   MultiAgentRiskLevel,
   MultiAgentRun,
   MultiAgentRunStatus,
@@ -47,8 +50,18 @@ type LoadStateOptions = {
   now?: Clock
 }
 
+type CreateMissionInput = {
+  projectId: string
+  title: string
+  productBrief: MultiAgentProductBrief
+  constraints?: string[]
+  desiredOutput?: string
+  status?: MultiAgentMissionStatus
+}
+
 type CreateTaskInput = {
   projectId: string
+  missionId?: string | null
   title: string
   description: string
   assigneeProfileId: string
@@ -56,6 +69,7 @@ type CreateTaskInput = {
   parentIds?: string[]
   childIds?: string[]
   workPacket?: string
+  productBrief?: MultiAgentProductBrief | null
   acceptanceCriteria?: string[]
   status?: MultiAgentTaskStatus
 }
@@ -80,6 +94,11 @@ type CreateApprovalInput = {
 }
 
 type CreateArtifactInput = Omit<MultiAgentArtifact, 'id' | 'createdAt'>
+
+type MissionFilter = {
+  projectId?: string
+  status?: MultiAgentMissionStatus
+}
 
 type TaskFilter = {
   projectId?: string
@@ -111,6 +130,7 @@ export function emptyMultiAgentState(now = defaultNow()): MultiAgentState {
   return {
     projects: {},
     profiles: {},
+    missions: {},
     tasks: {},
     runs: {},
     approvals: {},
@@ -131,6 +151,7 @@ function normalizeState(value: unknown, now: string): MultiAgentState {
   return {
     projects: isRecord(value.projects) ? (value.projects as MultiAgentState['projects']) : {},
     profiles: isRecord(value.profiles) ? (value.profiles as MultiAgentState['profiles']) : {},
+    missions: isRecord(value.missions) ? (value.missions as MultiAgentState['missions']) : {},
     tasks: isRecord(value.tasks) ? (value.tasks as MultiAgentState['tasks']) : {},
     runs: isRecord(value.runs) ? (value.runs as MultiAgentState['runs']) : {},
     approvals: isRecord(value.approvals) ? (value.approvals as MultiAgentState['approvals']) : {},
@@ -191,11 +212,39 @@ function mutateState<T>(store: MultiAgentStore, mutator: (state: MultiAgentState
   return result
 }
 
+export function createMission(store: MultiAgentStore, input: CreateMissionInput): MultiAgentMission {
+  return mutateState(store, (state, now) => {
+    const mission: MultiAgentMission = {
+      id: `mission-${store.id()}`,
+      projectId: input.projectId,
+      title: input.title,
+      status: input.status ?? 'draft',
+      productBrief: input.productBrief,
+      constraints: input.constraints ?? [],
+      desiredOutput: input.desiredOutput ?? '',
+      taskIds: [],
+      createdAt: now,
+      updatedAt: now,
+    }
+    state.missions[mission.id] = mission
+    return mission
+  })
+}
+
+export function listMissions(store: MultiAgentStore, filter: MissionFilter = {}): MultiAgentMission[] {
+  const state = loadState(store.stateFile, { now: store.now })
+  return Object.values(state.missions)
+    .filter((mission) => !filter.projectId || mission.projectId === filter.projectId)
+    .filter((mission) => !filter.status || mission.status === filter.status)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
 export function createTask(store: MultiAgentStore, input: CreateTaskInput): MultiAgentTask {
   return mutateState(store, (state, now) => {
     const task: MultiAgentTask = {
       id: `task-${store.id()}`,
       projectId: input.projectId,
+      missionId: input.missionId ?? null,
       title: input.title,
       description: input.description,
       status: input.status ?? 'backlog',
@@ -204,11 +253,20 @@ export function createTask(store: MultiAgentStore, input: CreateTaskInput): Mult
       parentIds: input.parentIds ?? [],
       childIds: input.childIds ?? [],
       workPacket: input.workPacket ?? '',
+      productBrief: input.productBrief ?? null,
       acceptanceCriteria: input.acceptanceCriteria ?? [],
       createdAt: now,
       updatedAt: now,
     }
     state.tasks[task.id] = task
+    if (task.missionId && state.missions[task.missionId]) {
+      const mission = state.missions[task.missionId]
+      state.missions[task.missionId] = {
+        ...mission,
+        taskIds: Array.from(new Set([...mission.taskIds, task.id])),
+        updatedAt: now,
+      }
+    }
     return task
   })
 }

--- a/src/server/multi-agent/store.ts
+++ b/src/server/multi-agent/store.ts
@@ -66,6 +66,7 @@ type CreateRunInput = {
   status?: MultiAgentRunStatus
   pid?: number | null
   sessionId?: string | null
+  summary?: string | null
 }
 
 type CreateApprovalInput = {
@@ -260,6 +261,7 @@ export function createRun(store: MultiAgentStore, input: CreateRunInput): MultiA
       status: input.status ?? 'queued',
       pid: input.pid,
       sessionId: input.sessionId,
+      summary: input.summary,
       startedAt: null,
       finishedAt: null,
     }

--- a/src/server/multi-agent/store.ts
+++ b/src/server/multi-agent/store.ts
@@ -11,6 +11,7 @@ import type {
   MultiAgentRun,
   MultiAgentRunStatus,
   MultiAgentState,
+  MultiAgentValidation,
   MultiAgentTask,
   MultiAgentTaskStatus,
 } from './types'
@@ -82,6 +83,11 @@ type CreateArtifactInput = Omit<MultiAgentArtifact, 'id' | 'createdAt'>
 type TaskFilter = {
   projectId?: string
   status?: MultiAgentTaskStatus
+}
+
+type ApprovalFilter = {
+  taskId?: string
+  status?: MultiAgentApprovalStatus
 }
 
 function defaultNow(): string {
@@ -314,6 +320,28 @@ export function resolveApproval(
     state.approvals[approvalId] = resolved
     return resolved
   })
+}
+
+export function listApprovals(store: MultiAgentStore, filter: ApprovalFilter = {}): MultiAgentApproval[] {
+  const state = loadState(store.stateFile, { now: store.now })
+  return Object.values(state.approvals)
+    .filter((approval) => !filter.taskId || approval.taskId === filter.taskId)
+    .filter((approval) => !filter.status || approval.status === filter.status)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+export function saveValidation(store: MultiAgentStore, validation: MultiAgentValidation): MultiAgentValidation {
+  return mutateState(store, (state) => {
+    state.validations[validation.id] = validation
+    return validation
+  })
+}
+
+export function listTaskValidations(store: MultiAgentStore, taskId: string): MultiAgentValidation[] {
+  const state = loadState(store.stateFile, { now: store.now })
+  return Object.values(state.validations)
+    .filter((validation) => validation.taskId === taskId)
+    .sort((a, b) => (b.finishedAt ?? '').localeCompare(a.finishedAt ?? ''))
 }
 
 export function createArtifact(store: MultiAgentStore, input: CreateArtifactInput): MultiAgentArtifact {

--- a/src/server/multi-agent/types.test.ts
+++ b/src/server/multi-agent/types.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  MultiAgentApproval,
+  MultiAgentEvent,
+  MultiAgentProfile,
+  MultiAgentProject,
+  MultiAgentRun,
+  MultiAgentState,
+  MultiAgentTask,
+  MultiAgentValidation,
+} from './types'
+
+describe('multi-agent domain types', () => {
+  it('models the MVP create task → worktree → run lifecycle', () => {
+    const now = '2026-05-16T18:10:00.000Z'
+    const project: MultiAgentProject = {
+      id: 'workspace',
+      name: 'Hermes Workspace',
+      repoPath: '/repo/hermes-workspace',
+      defaultBranch: 'main',
+      worktreeRoot: '/repo/hermes-workspace/.hermes-worktrees',
+      githubRemote: 'git@github.com:example/hermes-workspace.git',
+      graphifyGraphPath: null,
+      obsidianPath: null,
+      validation: { test: 'pnpm test', build: 'pnpm build' },
+      createdAt: now,
+      updatedAt: now,
+    }
+    const profile: MultiAgentProfile = {
+      id: 'backend-engineer',
+      name: 'Backend Engineer',
+      role: 'backend-engineer',
+      runtime: 'hermes-agent',
+      skills: ['test-driven-development'],
+      enabledToolsets: ['terminal', 'file'],
+      permissionPolicy: 'ask-risky',
+      createdAt: now,
+      updatedAt: now,
+    }
+    const task: MultiAgentTask = {
+      id: 'task-123',
+      projectId: project.id,
+      title: 'Add store',
+      description: 'Persist multi-agent state',
+      status: 'ready',
+      priority: 'high',
+      assigneeProfileId: profile.id,
+      parentIds: [],
+      childIds: [],
+      workPacket: 'Implement file-backed store',
+      acceptanceCriteria: ['Stores tasks', 'Handles corrupt JSON'],
+      branchName: 'hermes/task-task-123-add-store',
+      worktreePath: '/repo/hermes-workspace/.hermes-worktrees/task-task-123-add-store',
+      latestRunId: 'run-123',
+      createdAt: now,
+      updatedAt: now,
+    }
+    const run: MultiAgentRun = {
+      id: 'run-123',
+      taskId: task.id,
+      profileId: profile.id,
+      status: 'queued',
+    }
+    const event: MultiAgentEvent = {
+      id: 'event-123',
+      taskId: task.id,
+      runId: run.id,
+      type: 'worktree.created',
+      message: 'Created worktree',
+      payload: { branchName: task.branchName },
+      createdAt: now,
+    }
+    const approval: MultiAgentApproval = {
+      id: 'approval-123',
+      taskId: task.id,
+      riskLevel: 'high',
+      actionType: 'github.pr_create',
+      title: 'Create PR',
+      description: 'Push branch and create GitHub PR',
+      payload: { branchName: task.branchName },
+      status: 'pending',
+      createdAt: now,
+    }
+    const validation: MultiAgentValidation = {
+      id: 'validation-123',
+      taskId: task.id,
+      type: 'test',
+      command: 'pnpm test',
+      status: 'queued',
+    }
+    const state: MultiAgentState = {
+      projects: { [project.id]: project },
+      profiles: { [profile.id]: profile },
+      tasks: { [task.id]: task },
+      runs: { [run.id]: run },
+      approvals: { [approval.id]: approval },
+      validations: { [validation.id]: validation },
+      artifacts: {},
+      schemaVersion: 1,
+      updatedAt: now,
+    }
+
+    expect(state.tasks[task.id]?.status).toBe('ready')
+    expect(event.type).toBe('worktree.created')
+    expect(approval.status).toBe('pending')
+    expect(profile.runtime).toBe('hermes-agent')
+  })
+})

--- a/src/server/multi-agent/types.ts
+++ b/src/server/multi-agent/types.ts
@@ -72,6 +72,7 @@ export type MultiAgentTask = {
   branchName?: string | null
   worktreePath?: string | null
   latestRunId?: string | null
+  finalSummary?: string | null
   createdAt: string
   updatedAt: string
 }

--- a/src/server/multi-agent/types.ts
+++ b/src/server/multi-agent/types.ts
@@ -1,0 +1,195 @@
+export type MultiAgentTaskStatus =
+  | 'backlog'
+  | 'ready'
+  | 'running'
+  | 'needs_approval'
+  | 'review'
+  | 'blocked'
+  | 'done'
+  | 'failed'
+  | 'cancelled'
+
+export type MultiAgentPriority = 'low' | 'medium' | 'high' | 'urgent'
+
+export type MultiAgentProfileRole =
+  | 'orchestrator'
+  | 'frontend-engineer'
+  | 'backend-engineer'
+  | 'qa-validator'
+  | 'reviewer'
+  | 'docs-writer'
+
+export type MultiAgentRuntime = 'hermes-agent'
+
+export type MultiAgentPermissionPolicy = 'safe-default' | 'ask-risky' | 'read-only'
+
+export type MultiAgentProjectValidation = {
+  lint?: string | null
+  typecheck?: string | null
+  test?: string | null
+  build?: string | null
+}
+
+export type MultiAgentProject = {
+  id: string
+  name: string
+  repoPath: string
+  defaultBranch: string
+  worktreeRoot: string
+  githubRemote?: string | null
+  graphifyGraphPath?: string | null
+  obsidianPath?: string | null
+  validation?: MultiAgentProjectValidation
+  createdAt: string
+  updatedAt: string
+}
+
+export type MultiAgentProfile = {
+  id: string
+  name: string
+  role: MultiAgentProfileRole
+  runtime: MultiAgentRuntime
+  model?: string | null
+  skills: string[]
+  enabledToolsets?: string[]
+  permissionPolicy: MultiAgentPermissionPolicy
+  createdAt: string
+  updatedAt: string
+}
+
+export type MultiAgentTask = {
+  id: string
+  projectId: string
+  title: string
+  description: string
+  status: MultiAgentTaskStatus
+  priority: MultiAgentPriority
+  assigneeProfileId: string
+  parentIds: string[]
+  childIds: string[]
+  workPacket: string
+  acceptanceCriteria: string[]
+  branchName?: string | null
+  worktreePath?: string | null
+  latestRunId?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type MultiAgentRunStatus =
+  | 'queued'
+  | 'starting'
+  | 'running'
+  | 'waiting_approval'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export type MultiAgentRun = {
+  id: string
+  taskId: string
+  profileId: string
+  status: MultiAgentRunStatus
+  pid?: number | null
+  sessionId?: string | null
+  startedAt?: string | null
+  finishedAt?: string | null
+  tokenIn?: number | null
+  tokenOut?: number | null
+  costUsd?: number | null
+  summary?: string | null
+  error?: string | null
+}
+
+export type MultiAgentEventType =
+  | 'task.created'
+  | 'worktree.created'
+  | 'run.started'
+  | 'run.log'
+  | 'run.tool_call'
+  | 'approval.requested'
+  | 'approval.resolved'
+  | 'validation.started'
+  | 'validation.completed'
+  | 'diff.updated'
+  | 'pr.created'
+  | 'task.completed'
+  | 'task.failed'
+
+export type MultiAgentEvent = {
+  id: string
+  taskId: string
+  runId?: string | null
+  type: MultiAgentEventType
+  message: string
+  payload?: unknown
+  createdAt: string
+}
+
+export type MultiAgentRiskLevel = 'low' | 'medium' | 'high' | 'critical'
+
+export type MultiAgentApprovalActionType =
+  | 'git.push'
+  | 'github.pr_create'
+  | 'file.delete'
+  | 'shell.risky'
+  | 'external.message'
+  | 'deploy'
+  | 'secret_or_env'
+
+export type MultiAgentApprovalStatus = 'pending' | 'approved' | 'denied' | 'expired'
+
+export type MultiAgentApproval = {
+  id: string
+  taskId: string
+  runId?: string | null
+  riskLevel: MultiAgentRiskLevel
+  actionType: MultiAgentApprovalActionType
+  title: string
+  description: string
+  payload: unknown
+  status: MultiAgentApprovalStatus
+  createdAt: string
+  resolvedAt?: string | null
+}
+
+export type MultiAgentValidationType = 'lint' | 'typecheck' | 'test' | 'build' | 'custom'
+
+export type MultiAgentValidationStatus = 'queued' | 'running' | 'passed' | 'failed' | 'cancelled'
+
+export type MultiAgentValidation = {
+  id: string
+  taskId: string
+  type: MultiAgentValidationType
+  command: string
+  status: MultiAgentValidationStatus
+  exitCode?: number | null
+  outputSummary?: string | null
+  outputArtifactId?: string | null
+  startedAt?: string | null
+  finishedAt?: string | null
+}
+
+export type MultiAgentArtifactType = 'diff' | 'log' | 'pr' | 'screenshot' | 'report' | 'validation-output'
+
+export type MultiAgentArtifact = {
+  id: string
+  taskId: string
+  type: MultiAgentArtifactType
+  pathOrUrl: string
+  title: string
+  metadata?: Record<string, unknown>
+  createdAt: string
+}
+
+export type MultiAgentState = {
+  projects: Record<string, MultiAgentProject>
+  profiles: Record<string, MultiAgentProfile>
+  tasks: Record<string, MultiAgentTask>
+  runs: Record<string, MultiAgentRun>
+  approvals: Record<string, MultiAgentApproval>
+  validations: Record<string, MultiAgentValidation>
+  artifacts: Record<string, MultiAgentArtifact>
+  schemaVersion: 1
+  updatedAt: string
+}

--- a/src/server/multi-agent/types.ts
+++ b/src/server/multi-agent/types.ts
@@ -170,7 +170,7 @@ export type MultiAgentValidation = {
   finishedAt?: string | null
 }
 
-export type MultiAgentArtifactType = 'diff' | 'log' | 'pr' | 'screenshot' | 'report' | 'validation-output'
+export type MultiAgentArtifactType = 'diff' | 'log' | 'pr' | 'screenshot' | 'report' | 'validation-output' | 'github-pr'
 
 export type MultiAgentArtifact = {
   id: string

--- a/src/server/multi-agent/types.ts
+++ b/src/server/multi-agent/types.ts
@@ -29,6 +29,7 @@ export type MultiAgentProfileRole =
   | 'qa-validator'
   | 'reviewer'
   | 'docs-writer'
+  | 'architect'
 
 export type MultiAgentRuntime = 'hermes-agent'
 

--- a/src/server/multi-agent/types.ts
+++ b/src/server/multi-agent/types.ts
@@ -9,6 +9,17 @@ export type MultiAgentTaskStatus =
   | 'failed'
   | 'cancelled'
 
+export type MultiAgentMissionStatus =
+  | 'draft'
+  | 'planned'
+  | 'running'
+  | 'waiting_approval'
+  | 'reviewing'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
 export type MultiAgentPriority = 'low' | 'medium' | 'high' | 'urgent'
 
 export type MultiAgentProfileRole =
@@ -57,9 +68,30 @@ export type MultiAgentProfile = {
   updatedAt: string
 }
 
+export type MultiAgentProductBrief = {
+  goal: string
+  userStory: string
+  successMetrics: string[]
+  nonGoals: string[]
+}
+
+export type MultiAgentMission = {
+  id: string
+  projectId: string
+  title: string
+  status: MultiAgentMissionStatus
+  productBrief: MultiAgentProductBrief
+  constraints: string[]
+  desiredOutput: string
+  taskIds: string[]
+  createdAt: string
+  updatedAt: string
+}
+
 export type MultiAgentTask = {
   id: string
   projectId: string
+  missionId?: string | null
   title: string
   description: string
   status: MultiAgentTaskStatus
@@ -68,6 +100,7 @@ export type MultiAgentTask = {
   parentIds: string[]
   childIds: string[]
   workPacket: string
+  productBrief?: MultiAgentProductBrief | null
   acceptanceCriteria: string[]
   branchName?: string | null
   worktreePath?: string | null
@@ -186,6 +219,7 @@ export type MultiAgentArtifact = {
 export type MultiAgentState = {
   projects: Record<string, MultiAgentProject>
   profiles: Record<string, MultiAgentProfile>
+  missions: Record<string, MultiAgentMission>
   tasks: Record<string, MultiAgentTask>
   runs: Record<string, MultiAgentRun>
   approvals: Record<string, MultiAgentApproval>

--- a/src/server/multi-agent/validation-runner.test.ts
+++ b/src/server/multi-agent/validation-runner.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { runTaskValidation } from './validation-runner'
+
+describe('multi-agent validation runner', () => {
+  it('runs a passing command in the task worktree and captures output', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'hermes-ma-validation-pass-'))
+    try {
+      writeFileSync(join(worktreePath, 'marker.txt'), 'ok\n', 'utf-8')
+
+      const result = runTaskValidation({
+        taskId: 'task-1',
+        type: 'test',
+        command: `${process.execPath} -e "const fs=require('fs'); console.log(fs.readFileSync('marker.txt','utf8').trim())"`,
+        worktreePath,
+        now: () => '2026-05-18T12:00:00.000Z',
+        id: () => '123',
+      })
+
+      expect(result.validation).toMatchObject({
+        id: 'validation-123',
+        taskId: 'task-1',
+        type: 'test',
+        command: result.validation.command,
+        status: 'passed',
+        exitCode: 0,
+        startedAt: '2026-05-18T12:00:00.000Z',
+        finishedAt: '2026-05-18T12:00:00.000Z',
+      })
+      expect(result.output).toContain('ok')
+      expect(result.validation.outputSummary).toContain('ok')
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
+  it('marks non-zero commands as failed and preserves stderr', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'hermes-ma-validation-fail-'))
+    try {
+      const result = runTaskValidation({
+        taskId: 'task-1',
+        type: 'custom',
+        command: `${process.execPath} -e "console.error('bad validation'); process.exit(7)"`,
+        worktreePath,
+        allowCustomCommand: true,
+        now: () => '2026-05-18T12:00:00.000Z',
+        id: () => 'fail',
+      })
+
+      expect(result.validation).toMatchObject({
+        id: 'validation-fail',
+        status: 'failed',
+        exitCode: 7,
+      })
+      expect(result.output).toContain('bad validation')
+      expect(result.validation.outputSummary).toContain('bad validation')
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects custom commands when custom validation is not explicitly allowed', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'hermes-ma-validation-custom-'))
+    try {
+      expect(() => runTaskValidation({
+        taskId: 'task-1',
+        type: 'custom',
+        command: 'echo unsafe',
+        worktreePath,
+      })).toThrow(/Custom validation commands require approval/)
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves configured validation commands by type', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'hermes-ma-validation-config-'))
+    try {
+      const result = runTaskValidation({
+        taskId: 'task-1',
+        type: 'build',
+        validationConfig: { build: `${process.execPath} -e "console.log('build ok')"` },
+        worktreePath,
+        now: () => '2026-05-18T12:00:00.000Z',
+        id: () => 'build',
+      })
+
+      expect(result.validation.command).toContain('build ok')
+      expect(result.validation.status).toBe('passed')
+      expect(result.output).toContain('build ok')
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/multi-agent/validation-runner.ts
+++ b/src/server/multi-agent/validation-runner.ts
@@ -1,0 +1,93 @@
+import { execSync } from 'node:child_process'
+import type {
+  MultiAgentProjectValidation,
+  MultiAgentValidation,
+  MultiAgentValidationType,
+} from './types'
+
+export type RunTaskValidationInput = {
+  taskId: string
+  type: MultiAgentValidationType
+  command?: string | null
+  validationConfig?: MultiAgentProjectValidation | null
+  worktreePath: string
+  allowCustomCommand?: boolean
+  timeoutMs?: number
+  now?: () => string
+  id?: () => string
+}
+
+export type RunTaskValidationResult = {
+  validation: MultiAgentValidation
+  output: string
+}
+
+function defaultNow(): string {
+  return new Date().toISOString()
+}
+
+function defaultId(): string {
+  return crypto.randomUUID()
+}
+
+function summarizeOutput(output: string): string {
+  const text = output.trim()
+  if (text.length <= 4000) return text
+  return `${text.slice(0, 4000)}\n… truncated`
+}
+
+function resolveValidationCommand(input: RunTaskValidationInput): string {
+  const command = input.command?.trim()
+  if (input.type === 'custom') {
+    if (!input.allowCustomCommand) {
+      throw new Error('Custom validation commands require approval')
+    }
+    if (!command) throw new Error('Custom validation command is required')
+    return command
+  }
+
+  const configured = input.validationConfig?.[input.type]?.trim()
+  if (configured) return configured
+  if (command) return command
+  throw new Error(`No validation command configured for ${input.type}`)
+}
+
+export function runTaskValidation(input: RunTaskValidationInput): RunTaskValidationResult {
+  const now = input.now ?? defaultNow
+  const id = input.id ?? defaultId
+  const startedAt = now()
+  const command = resolveValidationCommand(input)
+  let output = ''
+  let exitCode = 0
+
+  try {
+    output = execSync(command, {
+      cwd: input.worktreePath,
+      encoding: 'utf-8',
+      shell: '/bin/bash',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: input.timeoutMs ?? 120_000,
+    })
+  } catch (err) {
+    const error = err as { status?: number | null; stdout?: Buffer | string; stderr?: Buffer | string; message?: string }
+    exitCode = typeof error.status === 'number' ? error.status : 1
+    const stdout = Buffer.isBuffer(error.stdout) ? error.stdout.toString('utf-8') : error.stdout ?? ''
+    const stderr = Buffer.isBuffer(error.stderr) ? error.stderr.toString('utf-8') : error.stderr ?? ''
+    output = [stdout, stderr || error.message || 'Validation command failed'].filter(Boolean).join('\n')
+  }
+
+  const validation: MultiAgentValidation = {
+    id: `validation-${id()}`,
+    taskId: input.taskId,
+    type: input.type,
+    command,
+    status: exitCode === 0 ? 'passed' : 'failed',
+    exitCode,
+    outputSummary: summarizeOutput(output),
+    outputArtifactId: null,
+    startedAt,
+    finishedAt: now(),
+  }
+
+  return { validation, output }
+}

--- a/src/server/multi-agent/worktree-manager.test.ts
+++ b/src/server/multi-agent/worktree-manager.test.ts
@@ -1,0 +1,163 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { MultiAgentProject, MultiAgentTask } from './types'
+import {
+  buildTaskBranchName,
+  buildTaskWorktreePath,
+  createTaskWorktree,
+  getWorktreeStatus,
+  removeTaskWorktree,
+} from './worktree-manager'
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function initRepo(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'hermes-ma-worktree-repo-'))
+  git(repoPath, ['init', '-b', 'main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  writeFileSync(join(repoPath, 'README.md'), '# test repo\n', 'utf-8')
+  git(repoPath, ['add', 'README.md'])
+  git(repoPath, ['commit', '-m', 'initial commit'])
+  return repoPath
+}
+
+function project(repoPath = initRepo()): MultiAgentProject {
+  return {
+    id: 'project-1',
+    name: 'Project 1',
+    repoPath,
+    defaultBranch: 'main',
+    worktreeRoot: join(repoPath, '.hermes-worktrees'),
+    githubRemote: null,
+    graphifyGraphPath: null,
+    obsidianPath: null,
+    createdAt: '2026-05-16T19:00:00.000Z',
+    updatedAt: '2026-05-16T19:00:00.000Z',
+  }
+}
+
+function task(overrides: Partial<MultiAgentTask> = {}): MultiAgentTask {
+  return {
+    id: overrides.id ?? 'task-123',
+    projectId: overrides.projectId ?? 'project-1',
+    title: overrides.title ?? 'Create Worktree',
+    description: overrides.description ?? '',
+    status: overrides.status ?? 'backlog',
+    priority: overrides.priority ?? 'medium',
+    assigneeProfileId: overrides.assigneeProfileId ?? 'backend-engineer',
+    parentIds: overrides.parentIds ?? [],
+    childIds: overrides.childIds ?? [],
+    workPacket: overrides.workPacket ?? '',
+    acceptanceCriteria: overrides.acceptanceCriteria ?? [],
+    branchName: overrides.branchName,
+    worktreePath: overrides.worktreePath,
+    latestRunId: overrides.latestRunId,
+    createdAt: overrides.createdAt ?? '2026-05-16T19:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-05-16T19:00:00.000Z',
+  }
+}
+
+describe('multi-agent worktree manager', () => {
+  it('builds safe branch and worktree paths from task metadata', () => {
+    const repoPath = initRepo()
+    const resolvedProject = project(repoPath)
+    const resolvedTask = task({ id: 'task-123', title: 'Add Store & Events!' })
+
+    expect(buildTaskBranchName(resolvedTask)).toBe('hermes/task-task-123-add-store-events')
+    expect(buildTaskWorktreePath(resolvedProject, resolvedTask)).toBe(
+      join(repoPath, '.hermes-worktrees', 'task-task-123-add-store-events'),
+    )
+  })
+
+  it('creates a git worktree and branch under the project worktree root', async () => {
+    const resolvedProject = project()
+    const resolvedTask = task({ id: 'task-123', title: 'Implement worktree manager' })
+
+    const result = await createTaskWorktree(resolvedProject, resolvedTask)
+
+    expect(result.branchName).toBe('hermes/task-task-123-implement-worktree-manager')
+    expect(result.worktreePath.startsWith(resolve(resolvedProject.worktreeRoot))).toBe(true)
+    expect(existsSync(join(result.worktreePath, 'README.md'))).toBe(true)
+    expect(git(resolvedProject.repoPath, ['branch', '--list', result.branchName])).toContain(result.branchName)
+  })
+
+  it('returns the existing worktree for duplicate creation of the same task', async () => {
+    const resolvedProject = project()
+    const resolvedTask = task({ id: 'task-123', title: 'Duplicate Safe' })
+
+    const first = await createTaskWorktree(resolvedProject, resolvedTask)
+    const second = await createTaskWorktree(resolvedProject, resolvedTask)
+
+    expect(second).toEqual(first)
+  })
+
+  it('reports modified and untracked files in a task worktree', async () => {
+    const resolvedProject = project()
+    const result = await createTaskWorktree(resolvedProject, task())
+    writeFileSync(join(result.worktreePath, 'README.md'), '# changed\n', 'utf-8')
+    writeFileSync(join(result.worktreePath, 'new-file.txt'), 'new\n', 'utf-8')
+
+    const status = getWorktreeStatus(result.worktreePath)
+
+    expect(status.clean).toBe(false)
+    expect(status.changedFiles).toContain('README.md')
+    expect(status.changedFiles).toContain('new-file.txt')
+    expect(status.porcelain).toContain('README.md')
+  })
+
+  it('refuses unsafe task ids before constructing branch names', () => {
+    expect(() => buildTaskBranchName(task({ id: '../bad' }))).toThrow(/Unsafe task id/)
+    expect(() => buildTaskBranchName(task({ id: 'task/123' }))).toThrow(/Unsafe task id/)
+  })
+
+  it('refuses worktree paths outside the project worktree root', () => {
+    const resolvedProject = project()
+    const outsidePath = join(tmpdir(), 'outside-worktree')
+
+    expect(() => removeTaskWorktree(resolvedProject, outsidePath, 'hermes/task-task-123-safe')).toThrow(
+      /outside worktree root/,
+    )
+  })
+
+  it('removes a clean managed worktree when explicitly requested', async () => {
+    const resolvedProject = project()
+    const result = await createTaskWorktree(resolvedProject, task({ id: 'task-456', title: 'Remove Me' }))
+
+    removeTaskWorktree(resolvedProject, result.worktreePath, result.branchName)
+
+    expect(existsSync(result.worktreePath)).toBe(false)
+    expect(git(resolvedProject.repoPath, ['branch', '--list', result.branchName])).toBe('')
+  })
+
+  it('refuses to remove a dirty worktree unless force is true', async () => {
+    const resolvedProject = project()
+    const result = await createTaskWorktree(resolvedProject, task({ id: 'task-789', title: 'Dirty Remove' }))
+    writeFileSync(join(result.worktreePath, 'dirty.txt'), 'dirty\n', 'utf-8')
+
+    expect(() => removeTaskWorktree(resolvedProject, result.worktreePath, result.branchName)).toThrow(
+      /dirty worktree/,
+    )
+
+    removeTaskWorktree(resolvedProject, result.worktreePath, result.branchName, { force: true })
+    expect(existsSync(result.worktreePath)).toBe(false)
+  })
+
+  it('does not treat repo root as removable worktree', () => {
+    const resolvedProject = project()
+    const head = readFileSync(join(resolvedProject.repoPath, 'README.md'), 'utf-8')
+
+    expect(() => removeTaskWorktree(resolvedProject, resolvedProject.repoPath, 'main', { force: true })).toThrow(
+      /Refusing to remove repository root/,
+    )
+    expect(readFileSync(join(resolvedProject.repoPath, 'README.md'), 'utf-8')).toBe(head)
+  })
+})

--- a/src/server/multi-agent/worktree-manager.ts
+++ b/src/server/multi-agent/worktree-manager.ts
@@ -1,0 +1,207 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, realpathSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+import type { MultiAgentProject, MultiAgentTask } from './types'
+
+export type TaskWorktreeResult = {
+  branchName: string
+  worktreePath: string
+}
+
+export type WorktreeStatus = {
+  clean: boolean
+  changedFiles: string[]
+  porcelain: string
+}
+
+export type RemoveWorktreeOptions = {
+  force?: boolean
+}
+
+const SAFE_TASK_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,159}$/
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', ['-C', repoPath, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  }).trim()
+}
+
+function assertSafeTaskId(taskId: string): void {
+  if (!SAFE_TASK_ID_PATTERN.test(taskId)) {
+    throw new Error(`Unsafe task id: ${taskId}`)
+  }
+}
+
+function slugifyTitle(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64) || 'task'
+  )
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relativePath = relative(resolve(parent), resolve(child))
+  return relativePath === '' || (!relativePath.startsWith('..') && !relativePath.startsWith(sep))
+}
+
+function existingPath(path: string): string | null {
+  try {
+    return realpathSync(path)
+  } catch {
+    return null
+  }
+}
+
+export function buildTaskBranchName(task: Pick<MultiAgentTask, 'id' | 'title'>): string {
+  assertSafeTaskId(task.id)
+  return `hermes/task-${task.id}-${slugifyTitle(task.title)}`
+}
+
+function worktreeDirName(task: Pick<MultiAgentTask, 'id' | 'title'>): string {
+  assertSafeTaskId(task.id)
+  return `task-${task.id}-${slugifyTitle(task.title)}`
+}
+
+export function buildTaskWorktreePath(
+  project: Pick<MultiAgentProject, 'worktreeRoot'>,
+  task: Pick<MultiAgentTask, 'id' | 'title'>,
+): string {
+  const worktreePath = resolve(project.worktreeRoot, worktreeDirName(task))
+  assertWorktreePathInsideRoot(project, worktreePath)
+  return worktreePath
+}
+
+function assertWorktreePathInsideRoot(
+  project: Pick<MultiAgentProject, 'worktreeRoot'> & Partial<Pick<MultiAgentProject, 'repoPath'>>,
+  worktreePath: string,
+): void {
+  const rootPath = resolve(project.worktreeRoot)
+  const resolvedWorktreePath = resolve(worktreePath)
+  if (!isPathInside(rootPath, resolvedWorktreePath) || rootPath === resolvedWorktreePath) {
+    throw new Error(`Worktree path is outside worktree root: ${worktreePath}`)
+  }
+  if (project.repoPath && resolve(project.repoPath) === resolvedWorktreePath) {
+    throw new Error('Refusing to use repository root as task worktree')
+  }
+}
+
+function branchExists(repoPath: string, branchName: string): boolean {
+  try {
+    git(repoPath, ['rev-parse', '--verify', branchName])
+    return true
+  } catch {
+    return false
+  }
+}
+
+function worktreeList(repoPath: string): Array<{ path: string; branch: string | null }> {
+  const output = git(repoPath, ['worktree', 'list', '--porcelain'])
+  const entries: Array<{ path: string; branch: string | null }> = []
+  let currentPath: string | null = null
+  let currentBranch: string | null = null
+
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (currentPath) entries.push({ path: currentPath, branch: currentBranch })
+      currentPath = line.slice('worktree '.length)
+      currentBranch = null
+      continue
+    }
+    if (line.startsWith('branch ')) {
+      currentBranch = line.slice('branch '.length).replace(/^refs\/heads\//, '')
+    }
+  }
+  if (currentPath) entries.push({ path: currentPath, branch: currentBranch })
+  return entries
+}
+
+function existingManagedWorktree(repoPath: string, branchName: string, worktreePath: string): boolean {
+  const expectedPath = resolve(worktreePath)
+  return worktreeList(repoPath).some(
+    (entry) => entry.branch === branchName && resolve(entry.path) === expectedPath,
+  )
+}
+
+export async function createTaskWorktree(
+  project: MultiAgentProject,
+  task: MultiAgentTask,
+): Promise<TaskWorktreeResult> {
+  const branchName = task.branchName ?? buildTaskBranchName(task)
+  const worktreePath = task.worktreePath ? resolve(task.worktreePath) : buildTaskWorktreePath(project, task)
+  assertWorktreePathInsideRoot(project, worktreePath)
+
+  if (existingManagedWorktree(project.repoPath, branchName, worktreePath)) {
+    return { branchName, worktreePath }
+  }
+
+  if (existsSync(worktreePath)) {
+    throw new Error(`Worktree path already exists but is not registered for branch ${branchName}: ${worktreePath}`)
+  }
+
+  mkdirSync(project.worktreeRoot, { recursive: true })
+
+  const args = ['worktree', 'add', worktreePath]
+  if (!branchExists(project.repoPath, branchName)) {
+    args.push('-b', branchName, project.defaultBranch)
+  } else {
+    args.push(branchName)
+  }
+  git(project.repoPath, args)
+
+  return { branchName, worktreePath }
+}
+
+export function getWorktreeStatus(worktreePath: string): WorktreeStatus {
+  const porcelain = git(worktreePath, ['status', '--porcelain'])
+  const changedFiles = porcelain
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(2).trim())
+    .map((file) => file.split(' -> ').at(-1) || file)
+
+  return {
+    clean: changedFiles.length === 0,
+    changedFiles,
+    porcelain,
+  }
+}
+
+export function removeTaskWorktree(
+  project: MultiAgentProject,
+  worktreePath: string,
+  branchName: string,
+  options: RemoveWorktreeOptions = {},
+): void {
+  const resolvedRepoPath = resolve(project.repoPath)
+  const resolvedWorktreePath = resolve(worktreePath)
+
+  if (resolvedWorktreePath === resolvedRepoPath) {
+    throw new Error('Refusing to remove repository root as a worktree')
+  }
+  assertWorktreePathInsideRoot(project, resolvedWorktreePath)
+
+  const realRepoPath = existingPath(resolvedRepoPath)
+  const realWorktreePath = existingPath(resolvedWorktreePath)
+  if (realRepoPath && realWorktreePath && realRepoPath === realWorktreePath) {
+    throw new Error('Refusing to remove repository root as a worktree')
+  }
+
+  if (existsSync(resolvedWorktreePath)) {
+    const status = getWorktreeStatus(resolvedWorktreePath)
+    if (!status.clean && !options.force) {
+      throw new Error(`Refusing to remove dirty worktree: ${resolvedWorktreePath}`)
+    }
+  }
+
+  git(project.repoPath, ['worktree', 'remove', options.force ? '--force' : '', resolvedWorktreePath].filter(Boolean))
+
+  if (branchName && branchName !== project.defaultBranch && branchExists(project.repoPath, branchName)) {
+    git(project.repoPath, ['branch', '-D', branchName])
+  }
+}

--- a/src/server/project-registry.test.ts
+++ b/src/server/project-registry.test.ts
@@ -41,6 +41,22 @@ describe('buildProjectRegistry', () => {
       '# Demo Project\nUseful docs.',
     )
     execFileSync('git', ['init'], { cwd: workspaceDir, stdio: 'ignore' })
+    execFileSync('git', ['config', 'user.name', 'Test User'], {
+      cwd: workspaceDir,
+      stdio: 'ignore',
+    })
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], {
+      cwd: workspaceDir,
+      stdio: 'ignore',
+    })
+    execFileSync('git', ['add', 'AGENTS.md', 'README.md'], {
+      cwd: workspaceDir,
+      stdio: 'ignore',
+    })
+    execFileSync('git', ['commit', '-m', 'Initial commit'], {
+      cwd: workspaceDir,
+      stdio: 'ignore',
+    })
     execFileSync(
       'git',
       ['remote', 'add', 'origin', 'git@github.com:acme/demo.git'],
@@ -49,6 +65,7 @@ describe('buildProjectRegistry', () => {
         stdio: 'ignore',
       },
     )
+    writeFileSync(join(workspaceDir, 'scratch.txt'), 'dirty worktree')
 
     const { buildProjectRegistry } = await import('./project-registry')
     const registry = await buildProjectRegistry()
@@ -60,7 +77,22 @@ describe('buildProjectRegistry', () => {
       path: workspaceDir,
       active: true,
       gitRemote: 'git@github.com:acme/demo.git',
-      gitBranch: null,
+      gitBranch: 'master',
+    })
+    expect(registry.projects[0].status).toMatchObject({
+      gitDirty: true,
+      changedFiles: 1,
+      lastCommit: expect.any(String),
+      lastCommitAt: expect.any(String),
+    })
+    expect(registry.projects[0].contextPreview.summary).toContain(
+      `Path: ${workspaceDir}`,
+    )
+    expect(registry.projects[0].contextPreview.summary).toContain(
+      'Stack: not detected',
+    )
+    expect(registry.projects[0].contextPreview.files[0]).toMatchObject({
+      name: 'AGENTS.md',
     })
     expect(registry.projects[0].instructionFiles[0]).toMatchObject({
       name: 'AGENTS.md',

--- a/src/server/project-registry.test.ts
+++ b/src/server/project-registry.test.ts
@@ -70,42 +70,46 @@ describe('buildProjectRegistry', () => {
     const { buildProjectRegistry } = await import('./project-registry')
     const registry = await buildProjectRegistry()
 
-    expect(registry.projects).toHaveLength(1)
-    expect(registry.activeProjectId).toBe(registry.projects[0].id)
-    expect(registry.projects[0]).toMatchObject({
+    const activeProject = registry.projects.find(
+      (project) => project.path === workspaceDir,
+    )
+    expect(activeProject).toBeDefined()
+    expect(registry.activeProjectId).toBe(activeProject?.id)
+    expect(activeProject).toMatchObject({
       name: workspaceDir.split('/').at(-1),
       path: workspaceDir,
+      source: 'discovered',
       active: true,
       gitRemote: 'git@github.com:acme/demo.git',
       gitBranch: 'master',
     })
-    expect(registry.projects[0].status).toMatchObject({
+    expect(activeProject?.status).toMatchObject({
       gitDirty: true,
       changedFiles: 1,
       lastCommit: expect.any(String),
       lastCommitAt: expect.any(String),
     })
-    expect(registry.projects[0].contextPreview.summary).toContain(
+    expect(activeProject?.contextPreview.summary).toContain(
       `Path: ${workspaceDir}`,
     )
-    expect(registry.projects[0].contextPreview.summary).toContain(
+    expect(activeProject?.contextPreview.summary).toContain(
       'Stack: not detected',
     )
-    expect(registry.projects[0].contextPreview.files[0]).toMatchObject({
+    expect(activeProject?.contextPreview.files[0]).toMatchObject({
       name: 'AGENTS.md',
     })
-    expect(registry.projects[0].instructionFiles[0]).toMatchObject({
+    expect(activeProject?.instructionFiles[0]).toMatchObject({
       name: 'AGENTS.md',
       path: join(workspaceDir, 'AGENTS.md'),
     })
-    expect(registry.projects[0].instructionFiles[0].excerpt).toContain(
+    expect(activeProject?.instructionFiles[0].excerpt).toContain(
       'Follow project instructions',
     )
-    expect(registry.projects[0].readme?.excerpt).toContain('Demo Project')
+    expect(activeProject?.readme?.excerpt).toContain('Demo Project')
 
     const { buildProjectContextPromptBlock } =
       await import('./project-registry')
-    const promptBlock = buildProjectContextPromptBlock(registry.projects[0])
+    const promptBlock = buildProjectContextPromptBlock(activeProject!)
     expect(promptBlock).toContain('## Active Project Context')
     expect(promptBlock).toContain(`Path: ${workspaceDir}`)
     expect(promptBlock).toContain('git@github.com:acme/demo.git')

--- a/src/server/project-registry.test.ts
+++ b/src/server/project-registry.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+let tempHome = ''
+let workspaceDir = ''
+let originalHermesHome: string | undefined
+let originalWorkspaceDir: string | undefined
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), 'hermes-project-registry-home-'))
+  workspaceDir = mkdtempSync(
+    join(tmpdir(), 'hermes-project-registry-workspace-'),
+  )
+  originalHermesHome = process.env.HERMES_HOME
+  originalWorkspaceDir = process.env.HERMES_WORKSPACE_DIR
+  process.env.HERMES_HOME = tempHome
+  process.env.HERMES_WORKSPACE_DIR = workspaceDir
+})
+
+afterEach(() => {
+  if (originalHermesHome === undefined) delete process.env.HERMES_HOME
+  else process.env.HERMES_HOME = originalHermesHome
+  if (originalWorkspaceDir === undefined)
+    delete process.env.HERMES_WORKSPACE_DIR
+  else process.env.HERMES_WORKSPACE_DIR = originalWorkspaceDir
+  rmSync(tempHome, { recursive: true, force: true })
+  rmSync(workspaceDir, { recursive: true, force: true })
+})
+
+describe('buildProjectRegistry', () => {
+  it('returns active project metadata, instruction excerpts, readme, and git remote', async () => {
+    writeFileSync(
+      join(workspaceDir, 'AGENTS.md'),
+      'Follow project instructions.\n'.repeat(4),
+    )
+    writeFileSync(
+      join(workspaceDir, 'README.md'),
+      '# Demo Project\nUseful docs.',
+    )
+    execFileSync('git', ['init'], { cwd: workspaceDir, stdio: 'ignore' })
+    execFileSync(
+      'git',
+      ['remote', 'add', 'origin', 'git@github.com:acme/demo.git'],
+      {
+        cwd: workspaceDir,
+        stdio: 'ignore',
+      },
+    )
+
+    const { buildProjectRegistry } = await import('./project-registry')
+    const registry = await buildProjectRegistry()
+
+    expect(registry.projects).toHaveLength(1)
+    expect(registry.activeProjectId).toBe(registry.projects[0].id)
+    expect(registry.projects[0]).toMatchObject({
+      name: workspaceDir.split('/').at(-1),
+      path: workspaceDir,
+      active: true,
+      gitRemote: 'git@github.com:acme/demo.git',
+      gitBranch: null,
+    })
+    expect(registry.projects[0].instructionFiles[0]).toMatchObject({
+      name: 'AGENTS.md',
+      path: join(workspaceDir, 'AGENTS.md'),
+    })
+    expect(registry.projects[0].instructionFiles[0].excerpt).toContain(
+      'Follow project instructions',
+    )
+    expect(registry.projects[0].readme?.excerpt).toContain('Demo Project')
+
+    const { buildProjectContextPromptBlock } =
+      await import('./project-registry')
+    const promptBlock = buildProjectContextPromptBlock(registry.projects[0])
+    expect(promptBlock).toContain('## Active Project Context')
+    expect(promptBlock).toContain(`Path: ${workspaceDir}`)
+    expect(promptBlock).toContain('git@github.com:acme/demo.git')
+    expect(promptBlock).toContain('### AGENTS.md')
+    expect(promptBlock).toContain('Follow project instructions')
+  })
+
+  it('discovers direct child projects under the active workspace', async () => {
+    const child = join(workspaceDir, 'child-app')
+    mkdirSync(child)
+    writeFileSync(join(child, 'package.json'), '{"name":"child-app"}')
+    writeFileSync(join(child, 'CLAUDE.md'), 'Child instructions')
+
+    const { buildProjectRegistry } = await import('./project-registry')
+    const registry = await buildProjectRegistry()
+
+    expect(registry.projects.some((project) => project.path === child)).toBe(
+      true,
+    )
+    expect(
+      registry.projects.find((project) => project.path === child)
+        ?.instructionFiles[0]?.name,
+    ).toBe('CLAUDE.md')
+  })
+})

--- a/src/server/project-registry.ts
+++ b/src/server/project-registry.ts
@@ -1,5 +1,13 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { loadWorkspaceCatalog } from '../routes/api/workspace'
@@ -28,6 +36,7 @@ export type ProjectRegistryEntry = {
   id: string
   name: string
   path: string
+  source: 'shared' | 'discovered'
   active: boolean
   gitRemote: string | null
   gitBranch: string | null
@@ -76,6 +85,17 @@ const IGNORED_DIRS = new Set([
   '.venv',
 ])
 
+const SHARED_PROJECTS: Array<{ name: string; path: string }> = [
+  { name: 'pilulus', path: '~/pilulus' },
+  { name: 'eycharochka', path: '~/eycharochka' },
+  {
+    name: 'hermes-workspace',
+    path: '~/ai-workspace/apps/hermes-workspace',
+  },
+]
+
+const ACTIVE_PROJECT_STATE_FILE = 'active-project.json'
+
 function expandHome(input: string): string {
   if (input === '~') return os.homedir()
   if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2))
@@ -88,6 +108,46 @@ function normalizePath(input: string): string {
 
 function stableProjectId(projectPath: string): string {
   return Buffer.from(projectPath).toString('base64url')
+}
+
+function hermesStateDir(): string {
+  const configured =
+    process.env.HERMES_HOME ||
+    process.env.CLAUDE_HOME ||
+    path.join(os.homedir(), '.hermes')
+  return normalizePath(configured)
+}
+
+function activeProjectStatePath(): string {
+  return path.join(hermesStateDir(), 'workspace', ACTIVE_PROJECT_STATE_FILE)
+}
+
+function readPersistedActiveProjectId(): string | null {
+  try {
+    const raw = readFileSync(activeProjectStatePath(), 'utf-8')
+    const parsed = JSON.parse(raw) as { activeProjectId?: unknown }
+    return typeof parsed.activeProjectId === 'string' && parsed.activeProjectId
+      ? parsed.activeProjectId
+      : null
+  } catch {
+    return null
+  }
+}
+
+function writePersistedActiveProjectId(activeProjectId: string): void {
+  const statePath = activeProjectStatePath()
+  mkdirSync(path.dirname(statePath), { recursive: true })
+  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(
+    tmpPath,
+    `${JSON.stringify(
+      { activeProjectId, updatedAt: new Date().toISOString() },
+      null,
+      2,
+    )}\n`,
+    { encoding: 'utf-8', mode: 0o600 },
+  )
+  renameSync(tmpPath, statePath)
 }
 
 function isDirectory(candidate: string): boolean {
@@ -283,8 +343,12 @@ function buildContextPreview(project: {
 function toProjectEntry(
   projectPath: string,
   activePath: string,
+  activeProjectId: string | null,
+  source: ProjectRegistryEntry['source'],
+  displayName?: string,
 ): ProjectRegistryEntry {
   const normalizedPath = normalizePath(projectPath)
+  const id = stableProjectId(normalizedPath)
   const gitRemoteValue = gitRemote(normalizedPath)
   const gitBranchValue = gitBranch(normalizedPath)
   const instructionFiles = readInstructionFiles(normalizedPath)
@@ -299,10 +363,13 @@ function toProjectEntry(
     status,
   }
   return {
-    id: stableProjectId(normalizedPath),
-    name: path.basename(normalizedPath),
+    id,
+    name: displayName || path.basename(normalizedPath),
     path: normalizedPath,
-    active: normalizedPath === activePath,
+    source,
+    active: activeProjectId
+      ? id === activeProjectId
+      : normalizedPath === activePath,
     gitRemote: gitRemoteValue,
     gitBranch: gitBranchValue,
     status,
@@ -316,35 +383,91 @@ export async function buildProjectRegistry(): Promise<ProjectRegistryResponse> {
   const catalog = await loadWorkspaceCatalog()
   const activePath =
     catalog.isValid && catalog.path ? normalizePath(catalog.path) : ''
+  const persistedActiveProjectId = readPersistedActiveProjectId()
   const roots =
     catalog.workspaces.length > 0
       ? catalog.workspaces.map((workspace) => workspace.path)
       : activePath
         ? [activePath]
         : []
-  const candidates = new Set<string>()
+  const candidates = new Map<
+    string,
+    { source: ProjectRegistryEntry['source']; name?: string }
+  >()
+
+  for (const shared of SHARED_PROJECTS) {
+    const normalizedSharedPath = normalizePath(shared.path)
+    if (!isDirectory(normalizedSharedPath)) continue
+    candidates.set(normalizedSharedPath, {
+      source: 'shared',
+      name: shared.name,
+    })
+  }
 
   for (const root of roots) {
     const normalizedRoot = normalizePath(root)
     if (!isDirectory(normalizedRoot)) continue
-    if (hasProjectMarker(normalizedRoot)) candidates.add(normalizedRoot)
+    if (hasProjectMarker(normalizedRoot)) {
+      const existing = candidates.get(normalizedRoot)
+      candidates.set(normalizedRoot, {
+        source: existing?.source ?? 'discovered',
+        name: existing?.name,
+      })
+    }
     for (const child of listDirectChildProjects(normalizedRoot)) {
-      candidates.add(normalizePath(child))
+      const normalizedChild = normalizePath(child)
+      const existing = candidates.get(normalizedChild)
+      candidates.set(normalizedChild, {
+        source: existing?.source ?? 'discovered',
+        name: existing?.name,
+      })
     }
   }
 
-  if (activePath && isDirectory(activePath)) candidates.add(activePath)
+  if (activePath && isDirectory(activePath)) {
+    const existing = candidates.get(activePath)
+    candidates.set(activePath, {
+      source: existing?.source ?? 'discovered',
+      name: existing?.name,
+    })
+  }
 
-  const projects = [...candidates]
-    .sort((a, b) => path.basename(a).localeCompare(path.basename(b)))
+  const projects = [...candidates.entries()]
+    .sort(([aPath, aMeta], [bPath, bMeta]) => {
+      const sourceOrder = aMeta.source.localeCompare(bMeta.source)
+      if (sourceOrder !== 0) return sourceOrder
+      return (aMeta.name || path.basename(aPath)).localeCompare(
+        bMeta.name || path.basename(bPath),
+      )
+    })
     .slice(0, MAX_PROJECTS)
-    .map((projectPath) => toProjectEntry(projectPath, activePath))
+    .map(([projectPath, meta]) =>
+      toProjectEntry(
+        projectPath,
+        activePath,
+        persistedActiveProjectId,
+        meta.source,
+        meta.name,
+      ),
+    )
 
   return {
     activeProjectId: projects.find((project) => project.active)?.id ?? null,
     projects,
     fetchedAt: Date.now(),
   }
+}
+
+export async function setActiveProjectById(
+  projectId: string,
+): Promise<ProjectRegistryResponse> {
+  const registry = await buildProjectRegistry()
+  const selected = registry.projects.find((project) => project.id === projectId)
+  if (!selected) {
+    throw new Error('Project not found')
+  }
+  writePersistedActiveProjectId(selected.id)
+  return buildProjectRegistry()
 }
 
 function formatProjectFileForPrompt(

--- a/src/server/project-registry.ts
+++ b/src/server/project-registry.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadWorkspaceCatalog } from '../routes/api/workspace'
+
+export type ProjectRegistryInstructionFile = {
+  name: string
+  path: string
+  excerpt: string
+}
+
+export type ProjectRegistryEntry = {
+  id: string
+  name: string
+  path: string
+  active: boolean
+  gitRemote: string | null
+  gitBranch: string | null
+  instructionFiles: Array<ProjectRegistryInstructionFile>
+  readme: ProjectRegistryInstructionFile | null
+}
+
+export type ProjectRegistryResponse = {
+  activeProjectId: string | null
+  projects: Array<ProjectRegistryEntry>
+  fetchedAt: number
+}
+
+export type ActiveProjectContext = {
+  project: ProjectRegistryEntry | null
+  promptBlock: string
+}
+
+const MAX_PROJECTS = 60
+const MAX_EXCERPT_CHARS = 1200
+const MAX_PROMPT_FILE_CHARS = 1800
+const PROJECT_MARKERS = [
+  'AGENTS.md',
+  'CLAUDE.md',
+  '.cursorrules',
+  'README.md',
+  'package.json',
+  'pyproject.toml',
+  'Cargo.toml',
+  'go.mod',
+  '.git',
+]
+const INSTRUCTION_FILES = ['AGENTS.md', 'CLAUDE.md', '.cursorrules']
+const README_FILES = ['README.md', 'readme.md']
+const IGNORED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.cache',
+  '__pycache__',
+  '.venv',
+])
+
+function expandHome(input: string): string {
+  if (input === '~') return os.homedir()
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2))
+  return input
+}
+
+function normalizePath(input: string): string {
+  return path.resolve(expandHome(input.trim()))
+}
+
+function stableProjectId(projectPath: string): string {
+  return Buffer.from(projectPath).toString('base64url')
+}
+
+function isDirectory(candidate: string): boolean {
+  try {
+    return statSync(candidate).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function hasProjectMarker(dirPath: string): boolean {
+  return PROJECT_MARKERS.some((marker) =>
+    existsSync(path.join(dirPath, marker)),
+  )
+}
+
+function listDirectChildProjects(rootPath: string): Array<string> {
+  try {
+    return readdirSync(rootPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !IGNORED_DIRS.has(entry.name))
+      .map((entry) => path.join(rootPath, entry.name))
+      .filter(hasProjectMarker)
+      .slice(0, MAX_PROJECTS)
+  } catch {
+    return []
+  }
+}
+
+function readExcerpt(filePath: string): string {
+  try {
+    const raw = readFileSync(filePath, 'utf-8')
+    return raw.trim().slice(0, MAX_EXCERPT_CHARS)
+  } catch {
+    return ''
+  }
+}
+
+function readProjectFile(
+  projectPath: string,
+  name: string,
+): ProjectRegistryInstructionFile | null {
+  const filePath = path.join(projectPath, name)
+  if (!existsSync(filePath)) return null
+  const excerpt = readExcerpt(filePath)
+  if (!excerpt) return null
+  return {
+    name,
+    path: filePath,
+    excerpt,
+  }
+}
+
+function readInstructionFiles(
+  projectPath: string,
+): Array<ProjectRegistryInstructionFile> {
+  return INSTRUCTION_FILES.map((name) =>
+    readProjectFile(projectPath, name),
+  ).filter((file): file is ProjectRegistryInstructionFile => Boolean(file))
+}
+
+function readReadme(
+  projectPath: string,
+): ProjectRegistryInstructionFile | null {
+  for (const name of README_FILES) {
+    const file = readProjectFile(projectPath, name)
+    if (file) return file
+  }
+  return null
+}
+
+function gitOutput(cwd: string, args: Array<string>): string | null {
+  try {
+    const out = execFileSync('git', ['-C', cwd, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1500,
+    })
+    const trimmed = out.trim()
+    return trimmed || null
+  } catch {
+    return null
+  }
+}
+
+function gitBranch(projectPath: string): string | null {
+  const branch = gitOutput(projectPath, ['rev-parse', '--abbrev-ref', 'HEAD'])
+  return branch && branch !== 'HEAD' ? branch : null
+}
+
+function gitRemote(projectPath: string): string | null {
+  return gitOutput(projectPath, ['remote', 'get-url', 'origin'])
+}
+
+function toProjectEntry(
+  projectPath: string,
+  activePath: string,
+): ProjectRegistryEntry {
+  const normalizedPath = normalizePath(projectPath)
+  return {
+    id: stableProjectId(normalizedPath),
+    name: path.basename(normalizedPath),
+    path: normalizedPath,
+    active: normalizedPath === activePath,
+    gitRemote: gitRemote(normalizedPath),
+    gitBranch: gitBranch(normalizedPath),
+    instructionFiles: readInstructionFiles(normalizedPath),
+    readme: readReadme(normalizedPath),
+  }
+}
+
+export async function buildProjectRegistry(): Promise<ProjectRegistryResponse> {
+  const catalog = await loadWorkspaceCatalog()
+  const activePath =
+    catalog.isValid && catalog.path ? normalizePath(catalog.path) : ''
+  const roots =
+    catalog.workspaces.length > 0
+      ? catalog.workspaces.map((workspace) => workspace.path)
+      : activePath
+        ? [activePath]
+        : []
+  const candidates = new Set<string>()
+
+  for (const root of roots) {
+    const normalizedRoot = normalizePath(root)
+    if (!isDirectory(normalizedRoot)) continue
+    if (hasProjectMarker(normalizedRoot)) candidates.add(normalizedRoot)
+    for (const child of listDirectChildProjects(normalizedRoot)) {
+      candidates.add(normalizePath(child))
+    }
+  }
+
+  if (activePath && isDirectory(activePath)) candidates.add(activePath)
+
+  const projects = [...candidates]
+    .sort((a, b) => path.basename(a).localeCompare(path.basename(b)))
+    .slice(0, MAX_PROJECTS)
+    .map((projectPath) => toProjectEntry(projectPath, activePath))
+
+  return {
+    activeProjectId: projects.find((project) => project.active)?.id ?? null,
+    projects,
+    fetchedAt: Date.now(),
+  }
+}
+
+function formatProjectFileForPrompt(
+  file: ProjectRegistryInstructionFile,
+): string {
+  const excerpt = file.excerpt.slice(0, MAX_PROMPT_FILE_CHARS)
+  return [`### ${file.name}`, `Path: ${file.path}`, '', excerpt].join('\n')
+}
+
+export function buildProjectContextPromptBlock(
+  project: ProjectRegistryEntry | null,
+): string {
+  if (!project) return ''
+  const files =
+    project.instructionFiles.length > 0
+      ? project.instructionFiles
+      : project.readme
+        ? [project.readme]
+        : []
+  return [
+    '## Active Project Context',
+    '',
+    `Project: ${project.name}`,
+    `Path: ${project.path}`,
+    `Git remote: ${project.gitRemote ?? 'none'}`,
+    `Git branch: ${project.gitBranch ?? 'unknown'}`,
+    '',
+    'Use this project path as the primary working directory for spawned workers unless the user explicitly asks otherwise.',
+    'Pass the relevant instruction snippets below into worker prompts. Treat AGENTS.md/CLAUDE.md/.cursorrules as project instructions.',
+    ...(files.length > 0
+      ? ['', ...files.map(formatProjectFileForPrompt)]
+      : ['', 'No project instruction/readme files found at project root.']),
+  ].join('\n')
+}
+
+export async function getActiveProjectContext(): Promise<ActiveProjectContext> {
+  const registry = await buildProjectRegistry()
+  const project =
+    registry.projects.find((entry) => entry.id === registry.activeProjectId) ??
+    registry.projects.find((entry) => entry.active) ??
+    null
+  return {
+    project,
+    promptBlock: buildProjectContextPromptBlock(project),
+  }
+}

--- a/src/server/project-registry.ts
+++ b/src/server/project-registry.ts
@@ -10,6 +10,20 @@ export type ProjectRegistryInstructionFile = {
   excerpt: string
 }
 
+export type ProjectRegistryStatus = {
+  gitDirty: boolean | null
+  changedFiles: number | null
+  lastCommit: string | null
+  lastCommitAt: string | null
+  detectedStack: Array<string>
+  packageManager: string | null
+}
+
+export type ProjectRegistryContextPreview = {
+  summary: string
+  files: Array<{ name: string; path: string; chars: number }>
+}
+
 export type ProjectRegistryEntry = {
   id: string
   name: string
@@ -17,6 +31,8 @@ export type ProjectRegistryEntry = {
   active: boolean
   gitRemote: string | null
   gitBranch: string | null
+  status: ProjectRegistryStatus
+  contextPreview: ProjectRegistryContextPreview
   instructionFiles: Array<ProjectRegistryInstructionFile>
   readme: ProjectRegistryInstructionFile | null
 }
@@ -165,20 +181,134 @@ function gitRemote(projectPath: string): string | null {
   return gitOutput(projectPath, ['remote', 'get-url', 'origin'])
 }
 
+function gitChangedFiles(projectPath: string): number | null {
+  const status = gitOutput(projectPath, ['status', '--short'])
+  if (status === null) return null
+  if (!status) return 0
+  return status.split('\n').filter(Boolean).length
+}
+
+function gitLastCommit(
+  projectPath: string,
+): { hash: string; at: string | null } | null {
+  const output = gitOutput(projectPath, ['log', '-1', '--format=%h%x09%cI'])
+  if (!output) return null
+  const [hash, at] = output.split('\t')
+  return hash ? { hash, at: at || null } : null
+}
+
+function detectPackageManager(projectPath: string): string | null {
+  const candidates: Array<[string, string]> = [
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['yarn.lock', 'yarn'],
+    ['package-lock.json', 'npm'],
+    ['bun.lockb', 'bun'],
+    ['uv.lock', 'uv'],
+    ['poetry.lock', 'poetry'],
+  ]
+  return (
+    candidates.find(([file]) =>
+      existsSync(path.join(projectPath, file)),
+    )?.[1] ?? null
+  )
+}
+
+function detectStack(projectPath: string): Array<string> {
+  const markers: Array<[string, string]> = [
+    ['package.json', 'Node/TypeScript'],
+    ['vite.config.ts', 'Vite'],
+    ['vite.config.js', 'Vite'],
+    ['next.config.js', 'Next.js'],
+    ['next.config.mjs', 'Next.js'],
+    ['pyproject.toml', 'Python'],
+    ['requirements.txt', 'Python'],
+    ['Cargo.toml', 'Rust'],
+    ['go.mod', 'Go'],
+    ['Dockerfile', 'Docker'],
+  ]
+  return [
+    ...new Set(
+      markers
+        .filter(([file]) => existsSync(path.join(projectPath, file)))
+        .map(([, label]) => label),
+    ),
+  ]
+}
+
+function buildProjectStatus(projectPath: string): ProjectRegistryStatus {
+  const changedFiles = gitChangedFiles(projectPath)
+  const lastCommit = gitLastCommit(projectPath)
+  return {
+    gitDirty: changedFiles === null ? null : changedFiles > 0,
+    changedFiles,
+    lastCommit: lastCommit?.hash ?? null,
+    lastCommitAt: lastCommit?.at ?? null,
+    detectedStack: detectStack(projectPath),
+    packageManager: detectPackageManager(projectPath),
+  }
+}
+
+function buildContextPreview(project: {
+  path: string
+  gitRemote: string | null
+  gitBranch: string | null
+  instructionFiles: Array<ProjectRegistryInstructionFile>
+  readme: ProjectRegistryInstructionFile | null
+  status: ProjectRegistryStatus
+}): ProjectRegistryContextPreview {
+  const files =
+    project.instructionFiles.length > 0
+      ? project.instructionFiles
+      : project.readme
+        ? [project.readme]
+        : []
+  const summaryParts = [
+    `Path: ${project.path}`,
+    `Git: ${project.gitBranch ?? 'unknown branch'} · ${project.gitRemote ?? 'no remote'}`,
+    project.status.detectedStack.length
+      ? `Stack: ${project.status.detectedStack.join(', ')}`
+      : 'Stack: not detected',
+    `Context files: ${files.length}`,
+  ]
+  return {
+    summary: summaryParts.join('\n'),
+    files: files.map((file) => ({
+      name: file.name,
+      path: file.path,
+      chars: file.excerpt.length,
+    })),
+  }
+}
+
 function toProjectEntry(
   projectPath: string,
   activePath: string,
 ): ProjectRegistryEntry {
   const normalizedPath = normalizePath(projectPath)
+  const gitRemoteValue = gitRemote(normalizedPath)
+  const gitBranchValue = gitBranch(normalizedPath)
+  const instructionFiles = readInstructionFiles(normalizedPath)
+  const readme = readReadme(normalizedPath)
+  const status = buildProjectStatus(normalizedPath)
+  const baseProject = {
+    path: normalizedPath,
+    gitRemote: gitRemoteValue,
+    gitBranch: gitBranchValue,
+    instructionFiles,
+    readme,
+    status,
+  }
   return {
     id: stableProjectId(normalizedPath),
     name: path.basename(normalizedPath),
     path: normalizedPath,
     active: normalizedPath === activePath,
-    gitRemote: gitRemote(normalizedPath),
-    gitBranch: gitBranch(normalizedPath),
-    instructionFiles: readInstructionFiles(normalizedPath),
-    readme: readReadme(normalizedPath),
+    gitRemote: gitRemoteValue,
+    gitBranch: gitBranchValue,
+    status,
+    contextPreview: buildContextPreview(baseProject),
+    instructionFiles,
+    readme,
   }
 }
 

--- a/src/server/swarm-agent-team.test.ts
+++ b/src/server/swarm-agent-team.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_SWARM_AGENT_TEAM, fallbackRoster } from './swarm-roster'
+
+describe('default Swarm agent team', () => {
+  it('defines the final 15 specialized Hermes roles in order', () => {
+    expect(DEFAULT_SWARM_AGENT_TEAM.map((agent) => agent.role)).toEqual([
+      'CTO / Conductor',
+      'Product Manager',
+      'Architect',
+      'Backend Coder',
+      'ML Coder',
+      'Frontend Coder',
+      'Integration Agent',
+      'QA Tester',
+      'DevOps',
+      'Reviewer',
+      'Memory / Knowledge',
+      'Research',
+      'Designer / OpenDesign',
+      'CyberSecurity',
+      'Data Analyst',
+    ])
+  })
+
+  it('uses practical specialist names instead of legacy abstract names', () => {
+    const names = DEFAULT_SWARM_AGENT_TEAM.map((agent) => agent.name)
+    expect(names).toContain('Conductor')
+    expect(names).toContain('Backend')
+    expect(names).toContain('Security')
+    expect(names).not.toContain('Overflow')
+    expect(names).not.toContain('Mirror')
+  })
+
+  it('uses the specialist team for missing swarm worker fallback metadata', () => {
+    const roster = fallbackRoster(['swarm1', 'swarm3', 'swarm15'])
+
+    expect(roster.workers).toMatchObject([
+      {
+        id: 'swarm1',
+        name: 'Conductor',
+        role: 'CTO / Conductor',
+      },
+      {
+        id: 'swarm3',
+        name: 'Architect',
+        role: 'Architect',
+      },
+      {
+        id: 'swarm15',
+        name: 'Data Analyst',
+        role: 'Data Analyst',
+      },
+    ])
+  })
+})

--- a/src/server/swarm-autopilot.test.ts
+++ b/src/server/swarm-autopilot.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAutopilotDispatchPlan,
+  buildSwarmWorkPacket,
+  selectSwarmWorkersForPrompt,
+} from './swarm-autopilot'
+import { DEFAULT_SWARM_AGENT_TEAM } from './swarm-roster'
+
+describe('swarm autopilot routing', () => {
+  it('selects practical specialist workers from prompt context instead of abstract fallback agents', () => {
+    const selected = selectSwarmWorkersForPrompt(
+      'Implement a Telegram webhook integration with backend API, React UI status panel, tests, security review and docs',
+      DEFAULT_SWARM_AGENT_TEAM,
+    )
+
+    expect(selected.map((item) => item.workerId)).toEqual([
+      'swarm7',
+      'swarm4',
+      'swarm6',
+      'swarm8',
+      'swarm10',
+      'swarm11',
+      'swarm14',
+      'swarm3',
+    ])
+    expect(selected.every((item) => item.score > 0)).toBe(true)
+  })
+
+  it('builds role-specific work packets with constraints and checkpoint contract', () => {
+    const packet = buildSwarmWorkPacket({
+      missionTitle: 'Telegram agent room MVP',
+      userPrompt: 'Add bot-to-bot Telegram agent room support.',
+      worker: DEFAULT_SWARM_AGENT_TEAM.find((worker) => worker.id === 'swarm7')!,
+      rationale: 'Integration lane owns Telegram/webhooks.',
+      dependsOn: ['swarm3'],
+      reviewRequired: true,
+    })
+
+    expect(packet).toContain('Role: Integration Agent')
+    expect(packet).toContain('Goal: Telegram agent room MVP')
+    expect(packet).toContain('Context: Add bot-to-bot Telegram agent room support.')
+    expect(packet).toContain('Relevant dependencies: swarm3')
+    expect(packet).toContain('Never print or persist secrets')
+    expect(packet).toContain('STATE:')
+    expect(packet).toContain('FILES_CHANGED:')
+    expect(packet).toContain('NEXT_ACTION:')
+  })
+
+  it('creates an end-to-end dispatch plan including conductor coordination and review dependencies', () => {
+    const plan = buildAutopilotDispatchPlan({
+      prompt: 'Build backend API and frontend dashboard, run QA, security review, update docs',
+      missionTitle: 'Task 18 autopilot routing',
+      workers: DEFAULT_SWARM_AGENT_TEAM,
+      maxWorkers: 8,
+    })
+
+    expect(plan.missionTitle).toBe('Task 18 autopilot routing')
+    expect(plan.assignments[0]).toMatchObject({
+      workerId: 'swarm1',
+      rationale: 'CTO / Conductor coordinates the swarm plan and approval gates.',
+      dependsOn: [],
+      reviewRequired: false,
+    })
+    const ids = plan.assignments.map((assignment) => assignment.workerId)
+    expect(ids).toContain('swarm4')
+    expect(ids).toContain('swarm6')
+    expect(ids).toContain('swarm8')
+    expect(ids).toContain('swarm10')
+    expect(ids).toContain('swarm14')
+    expect(ids).toContain('swarm11')
+
+    const reviewer = plan.assignments.find((assignment) => assignment.workerId === 'swarm10')
+    expect(reviewer?.dependsOn).toEqual(expect.arrayContaining(['swarm4', 'swarm6']))
+    expect(reviewer?.task).toContain('Review gate')
+
+    expect(plan.unassigned).toEqual([])
+  })
+})

--- a/src/server/swarm-autopilot.ts
+++ b/src/server/swarm-autopilot.ts
@@ -1,0 +1,336 @@
+import { DEFAULT_SWARM_AGENT_TEAM } from './swarm-roster'
+
+type DefaultSwarmAgent = (typeof DEFAULT_SWARM_AGENT_TEAM)[number]
+
+export type SwarmAutopilotWorker = Pick<
+  DefaultSwarmAgent,
+  | 'id'
+  | 'name'
+  | 'role'
+  | 'specialty'
+  | 'mission'
+  | 'skills'
+  | 'capabilities'
+  | 'preferredTaskTypes'
+  | 'reviewRequired'
+>
+
+export type SwarmWorkerSelection = {
+  workerId: string
+  score: number
+  rationale: string
+}
+
+export type SwarmAutopilotAssignment = {
+  workerId: string
+  task: string
+  rationale: string
+  dependsOn: Array<string>
+  reviewRequired: boolean
+}
+
+export type SwarmAutopilotPlan = {
+  missionTitle: string
+  assignments: Array<SwarmAutopilotAssignment>
+  unassigned: Array<string>
+}
+
+type WorkPacketInput = {
+  missionTitle: string
+  userPrompt: string
+  worker: SwarmAutopilotWorker
+  rationale: string
+  dependsOn?: Array<string>
+  reviewRequired?: boolean
+}
+
+const ROLE_HINTS: Array<{
+  id: string
+  patterns: Array<RegExp>
+  terms: Array<string>
+  rationale: string
+}> = [
+  {
+    id: 'swarm7',
+    patterns: [/telegram|webhook|github|google|obsidian|oauth|mcp|integration|bot-to-bot|api integration/i],
+    terms: ['integration', 'webhook', 'telegram', 'github', 'google', 'obsidian', 'mcp', 'oauth'],
+    rationale: 'Integration lane owns external systems, webhooks, OAuth, and bot/API wiring.',
+  },
+  {
+    id: 'swarm4',
+    patterns: [/backend|server|route|api|database|storage|worker|business logic|endpoint/i],
+    terms: ['backend', 'api', 'server', 'storage', 'worker', 'business logic'],
+    rationale: 'Backend lane owns server routes, data flow, persistence, and worker-side business logic.',
+  },
+  {
+    id: 'swarm6',
+    patterns: [/frontend|react|ui|dashboard|screen|component|status panel|ux|browser/i],
+    terms: ['frontend', 'react', 'ui', 'dashboard', 'component', 'status panel', 'browser'],
+    rationale: 'Frontend lane owns React UI, visible state, and browser-facing workflows.',
+  },
+  {
+    id: 'swarm5',
+    patterns: [/ml|llm|model|embedding|eval|inference|prompt|rag/i],
+    terms: ['ml', 'llm', 'model', 'embedding', 'eval', 'inference', 'prompt'],
+    rationale: 'ML lane owns model, prompt, eval, inference, and embedding concerns.',
+  },
+  {
+    id: 'swarm12',
+    patterns: [/research|investigate|community|compare|source|changelog|paper|evidence/i],
+    terms: ['research', 'investigate', 'community', 'source', 'evidence'],
+    rationale: 'Research lane owns external docs, community practice, and evidence gathering.',
+  },
+  {
+    id: 'swarm8',
+    patterns: [/qa|test|vitest|smoke|e2e|regression|verify|acceptance/i],
+    terms: ['qa', 'test', 'vitest', 'smoke', 'e2e', 'regression', 'verify'],
+    rationale: 'QA lane owns tests, smoke coverage, repros, and acceptance checks.',
+  },
+  {
+    id: 'swarm9',
+    patterns: [/devops|deploy|ci|runtime|tmux|process|monitoring|electron|infra/i],
+    terms: ['devops', 'deploy', 'ci', 'runtime', 'tmux', 'process', 'monitoring', 'electron'],
+    rationale: 'DevOps lane owns process/runtime, CI, deployment, and monitoring concerns.',
+  },
+  {
+    id: 'swarm10',
+    patterns: [/review|reviewer|quality gate|code review|risk|approve/i],
+    terms: ['review', 'quality gate', 'code review', 'risk', 'approve'],
+    rationale: 'Reviewer lane owns independent code/product review gates.',
+  },
+  {
+    id: 'swarm11',
+    patterns: [/memory|knowledge|docs|documentation|runbook|handoff|summary|obsidian|skill/i],
+    terms: ['memory', 'knowledge', 'docs', 'documentation', 'runbook', 'handoff', 'summary', 'obsidian', 'skill'],
+    rationale: 'Memory / Knowledge lane owns durable summaries, docs, runbooks, and skills.',
+  },
+  {
+    id: 'swarm13',
+    patterns: [/design|opendesign|visual|prototype|mockup|figma|landing/i],
+    terms: ['design', 'opendesign', 'visual', 'prototype', 'mockup', 'figma'],
+    rationale: 'Designer / OpenDesign lane owns visual UX, prototypes, and design artifacts.',
+  },
+  {
+    id: 'swarm14',
+    patterns: [/security|secret|credential|auth|token|abuse|threat|permission|privacy/i],
+    terms: ['security', 'secret', 'credential', 'auth', 'token', 'abuse', 'threat', 'permission', 'privacy'],
+    rationale: 'CyberSecurity lane owns auth, secrets, threat modeling, and abuse risk.',
+  },
+  {
+    id: 'swarm15',
+    patterns: [/data|analytics|metric|sql|dashboard|experiment|tracking|kpi/i],
+    terms: ['data', 'analytics', 'metric', 'sql', 'dashboard', 'experiment', 'tracking', 'kpi'],
+    rationale: 'Data Analyst lane owns metrics, analytics, dashboards, and experiment readouts.',
+  },
+  {
+    id: 'swarm3',
+    patterns: [/architect|architecture|system design|contract|boundary|tradeoff|api design/i],
+    terms: ['architect', 'architecture', 'system design', 'contract', 'boundary', 'tradeoff'],
+    rationale: 'Architect lane owns system boundaries, contracts, and design tradeoffs.',
+  },
+  {
+    id: 'swarm2',
+    patterns: [/product|prd|scope|acceptance criteria|priority|roadmap|user story/i],
+    terms: ['product', 'prd', 'scope', 'acceptance criteria', 'priority', 'roadmap'],
+    rationale: 'Product Manager lane owns scope, requirements, and acceptance criteria.',
+  },
+]
+
+function normalize(value: string): string {
+  return value.toLowerCase()
+}
+
+function workerText(worker: SwarmAutopilotWorker): string {
+  return [
+    worker.id,
+    worker.name,
+    worker.role,
+    worker.specialty,
+    worker.mission,
+    ...(worker.skills ?? []),
+    ...(worker.capabilities ?? []),
+    ...(worker.preferredTaskTypes ?? []),
+  ].filter(Boolean).join(' ').toLowerCase()
+}
+
+function unique<T>(items: Array<T>): Array<T> {
+  return Array.from(new Set(items))
+}
+
+function scoreWorker(prompt: string, worker: SwarmAutopilotWorker): SwarmWorkerSelection {
+  const lower = normalize(prompt)
+  const text = workerText(worker)
+  let score = 0
+  const reasons: Array<string> = []
+
+  for (const hint of ROLE_HINTS) {
+    const promptMatches = hint.patterns.some((pattern) => pattern.test(prompt))
+    if (!promptMatches) continue
+    if (worker.id === hint.id) {
+      score += 12
+      reasons.push(hint.rationale)
+      continue
+    }
+    for (const term of hint.terms) {
+      if (text.includes(term) && lower.includes(term)) {
+        score += 2
+      }
+    }
+  }
+
+  if (worker.id === 'swarm1') score += 1
+  if (worker.role === 'Reviewer' && /implement|build|code|frontend|backend|integration/i.test(prompt)) score += 4
+  if (worker.role === 'Memory / Knowledge' && /build|implement|task|mvp|docs|skill/i.test(prompt)) score += 3
+  if (worker.role === 'CyberSecurity' && /integration|webhook|auth|token|api|secret|credential|telegram|security/i.test(prompt)) score += 8
+  if (worker.id === 'swarm5' && !/\b(ml|llm|model|embedding|eval|inference|rag)\b/i.test(prompt)) score = 0
+  if (worker.id === 'swarm12' && !/research|investigate|community|source|changelog|paper|evidence/i.test(prompt)) score = 0
+  if (worker.id === 'swarm13' && !/design|opendesign|visual|prototype|mockup|figma|ux/i.test(prompt)) score = 0
+
+  return {
+    workerId: worker.id,
+    score,
+    rationale: reasons[0] ?? `Matched ${worker.role} to mission context.`,
+  }
+}
+
+export function selectSwarmWorkersForPrompt(
+  prompt: string,
+  workers: ReadonlyArray<SwarmAutopilotWorker> = DEFAULT_SWARM_AGENT_TEAM,
+  maxWorkers = 8,
+): Array<SwarmWorkerSelection> {
+  const selections = workers
+    .map((worker) => scoreWorker(prompt, worker))
+    .filter((selection) => selection.score > 0 && selection.workerId !== 'swarm1')
+    .sort((a, b) => b.score - a.score || a.workerId.localeCompare(b.workerId, undefined, { numeric: true }))
+
+  const byId = new Map(selections.map((selection) => [selection.workerId, selection]))
+  const preferredOrder = [
+    'swarm7',
+    'swarm4',
+    'swarm6',
+    'swarm5',
+    'swarm12',
+    'swarm8',
+    'swarm9',
+    'swarm10',
+    'swarm11',
+    'swarm13',
+    'swarm14',
+    'swarm15',
+    'swarm3',
+    'swarm2',
+  ]
+  const ordered = [
+    ...preferredOrder.map((id) => byId.get(id)).filter((selection): selection is SwarmWorkerSelection => Boolean(selection)),
+    ...selections.filter((selection) => !preferredOrder.includes(selection.workerId)),
+  ]
+  return ordered.slice(0, Math.max(1, maxWorkers))
+}
+
+export function buildSwarmWorkPacket(input: WorkPacketInput): string {
+  const skills = input.worker.skills?.length ? input.worker.skills.join(', ') : 'none declared'
+  const capabilities = input.worker.capabilities?.length ? input.worker.capabilities.join(', ') : 'none declared'
+  const dependsOn = input.dependsOn?.length ? input.dependsOn.join(', ') : 'none'
+
+  return [
+    '### Swarm Work Packet',
+    `Role: ${input.worker.role}`,
+    `Worker: ${input.worker.id} / ${input.worker.name}`,
+    `Goal: ${input.missionTitle}`,
+    `Context: ${input.userPrompt}`,
+    `Routing rationale: ${input.rationale}`,
+    `Relevant dependencies: ${dependsOn}`,
+    `Skills to consider: ${skills}`,
+    `Capabilities: ${capabilities}`,
+    '',
+    'Constraints:',
+    '- Stay strictly inside your role lane unless the CTO / Conductor reroutes you.',
+    '- Do not broaden scope; produce the smallest useful result for this packet.',
+    '- Never run deploy, git push, destructive cleanup, or secret/env edits without explicit approval.',
+    '- Never print or persist secrets; redact credentials as [REDACTED].',
+    input.reviewRequired ? '- Your output requires independent Reviewer/QA/Security review before landing.' : '- Return proof so the Conductor can decide whether review is needed.',
+    '',
+    'Expected output:',
+    '- Concrete findings/changes for your lane.',
+    '- Files touched or files that should be touched.',
+    '- Commands run or commands recommended.',
+    '- Blockers and exact next action.',
+    '',
+    'Required checkpoint format:',
+    'STATE: IN_PROGRESS | DONE | BLOCKED | NEEDS_INPUT | HANDOFF',
+    'FILES_CHANGED: exact files or none',
+    'COMMANDS_RUN: exact commands or none',
+    'RESULT: concise outcome',
+    'BLOCKER: blocker/question or none',
+    'NEXT_ACTION: exact next action',
+  ].join('\n')
+}
+
+function workerById(workers: ReadonlyArray<SwarmAutopilotWorker>, id: string): SwarmAutopilotWorker | null {
+  return workers.find((worker) => worker.id === id) ?? null
+}
+
+function dependencyIds(assignments: Array<SwarmAutopilotAssignment>, roles: Array<RegExp>): Array<string> {
+  return assignments
+    .filter((assignment) => roles.some((pattern) => pattern.test(assignment.task)))
+    .map((assignment) => assignment.workerId)
+}
+
+export function buildAutopilotDispatchPlan(input: {
+  prompt: string
+  missionTitle?: string
+  workers?: ReadonlyArray<SwarmAutopilotWorker>
+  maxWorkers?: number
+}): SwarmAutopilotPlan {
+  const workers = input.workers ?? DEFAULT_SWARM_AGENT_TEAM
+  const missionTitle = input.missionTitle?.trim() || input.prompt.trim().slice(0, 80) || 'Swarm autopilot mission'
+  const selected = selectSwarmWorkersForPrompt(input.prompt, workers, input.maxWorkers ?? 8)
+  const assignments: Array<SwarmAutopilotAssignment> = []
+  const conductor = workerById(workers, 'swarm1')
+  if (conductor) {
+    assignments.push({
+      workerId: conductor.id,
+      rationale: 'CTO / Conductor coordinates the swarm plan and approval gates.',
+      dependsOn: [],
+      reviewRequired: false,
+      task: buildSwarmWorkPacket({
+        missionTitle,
+        userPrompt: input.prompt,
+        worker: conductor,
+        rationale: 'Coordinate task decomposition, dependencies, approval gates, and final synthesis.',
+      }),
+    })
+  }
+
+  for (const selection of selected) {
+    const worker = workerById(workers, selection.workerId)
+    if (!worker) continue
+    const dependsOn = worker.id === 'swarm10'
+      ? assignments.filter((assignment) => !['swarm1', 'swarm10', 'swarm8', 'swarm14', 'swarm11'].includes(assignment.workerId)).map((assignment) => assignment.workerId)
+      : worker.id === 'swarm14'
+        ? assignments.filter((assignment) => ['swarm4', 'swarm6', 'swarm7', 'swarm9'].includes(assignment.workerId)).map((assignment) => assignment.workerId)
+        : []
+    const reviewRequired = worker.reviewRequired === true || ['swarm8', 'swarm10', 'swarm14'].includes(worker.id)
+    const prefix = worker.id === 'swarm10' ? 'Review gate. ' : ''
+    assignments.push({
+      workerId: worker.id,
+      rationale: selection.rationale,
+      dependsOn: unique(dependsOn),
+      reviewRequired,
+      task: `${prefix}${buildSwarmWorkPacket({
+        missionTitle,
+        userPrompt: input.prompt,
+        worker,
+        rationale: selection.rationale,
+        dependsOn: unique(dependsOn),
+        reviewRequired,
+      })}`,
+    })
+  }
+
+  return {
+    missionTitle,
+    assignments,
+    unassigned: selected.length ? [] : ['No confident worker match; only Conductor assignment was created.'],
+  }
+}

--- a/src/server/swarm-live-workers.test.ts
+++ b/src/server/swarm-live-workers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as yaml from 'yaml'
+import { DEFAULT_SWARM_AGENT_TEAM } from './swarm-roster'
+import {
+  ensureDefaultSwarmLiveWorkers,
+  planDefaultSwarmLiveWorkers,
+} from './swarm-live-workers'
+
+describe('Swarm live workers bootstrap', () => {
+  it('plans one live worker asset set for each default specialist agent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swarm-live-workers-'))
+    try {
+      const plan = planDefaultSwarmLiveWorkers({
+        profilesDir: join(root, 'profiles'),
+        localBinDir: join(root, 'bin'),
+        workspaceRoot: '/workspace/hermes',
+        hermesBin: '/usr/local/bin/hermes',
+      })
+
+      expect(plan).toHaveLength(15)
+      expect(plan.map((worker) => worker.id)).toEqual(DEFAULT_SWARM_AGENT_TEAM.map((agent) => agent.id))
+      expect(plan[0]).toMatchObject({
+        id: 'swarm1',
+        name: 'Conductor',
+        role: 'CTO / Conductor',
+        sessionName: 'swarm-swarm1',
+      })
+      expect(plan[14]).toMatchObject({
+        id: 'swarm15',
+        name: 'Data Analyst',
+        role: 'Data Analyst',
+        sessionName: 'swarm-swarm15',
+      })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('creates profile config, runtime metadata, and executable wrappers for all 15 agents', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swarm-live-workers-'))
+    try {
+      const result = ensureDefaultSwarmLiveWorkers({
+        profilesDir: join(root, 'profiles'),
+        localBinDir: join(root, 'bin'),
+        workspaceRoot: '/workspace/hermes',
+        hermesBin: '/usr/local/bin/hermes',
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.workers).toHaveLength(15)
+      expect(result.createdProfiles).toBe(15)
+      expect(result.createdWrappers).toBe(15)
+
+      const conductorConfig = yaml.parse(
+        readFileSync(join(root, 'profiles', 'swarm1', 'config.yaml'), 'utf8'),
+      ) as Record<string, unknown>
+      expect(conductorConfig.profile?.['id']).toBe('swarm1')
+      expect(conductorConfig.profile?.['role']).toBe('CTO / Conductor')
+      expect(conductorConfig.system_prompt).toContain('CTO / Conductor')
+      expect(conductorConfig.system_prompt).toContain('protocol-driven-orchestrator')
+
+      const backendRuntime = JSON.parse(
+        readFileSync(join(root, 'profiles', 'swarm4', 'runtime.json'), 'utf8'),
+      ) as Record<string, unknown>
+      expect(backendRuntime.workerId).toBe('swarm4')
+      expect(backendRuntime.role).toBe('Backend Coder')
+      expect(backendRuntime.state).toBe('idle')
+      expect(backendRuntime.phase).toBe('live-worker-ready')
+
+      const wrapperPath = join(root, 'bin', 'swarm6')
+      const wrapper = readFileSync(wrapperPath, 'utf8')
+      expect(wrapper).toContain("cd '/workspace/hermes'")
+      expect(wrapper).toContain("HERMES_HOME='")
+      expect(wrapper).toContain("exec '/usr/local/bin/hermes' chat --tui")
+      expect(statSync(wrapperPath).mode & 0o111).toBeGreaterThan(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/swarm-live-workers.ts
+++ b/src/server/swarm-live-workers.ts
@@ -1,0 +1,285 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import * as yaml from 'yaml'
+import { getLocalBinDir, getProfilesDir } from './claude-paths'
+import { SWARM_CANONICAL_REPO } from './swarm-environment'
+import { DEFAULT_SWARM_AGENT_TEAM } from './swarm-roster'
+
+type DefaultSwarmAgent = (typeof DEFAULT_SWARM_AGENT_TEAM)[number]
+
+export type SwarmLiveWorkerPlan = {
+  id: string
+  name: string
+  role: string
+  profilePath: string
+  wrapperPath: string
+  sessionName: string
+  workspaceRoot: string
+  hermesBin: string
+  profileConfigPath: string
+  runtimePath: string
+}
+
+export type SwarmLiveWorkersOptions = {
+  profilesDir?: string
+  localBinDir?: string
+  workspaceRoot?: string
+  hermesBin?: string
+}
+
+export type SwarmLiveWorkerEnsureResult = SwarmLiveWorkerPlan & {
+  profileCreated: boolean
+  configChanged: boolean
+  runtimeChanged: boolean
+  wrapperCreated: boolean
+  wrapperChanged: boolean
+}
+
+export type SwarmLiveWorkersEnsureResult = {
+  ok: true
+  workers: Array<SwarmLiveWorkerEnsureResult>
+  createdProfiles: number
+  changedConfigs: number
+  changedRuntimes: number
+  createdWrappers: number
+  changedWrappers: number
+}
+
+export type SwarmWorkerStartResult = {
+  workerId: string
+  ok: boolean
+  started: boolean
+  alreadyRunning: boolean
+  error?: string
+}
+
+export type SwarmLiveWorkersStartSummary = {
+  requested: number
+  ok: boolean
+  started: number
+  alreadyRunning: number
+  failed: number
+}
+
+export function buildSwarmLiveWorkersStartSummary(
+  results: Array<SwarmWorkerStartResult>,
+): SwarmLiveWorkersStartSummary {
+  const failed = results.filter((result) => !result.ok).length
+  return {
+    requested: results.length,
+    ok: failed === 0,
+    started: results.filter((result) => result.ok && result.started).length,
+    alreadyRunning: results.filter((result) => result.ok && result.alreadyRunning).length,
+    failed,
+  }
+}
+
+const DEFAULT_HERMES_BIN_CANDIDATES = [
+  process.env.HERMES_CLI_BIN,
+  join(homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
+  join(homedir(), '.local', 'bin', 'hermes'),
+  'hermes',
+].filter((value): value is string => Boolean(value))
+
+function resolveHermesBin(): string {
+  for (const candidate of DEFAULT_HERMES_BIN_CANDIDATES) {
+    if (!candidate.includes('/') || existsSync(candidate)) return candidate
+  }
+  return 'hermes'
+}
+
+function shellEscapeSingle(value: string): string {
+  return value.replace(/'/g, `'\\''`)
+}
+
+function rolePrompt(worker: DefaultSwarmAgent): string {
+  return [
+    `You are ${worker.role} (${worker.name}) in the Hermes Swarm live-worker team.`,
+    '',
+    `Specialty: ${worker.specialty || 'general Hermes worker'}`,
+    `Mission: ${worker.mission || 'Await orchestrator dispatch and return proof-bearing checkpoints.'}`,
+    '',
+    'Operating rules:',
+    '- Stay inside your role unless the CTO / Conductor explicitly reroutes you.',
+    '- Read the dispatched work packet before acting.',
+    '- Use relevant skills when the task context calls for them.',
+    '- Produce concise checkpoints with files changed, commands run, result, blockers, and next action.',
+    '- Never run deploy, git push, destructive filesystem cleanup, or secret/env edits without explicit approval.',
+    '- Never print or persist secrets; redact credentials as [REDACTED].',
+    '',
+    `Default skills: ${(worker.skills ?? []).join(', ') || 'none'}`,
+    `Capabilities: ${(worker.capabilities ?? []).join(', ') || 'none'}`,
+  ].join('\n')
+}
+
+function profileConfig(worker: DefaultSwarmAgent): Record<string, unknown> {
+  return {
+    profile: {
+      id: worker.id,
+      name: worker.name,
+      role: worker.role,
+      specialty: worker.specialty,
+      mission: worker.mission,
+      capabilities: worker.capabilities ?? [],
+      preferredTaskTypes: worker.preferredTaskTypes ?? [],
+      acceptsBroadcast: worker.acceptsBroadcast ?? true,
+      reviewRequired: worker.reviewRequired ?? false,
+    },
+    system_prompt: rolePrompt(worker),
+    agent: {
+      kind: 'swarm-live-worker',
+      max_turns: 80,
+      checkpoint_required: true,
+    },
+  }
+}
+
+function runtimeMetadata(worker: DefaultSwarmAgent, workspaceRoot: string): Record<string, unknown> {
+  const now = Date.now()
+  return {
+    workerId: worker.id,
+    role: worker.role,
+    state: 'idle',
+    phase: 'live-worker-ready',
+    currentTask: null,
+    activeTool: null,
+    cwd: workspaceRoot,
+    startedAt: null,
+    lastOutputAt: null,
+    lastCheckIn: new Date(now).toISOString(),
+    lastSummary: `Ready as ${worker.role}`,
+    needsHuman: false,
+    blockedReason: null,
+    checkpointStatus: 'none',
+    nextAction: 'Await CTO / Conductor dispatch.',
+    lastResult: null,
+    assignedTaskCount: 0,
+    cronJobCount: 0,
+    sessionId: null,
+    sessionTitle: null,
+    historySource: 'unavailable',
+    transport: 'unknown',
+    lastDispatchAt: null,
+    lastDispatchMode: 'none',
+    lastDispatchResult: null,
+    tasks: [],
+    artifacts: [],
+    previews: [],
+    boundary: {
+      workspaceRoot,
+      cwd: workspaceRoot,
+      insideWorkspace: true,
+      relativeCwd: '.',
+      owner: 'workspace',
+    },
+    liveWorker: {
+      version: 1,
+      name: worker.name,
+      specialty: worker.specialty,
+      skills: worker.skills ?? [],
+      sessionName: `swarm-${worker.id}`,
+    },
+  }
+}
+
+function wrapperScript(input: { profilePath: string; workspaceRoot: string; hermesBin: string }): string {
+  const workspace = shellEscapeSingle(input.workspaceRoot)
+  const profile = shellEscapeSingle(input.profilePath)
+  const hermes = shellEscapeSingle(input.hermesBin)
+  return [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    `cd '${workspace}'`,
+    `export HERMES_HOME='${profile}'`,
+    `export HERMES_CLI_BIN='${hermes}'`,
+    `exec '${hermes}' chat --tui`,
+    '',
+  ].join('\n')
+}
+
+function writeIfChanged(path: string, content: string): { existed: boolean; changed: boolean } {
+  const existed = existsSync(path)
+  if (existed) {
+    try {
+      if (readFileSync(path, 'utf8') === content) return { existed, changed: false }
+    } catch {
+      // Rewrite unreadable/corrupt file below.
+    }
+  }
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content, 'utf8')
+  return { existed, changed: true }
+}
+
+export function planDefaultSwarmLiveWorkers(options: SwarmLiveWorkersOptions = {}): Array<SwarmLiveWorkerPlan> {
+  const profilesDir = options.profilesDir ?? getProfilesDir()
+  const localBinDir = options.localBinDir ?? getLocalBinDir()
+  const workspaceRoot = options.workspaceRoot ?? SWARM_CANONICAL_REPO
+  const hermesBin = options.hermesBin ?? resolveHermesBin()
+
+  return DEFAULT_SWARM_AGENT_TEAM.map((worker) => {
+    const profilePath = join(profilesDir, worker.id)
+    return {
+      id: worker.id,
+      name: worker.name,
+      role: worker.role,
+      profilePath,
+      wrapperPath: join(localBinDir, worker.id),
+      sessionName: `swarm-${worker.id}`,
+      workspaceRoot,
+      hermesBin,
+      profileConfigPath: join(profilePath, 'config.yaml'),
+      runtimePath: join(profilePath, 'runtime.json'),
+    }
+  })
+}
+
+export function ensureDefaultSwarmLiveWorkers(options: SwarmLiveWorkersOptions = {}): SwarmLiveWorkersEnsureResult {
+  const plan = planDefaultSwarmLiveWorkers(options)
+  const workers = plan.map((item, index): SwarmLiveWorkerEnsureResult => {
+    const worker = DEFAULT_SWARM_AGENT_TEAM[index]
+    if (!worker || worker.id !== item.id) throw new Error(`Missing default worker metadata for ${item.id}`)
+
+    const profileCreated = !existsSync(item.profilePath)
+    mkdirSync(join(item.profilePath, 'logs'), { recursive: true })
+    mkdirSync(join(item.profilePath, 'memory', 'handoffs'), { recursive: true })
+
+    const configWrite = writeIfChanged(
+      item.profileConfigPath,
+      yaml.stringify(profileConfig(worker), { lineWidth: 0 }),
+    )
+    const runtimeWrite = writeIfChanged(
+      item.runtimePath,
+      JSON.stringify(runtimeMetadata(worker, item.workspaceRoot), null, 2) + '\n',
+    )
+    const wrapperWrite = writeIfChanged(
+      item.wrapperPath,
+      wrapperScript({
+        profilePath: item.profilePath,
+        workspaceRoot: item.workspaceRoot,
+        hermesBin: item.hermesBin,
+      }),
+    )
+    chmodSync(item.wrapperPath, 0o755)
+
+    return {
+      ...item,
+      profileCreated,
+      configChanged: configWrite.changed,
+      runtimeChanged: runtimeWrite.changed,
+      wrapperCreated: !wrapperWrite.existed,
+      wrapperChanged: wrapperWrite.changed,
+    }
+  })
+
+  return {
+    ok: true,
+    workers,
+    createdProfiles: workers.filter((worker) => worker.profileCreated).length,
+    changedConfigs: workers.filter((worker) => worker.configChanged).length,
+    changedRuntimes: workers.filter((worker) => worker.runtimeChanged).length,
+    createdWrappers: workers.filter((worker) => worker.wrapperCreated).length,
+    changedWrappers: workers.filter((worker) => worker.wrapperChanged).length,
+  }
+}

--- a/src/server/swarm-roster.ts
+++ b/src/server/swarm-roster.ts
@@ -6,6 +6,204 @@ import { SWARM_CANONICAL_REPO } from './swarm-environment'
 
 export const SWARM_ROSTER_PATH = join(SWARM_CANONICAL_REPO, 'swarm.yaml')
 
+export const DEFAULT_SWARM_AGENT_TEAM = [
+  {
+    id: 'swarm1',
+    name: 'Conductor',
+    role: 'CTO / Conductor',
+    specialty: 'strategy, orchestration, task decomposition, agent routing, approval gates',
+    mission: 'Own the whole mission: clarify outcomes, decompose work, route packets to specialists, keep humans in the approval loop, and synthesize final decisions.',
+    skills: ['protocol-driven-orchestrator', 'agent-team-operating-manual', 'review-gate'],
+    capabilities: ['orchestration', 'task-decomposition', 'agent-routing', 'approval-gates', 'decision-synthesis'],
+    preferredTaskTypes: ['orchestration', 'planning', 'coordination', 'approval', 'handoff'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm2',
+    name: 'Product',
+    role: 'Product Manager',
+    specialty: 'requirements, PRDs, priorities, acceptance criteria, user outcomes',
+    mission: 'Turn vague ideas into scoped product requirements, acceptance criteria, non-goals, and priority calls.',
+    skills: ['cto-product-ops', 'office-hours', 'writing-plans'],
+    capabilities: ['prd', 'requirements', 'prioritization', 'acceptance-criteria', 'scope-control'],
+    preferredTaskTypes: ['product', 'requirements', 'prd', 'scope', 'roadmap'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm3',
+    name: 'Architect',
+    role: 'Architect',
+    specialty: 'system design, module boundaries, data flow, technical tradeoffs',
+    mission: 'Design robust architecture before code: APIs, boundaries, risk analysis, migration paths, and maintainability constraints.',
+    skills: ['plan-eng-review', 'best-of-n-planning', 'graphify'],
+    capabilities: ['architecture', 'api-design', 'data-flow', 'tradeoff-analysis', 'technical-risk'],
+    preferredTaskTypes: ['architecture', 'design', 'api', 'refactor', 'technical-plan'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm4',
+    name: 'Backend',
+    role: 'Backend Coder',
+    specialty: 'server APIs, business logic, storage, auth, workers, integrations backend',
+    mission: 'Implement backend slices with tests, clear contracts, safe persistence, and minimal production risk.',
+    skills: ['test-driven-development', 'systematic-debugging', 'github-pr-workflow'],
+    capabilities: ['backend', 'api-routes', 'storage', 'auth', 'server-runtime'],
+    preferredTaskTypes: ['backend', 'api', 'database', 'auth', 'worker'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: true,
+  },
+  {
+    id: 'swarm5',
+    name: 'ML',
+    role: 'ML Coder',
+    specialty: 'ML pipelines, LLM features, evals, inference, embeddings, model tooling',
+    mission: 'Build and evaluate AI/ML features with reproducible metrics, cost awareness, and safety constraints.',
+    skills: ['autoresearch', 'dspy', 'evaluating-llms-harness'],
+    capabilities: ['ml', 'llm', 'evals', 'inference', 'embeddings'],
+    preferredTaskTypes: ['ml', 'llm', 'eval', 'model', 'rag'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: true,
+  },
+  {
+    id: 'swarm6',
+    name: 'Frontend',
+    role: 'Frontend Coder',
+    specialty: 'React UI, state, accessibility, responsive layouts, browser behavior',
+    mission: 'Ship polished frontend experiences with focused tests, accessibility, responsive layout, and browser verification.',
+    skills: ['frontend-design', 'test-driven-development', 'browse'],
+    capabilities: ['frontend', 'react', 'ui-state', 'accessibility', 'responsive-layout'],
+    preferredTaskTypes: ['frontend', 'ui', 'react', 'layout', 'browser'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: true,
+  },
+  {
+    id: 'swarm7',
+    name: 'Integration',
+    role: 'Integration Agent',
+    specialty: 'Telegram, GitHub, Google Workspace, Obsidian, MCP, webhooks, OAuth, external APIs',
+    mission: 'Connect Hermes to external systems with safe auth boundaries, retries, webhook handling, and clear operator docs.',
+    skills: ['native-mcp', 'github-pr-workflow', 'google-workspace'],
+    capabilities: ['integrations', 'webhooks', 'oauth', 'telegram', 'github', 'mcp'],
+    preferredTaskTypes: ['integration', 'webhook', 'telegram', 'github', 'google', 'mcp'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: true,
+  },
+  {
+    id: 'swarm8',
+    name: 'QA',
+    role: 'QA Tester',
+    specialty: 'test plans, regression suites, smoke tests, browser QA, reproducible bug reports',
+    mission: 'Prove whether work is ready: reproduce bugs, run targeted checks, write smoke tests, and report evidence.',
+    skills: ['qa', 'playwright-mcp', 'test-driven-development'],
+    capabilities: ['qa', 'regression', 'smoke-tests', 'e2e', 'bug-reproduction'],
+    preferredTaskTypes: ['qa', 'test', 'regression', 'smoke', 'verification'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm9',
+    name: 'DevOps',
+    role: 'DevOps',
+    specialty: 'runtime, CI/CD, deploy, env, monitoring, Electron, process health',
+    mission: 'Keep Hermes running locally and in production: scripts, CI, deploys, env safety, monitoring, and rollback plans.',
+    skills: ['setup-deploy', 'health', 'careful'],
+    capabilities: ['devops', 'ci-cd', 'deploy', 'monitoring', 'runtime-health'],
+    preferredTaskTypes: ['devops', 'deploy', 'ci', 'infra', 'runtime', 'electron'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: true,
+  },
+  {
+    id: 'swarm10',
+    name: 'Reviewer',
+    role: 'Reviewer',
+    specialty: 'code review, product review, regression risk, merge readiness',
+    mission: 'Act as the independent review gate: inspect diffs, verify requirements, catch regressions, and request fixes before shipping.',
+    skills: ['review-gate', 'github-code-review', 'requesting-code-review'],
+    capabilities: ['code-review', 'quality-gate', 'regression-analysis', 'merge-readiness'],
+    preferredTaskTypes: ['review', 'code-review', 'quality', 'merge-gate', 'risk'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm11',
+    name: 'Memory',
+    role: 'Memory / Knowledge',
+    specialty: 'Obsidian, docs, summaries, skills, decisions, knowledge hygiene',
+    mission: 'Preserve useful context: final summaries, lessons learned, docs, runbooks, skills, and knowledge-base updates.',
+    skills: ['obsidian', 'document-release', 'context-checkpoint'],
+    capabilities: ['memory', 'knowledge-base', 'docs', 'summaries', 'skills'],
+    preferredTaskTypes: ['memory', 'docs', 'summary', 'obsidian', 'runbook', 'skill'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm12',
+    name: 'Research',
+    role: 'Research',
+    specialty: 'technical research, docs reading, competitor analysis, papers, decision briefs',
+    mission: 'Find decision-grade evidence quickly, cite sources, compare options, and summarize what matters for execution.',
+    skills: ['arxiv', 'autoresearch', 'research-paper-writing'],
+    capabilities: ['research', 'docs-analysis', 'competitive-analysis', 'technical-synthesis'],
+    preferredTaskTypes: ['research', 'analysis', 'docs', 'papers', 'options'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm13',
+    name: 'Designer',
+    role: 'Designer / OpenDesign',
+    specialty: 'product design, UX flows, visual systems, OpenDesign artifacts, prototypes',
+    mission: 'Design clear product experiences, states, flows, and polished visual artifacts before frontend implementation.',
+    skills: ['frontend-design', 'open-design-hermes-integration', 'design-review'],
+    capabilities: ['design', 'ux', 'prototype', 'opendesign', 'visual-system'],
+    preferredTaskTypes: ['design', 'ux', 'prototype', 'visual', 'opendesign'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm14',
+    name: 'Security',
+    role: 'CyberSecurity',
+    specialty: 'threat modeling, secrets, auth, abuse cases, supply chain, secure review',
+    mission: 'Protect Hermes and user data: threat-model changes, scan for secrets, review auth boundaries, and block unsafe releases.',
+    skills: ['cso', 'careful', 'review-gate'],
+    capabilities: ['security', 'threat-modeling', 'secrets', 'auth-review', 'supply-chain'],
+    preferredTaskTypes: ['security', 'auth', 'secrets', 'threat-model', 'audit'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+  {
+    id: 'swarm15',
+    name: 'Data Analyst',
+    role: 'Data Analyst',
+    specialty: 'metrics, SQL, analytics events, dashboards, product insights, experiment readouts',
+    mission: 'Turn product and system activity into useful metrics, dashboards, tracking plans, and analytical decisions.',
+    skills: ['analytics-tracking', 'jupyter-live-kernel', 'xlsx'],
+    capabilities: ['analytics', 'metrics', 'sql', 'dashboards', 'experiments'],
+    preferredTaskTypes: ['analytics', 'data', 'metrics', 'dashboard', 'experiment'],
+    maxConcurrentTasks: 1,
+    acceptsBroadcast: true,
+    reviewRequired: false,
+  },
+] as const
+
 export const SwarmRosterWorkerSchema = z.object({
   id: z.string(),
   name: z.string().default(''),
@@ -36,47 +234,38 @@ export const SwarmRosterUpsertSchema = SwarmRosterWorkerSchema.extend({
 
 export type SwarmRosterUpsert = z.infer<typeof SwarmRosterUpsertSchema>
 
-function defaultRoleFromId(id: string): string {
-  const n = id.match(/(\d+)/)?.[1] ?? ''
-  switch (n) {
-    case '1':
-    case '12':
-      return 'PR / Issues'
-    case '2':
-      return 'Backend Foundation'
-    case '3':
-      return 'Main Session Mirror'
-    case '4':
-      return 'Research'
-    case '5':
-    case '10':
-      return 'Builder'
-    case '6':
-    case '11':
-      return 'Reviewer'
-    case '7':
-      return 'Docs'
-    case '8':
-      return 'Ops'
-    case '9':
-      return 'Hackathon'
-    default:
-      return 'Worker'
-  }
+function defaultAgentForId(id: string): SwarmRosterWorker | null {
+  const normalized = id.toLowerCase()
+  const agent = DEFAULT_SWARM_AGENT_TEAM.find((candidate) => candidate.id === normalized)
+  if (!agent) return null
+  return SwarmRosterWorkerSchema.parse({
+    ...agent,
+    id,
+    model: 'Hermes Agent',
+  })
 }
 
 export function fallbackRoster(ids: Array<string> = []): SwarmRoster {
   return {
     version: 1,
-    workers: ids.map((id) => ({
-      id,
-      name: id.replace(/^swarm/i, 'Swarm'),
-      role: defaultRoleFromId(id),
-      specialty: '',
-      model: 'Worker',
-      mission: 'Awaiting orchestrator dispatch.',
-      skills: [],
-    })),
+    workers: ids.map((id) => {
+      const defaultAgent = defaultAgentForId(id)
+      if (defaultAgent) return defaultAgent
+      return {
+        id,
+        name: id.replace(/^swarm/i, 'Swarm'),
+        role: 'Worker',
+        specialty: '',
+        model: 'Hermes Agent',
+        mission: 'Awaiting orchestrator dispatch.',
+        skills: [],
+        capabilities: [],
+        preferredTaskTypes: [],
+        maxConcurrentTasks: 1,
+        acceptsBroadcast: true,
+        reviewRequired: false,
+      }
+    }),
   }
 }
 

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -1,263 +1,379 @@
 version: 1
 workers:
-  - id: swarm6
-    name: Reviewer
-    role: Reviewer / Merge Gate
-    specialty: code review, regression detection, test coverage, merge readiness
-    model: Opus 4.7
-    mission: Catch breakage before it reaches Eric. Be the final quality gate.
+  - id: swarm1
+    name: Conductor
+    role: CTO / Conductor
+    specialty: strategy, orchestration, task decomposition, agent routing, approval gates
+    model: Hermes Agent
+    mission: Own the whole mission; clarify outcomes, decompose work, route packets to specialists, keep humans in the approval loop, and synthesize final decisions.
     skills:
-      - swarm-pr-worker
-      - swarm-worker-core
+      - protocol-driven-orchestrator
+      - agent-team-operating-manual
+      - review-gate
+    capabilities:
+      - orchestration
+      - task-decomposition
+      - agent-routing
+      - approval-gates
+      - decision-synthesis
+    preferredTaskTypes:
+      - orchestration
+      - planning
+      - coordination
+      - approval
+      - handoff
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm2
+    name: Product
+    role: Product Manager
+    specialty: requirements, PRDs, priorities, acceptance criteria, user outcomes
+    model: Hermes Agent
+    mission: Turn vague ideas into scoped product requirements, acceptance criteria, non-goals, and priority calls.
+    skills:
+      - cto-product-ops
+      - office-hours
+      - writing-plans
+    capabilities:
+      - prd
+      - requirements
+      - prioritization
+      - acceptance-criteria
+      - scope-control
+    preferredTaskTypes:
+      - product
+      - requirements
+      - prd
+      - scope
+      - roadmap
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm3
+    name: Architect
+    role: Architect
+    specialty: system design, module boundaries, data flow, technical tradeoffs
+    model: Hermes Agent
+    mission: Design robust architecture before code; APIs, boundaries, risk analysis, migration paths, and maintainability constraints.
+    skills:
+      - plan-eng-review
+      - best-of-n-planning
+      - graphify
+    capabilities:
+      - architecture
+      - api-design
+      - data-flow
+      - tradeoff-analysis
+      - technical-risk
+    preferredTaskTypes:
+      - architecture
+      - design
+      - api
+      - refactor
+      - technical-plan
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm4
+    name: Backend
+    role: Backend Coder
+    specialty: server APIs, business logic, storage, auth, workers, integrations backend
+    model: Hermes Agent
+    mission: Implement backend slices with tests, clear contracts, safe persistence, and minimal production risk.
+    skills:
+      - test-driven-development
+      - systematic-debugging
+      - github-pr-workflow
+    capabilities:
+      - backend
+      - api-routes
+      - storage
+      - auth
+      - server-runtime
+    preferredTaskTypes:
+      - backend
+      - api
+      - database
+      - auth
+      - worker
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: true
+  - id: swarm5
+    name: ML
+    role: ML Coder
+    specialty: ML pipelines, LLM features, evals, inference, embeddings, model tooling
+    model: Hermes Agent
+    mission: Build and evaluate AI/ML features with reproducible metrics, cost awareness, and safety constraints.
+    skills:
+      - autoresearch
+      - dspy
+      - evaluating-llms-harness
+    capabilities:
+      - ml
+      - llm
+      - evals
+      - inference
+      - embeddings
+    preferredTaskTypes:
+      - ml
+      - llm
+      - eval
+      - model
+      - rag
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: true
+  - id: swarm6
+    name: Frontend
+    role: Frontend Coder
+    specialty: React UI, state, accessibility, responsive layouts, browser behavior
+    model: Hermes Agent
+    mission: Ship polished frontend experiences with focused tests, accessibility, responsive layout, and browser verification.
+    skills:
+      - frontend-design
+      - test-driven-development
+      - browse
+    capabilities:
+      - frontend
+      - react
+      - ui-state
+      - accessibility
+      - responsive-layout
+    preferredTaskTypes:
+      - frontend
+      - ui
+      - react
+      - layout
+      - browser
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: true
+  - id: swarm7
+    name: Integration
+    role: Integration Agent
+    specialty: Telegram, GitHub, Google Workspace, Obsidian, MCP, webhooks, OAuth, external APIs
+    model: Hermes Agent
+    mission: Connect Hermes to external systems with safe auth boundaries, retries, webhook handling, and clear operator docs.
+    skills:
+      - native-mcp
+      - github-pr-workflow
+      - google-workspace
+    capabilities:
+      - integrations
+      - webhooks
+      - oauth
+      - telegram
+      - github
+      - mcp
+    preferredTaskTypes:
+      - integration
+      - webhook
+      - telegram
+      - github
+      - google
+      - mcp
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: true
+  - id: swarm8
+    name: QA
+    role: QA Tester
+    specialty: test plans, regression suites, smoke tests, browser QA, reproducible bug reports
+    model: Hermes Agent
+    mission: Prove whether work is ready; reproduce bugs, run targeted checks, write smoke tests, and report evidence.
+    skills:
+      - qa
+      - playwright-mcp
+      - test-driven-development
+    capabilities:
+      - qa
+      - regression
+      - smoke-tests
+      - e2e
+      - bug-reproduction
+    preferredTaskTypes:
+      - qa
+      - test
+      - regression
+      - smoke
+      - verification
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm9
+    name: DevOps
+    role: DevOps
+    specialty: runtime, CI/CD, deploy, env, monitoring, Electron, process health
+    model: Hermes Agent
+    mission: Keep Hermes running locally and in production; scripts, CI, deploys, env safety, monitoring, and rollback plans.
+    skills:
+      - setup-deploy
+      - health
+      - careful
+    capabilities:
+      - devops
+      - ci-cd
+      - deploy
+      - monitoring
+      - runtime-health
+    preferredTaskTypes:
+      - devops
+      - deploy
+      - ci
+      - infra
+      - runtime
+      - electron
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: true
+  - id: swarm10
+    name: Reviewer
+    role: Reviewer
+    specialty: code review, product review, regression risk, merge readiness
+    model: Hermes Agent
+    mission: Act as the independent review gate; inspect diffs, verify requirements, catch regressions, and request fixes before shipping.
+    skills:
+      - review-gate
+      - github-code-review
+      - requesting-code-review
     capabilities:
       - code-review
-      - regression-analysis
-      - test-planning
       - quality-gate
+      - regression-analysis
       - merge-readiness
     preferredTaskTypes:
       - review
-      - qa
-      - regression
-      - verification
+      - code-review
+      - quality
       - merge-gate
+      - risk
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
     reviewRequired: false
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm12
-    name: Triage
-    role: PR / Issues Primary
-    specialty: GitHub triage, issue reproduction, PR review prep, focused fixes
-    model: GPT-5.5
-    mission: Turn repo issues and review feedback into reproductions, plans, and tested PRs.
-    skills:
-      - swarm-pr-worker
-      - swarm-worker-core
-    capabilities:
-      - github-triage
-      - issue-reproduction
-      - pr-patching
-      - review-feedback
-      - gh-cli
-    preferredTaskTypes:
-      - pr
-      - issue
-      - bugfix
-      - github
-      - triage
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm5
-    name: Builder
-    role: Primary Builder
-    specialty: full-stack implementation across Hermes Workspace and Swarm2
-    model: GPT-5.5
-    mission: Ship focused product slices with tests and clean diffs.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - code-editing
-      - ui-implementation
-      - full-stack-integration
-      - build-verification
-    preferredTaskTypes:
-      - implementation
-      - ui
-      - frontend
-      - integration
-      - feature
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm4
-    name: Sage
-    role: Research / AI Intelligence / X Content
-    specialty: AI/model/runtime research, technical synthesis, X post drafting
-    model: GPT-5.5
-    mission: Produce decision-grade research and copy so builders and Eric stay unblocked.
-    skills:
-      - swarm-worker-core
-    capabilities:
-      - research
-      - benchmark-planning
-      - model-analysis
-      - technical-synthesis
-      - x-content
-    preferredTaskTypes:
-      - research
-      - benchmark
-      - analysis
-      - options
-      - x-post
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm10
-    name: Sidekick
-    role: Secondary Builder / Fast Patch Lane
-    specialty: parallel implementation slices, refactors, focused bug fixes
-    model: GPT-5.5
-    mission: Take decomposed tasks and produce clean patches quickly.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - code-editing
-      - refactor
-      - parallel-implementation
-      - bug-fix
-      - build-verification
-    preferredTaskTypes:
-      - implementation
-      - refactor
-      - backend
-      - frontend
-      - patch
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm2
-    name: Foundation
-    role: Backend Foundation / Runtime Contracts
-    specialty: ClaudeSwarm runtime contracts, API design, plugin foundations, state
-    model: GPT-5.4
-    mission: Build the backend substrate that keeps swarm state, dispatch, sessions, and plugins coherent.
-    skills:
-      - swarm-dev-runtime
-      - swarm-worker-core
-    capabilities:
-      - api-design
-      - runtime-contracts
-      - plugin-foundation
-      - state-management
-    preferredTaskTypes:
-      - backend
-      - runtime
-      - api
-      - infrastructure
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm3
-    name: Mirror
-    role: Swarm Control Plane / Main-Session Mirror
-    specialty: control-plane state, card parity, main-agent continuity
-    model: GPT-5.4
-    mission: Keep the swarm control plane operationally useful and visually canonical.
-    skills:
-      - swarm-orchestrator
-      - swarm-worker-core
-    capabilities:
-      - orchestration
-      - main-session-continuity
-      - control-plane-state
-    preferredTaskTypes:
-      - orchestration
-      - coordination
-      - handoff
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm8
-    name: Watch
-    role: Ops / Health / Lifecycle
-    specialty: gateway health, cron, runtime/process status, lifecycle sweeps
-    model: GPT-5.4
-    mission: Keep the local swarm/gateway environment stable and observable.
-    skills:
-      - swarm-dev-runtime
-      - swarm-worker-core
-    capabilities:
-      - ops-health
-      - gateway-status
-      - runtime-monitoring
-      - cron
-      - lifecycle-sweep
-    preferredTaskTypes:
-      - ops
-      - health
-      - monitoring
-      - lifecycle
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm7
-    name: Scribe
-    role: Docs / Specs / Handoffs / Memory Hygiene
-    specialty: handoffs, specs, README/docs, skill documentation, memory curation
-    model: GPT-5.5
-    mission: Preserve context and make the swarm understandable across sessions.
-    skills:
-      - swarm-worker-core
-    capabilities:
-      - documentation
-      - handoffs
-      - spec-writing
-      - runbooks
-      - memory-curation
-    preferredTaskTypes:
-      - docs
-      - handoff
-      - spec
-      - runbook
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
-  - id: swarm9
-    name: Lab
-    role: PC1 Experiments / Local-Model R&D / BenchLoop
-    specialty: PC1 experiments, local model testing, model runtime comparisons
-    model: GPT-5.5
-    mission: Explore fast without destabilizing canonical paths.
-    skills:
-      - swarm-ui-worker
-      - swarm-worker-core
-    capabilities:
-      - prototype
-      - experiment
-      - local-model
-      - benchmark-experiment
-      - rapid-build
-    preferredTaskTypes:
-      - prototype
-      - experiment
-      - hackathon
-      - benchmark
-    maxConcurrentTasks: 1
-    acceptsBroadcast: true
   - id: swarm11
-    name: QA
-    role: Secondary QA / Reviewer Support
-    specialty: secondary review, smoke verification, expected-vs-actual checks
-    model: GPT-5.4
-    mission: Review parallel outputs and protect quality gates.
+    name: Memory
+    role: Memory / Knowledge
+    specialty: Obsidian, docs, summaries, skills, decisions, knowledge hygiene
+    model: Hermes Agent
+    mission: Preserve useful context; final summaries, lessons learned, docs, runbooks, skills, and knowledge-base updates.
     skills:
-      - swarm-pr-worker
-      - swarm-worker-core
+      - obsidian
+      - document-release
+      - context-checkpoint
     capabilities:
-      - secondary-review
-      - quality-gate
-      - regression-analysis
-      - smoke-verification
+      - memory
+      - knowledge-base
+      - docs
+      - summaries
+      - skills
     preferredTaskTypes:
-      - review
-      - qa
-      - verification
-      - smoke
+      - memory
+      - docs
+      - summary
+      - obsidian
+      - runbook
+      - skill
     maxConcurrentTasks: 1
     acceptsBroadcast: true
-  - id: swarm1
-    name: Overflow
-    role: PR / Issues Overflow / Clawsuite (offline for now)
-    specialty: parked broken lane, keep out of rotation until worker runtime is repaired
-    model: GPT-5.5
-    mission: Stay out of active rotation until the swarm1 worker runtime is repaired, then absorb overflow from PR/issues lanes and cover Clawsuite.
+    reviewRequired: false
+  - id: swarm12
+    name: Research
+    role: Research
+    specialty: technical research, docs reading, competitor analysis, papers, decision briefs
+    model: Hermes Agent
+    mission: Find decision-grade evidence quickly, cite sources, compare options, and summarize what matters for execution.
     skills:
-      - swarm-pr-worker
-      - swarm-worker-core
+      - arxiv
+      - autoresearch
+      - research-paper-writing
     capabilities:
-      - github-triage
-      - small-patches
-      - issue-reproduction
-      - clawsuite
+      - research
+      - docs-analysis
+      - competitive-analysis
+      - technical-synthesis
     preferredTaskTypes:
-      - pr
-      - issue
-      - small-fix
-      - clawsuite
+      - research
+      - analysis
+      - docs
+      - papers
+      - options
     maxConcurrentTasks: 1
-    acceptsBroadcast: false
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm13
+    name: Designer
+    role: Designer / OpenDesign
+    specialty: product design, UX flows, visual systems, OpenDesign artifacts, prototypes
+    model: Hermes Agent
+    mission: Design clear product experiences, states, flows, and polished visual artifacts before frontend implementation.
+    skills:
+      - frontend-design
+      - open-design-hermes-integration
+      - design-review
+    capabilities:
+      - design
+      - ux
+      - prototype
+      - opendesign
+      - visual-system
+    preferredTaskTypes:
+      - design
+      - ux
+      - prototype
+      - visual
+      - opendesign
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm14
+    name: Security
+    role: CyberSecurity
+    specialty: threat modeling, secrets, auth, abuse cases, supply chain, secure review
+    model: Hermes Agent
+    mission: Protect Hermes and user data; threat-model changes, scan for secrets, review auth boundaries, and block unsafe releases.
+    skills:
+      - cso
+      - careful
+      - review-gate
+    capabilities:
+      - security
+      - threat-modeling
+      - secrets
+      - auth-review
+      - supply-chain
+    preferredTaskTypes:
+      - security
+      - auth
+      - secrets
+      - threat-model
+      - audit
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false
+  - id: swarm15
+    name: Data Analyst
+    role: Data Analyst
+    specialty: metrics, SQL, analytics events, dashboards, product insights, experiment readouts
+    model: Hermes Agent
+    mission: Turn product and system activity into useful metrics, dashboards, tracking plans, and analytical decisions.
+    skills:
+      - analytics-tracking
+      - jupyter-live-kernel
+      - xlsx
+    capabilities:
+      - analytics
+      - metrics
+      - sql
+      - dashboards
+      - experiments
+    preferredTaskTypes:
+      - analytics
+      - data
+      - metrics
+      - dashboard
+      - experiment
+    maxConcurrentTasks: 1
+    acceptsBroadcast: true
+    reviewRequired: false


### PR DESCRIPTION
## Summary
- Add multi-agent MVP plan documentation
- Add active project context and conductor spawn context
- Add gateway mission trace recovery and mission history wiring
- Add multi-agent domain types, file-backed store, event log, project resolver, and worktree manager
- Add multi-agent API routes for projects, profiles, tasks, and task start

## Commits
- 6dc907f4 feat(ma): add task and project API routes
- 662ff8ba feat(ma): add control plane domain store
- b1d814db feat(gateway): add mission trace recovery
- a8108369 feat(projects): add active project context
- 2d5465b1 docs: add multi-agent MVP plan

## Test Plan
- pnpm exec vitest run src/routes/api/ma/-routes.test.ts src/routes/api/ma/-task-start.test.ts src/routes/api/ma/-project-config.test.ts src/server/multi-agent/*.test.ts --pool forks --no-file-parallelism
- pnpm build
- git diff --check

Review gate: PASS