### PR TITLE
fix(chat): ignore stale runs + Background runs panel

### DIFF
--- a/src/components/agent-view/agent-view-panel.tsx
+++ b/src/components/agent-view/agent-view-panel.tsx
@@ -13,6 +13,7 @@ import {
   useReducedMotion,
 } from 'motion/react'
 import { AgentCard } from './agent-card'
+import { BackgroundRunsSection } from './background-runs-section'
 import { useAgentSpawn } from './hooks/use-agent-spawn'
 import type {
   AgentNode,
@@ -1142,6 +1143,8 @@ export function AgentViewPanel() {
                     )}
                   </LayoutGroup>
                 </section>}
+
+                <BackgroundRunsSection />
 
                 {(cliAgentsQuery.isLoading || visibleCliAgents.length > 0) ? (
                   <section className="rounded-2xl bg-primary-200/15 p-2">

--- a/src/components/agent-view/background-runs-section.tsx
+++ b/src/components/agent-view/background-runs-section.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+} from '@hugeicons/core-free-icons'
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+type BackgroundRun = {
+  runId: string
+  sessionKey: string
+  friendlyId: string
+  status: 'accepted' | 'active' | 'handoff' | 'stalled'
+  createdAt: number
+  updatedAt: number
+  stalenessMs: number
+  lastAssistantText: string
+  lastToolName: string | null
+  lifecycleEventCount: number
+  lastLifecycleEvent: string | null
+  errorMessage: string | null
+}
+
+const POLL_INTERVAL_MS = 10_000
+const STALE_THRESHOLD_MS = 5 * 60 * 1000
+
+function formatAge(ms: number): string {
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+function statusColor(run: BackgroundRun): string {
+  if (run.stalenessMs >= STALE_THRESHOLD_MS) return 'bg-amber-400'
+  if (run.status === 'handoff') return 'bg-blue-400'
+  if (run.status === 'stalled') return 'bg-orange-400'
+  return 'bg-emerald-400 animate-pulse'
+}
+
+export function BackgroundRunsSection() {
+  const navigate = useNavigate()
+  const [runs, setRuns] = useState<Array<BackgroundRun>>([])
+  const [expanded, setExpanded] = useState(false)
+  const [busyRunId, setBusyRunId] = useState<string | null>(null)
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await fetch('/api/runs/active', { signal })
+      if (!res.ok) return
+      const data = (await res.json()) as {
+        ok?: boolean
+        runs?: Array<BackgroundRun>
+      }
+      if (!data.ok || !data.runs) return
+      setRuns(data.runs)
+    } catch {
+      /* abort or transient network — leave existing list in place */
+    }
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void refresh(controller.signal)
+    const timer = window.setInterval(() => {
+      void refresh()
+    }, POLL_INTERVAL_MS)
+    return () => {
+      controller.abort()
+      window.clearInterval(timer)
+    }
+  }, [refresh])
+
+  const handleAbandon = useCallback(
+    async (run: BackgroundRun) => {
+      setBusyRunId(run.runId)
+      try {
+        await fetch(
+          `/api/runs/${encodeURIComponent(run.sessionKey)}/${encodeURIComponent(run.runId)}/abandon`,
+          { method: 'POST' },
+        )
+        // Optimistic removal — server poll will catch up.
+        setRuns((prev) => prev.filter((r) => r.runId !== run.runId))
+      } catch {
+        /* surface via reload */
+      } finally {
+        setBusyRunId(null)
+      }
+    },
+    [],
+  )
+
+  const handleOpen = useCallback(
+    (run: BackgroundRun) => {
+      void navigate({
+        to: '/chat/$sessionKey',
+        params: { sessionKey: run.friendlyId || run.sessionKey },
+      })
+    },
+    [navigate],
+  )
+
+  if (runs.length === 0) return null
+
+  const staleCount = runs.filter((r) => r.stalenessMs >= STALE_THRESHOLD_MS)
+    .length
+
+  return (
+    <section className="rounded-2xl bg-primary-200/15 p-2">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <div className="flex items-center justify-between">
+          <CollapsibleTrigger className="h-7 px-0 text-xs font-medium hover:bg-transparent">
+            <HugeiconsIcon
+              icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
+              size={20}
+              strokeWidth={1.5}
+            />
+            Background runs
+          </CollapsibleTrigger>
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-[11px] tabular-nums',
+              staleCount > 0
+                ? 'bg-amber-400/20 text-amber-700'
+                : 'bg-primary-300/70 text-primary-800',
+            )}
+            title={
+              staleCount > 0
+                ? `${staleCount} stale (>5m silent)`
+                : `${runs.length} running`
+            }
+          >
+            {runs.length}
+            {staleCount > 0 ? ` · ${staleCount} stale` : ''}
+          </span>
+        </div>
+        <CollapsiblePanel contentClassName="pt-1">
+          <div className="space-y-1">
+            {runs.map((run) => {
+              const isStale = run.stalenessMs >= STALE_THRESHOLD_MS
+              const isBusy = busyRunId === run.runId
+              const snippet =
+                run.lastAssistantText?.trim() ||
+                run.lastLifecycleEvent ||
+                (run.lastToolName ? `tool: ${run.lastToolName}` : '') ||
+                'no output yet'
+              return (
+                <div
+                  key={`${run.sessionKey}:${run.runId}`}
+                  className="rounded-lg px-2 py-1.5 hover:bg-primary-200/50"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        'size-1.5 shrink-0 rounded-full',
+                        statusColor(run),
+                      )}
+                    />
+                    <span
+                      className="min-w-0 flex-1 truncate text-[11px] font-medium text-primary-800"
+                      title={run.sessionKey}
+                    >
+                      {run.friendlyId || run.sessionKey}
+                    </span>
+                    <span
+                      className={cn(
+                        'shrink-0 text-[10px] tabular-nums',
+                        isStale ? 'text-amber-600' : 'text-primary-500',
+                      )}
+                    >
+                      {formatAge(run.stalenessMs)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 truncate pl-3 text-[10px] text-primary-500">
+                    {run.status} · {snippet}
+                  </p>
+                  <div className="mt-1 flex justify-end gap-1 pl-3">
+                    <button
+                      type="button"
+                      onClick={() => handleOpen(run)}
+                      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-accent-600 hover:bg-accent-100 hover:text-accent-800"
+                    >
+                      Open
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => handleAbandon(run)}
+                      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-red-500 hover:bg-red-100 hover:text-red-700 disabled:opacity-50"
+                      title="Mark this run as failed and remove it from the active list"
+                    >
+                      {isBusy ? 'Killing…' : 'Mark dead'}
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CollapsiblePanel>
+      </Collapsible>
+    </section>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -119,6 +119,7 @@ import { Route as ApiSkillsToggleRouteImport } from './routes/api/skills/toggle'
 import { Route as ApiSkillsInstallRouteImport } from './routes/api/skills/install'
 import { Route as ApiSkillsHubSearchRouteImport } from './routes/api/skills/hub-search'
 import { Route as ApiSessionsSendRouteImport } from './routes/api/sessions/send'
+import { Route as ApiRunsActiveRouteImport } from './routes/api/runs/active'
 import { Route as ApiProfilesUpdateRouteImport } from './routes/api/profiles/update'
 import { Route as ApiProfilesRenameRouteImport } from './routes/api/profiles/rename'
 import { Route as ApiProfilesReadRouteImport } from './routes/api/profiles/read'
@@ -158,6 +159,7 @@ import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
+import { Route as ApiRunsSessionKeyRunIdAbandonRouteImport } from './routes/api/runs/$sessionKey.$runId.abandon'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -710,6 +712,11 @@ const ApiSessionsSendRoute = ApiSessionsSendRouteImport.update({
   path: '/send',
   getParentRoute: () => ApiSessionsRoute,
 } as any)
+const ApiRunsActiveRoute = ApiRunsActiveRouteImport.update({
+  id: '/api/runs/active',
+  path: '/api/runs/active',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiProfilesUpdateRoute = ApiProfilesUpdateRouteImport.update({
   id: '/api/profiles/update',
   path: '/api/profiles/update',
@@ -909,6 +916,12 @@ const ApiHermesworldReservationsConfirmRoute =
     path: '/confirm',
     getParentRoute: () => ApiHermesworldReservationsRoute,
   } as any)
+const ApiRunsSessionKeyRunIdAbandonRoute =
+  ApiRunsSessionKeyRunIdAbandonRouteImport.update({
+    id: '/api/runs/$sessionKey/$runId/abandon',
+    path: '/api/runs/$sessionKey/$runId/abandon',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -1045,6 +1058,7 @@ export interface FileRoutesByFullPath {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1060,6 +1074,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -1195,6 +1210,7 @@ export interface FileRoutesByTo {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1210,6 +1226,7 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -1347,6 +1364,7 @@ export interface FileRoutesById {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1362,6 +1380,7 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -1500,6 +1519,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1515,6 +1535,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1650,6 +1671,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1665,6 +1687,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   id:
     | '__root__'
     | '/'
@@ -1801,6 +1824,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1816,6 +1840,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1935,9 +1960,11 @@ export interface RootRouteChildren {
   ApiProfilesReadRoute: typeof ApiProfilesReadRoute
   ApiProfilesRenameRoute: typeof ApiProfilesRenameRoute
   ApiProfilesUpdateRoute: typeof ApiProfilesUpdateRoute
+  ApiRunsActiveRoute: typeof ApiRunsActiveRoute
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
   ApiUpdateWorkspaceRoute: typeof ApiUpdateWorkspaceRoute
+  ApiRunsSessionKeyRunIdAbandonRoute: typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -2712,6 +2739,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSessionsSendRouteImport
       parentRoute: typeof ApiSessionsRoute
     }
+    '/api/runs/active': {
+      id: '/api/runs/active'
+      path: '/api/runs/active'
+      fullPath: '/api/runs/active'
+      preLoaderRoute: typeof ApiRunsActiveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/profiles/update': {
       id: '/api/profiles/update'
       path: '/api/profiles/update'
@@ -2984,6 +3018,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/hermesworld/reservations/confirm'
       preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
       parentRoute: typeof ApiHermesworldReservationsRoute
+    }
+    '/api/runs/$sessionKey/$runId/abandon': {
+      id: '/api/runs/$sessionKey/$runId/abandon'
+      path: '/api/runs/$sessionKey/$runId/abandon'
+      fullPath: '/api/runs/$sessionKey/$runId/abandon'
+      preLoaderRoute: typeof ApiRunsSessionKeyRunIdAbandonRouteImport
+      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -3315,9 +3356,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiProfilesReadRoute: ApiProfilesReadRoute,
   ApiProfilesRenameRoute: ApiProfilesRenameRoute,
   ApiProfilesUpdateRoute: ApiProfilesUpdateRoute,
+  ApiRunsActiveRoute: ApiRunsActiveRoute,
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,
   ApiUpdateWorkspaceRoute: ApiUpdateWorkspaceRoute,
+  ApiRunsSessionKeyRunIdAbandonRoute: ApiRunsSessionKeyRunIdAbandonRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/runs/$sessionKey.$runId.abandon.ts
+++ b/src/routes/api/runs/$sessionKey.$runId.abandon.ts
@@ -1,0 +1,46 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { markRunStatus } from '../../../server/run-store'
+
+export const Route = createFileRoute('/api/runs/$sessionKey/$runId/abandon')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const sessionKey = params.sessionKey?.trim()
+        const runId = params.runId?.trim()
+        if (!sessionKey || !runId) {
+          return json(
+            { ok: false, error: 'sessionKey and runId required' },
+            { status: 400 },
+          )
+        }
+
+        try {
+          const run = await markRunStatus(
+            sessionKey,
+            runId,
+            'error',
+            'Abandoned by user',
+          )
+          if (!run) {
+            return json({ ok: false, error: 'run not found' }, { status: 404 })
+          }
+          return json({ ok: true, run })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/runs/active.ts
+++ b/src/routes/api/runs/active.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { listAllActiveRuns } from '../../../server/run-store'
+
+export const Route = createFileRoute('/api/runs/active')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const runs = await listAllActiveRuns()
+          const now = Date.now()
+          return json({
+            ok: true,
+            runs: runs.map((run) => ({
+              runId: run.runId,
+              sessionKey: run.sessionKey,
+              friendlyId: run.friendlyId,
+              status: run.status,
+              createdAt: run.createdAt,
+              updatedAt: run.updatedAt,
+              stalenessMs: Math.max(0, now - run.updatedAt),
+              lastAssistantText: run.assistantText.slice(-160),
+              lastToolName:
+                run.toolCalls[run.toolCalls.length - 1]?.name ?? null,
+              lifecycleEventCount: run.lifecycleEvents.length,
+              lastLifecycleEvent:
+                run.lifecycleEvents[run.lifecycleEvents.length - 1]?.text ??
+                null,
+              errorMessage: run.errorMessage ?? null,
+            })),
+          })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -211,29 +211,60 @@ export async function markRunStatus(
   }))
 }
 
+// A run that hasn't been touched in this long is considered orphaned (e.g.
+// the agent process crashed, the network dropped silently, or the user
+// navigated away during a `handoff` that never resolved). Treating these as
+// "active" makes every chat re-open show a phantom "Thinking…" indicator
+// until the 120s client-side failsafe clears it.
+const STALE_RUN_THRESHOLD_MS = 5 * 60 * 1000
+
+async function readRunsInDir(dir: string): Promise<Array<PersistedRunState>> {
+  const files = (await readdir(dir)).filter((name) => name.endsWith('.json'))
+  if (files.length === 0) return []
+  const runs = await Promise.all(
+    files.map(async (name) => {
+      try {
+        const raw = await readFile(path.join(dir, name), 'utf8')
+        return JSON.parse(raw) as PersistedRunState
+      } catch {
+        return null
+      }
+    }),
+  )
+  return runs.filter((run): run is PersistedRunState => Boolean(run))
+}
+
 export async function getActiveRunForSession(
   sessionKey: string,
 ): Promise<PersistedRunState | null> {
   try {
-    const dir = sessionDir(sessionKey)
-    const files = (await readdir(dir)).filter((name) => name.endsWith('.json'))
-    if (files.length === 0) return null
-    const runs = await Promise.all(
-      files.map(async (name) => {
-        try {
-          const raw = await readFile(path.join(dir, name), 'utf8')
-          return JSON.parse(raw) as PersistedRunState
-        } catch {
-          return null
-        }
-      }),
-    )
+    const runs = await readRunsInDir(sessionDir(sessionKey))
+    const now = Date.now()
     const candidates = runs
-      .filter((run): run is PersistedRunState => Boolean(run))
       .filter((run) => !['complete', 'error'].includes(run.status))
+      .filter((run) => now - run.updatedAt < STALE_RUN_THRESHOLD_MS)
       .sort((a, b) => b.updatedAt - a.updatedAt)
     return candidates[0] ?? null
   } catch {
     return null
+  }
+}
+
+// Lists every non-complete/error run across all sessions, regardless of
+// staleness. Powers the "Background runs" panel so users can inspect and
+// abandon orphans that the staleness filter hides from the chat UI.
+export async function listAllActiveRuns(): Promise<Array<PersistedRunState>> {
+  try {
+    const entries = await readdir(RUNS_ROOT, { withFileTypes: true })
+    const sessionDirs = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(RUNS_ROOT, entry.name))
+    const runsBySession = await Promise.all(sessionDirs.map(readRunsInDir))
+    return runsBySession
+      .flat()
+      .filter((run) => !['complete', 'error'].includes(run.status))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch {
+    return []
   }
 }


### PR DESCRIPTION
## Summary

Fixes the phantom "Thinking…" indicator that appears on every chat re-open when prior streams were interrupted (server crash, navigate-away mid-stream, silent network drop).

### Commit 1 — the fix

When the SSE `cancel()` handler fires (e.g. user navigates away during a stream), the run is intentionally marked as `handoff` so the agent can keep working server-side. If the agent never finishes — process crash, host kill, etc. — the run stays in `handoff` forever.

`getActiveRunForSession()` returned the most-recent non-complete/error run, so it kept picking up these orphans. `useActiveRunCheck` treats `handoff` as active, marks the session waiting, and both the chat `ThinkingBubble` and the Agent View "Thinking…" label show until the 120s client-side failsafe clears them. Every chat re-open shows a phantom indicator.

Filter out runs whose `updatedAt` is older than 5 minutes. Genuinely active runs refresh `updatedAt` on every chunk / tool call / lifecycle event, so they're unaffected; orphans no longer surface to the UI.

### Commit 2 — the safety net

A collapsible **Background runs** section in the Agent View panel lists every non-complete run across sessions, including the stale ones the chat UI now hides. Per row: session id, status dot (emerald=active, blue=handoff, amber=stale, orange=stalled), age, snippet of latest assistant text / tool / lifecycle event, and two actions:

- **Open** — navigate to that session's chat
- **Mark dead** — `POST /api/runs/:sessionKey/:runId/abandon` flips the run to `error` so it stops counting

New endpoints:
- \`GET  /api/runs/active\` — list every non-complete run with \`stalenessMs\` and recent metadata
- \`POST /api/runs/:sessionKey/:runId/abandon\` — mark a run as error ("Abandoned by user")

Section is hidden when no runs are active.

## Test plan

- [ ] Verify on a fresh workspace: chat opens with no Thinking… indicator
- [ ] Verify on a workspace with old handoff runs in \`~/.hermes/webui-mvp/runs/\`: chat opens cleanly; runs appear in Background runs with amber stale dots
- [ ] Click **Mark dead** on a stale run → it disappears from the panel and the run JSON shows status \`error\`
- [ ] Click **Open** on an active run → navigates to that chat
- [ ] Start a fresh stream and let it finish normally → indicator clears, no orphan appears
- [ ] Start a stream and close the tab → run marked \`handoff\`; reappears in Background runs but chat does not show Thinking… on reopen after 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)