### PR TITLE
fix(portable-history): opt-in env flag to replay history on stateless backends

### DIFF
--- a/src/server/portable-history.test.ts
+++ b/src/server/portable-history.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   selectPortableConversationHistory,
@@ -6,6 +6,20 @@ import {
 } from './portable-history'
 
 describe('portable history replay', () => {
+  const originalForceFlag = process.env.HERMES_WORKSPACE_FORCE_HISTORY
+
+  beforeEach(() => {
+    delete process.env.HERMES_WORKSPACE_FORCE_HISTORY
+  })
+
+  afterEach(() => {
+    if (originalForceFlag === undefined) {
+      delete process.env.HERMES_WORKSPACE_FORCE_HISTORY
+    } else {
+      process.env.HERMES_WORKSPACE_FORCE_HISTORY = originalForceFlag
+    }
+  })
+
   it('skips replay when the gateway can bind portable chat to a server session', () => {
     expect(
       shouldReplayPortableHistory({
@@ -40,5 +54,31 @@ describe('portable history replay', () => {
         { bearerToken: '' },
       ),
     ).toEqual([{ role: 'user', content: 'fallback' }])
+  })
+
+  it('replays persisted history when HERMES_WORKSPACE_FORCE_HISTORY=1 even with a bearer token', () => {
+    process.env.HERMES_WORKSPACE_FORCE_HISTORY = '1'
+
+    expect(
+      shouldReplayPortableHistory({
+        bearerToken: 'token',
+      }),
+    ).toBe(true)
+
+    expect(
+      selectPortableConversationHistory(
+        [{ role: 'assistant', content: 'old reply' }],
+        [{ role: 'user', content: 'fallback' }],
+        { bearerToken: 'token' },
+      ),
+    ).toEqual([{ role: 'assistant', content: 'old reply' }])
+  })
+
+  it('preserves default skip-replay behavior when the force flag is unset', () => {
+    expect(
+      shouldReplayPortableHistory({
+        bearerToken: 'token',
+      }),
+    ).toBe(false)
   })
 })

--- a/src/server/portable-history.ts
+++ b/src/server/portable-history.ts
@@ -5,10 +5,31 @@ export type PortableHistoryMessage = {
   content: string
 }
 
+/**
+ * Decide whether the Workspace server should replay the local persisted
+ * transcript when calling the chat backend.
+ *
+ * Default behavior: skip replay when a bearer token is present AND no
+ * `localBaseUrl` override is set, since a stateful gateway is expected to
+ * resolve conversation continuity from `X-Claude-Session-Id`.
+ *
+ * Override behavior: when `HERMES_WORKSPACE_FORCE_HISTORY=1`, always replay
+ * the local transcript. This is needed when the chat backend is a *stateless*
+ * OpenAI-compatible endpoint (e.g. Hermes Agent's `/v1/chat/completions`
+ * on `:8642`), which does NOT auto-rehydrate session messages server-side.
+ * Without the override, such backends receive only the current turn and
+ * effectively appear to "forget" prior in-session messages.
+ *
+ * See issue: in-session conversational memory loss against Hermes-Agent-style
+ * stateless backends.
+ */
 export function shouldReplayPortableHistory(options?: {
   localBaseUrl?: string
   bearerToken?: string
 }): boolean {
+  // Explicit opt-in escape hatch for stateless OpenAI-compatible backends.
+  if (process.env.HERMES_WORKSPACE_FORCE_HISTORY === '1') return true
+
   const localBaseUrl = options?.localBaseUrl?.trim() || ''
   if (localBaseUrl) return true
 


### PR DESCRIPTION
## Summary

When Workspace is wired to a Hermes-Agent-style **stateless** OpenAI-compatible backend (e.g. Hermes Agent v0.12.x serving `/v1/chat/completions` on `:8642`), in-session conversational memory is silently lost — the model receives only the current user message and answers as if every turn were a fresh session.

## Root cause

`shouldReplayPortableHistory()` in `src/server/portable-history.ts` short-circuits to `false` whenever `bearerToken` is set, under the assumption that a stateful gateway behind the bearer will rehydrate session messages from `X-Claude-Session-Id`. That assumption holds for `enhanced-claude` mode but breaks for any stateless OpenAI-compat backend: there is no server-side session store to fall back to, and the client-side persisted transcript gets dropped.

Reproduces consistently against Hermes Agent v0.12.0 + Workspace v2.3.0 (verified on WSL Ubuntu 24.04). A user can send "my favorite color is purple" and 30 seconds later ask "what color did I say?" and the model has no record of the first turn.

## Fix

Introduce an opt-in environment flag `HERMES_WORKSPACE_FORCE_HISTORY=1` that forces `selectPortableConversationHistory()` to replay the persisted local transcript regardless of bearer-token presence.

**No behavior change for existing users** unless they explicitly opt in. Users running Workspace against the canonical enhanced-claude gateway are unaffected by default.

## Tests

5 tests pass (3 existing + 2 new) in `src/server/portable-history.test.ts`:

```
✓ skips replay when the gateway can bind portable chat to a server session
✓ replays persisted history for direct local-provider requests
✓ falls back to client-sent history when no persisted local session exists
✓ replays persisted history when HERMES_WORKSPACE_FORCE_HISTORY=1 even with a bearer token
✓ preserves default skip-replay behavior when the force flag is unset
```

Test setup/teardown saves and restores the env var so tests run hermetically regardless of host environment.

## How to use after merge

For users running Workspace against Hermes Agent (or any other stateless OpenAI-compat backend), add to `.env`:

```bash
HERMES_WORKSPACE_FORCE_HISTORY=1
```

Restart Workspace (`vite dev`) and prior in-session messages will be replayed on every turn, restoring expected conversational memory.

## Out of scope

This change addresses transport-layer history replay only. A more comprehensive fix would auto-detect stateless vs stateful backends via a capability probe and choose replay strategy accordingly — happy to follow up with that in a separate PR if maintainers prefer that direction over the env-var opt-in.
