### PR TITLE
chore: preserve pnpm approved builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
Summary:
- Add pnpm-workspace.yaml approved-builds config for Electron/esbuild-related packages.
- Keeps pnpm installs/builds reproducible without re-approval prompts.

Test Plan:
- Not run; config-only change.