### PR TITLE
fix(claude-agent): detect `hermes` binary for auto-start

### DIFF
--- a/src/server/claude-agent.ts
+++ b/src/server/claude-agent.ts
@@ -81,6 +81,8 @@ export function resolveClaudeAgentDir(
 /** Find the `claude` CLI binary installed by Nous's installer (or on PATH). */
 export function resolveClaudeBinary(): string | null {
   const candidates = [
+    resolve(homedir(), '.local', 'bin', 'hermes'),
+    resolve(homedir(), '.hermes', 'bin', 'hermes'),
     resolve(homedir(), '.claude', 'bin', 'claude'),
     resolve(homedir(), '.local', 'bin', 'claude'),
   ]


### PR DESCRIPTION
## Summary

- `resolveClaudeBinary()` in `src/server/claude-agent.ts` only searched for the legacy `claude` executable under `~/.claude/bin` and `~/.local/bin`. The Nous installer ships the gateway entrypoint as `hermes` (installed via pipx at `~/.local/bin/hermes`), so a fresh zero-fork install hit:

  > `hermes-agent not found. Run the installer: curl -fsSL https://hermes-workspace.com/install.sh | bash`

  even right after `install.sh` succeeded.
- Add `hermes` candidates ahead of the legacy `claude` paths so the onboarding "Auto-Start Hermes Agent Gateway" button finds the binary on a fresh install.

## Repro

1. Run `install.sh` on a clean machine (no prior `~/.claude/bin/claude`).
2. Open the workspace, hit **Auto-Start Hermes Agent Gateway** in onboarding.
3. Before fix: error above. After fix: gateway spawns via `hermes gateway run`.

## Notes

- `~/.local/bin` already lives on the spawned subprocess `PATH` (line ~175), so no PATH change is needed.
- The new candidates are first; legacy `claude` paths retained for back-compat with older Nous installs.

## Test plan

- [ ] Fresh machine without `~/.claude/bin/claude`, with `~/.local/bin/hermes` installed → auto-start succeeds and `:8642` becomes healthy.
- [ ] Existing install with legacy `claude` binary → still resolves (fallback path preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)