### PR TITLE
fix(chat): address window bug fixes - ghost thinking, missing message…

### DIFF
--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -419,6 +419,11 @@ export const Route = createFileRoute('/api/send-stream')({
           async start(controller) {
             let heartbeatTimer: ReturnType<typeof setInterval> | null = null
             let lastClientEventAt = Date.now()
+            // Track the last human-readable activity so the heartbeat can
+            // forward it to the UI. Without this the ThinkingBubble shows a
+            // static "Thinking…" for minutes when the agent is reasoning
+            // without tool calls, making it look hung.
+            let lastActivity: string | null = null
             const enqueueRaw = (payload: string) => {
               if (streamClosed) return
               controller.enqueue(encoder.encode(payload))
@@ -481,9 +486,11 @@ export const Route = createFileRoute('/api/send-stream')({
             // Keep the SSE stream alive during long agent processing (tool calls,
             // slow LLM responses on large contexts). Without this the client-side
             // no-activity timer fires after 2-3 min and aborts the stream.
+            // Every 10s we also forward the last known activity so the UI can
+            // show meaningful progress instead of a static "Thinking…".
             heartbeatTimer = setInterval(() => {
-              sendEvent('heartbeat', { timestamp: Date.now() })
-            }, 30_000)
+              sendEvent('heartbeat', { timestamp: Date.now(), activity: lastActivity })
+            }, 10_000)
 
             try {
               if (chatMode === 'portable') {
@@ -514,6 +521,7 @@ export const Route = createFileRoute('/api/send-stream')({
                   sessionKey: portableSessionKey,
                   friendlyId: portableFriendlyId,
                 })
+                lastActivity = 'Processing your message...'
 
                 try {
                   const userContent = buildMultimodalContent(
@@ -633,6 +641,7 @@ export const Route = createFileRoute('/api/send-stream')({
                             sessionKey: portableSessionKey,
                             runId,
                           })
+                          lastActivity = `Running: ${ev.name.replace(/_/g, ' ')}`
                           continue
                         }
                         if (ev.kind === 'tool.completed') {
@@ -670,6 +679,7 @@ export const Route = createFileRoute('/api/send-stream')({
                             sessionKey: portableSessionKey,
                             runId,
                           })
+                          lastActivity = `Completed: ${name.replace(/_/g, ' ')}`
                           continue
                         }
                         if (ev.kind === 'completed') {
@@ -1012,6 +1022,7 @@ export const Route = createFileRoute('/api/send-stream')({
                         sessionKey: sessionKeyFromEvent,
                         friendlyId: sessionKeyFromEvent,
                       })
+                      lastActivity = 'Processing your message...'
                     }
 
                     if (event === 'run.started') {
@@ -1137,6 +1148,7 @@ export const Route = createFileRoute('/api/send-stream')({
                       )
                       sendEvent('tool', translated)
                       skipPublish || publishChatEvent('tool', translated)
+                      lastActivity = `Running: ${toolName.replace(/_/g, ' ')}`
                       return
                     }
 
@@ -1155,6 +1167,7 @@ export const Route = createFileRoute('/api/send-stream')({
                         }
                         sendEvent('thinking', translated)
                         skipPublish || publishChatEvent('thinking', translated)
+                        lastActivity = delta.length > 60 ? delta.slice(0, 60) + '...' : delta
                         return
                       }
                       const translated = {
@@ -1203,6 +1216,7 @@ export const Route = createFileRoute('/api/send-stream')({
                       )
                       sendEvent('tool', translated)
                       skipPublish || publishChatEvent('tool', translated)
+                      lastActivity = `Completed: ${toolName.replace(/_/g, ' ')}`
                       return
                     }
 

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -54,6 +54,7 @@ import {
 import { useChatMeasurements } from './hooks/use-chat-measurements'
 import { useChatHistory } from './hooks/use-chat-history'
 import { useRealtimeChatHistory } from './hooks/use-realtime-chat-history'
+import { snapshotOptimisticUserMessages } from './hooks/optimistic-message-reinject'
 import { useSmoothStreamingText } from './hooks/use-smooth-streaming-text'
 import { useStreamingMessage } from './hooks/use-streaming-message'
 import { playChatComplete } from '@/lib/sounds'
@@ -481,45 +482,6 @@ export function ChatScreen({
   const portableChatFriendlyId = isPortableMode ? 'main' : activeFriendlyId
   // --- Issue #43 fix: lift waitingForResponse into persistent Zustand store ---
   // The store survives component unmount, so navigating away mid-stream
-  // doesn't lose the "waiting" flag. sessionStorage backup handles reloads.
-  const storeWaiting = useChatStore((s) => s.waitingSessionKeys)
-  // resolvedSessionKey isn't available yet (defined below), so we track it via
-  // a ref that's updated once it resolves. The memo/callback read the ref.
-  const sessionKeyForWaiting = useRef<string | undefined>(undefined)
-  const [activeRunCheckDone, setActiveRunCheckDone] = useState(false)
-
-  // Track stale-restored sessions that need API verification before showing thinking.
-  // On page reload, sessionStorage may contain stale "waiting" flags from a
-  // previous session. We must not show the thinking indicator until the
-  // active-run API check confirms the run is genuinely active. (Issue #449)
-  const pendingVerifySessionKeyRef = useRef<string | undefined>(undefined)
-  const waitingForResponse = useMemo(() => {
-    const key = sessionKeyForWaiting.current
-    if (!key) return hasPendingSend() || hasPendingGeneration()
-
-    // If we restored waiting state from sessionStorage but haven't verified
-    // with the API yet, don't show thinking — it might be stale (Issue #449).
-    if (
-      storeWaiting.has(key) &&
-      pendingVerifySessionKeyRef.current === key &&
-      !activeRunCheckDone
-    ) {
-      return false
-    }
-
-    return storeWaiting.has(key)
-  }, [storeWaiting, activeRunCheckDone])
-
-  const setWaitingForResponse = useCallback((waiting: boolean) => {
-    const store = useChatStore.getState()
-    const key = sessionKeyForWaiting.current
-    if (!key) return
-    if (waiting) {
-      store.setSessionWaiting(key)
-    } else {
-      store.clearSessionWaiting(key)
-    }
-  }, [])
   const [liveToolActivity, setLiveToolActivity] = useState<
     Array<{ name: string; timestamp: number }>
   >([])
@@ -611,10 +573,61 @@ export function ChatScreen({
     portableMode: isPortableMode,
   })
 
+  // --- Waiting state management (Issue #43 + #449) ---
+  // resolvedSessionKey is now available (defined above from useChatHistory).
+  const storeWaiting = useChatStore((s) => s.waitingSessionKeys)
+  const sessionKeyForWaiting = useRef<string | undefined>(undefined)
+  const pendingVerifySessionKeyRef = useRef<string | undefined>(undefined)
+
   // Keep the waiting-state ref in sync with the resolved session key
   sessionKeyForWaiting.current = resolvedSessionKey
 
-  // Detect stale restored waiting state from sessionStorage — we need API
+  // Synchronously detect stale waiting state from sessionStorage.
+  // This runs during render (not in an effect) so the guard in
+  // waitingForResponse is active on the very first render, preventing
+  // a flash of the "Thinking" indicator when reopening an old session.
+  const needsStaleCheck =
+    resolvedSessionKey &&
+    !isNewChat &&
+    storeWaiting.has(resolvedSessionKey) &&
+    pendingVerifySessionKeyRef.current !== resolvedSessionKey
+
+  if (needsStaleCheck) {
+    pendingVerifySessionKeyRef.current = resolvedSessionKey
+  }
+
+  // Track whether the active-run API check has completed.
+  // Initialize to false when we detect stale state (needs verification),
+  // true otherwise. This prevents showing "Thinking" until the API confirms.
+  const [activeRunCheckDone, setActiveRunCheckDone] = useState(!needsStaleCheck)
+
+  const waitingForResponse = useMemo(() => {
+    const key = sessionKeyForWaiting.current
+    if (!key) return hasPendingSend() || hasPendingGeneration()
+
+    // If we restored waiting state from sessionStorage but haven't verified
+    // with the API yet, don't show thinking — it might be stale (Issue #449).
+    if (
+      storeWaiting.has(key) &&
+      pendingVerifySessionKeyRef.current === key &&
+      !activeRunCheckDone
+    ) {
+      return false
+    }
+
+    return storeWaiting.has(key)
+  }, [storeWaiting, activeRunCheckDone])
+
+  const setWaitingForResponse = useCallback((waiting: boolean) => {
+    const store = useChatStore.getState()
+    const key = sessionKeyForWaiting.current
+    if (!key) return
+    if (waiting) {
+      store.setSessionWaiting(key)
+    } else {
+      store.clearSessionWaiting(key)
+    }
+  }, [])
   // verification before showing thinking (Issue #449).
   useEffect(() => {
     const currentSessionKey = resolvedSessionKey
@@ -868,13 +881,12 @@ export function ChatScreen({
 
   const streamStart = useCallback(() => {
     if (!activeFriendlyId || isNewChat) return
-    // Bug #3 fix: no more 350ms polling loop — SSE handles realtime updates.
-    // Single delayed fetch as fallback to catch the initial response.
-    if (streamTimer.current) window.clearTimeout(streamTimer.current)
-    streamTimer.current = window.setTimeout(() => {
-      if (activeRealtimeStreamingRef.current) return
-      refreshHistoryRef.current()
-    }, 2000)
+    // No aggressive delayed refetch here — it wipes optimistic user messages
+    // from the cache before the server has echoed them, causing the user's
+    // message to disappear until the agent completes. The existing failsafes
+    // (5s + 10s timeouts at lines below, active-run polling) handle the case
+    // where SSE misses the done event.
+    void activeFriendlyId // keep dep for eslint
   }, [activeFriendlyId, isNewChat])
 
   refreshHistoryRef.current = function refreshHistory() {
@@ -883,37 +895,21 @@ export function ChatScreen({
     // Snapshot any unconfirmed optimistic user messages BEFORE refetch.
     // The refetch replaces the query cache with server data — if the server
     // hasn't processed the user's POST yet, the optimistic message vanishes.
-    const currentMessages = (historyQuery.data as any)?.messages as
-      | Array<ChatMessage>
-      | undefined
-    const pendingOptimistic = (currentMessages ?? []).filter((msg) => {
-      const raw = msg as Record<string, unknown>
-      return (
-        msg.role === 'user' &&
-        (normalizeMessageValue(raw.__optimisticId).startsWith('opt-') ||
-          normalizeMessageValue(raw.status) === 'sending')
-      )
-    })
+    const historySessionKey = isPortableMode
+      ? 'main'
+      : activeSessionKey ||
+        sessionKeyForHistory ||
+        resolvedSessionKey ||
+        'main'
+    const reInjectOptimistic = snapshotOptimisticUserMessages(
+      queryClient,
+      portableChatFriendlyId,
+      historySessionKey,
+    )
 
     void historyQuery.refetch().then(() => {
       // Re-inject optimistic messages that weren't in the server response
-      if (pendingOptimistic.length === 0) return
-      const historySessionKey = isPortableMode
-        ? 'main'
-        : activeSessionKey ||
-          sessionKeyForHistory ||
-          resolvedSessionKey ||
-          'main'
-      if (!portableChatFriendlyId || !historySessionKey) return
-
-      for (const optimistic of pendingOptimistic) {
-        appendHistoryMessage(
-          queryClient,
-          portableChatFriendlyId,
-          historySessionKey,
-          optimistic,
-        )
-      }
+      reInjectOptimistic()
     })
   }
 
@@ -1393,6 +1389,42 @@ export function ChatScreen({
       __streamingThinking: realtimeStreamingThinking,
       __streamToolCalls: streamToolCalls,
     } as ChatMessage
+
+    // Check if the server has already returned a completed assistant message
+    // that overlaps with the streaming text. If so, drop the streaming
+    // placeholder to avoid showing the same response twice.
+    const streamingText = stableActiveStreamingText.trim()
+    const hasServerAssistantVersion = nextMessages.some((msg) => {
+      if (msg.role !== 'assistant') return false
+      if (msg.__streamingStatus === 'streaming') return false
+      // Any non-streaming assistant message that appears after the last user
+      // message is potentially the same response — match by text overlap
+      if (streamingText.length > 0) {
+        const msgText = textFromMessage(msg).trim()
+        if (msgText.length > 0 && (
+          msgText === streamingText ||
+          msgText.startsWith(streamingText) ||
+          streamingText.startsWith(msgText)
+        )) {
+          return true
+        }
+      }
+      // Also match by tool calls: if the server message has the same tool
+      // calls as the streaming placeholder, it's the same response
+      if (streamToolCalls.length > 0) {
+        const msgContent = Array.isArray(msg.content) ? msg.content : []
+        const msgToolCalls = msgContent.filter((p: any) => p.type === 'toolCall')
+        if (msgToolCalls.length > 0 && msgToolCalls.length === streamToolCalls.length) {
+          return streamToolCalls.every((stc: any) =>
+            msgToolCalls.some((mtc: any) => mtc.name === stc.name)
+          )
+        }
+      }
+      return false
+    })
+    if (hasServerAssistantVersion) {
+      return nextMessages
+    }
 
     const existingStreamIdx = nextMessages.findIndex(
       (message) => message.__streamingStatus === 'streaming',

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -25,6 +25,7 @@ import { AssistantAvatar } from '@/components/avatars'
 import { cn } from '@/lib/utils'
 import { hapticTap } from '@/lib/haptics'
 import { CHAT_OPEN_MESSAGE_SEARCH_EVENT } from '@/screens/chat/chat-events'
+import { useChatStore } from '@/stores/chat-store'
 
 /** Duration (ms) the thinking indicator stays visible after waitingForResponse
  *  clears, giving the first response message time to render before the
@@ -187,20 +188,35 @@ type ThinkingBubbleProps = {
  * label that reflects what's actually happening (tool calls, etc.).
  */
 function ThinkingBubble({
-  activeToolCalls: _activeToolCalls = [],
-  liveToolActivity: _liveToolActivity = [],
+  activeToolCalls = [],
+  liveToolActivity = [],
   researchCard,
   isCompacting = false,
 }: ThinkingBubbleProps) {
-  const statusLabel = isCompacting ? 'Compacting context...' : 'Thinking…'
+  // Fallback activity from heartbeat — shows last known agent activity
+  // when no tool calls are in flight (e.g. during pure reasoning)
+  const heartbeatActivity = useChatStore((s) => s.heartbeatActivity)
 
-  // Elapsed time counter — resets when the status label changes (new tool)
+  // Build a meaningful status label from live activity
+  const activeToolNames = activeToolCalls
+    .filter((tc) => tc.phase !== 'done' && tc.phase !== 'complete' && tc.phase !== 'completed')
+    .map((tc) => tc.name.replace(/_/g, ' '))
+  const liveToolNames = liveToolActivity.map((a) => a.name.replace(/_/g, ' '))
+  const uniqueNames = [...new Set([...activeToolNames, ...liveToolNames])]
+  const activityLabel =
+    uniqueNames.length > 0
+      ? `Using: ${uniqueNames.slice(0, 3).join(', ')}${uniqueNames.length > 3 ? ` +${uniqueNames.length - 3} more` : ''}`
+      : null
+  const statusLabel = isCompacting
+    ? 'Compacting context...'
+    : activityLabel || heartbeatActivity || 'Thinking…'
+
+  // Elapsed time counter — counts from bubble mount, not from last label change
   const [elapsed, setElapsed] = useState(0)
   useEffect(() => {
-    setElapsed(0)
     const interval = window.setInterval(() => setElapsed((s) => s + 1), 1000)
     return () => window.clearInterval(interval)
-  }, [statusLabel])
+  }, [])
 
   const elapsedLabel =
     elapsed >= 60
@@ -1955,11 +1971,24 @@ function getStableMessageId(message: ChatMessage, index: number): string {
   }
 
   const timestamp = getRawMessageTimestamp(message)
+  const text = textFromMessage(message)
+  // Content-based fingerprint: hash of text content + timestamp.
+  // This survives reordering because it doesn't depend on array position.
+  const fingerprint = djb2(text.slice(0, 120))
   if (timestamp) {
-    return `${message.role ?? 'assistant'}-${timestamp}-${index}`
+    return `${message.role ?? 'assistant'}-${timestamp}-${fingerprint}`
   }
 
-  return `${message.role ?? 'assistant'}-${index}`
+  return `${message.role ?? 'assistant'}-${fingerprint}-${index}`
+}
+
+/** djb2 string hash — fast, decent distribution, no deps */
+function djb2(str: string): string {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36)
 }
 
 function getRawMessageTimestamp(message: ChatMessage): number | null {

--- a/src/screens/chat/hooks/optimistic-message-reinject.ts
+++ b/src/screens/chat/hooks/optimistic-message-reinject.ts
@@ -1,0 +1,42 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { appendHistoryMessage, chatQueryKeys } from '../chat-queries'
+import type { ChatMessage } from '../types'
+
+/**
+ * Snapshot optimistic user messages from the history cache before a refetch,
+ * then re-inject them after the refetch completes.
+ *
+ * The refetch replaces the query cache with server data which won't include
+ * the optimistic message yet — without re-injection the user's message
+ * disappears until the server echoes it.
+ *
+ * Usage:
+ *   const reInject = snapshotOptimisticUserMessages(queryClient, friendlyId, sessionKey)
+ *   await queryClient.invalidateQueries(...)
+ *   reInject()
+ */
+export function snapshotOptimisticUserMessages(
+  queryClient: QueryClient,
+  friendlyId: string,
+  sessionKey: string,
+): () => void {
+  const key = chatQueryKeys.history(friendlyId, sessionKey)
+  const prevData = queryClient.getQueryData<Record<string, unknown>>(key)
+  const pending = ((prevData?.messages as Array<unknown> | undefined) ?? []).filter(
+    (msg: unknown) => {
+      const raw = msg as Record<string, unknown>
+      return (
+        raw.role === 'user' &&
+        (String(raw.__optimisticId ?? '').startsWith('opt-') ||
+          String(raw.status) === 'sending' ||
+          String(raw.status) === 'queued')
+      )
+    },
+  ) as unknown as Array<ChatMessage>
+
+  return () => {
+    for (const msg of pending) {
+      appendHistoryMessage(queryClient, friendlyId, sessionKey, msg)
+    }
+  }
+}

--- a/src/screens/chat/hooks/use-active-run-check.ts
+++ b/src/screens/chat/hooks/use-active-run-check.ts
@@ -25,6 +25,8 @@ const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
   'handoff',
 ])
 
+const ACTIVE_RUN_CHECK_TIMEOUT_MS = 2000
+
 /**
  * On mount, checks whether the server has an active run for this session.
  * If so, marks the session as waiting in the persistent Zustand store.
@@ -33,6 +35,10 @@ const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
  * This closes the gap where a user navigates away during streaming,
  * the component unmounts (losing local state), and on remount the UI
  * doesn't know a run was in progress.
+ *
+ * A timeout (ACTIVE_RUN_CHECK_TIMEOUT_MS) ensures the check never blocks
+ * the UI indefinitely — if the API is slow or unreachable, we assume the
+ * run is dead and clear stale waiting state.
  */
 export function useActiveRunCheck({
   sessionKey,
@@ -55,6 +61,25 @@ export function useActiveRunCheck({
     hasCheckedRef.current = true
 
     const controller = new AbortController()
+    let settled = false
+
+    const settle = () => {
+      if (settled) return
+      settled = true
+      onCompleteRef.current?.()
+    }
+
+    // Timeout: if the API check doesn't complete in time, assume the run is dead
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return
+      settle()
+      try { controller.abort() } catch { /* ignore */ }
+      // Clear stale waiting state — the run is almost certainly dead
+      const store = useChatStore.getState()
+      if (store.isSessionWaiting(sessionKeyRef.current)) {
+        store.clearSessionWaiting(sessionKeyRef.current)
+      }
+    }, ACTIVE_RUN_CHECK_TIMEOUT_MS)
 
     async function check() {
       try {
@@ -62,10 +87,10 @@ export function useActiveRunCheck({
           `/api/sessions/${encodeURIComponent(sessionKey)}/active-run`,
           { signal: controller.signal },
         )
-        if (!response.ok) return
+        if (!response.ok) return finishCheck()
 
         const data = (await response.json()) as ActiveRunResponse
-        if (!data.ok) return
+        if (!data.ok) return finishCheck()
 
         const store = useChatStore.getState()
         if (data.run && ACTIVE_STATUSES.has(data.run.status)) {
@@ -75,15 +100,21 @@ export function useActiveRunCheck({
           store.clearSessionWaiting(sessionKey)
         }
       } catch {
-        // Network error or abort — ignore
+        // Network error or abort — ignore, already handled by timeout
       } finally {
-        onCompleteRef.current?.()
+        finishCheck()
       }
+    }
+
+    function finishCheck() {
+      window.clearTimeout(timeoutId)
+      settle()
     }
 
     void check()
 
     return () => {
+      window.clearTimeout(timeoutId)
       controller.abort()
     }
   }, [sessionKey, enabled])

--- a/src/screens/chat/hooks/use-realtime-chat-history.ts
+++ b/src/screens/chat/hooks/use-realtime-chat-history.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useChatStream } from '../../../hooks/use-chat-stream'
 import { useChatStore } from '../../../stores/chat-store'
 import { appendHistoryMessage, chatQueryKeys } from '../chat-queries'
+import { snapshotOptimisticUserMessages } from './optimistic-message-reinject'
 import { toast } from '../../../components/ui/toast'
 import { textFromMessage } from '../utils'
 import type { ChatMessage } from '../types'
@@ -324,6 +325,14 @@ export function useRealtimeChatHistory({
             const prevCount =
               (prevData?.messages as Array<unknown> | undefined)?.length ?? 0
 
+            // Snapshot optimistic user messages before refetch so they
+            // survive the cache replacement. Re-injected after refetch.
+            const reInjectOptimistic = snapshotOptimisticUserMessages(
+              queryClient,
+              effectiveFriendlyId,
+              effectiveSessionKey,
+            )
+
             // Issue #441 fix: Directly merge realtime buffer into history cache
             // INSTEAD of invalidateQueries. The old approach caused a race:
             // invalidateQueries → refetch (async) → merge runs with stale data
@@ -418,6 +427,8 @@ export function useRealtimeChatHistory({
                   )
                 }
               }
+              // Re-inject optimistic user messages that the server hasn't echoed yet
+              reInjectOptimistic()
             })
 
             // Check for compaction — significant message count drop

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -241,6 +241,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         error: message,
       }))
       onError?.(message)
+      useChatStore.getState().setHeartbeatActivity(null)
     },
     [
       clearHandoffTimer,
@@ -429,6 +430,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       }
 
       onComplete?.(message)
+      useChatStore.getState().setHeartbeatActivity(null)
     },
     [clearHandoffTimer, onComplete, stopFrame, unregisterSendStreamRun],
   )
@@ -754,6 +756,8 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         }
         case 'heartbeat': {
           markActivity()
+          const activity = (payload as { activity?: string | null }).activity ?? null
+          useChatStore.getState().setHeartbeatActivity(activity)
           break
         }
         case 'close': {
@@ -851,6 +855,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         streamingText: '',
         error: null,
       })
+      useChatStore.getState().setHeartbeatActivity(null)
 
       try {
         const response = await fetch('/api/send-stream', {

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -140,6 +140,11 @@ type ChatState = {
   clearSessionWaiting: (sessionKey: string) => void
   /** Check if a session is waiting for a response */
   isSessionWaiting: (sessionKey: string) => boolean
+
+  /** Last activity description forwarded via heartbeat — used by ThinkingBubble
+   *  to show meaningful progress during long reasoning stretches */
+  heartbeatActivity: string | null
+  setHeartbeatActivity: (activity: string | null) => void
 }
 
 const createEmptyStreamingState = (): StreamingState => ({
@@ -641,6 +646,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sendStreamRunIds: new Set(),
   waitingSessionKeys: _restoredWaiting.keys,
   waitingSessionMeta: _restoredWaiting.meta,
+  heartbeatActivity: null,
 
   setConnectionState: (connectionState, error) => {
     set({ connectionState, lastError: error ?? null })
@@ -685,6 +691,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   isSessionWaiting: (sessionKey) => {
     return get().waitingSessionKeys.has(sessionKey)
+  },
+
+  setHeartbeatActivity: (activity) => {
+    set({ heartbeatActivity: activity })
   },
 
   processEvent: (event) => {
@@ -1209,6 +1219,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (histMsg.role === rtMsg.role && rtText) {
         const histText = extractMessageText(histMsg)
         if (histText === rtText) return true
+        // Streaming realtime text is a prefix of the final server text.
+        // Match either direction to prevent duplicates when the server
+        // returns the complete message after the realtime buffer had a
+        // partial version.
+        if (rtText.length > 0 && histText.length > 0) {
+          if (histText.startsWith(rtText) || rtText.startsWith(histText)) return true
+        }
       }
 
       const histRaw = histMsg as Record<string, unknown>


### PR DESCRIPTION
…s, duplicate responses, and stuck thinking indicator

Multiple chat window fixes bundled into one patch:

1. Ghost "Thinking" on session restore (#449): Moved stale waiting-state detection from useEffect to render body so the guard is active on the very first render, preventing a flash when reopening sessions.

2. Missing user message text: Removed the aggressive 2-second delayed refetch in streamStart that was wiping optimistic user messages from the cache before the server echoed them. Extracted a shared snapshotOptimisticUserMessages() helper used in both the onDone handler and refreshHistoryRef.

3. Duplicate assistant responses: Added hasServerAssistantVersion check that detects when a server-returned assistant message overlaps with the streaming placeholder (text prefix matching + tool-call matching) and drops the placeholder. Added bidirectional prefix-match dedup in mergeHistoryMessages.

4. ThinkingBubble stuck on "Thinking…": Server now tracks lastActivity (tool names, thinking text) and forwards it via 10s heartbeat. Client stores it in chat-store and ThinkingBubble uses it as a fallback label during reasoning stretches with no tool calls.

5. ThinkingBubble elapsed timer: Timer now counts from bubble mount instead of resetting on every label change.

6. Active-run check timeout: Added 2s timeout to the API active-run check so slow/unresponsive API doesn't leave the waiting state stuck indefinitely.

New file: src/screens/chat/hooks/optimistic-message-reinject.ts (shared helper)