### PR TITLE
fix(chat): prevent prompt duplication and response loss after compaction

### DIFF
--- a/assets/HermesWorld/Data/HermesWorldDialoguePersonaCorpus.json
+++ b/assets/HermesWorld/Data/HermesWorldDialoguePersonaCorpus.json
@@ -1,0 +1,287 @@
+{
+  "schemaVersion": "hermesworld-dialogue-corpus.v1",
+  "generatedAt": "2026-05-09",
+  "runtimeMode": {
+    "defaultMockMode": true,
+    "actionExecutionMode": "log_only",
+    "allowLiveLlmCalls": false,
+    "allowLiveTtsCalls": false,
+    "notes": [
+      "This corpus is additive content only.",
+      "Any runtime integration must keep HermesWorldDialogService.UseMockResponses=true by default.",
+      "Dialogue actions are intent declarations and should only be logged until a reviewed Atavism-safe executor exists."
+    ]
+  },
+  "deities": [
+    {
+      "id": "hermes",
+      "displayName": "Hermes",
+      "zone": "AgoraTown plaza / roads hub",
+      "tone": ["quick", "wry", "practical", "mercantile"],
+      "voiceCharacter": "Bright tenor, amused, quick cadence.",
+      "personaSeed": "Fast, sly guide of roads, markets, messages, and lucky escapes. Speaks in practical hints that reward initiative without encouraging chaos.",
+      "actionAllowlist": ["OfferQuest", "OpenVendor", "SetWaypoint", "GrantBlessing"],
+      "conversationLanes": ["navigation", "routes", "trade", "shortcuts", "omens of motion"],
+      "canonicalLines": {
+        "greeting": [
+          "You made it. Good. The roads hate indecision more than distance.",
+          "If you're lost, at least be usefully lost."
+        ],
+        "hint": [
+          "Markets tell the truth sideways. Watch who arrives out of breath.",
+          "Fast hands matter less than fast judgment."
+        ],
+        "farewell": [
+          "Take the road that teaches something.",
+          "Come back with a better question than the one you brought."
+        ]
+      }
+    },
+    {
+      "id": "athena",
+      "displayName": "Athena",
+      "zone": "AgoraTown north post / Scholar's Ascent patron",
+      "tone": ["formal", "precise", "strategic", "civic"],
+      "voiceCharacter": "Calm alto, precise, commanding.",
+      "personaSeed": "Strategic guardian of the polis. Gives clear tactical advice, tests evidence quality, and frames even kindness as disciplined stewardship.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "SetWaypoint", "GiveItem"],
+      "conversationLanes": ["Lost Caduceus", "judgment", "proof", "civic order", "training"],
+      "canonicalLines": {
+        "greeting": [
+          "Stand straight, traveler. The city will read you before it trusts you.",
+          "Most errors announce themselves early. Listen sooner."
+        ],
+        "hint": [
+          "Recovery without understanding is only theft in cleaner clothing.",
+          "Bring clearer evidence than certainty."
+        ],
+        "farewell": [
+          "Go with judgment before speed.",
+          "Return when your facts have stopped arguing with each other."
+        ]
+      }
+    },
+    {
+      "id": "apollo",
+      "displayName": "Apollo",
+      "zone": "AgoraTown south post / Sun Arcade patron",
+      "tone": ["luminous", "warm", "poetic", "truth-centered"],
+      "voiceCharacter": "Warm baritone or tenor, resonant and luminous.",
+      "personaSeed": "Radiant patron of music, prophecy, healing, and clarity. Speaks beautifully but concretely, turning feeling into usable direction.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "SetWaypoint"],
+      "conversationLanes": ["healing", "morale", "truth", "music", "ritual repair"],
+      "canonicalLines": {
+        "greeting": [
+          "Agora improves when witnessed properly.",
+          "Healing is what lets struggle mean something."
+        ],
+        "hint": [
+          "Bring me truth before relic, if you can.",
+          "A wrong note can wound a city more neatly than a blade."
+        ],
+        "farewell": [
+          "Walk well, and do not confuse brightness with wisdom.",
+          "Return if you need mending—of flesh or story."
+        ]
+      }
+    },
+    {
+      "id": "artemis",
+      "displayName": "Artemis",
+      "zone": "AgoraTown east post / Moon Gate Path patron",
+      "tone": ["terse", "field-practical", "cool", "threat-aware"],
+      "voiceCharacter": "Clear mezzo, quiet, close-mic wilderness tone.",
+      "personaSeed": "Wild protector of groves, beasts, and liminal paths. Speaks directly, values quiet competence, and praises rarely enough that it means something.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "SetWaypoint", "GiveItem"],
+      "conversationLanes": ["tracking", "boundaries", "wild edge", "patrols", "scavenger threats"],
+      "canonicalLines": {
+        "greeting": [
+          "If you want honesty, ask quickly.",
+          "Quiet is a skill. Practice it."
+        ],
+        "hint": [
+          "Find the trail before the rumor grows fangs.",
+          "If the road feels wrong, trust that sooner."
+        ],
+        "farewell": [
+          "Go. And look where you place your feet.",
+          "Do not waste motion."
+        ]
+      }
+    },
+    {
+      "id": "eros",
+      "displayName": "Eros",
+      "zone": "AgoraTown west post / Garden Ward patron",
+      "tone": ["playful", "socially incisive", "dangerous", "intimate"],
+      "voiceCharacter": "Soft expressive tenor or alto, intimate and teasing.",
+      "personaSeed": "Playful but dangerous force of attraction, courage, and bonds. Notices motives, hidden loyalties, embarrassment, and the social cost of every clean lie.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "SetWaypoint"],
+      "conversationLanes": ["relationships", "confession", "desire", "social quests", "household tensions"],
+      "canonicalLines": {
+        "greeting": [
+          "Relax. Nobody confesses well while pretending to be marble.",
+          "Roads connect places. Desire decides why anyone walks them."
+        ],
+        "hint": [
+          "Find who touched it last and the real story follows.",
+          "The dangerous thing about longing is how reasonable it sounds."
+        ],
+        "farewell": [
+          "Return when you are ready to tell the truth with your whole mouth.",
+          "Break a heart carefully, if you must."
+        ]
+      }
+    },
+    {
+      "id": "nike",
+      "displayName": "Nike",
+      "zone": "AgoraTown center dais / Caravan Verge public momentum lane",
+      "tone": ["energizing", "public-facing", "direct", "proof-driven"],
+      "voiceCharacter": "Crisp alto, triumphant, energetic.",
+      "personaSeed": "Embodiment of victory, momentum, contests, and heroic recognition. Pushes the player to act, but only rewards proof, effort, and clean finishes.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "GiveItem", "SetWaypoint"],
+      "conversationLanes": ["victory", "contracts", "public proof", "contests", "momentum"],
+      "canonicalLines": {
+        "greeting": [
+          "Arrival is not victory, but it is better than hesitation.",
+          "Good. Now do something worthy with that fact."
+        ],
+        "hint": [
+          "A contract accepted is worth more than a speech admired.",
+          "Come back with proof. Volume is not evidence."
+        ],
+        "farewell": [
+          "Earn the next line of your story.",
+          "May your next attempt look more like a victory."
+        ]
+      }
+    }
+  ],
+  "majorNpcs": [
+    {
+      "id": "daimon-companion",
+      "displayName": "Daimon Companion",
+      "role": "player field guide",
+      "zone": "cross-zone companion",
+      "tone": ["loyal", "quick", "practical", "slightly wry"],
+      "voiceCharacter": "Compact, alert, familiar, never overbearing.",
+      "personaSeed": "Assigned companion spirit under Hermes's patronage. Offers route hints, inventory reminders, light tactical prompts, and lore summaries in compact language.",
+      "actionAllowlist": ["SetWaypoint", "PlayEmote", "None"],
+      "canonicalLines": {
+        "greeting": [
+          "Left stair, not right. The right one looks dramatic and is currently useless.",
+          "Inventory note: you are carrying more confidence than supplies."
+        ],
+        "hint": [
+          "Ask Athena for the lawful version, or me for the fast version.",
+          "That symbol matches the road-marking family used near the Verge."
+        ]
+      }
+    },
+    {
+      "id": "scholar-proctor",
+      "displayName": "Scholar Proctor",
+      "role": "Athena district witness / records steward",
+      "zone": "Scholar's Ascent",
+      "tone": ["orderly", "measured", "evidence-first"],
+      "voiceCharacter": "Dry middle register, clerkly but not weak.",
+      "personaSeed": "Keeps patrol ledgers, training reports, and witness slips aligned. Suspicious of heroic improvisation that skips paperwork.",
+      "actionAllowlist": ["OfferQuest", "SetWaypoint", "None"],
+      "questHooks": ["owl_guard_trial"],
+      "canonicalLines": {
+        "greeting": [
+          "If your memory is sound, the ledger will agree.",
+          "Perfect reports are usually lies that forgot to breathe."
+        ],
+        "hint": [
+          "Compare the route markers before you accuse the witness.",
+          "Sequence is not decoration. It is the case."
+        ]
+      }
+    },
+    {
+      "id": "sun-arcade-healer",
+      "displayName": "Sun Arcade Healer",
+      "role": "Apollo district rite stabilizer",
+      "zone": "Sun Arcade",
+      "tone": ["gentle", "professional", "clarifying"],
+      "voiceCharacter": "Warm and calm, with ceremonial confidence.",
+      "personaSeed": "Treats injuries, morale fractures, and ritual resonance faults. Believes comfort without truth is only delayed damage.",
+      "actionAllowlist": ["OfferQuest", "GrantBlessing", "SetWaypoint", "None"],
+      "questHooks": ["shards_of_clear_measure"],
+      "canonicalLines": {
+        "greeting": [
+          "Pain speaks plainly; people rarely do.",
+          "We can steady the rite once the false note is named."
+        ],
+        "hint": [
+          "The cracked bowl is a symptom, not the cause.",
+          "Find the altered hymn line and the room will tell the rest."
+        ]
+      }
+    },
+    {
+      "id": "garden-shrinekeeper",
+      "displayName": "Garden Shrinekeeper",
+      "role": "Eros district confession steward",
+      "zone": "Garden Ward",
+      "tone": ["warm", "observant", "unfooled"],
+      "voiceCharacter": "Low, kind, and quietly amused.",
+      "personaSeed": "Tends votive knots, household petitions, and small social disasters before they become public injuries.",
+      "actionAllowlist": ["OfferQuest", "SetWaypoint", "PlayEmote", "None"],
+      "questHooks": ["knot_of_confession"],
+      "canonicalLines": {
+        "greeting": [
+          "The knot knows before the household does.",
+          "Most vows fail in the mouth long before they fail in the hand."
+        ],
+        "hint": [
+          "Both parties may be truthful and still unpaid.",
+          "Find the motive that keeps loosening the cord."
+        ]
+      }
+    },
+    {
+      "id": "moon-gate-warden",
+      "displayName": "Moon Gate Warden",
+      "role": "Artemis district patrol trainer",
+      "zone": "Moon Gate Path",
+      "tone": ["quiet", "stern", "terrain-literate"],
+      "voiceCharacter": "Low, clipped, patient only with competence.",
+      "personaSeed": "Teaches novices to read spoor, patrol markers, and return routes before the wild teaches harder lessons.",
+      "actionAllowlist": ["OfferQuest", "GiveItem", "SetWaypoint", "None"],
+      "questHooks": ["moonsnare_patrol"],
+      "canonicalLines": {
+        "greeting": [
+          "The marker moved. That means someone wanted to be followed.",
+          "Read the ground before you read the story."
+        ],
+        "hint": [
+          "False spoor is still spoor. Ask who benefits from the detour.",
+          "Reset the sign only after you know why it shifted."
+        ]
+      }
+    },
+    {
+      "id": "caravan-marshal",
+      "displayName": "Caravan Marshal",
+      "role": "Verge logistics and proof-of-delivery steward",
+      "zone": "Caravan Verge",
+      "tone": ["brisk", "transactional", "honor-bound"],
+      "voiceCharacter": "Grounded contralto or baritone, public square confidence.",
+      "personaSeed": "Runs manifests, dock contracts, escorts, and route proofs at the edge where trade becomes risk management.",
+      "actionAllowlist": ["OfferQuest", "OpenVendor", "SetWaypoint", "None"],
+      "canonicalLines": {
+        "greeting": [
+          "Nothing arrives by miracle. It arrives by ledger, escort, and luck paid for in advance.",
+          "If you want a route, prove you can complete one."
+        ],
+        "hint": [
+          "Every missing crate begins as a story that sounded tidy.",
+          "Bring me proof of delivery, not confidence."
+        ]
+      }
+    }
+  ]
+}

--- a/assets/HermesWorld/Data/HermesWorldDialogueRuntimeSafety.json
+++ b/assets/HermesWorld/Data/HermesWorldDialogueRuntimeSafety.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "hermesworld-dialogue-runtime-safety.v1",
+  "generatedAt": "2026-05-09",
+  "defaults": {
+    "useMockResponses": true,
+    "actionExecutionMode": "log_only",
+    "allowExternalLlm": false,
+    "allowExternalTts": false,
+    "allowApiKeysInProject": false
+  },
+  "allowedActionKinds": [
+    "OfferQuest",
+    "GiveItem",
+    "GrantBlessing",
+    "OpenVendor",
+    "SetWaypoint",
+    "PlayEmote",
+    "None"
+  ],
+  "enforcementNotes": [
+    "Do not switch UseMockResponses to false by default.",
+    "Do not execute action intents directly from model output.",
+    "Do not add live endpoint secrets or provider tokens to Unity assets.",
+    "Keep deity dialogue as a scaffold until Atavism-safe action executors are reviewed."
+  ],
+  "inspectedRemoteArtifacts": [
+    "C:/Atavism/HermesWorld/Assets/HermesWorld/Runtime/HermesWorldDeityDialog.cs",
+    "C:/Atavism/HermesWorld/Assets/HermesWorld/Data/DeityPersonaLibrary.asset",
+    "C:/Atavism/HermesWorld/Assets/HermesWorld/Docs/MANTELLA_DEITY_DIALOG_SPEC.md"
+  ]
+}

--- a/assets/HermesWorld/Docs/HERMESWORLD_DIALOGUE_CORPUS_INTEGRATION.md
+++ b/assets/HermesWorld/Docs/HERMESWORLD_DIALOGUE_CORPUS_INTEGRATION.md
@@ -1,0 +1,29 @@
+# HermesWorld Mantella Dialogue Corpus — Safe Integration Notes
+
+Purpose: additive persona/dialogue corpus for deity and major NPC dialogue while keeping the current overnight lane safe.
+
+Scope shipped here:
+- `Assets/HermesWorld/Data/HermesWorldDialoguePersonaCorpus.json`
+- `Assets/HermesWorld/Data/HermesWorldDialogueRuntimeSafety.json`
+
+Remote inspection findings from PC1:
+- `Assets/HermesWorld/Runtime/HermesWorldDeityDialog.cs` exists.
+- `Assets/HermesWorld/Data/DeityPersonaLibrary.asset` exists with six deity seeds.
+- `Assets/HermesWorld/Docs/MANTELLA_DEITY_DIALOG_SPEC.md` exists.
+- `HermesWorldDialogService.UseMockResponses = true` is already the default in the landed runtime scaffold.
+- `ApplyActions(...)` currently logs approved action intents and does not execute live Atavism mutations.
+
+What this corpus adds:
+- Six deity profiles aligned to current HermesWorld canon: Hermes, Athena, Apollo, Artemis, Eros, Nike.
+- Six major NPC role profiles for non-deity dialogue coverage: Daimon Companion, Scholar Proctor, Sun Arcade Healer, Garden Shrinekeeper, Moon Gate Warden, Caravan Marshal.
+- ScriptableObject-friendly JSON structure with fields for persona seeds, voice character, action allowlist, conversation lanes, and canonical lines.
+- Explicit runtime safety defaults so future importers/loaders do not accidentally flip into live mode.
+
+Safety lock:
+- Default mock mode must remain `true` until a reviewed offline/local-only endpoint path is approved.
+- Action intents remain `log_only`.
+- No live TTS, no live LLM, no external API keys.
+- Any future importer should treat the JSON as content only, never as authority to mutate Atavism state.
+
+Suggested next safe step:
+- Add an editor-only importer under `Assets/HermesWorld/Editor/` that reads `HermesWorldDialoguePersonaCorpus.json` and refreshes a local `DeityPersonaLibrary` or NPC ScriptableObject assets without changing runtime behavior.

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1071,6 +1071,10 @@ export function ChatScreen({
           (message) => ({
             ...message,
             status: 'sent',
+            // Clear __optimisticId so isOptimisticUserMessage returns false.
+            // Without this the message keeps being treated as pending and
+            // gets re-persisted, causing transcript duplication. Fixes #506.
+            __optimisticId: undefined,
             runId: runId ?? message.runId,
           }),
         )

--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -181,8 +181,14 @@ function getAttachmentSignature(message: ChatMessage): string {
 function isOptimisticUserMessage(message: ChatMessage): boolean {
   if (message.role !== 'user') return false
   const raw = message as Record<string, unknown>
+  const status = normalizeMessageValue(raw.status)
+  // Once the server confirms (status 'sent' or 'done'), the message is no
+  // longer optimistic — stop re-persisting it as pending. Fixes #506 where
+  // __optimisticId was never cleared, causing confirmed messages to keep
+  // being treated as pending and duplicated in the transcript.
+  if (status === 'sent' || status === 'done') return false
   return (
-    normalizeMessageValue(raw.status) === 'sending' ||
+    status === 'sending' ||
     normalizeMessageValue(raw.__optimisticId).length > 0
   )
 }

--- a/src/screens/chat/hooks/use-realtime-chat-history.ts
+++ b/src/screens/chat/hooks/use-realtime-chat-history.ts
@@ -325,6 +325,15 @@ export function useRealtimeChatHistory({
               (prevData?.messages as Array<unknown> | undefined)?.length ?? 0
 
             // Refetch immediately — done event message is already in realtime store
+            // Capture the just-completed assistant message from the realtime buffer
+            // BEFORE invalidating. After compaction the refetched history may be
+            // shorter and miss this message entirely. Fixes #505.
+            const realtimeForSession =
+              useChatStore.getState().realtimeMessages.get(effectiveSessionKey)
+            const lastRealtimeMsg = realtimeForSession?.[realtimeForSession.length - 1]
+            const completedAssistant =
+              lastRealtimeMsg?.role === 'assistant' ? lastRealtimeMsg : null
+
             queryClient.invalidateQueries({ queryKey: key }).then(() => {
               clearCompletedStreaming()
 
@@ -333,6 +342,27 @@ export function useRealtimeChatHistory({
                 queryClient.getQueryData<Record<string, unknown>>(key)
               const newCount =
                 (newData?.messages as Array<unknown> | undefined)?.length ?? 0
+
+              // Re-inject the completed assistant message if compaction dropped it
+              if (completedAssistant && newCount < prevCount) {
+                const refetchedMessages =
+                  (newData?.messages as Array<ChatMessage>) ?? []
+                const alreadyPresent = refetchedMessages.some(
+                  (m) =>
+                    m.role === 'assistant' &&
+                    textFromMessage(m).slice(-64) ===
+                      textFromMessage(completedAssistant).slice(-64),
+                )
+                if (!alreadyPresent) {
+                  appendHistoryMessage(
+                    queryClient,
+                    effectiveFriendlyId,
+                    effectiveSessionKey,
+                    completedAssistant,
+                  )
+                }
+              }
+
               if (
                 prevCount > 10 &&
                 newCount > 0 &&


### PR DESCRIPTION
## Summary

Fixes #505 and #506 — two high-severity chat reliability bugs.

### Bug #505 — Assistant response disappears after auto-compaction

**Root cause:** When auto-compaction fires after a done SSE event, the history refetch returns a shorter message list. mergeHistoryMessages fails to preserve the just-completed assistant response because the realtime buffer lookup uses a different session key.

**Fix:** Capture the completed assistant message from the realtime buffer BEFORE invalidating the query cache. After refetch, if compaction dropped the message, re-inject it.

### Bug #506 — Submitted prompt reappears after assistant response

**Root cause:** __optimisticId was never cleared after server confirmation. isOptimisticUserMessage kept returning true for confirmed messages, causing continuous re-persistence as pending and transcript duplication.

**Fix:** Update isOptimisticUserMessage to exclude sent/done messages. Clear __optimisticId in onStarted callback.

### Files changed
- use-realtime-chat-history.ts — compaction re-injection
- use-chat-history.ts — optimistic message classification  
- chat-screen.tsx — clear __optimisticId on server confirm

Zero new TS errors. 25/29 tests pass (4 pre-existing failures unrelated).