### PR TITLE
feat(files): load files into Monaco editor with download/open actions

### DIFF
--- a/src/components/file-explorer/file-explorer-sidebar.tsx
+++ b/src/components/file-explorer/file-explorer-sidebar.tsx
@@ -41,6 +41,12 @@ type FileExplorerSidebarProps = {
   collapsed: boolean
   onToggle: () => void
   onInsertReference: (reference: string) => void
+  // When provided, clicking a file calls this instead of opening the built-in
+  // modal preview — lets parents (e.g. the /files route) render the file in
+  // their own side editor.
+  onOpenFile?: (entry: FileEntry) => void
+  // Path of the currently-open file, used to highlight the row.
+  activePath?: string | null
   hidden?: boolean
   className?: string
 }
@@ -118,6 +124,8 @@ export function FileExplorerSidebar({
   collapsed,
   onToggle,
   onInsertReference,
+  onOpenFile,
+  activePath = null,
   hidden = false,
   className,
 }: FileExplorerSidebarProps) {
@@ -310,9 +318,13 @@ export function FileExplorerSidebar({
         return
       }
       onInsertReference(buildReference(entry.path))
-      setPreviewPath(entry.path)
+      if (onOpenFile) {
+        onOpenFile(entry)
+      } else {
+        setPreviewPath(entry.path)
+      }
     },
-    [onInsertReference, toggleFolder],
+    [onInsertReference, onOpenFile, toggleFolder],
   )
 
   const renderEntry = useCallback(
@@ -337,6 +349,9 @@ export function FileExplorerSidebar({
             className={cn(
               'group flex w-full items-center gap-2 rounded-md py-1.5 text-left text-sm text-primary-900',
               'hover:bg-primary-200',
+              activePath === entry.path &&
+                entry.type === 'file' &&
+                'bg-accent-100 font-medium text-accent-800 hover:bg-accent-100',
             )}
             style={{ paddingLeft: padding }}
           >
@@ -363,7 +378,7 @@ export function FileExplorerSidebar({
         </div>
       )
     },
-    [expanded, handleFileClick, isSearchActive, setContextMenu],
+    [activePath, expanded, handleFileClick, isSearchActive, setContextMenu],
   )
 
   if (hidden) return null

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -236,6 +236,26 @@ function getMimeType(filePath: string) {
       return 'image/webp'
     case '.svg':
       return 'image/svg+xml'
+    case '.pdf':
+      return 'application/pdf'
+    case '.md':
+    case '.markdown':
+      return 'text/markdown; charset=utf-8'
+    case '.txt':
+    case '.log':
+      return 'text/plain; charset=utf-8'
+    case '.json':
+      return 'application/json; charset=utf-8'
+    case '.html':
+    case '.htm':
+      return 'text/html; charset=utf-8'
+    case '.css':
+      return 'text/css; charset=utf-8'
+    case '.js':
+    case '.mjs':
+      return 'text/javascript; charset=utf-8'
+    case '.csv':
+      return 'text/csv; charset=utf-8'
     default:
       return 'application/octet-stream'
   }
@@ -295,16 +315,20 @@ export const Route = createFileRoute('/api/files')({
             })
           }
 
-          if (action === 'download') {
+          if (action === 'download' || action === 'view') {
             const buffer = await fs.readFile(resolvedPath)
-            return new Response(buffer, {
-              headers: {
-                'Content-Type': getMimeType(resolvedPath),
-                'Content-Disposition': `attachment; filename="${path.basename(
-                  resolvedPath,
-                )}"`,
-              },
-            })
+            const mime = getMimeType(resolvedPath)
+            const headers: Record<string, string> = {
+              'Content-Type':
+                action === 'view' && mime === 'application/octet-stream'
+                  ? 'text/plain; charset=utf-8'
+                  : mime,
+            }
+            if (action === 'download') {
+              headers['Content-Disposition'] =
+                `attachment; filename="${path.basename(resolvedPath)}"`
+            }
+            return new Response(buffer, { headers })
           }
 
           const tree = await readDirectory(resolvedPath, 0, {

--- a/src/routes/files.tsx
+++ b/src/routes/files.tsx
@@ -1,20 +1,89 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Editor } from '@monaco-editor/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Folder01Icon } from '@hugeicons/core-free-icons'
+import {
+  Download01Icon,
+  ExternalLink,
+  Folder01Icon,
+} from '@hugeicons/core-free-icons'
+import { Markdown } from '@/components/prompt-kit/markdown'
+import {
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '@/components/ui/scroll-area'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { FileExplorerSidebar } from '@/components/file-explorer'
+import type { FileEntry } from '@/components/file-explorer/file-explorer-sidebar'
 import { resolveTheme, useSettings } from '@/hooks/use-settings'
 
-const INITIAL_EDITOR_VALUE = `// Files workspace
-// Use the file tree on the left to browse and manage project files.
-// "Insert as reference" actions appear here for quick context snippets.
-
-function note() {
-  return 'Ready to explore files.'
-}
+const PLACEHOLDER_VALUE = `// Files workspace
+// Click a file in the tree to load it into this editor.
 `
+
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  json: 'json',
+  md: 'markdown',
+  markdown: 'markdown',
+  yml: 'yaml',
+  yaml: 'yaml',
+  toml: 'ini',
+  ini: 'ini',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  htm: 'html',
+  sh: 'shell',
+  bash: 'shell',
+  zsh: 'shell',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'cpp',
+  hpp: 'cpp',
+  sql: 'sql',
+  xml: 'xml',
+  dockerfile: 'dockerfile',
+  env: 'plaintext',
+  log: 'plaintext',
+  txt: 'plaintext',
+}
+
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
+
+function getExt(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
+}
+
+function languageFor(name: string): string {
+  if (/^Dockerfile$/i.test(name)) return 'dockerfile'
+  return LANGUAGE_BY_EXT[getExt(name)] ?? 'plaintext'
+}
+
+type LoadedFile = {
+  path: string
+  name: string
+  language: string
+  content: string
+  imageDataUrl: string | null
+  loading: boolean
+  error: string | null
+  dirty: boolean
+}
 
 export const Route = createFileRoute('/files')({
   ssr: false,
@@ -56,7 +125,10 @@ function FilesRoute() {
   const { settings } = useSettings()
   const [isMobile, setIsMobile] = useState(false)
   const [fileExplorerCollapsed, setFileExplorerCollapsed] = useState(false)
-  const [editorValue, setEditorValue] = useState(INITIAL_EDITOR_VALUE)
+  const [loaded, setLoaded] = useState<LoadedFile | null>(null)
+  const [renderMarkdown, setRenderMarkdown] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [savedFlash, setSavedFlash] = useState(false)
   const resolvedTheme = resolveTheme(settings.theme)
 
   useEffect(() => {
@@ -72,60 +144,264 @@ function FilesRoute() {
     setFileExplorerCollapsed(true)
   }, [isMobile])
 
-  const handleInsertReference = useCallback(function handleInsertReference(
-    reference: string,
-  ) {
-    setEditorValue((prev) => `${prev}\n${reference}\n`)
+  const handleInsertReference = useCallback(() => {
+    // Reference insertion is only useful when there's a composer; on this
+    // route we just want the click to open the file, so ignore.
   }, [])
+
+  const handleOpenFile = useCallback(async (entry: FileEntry) => {
+    const ext = getExt(entry.name)
+    const isImage = IMAGE_EXTS.has(ext)
+    setLoaded({
+      path: entry.path,
+      name: entry.name,
+      language: languageFor(entry.name),
+      content: '',
+      imageDataUrl: null,
+      loading: true,
+      error: null,
+      dirty: false,
+    })
+    try {
+      const res = await fetch(
+        `/api/files?action=read&path=${encodeURIComponent(entry.path)}`,
+      )
+      if (!res.ok) throw new Error(`Failed to read file (${res.status})`)
+      const data = (await res.json()) as {
+        type: 'text' | 'image'
+        content: string
+      }
+      setLoaded({
+        path: entry.path,
+        name: entry.name,
+        language: languageFor(entry.name),
+        content: data.type === 'text' ? data.content : '',
+        imageDataUrl:
+          data.type === 'image' || isImage ? data.content || null : null,
+        loading: false,
+        error: null,
+        dirty: false,
+      })
+    } catch (err) {
+      setLoaded((prev) =>
+        prev && prev.path === entry.path
+          ? {
+              ...prev,
+              loading: false,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          : prev,
+      )
+    }
+  }, [])
+
+  const handleDownload = useCallback(() => {
+    if (!loaded) return
+    const url = `/api/files?action=download&path=${encodeURIComponent(loaded.path)}`
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = loaded.name
+    anchor.click()
+  }, [loaded])
+
+  const handleOpenInTab = useCallback(() => {
+    if (!loaded) return
+    const url = `/api/files?action=view&path=${encodeURIComponent(loaded.path)}`
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }, [loaded])
+
+  const handleSave = useCallback(async () => {
+    if (!loaded || !loaded.dirty || loaded.imageDataUrl) return
+    setSaving(true)
+    try {
+      const res = await fetch('/api/files', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'write',
+          path: loaded.path,
+          content: loaded.content,
+        }),
+      })
+      if (!res.ok) throw new Error(`Save failed (${res.status})`)
+      setLoaded((prev) => (prev ? { ...prev, dirty: false } : prev))
+      setSavedFlash(true)
+      window.setTimeout(() => setSavedFlash(false), 1500)
+    } catch (err) {
+      setLoaded((prev) =>
+        prev
+          ? {
+              ...prev,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          : prev,
+      )
+    } finally {
+      setSaving(false)
+    }
+  }, [loaded])
+
+  const isMarkdown = loaded?.language === 'markdown'
+  const isImage = Boolean(loaded?.imageDataUrl)
+  const editorValue = loaded?.content ?? PLACEHOLDER_VALUE
+  const editorLanguage = useMemo(
+    () => (loaded ? loaded.language : 'plaintext'),
+    [loaded],
+  )
 
   return (
     <div className="h-full min-h-0 overflow-hidden bg-surface text-primary-900">
       <div className="flex h-full min-h-0 overflow-hidden">
         <FileExplorerSidebar
           collapsed={fileExplorerCollapsed}
-          onToggle={function onToggleFileExplorer() {
-            setFileExplorerCollapsed((prev) => !prev)
-          }}
+          onToggle={() => setFileExplorerCollapsed((prev) => !prev)}
           onInsertReference={handleInsertReference}
+          onOpenFile={handleOpenFile}
+          activePath={loaded?.path ?? null}
         />
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <header className="flex items-center gap-3 border-b border-primary-200 px-3 py-2 md:px-4 md:py-3">
             <button
               type="button"
-              onClick={function onToggleFileExplorerHeader() {
-                setFileExplorerCollapsed((prev) => !prev)
-              }}
+              onClick={() => setFileExplorerCollapsed((prev) => !prev)}
               className="rounded-lg p-1.5 text-primary-600 hover:bg-primary-100 transition-colors"
               aria-label={fileExplorerCollapsed ? 'Show files' : 'Hide files'}
               title={fileExplorerCollapsed ? 'Show files' : 'Hide files'}
             >
               <HugeiconsIcon icon={Folder01Icon} size={20} strokeWidth={1.5} />
             </button>
-            <div>
-              <h1 className="text-base font-medium text-balance md:text-lg">
-                Files
-              </h1>
-              <p className="hidden text-sm text-primary-600 text-pretty sm:block">
-                Explore your workspace and draft notes in the editor.
-              </p>
+            <div className="min-w-0 flex-1">
+              {loaded ? (
+                <>
+                  <h1
+                    className="truncate text-base font-medium md:text-lg"
+                    title={loaded.path}
+                  >
+                    {loaded.name}
+                  </h1>
+                  <p className="hidden truncate text-xs text-primary-500 sm:block">
+                    {loaded.path}
+                    {loaded.dirty && (
+                      <span className="ml-2 text-accent-500">
+                        · unsaved changes
+                      </span>
+                    )}
+                    {savedFlash && (
+                      <span className="ml-2 text-emerald-600">· saved</span>
+                    )}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h1 className="text-base font-medium md:text-lg">Files</h1>
+                  <p className="hidden text-sm text-primary-600 sm:block">
+                    Click a file in the sidebar to load it into the editor.
+                  </p>
+                </>
+              )}
             </div>
+            {loaded ? (
+              <div className="flex shrink-0 items-center gap-2">
+                {isMarkdown && !isImage ? (
+                  <button
+                    type="button"
+                    onClick={() => setRenderMarkdown((v) => !v)}
+                    className="rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  >
+                    {renderMarkdown ? 'Edit' : 'Preview'}
+                  </button>
+                ) : null}
+                {!isImage ? (
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={!loaded.dirty || saving}
+                    className="rounded-md bg-accent-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-accent-600 disabled:opacity-50"
+                  >
+                    {saving ? 'Saving…' : 'Save'}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={handleOpenInTab}
+                  className="inline-flex items-center gap-1 rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  title="Open this file in a new browser tab"
+                >
+                  <HugeiconsIcon
+                    icon={ExternalLink}
+                    size={14}
+                    strokeWidth={1.6}
+                  />
+                  Open
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDownload}
+                  className="inline-flex items-center gap-1 rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  title="Download this file to your computer"
+                >
+                  <HugeiconsIcon
+                    icon={Download01Icon}
+                    size={14}
+                    strokeWidth={1.6}
+                  />
+                  Download
+                </button>
+              </div>
+            ) : null}
           </header>
           <div className="min-h-0 flex-1 pb-24 md:pb-0">
-            <Editor
-              height="100%"
-              theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}
-              language="typescript"
-              value={editorValue}
-              onChange={function onEditorChange(value) {
-                setEditorValue(value || '')
-              }}
-              options={{
-                minimap: { enabled: settings.editorMinimap },
-                fontSize: settings.editorFontSize,
-                scrollBeyondLastLine: false,
-                wordWrap: settings.editorWordWrap ? 'on' : 'off',
-              }}
-            />
+            {loaded?.loading ? (
+              <div className="flex h-full items-center justify-center text-sm text-primary-500">
+                Loading…
+              </div>
+            ) : loaded?.error ? (
+              <div className="flex h-full items-center justify-center p-6 text-sm text-red-600">
+                {loaded.error}
+              </div>
+            ) : isImage && loaded?.imageDataUrl ? (
+              <div className="flex h-full items-center justify-center overflow-auto p-6">
+                <img
+                  src={loaded.imageDataUrl}
+                  alt={loaded.name}
+                  className="max-h-full max-w-full rounded-lg border border-primary-200 shadow-sm object-contain"
+                />
+              </div>
+            ) : isMarkdown && renderMarkdown && loaded ? (
+              <ScrollAreaRoot className="h-full">
+                <ScrollAreaViewport>
+                  <div className="markdown-preview mx-auto max-w-4xl px-6 py-5 text-sm text-primary-900">
+                    <Markdown className="gap-3">{loaded.content}</Markdown>
+                  </div>
+                </ScrollAreaViewport>
+                <ScrollAreaScrollbar orientation="vertical">
+                  <ScrollAreaThumb />
+                </ScrollAreaScrollbar>
+                <ScrollAreaCorner />
+              </ScrollAreaRoot>
+            ) : (
+              <Editor
+                height="100%"
+                theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+                language={editorLanguage}
+                value={editorValue}
+                onChange={(value) => {
+                  if (!loaded) return
+                  setLoaded({
+                    ...loaded,
+                    content: value ?? '',
+                    dirty: (value ?? '') !== loaded.content,
+                  })
+                }}
+                options={{
+                  minimap: { enabled: settings.editorMinimap },
+                  fontSize: settings.editorFontSize,
+                  scrollBeyondLastLine: false,
+                  wordWrap: settings.editorWordWrap ? 'on' : 'off',
+                  readOnly: !loaded,
+                }}
+              />
+            )}
           </div>
         </main>
       </div>


### PR DESCRIPTION
## Summary

The \`/files\` route already rendered a Monaco editor in the right pane, but clicking a file in the sidebar opened a modal preview and dropped a \`See file: workspace/…\` reference into a placeholder buffer — the editor on the side stayed empty.

### Changes

- **\`FileExplorerSidebar\`** gains optional \`onOpenFile(entry)\` and \`activePath\` props. When \`onOpenFile\` is provided, the click skips the built-in modal preview. Chat-screen behavior is **unchanged** — it still uses the modal because there's no side editor there.
- **\`/files\` route** now tracks the loaded file, fetches via \`/api/files?action=read\`, picks a Monaco language from the extension (typescript, markdown, python, …), and renders markdown formatted by default with an Edit/Preview toggle.
- **Save** writes back via \`POST /api/files action=write\`, with dirty detection and a brief "saved" flash on success.
- Active file is highlighted in the sidebar.

### New header actions

- **Open** — opens the file in a new browser tab via \`/api/files?action=view\` (no \`Content-Disposition\`), so the browser/OS handles it by MIME type.
- **Download** — \`/api/files?action=download\` triggers a save dialog.

### API

- \`GET /api/files?action=view\` — new; streams the file inline.
- Expanded MIME map: \`.md\`, \`.markdown\`, \`.json\`, \`.html\`, \`.txt\`, \`.log\`, \`.pdf\`, \`.csv\`, \`.css\`, \`.js\`, \`.mjs\` all serve with sensible \`Content-Type\` headers (previously only images were typed; everything else fell to \`application/octet-stream\`).

## Test plan

- [ ] Click an \`.md\` file in the sidebar → loads in the right pane, renders formatted, sidebar row highlights
- [ ] Toggle **Edit/Preview** on a markdown file → swaps between rendered view and raw Monaco
- [ ] Edit a file, click **Save** → \`unsaved changes\` indicator clears, brief \`saved\` flash appears, file on disk reflects the change
- [ ] Click **Open** on a \`.md\` file → opens in a new tab, browser renders or downloads per its handler
- [ ] Click **Download** → triggers save-to-disk with original filename
- [ ] Click a \`.png\` file → renders as image preview
- [ ] Click a \`.ts\` file → loads with TypeScript syntax highlighting in Monaco
- [ ] Verify chat screen unchanged: clicking a file in the chat-side file explorer still opens the modal preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)