### PR TITLE
fix(files): prevent path traversal via crafted upload filename

### DIFF
--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -355,8 +355,9 @@ export const Route = createFileRoute('/api/files')({
             )
             const isDir = (await fs.stat(resolvedTarget)).isDirectory()
             const destination = isDir
-              ? path.join(resolvedTarget, file.name)
+              ? path.join(resolvedTarget, path.basename(file.name))
               : resolvedTarget
+            ensureWorkspacePath(destination, workspaceRoot)
             await fs.mkdir(path.dirname(destination), { recursive: true })
             const buffer = Buffer.from(await file.arrayBuffer())
             await fs.writeFile(destination, buffer)


### PR DESCRIPTION
## Vulnerability Summary

The multipart file upload handler in `src/routes/api/files.ts` (line 358) uses the user-supplied `file.name` from a `FormData` upload directly in `path.join(resolvedTarget, file.name)` to compute the write destination. While the `targetPath` parameter is validated through `ensureWorkspacePath()`, the **filename itself** is not sanitized or re-validated.

A crafted filename containing path traversal sequences (e.g. `../../etc/cron.d/backdoor`) causes the final `destination` to resolve outside the workspace root. Since `ensureWorkspacePath` is only called on `targetPath` (the directory) and not on the computed `destination`, the traversal bypasses the workspace boundary check entirely.

- **CWE-22** (Path Traversal) / **CWE-434** (Unrestricted File Upload)
- **Affected function**: `PUT /api/files` multipart upload handler
- **Affected file**: `src/routes/api/files.ts`, lines 352–363

## Proof of Concept

An authenticated user can upload a file that escapes the workspace:

```bash
# Assuming workspace root is /home/user/workspace and auth is configured
curl -X PUT http://localhost:3000/api/files \
  -H "Cookie: <valid-session-cookie>" \
  -F "action=upload" \
  -F "path=." \
  -F "file=@payload.txt;filename=../../outside-workspace/malicious.txt"
```

The server resolves `targetPath` = `.` → `/home/user/workspace` (passes `ensureWorkspacePath`), then computes `destination` = `path.join("/home/user/workspace", "../../outside-workspace/malicious.txt")` → `/home/outside-workspace/malicious.txt`. The file is written outside the workspace boundary.

## Fix Description

Two changes, both on the `destination` computation path:

1. **`path.basename(file.name)`** — strips any directory components from the uploaded filename, so `../../malicious.txt` becomes `malicious.txt`.
2. **`ensureWorkspacePath(destination, workspaceRoot)`** — adds a second boundary check on the fully resolved destination path, providing defense-in-depth in case any edge case bypasses `basename` stripping.

This is a minimal two-line fix. The `basename` call prevents traversal, and the `ensureWorkspacePath` call provides a hard boundary guarantee.

## Testing

- Verified the project builds cleanly with `npx tsc --noEmit` after the change
- Confirmed that normal uploads (flat filenames like `readme.txt`) are unaffected — `path.basename("readme.txt")` returns `"readme.txt"`
- Confirmed that traversal filenames like `../../etc/passwd` are reduced to `passwd` by `path.basename`, and the second `ensureWorkspacePath` call would throw if the result somehow still escaped

## Adversarial Review

Before submitting, we considered whether existing protections already prevent this. The `ensureWorkspacePath` call on `targetPath` (line 352) only validates the *directory* the user specifies — it does not and cannot validate the final write path because `file.name` is appended afterward. The auth requirement (password-protected access) reduces the attack surface to authenticated users, but authenticated users should not be able to write arbitrary files outside their workspace boundary — that's the entire purpose of `ensureWorkspacePath`. The workspace sandbox is a meaningful security boundary even for authenticated users.