### PR TITLE
fix(chat): prevent prompt duplication and response loss after compaction

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1122,6 +1122,10 @@ export function ChatScreen({
           (message) => ({
             ...message,
             status: 'sent',
+            // Clear __optimisticId so isOptimisticUserMessage returns false.
+            // Without this the message keeps being treated as pending and
+            // gets re-persisted, causing transcript duplication. Fixes #506.
+            __optimisticId: undefined,
             runId: runId ?? message.runId,
           }),
         )

--- a/src/screens/chat/hooks/use-chat-history.ts
+++ b/src/screens/chat/hooks/use-chat-history.ts
@@ -181,8 +181,14 @@ function getAttachmentSignature(message: ChatMessage): string {
 function isOptimisticUserMessage(message: ChatMessage): boolean {
   if (message.role !== 'user') return false
   const raw = message as Record<string, unknown>
+  const status = normalizeMessageValue(raw.status)
+  // Once the server confirms (status 'sent' or 'done'), the message is no
+  // longer optimistic — stop re-persisting it as pending. Fixes #506 where
+  // __optimisticId was never cleared, causing confirmed messages to keep
+  // being treated as pending and duplicated in the transcript.
+  if (status === 'sent' || status === 'done') return false
   return (
-    normalizeMessageValue(raw.status) === 'sending' ||
+    status === 'sending' ||
     normalizeMessageValue(raw.__optimisticId).length > 0
   )
 }

--- a/src/screens/chat/hooks/use-realtime-chat-history.ts
+++ b/src/screens/chat/hooks/use-realtime-chat-history.ts
@@ -376,12 +376,49 @@ export function useRealtimeChatHistory({
               }
             }
 
+            // Capture the just-completed assistant message from the realtime
+            // buffer BEFORE clearing it. After compaction the refetched history
+            // may be shorter and miss this message entirely. Fixes #505.
+            const completedAssistant =
+              realtimeMessages.length > 0
+                ? (() => {
+                    const last = realtimeMessages[realtimeMessages.length - 1] as
+                      | Record<string, unknown>
+                      | undefined
+                    return last?.role === 'assistant' ? last : null
+                  })()
+                : null
+
             // Clear realtime buffer immediately — no more stale data in render
             store.clearRealtimeBuffer(effectiveSessionKey)
             clearCompletedStreaming()
 
             // Background refetch for long-term consistency — doesn't block render
-            queryClient.invalidateQueries({ queryKey: key, refetchType: 'all' })
+            queryClient.invalidateQueries({ queryKey: key, refetchType: 'all' }).then(() => {
+              // Re-inject the completed assistant message if compaction dropped it
+              if (completedAssistant) {
+                const refetchData =
+                  queryClient.getQueryData<Record<string, unknown>>(key)
+                const refetchedMessages =
+                  (refetchData?.messages as Array<Record<string, unknown>>) ?? []
+                const assistantTail = (completedAssistant.content ?? completedAssistant.text ?? '')
+                  .toString()
+                  .slice(-64)
+                const alreadyPresent = refetchedMessages.some(
+                  (m) =>
+                    m.role === 'assistant' &&
+                    ((m.content ?? m.text ?? '') as string).toString().slice(-64) === assistantTail,
+                )
+                if (!alreadyPresent) {
+                  appendHistoryMessage(
+                    queryClient,
+                    effectiveFriendlyId,
+                    effectiveSessionKey,
+                    completedAssistant as unknown as import('@/types/chat').ChatMessage,
+                  )
+                }
+              }
+            })
 
             // Check for compaction — significant message count drop
             const newData =


### PR DESCRIPTION
## Summary

Fixes #505 and #506 — two high-severity chat reliability bugs.

### Bug #505 — Assistant response disappears after auto-compaction
Capture the completed assistant message from the realtime buffer before clearing it. After background refetch, re-inject if compaction dropped it.

### Bug #506 — Submitted prompt reappears after assistant response
- Update isOptimisticUserMessage to return false for sent/done messages.
- Clear __optimisticId in onStarted callback on server confirmation.

### Files changed
- src/screens/chat/chat-screen.tsx
- src/screens/chat/hooks/use-chat-history.ts
- src/screens/chat/hooks/use-realtime-chat-history.ts

Salvaged from contaminated PR #524 (which included unrelated HermesWorld game assets). Only the targeted chat fixes here. pnpm build passes. Closes #505, closes #506