### PR TITLE
fix(profiles): add dashboard API fallback for split-host deployments

### DIFF
--- a/src/routes/api/profiles/list.ts
+++ b/src/routes/api/profiles/list.ts
@@ -1,10 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
-import {
-  getActiveProfileName,
-  listProfiles,
-} from '../../../server/profiles-browser'
+import { listProfilesWithFallback } from '../../../server/profiles-browser'
 
 export const Route = createFileRoute('/api/profiles/list')({
   server: {
@@ -14,10 +11,9 @@ export const Route = createFileRoute('/api/profiles/list')({
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         try {
-          return json({
-            profiles: listProfiles(),
-            activeProfile: getActiveProfileName(),
-          })
+          const { profiles, activeProfile } =
+            await listProfilesWithFallback()
+          return json({ profiles, activeProfile })
         } catch (error) {
           return json(
             {

--- a/src/routes/api/profiles/read.ts
+++ b/src/routes/api/profiles/read.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
-import { readProfile } from '../../../server/profiles-browser'
+import { readProfileWithFallback } from '../../../server/profiles-browser'
 
 export const Route = createFileRoute('/api/profiles/read')({
   server: {
@@ -13,7 +13,8 @@ export const Route = createFileRoute('/api/profiles/read')({
         try {
           const url = new URL(request.url)
           const name = (url.searchParams.get('name') || '').trim() || 'default'
-          return json({ profile: readProfile(name) })
+          const profile = await readProfileWithFallback(name)
+          return json({ profile })
         } catch (error) {
           return json(
             {

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -82,7 +82,7 @@ function validateProfileName(name: string): string {
 }
 
 /**
- * Validate a profile name that will only be *read* (e.g. \`cloneFrom\` source).
+ * Validate a profile name that will only be *read* (e.g. `cloneFrom` source).
  * Any existing profile name is allowed, including 'default'.
  */
 function validateProfileIdentifier(name: string): string {
@@ -166,6 +166,177 @@ function extractDescription(config: Record<string, unknown>): string {
   }
 
   return ''
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard API fallback for split-host deployments
+// ---------------------------------------------------------------------------
+
+function getDashboardUrl(): string | undefined {
+  const url = process.env.HERMES_DASHBOARD_URL?.trim()
+  return url || undefined
+}
+
+function getDashboardToken(): string | undefined {
+  return (
+    process.env.HERMES_API_TOKEN?.trim() ||
+    process.env.CLAUDE_API_TOKEN?.trim() ||
+    process.env.CLAUDE_DASHBOARD_TOKEN?.trim() ||
+    undefined
+  )
+}
+
+async function fetchDashboardProfiles(): Promise<{
+  profiles: Array<ProfileSummary>
+  activeProfile: string
+} | null> {
+  const dashboardUrl = getDashboardUrl()
+  if (!dashboardUrl) return null
+
+  try {
+    const token = getDashboardToken()
+    const headers: Record<string, string> = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    const response = await fetch(`${dashboardUrl}/api/profiles`, {
+      headers,
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!response.ok) return null
+
+    const data = (await response.json()) as {
+      profiles?: Array<{
+        name: string
+        model?: string
+        provider?: string
+        description?: string
+        is_default?: boolean
+        skill_count?: number
+        session_count?: number
+        has_env?: boolean
+        updated_at?: string
+      }>
+    }
+
+    if (!data.profiles || !Array.isArray(data.profiles)) return null
+
+    const activeProfile =
+      data.profiles.find((p) => p.is_default)?.name || 'default'
+
+    const profiles: Array<ProfileSummary> = data.profiles.map((p) => ({
+      name: p.name,
+      path: p.is_default
+        ? getClaudeRoot()
+        : path.join(getProfilesRoot(), p.name),
+      active: p.name === activeProfile,
+      exists: true,
+      model: p.model,
+      provider: p.provider,
+      description: p.description,
+      skillCount: p.skill_count ?? 0,
+      sessionCount: p.session_count ?? 0,
+      hasEnv: p.has_env ?? false,
+      updatedAt: p.updated_at,
+    }))
+
+    profiles.sort((a, b) => {
+      if (a.active && !b.active) return -1
+      if (!a.active && b.active) return 1
+      return Date.parse(b.updatedAt || '') - Date.parse(a.updatedAt || '')
+    })
+
+    return { profiles, activeProfile }
+  } catch (error) {
+    // Dashboard unreachable or returned unexpected data — fall back to filesystem
+    return null
+  }
+}
+
+/**
+ * List profiles with dashboard API fallback for split-host deployments.
+ * When HERMES_DASHBOARD_URL is set and reachable, fetches from the dashboard
+ * API. Falls back to filesystem reads for colocated deployments.
+ */
+export async function listProfilesWithFallback(): Promise<{
+  profiles: Array<ProfileSummary>
+  activeProfile: string
+}> {
+  // Try dashboard first for split-host deployments
+  const dashboardResult = await fetchDashboardProfiles()
+  if (dashboardResult) return dashboardResult
+
+  // Fall back to filesystem (colocated deployment)
+  return {
+    profiles: listProfiles(),
+    activeProfile: getActiveProfileName(),
+  }
+}
+
+/**
+ * Read a single profile with dashboard API fallback for split-host deployments.
+ */
+export async function readProfileWithFallback(
+  name: string,
+): Promise<ProfileDetail> {
+  // Try filesystem first (fast path for colocated deployments)
+  const normalized = name.trim() || 'default'
+  const profilePath =
+    normalized === 'default'
+      ? getClaudeRoot()
+      : path.join(getProfilesRoot(), validateProfileIdentifier(normalized))
+
+  if (fs.existsSync(profilePath)) {
+    return readProfile(normalized)
+  }
+
+  // Filesystem miss — try dashboard API for split-host deployments
+  const dashboardUrl = getDashboardUrl()
+  if (dashboardUrl) {
+    try {
+      const token = getDashboardToken()
+      const headers: Record<string, string> = {}
+      if (token) headers['Authorization'] = `Bearer ${token}`
+
+      const response = await fetch(`${dashboardUrl}/api/profiles`, {
+        headers,
+        signal: AbortSignal.timeout(5000),
+      })
+      if (response.ok) {
+        const data = (await response.json()) as {
+          profiles?: Array<{
+            name: string
+            model?: string
+            provider?: string
+            description?: string
+            is_default?: boolean
+          }>
+        }
+        const match = data.profiles?.find(
+          (p) => p.name === normalized || (normalized === 'default' && p.is_default),
+        )
+        if (match) {
+          const active = getActiveProfileName()
+          return {
+            name: match.name,
+            path: match.is_default
+              ? getClaudeRoot()
+              : path.join(getProfilesRoot(), match.name),
+            active: match.name === active,
+            config: {
+              ...(match.model ? { model: match.model } : {}),
+              ...(match.provider ? { provider: match.provider } : {}),
+            },
+            description: match.description || '',
+            hasEnv: false,
+          }
+        }
+      }
+    } catch {
+      // Dashboard unreachable — fall through to error
+    }
+  }
+
+  throw new Error('Profile not found')
 }
 
 export function getActiveProfileName(): string {


### PR DESCRIPTION
Fixes #499

## Summary

In split-host deployments (workspace on Host B, agent on Host A), the `/profiles` route shows zero profiles because `profiles-browser.ts` reads exclusively from local filesystem. The dashboard's `/api/profiles` endpoint on the agent host already exposes this data but was never consulted.

## Changes

- **`src/server/profiles-browser.ts`**: Added `listProfilesWithFallback()` and `readProfileWithFallback()` async functions that:
  1. Try the dashboard `/api/profiles` API when `HERMES_DASHBOARD_URL` is set
  2. Fall back to local filesystem reads for colocated deployments
  3. Use existing `HERMES_API_TOKEN` / `CLAUDE_API_TOKEN` auth headers

- **`src/routes/api/profiles/list.ts`**: Switched from sync `listProfiles()` + `getActiveProfileName()` to async `listProfilesWithFallback()`

- **`src/routes/api/profiles/read.ts`**: Switched from sync `readProfile()` to async `readProfileWithFallback()`

## Design

- Dashboard-first when `HERMES_DASHBOARD_URL` is reachable (split-host)
- Filesystem fallback when dashboard is absent or unreachable (colocated)
- Sync filesystem code unchanged — no breaking changes for existing callers
- 5-second timeout on dashboard fetch to prevent blocking on slow networks
- Dashboard response mapped to the existing `ProfileSummary` / `ProfileDetail` types

## What's NOT covered

- Write operations (create, delete, rename, activate) still go through filesystem. A full split-host write path needs the agent's HTTP profile management endpoints (see #493 for the write-side gap).
