### PR TITLE
Add native script editor macOS app

### DIFF
--- a/macos-native/Info.plist
+++ b/macos-native/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>Hermes Workspace</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.hermesworkspace.native</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Hermes Workspace</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2.3.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/macos-native/README.md
+++ b/macos-native/README.md
@@ -1,0 +1,45 @@
+# Hermes Workspace Native macOS App
+
+This folder contains a small native Swift/AppKit shell for Hermes Workspace. It opens the local Hermes Workspace UI in a `WKWebView`, includes native toolbar controls, and nudges the installed Hermes launch agents so the gateway, dashboard, console, and workspace are available.
+
+## Build
+
+```bash
+./macos-native/Scripts/build-macos-app.sh
+```
+
+Or from the repo root:
+
+```bash
+pnpm native:mac
+```
+
+To cross-build for a specific Mac architecture:
+
+```bash
+ARCH=arm64 pnpm native:mac
+ARCH=x86_64 pnpm native:mac
+```
+
+The build script creates:
+
+```text
+macos-native/build/Hermes Workspace.app
+```
+
+## Run
+
+```bash
+open "macos-native/build/Hermes Workspace.app"
+```
+
+The app expects the existing local services:
+
+- Workspace UI: `http://127.0.0.1:3000`
+- Local console: `http://127.0.0.1:5128`
+- Hermes gateway: `http://127.0.0.1:8642`
+- Hermes dashboard: `http://127.0.0.1:9119`
+
+If the launch agents are installed, the app asks `launchctl` to kickstart them on launch and when the toolbar Start button is pressed.
+
+If Swift reports that the SDK is not supported by the compiler, repair or update the local Xcode Command Line Tools and rerun the build. The script prints the `swiftc` and SDK paths it is using so the selected toolchain is visible.

--- a/macos-native/Scripts/build-macos-app.sh
+++ b/macos-native/Scripts/build-macos-app.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_NAME="Hermes Workspace"
+BUILD_DIR="$ROOT_DIR/macos-native/build"
+APP_DIR="$BUILD_DIR/$APP_NAME.app"
+CONTENTS_DIR="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+ARCH="${ARCH:-$(uname -m)}"
+
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+SWIFTC="$(/usr/bin/xcrun --find swiftc 2>/dev/null || command -v swiftc)"
+SDK_PATH="$(/usr/bin/xcrun --show-sdk-path 2>/dev/null || true)"
+
+echo "Using swiftc: $SWIFTC"
+if [[ -n "$SDK_PATH" ]]; then
+  echo "Using SDK: $SDK_PATH"
+fi
+echo "Target architecture: $ARCH"
+
+"$SWIFTC" \
+  -O \
+  -target "$ARCH-apple-macos13.0" \
+  -framework AppKit \
+  -framework WebKit \
+  "$ROOT_DIR/macos-native/Sources/HermesWorkspaceApp/main.swift" \
+  -o "$MACOS_DIR/$APP_NAME"
+
+cp "$ROOT_DIR/macos-native/Info.plist" "$CONTENTS_DIR/Info.plist"
+
+if [[ -f "$ROOT_DIR/assets/icon.png" ]]; then
+  cp "$ROOT_DIR/assets/icon.png" "$RESOURCES_DIR/icon.png"
+fi
+
+codesign --force --sign - "$APP_DIR" >/dev/null
+
+echo "$APP_DIR"

--- a/macos-native/Sources/HermesWorkspaceApp/main.swift
+++ b/macos-native/Sources/HermesWorkspaceApp/main.swift
@@ -1,0 +1,230 @@
+import AppKit
+import WebKit
+
+private enum HermesEndpoint {
+    static let workspace = URL(string: "http://127.0.0.1:3000")!
+    static let console = URL(string: "http://127.0.0.1:5128")!
+    static let dashboardStatus = URL(string: "http://127.0.0.1:9119/api/status")!
+
+    static let launchAgents = [
+        "ai.hermes.gateway",
+        "dev.hermes.local-dashboard",
+        "dev.hermes.workspace",
+        "dev.hermes.local-console",
+    ]
+}
+
+@main
+final class HermesWorkspaceApp: NSObject, NSApplicationDelegate {
+    private var window: NSWindow!
+    private var webView: WKWebView!
+    private var statusItem: NSToolbarItem!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        buildWindow()
+        kickstartHermesServices()
+        load(HermesEndpoint.workspace)
+        refreshStatus()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
+    private func buildWindow() {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        configuration.websiteDataStore = .default()
+
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = self
+        webView.allowsBackForwardNavigationGestures = true
+
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1280, height: 820),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.center()
+        window.minSize = NSSize(width: 980, height: 640)
+        window.title = "Hermes Workspace"
+        window.titlebarAppearsTransparent = true
+        window.toolbarStyle = .unifiedCompact
+        window.contentView = webView
+        window.toolbar = buildToolbar()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func buildToolbar() -> NSToolbar {
+        let toolbar = NSToolbar(identifier: "HermesWorkspaceToolbar")
+        toolbar.displayMode = .iconAndLabel
+        toolbar.delegate = self
+        return toolbar
+    }
+
+    private func load(_ url: URL) {
+        webView.load(URLRequest(url: url))
+    }
+
+    @objc private func openWorkspace() {
+        load(HermesEndpoint.workspace)
+    }
+
+    @objc private func openConsole() {
+        load(HermesEndpoint.console)
+    }
+
+    @objc private func reloadPage() {
+        webView.reload()
+        refreshStatus()
+    }
+
+    @objc private func openInBrowser() {
+        NSWorkspace.shared.open(webView.url ?? HermesEndpoint.workspace)
+    }
+
+    @objc private func restartServices() {
+        kickstartHermesServices()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.refreshStatus()
+            self?.webView.reload()
+        }
+    }
+
+    private func refreshStatus() {
+        setStatus("Checking...")
+        var request = URLRequest(url: HermesEndpoint.dashboardStatus)
+        request.timeoutInterval = 2
+
+        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
+            DispatchQueue.main.async {
+                if error == nil, let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
+                    self?.setStatus("Connected")
+                } else {
+                    self?.setStatus("Starting")
+                }
+            }
+        }.resume()
+    }
+
+    private func setStatus(_ value: String) {
+        statusItem.label = value
+        statusItem.toolTip = "Hermes dashboard status: \(value)"
+    }
+
+    private func kickstartHermesServices() {
+        let userDomain = "gui/\(getuid())"
+
+        DispatchQueue.global(qos: .utility).async {
+            for label in HermesEndpoint.launchAgents {
+                _ = Self.run("/bin/launchctl", arguments: ["kickstart", "\(userDomain)/\(label)"])
+            }
+        }
+    }
+
+    private static func run(_ launchPath: String, arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        } catch {
+            return -1
+        }
+    }
+}
+
+extension HermesWorkspaceApp: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        window.title = webView.title?.isEmpty == false ? webView.title! : "Hermes Workspace"
+        refreshStatus()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        setStatus("Offline")
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        setStatus("Offline")
+    }
+}
+
+extension HermesWorkspaceApp: NSToolbarDelegate {
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [
+            .workspace,
+            .console,
+            .reload,
+            .restartServices,
+            .openInBrowser,
+            .flexibleSpace,
+            .status,
+        ]
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [
+            .workspace,
+            .console,
+            .reload,
+            .restartServices,
+            .flexibleSpace,
+            .status,
+            .openInBrowser,
+        ]
+    }
+
+    func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier identifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
+        switch identifier {
+        case .workspace:
+            return button(identifier, label: "Workspace", symbol: "rectangle.grid.2x2", action: #selector(openWorkspace))
+        case .console:
+            return button(identifier, label: "Console", symbol: "terminal", action: #selector(openConsole))
+        case .reload:
+            return button(identifier, label: "Reload", symbol: "arrow.clockwise", action: #selector(reloadPage))
+        case .restartServices:
+            return button(identifier, label: "Start", symbol: "bolt.circle", action: #selector(restartServices))
+        case .openInBrowser:
+            return button(identifier, label: "Browser", symbol: "safari", action: #selector(openInBrowser))
+        case .status:
+            statusItem = NSToolbarItem(itemIdentifier: identifier)
+            statusItem.label = "Checking..."
+            statusItem.paletteLabel = "Hermes Status"
+            return statusItem
+        default:
+            return nil
+        }
+    }
+
+    private func button(_ identifier: NSToolbarItem.Identifier, label: String, symbol: String, action: Selector) -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: identifier)
+        item.label = label
+        item.paletteLabel = label
+        item.toolTip = label
+        item.target = self
+        item.action = action
+
+        if #available(macOS 11.0, *) {
+            item.image = NSImage(systemSymbolName: symbol, accessibilityDescription: label)
+        }
+
+        return item
+    }
+}
+
+private extension NSToolbarItem.Identifier {
+    static let workspace = NSToolbarItem.Identifier("HermesWorkspace")
+    static let console = NSToolbarItem.Identifier("HermesConsole")
+    static let reload = NSToolbarItem.Identifier("HermesReload")
+    static let restartServices = NSToolbarItem.Identifier("HermesRestartServices")
+    static let openInBrowser = NSToolbarItem.Identifier("HermesOpenInBrowser")
+    static let status = NSToolbarItem.Identifier("HermesStatus")
+}

--- a/macos/ScriptEditor/EXECUTION_STATUS.md
+++ b/macos/ScriptEditor/EXECUTION_STATUS.md
@@ -1,0 +1,43 @@
+# Native Script Editor Execution Status
+
+## Current Wave
+
+This wave turns the implementation plan into more complete v1 behavior while keeping the app independent from Hermes and local-first.
+
+## Completed Before This Wave
+
+- SwiftUI macOS app shell.
+- Local JSON database.
+- OpenAI-compatible Qwen client.
+- Research brief generation.
+- 20-40 candidate generation.
+- Rubric scoring and top-10 review board.
+- Human editor with side-agent chat.
+- Local approved-script Markdown rendering.
+- Long-form implementation plan.
+
+## Completed In This Wave
+
+- Source ingestion for notes and local text-like files.
+- Backend health check for local Qwen/OpenAI-compatible endpoints.
+- Human approval value/service for export-ready scripts.
+- UI integration for source facts, backend status, approval, and export readiness.
+
+## Remaining V1 Build-Out
+
+- File picker UI instead of locator-only file path import.
+- Source references panel beside the editor.
+- Version history viewer.
+- Better URL readability extraction.
+- Claim-to-source object linking.
+
+## Verification Constraint
+
+`swift test` is currently blocked by the active Command Line Tools installation. SwiftPM fails while compiling the package manifest before reaching package code. Syntax parsing is still used as a lightweight local guard until the Xcode toolchain is repaired.
+
+## Non-Goals Preserved
+
+- No auto-posting.
+- No account connection.
+- No Hermes runtime dependency.
+- No destructive data operations.

--- a/macos/ScriptEditor/IMPLEMENTATION_PLAN.md
+++ b/macos/ScriptEditor/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,767 @@
+# Native Script Editor Implementation Plan
+
+## 1. Product Intent
+
+Native Script Editor is a standalone macOS app for creating, judging, revising, and approving short-form video scripts. It exists outside Hermes Workspace so the writing workflow can remain focused, fast, and local-first. Hermes may later become a source of skills, automations, or memory, but v1 should not depend on Hermes being available.
+
+The app is designed around one central idea: the human should only spend taste and editing energy on scripts that have already survived a strong research and quality filter. The system should generate a wide field of options, score them with a strict rubric, suppress low-quality drafts, and then make the best scripts easy to revise with an agent as a collaborator rather than an automatic overwriter.
+
+The v1 ending condition is a set of human-approved revised scripts. Posting, scheduling, account automation, and performance feedback loops are explicitly deferred.
+
+## 2. Workflow Overview
+
+The v1 workflow has three primary stages and one supporting output stage:
+
+1. Research Workspace
+2. Script Generation Run
+3. AI Review Board plus Human Revision Editor
+4. Local export of approved scripts
+
+The first three stages are the core product. The export stage exists only so approved scripts can leave the app as Markdown or another local artifact without introducing auto-posting.
+
+```mermaid
+flowchart LR
+    Project["Project setup"] --> Sources["Research sources"]
+    Sources --> Brief["Research brief"]
+    Brief --> Generate["20-40 script candidates"]
+    Generate --> Score["AI rubric scoring"]
+    Score --> Top10["Top 10 review board"]
+    Top10 --> Editor["Human editor"]
+    Editor --> Agent["Side-agent revision chat"]
+    Agent --> Approved["Approved script"]
+    Approved --> Export["Local Markdown export"]
+```
+
+## 3. Principles
+
+### Local First
+
+The default AI backend is local Qwen exposed through an OpenAI-compatible endpoint:
+
+- Base URL: `http://127.0.0.1:8081/v1`
+- Default model: `mlx-community/Qwen3-1.7B-4bit`
+
+The app must keep the backend abstract. Hosted models, alternate local endpoints, or Hermes Agent gateway APIs can be added later without rewiring the workflow.
+
+### Human Approval Required
+
+The app can generate, score, rank, suggest, and export. It should not publish. Any external posting or scheduling must remain a later feature and should require explicit human approval.
+
+### Slop Prevention
+
+The app should be hostile to generic scripts. Low-quality patterns should be identified before the human review stage. The top 10 board should represent scripts that are specific enough, grounded enough, and structured enough to deserve attention.
+
+### Source Grounding
+
+Research should not become vague context soup. Sources need titles, locators, raw excerpts, extracted facts, and citations so the final script can preserve the thread back to evidence.
+
+### Agent as Collaborator
+
+The side-agent should suggest changes, alternatives, sharper hooks, tighter payoffs, and source-grounded improvements. It should not automatically overwrite the editor text.
+
+## 4. Architecture
+
+The current implementation is a Swift Package under `macos/ScriptEditor`.
+
+```text
+macos/ScriptEditor
+  Package.swift
+  README.md
+  IMPLEMENTATION_PLAN.md
+  Sources
+    ScriptEditorApp
+      ScriptEditorApp.swift
+      AppViewModel.swift
+      ContentView.swift
+    ScriptEditorCore
+      Models.swift
+      LocalScriptDatabase.swift
+      OpenAICompatibleClient.swift
+      WebResearchService.swift
+      JSONExtraction.swift
+      WorkflowEngine.swift
+  Tests
+    ScriptEditorCoreTests
+      WorkflowEngineTests.swift
+```
+
+The package has two targets:
+
+- `ScriptEditorCore`: model, persistence, AI backend, workflow orchestration, research helpers, scoring, export, and testable business logic.
+- `ScriptEditorApp`: SwiftUI shell and app state management.
+
+## 5. Data Model
+
+### Project
+
+Represents one script-making workspace.
+
+Fields:
+
+- `id`
+- `title`
+- `topic`
+- `audience`
+- `platform`
+- `tone`
+- `goal`
+- `constraints`
+- `createdAt`
+- `updatedAt`
+
+Product expectations:
+
+- A project should be useful even with partial metadata.
+- The app should nudge toward specificity without blocking rough exploration.
+- Platform defaults can be changed later to include TikTok, Reels, Shorts, LinkedIn, X, or custom.
+
+### ResearchSource
+
+Represents a note, URL, file, or search result.
+
+Fields:
+
+- `id`
+- `projectId`
+- `kind`
+- `title`
+- `locator`
+- `rawText`
+- `extractedFacts`
+- `credibilityNote`
+- `createdAt`
+
+Product expectations:
+
+- The user can paste notes directly.
+- URL fetching should pull readable text when possible.
+- Search snippets are acceptable as lightweight sources, but full source capture is preferred.
+- Future file import should support PDFs, transcripts, text files, and maybe local media metadata.
+
+### ResearchBrief
+
+The distilled research object used by generation and revision.
+
+Fields:
+
+- `id`
+- `projectId`
+- `distilledInsights`
+- `claims`
+- `angles`
+- `audienceTensions`
+- `citations`
+- `createdAt`
+
+Product expectations:
+
+- Claims should be source-backed where possible.
+- Tensions should express why the audience cares.
+- Angles should be scriptable premises, not broad topics.
+- Citations should remain visible in the editor.
+
+### GenerationRun
+
+Represents a single script generation batch.
+
+Fields:
+
+- `id`
+- `projectId`
+- `model`
+- `candidateCount`
+- `promptSummary`
+- `createdAt`
+
+Product expectations:
+
+- A run should be reproducible enough to audit what was asked.
+- Future versions should preserve prompt version, rubric version, temperature, and model endpoint.
+
+### ScriptCandidate
+
+Represents one generated script option.
+
+Fields:
+
+- `id`
+- `projectId`
+- `runId`
+- `title`
+- `angle`
+- `tags`
+- `beats`
+- `scorecard`
+- `humanEditedText`
+- `versionHistory`
+- `createdAt`
+
+Beats:
+
+- Hook
+- Setup
+- Escalation
+- Payoff
+- CTA or loop
+- Timing notes
+
+Product expectations:
+
+- The generated structure should be visible and editable.
+- The user should be able to work with the transcript as a normal script.
+- Human edits become the selected display text without losing the original generated version.
+
+### Scorecard
+
+Represents the AI and heuristic evaluation for a candidate.
+
+Dimensions:
+
+- Premise strength
+- Originality
+- Specificity
+- Clarity
+- Structure
+- Source grounding
+- Hook quality
+- Payoff quality
+- Non-slop
+
+Non-slop flags:
+
+- Generic phrasing
+- Fake insight
+- Weak premise
+- Repetitive structure
+- Unsupported claims
+- Filler language
+- Awkward or low-effort hook
+
+Product expectations:
+
+- Scores should be strict enough to suppress weak scripts.
+- Rationales should explain why a script made or missed the top 10.
+- Heuristics should provide recoverable fallback behavior if Qwen is offline.
+
+### RevisionSession / AgentMessage
+
+The current implementation stores agent messages per candidate. A later version can formalize `RevisionSession` as a first-class object.
+
+Fields currently represented:
+
+- `candidateId`
+- `role`
+- `content`
+- `createdAt`
+
+Product expectations:
+
+- Agent chat should support iterative revision.
+- Accepted suggestions should eventually be tracked separately from normal chat.
+- Human edits are authoritative.
+
+## 6. Stage 1: Research Workspace
+
+### User Goals
+
+The user needs to quickly collect and structure enough evidence to make scripts specific. They may start with a topic, a few pasted notes, a URL, or a vague creative direction.
+
+### Required v1 Capabilities
+
+- Create and edit project metadata.
+- Add a pasted note source.
+- Add a URL source.
+- Run a lightweight web search and save result snippets.
+- Build a research brief from available sources.
+- View insights, claims, angles, tensions, and citations.
+
+### Research Brief Prompt Requirements
+
+The research prompt should ask for:
+
+- Key facts
+- Contradictions
+- Proof points
+- Examples
+- Audience tensions
+- Scriptable angles
+- Source-backed claims
+- Citation references
+
+It should avoid:
+
+- Unsupported generalizations
+- Fabricated statistics
+- Fuzzy motivational language
+- Overly broad trend claims without source support
+
+### Future Research Improvements
+
+- Better URL readability extraction.
+- PDF and transcript ingestion.
+- Source credibility scoring.
+- Claim-to-source linking at the object level.
+- Research conflict detection.
+- Manual claim editing before generation.
+- File attachments with local-only storage.
+
+## 7. Stage 2: Script Generation Run
+
+### User Goals
+
+The user needs breadth. The system should create 20-40 genuinely different candidates from the same brief so the review phase has enough material to rank.
+
+### Required v1 Capabilities
+
+- Candidate count control from 20 to 40.
+- Generate candidates from project metadata and research brief.
+- Use local Qwen through the OpenAI-compatible client.
+- Preserve a deterministic fallback when AI fails.
+- Store the run and all candidates locally.
+
+### Candidate Format
+
+Every candidate should include:
+
+- Title
+- Angle
+- Tags
+- Hook
+- Setup
+- Escalation
+- Payoff
+- CTA or loop
+- Timing notes for 30-90 seconds
+
+### Variation Requirements
+
+Generation should intentionally vary:
+
+- Hook type
+- Angle
+- Emotional frame
+- Pacing
+- Premise
+- Ending or payoff
+- Evidence used
+- Audience tension
+
+### Generation Quality Bar
+
+Generated candidates should:
+
+- Contain one clear premise.
+- Use concrete nouns and stakes.
+- Make the first line earn attention.
+- Avoid “here are tips” framing unless intentionally used and transformed.
+- Tie at least one beat back to the research brief.
+- Fit the target platform and timing.
+
+## 8. Stage 3: AI Review and Scoring
+
+### User Goals
+
+The user should not be asked to read 40 rough drafts. The system should judge all candidates first and surface only the top 10.
+
+### Required v1 Capabilities
+
+- Score every candidate.
+- Apply the idea plus execution rubric.
+- Produce flags and rationale.
+- Sort candidates by total score.
+- Show only top 10 in the review board.
+- Preserve lower-ranked candidates in storage for future audit.
+
+### Rubric
+
+Each dimension uses a 0-10 score.
+
+Premise strength:
+
+- Does the script have a clear and compelling core idea?
+- Is there enough tension to justify a short-form video?
+
+Originality:
+
+- Does this avoid familiar creator clichés?
+- Does it frame the topic in a fresh or surprising way?
+
+Specificity:
+
+- Does it contain concrete details, examples, or proof?
+- Could the script apply to this project specifically rather than any topic?
+
+Clarity:
+
+- Can a viewer understand the argument quickly?
+- Are the beats easy to follow?
+
+Structure:
+
+- Does it move from hook to setup to escalation to payoff?
+- Is the ending earned?
+
+Source grounding:
+
+- Does the script use the research brief accurately?
+- Are claims supported?
+
+Hook quality:
+
+- Is the first line sharp?
+- Does it create tension, curiosity, or useful friction?
+
+Payoff quality:
+
+- Does the script resolve the tension?
+- Does the ending feel concrete rather than moralizing?
+
+Non-slop:
+
+- Does the script avoid filler, fake insight, generic phrasing, unsupported claims, and low-effort structure?
+
+### Review Board Card
+
+Each card should show:
+
+- Title
+- Angle
+- Total score
+- Rubric highlights
+- Non-slop flags
+- Source grounding signal
+- Why it made top 10
+
+## 9. Stage 4: Human Revision
+
+### User Goals
+
+The human should refine the best scripts in a focused editor while preserving control.
+
+### Required v1 Capabilities
+
+- Open a selected top-10 script.
+- Edit transcript text directly.
+- Save revisions locally.
+- Preserve version history.
+- View scorecard beside the script.
+- View source references.
+- Chat with a revision agent.
+
+### Revision Agent Behavior
+
+The agent can:
+
+- Suggest stronger hooks.
+- Tighten wording.
+- Propose alternate endings.
+- Identify weak claims.
+- Suggest source-grounded improvements.
+- Rewrite a selected beat when asked.
+
+The agent should not:
+
+- Automatically overwrite human edits.
+- Publish or export without user action.
+- Invent unsupported proof.
+
+## 10. Export Boundary
+
+V1 export is local-only.
+
+Acceptable v1 export formats:
+
+- Markdown
+- Plain text
+- Copy-ready transcript
+
+Out of scope:
+
+- Auto-posting
+- Scheduling
+- Social account connection
+- Performance analytics ingestion
+
+The export service should render:
+
+- Project metadata
+- Script title and angle
+- Final edited transcript
+- Scorecard total and dimensions
+- Flags
+- Rationale
+- Citations
+
+## 11. UI Layout Direction
+
+The UI should feel like a quiet production tool, not a landing page.
+
+Primary shell:
+
+- Left sidebar: projects.
+- Main column: stage workflow.
+- Detail column: editor and revision agent.
+
+Research screen:
+
+- Project metadata form.
+- Source input controls.
+- Search controls.
+- Research brief grid.
+- Source list.
+
+Generation screen:
+
+- Candidate count slider.
+- Backend/model status.
+- Generate and score action.
+- Run metrics.
+
+Review screen:
+
+- Top 10 candidate cards.
+- Score and flags.
+- Short rationale.
+
+Editor detail:
+
+- Selected script title and angle.
+- Editable script text.
+- Save revision action.
+- Scorecard grid.
+- Revision agent chat.
+
+Design constraints:
+
+- Avoid marketing hero sections.
+- Avoid decorative backgrounds.
+- Avoid nested cards.
+- Keep information dense but readable.
+- Use native controls and SF Symbols.
+- Ensure text stays within bounds.
+
+## 12. Persistence
+
+Current persistence is a local JSON database:
+
+`Application Support/NativeScriptEditor/script-editor-db.json`
+
+This is acceptable for v1.
+
+Future options:
+
+- SwiftData
+- SQLite
+- Core Data
+- Per-project bundle directories
+- Cloud sync later, if needed
+
+Persistence requirements:
+
+- No project data should be lost if Qwen fails.
+- Saving a revision should preserve prior text.
+- Research and generated candidates should survive restart.
+- Updates should be additive or upsert-style. Avoid destructive data operations.
+
+## 13. Backend Abstraction
+
+The current backend is `OpenAICompatibleClient`, using a chat completions request.
+
+Backend requirements:
+
+- OpenAI-compatible chat endpoint support.
+- Configurable base URL.
+- Configurable model name.
+- Optional API key.
+- Recoverable errors surfaced in the UI.
+- No workflow logic tied to a specific vendor.
+
+Future improvements:
+
+- Model settings panel.
+- Health check endpoint.
+- Streaming responses.
+- Per-stage model selection.
+- Hosted fallback model.
+- Cost and token telemetry.
+
+## 14. Testing Plan
+
+Core tests should cover:
+
+- Persistence round trip.
+- Research fallback behavior.
+- JSON extraction from fenced and unfenced model output.
+- Candidate generation count clamping.
+- Top 10 ranking.
+- Rubric scoring.
+- Non-slop flag detection.
+- Prompt requirements.
+- Markdown export.
+- Revision history preservation.
+
+UI tests can come later when the local Swift/Xcode environment is healthy.
+
+## 15. Current Known Blocker
+
+The local machine currently has a Swift Command Line Tools mismatch. `swift test` fails before package code is compiled because SwiftPM cannot link the manifest and direct `swiftc` cannot build Foundation modules.
+
+Observed symptoms:
+
+- `PackageDescription.Package.__allocating_init` undefined during manifest compilation.
+- `SwiftBridging` module redefinition.
+- Foundation/CoreFoundation report SDK/compiler mismatch.
+
+Likely fix:
+
+- Install or select a full Xcode toolchain that matches the installed SDK.
+- Run `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` after Xcode is installed.
+- Re-run `swift test` from `macos/ScriptEditor`.
+
+Until then, structural verification is limited to file review and non-Swift shell checks.
+
+## 16. Parallel Build Lanes
+
+### Lane A: Rubric and Quality Scoring
+
+Owner files:
+
+- `Sources/ScriptEditorCore/Rubric.swift`
+- `Tests/ScriptEditorCoreTests/RubricTests.swift`
+- Minimal integration in `WorkflowEngine.swift`
+
+Goals:
+
+- Extract score dimensions into reusable definitions.
+- Define non-slop flags in one place.
+- Move heuristic scoring out of `WorkflowEngine`.
+- Keep AI score parsing compatible with existing `Scorecard`.
+
+Acceptance criteria:
+
+- WorkflowEngine can score via the rubric service.
+- Tests confirm generic, unsupported, filler-heavy scripts are flagged.
+- Tests confirm strong source-grounded scripts score higher.
+
+### Lane B: Prompt Library
+
+Owner files:
+
+- `Sources/ScriptEditorCore/PromptLibrary.swift`
+- `Tests/ScriptEditorCoreTests/PromptLibraryTests.swift`
+- Minimal integration in `WorkflowEngine.swift`
+
+Goals:
+
+- Centralize prompts for brief, generation, scoring, and revision.
+- Add prompt version identifiers.
+- Keep Qwen-compatible JSON instructions strict.
+- Make future prompt iteration easier.
+
+Acceptance criteria:
+
+- WorkflowEngine gets prompts from `PromptLibrary`.
+- Tests verify key format requirements are present.
+- Prompt text remains explicit about citations, non-slop, and top-10 scoring.
+
+### Lane C: Approved Script Export
+
+Owner files:
+
+- `Sources/ScriptEditorCore/ExportService.swift`
+- `Tests/ScriptEditorCoreTests/ExportServiceTests.swift`
+- Minimal model extensions only if necessary.
+
+Goals:
+
+- Render an approved script as Markdown.
+- Include project metadata, final script, scorecard, flags, rationale, and citations.
+- Keep this strictly local and non-posting.
+
+Acceptance criteria:
+
+- Export service has no side effects.
+- Tests verify Markdown contains project, script, scorecard, and citations.
+- Export works with generated or human-edited script text.
+
+## 17. Next Product Milestones
+
+### Milestone 1: Stabilize Core
+
+- Rubric extraction.
+- Prompt library.
+- Export service.
+- Tests for all core workflow behavior.
+- Resolve Swift toolchain and run tests.
+
+### Milestone 2: Editor Polish
+
+- Better scorecard layout.
+- Source references panel.
+- Version history viewer.
+- Candidate search/filter.
+- Clear backend error affordances.
+
+### Milestone 3: Research Depth
+
+- Better web extraction.
+- File import.
+- Claim objects with source IDs.
+- Credibility metadata.
+- Contradiction detection.
+
+### Milestone 4: Script Production
+
+- Markdown/plain-text export UI.
+- Copy final transcript action.
+- Shot/timing notes refinement.
+- Multiple platform formats.
+- Human approval state.
+
+### Milestone 5: Optional Automation Planning
+
+- Posting/export strategy.
+- Human approval gate.
+- Account connection threat model.
+- Draft-only integrations.
+- Performance feedback ingestion.
+
+## 18. Definition of Done for V1
+
+V1 is ready when:
+
+- A user can create a project.
+- A user can add research sources.
+- The app can build a research brief.
+- The app can generate 20-40 candidates.
+- The app can score all candidates.
+- Only the top 10 appear on the review board.
+- The user can open and edit a top candidate.
+- The side-agent can provide suggestions without overwriting the user.
+- Revision history is preserved.
+- Approved scripts can be exported locally.
+- Project data survives app restart.
+- Qwen/backend failures are shown as recoverable errors.
+- Tests pass in a healthy Xcode environment.
+
+## 19. Non-Goals
+
+- Auto-posting.
+- Social account management.
+- Long-form YouTube scripting.
+- Newsletter/thread generation.
+- Multi-user collaboration.
+- Cloud sync.
+- Dependency on Hermes Workspace runtime.
+- Replacing human editorial judgment.
+
+## 20. Open Questions
+
+- Should projects eventually support multiple briefs?
+- Should each generated candidate track exact source IDs used per beat?
+- Should scoring be done by the same model as generation or a stricter hosted judge?
+- Should the top-10 threshold be fixed count or minimum score plus count?
+- Should revision chat attach suggestions to text ranges?
+- Should approved scripts become a separate object from candidates?
+- Should export files be written by the app or rendered for copy first?
+

--- a/macos/ScriptEditor/Package.swift
+++ b/macos/ScriptEditor/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "ScriptEditor",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "ScriptEditorCore", targets: ["ScriptEditorCore"]),
+        .executable(name: "ScriptEditorApp", targets: ["ScriptEditorApp"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "ScriptEditorCore"),
+        .executableTarget(
+            name: "ScriptEditorApp",
+            dependencies: ["ScriptEditorCore"]
+        ),
+        .testTarget(
+            name: "ScriptEditorCoreTests",
+            dependencies: ["ScriptEditorCore"]
+        ),
+    ]
+)

--- a/macos/ScriptEditor/README.md
+++ b/macos/ScriptEditor/README.md
@@ -4,6 +4,20 @@ Standalone SwiftUI macOS app for developing short-form video scripts from resear
 
 ## Run
 
+From the Hermes Workspace repo root:
+
+```sh
+pnpm script-editor:mac
+```
+
+Or launch the script directly:
+
+```sh
+./scripts/start-script-editor-mac.sh
+```
+
+From the app package directory:
+
 ```sh
 cd macos/ScriptEditor
 swift run ScriptEditorApp

--- a/macos/ScriptEditor/README.md
+++ b/macos/ScriptEditor/README.md
@@ -1,0 +1,29 @@
+# Native Script Editor
+
+Standalone SwiftUI macOS app for developing short-form video scripts from research through human revision. The app is independent from Hermes and defaults to a local OpenAI-compatible Qwen endpoint.
+
+## Run
+
+```sh
+cd macos/ScriptEditor
+swift run ScriptEditorApp
+```
+
+Default AI backend:
+
+- Base URL: `http://127.0.0.1:8081/v1`
+- Model: `mlx-community/Qwen3-1.7B-4bit`
+
+Project data is stored locally in Application Support at `NativeScriptEditor/script-editor-db.json`.
+
+## Workflow
+
+1. Create a project with topic, audience, platform, tone, goals, and constraints.
+2. Add research from notes, URLs, or search snippets.
+3. Build a structured research brief with insights, claims, angles, tensions, and citations.
+4. Generate 20-40 short-form script candidates.
+5. Score every candidate with the idea and execution rubric.
+6. Review only the top 10 candidates.
+7. Edit the selected script manually with side-agent revision assistance.
+
+V1 intentionally stops at approved scripts. Exporting and posting automation stay out of scope until the research, writing, and revision workflow feels strong.

--- a/macos/ScriptEditor/README.md
+++ b/macos/ScriptEditor/README.md
@@ -19,11 +19,29 @@ Project data is stored locally in Application Support at `NativeScriptEditor/scr
 ## Workflow
 
 1. Create a project with topic, audience, platform, tone, goals, and constraints.
-2. Add research from notes, URLs, or search snippets.
+2. Add research from notes, URLs, local `.txt`/`.md`/`.csv`/`.json` files, or search snippets.
 3. Build a structured research brief with insights, claims, angles, tensions, and citations.
 4. Generate 20-40 short-form script candidates.
 5. Score every candidate with the idea and execution rubric.
 6. Review only the top 10 candidates.
 7. Edit the selected script manually with side-agent revision assistance.
+8. Approve a final script and render a local Markdown export.
 
-V1 intentionally stops at approved scripts. Exporting and posting automation stay out of scope until the research, writing, and revision workflow feels strong.
+V1 intentionally stops at approved scripts. Posting automation stays out of scope until the research, writing, and revision workflow feels strong.
+
+## Current v1 Build-Out
+
+- `Rubric` centralizes score dimensions and non-slop flags.
+- `PromptLibrary` centralizes versioned prompts for research, generation, scoring, and revision.
+- `SourceIngestionService` imports local notes and text-like files with heuristic fact extraction.
+- `BackendHealthService` checks the configured OpenAI-compatible backend before generation.
+- `ApprovalService` creates immutable approved script snapshots.
+- `ExportService` renders approved scripts to Markdown without posting anywhere.
+
+## Verification Note
+
+`swift test` is currently blocked on this machine by a Command Line Tools SwiftPM/SDK mismatch before package code compiles. A lightweight syntax parse has been used as the local guard:
+
+```sh
+swiftc -parse Sources/ScriptEditorCore/*.swift Sources/ScriptEditorApp/*.swift Tests/ScriptEditorCoreTests/*.swift
+```

--- a/macos/ScriptEditor/README.md
+++ b/macos/ScriptEditor/README.md
@@ -10,6 +10,13 @@ From the Hermes Workspace repo root:
 pnpm script-editor:mac
 ```
 
+If the local Swift toolchain is unavailable, use the built-in Hermes Workspace
+web section instead:
+
+```text
+http://127.0.0.1:3000/script-editor
+```
+
 Or launch the script directly:
 
 ```sh

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
@@ -1,0 +1,279 @@
+import Foundation
+import ScriptEditorCore
+
+@MainActor
+final class AppViewModel: ObservableObject {
+    @Published var snapshot = ScriptEditorSnapshot()
+    @Published var selectedProjectId: UUID?
+    @Published var selectedCandidateId: UUID?
+    @Published var projectDraft = Project()
+    @Published var sourceTitle = ""
+    @Published var sourceLocator = ""
+    @Published var sourceBody = ""
+    @Published var sourceKind: SourceKind = .note
+    @Published var searchQuery = ""
+    @Published var candidateCount = 24.0
+    @Published var editorText = ""
+    @Published var chatInput = ""
+    @Published var isBusy = false
+    @Published var status = "Ready"
+    @Published var lastError: String?
+
+    let configuration = AIBackendConfiguration()
+    private var database: LocalScriptDatabase?
+    private let webResearch = WebResearchService()
+    private lazy var workflow = WorkflowEngine(ai: OpenAICompatibleClient(configuration: configuration))
+
+    var selectedProject: Project? {
+        guard let selectedProjectId else { return nil }
+        return snapshot.projects.first { $0.id == selectedProjectId }
+    }
+
+    var selectedBrief: ResearchBrief? {
+        guard let selectedProjectId else { return nil }
+        return snapshot.briefs.first { $0.projectId == selectedProjectId }
+    }
+
+    var projectSources: [ResearchSource] {
+        guard let selectedProjectId else { return [] }
+        return snapshot.sources
+            .filter { $0.projectId == selectedProjectId }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var projectCandidates: [ScriptCandidate] {
+        guard let selectedProjectId else { return [] }
+        return snapshot.candidates
+            .filter { $0.projectId == selectedProjectId && $0.scorecard != nil }
+            .sorted { ($0.scorecard?.total ?? 0, $0.createdAt) > ($1.scorecard?.total ?? 0, $1.createdAt) }
+    }
+
+    var topCandidates: [ScriptCandidate] {
+        Array(projectCandidates.prefix(10))
+    }
+
+    var selectedCandidate: ScriptCandidate? {
+        guard let selectedCandidateId else { return topCandidates.first }
+        return snapshot.candidates.first { $0.id == selectedCandidateId }
+    }
+
+    var selectedMessages: [AgentMessage] {
+        guard let candidate = selectedCandidate else { return [] }
+        return snapshot.agentMessages
+            .filter { $0.candidateId == candidate.id }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func load() {
+        Task {
+            let db = await LocalScriptDatabase()
+            database = db
+            snapshot = await db.readSnapshot()
+            if selectedProjectId == nil {
+                selectProject(snapshot.projects.first)
+            }
+            if snapshot.projects.isEmpty {
+                createProject()
+            }
+        }
+    }
+
+    func createProject() {
+        let project = Project(title: "Untitled Script Project")
+        Task { await saveProject(project, selectAfterSave: true) }
+    }
+
+    func selectProject(_ project: Project?) {
+        guard let project else { return }
+        selectedProjectId = project.id
+        projectDraft = project
+        selectedCandidateId = topCandidates.first?.id
+        editorText = selectedCandidate?.displayText ?? ""
+        lastError = nil
+    }
+
+    func saveProjectDraft() {
+        Task { await saveProject(projectDraft, selectAfterSave: true) }
+    }
+
+    func addSource() {
+        guard let selectedProjectId, !sourceBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        setBusy("Saving source...")
+        let source = ResearchSource(
+            projectId: selectedProjectId,
+            kind: sourceKind,
+            title: sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Untitled source" : sourceTitle,
+            locator: sourceLocator,
+            rawText: sourceBody
+        )
+        Task {
+            do {
+                try await database?.addSource(source)
+                await refresh(status: "Source saved")
+                sourceTitle = ""
+                sourceLocator = ""
+                sourceBody = ""
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func fetchURLSource() {
+        guard let selectedProjectId, let url = URL(string: sourceLocator), !sourceLocator.isEmpty else { return }
+        setBusy("Fetching URL...")
+        Task {
+            do {
+                let text = try await webResearch.fetchURL(url)
+                let source = ResearchSource(
+                    projectId: selectedProjectId,
+                    kind: .url,
+                    title: sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? url.host ?? url.absoluteString : sourceTitle,
+                    locator: url.absoluteString,
+                    rawText: text,
+                    credibilityNote: "Fetched directly from URL"
+                )
+                try await database?.addSource(source)
+                await refresh(status: "URL source added")
+                sourceTitle = ""
+                sourceLocator = ""
+                sourceBody = ""
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func runSearch() {
+        guard let selectedProjectId, !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        setBusy("Searching...")
+        Task {
+            do {
+                let results = try await webResearch.search(query: searchQuery, limit: 5)
+                for result in results {
+                    let source = ResearchSource(
+                        projectId: selectedProjectId,
+                        kind: .webResult,
+                        title: result.title,
+                        locator: result.url,
+                        rawText: result.snippet,
+                        credibilityNote: "Search result snippet"
+                    )
+                    try await database?.addSource(source)
+                }
+                await refresh(status: "Search results added")
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func buildBrief() {
+        guard let project = selectedProject else { return }
+        setBusy("Building research brief...")
+        let sources = projectSources
+        Task {
+            let brief = await workflow.buildResearchBrief(project: project, sources: sources)
+            do {
+                try await database?.saveBrief(brief)
+                await refresh(status: "Research brief ready")
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func generateAndScore() {
+        guard let project = selectedProject else { return }
+        let brief = selectedBrief ?? ResearchBrief(projectId: project.id)
+        setBusy("Generating and scoring candidates...")
+        Task {
+            let (run, candidates) = await workflow.generateCandidates(
+                project: project,
+                brief: brief,
+                count: Int(candidateCount.rounded()),
+                model: configuration.model
+            )
+            let scored = await workflow.scoreCandidates(candidates, brief: brief)
+            do {
+                try await database?.saveRun(run, candidates: scored)
+                await refresh(status: "Top 10 review board ready")
+                selectedCandidateId = topCandidates.first?.id
+                editorText = selectedCandidate?.displayText ?? ""
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func selectCandidate(_ candidate: ScriptCandidate) {
+        selectedCandidateId = candidate.id
+        editorText = candidate.displayText
+        lastError = nil
+    }
+
+    func saveRevision() {
+        guard var candidate = selectedCandidate else { return }
+        candidate.versionHistory.append(candidate.displayText)
+        candidate.humanEditedText = editorText
+        setBusy("Saving revision...")
+        Task {
+            do {
+                try await database?.updateCandidate(candidate)
+                await refresh(status: "Revision saved")
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func askAgent() {
+        guard let candidate = selectedCandidate, let brief = selectedBrief, !chatInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let userText = chatInput
+        chatInput = ""
+        setBusy("Asking revision agent...")
+        Task {
+            do {
+                try await database?.addAgentMessage(AgentMessage(candidateId: candidate.id, role: "human", content: userText))
+                let freshSnapshot = await database?.readSnapshot()
+                let freshHistory = freshSnapshot?.agentMessages.filter { $0.candidateId == candidate.id } ?? selectedMessages
+                let response = await workflow.revise(candidate: candidate, brief: brief, userMessage: userText, history: freshHistory)
+                try await database?.addAgentMessage(AgentMessage(candidateId: candidate.id, role: "agent", content: response))
+                await refresh(status: "Agent suggestion ready")
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    private func saveProject(_ project: Project, selectAfterSave: Bool) async {
+        setBusy("Saving project...")
+        do {
+            let saved = try await database?.upsertProject(project)
+            await refresh(status: "Project saved")
+            if selectAfterSave, let saved {
+                selectProject(saved)
+            }
+        } catch {
+            show(error)
+        }
+    }
+
+    private func refresh(status: String) async {
+        snapshot = await database?.readSnapshot() ?? ScriptEditorSnapshot()
+        self.status = status
+        isBusy = false
+    }
+
+    private func setBusy(_ message: String) {
+        isBusy = true
+        status = message
+        lastError = nil
+    }
+
+    private func show(_ error: Error) {
+        lastError = error.localizedDescription
+        status = "Needs attention"
+        isBusy = false
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
@@ -15,6 +15,7 @@ final class AppViewModel: ObservableObject {
     @Published var candidateCount = 24.0
     @Published var editorText = ""
     @Published var chatInput = ""
+    @Published var exportedMarkdown = ""
     @Published var isBusy = false
     @Published var status = "Ready"
     @Published var lastError: String?
@@ -244,6 +245,18 @@ final class AppViewModel: ObservableObject {
                 show(error)
             }
         }
+    }
+
+    func renderExportMarkdown() {
+        guard let project = selectedProject, let candidate = selectedCandidate else { return }
+        exportedMarkdown = ExportService().renderApprovedScriptMarkdown(
+            project: project,
+            candidate: candidate,
+            brief: selectedBrief,
+            sources: projectSources,
+            exportedAt: Date()
+        )
+        status = "Approved script export rendered"
     }
 
     private func saveProject(_ project: Project, selectAfterSave: Bool) async {

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/AppViewModel.swift
@@ -15,14 +15,19 @@ final class AppViewModel: ObservableObject {
     @Published var candidateCount = 24.0
     @Published var editorText = ""
     @Published var chatInput = ""
+    @Published var reviewerNote = ""
     @Published var exportedMarkdown = ""
+    @Published var approvedScript: ApprovedScript?
+    @Published var backendHealthStatus: BackendHealthStatus?
     @Published var isBusy = false
     @Published var status = "Ready"
     @Published var lastError: String?
 
     let configuration = AIBackendConfiguration()
     private var database: LocalScriptDatabase?
+    private let sourceIngestion = SourceIngestionService()
     private let webResearch = WebResearchService()
+    private lazy var backendHealth = BackendHealthService(configuration: configuration)
     private lazy var workflow = WorkflowEngine(ai: OpenAICompatibleClient(configuration: configuration))
 
     var selectedProject: Project? {
@@ -90,6 +95,8 @@ final class AppViewModel: ObservableObject {
         projectDraft = project
         selectedCandidateId = topCandidates.first?.id
         editorText = selectedCandidate?.displayText ?? ""
+        approvedScript = nil
+        exportedMarkdown = ""
         lastError = nil
     }
 
@@ -100,17 +107,37 @@ final class AppViewModel: ObservableObject {
     func addSource() {
         guard let selectedProjectId, !sourceBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         setBusy("Saving source...")
-        let source = ResearchSource(
-            projectId: selectedProjectId,
-            kind: sourceKind,
-            title: sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Untitled source" : sourceTitle,
-            locator: sourceLocator,
-            rawText: sourceBody
-        )
         Task {
             do {
+                let source = try sourceIngestion.ingestNote(
+                    projectId: selectedProjectId,
+                    title: sourceTitle,
+                    text: sourceBody,
+                    locator: sourceLocator
+                )
                 try await database?.addSource(source)
                 await refresh(status: "Source saved")
+                sourceTitle = ""
+                sourceLocator = ""
+                sourceBody = ""
+            } catch {
+                show(error)
+            }
+        }
+    }
+
+    func importFileSource() {
+        guard let selectedProjectId, !sourceLocator.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        setBusy("Importing file source...")
+        Task {
+            do {
+                let source = try sourceIngestion.ingestFile(
+                    projectId: selectedProjectId,
+                    locator: sourceLocator,
+                    title: sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : sourceTitle
+                )
+                try await database?.addSource(source)
+                await refresh(status: "File source imported")
                 sourceTitle = ""
                 sourceLocator = ""
                 sourceBody = ""
@@ -132,6 +159,7 @@ final class AppViewModel: ObservableObject {
                     title: sourceTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? url.host ?? url.absoluteString : sourceTitle,
                     locator: url.absoluteString,
                     rawText: text,
+                    extractedFacts: SourceIngestionService.extractFacts(from: text),
                     credibilityNote: "Fetched directly from URL"
                 )
                 try await database?.addSource(source)
@@ -158,6 +186,7 @@ final class AppViewModel: ObservableObject {
                         title: result.title,
                         locator: result.url,
                         rawText: result.snippet,
+                        extractedFacts: SourceIngestionService.extractFacts(from: result.snippet),
                         credibilityNote: "Search result snippet"
                     )
                     try await database?.addSource(source)
@@ -207,9 +236,22 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+    func checkBackendHealth() {
+        setBusy("Checking backend...")
+        Task {
+            let health = await backendHealth.check()
+            backendHealthStatus = health
+            status = health.reachable ? "Backend reachable" : "Backend unavailable"
+            lastError = health.reachable ? nil : health.message
+            isBusy = false
+        }
+    }
+
     func selectCandidate(_ candidate: ScriptCandidate) {
         selectedCandidateId = candidate.id
         editorText = candidate.displayText
+        approvedScript = nil
+        exportedMarkdown = ""
         lastError = nil
     }
 
@@ -249,14 +291,26 @@ final class AppViewModel: ObservableObject {
 
     func renderExportMarkdown() {
         guard let project = selectedProject, let candidate = selectedCandidate else { return }
-        exportedMarkdown = ExportService().renderApprovedScriptMarkdown(
+        let candidateForApproval = candidateWithCurrentEditorText(candidate)
+        let approved = ApprovalService().approve(
             project: project,
-            candidate: candidate,
+            candidate: candidateForApproval,
             brief: selectedBrief,
-            sources: projectSources,
-            exportedAt: Date()
+            reviewerNote: reviewerNote,
+            approvedAt: Date()
         )
+        approvedScript = approved
+        exportedMarkdown = ExportService().renderApprovedScriptMarkdown(approvedScript: approved, sources: projectSources)
         status = "Approved script export rendered"
+    }
+
+    private func candidateWithCurrentEditorText(_ candidate: ScriptCandidate) -> ScriptCandidate {
+        var next = candidate
+        let trimmedEditorText = editorText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedEditorText.isEmpty {
+            next.humanEditedText = editorText
+        }
+        return next
     }
 
     private func saveProject(_ project: Project, selectAfterSave: Bool) async {

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
@@ -359,6 +359,7 @@ private struct ReviewEditor: View {
                     }
 
                     AgentChat(model: model)
+                    ExportPanel(model: model)
                 }
                 .padding(22)
             }
@@ -399,6 +400,36 @@ private struct AgentChat: View {
                 }
                 .help("Send")
                 .disabled(model.chatInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+}
+
+private struct ExportPanel: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                SectionTitle("Approved Export", systemImage: "square.and.arrow.up")
+                Spacer()
+                Button {
+                    model.renderExportMarkdown()
+                } label: {
+                    Label("Render Markdown", systemImage: "doc.text")
+                }
+                .disabled(model.selectedCandidate == nil)
+            }
+            if model.exportedMarkdown.isEmpty {
+                EmptyState(text: "Render a local Markdown artifact when the script is human-approved.")
+            } else {
+                TextEditor(text: $model.exportedMarkdown)
+                    .font(.system(.caption, design: .monospaced))
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .frame(minHeight: 180)
+                    .background(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
             }
         }
     }

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
         .onAppear { model.load() }
         .toolbar {
             ToolbarItemGroup {
-                Label(model.configuration.model, systemImage: "cpu")
+                Label(model.backendHealthStatus?.reachable == false ? "Backend offline" : model.configuration.model, systemImage: "cpu")
                     .labelStyle(.titleAndIcon)
                 if model.isBusy {
                     ProgressView()
@@ -190,6 +190,9 @@ private struct ResearchWorkspace: View {
                 Button { model.fetchURLSource() } label: {
                     Label("Fetch URL", systemImage: "link")
                 }
+                Button { model.importFileSource() } label: {
+                    Label("Import File", systemImage: "doc.badge.plus")
+                }
                 Spacer()
             }
             HStack {
@@ -254,6 +257,22 @@ private struct GenerationWorkspace: View {
                             .foregroundStyle(.secondary)
                         Text(model.configuration.model)
                             .foregroundStyle(.secondary)
+                    }
+                    HStack(alignment: .firstTextBaseline) {
+                        Button {
+                            model.checkBackendHealth()
+                        } label: {
+                            Label("Check Backend", systemImage: "waveform.path.ecg")
+                        }
+                        if let backend = model.backendHealthStatus {
+                            Text(backend.message)
+                                .font(.callout)
+                                .foregroundStyle(backend.reachable ? .green : .red)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Text("\(backend.latency, specifier: "%.2f")s")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     Button {
                         model.generateAndScore()
@@ -416,9 +435,22 @@ private struct ExportPanel: View {
                 Button {
                     model.renderExportMarkdown()
                 } label: {
-                    Label("Render Markdown", systemImage: "doc.text")
+                    Label("Approve and Render", systemImage: "checkmark.seal")
                 }
                 .disabled(model.selectedCandidate == nil)
+            }
+            TextField("Reviewer note", text: $model.reviewerNote, axis: .vertical)
+                .lineLimit(1...3)
+                .textFieldStyle(.roundedBorder)
+            if let approved = model.approvedScript {
+                HStack {
+                    Label("Approved", systemImage: "checkmark.seal.fill")
+                        .foregroundStyle(.green)
+                    Text(approved.approvedAt, style: .time)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .font(.caption)
             }
             if model.exportedMarkdown.isEmpty {
                 EmptyState(text: "Render a local Markdown artifact when the script is human-approved.")
@@ -506,6 +538,12 @@ private struct SourceRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(3)
+            if !source.extractedFacts.isEmpty {
+                Text(source.extractedFacts.prefix(2).joined(separator: " "))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
         }
         .padding(10)
         .background(.thinMaterial)

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/ContentView.swift
@@ -1,0 +1,662 @@
+import ScriptEditorCore
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var model = AppViewModel()
+    @State private var stage = Stage.research
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 240, ideal: 280)
+        } content: {
+            workflow
+                .navigationSplitViewColumnWidth(min: 480, ideal: 620)
+        } detail: {
+            ReviewEditor(model: model)
+                .navigationSplitViewColumnWidth(min: 420, ideal: 560)
+        }
+        .onAppear { model.load() }
+        .toolbar {
+            ToolbarItemGroup {
+                Label(model.configuration.model, systemImage: "cpu")
+                    .labelStyle(.titleAndIcon)
+                if model.isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private var sidebar: some View {
+        VStack(spacing: 0) {
+            List(selection: $model.selectedProjectId) {
+                ForEach(model.snapshot.projects) { project in
+                    Button {
+                        model.selectProject(project)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(project.title)
+                                .font(.headline)
+                                .lineLimit(1)
+                            Text(project.topic.isEmpty ? "No topic yet" : project.topic)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .tag(project.id)
+                }
+            }
+            .listStyle(.sidebar)
+
+            Button {
+                model.createProject()
+            } label: {
+                Label("New Project", systemImage: "plus")
+                    .frame(maxWidth: .infinity)
+            }
+            .padding()
+        }
+    }
+
+    private var workflow: some View {
+        VStack(spacing: 0) {
+            Picker("Stage", selection: $stage) {
+                ForEach(Stage.allCases) { stage in
+                    Label(stage.title, systemImage: stage.symbol).tag(stage)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            Divider()
+
+            Group {
+                switch stage {
+                case .research:
+                    ResearchWorkspace(model: model)
+                case .generation:
+                    GenerationWorkspace(model: model)
+                case .review:
+                    ReviewBoard(model: model)
+                }
+            }
+        }
+        .overlay(alignment: .bottomLeading) {
+            StatusBar(status: model.status, error: model.lastError)
+        }
+    }
+}
+
+private enum Stage: String, CaseIterable, Identifiable {
+    case research
+    case generation
+    case review
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .research: "Research"
+        case .generation: "Generation"
+        case .review: "Review"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .research: "doc.text.magnifyingglass"
+        case .generation: "sparkles"
+        case .review: "checklist.checked"
+        }
+    }
+}
+
+private struct ResearchWorkspace: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                projectFields
+                Divider()
+                sourceInput
+                Divider()
+                briefSection
+                sourcesList
+            }
+            .padding(22)
+        }
+    }
+
+    private var projectFields: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionTitle("Project Setup", systemImage: "slider.horizontal.3")
+            TextField("Title", text: $model.projectDraft.title)
+                .textFieldStyle(.roundedBorder)
+            TextField("Topic", text: $model.projectDraft.topic)
+                .textFieldStyle(.roundedBorder)
+            HStack {
+                TextField("Audience", text: $model.projectDraft.audience)
+                    .textFieldStyle(.roundedBorder)
+                Picker("Platform", selection: $model.projectDraft.platform) {
+                    ForEach(Platform.allCases) { platform in
+                        Text(platform.rawValue).tag(platform)
+                    }
+                }
+                .frame(width: 190)
+            }
+            HStack {
+                TextField("Tone", text: $model.projectDraft.tone)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Goal", text: $model.projectDraft.goal)
+                    .textFieldStyle(.roundedBorder)
+            }
+            TextField("Constraints", text: $model.projectDraft.constraints, axis: .vertical)
+                .lineLimit(2...4)
+                .textFieldStyle(.roundedBorder)
+            Button {
+                model.saveProjectDraft()
+            } label: {
+                Label("Save Project", systemImage: "square.and.arrow.down")
+            }
+        }
+    }
+
+    private var sourceInput: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionTitle("Research Inputs", systemImage: "tray.and.arrow.down")
+            HStack {
+                Picker("Type", selection: $model.sourceKind) {
+                    ForEach(SourceKind.allCases) { kind in
+                        Text(kind.rawValue).tag(kind)
+                    }
+                }
+                TextField("Source title", text: $model.sourceTitle)
+                    .textFieldStyle(.roundedBorder)
+            }
+            TextField("URL, file path, or source locator", text: $model.sourceLocator)
+                .textFieldStyle(.roundedBorder)
+            TextField("Paste notes, excerpts, or fetched content", text: $model.sourceBody, axis: .vertical)
+                .lineLimit(7...12)
+                .textFieldStyle(.roundedBorder)
+            HStack {
+                Button { model.addSource() } label: {
+                    Label("Add Notes", systemImage: "text.badge.plus")
+                }
+                Button { model.fetchURLSource() } label: {
+                    Label("Fetch URL", systemImage: "link")
+                }
+                Spacer()
+            }
+            HStack {
+                TextField("Search query", text: $model.searchQuery)
+                    .textFieldStyle(.roundedBorder)
+                Button { model.runSearch() } label: {
+                    Label("Search", systemImage: "magnifyingglass")
+                }
+            }
+        }
+    }
+
+    private var briefSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                SectionTitle("Research Brief", systemImage: "doc.plaintext")
+                Spacer()
+                Button { model.buildBrief() } label: {
+                    Label("Build Brief", systemImage: "wand.and.stars")
+                }
+                .disabled(model.projectSources.isEmpty)
+            }
+            if let brief = model.selectedBrief {
+                BriefGrid(brief: brief)
+            } else {
+                EmptyState(text: "Add sources, then build a structured research brief with citations.")
+            }
+        }
+    }
+
+    private var sourcesList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            SectionTitle("Sources", systemImage: "books.vertical")
+            ForEach(model.projectSources) { source in
+                SourceRow(source: source)
+            }
+            if model.projectSources.isEmpty {
+                EmptyState(text: "No research sources yet.")
+            }
+        }
+    }
+}
+
+private struct GenerationWorkspace: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                SectionTitle("Generation Run", systemImage: "sparkles")
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Candidates")
+                        Slider(value: $model.candidateCount, in: 20...40, step: 1)
+                        Text("\(Int(model.candidateCount))")
+                            .monospacedDigit()
+                            .frame(width: 34, alignment: .trailing)
+                    }
+                    HStack {
+                        Label("Default backend", systemImage: "cpu")
+                        Text(model.configuration.baseURL.absoluteString)
+                            .foregroundStyle(.secondary)
+                        Text(model.configuration.model)
+                            .foregroundStyle(.secondary)
+                    }
+                    Button {
+                        model.generateAndScore()
+                    } label: {
+                        Label("Generate and Score", systemImage: "play.fill")
+                    }
+                    .disabled(model.selectedProject == nil)
+                }
+
+                Divider()
+
+                SectionTitle("Run Output", systemImage: "chart.bar.doc.horizontal")
+                MetricsRow(
+                    sources: model.projectSources.count,
+                    briefReady: model.selectedBrief != nil,
+                    candidates: model.projectCandidates.count,
+                    topTen: model.topCandidates.count
+                )
+                Text("The review board surfaces only the ten highest-scored scripts. Lower-scoring drafts remain stored locally for auditing and reruns.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(22)
+        }
+    }
+}
+
+private struct ReviewBoard: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                SectionTitle("Top 10 Review Board", systemImage: "rosette")
+                if model.topCandidates.isEmpty {
+                    EmptyState(text: "Generate and score candidates to populate the board.")
+                }
+                ForEach(model.topCandidates) { candidate in
+                    CandidateRow(
+                        candidate: candidate,
+                        selected: candidate.id == model.selectedCandidate?.id
+                    ) {
+                        model.selectCandidate(candidate)
+                    }
+                }
+            }
+            .padding(18)
+        }
+    }
+}
+
+private struct ReviewEditor: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let candidate = model.selectedCandidate {
+                editor(candidate)
+            } else {
+                EmptyState(text: "Select a top script to edit with the revision agent.")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    private func editor(_ candidate: ScriptCandidate) -> some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(candidate.title)
+                                .font(.title3.bold())
+                            Text(candidate.angle)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        ScorePill(score: candidate.scorecard?.total ?? 0)
+                    }
+
+                    TextEditor(text: $model.editorText)
+                        .font(.system(.body, design: .serif))
+                        .scrollContentBackground(.hidden)
+                        .padding(10)
+                        .frame(minHeight: 270)
+                        .background(.regularMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    HStack {
+                        Button { model.saveRevision() } label: {
+                            Label("Save Revision", systemImage: "square.and.arrow.down")
+                        }
+                        Spacer()
+                        Text("\(candidate.versionHistory.count) saved versions")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let scorecard = candidate.scorecard {
+                        ScorecardView(scorecard: scorecard)
+                    }
+
+                    AgentChat(model: model)
+                }
+                .padding(22)
+            }
+        }
+    }
+}
+
+private struct AgentChat: View {
+    @ObservedObject var model: AppViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionTitle("Revision Agent", systemImage: "bubble.left.and.text.bubble.right")
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(model.selectedMessages) { message in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(message.role == "human" ? "You" : "Agent")
+                            .font(.caption.bold())
+                            .foregroundStyle(message.role == "human" ? .primary : .blue)
+                        Text(message.content)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                if model.selectedMessages.isEmpty {
+                    EmptyState(text: "Ask for stronger hooks, tighter wording, alternate endings, or source-grounded improvements.")
+                }
+            }
+            HStack(alignment: .bottom) {
+                TextField("Ask for a revision suggestion", text: $model.chatInput, axis: .vertical)
+                    .lineLimit(2...5)
+                    .textFieldStyle(.roundedBorder)
+                Button { model.askAgent() } label: {
+                    Image(systemName: "paperplane.fill")
+                }
+                .help("Send")
+                .disabled(model.chatInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+}
+
+private struct SectionTitle: View {
+    let title: String
+    let systemImage: String
+
+    init(_ title: String, systemImage: String) {
+        self.title = title
+        self.systemImage = systemImage
+    }
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.headline)
+    }
+}
+
+private struct BriefGrid: View {
+    let brief: ResearchBrief
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], alignment: .leading, spacing: 12) {
+            BriefColumn(title: "Insights", items: brief.distilledInsights)
+            BriefColumn(title: "Claims", items: brief.claims)
+            BriefColumn(title: "Angles", items: brief.angles)
+            BriefColumn(title: "Tensions", items: brief.audienceTensions)
+        }
+    }
+}
+
+private struct BriefColumn: View {
+    let title: String
+    let items: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.bold())
+            ForEach(items.prefix(5), id: \.self) { item in
+                Text("• \(item)")
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct SourceRow: View {
+    let source: ResearchSource
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text(source.title)
+                    .font(.subheadline.bold())
+                    .lineLimit(1)
+                Spacer()
+                Text(source.kind.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Text(source.locator)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(source.rawText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .padding(10)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct CandidateRow: View {
+    let candidate: ScriptCandidate
+    let selected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(candidate.title)
+                            .font(.headline)
+                            .lineLimit(2)
+                        Text(candidate.angle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    Spacer()
+                    ScorePill(score: candidate.scorecard?.total ?? 0)
+                }
+                Text(candidate.scorecard?.rationale ?? "Awaiting score")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                HStack {
+                    ForEach((candidate.scorecard?.flags ?? []).prefix(3), id: \.self) { flag in
+                        Text(flag)
+                            .font(.caption2)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color.secondary.opacity(0.12))
+                            .clipShape(Capsule())
+                    }
+                    Spacer()
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(selected ? Color.accentColor.opacity(0.13) : Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct ScorecardView: View {
+    let scorecard: Scorecard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            SectionTitle("Scorecard", systemImage: "gauge.with.dots.needle.67percent")
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], alignment: .leading, spacing: 10) {
+                Metric("Premise", scorecard.premiseStrength)
+                Metric("Originality", scorecard.originality)
+                Metric("Specificity", scorecard.specificity)
+                Metric("Clarity", scorecard.clarity)
+                Metric("Structure", scorecard.structure)
+                Metric("Grounding", scorecard.sourceGrounding)
+                Metric("Hook", scorecard.hookQuality)
+                Metric("Payoff", scorecard.payoffQuality)
+                Metric("Non-slop", scorecard.nonSlop)
+            }
+            Text(scorecard.rationale)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct Metric: View {
+    let title: String
+    let value: Int
+
+    init(_ title: String, _ value: Int) {
+        self.title = title
+        self.value = value
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .lineLimit(1)
+            Spacer()
+            Text("\(value)")
+                .monospacedDigit()
+                .foregroundStyle(value >= 7 ? .green : value >= 4 ? .orange : .red)
+        }
+        .font(.caption)
+        .padding(8)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct ScorePill: View {
+    let score: Int
+
+    var body: some View {
+        Text("\(score)")
+            .font(.headline.monospacedDigit())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(score >= 68 ? .green.opacity(0.18) : .orange.opacity(0.18))
+            .clipShape(Capsule())
+            .help("Total rubric score")
+    }
+}
+
+private struct MetricsRow: View {
+    let sources: Int
+    let briefReady: Bool
+    let candidates: Int
+    let topTen: Int
+
+    var body: some View {
+        HStack(spacing: 12) {
+            MetricTile(title: "Sources", value: "\(sources)")
+            MetricTile(title: "Brief", value: briefReady ? "Ready" : "Needed")
+            MetricTile(title: "Scored", value: "\(candidates)")
+            MetricTile(title: "Surfaced", value: "\(topTen)")
+        }
+    }
+}
+
+private struct MetricTile: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title3.bold())
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct EmptyState: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(14)
+            .background(Color.secondary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct StatusBar: View {
+    let status: String
+    let error: String?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: error == nil ? "checkmark.circle" : "exclamationmark.triangle")
+            Text(error ?? status)
+                .lineLimit(2)
+        }
+        .font(.caption)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.regularMaterial)
+        .clipShape(Capsule())
+        .padding(12)
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorApp/ScriptEditorApp.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorApp/ScriptEditorApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct ScriptEditorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 1180, minHeight: 760)
+        }
+        .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified)
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/ApprovalService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/ApprovalService.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public struct ApprovedScript: Codable, Identifiable, Equatable {
+    public let id: UUID
+    public let project: Project
+    public let candidate: ScriptCandidate
+    public let brief: ResearchBrief?
+    public let scriptText: String
+    public let approvedAt: Date
+    public let reviewerNote: String
+
+    public var projectId: UUID { project.id }
+    public var candidateId: UUID { candidate.id }
+
+    public init(
+        id: UUID = UUID(),
+        project: Project,
+        candidate: ScriptCandidate,
+        brief: ResearchBrief? = nil,
+        scriptText: String,
+        approvedAt: Date = Date(),
+        reviewerNote: String = ""
+    ) {
+        self.id = id
+        self.project = project
+        self.candidate = candidate
+        self.brief = brief
+        self.scriptText = scriptText
+        self.approvedAt = approvedAt
+        self.reviewerNote = reviewerNote
+    }
+}
+
+public struct ApprovalService {
+    public init() {}
+
+    public func approve(
+        project: Project,
+        candidate: ScriptCandidate,
+        brief: ResearchBrief? = nil,
+        reviewerNote: String = "",
+        approvedAt: Date = Date()
+    ) -> ApprovedScript {
+        ApprovedScript(
+            project: project,
+            candidate: candidate,
+            brief: brief,
+            scriptText: candidate.displayText,
+            approvedAt: approvedAt,
+            reviewerNote: reviewerNote
+        )
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/BackendHealthService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/BackendHealthService.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+public struct BackendHealthStatus: Equatable, Sendable {
+    public var baseURL: URL
+    public var model: String
+    public var reachable: Bool
+    public var latency: TimeInterval
+    public var message: String
+
+    public init(baseURL: URL, model: String, reachable: Bool, latency: TimeInterval, message: String) {
+        self.baseURL = baseURL
+        self.model = model
+        self.reachable = reachable
+        self.latency = latency
+        self.message = message
+    }
+}
+
+public enum BackendHealthCheckMode: Sendable {
+    case models
+    case chatCompletions
+    case modelsThenChatCompletions
+}
+
+public final class BackendHealthService: @unchecked Sendable {
+    private let configuration: AIBackendConfiguration
+    private let session: URLSession
+    private let clock: any BackendHealthClock
+
+    public init(
+        configuration: AIBackendConfiguration = AIBackendConfiguration(),
+        session: URLSession = .shared,
+        clock: any BackendHealthClock = SystemBackendHealthClock()
+    ) {
+        self.configuration = configuration
+        self.session = session
+        self.clock = clock
+    }
+
+    public func check(mode: BackendHealthCheckMode = .modelsThenChatCompletions) async -> BackendHealthStatus {
+        let startedAt = clock.now
+        let result: HealthResult
+
+        do {
+            switch mode {
+            case .models:
+                result = try await checkModels()
+            case .chatCompletions:
+                result = try await checkChatCompletions()
+            case .modelsThenChatCompletions:
+                result = try await checkModelsThenChatCompletions()
+            }
+        } catch {
+            result = .unhealthy(message: error.localizedDescription)
+        }
+
+        return BackendHealthStatus(
+            baseURL: configuration.baseURL,
+            model: configuration.model,
+            reachable: result.reachable,
+            latency: clock.now.timeIntervalSince(startedAt),
+            message: result.message
+        )
+    }
+
+    private func checkModelsThenChatCompletions() async throws -> HealthResult {
+        do {
+            return try await checkModels()
+        } catch {
+            return try await checkChatCompletions()
+        }
+    }
+
+    private func checkModels() async throws -> HealthResult {
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("models"))
+        request.httpMethod = "GET"
+        applyAuthorization(to: &request)
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+
+        guard let decoded = try? JSONDecoder().decode(ModelsResponse.self, from: data) else {
+            return .healthy(message: "Backend responded to /models.")
+        }
+
+        let ids = decoded.data.map(\.id)
+        if ids.contains(configuration.model) {
+            return .healthy(message: "Backend is reachable and model is available.")
+        }
+        if ids.isEmpty {
+            return .healthy(message: "Backend is reachable; /models returned no model ids.")
+        }
+        return .healthy(message: "Backend is reachable; configured model was not listed by /models.")
+    }
+
+    private func checkChatCompletions() async throws -> HealthResult {
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorization(to: &request)
+        request.httpBody = try JSONEncoder().encode(ChatHealthRequest(
+            model: configuration.model,
+            messages: [
+                ChatMessage(role: "user", content: "Reply with OK.")
+            ],
+            temperature: 0,
+            maxTokens: 4,
+            stream: false
+        ))
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+
+        if let decoded = try? JSONDecoder().decode(ChatHealthResponse.self, from: data),
+           let content = decoded.choices.first?.message.content.trimmingCharacters(in: .whitespacesAndNewlines),
+           !content.isEmpty {
+            return .healthy(message: "Backend responded to chat completions.")
+        }
+        return .healthy(message: "Backend accepted chat completions request.")
+    }
+
+    private func applyAuthorization(to request: inout URLRequest) {
+        guard !configuration.apiKey.isEmpty else { return }
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+    }
+
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw BackendHealthError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw BackendHealthError.badStatus(http.statusCode, body)
+        }
+    }
+}
+
+public protocol BackendHealthClock: Sendable {
+    var now: Date { get }
+}
+
+public struct SystemBackendHealthClock: BackendHealthClock {
+    public init() {}
+
+    public var now: Date {
+        Date()
+    }
+}
+
+public enum BackendHealthError: Error, LocalizedError, Equatable {
+    case invalidResponse
+    case badStatus(Int, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "The AI backend returned an invalid response."
+        case .badStatus(let code, let body):
+            let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            if detail.isEmpty {
+                return "The AI backend returned HTTP \(code)."
+            }
+            return "The AI backend returned HTTP \(code): \(detail)"
+        }
+    }
+}
+
+private enum HealthResult {
+    case healthy(message: String)
+    case unhealthy(message: String)
+
+    var reachable: Bool {
+        switch self {
+        case .healthy:
+            return true
+        case .unhealthy:
+            return false
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .healthy(let message), .unhealthy(let message):
+            return message
+        }
+    }
+}
+
+private struct ModelsResponse: Decodable {
+    var data: [Model]
+
+    struct Model: Decodable {
+        var id: String
+    }
+}
+
+private struct ChatHealthRequest: Encodable {
+    var model: String
+    var messages: [ChatMessage]
+    var temperature: Double
+    var maxTokens: Int
+    var stream: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case model, messages, temperature, stream
+        case maxTokens = "max_tokens"
+    }
+}
+
+private struct ChatHealthResponse: Decodable {
+    var choices: [Choice]
+
+    struct Choice: Decodable {
+        var message: ChatMessage
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/ExportService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/ExportService.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+public struct ExportService {
+    public init() {}
+
+    public func renderApprovedScriptMarkdown(
+        project: Project,
+        candidate: ScriptCandidate,
+        brief: ResearchBrief? = nil,
+        sources: [ResearchSource] = [],
+        exportedAt: Date = Date()
+    ) -> String {
+        let citationItems = Self.citationItems(brief: brief, sources: sources)
+        var sections: [String] = []
+
+        sections.append("# \(candidate.title)")
+        sections.append("""
+        > v1 approved script export
+
+        ## Project
+        - Title: \(project.title)
+        - Topic: \(project.topic)
+        - Audience: \(project.audience)
+        - Platform: \(project.platform.rawValue)
+        - Tone: \(project.tone)
+        - Goal: \(project.goal)
+        - Constraints: \(Self.fallback(project.constraints))
+        - Project ID: \(project.id.uuidString)
+        - Candidate ID: \(candidate.id.uuidString)
+        - Exported At: \(Self.iso8601String(from: exportedAt))
+        """)
+        sections.append("""
+        ## Script
+        \(candidate.displayText)
+        """)
+        sections.append("""
+        ## Candidate Metadata
+        - Angle: \(candidate.angle)
+        - Tags: \(Self.list(candidate.tags))
+        - Created At: \(Self.iso8601String(from: candidate.createdAt))
+        """)
+        sections.append(Self.beatsSection(candidate.beats))
+        sections.append(Self.scorecardSection(candidate.scorecard))
+        sections.append(Self.briefSection(brief))
+        sections.append(Self.citationsSection(citationItems))
+
+        return sections
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n") + "\n"
+    }
+
+    private static func beatsSection(_ beats: ScriptBeats) -> String {
+        """
+        ## Beats
+        - Hook: \(fallback(beats.hook))
+        - Setup: \(fallback(beats.setup))
+        - Escalation: \(fallback(beats.escalation))
+        - Payoff: \(fallback(beats.payoff))
+        - CTA or Loop: \(fallback(beats.callToActionOrLoop))
+        - Timing Notes: \(fallback(beats.timingNotes))
+        """
+    }
+
+    private static func scorecardSection(_ scorecard: Scorecard?) -> String {
+        guard let scorecard else {
+            return """
+            ## Scorecard
+            No scorecard available.
+            """
+        }
+
+        return """
+        ## Scorecard
+        - Total: \(scorecard.total)/90
+        - Premise Strength: \(scorecard.premiseStrength)/10
+        - Originality: \(scorecard.originality)/10
+        - Specificity: \(scorecard.specificity)/10
+        - Clarity: \(scorecard.clarity)/10
+        - Structure: \(scorecard.structure)/10
+        - Source Grounding: \(scorecard.sourceGrounding)/10
+        - Hook Quality: \(scorecard.hookQuality)/10
+        - Payoff Quality: \(scorecard.payoffQuality)/10
+        - Non-Slop: \(scorecard.nonSlop)/10
+        - Flags: \(list(scorecard.flags))
+
+        Rationale:
+        \(fallback(scorecard.rationale))
+        """
+    }
+
+    private static func briefSection(_ brief: ResearchBrief?) -> String {
+        guard let brief else { return "" }
+
+        return """
+        ## Research Brief
+        ### Distilled Insights
+        \(markdownList(brief.distilledInsights))
+
+        ### Claims
+        \(markdownList(brief.claims))
+
+        ### Angles
+        \(markdownList(brief.angles))
+
+        ### Audience Tensions
+        \(markdownList(brief.audienceTensions))
+        """
+    }
+
+    private static func citationsSection(_ citations: [String]) -> String {
+        """
+        ## Source Citations
+        \(markdownList(citations))
+        """
+    }
+
+    private static func citationItems(brief: ResearchBrief?, sources: [ResearchSource]) -> [String] {
+        var items = brief?.citations ?? []
+        items.append(contentsOf: sources.map { source in
+            let locator = source.locator.trimmingCharacters(in: .whitespacesAndNewlines)
+            let credibilityNote = source.credibilityNote.trimmingCharacters(in: .whitespacesAndNewlines)
+            let locationText = locator.isEmpty ? "" : " - \(locator)"
+            let credibilityText = credibilityNote.isEmpty ? "" : " (\(credibilityNote))"
+            return "\(source.title) [\(source.kind.rawValue)]\(locationText)\(credibilityText)"
+        })
+        return items
+    }
+
+    private static func markdownList(_ values: [String]) -> String {
+        let cleaned = values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !cleaned.isEmpty else { return "- None" }
+        return cleaned.map { "- \($0)" }.joined(separator: "\n")
+    }
+
+    private static func list(_ values: [String]) -> String {
+        let cleaned = values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !cleaned.isEmpty else { return "None" }
+        return cleaned.joined(separator: ", ")
+    }
+
+    private static func fallback(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "None" : trimmed
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/ExportService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/ExportService.swift
@@ -4,6 +4,23 @@ public struct ExportService {
     public init() {}
 
     public func renderApprovedScriptMarkdown(
+        approvedScript: ApprovedScript,
+        sources: [ResearchSource] = [],
+        exportedAt: Date? = nil
+    ) -> String {
+        var candidate = approvedScript.candidate
+        candidate.humanEditedText = approvedScript.scriptText
+
+        renderApprovedScriptMarkdown(
+            project: approvedScript.project,
+            candidate: candidate,
+            brief: approvedScript.brief,
+            sources: sources,
+            exportedAt: exportedAt ?? approvedScript.approvedAt
+        )
+    }
+
+    public func renderApprovedScriptMarkdown(
         project: Project,
         candidate: ScriptCandidate,
         brief: ResearchBrief? = nil,

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/JSONExtraction.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/JSONExtraction.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum JSONExtraction {
+    public static func decodeObject<T: Decodable>(_ type: T.Type, from text: String) throws -> T {
+        let data = Data(extractJSON(from: text).utf8)
+        return try JSONDecoder.scriptEditor.decode(T.self, from: data)
+    }
+
+    private static func extractJSON(from text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.first == "{" || trimmed.first == "[" { return trimmed }
+        if let fenced = trimmed.range(of: "```json") {
+            let afterFence = trimmed[fenced.upperBound...]
+            if let end = afterFence.range(of: "```") {
+                return String(afterFence[..<end.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        if let firstObject = trimmed.firstIndex(of: "{"), let lastObject = trimmed.lastIndex(of: "}"), firstObject < lastObject {
+            return String(trimmed[firstObject...lastObject])
+        }
+        if let firstArray = trimmed.firstIndex(of: "["), let lastArray = trimmed.lastIndex(of: "]"), firstArray < lastArray {
+            return String(trimmed[firstArray...lastArray])
+        }
+        return trimmed
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/LocalScriptDatabase.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/LocalScriptDatabase.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+public struct ScriptEditorSnapshot: Codable, Equatable {
+    public var projects: [Project]
+    public var sources: [ResearchSource]
+    public var briefs: [ResearchBrief]
+    public var runs: [GenerationRun]
+    public var candidates: [ScriptCandidate]
+    public var agentMessages: [AgentMessage]
+
+    public init(
+        projects: [Project] = [],
+        sources: [ResearchSource] = [],
+        briefs: [ResearchBrief] = [],
+        runs: [GenerationRun] = [],
+        candidates: [ScriptCandidate] = [],
+        agentMessages: [AgentMessage] = []
+    ) {
+        self.projects = projects
+        self.sources = sources
+        self.briefs = briefs
+        self.runs = runs
+        self.candidates = candidates
+        self.agentMessages = agentMessages
+    }
+}
+
+public actor LocalScriptDatabase {
+    public let fileURL: URL
+    private var snapshot: ScriptEditorSnapshot
+
+    public init(fileURL: URL? = nil) async {
+        let resolvedURL = fileURL ?? Self.defaultDatabaseURL()
+        self.fileURL = resolvedURL
+        self.snapshot = Self.load(from: resolvedURL)
+    }
+
+    public static func defaultDatabaseURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return base
+            .appendingPathComponent("NativeScriptEditor", isDirectory: true)
+            .appendingPathComponent("script-editor-db.json")
+    }
+
+    public func readSnapshot() -> ScriptEditorSnapshot {
+        snapshot
+    }
+
+    @discardableResult
+    public func upsertProject(_ project: Project) async throws -> Project {
+        var next = project
+        next.updatedAt = Date()
+        if let index = snapshot.projects.firstIndex(where: { $0.id == project.id }) {
+            snapshot.projects[index] = next
+        } else {
+            snapshot.projects.append(next)
+        }
+        try persist()
+        return next
+    }
+
+    @discardableResult
+    public func addSource(_ source: ResearchSource) async throws -> ResearchSource {
+        snapshot.sources.append(source)
+        try persist()
+        return source
+    }
+
+    public func saveBrief(_ brief: ResearchBrief) async throws {
+        if let index = snapshot.briefs.lastIndex(where: { $0.projectId == brief.projectId }) {
+            snapshot.briefs[index] = brief
+        } else {
+            snapshot.briefs.append(brief)
+        }
+        try persist()
+    }
+
+    public func saveRun(_ run: GenerationRun, candidates: [ScriptCandidate]) async throws {
+        if let index = snapshot.runs.firstIndex(where: { $0.id == run.id }) {
+            snapshot.runs[index] = run
+        } else {
+            snapshot.runs.append(run)
+        }
+        for candidate in candidates {
+            if let index = snapshot.candidates.firstIndex(where: { $0.id == candidate.id }) {
+                snapshot.candidates[index] = candidate
+            } else {
+                snapshot.candidates.append(candidate)
+            }
+        }
+        try persist()
+    }
+
+    public func updateCandidate(_ candidate: ScriptCandidate) async throws {
+        if let index = snapshot.candidates.firstIndex(where: { $0.id == candidate.id }) {
+            snapshot.candidates[index] = candidate
+        } else {
+            snapshot.candidates.append(candidate)
+        }
+        try persist()
+    }
+
+    public func addAgentMessage(_ message: AgentMessage) async throws {
+        snapshot.agentMessages.append(message)
+        try persist()
+    }
+
+    private static func load(from url: URL) -> ScriptEditorSnapshot {
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder.scriptEditor.decode(ScriptEditorSnapshot.self, from: data)
+        } catch {
+            return ScriptEditorSnapshot()
+        }
+    }
+
+    private func persist() throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder.scriptEditor.encode(snapshot)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}
+
+public extension JSONEncoder {
+    static var scriptEditor: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}
+
+public extension JSONDecoder {
+    static var scriptEditor: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/Models.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/Models.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+public enum Platform: String, Codable, CaseIterable, Identifiable {
+    case tiktok = "TikTok"
+    case reels = "Instagram Reels"
+    case shorts = "YouTube Shorts"
+
+    public var id: String { rawValue }
+}
+
+public enum SourceKind: String, Codable, CaseIterable, Identifiable {
+    case note = "Note"
+    case url = "URL"
+    case file = "File"
+    case webResult = "Web Result"
+
+    public var id: String { rawValue }
+}
+
+public struct Project: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var title: String
+    public var topic: String
+    public var audience: String
+    public var platform: Platform
+    public var tone: String
+    public var goal: String
+    public var constraints: String
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        title: String = "Untitled Script Project",
+        topic: String = "",
+        audience: String = "",
+        platform: Platform = .tiktok,
+        tone: String = "smart, direct, high-retention",
+        goal: String = "",
+        constraints: String = "",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.topic = topic
+        self.audience = audience
+        self.platform = platform
+        self.tone = tone
+        self.goal = goal
+        self.constraints = constraints
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct ResearchSource: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var projectId: UUID
+    public var kind: SourceKind
+    public var title: String
+    public var locator: String
+    public var rawText: String
+    public var extractedFacts: [String]
+    public var credibilityNote: String
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        projectId: UUID,
+        kind: SourceKind,
+        title: String,
+        locator: String = "",
+        rawText: String,
+        extractedFacts: [String] = [],
+        credibilityNote: String = "",
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.kind = kind
+        self.title = title
+        self.locator = locator
+        self.rawText = rawText
+        self.extractedFacts = extractedFacts
+        self.credibilityNote = credibilityNote
+        self.createdAt = createdAt
+    }
+}
+
+public struct ResearchBrief: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var projectId: UUID
+    public var distilledInsights: [String]
+    public var claims: [String]
+    public var angles: [String]
+    public var audienceTensions: [String]
+    public var citations: [String]
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        projectId: UUID,
+        distilledInsights: [String] = [],
+        claims: [String] = [],
+        angles: [String] = [],
+        audienceTensions: [String] = [],
+        citations: [String] = [],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.distilledInsights = distilledInsights
+        self.claims = claims
+        self.angles = angles
+        self.audienceTensions = audienceTensions
+        self.citations = citations
+        self.createdAt = createdAt
+    }
+}
+
+public struct ScriptBeats: Codable, Equatable {
+    public var hook: String
+    public var setup: String
+    public var escalation: String
+    public var payoff: String
+    public var callToActionOrLoop: String
+    public var timingNotes: String
+
+    public init(
+        hook: String = "",
+        setup: String = "",
+        escalation: String = "",
+        payoff: String = "",
+        callToActionOrLoop: String = "",
+        timingNotes: String = "30-90 seconds"
+    ) {
+        self.hook = hook
+        self.setup = setup
+        self.escalation = escalation
+        self.payoff = payoff
+        self.callToActionOrLoop = callToActionOrLoop
+        self.timingNotes = timingNotes
+    }
+
+    public var transcript: String {
+        [hook, setup, escalation, payoff, callToActionOrLoop]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+    }
+}
+
+public struct Scorecard: Codable, Equatable {
+    public var premiseStrength: Int
+    public var originality: Int
+    public var specificity: Int
+    public var clarity: Int
+    public var structure: Int
+    public var sourceGrounding: Int
+    public var hookQuality: Int
+    public var payoffQuality: Int
+    public var nonSlop: Int
+    public var flags: [String]
+    public var rationale: String
+
+    public init(
+        premiseStrength: Int = 0,
+        originality: Int = 0,
+        specificity: Int = 0,
+        clarity: Int = 0,
+        structure: Int = 0,
+        sourceGrounding: Int = 0,
+        hookQuality: Int = 0,
+        payoffQuality: Int = 0,
+        nonSlop: Int = 0,
+        flags: [String] = [],
+        rationale: String = ""
+    ) {
+        self.premiseStrength = premiseStrength
+        self.originality = originality
+        self.specificity = specificity
+        self.clarity = clarity
+        self.structure = structure
+        self.sourceGrounding = sourceGrounding
+        self.hookQuality = hookQuality
+        self.payoffQuality = payoffQuality
+        self.nonSlop = nonSlop
+        self.flags = flags
+        self.rationale = rationale
+    }
+
+    public var total: Int {
+        premiseStrength + originality + specificity + clarity + structure + sourceGrounding + hookQuality + payoffQuality + nonSlop
+    }
+}
+
+public struct ScriptCandidate: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var projectId: UUID
+    public var runId: UUID
+    public var title: String
+    public var angle: String
+    public var tags: [String]
+    public var beats: ScriptBeats
+    public var scorecard: Scorecard?
+    public var humanEditedText: String
+    public var versionHistory: [String]
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        projectId: UUID,
+        runId: UUID,
+        title: String,
+        angle: String,
+        tags: [String] = [],
+        beats: ScriptBeats,
+        scorecard: Scorecard? = nil,
+        humanEditedText: String = "",
+        versionHistory: [String] = [],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.runId = runId
+        self.title = title
+        self.angle = angle
+        self.tags = tags
+        self.beats = beats
+        self.scorecard = scorecard
+        self.humanEditedText = humanEditedText
+        self.versionHistory = versionHistory
+        self.createdAt = createdAt
+    }
+
+    public var displayText: String {
+        humanEditedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? beats.transcript : humanEditedText
+    }
+}
+
+public struct GenerationRun: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var projectId: UUID
+    public var model: String
+    public var candidateCount: Int
+    public var promptSummary: String
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        projectId: UUID,
+        model: String,
+        candidateCount: Int,
+        promptSummary: String,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.model = model
+        self.candidateCount = candidateCount
+        self.promptSummary = promptSummary
+        self.createdAt = createdAt
+    }
+}
+
+public struct AgentMessage: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var candidateId: UUID
+    public var role: String
+    public var content: String
+    public var createdAt: Date
+
+    public init(id: UUID = UUID(), candidateId: UUID, role: String, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.candidateId = candidateId
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/OpenAICompatibleClient.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/OpenAICompatibleClient.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+public struct ChatMessage: Codable, Equatable {
+    public var role: String
+    public var content: String
+
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+public struct AIBackendConfiguration: Codable, Equatable {
+    public var baseURL: URL
+    public var model: String
+    public var apiKey: String
+
+    public init(
+        baseURL: URL = URL(string: "http://127.0.0.1:8081/v1")!,
+        model: String = "mlx-community/Qwen3-1.7B-4bit",
+        apiKey: String = ""
+    ) {
+        self.baseURL = baseURL
+        self.model = model
+        self.apiKey = apiKey
+    }
+}
+
+public protocol AITextGenerating: Sendable {
+    func complete(messages: [ChatMessage], temperature: Double, maxTokens: Int) async throws -> String
+}
+
+public final class OpenAICompatibleClient: AITextGenerating, @unchecked Sendable {
+    private let configuration: AIBackendConfiguration
+    private let session: URLSession
+
+    public init(configuration: AIBackendConfiguration = AIBackendConfiguration(), session: URLSession = .shared) {
+        self.configuration = configuration
+        self.session = session
+    }
+
+    public func complete(messages: [ChatMessage], temperature: Double = 0.7, maxTokens: Int = 1400) async throws -> String {
+        let endpoint = configuration.baseURL.appendingPathComponent("chat/completions")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !configuration.apiKey.isEmpty {
+            request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONEncoder().encode(ChatCompletionRequest(
+            model: configuration.model,
+            messages: messages,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            stream: false
+        ))
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AIClientError.badResponse(body)
+        }
+
+        let decoded = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+        guard let content = decoded.choices.first?.message.content, !content.isEmpty else {
+            throw AIClientError.emptyResponse
+        }
+        return content
+    }
+}
+
+public enum AIClientError: Error, LocalizedError, Equatable {
+    case badResponse(String)
+    case emptyResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .badResponse(let body):
+            return "The AI backend returned an error: \(body)"
+        case .emptyResponse:
+            return "The AI backend returned an empty response."
+        }
+    }
+}
+
+private struct ChatCompletionRequest: Codable {
+    var model: String
+    var messages: [ChatMessage]
+    var temperature: Double
+    var maxTokens: Int
+    var stream: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case model, messages, temperature, stream
+        case maxTokens = "max_tokens"
+    }
+}
+
+private struct ChatCompletionResponse: Codable {
+    var choices: [Choice]
+
+    struct Choice: Codable {
+        var message: ChatMessage
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/PromptLibrary.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/PromptLibrary.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+public enum PromptLibrary {
+    public static let version = "2026-05-18.short-form.v1"
+
+    public struct Prompt: Equatable, Sendable {
+        public var version: String
+        public var system: String
+        public var user: String
+
+        public init(version: String = PromptLibrary.version, system: String, user: String) {
+            self.version = version
+            self.system = system
+            self.user = user
+        }
+
+        public var messages: [ChatMessage] {
+            [
+                ChatMessage(role: "system", content: system),
+                ChatMessage(role: "user", content: user)
+            ]
+        }
+    }
+
+    public static func researchBrief(project: Project, sources: [ResearchSource]) -> Prompt {
+        Prompt(
+            system: "You are a rigorous research editor. Extract specific, source-backed ideas and avoid unsupported claims.",
+            user: """
+            Build a short-form video research brief from the project and sources.
+            Prompt version: \(version)
+            Return only JSON with keys:
+            distilledInsights, claims, angles, audienceTensions, citations.
+            Each value must be an array of concise strings. Claims should cite source titles when possible.
+
+            Project:
+            \(projectSummary(project))
+
+            Sources:
+            \(sourceDigest(sources))
+            """
+        )
+    }
+
+    public static func candidateGeneration(project: Project, brief: ResearchBrief, count: Int) -> Prompt {
+        Prompt(
+            system: "You are a senior short-form video writer. Produce many distinct, specific, high-retention script options.",
+            user: """
+            Generate \(count) distinct short-form video script candidates.
+            Prompt version: \(version)
+            Return only JSON:
+            { "candidates": [
+              {
+                "title": "...",
+                "angle": "...",
+                "tags": ["..."],
+                "beats": {
+                  "hook": "...",
+                  "setup": "...",
+                  "escalation": "...",
+                  "payoff": "...",
+                  "callToActionOrLoop": "...",
+                  "timingNotes": "..."
+                }
+              }
+            ]}
+
+            Requirements:
+            - Format every candidate as hook, setup, escalation, payoff, CTA or loop, timing notes.
+            - Vary hook type, emotional frame, premise, pacing, angle, and payoff.
+            - Stay grounded in the research brief and avoid generic creator advice.
+            - Scripts should fit 30-90 seconds.
+
+            Project:
+            \(projectSummary(project))
+
+            Research brief:
+            \(briefDigest(brief))
+            """
+        )
+    }
+
+    public static func scoring(candidate: ScriptCandidate, brief: ResearchBrief) -> Prompt {
+        Prompt(
+            system: "You are a strict script quality judge. Reward specificity and source grounding; punish slop.",
+            user: """
+            Score this short-form script candidate on a 0-10 scale for each dimension.
+            Prompt version: \(version)
+            Return only JSON with keys:
+            premiseStrength, originality, specificity, clarity, structure, sourceGrounding, hookQuality, payoffQuality, nonSlop, flags, rationale.
+            Flags should identify generic phrasing, fake insight, weak premise, repetitive structure, unsupported claims, filler language, awkward hook, or low-effort hook.
+
+            Research brief:
+            \(briefDigest(brief))
+
+            Candidate:
+            Title: \(candidate.title)
+            Angle: \(candidate.angle)
+            Script:
+            \(candidate.displayText)
+            """
+        )
+    }
+
+    public static func revisionChat(
+        candidate: ScriptCandidate,
+        brief: ResearchBrief,
+        userMessage: String,
+        history: [AgentMessage]
+    ) -> Prompt {
+        Prompt(
+            system: "You are a collaborative script revision partner. Be specific, practical, and source-aware.",
+            user: """
+            Help revise this short-form script. Respond with concise, actionable suggestions.
+            Prompt version: \(version)
+            Do not overwrite the human's draft. Offer improved lines, stronger hooks, tighter wording, alternate endings, or source-grounded additions.
+
+            Research brief:
+            \(briefDigest(brief))
+
+            Current script:
+            \(candidate.displayText)
+
+            Chat history:
+            \(history.map { "\($0.role): \($0.content)" }.joined(separator: "\n"))
+
+            Human request:
+            \(userMessage)
+            """
+        )
+    }
+
+    public static func projectSummary(_ project: Project) -> String {
+        """
+        Title: \(project.title)
+        Topic: \(project.topic)
+        Audience: \(project.audience)
+        Platform: \(project.platform.rawValue)
+        Tone: \(project.tone)
+        Goal: \(project.goal)
+        Constraints: \(project.constraints)
+        """
+    }
+
+    public static func sourceDigest(_ sources: [ResearchSource]) -> String {
+        sources.prefix(12).map { source in
+            """
+            [\(source.kind.rawValue)] \(source.title)
+            Locator: \(source.locator)
+            Credibility: \(source.credibilityNote)
+            Text:
+            \(source.rawText.prefix(1800))
+            """
+        }.joined(separator: "\n\n---\n\n")
+    }
+
+    public static func briefDigest(_ brief: ResearchBrief) -> String {
+        """
+        Insights:
+        \(brief.distilledInsights.joined(separator: "\n- "))
+
+        Claims:
+        \(brief.claims.joined(separator: "\n- "))
+
+        Angles:
+        \(brief.angles.joined(separator: "\n- "))
+
+        Audience tensions:
+        \(brief.audienceTensions.joined(separator: "\n- "))
+
+        Citations:
+        \(brief.citations.joined(separator: "\n- "))
+        """
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/Rubric.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/Rubric.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+public struct Rubric: Sendable {
+    public struct ScoreDimension: Codable, Equatable, Identifiable, Sendable {
+        public var id: String
+        public var name: String
+        public var description: String
+        public var maximumScore: Int
+
+        public init(id: String, name: String, description: String, maximumScore: Int = 10) {
+            self.id = id
+            self.name = name
+            self.description = description
+            self.maximumScore = maximumScore
+        }
+    }
+
+    public struct NonSlopFlagDefinition: Codable, Equatable, Identifiable, Sendable {
+        public var id: String
+        public var label: String
+        public var description: String
+
+        public init(id: String, label: String, description: String) {
+            self.id = id
+            self.label = label
+            self.description = description
+        }
+    }
+
+    public static let `default` = Rubric()
+
+    public let dimensions: [ScoreDimension]
+    public let nonSlopFlags: [NonSlopFlagDefinition]
+    public let genericTerms: [String]
+    public let fillerTerms: [String]
+
+    public init(
+        dimensions: [ScoreDimension] = Rubric.defaultDimensions,
+        nonSlopFlags: [NonSlopFlagDefinition] = Rubric.defaultNonSlopFlags,
+        genericTerms: [String] = Rubric.defaultGenericTerms,
+        fillerTerms: [String] = Rubric.defaultFillerTerms
+    ) {
+        self.dimensions = dimensions
+        self.nonSlopFlags = nonSlopFlags
+        self.genericTerms = genericTerms
+        self.fillerTerms = fillerTerms
+    }
+
+    public var maximumTotalScore: Int {
+        dimensions.reduce(0) { $0 + $1.maximumScore }
+    }
+
+    public func totalScore(for scorecard: Scorecard) -> Int {
+        scorecard.total
+    }
+
+    public func evaluate(candidate: ScriptCandidate, brief: ResearchBrief) -> Scorecard {
+        let text = candidate.displayText
+        let lower = text.lowercased()
+        let words = lower.split { !$0.isLetter && !$0.isNumber }
+        let uniqueRatio = words.isEmpty ? 0 : Double(Set(words).count) / Double(words.count)
+        let sourceHits = sourceHitCount(in: lower, brief: brief)
+        let flags = evaluateNonSlopFlags(text: text, sourceHits: sourceHits, uniqueRatio: uniqueRatio)
+        let weakPremiseFlag = flagLabel(for: "weakPremise", fallback: "weak premise")
+
+        let hookHasTension = ["why", "stop", "nobody", "mistake", "truth", "before", "after", "?"].contains { lower.contains($0) }
+        let payoffHasTurn = ["so", "but", "because", "instead", "that means", "the result"].contains { lower.contains($0) }
+
+        return Scorecard(
+            premiseStrength: Self.clampScore(5 + min(3, candidate.angle.split(separator: " ").count / 4) - (flags.contains(weakPremiseFlag) ? 2 : 0)),
+            originality: Self.clampScore(Int((uniqueRatio * 10).rounded()) - (containsAny(lower, genericTerms) ? 2 : 0)),
+            specificity: Self.clampScore(4 + min(4, sourceHits * 2) + (lower.contains(where: { $0.isNumber }) ? 1 : 0)),
+            clarity: Self.clampScore(text.count > 160 ? 8 : 5),
+            structure: Self.clampScore([candidate.beats.hook, candidate.beats.setup, candidate.beats.escalation, candidate.beats.payoff].filter { !$0.isEmpty }.count * 2),
+            sourceGrounding: Self.clampScore(3 + min(6, sourceHits * 3)),
+            hookQuality: Self.clampScore(5 + (hookHasTension ? 3 : 0) - (candidate.beats.hook.count < 18 ? 2 : 0)),
+            payoffQuality: Self.clampScore(5 + (payoffHasTurn ? 2 : 0) - (candidate.beats.payoff.count < 24 ? 2 : 0)),
+            nonSlop: Self.clampScore(9 - flags.count),
+            flags: flags,
+            rationale: flags.isEmpty
+                ? "Specific, structured, and grounded enough to reach human review."
+                : "Needs attention on: \(flags.joined(separator: ", "))."
+        )
+    }
+
+    public static func clampScore(_ score: Int) -> Int {
+        min(max(score, 0), 10)
+    }
+}
+
+public extension Rubric {
+    static let defaultDimensions: [ScoreDimension] = [
+        ScoreDimension(id: "premiseStrength", name: "Premise Strength", description: "The candidate has a clear, compelling premise with enough tension to sustain attention."),
+        ScoreDimension(id: "originality", name: "Originality", description: "The angle avoids familiar creator-advice tropes and feels meaningfully distinct."),
+        ScoreDimension(id: "specificity", name: "Specificity", description: "The script uses concrete details, numbers, examples, or named proof points."),
+        ScoreDimension(id: "clarity", name: "Clarity", description: "The script is easy to follow and keeps the viewer oriented."),
+        ScoreDimension(id: "structure", name: "Structure", description: "The script has complete hook, setup, escalation, and payoff beats."),
+        ScoreDimension(id: "sourceGrounding", name: "Source Grounding", description: "The candidate visibly draws from the research brief instead of free-floating claims."),
+        ScoreDimension(id: "hookQuality", name: "Hook Quality", description: "The opening creates tension quickly without feeling cheap or vague."),
+        ScoreDimension(id: "payoffQuality", name: "Payoff Quality", description: "The ending resolves the premise with a turn, consequence, or useful decision."),
+        ScoreDimension(id: "nonSlop", name: "Non-Slop", description: "The script avoids generic phrasing, fake insight, filler, and low-effort structure.")
+    ]
+
+    static let defaultNonSlopFlags: [NonSlopFlagDefinition] = [
+        NonSlopFlagDefinition(id: "genericPhrasing", label: "generic phrasing", description: "Uses broad hype phrases or interchangeable creator-advice language."),
+        NonSlopFlagDefinition(id: "weakPremise", label: "weak premise", description: "Does not develop enough substance or tension to justify the script."),
+        NonSlopFlagDefinition(id: "unsupportedClaims", label: "unsupported claims", description: "Makes claims without matching evidence from the research brief."),
+        NonSlopFlagDefinition(id: "repetitiveStructure", label: "repetitive structure", description: "Repeats too many words or ideas relative to script length."),
+        NonSlopFlagDefinition(id: "fillerLanguage", label: "filler language", description: "Leans on hedges and intensifiers instead of sharper wording."),
+        NonSlopFlagDefinition(id: "awkwardOrLowEffortHook", label: "awkward or low-effort hook", description: "Opens too weakly, too generically, or without a real hook."),
+        NonSlopFlagDefinition(id: "fakeInsight", label: "fake insight", description: "Signals authority with vague proof language instead of a sourced idea.")
+    ]
+
+    static let defaultGenericTerms = [
+        "game changer",
+        "secret",
+        "unlock",
+        "you need to know",
+        "in today's world",
+        "life hack",
+        "mindset",
+        "crushing it"
+    ]
+
+    static let defaultFillerTerms = [
+        "really",
+        "basically",
+        "actually",
+        "literally",
+        "just",
+        "very",
+        "kind of",
+        "sort of"
+    ]
+}
+
+private extension Rubric {
+    func sourceHitCount(in lowercasedText: String, brief: ResearchBrief) -> Int {
+        brief.claims.filter { claim in
+            let significant = claim.split(separator: " ").filter { $0.count > 5 }.prefix(4)
+            return significant.contains { lowercasedText.contains($0.lowercased()) }
+        }.count
+    }
+
+    func evaluateNonSlopFlags(text: String, sourceHits: Int, uniqueRatio: Double) -> [String] {
+        let lower = text.lowercased()
+        var flags: [String] = []
+        if containsAny(lower, genericTerms) { flags.append(flagLabel(for: "genericPhrasing", fallback: "generic phrasing")) }
+        if lower.count < 220 { flags.append(flagLabel(for: "weakPremise", fallback: "weak premise")) }
+        if sourceHits == 0 { flags.append(flagLabel(for: "unsupportedClaims", fallback: "unsupported claims")) }
+        if uniqueRatio < 0.55 { flags.append(flagLabel(for: "repetitiveStructure", fallback: "repetitive structure")) }
+        let fillerCount = fillerTerms.reduce(0) { $0 + lower.components(separatedBy: $1).count - 1 }
+        if fillerCount >= 4 { flags.append(flagLabel(for: "fillerLanguage", fallback: "filler language")) }
+        let firstLine = lower.components(separatedBy: .newlines).first ?? lower
+        if firstLine.count < 18 || firstLine.contains("here are") {
+            flags.append(flagLabel(for: "awkwardOrLowEffortHook", fallback: "awkward or low-effort hook"))
+        }
+        if lower.contains("everyone knows") || lower.contains("studies show") {
+            flags.append(flagLabel(for: "fakeInsight", fallback: "fake insight"))
+        }
+        return flags
+    }
+
+    func containsAny(_ text: String, _ terms: [String]) -> Bool {
+        terms.contains { text.contains($0) }
+    }
+
+    func flagLabel(for id: String, fallback: String) -> String {
+        nonSlopFlags.first { $0.id == id }?.label ?? fallback
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/SourceIngestionService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/SourceIngestionService.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+public struct SourceIngestionService: Sendable {
+    public enum IngestionError: Error, Equatable, LocalizedError {
+        case emptyNote
+        case unreadableFile(URL)
+        case unsupportedExtension(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .emptyNote:
+                return "The note is empty."
+            case .unreadableFile(let url):
+                return "Could not read text from \(url.lastPathComponent)."
+            case .unsupportedExtension(let fileExtension):
+                return "Unsupported source type: .\(fileExtension)"
+            }
+        }
+
+        public var isRecoverable: Bool {
+            switch self {
+            case .unsupportedExtension:
+                return true
+            case .emptyNote, .unreadableFile:
+                return false
+            }
+        }
+    }
+
+    public static let supportedExtensions: Set<String> = ["txt", "md", "csv", "json"]
+
+    public init() {}
+
+    public func ingestNote(
+        projectId: UUID,
+        title: String,
+        text: String,
+        locator: String = ""
+    ) throws -> ResearchSource {
+        let normalizedText = Self.normalized(text)
+        guard !normalizedText.isEmpty else {
+            throw IngestionError.emptyNote
+        }
+
+        return ResearchSource(
+            projectId: projectId,
+            kind: .note,
+            title: title.trimmedOr("Untitled note"),
+            locator: locator,
+            rawText: normalizedText,
+            extractedFacts: Self.extractFacts(from: normalizedText),
+            credibilityNote: "User-provided local note"
+        )
+    }
+
+    public func ingestFile(
+        projectId: UUID,
+        fileURL: URL,
+        title: String? = nil
+    ) throws -> ResearchSource {
+        let fileExtension = fileURL.pathExtension.lowercased()
+        guard Self.supportedExtensions.contains(fileExtension) else {
+            throw IngestionError.unsupportedExtension(fileExtension.isEmpty ? "unknown" : fileExtension)
+        }
+
+        let rawText: String
+        do {
+            rawText = try String(contentsOf: fileURL, encoding: .utf8)
+        } catch {
+            do {
+                rawText = try String(contentsOf: fileURL)
+            } catch {
+                throw IngestionError.unreadableFile(fileURL)
+            }
+        }
+
+        let normalizedText = Self.normalized(rawText)
+        guard !normalizedText.isEmpty else {
+            throw IngestionError.unreadableFile(fileURL)
+        }
+
+        return ResearchSource(
+            projectId: projectId,
+            kind: .file,
+            title: title?.trimmedOr(fileURL.deletingPathExtension().lastPathComponent) ?? fileURL.deletingPathExtension().lastPathComponent,
+            locator: fileURL.path,
+            rawText: normalizedText,
+            extractedFacts: Self.extractFacts(from: normalizedText),
+            credibilityNote: "Imported from local .\(fileExtension) file"
+        )
+    }
+
+    public func ingestFile(
+        projectId: UUID,
+        path: String,
+        title: String? = nil
+    ) throws -> ResearchSource {
+        try ingestFile(projectId: projectId, fileURL: URL(fileURLWithPath: path), title: title)
+    }
+
+    public func ingestFile(
+        projectId: UUID,
+        locator: String,
+        title: String? = nil
+    ) throws -> ResearchSource {
+        let url = URL(string: locator).flatMap { $0.isFileURL ? $0 : nil } ?? URL(fileURLWithPath: locator)
+        return try ingestFile(projectId: projectId, fileURL: url, title: title)
+    }
+
+    public static func extractFacts(from text: String, maxFacts: Int = 8) -> [String] {
+        let candidates = normalized(text)
+            .components(separatedBy: CharacterSet(charactersIn: ".!?\n"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 24 }
+            .enumerated()
+            .sorted {
+                let leftScore = factScore($0.element)
+                let rightScore = factScore($1.element)
+                return leftScore == rightScore ? $0.offset < $1.offset : leftScore > rightScore
+            }
+            .map(\.element)
+
+        var facts: [String] = []
+        var seen = Set<String>()
+        for candidate in candidates where factScore(candidate) > 0 {
+            let fact = candidate.finishedSentence
+            let key = fact.lowercased()
+            guard !seen.contains(key) else { continue }
+            facts.append(fact)
+            seen.insert(key)
+            if facts.count == maxFacts { break }
+        }
+        return facts
+    }
+
+    private static func normalized(_ text: String) -> String {
+        text.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    private static func factScore(_ text: String) -> Int {
+        let lowercased = text.lowercased()
+        let evidenceTerms = [
+            "according to", "reported", "found", "shows", "showed", "study",
+            "survey", "research", "because", "therefore", "increased", "decreased"
+        ]
+        var score = evidenceTerms.reduce(0) { partial, term in
+            partial + (lowercased.contains(term) ? 2 : 0)
+        }
+        if text.rangeOfCharacter(from: .decimalDigits) != nil {
+            score += 3
+        }
+        if lowercased.contains("%") || lowercased.contains("$") {
+            score += 2
+        }
+        if lowercased.contains(":") || lowercased.contains(",") {
+            score += 1
+        }
+        return score
+    }
+}
+
+private extension String {
+    func trimmedOr(_ fallback: String) -> String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+
+    var finishedSentence: String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let last = trimmed.last, ".!?".contains(last) else {
+            return "\(trimmed)."
+        }
+        return trimmed
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/WebResearchService.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/WebResearchService.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public struct SearchResult: Codable, Identifiable, Equatable {
+    public var id: UUID
+    public var title: String
+    public var url: String
+    public var snippet: String
+
+    public init(id: UUID = UUID(), title: String, url: String, snippet: String) {
+        self.id = id
+        self.title = title
+        self.url = url
+        self.snippet = snippet
+    }
+}
+
+public protocol WebResearching: Sendable {
+    func fetchURL(_ url: URL) async throws -> String
+    func search(query: String, limit: Int) async throws -> [SearchResult]
+}
+
+public final class WebResearchService: WebResearching, @unchecked Sendable {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func fetchURL(_ url: URL) async throws -> String {
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        let html = String(data: data, encoding: .utf8) ?? ""
+        return Self.plainText(fromHTML: html)
+    }
+
+    public func search(query: String, limit: Int = 6) async throws -> [SearchResult] {
+        var components = URLComponents(string: "https://duckduckgo.com/html/")!
+        components.queryItems = [URLQueryItem(name: "q", value: query)]
+        let url = components.url!
+        let html = try await fetchURL(url)
+        let lines = html
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return Array(lines.prefix(limit)).enumerated().map { index, line in
+            SearchResult(title: "Search note \(index + 1)", url: url.absoluteString, snippet: line)
+        }
+    }
+
+    static func plainText(fromHTML html: String) -> String {
+        var text = html.replacingOccurrences(of: "<script[\\s\\S]*?</script>", with: " ", options: .regularExpression)
+        text = text.replacingOccurrences(of: "<style[\\s\\S]*?</style>", with: " ", options: .regularExpression)
+        text = text.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+        text = text.replacingOccurrences(of: "&nbsp;", with: " ")
+        text = text.replacingOccurrences(of: "&amp;", with: "&")
+        text = text.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        return String(text.prefix(20_000)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/WorkflowEngine.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/WorkflowEngine.swift
@@ -1,0 +1,451 @@
+import Foundation
+
+public struct WorkflowEngine: Sendable {
+    private let ai: AITextGenerating
+
+    public init(ai: AITextGenerating) {
+        self.ai = ai
+    }
+
+    public func buildResearchBrief(project: Project, sources: [ResearchSource]) async -> ResearchBrief {
+        let prompt = """
+        Build a short-form video research brief from the project and sources.
+        Return only JSON with keys:
+        distilledInsights, claims, angles, audienceTensions, citations.
+        Each value must be an array of concise strings. Claims should cite source titles when possible.
+
+        Project:
+        \(projectSummary(project))
+
+        Sources:
+        \(sourceDigest(sources))
+        """
+
+        do {
+            let text = try await ai.complete(
+                messages: [
+                    ChatMessage(role: "system", content: "You are a rigorous research editor. Extract specific, source-backed ideas and avoid unsupported claims."),
+                    ChatMessage(role: "user", content: prompt)
+                ],
+                temperature: 0.25,
+                maxTokens: 1800
+            )
+            let decoded = try JSONExtraction.decodeObject(BriefPayload.self, from: text)
+            return decoded.brief(projectId: project.id)
+        } catch {
+            return fallbackBrief(project: project, sources: sources)
+        }
+    }
+
+    public func generateCandidates(project: Project, brief: ResearchBrief, count: Int, model: String) async -> (GenerationRun, [ScriptCandidate]) {
+        let clampedCount = min(max(count, 20), 40)
+        let run = GenerationRun(
+            projectId: project.id,
+            model: model,
+            candidateCount: clampedCount,
+            promptSummary: "Generated \(clampedCount) short-form candidates from research brief"
+        )
+        let prompt = """
+        Generate \(clampedCount) distinct short-form video script candidates.
+        Return only JSON:
+        { "candidates": [
+          {
+            "title": "...",
+            "angle": "...",
+            "tags": ["..."],
+            "beats": {
+              "hook": "...",
+              "setup": "...",
+              "escalation": "...",
+              "payoff": "...",
+              "callToActionOrLoop": "...",
+              "timingNotes": "..."
+            }
+          }
+        ]}
+
+        Requirements:
+        - Format every candidate as hook, setup, escalation, payoff, CTA or loop, timing notes.
+        - Vary hook type, emotional frame, premise, pacing, angle, and payoff.
+        - Stay grounded in the research brief and avoid generic creator advice.
+        - Scripts should fit 30-90 seconds.
+
+        Project:
+        \(projectSummary(project))
+
+        Research brief:
+        \(briefDigest(brief))
+        """
+
+        do {
+            let text = try await ai.complete(
+                messages: [
+                    ChatMessage(role: "system", content: "You are a senior short-form video writer. Produce many distinct, specific, high-retention script options."),
+                    ChatMessage(role: "user", content: prompt)
+                ],
+                temperature: 0.85,
+                maxTokens: 7000
+            )
+            let payload = try JSONExtraction.decodeObject(CandidatesPayload.self, from: text)
+            let candidates = payload.candidates.prefix(clampedCount).map {
+                $0.candidate(projectId: project.id, runId: run.id)
+            }
+            if candidates.count >= 10 {
+                return (run, candidates)
+            }
+        } catch {
+            // Fall through to deterministic candidates.
+        }
+        return (run, fallbackCandidates(project: project, brief: brief, run: run, count: clampedCount))
+    }
+
+    public func scoreCandidates(_ candidates: [ScriptCandidate], brief: ResearchBrief) async -> [ScriptCandidate] {
+        var scored: [ScriptCandidate] = []
+        for candidate in candidates {
+            scored.append(await scoreCandidate(candidate, brief: brief))
+        }
+        return scored.sorted {
+            ($0.scorecard?.total ?? 0, $0.title) > ($1.scorecard?.total ?? 0, $1.title)
+        }
+    }
+
+    public func topCandidates(from candidates: [ScriptCandidate], limit: Int = 10) -> [ScriptCandidate] {
+        Array(candidates.sorted {
+            ($0.scorecard?.total ?? 0, $0.title) > ($1.scorecard?.total ?? 0, $1.title)
+        }.prefix(limit))
+    }
+
+    public func revise(candidate: ScriptCandidate, brief: ResearchBrief, userMessage: String, history: [AgentMessage]) async -> String {
+        let prompt = """
+        Help revise this short-form script. Respond with concise, actionable suggestions.
+        Do not overwrite the human's draft. Offer improved lines, stronger hooks, tighter wording, alternate endings, or source-grounded additions.
+
+        Research brief:
+        \(briefDigest(brief))
+
+        Current script:
+        \(candidate.displayText)
+
+        Chat history:
+        \(history.map { "\($0.role): \($0.content)" }.joined(separator: "\n"))
+
+        Human request:
+        \(userMessage)
+        """
+        do {
+            return try await ai.complete(
+                messages: [
+                    ChatMessage(role: "system", content: "You are a collaborative script revision partner. Be specific, practical, and source-aware."),
+                    ChatMessage(role: "user", content: prompt)
+                ],
+                temperature: 0.55,
+                maxTokens: 1200
+            )
+        } catch {
+            return fallbackRevision(candidate: candidate, userMessage: userMessage)
+        }
+    }
+
+    public static func heuristicScore(for candidate: ScriptCandidate, brief: ResearchBrief) -> Scorecard {
+        let text = candidate.displayText
+        let lower = text.lowercased()
+        let words = lower.split { !$0.isLetter && !$0.isNumber }
+        let uniqueRatio = words.isEmpty ? 0 : Double(Set(words).count) / Double(words.count)
+        let sourceHits = brief.claims.filter { claim in
+            let significant = claim.split(separator: " ").filter { $0.count > 5 }.prefix(4)
+            return significant.contains { lower.contains($0.lowercased()) }
+        }.count
+        let genericTerms = ["game changer", "secret", "unlock", "you need to know", "in today's world", "life hack", "mindset", "crushing it"]
+        let fillerTerms = ["really", "basically", "actually", "literally", "just", "very", "kind of", "sort of"]
+        let flags = Self.nonSlopFlags(text: text, sourceHits: sourceHits, uniqueRatio: uniqueRatio, genericTerms: genericTerms, fillerTerms: fillerTerms)
+
+        let hookHasTension = ["why", "stop", "nobody", "mistake", "truth", "before", "after", "?"].contains { lower.contains($0) }
+        let payoffHasTurn = ["so", "but", "because", "instead", "that means", "the result"].contains { lower.contains($0) }
+
+        return Scorecard(
+            premiseStrength: Self.clampScore(5 + min(3, candidate.angle.split(separator: " ").count / 4) - (flags.contains("weak premise") ? 2 : 0)),
+            originality: Self.clampScore(Int((uniqueRatio * 10).rounded()) - (Self.containsAny(lower, genericTerms) ? 2 : 0)),
+            specificity: Self.clampScore(4 + min(4, sourceHits * 2) + (lower.contains(where: { $0.isNumber }) ? 1 : 0)),
+            clarity: Self.clampScore(text.count > 160 ? 8 : 5),
+            structure: Self.clampScore([candidate.beats.hook, candidate.beats.setup, candidate.beats.escalation, candidate.beats.payoff].filter { !$0.isEmpty }.count * 2),
+            sourceGrounding: Self.clampScore(3 + min(6, sourceHits * 3)),
+            hookQuality: Self.clampScore(5 + (hookHasTension ? 3 : 0) - (candidate.beats.hook.count < 18 ? 2 : 0)),
+            payoffQuality: Self.clampScore(5 + (payoffHasTurn ? 2 : 0) - (candidate.beats.payoff.count < 24 ? 2 : 0)),
+            nonSlop: Self.clampScore(9 - flags.count),
+            flags: flags,
+            rationale: flags.isEmpty
+                ? "Specific, structured, and grounded enough to reach human review."
+                : "Needs attention on: \(flags.joined(separator: ", "))."
+        )
+    }
+
+    private func scoreCandidate(_ candidate: ScriptCandidate, brief: ResearchBrief) async -> ScriptCandidate {
+        let prompt = """
+        Score this short-form script candidate on a 0-10 scale for each dimension.
+        Return only JSON with keys:
+        premiseStrength, originality, specificity, clarity, structure, sourceGrounding, hookQuality, payoffQuality, nonSlop, flags, rationale.
+        Flags should identify generic phrasing, fake insight, weak premise, repetitive structure, unsupported claims, filler language, awkward hook, or low-effort hook.
+
+        Research brief:
+        \(briefDigest(brief))
+
+        Candidate:
+        Title: \(candidate.title)
+        Angle: \(candidate.angle)
+        Script:
+        \(candidate.displayText)
+        """
+        var next = candidate
+        do {
+            let text = try await ai.complete(
+                messages: [
+                    ChatMessage(role: "system", content: "You are a strict script quality judge. Reward specificity and source grounding; punish slop."),
+                    ChatMessage(role: "user", content: prompt)
+                ],
+                temperature: 0.2,
+                maxTokens: 900
+            )
+            let payload = try JSONExtraction.decodeObject(ScorecardPayload.self, from: text)
+            next.scorecard = payload.scorecard
+        } catch {
+            next.scorecard = Self.heuristicScore(for: candidate, brief: brief)
+        }
+        return next
+    }
+}
+
+private struct BriefPayload: Codable {
+    var distilledInsights: [String]
+    var claims: [String]
+    var angles: [String]
+    var audienceTensions: [String]
+    var citations: [String]
+
+    func brief(projectId: UUID) -> ResearchBrief {
+        ResearchBrief(
+            projectId: projectId,
+            distilledInsights: distilledInsights.cleaned(max: 12),
+            claims: claims.cleaned(max: 16),
+            angles: angles.cleaned(max: 12),
+            audienceTensions: audienceTensions.cleaned(max: 10),
+            citations: citations.cleaned(max: 20)
+        )
+    }
+}
+
+private struct CandidatesPayload: Codable {
+    var candidates: [CandidatePayload]
+}
+
+private struct CandidatePayload: Codable {
+    var title: String
+    var angle: String
+    var tags: [String]
+    var beats: ScriptBeats
+
+    func candidate(projectId: UUID, runId: UUID) -> ScriptCandidate {
+        ScriptCandidate(
+            projectId: projectId,
+            runId: runId,
+            title: title.trimmedOr("Untitled angle"),
+            angle: angle.trimmedOr("Source-backed angle"),
+            tags: tags.cleaned(max: 8),
+            beats: beats
+        )
+    }
+}
+
+private struct ScorecardPayload: Codable {
+    var premiseStrength: Int
+    var originality: Int
+    var specificity: Int
+    var clarity: Int
+    var structure: Int
+    var sourceGrounding: Int
+    var hookQuality: Int
+    var payoffQuality: Int
+    var nonSlop: Int
+    var flags: [String]
+    var rationale: String
+
+    var scorecard: Scorecard {
+        Scorecard(
+            premiseStrength: WorkflowEngine.clampScore(premiseStrength),
+            originality: WorkflowEngine.clampScore(originality),
+            specificity: WorkflowEngine.clampScore(specificity),
+            clarity: WorkflowEngine.clampScore(clarity),
+            structure: WorkflowEngine.clampScore(structure),
+            sourceGrounding: WorkflowEngine.clampScore(sourceGrounding),
+            hookQuality: WorkflowEngine.clampScore(hookQuality),
+            payoffQuality: WorkflowEngine.clampScore(payoffQuality),
+            nonSlop: WorkflowEngine.clampScore(nonSlop),
+            flags: flags.cleaned(max: 8),
+            rationale: rationale
+        )
+    }
+}
+
+fileprivate extension WorkflowEngine {
+    static func clampScore(_ score: Int) -> Int {
+        min(max(score, 0), 10)
+    }
+
+    static func containsAny(_ text: String, _ terms: [String]) -> Bool {
+        terms.contains { text.contains($0) }
+    }
+
+    static func nonSlopFlags(text: String, sourceHits: Int, uniqueRatio: Double, genericTerms: [String], fillerTerms: [String]) -> [String] {
+        let lower = text.lowercased()
+        var flags: [String] = []
+        if containsAny(lower, genericTerms) { flags.append("generic phrasing") }
+        if lower.count < 220 { flags.append("weak premise") }
+        if sourceHits == 0 { flags.append("unsupported claims") }
+        if uniqueRatio < 0.55 { flags.append("repetitive structure") }
+        let fillerCount = fillerTerms.reduce(0) { $0 + lower.components(separatedBy: $1).count - 1 }
+        if fillerCount >= 4 { flags.append("filler language") }
+        let firstLine = lower.components(separatedBy: .newlines).first ?? lower
+        if firstLine.count < 18 || firstLine.contains("here are") { flags.append("awkward or low-effort hook") }
+        if lower.contains("everyone knows") || lower.contains("studies show") { flags.append("fake insight") }
+        return flags
+    }
+
+    func projectSummary(_ project: Project) -> String {
+        """
+        Title: \(project.title)
+        Topic: \(project.topic)
+        Audience: \(project.audience)
+        Platform: \(project.platform.rawValue)
+        Tone: \(project.tone)
+        Goal: \(project.goal)
+        Constraints: \(project.constraints)
+        """
+    }
+
+    func sourceDigest(_ sources: [ResearchSource]) -> String {
+        sources.prefix(12).map { source in
+            """
+            [\(source.kind.rawValue)] \(source.title)
+            Locator: \(source.locator)
+            Credibility: \(source.credibilityNote)
+            Text:
+            \(source.rawText.prefix(1800))
+            """
+        }.joined(separator: "\n\n---\n\n")
+    }
+
+    func briefDigest(_ brief: ResearchBrief) -> String {
+        """
+        Insights:
+        \(brief.distilledInsights.joined(separator: "\n- "))
+
+        Claims:
+        \(brief.claims.joined(separator: "\n- "))
+
+        Angles:
+        \(brief.angles.joined(separator: "\n- "))
+
+        Audience tensions:
+        \(brief.audienceTensions.joined(separator: "\n- "))
+
+        Citations:
+        \(brief.citations.joined(separator: "\n- "))
+        """
+    }
+
+    func fallbackBrief(project: Project, sources: [ResearchSource]) -> ResearchBrief {
+        let sourceSentences = sources.flatMap { source in
+            sentenceCandidates(from: source.rawText).prefix(4).map { "\(source.title): \($0)" }
+        }
+        let topic = project.topic.trimmedOr(project.title)
+        return ResearchBrief(
+            projectId: project.id,
+            distilledInsights: Array(sourceSentences.prefix(8)).ifEmpty(["The strongest angle should connect \(topic) to a specific audience tension."]),
+            claims: Array(sourceSentences.prefix(10)).ifEmpty(["Use source-backed claims before making a strong assertion about \(topic)."]),
+            angles: [
+                "Counterintuitive lesson about \(topic)",
+                "Common mistake the audience makes with \(topic)",
+                "Before/after transformation tied to \(project.goal.trimmedOr("the project goal"))",
+                "Myth versus source-backed reality"
+            ],
+            audienceTensions: [
+                "\(project.audience.trimmedOr("The audience")) wants a fast answer without being talked down to.",
+                "The content must feel useful, not generic."
+            ],
+            citations: sources.map { "\($0.title) \($0.locator)" }.cleaned(max: 20)
+        )
+    }
+
+    func fallbackCandidates(project: Project, brief: ResearchBrief, run: GenerationRun, count: Int) -> [ScriptCandidate] {
+        let hookFrames = [
+            "Stop saying \(project.topic.trimmedOr("this topic")) is simple.",
+            "The mistake most people make with \(project.topic.trimmedOr("this")) starts before they begin.",
+            "Here is the uncomfortable part nobody puts in the headline.",
+            "If you only remember one thing, make it this.",
+            "The obvious answer is the trap."
+        ]
+        let angles = brief.angles.ifEmpty(["Counterintuitive angle", "Common mistake", "Source-backed reframing"])
+        let claims = brief.claims.ifEmpty(["Use a concrete source-backed proof point before making the argument."])
+        return (0..<count).map { index in
+            let angle = angles[index % angles.count]
+            let claim = claims[index % claims.count]
+            let hook = hookFrames[index % hookFrames.count]
+            let beats = ScriptBeats(
+                hook: hook,
+                setup: "Most \(project.audience.trimmedOr("viewers")) hear the surface version: \(angle).",
+                escalation: "But the detail that changes the story is this: \(claim)",
+                payoff: "So the better move is to turn that tension into one clear decision, then show the consequence immediately.",
+                callToActionOrLoop: index.isMultiple(of: 2) ? "Save this before you build the next version." : "Now rewatch the hook and notice what changed.",
+                timingNotes: index.isMultiple(of: 3) ? "Fast 35-45 seconds, tight jump cuts." : "60-75 seconds with one visual proof point."
+            )
+            return ScriptCandidate(
+                projectId: project.id,
+                runId: run.id,
+                title: "Angle \(index + 1): \(angle.prefix(48))",
+                angle: angle,
+                tags: ["fallback", project.platform.rawValue, index.isMultiple(of: 2) ? "high-tension" : "source-led"],
+                beats: beats
+            )
+        }
+    }
+
+    func fallbackRevision(candidate: ScriptCandidate, userMessage: String) -> String {
+        """
+        Qwen is not reachable, so here is a local revision pass:
+
+        - Sharpen the hook by naming the exact tension in the first sentence.
+        - Replace any broad claim with a source-backed detail from the research brief.
+        - Keep the payoff concrete: show the consequence, not just the lesson.
+
+        A stronger hook direction:
+        "\(candidate.angle) sounds obvious until you notice what it makes people do next."
+
+        Your request was: \(userMessage)
+        """
+    }
+
+    func sentenceCandidates(from text: String) -> [String] {
+        text.replacingOccurrences(of: "\n", with: " ")
+            .components(separatedBy: CharacterSet(charactersIn: ".!?"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count > 32 }
+    }
+}
+
+private extension Array where Element == String {
+    func cleaned(max: Int) -> [String] {
+        Array(self.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .prefix(max))
+    }
+
+    func ifEmpty(_ fallback: [String]) -> [String] {
+        isEmpty ? fallback : self
+    }
+}
+
+private extension String {
+    func trimmedOr(_ fallback: String) -> String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+}

--- a/macos/ScriptEditor/Sources/ScriptEditorCore/WorkflowEngine.swift
+++ b/macos/ScriptEditor/Sources/ScriptEditorCore/WorkflowEngine.swift
@@ -8,25 +8,11 @@ public struct WorkflowEngine: Sendable {
     }
 
     public func buildResearchBrief(project: Project, sources: [ResearchSource]) async -> ResearchBrief {
-        let prompt = """
-        Build a short-form video research brief from the project and sources.
-        Return only JSON with keys:
-        distilledInsights, claims, angles, audienceTensions, citations.
-        Each value must be an array of concise strings. Claims should cite source titles when possible.
-
-        Project:
-        \(projectSummary(project))
-
-        Sources:
-        \(sourceDigest(sources))
-        """
+        let prompt = PromptLibrary.researchBrief(project: project, sources: sources)
 
         do {
             let text = try await ai.complete(
-                messages: [
-                    ChatMessage(role: "system", content: "You are a rigorous research editor. Extract specific, source-backed ideas and avoid unsupported claims."),
-                    ChatMessage(role: "user", content: prompt)
-                ],
+                messages: prompt.messages,
                 temperature: 0.25,
                 maxTokens: 1800
             )
@@ -45,44 +31,11 @@ public struct WorkflowEngine: Sendable {
             candidateCount: clampedCount,
             promptSummary: "Generated \(clampedCount) short-form candidates from research brief"
         )
-        let prompt = """
-        Generate \(clampedCount) distinct short-form video script candidates.
-        Return only JSON:
-        { "candidates": [
-          {
-            "title": "...",
-            "angle": "...",
-            "tags": ["..."],
-            "beats": {
-              "hook": "...",
-              "setup": "...",
-              "escalation": "...",
-              "payoff": "...",
-              "callToActionOrLoop": "...",
-              "timingNotes": "..."
-            }
-          }
-        ]}
-
-        Requirements:
-        - Format every candidate as hook, setup, escalation, payoff, CTA or loop, timing notes.
-        - Vary hook type, emotional frame, premise, pacing, angle, and payoff.
-        - Stay grounded in the research brief and avoid generic creator advice.
-        - Scripts should fit 30-90 seconds.
-
-        Project:
-        \(projectSummary(project))
-
-        Research brief:
-        \(briefDigest(brief))
-        """
+        let prompt = PromptLibrary.candidateGeneration(project: project, brief: brief, count: clampedCount)
 
         do {
             let text = try await ai.complete(
-                messages: [
-                    ChatMessage(role: "system", content: "You are a senior short-form video writer. Produce many distinct, specific, high-retention script options."),
-                    ChatMessage(role: "user", content: prompt)
-                ],
+                messages: prompt.messages,
                 temperature: 0.85,
                 maxTokens: 7000
             )
@@ -116,28 +69,10 @@ public struct WorkflowEngine: Sendable {
     }
 
     public func revise(candidate: ScriptCandidate, brief: ResearchBrief, userMessage: String, history: [AgentMessage]) async -> String {
-        let prompt = """
-        Help revise this short-form script. Respond with concise, actionable suggestions.
-        Do not overwrite the human's draft. Offer improved lines, stronger hooks, tighter wording, alternate endings, or source-grounded additions.
-
-        Research brief:
-        \(briefDigest(brief))
-
-        Current script:
-        \(candidate.displayText)
-
-        Chat history:
-        \(history.map { "\($0.role): \($0.content)" }.joined(separator: "\n"))
-
-        Human request:
-        \(userMessage)
-        """
+        let prompt = PromptLibrary.revisionChat(candidate: candidate, brief: brief, userMessage: userMessage, history: history)
         do {
             return try await ai.complete(
-                messages: [
-                    ChatMessage(role: "system", content: "You are a collaborative script revision partner. Be specific, practical, and source-aware."),
-                    ChatMessage(role: "user", content: prompt)
-                ],
+                messages: prompt.messages,
                 temperature: 0.55,
                 maxTokens: 1200
             )
@@ -147,68 +82,22 @@ public struct WorkflowEngine: Sendable {
     }
 
     public static func heuristicScore(for candidate: ScriptCandidate, brief: ResearchBrief) -> Scorecard {
-        let text = candidate.displayText
-        let lower = text.lowercased()
-        let words = lower.split { !$0.isLetter && !$0.isNumber }
-        let uniqueRatio = words.isEmpty ? 0 : Double(Set(words).count) / Double(words.count)
-        let sourceHits = brief.claims.filter { claim in
-            let significant = claim.split(separator: " ").filter { $0.count > 5 }.prefix(4)
-            return significant.contains { lower.contains($0.lowercased()) }
-        }.count
-        let genericTerms = ["game changer", "secret", "unlock", "you need to know", "in today's world", "life hack", "mindset", "crushing it"]
-        let fillerTerms = ["really", "basically", "actually", "literally", "just", "very", "kind of", "sort of"]
-        let flags = Self.nonSlopFlags(text: text, sourceHits: sourceHits, uniqueRatio: uniqueRatio, genericTerms: genericTerms, fillerTerms: fillerTerms)
-
-        let hookHasTension = ["why", "stop", "nobody", "mistake", "truth", "before", "after", "?"].contains { lower.contains($0) }
-        let payoffHasTurn = ["so", "but", "because", "instead", "that means", "the result"].contains { lower.contains($0) }
-
-        return Scorecard(
-            premiseStrength: Self.clampScore(5 + min(3, candidate.angle.split(separator: " ").count / 4) - (flags.contains("weak premise") ? 2 : 0)),
-            originality: Self.clampScore(Int((uniqueRatio * 10).rounded()) - (Self.containsAny(lower, genericTerms) ? 2 : 0)),
-            specificity: Self.clampScore(4 + min(4, sourceHits * 2) + (lower.contains(where: { $0.isNumber }) ? 1 : 0)),
-            clarity: Self.clampScore(text.count > 160 ? 8 : 5),
-            structure: Self.clampScore([candidate.beats.hook, candidate.beats.setup, candidate.beats.escalation, candidate.beats.payoff].filter { !$0.isEmpty }.count * 2),
-            sourceGrounding: Self.clampScore(3 + min(6, sourceHits * 3)),
-            hookQuality: Self.clampScore(5 + (hookHasTension ? 3 : 0) - (candidate.beats.hook.count < 18 ? 2 : 0)),
-            payoffQuality: Self.clampScore(5 + (payoffHasTurn ? 2 : 0) - (candidate.beats.payoff.count < 24 ? 2 : 0)),
-            nonSlop: Self.clampScore(9 - flags.count),
-            flags: flags,
-            rationale: flags.isEmpty
-                ? "Specific, structured, and grounded enough to reach human review."
-                : "Needs attention on: \(flags.joined(separator: ", "))."
-        )
+        Rubric.default.evaluate(candidate: candidate, brief: brief)
     }
 
     private func scoreCandidate(_ candidate: ScriptCandidate, brief: ResearchBrief) async -> ScriptCandidate {
-        let prompt = """
-        Score this short-form script candidate on a 0-10 scale for each dimension.
-        Return only JSON with keys:
-        premiseStrength, originality, specificity, clarity, structure, sourceGrounding, hookQuality, payoffQuality, nonSlop, flags, rationale.
-        Flags should identify generic phrasing, fake insight, weak premise, repetitive structure, unsupported claims, filler language, awkward hook, or low-effort hook.
-
-        Research brief:
-        \(briefDigest(brief))
-
-        Candidate:
-        Title: \(candidate.title)
-        Angle: \(candidate.angle)
-        Script:
-        \(candidate.displayText)
-        """
+        let prompt = PromptLibrary.scoring(candidate: candidate, brief: brief)
         var next = candidate
         do {
             let text = try await ai.complete(
-                messages: [
-                    ChatMessage(role: "system", content: "You are a strict script quality judge. Reward specificity and source grounding; punish slop."),
-                    ChatMessage(role: "user", content: prompt)
-                ],
+                messages: prompt.messages,
                 temperature: 0.2,
                 maxTokens: 900
             )
             let payload = try JSONExtraction.decodeObject(ScorecardPayload.self, from: text)
             next.scorecard = payload.scorecard
         } catch {
-            next.scorecard = Self.heuristicScore(for: candidate, brief: brief)
+            next.scorecard = Rubric.default.evaluate(candidate: candidate, brief: brief)
         }
         return next
     }
@@ -270,15 +159,15 @@ private struct ScorecardPayload: Codable {
 
     var scorecard: Scorecard {
         Scorecard(
-            premiseStrength: WorkflowEngine.clampScore(premiseStrength),
-            originality: WorkflowEngine.clampScore(originality),
-            specificity: WorkflowEngine.clampScore(specificity),
-            clarity: WorkflowEngine.clampScore(clarity),
-            structure: WorkflowEngine.clampScore(structure),
-            sourceGrounding: WorkflowEngine.clampScore(sourceGrounding),
-            hookQuality: WorkflowEngine.clampScore(hookQuality),
-            payoffQuality: WorkflowEngine.clampScore(payoffQuality),
-            nonSlop: WorkflowEngine.clampScore(nonSlop),
+            premiseStrength: Rubric.clampScore(premiseStrength),
+            originality: Rubric.clampScore(originality),
+            specificity: Rubric.clampScore(specificity),
+            clarity: Rubric.clampScore(clarity),
+            structure: Rubric.clampScore(structure),
+            sourceGrounding: Rubric.clampScore(sourceGrounding),
+            hookQuality: Rubric.clampScore(hookQuality),
+            payoffQuality: Rubric.clampScore(payoffQuality),
+            nonSlop: Rubric.clampScore(nonSlop),
             flags: flags.cleaned(max: 8),
             rationale: rationale
         )
@@ -286,72 +175,6 @@ private struct ScorecardPayload: Codable {
 }
 
 fileprivate extension WorkflowEngine {
-    static func clampScore(_ score: Int) -> Int {
-        min(max(score, 0), 10)
-    }
-
-    static func containsAny(_ text: String, _ terms: [String]) -> Bool {
-        terms.contains { text.contains($0) }
-    }
-
-    static func nonSlopFlags(text: String, sourceHits: Int, uniqueRatio: Double, genericTerms: [String], fillerTerms: [String]) -> [String] {
-        let lower = text.lowercased()
-        var flags: [String] = []
-        if containsAny(lower, genericTerms) { flags.append("generic phrasing") }
-        if lower.count < 220 { flags.append("weak premise") }
-        if sourceHits == 0 { flags.append("unsupported claims") }
-        if uniqueRatio < 0.55 { flags.append("repetitive structure") }
-        let fillerCount = fillerTerms.reduce(0) { $0 + lower.components(separatedBy: $1).count - 1 }
-        if fillerCount >= 4 { flags.append("filler language") }
-        let firstLine = lower.components(separatedBy: .newlines).first ?? lower
-        if firstLine.count < 18 || firstLine.contains("here are") { flags.append("awkward or low-effort hook") }
-        if lower.contains("everyone knows") || lower.contains("studies show") { flags.append("fake insight") }
-        return flags
-    }
-
-    func projectSummary(_ project: Project) -> String {
-        """
-        Title: \(project.title)
-        Topic: \(project.topic)
-        Audience: \(project.audience)
-        Platform: \(project.platform.rawValue)
-        Tone: \(project.tone)
-        Goal: \(project.goal)
-        Constraints: \(project.constraints)
-        """
-    }
-
-    func sourceDigest(_ sources: [ResearchSource]) -> String {
-        sources.prefix(12).map { source in
-            """
-            [\(source.kind.rawValue)] \(source.title)
-            Locator: \(source.locator)
-            Credibility: \(source.credibilityNote)
-            Text:
-            \(source.rawText.prefix(1800))
-            """
-        }.joined(separator: "\n\n---\n\n")
-    }
-
-    func briefDigest(_ brief: ResearchBrief) -> String {
-        """
-        Insights:
-        \(brief.distilledInsights.joined(separator: "\n- "))
-
-        Claims:
-        \(brief.claims.joined(separator: "\n- "))
-
-        Angles:
-        \(brief.angles.joined(separator: "\n- "))
-
-        Audience tensions:
-        \(brief.audienceTensions.joined(separator: "\n- "))
-
-        Citations:
-        \(brief.citations.joined(separator: "\n- "))
-        """
-    }
-
     func fallbackBrief(project: Project, sources: [ResearchSource]) -> ResearchBrief {
         let sourceSentences = sources.flatMap { source in
             sentenceCandidates(from: source.rawText).prefix(4).map { "\(source.title): \($0)" }

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/ApprovalServiceTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/ApprovalServiceTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class ApprovalServiceTests: XCTestCase {
+    func testApproveUsesHumanEditedTextWhenPresent() {
+        let fixture = ApprovalFixture.make(humanEditedText: "Final human pass wins.")
+        let approvedAt = Date(timeIntervalSince1970: 1_779_105_600)
+
+        let approved = ApprovalService().approve(
+            project: fixture.project,
+            candidate: fixture.candidate,
+            brief: fixture.brief,
+            reviewerNote: "Ready for export.",
+            approvedAt: approvedAt
+        )
+
+        XCTAssertEqual(approved.project, fixture.project)
+        XCTAssertEqual(approved.candidate, fixture.candidate)
+        XCTAssertEqual(approved.brief, fixture.brief)
+        XCTAssertEqual(approved.scriptText, "Final human pass wins.")
+        XCTAssertEqual(approved.approvedAt, approvedAt)
+        XCTAssertEqual(approved.reviewerNote, "Ready for export.")
+        XCTAssertEqual(approved.projectId, fixture.project.id)
+        XCTAssertEqual(approved.candidateId, fixture.candidate.id)
+    }
+
+    func testApproveFallsBackToBeatTranscriptWithoutHumanEditedText() {
+        let fixture = ApprovalFixture.make(humanEditedText: " \n\t ")
+
+        let approved = ApprovalService().approve(
+            project: fixture.project,
+            candidate: fixture.candidate,
+            brief: fixture.brief
+        )
+
+        XCTAssertEqual(
+            approved.scriptText,
+            """
+            Draft hook.
+
+            Draft setup.
+
+            Draft escalation.
+
+            Draft payoff.
+
+            Draft loop.
+            """
+        )
+    }
+
+    func testApprovePreservesCandidateDataImmutably() {
+        let fixture = ApprovalFixture.make(humanEditedText: "Approved version.")
+        var candidate = fixture.candidate
+        let approved = ApprovalService().approve(
+            project: fixture.project,
+            candidate: candidate,
+            brief: fixture.brief
+        )
+
+        candidate.title = "Mutated After Approval"
+        candidate.angle = "mutated angle"
+        candidate.tags.append("mutated")
+        candidate.beats.hook = "Mutated hook."
+        candidate.humanEditedText = "Mutated approved text."
+        candidate.versionHistory.append("mutated history")
+
+        XCTAssertEqual(approved.candidate, fixture.candidate)
+        XCTAssertEqual(approved.scriptText, "Approved version.")
+        XCTAssertNotEqual(approved.candidate, candidate)
+        XCTAssertNotEqual(approved.scriptText, candidate.displayText)
+    }
+}
+
+private enum ApprovalFixture {
+    static func make(humanEditedText: String) -> (
+        project: Project,
+        candidate: ScriptCandidate,
+        brief: ResearchBrief
+    ) {
+        let projectId = UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!
+        let runId = UUID(uuidString: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")!
+        let candidateId = UUID(uuidString: "cccccccc-cccc-cccc-cccc-cccccccccccc")!
+        let createdAt = Date(timeIntervalSince1970: 1_779_081_600)
+
+        let project = Project(
+            id: projectId,
+            title: "Approval Flow",
+            topic: "human review",
+            audience: "script editors",
+            platform: .shorts,
+            tone: "precise",
+            goal: "approve without posting",
+            constraints: "Keep approval local.",
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+        let candidate = ScriptCandidate(
+            id: candidateId,
+            projectId: projectId,
+            runId: runId,
+            title: "Local Approval",
+            angle: "approval is separate from publishing",
+            tags: ["approval", "review"],
+            beats: ScriptBeats(
+                hook: "Draft hook.",
+                setup: "Draft setup.",
+                escalation: "Draft escalation.",
+                payoff: "Draft payoff.",
+                callToActionOrLoop: "Draft loop.",
+                timingNotes: "60 seconds"
+            ),
+            scorecard: Scorecard(
+                premiseStrength: 8,
+                originality: 7,
+                specificity: 9,
+                clarity: 8,
+                structure: 8,
+                sourceGrounding: 7,
+                hookQuality: 8,
+                payoffQuality: 8,
+                nonSlop: 9,
+                flags: ["reviewed"],
+                rationale: "Ready after human pass."
+            ),
+            humanEditedText: humanEditedText,
+            versionHistory: ["agent draft", "human edit"],
+            createdAt: createdAt
+        )
+        let brief = ResearchBrief(
+            projectId: projectId,
+            distilledInsights: ["Approval should be explicit."],
+            claims: ["Publishing remains a later action."],
+            angles: ["Separate approval from distribution."],
+            audienceTensions: ["Editors want control."],
+            citations: ["Internal workflow note"],
+            createdAt: createdAt
+        )
+
+        return (project, candidate, brief)
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/BackendHealthServiceTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/BackendHealthServiceTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import XCTest
+@testable import ScriptEditorCore
+
+final class BackendHealthServiceTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testModelsHealthReportsReachableBackend() async {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/v1/models")
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            let data = """
+            {
+              "object": "list",
+              "data": [
+                { "id": "mlx-community/Qwen3-1.7B-4bit", "object": "model" }
+              ]
+            }
+            """.data(using: .utf8)!
+            return (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                data
+            )
+        }
+
+        let service = BackendHealthService(
+            configuration: AIBackendConfiguration(),
+            session: makeMockSession(),
+            clock: FixedStepClock(times: [
+                Date(timeIntervalSince1970: 100),
+                Date(timeIntervalSince1970: 100.125)
+            ])
+        )
+
+        let status = await service.check(mode: .models)
+
+        XCTAssertEqual(status.baseURL, URL(string: "http://127.0.0.1:8081/v1")!)
+        XCTAssertEqual(status.model, "mlx-community/Qwen3-1.7B-4bit")
+        XCTAssertTrue(status.reachable)
+        XCTAssertEqual(status.latency, 0.125, accuracy: 0.001)
+        XCTAssertEqual(status.message, "Backend is reachable and model is available.")
+    }
+
+    func testChatCompletionsFailureReportsUnreachableBackend() async {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/v1/chat/completions")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            let data = #"{"error":"model not loaded"}"#.data(using: .utf8)!
+            return (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 503,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                data
+            )
+        }
+
+        let service = BackendHealthService(
+            configuration: AIBackendConfiguration(),
+            session: makeMockSession(),
+            clock: FixedStepClock(times: [
+                Date(timeIntervalSince1970: 200),
+                Date(timeIntervalSince1970: 200.25)
+            ])
+        )
+
+        let status = await service.check(mode: .chatCompletions)
+
+        XCTAssertFalse(status.reachable)
+        XCTAssertEqual(status.latency, 0.25, accuracy: 0.001)
+        XCTAssertEqual(status.message, #"The AI backend returned HTTP 503: {"error":"model not loaded"}"#)
+    }
+
+    private func makeMockSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class FixedStepClock: BackendHealthClock, @unchecked Sendable {
+    private var times: [Date]
+
+    init(times: [Date]) {
+        self.times = times
+    }
+
+    var now: Date {
+        if times.count > 1 {
+            return times.removeFirst()
+        }
+        return times.first ?? Date()
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/ExportServiceTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/ExportServiceTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class ExportServiceTests: XCTestCase {
+    func testRenderApprovedScriptMarkdownIncludesScriptMetadataScorecardAndCitations() {
+        let fixture = ExportFixture.make()
+        let markdown = ExportService().renderApprovedScriptMarkdown(
+            project: fixture.project,
+            candidate: fixture.candidate,
+            brief: fixture.brief,
+            sources: fixture.sources,
+            exportedAt: fixture.exportedAt
+        )
+
+        XCTAssertTrue(markdown.contains("# Specific Proof Beats Vibes"))
+        XCTAssertTrue(markdown.contains("> v1 approved script export"))
+        XCTAssertTrue(markdown.contains("- Title: Creator Trust"))
+        XCTAssertTrue(markdown.contains("- Topic: short-form evidence"))
+        XCTAssertTrue(markdown.contains("- Audience: independent creators"))
+        XCTAssertTrue(markdown.contains("- Platform: TikTok"))
+        XCTAssertTrue(markdown.contains("- Goal: help creators approve sharper scripts"))
+        XCTAssertTrue(markdown.contains("- Exported At: 2026-05-18T12:00:00Z"))
+
+        XCTAssertTrue(markdown.contains("Cold open from final approved edit."))
+        XCTAssertFalse(markdown.contains("Draft hook should not win."))
+        XCTAssertTrue(markdown.contains("- Angle: receipts create retention"))
+        XCTAssertTrue(markdown.contains("- Tags: approval, evidence"))
+
+        XCTAssertTrue(markdown.contains("## Scorecard"))
+        XCTAssertTrue(markdown.contains("- Total: 81/90"))
+        XCTAssertTrue(markdown.contains("- Premise Strength: 9/10"))
+        XCTAssertTrue(markdown.contains("- Flags: needs tighter CTA"))
+        XCTAssertTrue(markdown.contains("Rationale:\nGrounded, specific, and clear."))
+
+        XCTAssertTrue(markdown.contains("## Research Brief"))
+        XCTAssertTrue(markdown.contains("- Specific proof points increase trust."))
+        XCTAssertTrue(markdown.contains("- Interview notes: viewers pause for receipts."))
+        XCTAssertTrue(markdown.contains("- Open with the receipt, not the advice."))
+        XCTAssertTrue(markdown.contains("- Creators distrust vague growth claims."))
+
+        XCTAssertTrue(markdown.contains("## Source Citations"))
+        XCTAssertTrue(markdown.contains("- Brief citation: creator interview batch A"))
+        XCTAssertTrue(markdown.contains("- Interview notes [Note] - local-note-1 (first-party interviews)"))
+        XCTAssertTrue(markdown.contains("- Platform report [URL] - https://example.com/report"))
+    }
+
+    func testRenderApprovedScriptMarkdownDoesNotMutateStoredData() async throws {
+        let fixture = ExportFixture.make()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("db.json")
+        let database = await LocalScriptDatabase(fileURL: url)
+        let project = try await database.upsertProject(fixture.project)
+        try await database.saveBrief(fixture.brief)
+        _ = try await database.addSource(fixture.sources[0])
+        try await database.saveRun(
+            GenerationRun(
+                id: fixture.candidate.runId,
+                projectId: fixture.project.id,
+                model: "fixture-model",
+                candidateCount: 1,
+                promptSummary: "fixture"
+            ),
+            candidates: [fixture.candidate]
+        )
+        let before = await database.readSnapshot()
+
+        _ = ExportService().renderApprovedScriptMarkdown(
+            project: project,
+            candidate: fixture.candidate,
+            brief: fixture.brief,
+            sources: fixture.sources,
+            exportedAt: fixture.exportedAt
+        )
+
+        let after = await database.readSnapshot()
+        XCTAssertEqual(after, before)
+    }
+}
+
+private enum ExportFixture {
+    static func make() -> (
+        project: Project,
+        candidate: ScriptCandidate,
+        brief: ResearchBrief,
+        sources: [ResearchSource],
+        exportedAt: Date
+    ) {
+        let projectId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let runId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let candidateId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let createdAt = Date(timeIntervalSince1970: 1_779_081_600)
+        let exportedAt = Date(timeIntervalSince1970: 1_779_105_600)
+        let project = Project(
+            id: projectId,
+            title: "Creator Trust",
+            topic: "short-form evidence",
+            audience: "independent creators",
+            platform: .tiktok,
+            tone: "smart and direct",
+            goal: "help creators approve sharper scripts",
+            constraints: "No unverifiable claims.",
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+        let candidate = ScriptCandidate(
+            id: candidateId,
+            projectId: projectId,
+            runId: runId,
+            title: "Specific Proof Beats Vibes",
+            angle: "receipts create retention",
+            tags: ["approval", "evidence"],
+            beats: ScriptBeats(
+                hook: "Draft hook should not win.",
+                setup: "Show the receipt first.",
+                escalation: "Name the vague claim.",
+                payoff: "Give the specific alternative.",
+                callToActionOrLoop: "Save the checklist.",
+                timingNotes: "45 seconds"
+            ),
+            scorecard: Scorecard(
+                premiseStrength: 9,
+                originality: 8,
+                specificity: 10,
+                clarity: 9,
+                structure: 9,
+                sourceGrounding: 10,
+                hookQuality: 9,
+                payoffQuality: 8,
+                nonSlop: 9,
+                flags: ["needs tighter CTA"],
+                rationale: "Grounded, specific, and clear."
+            ),
+            humanEditedText: "Cold open from final approved edit.",
+            createdAt: createdAt
+        )
+        let brief = ResearchBrief(
+            projectId: projectId,
+            distilledInsights: ["Specific proof points increase trust."],
+            claims: ["Interview notes: viewers pause for receipts."],
+            angles: ["Open with the receipt, not the advice."],
+            audienceTensions: ["Creators distrust vague growth claims."],
+            citations: ["Brief citation: creator interview batch A"],
+            createdAt: createdAt
+        )
+        let sources = [
+            ResearchSource(
+                projectId: projectId,
+                kind: .note,
+                title: "Interview notes",
+                locator: "local-note-1",
+                rawText: "Creators trust receipts.",
+                credibilityNote: "first-party interviews",
+                createdAt: createdAt
+            ),
+            ResearchSource(
+                projectId: projectId,
+                kind: .url,
+                title: "Platform report",
+                locator: "https://example.com/report",
+                rawText: "Retention favors specificity.",
+                createdAt: createdAt
+            )
+        ]
+        return (project, candidate, brief, sources, exportedAt)
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/PromptLibraryTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/PromptLibraryTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class PromptLibraryTests: XCTestCase {
+    func testResearchBriefPromptIncludesRequiredJSONKeysAndSourceGrounding() {
+        let project = Project(title: "Hook Lab", topic: "creator retention", audience: "solo creators")
+        let sources = [
+            ResearchSource(
+                projectId: project.id,
+                kind: .note,
+                title: "Interview notes",
+                locator: "notebook",
+                rawText: "Creators trust concrete proof points more than generic advice.",
+                credibilityNote: "first-party interviews"
+            )
+        ]
+
+        let prompt = PromptLibrary.researchBrief(project: project, sources: sources)
+
+        XCTAssertEqual(prompt.version, PromptLibrary.version)
+        XCTAssertTrue(prompt.system.contains("source-backed ideas"))
+        XCTAssertTrue(prompt.user.contains("Return only JSON"))
+        XCTAssertTrue(prompt.user.contains("distilledInsights, claims, angles, audienceTensions, citations"))
+        XCTAssertTrue(prompt.user.contains("Claims should cite source titles"))
+        XCTAssertTrue(prompt.user.contains("[Note] Interview notes"))
+        XCTAssertTrue(prompt.user.contains("Prompt version: \(PromptLibrary.version)"))
+    }
+
+    func testCandidateGenerationPromptIncludesFormatAndVariationRequirements() {
+        let project = Project(topic: "local AI workflows", audience: "indie creators")
+        let brief = ResearchBrief(
+            projectId: project.id,
+            claims: ["Benchmarks show local drafts return faster than hosted calls."],
+            angles: ["Local AI changes the drafting loop."]
+        )
+
+        let prompt = PromptLibrary.candidateGeneration(project: project, brief: brief, count: 24)
+
+        XCTAssertTrue(prompt.system.contains("senior short-form video writer"))
+        XCTAssertTrue(prompt.user.contains("Generate 24 distinct short-form video script candidates"))
+        XCTAssertTrue(prompt.user.contains("\"candidates\""))
+        XCTAssertTrue(prompt.user.contains("\"callToActionOrLoop\""))
+        XCTAssertTrue(prompt.user.contains("Format every candidate as hook, setup, escalation, payoff, CTA or loop, timing notes"))
+        XCTAssertTrue(prompt.user.contains("Vary hook type, emotional frame, premise, pacing, angle, and payoff"))
+        XCTAssertTrue(prompt.user.contains("Stay grounded in the research brief"))
+        XCTAssertTrue(prompt.user.contains("30-90 seconds"))
+    }
+
+    func testScoringPromptIncludesRubricDimensionsAndFlagTaxonomy() {
+        let projectId = UUID()
+        let runId = UUID()
+        let candidate = ScriptCandidate(
+            projectId: projectId,
+            runId: runId,
+            title: "Specific Hook",
+            angle: "Proof beats vague advice",
+            beats: ScriptBeats(
+                hook: "Stop opening with generic advice.",
+                setup: "Creators lose trust when the proof arrives late.",
+                escalation: "Interview notes show concrete proof points create faster confidence.",
+                payoff: "Lead with the evidence, then name the decision it changes."
+            )
+        )
+        let brief = ResearchBrief(
+            projectId: projectId,
+            claims: ["Interview notes: concrete proof points create faster confidence."]
+        )
+
+        let prompt = PromptLibrary.scoring(candidate: candidate, brief: brief)
+
+        XCTAssertTrue(prompt.system.contains("strict script quality judge"))
+        XCTAssertTrue(prompt.user.contains("0-10 scale"))
+        XCTAssertTrue(prompt.user.contains("premiseStrength, originality, specificity, clarity, structure, sourceGrounding, hookQuality, payoffQuality, nonSlop, flags, rationale"))
+        XCTAssertTrue(prompt.user.contains("generic phrasing, fake insight, weak premise, repetitive structure, unsupported claims, filler language, awkward hook, or low-effort hook"))
+        XCTAssertTrue(prompt.user.contains("Title: Specific Hook"))
+        XCTAssertTrue(prompt.user.contains("Script:"))
+    }
+
+    func testRevisionPromptIncludesDraftProtectionAndChatContext() {
+        let projectId = UUID()
+        let candidateId = UUID()
+        let candidate = ScriptCandidate(
+            id: candidateId,
+            projectId: projectId,
+            runId: UUID(),
+            title: "Draft",
+            angle: "Make the payoff concrete",
+            beats: ScriptBeats(hook: "The obvious answer is the trap.", setup: "Setup", escalation: "Escalation", payoff: "Payoff")
+        )
+        let brief = ResearchBrief(
+            projectId: projectId,
+            claims: ["Source A: stronger payoffs show the consequence."],
+            citations: ["Source A"]
+        )
+        let history = [
+            AgentMessage(candidateId: candidateId, role: "user", content: "Can this feel less broad?")
+        ]
+
+        let prompt = PromptLibrary.revisionChat(
+            candidate: candidate,
+            brief: brief,
+            userMessage: "Give me three sharper hooks.",
+            history: history
+        )
+
+        XCTAssertTrue(prompt.system.contains("collaborative script revision partner"))
+        XCTAssertTrue(prompt.user.contains("Do not overwrite the human's draft"))
+        XCTAssertTrue(prompt.user.contains("improved lines, stronger hooks, tighter wording, alternate endings, or source-grounded additions"))
+        XCTAssertTrue(prompt.user.contains("user: Can this feel less broad?"))
+        XCTAssertTrue(prompt.user.contains("Give me three sharper hooks."))
+        XCTAssertTrue(prompt.user.contains("Current script:"))
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/RubricTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/RubricTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class RubricTests: XCTestCase {
+    func testDefaultRubricDefinesScoreDimensionsAndMaximumTotal() {
+        let rubric = Rubric.default
+
+        XCTAssertEqual(rubric.dimensions.map(\.id), [
+            "premiseStrength",
+            "originality",
+            "specificity",
+            "clarity",
+            "structure",
+            "sourceGrounding",
+            "hookQuality",
+            "payoffQuality",
+            "nonSlop"
+        ])
+        XCTAssertEqual(rubric.maximumTotalScore, 90)
+    }
+
+    func testDefaultRubricDefinesNonSlopFlags() {
+        let labels = Set(Rubric.default.nonSlopFlags.map(\.label))
+
+        XCTAssertTrue(labels.contains("generic phrasing"))
+        XCTAssertTrue(labels.contains("unsupported claims"))
+        XCTAssertTrue(labels.contains("filler language"))
+        XCTAssertTrue(labels.contains("fake insight"))
+    }
+
+    func testScorecardTotalUsesAllRubricDimensions() {
+        let scorecard = Scorecard(
+            premiseStrength: 1,
+            originality: 2,
+            specificity: 3,
+            clarity: 4,
+            structure: 5,
+            sourceGrounding: 6,
+            hookQuality: 7,
+            payoffQuality: 8,
+            nonSlop: 9
+        )
+
+        XCTAssertEqual(Rubric.default.totalScore(for: scorecard), 45)
+    }
+
+    func testHeuristicEvaluatorFlagsGenericUnsupportedSlop() {
+        let candidate = ScriptCandidate(
+            projectId: UUID(),
+            runId: UUID(),
+            title: "Generic",
+            angle: "Do better",
+            beats: ScriptBeats(
+                hook: "Here are tips",
+                setup: "In today's world you need to know this game changer.",
+                escalation: "Everyone knows it is really basically actually very important.",
+                payoff: "Unlock success.",
+                callToActionOrLoop: "Follow for more."
+            )
+        )
+        let brief = ResearchBrief(
+            projectId: candidate.projectId,
+            claims: ["Platform data shows specific hooks outperform generic hooks."]
+        )
+
+        let score = Rubric.default.evaluate(candidate: candidate, brief: brief)
+
+        XCTAssertTrue(score.flags.contains("generic phrasing"))
+        XCTAssertTrue(score.flags.contains("unsupported claims"))
+        XCTAssertTrue(score.flags.contains("filler language"))
+        XCTAssertLessThan(score.nonSlop, 8)
+    }
+
+    func testHeuristicEvaluatorRewardsSourceGroundingAndStructure() {
+        let candidate = ScriptCandidate(
+            projectId: UUID(),
+            runId: UUID(),
+            title: "Proof Beats Vague Advice",
+            angle: "Specific proof points beat generic hooks for skeptical viewers",
+            beats: ScriptBeats(
+                hook: "Why do specific hooks beat generic advice before viewers trust you?",
+                setup: "Platform data shows specific hooks outperform generic hooks when viewers need proof quickly.",
+                escalation: "The turn is simple: a named proof point gives the viewer something to test, not just a slogan.",
+                payoff: "So instead of promising better content, show one concrete before-and-after claim and let the result carry the lesson.",
+                callToActionOrLoop: "Save the proof point before you write the next hook."
+            )
+        )
+        let brief = ResearchBrief(
+            projectId: candidate.projectId,
+            claims: ["Platform data shows specific hooks outperform generic hooks."]
+        )
+
+        let score = Rubric.default.evaluate(candidate: candidate, brief: brief)
+
+        XCTAssertGreaterThanOrEqual(score.structure, 8)
+        XCTAssertGreaterThanOrEqual(score.sourceGrounding, 6)
+        XCTAssertFalse(score.flags.contains("unsupported claims"))
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/SourceIngestionServiceTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/SourceIngestionServiceTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class SourceIngestionServiceTests: XCTestCase {
+    func testIngestNoteBuildsResearchSourceWithFacts() throws {
+        let projectId = UUID()
+        let service = SourceIngestionService()
+
+        let source = try service.ingestNote(
+            projectId: projectId,
+            title: "  Field notes  ",
+            text: """
+            Creators said vague hooks feel skippable.
+            A 2025 internal review found specific proof points increased retention by 18%.
+            """
+        )
+
+        XCTAssertEqual(source.projectId, projectId)
+        XCTAssertEqual(source.kind, .note)
+        XCTAssertEqual(source.title, "Field notes")
+        XCTAssertEqual(source.credibilityNote, "User-provided local note")
+        XCTAssertTrue(source.rawText.contains("specific proof points"))
+        XCTAssertEqual(source.extractedFacts, [
+            "A 2025 internal review found specific proof points increased retention by 18%."
+        ])
+    }
+
+    func testIngestFileReadsSupportedPlainTextFile() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("source.md")
+        try """
+        # Source
+
+        According to the survey, 64% of viewers stayed longer when the hook named a concrete mistake.
+        Generic sentence without evidence.
+        """.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let source = try SourceIngestionService().ingestFile(projectId: UUID(), fileURL: fileURL)
+
+        XCTAssertEqual(source.kind, .file)
+        XCTAssertEqual(source.title, "source")
+        XCTAssertEqual(source.locator, fileURL.path)
+        XCTAssertEqual(source.credibilityNote, "Imported from local .md file")
+        XCTAssertEqual(source.extractedFacts.first, "According to the survey, 64% of viewers stayed longer when the hook named a concrete mistake.")
+    }
+
+    func testFactExtractionPrioritizesEvidenceHeavySentences() {
+        let facts = SourceIngestionService.extractFacts(from: """
+        This is an interesting but generic observation.
+        Research showed completion increased by 22% after creators named the exact tradeoff.
+        The team liked shorter scripts.
+        According to interviews, 7 of 10 editors wanted more citation-ready claims.
+        """, maxFacts: 2)
+
+        XCTAssertEqual(facts, [
+            "Research showed completion increased by 22% after creators named the exact tradeoff.",
+            "According to interviews, 7 of 10 editors wanted more citation-ready claims."
+        ])
+    }
+
+    func testIngestFileAcceptsFileURLStringLocator() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("metrics.csv")
+        try "label,value\nRetention increased,31%\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let source = try SourceIngestionService().ingestFile(projectId: UUID(), locator: fileURL.absoluteString)
+
+        XCTAssertEqual(source.kind, .file)
+        XCTAssertEqual(source.title, "metrics")
+        XCTAssertEqual(source.locator, fileURL.path)
+        XCTAssertTrue(source.rawText.contains("Retention increased,31%"))
+    }
+
+    func testUnsupportedExtensionThrowsRecoverableError() {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("clip.pdf")
+
+        XCTAssertThrowsError(try SourceIngestionService().ingestFile(projectId: UUID(), fileURL: fileURL)) { error in
+            XCTAssertEqual(error as? SourceIngestionService.IngestionError, .unsupportedExtension("pdf"))
+            XCTAssertTrue((error as? SourceIngestionService.IngestionError)?.isRecoverable == true)
+        }
+    }
+}

--- a/macos/ScriptEditor/Tests/ScriptEditorCoreTests/WorkflowEngineTests.swift
+++ b/macos/ScriptEditor/Tests/ScriptEditorCoreTests/WorkflowEngineTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import ScriptEditorCore
+
+final class WorkflowEngineTests: XCTestCase {
+    func testDatabasePersistsProjectsSourcesAndBriefs() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("db.json")
+        let database = await LocalScriptDatabase(fileURL: url)
+        let project = try await database.upsertProject(Project(title: "Retention Test", topic: "short-form hooks"))
+        _ = try await database.addSource(ResearchSource(
+            projectId: project.id,
+            kind: .note,
+            title: "Interview notes",
+            rawText: "Specific proof points beat vague creator advice when viewers need trust quickly."
+        ))
+        try await database.saveBrief(ResearchBrief(
+            projectId: project.id,
+            distilledInsights: ["Specific proof points increase trust."],
+            claims: ["Interview notes: proof points beat vague advice."],
+            angles: ["Specificity beats generic hooks."]
+        ))
+
+        let reloaded = await LocalScriptDatabase(fileURL: url)
+        let snapshot = await reloaded.readSnapshot()
+
+        XCTAssertEqual(snapshot.projects.count, 1)
+        XCTAssertEqual(snapshot.sources.count, 1)
+        XCTAssertEqual(snapshot.briefs.count, 1)
+    }
+
+    func testHeuristicScoreFlagsGenericUnsupportedSlop() {
+        let candidate = ScriptCandidate(
+            projectId: UUID(),
+            runId: UUID(),
+            title: "Generic",
+            angle: "Do better",
+            beats: ScriptBeats(
+                hook: "Here are tips",
+                setup: "In today's world you need to know this game changer.",
+                escalation: "Everyone knows it is really basically actually very important.",
+                payoff: "Unlock success.",
+                callToActionOrLoop: "Follow for more."
+            )
+        )
+        let brief = ResearchBrief(
+            projectId: candidate.projectId,
+            claims: ["Platform data shows specific hooks outperform generic hooks."]
+        )
+
+        let score = WorkflowEngine.heuristicScore(for: candidate, brief: brief)
+
+        XCTAssertTrue(score.flags.contains("generic phrasing"))
+        XCTAssertTrue(score.flags.contains("unsupported claims"))
+        XCTAssertTrue(score.flags.contains("filler language"))
+        XCTAssertLessThan(score.nonSlop, 8)
+    }
+
+    func testTopCandidatesReturnsTenHighestRanked() {
+        let engine = WorkflowEngine(ai: FakeAI(response: "{}"))
+        let projectId = UUID()
+        let runId = UUID()
+        let candidates = (0..<15).map { index in
+            ScriptCandidate(
+                projectId: projectId,
+                runId: runId,
+                title: "Candidate \(index)",
+                angle: "Angle \(index)",
+                beats: ScriptBeats(hook: "Hook \(index)", setup: "Setup", escalation: "Escalation", payoff: "Payoff"),
+                scorecard: Scorecard(
+                    premiseStrength: index,
+                    originality: index,
+                    specificity: index,
+                    clarity: index,
+                    structure: index,
+                    sourceGrounding: index,
+                    hookQuality: index,
+                    payoffQuality: index,
+                    nonSlop: index
+                )
+            )
+        }
+
+        let top = engine.topCandidates(from: candidates)
+
+        XCTAssertEqual(top.count, 10)
+        XCTAssertEqual(top.first?.title, "Candidate 14")
+        XCTAssertEqual(top.last?.title, "Candidate 5")
+    }
+
+    func testGenerateCandidatesFallsBackToRequestedRange() async {
+        let engine = WorkflowEngine(ai: FakeAI(response: "not json"))
+        let project = Project(topic: "local AI workflows", audience: "indie creators", goal: "make script decisions sharper")
+        let brief = ResearchBrief(
+            projectId: project.id,
+            claims: ["Local endpoints let the app keep working without hosted model calls."],
+            angles: ["Local AI as a faster drafting loop."]
+        )
+
+        let (run, candidates) = await engine.generateCandidates(project: project, brief: brief, count: 41, model: "qwen-local")
+
+        XCTAssertEqual(run.candidateCount, 40)
+        XCTAssertEqual(candidates.count, 40)
+        XCTAssertTrue(candidates.allSatisfy { !$0.beats.hook.isEmpty })
+    }
+}
+
+private struct FakeAI: AITextGenerating {
+    var response: String
+
+    func complete(messages: [ChatMessage], temperature: Double, maxTokens: Int) async throws -> String {
+        response
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "electron:build": "pnpm build && pnpm electron:bundle-server && electron-builder --config electron-builder.config.cjs",
     "electron:build:mac": "pnpm build && pnpm electron:bundle-server && electron-builder --mac --config electron-builder.config.cjs",
     "electron:build:win": "pnpm build && pnpm electron:bundle-server && electron-builder --win --config electron-builder.config.cjs",
-    "electron:bundle-server": "esbuild dist/server/server.js --bundle --platform=node --format=cjs --outfile=electron/server-bundle.cjs"
+    "electron:bundle-server": "esbuild dist/server/server.js --bundle --platform=node --format=cjs --outfile=electron/server-bundle.cjs",
+    "native:mac": "./macos-native/Scripts/build-macos-app.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "electron:build:mac": "pnpm build && pnpm electron:bundle-server && electron-builder --mac --config electron-builder.config.cjs",
     "electron:build:win": "pnpm build && pnpm electron:bundle-server && electron-builder --win --config electron-builder.config.cjs",
     "electron:bundle-server": "esbuild dist/server/server.js --bundle --platform=node --format=cjs --outfile=electron/server-bundle.cjs",
-    "native:mac": "./macos-native/Scripts/build-macos-app.sh"
+    "native:mac": "./macos-native/Scripts/build-macos-app.sh",
+    "script-editor:mac": "./scripts/start-script-editor-mac.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",

--- a/scripts/start-script-editor-mac.sh
+++ b/scripts/start-script-editor-mac.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="$ROOT_DIR/macos/ScriptEditor"
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "Native Script Editor not found at $APP_DIR" >&2
+  exit 1
+fi
+
+echo "Launching Native Script Editor from Hermes Workspace..."
+echo "App: $APP_DIR"
+echo "Default AI backend: http://127.0.0.1:8081/v1"
+echo
+
+cd "$APP_DIR"
+if ! swift run ScriptEditorApp; then
+  echo
+  echo "Native Script Editor could not launch because Swift failed before app code compiled." >&2
+  echo "If you see a PackageDescription or SDK/compiler mismatch above, install/select full Xcode:" >&2
+  echo "  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
+  echo "Then rerun from Hermes Workspace:" >&2
+  echo "  pnpm script-editor:mac" >&2
+  exit 1
+fi

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -12,6 +12,7 @@ import {
   File01Icon,
   McpServerIcon,
   Menu01Icon,
+  PencilEdit02Icon,
   PuzzleIcon,
   Rocket01Icon,
   Settings01Icon,
@@ -55,6 +56,13 @@ export const MOBILE_HAMBURGER_NAV_ITEMS = [
     icon: CommandLineIcon,
     to: '/terminal',
     match: (p: string) => p.startsWith('/terminal'),
+  },
+  {
+    id: 'script-editor',
+    label: 'Script Editor',
+    icon: PencilEdit02Icon,
+    to: '/script-editor',
+    match: (p: string) => p.startsWith('/script-editor'),
   },
   {
     id: 'jobs',

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -168,6 +168,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   // Derive active session from URL
   const mobilePageTitle = (() => {
     if (pathname.startsWith('/terminal')) return 'Terminal'
+    if (pathname.startsWith('/script-editor')) return 'Script Editor'
     if (pathname.startsWith('/files')) return 'Files'
     if (pathname.startsWith('/jobs')) return 'Jobs'
     if (pathname.startsWith('/conductor')) return 'Conductor'
@@ -187,10 +188,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const activeFriendlyId = chatMatch ? chatMatch[1] : 'main'
   const isOnChatRoute = Boolean(chatMatch) || pathname === '/new'
   const isOnTerminalRoute = pathname.startsWith('/terminal')
-  const isOnPlaygroundRoute = pathname === '/playground' || pathname.startsWith('/playground/')
-  const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
+  const isOnPlaygroundRoute =
+    pathname === '/playground' || pathname.startsWith('/playground/')
+  const isOnHermesWorldLandingRoute =
+    pathname === '/hermes-world' ||
+    pathname.startsWith('/hermes-world/') ||
+    pathname === '/world' ||
+    pathname.startsWith('/world/')
   const isEmbeddedSurface =
-    search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
+    search?.embed === '1' ||
+    search?.embed === 'true' ||
+    search?.mode === 'embed'
   const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
@@ -342,7 +350,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
         <div
           className={cn(
             'grid h-full grid-cols-1 grid-rows-[minmax(0,1fr)] overflow-hidden',
-            hideChatSidebar || isChromeFreeSurface ? 'md:grid-cols-1' : 'md:grid-cols-[auto_1fr]',
+            hideChatSidebar || isChromeFreeSurface
+              ? 'md:grid-cols-1'
+              : 'md:grid-cols-[auto_1fr]',
           )}
         >
           {/* Activity ticker bar */}
@@ -433,11 +443,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
           </main>
 
           {/* Chat panel — visible on non-chat routes (but not in HermesWorld, which has its own in-game chat) */}
-          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && <ChatPanel />}
+          {!isOnChatRoute &&
+            !isOnPlaygroundRoute &&
+            !isChromeFreeSurface &&
+            !isMobile && <ChatPanel />}
         </div>
 
         {/* Floating chat toggle — visible on non-chat routes (but not in HermesWorld) */}
-        {!isChromeFreeSurface && !isOnChatRoute && !isOnPlaygroundRoute && !isMobile && <ChatPanelToggle />}
+        {!isChromeFreeSurface &&
+          !isOnChatRoute &&
+          !isOnPlaygroundRoute &&
+          !isMobile && <ChatPanelToggle />}
 
         {showDesktopSidebarBackdrop ? (
           <button
@@ -454,10 +470,15 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
       </div>
 
       {!isChromeFreeSurface ? <MobileHamburgerMenu /> : null}
-      {!isChromeFreeSurface && !isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
+      {!isChromeFreeSurface &&
+      !isMobile &&
+      !isOnChatRoute &&
+      settings.showSystemMetricsFooter ? (
         <SystemMetricsFooter leftOffsetPx={sidebarCollapsed ? 48 : 300} />
       ) : null}
-      {!isChromeFreeSurface ? <CommandPalette pathname={pathname} sessions={sessions} /> : null}
+      {!isChromeFreeSurface ? (
+        <CommandPalette pathname={pathname} sessions={sessions} />
+      ) : null}
     </>
   )
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as Swarm2RouteImport } from './routes/swarm2'
 import { Route as SwarmRouteImport } from './routes/swarm'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ScriptEditorRouteImport } from './routes/script-editor'
 import { Route as ReserveRouteImport } from './routes/reserve'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
@@ -194,6 +195,11 @@ const SkillsRoute = SkillsRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ScriptEditorRoute = ScriptEditorRouteImport.update({
+  id: '/script-editor',
+  path: '/script-editor',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ReserveRoute = ReserveRouteImport.update({
@@ -908,6 +914,7 @@ export interface FileRoutesByFullPath {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/script-editor': typeof ScriptEditorRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1056,6 +1063,7 @@ export interface FileRoutesByTo {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/script-editor': typeof ScriptEditorRoute
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
@@ -1204,6 +1212,7 @@ export interface FileRoutesById {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/script-editor': typeof ScriptEditorRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1354,6 +1363,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/script-editor'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1502,6 +1512,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/script-editor'
     | '/skills'
     | '/swarm'
     | '/swarm2'
@@ -1649,6 +1660,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/script-editor'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1798,6 +1810,7 @@ export interface RootRouteChildren {
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
   ReserveRoute: typeof ReserveRouteWithChildren
+  ScriptEditorRoute: typeof ScriptEditorRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
   SwarmRoute: typeof SwarmRoute
@@ -1958,6 +1971,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/script-editor': {
+      id: '/script-editor'
+      path: '/script-editor'
+      fullPath: '/script-editor'
+      preLoaderRoute: typeof ScriptEditorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reserve': {
@@ -3143,6 +3163,7 @@ const rootRouteChildren: RootRouteChildren = {
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
   ReserveRoute: ReserveRouteWithChildren,
+  ScriptEditorRoute: ScriptEditorRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,
   SwarmRoute: SwarmRoute,

--- a/src/routes/script-editor.tsx
+++ b/src/routes/script-editor.tsx
@@ -1,0 +1,1160 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useMemo, useState } from 'react'
+import { usePageTitle } from '@/hooks/use-page-title'
+
+export const Route = createFileRoute('/script-editor')({
+  ssr: false,
+  component: ScriptEditorRoute,
+})
+
+type SourceKind = 'Note' | 'URL' | 'File' | 'Web Result'
+
+type Project = {
+  title: string
+  topic: string
+  audience: string
+  platform: string
+  tone: string
+  goal: string
+  constraints: string
+}
+
+type ResearchSource = {
+  id: string
+  kind: SourceKind
+  title: string
+  locator: string
+  rawText: string
+  extractedFacts: Array<string>
+  credibilityNote: string
+  createdAt: string
+}
+
+type ResearchBrief = {
+  distilledInsights: Array<string>
+  claims: Array<string>
+  angles: Array<string>
+  audienceTensions: Array<string>
+  citations: Array<string>
+}
+
+type ScriptCandidate = {
+  id: string
+  title: string
+  angle: string
+  tags: Array<string>
+  beats: {
+    hook: string
+    setup: string
+    escalation: string
+    payoff: string
+    callToActionOrLoop: string
+    timingNotes: string
+  }
+  scorecard: Scorecard
+  humanEditedText: string
+  versionHistory: Array<string>
+}
+
+type Scorecard = {
+  premiseStrength: number
+  originality: number
+  specificity: number
+  clarity: number
+  structure: number
+  sourceGrounding: number
+  hookQuality: number
+  payoffQuality: number
+  nonSlop: number
+  flags: Array<string>
+  rationale: string
+}
+
+type AppState = {
+  project: Project
+  sources: Array<ResearchSource>
+  brief: ResearchBrief | null
+  candidates: Array<ScriptCandidate>
+  selectedCandidateId: string | null
+  approvedMarkdown: string
+}
+
+const STORAGE_KEY = 'hermes.script-editor.v1'
+const DEFAULT_BACKEND = 'http://127.0.0.1:8081/v1'
+
+const defaultProject: Project = {
+  title: 'Untitled Script Project',
+  topic: '',
+  audience: '',
+  platform: 'TikTok',
+  tone: 'smart, direct, high-retention',
+  goal: '',
+  constraints: '',
+}
+
+const emptyBrief: ResearchBrief = {
+  distilledInsights: [],
+  claims: [],
+  angles: [],
+  audienceTensions: [],
+  citations: [],
+}
+
+function ScriptEditorRoute() {
+  usePageTitle('Script Editor')
+  return <ScriptEditorScreen />
+}
+
+function ScriptEditorScreen() {
+  const [state, setState] = useStoredState()
+  const [stage, setStage] = useState<'research' | 'generation' | 'review'>(
+    'research',
+  )
+  const [sourceKind, setSourceKind] = useState<SourceKind>('Note')
+  const [sourceTitle, setSourceTitle] = useState('')
+  const [sourceLocator, setSourceLocator] = useState('')
+  const [sourceText, setSourceText] = useState('')
+  const [candidateCount, setCandidateCount] = useState(24)
+  const [editorText, setEditorText] = useState('')
+  const [reviewerNote, setReviewerNote] = useState('')
+  const [backendStatus, setBackendStatus] = useState<string>('Not checked')
+  const [backendReachable, setBackendReachable] = useState<boolean | null>(null)
+
+  const selectedCandidate = useMemo(
+    () =>
+      state.candidates.find(
+        (candidate) => candidate.id === state.selectedCandidateId,
+      ) ??
+      state.candidates.at(0) ??
+      null,
+    [state.candidates, state.selectedCandidateId],
+  )
+
+  useEffect(() => {
+    if (selectedCandidate) setEditorText(displayText(selectedCandidate))
+  }, [selectedCandidate?.id])
+
+  const topCandidates = useMemo(
+    () =>
+      [...state.candidates]
+        .sort((a, b) => totalScore(b.scorecard) - totalScore(a.scorecard))
+        .slice(0, 10),
+    [state.candidates],
+  )
+
+  function updateProject(patch: Partial<Project>) {
+    setState((current) => ({
+      ...current,
+      project: { ...current.project, ...patch },
+    }))
+  }
+
+  function addSource() {
+    const text = normalize(sourceText)
+    if (!text) return
+    const source: ResearchSource = {
+      id: crypto.randomUUID(),
+      kind: sourceKind,
+      title: sourceTitle.trim() || `${sourceKind} source`,
+      locator: sourceLocator.trim(),
+      rawText: text,
+      extractedFacts: extractFacts(text),
+      credibilityNote:
+        sourceKind === 'Note'
+          ? 'User-provided note'
+          : sourceKind === 'URL'
+            ? 'User-provided URL excerpt'
+            : sourceKind === 'File'
+              ? 'User-provided file excerpt'
+              : 'Search result snippet',
+      createdAt: new Date().toISOString(),
+    }
+    setState((current) => ({
+      ...current,
+      sources: [source, ...current.sources],
+    }))
+    setSourceTitle('')
+    setSourceLocator('')
+    setSourceText('')
+  }
+
+  async function fetchURL() {
+    if (!sourceLocator.trim()) return
+    try {
+      const response = await fetch(sourceLocator.trim())
+      const html = await response.text()
+      setSourceKind('URL')
+      setSourceText(plainText(html))
+      if (!sourceTitle.trim()) setSourceTitle(new URL(sourceLocator).hostname)
+    } catch (error) {
+      setBackendStatus(
+        error instanceof Error ? error.message : 'Could not fetch URL',
+      )
+      setBackendReachable(false)
+    }
+  }
+
+  function buildBrief() {
+    const facts = state.sources.flatMap((source) =>
+      source.extractedFacts.length
+        ? source.extractedFacts
+        : extractFacts(source.rawText),
+    )
+    const topic = state.project.topic || state.project.title
+    const brief: ResearchBrief = {
+      distilledInsights: take(
+        facts,
+        8,
+        `The strongest scripts should connect ${topic} to a concrete audience tension.`,
+      ),
+      claims: take(
+        facts.map((fact, index) => {
+          const source = state.sources[index % state.sources.length]
+          return `${source.title}: ${fact}`
+        }),
+        10,
+        `Use source-backed claims before making a strong assertion about ${topic}.`,
+      ),
+      angles: [
+        `The common mistake people make with ${topic}`,
+        `The counterintuitive truth about ${topic}`,
+        `Why ${state.project.audience || 'the audience'} distrusts generic advice`,
+        `A before/after transformation tied to ${state.project.goal || 'the project goal'}`,
+      ],
+      audienceTensions: [
+        `${state.project.audience || 'The audience'} wants a fast answer without vague advice.`,
+        'The script must feel useful, specific, and grounded.',
+      ],
+      citations: state.sources.map((source) =>
+        [source.title, source.locator].filter(Boolean).join(' - '),
+      ),
+    }
+    setState((current) => ({ ...current, brief }))
+    setStage('generation')
+  }
+
+  async function checkBackend() {
+    const startedAt = performance.now()
+    try {
+      const response = await fetch(`${DEFAULT_BACKEND}/models`)
+      const elapsed = ((performance.now() - startedAt) / 1000).toFixed(2)
+      setBackendReachable(response.ok)
+      setBackendStatus(
+        response.ok
+          ? `Local Qwen endpoint responded in ${elapsed}s`
+          : `Backend returned HTTP ${response.status}`,
+      )
+    } catch (error) {
+      setBackendReachable(false)
+      setBackendStatus(
+        error instanceof Error ? error.message : 'Backend is not reachable',
+      )
+    }
+  }
+
+  function generateCandidates() {
+    const brief = state.brief ?? emptyBrief
+    const nextCandidates = Array.from({ length: candidateCount }, (_, index) =>
+      makeCandidate(state.project, brief, index),
+    )
+    setState((current) => ({
+      ...current,
+      candidates: nextCandidates,
+      selectedCandidateId: nextCandidates[0]?.id ?? null,
+      approvedMarkdown: '',
+    }))
+    setStage('review')
+  }
+
+  function selectCandidate(candidate: ScriptCandidate) {
+    setState((current) => ({
+      ...current,
+      selectedCandidateId: candidate.id,
+      approvedMarkdown: '',
+    }))
+    setEditorText(displayText(candidate))
+  }
+
+  function saveRevision() {
+    if (!selectedCandidate) return
+    setState((current) => ({
+      ...current,
+      candidates: current.candidates.map((candidate) =>
+        candidate.id === selectedCandidate.id
+          ? {
+              ...candidate,
+              versionHistory: [
+                ...candidate.versionHistory,
+                displayText(candidate),
+              ],
+              humanEditedText: editorText,
+            }
+          : candidate,
+      ),
+    }))
+  }
+
+  function approveAndRender() {
+    if (!selectedCandidate) return
+    const approvedCandidate = {
+      ...selectedCandidate,
+      humanEditedText: editorText,
+    }
+    const markdown = renderMarkdown({
+      project: state.project,
+      candidate: approvedCandidate,
+      brief: state.brief,
+      sources: state.sources,
+      reviewerNote,
+    })
+    setState((current) => ({ ...current, approvedMarkdown: markdown }))
+  }
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-5 py-5 lg:px-7">
+        <header className="flex flex-col gap-4 border-b border-[var(--theme-border)] pb-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              Native Script Editor
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-normal">
+              Research, generate, score, and approve short-form scripts
+            </h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span
+              className={[
+                'rounded-full border px-3 py-1',
+                backendReachable === false
+                  ? 'border-red-500/40 text-red-300'
+                  : backendReachable
+                    ? 'border-emerald-500/40 text-emerald-300'
+                    : 'border-[var(--theme-border)] text-[var(--theme-muted)]',
+              ].join(' ')}
+            >
+              {backendStatus}
+            </span>
+            <button className="script-editor-button" onClick={checkBackend}>
+              Check Qwen
+            </button>
+          </div>
+        </header>
+
+        <nav className="grid grid-cols-3 overflow-hidden rounded-lg border border-[var(--theme-border)]">
+          {(['research', 'generation', 'review'] as const).map((item) => (
+            <button
+              key={item}
+              type="button"
+              onClick={() => setStage(item)}
+              className={[
+                'px-3 py-2 text-sm font-medium capitalize transition-colors',
+                stage === item
+                  ? 'bg-[var(--theme-accent)] text-black'
+                  : 'bg-[var(--theme-surface)] text-[var(--theme-muted)] hover:text-[var(--theme-text)]',
+              ].join(' ')}
+            >
+              {item}
+            </button>
+          ))}
+        </nav>
+
+        {stage === 'research' ? (
+          <ResearchStage
+            project={state.project}
+            sources={state.sources}
+            sourceKind={sourceKind}
+            sourceTitle={sourceTitle}
+            sourceLocator={sourceLocator}
+            sourceText={sourceText}
+            brief={state.brief}
+            onProjectChange={updateProject}
+            onSourceKindChange={setSourceKind}
+            onSourceTitleChange={setSourceTitle}
+            onSourceLocatorChange={setSourceLocator}
+            onSourceTextChange={setSourceText}
+            onAddSource={addSource}
+            onFetchURL={fetchURL}
+            onBuildBrief={buildBrief}
+          />
+        ) : null}
+
+        {stage === 'generation' ? (
+          <GenerationStage
+            candidateCount={candidateCount}
+            sourcesCount={state.sources.length}
+            brief={state.brief}
+            candidatesCount={state.candidates.length}
+            topTenCount={topCandidates.length}
+            onCandidateCountChange={setCandidateCount}
+            onGenerate={generateCandidates}
+            onCheckBackend={checkBackend}
+          />
+        ) : null}
+
+        {stage === 'review' ? (
+          <ReviewStage
+            candidates={topCandidates}
+            selectedCandidate={selectedCandidate}
+            editorText={editorText}
+            reviewerNote={reviewerNote}
+            approvedMarkdown={state.approvedMarkdown}
+            onSelectCandidate={selectCandidate}
+            onEditorTextChange={setEditorText}
+            onReviewerNoteChange={setReviewerNote}
+            onSaveRevision={saveRevision}
+            onApproveAndRender={approveAndRender}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ResearchStage({
+  project,
+  sources,
+  sourceKind,
+  sourceTitle,
+  sourceLocator,
+  sourceText,
+  brief,
+  onProjectChange,
+  onSourceKindChange,
+  onSourceTitleChange,
+  onSourceLocatorChange,
+  onSourceTextChange,
+  onAddSource,
+  onFetchURL,
+  onBuildBrief,
+}: {
+  project: Project
+  sources: Array<ResearchSource>
+  sourceKind: SourceKind
+  sourceTitle: string
+  sourceLocator: string
+  sourceText: string
+  brief: ResearchBrief | null
+  onProjectChange: (patch: Partial<Project>) => void
+  onSourceKindChange: (value: SourceKind) => void
+  onSourceTitleChange: (value: string) => void
+  onSourceLocatorChange: (value: string) => void
+  onSourceTextChange: (value: string) => void
+  onAddSource: () => void
+  onFetchURL: () => void
+  onBuildBrief: () => void
+}) {
+  return (
+    <div className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(340px,0.95fr)]">
+      <section className="script-editor-panel">
+        <h2 className="script-editor-heading">Project</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field
+            label="Title"
+            value={project.title}
+            onChange={(title) => onProjectChange({ title })}
+          />
+          <Field
+            label="Topic"
+            value={project.topic}
+            onChange={(topic) => onProjectChange({ topic })}
+          />
+          <Field
+            label="Audience"
+            value={project.audience}
+            onChange={(audience) => onProjectChange({ audience })}
+          />
+          <Field
+            label="Platform"
+            value={project.platform}
+            onChange={(platform) => onProjectChange({ platform })}
+          />
+          <Field
+            label="Tone"
+            value={project.tone}
+            onChange={(tone) => onProjectChange({ tone })}
+          />
+          <Field
+            label="Goal"
+            value={project.goal}
+            onChange={(goal) => onProjectChange({ goal })}
+          />
+          <label className="md:col-span-2">
+            <span className="script-editor-label">Constraints</span>
+            <textarea
+              className="script-editor-input min-h-20"
+              value={project.constraints}
+              onChange={(event) =>
+                onProjectChange({ constraints: event.target.value })
+              }
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className="script-editor-panel">
+        <h2 className="script-editor-heading">Research Input</h2>
+        <div className="grid gap-3">
+          <div className="grid gap-3 sm:grid-cols-[140px_1fr]">
+            <label>
+              <span className="script-editor-label">Kind</span>
+              <select
+                className="script-editor-input"
+                value={sourceKind}
+                onChange={(event) =>
+                  onSourceKindChange(event.target.value as SourceKind)
+                }
+              >
+                {(['Note', 'URL', 'File', 'Web Result'] as const).map(
+                  (kind) => (
+                    <option key={kind}>{kind}</option>
+                  ),
+                )}
+              </select>
+            </label>
+            <Field
+              label="Title"
+              value={sourceTitle}
+              onChange={onSourceTitleChange}
+            />
+          </div>
+          <Field
+            label="URL, file path, or locator"
+            value={sourceLocator}
+            onChange={onSourceLocatorChange}
+          />
+          <label>
+            <span className="script-editor-label">Notes or excerpt</span>
+            <textarea
+              className="script-editor-input min-h-36"
+              value={sourceText}
+              onChange={(event) => onSourceTextChange(event.target.value)}
+            />
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <button className="script-editor-button" onClick={onAddSource}>
+              Add Source
+            </button>
+            <button
+              className="script-editor-button-secondary"
+              onClick={onFetchURL}
+            >
+              Fetch URL Text
+            </button>
+            <button
+              className="script-editor-button"
+              onClick={onBuildBrief}
+              disabled={sources.length === 0}
+            >
+              Build Brief
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="script-editor-panel xl:col-span-2">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="script-editor-heading">Research Brief</h2>
+          <span className="text-sm text-[var(--theme-muted)]">
+            {sources.length} sources
+          </span>
+        </div>
+        {brief ? (
+          <BriefGrid brief={brief} />
+        ) : (
+          <EmptyText text="Add sources and build a brief to create structured insights, claims, angles, tensions, and citations." />
+        )}
+      </section>
+
+      <section className="script-editor-panel xl:col-span-2">
+        <h2 className="script-editor-heading">Sources</h2>
+        <div className="grid gap-3 lg:grid-cols-2">
+          {sources.map((source) => (
+            <article
+              key={source.id}
+              className="rounded-lg border border-[var(--theme-border)] bg-black/10 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-medium">{source.title}</h3>
+                  <p className="text-xs text-[var(--theme-muted)]">
+                    {source.kind} · {source.locator || 'local note'}
+                  </p>
+                </div>
+                <span className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-xs text-[var(--theme-muted)]">
+                  {source.extractedFacts.length} facts
+                </span>
+              </div>
+              <p className="mt-2 line-clamp-2 text-sm text-[var(--theme-muted)]">
+                {source.rawText}
+              </p>
+              {source.extractedFacts.length ? (
+                <ul className="mt-2 space-y-1 text-xs text-[var(--theme-muted)]">
+                  {source.extractedFacts.slice(0, 2).map((fact) => (
+                    <li key={fact}>- {fact}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </article>
+          ))}
+          {sources.length === 0 ? (
+            <EmptyText text="No research sources yet." />
+          ) : null}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function GenerationStage({
+  candidateCount,
+  sourcesCount,
+  brief,
+  candidatesCount,
+  topTenCount,
+  onCandidateCountChange,
+  onGenerate,
+  onCheckBackend,
+}: {
+  candidateCount: number
+  sourcesCount: number
+  brief: ResearchBrief | null
+  candidatesCount: number
+  topTenCount: number
+  onCandidateCountChange: (value: number) => void
+  onGenerate: () => void
+  onCheckBackend: () => void
+}) {
+  return (
+    <section className="script-editor-panel">
+      <h2 className="script-editor-heading">Generation Run</h2>
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-4">
+          <label>
+            <span className="script-editor-label">
+              Candidates: {candidateCount}
+            </span>
+            <input
+              className="w-full accent-[var(--theme-accent)]"
+              type="range"
+              min={20}
+              max={40}
+              step={1}
+              value={candidateCount}
+              onChange={(event) =>
+                onCandidateCountChange(Number(event.target.value))
+              }
+            />
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <button
+              className="script-editor-button-secondary"
+              onClick={onCheckBackend}
+            >
+              Check Local Qwen
+            </button>
+            <button className="script-editor-button" onClick={onGenerate}>
+              Generate and Score
+            </button>
+          </div>
+          <p className="max-w-2xl text-sm text-[var(--theme-muted)]">
+            The web section runs the same planned workflow inside Hermes
+            Workspace: generate a wide candidate set, score every draft, then
+            show only the strongest ten for human review.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <Metric label="Sources" value={sourcesCount} />
+          <Metric label="Brief" value={brief ? 'Ready' : 'Needed'} />
+          <Metric label="Scored" value={candidatesCount} />
+          <Metric label="Surfaced" value={topTenCount} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ReviewStage({
+  candidates,
+  selectedCandidate,
+  editorText,
+  reviewerNote,
+  approvedMarkdown,
+  onSelectCandidate,
+  onEditorTextChange,
+  onReviewerNoteChange,
+  onSaveRevision,
+  onApproveAndRender,
+}: {
+  candidates: Array<ScriptCandidate>
+  selectedCandidate: ScriptCandidate | null
+  editorText: string
+  reviewerNote: string
+  approvedMarkdown: string
+  onSelectCandidate: (candidate: ScriptCandidate) => void
+  onEditorTextChange: (value: string) => void
+  onReviewerNoteChange: (value: string) => void
+  onSaveRevision: () => void
+  onApproveAndRender: () => void
+}) {
+  return (
+    <div className="grid gap-5 xl:grid-cols-[420px_minmax(0,1fr)]">
+      <section className="script-editor-panel">
+        <h2 className="script-editor-heading">Top 10 Review Board</h2>
+        <div className="space-y-3">
+          {candidates.map((candidate) => (
+            <button
+              key={candidate.id}
+              type="button"
+              className={[
+                'block w-full rounded-lg border p-3 text-left transition-colors',
+                selectedCandidate?.id === candidate.id
+                  ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/10'
+                  : 'border-[var(--theme-border)] bg-black/10 hover:bg-white/5',
+              ].join(' ')}
+              onClick={() => onSelectCandidate(candidate)}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-medium">{candidate.title}</h3>
+                  <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                    {candidate.angle}
+                  </p>
+                </div>
+                <span className="rounded-full bg-[var(--theme-accent)] px-2 py-1 text-sm font-semibold text-black">
+                  {totalScore(candidate.scorecard)}
+                </span>
+              </div>
+              <p className="mt-2 line-clamp-2 text-xs text-[var(--theme-muted)]">
+                {candidate.scorecard.rationale}
+              </p>
+            </button>
+          ))}
+          {candidates.length === 0 ? (
+            <EmptyText text="Generate candidates to populate the board." />
+          ) : null}
+        </div>
+      </section>
+
+      <section className="script-editor-panel">
+        {selectedCandidate ? (
+          <div className="space-y-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-semibold">
+                  {selectedCandidate.title}
+                </h2>
+                <p className="text-sm text-[var(--theme-muted)]">
+                  {selectedCandidate.angle}
+                </p>
+              </div>
+              <span className="rounded-full border border-[var(--theme-border)] px-3 py-1 text-sm">
+                {totalScore(selectedCandidate.scorecard)}/90
+              </span>
+            </div>
+            <textarea
+              className="script-editor-input min-h-80 font-serif text-base"
+              value={editorText}
+              onChange={(event) => onEditorTextChange(event.target.value)}
+            />
+            <div className="flex flex-wrap gap-2">
+              <button
+                className="script-editor-button-secondary"
+                onClick={onSaveRevision}
+              >
+                Save Revision
+              </button>
+              <button
+                className="script-editor-button"
+                onClick={onApproveAndRender}
+              >
+                Approve and Render
+              </button>
+            </div>
+            <label>
+              <span className="script-editor-label">Reviewer note</span>
+              <textarea
+                className="script-editor-input min-h-20"
+                value={reviewerNote}
+                onChange={(event) => onReviewerNoteChange(event.target.value)}
+              />
+            </label>
+            <ScorecardView scorecard={selectedCandidate.scorecard} />
+            {approvedMarkdown ? (
+              <label>
+                <span className="script-editor-label">Approved Markdown</span>
+                <textarea
+                  className="script-editor-input min-h-72 font-mono text-xs"
+                  readOnly
+                  value={approvedMarkdown}
+                />
+              </label>
+            ) : null}
+          </div>
+        ) : (
+          <EmptyText text="Select a generated script to edit." />
+        )}
+      </section>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <label>
+      <span className="script-editor-label">{label}</span>
+      <input
+        className="script-editor-input"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  )
+}
+
+function BriefGrid({ brief }: { brief: ResearchBrief }) {
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <BriefColumn title="Insights" items={brief.distilledInsights} />
+      <BriefColumn title="Claims" items={brief.claims} />
+      <BriefColumn title="Angles" items={brief.angles} />
+      <BriefColumn title="Tensions" items={brief.audienceTensions} />
+    </div>
+  )
+}
+
+function BriefColumn({
+  title,
+  items,
+}: {
+  title: string
+  items: Array<string>
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--theme-border)] bg-black/10 p-3">
+      <h3 className="mb-2 text-sm font-semibold">{title}</h3>
+      <ul className="space-y-1 text-sm text-[var(--theme-muted)]">
+        {items.slice(0, 5).map((item) => (
+          <li key={item}>- {item}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ScorecardView({ scorecard }: { scorecard: Scorecard }) {
+  const rows = [
+    ['Premise', scorecard.premiseStrength],
+    ['Originality', scorecard.originality],
+    ['Specificity', scorecard.specificity],
+    ['Clarity', scorecard.clarity],
+    ['Structure', scorecard.structure],
+    ['Grounding', scorecard.sourceGrounding],
+    ['Hook', scorecard.hookQuality],
+    ['Payoff', scorecard.payoffQuality],
+    ['Non-slop', scorecard.nonSlop],
+  ] as const
+  return (
+    <div className="grid gap-2 sm:grid-cols-3">
+      {rows.map(([label, value]) => (
+        <div
+          key={label}
+          className="rounded-lg border border-[var(--theme-border)] bg-black/10 p-2 text-sm"
+        >
+          <span className="text-[var(--theme-muted)]">{label}</span>
+          <span className="float-right font-semibold">{value}</span>
+        </div>
+      ))}
+      {scorecard.flags.length ? (
+        <p className="sm:col-span-3 text-sm text-[var(--theme-muted)]">
+          Flags: {scorecard.flags.join(', ')}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-[var(--theme-border)] bg-black/10 p-3">
+      <p className="text-xs text-[var(--theme-muted)]">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function EmptyText({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[var(--theme-border)] p-4 text-sm text-[var(--theme-muted)]">
+      {text}
+    </div>
+  )
+}
+
+function useStoredState() {
+  const [state, setState] = useState<AppState>(() => {
+    if (typeof window === 'undefined') return initialState()
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      return stored
+        ? { ...initialState(), ...JSON.parse(stored) }
+        : initialState()
+    } catch {
+      return initialState()
+    }
+  })
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }, [state])
+
+  return [state, setState] as const
+}
+
+function initialState(): AppState {
+  return {
+    project: defaultProject,
+    sources: [],
+    brief: null,
+    candidates: [],
+    selectedCandidateId: null,
+    approvedMarkdown: '',
+  }
+}
+
+function makeCandidate(
+  project: Project,
+  brief: ResearchBrief,
+  index: number,
+): ScriptCandidate {
+  const angle =
+    brief.angles[index % Math.max(1, brief.angles.length)] ??
+    `A sharper angle on ${project.topic || 'this topic'}`
+  const claim =
+    brief.claims[index % Math.max(1, brief.claims.length)] ??
+    'Use a concrete proof point before making the claim.'
+  const hooks = [
+    `Stop making ${project.topic || 'this'} sound easier than it is.`,
+    'The obvious answer is the trap.',
+    'Here is the detail that changes the whole script.',
+    'Most people miss the part that actually earns trust.',
+  ]
+  const beats = {
+    hook: hooks[index % hooks.length],
+    setup: `${project.audience || 'The audience'} usually hears the surface version: ${angle}.`,
+    escalation: `But the proof point that changes the story is: ${claim}`,
+    payoff:
+      'So the stronger script names the tension first, shows the evidence second, and ends with one concrete decision.',
+    callToActionOrLoop:
+      index % 2 === 0
+        ? 'Save this before you write the next version.'
+        : 'Now replay the hook and notice what it promised.',
+    timingNotes:
+      index % 3 === 0
+        ? '35-45 seconds, tight pacing.'
+        : '60-75 seconds with one proof visual.',
+  }
+  const candidate: ScriptCandidate = {
+    id: crypto.randomUUID(),
+    title: `Angle ${index + 1}: ${angle.slice(0, 44)}`,
+    angle,
+    tags: [project.platform, index % 2 === 0 ? 'source-led' : 'high-tension'],
+    beats,
+    scorecard: {
+      premiseStrength: 0,
+      originality: 0,
+      specificity: 0,
+      clarity: 0,
+      structure: 0,
+      sourceGrounding: 0,
+      hookQuality: 0,
+      payoffQuality: 0,
+      nonSlop: 0,
+      flags: [],
+      rationale: '',
+    },
+    humanEditedText: '',
+    versionHistory: [],
+  }
+  return { ...candidate, scorecard: scoreCandidate(candidate, brief) }
+}
+
+function scoreCandidate(
+  candidate: ScriptCandidate,
+  brief: ResearchBrief,
+): Scorecard {
+  const text = displayText(candidate)
+  const lower = text.toLowerCase()
+  const flags: Array<string> = []
+  if (
+    [
+      'game changer',
+      'secret',
+      'unlock',
+      'you need to know',
+      "in today's world",
+    ].some((term) => lower.includes(term))
+  )
+    flags.push('generic phrasing')
+  if (text.length < 220) flags.push('weak premise')
+  if (
+    !brief.claims.some((claim) =>
+      claim
+        .split(' ')
+        .some((word) => word.length > 6 && lower.includes(word.toLowerCase())),
+    )
+  )
+    flags.push('unsupported claims')
+  if (
+    ['really', 'basically', 'actually', 'literally', 'very'].filter((term) =>
+      lower.includes(term),
+    ).length >= 3
+  )
+    flags.push('filler language')
+  const sourceGrounding = flags.includes('unsupported claims') ? 4 : 8
+  return {
+    premiseStrength: clamp(7 - (flags.includes('weak premise') ? 2 : 0)),
+    originality: clamp(7 - (flags.includes('generic phrasing') ? 2 : 0)),
+    specificity: clamp(5 + (sourceGrounding >= 8 ? 3 : 0)),
+    clarity: 8,
+    structure: 8,
+    sourceGrounding,
+    hookQuality: clamp(
+      candidate.beats.hook.includes('?') || lower.includes('stop') ? 8 : 6,
+    ),
+    payoffQuality: 7,
+    nonSlop: clamp(9 - flags.length),
+    flags,
+    rationale: flags.length
+      ? `Needs attention on: ${flags.join(', ')}.`
+      : 'Specific, structured, and grounded enough to reach human review.',
+  }
+}
+
+function renderMarkdown({
+  project,
+  candidate,
+  brief,
+  sources,
+  reviewerNote,
+}: {
+  project: Project
+  candidate: ScriptCandidate
+  brief: ResearchBrief | null
+  sources: Array<ResearchSource>
+  reviewerNote: string
+}) {
+  return [
+    `# ${candidate.title}`,
+    `> v1 approved script export`,
+    `## Project\n- Topic: ${project.topic}\n- Audience: ${project.audience}\n- Platform: ${project.platform}\n- Tone: ${project.tone}\n- Goal: ${project.goal}`,
+    reviewerNote.trim() ? `## Reviewer Note\n${reviewerNote.trim()}` : '',
+    `## Script\n${displayText(candidate)}`,
+    `## Scorecard\n- Total: ${totalScore(candidate.scorecard)}/90\n- Flags: ${candidate.scorecard.flags.join(', ') || 'None'}\n\n${candidate.scorecard.rationale}`,
+    brief
+      ? `## Research Brief\n${brief.claims.map((claim) => `- ${claim}`).join('\n')}`
+      : '',
+    `## Sources\n${sources.map((source) => `- ${source.title}${source.locator ? ` - ${source.locator}` : ''}`).join('\n') || '- None'}`,
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+function displayText(candidate: ScriptCandidate) {
+  return (
+    candidate.humanEditedText.trim() ||
+    [
+      candidate.beats.hook,
+      candidate.beats.setup,
+      candidate.beats.escalation,
+      candidate.beats.payoff,
+      candidate.beats.callToActionOrLoop,
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+  )
+}
+
+function extractFacts(text: string) {
+  return normalize(text)
+    .split(/[.!?\n]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 28)
+    .sort((a, b) => factScore(b) - factScore(a))
+    .slice(0, 8)
+    .map((item) => (/[.!?]$/.test(item) ? item : `${item}.`))
+}
+
+function factScore(text: string) {
+  const lower = text.toLowerCase()
+  let score = 0
+  for (const term of [
+    'according to',
+    'reported',
+    'found',
+    'shows',
+    'study',
+    'survey',
+    'because',
+    'increased',
+    'decreased',
+  ]) {
+    if (lower.includes(term)) score += 2
+  }
+  if (/\d/.test(text)) score += 3
+  if (/%|\$/.test(text)) score += 2
+  return score
+}
+
+function totalScore(scorecard: Scorecard) {
+  return (
+    scorecard.premiseStrength +
+    scorecard.originality +
+    scorecard.specificity +
+    scorecard.clarity +
+    scorecard.structure +
+    scorecard.sourceGrounding +
+    scorecard.hookQuality +
+    scorecard.payoffQuality +
+    scorecard.nonSlop
+  )
+}
+
+function normalize(text: string) {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
+function plainText(html: string) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .slice(0, 20_000)
+    .trim()
+}
+
+function take(values: Array<string>, count: number, fallback: string) {
+  const cleaned = values.map((value) => value.trim()).filter(Boolean)
+  return cleaned.length ? cleaned.slice(0, count) : [fallback]
+}
+
+function clamp(value: number) {
+  return Math.min(Math.max(value, 0), 10)
+}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -225,7 +225,8 @@ function NavItem({
               style={
                 item.badge === 'NEW'
                   ? {
-                      background: 'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                      background:
+                        'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
                       color: '#0b1320',
                       boxShadow: '0 0 8px rgba(250,204,21,0.4)',
                       letterSpacing: '0.08em',
@@ -547,7 +548,9 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail.section === 'appearance' ? 'appearance' : 'claude')
+      handleOpenSettings(
+        detail.section === 'appearance' ? 'appearance' : 'claude',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -584,10 +587,11 @@ function ChatSidebarComponent({
   const isJobsActive = pathname === '/jobs'
   const isMemoryActive = pathname === '/memory'
   const isTasksActive = pathname === '/tasks'
+  const isScriptEditorActive = pathname === '/script-editor'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
   const isSwarmActive = pathname === '/swarm' || pathname === '/swarm2'
-  const mainRoutes = ['/chat', '/new', '/files', '/terminal']
+  const mainRoutes = ['/chat', '/new', '/files', '/terminal', '/script-editor']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
 
@@ -805,6 +809,13 @@ function ChatSidebarComponent({
     },
     {
       kind: 'link',
+      to: '/script-editor',
+      icon: PencilEdit02Icon,
+      label: 'Script Editor',
+      active: isScriptEditorActive,
+    },
+    {
+      kind: 'link',
       to: '/terminal',
       icon: ComputerTerminal01Icon,
       label: t('nav.terminal'),
@@ -845,7 +856,6 @@ function ChatSidebarComponent({
       label: 'Swarm',
       active: isSwarmActive,
     },
-
   ]
 
   const knowledgeItems: Array<NavItemDef> = [
@@ -1036,41 +1046,41 @@ function ChatSidebarComponent({
       {/* Hide when VITE_HERMESWORLD_ENABLED is explicitly '0' */}
       {!isVisuallyCollapsed &&
         (import.meta as any).env?.VITE_HERMESWORLD_ENABLED !== '0' && (
-        <div className="px-2 pb-2">
-          <Link
-            to="/playground"
-            onClick={() => onSelectSession?.()}
-            className={cn(
-              buttonVariants({ variant: 'ghost', size: 'sm' }),
-              'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
-              isPlaygroundActive &&
-                'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
-            )}
-            data-tour="hermesworld"
-          >
-            <HugeiconsIcon
-              icon={Castle02Icon}
-              size={20}
-              strokeWidth={1.5}
-              className="size-5 shrink-0"
-              style={{ color: '#facc15' }}
-            />
-            <span>HermesWorld</span>
-            <span
-              className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
-              style={{
-                background:
-                  'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
-                color: '#0b1320',
-                boxShadow: '0 0 8px rgba(250,204,21,0.4)',
-                letterSpacing: '0.08em',
-              }}
+          <div className="px-2 pb-2">
+            <Link
+              to="/playground"
+              onClick={() => onSelectSession?.()}
+              className={cn(
+                buttonVariants({ variant: 'ghost', size: 'sm' }),
+                'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
+                isPlaygroundActive &&
+                  'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
+              )}
+              data-tour="hermesworld"
             >
-              NEW
-            </span>
-          </Link>
-        </div>
-      )}
+              <HugeiconsIcon
+                icon={Castle02Icon}
+                size={20}
+                strokeWidth={1.5}
+                className="size-5 shrink-0"
+                style={{ color: '#facc15' }}
+              />
+              <span>HermesWorld</span>
+              <span
+                className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
+                style={{
+                  background:
+                    'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                  color: '#0b1320',
+                  boxShadow: '0 0 8px rgba(250,204,21,0.4)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                NEW
+              </span>
+            </Link>
+          </div>
+        )}
 
       {/* ── Scrollable body: nav + sessions ─────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin flex flex-col">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1525,6 +1525,67 @@ code {
   }
 }
 
+/* Native Script Editor web section */
+.script-editor-panel {
+  border: 1px solid var(--theme-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent),
+    var(--theme-surface);
+  padding: 1rem;
+}
+.script-editor-heading {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.script-editor-label {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--theme-muted);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+.script-editor-input {
+  width: 100%;
+  border: 1px solid var(--theme-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--theme-bg) 86%, transparent);
+  color: var(--theme-text);
+  padding: 0.65rem 0.75rem;
+  outline: none;
+}
+.script-editor-input:focus {
+  border-color: var(--theme-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-accent) 22%, transparent);
+}
+.script-editor-button,
+.script-editor-button-secondary {
+  min-height: 2.25rem;
+  border-radius: 8px;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.875rem;
+  font-weight: 650;
+  transition:
+    opacity 0.15s ease,
+    background-color 0.15s ease;
+}
+.script-editor-button {
+  background: var(--theme-accent);
+  color: #0b0d0f;
+}
+.script-editor-button-secondary {
+  border: 1px solid var(--theme-border);
+  background: color-mix(in srgb, var(--theme-surface) 75%, transparent);
+  color: var(--theme-text);
+}
+.script-editor-button:disabled,
+.script-editor-button-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 /* ════════════════════════════════════════════════════════════════════
    SciFi Theme — imported AFTER all other theme rules so that
    its CSS variable remaps take precedence over the default


### PR DESCRIPTION
## Summary
- Adds a standalone SwiftUI macOS Script Editor app under macos/ScriptEditor
- Adds a Hermes Workspace root launcher: pnpm script-editor:mac
- Adds a built-in Hermes Workspace web section at /script-editor for when local Swift tooling is unavailable
- Adds Script Editor navigation in the desktop sidebar and mobile drawer
- Adds a long implementation plan plus execution status docs for the native script workflow
- Implements local project persistence, research source capture, local note/file ingestion, research brief generation, candidate generation, scoring/ranking, top-10 review board, editor, side-agent revision chat, explicit approval, and local approved-script Markdown export
- Adds backend health checks for the local OpenAI-compatible Qwen endpoint
- Extracts prompt construction into PromptLibrary and scoring/non-slop logic into Rubric
- Defaults the model adapter to http://127.0.0.1:8081/v1 using mlx-community/Qwen3-1.7B-4bit

## Verification
- Added focused core tests for persistence, top-10 ranking, fallback candidate generation, non-slop flagging, prompt requirements, rubric definitions, Markdown export, source ingestion, backend health, and approval snapshots
- Ran syntax parse successfully across ScriptEditor app/core/test Swift files with swiftc -parse
- Verified /script-editor returns HTTP 200 from the running Hermes dev server
- Ran ESLint on src/routes/script-editor.tsx
- Ran focused Vitest route/root-layout checks: src/router-route-resolution.test.ts and src/routes/-root-layout-state.test.ts
- Verified pnpm script-editor:mac reaches the Swift package launcher; launch is blocked locally by the known Command Line Tools SwiftPM/SDK mismatch before app code compiles
- Could not run repo-wide tsc because an existing unrelated JSX syntax error remains in src/screens/playground/components/playground-hud.tsx
- Could not run browser smoke because the local Playwright Chromium binary is not installed