### PR TITLE
fix(router): support runtime basepath override for reverse-proxy hosting

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveRouterBasepath } from './router'
+
+function setBasepathGlobal(value: unknown) {
+  ;(window as unknown as Record<string, unknown>).__HERMES_WORKSPACE_BASEPATH__ =
+    value
+}
+
+function clearBasepathGlobal() {
+  delete (window as unknown as Record<string, unknown>)
+    .__HERMES_WORKSPACE_BASEPATH__
+}
+
+afterEach(() => {
+  clearBasepathGlobal()
+})
+
+describe('resolveRouterBasepath', () => {
+  it('returns "/" when no global override is set', () => {
+    clearBasepathGlobal()
+    expect(resolveRouterBasepath()).toBe('/')
+  })
+
+  it('returns "/" when the global is not a string', () => {
+    setBasepathGlobal(42)
+    expect(resolveRouterBasepath()).toBe('/')
+  })
+
+  it('returns "/" when the global is an empty or whitespace string', () => {
+    setBasepathGlobal('   ')
+    expect(resolveRouterBasepath()).toBe('/')
+  })
+
+  it('normalizes a valid prefix with a leading slash and no trailing slash', () => {
+    setBasepathGlobal('/workspaces/abc/')
+    expect(resolveRouterBasepath()).toBe('/workspaces/abc')
+  })
+
+  it('adds a leading slash if one is missing', () => {
+    setBasepathGlobal('workspaces/abc')
+    expect(resolveRouterBasepath()).toBe('/workspaces/abc')
+  })
+
+  it('collapses multiple trailing slashes', () => {
+    setBasepathGlobal('/workspaces/abc////')
+    expect(resolveRouterBasepath()).toBe('/workspaces/abc')
+  })
+})

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,11 +3,39 @@ import { createRouter } from '@tanstack/react-router'
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'
 
+declare global {
+  interface Window {
+    /**
+     * Optional runtime override for the TanStack router basepath. Allows the
+     * same built artifact to be hosted under a path prefix by reverse proxies
+     * or container orchestrators (e.g. mounted at `/workspaces/<id>/`) without
+     * a rebuild. Set this on `window` before the app bundle executes — for
+     * example via an inline `<script>` injected by the proxy.
+     */
+    __HERMES_WORKSPACE_BASEPATH__?: string
+  }
+}
+
+export function resolveRouterBasepath(): string {
+  if (typeof window === 'undefined') return '/'
+  const value = window.__HERMES_WORKSPACE_BASEPATH__
+  if (typeof value !== 'string') return '/'
+  const trimmed = value.trim()
+  if (!trimmed) return '/'
+  // Normalize to leading slash and no trailing slash so TanStack's internal
+  // pathname matching produces stable results (`basepath: ''` and trailing
+  // slashes both cause subtle mismatches in route resolution).
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  const withoutTrailing = withLeadingSlash.replace(/\/+$/, '')
+  return withoutTrailing.length > 0 ? withoutTrailing : '/'
+}
+
 // Create a new router instance
 export const getRouter = () => {
   const router = createRouter({
     routeTree,
     context: {},
+    basepath: resolveRouterBasepath(),
 
     scrollRestoration: true,
     defaultPreloadStaleTime: 0,


### PR DESCRIPTION
## Summary

The TanStack router in `src/router.tsx` is created without a `basepath` option, which prevents the same built bundle from being hosted under a path prefix (for example behind a reverse proxy that mounts the app at `/workspaces/<id>/`).

When hosted that way:

- Hard refreshes *appear* to work, because the server-side render runs at the proxy-stripped path.
- Client-side navigation to dynamic routes such as `/chat/$sessionKey` silently falls through to the catch-all `/$` route and renders the "404 — Not Found" page from inside the SPA. Static-looking navigation can mask this because the 404 page itself contains the same Chat / Files / Memory / Skills quick-links.

This PR makes the basepath runtime-configurable without changing default behavior:

- Reads an optional `window.__HERMES_WORKSPACE_BASEPATH__` global and passes it through to `createRouter`.
- Normalizes the value (ensures a single leading slash, strips trailing slashes, treats empty/whitespace as unset) so callers can pass `/workspaces/abc`, `workspaces/abc`, or `/workspaces/abc/` interchangeably without upsetting TanStack's pathname matching.
- When the global is unset, `basepath` resolves to `/` — identical to today's behavior.

Hosting layers can then inject a tiny inline `<script>` before the bundle loads to mount the app at any path, without rebuilding:

```html
<script>window.__HERMES_WORKSPACE_BASEPATH__ = "/workspaces/abc"</script>
```

## Files

- `src/router.tsx` — exports `resolveRouterBasepath()` and wires it into `createRouter({ ..., basepath })`.
- `src/router.test.ts` — six unit tests covering: unset, non-string, empty/whitespace, leading-slash normalization, trailing-slash trimming, and the no-op default case.

## Test plan

- [x] `npx vitest run src/router.test.ts` — 6/6 passing locally
- [x] `npx eslint src/router.tsx src/router.test.ts` — clean
- [x] Default behavior verified: with the global unset, `resolveRouterBasepath()` returns `"/"`, matching previous router config
- [ ] Verified end-to-end behind a reverse proxy that injects the global (out of scope for this repo; happy to add docs if useful)

## Notes

- No change to the public API surface; `getRouter()` keeps the same signature.
- No change to SSR — the value is sourced from `window`, which is only present on the client, so the server keeps using `basepath: "/"` exactly as before.
