### PR TITLE
fix: batch post-483 workspace follow-ups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # Or pull pre-built:
 #   docker pull ghcr.io/outsourc-e/hermes-workspace:latest
 #
-FROM tianon/gosu:1.19-bookworm AS gosu_source
+FROM tianon/gosu:1.17-bookworm AS gosu_source
 # ─── build stage ─────────────────────────────────────────────────────────
 FROM node:22-slim AS build
 RUN corepack enable && apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "tailwindcss": "^4.1.18",
     "three": "^0.184.0",
     "vite-tsconfig-paths": "^6.0.2",
-    "ws": "^8.19.0",
+    "ws": "^8.20.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-search": "^0.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^6.0.2
         version: 6.1.1(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       ws:
-        specifier: ^8.19.0
-        version: 8.19.0
+        specifier: ^8.20.1
+        version: 8.20.1
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -6175,8 +6175,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10844,7 +10844,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.19.0
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -13291,7 +13291,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/lib/workspace-message-scope.test.ts
+++ b/src/lib/workspace-message-scope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildWorkspaceScopedTextMessage } from './workspace-message-scope'
+import {
+  buildWorkspaceScopedTextMessage,
+  stripWorkspaceDirective,
+} from './workspace-message-scope'
 
 describe('buildWorkspaceScopedTextMessage', () => {
   it('prepends an explicit active workspace directive to plain text chat messages', () => {
@@ -38,5 +41,13 @@ describe('buildWorkspaceScopedTextMessage', () => {
         isValid: false,
       }),
     ).toBe('hello')
+  })
+
+  it('strips the workspace directive back out for user-visible rendering', () => {
+    expect(
+      stripWorkspaceDirective(
+        '<workspace_context active="true" name="Home" path="/Users/aurora/workspace" />\n\nRun the tests',
+      ),
+    ).toBe('Run the tests')
   })
 })

--- a/src/lib/workspace-message-scope.ts
+++ b/src/lib/workspace-message-scope.ts
@@ -4,6 +4,9 @@ export type WorkspaceScope = {
   isValid?: boolean
 }
 
+const WORKSPACE_DIRECTIVE_RE =
+  /^\s*<workspace_context\s+active="true"\s+name="[^"]*"\s+path="[^"]*"\s*\/?>\s*/i
+
 function escapeAttribute(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -27,4 +30,9 @@ export function buildWorkspaceScopedTextMessage(
   const directive = workspace ? buildWorkspaceDirective(workspace) : ''
   if (!directive) return message
   return `${directive}\n\n${message}`
+}
+
+export function stripWorkspaceDirective(message: string): string {
+  if (!message.includes('<workspace_context active="true"')) return message
+  return message.replace(WORKSPACE_DIRECTIVE_RE, '').trimStart()
 }

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -49,6 +49,7 @@ import {
   isRecentSession,
   resetPendingSend,
   setPendingGeneration,
+  clearPendingSendForSession,
 } from './pending-send'
 import { useChatMeasurements } from './hooks/use-chat-measurements'
 import { useChatHistory } from './hooks/use-chat-history'
@@ -100,7 +101,7 @@ import { MobileSessionsPanel } from '@/components/mobile-sessions-panel'
 import { ContextAlertModal } from '@/components/usage-meter/context-alert-modal'
 import { ErrorToastContainer, showErrorToast } from '@/components/error-toast'
 // ContextMeter removed — ContextBar (PR #32) replaces it
-import { useChatStore } from '@/stores/chat-store'
+import { useChatStore, persistRecoveryMessage } from '@/stores/chat-store'
 import { useResearchCard } from '@/hooks/use-research-card'
 // MOBILE_TAB_BAR_OFFSET removed — tab bar always hidden in chat
 import { useTapDebug } from '@/hooks/use-tap-debug'
@@ -1128,7 +1129,7 @@ export function ChatScreen({
       },
       [queryClient],
     ),
-    onComplete: useCallback(() => {
+    onComplete: useCallback((message: ChatMessage) => {
       const activeSend = activeSendRef.current
       if (activeSend?.clientId) {
         updateHistoryMessageByClientIdEverywhere(
@@ -1138,6 +1139,13 @@ export function ChatScreen({
             ...message,
             status: 'done',
           }),
+        )
+      }
+      if (activeSend?.sessionKey) {
+        persistRecoveryMessage(activeSend.sessionKey, message)
+        clearPendingSendForSession(
+          activeSend.sessionKey,
+          activeSend.friendlyId,
         )
       }
       activeSendRef.current = null

--- a/src/screens/chat/utils.test.ts
+++ b/src/screens/chat/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSessions, textFromMessage } from './utils'
+import type { ChatMessage, SessionSummary } from './types'
+
+describe('chat utils workspace directive cleanup', () => {
+  it('hides workspace_context directives from user-visible message text', () => {
+    const message: ChatMessage = {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: '<workspace_context active="true" name="Home" path="/Users/aurora/workspace" />\n\nRun the tests',
+        },
+      ],
+    }
+
+    expect(textFromMessage(message)).toBe('Run the tests')
+  })
+
+  it('strips workspace_context directives from session previews and derived titles', () => {
+    const sessions = normalizeSessions([
+      {
+        key: 'session-1',
+        friendlyId: 'session-1',
+        preview:
+          '<workspace_context active="true" name="Home" path="/Users/aurora/workspace" />\n\nReview the open PRs',
+      },
+      {
+        key: 'session-2',
+        friendlyId: 'session-2',
+        derivedTitle:
+          '<workspace_context active="true" name="Home" path="/Users/aurora/workspace" />\n\nFix Docker publish',
+      },
+    ] satisfies Array<SessionSummary>)
+
+    expect(sessions[0]?.preview).toBe('Review the open PRs')
+    expect(sessions[0]?.derivedTitle).toBe('Review the open PRs')
+    expect(sessions[1]?.derivedTitle).toBe('Fix Docker publish')
+  })
+})

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -6,6 +6,7 @@ import type {
   SessionTitleStatus,
   ToolCallContent,
 } from './types'
+import { stripWorkspaceDirective } from '../../lib/workspace-message-scope'
 
 export function deriveFriendlyIdFromKey(key: string | undefined): string {
   if (!key) return 'main'
@@ -52,7 +53,7 @@ function stripChannelPrefix(text: string): string {
  * and [Telegram/Signal/etc ...] headers, leaving just the user's text.
  */
 function cleanUserText(raw: string): string {
-  let text = raw
+  let text = stripWorkspaceDirective(raw)
 
   // Remove "Conversation info (untrusted metadata):" headers + JSON block
   // Format: "Conversation info (untrusted metadata):\n```json\n{...}\n```\n\n"
@@ -226,15 +227,15 @@ export function normalizeSessions(
         : undefined
     const explicitTitle =
       typeof session.title === 'string' && session.title.trim().length > 0
-        ? session.title.trim()
+        ? cleanUserText(session.title.trim()) || session.title.trim()
         : undefined
     const derivedTitle =
       typeof session.derivedTitle === 'string' &&
         session.derivedTitle.trim().length > 0
-        ? session.derivedTitle.trim()
+        ? cleanUserText(session.derivedTitle.trim()) || session.derivedTitle.trim()
         : typeof session.preview === 'string' &&
           session.preview.trim().length > 0
-          ? session.preview.trim()
+          ? cleanUserText(session.preview.trim()) || session.preview.trim()
           : undefined
     const titleStatus = deriveTitleStatus(
       label,
@@ -261,7 +262,10 @@ export function normalizeSessions(
       titleStatus,
       titleSource,
       titleError: session.titleError ?? null,
-      preview: session.preview ?? null,
+      preview:
+        typeof session.preview === 'string'
+          ? cleanUserText(session.preview) || session.preview.trim() || null
+          : session.preview ?? null,
     }
   })
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -478,7 +478,10 @@ const config = defineConfig(({ mode, command }) => {
       //   2. $PORT env var (for containers, reverse proxies, WhatsApp bridge collisions, etc. — see #96)
       //   3. default 3000 (matches README/docs/docker-compose expectations)
       port: process.env.PORT ? Number(process.env.PORT) : 3000,
-      strictPort: false, // allow fallback if port is taken, but log clearly
+      // Managed Workspace launchers expect a stable port. Fail loudly instead
+      // of silently hopping to 3001+ so launchctl/service health matches the
+      // actual listening socket.
+      strictPort: true,
       allowedHosts: true,
       watch: {
         ignored: [


### PR DESCRIPTION
## Summary
- fix Docker publish by using a real gosu image tag again
- hide `<workspace_context ... />` from visible chat/session titles and add regression coverage
- make managed launches fail loudly if port 3000 is occupied instead of silently hopping ports
- bump `ws` from `8.19.0` to `8.20.1`
- harden chat completion handoff by persisting the final assistant recovery message and clearing pending-send state on completion

## Covers
- #501
- #504
- #507
- #498
- partial hardening for #505 / #506

## Validation
- `pnpm test src/lib/workspace-message-scope.test.ts src/screens/chat/utils.test.ts`
- `pnpm build`

## Notes
- #499 still wants a dashboard-backed profiles route pass.
- #505 / #506 still deserve a focused repro/test pass before claiming them fully resolved.
