### PR TITLE
fix: preserve workspace chat session routing

### DIFF
--- a/docs/workspace-chat-session-routing.md
+++ b/docs/workspace-chat-session-routing.md
@@ -1,0 +1,98 @@
+# Workspace Chat Session Routing
+
+## Purpose
+
+Hermes Workspace supports a portable chat path through OpenAI-compatible `/v1/chat/completions`. In this mode, the browser route alone is not enough to preserve conversational context: Workspace must forward a stable server-side session identifier to the Hermes Agent gateway.
+
+This document records the routing contract and the failure mode that caused related turns and attachments to be stored as separate `api-*` sessions.
+
+## Routing Contract
+
+There are two distinct header layers:
+
+| Layer | Headers | Purpose |
+| --- | --- | --- |
+| Workspace UI route resolution | `X-Hermes-Session-Key`, `X-Hermes-Friendly-Id` | Tells the browser which Workspace chat route/friendly ID is resolved for the visible conversation. |
+| Hermes Agent gateway continuation | `X-Hermes-Session-Id`, `X-Claude-Session-Id` | Tells the gateway which server-side Hermes session should receive the next chat completion request. |
+
+Do not conflate these. A response can correctly resolve a Workspace route while the next gateway request still loses server-side context if `X-Hermes-Session-Id` is missing.
+
+## Portable OpenAI-Compatible Flow
+
+1. `src/routes/api/send-stream.ts` receives `sessionKey`, `friendlyId`, `message`, `history`, and optional `attachments` from the UI.
+2. It resolves a persistent Workspace `sessionKey`.
+3. It builds OpenAI-compatible messages, including multimodal image parts when attachments are present.
+4. It calls `openaiChat(..., { sessionId: portableSessionKey })`.
+5. `src/server/openai-compat-api.ts` forwards that session ID to the gateway via:
+   - `X-Hermes-Session-Id`
+   - `X-Claude-Session-Id` as a legacy/back-compat alias.
+6. Hermes Agent uses the provided session ID for continuity instead of deriving a fresh deterministic `api-*` session from the request payload.
+
+## Failure Mode
+
+The bug was coupling session-continuity headers to bearer-token presence:
+
+```ts
+if (options.sessionId && bearer) {
+  headers['X-Hermes-Session-Id'] = options.sessionId
+  headers['X-Claude-Session-Id'] = options.sessionId
+}
+```
+
+That made routing depend on auth configuration. If a bearer token was unavailable or not used, Workspace still had a local session key, but the gateway never received it. The gateway then derived sessions such as `api-*` from request content, which could split related turns and attachment-only/image requests across separate API sessions.
+
+## Correct Behavior
+
+Session routing is independent of whether a bearer token is configured. If the gateway requires auth, its auth check enforces the bearer token separately.
+
+```ts
+const bearer = getBearerToken()
+if (bearer) {
+  headers['Authorization'] = `Bearer ${bearer}`
+}
+
+if (options.sessionId) {
+  headers['X-Hermes-Session-Id'] = options.sessionId
+  headers['X-Claude-Session-Id'] = options.sessionId
+}
+```
+
+## Regression Coverage
+
+`src/server/openai-compat-api.test.ts` should cover both cases:
+
+- session headers are sent when a bearer token is present
+- session headers are still sent when no bearer token is present
+
+`src/server/chat-backends.ts` should forward `options.sessionId` into `openaiChat(...)` for both streaming and non-streaming OpenAI-compatible calls.
+
+## Manual Verification Recipe
+
+1. Run the targeted test:
+
+   ```bash
+   pnpm vitest run src/server/openai-compat-api.test.ts
+   ```
+
+2. Build production assets:
+
+   ```bash
+   pnpm build
+   ```
+
+3. Restart Workspace where deployed:
+
+   ```bash
+   systemctl --user restart hermes-workspace.service
+   systemctl --user is-active hermes-workspace.service
+   ```
+
+4. Send two `/api/send-stream` turns with the same `sessionKey` and a unique token in the first prompt.
+5. Search session history for that token. Both turns should appear under the same `session_id` equal to the supplied Workspace session key, not separate `api-*` sessions.
+6. Send an image attachment with the same `sessionKey`; session history should show `[screenshot]` in that same session.
+
+## Operational Notes
+
+- Keep credentials redacted when inspecting `.env`, service files, or built bundles.
+- In zero-fork deployments, Workspace commonly talks to Hermes Agent gateway on `127.0.0.1:8642` and Dashboard on `127.0.0.1:9119`.
+- A successful `/health` probe means the gateway is reachable; it does not prove session continuity is wired correctly. Verify the actual chat path.

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -527,7 +527,7 @@ export const Route = createFileRoute('/api/send-stream')({
                     : []
                   // Load persisted history for this session, then append user message.
                   // When the gateway can bind portable chat to a server-side session
-                  // via X-Claude-Session-Id, replaying the entire local transcript on
+                  // via X-Hermes-Session-Id, replaying the entire local transcript on
                   // every turn duplicates prompt context and can trip model limits
                   // on otherwise simple tasks (#405).
                   const persistedMessages = getLocalMessages(portableSessionKey)

--- a/src/server/chat-backends.ts
+++ b/src/server/chat-backends.ts
@@ -108,6 +108,7 @@ export async function sendChatUnified(
       temperature: options.temperature,
       signal: options.signal,
       stream: false,
+      sessionId: options.sessionId,
     })
   }
 
@@ -134,6 +135,7 @@ export async function streamChatUnified(
       temperature: options.temperature,
       signal: options.signal,
       stream: true,
+      sessionId: options.sessionId,
     })
     // Adapt StreamChunkType to plain string for legacy callers
     async function* toStringStream() {

--- a/src/server/openai-compat-api.test.ts
+++ b/src/server/openai-compat-api.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { parseOpenAIStream } from './openai-compat-api'
+import { openaiChat, parseOpenAIStream } from './openai-compat-api'
 
 function createStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder()
@@ -20,6 +20,60 @@ function createStreamResponse(chunks: string[]): Response {
     },
   )
 }
+
+const ORIGINAL_HOME = process.env.HOME
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete process.env.HERMES_API_TOKEN
+  delete process.env.CLAUDE_API_TOKEN
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = ORIGINAL_HOME
+})
+
+describe('openaiChat', () => {
+  it('sends Hermes session continuity headers with authentication when available', async () => {
+    process.env.HERMES_API_TOKEN = 'test-token'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: 'ok' } }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await openaiChat([{ role: 'user', content: 'hello' }], {
+      model: 'hermes-agent',
+      sessionId: 'workspace-session-1',
+    })
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer test-token')
+    expect(headers['X-Hermes-Session-Id']).toBe('workspace-session-1')
+    expect(headers['X-Claude-Session-Id']).toBe('workspace-session-1')
+  })
+
+  it('sends Hermes session continuity headers even without a bearer token', async () => {
+    process.env.HOME = '/tmp/hermes-workspace-test-no-codex-auth'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: 'ok' } }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await openaiChat([{ role: 'user', content: 'hello' }], {
+      model: 'hermes-agent',
+      sessionId: 'workspace-session-2',
+    })
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+    expect(headers['X-Hermes-Session-Id']).toBe('workspace-session-2')
+    expect(headers['X-Claude-Session-Id']).toBe('workspace-session-2')
+  })
+})
 
 describe('parseOpenAIStream', () => {
   it('passes through ordinary content chunks', async () => {

--- a/src/server/openai-compat-api.ts
+++ b/src/server/openai-compat-api.ts
@@ -283,9 +283,14 @@ export async function openaiChat(
   if (bearer) {
     headers['Authorization'] = `Bearer ${bearer}`
   }
-  // Only send session header when authenticated — gateways without
-  // API_SERVER_KEY reject this header with an auth error.
-  if (options.sessionId && bearer) {
+  // Session continuity is part of request routing, not authentication.
+  // If the gateway requires auth, _check_auth has already validated the
+  // bearer above; when it does not, dropping these headers forces Hermes
+  // Agent to derive a fresh api-* session from each message payload.
+  if (options.sessionId) {
+    headers['X-Hermes-Session-Id'] = options.sessionId
+    // Back-compat for older/Claude-compatible adapters that still look for
+    // the pre-Hermes header name.  Hermes Agent ignores this alias.
     headers['X-Claude-Session-Id'] = options.sessionId
   }
 


### PR DESCRIPTION
## Summary
- Always sends Hermes session-continuity headers when Workspace has a session ID.
- Keeps the legacy Claude-compatible session header alias for compatibility.
- Forwards session IDs through OpenAI-compatible chat backend paths.
- Adds regression coverage for header construction with and without bearer auth.
- Documents the Workspace UI route headers vs Hermes gateway continuation headers.

## Why
Workspace portable chat could lose context because session headers were only sent when a bearer token existed. When omitted, Hermes Agent gateway derived fresh `api-*` sessions per request, splitting related turns and attachments across sessions.

## Test Plan
- [x] `corepack pnpm vitest run src/server/openai-compat-api.test.ts`
- [x] `corepack pnpm build`
- [x] Live verification on kt-bot2: two `/api/send-stream` turns with same session key landed in one Hermes API session.
- [x] Live verification on kt-bot2: image attachment routed into the same session.
