### PR TITLE
fix: harden workspace cron jobs path and delivery targets

### DIFF
--- a/src/server/hermes-cron-profiles.ts
+++ b/src/server/hermes-cron-profiles.ts
@@ -1,10 +1,29 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { getHermesRoot, getProfilesDir } from './claude-paths'
 
 const PROFILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/
 const JOB_ID_RE = /^[A-Fa-f0-9]{8,64}$/
+
+const HERMES_BIN_CANDIDATES = [
+  process.env.HERMES_CLI_BIN,
+  join(homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
+  join(homedir(), '.local', 'bin', 'hermes'),
+  'hermes',
+].filter((value): value is string => Boolean(value))
+
+function resolveHermesBin(): string {
+  for (const candidate of HERMES_BIN_CANDIDATES) {
+    if (candidate.includes('/')) {
+      if (existsSync(candidate)) return candidate
+      continue
+    }
+    return candidate
+  }
+  return 'hermes'
+}
 
 type RawCronJob = Record<string, unknown>
 
@@ -224,7 +243,7 @@ export function createProfileCronJob(
   profile: string,
   input: Record<string, unknown>,
 ): Record<string, unknown> {
-  const output = execFileSync('hermes', normalizeCreateArgs(profile, input), {
+  const output = execFileSync(resolveHermesBin(), normalizeCreateArgs(profile, input), {
     encoding: 'utf8',
     timeout: 30_000,
   })
@@ -250,7 +269,7 @@ export function runProfileCronAction(
   validateProfileAndMaybeJob(profile, jobId)
   const cliAction = action === 'remove' ? 'remove' : action
   const output = execFileSync(
-    'hermes',
+    resolveHermesBin(),
     ['--profile', profile, 'cron', cliAction, jobId],
     {
       encoding: 'utf8',
@@ -288,7 +307,7 @@ export function updateProfileCronJob(
       ? String(updates.repeat)
       : null
   if (repeat) args.push('--repeat', repeat)
-  const output = execFileSync('hermes', args, {
+  const output = execFileSync(resolveHermesBin(), args, {
     encoding: 'utf8',
     timeout: 30_000,
   })

--- a/src/server/hermes-cron-profiles.ts
+++ b/src/server/hermes-cron-profiles.ts
@@ -72,13 +72,24 @@ function readBoolean(value: unknown, fallback: boolean): boolean {
 
 function normalizeDeliver(value: unknown): Array<string> {
   if (Array.isArray(value)) {
-    return value.filter(
-      (entry): entry is string =>
-        typeof entry === 'string' && entry.trim().length > 0,
-    )
+    return value
+      .flatMap((entry) =>
+        typeof entry === 'string' ? entry.split(',') : [],
+      )
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
   }
-  if (typeof value === 'string' && value.trim()) return [value.trim()]
+  if (typeof value === 'string' && value.trim()) {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+  }
   return []
+}
+
+function readDeliverTargets(value: unknown): Array<string> {
+  return Array.from(new Set(normalizeDeliver(value)))
 }
 
 function lastRunSuccess(job: RawCronJob): boolean | null {
@@ -214,11 +225,7 @@ function normalizeCreateArgs(
   const args = ['--profile', profile, 'cron', 'create']
   const name = readString(input.name)
   if (name) args.push('--name', name)
-  const deliver = Array.isArray(input.deliver)
-    ? input.deliver
-        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-        .filter((value) => value.length > 0)
-    : []
+  const deliver = readDeliverTargets(input.deliver)
   if (deliver.length > 0) args.push('--deliver', deliver.join(','))
   const skills = Array.isArray(input.skills)
     ? input.skills
@@ -293,11 +300,7 @@ export function updateProfileCronJob(
   const name = readString(updates.name)
   const schedule = readString(updates.schedule)
   const prompt = readString(updates.prompt, updates.input)
-  const deliver = Array.isArray(updates.deliver)
-    ? updates.deliver
-        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-        .filter((value) => value.length > 0)
-    : []
+  const deliver = readDeliverTargets(updates.deliver)
   if (name) args.push('--name', name)
   if (schedule) args.push('--schedule', schedule)
   if (prompt !== null) args.push('--prompt', prompt)


### PR DESCRIPTION
## Summary
- resolve the Hermes CLI path explicitly before running Workspace cron profile operations
- preserve multi-target delivery selections like `local,telegram` for profile-backed jobs
- normalize saved delivery values back into arrays for the Jobs UI
- update the tracked Electron server bundle so the desktop app picks up the server-side fix

## Problems fixed
1. Editing or acting on Workspace jobs could fail with:

```text
spawnSync hermes ENOENT
```

2. In the Jobs UI, selecting Telegram/Discord alongside local delivery could be lost, leaving jobs saved as local-only.

## Root causes
- Workspace invoked `execFileSync(hermes, ...)` directly from the server-side cron profile helpers. In some launch environments, especially desktop/app-managed processes, the runtime PATH does not include the same shell-resolved locations as an interactive terminal, so Node could not find the `hermes` binary.
- Workspace serializes deliver targets as a comma-separated string for job mutations, but the profile-backed cron helpers only handled array input when building and updating cron commands. That caused extra targets like `telegram` to be dropped.

## Fix
- add a small resolver that checks, in order:
  - `HERMES_CLI_BIN`
  - `~/.hermes/hermes-agent/venv/bin/hermes`
  - `~/.local/bin/hermes`
  - fallback `hermes`
- use the resolved binary for profile cron create/update/action commands
- accept both comma-separated strings and arrays for delivery targets in profile-backed cron helpers
- normalize persisted delivery values back into arrays for the Jobs UI
- refresh `electron/server-bundle.cjs` so the desktop app ships the server-side fix

## Verification
- `pnpm build`
- `pnpm electron:bundle-server`
- reproduced the failing live API call before the reload:
  - `PATCH /api/claude-jobs/default:12d105f5586c`
  - response: `400 {"ok":false,"error":"spawnSync hermes ENOENT"}`
- reloaded the running Workspace server
- repeated the same PATCH call after the path fix:
  - response: `200 {"ok":true,...}`
- verified the delivery-target fix through the Workspace API:
  - created a temporary job with `deliver: "local,telegram"`
  - confirmed the returned job had `deliver: ["local", "telegram"]`
  - updated the job and confirmed delivery changes persisted
  - removed the temporary job

## Risk
Low. The changes are scoped to Workspace cron/profile job operations and preserve the existing `hermes` fallback for environments where PATH resolution already works.