### PR TITLE
fix(api): use loopback for session-send fire-and-forget (auth lost via reverse proxy)

### DIFF
--- a/src/routes/api/session-send.ts
+++ b/src/routes/api/session-send.ts
@@ -41,7 +41,15 @@ export const Route = createFileRoute('/api/session-send')({
           }
           // Fire-and-forget: kick off the stream, then return. Operations
           // chat panel polls /api/session-history for new assistant turns.
-          const url = new URL('/api/send-stream', request.url)
+          //
+          // Use loopback rather than `request.url` so the internal hop never
+          // leaves the host. Going back through a public hostname + reverse
+          // proxy can drop the session cookie (SameSite / forbidden-header
+          // handling differs across Node fetch implementations), which causes
+          // the downstream /api/send-stream call to 401 silently and the user
+          // never sees their assistant reply. See #XXX.
+          const internalPort = process.env.PORT || '3000'
+          const url = new URL('/api/send-stream', `http://127.0.0.1:${internalPort}`)
           const cookie = request.headers.get('cookie') || ''
           fetch(url, {
             method: 'POST',


### PR DESCRIPTION
## Problem

When `hermes-workspace` is deployed behind a reverse proxy with HTTPS (Traefik, Nginx, Caddy, Cloudflare, etc.), the **Operations chat is broken**: messages sent from per-agent cards return `{ok: true, queued: true}` to the UI, but no assistant reply ever arrives. The chat appears dead.

## Root cause

`POST /api/session-send` kicks off `/api/send-stream` as a fire-and-forget:

```ts
// src/routes/api/session-send.ts (before)
const url = new URL('/api/send-stream', request.url)
const cookie = request.headers.get('cookie') || ''
fetch(url, {
  method: 'POST',
  headers: { 'content-type': 'application/json', ...(cookie ? { cookie } : {}) },
  body: JSON.stringify({ sessionKey, message }),
}).catch(() => {}) // ← swallows everything
```

When the request arrived via a reverse proxy, `request.url` resolves to the public hostname (e.g. `https://app.example.com/api/session-send`). The fire-and-forget therefore travels **Workspace → DNS → reverse proxy → TLS → Workspace** instead of staying in-process.

On that hop, the session cookie (`claude-auth=…`) is dropped — SameSite handling and the "forbidden header names" list behave differently across Node `fetch` implementations (undici / node-fetch / bundler shims). The downstream `/api/send-stream` call hits `isAuthenticated()` without a cookie and returns **401 Unauthorized**.

The `.catch(() => {})` on the outer fetch swallows the failure, the UI happily polls `/api/session-history` every 5 s, and the assistant message never lands. From the user's perspective Operations is silently dead.

## Repro

1. Deploy `hermes-workspace` behind any reverse proxy that does TLS termination (Traefik, Nginx, Caddy, etc.)
2. Set `HERMES_PASSWORD` so the auth middleware is active
3. Open Operations, type something into any agent card → send
4. Watch the reverse proxy access log:

```
POST 200   3ms  /api/session-send       ← OK
POST 401   2ms  /api/send-stream        ← fire-and-forget dead
```

The UI's history polls keep returning empty messages forever.

## Fix

Pin the internal fire-and-forget hop to loopback so the cookie stays in-process:

```ts
const internalPort = process.env.PORT || '3000'
const url = new URL('/api/send-stream', `http://127.0.0.1:${internalPort}`)
```

Auth survives end-to-end, the reverse proxy is bypassed for the internal hop, and as a side bonus we shave the TLS handshake + proxy round-trip off every send (~50–100 ms locally).

## Risk

- **Single-instance only by design** — `hermes-workspace` is single-process per host, so loopback is always the right target for the fire-and-forget. (If a future multi-instance topology lands, this would need to be revisited along with the local-session-store which is also process-local.)
- **HOST=0.0.0.0 deployments**: unaffected. We always use `127.0.0.1` for loopback regardless of bind address.

## Tested on

Debian 13 / Node 22.22.2 / pnpm 11.2.2 / behind Traefik 3.6 with Let's Encrypt. Operations cards confirmed receiving assistant replies for `librarian`, `content`, and `thelongbuild` profiles after the patch.
