### PR TITLE
fix(streaming): detect premature connection close and surface error

### DIFF
--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -983,7 +983,21 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
 
         const lifecyclePhase = lifecyclePhaseRef.current as StreamLifecyclePhase
         if (!finishedRef.current && lifecyclePhase !== 'handoff') {
-          finishStream()
+          // If the stream ended cleanly (no 'done' event) but we never received
+          // any response text, treat it as a failure rather than a successful
+          // empty completion. This happens when a proxy (e.g., Tailscale Serve)
+          // closes the connection after an idle timeout — the reader returns
+          // { done: true } but the model was still generating. Fixes #512.
+          if (
+            !fullTextRef.current &&
+            (lifecyclePhase === 'accepted' || lifecyclePhase === 'active')
+          ) {
+            markFailed(
+              'Connection closed before response was received. The backend may still be processing — check server logs or retry.',
+            )
+          } else {
+            finishStream()
+          }
         }
       } catch (err) {
         if ((err as Error).name === 'AbortError') {


### PR DESCRIPTION
Fixes #512

## Problem

When a reverse proxy (Tailscale Serve, nginx, etc.) closes the SSE connection after an idle timeout, the reader returns `{ done: true }` cleanly. This was treated as a successful completion — the thinking indicator disappears, a retry button appears, and no error is surfaced. The backend may still be generating, and all that work is silently discarded.

## Root cause

In `use-streaming-message.ts`, when the reader loop exits normally (line 976-979), `finishStream()` is called unconditionally. If no response text was received yet (model was still thinking/generating), this creates an empty assistant message and marks the stream as complete.

## Fix

After the reader loop exits, check if:
1. No `done` event was received (`finishedRef.current === false`)
2. No response text was accumulated (`fullTextRef.current` is empty)
3. The stream was in `accepted` or `active` phase (server confirmed the request)

If all three are true, call `markFailed()` with a descriptive message instead of `finishStream()`. This:
- Shows an error toast to the user
- Persists the error state on the user message (retry button with context)
- Logs the failure so it's debuggable

## Validation

- `pnpm build` ✓
- `use-streaming-message.test.ts`: 4/4 pass
- All pre-existing test failures are unrelated to this change