### PR TITLE
fix(ui): remove broken Settings → Config reference from context alert modal

### DIFF
--- a/src/components/usage-meter/context-alert-modal.tsx
+++ b/src/components/usage-meter/context-alert-modal.tsx
@@ -120,10 +120,6 @@ function ContextAlertModalComponent({
                 />
               )}
               <Recommendation
-                icon="🗜️"
-                text="Enable auto-compaction in Settings → Config to automatically manage context"
-              />
-              <Recommendation
                 icon="📋"
                 text="Summarize important details before starting a new chat"
               />


### PR DESCRIPTION
## Summary

The context alert modal recommendation "Enable auto-compaction in Settings → Config to automatically manage context" points at a UI path that doesn't exist — workspace settings are only `Providers` and `MCP`, there is no `Config` screen and no auto-compaction toggle anywhere in the UI.

Auto-compaction is also already on by default (triggers at ~40% per Hermes Agent, per the comment on line 22 and the "What does this mean?" copy on line 105 of the same file), so even if a toggle existed, telling the user to "enable" it would be misleading.

Removing the broken recommendation leaves two accurate recs in the warning state (`📋 Summarize`, `💡 Keep concise`) and two in the critical state (`🆕 Start a new chat`, `📋 Summarize`).

## Test plan
- [ ] Verify modal still renders cleanly at 35%, 75%, 90% thresholds
- [ ] Verify no other component references the deleted recommendation text

🤖 Generated with [Claude Code](https://claude.com/claude-code)