### PR TITLE
feat(memory): Honcho browser — peers, sessions, conclusions

### DIFF
--- a/src/components/agent-view/agent-view-panel.tsx
+++ b/src/components/agent-view/agent-view-panel.tsx
@@ -13,6 +13,7 @@ import {
   useReducedMotion,
 } from 'motion/react'
 import { AgentCard } from './agent-card'
+import { BackgroundRunsSection } from './background-runs-section'
 import { useAgentSpawn } from './hooks/use-agent-spawn'
 import type {
   AgentNode,
@@ -1142,6 +1143,8 @@ export function AgentViewPanel() {
                     )}
                   </LayoutGroup>
                 </section>}
+
+                <BackgroundRunsSection />
 
                 {(cliAgentsQuery.isLoading || visibleCliAgents.length > 0) ? (
                   <section className="rounded-2xl bg-primary-200/15 p-2">

--- a/src/components/agent-view/background-runs-section.tsx
+++ b/src/components/agent-view/background-runs-section.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+} from '@hugeicons/core-free-icons'
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
+
+type BackgroundRun = {
+  runId: string
+  sessionKey: string
+  friendlyId: string
+  status: 'accepted' | 'active' | 'handoff' | 'stalled'
+  createdAt: number
+  updatedAt: number
+  stalenessMs: number
+  lastAssistantText: string
+  lastToolName: string | null
+  lifecycleEventCount: number
+  lastLifecycleEvent: string | null
+  errorMessage: string | null
+}
+
+const POLL_INTERVAL_MS = 10_000
+const STALE_THRESHOLD_MS = 5 * 60 * 1000
+
+function formatAge(ms: number): string {
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+function statusColor(run: BackgroundRun): string {
+  if (run.stalenessMs >= STALE_THRESHOLD_MS) return 'bg-amber-400'
+  if (run.status === 'handoff') return 'bg-blue-400'
+  if (run.status === 'stalled') return 'bg-orange-400'
+  return 'bg-emerald-400 animate-pulse'
+}
+
+export function BackgroundRunsSection() {
+  const navigate = useNavigate()
+  const [runs, setRuns] = useState<Array<BackgroundRun>>([])
+  const [expanded, setExpanded] = useState(false)
+  const [busyRunId, setBusyRunId] = useState<string | null>(null)
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await fetch('/api/runs/active', { signal })
+      if (!res.ok) return
+      const data = (await res.json()) as {
+        ok?: boolean
+        runs?: Array<BackgroundRun>
+      }
+      if (!data.ok || !data.runs) return
+      setRuns(data.runs)
+    } catch {
+      /* abort or transient network — leave existing list in place */
+    }
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void refresh(controller.signal)
+    const timer = window.setInterval(() => {
+      void refresh()
+    }, POLL_INTERVAL_MS)
+    return () => {
+      controller.abort()
+      window.clearInterval(timer)
+    }
+  }, [refresh])
+
+  const handleAbandon = useCallback(
+    async (run: BackgroundRun) => {
+      setBusyRunId(run.runId)
+      try {
+        await fetch(
+          `/api/runs/${encodeURIComponent(run.sessionKey)}/${encodeURIComponent(run.runId)}/abandon`,
+          { method: 'POST' },
+        )
+        // Optimistic removal — server poll will catch up.
+        setRuns((prev) => prev.filter((r) => r.runId !== run.runId))
+      } catch {
+        /* surface via reload */
+      } finally {
+        setBusyRunId(null)
+      }
+    },
+    [],
+  )
+
+  const handleOpen = useCallback(
+    (run: BackgroundRun) => {
+      void navigate({
+        to: '/chat/$sessionKey',
+        params: { sessionKey: run.friendlyId || run.sessionKey },
+      })
+    },
+    [navigate],
+  )
+
+  if (runs.length === 0) return null
+
+  const staleCount = runs.filter((r) => r.stalenessMs >= STALE_THRESHOLD_MS)
+    .length
+
+  return (
+    <section className="rounded-2xl bg-primary-200/15 p-2">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <div className="flex items-center justify-between">
+          <CollapsibleTrigger className="h-7 px-0 text-xs font-medium hover:bg-transparent">
+            <HugeiconsIcon
+              icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
+              size={20}
+              strokeWidth={1.5}
+            />
+            Background runs
+          </CollapsibleTrigger>
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-[11px] tabular-nums',
+              staleCount > 0
+                ? 'bg-amber-400/20 text-amber-700'
+                : 'bg-primary-300/70 text-primary-800',
+            )}
+            title={
+              staleCount > 0
+                ? `${staleCount} stale (>5m silent)`
+                : `${runs.length} running`
+            }
+          >
+            {runs.length}
+            {staleCount > 0 ? ` · ${staleCount} stale` : ''}
+          </span>
+        </div>
+        <CollapsiblePanel contentClassName="pt-1">
+          <div className="space-y-1">
+            {runs.map((run) => {
+              const isStale = run.stalenessMs >= STALE_THRESHOLD_MS
+              const isBusy = busyRunId === run.runId
+              const snippet =
+                run.lastAssistantText?.trim() ||
+                run.lastLifecycleEvent ||
+                (run.lastToolName ? `tool: ${run.lastToolName}` : '') ||
+                'no output yet'
+              return (
+                <div
+                  key={`${run.sessionKey}:${run.runId}`}
+                  className="rounded-lg px-2 py-1.5 hover:bg-primary-200/50"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        'size-1.5 shrink-0 rounded-full',
+                        statusColor(run),
+                      )}
+                    />
+                    <span
+                      className="min-w-0 flex-1 truncate text-[11px] font-medium text-primary-800"
+                      title={run.sessionKey}
+                    >
+                      {run.friendlyId || run.sessionKey}
+                    </span>
+                    <span
+                      className={cn(
+                        'shrink-0 text-[10px] tabular-nums',
+                        isStale ? 'text-amber-600' : 'text-primary-500',
+                      )}
+                    >
+                      {formatAge(run.stalenessMs)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 truncate pl-3 text-[10px] text-primary-500">
+                    {run.status} · {snippet}
+                  </p>
+                  <div className="mt-1 flex justify-end gap-1 pl-3">
+                    <button
+                      type="button"
+                      onClick={() => handleOpen(run)}
+                      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-accent-600 hover:bg-accent-100 hover:text-accent-800"
+                    >
+                      Open
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => handleAbandon(run)}
+                      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-red-500 hover:bg-red-100 hover:text-red-700 disabled:opacity-50"
+                      title="Mark this run as failed and remove it from the active list"
+                    >
+                      {isBusy ? 'Killing…' : 'Mark dead'}
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CollapsiblePanel>
+      </Collapsible>
+    </section>
+  )
+}

--- a/src/components/file-explorer/file-explorer-sidebar.tsx
+++ b/src/components/file-explorer/file-explorer-sidebar.tsx
@@ -41,6 +41,12 @@ type FileExplorerSidebarProps = {
   collapsed: boolean
   onToggle: () => void
   onInsertReference: (reference: string) => void
+  // When provided, clicking a file calls this instead of opening the built-in
+  // modal preview — lets parents (e.g. the /files route) render the file in
+  // their own side editor.
+  onOpenFile?: (entry: FileEntry) => void
+  // Path of the currently-open file, used to highlight the row.
+  activePath?: string | null
   hidden?: boolean
   className?: string
 }
@@ -118,6 +124,8 @@ export function FileExplorerSidebar({
   collapsed,
   onToggle,
   onInsertReference,
+  onOpenFile,
+  activePath = null,
   hidden = false,
   className,
 }: FileExplorerSidebarProps) {
@@ -310,9 +318,13 @@ export function FileExplorerSidebar({
         return
       }
       onInsertReference(buildReference(entry.path))
-      setPreviewPath(entry.path)
+      if (onOpenFile) {
+        onOpenFile(entry)
+      } else {
+        setPreviewPath(entry.path)
+      }
     },
-    [onInsertReference, toggleFolder],
+    [onInsertReference, onOpenFile, toggleFolder],
   )
 
   const renderEntry = useCallback(
@@ -337,6 +349,9 @@ export function FileExplorerSidebar({
             className={cn(
               'group flex w-full items-center gap-2 rounded-md py-1.5 text-left text-sm text-primary-900',
               'hover:bg-primary-200',
+              activePath === entry.path &&
+                entry.type === 'file' &&
+                'bg-accent-100 font-medium text-accent-800 hover:bg-accent-100',
             )}
             style={{ paddingLeft: padding }}
           >
@@ -363,7 +378,7 @@ export function FileExplorerSidebar({
         </div>
       )
     },
-    [expanded, handleFileClick, isSearchActive, setContextMenu],
+    [activePath, expanded, handleFileClick, isSearchActive, setContextMenu],
   )
 
   if (hidden) return null

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -147,6 +147,11 @@ import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/rea
 import { Route as ApiKnowledgeListRouteImport } from './routes/api/knowledge/list'
 import { Route as ApiKnowledgeGraphRouteImport } from './routes/api/knowledge/graph'
 import { Route as ApiKnowledgeConfigRouteImport } from './routes/api/knowledge/config'
+import { Route as ApiHonchoSessionsRouteImport } from './routes/api/honcho/sessions'
+import { Route as ApiHonchoSearchRouteImport } from './routes/api/honcho/search'
+import { Route as ApiHonchoPeersRouteImport } from './routes/api/honcho/peers'
+import { Route as ApiHonchoHealthRouteImport } from './routes/api/honcho/health'
+import { Route as ApiHonchoConclusionsRouteImport } from './routes/api/honcho/conclusions'
 import { Route as ApiHermesworldReservationsRouteImport } from './routes/api/hermesworld/reservations'
 import { Route as ApiHermesTasksTaskIdRouteImport } from './routes/api/hermes-tasks.$taskId'
 import { Route as ApiDashboardOverviewRouteImport } from './routes/api/dashboard/overview'
@@ -852,6 +857,31 @@ const ApiKnowledgeConfigRoute = ApiKnowledgeConfigRouteImport.update({
   path: '/api/knowledge/config',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHonchoSessionsRoute = ApiHonchoSessionsRouteImport.update({
+  id: '/api/honcho/sessions',
+  path: '/api/honcho/sessions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHonchoSearchRoute = ApiHonchoSearchRouteImport.update({
+  id: '/api/honcho/search',
+  path: '/api/honcho/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHonchoPeersRoute = ApiHonchoPeersRouteImport.update({
+  id: '/api/honcho/peers',
+  path: '/api/honcho/peers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHonchoHealthRoute = ApiHonchoHealthRouteImport.update({
+  id: '/api/honcho/health',
+  path: '/api/honcho/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHonchoConclusionsRoute = ApiHonchoConclusionsRouteImport.update({
+  id: '/api/honcho/conclusions',
+  path: '/api/honcho/conclusions',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHermesworldReservationsRoute =
   ApiHermesworldReservationsRouteImport.update({
     id: '/api/hermesworld/reservations',
@@ -1031,6 +1061,11 @@ export interface FileRoutesByFullPath {
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/honcho/conclusions': typeof ApiHonchoConclusionsRoute
+  '/api/honcho/health': typeof ApiHonchoHealthRoute
+  '/api/honcho/peers': typeof ApiHonchoPeersRoute
+  '/api/honcho/search': typeof ApiHonchoSearchRoute
+  '/api/honcho/sessions': typeof ApiHonchoSessionsRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -1183,6 +1218,11 @@ export interface FileRoutesByTo {
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/honcho/conclusions': typeof ApiHonchoConclusionsRoute
+  '/api/honcho/health': typeof ApiHonchoHealthRoute
+  '/api/honcho/peers': typeof ApiHonchoPeersRoute
+  '/api/honcho/search': typeof ApiHonchoSearchRoute
+  '/api/honcho/sessions': typeof ApiHonchoSessionsRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -1337,6 +1377,11 @@ export interface FileRoutesById {
   '/api/dashboard/overview': typeof ApiDashboardOverviewRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
   '/api/hermesworld/reservations': typeof ApiHermesworldReservationsRouteWithChildren
+  '/api/honcho/conclusions': typeof ApiHonchoConclusionsRoute
+  '/api/honcho/health': typeof ApiHonchoHealthRoute
+  '/api/honcho/peers': typeof ApiHonchoPeersRoute
+  '/api/honcho/search': typeof ApiHonchoSearchRoute
+  '/api/honcho/sessions': typeof ApiHonchoSessionsRoute
   '/api/knowledge/config': typeof ApiKnowledgeConfigRoute
   '/api/knowledge/graph': typeof ApiKnowledgeGraphRoute
   '/api/knowledge/list': typeof ApiKnowledgeListRoute
@@ -1492,6 +1537,11 @@ export interface FileRouteTypes {
     | '/api/dashboard/overview'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
+    | '/api/honcho/conclusions'
+    | '/api/honcho/health'
+    | '/api/honcho/peers'
+    | '/api/honcho/search'
+    | '/api/honcho/sessions'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1644,6 +1694,11 @@ export interface FileRouteTypes {
     | '/api/dashboard/overview'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
+    | '/api/honcho/conclusions'
+    | '/api/honcho/health'
+    | '/api/honcho/peers'
+    | '/api/honcho/search'
+    | '/api/honcho/sessions'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1797,6 +1852,11 @@ export interface FileRouteTypes {
     | '/api/dashboard/overview'
     | '/api/hermes-tasks/$taskId'
     | '/api/hermesworld/reservations'
+    | '/api/honcho/conclusions'
+    | '/api/honcho/health'
+    | '/api/honcho/peers'
+    | '/api/honcho/search'
+    | '/api/honcho/sessions'
     | '/api/knowledge/config'
     | '/api/knowledge/graph'
     | '/api/knowledge/list'
@@ -1944,6 +2004,11 @@ export interface RootRouteChildren {
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiDashboardOverviewRoute: typeof ApiDashboardOverviewRoute
   ApiHermesworldReservationsRoute: typeof ApiHermesworldReservationsRouteWithChildren
+  ApiHonchoConclusionsRoute: typeof ApiHonchoConclusionsRoute
+  ApiHonchoHealthRoute: typeof ApiHonchoHealthRoute
+  ApiHonchoPeersRoute: typeof ApiHonchoPeersRoute
+  ApiHonchoSearchRoute: typeof ApiHonchoSearchRoute
+  ApiHonchoSessionsRoute: typeof ApiHonchoSessionsRoute
   ApiKnowledgeConfigRoute: typeof ApiKnowledgeConfigRoute
   ApiKnowledgeGraphRoute: typeof ApiKnowledgeGraphRoute
   ApiKnowledgeListRoute: typeof ApiKnowledgeListRoute
@@ -2935,6 +3000,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiKnowledgeConfigRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/honcho/sessions': {
+      id: '/api/honcho/sessions'
+      path: '/api/honcho/sessions'
+      fullPath: '/api/honcho/sessions'
+      preLoaderRoute: typeof ApiHonchoSessionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/honcho/search': {
+      id: '/api/honcho/search'
+      path: '/api/honcho/search'
+      fullPath: '/api/honcho/search'
+      preLoaderRoute: typeof ApiHonchoSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/honcho/peers': {
+      id: '/api/honcho/peers'
+      path: '/api/honcho/peers'
+      fullPath: '/api/honcho/peers'
+      preLoaderRoute: typeof ApiHonchoPeersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/honcho/health': {
+      id: '/api/honcho/health'
+      path: '/api/honcho/health'
+      fullPath: '/api/honcho/health'
+      preLoaderRoute: typeof ApiHonchoHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/honcho/conclusions': {
+      id: '/api/honcho/conclusions'
+      path: '/api/honcho/conclusions'
+      fullPath: '/api/honcho/conclusions'
+      preLoaderRoute: typeof ApiHonchoConclusionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/hermesworld/reservations': {
       id: '/api/hermesworld/reservations'
       path: '/api/hermesworld/reservations'
@@ -3340,6 +3440,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiDashboardOverviewRoute: ApiDashboardOverviewRoute,
   ApiHermesworldReservationsRoute: ApiHermesworldReservationsRouteWithChildren,
+  ApiHonchoConclusionsRoute: ApiHonchoConclusionsRoute,
+  ApiHonchoHealthRoute: ApiHonchoHealthRoute,
+  ApiHonchoPeersRoute: ApiHonchoPeersRoute,
+  ApiHonchoSearchRoute: ApiHonchoSearchRoute,
+  ApiHonchoSessionsRoute: ApiHonchoSessionsRoute,
   ApiKnowledgeConfigRoute: ApiKnowledgeConfigRoute,
   ApiKnowledgeGraphRoute: ApiKnowledgeGraphRoute,
   ApiKnowledgeListRoute: ApiKnowledgeListRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -119,6 +119,7 @@ import { Route as ApiSkillsToggleRouteImport } from './routes/api/skills/toggle'
 import { Route as ApiSkillsInstallRouteImport } from './routes/api/skills/install'
 import { Route as ApiSkillsHubSearchRouteImport } from './routes/api/skills/hub-search'
 import { Route as ApiSessionsSendRouteImport } from './routes/api/sessions/send'
+import { Route as ApiRunsActiveRouteImport } from './routes/api/runs/active'
 import { Route as ApiProfilesUpdateRouteImport } from './routes/api/profiles/update'
 import { Route as ApiProfilesRenameRouteImport } from './routes/api/profiles/rename'
 import { Route as ApiProfilesReadRouteImport } from './routes/api/profiles/read'
@@ -158,6 +159,7 @@ import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
+import { Route as ApiRunsSessionKeyRunIdAbandonRouteImport } from './routes/api/runs/$sessionKey.$runId.abandon'
 
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
@@ -710,6 +712,11 @@ const ApiSessionsSendRoute = ApiSessionsSendRouteImport.update({
   path: '/send',
   getParentRoute: () => ApiSessionsRoute,
 } as any)
+const ApiRunsActiveRoute = ApiRunsActiveRouteImport.update({
+  id: '/api/runs/active',
+  path: '/api/runs/active',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiProfilesUpdateRoute = ApiProfilesUpdateRouteImport.update({
   id: '/api/profiles/update',
   path: '/api/profiles/update',
@@ -909,6 +916,12 @@ const ApiHermesworldReservationsConfirmRoute =
     path: '/confirm',
     getParentRoute: () => ApiHermesworldReservationsRoute,
   } as any)
+const ApiRunsSessionKeyRunIdAbandonRoute =
+  ApiRunsSessionKeyRunIdAbandonRouteImport.update({
+    id: '/api/runs/$sessionKey/$runId/abandon',
+    path: '/api/runs/$sessionKey/$runId/abandon',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -1045,6 +1058,7 @@ export interface FileRoutesByFullPath {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1060,6 +1074,7 @@ export interface FileRoutesByFullPath {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -1195,6 +1210,7 @@ export interface FileRoutesByTo {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1210,6 +1226,7 @@ export interface FileRoutesByTo {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -1347,6 +1364,7 @@ export interface FileRoutesById {
   '/api/profiles/read': typeof ApiProfilesReadRoute
   '/api/profiles/rename': typeof ApiProfilesRenameRoute
   '/api/profiles/update': typeof ApiProfilesUpdateRoute
+  '/api/runs/active': typeof ApiRunsActiveRoute
   '/api/sessions/send': typeof ApiSessionsSendRoute
   '/api/skills/hub-search': typeof ApiSkillsHubSearchRoute
   '/api/skills/install': typeof ApiSkillsInstallRoute
@@ -1362,6 +1380,7 @@ export interface FileRoutesById {
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
+  '/api/runs/$sessionKey/$runId/abandon': typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -1500,6 +1519,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1515,6 +1535,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1650,6 +1671,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1665,6 +1687,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   id:
     | '__root__'
     | '/'
@@ -1801,6 +1824,7 @@ export interface FileRouteTypes {
     | '/api/profiles/read'
     | '/api/profiles/rename'
     | '/api/profiles/update'
+    | '/api/runs/active'
     | '/api/sessions/send'
     | '/api/skills/hub-search'
     | '/api/skills/install'
@@ -1816,6 +1840,7 @@ export interface FileRouteTypes {
     | '/api/mcp/hub-sources/$id'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
+    | '/api/runs/$sessionKey/$runId/abandon'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1935,9 +1960,11 @@ export interface RootRouteChildren {
   ApiProfilesReadRoute: typeof ApiProfilesReadRoute
   ApiProfilesRenameRoute: typeof ApiProfilesRenameRoute
   ApiProfilesUpdateRoute: typeof ApiProfilesUpdateRoute
+  ApiRunsActiveRoute: typeof ApiRunsActiveRoute
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
   ApiUpdateWorkspaceRoute: typeof ApiUpdateWorkspaceRoute
+  ApiRunsSessionKeyRunIdAbandonRoute: typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -2712,6 +2739,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSessionsSendRouteImport
       parentRoute: typeof ApiSessionsRoute
     }
+    '/api/runs/active': {
+      id: '/api/runs/active'
+      path: '/api/runs/active'
+      fullPath: '/api/runs/active'
+      preLoaderRoute: typeof ApiRunsActiveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/profiles/update': {
       id: '/api/profiles/update'
       path: '/api/profiles/update'
@@ -2984,6 +3018,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/hermesworld/reservations/confirm'
       preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
       parentRoute: typeof ApiHermesworldReservationsRoute
+    }
+    '/api/runs/$sessionKey/$runId/abandon': {
+      id: '/api/runs/$sessionKey/$runId/abandon'
+      path: '/api/runs/$sessionKey/$runId/abandon'
+      fullPath: '/api/runs/$sessionKey/$runId/abandon'
+      preLoaderRoute: typeof ApiRunsSessionKeyRunIdAbandonRouteImport
+      parentRoute: typeof rootRouteImport
     }
   }
 }
@@ -3315,9 +3356,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiProfilesReadRoute: ApiProfilesReadRoute,
   ApiProfilesRenameRoute: ApiProfilesRenameRoute,
   ApiProfilesUpdateRoute: ApiProfilesUpdateRoute,
+  ApiRunsActiveRoute: ApiRunsActiveRoute,
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,
   ApiUpdateWorkspaceRoute: ApiUpdateWorkspaceRoute,
+  ApiRunsSessionKeyRunIdAbandonRoute: ApiRunsSessionKeyRunIdAbandonRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -236,6 +236,26 @@ function getMimeType(filePath: string) {
       return 'image/webp'
     case '.svg':
       return 'image/svg+xml'
+    case '.pdf':
+      return 'application/pdf'
+    case '.md':
+    case '.markdown':
+      return 'text/markdown; charset=utf-8'
+    case '.txt':
+    case '.log':
+      return 'text/plain; charset=utf-8'
+    case '.json':
+      return 'application/json; charset=utf-8'
+    case '.html':
+    case '.htm':
+      return 'text/html; charset=utf-8'
+    case '.css':
+      return 'text/css; charset=utf-8'
+    case '.js':
+    case '.mjs':
+      return 'text/javascript; charset=utf-8'
+    case '.csv':
+      return 'text/csv; charset=utf-8'
     default:
       return 'application/octet-stream'
   }
@@ -295,16 +315,20 @@ export const Route = createFileRoute('/api/files')({
             })
           }
 
-          if (action === 'download') {
+          if (action === 'download' || action === 'view') {
             const buffer = await fs.readFile(resolvedPath)
-            return new Response(buffer, {
-              headers: {
-                'Content-Type': getMimeType(resolvedPath),
-                'Content-Disposition': `attachment; filename="${path.basename(
-                  resolvedPath,
-                )}"`,
-              },
-            })
+            const mime = getMimeType(resolvedPath)
+            const headers: Record<string, string> = {
+              'Content-Type':
+                action === 'view' && mime === 'application/octet-stream'
+                  ? 'text/plain; charset=utf-8'
+                  : mime,
+            }
+            if (action === 'download') {
+              headers['Content-Disposition'] =
+                `attachment; filename="${path.basename(resolvedPath)}"`
+            }
+            return new Response(buffer, { headers })
           }
 
           const tree = await readDirectory(resolvedPath, 0, {

--- a/src/routes/api/honcho/conclusions.ts
+++ b/src/routes/api/honcho/conclusions.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { fetchHoncho, getHonchoConfig } from '../../../server/honcho-proxy'
+
+type HonchoConclusion = {
+  id: string
+  workspace_id?: string
+  content?: string
+  created_at?: string
+  metadata?: Record<string, unknown>
+}
+
+type HonchoPaged<T> = {
+  items?: Array<T>
+  total?: number
+}
+
+export const Route = createFileRoute('/api/honcho/conclusions')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const config = getHonchoConfig()
+        if (!config.enabled) {
+          return json({ ok: false, error: 'Honcho is not enabled.' }, { status: 503 })
+        }
+
+        const url = new URL(request.url)
+        const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
+
+        const list = await fetchHoncho<HonchoPaged<HonchoConclusion>>(
+          `/v3/workspaces/${encodeURIComponent(workspaceId)}/conclusions/list`,
+          { method: 'POST', body: {} },
+        )
+        if (!list.ok) {
+          return json({ ok: false, error: list.error }, { status: list.status })
+        }
+        return json({
+          ok: true,
+          conclusions: list.data.items ?? [],
+          total: list.data.total ?? 0,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/honcho/health.ts
+++ b/src/routes/api/honcho/health.ts
@@ -1,0 +1,40 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { fetchHoncho, getHonchoConfig } from '../../../server/honcho-proxy'
+
+export const Route = createFileRoute('/api/honcho/health')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const config = getHonchoConfig()
+        if (!config.enabled) {
+          return json({
+            ok: true,
+            enabled: false,
+            baseUrl: config.baseUrl,
+            workspaceId: config.workspaceId,
+            reachable: false,
+          })
+        }
+
+        const probe = await fetchHoncho<{ status?: string }>('/health')
+        return json({
+          ok: true,
+          enabled: true,
+          baseUrl: config.baseUrl,
+          workspaceId: config.workspaceId,
+          aiPeer: config.aiPeer,
+          userPeer: config.userPeer,
+          reachable: probe.ok,
+          status: probe.ok ? probe.data.status : null,
+          error: probe.ok ? null : probe.error,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/honcho/peers.ts
+++ b/src/routes/api/honcho/peers.ts
@@ -1,0 +1,79 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { fetchHoncho, getHonchoConfig } from '../../../server/honcho-proxy'
+
+type HonchoPeer = {
+  id: string
+  workspace_id: string
+  created_at: string
+  metadata?: Record<string, unknown>
+  configuration?: Record<string, unknown>
+}
+
+type HonchoPagedPeers = {
+  items?: Array<HonchoPeer>
+  total?: number
+  page?: number
+  size?: number
+}
+
+export const Route = createFileRoute('/api/honcho/peers')({
+  server: {
+    handlers: {
+      // GET /api/honcho/peers           — list all peers in the default workspace
+      // GET /api/honcho/peers?id=<peerId> — detail (peer + card + representation)
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const config = getHonchoConfig()
+        if (!config.enabled) {
+          return json({ ok: false, error: 'Honcho is not enabled.' }, { status: 503 })
+        }
+
+        const url = new URL(request.url)
+        const peerId = url.searchParams.get('id')?.trim()
+        const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
+
+        if (peerId) {
+          const [peerRes, cardRes, repRes] = await Promise.all([
+            fetchHoncho<HonchoPeer>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}`,
+            ),
+            fetchHoncho<unknown>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}/card`,
+            ),
+            fetchHoncho<unknown>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}/representation`,
+            ),
+          ])
+          if (!peerRes.ok) {
+            return json({ ok: false, error: peerRes.error }, { status: peerRes.status })
+          }
+          return json({
+            ok: true,
+            peer: peerRes.data,
+            card: cardRes.ok ? cardRes.data : null,
+            representation: repRes.ok ? repRes.data : null,
+            cardError: cardRes.ok ? null : cardRes.error,
+            representationError: repRes.ok ? null : repRes.error,
+          })
+        }
+
+        const list = await fetchHoncho<HonchoPagedPeers>(
+          `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/list`,
+          { method: 'POST', body: {} },
+        )
+        if (!list.ok) {
+          return json({ ok: false, error: list.error }, { status: list.status })
+        }
+        return json({
+          ok: true,
+          peers: list.data.items ?? [],
+          total: list.data.total ?? 0,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/honcho/peers.ts
+++ b/src/routes/api/honcho/peers.ts
@@ -22,7 +22,9 @@ export const Route = createFileRoute('/api/honcho/peers')({
   server: {
     handlers: {
       // GET /api/honcho/peers           — list all peers in the default workspace
-      // GET /api/honcho/peers?id=<peerId> — detail (peer + card + representation)
+      // GET /api/honcho/peers?id=<peerId> — detail (card + representation only;
+      //                                    peer metadata comes from the list cache
+      //                                    since Honcho has no GET /peers/{id})
       GET: async ({ request }) => {
         if (!isAuthenticated(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
@@ -37,23 +39,22 @@ export const Route = createFileRoute('/api/honcho/peers')({
         const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
 
         if (peerId) {
-          const [peerRes, cardRes, repRes] = await Promise.all([
-            fetchHoncho<HonchoPeer>(
-              `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}`,
-            ),
+          // Honcho has no GET /peers/{id} — only PUT. Peer metadata comes
+          // from the /peers/list response (cached on the client). The
+          // detail call returns only card + representation. Note:
+          // /representation is POST (with optional body), not GET.
+          const [cardRes, repRes] = await Promise.all([
             fetchHoncho<unknown>(
               `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}/card`,
             ),
             fetchHoncho<unknown>(
               `/v3/workspaces/${encodeURIComponent(workspaceId)}/peers/${encodeURIComponent(peerId)}/representation`,
+              { method: 'POST', body: {} },
             ),
           ])
-          if (!peerRes.ok) {
-            return json({ ok: false, error: peerRes.error }, { status: peerRes.status })
-          }
           return json({
             ok: true,
-            peer: peerRes.data,
+            peerId,
             card: cardRes.ok ? cardRes.data : null,
             representation: repRes.ok ? repRes.data : null,
             cardError: cardRes.ok ? null : cardRes.error,

--- a/src/routes/api/honcho/search.ts
+++ b/src/routes/api/honcho/search.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { fetchHoncho, getHonchoConfig } from '../../../server/honcho-proxy'
+
+export const Route = createFileRoute('/api/honcho/search')({
+  server: {
+    handlers: {
+      // GET /api/honcho/search?q=<query>
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const config = getHonchoConfig()
+        if (!config.enabled) {
+          return json({ ok: false, error: 'Honcho is not enabled.' }, { status: 503 })
+        }
+
+        const url = new URL(request.url)
+        const query = url.searchParams.get('q')?.trim() || ''
+        const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
+        if (!query) {
+          return json({ ok: true, results: [] })
+        }
+
+        const result = await fetchHoncho<{ items?: Array<unknown> }>(
+          `/v3/workspaces/${encodeURIComponent(workspaceId)}/search`,
+          { method: 'POST', body: { query } },
+        )
+        if (!result.ok) {
+          return json({ ok: false, error: result.error }, { status: result.status })
+        }
+        return json({ ok: true, results: result.data.items ?? [] })
+      },
+    },
+  },
+})

--- a/src/routes/api/honcho/sessions.ts
+++ b/src/routes/api/honcho/sessions.ts
@@ -1,0 +1,84 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { fetchHoncho, getHonchoConfig } from '../../../server/honcho-proxy'
+
+type HonchoSession = {
+  id: string
+  workspace_id: string
+  created_at: string
+  metadata?: Record<string, unknown>
+  configuration?: Record<string, unknown>
+}
+
+type HonchoPaged<T> = {
+  items?: Array<T>
+  total?: number
+  page?: number
+  size?: number
+}
+
+export const Route = createFileRoute('/api/honcho/sessions')({
+  server: {
+    handlers: {
+      // GET /api/honcho/sessions                  — list sessions
+      // GET /api/honcho/sessions?id=<sessionId>   — detail (messages + summaries)
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const config = getHonchoConfig()
+        if (!config.enabled) {
+          return json({ ok: false, error: 'Honcho is not enabled.' }, { status: 503 })
+        }
+
+        const url = new URL(request.url)
+        const sessionId = url.searchParams.get('id')?.trim()
+        const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
+
+        if (sessionId) {
+          const [sessionRes, messagesRes, summariesRes] = await Promise.all([
+            fetchHoncho<HonchoSession>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
+            ),
+            fetchHoncho<HonchoPaged<unknown>>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/messages/list`,
+              { method: 'POST', body: {} },
+            ),
+            fetchHoncho<unknown>(
+              `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/summaries`,
+            ),
+          ])
+          if (!sessionRes.ok) {
+            return json(
+              { ok: false, error: sessionRes.error },
+              { status: sessionRes.status },
+            )
+          }
+          return json({
+            ok: true,
+            session: sessionRes.data,
+            messages: messagesRes.ok ? (messagesRes.data.items ?? []) : [],
+            messagesTotal: messagesRes.ok ? (messagesRes.data.total ?? 0) : 0,
+            summaries: summariesRes.ok ? summariesRes.data : null,
+            messagesError: messagesRes.ok ? null : messagesRes.error,
+            summariesError: summariesRes.ok ? null : summariesRes.error,
+          })
+        }
+
+        const list = await fetchHoncho<HonchoPaged<HonchoSession>>(
+          `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/list`,
+          { method: 'POST', body: {} },
+        )
+        if (!list.ok) {
+          return json({ ok: false, error: list.error }, { status: list.status })
+        }
+        return json({
+          ok: true,
+          sessions: list.data.items ?? [],
+          total: list.data.total ?? 0,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/honcho/sessions.ts
+++ b/src/routes/api/honcho/sessions.ts
@@ -37,10 +37,10 @@ export const Route = createFileRoute('/api/honcho/sessions')({
         const workspaceId = url.searchParams.get('workspace')?.trim() || config.workspaceId
 
         if (sessionId) {
-          const [sessionRes, messagesRes, summariesRes] = await Promise.all([
-            fetchHoncho<HonchoSession>(
-              `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
-            ),
+          // Honcho has no GET /sessions/{id} — only DELETE/PUT. Session
+          // metadata comes from the /sessions/list response (cached on the
+          // client). This detail call returns only the sub-resources.
+          const [messagesRes, summariesRes] = await Promise.all([
             fetchHoncho<HonchoPaged<unknown>>(
               `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/messages/list`,
               { method: 'POST', body: {} },
@@ -49,15 +49,9 @@ export const Route = createFileRoute('/api/honcho/sessions')({
               `/v3/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}/summaries`,
             ),
           ])
-          if (!sessionRes.ok) {
-            return json(
-              { ok: false, error: sessionRes.error },
-              { status: sessionRes.status },
-            )
-          }
           return json({
             ok: true,
-            session: sessionRes.data,
+            sessionId,
             messages: messagesRes.ok ? (messagesRes.data.items ?? []) : [],
             messagesTotal: messagesRes.ok ? (messagesRes.data.total ?? 0) : 0,
             summaries: summariesRes.ok ? summariesRes.data : null,

--- a/src/routes/api/runs/$sessionKey.$runId.abandon.ts
+++ b/src/routes/api/runs/$sessionKey.$runId.abandon.ts
@@ -1,0 +1,46 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { markRunStatus } from '../../../server/run-store'
+
+export const Route = createFileRoute('/api/runs/$sessionKey/$runId/abandon')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const sessionKey = params.sessionKey?.trim()
+        const runId = params.runId?.trim()
+        if (!sessionKey || !runId) {
+          return json(
+            { ok: false, error: 'sessionKey and runId required' },
+            { status: 400 },
+          )
+        }
+
+        try {
+          const run = await markRunStatus(
+            sessionKey,
+            runId,
+            'error',
+            'Abandoned by user',
+          )
+          if (!run) {
+            return json({ ok: false, error: 'run not found' }, { status: 404 })
+          }
+          return json({ ok: true, run })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/runs/active.ts
+++ b/src/routes/api/runs/active.ts
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { listAllActiveRuns } from '../../../server/run-store'
+
+export const Route = createFileRoute('/api/runs/active')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const runs = await listAllActiveRuns()
+          const now = Date.now()
+          return json({
+            ok: true,
+            runs: runs.map((run) => ({
+              runId: run.runId,
+              sessionKey: run.sessionKey,
+              friendlyId: run.friendlyId,
+              status: run.status,
+              createdAt: run.createdAt,
+              updatedAt: run.updatedAt,
+              stalenessMs: Math.max(0, now - run.updatedAt),
+              lastAssistantText: run.assistantText.slice(-160),
+              lastToolName:
+                run.toolCalls[run.toolCalls.length - 1]?.name ?? null,
+              lifecycleEventCount: run.lifecycleEvents.length,
+              lastLifecycleEvent:
+                run.lifecycleEvents[run.lifecycleEvents.length - 1]?.text ??
+                null,
+              errorMessage: run.errorMessage ?? null,
+            })),
+          })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/files.tsx
+++ b/src/routes/files.tsx
@@ -1,20 +1,89 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Editor } from '@monaco-editor/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Folder01Icon } from '@hugeicons/core-free-icons'
+import {
+  Download01Icon,
+  ExternalLink,
+  Folder01Icon,
+} from '@hugeicons/core-free-icons'
+import { Markdown } from '@/components/prompt-kit/markdown'
+import {
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '@/components/ui/scroll-area'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { FileExplorerSidebar } from '@/components/file-explorer'
+import type { FileEntry } from '@/components/file-explorer/file-explorer-sidebar'
 import { resolveTheme, useSettings } from '@/hooks/use-settings'
 
-const INITIAL_EDITOR_VALUE = `// Files workspace
-// Use the file tree on the left to browse and manage project files.
-// "Insert as reference" actions appear here for quick context snippets.
-
-function note() {
-  return 'Ready to explore files.'
-}
+const PLACEHOLDER_VALUE = `// Files workspace
+// Click a file in the tree to load it into this editor.
 `
+
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  json: 'json',
+  md: 'markdown',
+  markdown: 'markdown',
+  yml: 'yaml',
+  yaml: 'yaml',
+  toml: 'ini',
+  ini: 'ini',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  htm: 'html',
+  sh: 'shell',
+  bash: 'shell',
+  zsh: 'shell',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'cpp',
+  hpp: 'cpp',
+  sql: 'sql',
+  xml: 'xml',
+  dockerfile: 'dockerfile',
+  env: 'plaintext',
+  log: 'plaintext',
+  txt: 'plaintext',
+}
+
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
+
+function getExt(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
+}
+
+function languageFor(name: string): string {
+  if (/^Dockerfile$/i.test(name)) return 'dockerfile'
+  return LANGUAGE_BY_EXT[getExt(name)] ?? 'plaintext'
+}
+
+type LoadedFile = {
+  path: string
+  name: string
+  language: string
+  content: string
+  imageDataUrl: string | null
+  loading: boolean
+  error: string | null
+  dirty: boolean
+}
 
 export const Route = createFileRoute('/files')({
   ssr: false,
@@ -56,7 +125,10 @@ function FilesRoute() {
   const { settings } = useSettings()
   const [isMobile, setIsMobile] = useState(false)
   const [fileExplorerCollapsed, setFileExplorerCollapsed] = useState(false)
-  const [editorValue, setEditorValue] = useState(INITIAL_EDITOR_VALUE)
+  const [loaded, setLoaded] = useState<LoadedFile | null>(null)
+  const [renderMarkdown, setRenderMarkdown] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [savedFlash, setSavedFlash] = useState(false)
   const resolvedTheme = resolveTheme(settings.theme)
 
   useEffect(() => {
@@ -72,60 +144,264 @@ function FilesRoute() {
     setFileExplorerCollapsed(true)
   }, [isMobile])
 
-  const handleInsertReference = useCallback(function handleInsertReference(
-    reference: string,
-  ) {
-    setEditorValue((prev) => `${prev}\n${reference}\n`)
+  const handleInsertReference = useCallback(() => {
+    // Reference insertion is only useful when there's a composer; on this
+    // route we just want the click to open the file, so ignore.
   }, [])
+
+  const handleOpenFile = useCallback(async (entry: FileEntry) => {
+    const ext = getExt(entry.name)
+    const isImage = IMAGE_EXTS.has(ext)
+    setLoaded({
+      path: entry.path,
+      name: entry.name,
+      language: languageFor(entry.name),
+      content: '',
+      imageDataUrl: null,
+      loading: true,
+      error: null,
+      dirty: false,
+    })
+    try {
+      const res = await fetch(
+        `/api/files?action=read&path=${encodeURIComponent(entry.path)}`,
+      )
+      if (!res.ok) throw new Error(`Failed to read file (${res.status})`)
+      const data = (await res.json()) as {
+        type: 'text' | 'image'
+        content: string
+      }
+      setLoaded({
+        path: entry.path,
+        name: entry.name,
+        language: languageFor(entry.name),
+        content: data.type === 'text' ? data.content : '',
+        imageDataUrl:
+          data.type === 'image' || isImage ? data.content || null : null,
+        loading: false,
+        error: null,
+        dirty: false,
+      })
+    } catch (err) {
+      setLoaded((prev) =>
+        prev && prev.path === entry.path
+          ? {
+              ...prev,
+              loading: false,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          : prev,
+      )
+    }
+  }, [])
+
+  const handleDownload = useCallback(() => {
+    if (!loaded) return
+    const url = `/api/files?action=download&path=${encodeURIComponent(loaded.path)}`
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = loaded.name
+    anchor.click()
+  }, [loaded])
+
+  const handleOpenInTab = useCallback(() => {
+    if (!loaded) return
+    const url = `/api/files?action=view&path=${encodeURIComponent(loaded.path)}`
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }, [loaded])
+
+  const handleSave = useCallback(async () => {
+    if (!loaded || !loaded.dirty || loaded.imageDataUrl) return
+    setSaving(true)
+    try {
+      const res = await fetch('/api/files', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: 'write',
+          path: loaded.path,
+          content: loaded.content,
+        }),
+      })
+      if (!res.ok) throw new Error(`Save failed (${res.status})`)
+      setLoaded((prev) => (prev ? { ...prev, dirty: false } : prev))
+      setSavedFlash(true)
+      window.setTimeout(() => setSavedFlash(false), 1500)
+    } catch (err) {
+      setLoaded((prev) =>
+        prev
+          ? {
+              ...prev,
+              error: err instanceof Error ? err.message : String(err),
+            }
+          : prev,
+      )
+    } finally {
+      setSaving(false)
+    }
+  }, [loaded])
+
+  const isMarkdown = loaded?.language === 'markdown'
+  const isImage = Boolean(loaded?.imageDataUrl)
+  const editorValue = loaded?.content ?? PLACEHOLDER_VALUE
+  const editorLanguage = useMemo(
+    () => (loaded ? loaded.language : 'plaintext'),
+    [loaded],
+  )
 
   return (
     <div className="h-full min-h-0 overflow-hidden bg-surface text-primary-900">
       <div className="flex h-full min-h-0 overflow-hidden">
         <FileExplorerSidebar
           collapsed={fileExplorerCollapsed}
-          onToggle={function onToggleFileExplorer() {
-            setFileExplorerCollapsed((prev) => !prev)
-          }}
+          onToggle={() => setFileExplorerCollapsed((prev) => !prev)}
           onInsertReference={handleInsertReference}
+          onOpenFile={handleOpenFile}
+          activePath={loaded?.path ?? null}
         />
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <header className="flex items-center gap-3 border-b border-primary-200 px-3 py-2 md:px-4 md:py-3">
             <button
               type="button"
-              onClick={function onToggleFileExplorerHeader() {
-                setFileExplorerCollapsed((prev) => !prev)
-              }}
+              onClick={() => setFileExplorerCollapsed((prev) => !prev)}
               className="rounded-lg p-1.5 text-primary-600 hover:bg-primary-100 transition-colors"
               aria-label={fileExplorerCollapsed ? 'Show files' : 'Hide files'}
               title={fileExplorerCollapsed ? 'Show files' : 'Hide files'}
             >
               <HugeiconsIcon icon={Folder01Icon} size={20} strokeWidth={1.5} />
             </button>
-            <div>
-              <h1 className="text-base font-medium text-balance md:text-lg">
-                Files
-              </h1>
-              <p className="hidden text-sm text-primary-600 text-pretty sm:block">
-                Explore your workspace and draft notes in the editor.
-              </p>
+            <div className="min-w-0 flex-1">
+              {loaded ? (
+                <>
+                  <h1
+                    className="truncate text-base font-medium md:text-lg"
+                    title={loaded.path}
+                  >
+                    {loaded.name}
+                  </h1>
+                  <p className="hidden truncate text-xs text-primary-500 sm:block">
+                    {loaded.path}
+                    {loaded.dirty && (
+                      <span className="ml-2 text-accent-500">
+                        · unsaved changes
+                      </span>
+                    )}
+                    {savedFlash && (
+                      <span className="ml-2 text-emerald-600">· saved</span>
+                    )}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h1 className="text-base font-medium md:text-lg">Files</h1>
+                  <p className="hidden text-sm text-primary-600 sm:block">
+                    Click a file in the sidebar to load it into the editor.
+                  </p>
+                </>
+              )}
             </div>
+            {loaded ? (
+              <div className="flex shrink-0 items-center gap-2">
+                {isMarkdown && !isImage ? (
+                  <button
+                    type="button"
+                    onClick={() => setRenderMarkdown((v) => !v)}
+                    className="rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  >
+                    {renderMarkdown ? 'Edit' : 'Preview'}
+                  </button>
+                ) : null}
+                {!isImage ? (
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={!loaded.dirty || saving}
+                    className="rounded-md bg-accent-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-accent-600 disabled:opacity-50"
+                  >
+                    {saving ? 'Saving…' : 'Save'}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={handleOpenInTab}
+                  className="inline-flex items-center gap-1 rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  title="Open this file in a new browser tab"
+                >
+                  <HugeiconsIcon
+                    icon={ExternalLink}
+                    size={14}
+                    strokeWidth={1.6}
+                  />
+                  Open
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDownload}
+                  className="inline-flex items-center gap-1 rounded-md border border-primary-200 px-2.5 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100"
+                  title="Download this file to your computer"
+                >
+                  <HugeiconsIcon
+                    icon={Download01Icon}
+                    size={14}
+                    strokeWidth={1.6}
+                  />
+                  Download
+                </button>
+              </div>
+            ) : null}
           </header>
           <div className="min-h-0 flex-1 pb-24 md:pb-0">
-            <Editor
-              height="100%"
-              theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}
-              language="typescript"
-              value={editorValue}
-              onChange={function onEditorChange(value) {
-                setEditorValue(value || '')
-              }}
-              options={{
-                minimap: { enabled: settings.editorMinimap },
-                fontSize: settings.editorFontSize,
-                scrollBeyondLastLine: false,
-                wordWrap: settings.editorWordWrap ? 'on' : 'off',
-              }}
-            />
+            {loaded?.loading ? (
+              <div className="flex h-full items-center justify-center text-sm text-primary-500">
+                Loading…
+              </div>
+            ) : loaded?.error ? (
+              <div className="flex h-full items-center justify-center p-6 text-sm text-red-600">
+                {loaded.error}
+              </div>
+            ) : isImage && loaded?.imageDataUrl ? (
+              <div className="flex h-full items-center justify-center overflow-auto p-6">
+                <img
+                  src={loaded.imageDataUrl}
+                  alt={loaded.name}
+                  className="max-h-full max-w-full rounded-lg border border-primary-200 shadow-sm object-contain"
+                />
+              </div>
+            ) : isMarkdown && renderMarkdown && loaded ? (
+              <ScrollAreaRoot className="h-full">
+                <ScrollAreaViewport>
+                  <div className="markdown-preview mx-auto max-w-4xl px-6 py-5 text-sm text-primary-900">
+                    <Markdown className="gap-3">{loaded.content}</Markdown>
+                  </div>
+                </ScrollAreaViewport>
+                <ScrollAreaScrollbar orientation="vertical">
+                  <ScrollAreaThumb />
+                </ScrollAreaScrollbar>
+                <ScrollAreaCorner />
+              </ScrollAreaRoot>
+            ) : (
+              <Editor
+                height="100%"
+                theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+                language={editorLanguage}
+                value={editorValue}
+                onChange={(value) => {
+                  if (!loaded) return
+                  setLoaded({
+                    ...loaded,
+                    content: value ?? '',
+                    dirty: (value ?? '') !== loaded.content,
+                  })
+                }}
+                options={{
+                  minimap: { enabled: settings.editorMinimap },
+                  fontSize: settings.editorFontSize,
+                  scrollBeyondLastLine: false,
+                  wordWrap: settings.editorWordWrap ? 'on' : 'off',
+                  readOnly: !loaded,
+                }}
+              />
+            )}
           </div>
         </main>
       </div>

--- a/src/routes/memory.tsx
+++ b/src/routes/memory.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
@@ -16,11 +17,33 @@ const KnowledgeBrowserScreen = lazy(async () => {
   return { default: module.KnowledgeBrowserScreen }
 })
 
+const HonchoBrowserScreen = lazy(async () => {
+  const module = await import('@/screens/memory/honcho-browser-screen')
+  return { default: module.HonchoBrowserScreen }
+})
+
+type MemoryTab = 'memory' | 'knowledge' | 'honcho'
+
 export const Route = createFileRoute('/memory')({
   ssr: false,
   component: function MemoryRoute() {
-    const [tab, setTab] = useState<'memory' | 'knowledge'>('memory')
+    const [tab, setTab] = useState<MemoryTab>('memory')
     const memoryAvailable = useFeatureAvailable('memory')
+
+    // Honcho tab appears only when the workspace can see a configured
+    // Honcho install. Cheap probe — the route returns {enabled:false}
+    // when there's no honcho.json, no spinner needed.
+    const honchoQuery = useQuery({
+      queryKey: ['honcho', 'enabled'],
+      queryFn: async () => {
+        const res = await fetch('/api/honcho/health')
+        if (!res.ok) return { enabled: false }
+        return (await res.json()) as { enabled?: boolean }
+      },
+      staleTime: 60_000,
+      retry: false,
+    })
+    const honchoEnabled = Boolean(honchoQuery.data?.enabled)
 
     usePageTitle('Memory')
 
@@ -28,7 +51,7 @@ export const Route = createFileRoute('/memory')({
       <div className="flex h-full min-h-0 flex-col">
         <Tabs
           value={tab}
-          onValueChange={(value) => setTab(value as 'memory' | 'knowledge')}
+          onValueChange={(value) => setTab(value as MemoryTab)}
           className="h-full min-h-0 gap-0"
         >
           <div className="border-b border-primary-200 px-3 pt-3 dark:border-neutral-800 md:px-4 md:pt-4">
@@ -38,6 +61,9 @@ export const Route = createFileRoute('/memory')({
             >
               <TabsTab value="memory">Memory</TabsTab>
               <TabsTab value="knowledge">Knowledge</TabsTab>
+              {honchoEnabled ? (
+                <TabsTab value="honcho">Honcho</TabsTab>
+              ) : null}
             </TabsList>
           </div>
 
@@ -71,6 +97,20 @@ export const Route = createFileRoute('/memory')({
               </Suspense>
             ) : null}
           </TabsPanel>
+
+          {honchoEnabled ? (
+            <TabsPanel value="honcho" className="min-h-0 flex-1">
+              {tab === 'honcho' ? (
+                <Suspense
+                  fallback={
+                    <RouteLoadingState label="Loading Honcho browser..." />
+                  }
+                >
+                  <HonchoBrowserScreen />
+                </Suspense>
+              ) : null}
+            </TabsPanel>
+          ) : null}
         </Tabs>
       </div>
     )

--- a/src/screens/memory/honcho-browser-screen.tsx
+++ b/src/screens/memory/honcho-browser-screen.tsx
@@ -1,0 +1,508 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '@/components/ui/scroll-area'
+import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
+
+type HonchoHealth = {
+  ok: boolean
+  enabled: boolean
+  reachable: boolean
+  baseUrl: string | null
+  workspaceId: string
+  aiPeer?: string
+  userPeer?: string
+  status?: string | null
+  error?: string | null
+}
+
+type HonchoPeer = {
+  id: string
+  workspace_id: string
+  created_at: string
+  metadata?: Record<string, unknown>
+}
+
+type HonchoSession = {
+  id: string
+  workspace_id: string
+  created_at: string
+}
+
+type HonchoConclusion = {
+  id: string
+  content?: string
+  created_at?: string
+  metadata?: Record<string, unknown>
+}
+
+type HonchoSubTab = 'peers' | 'sessions' | 'conclusions'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(body || `Request failed (${res.status})`)
+  }
+  return (await res.json()) as T
+}
+
+function formatTimestamp(value?: string | null): string {
+  if (!value) return ''
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) return value
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(parsed)
+}
+
+function StatusBanner({ health }: { health: HonchoHealth }) {
+  if (!health.enabled) {
+    return (
+      <div className="rounded-lg border border-primary-200 bg-primary-100/40 p-3 text-xs text-primary-600">
+        Honcho is not enabled in <code>~/.hermes/honcho.json</code>. Add an
+        entry with <code>enabled: true</code> and a <code>baseUrl</code> to
+        light up this view.
+      </div>
+    )
+  }
+  if (!health.reachable) {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-xs text-red-700 dark:bg-red-900/20">
+        Honcho is configured ({health.baseUrl}) but unreachable.
+        {health.error ? <> Last error: <code>{health.error}</code></> : null}
+      </div>
+    )
+  }
+  return (
+    <div className="rounded-lg border border-emerald-200 bg-emerald-50/60 p-3 text-xs text-emerald-700 dark:bg-emerald-900/20">
+      Honcho connected · workspace{' '}
+      <code className="font-semibold">{health.workspaceId}</code> · ai peer{' '}
+      <code>{health.aiPeer}</code> · user peer <code>{health.userPeer}</code>
+    </div>
+  )
+}
+
+function PeersTab() {
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const listQuery = useQuery({
+    queryKey: ['honcho', 'peers'],
+    queryFn: () =>
+      fetchJson<{ peers: Array<HonchoPeer>; total: number }>(
+        '/api/honcho/peers',
+      ),
+    staleTime: 30_000,
+  })
+
+  const detailQuery = useQuery({
+    queryKey: ['honcho', 'peer', selected],
+    enabled: Boolean(selected),
+    queryFn: () =>
+      fetchJson<{
+        peer: HonchoPeer
+        card: unknown
+        representation: unknown
+      }>(`/api/honcho/peers?id=${encodeURIComponent(selected!)}`),
+  })
+
+  return (
+    <div className="grid h-full min-h-0 grid-cols-[260px_minmax(0,1fr)] gap-3">
+      <div className="rounded-lg border border-primary-200 dark:border-neutral-800">
+        <div className="border-b border-primary-200 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-primary-500 dark:border-neutral-800">
+          Peers {listQuery.data ? `(${listQuery.data.total})` : null}
+        </div>
+        <ScrollAreaRoot className="h-[calc(100%-2.25rem)]">
+          <ScrollAreaViewport>
+            {listQuery.isLoading ? (
+              <p className="px-3 py-2 text-xs text-primary-500">Loading…</p>
+            ) : listQuery.error ? (
+              <p className="px-3 py-2 text-xs text-red-600">
+                {(listQuery.error as Error).message}
+              </p>
+            ) : (listQuery.data?.peers ?? []).length === 0 ? (
+              <p className="px-3 py-2 text-xs text-primary-500">
+                No peers yet.
+              </p>
+            ) : (
+              <ul>
+                {listQuery.data!.peers.map((peer) => (
+                  <li key={peer.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(peer.id)}
+                      className={cn(
+                        'flex w-full flex-col items-start gap-0.5 border-b border-primary-100 px-3 py-2 text-left hover:bg-primary-100/60 dark:border-neutral-800',
+                        selected === peer.id &&
+                          'bg-accent-100 text-accent-900',
+                      )}
+                    >
+                      <span className="truncate text-sm font-medium">
+                        {peer.id}
+                      </span>
+                      <span className="text-[10px] text-primary-400">
+                        {formatTimestamp(peer.created_at)}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </ScrollAreaViewport>
+          <ScrollAreaScrollbar orientation="vertical">
+            <ScrollAreaThumb />
+          </ScrollAreaScrollbar>
+          <ScrollAreaCorner />
+        </ScrollAreaRoot>
+      </div>
+
+      <div className="min-h-0 rounded-lg border border-primary-200 dark:border-neutral-800">
+        {!selected ? (
+          <div className="flex h-full items-center justify-center text-xs text-primary-400">
+            Select a peer to view its card and representation.
+          </div>
+        ) : detailQuery.isLoading ? (
+          <div className="p-3 text-xs text-primary-500">Loading…</div>
+        ) : detailQuery.error ? (
+          <div className="p-3 text-xs text-red-600">
+            {(detailQuery.error as Error).message}
+          </div>
+        ) : detailQuery.data ? (
+          <ScrollAreaRoot className="h-full">
+            <ScrollAreaViewport>
+              <div className="space-y-4 p-3">
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Peer
+                  </h3>
+                  <p className="mt-1 font-mono text-sm">
+                    {detailQuery.data.peer.id}
+                  </p>
+                  <p className="text-[11px] text-primary-400">
+                    Created {formatTimestamp(detailQuery.data.peer.created_at)}
+                  </p>
+                </section>
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Card
+                  </h3>
+                  <pre className="mt-1 overflow-x-auto rounded-md bg-primary-100/40 p-2 text-[11px] dark:bg-neutral-900/40">
+                    {detailQuery.data.card
+                      ? JSON.stringify(detailQuery.data.card, null, 2)
+                      : 'No card yet — Honcho will build one as messages accumulate.'}
+                  </pre>
+                </section>
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Representation
+                  </h3>
+                  <pre className="mt-1 overflow-x-auto rounded-md bg-primary-100/40 p-2 text-[11px] dark:bg-neutral-900/40">
+                    {detailQuery.data.representation
+                      ? JSON.stringify(
+                          detailQuery.data.representation,
+                          null,
+                          2,
+                        )
+                      : 'No representation yet.'}
+                  </pre>
+                </section>
+              </div>
+            </ScrollAreaViewport>
+            <ScrollAreaScrollbar orientation="vertical">
+              <ScrollAreaThumb />
+            </ScrollAreaScrollbar>
+            <ScrollAreaCorner />
+          </ScrollAreaRoot>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function SessionsTab() {
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const listQuery = useQuery({
+    queryKey: ['honcho', 'sessions'],
+    queryFn: () =>
+      fetchJson<{ sessions: Array<HonchoSession>; total: number }>(
+        '/api/honcho/sessions',
+      ),
+    staleTime: 30_000,
+  })
+
+  const detailQuery = useQuery({
+    queryKey: ['honcho', 'session', selected],
+    enabled: Boolean(selected),
+    queryFn: () =>
+      fetchJson<{
+        session: HonchoSession
+        messages: Array<Record<string, unknown>>
+        messagesTotal: number
+        summaries: unknown
+      }>(`/api/honcho/sessions?id=${encodeURIComponent(selected!)}`),
+  })
+
+  return (
+    <div className="grid h-full min-h-0 grid-cols-[260px_minmax(0,1fr)] gap-3">
+      <div className="rounded-lg border border-primary-200 dark:border-neutral-800">
+        <div className="border-b border-primary-200 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-primary-500 dark:border-neutral-800">
+          Sessions {listQuery.data ? `(${listQuery.data.total})` : null}
+        </div>
+        <ScrollAreaRoot className="h-[calc(100%-2.25rem)]">
+          <ScrollAreaViewport>
+            {listQuery.isLoading ? (
+              <p className="px-3 py-2 text-xs text-primary-500">Loading…</p>
+            ) : listQuery.error ? (
+              <p className="px-3 py-2 text-xs text-red-600">
+                {(listQuery.error as Error).message}
+              </p>
+            ) : (listQuery.data?.sessions ?? []).length === 0 ? (
+              <p className="px-3 py-2 text-xs text-primary-500">
+                No sessions yet.
+              </p>
+            ) : (
+              <ul>
+                {listQuery.data!.sessions.map((session) => (
+                  <li key={session.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(session.id)}
+                      className={cn(
+                        'flex w-full flex-col items-start gap-0.5 border-b border-primary-100 px-3 py-2 text-left hover:bg-primary-100/60 dark:border-neutral-800',
+                        selected === session.id &&
+                          'bg-accent-100 text-accent-900',
+                      )}
+                    >
+                      <span className="truncate font-mono text-xs">
+                        {session.id}
+                      </span>
+                      <span className="text-[10px] text-primary-400">
+                        {formatTimestamp(session.created_at)}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </ScrollAreaViewport>
+          <ScrollAreaScrollbar orientation="vertical">
+            <ScrollAreaThumb />
+          </ScrollAreaScrollbar>
+          <ScrollAreaCorner />
+        </ScrollAreaRoot>
+      </div>
+
+      <div className="min-h-0 rounded-lg border border-primary-200 dark:border-neutral-800">
+        {!selected ? (
+          <div className="flex h-full items-center justify-center text-xs text-primary-400">
+            Select a session to inspect messages and summaries.
+          </div>
+        ) : detailQuery.isLoading ? (
+          <div className="p-3 text-xs text-primary-500">Loading…</div>
+        ) : detailQuery.error ? (
+          <div className="p-3 text-xs text-red-600">
+            {(detailQuery.error as Error).message}
+          </div>
+        ) : detailQuery.data ? (
+          <ScrollAreaRoot className="h-full">
+            <ScrollAreaViewport>
+              <div className="space-y-4 p-3">
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Session
+                  </h3>
+                  <p className="mt-1 font-mono text-sm">
+                    {detailQuery.data.session.id}
+                  </p>
+                  <p className="text-[11px] text-primary-400">
+                    Created{' '}
+                    {formatTimestamp(detailQuery.data.session.created_at)} ·{' '}
+                    {detailQuery.data.messagesTotal} messages
+                  </p>
+                </section>
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Summaries
+                  </h3>
+                  <pre className="mt-1 overflow-x-auto rounded-md bg-primary-100/40 p-2 text-[11px] dark:bg-neutral-900/40">
+                    {detailQuery.data.summaries
+                      ? JSON.stringify(detailQuery.data.summaries, null, 2)
+                      : 'No summaries.'}
+                  </pre>
+                </section>
+                <section>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
+                    Messages
+                  </h3>
+                  {detailQuery.data.messages.length === 0 ? (
+                    <p className="mt-1 text-xs text-primary-400">No messages.</p>
+                  ) : (
+                    <ul className="mt-1 space-y-2">
+                      {detailQuery.data.messages.map((msg, idx) => (
+                        <li
+                          key={String(
+                            (msg as { id?: unknown }).id ?? idx,
+                          )}
+                          className="rounded-md border border-primary-200 bg-primary-50/50 p-2 dark:border-neutral-800 dark:bg-neutral-900/40"
+                        >
+                          <div className="mb-1 flex items-center gap-2 text-[10px] text-primary-500">
+                            <span className="font-semibold">
+                              {String(
+                                (msg as { peer_id?: unknown }).peer_id ??
+                                  'unknown',
+                              )}
+                            </span>
+                            <span>
+                              {formatTimestamp(
+                                (msg as { created_at?: string }).created_at,
+                              )}
+                            </span>
+                          </div>
+                          <div className="whitespace-pre-wrap text-xs">
+                            {String(
+                              (msg as { content?: unknown }).content ?? '',
+                            )}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              </div>
+            </ScrollAreaViewport>
+            <ScrollAreaScrollbar orientation="vertical">
+              <ScrollAreaThumb />
+            </ScrollAreaScrollbar>
+            <ScrollAreaCorner />
+          </ScrollAreaRoot>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ConclusionsTab() {
+  const query = useQuery({
+    queryKey: ['honcho', 'conclusions'],
+    queryFn: () =>
+      fetchJson<{ conclusions: Array<HonchoConclusion>; total: number }>(
+        '/api/honcho/conclusions',
+      ),
+    staleTime: 30_000,
+  })
+
+  if (query.isLoading) {
+    return <p className="p-3 text-xs text-primary-500">Loading…</p>
+  }
+  if (query.error) {
+    return (
+      <p className="p-3 text-xs text-red-600">
+        {(query.error as Error).message}
+      </p>
+    )
+  }
+  const items = query.data?.conclusions ?? []
+  if (items.length === 0) {
+    return (
+      <p className="p-3 text-xs text-primary-500">
+        No conclusions yet. The Honcho deriver writes these as it learns from
+        sessions — give it some conversations first.
+      </p>
+    )
+  }
+  return (
+    <ScrollAreaRoot className="h-full">
+      <ScrollAreaViewport>
+        <ul className="space-y-2 p-3">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-md border border-primary-200 bg-primary-50/50 p-3 dark:border-neutral-800 dark:bg-neutral-900/40"
+            >
+              <div className="mb-1 flex items-center gap-2 text-[10px] text-primary-500">
+                <span className="font-mono">{item.id}</span>
+                {item.created_at ? (
+                  <span>{formatTimestamp(item.created_at)}</span>
+                ) : null}
+              </div>
+              <div className="whitespace-pre-wrap text-xs text-primary-800 dark:text-primary-100">
+                {item.content || '(no content)'}
+              </div>
+              {item.metadata && Object.keys(item.metadata).length > 0 ? (
+                <pre className="mt-2 overflow-x-auto rounded bg-primary-100/40 p-2 text-[10px] dark:bg-neutral-950/40">
+                  {JSON.stringify(item.metadata, null, 2)}
+                </pre>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </ScrollAreaViewport>
+      <ScrollAreaScrollbar orientation="vertical">
+        <ScrollAreaThumb />
+      </ScrollAreaScrollbar>
+      <ScrollAreaCorner />
+    </ScrollAreaRoot>
+  )
+}
+
+export function HonchoBrowserScreen() {
+  const healthQuery = useQuery({
+    queryKey: ['honcho', 'health'],
+    queryFn: () => fetchJson<HonchoHealth>('/api/honcho/health'),
+    staleTime: 60_000,
+  })
+  const [tab, setTab] = useState<HonchoSubTab>('peers')
+
+  const health = healthQuery.data
+  const ready = useMemo(
+    () => Boolean(health?.enabled && health.reachable),
+    [health],
+  )
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 p-3 md:p-4">
+      {healthQuery.isLoading ? (
+        <p className="text-xs text-primary-500">Checking Honcho…</p>
+      ) : healthQuery.error ? (
+        <p className="text-xs text-red-600">
+          {(healthQuery.error as Error).message}
+        </p>
+      ) : health ? (
+        <StatusBanner health={health} />
+      ) : null}
+
+      <Tabs
+        value={tab}
+        onValueChange={(value) => setTab(value as HonchoSubTab)}
+        className="flex min-h-0 flex-1 flex-col gap-3"
+      >
+        <TabsList variant="underline" className="w-full justify-start gap-1">
+          <TabsTab value="peers">Peers</TabsTab>
+          <TabsTab value="sessions">Sessions</TabsTab>
+          <TabsTab value="conclusions">Conclusions</TabsTab>
+        </TabsList>
+
+        <TabsPanel value="peers" className="min-h-0 flex-1">
+          {tab === 'peers' && ready ? <PeersTab /> : null}
+        </TabsPanel>
+        <TabsPanel value="sessions" className="min-h-0 flex-1">
+          {tab === 'sessions' && ready ? <SessionsTab /> : null}
+        </TabsPanel>
+        <TabsPanel value="conclusions" className="min-h-0 flex-1">
+          {tab === 'conclusions' && ready ? <ConclusionsTab /> : null}
+        </TabsPanel>
+      </Tabs>
+    </div>
+  )
+}

--- a/src/screens/memory/honcho-browser-screen.tsx
+++ b/src/screens/memory/honcho-browser-screen.tsx
@@ -110,11 +110,19 @@ function PeersTab() {
     enabled: Boolean(selected),
     queryFn: () =>
       fetchJson<{
-        peer: HonchoPeer
+        peerId: string
         card: unknown
         representation: unknown
+        cardError: string | null
+        representationError: string | null
       }>(`/api/honcho/peers?id=${encodeURIComponent(selected!)}`),
   })
+
+  // Honcho has no GET /peers/{id} — pull metadata from the list cache.
+  const selectedPeer = useMemo(
+    () => listQuery.data?.peers.find((p) => p.id === selected) ?? null,
+    [listQuery.data, selected],
+  )
 
   return (
     <div className="grid h-full min-h-0 grid-cols-[260px_minmax(0,1fr)] gap-3">
@@ -186,11 +194,13 @@ function PeersTab() {
                     Peer
                   </h3>
                   <p className="mt-1 font-mono text-sm">
-                    {detailQuery.data.peer.id}
+                    {selectedPeer?.id ?? detailQuery.data.peerId}
                   </p>
-                  <p className="text-[11px] text-primary-400">
-                    Created {formatTimestamp(detailQuery.data.peer.created_at)}
-                  </p>
+                  {selectedPeer?.created_at ? (
+                    <p className="text-[11px] text-primary-400">
+                      Created {formatTimestamp(selectedPeer.created_at)}
+                    </p>
+                  ) : null}
                 </section>
                 <section>
                   <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">
@@ -246,12 +256,20 @@ function SessionsTab() {
     enabled: Boolean(selected),
     queryFn: () =>
       fetchJson<{
-        session: HonchoSession
+        sessionId: string
         messages: Array<Record<string, unknown>>
         messagesTotal: number
         summaries: unknown
+        messagesError: string | null
+        summariesError: string | null
       }>(`/api/honcho/sessions?id=${encodeURIComponent(selected!)}`),
   })
+
+  // Honcho has no GET /sessions/{id} — pull metadata from the list cache.
+  const selectedSession = useMemo(
+    () => listQuery.data?.sessions.find((s) => s.id === selected) ?? null,
+    [listQuery.data, selected],
+  )
 
   return (
     <div className="grid h-full min-h-0 grid-cols-[260px_minmax(0,1fr)] gap-3">
@@ -323,11 +341,12 @@ function SessionsTab() {
                     Session
                   </h3>
                   <p className="mt-1 font-mono text-sm">
-                    {detailQuery.data.session.id}
+                    {selectedSession?.id ?? detailQuery.data.sessionId}
                   </p>
                   <p className="text-[11px] text-primary-400">
-                    Created{' '}
-                    {formatTimestamp(detailQuery.data.session.created_at)} ·{' '}
+                    {selectedSession?.created_at ? (
+                      <>Created {formatTimestamp(selectedSession.created_at)} · </>
+                    ) : null}
                     {detailQuery.data.messagesTotal} messages
                   </p>
                 </section>

--- a/src/server/honcho-config.ts
+++ b/src/server/honcho-config.ts
@@ -1,0 +1,137 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Honcho config — mirrors the resolution chain Hermes itself uses
+ * (plugins/memory/honcho/client.py:resolve_config_path):
+ *
+ *   1. $HERMES_HOME/honcho.json   (profile-local)
+ *   2. ~/.honcho/config.json      (legacy global)
+ *   3. Environment variables      (HONCHO_API_KEY / HONCHO_BASE_URL)
+ *
+ * When this returns `enabled: true`, the workspace UI exposes the Honcho
+ * memory browser. Detection is "is the file there and enabled?" — the
+ * health route does the actual reachability ping.
+ */
+
+export type HonchoConfig = {
+  enabled: boolean
+  baseUrl: string | null
+  apiKey: string | null
+  workspaceId: string
+  aiPeer: string
+  userPeer: string
+}
+
+const DEFAULT_BASE_URL = 'http://localhost:8000'
+const DEFAULT_WORKSPACE = 'hermes'
+const DEFAULT_AI_PEER = 'hermes'
+const DEFAULT_USER_PEER = 'user'
+
+type RecordLike = Record<string, unknown>
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readBool(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value
+  return null
+}
+
+function readRecord(value: unknown): RecordLike {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as RecordLike)
+    : {}
+}
+
+function hermesHome(): string {
+  return (
+    process.env.HERMES_HOME ||
+    process.env.CLAUDE_HOME ||
+    join(homedir(), '.hermes')
+  )
+}
+
+function activeHost(): string {
+  // Mirrors plugins/memory/honcho/client.py:resolve_active_host but kept
+  // dead simple — the workspace UI doesn't currently track which Hermes
+  // profile is active, so we use the env var if set, else the default host.
+  const explicit = readString(process.env.HERMES_HONCHO_HOST)
+  if (explicit) return explicit
+  return 'hermes'
+}
+
+function readJson(path: string): RecordLike | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+    return readRecord(parsed)
+  } catch {
+    return null
+  }
+}
+
+function loadFile(): RecordLike | null {
+  return (
+    readJson(join(hermesHome(), 'honcho.json')) ||
+    readJson(join(homedir(), '.honcho', 'config.json'))
+  )
+}
+
+export function loadHonchoConfig(): HonchoConfig {
+  const raw = loadFile()
+  const host = activeHost()
+  const hostBlock = raw ? readRecord(readRecord(raw.hosts)[host]) : {}
+
+  // Resolution: host-block field > root field > env > default.
+  const baseUrl =
+    readString(hostBlock.baseUrl) ||
+    readString(hostBlock.base_url) ||
+    readString(raw?.baseUrl) ||
+    readString(raw?.base_url) ||
+    readString(process.env.HONCHO_BASE_URL) ||
+    null
+
+  const apiKey =
+    readString(hostBlock.apiKey) ||
+    readString(raw?.apiKey) ||
+    readString(process.env.HONCHO_API_KEY) ||
+    null
+
+  const workspaceId =
+    readString(hostBlock.workspace) ||
+    readString(raw?.workspace) ||
+    DEFAULT_WORKSPACE
+
+  const aiPeer =
+    readString(hostBlock.aiPeer) ||
+    readString(raw?.aiPeer) ||
+    DEFAULT_AI_PEER
+
+  const userPeer =
+    readString(hostBlock.peerName) ||
+    readString(raw?.peerName) ||
+    DEFAULT_USER_PEER
+
+  // Honcho is "enabled" when: host block says so, root says so, OR a
+  // baseUrl/apiKey is present and nothing has explicitly disabled it.
+  const hostEnabled = readBool(hostBlock.enabled)
+  const rootEnabled = readBool(raw?.enabled)
+  const enabled =
+    hostEnabled !== null
+      ? hostEnabled
+      : rootEnabled !== null
+        ? rootEnabled
+        : Boolean(baseUrl || apiKey)
+
+  return {
+    enabled,
+    baseUrl: baseUrl || (enabled ? DEFAULT_BASE_URL : null),
+    apiKey,
+    workspaceId,
+    aiPeer,
+    userPeer,
+  }
+}

--- a/src/server/honcho-proxy.ts
+++ b/src/server/honcho-proxy.ts
@@ -1,0 +1,96 @@
+import type { HonchoConfig } from './honcho-config'
+import { loadHonchoConfig } from './honcho-config'
+
+/**
+ * Honcho proxy — forwards a request to the configured Honcho server.
+ * The browser never talks to Honcho directly: this server reads the same
+ * config Hermes uses, applies the API key if any, and returns the upstream
+ * payload as-is.
+ *
+ * Honcho's v3 list endpoints are POST with optional filter/pagination
+ * bodies; detail/card endpoints are GET. We expose a single helper and let
+ * each route pick the verb.
+ */
+
+const REQUEST_TIMEOUT_MS = 15_000
+
+export type HonchoFetchOptions = {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  body?: unknown
+  query?: Record<string, string | number | undefined>
+}
+
+export type HonchoFetchResult<T = unknown> =
+  | { ok: true; data: T; status: number }
+  | { ok: false; error: string; status: number }
+
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string | number | undefined>,
+): string {
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  const url = new URL(`${baseUrl.replace(/\/$/, '')}${normalized}`)
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined) continue
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url.toString()
+}
+
+export function getHonchoConfig(): HonchoConfig {
+  return loadHonchoConfig()
+}
+
+export async function fetchHoncho<T = unknown>(
+  path: string,
+  options: HonchoFetchOptions = {},
+): Promise<HonchoFetchResult<T>> {
+  const config = loadHonchoConfig()
+  if (!config.enabled || !config.baseUrl) {
+    return { ok: false, error: 'Honcho is not enabled.', status: 503 }
+  }
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  }
+  if (config.apiKey) {
+    headers.Authorization = `Bearer ${config.apiKey}`
+  }
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(buildUrl(config.baseUrl, path, options.query), {
+      method: options.method ?? 'GET',
+      headers,
+      body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+      signal: controller.signal,
+    })
+    const status = response.status
+    const text = await response.text()
+    if (!response.ok) {
+      return { ok: false, error: text || `Honcho ${status}`, status }
+    }
+    const data = text ? (JSON.parse(text) as T) : ({} as T)
+    return { ok: true, data, status }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes('aborted')) {
+      return { ok: false, error: 'Honcho request timed out.', status: 504 }
+    }
+    return {
+      ok: false,
+      error: `Failed to reach Honcho: ${msg}`,
+      status: 502,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -211,29 +211,60 @@ export async function markRunStatus(
   }))
 }
 
+// A run that hasn't been touched in this long is considered orphaned (e.g.
+// the agent process crashed, the network dropped silently, or the user
+// navigated away during a `handoff` that never resolved). Treating these as
+// "active" makes every chat re-open show a phantom "Thinking…" indicator
+// until the 120s client-side failsafe clears it.
+const STALE_RUN_THRESHOLD_MS = 5 * 60 * 1000
+
+async function readRunsInDir(dir: string): Promise<Array<PersistedRunState>> {
+  const files = (await readdir(dir)).filter((name) => name.endsWith('.json'))
+  if (files.length === 0) return []
+  const runs = await Promise.all(
+    files.map(async (name) => {
+      try {
+        const raw = await readFile(path.join(dir, name), 'utf8')
+        return JSON.parse(raw) as PersistedRunState
+      } catch {
+        return null
+      }
+    }),
+  )
+  return runs.filter((run): run is PersistedRunState => Boolean(run))
+}
+
 export async function getActiveRunForSession(
   sessionKey: string,
 ): Promise<PersistedRunState | null> {
   try {
-    const dir = sessionDir(sessionKey)
-    const files = (await readdir(dir)).filter((name) => name.endsWith('.json'))
-    if (files.length === 0) return null
-    const runs = await Promise.all(
-      files.map(async (name) => {
-        try {
-          const raw = await readFile(path.join(dir, name), 'utf8')
-          return JSON.parse(raw) as PersistedRunState
-        } catch {
-          return null
-        }
-      }),
-    )
+    const runs = await readRunsInDir(sessionDir(sessionKey))
+    const now = Date.now()
     const candidates = runs
-      .filter((run): run is PersistedRunState => Boolean(run))
       .filter((run) => !['complete', 'error'].includes(run.status))
+      .filter((run) => now - run.updatedAt < STALE_RUN_THRESHOLD_MS)
       .sort((a, b) => b.updatedAt - a.updatedAt)
     return candidates[0] ?? null
   } catch {
     return null
+  }
+}
+
+// Lists every non-complete/error run across all sessions, regardless of
+// staleness. Powers the "Background runs" panel so users can inspect and
+// abandon orphans that the staleness filter hides from the chat UI.
+export async function listAllActiveRuns(): Promise<Array<PersistedRunState>> {
+  try {
+    const entries = await readdir(RUNS_ROOT, { withFileTypes: true })
+    const sessionDirs = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(RUNS_ROOT, entry.name))
+    const runsBySession = await Promise.all(sessionDirs.map(readRunsInDir))
+    return runsBySession
+      .flat()
+      .filter((run) => !['complete', 'error'].includes(run.status))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch {
+    return []
   }
 }


### PR DESCRIPTION
## Summary

Hermes-agent already integrates with Honcho (\`~/.hermes/honcho.json\`, the \`memory/honcho\` plugin, auto-config in the install wizard) but the workspace UI had no surface for it. This adds a third tab to the Memory screen that lights up only when the workspace can detect a configured Honcho install. Read-only first cut — no writes, no Hermes↔Honcho session mapping yet.

### Server

- \`src/server/honcho-config.ts\` — mirrors Hermes' config resolution chain (\`$HERMES_HOME/honcho.json\` → \`~/.honcho/config.json\` → env). Resolves workspace, ai peer, user peer, baseUrl, and optional API key for the active host block.
- \`src/server/honcho-proxy.ts\` — typed fetch wrapper that forwards to Honcho with Bearer auth (if \`apiKey\` set) and a 15s timeout. **Browser never talks to Honcho directly.**

### Routes (all GET, all auth-gated)

- \`GET /api/honcho/health\` — config + reachability probe; returns \`{enabled, reachable, workspaceId, aiPeer, userPeer, baseUrl}\`
- \`GET /api/honcho/peers\` — list, or \`?id=<peerId>\` → peer + card + representation in one round trip
- \`GET /api/honcho/sessions\` — list, or \`?id=<sessionId>\` → session + messages + summaries
- \`GET /api/honcho/conclusions\` — list deriver-produced insights
- \`GET /api/honcho/search?q=...\` — POSTs to Honcho's workspace search

### UI

- \`src/screens/memory/honcho-browser-screen.tsx\` — internal **Peers / Sessions / Conclusions** subtabs. Status banner reflects health probe state (not enabled / unreachable / connected with workspace + peer ids). Master-detail layout for peers and sessions.
- \`src/routes/memory.tsx\` — Honcho tab renders only when \`/api/honcho/health\` returns \`enabled: true\`; existing Memory and Knowledge tabs are unaffected when Honcho isn't configured.

## Test plan

- [ ] Without \`~/.hermes/honcho.json\` (or with \`enabled: false\`), Memory screen shows only Memory + Knowledge tabs
- [ ] With Honcho running on localhost:8000 and a valid \`~/.hermes/honcho.json\`, Honcho tab appears; banner shows green "connected" with workspace/peer ids
- [ ] Peers tab lists workspace peers; clicking one shows card + representation in detail pane
- [ ] Sessions tab lists sessions; clicking one shows summaries + paginated messages with peer attribution
- [ ] Conclusions tab lists deriver-written insights (may be empty initially)
- [ ] With Honcho service stopped, banner flips to red "unreachable"
- [ ] No browser-side calls to \`:8000\` — DevTools Network shows all requests going through \`/api/honcho/*\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)