### PR TITLE
Add Agent Bus operations panel

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -107,6 +107,7 @@ import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
 import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiArtifactsRouteImport } from './routes/api/artifacts'
+import { Route as ApiAgentBusRouteImport } from './routes/api/agent-bus'
 import { Route as ApiUpdateWorkspaceRouteImport } from './routes/api/update/workspace'
 import { Route as ApiUpdateStatusRouteImport } from './routes/api/update/status'
 import { Route as ApiUpdateAgentRouteImport } from './routes/api/update/agent'
@@ -647,6 +648,11 @@ const ApiArtifactsRoute = ApiArtifactsRouteImport.update({
   path: '/api/artifacts',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAgentBusRoute = ApiAgentBusRouteImport.update({
+  id: '/api/agent-bus',
+  path: '/api/agent-bus',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiUpdateWorkspaceRoute = ApiUpdateWorkspaceRouteImport.update({
   id: '/api/update/workspace',
   path: '/api/update/workspace',
@@ -916,6 +922,7 @@ export interface FileRoutesByFullPath {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1063,6 +1070,7 @@ export interface FileRoutesByTo {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1212,6 +1220,7 @@ export interface FileRoutesById {
   '/terminal': typeof TerminalRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -1362,6 +1371,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1509,6 +1519,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1657,6 +1668,7 @@ export interface FileRouteTypes {
     | '/terminal'
     | '/vt-capital'
     | '/world'
+    | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1806,6 +1818,7 @@ export interface RootRouteChildren {
   TerminalRoute: typeof TerminalRoute
   VtCapitalRoute: typeof VtCapitalRoute
   WorldRoute: typeof WorldRoute
+  ApiAgentBusRoute: typeof ApiAgentBusRoute
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
   ApiAuthCheckRoute: typeof ApiAuthCheckRoute
@@ -2590,6 +2603,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiArtifactsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/agent-bus': {
+      id: '/api/agent-bus'
+      path: '/api/agent-bus'
+      fullPath: '/api/agent-bus'
+      preLoaderRoute: typeof ApiAgentBusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/update/workspace': {
       id: '/api/update/workspace'
       path: '/api/update/workspace'
@@ -3151,6 +3171,7 @@ const rootRouteChildren: RootRouteChildren = {
   TerminalRoute: TerminalRoute,
   VtCapitalRoute: VtCapitalRoute,
   WorldRoute: WorldRoute,
+  ApiAgentBusRoute: ApiAgentBusRoute,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
   ApiAuthCheckRoute: ApiAuthCheckRoute,

--- a/src/routes/api/agent-bus.ts
+++ b/src/routes/api/agent-bus.ts
@@ -1,0 +1,242 @@
+import { execFile } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { createFileRoute } from '@tanstack/react-router'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+
+const execFileAsync = promisify(execFile)
+
+const AGENT_BUS_DIR =
+  process.env.AGENT_BUS_OUTPUT_DIR ||
+  '/opt/central-inteligencia/runtime/hermes-agent-bus'
+const STATUS_PATH = join(AGENT_BUS_DIR, 'agent-bus-status.json')
+const EVENTS_PATH = join(AGENT_BUS_DIR, 'agent-events-current.jsonl')
+const REPORT_PATH = join(AGENT_BUS_DIR, 'ESTADO_DA_TROPA.md')
+const MISSIONS_DIR = join(AGENT_BUS_DIR, 'missions')
+const AGENT_BUS_SCRIPT =
+  process.env.AGENT_BUS_SCRIPT ||
+  '/opt/central-inteligencia/services/hermes-agent-bus/agent_bus.py'
+
+const HANDOFF_CONTRACTS: Record<string, { businessScope: string; reason: string }> = {
+  'dona-helena->larissinha': {
+    businessScope: 'DES',
+    reason: 'duvida_juridica_interna',
+  },
+  'larissinha->dona-helena': {
+    businessScope: 'DES',
+    reason: 'cliente_precisa_sac',
+  },
+  'dra-clara-des->hermes': {
+    businessScope: 'DES',
+    reason: 'lead_ou_venda_precisa_supervisao',
+  },
+  'clara-sdr->hermes': {
+    businessScope: '100K',
+    reason: 'lead_quente_ou_handoff_comercial',
+  },
+  'fofoqueiro->hermes': {
+    businessScope: '100K',
+    reason: 'sinal_de_grupo_ou_risco_operacional',
+  },
+  'hermes->thumbnail-worker': {
+    businessScope: 'Advogando',
+    reason: 'missao_de_criativo',
+  },
+}
+
+type AgentBusStatus = {
+  checked_at?: string
+  registry_last_updated?: string
+  summary?: {
+    total?: number
+    up?: number
+    down?: number
+    no_endpoint?: number
+    non_operational?: number
+    events?: number
+  }
+  agents?: Array<Record<string, unknown>>
+}
+
+function readJsonFile<T>(path: string, fallback: T): T {
+  if (!existsSync(path)) return fallback
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+  } catch {
+    return fallback
+  }
+}
+
+function readEvents(): Array<Record<string, unknown>> {
+  if (!existsSync(EVENTS_PATH)) return []
+  return readFileSync(EVENTS_PATH, 'utf-8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as Record<string, unknown>
+      } catch {
+        return { error: 'json_invalido', raw: line.slice(0, 500) }
+      }
+    })
+}
+
+function readMissions(limit = 12): Array<Record<string, unknown>> {
+  if (!existsSync(MISSIONS_DIR)) return []
+  return readdirSync(MISSIONS_DIR)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .reverse()
+    .slice(0, limit)
+    .map((name) => {
+      const path = join(MISSIONS_DIR, name)
+      const mission = readJsonFile<Record<string, unknown>>(path, {
+        error: 'json_invalido',
+      })
+      return { ...mission, path }
+    })
+}
+
+function readReportPreview(): string {
+  if (!existsSync(REPORT_PATH)) return ''
+  return readFileSync(REPORT_PATH, 'utf-8').slice(0, 6000)
+}
+
+function issueAgents(status: AgentBusStatus): Array<Record<string, unknown>> {
+  const agents = Array.isArray(status.agents) ? status.agents : []
+  return agents.filter((agent) => {
+    const statusConfig = String(agent.status_config ?? '')
+    const health = String(agent.health ?? '')
+    const operational = statusConfig === 'active' || statusConfig === 'observer_mode'
+    return !operational || health !== 'up'
+  })
+}
+
+function utcStamp(): string {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+}
+
+function writeMission(payload: Record<string, unknown>): string {
+  mkdirSync(MISSIONS_DIR, { recursive: true })
+  const target = String(payload.target ?? 'mission').replace(/[^a-z0-9-]/gi, '-')
+  const missionType = String(payload.mission_type ?? 'mission').replace(/[^a-z0-9-]/gi, '-')
+  const path = join(MISSIONS_DIR, `${utcStamp()}-${missionType}-${target}.json`)
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8')
+  return path
+}
+
+async function syncRoadmap() {
+  const result = await execFileAsync('/usr/bin/python3', [AGENT_BUS_SCRIPT, '--sync-roadmap'], {
+    cwd: '/opt/central-inteligencia',
+    timeout: 60_000,
+  })
+  return {
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  }
+}
+
+async function handleAction(request: Request) {
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return Response.json({ ok: false, error: 'JSON invalido' }, { status: 400 })
+  }
+
+  const action = String(body.action ?? '')
+  if (action === 'sync-roadmap') {
+    try {
+      return Response.json({ ok: true, action, result: await syncRoadmap() })
+    } catch (err) {
+      return Response.json(
+        { ok: false, action, error: err instanceof Error ? err.message : 'sync falhou' },
+        { status: 500 },
+      )
+    }
+  }
+
+  if (action === 'thumbnail-mission') {
+    const target = String(body.target ?? 'vini').toLowerCase()
+    if (!['vini', 'daiane'].includes(target)) {
+      return Response.json({ ok: false, error: 'target invalido' }, { status: 400 })
+    }
+    const brief =
+      String(body.brief ?? '').trim() ||
+      (target === 'vini'
+        ? 'Criar thumbnail operacional para briefing do Vinicius'
+        : 'Criar thumbnail operacional para briefing da Daiane')
+    const payload = {
+      ok: true,
+      mission_type: 'thumbnail',
+      target,
+      brief,
+      render: false,
+      allow_paid_provider: false,
+      safe_mode: true,
+      source: 'hermes-workspace',
+      created_at: new Date().toISOString(),
+    }
+    return Response.json({ ok: true, action, mission: { ...payload, mission_record_path: writeMission(payload) } })
+  }
+
+  if (action === 'handoff-mission') {
+    const source = String(body.source ?? 'dona-helena').toLowerCase()
+    const target = String(body.target ?? 'larissinha').toLowerCase()
+    const key = `${source}->${target}`
+    const contract = HANDOFF_CONTRACTS[key]
+    if (!contract) {
+      return Response.json({ ok: false, error: 'contrato de handoff nao aprovado', key }, { status: 400 })
+    }
+    const payload = {
+      ok: true,
+      mission_type: 'handoff',
+      source_agent: source,
+      target,
+      business_scope: contract.businessScope,
+      reason: contract.reason,
+      external_actions: [],
+      safe_mode: true,
+      source: 'hermes-workspace',
+      created_at: new Date().toISOString(),
+    }
+    return Response.json({ ok: true, action, mission: { ...payload, mission_record_path: writeMission(payload) } })
+  }
+
+  return Response.json({ ok: false, error: 'acao desconhecida' }, { status: 400 })
+}
+
+export const Route = createFileRoute('/api/agent-bus')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return Response.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        const status = readJsonFile<AgentBusStatus>(STATUS_PATH, {})
+        return Response.json({
+          ok: true,
+          status,
+          events: readEvents(),
+          missions: readMissions(),
+          issues: issueAgents(status),
+          reportPreview: readReportPreview(),
+          paths: {
+            status: STATUS_PATH,
+            events: EVENTS_PATH,
+            report: REPORT_PATH,
+            missions: MISSIONS_DIR,
+          },
+        })
+      },
+      POST: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return Response.json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        return handleAction(request)
+      },
+    },
+  },
+})

--- a/src/screens/agents/components/agent-bus-panel.tsx
+++ b/src/screens/agents/components/agent-bus-panel.tsx
@@ -1,0 +1,331 @@
+import { useEffect, useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type AgentBusSummary = {
+  total?: number
+  up?: number
+  down?: number
+  no_endpoint?: number
+  non_operational?: number
+  events?: number
+}
+
+type AgentBusAgent = {
+  id?: string
+  name?: string
+  status_config?: string
+  health?: string
+  listener?: string
+  port?: number | null
+  error?: string | null
+}
+
+type AgentBusMission = {
+  mission_type?: string
+  target?: string
+  source_agent?: string
+  brief?: string
+  reason?: string
+  safe_mode?: boolean
+  created_at?: string
+  mission_record_path?: string
+  path?: string
+}
+
+type AgentBusPayload = {
+  ok: boolean
+  status?: {
+    checked_at?: string
+    registry_last_updated?: string
+    summary?: AgentBusSummary
+    agents?: AgentBusAgent[]
+  }
+  events?: Array<Record<string, unknown>>
+  missions?: AgentBusMission[]
+  issues?: AgentBusAgent[]
+  reportPreview?: string
+}
+
+type ActionState =
+  | { status: 'idle'; message: string }
+  | { status: 'running'; message: string }
+  | { status: 'ok'; message: string }
+  | { status: 'error'; message: string }
+
+const initialActionState: ActionState = {
+  status: 'idle',
+  message: 'Acoes seguras ficam registradas no Agent Bus.',
+}
+
+function formatDate(value?: string): string {
+  if (!value) return 'sem leitura'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function firstLine(value?: string): string {
+  return String(value || '').split('\n').find(Boolean) || 'sem detalhe'
+}
+
+function missionTitle(mission: AgentBusMission): string {
+  if (mission.mission_type === 'handoff') {
+    return `${mission.source_agent || 'agente'} -> ${mission.target || 'agente'}`
+  }
+  if (mission.mission_type === 'thumbnail') {
+    return `Thumbnail ${mission.target || ''}`.trim()
+  }
+  return mission.mission_type || 'Missao'
+}
+
+function StatTile({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string
+  value: number | string
+  tone?: 'neutral' | 'good' | 'warn' | 'bad'
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border px-4 py-3',
+        tone === 'good' && 'border-emerald-200 bg-emerald-50 text-emerald-900',
+        tone === 'warn' && 'border-amber-200 bg-amber-50 text-amber-950',
+        tone === 'bad' && 'border-red-200 bg-red-50 text-red-900',
+        tone === 'neutral' && 'border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-text)]',
+      )}
+    >
+      <div className="text-2xl font-semibold leading-none">{value}</div>
+      <div className="mt-1 text-xs font-medium uppercase tracking-[0.08em] opacity-70">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+export function AgentBusPanel() {
+  const [data, setData] = useState<AgentBusPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [action, setAction] = useState<ActionState>(initialActionState)
+
+  async function load() {
+    setError(null)
+    try {
+      const response = await fetch('/api/agent-bus', {
+        headers: { Accept: 'application/json' },
+      })
+      if (!response.ok) throw new Error(`Agent Bus respondeu HTTP ${response.status}`)
+      setData((await response.json()) as AgentBusPayload)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Falha ao carregar Agent Bus')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    const timer = window.setInterval(() => void load(), 30_000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const summary = data?.status?.summary ?? {}
+  const missions = data?.missions ?? []
+  const issues = data?.issues ?? []
+  const events = data?.events ?? []
+  const visibleIssues = useMemo(() => issues.slice(0, 5), [issues])
+
+  async function runAction(body: Record<string, unknown>, successMessage: string) {
+    setAction({ status: 'running', message: 'Executando acao segura...' })
+    try {
+      const response = await fetch('/api/agent-bus', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const payload = (await response.json()) as { ok?: boolean; error?: string }
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error || `HTTP ${response.status}`)
+      }
+      setAction({ status: 'ok', message: successMessage })
+      await load()
+    } catch (err) {
+      setAction({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Acao falhou',
+      })
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--theme-accent-strong)]">
+            Agent Bus
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">
+            Estado da Tropa
+          </h2>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+            Leitura do Scumbag, missões e pendências operacionais do Hermes.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-muted)]">
+          Última leitura: {formatDate(data?.status?.checked_at)}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="mt-5 rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-8 text-center text-sm text-[var(--theme-muted)]">
+          Carregando Agent Bus...
+        </div>
+      ) : error ? (
+        <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-900">
+          {error}
+        </div>
+      ) : (
+        <>
+          <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-6">
+            <StatTile label="total" value={summary.total ?? 0} />
+            <StatTile label="online" value={summary.up ?? 0} tone="good" />
+            <StatTile label="down" value={summary.down ?? 0} tone={(summary.down ?? 0) > 0 ? 'bad' : 'good'} />
+            <StatTile label="sem endpoint" value={summary.no_endpoint ?? 0} tone={(summary.no_endpoint ?? 0) > 0 ? 'warn' : 'good'} />
+            <StatTile label="fora op." value={summary.non_operational ?? 0} tone={(summary.non_operational ?? 0) > 0 ? 'warn' : 'good'} />
+            <StatTile label="eventos" value={events.length || summary.events || 0} tone={events.length > 0 ? 'bad' : 'good'} />
+          </div>
+
+          <div className="mt-5 grid grid-cols-1 gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Pendências vivas</h3>
+                <span className="text-xs text-[var(--theme-muted)]">{issues.length} itens</span>
+              </div>
+              <div className="mt-3 space-y-2">
+                {visibleIssues.length ? (
+                  visibleIssues.map((agent) => (
+                    <div
+                      key={`${agent.id}-${agent.port ?? 'no-port'}`}
+                      className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-sm font-medium text-[var(--theme-text)]">
+                          {agent.name || agent.id}
+                        </span>
+                        <span className="text-xs text-[var(--theme-muted)]">
+                          {agent.status_config || 'sem status'} / {agent.health || 'sem health'}
+                        </span>
+                      </div>
+                      {agent.error ? (
+                        <p className="mt-1 text-xs text-[var(--theme-muted)]">{firstLine(agent.error)}</p>
+                      ) : null}
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-5 text-sm text-[var(--theme-muted)]">
+                    Nenhum agente operacional caído agora.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Últimas missões</h3>
+                <span className="text-xs text-[var(--theme-muted)]">{missions.length} registros</span>
+              </div>
+              <div className="mt-3 space-y-2">
+                {missions.slice(0, 5).map((mission, index) => (
+                  <div
+                    key={`${mission.path || mission.mission_record_path || index}`}
+                    className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium text-[var(--theme-text)]">
+                        {missionTitle(mission)}
+                      </span>
+                      <span className="text-xs text-[var(--theme-muted)]">
+                        {mission.safe_mode ? 'safe' : 'exec'}
+                      </span>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs text-[var(--theme-muted)]">
+                      {mission.brief || mission.reason || 'missão registrada'}
+                    </p>
+                  </div>
+                ))}
+                {!missions.length ? (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-5 text-sm text-[var(--theme-muted)]">
+                    Nenhuma missão registrada ainda.
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Ações seguras</h3>
+                <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                  Sem restart, sem WhatsApp e sem gasto pago automático.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => runAction({ action: 'sync-roadmap' }, 'Roadmap sincronizado com eventos atuais.')}
+                  className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
+                >
+                  Sincronizar Roadmap
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    runAction(
+                      { action: 'thumbnail-mission', target: 'vini' },
+                      'Missão de thumbnail do Vini registrada.',
+                    )
+                  }
+                  className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
+                >
+                  Missão Thumbnail Vini
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    runAction(
+                      { action: 'handoff-mission', source: 'dona-helena', target: 'larissinha' },
+                      'Handoff Dona Helena -> Larissinha registrado.',
+                    )
+                  }
+                  className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
+                >
+                  Handoff Helena para Larissinha
+                </button>
+              </div>
+            </div>
+            <p
+              className={cn(
+                'mt-3 text-sm',
+                action.status === 'ok' && 'text-emerald-700',
+                action.status === 'error' && 'text-red-700',
+                action.status === 'running' && 'text-[var(--theme-accent-strong)]',
+                action.status === 'idle' && 'text-[var(--theme-muted)]',
+              )}
+            >
+              {action.message}
+            </p>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/screens/agents/operations-screen.tsx
+++ b/src/screens/agents/operations-screen.tsx
@@ -16,6 +16,7 @@ import { OperationsAgentDetail } from './components/operations-agent-detail'
 import { OperationsNewAgentModal } from './components/operations-new-agent-modal'
 import { OperationsSettingsModal } from './components/operations-settings-modal'
 import { FullOutputsView } from './components/full-outputs-view'
+import { AgentBusPanel } from './components/agent-bus-panel'
 import { useOperations } from './hooks/use-operations'
 
 export const THEME_STYLE: CSSProperties = {
@@ -157,6 +158,14 @@ export function OperationsScreen() {
               <OrchestratorCard
                 totalAgents={agents.length}
               />
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.05, duration: 0.25 }}
+            >
+              <AgentBusPanel />
             </motion.div>
 
             <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
Adds the SPEC-181 Agent Bus / Estado da Tropa panel to Operations, backed by /api/agent-bus.\n\nIncludes safe actions for roadmap sync, thumbnail mission registration, and approved handoff mission registration.\n\nRuntime smoke already validated on VPS:\n- GET /api/agent-bus returns 18 total, 15 up, 0 operational down, 3 non_operational, 0 events.\n- POST sync-roadmap returns roadmap_created=0 when no current events exist.\n- POST thumbnail-mission creates a safe-mode mission without paid render.\n- POST handoff-mission creates Dona Helena -> Larissinha handoff without external actions.\n\nNote: deployed runtime commit on VPS is e008464; this PR reapplies the archived patch on the public fork as 4d912204 because VPS token lacked push permissions.