### PR TITLE
feat: hardwire Workspace Toolmindset policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,6 @@ This workspace uses semantic Hermes swarm workers, not numbered-only lanes. The 
 
 - Keep `swarm.yaml`, profile `config.yaml`, profile core skills, and wrappers aligned when changing a worker.
 - Prefer GBrain-first lookup for context-sensitive RAZSOC/Hermes/workflow decisions.
+- Workspace agents should use the token-saving Toolmindset control lane: smart-read first for files, jcodemunch for code indexes, jdocmunch for docs. If unsure, run the `cli-anything-*` wrappers through terminal and report fallback honestly.
 - Builder implements; Reviewer gates; QA verifies behavior; Orchestrator routes and enforces greenlight.
 - Do not enable optional Hermes plugins globally unless the task explicitly needs them; record plugin/toolset alignment in `swarm.yaml` first.

--- a/policies/hermes-toolmindset-directive.md
+++ b/policies/hermes-toolmindset-directive.md
@@ -1,0 +1,18 @@
+# Hermes Workspace Toolmindset Directive
+
+When working inside Workspace/API sessions, prefer token-saving Toolmindset CLI wrappers before raw file reads or broad searches.
+
+Required default order:
+
+1. For file inspection, use terminal with:
+   `cli-anything-smart-read-mcp sc-read <path> --mode outline|symbol|full`
+2. For code repo navigation/search, use terminal with:
+   `cli-anything-jcodemunch-mcp ...`
+3. For docs/wiki navigation/search, use terminal with:
+   `cli-anything-jdocmunch-mcp ...`
+4. Use Hermes native `read_file` / `search_files` only when the wrapper is missing, broken, or the requested operation is simpler and lower risk.
+5. Do not use native `mcp__*` tools. Prefer `cli-anything-*`; fallback to `mcp2cli` only if wrapper missing/broken.
+
+If a wrapper fails, report the fallback clearly instead of silently switching lanes.
+
+This is routing policy for Workspace/API sessions.

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { buildResolvedSessionHeaders } from '../../lib/send-stream-session-headers'
 import { buildWorkspaceScopedTextMessage } from '../../lib/workspace-message-scope'
+import { applyToolmindsetPolicy, loadToolmindsetPolicy } from '../../server/toolmindset-policy'
 import {
   collectSyntheticLiveToolEvents,
   createSyntheticLiveToolTracker,
@@ -371,9 +372,12 @@ export const Route = createFileRoute('/api/send-stream')({
         }
 
         const workspaceScope = await loadWorkspaceCatalog().catch(() => null)
-        const scopedMessage = buildWorkspaceScopedTextMessage(
-          getChatMessage(message, attachments),
-          workspaceScope,
+        const scopedMessage = applyToolmindsetPolicy(
+          buildWorkspaceScopedTextMessage(
+            getChatMessage(message, attachments),
+            workspaceScope,
+          ),
+          loadToolmindsetPolicy(),
         )
 
         // Create streaming response using the SHARED server connection

--- a/src/server/toolmindset-policy.test.ts
+++ b/src/server/toolmindset-policy.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  TOOLMINDSET_POLICY_MAX_CHARS,
+  applyToolmindsetPolicy,
+  loadToolmindsetPolicy,
+} from './toolmindset-policy'
+
+const originalPolicyFile = process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE
+
+afterEach(() => {
+  if (originalPolicyFile === undefined) {
+    delete process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE
+  } else {
+    process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE = originalPolicyFile
+  }
+})
+
+describe('loadToolmindsetPolicy', () => {
+  it('loads policy from WORKSPACE_TOOLMINDSET_POLICY_FILE', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'workspace-toolmindset-'))
+    try {
+      const policyFile = join(dir, 'policy.md')
+      writeFileSync(policyFile, 'custom wrapper policy', 'utf8')
+      process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE = policyFile
+
+      expect(loadToolmindsetPolicy()).toBe('custom wrapper policy')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the repo policy file', () => {
+    delete process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE
+
+    const policy = loadToolmindsetPolicy()
+
+    expect(policy).toContain('cli-anything-smart-read-mcp')
+    expect(policy).toContain('cli-anything-jcodemunch-mcp')
+    expect(policy).toContain('cli-anything-jdocmunch-mcp')
+  })
+
+  it('caps large policy files to prevent prompt bloat', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'workspace-toolmindset-'))
+    try {
+      const policyFile = join(dir, 'policy.md')
+      writeFileSync(policyFile, 'x'.repeat(TOOLMINDSET_POLICY_MAX_CHARS + 100), 'utf8')
+      process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE = policyFile
+
+      expect(loadToolmindsetPolicy()).toHaveLength(TOOLMINDSET_POLICY_MAX_CHARS)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails open when the policy file is missing', () => {
+    process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE = '/tmp/does-not-exist-workspace-toolmindset.md'
+
+    expect(loadToolmindsetPolicy()).toBe('')
+  })
+})
+
+describe('applyToolmindsetPolicy', () => {
+  it('injects the policy after workspace context and before user content', () => {
+    const message = '<workspace_context active="true" name="Home" path="/repo" />\n\nInspect src/main.ts'
+
+    expect(applyToolmindsetPolicy(message, 'use smart-read first')).toBe(
+      '<workspace_context active="true" name="Home" path="/repo" />\n\n<workspace_toolmindset_policy>\nuse smart-read first\n</workspace_toolmindset_policy>\n\nInspect src/main.ts',
+    )
+  })
+
+  it('does not inject the policy twice', () => {
+    const message = '<workspace_context active="true" name="Home" path="/repo" />\n\n<workspace_toolmindset_policy>\nold\n</workspace_toolmindset_policy>\n\nInspect src/main.ts'
+
+    expect(applyToolmindsetPolicy(message, 'new')).toBe(message)
+  })
+
+  it('returns the original message when policy is empty', () => {
+    expect(applyToolmindsetPolicy('Inspect src/main.ts', '')).toBe('Inspect src/main.ts')
+  })
+})

--- a/src/server/toolmindset-policy.ts
+++ b/src/server/toolmindset-policy.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const TOOLMINDSET_POLICY_MAX_CHARS = 4096
+
+const defaultPolicyFile = join(process.cwd(), 'policies', 'hermes-toolmindset-directive.md')
+
+function readPolicyFile(path: string): string {
+  if (!path || !existsSync(path)) return ''
+  try {
+    return readFileSync(path, 'utf8').trim().slice(0, TOOLMINDSET_POLICY_MAX_CHARS)
+  } catch {
+    return ''
+  }
+}
+
+export function loadToolmindsetPolicy(): string {
+  const envPath = process.env.WORKSPACE_TOOLMINDSET_POLICY_FILE?.trim()
+  if (envPath) {
+    return readPolicyFile(envPath)
+  }
+  return readPolicyFile(defaultPolicyFile)
+}
+
+export function applyToolmindsetPolicy(message: string, policy: string): string {
+  const trimmedPolicy = policy.trim()
+  if (!trimmedPolicy) return message
+  if (message.includes('<workspace_toolmindset_policy>')) return message
+
+  const policyBlock = `<workspace_toolmindset_policy>\n${trimmedPolicy}\n</workspace_toolmindset_policy>`
+  const workspaceClose = '/>'
+  const workspaceStart = message.indexOf('<workspace_context active="true"')
+
+  if (workspaceStart >= 0) {
+    const workspaceEnd = message.indexOf(workspaceClose, workspaceStart)
+    if (workspaceEnd >= 0) {
+      const insertAt = workspaceEnd + workspaceClose.length
+      const before = message.slice(0, insertAt).trimEnd()
+      const after = message.slice(insertAt).trimStart()
+      return after ? `${before}\n\n${policyBlock}\n\n${after}` : `${before}\n\n${policyBlock}`
+    }
+  }
+
+  return `${policyBlock}\n\n${message}`
+}


### PR DESCRIPTION
Adds Workspace-side Toolmindset policy injection for API/send-stream sessions without modifying Hermes native core.\n\nProof:\n- npm exec -- vitest run src/server/toolmindset-policy.test.ts: 7 passed\n- npm run build: passed\n- live /api/send-stream smoke inserted <workspace_toolmindset_policy> and called terminal with cli-anything-smart-read-mcp\n\nNote: full npm test currently has unrelated baseline failures in MCP hub/store and chat component tests; focused lane and build pass.