### PR TITLE
[codex] add company os beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,8 @@
 # Set to 1 to force the Secure attribute on session cookies even when
 # NODE_ENV is not production — useful when terminating TLS at a reverse
 # proxy. Set to 0 to force it off (only safe for localhost HTTP).
-# COOKIE_SECURE=1
+# COOKIE_SECURE=1   # use behind HTTPS / reverse proxy
+# COOKIE_SECURE=0   # required for plain HTTP on HOST=0.0.0.0 / LAN access
 
 # Trust proxy-forwarded headers (default: off)
 #

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,257 @@
+---
+version: alpha
+name: Hermes Workspace
+description: "Command-center UI for Hermes Agent: agent orchestration, chat, files, memory, skills, terminal, jobs, and operations."
+colors:
+  primary: "#041C1C"
+  primary-surface: "#06282A"
+  primary-card: "#082F31"
+  primary-card-raised: "#0A3638"
+  primary-text: "#FFE6CB"
+  primary-muted: "#A99582"
+  accent: "#FFAC02"
+  accent-secondary: "#FFE6CB"
+  success: "#8FFF89"
+  warning: "#FFAC02"
+  danger: "#FB2C36"
+  light-background: "#F8FAF8"
+  light-panel: "#F4F7F5"
+  light-card: "#FBFDFB"
+  light-text: "#16315F"
+  light-muted: "#53687D"
+  light-accent: "#2557B7"
+  classic-accent: "#B98A44"
+  slate-accent: "#7EB8F6"
+typography:
+  display:
+    fontFamily: "EB Garamond"
+    fontSize: 3rem
+    fontWeight: 500
+    lineHeight: 1.05
+    letterSpacing: 0px
+  h1:
+    fontFamily: "Inter"
+    fontSize: 1.875rem
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: 0px
+  h2:
+    fontFamily: "Inter"
+    fontSize: 1.25rem
+    fontWeight: 650
+    lineHeight: 1.3
+    letterSpacing: 0px
+  body:
+    fontFamily: "Inter"
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.55
+    letterSpacing: 0px
+  label:
+    fontFamily: "Inter"
+    fontSize: 0.6875rem
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: 0.2em
+  code:
+    fontFamily: "JetBrains Mono"
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 40px
+  xxl: 64px
+rounded:
+  none: 0px
+  sm: 4px
+  card: 6px
+  panel: 8px
+  dialog: 10px
+  pill: 9999px
+components:
+  frame:
+    backgroundColor: "{colors.primary-card}"
+    textColor: "{colors.primary-text}"
+    rounded: "{rounded.card}"
+    padding: "{spacing.md}"
+  frame-panel:
+    backgroundColor: "{colors.primary-surface}"
+    textColor: "{colors.primary-text}"
+    rounded: "{rounded.panel}"
+    padding: "{spacing.lg}"
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  button-secondary:
+    backgroundColor: "{colors.primary-surface}"
+    textColor: "{colors.primary-text}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  input:
+    backgroundColor: "{colors.primary-surface}"
+    textColor: "{colors.primary-text}"
+    rounded: "{rounded.card}"
+    padding: "{spacing.md}"
+  raised-frame:
+    backgroundColor: "{colors.primary-card-raised}"
+    textColor: "{colors.primary-text}"
+    rounded: "{rounded.panel}"
+    padding: "{spacing.md}"
+  muted-label:
+    backgroundColor: "{colors.primary-surface}"
+    textColor: "{colors.primary-muted}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.xs}"
+  accent-quiet:
+    backgroundColor: "{colors.primary-surface}"
+    textColor: "{colors.accent-secondary}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.sm}"
+  status-success:
+    backgroundColor: "{colors.success}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.pill}"
+    padding: "{spacing.sm}"
+  status-warning:
+    backgroundColor: "{colors.warning}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.pill}"
+    padding: "{spacing.sm}"
+  status-danger:
+    backgroundColor: "{colors.danger}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.pill}"
+    padding: "{spacing.sm}"
+  light-shell:
+    backgroundColor: "{colors.light-background}"
+    textColor: "{colors.light-text}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  light-frame:
+    backgroundColor: "{colors.light-card}"
+    textColor: "{colors.light-text}"
+    rounded: "{rounded.card}"
+    padding: "{spacing.md}"
+  light-panel:
+    backgroundColor: "{colors.light-panel}"
+    textColor: "{colors.light-text}"
+    rounded: "{rounded.panel}"
+    padding: "{spacing.lg}"
+  light-muted-label:
+    backgroundColor: "{colors.light-card}"
+    textColor: "{colors.light-muted}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.xs}"
+  light-button-primary:
+    backgroundColor: "{colors.light-accent}"
+    textColor: "{colors.light-card}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  classic-button-primary:
+    backgroundColor: "{colors.classic-accent}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  slate-button-primary:
+    backgroundColor: "{colors.slate-accent}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+---
+
+## Overview
+
+Hermes Workspace should feel like an operational command center with an editorial museum-catalog finish: calm, precise, legible, and capable. The product is for people who spend time inside agent workflows, so the interface should reward repeated use rather than perform like a marketing page.
+
+The default visual identity is Hermes Nous: deep teal architecture, warm cream text, and an amber action accent. Secondary themes are allowed, but new UI should use the same underlying grammar: restrained surfaces, compact hierarchy, thin rules, and deliberate accent use.
+
+## Colors
+
+Use the Hermes Nous palette as the primary brand language.
+
+- Deep Teal Foundation (#041C1C): page background and deepest shell chrome.
+- Teal Panel (#06282A): sidebars, persistent panels, chat surfaces, and composer areas.
+- Teal Card (#082F31): standard cards and framed content.
+- Raised Teal (#0A3638): selected rows, nested surfaces, and slightly elevated cards.
+- Warm Cream (#FFE6CB): primary text in dark mode and the signature Hermes color.
+- Amber Signal (#FFAC02): primary actions, focus rings, active states, and important live activity.
+- Cobalt Light Accent (#2557B7): primary accent for light themes, where amber should be reserved for warning or brand moments.
+
+Semantic color use:
+
+- Success is reserved for completed work, healthy services, and verified states.
+- Warning is reserved for attention-needed states, not decorative emphasis.
+- Danger is reserved for destructive actions, failed checks, auth failures, and irreversible operations.
+
+Avoid rainbow dashboards. Hermes can show complex system state without every panel getting its own accent family.
+
+## Typography
+
+Inter is the product typeface. It carries the dense operational UI: chat, tables, forms, nav, controls, and settings. Use normal letter spacing for readable text.
+
+EB Garamond is a rare display accent. Use it for splash screens, empty states, large editorial metrics, and moments where Hermes needs a little ceremony. Do not use it inside dense panels, tables, buttons, or sidebars.
+
+JetBrains Mono is for code, terminal output, paths, command names, model IDs, tokens, and literal values.
+
+Micro-labels are uppercase, small, and widely tracked. They should label operational groups, metrics, sections, and status clusters. They should not become body copy.
+
+## Layout
+
+Hermes is a workspace, not a landing page. Prefer dense but calm layouts built from full-height regions, split panes, drawers, tabs, and toolbars.
+
+Use stable dimensions for repeated operational surfaces: chat panes, kanban columns, session rows, terminal panels, KPI cards, and file lists. Hover, loading, streaming, and selected states should not resize the layout.
+
+Whitespace should create scannability, not decoration. Use tighter spacing inside panels and more breathing room only between major regions.
+
+On mobile, preserve the same information architecture with stacked panels, drawers, and reachable controls. Do not simplify away core workflows.
+
+## Elevation & Depth
+
+Depth is architectural, not glossy. Standard surfaces should use 1px borders and very soft shadows. In light themes, prefer inset highlights and borders over heavy drop shadows.
+
+Use real elevation only for modals, popovers, toasts, command palettes, active drags, and other floating UI. Avoid stacked cards inside cards.
+
+Streaming and live-agent states may use glow, but keep it subtle and tied to activity. Glow is not a background decoration.
+
+## Shapes
+
+Default cards are square-ish: 6px for compact cards, 8px for panels, 10px for dialogs. Pills are for badges, segmented selections, compact status indicators, and avatar-like affordances.
+
+Avoid large, soft SaaS rounding unless a specific mobile control or floating overlay needs it. Hermes should feel precise and built, not bubbly.
+
+## Components
+
+Buttons are compact and explicit. Primary buttons use the theme accent and should be reserved for the main action in a region. Secondary buttons are framed and quiet. Icon buttons should use familiar icons with tooltips when the action is not obvious.
+
+Cards and panels are functional containers. Use `.frame`, `.frame-panel`, and `.frame-elevated` patterns where possible. Cards should not be decorative wrappers around whole page sections.
+
+Inputs and composers should feel steady and durable: framed surfaces, clear focus ring, readable placeholder text, and stable height during streaming or upload states.
+
+Tables, lists, queues, and kanban boards should prioritize scan speed. Use concise labels, aligned metadata, monospaced identifiers where useful, and calm selected states.
+
+Status badges should combine color, label, and sometimes icon. Do not rely on color alone.
+
+## Do's and Don'ts
+
+Do:
+
+- Reuse existing theme CSS variables before adding new colors.
+- Use Inter for functional UI and EB Garamond sparingly for editorial display.
+- Keep panels compact, aligned, and predictable.
+- Use thin borders, restrained shadows, and subtle activity glow.
+- Make complex agent state easy to scan.
+
+Don't:
+
+- Build marketing-style hero sections inside the app shell.
+- Add decorative gradient blobs, abstract orbs, or unrelated illustrations.
+- Introduce a new accent color for each feature.
+- Nest cards inside cards.
+- Let text, buttons, counters, or badges resize their parent layout on hover or loading.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 # ─── runtime stage ────────────────────────────────────────────────────────
 FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini \
+      ca-certificates curl tini python3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 workspace
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Features pending cloud infrastructure:
 
 - `HERMES_PASSWORD` — required whenever `HOST ≠ 127.0.0.1`
 - `COOKIE_SECURE=1` — force the `Secure` cookie flag when terminating HTTPS at a proxy
+- `COOKIE_SECURE=0` — required for plain HTTP LAN access on `HOST=0.0.0.0` so the browser will actually send the auth cookie
 - `TRUST_PROXY=1` — trust `x-forwarded-for` / `x-real-ip` (only set behind a sanitizing reverse proxy)
 - `HERMES_DASHBOARD_TOKEN` — explicit bearer for dashboard API (preferred over the legacy HTML-scrape fallback)
 - `HERMES_ALLOW_INSECURE_REMOTE=1` — bypass the fail-closed guard (not recommended)

--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ No local build. First run takes a minute to pull; subsequent starts are instant.
 Agent state (config, sessions, skills, memory, credentials) persists in the
 `hermes-data` named volume, so containers can be recreated without data loss.
 
+> **Skills Hub note:** the published `ghcr.io/outsourc-e/hermes-workspace` image
+> includes the bundled skills fallback. Full Marketplace / Skills Hub registry
+> search needs the Python `scripts/skills-search.py` runtime plus a Hermes Agent
+> source/install tree; use the source/dev Docker overlay or a derived image if
+> you need non-bundled hub results from an image-only deployment. The
+> `/api/skills/hub-search` response includes `source: "bundled-skills-fallback"`
+> and a `warning` when the container is running fallback-only mode.
+
 ### Step 3: Access the Workspace
 
 Open `http://localhost:3000` and complete the onboarding.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 - 🤖 **Hermes Agent Integration** — Direct gateway connection with real-time SSE streaming
 - 🎨 **8-Theme System** — Official, Classic, Slate, Mono — each with light and dark variants
+- 🧬 **DESIGN.md Visual System** — Shared design memory for agents building Hermes UI
 - 🔒 **Security Hardened** — Auth middleware on all API routes, CSP headers, exec approval prompts
 - 📱 **Mobile-First PWA** — Full feature parity on any device via Tailscale
 - ⚡ **Live SSE Streaming** — Real-time agent output with tool call rendering

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,23 @@
 
 If you discover a security vulnerability in Hermes Workspace, please report it responsibly.
 
-**Do NOT open a public GitHub issue for security vulnerabilities.**
+**Do not open a public GitHub issue for security vulnerabilities.** Public issues are for non-sensitive bugs only.
 
-Instead, report via [GitHub Security Advisories](https://github.com/outsourc-e/hermes-workspace/security/advisories) or DM [@ericousodev on X](https://x.com/ericousodev).
+Preferred disclosure channels:
+
+1. [GitHub Private Vulnerability Reporting / Security Advisories](https://github.com/outsourc-e/hermes-workspace/security/advisories/new)
+2. Email: [security@buildingthefuture.io](mailto:security@buildingthefuture.io)
+
+If GitHub reports that private vulnerability reporting is disabled, use the email address above and include enough detail for maintainers to reproduce the issue safely.
+
+Maintainer action required: GitHub private vulnerability reporting is controlled in repository settings under **Settings → Code security and analysis → Private vulnerability reporting**. That setting must be enabled by a repository administrator; this policy file provides the public fallback channel but does not change the repository setting.
+
+Please include:
+
+- affected version, commit, or deployment mode
+- reproduction steps or a proof-of-concept, if safe to share
+- expected impact and affected data/systems
+- any suggested remediation or mitigation
 
 We will acknowledge your report within 48 hours and aim to provide a fix within 7 days for critical issues.
 

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm
 
 WORKDIR /app

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,42 @@ This means the Vite SSR server tried `GET /api/gateway-status` which internally 
 
 ---
 
+### Docker: Skills Hub / Marketplace only shows bundled skills
+
+The published `ghcr.io/outsourc-e/hermes-workspace` image is intentionally
+self-contained for the Workspace UI and bundled skills. It does **not** include a
+full Hermes Agent source checkout plus Python Skills Hub dependencies for
+non-bundled registry search.
+
+When full hub search is unavailable, `GET /api/skills/hub-search` falls back to
+installed/bundled skills and returns:
+
+```json
+{
+  "source": "bundled-skills-fallback",
+  "warning": "Skills Hub search is unavailable in this runtime; showing bundled skills fallback."
+}
+```
+
+To enable full Marketplace / Skills Hub registry search in Docker, use one of:
+
+1. The source/dev overlay, which builds from local source:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+   ```
+
+2. A derived image that adds `python3`, `scripts/skills-search.py`, and the
+   Hermes Agent Python package/source tree expected by the search script.
+
+3. A host-mounted Hermes Agent checkout plus matching environment variables, if
+   your deployment platform supports bind mounts.
+
+If you only need the skills bundled with the Workspace image, no action is
+required; the fallback mode is expected.
+
+---
+
 ## Diagnostic bundle
 
 If nothing above helps, run this and share the output:

--- a/scripts/company_os_gmail_snapshot.py
+++ b/scripts/company_os_gmail_snapshot.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Refresh the local Company OS Gmail lead snapshot.
+
+This uses the existing readonly Gmail OAuth token on this machine and writes a
+small, cleaned cache for the dashboard. It never sends, labels, archives, or
+modifies email.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import google.auth.transport.requests
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+CLIENT_SECRET_FILE = Path("~/.config/google-credentials/client_secret.json").expanduser()
+TOKEN_FILE = Path("~/.config/google-credentials/gmail-token.json").expanduser()
+DEFAULT_QUERY = (
+    '("Follow Up From X" OR "Collaboration Inquiry for 360" OR "Paid Collaboration" '
+    'OR "paid collab" OR "sponsorship information" OR "quote rates" OR '
+    '"thread post" OR "Robert\'s rate" OR "Scobleizer\'s manager") '
+    "newer_than:30d -in:spam -in:trash -category:promotions"
+)
+QUOTE_MARKERS = (
+    "\nOn ",
+    "\n> On ",
+    "\n---------- Forwarded message",
+    "\nFrom: ",
+    "\nSent from ",
+)
+
+
+def get_gmail_service():
+    creds = None
+    if TOKEN_FILE.exists():
+        creds = Credentials.from_authorized_user_file(str(TOKEN_FILE), SCOPES)
+
+    if not creds:
+        flow = InstalledAppFlow.from_client_secrets_file(str(CLIENT_SECRET_FILE), SCOPES)
+        creds = flow.run_local_server(port=0)
+        TOKEN_FILE.write_text(creds.to_json())
+
+    if creds.expired and creds.refresh_token:
+        creds.refresh(google.auth.transport.requests.Request())
+        TOKEN_FILE.write_text(creds.to_json())
+
+    return build("gmail", "v1", credentials=creds)
+
+
+def header_value(payload, name):
+    for header in payload.get("headers", []):
+        if header.get("name", "").lower() == name.lower():
+            return header.get("value", "")
+    return ""
+
+
+def decode_part_body(part):
+    data = part.get("body", {}).get("data")
+    if not data:
+        return ""
+    try:
+        return base64.urlsafe_b64decode(data.encode("utf-8")).decode(
+            "utf-8", errors="replace"
+        )
+    except Exception:
+        return ""
+
+
+def extract_text(payload):
+    mime_type = payload.get("mimeType", "")
+    if mime_type == "text/plain":
+        return decode_part_body(payload)
+
+    for part in payload.get("parts", []) or []:
+        text = extract_text(part)
+        if text:
+            return text
+
+    if not payload.get("parts"):
+        return decode_part_body(payload)
+
+    return ""
+
+
+def clean_body(body, limit=900):
+    text = re.sub(r"\r\n?", "\n", body or "").strip()
+    for marker in QUOTE_MARKERS:
+        index = text.find(marker)
+        if index > 80:
+            text = text[:index].strip()
+            break
+
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    if len(text) > limit:
+        text = text[: limit - 1].rstrip() + "..."
+    return text or "No readable plain-text body found."
+
+
+def parse_ts(value, fallback_ms=None):
+    if value:
+        try:
+            return parsedate_to_datetime(value).isoformat()
+        except Exception:
+            pass
+    if fallback_ms:
+        return datetime.fromtimestamp(int(fallback_ms) / 1000, timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat()
+
+
+def message_to_snapshot(message):
+    payload = message.get("payload", {})
+    subject = header_value(payload, "Subject")
+    from_ = header_value(payload, "From")
+    to = header_value(payload, "To")
+    cc = header_value(payload, "Cc")
+    date = header_value(payload, "Date")
+    attachments = []
+
+    def walk_parts(part):
+        filename = part.get("filename")
+        if filename:
+            attachments.append(filename)
+        for child in part.get("parts", []) or []:
+            walk_parts(child)
+
+    walk_parts(payload)
+
+    return {
+        "id": message.get("id", ""),
+        "from": from_ or "Unknown sender",
+        "to": [item.strip() for item in to.split(",") if item.strip()],
+        "cc": [item.strip() for item in cc.split(",") if item.strip()],
+        "timestamp": parse_ts(date, message.get("internalDate")),
+        "subject": subject,
+        "body": clean_body(extract_text(payload)),
+        "attachments": attachments,
+    }
+
+
+def classify_kind(subject, from_, body):
+    haystack = f"{subject} {from_} {body}".lower()
+    if re.search(r"receipt|invoice|payment|stripe", haystack):
+        return "expense" if "receipt" in haystack else "lead"
+    if re.search(r"sponsor|collaboration|paid|rates|quote|follow up|qrt|thread", haystack):
+        return "lead"
+    if re.search(r"briefing|webinar|invitation|nvidia|handoff", haystack):
+        return "handoff"
+    return "lead"
+
+
+def needs_for(kind, subject, latest_body):
+    haystack = f"{subject} {latest_body}".lower()
+    if kind == "expense":
+        return "Classify as expense/receipt, not client revenue invoice."
+    if "qrt" in haystack or "kombai" in haystack:
+        return "Confirm timing, product test requirements, and posting window before any commitment."
+    if "rates" in haystack or "quote" in haystack or "paid" in haystack:
+        return "Track as active sponsorship lead and confirm follow-up owner."
+    if kind == "handoff":
+        return "Mark as low-risk access/admin item unless a reply is required."
+    return "Review thread, assign owner, and draft next reply for approval."
+
+
+def status_for(kind, subject):
+    if kind == "expense":
+        return "Finance signal; review before moving invoice or payment status."
+    if kind == "handoff":
+        return "Handoff/admin signal; review whether action is required."
+    if "follow up from x" in subject.lower():
+        return "Active sponsorship lead; timing and product-use comfort need review."
+    return "Active inbound lead; review thread before replying."
+
+
+def read_threads(service, query, max_threads, max_messages):
+    results = (
+        service.users()
+        .messages()
+        .list(userId="me", q=query, maxResults=max_threads * 3)
+        .execute()
+    )
+    seen_threads = []
+    for ref in results.get("messages", []):
+        thread_id = ref.get("threadId")
+        if thread_id and thread_id not in seen_threads:
+            seen_threads.append(thread_id)
+        if len(seen_threads) >= max_threads:
+            break
+
+    signals = []
+    for thread_id in seen_threads:
+        thread = (
+            service.users()
+            .threads()
+            .get(userId="me", id=thread_id, format="full")
+            .execute()
+        )
+        messages = [message_to_snapshot(item) for item in thread.get("messages", [])]
+        if not messages:
+            continue
+
+        kept_messages = messages[-max_messages:]
+        latest = messages[-1]
+        first = messages[0]
+        subject = latest.get("subject") or first.get("subject") or "Gmail thread"
+        latest_body = latest.get("body", "")
+        kind = classify_kind(subject, latest.get("from", ""), latest_body)
+
+        signals.append(
+            {
+                "kind": kind,
+                "subject": subject,
+                "from": latest.get("from", ""),
+                "timestamp": latest.get("timestamp"),
+                "summary": latest_body[:240],
+                "needs": needs_for(kind, subject, latest_body),
+                "threadId": thread_id,
+                "messageId": latest.get("id"),
+                "gmailUrl": f"https://mail.google.com/mail/u/0/#inbox/{thread_id}",
+                "thread": {
+                    "status": status_for(kind, subject),
+                    "latestAction": f"Latest message from {latest.get('from', 'unknown sender')}: {latest_body[:220]}",
+                    "messages": kept_messages,
+                },
+            }
+        )
+
+    return signals
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--slug", default="unalignedos")
+    parser.add_argument("--query", default=DEFAULT_QUERY)
+    parser.add_argument("--max-threads", type=int, default=8)
+    parser.add_argument("--max-messages", type=int, default=6)
+    args = parser.parse_args()
+
+    service = get_gmail_service()
+    signals = read_threads(service, args.query, args.max_threads, args.max_messages)
+    target = Path("~/.hermes/company-os").expanduser() / args.slug / "live" / "email-signals.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "updatedAt": datetime.now(timezone.utc).isoformat(),
+        "refreshMode": "gmail-readonly",
+        "scope": args.query,
+        "signals": signals,
+    }
+    target.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n")
+    print(json.dumps({"ok": True, "path": str(target), "count": len(signals)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/hermes-ui/SKILL.md
+++ b/skills/hermes-ui/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: hermes-ui
+description: Build or revise Hermes Workspace UI using the shared DESIGN.md visual system, existing theme variables, and operational workspace patterns.
+---
+
+# Hermes UI
+
+Use this skill whenever creating or changing Hermes Workspace screens, components, dashboards, settings, chat surfaces, memory views, job views, or agent orchestration UI.
+
+## Source of Truth
+
+Read `/Users/asherweisberger/hermes-workspace/DESIGN.md` before making UI decisions. Treat it as the visual contract for colors, typography, spacing, shape, density, component behavior, and motion.
+
+Also inspect nearby existing components and `/Users/asherweisberger/hermes-workspace/src/styles.css` before adding new styles. Prefer the existing theme variables:
+
+- `--theme-bg`
+- `--theme-sidebar`
+- `--theme-panel`
+- `--theme-card`
+- `--theme-card2`
+- `--theme-border`
+- `--theme-border-subtle`
+- `--theme-text`
+- `--theme-muted`
+- `--theme-accent`
+- `--theme-accent-subtle`
+- `--theme-accent-border`
+
+## UI Direction
+
+Hermes should feel like an operational command center with an editorial finish. Build dense, calm, highly scannable interfaces for repeated use. Favor panes, frames, rows, tabs, toolbars, drawers, and stable lists over decorative marketing composition.
+
+Use the established utility vocabulary where it fits:
+
+- `.micro-label` for compact uppercase section labels.
+- `.editorial-display` for rare display moments.
+- `.numeral-display` for hero metrics.
+- `.frame`, `.frame-panel`, and `.frame-elevated` for framed surfaces.
+- `.editorial-rule` and `.editorial-rule-double` for major dividers.
+
+## Rules
+
+- Use existing theme variables instead of hardcoded colors unless adding a true design token.
+- Keep cards at 6-8px radius in normal app surfaces.
+- Use real elevation only for floating UI such as modals, popovers, command palettes, and toasts.
+- Keep text readable and stable across mobile and desktop.
+- Preserve layout dimensions during loading, streaming, hover, selection, and empty states.
+- Use icons for tool actions when an icon exists, with accessible labels or tooltips.
+- Do not add decorative gradient blobs, abstract orbs, nested cards, or one-off accent palettes.
+- Do not turn app screens into landing pages.
+
+## Verification
+
+Before finishing a UI change, check:
+
+- The screen still works in both Hermes Nous dark and light variants.
+- Text does not overlap or overflow its controls.
+- The layout remains stable during loading, empty, selected, and streaming states.
+- The change reuses existing component patterns where reasonable.

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -7,6 +7,7 @@ import {
   ArrowDown01Icon,
   ArrowUp01Icon,
   BrainIcon,
+  Building02Icon,
   Chat01Icon,
   CommandLineIcon,
   File01Icon,
@@ -185,6 +186,15 @@ export function CommandPalette({ pathname, sessions }: CommandPaletteProps) {
         shortcut: 'Go',
         icon: CommandLineIcon,
         onSelect: () => void navigate({ to: '/terminal' }),
+      },
+      {
+        id: 'screen-company-os-beta',
+        group: 'Screens',
+        label: 'Company OS Beta',
+        keywords: 'company operator business founder workspace tasks docs site beta',
+        shortcut: 'Go',
+        icon: Building02Icon,
+        onSelect: () => void navigate({ to: '/company-os-beta' }),
       },
       {
         id: 'screen-memory',

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   BrainIcon,
+  Building02Icon,
   Cancel01Icon,
   Chat01Icon,
   Clock01Icon,
@@ -65,6 +66,13 @@ const NAV_ITEMS = [
     icon: UserGroupIcon,
     to: '/operations',
     match: (p: string) => p.startsWith('/operations'),
+  },
+  {
+    id: 'company-os-beta',
+    label: 'Company OS Beta',
+    icon: Building02Icon,
+    to: '/company-os-beta',
+    match: (p: string) => p.startsWith('/company-os-beta'),
   },
   {
     id: 'memory',

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type Props = {
   open: boolean
@@ -34,17 +35,19 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-function formatUpdatedAt(updatedAt?: number): string {
+function formatUpdatedAt(
+  updatedAt: number | undefined,
+  use24HourTime: boolean,
+): string {
   if (typeof updatedAt !== 'number') return ''
   const value = new Date(updatedAt)
   const now = new Date()
   if (value.toDateString() === now.toDateString()) {
-    return timeFormatter.format(value)
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: !use24HourTime,
+    }).format(value)
   }
   return dayFormatter.format(value)
 }
@@ -57,6 +60,10 @@ export function MobileSessionsPanel({
   onSelectSession,
   onNewChat,
 }: Props) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+
   useEffect(() => {
     if (!open) return
     function handleKeyDown(event: KeyboardEvent) {
@@ -120,7 +127,10 @@ export function MobileSessionsPanel({
               <div className="space-y-1">
                 {sessions.map((session) => {
                   const active = session.friendlyId === activeFriendlyId
-                  const timestamp = formatUpdatedAt(session.updatedAt)
+                  const timestamp = formatUpdatedAt(
+                    session.updatedAt,
+                    use24HourTime,
+                  )
                   return (
                     <button
                       key={session.key}

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1229,6 +1229,16 @@ function ChatContent() {
           />
         </Row>
         <Row
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={cs.use24HourTime}
+            onCheckedChange={(c) => updateCS({ use24HourTime: c })}
+            aria-label="Use 24-hour time"
+          />
+        </Row>
+        <Row
           label="Enter key behavior"
           description={
             cs.enterBehavior === 'newline'
@@ -1971,7 +1981,7 @@ export function SettingsDialog({
 
   return (
     <DialogRoot open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="inset-0 h-full w-full max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:inset-auto md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
+      <DialogContent className="left-0 top-0 h-[100dvh] w-screen max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 shadow-xl md:left-1/2 md:top-1/2 md:h-[min(88dvh,740px)] md:min-h-[520px] md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl md:border md:border-primary-200 bg-[var(--theme-bg)]">
         <div className="flex h-full min-h-0 flex-col">
           <div className="flex items-center justify-between border-b border-primary-200 bg-primary-50/80 px-4 py-4 md:rounded-t-2xl md:px-5">
             <div>

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -82,6 +82,7 @@ const SECTIONS: Array<{ id: SectionId; label: string; icon: any }> = [
 ]
 
 const DARK_ENTERPRISE_THEMES = new Set<ThemeId>([
+  'hermes-codex',
   'hermes-nous',
   'hermes-official',
   'hermes-classic',
@@ -908,6 +909,7 @@ function AppearanceContent() {
 }
 
 const ENTERPRISE_THEME_FAMILIES: Array<ThemeId> = [
+  'hermes-codex',
   'hermes-nous',
   'hermes-official',
   'hermes-classic',
@@ -918,7 +920,15 @@ const ENTERPRISE_THEMES = THEMES.map((theme) => ({
   ...theme,
   desc: theme.description,
   preview:
-    theme.id === 'hermes-nous'
+    theme.id === 'hermes-codex'
+      ? {
+          bg: '#0d0d0d',
+          panel: '#1a1a1a',
+          border: '#2d2d2d',
+          accent: '#f97316',
+          text: '#e5e5e5',
+        }
+      : theme.id === 'hermes-nous'
       ? {
           bg: '#041C1C',
           panel: '#06282A',

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -284,6 +284,24 @@ export function TerminalPanel({ isMobile }: TerminalPanelProps) {
             )
             continue
           }
+          if (currentEvent === 'exit' || currentEvent === 'close') {
+            // Server reported the PTY is gone. Clear the tab's sessionId so
+            // any subsequent /api/terminal-input or /api/terminal-resize
+            // calls don't fire against a dead session and 404. (#80)
+            const exitInfo =
+              currentEvent === 'exit' && typeof payload === 'object'
+                ? ` (exit code ${payload?.code ?? '?'}${payload?.signal ? `, signal ${payload.signal}` : ''})`
+                : ''
+            terminal.writeln(`\r\n\x1b[2m[session ended${exitInfo}]\x1b[0m`)
+            terminal.writeln(`\x1b[2m[click + to open a new tab, or reload to retry]\x1b[0m`)
+            setTabs((prev) =>
+              prev.map((tab) =>
+                tab.id === tabId ? { ...tab, sessionId: undefined } : tab,
+              ),
+            )
+            sessionId = undefined
+            continue
+          }
           if (currentEvent === 'data') {
             const textChunk =
               payload?.data ??

--- a/src/components/usage-meter/context-alert-modal.tsx
+++ b/src/components/usage-meter/context-alert-modal.tsx
@@ -121,7 +121,7 @@ function ContextAlertModalComponent({
               )}
               <Recommendation
                 icon="🗜️"
-                text="Enable auto-compaction in Settings → Config to automatically manage context"
+                text="Auto-compaction is configured in ~/.hermes/config.yaml under the compression section"
               />
               <Recommendation
                 icon="📋"

--- a/src/components/usage-meter/usage-details-modal.tsx
+++ b/src/components/usage-meter/usage-details-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { formatModelName } from '@/lib/format-model-name'
 
 type ModelUsage = {
@@ -81,10 +82,10 @@ function formatTokens(value: number): string {
   return Math.round(value).toString()
 }
 
-function formatTimestamp(value?: number): string {
+function formatTimestamp(value: number | undefined, use24HourTime: boolean): string {
   if (!value) return '—'
   const date = new Date(value < 1_000_000_000_000 ? value * 1000 : value)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: !use24HourTime })
 }
 
 function formatResetTime(iso?: string): string {
@@ -259,7 +260,7 @@ function buildCsv(usage: UsageSummary): string {
   )
   usage.sessions.forEach((session) => {
     rows.push(
-      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt)},${formatTimestamp(session.updatedAt)}`,
+      `${session.id},${session.model},${session.inputTokens},${session.outputTokens},${session.costUsd.toFixed(4)},${formatTimestamp(session.startedAt, use24HourTime)},${formatTimestamp(session.updatedAt, use24HourTime)}`,
     )
   })
   return rows.join('\n')
@@ -441,8 +442,8 @@ export function UsageDetailsModal({
                         {formatTokens(session.outputTokens)} out
                       </div>
                       <div className="text-xs text-primary-500">
-                        {formatTimestamp(session.startedAt)} →{' '}
-                        {formatTimestamp(session.updatedAt)}
+                        {formatTimestamp(session.startedAt, use24HourTime)} →{' '}
+                        {formatTimestamp(session.updatedAt, use24HourTime)}
                       </div>
                       <div className="font-semibold text-primary-900">
                         {formatCurrency(session.costUsd)}
@@ -473,7 +474,7 @@ export function UsageDetailsModal({
             <div className="flex items-center justify-between gap-3">
               <div className="text-xs text-primary-500">
                 Auto-polls every 30s · Last updated{' '}
-                {formatTimestamp(providerUpdatedAt ?? undefined)}
+                {formatTimestamp(providerUpdatedAt ?? undefined, use24HourTime)}
               </div>
               <Button
                 size="sm"
@@ -529,7 +530,7 @@ export function UsageDetailsModal({
                         <div className="flex items-center gap-2">
                           {statusBadge(provider.status)}
                           <span className="text-[10px] text-primary-400">
-                            {formatTimestamp(provider.updatedAt)}
+                            {formatTimestamp(provider.updatedAt, use24HourTime)}
                           </span>
                         </div>
                       </div>

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -11,10 +11,9 @@
  * Chat routes get the full ChatScreen treatment.
  * Non-chat routes show the sub-page content.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { Suspense, lazy } from 'react'
 import type { SessionMeta } from '@/screens/chat/types'
 import type { AuthStatus } from '@/lib/hermes-auth'
 import { cn } from '@/lib/utils'
@@ -77,8 +76,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   const { settings } = useSettings()
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
+  const sidebarPinned = useWorkspaceStore((s) => s.sidebarPinned)
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
+  const toggleSidebarPinned = useWorkspaceStore((s) => s.toggleSidebarPinned)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
@@ -150,7 +151,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed && !sidebarPinned
 
   // Sessions query — shared across sidebar and chat
   const sessionsQuery = useQuery({
@@ -311,7 +312,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 creatingSession={creatingSession}
                 onCreateSession={startNewChat}
                 isCollapsed={sidebarCollapsed}
+                isPinned={sidebarPinned}
                 onToggleCollapse={toggleSidebar}
+                onTogglePinned={toggleSidebarPinned}
                 onSelectSession={handleSelectSession}
                 onActiveSessionDelete={handleActiveSessionDelete}
                 sessionsLoading={sessionsLoading}

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -105,10 +105,12 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (path.startsWith('/jobs')) return 4
     if (path.startsWith('/conductor')) return 5
     if (path.startsWith('/operations')) return 6
-    if (path.startsWith('/memory')) return 7
-    if (path.startsWith('/skills')) return 8
-    if (path.startsWith('/profiles')) return 9
-    if (path.startsWith('/settings')) return 10
+    if (path.startsWith('/company-os-beta')) return 7
+    if (path.startsWith('/company-os')) return 7
+    if (path.startsWith('/memory')) return 8
+    if (path.startsWith('/skills')) return 9
+    if (path.startsWith('/profiles')) return 10
+    if (path.startsWith('/settings')) return 11
     return -1
   }, [])
 
@@ -136,6 +138,8 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (pathname.startsWith('/jobs')) return 'Jobs'
     if (pathname.startsWith('/conductor')) return 'Conductor'
     if (pathname.startsWith('/operations')) return 'Operations'
+    if (pathname.startsWith('/company-os-beta')) return 'Company OS Beta'
+    if (pathname.startsWith('/company-os')) return 'Company OS'
     if (pathname.startsWith('/memory')) return 'Memory'
     if (pathname.startsWith('/skills')) return 'Skills'
     if (pathname.startsWith('/profiles')) return 'Profiles'

--- a/src/hooks/use-chat-settings.ts
+++ b/src/hooks/use-chat-settings.ts
@@ -53,6 +53,7 @@ export type ChatSettings = {
    * surprised by sound on next page load.
    */
   soundOnChatComplete: boolean
+  use24HourTime: boolean
 }
 
 type ChatSettingsState = {
@@ -72,6 +73,7 @@ function defaultChatSettings(): ChatSettings {
     chatWidth: 'comfortable',
     sidebarHoverExpand: false,
     soundOnChatComplete: false,
+    use24HourTime: false,
   }
 }
 

--- a/src/lib/jobs-api.test.ts
+++ b/src/lib/jobs-api.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeJobsResponse } from './jobs-api'
+import type { HermesJob } from './jobs-api'
+
+const job = {
+  id: 'job-1',
+  name: 'Example job',
+  prompt: 'Run the example job',
+  schedule: {},
+  enabled: true,
+  state: 'scheduled',
+} satisfies HermesJob
+
+describe('normalizeJobsResponse', () => {
+  it('accepts dashboard cron jobs returned as a top-level array', () => {
+    expect(normalizeJobsResponse([job])).toEqual([job])
+  })
+
+  it('accepts gateway jobs returned in an object wrapper', () => {
+    expect(normalizeJobsResponse({ jobs: [job] })).toEqual([job])
+  })
+
+  it('falls back to an empty list for unexpected payloads', () => {
+    expect(normalizeJobsResponse({ jobs: null })).toEqual([])
+  })
+})

--- a/src/lib/jobs-api.ts
+++ b/src/lib/jobs-api.ts
@@ -30,11 +30,24 @@ export type JobOutput = {
   size: number
 }
 
+export function normalizeJobsResponse(data: unknown): Array<HermesJob> {
+  if (Array.isArray(data)) return data
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'jobs' in data &&
+    Array.isArray(data.jobs)
+  ) {
+    return data.jobs as Array<HermesJob>
+  }
+  return []
+}
+
 export async function fetchJobs(): Promise<Array<HermesJob>> {
   const res = await fetch(`${HERMES_API}?include_disabled=true`)
   if (!res.ok) throw new Error(`Failed to fetch jobs: ${res.status}`)
-  const data = await res.json()
-  return data.jobs ?? []
+  const data = (await res.json()) as unknown
+  return normalizeJobsResponse(data)
 }
 
 export async function createJob(input: {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,5 @@
 export type ThemeId =
+  | 'hermes-codex'
   | 'hermes-nous'
   | 'hermes-nous-light'
   | 'hermes-official'
@@ -14,6 +15,12 @@ export const THEMES: Array<{
   description: string
   icon: string
 }> = [
+  {
+    id: 'hermes-codex',
+    label: 'Codex',
+    description: 'Pure black terminal aesthetic — Codex / Claude Code look and feel',
+    icon: '⬛',
+  },
   {
     id: 'hermes-nous',
     label: 'Hermes Nous',
@@ -65,12 +72,13 @@ export const THEMES: Array<{
 ]
 
 const STORAGE_KEY = 'hermes-theme'
-const DEFAULT_THEME: ThemeId = 'hermes-nous'
+const DEFAULT_THEME: ThemeId = 'hermes-codex'
 const THEME_SET = new Set<ThemeId>(THEMES.map((theme) => theme.id))
 const LIGHT_THEME_MAP: Record<
   Exclude<ThemeId, `${string}-light`>,
   Extract<ThemeId, `${string}-light`>
 > = {
+  'hermes-codex': 'hermes-nous-light',
   'hermes-nous': 'hermes-nous-light',
   'hermes-official': 'hermes-official-light',
   'hermes-classic': 'hermes-classic-light',
@@ -80,7 +88,7 @@ const DARK_THEME_MAP: Record<
   Extract<ThemeId, `${string}-light`>,
   Exclude<ThemeId, `${string}-light`>
 > = {
-  'hermes-nous-light': 'hermes-nous',
+  'hermes-nous-light': 'hermes-codex',
   'hermes-official-light': 'hermes-official',
   'hermes-classic-light': 'hermes-classic',
   'hermes-slate-light': 'hermes-slate',

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,7 +47,9 @@ import { Route as ApiPathsRouteImport } from './routes/api/paths'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
+import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesUpdateRouteImport } from './routes/api/hermes-update'
 import { Route as ApiHermesTasksAssigneesRouteImport } from './routes/api/hermes-tasks-assignees'
 import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
 import { Route as ApiHermesJobsRouteImport } from './routes/api/hermes-jobs'
@@ -287,9 +289,19 @@ const ApiLocalProvidersRoute = ApiLocalProvidersRouteImport.update({
   path: '/api/local-providers',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiIntegrationsRoute = ApiIntegrationsRouteImport.update({
+  id: '/api/integrations',
+  path: '/api/integrations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHistoryRoute = ApiHistoryRouteImport.update({
   id: '/api/history',
   path: '/api/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHermesUpdateRoute = ApiHermesUpdateRouteImport.update({
+  id: '/api/hermes-update',
+  path: '/api/hermes-update',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHermesTasksAssigneesRoute = ApiHermesTasksAssigneesRouteImport.update({
@@ -565,7 +577,9 @@ export interface FileRoutesByFullPath {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -653,7 +667,9 @@ export interface FileRoutesByTo {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -743,7 +759,9 @@ export interface FileRoutesById {
   '/api/hermes-jobs': typeof ApiHermesJobsRouteWithChildren
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/hermes-tasks-assignees': typeof ApiHermesTasksAssigneesRoute
+  '/api/hermes-update': typeof ApiHermesUpdateRoute
   '/api/history': typeof ApiHistoryRoute
+  '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
@@ -834,7 +852,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -922,7 +942,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1011,7 +1033,9 @@ export interface FileRouteTypes {
     | '/api/hermes-jobs'
     | '/api/hermes-tasks'
     | '/api/hermes-tasks-assignees'
+    | '/api/hermes-update'
     | '/api/history'
+    | '/api/integrations'
     | '/api/local-providers'
     | '/api/memory'
     | '/api/models'
@@ -1101,7 +1125,9 @@ export interface RootRouteChildren {
   ApiHermesJobsRoute: typeof ApiHermesJobsRouteWithChildren
   ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
   ApiHermesTasksAssigneesRoute: typeof ApiHermesTasksAssigneesRoute
+  ApiHermesUpdateRoute: typeof ApiHermesUpdateRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
+  ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
@@ -1413,11 +1439,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiLocalProvidersRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/integrations': {
+      id: '/api/integrations'
+      path: '/api/integrations'
+      fullPath: '/api/integrations'
+      preLoaderRoute: typeof ApiIntegrationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/history': {
       id: '/api/history'
       path: '/api/history'
       fullPath: '/api/history'
       preLoaderRoute: typeof ApiHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/hermes-update': {
+      id: '/api/hermes-update'
+      path: '/api/hermes-update'
+      fullPath: '/api/hermes-update'
+      preLoaderRoute: typeof ApiHermesUpdateRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/hermes-tasks-assignees': {
@@ -1881,7 +1921,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHermesJobsRoute: ApiHermesJobsRouteWithChildren,
   ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
   ApiHermesTasksAssigneesRoute: ApiHermesTasksAssigneesRoute,
+  ApiHermesUpdateRoute: ApiHermesUpdateRoute,
   ApiHistoryRoute: ApiHistoryRoute,
+  ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-str
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
 import { Route as ApiTerminalCloseRouteImport } from './routes/api/terminal-close'
+import { Route as ApiSwarmKanbanRouteImport } from './routes/api/swarm-kanban'
 import { Route as ApiStartHermesRouteImport } from './routes/api/start-hermes'
 import { Route as ApiStartAgentRouteImport } from './routes/api/start-agent'
 import { Route as ApiSkillsRouteImport } from './routes/api/skills'
@@ -212,6 +213,11 @@ const ApiTerminalInputRoute = ApiTerminalInputRouteImport.update({
 const ApiTerminalCloseRoute = ApiTerminalCloseRouteImport.update({
   id: '/api/terminal-close',
   path: '/api/terminal-close',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSwarmKanbanRoute = ApiSwarmKanbanRouteImport.update({
+  id: '/api/swarm-kanban',
+  path: '/api/swarm-kanban',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiStartHermesRoute = ApiStartHermesRouteImport.update({
@@ -595,6 +601,7 @@ export interface FileRoutesByFullPath {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -685,6 +692,7 @@ export interface FileRoutesByTo {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -777,6 +785,7 @@ export interface FileRoutesById {
   '/api/skills': typeof ApiSkillsRouteWithChildren
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-hermes': typeof ApiStartHermesRoute
+  '/api/swarm-kanban': typeof ApiSwarmKanbanRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -870,6 +879,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -960,6 +970,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1051,6 +1062,7 @@ export interface FileRouteTypes {
     | '/api/skills'
     | '/api/start-agent'
     | '/api/start-hermes'
+    | '/api/swarm-kanban'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1143,6 +1155,7 @@ export interface RootRouteChildren {
   ApiSkillsRoute: typeof ApiSkillsRouteWithChildren
   ApiStartAgentRoute: typeof ApiStartAgentRoute
   ApiStartHermesRoute: typeof ApiStartHermesRoute
+  ApiSwarmKanbanRoute: typeof ApiSwarmKanbanRoute
   ApiTerminalCloseRoute: typeof ApiTerminalCloseRoute
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
@@ -1332,6 +1345,13 @@ declare module '@tanstack/react-router' {
       path: '/api/terminal-close'
       fullPath: '/api/terminal-close'
       preLoaderRoute: typeof ApiTerminalCloseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/swarm-kanban': {
+      id: '/api/swarm-kanban'
+      path: '/api/swarm-kanban'
+      fullPath: '/api/swarm-kanban'
+      preLoaderRoute: typeof ApiSwarmKanbanRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/start-hermes': {
@@ -1939,6 +1959,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSkillsRoute: ApiSkillsRouteWithChildren,
   ApiStartAgentRoute: ApiStartAgentRoute,
   ApiStartHermesRoute: ApiStartHermesRoute,
+  ApiSwarmKanbanRoute: ApiSwarmKanbanRoute,
   ApiTerminalCloseRoute: ApiTerminalCloseRoute,
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,8 @@ import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
+import { Route as CompanyOsBetaRouteImport } from './routes/company-os-beta'
+import { Route as CompanyOsRouteImport } from './routes/company-os'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -64,6 +66,7 @@ import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection
 import { Route as ApiConnectionSettingsRouteImport } from './routes/api/connection-settings'
 import { Route as ApiConductorStopRouteImport } from './routes/api/conductor-stop'
 import { Route as ApiConductorSpawnRouteImport } from './routes/api/conductor-spawn'
+import { Route as ApiCompanyOsRouteImport } from './routes/api/company-os'
 import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
 import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
@@ -97,6 +100,8 @@ import { Route as ApiKnowledgeConfigRouteImport } from './routes/api/knowledge/c
 import { Route as ApiHermesTasksTaskIdRouteImport } from './routes/api/hermes-tasks.$taskId'
 import { Route as ApiHermesProxySplatRouteImport } from './routes/api/hermes-proxy/$'
 import { Route as ApiHermesJobsJobIdRouteImport } from './routes/api/hermes-jobs.$jobId'
+import { Route as ApiCompanyOsSendRouteImport } from './routes/api/company-os.send'
+import { Route as ApiCompanyOsGmailRefreshRouteImport } from './routes/api/company-os.gmail-refresh'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
 import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api/sessions/$sessionKey.active-run'
 
@@ -153,6 +158,16 @@ const DashboardRoute = DashboardRouteImport.update({
 const ConductorRoute = ConductorRouteImport.update({
   id: '/conductor',
   path: '/conductor',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompanyOsBetaRoute = CompanyOsBetaRouteImport.update({
+  id: '/company-os-beta',
+  path: '/company-os-beta',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompanyOsRoute = CompanyOsRouteImport.update({
+  id: '/company-os',
+  path: '/company-os',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -375,6 +390,11 @@ const ApiConductorSpawnRoute = ApiConductorSpawnRouteImport.update({
   path: '/api/conductor-spawn',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiCompanyOsRoute = ApiCompanyOsRouteImport.update({
+  id: '/api/company-os',
+  path: '/api/company-os',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiChatEventsRoute = ApiChatEventsRouteImport.update({
   id: '/api/chat-events',
   path: '/api/chat-events',
@@ -540,6 +560,17 @@ const ApiHermesJobsJobIdRoute = ApiHermesJobsJobIdRouteImport.update({
   path: '/$jobId',
   getParentRoute: () => ApiHermesJobsRoute,
 } as any)
+const ApiCompanyOsSendRoute = ApiCompanyOsSendRouteImport.update({
+  id: '/send',
+  path: '/send',
+  getParentRoute: () => ApiCompanyOsRoute,
+} as any)
+const ApiCompanyOsGmailRefreshRoute =
+  ApiCompanyOsGmailRefreshRouteImport.update({
+    id: '/gmail-refresh',
+    path: '/gmail-refresh',
+    getParentRoute: () => ApiCompanyOsRoute,
+  } as any)
 const ApiSessionsSessionKeyStatusRoute =
   ApiSessionsSessionKeyStatusRouteImport.update({
     id: '/$sessionKey/status',
@@ -556,6 +587,8 @@ const ApiSessionsSessionKeyActiveRunRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/company-os': typeof CompanyOsRoute
+  '/company-os-beta': typeof CompanyOsBetaRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -570,6 +603,7 @@ export interface FileRoutesByFullPath {
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
   '/api/chat-events': typeof ApiChatEventsRoute
+  '/api/company-os': typeof ApiCompanyOsRouteWithChildren
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -612,6 +646,8 @@ export interface FileRoutesByFullPath {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/company-os/gmail-refresh': typeof ApiCompanyOsGmailRefreshRoute
+  '/api/company-os/send': typeof ApiCompanyOsSendRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
@@ -648,6 +684,8 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/company-os': typeof CompanyOsRoute
+  '/company-os-beta': typeof CompanyOsBetaRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -661,6 +699,7 @@ export interface FileRoutesByTo {
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
   '/api/chat-events': typeof ApiChatEventsRoute
+  '/api/company-os': typeof ApiCompanyOsRouteWithChildren
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -703,6 +742,8 @@ export interface FileRoutesByTo {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat': typeof ChatIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/api/company-os/gmail-refresh': typeof ApiCompanyOsGmailRefreshRoute
+  '/api/company-os/send': typeof ApiCompanyOsSendRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
@@ -740,6 +781,8 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/company-os': typeof CompanyOsRoute
+  '/company-os-beta': typeof CompanyOsBetaRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -754,6 +797,7 @@ export interface FileRoutesById {
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
   '/api/chat-events': typeof ApiChatEventsRoute
+  '/api/company-os': typeof ApiCompanyOsRouteWithChildren
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
   '/api/connection-settings': typeof ApiConnectionSettingsRoute
@@ -796,6 +840,8 @@ export interface FileRoutesById {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/company-os/gmail-refresh': typeof ApiCompanyOsGmailRefreshRoute
+  '/api/company-os/send': typeof ApiCompanyOsSendRoute
   '/api/hermes-jobs/$jobId': typeof ApiHermesJobsJobIdRoute
   '/api/hermes-proxy/$': typeof ApiHermesProxySplatRoute
   '/api/hermes-tasks/$taskId': typeof ApiHermesTasksTaskIdRoute
@@ -834,6 +880,8 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$'
+    | '/company-os'
+    | '/company-os-beta'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -848,6 +896,7 @@ export interface FileRouteTypes {
     | '/api/auth'
     | '/api/auth-check'
     | '/api/chat-events'
+    | '/api/company-os'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -890,6 +939,8 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/company-os/gmail-refresh'
+    | '/api/company-os/send'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
     | '/api/hermes-tasks/$taskId'
@@ -926,6 +977,8 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$'
+    | '/company-os'
+    | '/company-os-beta'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -939,6 +992,7 @@ export interface FileRouteTypes {
     | '/api/auth'
     | '/api/auth-check'
     | '/api/chat-events'
+    | '/api/company-os'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -981,6 +1035,8 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat'
     | '/settings'
+    | '/api/company-os/gmail-refresh'
+    | '/api/company-os/send'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
     | '/api/hermes-tasks/$taskId'
@@ -1017,6 +1073,8 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$'
+    | '/company-os'
+    | '/company-os-beta'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -1031,6 +1089,7 @@ export interface FileRouteTypes {
     | '/api/auth'
     | '/api/auth-check'
     | '/api/chat-events'
+    | '/api/company-os'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
     | '/api/connection-settings'
@@ -1073,6 +1132,8 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/company-os/gmail-refresh'
+    | '/api/company-os/send'
     | '/api/hermes-jobs/$jobId'
     | '/api/hermes-proxy/$'
     | '/api/hermes-tasks/$taskId'
@@ -1110,6 +1171,8 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  CompanyOsRoute: typeof CompanyOsRoute
+  CompanyOsBetaRoute: typeof CompanyOsBetaRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
   FilesRoute: typeof FilesRoute
@@ -1124,6 +1187,7 @@ export interface RootRouteChildren {
   ApiAuthRoute: typeof ApiAuthRoute
   ApiAuthCheckRoute: typeof ApiAuthCheckRoute
   ApiChatEventsRoute: typeof ApiChatEventsRoute
+  ApiCompanyOsRoute: typeof ApiCompanyOsRouteWithChildren
   ApiConductorSpawnRoute: typeof ApiConductorSpawnRoute
   ApiConductorStopRoute: typeof ApiConductorStopRoute
   ApiConnectionSettingsRoute: typeof ApiConnectionSettingsRoute
@@ -1261,6 +1325,20 @@ declare module '@tanstack/react-router' {
       path: '/conductor'
       fullPath: '/conductor'
       preLoaderRoute: typeof ConductorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/company-os-beta': {
+      id: '/company-os-beta'
+      path: '/company-os-beta'
+      fullPath: '/company-os-beta'
+      preLoaderRoute: typeof CompanyOsBetaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/company-os': {
+      id: '/company-os'
+      path: '/company-os'
+      fullPath: '/company-os'
+      preLoaderRoute: typeof CompanyOsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$': {
@@ -1571,6 +1649,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiConductorSpawnRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/company-os': {
+      id: '/api/company-os'
+      path: '/api/company-os'
+      fullPath: '/api/company-os'
+      preLoaderRoute: typeof ApiCompanyOsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/chat-events': {
       id: '/api/chat-events'
       path: '/api/chat-events'
@@ -1802,6 +1887,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHermesJobsJobIdRouteImport
       parentRoute: typeof ApiHermesJobsRoute
     }
+    '/api/company-os/send': {
+      id: '/api/company-os/send'
+      path: '/send'
+      fullPath: '/api/company-os/send'
+      preLoaderRoute: typeof ApiCompanyOsSendRouteImport
+      parentRoute: typeof ApiCompanyOsRoute
+    }
+    '/api/company-os/gmail-refresh': {
+      id: '/api/company-os/gmail-refresh'
+      path: '/gmail-refresh'
+      fullPath: '/api/company-os/gmail-refresh'
+      preLoaderRoute: typeof ApiCompanyOsGmailRefreshRouteImport
+      parentRoute: typeof ApiCompanyOsRoute
+    }
     '/api/sessions/$sessionKey/status': {
       id: '/api/sessions/$sessionKey/status'
       path: '/$sessionKey/status'
@@ -1833,6 +1932,20 @@ const SettingsRouteChildren: SettingsRouteChildren = {
 
 const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
   SettingsRouteChildren,
+)
+
+interface ApiCompanyOsRouteChildren {
+  ApiCompanyOsGmailRefreshRoute: typeof ApiCompanyOsGmailRefreshRoute
+  ApiCompanyOsSendRoute: typeof ApiCompanyOsSendRoute
+}
+
+const ApiCompanyOsRouteChildren: ApiCompanyOsRouteChildren = {
+  ApiCompanyOsGmailRefreshRoute: ApiCompanyOsGmailRefreshRoute,
+  ApiCompanyOsSendRoute: ApiCompanyOsSendRoute,
+}
+
+const ApiCompanyOsRouteWithChildren = ApiCompanyOsRoute._addFileChildren(
+  ApiCompanyOsRouteChildren,
 )
 
 interface ApiHermesJobsRouteChildren {
@@ -1914,6 +2027,8 @@ const ApiSkillsRouteWithChildren = ApiSkillsRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  CompanyOsRoute: CompanyOsRoute,
+  CompanyOsBetaRoute: CompanyOsBetaRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
   FilesRoute: FilesRoute,
@@ -1928,6 +2043,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthRoute: ApiAuthRoute,
   ApiAuthCheckRoute: ApiAuthCheckRoute,
   ApiChatEventsRoute: ApiChatEventsRoute,
+  ApiCompanyOsRoute: ApiCompanyOsRouteWithChildren,
   ApiConductorSpawnRoute: ApiConductorSpawnRoute,
   ApiConductorStopRoute: ApiConductorStopRoute,
   ApiConnectionSettingsRoute: ApiConnectionSettingsRoute,

--- a/src/routes/-root-layout-state.test.ts
+++ b/src/routes/-root-layout-state.test.ts
@@ -4,12 +4,14 @@ import { getRootSurfaceState } from './-root-layout-state'
 describe('root layout surface state', () => {
   it('shows fullscreen onboarding until onboarding is complete', () => {
     expect(getRootSurfaceState(false)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
     })
 
     expect(getRootSurfaceState(null)).toEqual({
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -18,9 +20,46 @@ describe('root layout surface state', () => {
 
   it('shows workspace shell and post-onboarding overlays after completion', () => {
     expect(getRootSurfaceState(true)).toEqual({
+      showLogin: false,
       showOnboarding: false,
       showWorkspaceShell: true,
       showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('shows login when auth is required and not authenticated, regardless of onboarding state', () => {
+    const unauthed = { authRequired: true, authenticated: false }
+    const expected = {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+
+    expect(getRootSurfaceState(false, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(null, unauthed)).toEqual(expected)
+    expect(getRootSurfaceState(true, unauthed)).toEqual(expected)
+  })
+
+  it('does not gate on auth when auth is not required', () => {
+    expect(
+      getRootSurfaceState(true, { authRequired: false, authenticated: false }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: false,
+      showWorkspaceShell: true,
+      showPostOnboardingOverlays: true,
+    })
+  })
+
+  it('does not gate on auth when authenticated', () => {
+    expect(
+      getRootSurfaceState(false, { authRequired: true, authenticated: true }),
+    ).toEqual({
+      showLogin: false,
+      showOnboarding: true,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
     })
   })
 })

--- a/src/routes/-root-layout-state.ts
+++ b/src/routes/-root-layout-state.ts
@@ -1,14 +1,31 @@
 export type RootSurfaceState = {
+  showLogin: boolean
   showOnboarding: boolean
   showWorkspaceShell: boolean
   showPostOnboardingOverlays: boolean
 }
 
+export type RootAuthStatus = {
+  authRequired: boolean
+  authenticated: boolean
+}
+
 export function getRootSurfaceState(
   onboardingComplete: boolean | null,
+  authStatus: RootAuthStatus | null = null,
 ): RootSurfaceState {
+  if (authStatus?.authRequired && !authStatus.authenticated) {
+    return {
+      showLogin: true,
+      showOnboarding: false,
+      showWorkspaceShell: false,
+      showPostOnboardingOverlays: false,
+    }
+  }
+
   if (onboardingComplete !== true) {
     return {
+      showLogin: false,
       showOnboarding: true,
       showWorkspaceShell: false,
       showPostOnboardingOverlays: false,
@@ -16,6 +33,7 @@ export function getRootSurfaceState(
   }
 
   return {
+    showLogin: false,
     showOnboarding: false,
     showWorkspaceShell: true,
     showPostOnboardingOverlays: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import {
   ONBOARDING_KEY,
 } from '@/components/onboarding/hermes-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { LoginScreen } from '@/components/auth/login-screen'
+import { fetchHermesAuthStatus, type AuthStatus } from '@/lib/hermes-auth'
 import { getRootSurfaceState } from './-root-layout-state'
 
 
@@ -249,6 +251,7 @@ function RootLayout() {
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
   useApplyChatWidth()
 
   useEffect(() => {
@@ -297,11 +300,29 @@ function RootLayout() {
     }
   }, [])
 
-  const rootSurfaceState = getRootSurfaceState(onboardingComplete)
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    let cancelled = false
+    fetchHermesAuthStatus()
+      .then((status) => {
+        if (!cancelled) setAuthStatus(status)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAuthStatus({ authenticated: true, authRequired: false })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />
+      {rootSurfaceState.showLogin ? <LoginScreen /> : null}
       {rootSurfaceState.showOnboarding ? <HermesOnboarding /> : null}
       {rootSurfaceState.showWorkspaceShell ? (
         <>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -45,8 +45,9 @@ const APP_CSP = [
 ].join('; ')
 
 const THEME_STORAGE_KEY = 'hermes-theme'
-const DEFAULT_THEME = 'hermes-nous'
+const DEFAULT_THEME = 'hermes-codex'
 const VALID_THEMES = [
+  'hermes-codex',
   'hermes-nous',
   'hermes-nous-light',
   'hermes-official',
@@ -88,6 +89,7 @@ const themeColorScript = `
     const root = document.documentElement
     const theme = root.getAttribute('data-theme') || '${DEFAULT_THEME}'
     const colors = {
+      'hermes-codex': '#0d0d0d',
       'hermes-nous': '#031A1A',
       'hermes-nous-light': '#F8FAF8',
       'hermes-official': '#0A0E1A',
@@ -382,10 +384,15 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             __html: wrapInlineScript(`
           (function(){
             if (document.getElementById('splash-screen')) return;
-            var bg = '#031A1A', txt = '#F8F1E3', muted = '#9CB2AE', accent = '#FFAC02';
+            var bg = '#0d0d0d', txt = '#e5e5e5', muted = '#737373', accent = '#f97316';
             try {
               var theme = localStorage.getItem('${THEME_STORAGE_KEY}') || '${DEFAULT_THEME}';
-              if (theme === 'hermes-nous') {
+              if (theme === 'hermes-codex') {
+                bg = '#0d0d0d';
+                txt = '#e5e5e5';
+                muted = '#737373';
+                accent = '#f97316';
+              } else if (theme === 'hermes-nous') {
                 bg = '#031A1A';
                 txt = '#F8F1E3';
                 muted = '#9CB2AE';

--- a/src/routes/api/-hermes-update.test.ts
+++ b/src/routes/api/-hermes-update.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createRemoteStatus, remoteUrlMatchesExpectedRepo } from './hermes-update'
+
+describe('hermes update repo gating', () => {
+  it('matches Claude/Hermes workspace repo aliases', () => {
+    expect(remoteUrlMatchesExpectedRepo('https://github.com/example/claude-workspace.git', ['claude-workspace', 'hermes-workspace'])).toBe(true)
+    expect(remoteUrlMatchesExpectedRepo('git@github.com:outsourc-e/hermes-workspace.git', ['claude-workspace', 'outsourc-e/hermes-workspace'])).toBe(true)
+  })
+
+  it('blocks update availability for wrong remote repos even when heads differ', () => {
+    const status = createRemoteStatus({
+      name: 'origin',
+      label: 'Hermes Workspace',
+      expectedRepo: 'hermes-workspace',
+      aliases: ['claude-workspace', 'hermes-workspace'],
+      url: 'https://github.com/example/not-workspace.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(false)
+    expect(status.updateAvailable).toBe(false)
+    expect(status.error).toContain('expected hermes-workspace')
+  })
+
+  it('allows update availability only for the expected repo with a newer remote head', () => {
+    const status = createRemoteStatus({
+      name: 'upstream',
+      label: 'Hermes Agent',
+      expectedRepo: 'hermes-agent',
+      aliases: ['claude-agent', 'hermes-agent'],
+      url: 'https://github.com/NousResearch/hermes-agent.git',
+      currentHead: 'local',
+      remoteHead: 'remote',
+    })
+
+    expect(status.repoMatches).toBe(true)
+    expect(status.updateAvailable).toBe(true)
+    expect(status.error).toBeNull()
+  })
+})

--- a/src/routes/api/company-os.gmail-refresh.ts
+++ b/src/routes/api/company-os.gmail-refresh.ts
@@ -1,0 +1,31 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { refreshCompanyOsGmailSnapshot } from '../../server/company-os-store'
+
+export const Route = createFileRoute('/api/company-os/gmail-refresh')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const body = await request.json().catch(() => ({} as { slug?: string }))
+
+        try {
+          const result = await refreshCompanyOsGmailSnapshot(body.slug || 'unalignedos')
+          return json({ ok: true, result })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/company-os.send.ts
+++ b/src/routes/api/company-os.send.ts
@@ -1,0 +1,260 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { homedir } from 'node:os'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { requireJsonContentType } from '../../server/rate-limit'
+
+type CompanyOsSendBody = {
+  to?: string | Array<string>
+  cc?: string | Array<string>
+  subject?: string
+  body?: string
+  threadId?: string | null
+  attachPdf?: boolean
+}
+
+type GmailTokenFile = {
+  refresh_token?: string
+  client_id?: string
+  client_secret?: string
+  account?: string
+}
+
+type MimeAttachment = {
+  filename: string
+  mimeType: string
+  data: Buffer
+}
+
+const ASHER_GMAIL_TOKEN_PATH =
+  process.env.ASHER_GMAIL_TOKEN_PATH ||
+  path.join(homedir(), '.config/google-credentials/gmail-token.json')
+
+const PARTNERSHIP_PACKAGES_PATH =
+  process.env.UNALIGNED_PARTNERSHIP_PACKAGES_PATH ||
+  path.join(homedir(), 'Desktop/MASTER FILES/docs/Unaligned_Partnership_Packages.pdf')
+
+let cachedAccessToken: { token: string; expiry: number } | null = null
+
+export const Route = createFileRoute('/api/company-os/send')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        try {
+          const body = (await request.json()) as CompanyOsSendBody
+          const to = normalizeEmailList(body.to)
+          const cc = normalizeEmailList(body.cc)
+          const subject = String(body.subject || '').trim()
+          const messageBody = String(body.body || '').trim()
+
+          if (!to.length || !subject || !messageBody) {
+            return json(
+              { ok: false, error: 'Missing to, subject, or body' },
+              { status: 400 },
+            )
+          }
+
+          const accessToken = await getAsherAccessToken()
+          const attachments = body.attachPdf ? await getPricingAttachments() : []
+          const rawMime = buildRawMime({
+            to,
+            cc,
+            subject,
+            body: messageBody,
+            attachments,
+          })
+
+          const gmailResponse = await fetch(
+            'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+            {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                raw: rawMime,
+                threadId: body.threadId || undefined,
+              }),
+            },
+          )
+
+          const data = (await gmailResponse.json()) as {
+            id?: string
+            error?: { message?: string }
+          }
+
+          if (!gmailResponse.ok || data.error) {
+            throw new Error(data.error?.message || `Gmail send failed (${gmailResponse.status})`)
+          }
+
+          return json({ ok: true, messageId: data.id || 'sent' })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})
+
+function normalizeEmailList(value: string | Array<string> | undefined): Array<string> {
+  if (!value) return []
+  const list = Array.isArray(value) ? value : value.split(/[,\s;]+/)
+  return Array.from(
+    new Set(
+      list
+        .map((item) => extractEmail(item))
+        .filter((item) => item.length > 0),
+    ),
+  )
+}
+
+function extractEmail(value: string): string {
+  const match = String(value || '').match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i)
+  return match?.[0]?.toLowerCase() || ''
+}
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url')
+}
+
+function buildRawMime({
+  to,
+  cc,
+  subject,
+  body,
+  attachments = [],
+}: {
+  to: Array<string>
+  cc: Array<string>
+  subject: string
+  body: string
+  attachments?: Array<MimeAttachment>
+}): string {
+  if (attachments.length) {
+    const boundary = `company-os-${Date.now().toString(36)}`
+    const headers = [
+      `To: ${to.join(', ')}`,
+      cc.length ? `Cc: ${cc.join(', ')}` : null,
+      `From: Asher Weisberger <asherunaligned@gmail.com>`,
+      `Subject: ${subject}`,
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    ].filter((line): line is string => Boolean(line))
+    const lines = [
+      ...headers,
+      '',
+      `--${boundary}`,
+      'Content-Type: text/plain; charset="UTF-8"',
+      'Content-Transfer-Encoding: 7bit',
+      '',
+      body,
+      ...attachments.flatMap((attachment) => [
+        '',
+        `--${boundary}`,
+        `Content-Type: ${attachment.mimeType}; name="${attachment.filename}"`,
+        'Content-Transfer-Encoding: base64',
+        `Content-Disposition: attachment; filename="${attachment.filename}"`,
+        '',
+        chunkBase64(attachment.data.toString('base64')).join('\r\n'),
+      ]),
+      '',
+      `--${boundary}--`,
+    ]
+
+    return encodeBase64Url(lines.join('\r\n'))
+  }
+
+  const lines = [
+    `To: ${to.join(', ')}`,
+    cc.length ? `Cc: ${cc.join(', ')}` : '',
+    `From: Asher Weisberger <asherunaligned@gmail.com>`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset="UTF-8"',
+    '',
+    body,
+  ].filter(Boolean)
+
+  return encodeBase64Url(lines.join('\r\n'))
+}
+
+async function getPricingAttachments(): Promise<Array<MimeAttachment>> {
+  try {
+    const data = await readFile(PARTNERSHIP_PACKAGES_PATH)
+    return [
+      {
+        filename: 'Unaligned_Partnership_Packages.pdf',
+        mimeType: 'application/pdf',
+        data,
+      },
+    ]
+  } catch {
+    return []
+  }
+}
+
+function chunkBase64(value: string): Array<string> {
+  const chunks: Array<string> = []
+  for (let index = 0; index < value.length; index += 76) {
+    chunks.push(value.slice(index, index + 76))
+  }
+  return chunks
+}
+
+async function getAsherAccessToken(): Promise<string> {
+  const now = Date.now()
+  if (cachedAccessToken && cachedAccessToken.expiry - now > 60_000) {
+    return cachedAccessToken.token
+  }
+
+  const raw = await readFile(ASHER_GMAIL_TOKEN_PATH, 'utf8')
+  const tokenFile = JSON.parse(raw) as GmailTokenFile
+  if (!tokenFile.refresh_token || !tokenFile.client_id || !tokenFile.client_secret) {
+    throw new Error('Asher Gmail credentials are incomplete')
+  }
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: tokenFile.client_id,
+      client_secret: tokenFile.client_secret,
+      refresh_token: tokenFile.refresh_token,
+      grant_type: 'refresh_token',
+    }).toString(),
+  })
+
+  const data = (await response.json()) as {
+    access_token?: string
+    expires_in?: number
+    error?: string
+    error_description?: string
+  }
+
+  if (!response.ok || data.error || !data.access_token) {
+    throw new Error(data.error_description || data.error || 'Failed to refresh Asher Gmail token')
+  }
+
+  cachedAccessToken = {
+    token: data.access_token,
+    expiry: now + Math.max((data.expires_in || 3600) * 1000, 60_000),
+  }
+
+  return cachedAccessToken.token
+}

--- a/src/routes/api/company-os.ts
+++ b/src/routes/api/company-os.ts
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { readCompanyOsSnapshot } from '../../server/company-os-store'
+
+export const Route = createFileRoute('/api/company-os')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const snapshot = await readCompanyOsSnapshot(url.searchParams.get('slug'))
+        if (!snapshot) {
+          return json(
+            { ok: false, error: 'No Company OS workspace found' },
+            { status: 404 },
+          )
+        }
+
+        return json({ ok: true, snapshot })
+      },
+    },
+  },
+})

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -1,6 +1,9 @@
 /**
- * Jobs API proxy — forwards individual job operations to Hermes FastAPI
- * or the upstream dashboard cron API.
+ * Per-job Hermes Workspace jobs proxy.
+ *
+ * Issue #162: use the same Hermes Agent profile resolution as the main jobs
+ * list route so reads, updates, triggers, and deletes all hit the same
+ * profile-scoped cron state.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -11,6 +14,10 @@ import {
   dashboardFetch,
   ensureGatewayProbed,
 } from '../../server/gateway-capabilities'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -39,11 +46,13 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
 
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardPath = action
-            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${action === 'run' ? 'trigger' : action}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const res = await dashboardFetch(dashboardPath)
           return new Response(await res.text(), {
             status: res.status,
@@ -52,8 +61,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${url.search}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
@@ -72,12 +81,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const url = new URL(request.url)
         const action = url.searchParams.get('action') || ''
         const body = await request.text()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
 
         if (capabilities.dashboard.available) {
           const dashboardAction = action === 'run' ? 'trigger' : action
           const dashboardPath = dashboardAction
-            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}`
-            : `/api/cron/jobs/${params.jobId}`
+            ? `/api/cron/jobs/${params.jobId}/${dashboardAction}${search}`
+            : `/api/cron/jobs/${params.jobId}${search}`
           const method = dashboardAction ? 'POST' : 'PUT'
           const res = await dashboardFetch(dashboardPath, {
             method,
@@ -91,8 +102,8 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
 
         const target = action
-          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}`
-          : `${HERMES_API}/api/jobs/${params.jobId}`
+          ? `${HERMES_API}/api/jobs/${params.jobId}/${action}${search}`
+          : `${HERMES_API}/api/jobs/${params.jobId}${search}`
         const res = await fetch(target, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -112,14 +123,17 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ updates: body ? JSON.parse(body) : {} }),
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,
@@ -138,11 +152,14 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.jobs) return notSupported()
 
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url.search, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}`, {
+          ? await dashboardFetch(`/api/cron/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
             })
-          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
+          : await fetch(`${HERMES_API}/api/jobs/${params.jobId}${search}`, {
               method: 'DELETE',
               headers: authHeaders(),
             })

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -1,5 +1,9 @@
 /**
- * Jobs API proxy — forwards to Hermes FastAPI /api/jobs
+ * Jobs API proxy for Hermes Workspace.
+ *
+ * Issue #162: resolve the jobs profile in one place, then forward it to the
+ * Hermes dashboard / FastAPI jobs endpoints so the screen reflects the active
+ * Hermes Agent profile instead of silently drifting to another profile.
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -9,9 +13,12 @@ import {
   HERMES_UPGRADE_INSTRUCTIONS,
   dashboardFetch,
   ensureGatewayProbed,
-  getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+} from '../../server/jobs-profile-resolution'
 
 function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -62,11 +69,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 200, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
         const url = new URL(request.url)
-        const params = url.searchParams.toString()
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const res = capabilities.dashboard.available
-          ? await dashboardFetch(`/api/cron/jobs${params ? `?${params}` : ''}`)
-          : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
+          ? await dashboardFetch(`/api/cron/jobs${search}`)
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               headers: authHeaders(),
             })
         return jobsResponse(res)
@@ -88,14 +97,18 @@ export const Route = createFileRoute('/api/hermes-jobs')({
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
+
+        const url = new URL(request.url)
+        const profile = resolveJobsProfile(url)
+        const search = buildJobsProfileSearch(url, profile)
         const body = await request.text()
         const res = capabilities.dashboard.available
-          ? await dashboardFetch('/api/cron/jobs', {
+          ? await dashboardFetch(`/api/cron/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body,
             })
-          : await fetch(`${HERMES_API}/api/jobs`, {
+          : await fetch(`${HERMES_API}/api/jobs${search}`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json', ...authHeaders() },
               body,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -17,6 +17,31 @@ function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
+async function jobsResponse(res: Response): Promise<Response> {
+  const text = await res.text()
+
+  if (!res.ok) {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+    const normalized = Array.isArray(data) ? { jobs: data } : data
+    return new Response(JSON.stringify(normalized), {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return new Response(text, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
+
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
     handlers: {
@@ -44,10 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           : await fetch(`${HERMES_API}/api/jobs${params ? `?${params}` : ''}`, {
               headers: authHeaders(),
             })
-        return new Response(res.body, {
-          status: res.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return jobsResponse(res)
       },
       POST: async ({ request }) => {
         if (!isAuthenticated(request)) {

--- a/src/routes/api/hermes-update.ts
+++ b/src/routes/api/hermes-update.ts
@@ -1,0 +1,160 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { isAuthenticated } from '../../server/auth-middleware'
+
+type RemoteName = 'origin' | 'upstream'
+
+type RemoteStatus = {
+  name: RemoteName
+  label: string
+  url: string | null
+  expectedRepo: string
+  expectedAliases: Array<string>
+  repoMatches: boolean
+  remoteHead: string | null
+  currentHead: string | null
+  updateAvailable: boolean
+  error: string | null
+}
+
+type RemoteDefinition = {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+}
+
+export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
+  {
+    name: 'origin',
+    label: 'Hermes Workspace',
+    expectedRepo: 'hermes-workspace',
+    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
+  },
+  {
+    name: 'upstream',
+    label: 'Hermes Agent',
+    expectedRepo: 'hermes-agent',
+    aliases: ['claude-agent', 'hermes-agent', 'NousResearch/hermes-agent'],
+  },
+]
+
+function git(args: string[], timeout = 5000): string | null {
+  try {
+    return execFileSync('git', args, { cwd: process.cwd(), encoding: 'utf8', timeout }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function pkgVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as { version?: string }
+    return pkg.version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export function remoteUrlMatchesExpectedRepo(url: string | null, aliases: Array<string>): boolean {
+  if (!url) return false
+  const normalizedUrl = url
+    .toLowerCase()
+    .replace(/^git@github\.com:/, 'github.com/')
+    .replace(/^https?:\/\//, '')
+    .replace(/\.git$/, '')
+  return aliases.some((alias) => normalizedUrl.includes(alias.toLowerCase().replace(/\.git$/, '')))
+}
+
+export function createRemoteStatus(input: {
+  name: RemoteName
+  label: string
+  expectedRepo: string
+  aliases: Array<string>
+  url: string | null
+  currentHead: string | null
+  remoteHead: string | null
+  lsRemoteFailed?: boolean
+}): RemoteStatus {
+  const repoMatches = remoteUrlMatchesExpectedRepo(input.url, input.aliases)
+  let error: string | null = null
+  if (!input.url) {
+    error = 'Remote is not configured.'
+  } else if (!repoMatches) {
+    error = `Remote URL does not match expected ${input.expectedRepo} repo.`
+  } else if (!input.remoteHead || input.lsRemoteFailed) {
+    error = 'Unable to read remote HEAD.'
+  }
+
+  return {
+    name: input.name,
+    label: input.label,
+    url: input.url,
+    expectedRepo: input.expectedRepo,
+    expectedAliases: input.aliases,
+    repoMatches,
+    remoteHead: repoMatches ? input.remoteHead : null,
+    currentHead: input.currentHead,
+    updateAvailable: Boolean(repoMatches && input.currentHead && input.remoteHead && input.currentHead !== input.remoteHead),
+    error,
+  }
+}
+
+function remoteStatus(definition: RemoteDefinition, currentHead: string | null): RemoteStatus {
+  const url = git(['remote', 'get-url', definition.name])
+  const repoMatches = remoteUrlMatchesExpectedRepo(url, definition.aliases)
+  let remoteHead: string | null = null
+  let lsRemoteFailed = false
+
+  if (url && repoMatches) {
+    const raw = git(['ls-remote', url, 'HEAD'], 8000)
+    remoteHead = raw?.split(/\s+/)[0] ?? null
+    lsRemoteFailed = !remoteHead
+  }
+
+  return createRemoteStatus({
+    name: definition.name,
+    label: definition.label,
+    expectedRepo: definition.expectedRepo,
+    aliases: definition.aliases,
+    url,
+    currentHead,
+    remoteHead,
+    lsRemoteFailed,
+  })
+}
+
+export const Route = createFileRoute('/api/hermes-update')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const currentHead = git(['rev-parse', 'HEAD'])
+        const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+        const dirty = Boolean(git(['status', '--porcelain']))
+        const remotes = UPDATE_REMOTE_DEFINITIONS.map((definition) => remoteStatus(definition, currentHead))
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          app: {
+            name: 'Hermes Workspace',
+            version: pkgVersion(),
+            branch,
+            currentHead,
+            dirty,
+          },
+          remotes,
+          updateAvailable: remotes.some((remote) => remote.updateAvailable),
+          manualConfirmRequired: true,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/history.ts
+++ b/src/routes/api/history.ts
@@ -48,13 +48,9 @@ export const Route = createFileRoute('/api/history')({
             })
           }
           // "main" doesn't exist in Hermes — resolve it to the user's real
-          // main chat session. We prefer (in order):
-          //   1. The most recent session with a real human-set title
-          //      (label !== id, e.g. "hows everything"). This is what users
-          //      actually mean by "main".
-          //   2. The most recent non-internal session with messages.
-          // Cron + Operations per-agent sessions are skipped so the
-          // orchestrator chat doesn't latch onto runtime junk.
+          // active chat session. Prefer the most recently active non-internal
+          // session with messages, and only fall back to a titled session when
+          // there is no better active candidate.
           if (sessionKey === 'main') {
             try {
               const sessions = await listSessions(30, 0)
@@ -66,18 +62,18 @@ export const Route = createFileRoute('/api/history')({
                 const t = (s.title ?? '').trim()
                 return t.length > 0 && t !== s.id
               }
-              const titled = sessions.find(
-                (s) => !isInternalKey(s.id) && hasRealTitle(s),
+              const active = sessions.find(
+                (s) =>
+                  !isInternalKey(s.id) &&
+                  typeof s.message_count === 'number' &&
+                  s.message_count > 0,
               )
-              const fallback = titled
+              const titled = active
                 ? null
                 : sessions.find(
-                    (s) =>
-                      !isInternalKey(s.id) &&
-                      typeof s.message_count === 'number' &&
-                      s.message_count > 0,
+                    (s) => !isInternalKey(s.id) && hasRealTitle(s),
                   )
-              const candidate = titled ?? fallback
+              const candidate = active ?? titled
               if (candidate) {
                 sessionKey = candidate.id
               } else {

--- a/src/routes/api/integrations.ts
+++ b/src/routes/api/integrations.ts
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { detectHonchoIntegration } from '../../server/integration-detection'
+
+export const Route = createFileRoute('/api/integrations')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          integrations: {
+            honcho: detectHonchoIntegration(),
+          },
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -544,10 +544,10 @@ export const Route = createFileRoute('/api/send-stream')({
               }
 
               if (SESSION_BOOTSTRAP_KEYS.has(sessionKey)) {
-                // 'main' should land in the user's existing main chat,
-                // not spin up a brand new session every time. Skip cron
-                // and Operations per-agent sessions so the orchestrator
-                // chat doesn't latch onto them.
+                // 'main' should land in the user's real active chat session,
+                // not an older titled thread. Skip cron and Operations sessions,
+                // prefer the most recently active session with messages, and
+                // only fall back to a titled session when nothing active exists.
                 let reused: string | null = null
                 if (sessionKey === 'main') {
                   try {
@@ -563,18 +563,18 @@ export const Route = createFileRoute('/api/send-stream')({
                       const t = (s.title ?? '').trim()
                       return t.length > 0 && t !== s.id
                     }
-                    const titled = recent.find(
-                      (s) => !isInternal(s.id) && hasRealTitle(s),
+                    const active = recent.find(
+                      (s) =>
+                        !isInternal(s.id) &&
+                        typeof s.message_count === 'number' &&
+                        s.message_count > 0,
                     )
-                    const fallback = titled
+                    const titled = active
                       ? null
                       : recent.find(
-                          (s) =>
-                            !isInternal(s.id) &&
-                            typeof s.message_count === 'number' &&
-                            s.message_count > 0,
+                          (s) => !isInternal(s.id) && hasRealTitle(s),
                         )
-                    const candidate = titled ?? fallback
+                    const candidate = active ?? titled
                     if (candidate) reused = candidate.id
                   } catch {
                     // fall through to createSession()

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -451,8 +451,12 @@ export const Route = createFileRoute('/api/send-stream')({
                     content: typeof body.message === 'string' ? body.message : '',
                     timestamp: Date.now(),
                   })
-                  // Use persisted history if available, otherwise fall back to client-sent history
-                  const effectiveHistory = persistedHistory.length > 0 ? persistedHistory : history
+                  // For gateway models (no localBaseUrl), the gateway manages its own session
+                  // history — sending local history causes duplication and context bloat.
+                  // For direct Ollama models, history is required since Ollama is stateless.
+                  const effectiveHistory = localBaseUrl
+                    ? (persistedHistory.length > 0 ? persistedHistory : history)
+                    : []
                   const portableMessages: Array<OpenAICompatMessage> = [
                     ...localeSystemMsg,
                     ...effectiveHistory,

--- a/src/routes/api/swarm-kanban.ts
+++ b/src/routes/api/swarm-kanban.ts
@@ -1,0 +1,60 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { z } from 'zod'
+import { createKanbanCard, getKanbanBackendMeta, listKanbanCards, updateKanbanCard } from '../../server/kanban-backend'
+
+const CreateCardSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  spec: z.string().trim().max(5000).optional().default(''),
+  acceptanceCriteria: z.string().trim().max(5000).optional().default(''),
+  assignedWorker: z.string().trim().max(120).optional().nullable(),
+  reviewer: z.string().trim().max(120).optional().nullable(),
+  status: z.enum(['backlog', 'ready', 'running', 'review', 'blocked', 'done']).optional().default('backlog'),
+  missionId: z.string().trim().max(200).optional().nullable(),
+  reportPath: z.string().trim().max(500).optional().nullable(),
+  createdBy: z.string().trim().max(120).optional().default('aurora'),
+})
+
+const UpdateCardSchema = CreateCardSchema.partial().extend({
+  id: z.string().trim().min(1),
+})
+
+export const Route = createFileRoute('/api/swarm-kanban')({
+  server: {
+    handlers: {
+      GET: async () => {
+        return json({ ok: true, cards: listKanbanCards(), backend: getKanbanBackendMeta() })
+      },
+      POST: async ({ request }) => {
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+        }
+        const parsed = CreateCardSchema.safeParse(body)
+        if (!parsed.success) {
+          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+        }
+        const card = createKanbanCard(parsed.data)
+        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+      },
+      PATCH: async ({ request }) => {
+        let body: unknown
+        try {
+          body = await request.json()
+        } catch {
+          return json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+        }
+        const parsed = UpdateCardSchema.safeParse(body)
+        if (!parsed.success) {
+          return json({ ok: false, error: parsed.error.issues.map((issue) => issue.message).join('; ') }, { status: 400 })
+        }
+        const { id, ...updates } = parsed.data
+        const card = updateKanbanCard(id, updates)
+        if (!card) return json({ ok: false, error: 'Card not found' }, { status: 404 })
+        return json({ ok: true, card, backend: getKanbanBackendMeta() })
+      },
+    },
+  },
+})

--- a/src/routes/api/terminal-input.ts
+++ b/src/routes/api/terminal-input.ts
@@ -12,7 +12,6 @@ export const Route = createFileRoute('/api/terminal-input')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        // Auth check
         if (!isAuthenticated(request)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'Unauthorized' }),
@@ -23,10 +22,6 @@ export const Route = createFileRoute('/api/terminal-input')({
         if (csrfCheck) return csrfCheck
 
         const ip = getClientIp(request)
-        if (!rateLimit(`terminal:${ip}`, 10, 60_000)) {
-          return rateLimitResponse()
-        }
-
         const body = (await request.json().catch(() => ({}))) as Record<
           string,
           unknown
@@ -34,6 +29,14 @@ export const Route = createFileRoute('/api/terminal-input')({
         const sessionId =
           typeof body.sessionId === 'string' ? body.sessionId : ''
         const data = typeof body.data === 'string' ? body.data : ''
+
+        const rateKey = sessionId
+          ? `terminal:${ip}:${sessionId}`
+          : `terminal:${ip}`
+        if (!rateLimit(rateKey, 600, 60_000)) {
+          return rateLimitResponse()
+        }
+
         const session = getTerminalSession(sessionId)
         if (!session) {
           return new Response(JSON.stringify({ ok: false }), {

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,10 +40,13 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return new Response(
+            JSON.stringify({ ok: false, missing: true, sessionId }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          )
         }
         session.resize(cols, rows)
         return new Response(JSON.stringify({ ok: true }), {

--- a/src/routes/company-os-beta.tsx
+++ b/src/routes/company-os-beta.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { CompanyOsRouteView } from './company-os'
+
+export const Route = createFileRoute('/company-os-beta')({
+  ssr: false,
+  component: CompanyOsRouteView,
+})

--- a/src/routes/company-os.tsx
+++ b/src/routes/company-os.tsx
@@ -1,0 +1,3649 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowReloadHorizontalIcon,
+  Building02Icon,
+  CheckListIcon,
+  Calendar01Icon,
+  DocumentValidationIcon,
+  Rocket01Icon,
+  Target02Icon,
+} from '@hugeicons/core-free-icons'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { cn } from '@/lib/utils'
+
+type CompanyOsTask = {
+  title: string
+  description: string
+  status: 'active' | 'waiting' | 'someday' | 'done'
+  tags: Array<string>
+  priority: string | null
+}
+
+type CompanyOsDocument = {
+  title: string
+  filename: string
+  body: string
+  excerpt: string
+}
+
+type CompanyOsInvoice = {
+  file: string
+  status: 'outstanding' | 'done' | 'needs-proof' | 'review'
+  source: string
+}
+
+type CompanyOsAsset = {
+  id: string
+  title: string
+  kind: 'pricing' | 'media-kit' | 'proposal' | 'tax' | 'contract' | 'invoice' | 'site' | 'brand'
+  file: string
+  path: string
+  note: string
+}
+
+type CompanyOsLead = {
+  id: number | string
+  title: string
+  businessName: string | null
+  listId: string | null
+  priority: string | null
+  estimatedValue: string | null
+  draftStatus: string | null
+  updatedAt: string | null
+}
+
+type CompanyOsKanbanAction = {
+  id: number | string
+  title: string
+  businessName: string | null
+  stage: string | null
+  priority: string | null
+  draftStatus: string | null
+  updatedAt: string | null
+  lane: string
+  urgency: 'p0' | 'p1' | 'p2'
+  reason: string
+  recommendedAction: string
+  publicAsset: string | null
+  assetIds: Array<string>
+}
+
+type CompanyOsSignal = {
+  kind: string
+  subject?: string
+  from?: string
+  title?: string
+  url?: string
+  threadId?: string
+  messageId?: string
+  gmailUrl?: string
+  timestamp?: string
+  updatedAt?: string
+  summary: string
+  needs?: string
+  thread?: {
+    status: string
+    latestAction: string
+    messages: Array<{
+      id: string
+      from: string
+      to?: Array<string>
+      cc?: Array<string>
+      timestamp?: string
+      subject?: string
+      body: string
+      attachments?: Array<string>
+    }>
+  }
+}
+
+type CompanyOsLiveOps = {
+  sources: Array<{
+    name: string
+    status: 'connected' | 'snapshot' | 'missing' | 'error'
+    count: number
+    note: string
+  }>
+  invoices: Array<CompanyOsInvoice>
+  invoiceCounts: Record<string, number>
+  assets: Array<CompanyOsAsset>
+  supabase: {
+    ok: boolean
+    count: number
+    stages: Record<string, number>
+    priorities: Record<string, number>
+    draftStatuses: Record<string, number>
+    hotLeads: Array<CompanyOsLead>
+    invoiceLeads: Array<CompanyOsLead>
+    kanbanActions: Array<CompanyOsKanbanAction>
+    error?: string
+  }
+  emailSignals: Array<CompanyOsSignal>
+  driveSignals: Array<CompanyOsSignal>
+}
+
+type CompanyOsSnapshot = {
+  slug: string
+  name: string
+  idea: string
+  audience: string
+  status: string
+  rules: Array<string>
+  tasks: Array<CompanyOsTask>
+  documents: Array<CompanyOsDocument>
+  log: string
+  siteHtml: string
+  workspacePath: string
+  liveOps: CompanyOsLiveOps
+  updatedAt: string
+}
+
+type TodayQueueItem = {
+  id: string
+  title: string
+  detail: string
+  lane: string
+  priority: 'p0' | 'p1' | 'p2'
+  action: string
+}
+
+type LeadReplyPacket = {
+  signal: CompanyOsSignal
+  item: TodayQueueItem
+  status: 'needs-us' | 'needs-robert' | 'waiting-them' | 'money-admin'
+  owner: 'Asher' | 'Robert' | 'Sam' | 'Internal'
+  urgency: 'today' | 'this-week' | 'parked'
+  blocker: string
+  nextMove: string
+  draft: string
+}
+
+type ReplySender = 'asher' | 'robert' | 'sam'
+
+type QueueFilter = 'all' | 'money' | 'leads' | 'email' | 'robert' | 'blocked'
+type WorkspaceTab = 'queue' | 'calendar'
+type PacketTab =
+  | 'summary'
+  | 'thread'
+  | 'draft'
+  | 'assets'
+  | 'actions'
+type LeadInboxLane = 'new' | 'needsReply' | 'followUp'
+
+type PacketReview = {
+  status: string
+  operator: string
+  dealQuestion: string
+  dealSteps: Array<string>
+  robertBrief: string
+  evidence: Array<string>
+  risks: Array<string>
+  recommendedAction: string
+  draftMessage: string
+  checklist: Array<string>
+}
+
+type LeadCommand = {
+  mode: string
+  objective: string
+  missing: Array<string>
+  robertGate: string
+  attachmentNote: string
+  proofNote: string
+}
+
+type CollabWorkflow = {
+  stageIndex: number
+  stageLabel: string
+  currentTask: string
+  operatorRule: string
+  invoiceState: string
+  paymentState: string
+  briefState: string
+  doneRule: string
+}
+
+type OpsBriefItem = {
+  title: string
+  chips: Array<string>
+  bullets: Array<string>
+  tone?: 'action' | 'waiting'
+}
+
+const OPS_PREP_ITEMS: Array<OpsBriefItem> = [
+  {
+    title: 'Kombai QRT via Marketing Guys',
+    chips: ['June 2', '$1,895', 'Robert test'],
+    bullets: [
+      'Launch moved to Tuesday, June 2.',
+      'Rate confirmed: $1,895.',
+      'Payment should happen 24 hours before post goes live.',
+      'Robert needs to test/review kombai.com before QRT.',
+      'Need receipt/payment confirmation before posting.',
+    ],
+  },
+  {
+    title: 'AhaCreator 3.0 launch',
+    chips: ['$2,495', 'June 2?', 'date mismatch'],
+    bullets: [
+      'Paid X narrative thread.',
+      'Budget: $2,495.',
+      'Original window was June 8-10; latest follow-up points toward June 2.',
+      'Resolve date mismatch, invoice, and whether Robert commentary is included or changes rate.',
+    ],
+  },
+  {
+    title: 'NVIDIA Nemotron / NemoClaw briefing',
+    chips: ['May 27 8am PT', 'embargo Jun 4', 'access'],
+    bullets: [
+      'Briefing: Wednesday, May 27 at 8am PT.',
+      'Embargo: Thursday, June 4 at 6am PT.',
+      'Need NVIDIA NGC login and Google Form completed for model access.',
+      'Do not mention Nemotron 3.5 Nano publicly until NVIDIA clears it.',
+    ],
+  },
+  {
+    title: 'ACL San Diego / Alibaba via Hockey Stick',
+    chips: ['July 5', '$20,000', 'May 27 call'],
+    bullets: [
+      'Event target: July 5 in San Diego.',
+      'Proposed fee: $20,000, with payment split before/on event.',
+      'Travel add-on being discussed, roughly $1,000.',
+      'Meeting set: Wednesday, May 27, 12:00-12:30pm ET.',
+      'Prep max content pieces, quote/forward posts, travel, video deliverables, approval process.',
+    ],
+  },
+  {
+    title: 'Life Summit / Bloomstack',
+    chips: ['June 11', 'LinkedIn', 'speaker kit'],
+    bullets: [
+      'Event: June 11.',
+      'Robert needs to accept Damini LinkedIn connection/speaker invite so he appears on speaker list.',
+      'Resource kit exists; they want speaker posts shared and Bloomstack tagged.',
+    ],
+  },
+  {
+    title: 'Riverside / Nadav',
+    chips: ['reschedule', 'draft ready'],
+    bullets: [
+      'Still needs rescheduling.',
+      'Draft offers Friday, May 29 after 10am PT; Monday, June 1 9-11am PT; Tuesday, June 2 9am-12pm PT; Wednesday, June 3 after 10am PT.',
+      'Send or confirm the reschedule email.',
+    ],
+  },
+]
+
+const OPS_WAITING_ITEMS: Array<OpsBriefItem> = [
+  {
+    title: 'Anything.com / Leo launch amplification',
+    chips: ['rates sent', 'waiting'],
+    bullets: [
+      'Recurring X + LinkedIn launch posts.',
+      'They want Robert rates on file.',
+      'Asher sent the rate PDF; waiting on next step/details.',
+    ],
+    tone: 'waiting',
+  },
+  {
+    title: 'Goodfire / SoCap',
+    chips: ['postponed'],
+    bullets: ['Was supposed to be May 26-28, but they postponed it. No prep until new dates.'],
+    tone: 'waiting',
+  },
+  {
+    title: 'Deel / SoCap',
+    chips: ['postponed'],
+    bullets: ['Was supposed to be June 2, but also postponed. No prep until new dates.'],
+    tone: 'waiting',
+  },
+  {
+    title: 'R3ACH / Declan',
+    chips: ['waiting on them'],
+    bullets: ['Asher asked for overview/onboarding details. Waiting on them.'],
+    tone: 'waiting',
+  },
+  {
+    title: 'IFM / Hector Liu',
+    chips: ['scheduling', 'not paid yet'],
+    bullets: [
+      'Dave Reddy asked what date/time works to meet Hector Liu at IFM Lab in Sunnyvale.',
+      'Scheduling needed, but not a paid collab yet.',
+    ],
+    tone: 'waiting',
+  },
+]
+
+const COMPANY_OS_OPERATIONS_THEME = {
+  colorScheme: 'light',
+  '--theme-bg': '#f3f5f2',
+  '--theme-sidebar': '#eef1ed',
+  '--theme-panel': '#eef1ed',
+  '--theme-card': '#fbfcfa',
+  '--theme-card2': '#eef2ef',
+  '--theme-border': '#d6ddd6',
+  '--theme-border-subtle': '#e5ebe5',
+  '--theme-text': '#1f2622',
+  '--theme-muted': '#5f6b64',
+  '--theme-shadow-1': '0 1px 2px rgba(31, 38, 34, 0.04)',
+  '--theme-shadow-2': '0 8px 22px rgba(31, 38, 34, 0.08)',
+  '--theme-shadow-3': '0 18px 40px rgba(31, 38, 34, 0.10)',
+  '--theme-glass': 'rgba(243, 245, 242, 0.92)',
+  '--theme-focus': '#1f6f5b',
+  '--theme-accent': '#1f6f5b',
+  '--theme-accent-secondary': '#2f806d',
+  '--theme-accent-subtle': 'rgba(31, 111, 91, 0.10)',
+  '--theme-accent-border': 'rgba(31, 111, 91, 0.24)',
+  '--theme-active': '#1f6f5b',
+  '--theme-link': '#1f6f5b',
+  '--theme-success': '#247a4b',
+  '--theme-warning': '#9a6216',
+  '--theme-danger': '#b23b3b',
+  '--theme-stripe': 'rgba(214, 221, 214, 0.48)',
+  '--theme-header-bg': '#f3f5f2',
+  '--theme-header-border': '#d6ddd6',
+  '--theme-input': '#ffffff',
+  '--color-primary-50': '#fbfcfa',
+  '--color-primary-100': '#eef2ef',
+  '--color-primary-200': '#d6ddd6',
+  '--color-primary-300': '#c5cec5',
+  '--color-primary-400': '#7c887f',
+  '--color-primary-500': '#5f6b64',
+  '--color-primary-600': '#4d5851',
+  '--color-primary-700': '#333d37',
+  '--color-primary-800': '#28312c',
+  '--color-primary-900': '#1f2622',
+  '--color-primary-950': '#151a17',
+  '--color-surface': '#f3f5f2',
+  '--color-surface-deep': '#eef1ed',
+  '--color-ink': '#1f2622',
+  '--color-accent-400': '#2f806d',
+  '--color-accent-500': '#1f6f5b',
+  '--color-accent-600': '#185a49',
+} as CSSProperties
+
+export const Route = createFileRoute('/company-os')({
+  ssr: false,
+  component: CompanyOsRouteView,
+})
+
+async function fetchCompanyOs(): Promise<CompanyOsSnapshot> {
+  const res = await fetch('/api/company-os?slug=unalignedos')
+  const data = await res.json()
+  if (!res.ok || !data?.snapshot) {
+    throw new Error(data?.error || `Company OS request failed (${res.status})`)
+  }
+  return data.snapshot as CompanyOsSnapshot
+}
+
+export function CompanyOsRouteView() {
+  usePageTitle('Company OS Beta')
+  const query = useQuery({
+    queryKey: ['company-os', 'unalignedos'],
+    queryFn: fetchCompanyOs,
+    refetchInterval: 15_000,
+  })
+
+  if (query.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-[var(--theme-muted)]">
+        Loading Company OS...
+      </div>
+    )
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <div className="max-w-lg rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+          <h1 className="text-lg font-semibold text-[var(--theme-text)]">Company OS is empty</h1>
+          <p className="mt-2 text-sm text-[var(--theme-muted)]">
+            Create a Hermes company workspace, then this dashboard will pick it up.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <CompanyOsDashboard
+      snapshot={query.data}
+      onRefreshSnapshot={async () => {
+        await query.refetch()
+      }}
+    />
+  )
+}
+
+function CompanyOsDashboard({
+  snapshot,
+  onRefreshSnapshot,
+}: {
+  snapshot: CompanyOsSnapshot
+  onRefreshSnapshot: () => Promise<void>
+}) {
+  const [focusedItem, setFocusedItem] = useState<TodayQueueItem | null>(null)
+  const [detailItem, setDetailItem] = useState<TodayQueueItem | null>(null)
+  const [workspaceTab, setWorkspaceTab] = useState<WorkspaceTab>('queue')
+  const [queueFilter, setQueueFilter] = useState<QueueFilter>('all')
+  const [gmailRefresh, setGmailRefresh] = useState<{
+    status: 'idle' | 'loading' | 'success' | 'error'
+    message: string
+  }>({ status: 'idle', message: '' })
+  const activeTasks = snapshot.tasks.filter((task) => task.status === 'active')
+  const waitingTasks = snapshot.tasks.filter((task) => task.status === 'waiting')
+  const live = snapshot.liveOps
+  const todayQueue = useMemo(() => buildTodayQueue(live), [live])
+  const leadInbox = useMemo(() => buildLeadInbox(live), [live])
+  const leadReplyDesk = useMemo(() => buildLeadReplyDesk(live), [live])
+  const robertCalendar = useMemo(
+    () => buildRobertCalendarAgenda(leadReplyDesk, todayQueue),
+    [leadReplyDesk, todayQueue],
+  )
+  const [activeReplyPacketId, setActiveReplyPacketId] = useState<string | null>(
+    leadReplyDesk[0]?.item.id || null,
+  )
+  const filteredQueue = useMemo(
+    () => filterQueue(todayQueue, queueFilter),
+    [queueFilter, todayQueue],
+  )
+
+  async function refreshGmail() {
+    setGmailRefresh({ status: 'loading', message: 'Refreshing Gmail...' })
+    try {
+      const response = await fetch('/api/company-os/gmail-refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug: snapshot.slug }),
+      })
+      const data = await response.json()
+      if (!response.ok || !data?.ok) {
+        throw new Error(data?.error || `Gmail refresh failed (${response.status})`)
+      }
+
+      setGmailRefresh({
+        status: 'success',
+        message: data.result?.message || 'Gmail refreshed.',
+      })
+      await onRefreshSnapshot()
+      window.setTimeout(() => {
+        setGmailRefresh((current) =>
+          current.status === 'success' ? { status: 'idle', message: '' } : current,
+        )
+      }, 2600)
+    } catch (error) {
+      setGmailRefresh({
+        status: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const p0Count = todayQueue.filter((item) => item.priority === 'p0').length
+  const topQueueItem =
+    leadInbox.needsReply[0] || leadInbox.new[0] || leadInbox.followUp[0] || todayQueue[0]
+  const leadCount =
+    leadInbox.new.length + leadInbox.needsReply.length + leadInbox.followUp.length
+  const activeReplyPacket =
+    leadReplyDesk.find((packet) => packet.item.id === activeReplyPacketId) ||
+    leadReplyDesk[0] ||
+    null
+
+  return (
+    <div
+      className="min-h-screen bg-[var(--theme-bg)] text-[var(--theme-text)]"
+      style={COMPANY_OS_OPERATIONS_THEME}
+    >
+      <div className="flex w-full max-w-none flex-col gap-4 bg-[var(--theme-bg)] px-4 py-4 md:px-6 md:py-5">
+        <div className="sticky top-0 z-20 -mx-4 border-b border-[var(--theme-border)] bg-[color-mix(in_srgb,var(--theme-bg)_92%,transparent)] px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-accent)]">
+                <HugeiconsIcon icon={Building02Icon} size={24} strokeWidth={1.7} />
+              </span>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                    Company OS Beta
+                  </p>
+                  <Badge>Live Unaligned demo</Badge>
+                </div>
+                <h1 className="truncate text-2xl font-semibold text-[var(--theme-text)]">
+                  {snapshot.name}
+                </h1>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusPill label="P0" value={p0Count} tone="danger" />
+              <StatusPill label="Lead inbox" value={leadCount} tone="warning" />
+              <StatusPill label="Sources" value={live.sources.length} tone="neutral" />
+              <button
+                type="button"
+                onClick={() => void refreshGmail()}
+                disabled={gmailRefresh.status === 'loading'}
+                className={cn(
+                  'inline-flex h-10 items-center justify-center gap-2 rounded-lg border px-4 text-sm font-semibold transition',
+                  gmailRefresh.status === 'loading'
+                    ? 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)]'
+                    : 'border-accent-500/35 bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] hover:bg-[var(--theme-accent)]/15',
+                )}
+              >
+                <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={18} />
+                {gmailRefresh.status === 'loading' ? 'Refreshing' : 'Refresh Gmail'}
+              </button>
+            </div>
+          </div>
+          {gmailRefresh.message ? (
+            <p
+              className={cn(
+                'mt-2 text-xs leading-5',
+                gmailRefresh.status === 'error' ? 'text-[var(--theme-danger)]' : 'text-[var(--theme-muted)]',
+              )}
+            >
+              {gmailRefresh.message}
+            </p>
+          ) : null}
+        </div>
+
+        <OpsBriefPanel />
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="space-y-4">
+            <LeadReplyDesk
+              packets={leadReplyDesk}
+              activePacketId={activeReplyPacketId}
+              onActivePacketChange={setActiveReplyPacketId}
+              onOpen={setDetailItem}
+            />
+
+            {!activeReplyPacket ? (
+              <FocusPanel item={focusedItem || topQueueItem} onOpen={setDetailItem} />
+            ) : null}
+          </div>
+
+          <WorkspaceRail
+            activeTab={workspaceTab}
+            onTabChange={setWorkspaceTab}
+            packets={leadReplyDesk}
+            activePacketId={activeReplyPacketId}
+            onActivePacketChange={setActiveReplyPacketId}
+            onFocusChange={setFocusedItem}
+            queue={todayQueue}
+            calendar={robertCalendar}
+          />
+        </div>
+
+        <details className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)]">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-[var(--theme-text)]">
+            Reference
+          </summary>
+          <div className="grid gap-4 border-t border-[var(--theme-border)] p-4 xl:grid-cols-3">
+            <Panel title="Money Watchlist" icon={DocumentValidationIcon}>
+              <InvoiceList invoices={live.invoices} />
+            </Panel>
+            <Panel title="Pipeline" icon={Rocket01Icon}>
+              <StageBreakdown stages={live.supabase.stages} />
+            </Panel>
+            <Panel title="Signals" icon={DocumentValidationIcon}>
+              <SignalList signals={live.emailSignals} />
+            </Panel>
+            <Panel title="Assets" icon={DocumentValidationIcon}>
+              <AssetList assets={live.assets.slice(0, 6)} />
+            </Panel>
+            <Panel title="Sources" icon={Target02Icon}>
+              <SourceList sources={live.sources} />
+            </Panel>
+            <Panel title="Tasks" icon={CheckListIcon}>
+              <div className="space-y-3">
+                {[...activeTasks, ...waitingTasks].slice(0, 5).map((task) => (
+                  <TaskCard key={task.title} task={task} />
+                ))}
+              </div>
+            </Panel>
+            <Panel title="Ops Queue" icon={CheckListIcon}>
+              <QueueFilterTabs
+                active={queueFilter}
+                items={todayQueue}
+                onChange={setQueueFilter}
+              />
+              <div className="space-y-2">
+                {filteredQueue.map((item) => (
+                  <QueueItemButton
+                    key={item.id}
+                    item={item}
+                    onSelect={(queueItem) => {
+                      setFocusedItem(queueItem)
+                      const packetId = findLeadReplyPacketId(queueItem, leadReplyDesk)
+                      if (packetId) setActiveReplyPacketId(packetId)
+                    }}
+                  />
+                ))}
+              </div>
+            </Panel>
+          </div>
+        </details>
+
+        <div className="hidden">
+          <Panel title="Drive Signals" icon={DocumentValidationIcon}>
+            <SignalList signals={live.driveSignals} />
+          </Panel>
+          <Panel title="Invoice / Payment Leads" icon={Target02Icon}>
+            <LeadList leads={live.supabase.invoiceLeads} />
+          </Panel>
+          <Panel title="Sales Asset Library" icon={DocumentValidationIcon}>
+            <AssetList assets={live.assets} />
+          </Panel>
+        </div>
+      </div>
+      {detailItem ? (
+        <QueueDetailDrawer
+          item={detailItem}
+          live={live}
+          onClose={() => setDetailItem(null)}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function buildTodayQueue(live: CompanyOsLiveOps): Array<TodayQueueItem> {
+  const queue: Array<TodayQueueItem> = []
+  const needsProof = live.invoices.find((invoice) => invoice.status === 'needs-proof')
+  const outstanding = live.invoices.filter((invoice) => invoice.status === 'outstanding')
+  const kanbanActions = live.supabase.kanbanActions.slice(0, 4)
+  const emailLead = live.emailSignals.find((signal) => signal.kind === 'lead')
+  const handoff = live.emailSignals.find((signal) => signal.kind === 'handoff')
+
+  if (outstanding.length) {
+    queue.push({
+      id: 'review-outstanding-invoices',
+      title: `Review ${outstanding.length} outstanding invoices`,
+      detail: `${outstanding.length} invoice file${outstanding.length === 1 ? '' : 's'} need review before any follow-up.`,
+      lane: 'finance',
+      priority: 'p0',
+      action: 'Open each outstanding invoice, confirm client/status, then draft follow-up only after review.',
+    })
+  }
+
+  if (needsProof) {
+    queue.push({
+      id: 'find-payment-proof',
+      title: 'Find payment proof',
+      detail: 'One invoice is waiting on payment proof before it can move on.',
+      lane: 'finance',
+      priority: 'p0',
+      action: 'Search payment evidence before moving this invoice to done or sending any follow-up.',
+    })
+  }
+
+  for (const action of kanbanActions) {
+    queue.push({
+      id: `kanban-action-${action.id}`,
+      title: action.businessName || action.title,
+      detail: action.reason,
+      lane: action.lane,
+      priority: action.urgency,
+      action: action.recommendedAction,
+    })
+  }
+
+  if (emailLead) {
+    queue.push({
+      id: `email-${emailLead.subject || 'lead'}`,
+      title: emailLead.subject || 'Gmail lead signal',
+      detail: emailLead.needs || emailLead.summary,
+      lane: 'email',
+      priority: 'p1',
+      action: 'Turn this Gmail signal into an owner, status, and next reply draft.',
+    })
+  }
+
+  if (handoff) {
+    queue.push({
+      id: `handoff-${handoff.subject || 'signal'}`,
+      title: handoff.subject || 'Handoff signal',
+      detail: handoff.needs || handoff.summary,
+      lane: 'Robert handoff',
+      priority: 'p2',
+      action: 'Add this to the Robert handoff list and clarify whether it needs action or just awareness.',
+    })
+  }
+
+  return queue.slice(0, 6)
+}
+
+function buildLeadInbox(
+  live: CompanyOsLiveOps,
+): Record<LeadInboxLane, Array<TodayQueueItem>> {
+  const newLeads: Array<TodayQueueItem> = []
+  const needsReply: Array<TodayQueueItem> = []
+  const followUp: Array<TodayQueueItem> = []
+
+  for (const signal of live.emailSignals.filter((item) => item.kind === 'lead')) {
+    const title = signal.subject || signal.title || 'New Gmail lead'
+    newLeads.push({
+      id: `email-lead-${title}`,
+      title,
+      detail: signal.needs || signal.summary,
+      lane: 'new lead',
+      priority: 'p1',
+      action:
+        'Review the inbound lead, identify the ask, choose the right Unaligned asset, and draft a reply for approval.',
+    })
+    needsReply.push({
+      id: `email-reply-${title}`,
+      title,
+      detail: signal.needs || signal.summary,
+      lane: 'needs reply',
+      priority: 'p1',
+      action:
+        'Draft a concise reply that answers the lead, confirms next step, and does not commit pricing or timing without approval.',
+    })
+  }
+
+  for (const lead of live.supabase.hotLeads) {
+    const stage = lead.listId || 'unknown'
+    const title = lead.businessName || lead.title
+    const item: TodayQueueItem = {
+      id: `lead-card-${lead.id}`,
+      title,
+      detail: `${lead.title} is ${lead.priority || 'unprioritized'} in ${stage}; draft status is ${lead.draftStatus || 'none'}.`,
+      lane: stage === 'first-touch' ? 'new lead' : 'needs reply',
+      priority: lead.priority === 'hot' ? 'p1' : 'p2',
+      action:
+        'Review the Supabase card, check whether a reply is waiting, and prepare the next outbound message for approval.',
+    }
+
+    if (stage === 'first-touch' || stage === 'engaged') {
+      newLeads.push(item)
+    }
+
+    if (['pending', 'drafted'].includes(lead.draftStatus || '')) {
+      needsReply.push({ ...item, lane: 'needs reply' })
+    }
+  }
+
+  for (const action of live.supabase.kanbanActions) {
+    if (!['rates-sent', 'negotiating', 'engaged', 'first-touch'].includes(action.stage || '')) {
+      continue
+    }
+
+    followUp.push({
+      id: `lead-follow-up-${action.id}`,
+      title: action.businessName || action.title,
+      detail: `${action.reason} Stage: ${action.stage || 'unknown'}; draft: ${action.draftStatus || 'none'}.`,
+      lane: 'follow-up due',
+      priority: action.urgency === 'p0' ? 'p1' : action.urgency,
+      action:
+        'Check the last touch, decide whether this needs a bump, and draft a follow-up for approval.',
+    })
+  }
+
+  return {
+    new: dedupeQueueItems(newLeads).slice(0, 5),
+    needsReply: dedupeQueueItems(needsReply).slice(0, 5),
+    followUp: dedupeQueueItems(followUp).slice(0, 5),
+  }
+}
+
+function buildLeadReplyDesk(live: CompanyOsLiveOps): Array<LeadReplyPacket> {
+  return live.emailSignals
+    .filter((signal) => signal.kind === 'lead')
+    .map((signal) => {
+      const item = queueItemFromSignal(signal)
+      const status = leadReplyStatus(signal)
+      const owner = leadReplyOwner(signal, status)
+      const urgency = leadReplyUrgency(signal, status)
+      const blocker = leadReplyBlocker(signal, status)
+      const nextMove = leadReplyNextMove(signal, status, owner)
+      const draft = buildPacketDraft(item, [], undefined, signal)
+
+      return {
+        signal,
+        item,
+        status,
+        owner,
+        urgency,
+        blocker,
+        nextMove,
+        draft,
+      }
+    })
+    .sort((left, right) => replyRank(left) - replyRank(right))
+    .slice(0, 6)
+}
+
+function findLeadReplyPacketId(
+  item: TodayQueueItem,
+  packets: Array<LeadReplyPacket>,
+): string | null {
+  const needle = normalizeQueueTitle(item.title)
+  const packet = packets.find((candidate) => {
+    const title = normalizeQueueTitle(candidate.item.title)
+    const subject = normalizeQueueTitle(candidate.signal.subject || candidate.signal.title || '')
+    return title === needle || subject === needle
+  })
+
+  return packet?.item.id || null
+}
+
+function normalizeQueueTitle(value: string): string {
+  return value.toLowerCase().replace(/^re:\s*/, '').replace(/\s+/g, ' ').trim()
+}
+
+function queueItemFromSignal(signal: CompanyOsSignal): TodayQueueItem {
+  const title = signal.subject || signal.title || 'Gmail lead signal'
+  const status = leadReplyStatus(signal)
+  const owner = leadReplyOwner(signal, status)
+  return {
+    id: `reply-desk-${signal.threadId || signal.messageId || title}`,
+    title,
+    detail: signal.needs || signal.summary,
+    lane: 'needs reply',
+    priority: /urgent|launch|today|approved|monday|timing|qrt/i.test(
+      `${title} ${signal.summary} ${signal.thread?.latestAction || ''}`,
+    )
+      ? 'p0'
+      : 'p1',
+    action: leadReplyNextMove(signal, status, owner),
+  }
+}
+
+function leadReplyStatus(signal: CompanyOsSignal): LeadReplyPacket['status'] {
+  const haystack = signalHaystack(signal)
+  if (/invoice|payment|paid out|receipt|stripe|w-?9|tax|procurement/.test(haystack)) {
+    return 'money-admin'
+  }
+  if (/robert|scoble|use the product|try the software|test out|approval|reshare/.test(haystack)) {
+    return 'needs-robert'
+  }
+  if (/sent|attached|shared|provided|rate card|sponsorship information/.test(haystack)) {
+    return 'waiting-them'
+  }
+  return 'needs-us'
+}
+
+function leadReplyOwner(
+  _signal: CompanyOsSignal,
+  status: LeadReplyPacket['status'],
+): LeadReplyPacket['owner'] {
+  if (status === 'money-admin') return 'Internal'
+  return 'Asher'
+}
+
+function leadReplyUrgency(
+  signal: CompanyOsSignal,
+  status: LeadReplyPacket['status'],
+): LeadReplyPacket['urgency'] {
+  const haystack = signalHaystack(signal)
+  if (/urgent|launch|today|approved|monday|may 25|within 30 minutes|qrt/.test(haystack)) {
+    return 'today'
+  }
+  if (status === 'waiting-them') return 'parked'
+  return 'this-week'
+}
+
+function leadReplyBlocker(
+  signal: CompanyOsSignal,
+  status: LeadReplyPacket['status'],
+): string {
+  const latest = latestExternalMessage(signal)
+  const ask = leadAskLabel(signal)
+  const customer = latest?.name || latest?.email || 'the lead'
+
+  if (status === 'needs-robert') {
+    return `${customer} is asking about ${ask}. Asher owns the reply and collects the facts; Sam reviews if needed; Robert only gets the one-minute approval brief.`
+  }
+  if (status === 'waiting-them') {
+    return `We already appear to have sent info or rates. This stays visible so ${customer} does not go cold before budget, timing, and deliverables are locked.`
+  }
+  if (status === 'money-admin') {
+    return `This touches payment or admin status. Verify paid vs waiting-for-payment before anyone sends a client-facing note.`
+  }
+  return signal.thread?.messages.length
+    ? `${customer} has an active ${ask} thread. Asher should move the conversation forward and collect the facts Robert will need later. Sam is oversight, not first reply.`
+    : 'Thread content is not cached yet; refresh Gmail before drafting.'
+}
+
+function leadReplyNextMove(
+  signal: CompanyOsSignal,
+  status: LeadReplyPacket['status'],
+  _owner: LeadReplyPacket['owner'],
+): string {
+  const sender = 'Asher'
+  const ask = leadAskLabel(signal)
+  const threadPrefix = signal.thread?.messages.length
+    ? `Reply as ${sender} in the existing thread`
+    : `Reply as ${sender}`
+
+  if (status === 'needs-robert') {
+    return `${threadPrefix}: collect ask, budget, timing, and deliverables; route Robert only when the final public action needs approval.`
+  }
+  if (status === 'waiting-them') {
+    return `Hold unless follow-up is due; then ${sender} nudges for the missing budget/timing/decision and keeps Robert out of it.`
+  }
+  if (status === 'money-admin') {
+    return `Verify paid vs waiting-for-payment before ${sender} sends anything external.`
+  }
+  return `${threadPrefix}: answer the ${ask} ask, send the sponsorship PDF if pricing is involved, and ask for budget, timing, and deliverables.`
+}
+
+function buildLeadCommand(packet: LeadReplyPacket): LeadCommand {
+  const ask = leadAskLabel(packet.signal)
+  const sender = 'Asher'
+  const customer = latestExternalMessage(packet.signal)?.name || 'the lead'
+
+  if (packet.status === 'money-admin') {
+    return {
+      mode: 'Payment check',
+      objective: `Verify ${customer}: paid, waiting for payment, or missing proof. Do not send until the money state is clean.`,
+      missing: ['invoice match', 'paid vs waiting', 'proof/status'],
+      robertGate: 'Robert only needs this if payment status changes the collaboration or relationship.',
+      attachmentNote: 'No pricing PDF on payment checks.',
+      proofNote: 'Do not mark paid or request payment until the record is verified.',
+    }
+  }
+
+  if (packet.status === 'waiting-them') {
+    return {
+      mode: 'Waiting',
+      objective: `${sender} follows up only if due. Otherwise wait for budget, timing, or package confirmation. Sam reviews only.`,
+      missing: ['lead reply', 'decision', 'budget/timing'],
+      robertGate: 'Robert stays out until the lead agrees on package, objective, and timing.',
+      attachmentNote: shouldSendPricingPdf(packet.signal)
+        ? 'Pricing PDF was likely already discussed; attach only if it was not actually sent.'
+        : 'No attachment needed yet.',
+      proofNote: 'Avoid extra pings unless there is a real due date.',
+    }
+  }
+
+  if (packet.status === 'needs-robert') {
+    return {
+      mode: 'Deal intake',
+      objective: `${sender} replies now, collects package, timing, deliverables, payment path, and the exact Robert ask. Sam stays in oversight.`,
+      missing: ['budget', 'timing', 'deliverables', 'payment path', 'Robert ask'],
+      robertGate: 'Robert gets one brief when the exact public action and payment state are clear.',
+      attachmentNote: shouldSendPricingPdf(packet.signal)
+        ? 'Pricing PDF should attach or be referenced in the reply.'
+        : 'No pricing attachment detected yet.',
+      proofNote: 'Keep Robert out of the middle. Collect the facts first.',
+    }
+  }
+
+  return {
+    mode: 'New lead',
+    objective: `${sender} replies in-thread, answers the ${ask} ask, and asks for the missing deal facts. Sam reviews only when needed.`,
+    missing: ['budget', 'timing', 'deliverables', 'next step'],
+    robertGate: 'Robert only enters after the deal has a clear objective, risk, and payment state.',
+    attachmentNote: shouldSendPricingPdf(packet.signal)
+      ? 'Pricing PDF should attach or be referenced in the reply.'
+      : 'No attachment needed unless pricing comes up.',
+    proofNote: 'Keep the thread moving without committing pricing, dates, or claims beyond the package.',
+  }
+}
+
+function leadAskLabel(signal: CompanyOsSignal): string {
+  const haystack = signalHaystack(signal)
+  if (/invoice|payment|paid out|receipt|stripe|w-?9|tax|procurement/.test(haystack)) {
+    return 'payment/admin'
+  }
+  if (/rate|rates|pricing|price|sponsor|sponsorship|package|media kit/.test(haystack)) {
+    return 'pricing/sponsorship'
+  }
+  if (/launch|january|monday|today|available|availability|posting|post/.test(haystack)) {
+    return 'launch timing and posting availability'
+  }
+  if (/collab|collaboration|partner|campaign|brief|deliverable/.test(haystack)) {
+    return 'paid collaboration'
+  }
+  if (/use the product|try the software|test out|demo|product/.test(haystack)) {
+    return 'product-fit approval'
+  }
+  return shortenText(signal.needs || signal.summary || signal.subject || 'lead request', 72)
+}
+
+function latestExternalMessage(signal: CompanyOsSignal): { name: string; email: string; body: string } | null {
+  const internal = new Set([
+    'scobleizer@gmail.com',
+    'unalignedx@gmail.com',
+    'asherunaligned@gmail.com',
+  ])
+
+  for (let index = (signal.thread?.messages.length || 0) - 1; index >= 0; index -= 1) {
+    const message = signal.thread?.messages[index]
+    const email = extractEmail(message?.from)
+    if (!email || internal.has(email)) continue
+    const name = String(message?.from || '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/["']/g, '')
+      .trim()
+    return {
+      name: name && !name.includes('@') ? name : email,
+      email,
+      body: message?.body || '',
+    }
+  }
+
+  const email = extractEmail(signal.from)
+  if (email && !internal.has(email)) {
+    const name = String(signal.from || '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/["']/g, '')
+      .trim()
+    return {
+      name: name && !name.includes('@') ? name : email,
+      email,
+      body: signal.summary || signal.needs || '',
+    }
+  }
+
+  return null
+}
+
+function signalHaystack(signal: CompanyOsSignal): string {
+  return [
+    signal.subject,
+    signal.title,
+    signal.from,
+    signal.summary,
+    signal.needs,
+    signal.thread?.status,
+    signal.thread?.latestAction,
+    ...(signal.thread?.messages.map((message) => message.body) || []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+function replyRank(packet: LeadReplyPacket): number {
+  const urgency = { today: 0, 'this-week': 10, parked: 20 }[packet.urgency]
+  const status = {
+    'needs-us': 0,
+    'needs-robert': 1,
+    'money-admin': 2,
+    'waiting-them': 3,
+  }[packet.status]
+  return urgency + status
+}
+
+function defaultReplySender(_packet: LeadReplyPacket): ReplySender {
+  return 'asher'
+}
+
+function senderName(sender: ReplySender): string {
+  if (sender === 'robert') return 'Robert Scoble'
+  if (sender === 'sam') return 'Sam Levin'
+  return 'Asher'
+}
+
+function senderShortName(sender: ReplySender): string {
+  if (sender === 'robert') return 'Robert'
+  if (sender === 'sam') return 'Sammy'
+  return 'Asher'
+}
+
+function senderEmail(sender: ReplySender): string {
+  if (sender === 'robert') return 'scobleizer@gmail.com'
+  if (sender === 'sam') return 'unalignedx@gmail.com'
+  return 'asherunaligned@gmail.com'
+}
+
+function senderSignature(sender: ReplySender): string {
+  if (sender === 'robert') {
+    return [
+      'Robert Scoble',
+      'Founder, Unaligned (media company about how AI is bringing us new things)',
+      'Mobile: +1-425-205-1921',
+      'X: https://x.com/scobleizer',
+      'Web: https://unaligned.io',
+      'This message copyright the sender. All rights reserved.',
+    ].join('\n')
+  }
+
+  if (sender === 'sam') {
+    return ['Sam Levin', 'Partnerships, UNALIGNED', 'unalignedx@gmail.com'].join('\n')
+  }
+
+  return [
+    'Asher Weisberger',
+    'Client Services Manager',
+    'Unaligned',
+    'asherunaligned@gmail.com',
+    'unaligned.io | x.com/unalignedx',
+  ].join('\n')
+}
+
+function ensureSenderSignature(body: string, sender: ReplySender): string {
+  const text = body.trim()
+  const signature = senderSignature(sender)
+  if (!text) return signature
+  if (normalizeText(text).includes(normalizeText(signature))) return text
+  return `${text}\n\n${signature}`
+}
+
+function internalEmails(excludeSender: ReplySender): Array<string> {
+  return ['scobleizer@gmail.com', 'UnalignedX@gmail.com', 'asherunaligned@gmail.com'].filter(
+    (email) => email.toLowerCase() !== senderEmail(excludeSender),
+  )
+}
+
+function extractEmail(value: unknown): string {
+  const match = String(value || '').match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i)
+  return match?.[0]?.toLowerCase() || ''
+}
+
+function splitEmails(value: unknown): Array<string> {
+  return String(value || '')
+    .split(/[,\s;]+/)
+    .map((email) => extractEmail(email))
+    .filter(Boolean)
+}
+
+function uniqueEmails(values: Array<string>): Array<string> {
+  const seen = new Set<string>()
+  return values.filter((email) => {
+    const normalized = email.trim().toLowerCase()
+    if (!normalized || seen.has(normalized)) return false
+    seen.add(normalized)
+    return true
+  })
+}
+
+function emailsFromValue(value: unknown): Array<string> {
+  if (!value) return []
+  if (Array.isArray(value)) return uniqueEmails(value.flatMap((item) => emailsFromValue(item)))
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return emailsFromValue(
+      record.email || record.emails || record.to || record.cc || record.replyTo || record.reply_to,
+    )
+  }
+  return uniqueEmails(splitEmails(value))
+}
+
+function threadParticipants(signal: CompanyOsSignal): Array<string> {
+  const emails: Array<string> = []
+  emails.push(...emailsFromValue(signal.from))
+
+  for (const message of signal.thread?.messages || []) {
+    emails.push(...emailsFromValue(message.from))
+    emails.push(...emailsFromValue(message.to))
+    emails.push(...emailsFromValue(message.cc))
+  }
+
+  return uniqueEmails(emails)
+}
+
+function leadReplyToEmail(signal: CompanyOsSignal, sender: ReplySender): string {
+  const senderAddress = senderEmail(sender)
+  const internal = new Set([
+    'scobleizer@gmail.com',
+    'unalignedx@gmail.com',
+    'asherunaligned@gmail.com',
+  ])
+  const candidates: Array<string> = []
+
+  for (let index = (signal.thread?.messages.length || 0) - 1; index >= 0; index -= 1) {
+    const message = signal.thread?.messages[index]
+    candidates.push(...emailsFromValue(message?.from))
+    candidates.push(...emailsFromValue(message?.to))
+    candidates.push(...emailsFromValue(message?.cc))
+  }
+
+  candidates.push(...emailsFromValue(signal.from))
+
+  for (const email of uniqueEmails(candidates)) {
+    if (email === senderAddress) continue
+    if (internal.has(email)) continue
+    return email
+  }
+
+  return ''
+}
+
+function replyRecipients(
+  signal: CompanyOsSignal,
+  sender: ReplySender,
+): { to: Array<string>; cc: Array<string> } {
+  const leadEmail = leadReplyToEmail(signal, sender)
+  const senderAddress = senderEmail(sender)
+  const participants = uniqueEmails([...threadParticipants(signal), ...internalEmails(sender)])
+  const to = leadEmail && leadEmail !== senderAddress ? [leadEmail] : []
+  const cc = participants.filter(
+    (email) => email !== leadEmail && email !== senderAddress,
+  )
+
+  return { to: uniqueEmails(to), cc: uniqueEmails(cc) }
+}
+
+function subjectForSignal(signal: CompanyOsSignal): string {
+  const last = signal.thread?.messages[signal.thread.messages.length - 1]
+  const base = signal.subject || last?.subject || signal.title || 'Lead conversation'
+  return /^re:/i.test(base) ? base : `Re: ${base}`
+}
+
+function fallbackReplyBody(packet: LeadReplyPacket, sender: ReplySender): string {
+  const first = leadFirstName(packet.signal)
+  const ask = leadAskLabel(packet.signal)
+  const pricing = shouldSendPricingPdf(packet.signal)
+  const question = pricing
+    ? 'Can you confirm budget range, target timing, and the deliverables you want covered?'
+    : 'Can you confirm the clean next step, timing, and what you need from us?'
+
+  if (sender === 'robert') {
+    return [
+      `Hi ${first},`,
+      '',
+      'Thanks for reaching out.',
+      'I am looping this through Asher so he can handle the details and bring me back the clean final brief when needed. Sam is copied for oversight.',
+      '',
+      'Best,',
+    ].join('\n')
+  }
+
+  if (sender === 'sam') {
+    return [
+      `Hi ${first},`,
+      '',
+      `I'm jumping in on the ${ask} side so we can keep this moving without making you repeat the thread.`,
+      pricing
+        ? "I'm including the sponsorship package/rates and can help narrow the right fit."
+        : "I'll help pin down the practical next step and keep the handoff clean.",
+      question,
+      '',
+      'Best,',
+    ].join('\n')
+  }
+
+  return [
+    `Hi ${first},`,
+    '',
+    `I'm jumping in on the ${ask} side so we can keep this moving cleanly from here.`,
+    pricing
+      ? "I'm including the sponsorship package/rates and can help narrow the right fit."
+      : "I'll keep the thread organized and make sure the next step is clear.",
+    question,
+    '',
+    'Best,',
+  ].join('\n')
+}
+
+function shouldSendPricingPdf(signal: CompanyOsSignal): boolean {
+  return /rate|rates|pricing|price|sponsor|sponsorship|package|media kit|paid collab|paid collaboration/i.test(
+    signalHaystack(signal),
+  )
+}
+
+function leadFirstName(signal: CompanyOsSignal): string {
+  const internal = new Set([
+    'scobleizer@gmail.com',
+    'unalignedx@gmail.com',
+    'asherunaligned@gmail.com',
+  ])
+  let from = ''
+
+  for (let index = (signal.thread?.messages.length || 0) - 1; index >= 0; index -= 1) {
+    const candidate = signal.thread?.messages[index]?.from || ''
+    const email = extractEmail(candidate)
+    if (email && !internal.has(email)) {
+      from = candidate
+      break
+    }
+  }
+
+  if (!from && signal.from && !internal.has(extractEmail(signal.from))) {
+    from = signal.from
+  }
+
+  const withoutEmail = from.replace(/<[^>]+>/g, '').replace(/["']/g, '').trim()
+  const first = withoutEmail.split(/\s+/)[0]
+  return first && !first.includes('@') ? first : 'there'
+}
+
+function composeReply(packet: LeadReplyPacket, sender: ReplySender) {
+  return {
+    subject: subjectForSignal(packet.signal),
+    body: ensureSenderSignature(fallbackReplyBody(packet, sender), sender),
+    recipients: replyRecipients(packet.signal, sender),
+  }
+}
+
+function buildReplyAsDraft(packet: LeadReplyPacket, sender: ReplySender): string {
+  const reply = composeReply(packet, sender)
+  return [
+    `From: ${senderName(sender)} <${senderEmail(sender)}>`,
+    `To: ${reply.recipients.to.join(', ') || '[add lead email]'}`,
+    reply.recipients.cc.length ? `Cc: ${reply.recipients.cc.join(', ')}` : '',
+    `Subject: ${reply.subject}`,
+    '',
+    reply.body,
+  ]
+    .filter((line, index, lines) => line || lines[index - 1] === '')
+    .join('\n')
+}
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function dedupeQueueItems(items: Array<TodayQueueItem>): Array<TodayQueueItem> {
+  const seen = new Set<string>()
+  return items.filter((item) => {
+    const key = item.title.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function queueMatchesFilter(item: TodayQueueItem, filter: QueueFilter): boolean {
+  const haystack = `${item.title} ${item.detail} ${item.lane} ${item.action}`.toLowerCase()
+  if (filter === 'all') return true
+  if (filter === 'money') return /money|finance|invoice|payment|paid|proof/.test(haystack)
+  if (filter === 'leads') return /lead|sales|sponsor|rates|kanban/.test(haystack)
+  if (filter === 'email') return /email|gmail|reply|draft/.test(haystack)
+  if (filter === 'robert') return /robert|scoble|handoff/.test(haystack)
+  if (filter === 'blocked') return /proof|blocked|confirm|approval|review/.test(haystack)
+  return true
+}
+
+function filterQueue(
+  items: Array<TodayQueueItem>,
+  filter: QueueFilter,
+): Array<TodayQueueItem> {
+  return items.filter((item) => queueMatchesFilter(item, filter))
+}
+
+function OpsBriefPanel() {
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <HugeiconsIcon
+              icon={CheckListIcon}
+              size={18}
+              strokeWidth={1.7}
+              className="text-[var(--theme-accent)]"
+            />
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+              Daily Operating Brief
+            </p>
+            <Badge>May 26</Badge>
+          </div>
+          <h2 className="mt-1 text-2xl font-semibold text-[var(--theme-text)]">What matters right now</h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-[var(--theme-muted)]">
+          Prep work, payment gates, and waiting items before opening any thread.
+        </p>
+      </div>
+
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.75fr)]">
+        <BriefSection title="Needs Prep / Action" items={OPS_PREP_ITEMS} />
+        <BriefSection title="Watch / Waiting" items={OPS_WAITING_ITEMS} compact />
+      </div>
+    </section>
+  )
+}
+
+function BriefSection({
+  title,
+  items,
+  compact = false,
+}: {
+  title: string
+  items: Array<OpsBriefItem>
+  compact?: boolean
+}) {
+  return (
+    <section className="min-w-0 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)]">
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--theme-border)] px-4 py-3">
+        <h3 className="text-sm font-semibold text-[var(--theme-text)]">{title}</h3>
+        <Badge>{items.length}</Badge>
+      </div>
+      <div className="divide-y divide-[var(--theme-border)]">
+        {items.map((item) => (
+          <BriefRow key={item.title} item={item} compact={compact} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function BriefRow({ item, compact }: { item: OpsBriefItem; compact: boolean }) {
+  return (
+    <article
+      className={cn(
+        'grid gap-3 px-4 py-3',
+        compact ? 'grid-cols-1' : 'md:grid-cols-[220px_minmax(0,1fr)]',
+      )}
+    >
+      <div className="min-w-0">
+        <h4 className="break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">{item.title}</h4>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {item.chips.map((chip) => (
+            <Badge key={chip}>{chip}</Badge>
+          ))}
+        </div>
+      </div>
+      <ul className={cn('space-y-1.5 text-sm leading-6 text-[var(--theme-muted)]', compact && 'text-xs leading-5')}>
+        {item.bullets.map((bullet) => (
+          <li key={bullet} className="flex gap-2">
+            <span className="mt-2 size-1.5 shrink-0 rounded-full bg-[var(--theme-accent)]" />
+            <span>{bullet}</span>
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
+}
+
+function QueueFilterTabs({
+  active,
+  items,
+  onChange,
+}: {
+  active: QueueFilter
+  items: Array<TodayQueueItem>
+  onChange: (filter: QueueFilter) => void
+}) {
+  const filters: Array<{ id: QueueFilter; label: string }> = [
+    { id: 'all', label: 'All' },
+    { id: 'money', label: 'Money' },
+    { id: 'leads', label: 'Leads' },
+    { id: 'email', label: 'Email' },
+    { id: 'robert', label: 'Robert' },
+    { id: 'blocked', label: 'Blocked' },
+  ]
+
+  return (
+    <div className="mb-3 flex flex-wrap gap-2">
+      {filters.map((filter) => {
+        const count = filterQueue(items, filter.id).length
+        const selected = filter.id === active
+        return (
+          <button
+            key={filter.id}
+            type="button"
+            onClick={() => onChange(filter.id)}
+            className={cn(
+              'inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs font-semibold transition',
+              selected
+                ? 'border-accent-500/50 bg-[var(--theme-accent)]/15 text-[var(--theme-accent)]'
+                : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] hover:border-accent-500/40',
+            )}
+          >
+            {filter.label}
+            <span className="tabular-nums text-[var(--theme-muted)]">{count}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function LeadInbox({
+  lanes,
+  onSelect,
+}: {
+  lanes: Record<LeadInboxLane, Array<TodayQueueItem>>
+  onSelect: (item: TodayQueueItem) => void
+}) {
+  const laneMeta: Array<{ id: LeadInboxLane; title: string; empty: string }> = [
+    { id: 'new', title: 'New Leads', empty: 'No new leads in the current snapshot.' },
+    { id: 'needsReply', title: 'Needs Reply', empty: 'No replies are flagged right now.' },
+    { id: 'followUp', title: 'Follow-Up Due', empty: 'No follow-ups are due in this view.' },
+  ]
+
+  return (
+    <div className="space-y-4 lg:max-h-[calc(100vh-180px)] lg:overflow-y-auto lg:pr-1">
+      {laneMeta.map((lane) => (
+        <section key={lane.id}>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+              {lane.title}
+            </p>
+            <Badge>{lanes[lane.id].length}</Badge>
+          </div>
+          <div className="space-y-2">
+            {lanes[lane.id].map((item) => (
+              <QueueItemButton key={item.id} item={item} onSelect={onSelect} compact />
+            ))}
+            {!lanes[lane.id].length ? (
+              <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3 text-xs leading-5 text-[var(--theme-muted)]">
+                {lane.empty}
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function LeadReplyDesk({
+  packets,
+  activePacketId,
+  onActivePacketChange,
+  onOpen,
+}: {
+  packets: Array<LeadReplyPacket>
+  activePacketId: string | null
+  onActivePacketChange: (id: string) => void
+  onOpen: (item: TodayQueueItem) => void
+}) {
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [sendState, setSendState] = useState<
+    Record<
+      string,
+      { status: 'idle' | 'sending' | 'sent' | 'error'; message: string }
+    >
+  >({})
+  const [selectedSenders, setSelectedSenders] = useState<Record<string, ReplySender>>({})
+  const activePacket =
+    packets.find((packet) => packet.item.id === activePacketId) || packets[0] || null
+
+  function senderFor(packet: LeadReplyPacket): ReplySender {
+    return selectedSenders[packet.item.id] || defaultReplySender(packet)
+  }
+
+  async function copyDraft(packet: LeadReplyPacket) {
+    const sender = senderFor(packet)
+    await navigator.clipboard?.writeText(buildReplyAsDraft(packet, sender))
+    setCopiedId(packet.item.id)
+    window.setTimeout(() => setCopiedId(null), 1400)
+  }
+
+  async function sendReply(packet: LeadReplyPacket) {
+    const sender = senderFor(packet)
+    const reply = composeReply(packet, sender)
+
+    if (!reply.recipients.to.length) {
+      setSendState((current) => ({
+        ...current,
+        [packet.item.id]: {
+          status: 'error',
+          message: 'Add the lead email before sending.',
+        },
+      }))
+      return
+    }
+
+    setSendState((current) => ({
+      ...current,
+      [packet.item.id]: { status: 'sending', message: 'Sending reply...' },
+    }))
+
+    try {
+      const endpoint =
+        sender === 'asher'
+          ? '/api/company-os/send'
+          : 'https://us-central1-unaligned-fc556.cloudfunctions.net/sendEmail'
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to: reply.recipients.to,
+          cc: reply.recipients.cc,
+          subject: reply.subject,
+          body: reply.body,
+          from: sender,
+          threadId: packet.signal.threadId || null,
+          attachPdf: shouldSendPricingPdf(packet.signal),
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok || data?.error) {
+        throw new Error(data?.error || `Send failed (${response.status})`)
+      }
+
+      setSendState((current) => ({
+        ...current,
+        [packet.item.id]: {
+          status: 'sent',
+          message: `Sent as ${senderName(sender)} to ${reply.recipients.to.join(', ')}`,
+        },
+      }))
+    } catch (error) {
+      setSendState((current) => ({
+        ...current,
+        [packet.item.id]: {
+          status: 'error',
+          message: error instanceof Error ? error.message : String(error),
+        },
+      }))
+    }
+  }
+
+  if (!packets.length) {
+    return (
+      <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon icon={Rocket01Icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+          <h2 className="text-sm font-semibold text-[var(--theme-text)]">Deal Machine</h2>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">
+          No Gmail lead threads are cached. Refresh Gmail to build reply packets.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+      <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon icon={Rocket01Icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+          <h2 className="text-sm font-semibold text-[var(--theme-text)]">Deal Machine</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge>{packets.filter((packet) => packet.urgency === 'today').length} today</Badge>
+          <Badge>{packets.length} leads</Badge>
+          <Badge>Asher replies</Badge>
+        </div>
+      </div>
+
+      {activePacket ? (
+        <LeadCommandSurface
+          packet={activePacket}
+          copied={copiedId === activePacket.item.id}
+          sender={senderFor(activePacket)}
+          sendState={sendState[activePacket.item.id]}
+          onCopy={() => void copyDraft(activePacket)}
+          onOpen={() => onOpen(activePacket.item)}
+          onSend={() => void sendReply(activePacket)}
+          onSenderChange={(sender) =>
+            setSelectedSenders((current) => ({
+              ...current,
+              [activePacket.item.id]: sender,
+            }))
+          }
+        />
+      ) : null}
+    </section>
+  )
+}
+
+function LeadCommandSurface({
+  packet,
+  copied,
+  sender,
+  sendState,
+  onCopy,
+  onOpen,
+  onSend,
+  onSenderChange,
+}: {
+  packet: LeadReplyPacket
+  copied: boolean
+  sender: ReplySender
+  sendState?: { status: 'idle' | 'sending' | 'sent' | 'error'; message: string }
+  onCopy: () => void
+  onOpen: () => void
+  onSend: () => void
+  onSenderChange: (sender: ReplySender) => void
+}) {
+  const reply = composeReply(packet, sender)
+  const command = buildLeadCommand(packet)
+  const workflow = buildCollabWorkflow(packet)
+  const sendBlocked = packet.status === 'money-admin'
+  const targetEmail = reply.recipients.to.join(', ') || 'Lead email missing'
+
+  return (
+    <article
+      className={cn(
+        'overflow-hidden rounded-lg border',
+        packet.urgency === 'today'
+          ? 'border-amber-500/30 bg-amber-500/[0.05]'
+          : 'border-[var(--theme-border)] bg-[var(--theme-card2)]',
+      )}
+    >
+      <div className="grid gap-0 xl:grid-cols-[minmax(0,1fr)_300px]">
+        <div className="space-y-4 p-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="mb-2 flex flex-wrap gap-2">
+                <Badge>{workflow.stageLabel}</Badge>
+                <Badge>{replyStatusLabel(packet.status)}</Badge>
+                <Badge>{packet.urgency}</Badge>
+              </div>
+              <h3 className="max-w-4xl break-words text-2xl font-semibold leading-8 text-[var(--theme-text)]">
+                {packet.item.title}
+              </h3>
+            </div>
+            <button
+              type="button"
+              onClick={onOpen}
+              className="h-10 shrink-0 rounded-lg border border-[var(--theme-border)] px-3 text-xs font-semibold text-[var(--theme-muted)] transition hover:bg-[var(--theme-card)]"
+            >
+              Open brief
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-accent-500/30 bg-[var(--theme-accent)]/[0.08] p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+              Current job
+            </p>
+            <p className="mt-2 text-lg font-semibold leading-7 text-[var(--theme-text)]">{workflow.currentTask}</p>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--theme-muted)]">{workflow.operatorRule}</p>
+          </div>
+
+          <LeadStageTracker workflow={workflow} />
+
+          <div className="grid gap-3 lg:grid-cols-4">
+            <CommandTile title="Client Inputs">
+              <div className="flex flex-wrap gap-1.5">
+                {command.missing.map((item) => (
+                  <Badge key={item}>{item}</Badge>
+                ))}
+              </div>
+            </CommandTile>
+            <CommandTile title="Invoice / Pay">
+              <p className="text-sm leading-6 text-[var(--theme-muted)]">{workflow.invoiceState}</p>
+              <p className="mt-1 text-xs leading-5 text-[var(--theme-muted)]">{workflow.paymentState}</p>
+            </CommandTile>
+            <CommandTile title="Robert Brief">
+              <p className="text-sm leading-6 text-[var(--theme-muted)]">{workflow.briefState}</p>
+            </CommandTile>
+            <CommandTile title="Done Rule">
+              <p className="text-sm leading-6 text-[var(--theme-muted)]">{workflow.doneRule}</p>
+            </CommandTile>
+          </div>
+        </div>
+
+        <aside className="border-t border-[var(--theme-border)] bg-[var(--theme-card)] p-4 xl:border-l xl:border-t-0">
+          <div className="space-y-4">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                Operator
+              </p>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <StatusChip label="Robert" value="Intake + execute" />
+                <StatusChip label="Asher" value="Client replies" />
+                <StatusChip label="Sammy" value="Oversight" />
+                <StatusChip label="Target" value={targetEmail} />
+              </div>
+            </div>
+
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                Send as
+              </p>
+              <div className="mt-2 grid grid-cols-3 gap-2">
+                {(['asher', 'robert', 'sam'] as Array<ReplySender>).map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    onClick={() => onSenderChange(option)}
+                    className={cn(
+                      'h-10 rounded-lg border px-2 text-xs font-semibold transition',
+                      sender === option
+                        ? 'border-accent-500/50 bg-[var(--theme-accent)]/[0.12] text-[var(--theme-accent)]'
+                        : 'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-muted)] hover:border-accent-500/40',
+                    )}
+                  >
+                    {senderShortName(option)}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+                Default is Asher. Switch only when Robert or Sammy should be the visible sender.
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                Guardrail
+              </p>
+              <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{command.proofNote}</p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={onSend}
+                disabled={sendBlocked || sendState?.status === 'sending'}
+                className={cn(
+                  'h-11 rounded-lg px-3 text-sm font-semibold transition',
+                  sendBlocked
+                    ? 'bg-[var(--theme-card2)] text-[var(--theme-muted)]'
+                    : sendState?.status === 'sent'
+                      ? 'bg-emerald-500 text-white hover:opacity-90'
+                      : 'bg-[var(--theme-accent)] text-white hover:opacity-90',
+                )}
+              >
+                {sendBlocked
+                  ? 'Verify first'
+                  : sendState?.status === 'sending'
+                    ? 'Sending...'
+                    : sendState?.status === 'sent'
+                      ? 'Sent'
+                      : `Send as ${senderName(sender)}`}
+              </button>
+              <button
+                type="button"
+                onClick={onCopy}
+                className="h-11 rounded-lg border border-[var(--theme-border)] px-3 text-sm font-semibold text-[var(--theme-muted)] transition hover:bg-[var(--theme-card2)]"
+              >
+                {copied ? 'Copied' : 'Copy draft'}
+              </button>
+            </div>
+
+            {sendState?.message ? (
+              <p
+                className={cn(
+                  'text-xs leading-5',
+                  sendState.status === 'error'
+                    ? 'text-[var(--theme-danger)]'
+                    : sendState.status === 'sent'
+                      ? 'text-[var(--theme-success)]'
+                      : 'text-[var(--theme-muted)]',
+                )}
+              >
+                {sendState.message}
+              </p>
+            ) : null}
+          </div>
+        </aside>
+      </div>
+    </article>
+  )
+}
+
+function buildCollabWorkflow(packet: LeadReplyPacket): CollabWorkflow {
+  const operatorInThread = threadParticipants(packet.signal).some((email) =>
+    ['asherunaligned@gmail.com', 'unalignedx@gmail.com'].includes(email),
+  )
+
+  if (packet.status === 'money-admin') {
+    return {
+      stageIndex: 3,
+      stageLabel: 'Invoice / payment',
+      currentTask: 'Verify whether the invoice is paid, waiting, or missing proof.',
+      operatorRule:
+        'Do not move this to done and do not ask the client for money until the payment record is clean.',
+      invoiceState: 'Invoice/admin item needs matching against source records.',
+      paymentState: 'Payment is not cleared in this system yet.',
+      briefState: 'Robert brief waits until payment status and deliverables are clear.',
+      doneRule: 'Done only after execution is complete and payment is cleared or explicitly marked waiting.',
+    }
+  }
+
+  if (packet.status === 'waiting-them') {
+    return {
+      stageIndex: 2,
+      stageLabel: 'Client work',
+      currentTask: 'Wait for the client response; nudge only if the deal is going cold.',
+      operatorRule:
+        'Asher keeps the thread moving. Sammy watches for risk. Robert stays out until there is a tight brief.',
+      invoiceState: 'Invoice is not the active gate unless the client already accepted terms.',
+      paymentState: 'Payment not cleared yet.',
+      briefState: 'Brief is drafted only after scope, timing, deliverables, and money are understood.',
+      doneRule: 'Done requires agreed work, Robert-ready brief, execution, and payment status.',
+    }
+  }
+
+  if (packet.status === 'needs-robert') {
+    return {
+      stageIndex: operatorInThread ? 2 : 1,
+      stageLabel: operatorInThread ? 'Client work' : 'Team intro',
+      currentTask: operatorInThread
+        ? 'Asher gets the deal facts before Robert sees anything.'
+        : 'Robert brings in Asher and Sammy, then Asher takes over the client thread.',
+      operatorRule:
+        'Robert is the source of the lead and final executor. Asher handles the back-and-forth. Sammy is oversight.',
+      invoiceState: 'Invoice comes after package, scope, deliverables, and timing are agreed.',
+      paymentState: 'Payment is not cleared yet.',
+      briefState: 'Create or rewrite the company brief into a 60-second Robert brief before execution.',
+      doneRule: 'Done means Robert has executed, brief is stored, and payment is cleared or tracked.',
+    }
+  }
+
+  return {
+    stageIndex: operatorInThread ? 2 : 1,
+    stageLabel: operatorInThread ? 'Client work' : 'Team intro',
+    currentTask: operatorInThread
+      ? 'Asher works the client toward a package, deliverables, timing, and payment path.'
+      : 'Bring Asher into the thread and let him start the client work.',
+    operatorRule:
+      'Asher replies first and owns the grunt work. Sammy watches for issues. Robert gets the brief later.',
+    invoiceState: 'Invoice not ready until deal terms are confirmed.',
+    paymentState: 'Payment is not cleared yet.',
+    briefState: 'No Robert brief until the objective, deliverables, and payment state are clear.',
+    doneRule: 'Done requires deal terms, invoice/payment status, 60-second brief, and execution.',
+  }
+}
+
+function LeadStageTracker({ workflow }: { workflow: CollabWorkflow }) {
+  const stages = [
+    'Robert contacted',
+    'Team intro',
+    'Client work',
+    'Invoice/pay',
+    '60-sec brief',
+    'Done',
+  ]
+  const activeIndex = workflow.stageIndex
+
+  return (
+    <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+          Deal Path
+        </p>
+        <Badge>{workflow.stageLabel}</Badge>
+      </div>
+      <div className="mt-4 grid grid-cols-6 gap-2">
+        {stages.map((stage, index) => (
+          <div key={stage} className="min-w-0">
+            <div
+              className={cn(
+                'h-1.5 rounded-full',
+                index <= activeIndex ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-card2)]',
+              )}
+            />
+            <p
+              className={cn(
+                'mt-2 truncate text-[11px] font-semibold',
+                index === activeIndex ? 'text-[var(--theme-text)]' : 'text-[var(--theme-muted)]',
+              )}
+            >
+              {stage}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function CommandTile({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+        {title}
+      </p>
+      <div className="mt-2">{children}</div>
+    </div>
+  )
+}
+
+function StatusChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-2">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+        {label}
+      </p>
+      <p className="mt-1 truncate text-xs font-semibold text-[var(--theme-muted)]">{value}</p>
+    </div>
+  )
+}
+
+function LeadPacketRail({
+  packets,
+  activePacketId,
+  onActivePacketChange,
+  onFocusChange,
+}: {
+  packets: Array<LeadReplyPacket>
+  activePacketId: string | null
+  onActivePacketChange: (id: string) => void
+  onFocusChange: (item: TodayQueueItem) => void
+}) {
+  if (!packets.length) return null
+
+  return (
+    <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon icon={Rocket01Icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+          <h2 className="text-sm font-semibold text-[var(--theme-text)]">Lead Queue</h2>
+        </div>
+        <Badge>{packets.length}</Badge>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {packets.map((packet) => (
+          <button
+          key={packet.item.id}
+          type="button"
+          onClick={() => {
+            onActivePacketChange(packet.item.id)
+            onFocusChange(packet.item)
+          }}
+            className={cn(
+              'min-w-[220px] rounded-lg border p-3 text-left transition hover:border-accent-500/50',
+              activePacketId === packet.item.id
+                ? 'border-accent-500/45 bg-[var(--theme-accent)]/[0.08]'
+                : 'border-[var(--theme-border)] bg-[var(--theme-card2)]',
+            )}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <p className="min-w-0 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                {packet.item.title}
+              </p>
+              <PriorityBadge priority={packet.item.priority} />
+            </div>
+            <p className="mt-2 line-clamp-2 text-xs leading-5 text-[var(--theme-muted)]">
+              {shortenText(packet.nextMove, 100)}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              <Badge>{packet.status === 'money-admin' ? 'verify first' : 'Asher'}</Badge>
+              <Badge>{replyStatusLabel(packet.status)}</Badge>
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function WorkspaceRail({
+  activeTab,
+  onTabChange,
+  packets,
+  activePacketId,
+  onActivePacketChange,
+  onFocusChange,
+  queue,
+  calendar,
+}: {
+  activeTab: WorkspaceTab
+  onTabChange: (tab: WorkspaceTab) => void
+  packets: Array<LeadReplyPacket>
+  activePacketId: string | null
+  onActivePacketChange: (id: string) => void
+  onFocusChange: (item: TodayQueueItem) => void
+  queue: Array<TodayQueueItem>
+  calendar: Array<RobertCalendarBlock>
+}) {
+  return (
+    <aside className="space-y-3 xl:sticky xl:top-24 xl:max-h-[calc(100vh-120px)] xl:overflow-hidden">
+      <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+        <div className="flex gap-2">
+          <TabPill
+            active={activeTab === 'queue'}
+            icon={Rocket01Icon}
+            label="Queue"
+            onClick={() => onTabChange('queue')}
+          />
+          <TabPill
+            active={activeTab === 'calendar'}
+            icon={Calendar01Icon}
+            label="Calendar"
+            onClick={() => onTabChange('calendar')}
+          />
+        </div>
+      </section>
+
+      {activeTab === 'queue' ? (
+        <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 xl:max-h-[calc(100vh-190px)] xl:overflow-hidden">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <HugeiconsIcon icon={Rocket01Icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+              <h2 className="text-sm font-semibold text-[var(--theme-text)]">Next Leads</h2>
+            </div>
+            <Badge>{packets.length}</Badge>
+          </div>
+          <div className="space-y-2 xl:max-h-[calc(100vh-250px)] xl:overflow-y-auto xl:pr-1">
+            {packets.map((packet) => {
+              const workflow = buildCollabWorkflow(packet)
+              return (
+                <button
+                  key={packet.item.id}
+                  type="button"
+                  onClick={() => {
+                    onActivePacketChange(packet.item.id)
+                    onFocusChange(packet.item)
+                  }}
+                  className={cn(
+                    'w-full rounded-lg border p-2.5 text-left transition hover:border-accent-500/50',
+                    activePacketId === packet.item.id
+                      ? 'border-accent-500/45 bg-[var(--theme-accent)]/[0.08]'
+                      : 'border-[var(--theme-border)] bg-[var(--theme-card2)]',
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="line-clamp-2 min-w-0 break-words text-xs font-semibold leading-5 text-[var(--theme-text)]">
+                        {packet.item.title}
+                      </p>
+                      <p className="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                        {workflow.stageLabel}
+                      </p>
+                    </div>
+                    <PriorityBadge priority={packet.item.priority} />
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    <Badge>{packet.status === 'money-admin' ? 'verify first' : 'Asher'}</Badge>
+                    <Badge>{workflow.stageIndex + 1}/6</Badge>
+                  </div>
+                </button>
+              )
+            })}
+            {!packets.length ? (
+              <p className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3 text-sm leading-6 text-[var(--theme-muted)]">
+                No lead packets are cached yet.
+              </p>
+            ) : null}
+          </div>
+        </section>
+      ) : (
+        <RobertCalendarPanel
+          calendar={calendar}
+          queue={queue}
+          packets={packets}
+          onSelectItem={(item) => {
+            onFocusChange(item)
+            const packetId = findLeadReplyPacketId(item, packets)
+            if (packetId) onActivePacketChange(packetId)
+          }}
+        />
+      )}
+    </aside>
+  )
+}
+
+function TabPill({
+  active,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean
+  icon: typeof Rocket01Icon
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-lg border px-3 text-xs font-semibold transition',
+        active
+          ? 'border-accent-500/50 bg-[var(--theme-accent)]/15 text-[var(--theme-accent)]'
+          : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] hover:border-accent-500/40',
+      )}
+    >
+      <HugeiconsIcon icon={icon} size={16} strokeWidth={1.7} />
+      <span className="truncate">{label}</span>
+    </button>
+  )
+}
+
+type RobertCalendarBlock = {
+  id: string
+  timeLabel: string
+  title: string
+  detail: string
+  badges: Array<string>
+  item: TodayQueueItem
+}
+
+function buildRobertCalendarAgenda(
+  packets: Array<LeadReplyPacket>,
+  queue: Array<TodayQueueItem>,
+): Array<RobertCalendarBlock> {
+  const queueById = new Map(queue.map((item) => [item.id, item]))
+  const agenda: Array<{ key: string; title: string; detail: string; badges: Array<string>; item: TodayQueueItem }> = []
+
+  for (const packet of packets) {
+    if (packet.status !== 'needs-robert' && packet.owner !== 'Robert') continue
+    agenda.push({
+      key: `packet-${packet.item.id}`,
+      title: packet.item.title,
+      detail: shortenText(packet.nextMove, 110),
+      badges: [packet.owner, replyStatusLabel(packet.status), packet.urgency],
+      item: packet.item,
+    })
+  }
+
+  for (const item of queue) {
+    if (!/robert/i.test(`${item.title} ${item.detail} ${item.lane} ${item.action}`)) continue
+    if (queueById.has(item.id) && agenda.some((entry) => entry.item.id === item.id)) continue
+    agenda.push({
+      key: `queue-${item.id}`,
+      title: item.title,
+      detail: shortenText(item.action, 110),
+      badges: [item.lane, item.priority.toUpperCase()],
+      item,
+    })
+  }
+
+  const slots = ['9:00 AM', '10:30 AM', '12:00 PM', '1:30 PM', '3:00 PM', '4:30 PM']
+
+  return agenda.slice(0, 6).map((entry, index) => ({
+    id: entry.key,
+    timeLabel: slots[index] || `Slot ${index + 1}`,
+    title: entry.title,
+    detail: entry.detail,
+    badges: entry.badges,
+    item: entry.item,
+  }))
+}
+
+function RobertCalendarPanel({
+  calendar,
+  queue,
+  packets,
+  onSelectItem,
+}: {
+  calendar: Array<RobertCalendarBlock>
+  queue: Array<TodayQueueItem>
+  packets: Array<LeadReplyPacket>
+  onSelectItem: (item: TodayQueueItem) => void
+}) {
+  const robertCount = calendar.length
+  const robertPacketCount = packets.filter(
+    (packet) => packet.status === 'needs-robert' || packet.owner === 'Robert',
+  ).length
+  const totalQueueCount = queue.filter((item) => /robert/i.test(`${item.title} ${item.detail} ${item.lane} ${item.action}`)).length
+
+  return (
+    <section className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon icon={Calendar01Icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+          <h2 className="text-sm font-semibold text-[var(--theme-text)]">Robert Calendar</h2>
+        </div>
+        <Badge>{robertCount || robertPacketCount || totalQueueCount} items</Badge>
+      </div>
+      <p className="mb-4 text-sm leading-6 text-[var(--theme-muted)]">
+        This tab follows the items that need Robert&apos;s attention so you can scan his day without pulling it into the main reply desk.
+      </p>
+      <div className="space-y-2">
+        {calendar.length ? (
+          calendar.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => onSelectItem(entry.item)}
+              className="w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3 text-left transition hover:border-accent-500/50 hover:bg-[var(--theme-card)]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                    {entry.timeLabel}
+                  </p>
+                  <p className="mt-1 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                    {entry.title}
+                  </p>
+                </div>
+                <PriorityBadge priority={entry.item.priority} />
+              </div>
+              <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{entry.detail}</p>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {entry.badges.map((badge) => (
+                  <Badge key={`${entry.id}-${badge}`}>{badge}</Badge>
+                ))}
+              </div>
+            </button>
+          ))
+        ) : (
+          <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-4 text-sm leading-6 text-[var(--theme-muted)]">
+            No Robert-specific blocks are cached yet. Once the calendar feed is wired in, this panel will show his day here.
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function replyStatusLabel(status: LeadReplyPacket['status']): string {
+  if (status === 'needs-us') return 'needs us'
+  if (status === 'needs-robert') return 'needs Robert'
+  if (status === 'waiting-them') return 'waiting them'
+  return 'money/admin'
+}
+
+function QueueItemButton({
+  item,
+  onSelect,
+  compact = false,
+}: {
+  item: TodayQueueItem
+  onSelect: (item: TodayQueueItem) => void
+  compact?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className={cn(
+        'w-full rounded-lg border text-left transition hover:border-accent-500/60 hover:bg-[var(--theme-card)]',
+        compact ? 'p-3' : 'p-3',
+        item.priority === 'p0'
+          ? 'border-red-500/30 bg-red-500/[0.06]'
+          : 'border-[var(--theme-border)] bg-[var(--theme-card2)]',
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="min-w-0 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+          {item.title}
+        </p>
+        <PriorityBadge priority={item.priority} />
+      </div>
+      <p className="mt-2 line-clamp-2 text-xs leading-5 text-[var(--theme-muted)]">{item.detail}</p>
+      <div className="mt-3">
+        <Badge>{item.lane}</Badge>
+      </div>
+    </button>
+  )
+}
+
+function FocusPanel({
+  item,
+  onOpen,
+}: {
+  item: TodayQueueItem | null | undefined
+  onOpen: (item: TodayQueueItem) => void
+}) {
+  if (!item) {
+    return (
+      <section className="min-w-0 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+        <p className="text-sm text-[var(--theme-muted)]">No active packet selected.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="min-w-0 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="mb-3 flex flex-wrap gap-2">
+            <PriorityBadge priority={item.priority} />
+            <Badge>{item.lane}</Badge>
+          </div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+            Focus Packet
+          </p>
+          <h2 className="mt-2 max-w-3xl break-words text-3xl font-semibold leading-tight text-[var(--theme-text)]">
+            {item.title}
+          </h2>
+          <p className="mt-4 max-w-3xl text-sm leading-6 text-[var(--theme-muted)]">
+            {shortenText(item.detail, 180)}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpen(item)}
+          className="inline-flex h-11 shrink-0 items-center justify-center rounded-lg bg-[var(--theme-accent)] px-5 text-sm font-semibold text-white transition hover:opacity-90"
+        >
+          Open packet
+        </button>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-accent-500/25 bg-[var(--theme-accent)]/[0.08] p-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+          Recommended next move
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">{item.action}</p>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+          Context
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">
+          {item.id === 'review-outstanding-invoices'
+            ? 'This is a finance review packet. Open the packet for the invoice list and any follow-up draft.'
+            : item.id === 'find-payment-proof'
+              ? 'This is a proof check packet. Open the packet to inspect the invoice evidence.'
+              : shortenText(item.detail, 120)}
+        </p>
+      </div>
+
+    </section>
+  )
+}
+
+function QueueDetailDrawer({
+  item,
+  live,
+  onClose,
+}: {
+  item: TodayQueueItem
+  live: CompanyOsLiveOps
+  onClose: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+  const [activeTab, setActiveTab] = useState<PacketTab>('summary')
+  const invoices =
+    item.id === 'review-outstanding-invoices'
+      ? live.invoices.filter((invoice) => invoice.status === 'outstanding')
+      : item.id === 'find-payment-proof'
+        ? live.invoices.filter((invoice) => invoice.status === 'needs-proof')
+        : []
+  const lead = [...live.supabase.hotLeads, ...live.supabase.invoiceLeads].find(
+    (candidate) => item.id.endsWith(String(candidate.id)),
+  )
+  const kanbanAction = live.supabase.kanbanActions.find(
+    (candidate) =>
+      item.id === `kanban-action-${candidate.id}` ||
+      item.id === `lead-follow-up-${candidate.id}`,
+  )
+  const matchedAssets = kanbanAction
+    ? live.assets.filter((asset) => kanbanAction.assetIds.includes(asset.id))
+    : packetDomain(item) === 'sales'
+      ? live.assets.filter(
+        (asset) => asset.id === 'partnership-packages' || asset.kind === 'pricing',
+      )
+      : []
+  const signal = [...live.emailSignals, ...live.driveSignals].find(
+    (candidate) => item.title === (candidate.subject || candidate.title),
+  )
+  const reviewPrompt = buildReviewPrompt(
+    item,
+    invoices,
+    lead,
+    signal,
+    kanbanAction,
+    matchedAssets,
+  )
+  const draftText = buildPacketDraft(item, invoices, lead, signal, kanbanAction, matchedAssets)
+  const packetReview = useMemo(
+    () => buildPacketReview(item, invoices, lead, signal, kanbanAction, matchedAssets),
+    [item, invoices, lead, signal, kanbanAction, matchedAssets],
+  )
+
+  async function copyReviewPrompt() {
+    await navigator.clipboard?.writeText(reviewPrompt)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1600)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black/45">
+      <button
+        type="button"
+        aria-label="Close queue detail"
+        className="hidden flex-1 md:block"
+        onClick={onClose}
+      />
+      <aside className="flex h-full w-full max-w-[860px] flex-col border-l border-[var(--theme-border)] bg-[var(--theme-bg)] shadow-2xl">
+        <header className="border-b border-[var(--theme-border)] p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="mb-2 flex flex-wrap gap-2">
+                <Badge>{item.lane}</Badge>
+                <PriorityBadge priority={item.priority} />
+              </div>
+              <h2 className="break-words text-xl font-semibold leading-7 text-[var(--theme-text)]">
+                {item.title}
+              </h2>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-sm text-[var(--theme-muted)] transition hover:bg-[var(--theme-card)]"
+            >
+              Close
+            </button>
+          </div>
+          <p className="mt-3 text-sm leading-6 text-[var(--theme-muted)]">{packetReview.dealQuestion}</p>
+          <PacketTabs active={activeTab} onChange={setActiveTab} />
+        </header>
+
+        <div className="flex-1 space-y-4 overflow-y-auto p-5">
+          {activeTab === 'summary' ? (
+            <PacketGeneratedReview
+              item={item}
+              review={packetReview}
+              kanbanAction={kanbanAction}
+            />
+          ) : null}
+          {activeTab === 'thread' ? (
+            <PacketThread signal={signal} />
+          ) : null}
+          {activeTab === 'draft' ? (
+            <PacketDraft
+              draftText={packetReview?.draftMessage || draftText}
+              onCopy={() => void navigator.clipboard?.writeText(packetReview?.draftMessage || draftText)}
+            />
+          ) : null}
+          {activeTab === 'assets' ? (
+            <PacketAssets assets={matchedAssets} />
+          ) : null}
+          {activeTab === 'actions' ? (
+            <PacketApproval
+              copied={copied}
+              review={packetReview}
+              onCopyReviewPrompt={() => void copyReviewPrompt()}
+              onCopyTitle={() => void navigator.clipboard?.writeText(item.title)}
+            />
+          ) : null}
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+function PacketTabs({
+  active,
+  onChange,
+}: {
+  active: PacketTab
+  onChange: (tab: PacketTab) => void
+}) {
+  const tabs: Array<{ id: PacketTab; label: string }> = [
+    { id: 'summary', label: 'Summary' },
+    { id: 'thread', label: 'Thread' },
+    { id: 'draft', label: 'Draft' },
+    { id: 'assets', label: 'Assets' },
+    { id: 'actions', label: 'Actions' },
+  ]
+
+  return (
+    <div className="mt-4 flex gap-1 overflow-x-auto rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-1">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => onChange(tab.id)}
+          className={cn(
+            'h-8 shrink-0 rounded-md px-3 text-xs font-semibold transition',
+            active === tab.id
+              ? 'bg-[var(--theme-accent)] text-white'
+              : 'text-[var(--theme-muted)] hover:bg-[var(--theme-card2)]',
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function PacketGeneratedReview({
+  item,
+  review,
+  kanbanAction,
+}: {
+  item: TodayQueueItem
+  review: PacketReview
+  kanbanAction?: CompanyOsKanbanAction
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+      <div className="space-y-4">
+        <DetailBlock title="Deal Brief">
+          <div className="rounded-lg border border-accent-500/25 bg-[var(--theme-accent)]/[0.08] p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+              Objective
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">{review.dealQuestion}</p>
+            <p className="mt-3 text-sm leading-6 text-[var(--theme-muted)]">{review.status}</p>
+          </div>
+        </DetailBlock>
+        <DetailBlock title="Deal Path">
+          <div className="space-y-2">
+            {review.dealSteps.map((step, index) => (
+              <div
+                key={`${step}-${index}`}
+                className="flex gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-3"
+              >
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--theme-accent)]/15 text-xs font-semibold text-[var(--theme-accent)]">
+                  {index + 1}
+                </span>
+                <p className="text-sm leading-6 text-[var(--theme-muted)]">{step}</p>
+              </div>
+            ))}
+          </div>
+        </DetailBlock>
+      </div>
+      <DetailBlock title="Operator Brief">
+        <div className="space-y-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <StatusRow label="Operator" value={review.operator === 'Internal' ? 'Verify first' : 'Asher'} />
+          <StatusRow label="Priority" value={item.priority.toUpperCase()} />
+          <StatusRow label="Stage" value={kanbanAction?.stage || 'Needs review'} />
+          <StatusRow label="Draft" value={kanbanAction?.draftStatus || 'Not prepared'} />
+          <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+              Robert sees this when
+            </p>
+            <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{review.robertBrief}</p>
+          </div>
+          <details className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+            <summary className="cursor-pointer list-none text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+              Evidence and risk
+            </summary>
+            <div className="mt-3 space-y-3">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                  Evidence
+                </p>
+                <div className="mt-2">
+                  <BulletList items={review.evidence} />
+                </div>
+              </div>
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                  Risks
+                </p>
+                <div className="mt-2">
+                  <BulletList items={review.risks} tone="warning" />
+                </div>
+              </div>
+            </div>
+          </details>
+        </div>
+      </DetailBlock>
+    </div>
+  )
+}
+
+function PacketThread({ signal }: { signal?: CompanyOsSignal }) {
+  const thread = signal?.thread
+  const messages = thread?.messages || []
+  const visibleMessages = messages.slice(-2).reverse()
+
+  if (!messages.length) {
+    return (
+      <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+        <p className="text-sm font-semibold text-[var(--theme-text)]">No email chain cached yet.</p>
+        <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">
+          This packet has a signal, but the actual Gmail messages have not been
+          saved into the local snapshot yet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <DetailBlock title="Thread Status">
+        <div className="rounded-lg border border-accent-500/25 bg-[var(--theme-accent)]/[0.08] p-4">
+          <p className="text-sm font-semibold text-[var(--theme-text)]">{thread.status}</p>
+          <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">{thread.latestAction}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Badge>Latest {visibleMessages.length} of {messages.length}</Badge>
+          </div>
+          {signal.gmailUrl ? (
+            <a
+              href={signal.gmailUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-flex rounded-lg border border-accent-500/35 px-3 py-1.5 text-xs font-semibold text-[var(--theme-accent)] transition hover:bg-[var(--theme-accent)]/10"
+            >
+              Open in Gmail
+            </a>
+          ) : null}
+        </div>
+      </DetailBlock>
+      <DetailBlock title="Email Chain">
+        <div className="space-y-3">
+          {visibleMessages.map((message) => (
+            <article
+              key={message.id}
+              className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <p className="break-words text-sm font-semibold text-[var(--theme-text)]">{message.from}</p>
+                  <p className="mt-1 break-words text-xs text-[var(--theme-muted)]">
+                    {message.subject || signal.subject || signal.title || 'Email message'}
+                  </p>
+                </div>
+                {message.timestamp ? (
+                  <Badge>{formatTimestamp(message.timestamp)}</Badge>
+                ) : null}
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {message.to?.length ? <Badge>To {message.to.length}</Badge> : null}
+                {message.cc?.length ? <Badge>Cc {message.cc.length}</Badge> : null}
+                {message.attachments?.length ? <Badge>{message.attachments.length} files</Badge> : null}
+              </div>
+              <details className="mt-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                <summary className="cursor-pointer list-none text-xs font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                  Message preview · {shortenText(message.body, 70)}
+                </summary>
+                <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--theme-muted)]">
+                  {shortenText(message.body, 200)}
+                </p>
+                {message.attachments?.length ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {message.attachments.map((attachment) => (
+                      <Badge key={attachment}>{attachment}</Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </details>
+            </article>
+          ))}
+        </div>
+      </DetailBlock>
+    </div>
+  )
+}
+
+function PacketDraft({
+  draftText,
+  onCopy,
+}: {
+  draftText: string
+  onCopy: () => void
+}) {
+  const [copiedDraft, setCopiedDraft] = useState(false)
+  const draft = splitDraftPreview(draftText)
+
+  function copyDraft() {
+    onCopy()
+    setCopiedDraft(true)
+    window.setTimeout(() => setCopiedDraft(false), 1400)
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px]">
+      <DetailBlock title={draft.blocked ? 'Operator Note' : 'Customer Draft'}>
+        <div className="space-y-3">
+          {draft.subject ? (
+            <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                Subject
+              </p>
+              <p className="mt-2 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                {draft.subject}
+              </p>
+            </div>
+          ) : null}
+          <div className="max-h-[520px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 text-sm leading-6 text-[var(--theme-muted)]">
+            {draft.body}
+          </div>
+        </div>
+      </DetailBlock>
+      <DetailBlock title="Draft Controls">
+        <div className="space-y-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <button
+            type="button"
+            onClick={copyDraft}
+            className="w-full rounded-lg bg-[var(--theme-accent)] px-3 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            {copiedDraft ? 'Copied' : draft.blocked ? 'Copy note' : 'Copy customer draft'}
+          </button>
+          <p className="text-xs leading-5 text-[var(--theme-muted)]">
+            Clean preview only. It does not send email or update any system.
+          </p>
+        </div>
+      </DetailBlock>
+    </div>
+  )
+}
+
+function splitDraftPreview(text: string): { subject: string; body: string; blocked: boolean } {
+  const lines = text.trim().split('\n')
+  const subjectLine = lines[0]?.match(/^Subject:\s*(.+)$/i)
+  const subject = subjectLine?.[1]?.trim() || ''
+  const body = subject ? lines.slice(1).join('\n').trim() : text.trim()
+  const blocked = /^(Payment verification required|Robert brief:|Action packet:)/i.test(text.trim())
+
+  return { subject, body, blocked }
+}
+
+function PacketAssets({ assets }: { assets: Array<CompanyOsAsset> }) {
+  if (!assets.length) {
+    return <p className="text-sm text-[var(--theme-muted)]">No matched assets for this packet.</p>
+  }
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {assets.map((asset) => (
+        <div
+          key={asset.id}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p className="break-words text-sm font-semibold text-[var(--theme-text)]">{asset.title}</p>
+            <Badge>{asset.kind}</Badge>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{asset.note}</p>
+          <p className="mt-3 break-words rounded-md bg-[var(--theme-card2)] px-2 py-1.5 text-[11px] leading-5 text-[var(--theme-muted)]">
+            {asset.file}
+          </p>
+          <button
+            type="button"
+            onClick={() => void navigator.clipboard?.writeText(asset.path)}
+            className="mt-3 rounded-lg border border-[var(--theme-border)] px-3 py-1.5 text-xs font-semibold text-[var(--theme-muted)] transition hover:bg-[var(--theme-card2)]"
+          >
+            Copy file path
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PacketApproval({
+  copied,
+  review,
+  onCopyReviewPrompt,
+  onCopyTitle,
+}: {
+  copied: boolean
+  review: PacketReview
+  onCopyReviewPrompt: () => void
+  onCopyTitle: () => void
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px]">
+      <DetailBlock title="Actions State">
+        <div className="rounded-lg border border-amber-500/25 bg-amber-500/[0.06] p-4">
+          <p className="text-sm font-semibold text-[var(--theme-text)]">Needs human approval</p>
+          <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">
+            Drafts and context are ready. Human approval still gates sending or record changes.
+          </p>
+        </div>
+      </DetailBlock>
+      <DetailBlock title="Safe Actions">
+        <div className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <button
+            type="button"
+            onClick={onCopyReviewPrompt}
+            className="w-full rounded-lg bg-[var(--theme-accent)] px-3 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            {copied ? 'Brief copied' : 'Copy execution brief'}
+          </button>
+          <button
+            type="button"
+            onClick={onCopyTitle}
+            className="w-full rounded-lg border border-[var(--theme-border)] px-3 py-2 text-sm font-semibold text-[var(--theme-muted)] transition hover:bg-[var(--theme-card2)]"
+          >
+            Copy title
+          </button>
+        </div>
+      </DetailBlock>
+      <DetailBlock title="Checklist">
+        <BulletList items={review.checklist} />
+      </DetailBlock>
+    </div>
+  )
+}
+
+function StatusRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-sm">
+      <span className="text-[var(--theme-muted)]">{label}</span>
+      <span className="truncate font-semibold text-[var(--theme-text)]">{value}</span>
+    </div>
+  )
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function shortenText(value: string, limit: number): string {
+  const trimmed = value.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= limit) return trimmed
+  return `${trimmed.slice(0, Math.max(0, limit - 1)).trimEnd()}…`
+}
+
+function BulletList({
+  items,
+  tone = 'default',
+}: {
+  items: Array<string>
+  tone?: 'default' | 'warning'
+}) {
+  if (!items.length) return <p className="text-sm text-[var(--theme-muted)]">Nothing flagged.</p>
+
+  return (
+    <div className="space-y-2">
+      {items.map((item) => (
+        <div
+          key={item}
+          className={cn(
+            'rounded-lg border p-3 text-sm leading-6',
+            tone === 'warning'
+              ? 'border-amber-500/25 bg-amber-500/[0.08] text-[var(--theme-warning)]'
+              : 'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-muted)]',
+          )}
+        >
+          {item}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function DetailBlock({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section>
+      <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+        {title}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+function buildReviewPrompt(
+  item: TodayQueueItem,
+  invoices: Array<CompanyOsInvoice>,
+  lead?: CompanyOsLead,
+  signal?: CompanyOsSignal,
+  kanbanAction?: CompanyOsKanbanAction,
+  assets: Array<CompanyOsAsset> = [],
+): string {
+  const evidence = [
+    ...invoices.map((invoice) => `- Invoice: ${invoice.file} (${invoice.status})`),
+    lead
+      ? `- Lead: ${lead.businessName || lead.title}; stage=${lead.listId || 'unknown'}; priority=${lead.priority || 'unknown'}`
+      : '',
+    signal ? `- Signal: ${signal.subject || signal.title}; ${shortenText(signal.summary, 140)}` : '',
+    signal?.thread
+      ? `- Email thread: ${signal.thread.status}; ${signal.thread.messages.length} messages; latest=${shortenText(signal.thread.latestAction, 100)}`
+      : '',
+    kanbanAction
+      ? `- Kanban action: ${kanbanAction.businessName || kanbanAction.title}; lane=${kanbanAction.lane}; stage=${kanbanAction.stage || 'unknown'}`
+      : '',
+    ...assets.map((asset) => `- Matched asset: ${asset.title} (${asset.kind})`),
+  ].filter(Boolean)
+
+  return [
+    `Review this Unaligned Company OS queue item: ${item.title}`,
+    '',
+    `Lane: ${item.lane}`,
+    `Priority: ${item.priority.toUpperCase()}`,
+    `Recommended action: ${item.action}`,
+    '',
+    'Evidence:',
+    evidence.length ? evidence.join('\n') : '- No structured evidence attached.',
+    '',
+    'Return a concise review with status, risks, next action, and a short draft. Do not send email, edit invoices, spend money, or update Supabase without explicit approval.',
+  ].join('\n')
+}
+
+function packetDomain(item: TodayQueueItem): 'money' | 'sales' | 'robert' | 'general' {
+  const haystack = `${item.title} ${item.detail} ${item.lane} ${item.action}`.toLowerCase()
+  if (/invoice|payment|paid|proof|money|finance/.test(haystack)) return 'money'
+  if (/lead|sales|sponsor|rates|pricing|collab|collaboration/.test(haystack)) return 'sales'
+  if (/robert|scoble/.test(haystack)) return 'robert'
+  return 'general'
+}
+
+function buildPacketReview(
+  item: TodayQueueItem,
+  invoices: Array<CompanyOsInvoice>,
+  lead?: CompanyOsLead,
+  signal?: CompanyOsSignal,
+  kanbanAction?: CompanyOsKanbanAction,
+  assets: Array<CompanyOsAsset> = [],
+): PacketReview {
+  const evidence: Array<string> = []
+  const risks: Array<string> = []
+  const checklist: Array<string> = [
+    'Confirm the latest email/thread context before external action.',
+    'Confirm owner and next step before sending or updating records.',
+  ]
+  const domain = packetDomain(item)
+
+  if (invoices.length) {
+    evidence.push(`${invoices.length} invoice file${invoices.length === 1 ? '' : 's'} attached.`)
+    checklist.push('Open the invoice file(s) and verify client, amount, date, and status.')
+  }
+
+  if (lead) {
+    evidence.push(
+      `Lead card: ${lead.businessName || lead.title}; stage=${lead.listId || 'unknown'}; priority=${lead.priority || 'unknown'}.`,
+    )
+  }
+
+  if (kanbanAction) {
+    evidence.push(
+      `Kanban classified this as ${kanbanAction.lane}.`,
+    )
+    if (kanbanAction.stage) evidence.push(`Current stage: ${kanbanAction.stage}.`)
+  }
+
+  if (signal) {
+    evidence.push(
+      `Signal: ${signal.subject || signal.title || signal.kind}; ${shortenText(signal.needs || signal.summary, 140)}`,
+    )
+    if (signal.thread) {
+      evidence.push(
+        `Email thread: ${signal.thread.status}; ${signal.thread.messages.length} messages.`,
+      )
+      checklist.push('Read the Thread tab before using the draft externally.')
+    }
+  }
+
+  if (assets.length) {
+    evidence.push(`Matched assets: ${assets.map((asset) => asset.title).join(', ')}.`)
+    checklist.push('Review matched assets before attaching or referencing them externally.')
+  }
+
+  const pricingAsset = assets.find((asset) => asset.id === 'partnership-packages')
+  if (domain === 'sales') {
+    checklist.push('Send the sponsorship pricing PDF before extra back-and-forth.')
+    if (pricingAsset) {
+      evidence.push(`Pricing asset ready: ${pricingAsset.title}.`)
+    }
+  }
+
+  const haystack = `${item.title} ${item.detail} ${item.lane} ${item.action}`.toLowerCase()
+  if (/invoice|payment|paid|proof|money|finance/.test(haystack)) {
+    risks.push('Money-related item: verify status before marking paid or asking for payment.')
+    if (!invoices.length) risks.push('No local invoice file is directly attached to this specific packet.')
+    checklist.push('Confirm whether this is a payment follow-up, status check, or internal cleanup.')
+  }
+
+  if (/lead|sales|sponsor|rates/.test(haystack)) {
+    risks.push('Sales item: confirm the offer before sending pricing or assets.')
+    checklist.push('Confirm which Unaligned offer or package applies.')
+  }
+
+  if (/robert|scoble/.test(haystack)) {
+    risks.push('Robert-related context may need an explicit handoff before messaging.')
+    checklist.push('Confirm what Robert must approve; Asher still owns the reply.')
+  }
+
+  if (/draft|email|reply/.test(haystack)) {
+    risks.push('Draft exists or email action is implied; treat generated copy as review-only.')
+  }
+
+  if (!risks.length) {
+    risks.push('No blocking risk detected, but external actions still need approval.')
+  }
+
+  const status =
+    domain === 'sales'
+      ? 'Asher owns the deal motion: answer the lead, send the pricing PDF when relevant, collect the brief, then route Robert only at approval time. Sam reviews from oversight.'
+      : domain === 'robert'
+        ? 'Asher handles the middle. Sam provides oversight. Robert gets a short decision brief only when the collaboration is ready for his public action.'
+        : item.priority === 'p0'
+          ? 'High-priority operating item. Handle the blocker first, then move the deal or payment state forward.'
+          : 'Operating item ready for the next concrete action.'
+
+  const recommendedAction = kanbanAction?.recommendedAction || item.action
+  const draftMessage = buildPacketDraft(item, invoices, lead, signal, kanbanAction, assets)
+  const ask = signal ? leadAskLabel(signal) : domain === 'money' ? 'payment status' : 'next step'
+  const latest = signal ? latestExternalMessage(signal) : null
+  const operator = signal
+    ? leadReplyOwner(signal, leadReplyStatus(signal))
+    : domain === 'money'
+      ? 'Internal'
+      : 'Asher'
+  const target = kanbanAction?.businessName || lead?.businessName || item.title
+  const dealQuestion =
+    domain === 'money'
+      ? `Is ${target} already paid, waiting for payment, or blocked by missing proof?`
+      : domain === 'sales'
+        ? `Can ${target} become a paid sponsorship by confirming package, timing, deliverables, and payment path?`
+        : domain === 'robert'
+          ? `What exact public action does Robert need to approve, and can Asher finish the details before he sees it?`
+          : `What single next action moves ${target} forward?`
+  const dealSteps =
+    domain === 'money'
+      ? [
+        'Verify invoice/payment proof before messaging.',
+        'Mark paid, waiting, or blocked in the source record.',
+        'Send one clean payment-status follow-up only after verification.',
+      ]
+      : domain === 'sales'
+        ? [
+          'Asher replies in the thread and keeps Robert out of the middle.',
+          'Send or reference the sponsorship pricing PDF when pricing is part of the ask.',
+          'Collect budget, timing, deliverables, assets needed, and payment state.',
+          'Sam reviews for oversight when risk or ambiguity shows up.',
+          'Package the final objective into a 60-second Robert brief.',
+        ]
+        : domain === 'robert'
+          ? [
+            'Asher cleans up the thread and turns the ask into a concrete proposed action.',
+            'Confirm what the lead wants Robert to do, when, and what Unaligned gets paid.',
+            'Sam reviews the handoff only if it needs a second set of eyes.',
+            'Give Robert only the final objective, risk, payment state, and exact approval ask.',
+          ]
+          : [
+            `${operator} owns the next reply or record update.`,
+            'Reduce the packet to owner, blocker, next action, and expected outcome.',
+            'Escalate only if money, public claims, or Robert approval is required.',
+          ]
+  const robertBrief =
+    domain === 'sales' || domain === 'robert'
+      ? `Robert should see this after Asher has the ask, price/package, timing, deliverables, and payment state. ${latest?.body ? `Latest outside note: ${shortenText(latest.body, 120)}` : ''}`.trim()
+      : domain === 'money'
+        ? 'Robert does not need this unless payment status changes the collaboration or requires his direct relationship.'
+        : 'Robert only needs this if the final action requires his approval.'
+
+  return {
+    status,
+    operator,
+    dealQuestion,
+    dealSteps,
+    robertBrief,
+    evidence: evidence.length ? evidence : ['Packet is based on the queue title and recommended action only.'],
+    risks,
+    recommendedAction,
+    draftMessage,
+    checklist,
+  }
+}
+
+function buildPacketDraft(
+  item: TodayQueueItem,
+  invoices: Array<CompanyOsInvoice>,
+  lead?: CompanyOsLead,
+  signal?: CompanyOsSignal,
+  kanbanAction?: CompanyOsKanbanAction,
+  assets: Array<CompanyOsAsset> = [],
+): string {
+  const target = kanbanAction?.businessName || lead?.businessName || item.title
+  const assetLine = assets.length
+    ? `Useful files to review first: ${assets.map((asset) => asset.title).join(', ')}.`
+    : 'No matched asset is required yet.'
+  const invoiceLine = invoices.length
+    ? `Invoice evidence to verify: ${invoices.map((invoice) => invoice.file).join(', ')}.`
+    : 'No invoice file is attached to this packet.'
+  const pricingAssetLine = assets.find((asset) => asset.id === 'partnership-packages')
+    ? 'Attach or send the sponsorship pricing PDF with this reply.'
+    : 'No pricing PDF is attached to this packet yet.'
+  const contextLine =
+    kanbanAction?.reason || signal?.needs || signal?.summary || item.detail
+
+  const domain = packetDomain(item)
+
+  if (signal) {
+    const status = leadReplyStatus(signal)
+    if (status === 'money-admin') {
+      return buildPaymentHoldDraft(target, invoices)
+    }
+    return buildCleanCustomerDraft(signal, assets)
+  }
+
+  if (domain === 'money') {
+    return buildPaymentHoldDraft(target, invoices)
+  }
+
+  if (domain === 'sales') {
+    return [
+      `Subject: Following up on ${target}`,
+      '',
+      'Hi,',
+      '',
+      `Thanks for reaching out about ${target}. I'm jumping in from Unaligned so we can keep this moving cleanly.`,
+      '',
+      pricingAssetLine,
+      '',
+      'Can you confirm budget range, target timing, deliverables, and what you need from Robert specifically?',
+      '',
+      'Best,',
+      'Asher',
+    ].join('\n')
+  }
+
+  if (domain === 'robert') {
+    return [
+      `Robert brief: ${target}`,
+      '',
+      `One-minute summary: ${contextLine}`,
+      '',
+      'Owner: Asher handles the thread and customer back-and-forth. Sam provides oversight.',
+      'Decision point: Robert only steps in when the final public move needs approval.',
+      '',
+      `Payment state: ${invoices.length ? 'invoice follow-up / payment check' : 'waiting on lead or internal handoff'}`,
+      assetLine,
+      invoiceLine,
+      '',
+      'Internal note: this is a brief, not a long thread dump.',
+    ].join('\n')
+  }
+
+  return [
+    `Action packet: ${item.title}`,
+    '',
+    `Recommended move: ${item.action}`,
+    '',
+    `Context: ${contextLine}`,
+    assetLine,
+    invoiceLine,
+    '',
+    'Internal note: decide owner, status, next action, and approval before any external change.',
+  ].join('\n')
+}
+
+function buildCleanCustomerDraft(
+  signal: CompanyOsSignal,
+  assets: Array<CompanyOsAsset>,
+): string {
+  const first = leadFirstName(signal)
+  const pricing = shouldSendPricingPdf(signal)
+  const hasPricingAsset = assets.some(
+    (asset) => asset.id === 'partnership-packages' || asset.kind === 'pricing',
+  )
+
+  return [
+    `Subject: ${subjectForSignal(signal)}`,
+    '',
+    `Hi ${first},`,
+    '',
+    "Thanks for reaching out. I'm jumping in from Unaligned so we can keep this moving cleanly.",
+    pricing
+      ? hasPricingAsset
+        ? "I'll attach the Unaligned sponsorship package so you can review the current options."
+        : 'I can send over the sponsorship package and help narrow the right fit.'
+      : `I can help coordinate the ${leadAskLabel(signal)} details and keep the next step simple.`,
+    '',
+    'Can you confirm:',
+    '- budget range',
+    '- target timing',
+    '- deliverables you want covered',
+    '- what you need from Robert specifically',
+    '',
+    'Best,',
+    'Asher',
+  ].join('\n')
+}
+
+function buildPaymentHoldDraft(
+  target: string,
+  invoices: Array<CompanyOsInvoice>,
+): string {
+  return [
+    'Payment verification required',
+    '',
+    `No customer email is drafted yet for ${target} because this touches payment/admin status.`,
+    '',
+    'Verify first:',
+    '- invoice match',
+    '- paid vs waiting for payment',
+    '- proof/status in the source record',
+    invoices.length ? `- related invoice files: ${invoices.map((invoice) => invoice.file).join(', ')}` : '',
+    '',
+    'After verification, Asher can send a short payment-status note if one is actually needed.',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function Panel({
+  title,
+  icon,
+  className,
+  children,
+}: {
+  title: string
+  icon: typeof Building02Icon
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <section
+      className={cn(
+        'min-w-0 overflow-hidden rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4',
+        className,
+      )}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <HugeiconsIcon icon={icon} size={18} strokeWidth={1.7} className="text-[var(--theme-accent)]" />
+        <h2 className="text-sm font-semibold text-[var(--theme-text)]">{title}</h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function StatusPill({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number
+  tone: 'danger' | 'warning' | 'neutral'
+}) {
+  const toneClass =
+    tone === 'danger'
+      ? 'border-[rgba(178,59,59,0.25)] bg-[rgba(178,59,59,0.08)] text-[var(--theme-danger)]'
+      : tone === 'warning'
+        ? 'border-[rgba(154,98,22,0.28)] bg-[rgba(154,98,22,0.09)] text-[var(--theme-warning)]'
+        : 'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-muted)]'
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-10 items-center gap-2 rounded-lg border px-3 text-sm font-semibold',
+        toneClass,
+      )}
+    >
+      <span className="tabular-nums">{value}</span>
+      <span className="text-xs font-medium">{label}</span>
+    </div>
+  )
+}
+
+function MiniSource({
+  label,
+  value,
+  detail,
+}: {
+  label: string
+  value: number
+  detail: string
+}) {
+  return (
+    <div className="rounded-lg bg-[var(--theme-card2)] p-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="truncate text-sm font-semibold text-[var(--theme-text)]">{label}</p>
+        <p className="text-xl font-semibold tabular-nums text-[var(--theme-text)]">{value}</p>
+      </div>
+      <p className="mt-1 truncate text-xs text-[var(--theme-muted)]">{detail}</p>
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg bg-[var(--theme-card2)] px-3 py-3 text-center">
+      <p className="text-2xl font-semibold tabular-nums text-[var(--theme-text)]">{value}</p>
+      <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+        {label}
+      </p>
+    </div>
+  )
+}
+
+function PriorityBadge({ priority }: { priority: TodayQueueItem['priority'] }) {
+  const className =
+    priority === 'p0'
+      ? 'border-[rgba(178,59,59,0.25)] bg-[rgba(178,59,59,0.08)] text-[var(--theme-danger)]'
+      : priority === 'p1'
+        ? 'border-[rgba(154,98,22,0.28)] bg-[rgba(154,98,22,0.09)] text-[var(--theme-warning)]'
+        : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)]'
+
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-md border px-2 py-1 text-xs font-semibold',
+        className,
+      )}
+    >
+      {priority.toUpperCase()}
+    </span>
+  )
+}
+
+function InvoiceList({ invoices }: { invoices: Array<CompanyOsInvoice> }) {
+  if (!invoices.length) return <p className="text-sm text-[var(--theme-muted)]">No invoices found.</p>
+
+  return (
+    <div className="space-y-2">
+      {invoices.slice(0, 9).map((invoice) => (
+        <div
+          key={`${invoice.source}-${invoice.file}`}
+          className={cn(
+            'rounded-lg border p-3',
+            invoice.status === 'outstanding'
+              ? 'border-red-500/25 bg-red-500/[0.06]'
+              : invoice.status === 'needs-proof'
+                ? 'border-amber-500/25 bg-amber-500/[0.06]'
+                : 'border-[var(--theme-border)] bg-[var(--theme-card2)]',
+          )}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p className="min-w-0 break-words text-xs font-semibold leading-5 text-[var(--theme-text)]">
+              {invoice.file}
+            </p>
+            <Badge>{invoice.status}</Badge>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function SourceList({
+  sources,
+}: {
+  sources: CompanyOsLiveOps['sources']
+}) {
+  return (
+    <div className="space-y-2">
+      {sources.map((source) => (
+        <div
+          key={source.name}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <p className="min-w-0 truncate text-sm font-semibold text-[var(--theme-text)]">
+              {source.name}
+            </p>
+            <Badge>{source.status}</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-[var(--theme-muted)]">
+            {source.count} items. {source.note}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function LiveMetric({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: number
+  sub: string
+}) {
+  return (
+    <div className="min-w-0 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <p className="text-2xl font-semibold tabular-nums text-[var(--theme-text)]">{value}</p>
+      <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+        {label}
+      </p>
+      <p className="mt-1 truncate text-xs text-[var(--theme-muted)]">{sub}</p>
+    </div>
+  )
+}
+
+function LeadList({ leads }: { leads: Array<CompanyOsLead> }) {
+  if (!leads.length) {
+    return <p className="text-sm text-[var(--theme-muted)]">No matching leads found.</p>
+  }
+
+  return (
+    <div className="space-y-2">
+      {leads.map((lead) => (
+        <article
+          key={lead.id}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                {lead.businessName || lead.title}
+              </p>
+              {lead.businessName ? (
+                <p className="mt-1 break-words text-xs leading-5 text-[var(--theme-muted)]">
+                  {lead.title}
+                </p>
+              ) : null}
+            </div>
+            {lead.estimatedValue ? <Badge>{lead.estimatedValue}</Badge> : null}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {lead.listId ? <Badge>{lead.listId}</Badge> : null}
+            {lead.priority ? <Badge>{lead.priority}</Badge> : null}
+            {lead.draftStatus ? <Badge>{lead.draftStatus}</Badge> : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function KanbanActionList({ actions }: { actions: Array<CompanyOsKanbanAction> }) {
+  if (!actions.length) {
+    return <p className="text-sm text-[var(--theme-muted)]">No Kanban actions matched yet.</p>
+  }
+
+  return (
+    <div className="space-y-2">
+      {actions.slice(0, 8).map((action) => (
+        <article
+          key={action.id}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+                {action.businessName || action.title}
+              </p>
+              {action.businessName ? (
+                <p className="mt-1 break-words text-xs leading-5 text-[var(--theme-muted)]">
+                  {action.title}
+                </p>
+              ) : null}
+            </div>
+            <Badge>{action.urgency.toUpperCase()}</Badge>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{action.reason}</p>
+          <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+            {action.recommendedAction}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Badge>{action.lane}</Badge>
+            {action.stage ? <Badge>{action.stage}</Badge> : null}
+            {action.priority ? <Badge>{action.priority}</Badge> : null}
+            {action.publicAsset ? <Badge>{action.publicAsset}</Badge> : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function AssetList({ assets }: { assets: Array<CompanyOsAsset> }) {
+  if (!assets.length) return <p className="text-sm text-[var(--theme-muted)]">No sales assets found.</p>
+
+  return (
+    <div className="space-y-2">
+      {assets.map((asset) => (
+        <article
+          key={asset.id}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p className="min-w-0 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+              {asset.title}
+            </p>
+            <Badge>{asset.kind}</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-[var(--theme-muted)]">{asset.note}</p>
+          <p className="mt-2 break-words text-[11px] leading-5 text-[var(--theme-muted)]">
+            {asset.file}
+          </p>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function SignalList({ signals }: { signals: Array<CompanyOsSignal> }) {
+  if (!signals.length) return <p className="text-sm text-[var(--theme-muted)]">No signals yet.</p>
+
+  return (
+    <div className="space-y-2">
+      {signals.slice(0, 6).map((signal, index) => (
+        <article
+          key={`${signal.subject || signal.title || signal.kind}-${index}`}
+          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p className="min-w-0 break-words text-sm font-semibold leading-5 text-[var(--theme-text)]">
+              {signal.title || signal.subject}
+            </p>
+            <Badge>{signal.kind}</Badge>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-[var(--theme-muted)]">{signal.summary}</p>
+          {signal.needs ? (
+            <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">
+              {signal.needs}
+            </p>
+          ) : null}
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function StageBreakdown({ stages }: { stages: Record<string, number> }) {
+  const entries = Object.entries(stages)
+    .filter(([, count]) => count > 0)
+    .sort((left, right) => right[1] - left[1])
+
+  if (!entries.length) {
+    return <p className="text-sm text-[var(--theme-muted)]">No Supabase stages found.</p>
+  }
+
+  const max = Math.max(...entries.map(([, count]) => count))
+
+  return (
+    <div className="space-y-2">
+      {entries.map(([stage, count]) => (
+        <div key={stage}>
+          <div className="mb-1 flex items-center justify-between gap-3">
+            <p className="truncate text-xs font-semibold text-[var(--theme-text)]">{stage}</p>
+            <p className="text-xs tabular-nums text-[var(--theme-muted)]">{count}</p>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--theme-card2)]">
+            <div
+              className="h-full rounded-full bg-[var(--theme-accent)]"
+              style={{ width: `${Math.max(8, (count / max) * 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TaskCard({ task }: { task: CompanyOsTask }) {
+  return (
+    <article className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-[var(--theme-text)]">{task.title}</h3>
+          <p className="mt-2 text-xs leading-5 text-[var(--theme-muted)]">{task.description}</p>
+        </div>
+        {task.priority ? <Badge>{task.priority.toUpperCase()}</Badge> : null}
+      </div>
+      {task.tags.length ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {task.tags.map((tag) => (
+            <Badge key={tag}>{tag}</Badge>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  )
+}
+
+function Badge({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex max-w-full min-w-0 items-center rounded-md border border-[var(--theme-border)] bg-[var(--theme-card2)] px-2 py-1 text-xs font-medium text-[var(--theme-muted)]">
+      <span className="truncate">{children}</span>
+    </span>
+  )
+}

--- a/src/routes/company-os.tsx
+++ b/src/routes/company-os.tsx
@@ -1605,7 +1605,7 @@ function LeadReplyDesk({
         ...current,
         [packet.item.id]: {
           status: 'sent',
-          message: `Sent as ${senderName(sender)} to ${reply.recipients.to.join(', ')}`,
+          message: `Sent as ${senderShortName(sender)} to ${reply.recipients.to.join(', ')}`,
         },
       }))
     } catch (error) {
@@ -1822,7 +1822,7 @@ function LeadCommandSurface({
                     ? 'Sending...'
                     : sendState?.status === 'sent'
                       ? 'Sent'
-                      : `Send as ${senderName(sender)}`}
+                      : `Send as ${senderShortName(sender)}`}
               </button>
               <button
                 type="button"

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -788,6 +788,18 @@ function ChatDisplaySection() {
           />
         </SettingsRow>
         <SettingsRow
+          label="Use 24-hour time"
+          description="Persist timestamp formatting in the browser across reloads."
+        >
+          <Switch
+            checked={chatSettings.use24HourTime}
+            onCheckedChange={(checked) =>
+              updateChatSettings({ use24HourTime: checked })
+            }
+            aria-label="Use 24-hour time"
+          />
+        </SettingsRow>
+        <SettingsRow
           label="Enter key behavior"
           description={
             chatSettings.enterBehavior === 'newline'

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -111,6 +111,13 @@ const THEME_PREVIEWS: Record<
   ThemeId,
   { bg: string; panel: string; border: string; accent: string; text: string }
 > = {
+  'hermes-codex': {
+    bg: '#0d0d0d',
+    panel: '#1a1a1a',
+    border: '#2d2d2d',
+    accent: '#f97316',
+    text: '#e5e5e5',
+  },
   'hermes-nous': {
     bg: '#031a1a',
     panel: '#082224',

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -575,7 +575,12 @@ export function buildDisplayEntries(
       return
     }
 
-    if (message.role === 'tool' || message.role === 'toolResult') {
+    if (
+      message.role === 'tool' ||
+      message.role === 'toolResult' ||
+      message.role === 'toolresult' ||
+      message.role === 'tool_result'
+    ) {
       const previousEntry = entries[entries.length - 1]
       if (previousEntry?.message.role === 'assistant') {
         previousEntry.attachedToolMessages.push(message)
@@ -1041,7 +1046,12 @@ function ChatMessageListComponent({
   const toolResultsByCallId = useMemo(() => {
     const map = new Map<string, ChatMessage>()
     for (const message of messages) {
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = message.toolCallId
       if (typeof toolCallId === 'string' && toolCallId.trim().length > 0) {
         map.set(toolCallId, message)
@@ -1087,7 +1097,12 @@ function ChatMessageListComponent({
         count += 1
       }
 
-      if (message.role !== 'toolResult') continue
+      if (
+        message.role !== 'toolResult' &&
+        message.role !== 'toolresult' &&
+        message.role !== 'tool_result' &&
+        message.role !== 'tool'
+      ) continue
       const toolCallId = (message.toolCallId || '').trim()
       if (toolCallId.length > 0 && seenToolCallIds.has(toolCallId)) continue
       if (toolCallId.length > 0) {

--- a/src/screens/chat/components/chat-message-list.tsx
+++ b/src/screens/chat/components/chat-message-list.tsx
@@ -1713,7 +1713,7 @@ function ChatMessageListComponent({
             </div>
           )}
           <ChatContainerContent
-            className="pt-2.5 md:pt-6 flex min-h-full flex-col"
+            className="chat-feed-area pt-2.5 md:pt-6 flex min-h-full flex-col"
             style={chatContentStyle}
           >
             {notice && noticePosition === 'start' ? notice : null}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -13,19 +13,17 @@ import {
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
+  PinIcon,
+  PinOffIcon,
   PuzzleIcon,
 
   Rocket01Icon,
   Search01Icon, Settings01Icon, Sun02Icon, UserGroupIcon, UserMultipleIcon
 } from '@hugeicons/core-free-icons'
 import { AnimatePresence, motion } from 'motion/react'
-import { t } from '@/lib/i18n'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
-import {
-  CHAT_OPEN_SETTINGS_EVENT
-  
-} from '../chat-events'
+import { CHAT_OPEN_SETTINGS_EVENT } from '../chat-events'
 import { useChatSettings as useSidebarSettings } from '../hooks/use-chat-settings'
 import { useDeleteSession } from '../hooks/use-delete-session'
 import { useRenameSession } from '../hooks/use-rename-session'
@@ -33,8 +31,9 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
-import type {ChatOpenSettingsDetail} from '../chat-events';
+import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
+import { t } from '@/lib/i18n'
 import { SettingsDialog } from '@/components/settings-dialog'
 import {
   TooltipContent,
@@ -115,7 +114,9 @@ type ChatSidebarProps = {
   creatingSession: boolean
   onCreateSession: () => void
   isCollapsed: boolean
+  isPinned: boolean
   onToggleCollapse: () => void
+  onTogglePinned: () => void
   onSelectSession?: () => void
   onActiveSessionDelete?: () => void
   sessionsLoading: boolean
@@ -124,15 +125,11 @@ type ChatSidebarProps = {
   onRetrySessions: () => void
 }
 
-
-
 // ── Reusable nav item ───────────────────────────────────────────────────
 
 type NavItemDef = {
   kind: 'link' | 'button'
   to?: string
-  search?: Record<string, unknown>
-  hash?: string
   icon: unknown
   label: string
   active: boolean
@@ -152,7 +149,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -229,9 +226,7 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to!}
-                  search={item.search}
-                  hash={item.hash}
+                  to={item.to}
                   onClick={handleSelect}
                   className={cls}
                   data-tour={item.dataTour}
@@ -247,9 +242,7 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to!}
-        search={item.search}
-        hash={item.hash}
+        to={item.to}
         onClick={handleSelect}
         className={cls}
         data-tour={item.dataTour}
@@ -496,7 +489,9 @@ function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
   isCollapsed,
+  isPinned,
   onToggleCollapse,
+  onTogglePinned,
   onSelectSession,
   onActiveSessionDelete,
   sessionsLoading,
@@ -526,8 +521,11 @@ function ChatSidebarComponent({
 
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
-      const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail?.section === 'appearance' ? 'appearance' : 'hermes')
+      const detail = (event as CustomEvent<ChatOpenSettingsDetail | undefined>)
+        .detail
+      handleOpenSettings(
+        detail?.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -581,8 +579,6 @@ function ChatSidebarComponent({
     duration: 0.15,
     ease: isCollapsed ? 'easeIn' : 'easeOut',
   } as const
-
-
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
@@ -886,7 +882,7 @@ function ChatSidebarComponent({
                 to="/chat"
                 className={cn(
                   buttonVariants({ variant: 'ghost', size: 'sm' }),
-                  'w-full pl-1.5 justify-start gap-2',
+                  'w-full pl-1.5 pr-20 justify-start gap-2',
                 )}
               >
                 <img src="/hermes-avatar.webp" alt="Hermes" className="size-6 rounded-lg" />
@@ -896,6 +892,36 @@ function ChatSidebarComponent({
           ) : null}
         </AnimatePresence>
         <TooltipProvider>
+          {!isVisuallyCollapsed ? (
+            <TooltipRoot>
+              <TooltipTrigger
+                onClick={onTogglePinned}
+                render={
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label={isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+                    aria-pressed={isPinned}
+                    className={cn(
+                      'absolute right-9 top-1/2 shrink-0 -translate-y-1/2 opacity-80 hover:opacity-100',
+                      isPinned &&
+                        'bg-[var(--theme-accent)]/10 text-[var(--theme-accent)] opacity-100',
+                    )}
+                    data-tour="sidebar-pin-toggle"
+                  >
+                    <HugeiconsIcon
+                      icon={isPinned ? PinOffIcon : PinIcon}
+                      size={18}
+                      strokeWidth={1.75}
+                    />
+                  </Button>
+                }
+              />
+              <TooltipContent side="right">
+                {isPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
+              </TooltipContent>
+            </TooltipRoot>
+          ) : null}
           <TooltipRoot>
             <TooltipTrigger
               onClick={handleSidebarToggle}
@@ -1202,6 +1228,7 @@ function areSidebarPropsEqual(
   if (prevProps.activeFriendlyId !== nextProps.activeFriendlyId) return false
   if (prevProps.creatingSession !== nextProps.creatingSession) return false
   if (prevProps.isCollapsed !== nextProps.isCollapsed) return false
+  if (prevProps.isPinned !== nextProps.isPinned) return false
   if (prevProps.sessionsLoading !== nextProps.sessionsLoading) return false
   if (prevProps.sessionsFetching !== nextProps.sessionsFetching) return false
   if (prevProps.sessionsError !== nextProps.sessionsError) return false

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft01Icon,
   ArrowRight01Icon,
   BrainIcon,
+  Building02Icon,
   Chat01Icon,
   CheckListIcon,
   Clock01Icon,
@@ -561,6 +562,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
+  const isCompanyOsBetaActive = pathname.startsWith('/company-os-beta')
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -810,6 +812,13 @@ function ChatSidebarComponent({
       icon: UserGroupIcon,
       label: 'Operations',
       active: isOperationsActive,
+    },
+    {
+      kind: 'link',
+      to: '/company-os-beta',
+      icon: Building02Icon,
+      label: 'Company OS Beta',
+      active: isCompanyOsBetaActive,
     },
   ]
 

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -75,8 +75,9 @@ function ThemeToggleMini() {
 
   // Map between dark and light counterparts — must include all theme families
   const LIGHT_DARK_PAIRS: Record<string, string> = {
+    'hermes-codex': 'hermes-nous-light',
     'hermes-nous': 'hermes-nous-light',
-    'hermes-nous-light': 'hermes-nous',
+    'hermes-nous-light': 'hermes-codex',
     'hermes-official': 'hermes-official-light',
     'hermes-official-light': 'hermes-official',
     'hermes-classic': 'hermes-classic-light',

--- a/src/screens/chat/components/message-item.test.ts
+++ b/src/screens/chat/components/message-item.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildInlineToolRenderPlan } from './message-item'
+import { buildInlineToolRenderPlan, compactInlineToolRenderPlan } from './message-item'
 import type { ChatMessage } from '../types'
 
 describe('buildInlineToolRenderPlan', () => {
@@ -43,6 +43,105 @@ describe('buildInlineToolRenderPlan', () => {
         },
       },
       { kind: 'text', text: 'After tool.' },
+    ])
+  })
+})
+
+describe('compactInlineToolRenderPlan', () => {
+  it('stacks consecutive tool calls without moving surrounding text', () => {
+    const plan = compactInlineToolRenderPlan([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+
+    expect(plan).toEqual([
+      { kind: 'text', text: 'Before. ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'After.' },
+    ])
+  })
+
+  it('keeps separate stacks when text appears between tool calls', () => {
+    const plan = compactInlineToolRenderPlan([
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-1',
+          type: 'read_file',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tool',
+        section: {
+          key: 'tc-2',
+          type: 'search_files',
+          outputText: '',
+          state: 'output-available',
+        },
+      },
+    ])
+
+    expect(plan).toEqual([
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-1',
+            type: 'read_file',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
+      { kind: 'text', text: 'Then ' },
+      {
+        kind: 'tools',
+        sections: [
+          {
+            key: 'tc-2',
+            type: 'search_files',
+            outputText: '',
+            state: 'output-available',
+          },
+        ],
+      },
     ])
   })
 })

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -232,15 +232,40 @@ export function compactInlineToolRenderPlan(
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
   if (!msg) return ''
-  // Prefer text from content blocks (exec stdout, Read output, etc.)
+  // Prefer text from structured content blocks first.
   if (Array.isArray(msg.content)) {
     const text = msg.content
-      .filter((b: any) => b?.type === 'text' && b?.text)
-      .map((b: any) => b.text as string)
+      .flatMap((block: any) => {
+        if (!block || typeof block !== 'object') return []
+        if (block.type === 'text' && typeof block.text === 'string') {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          typeof block.text === 'string'
+        ) {
+          return [block.text]
+        }
+        if (
+          (block.type === 'tool_result' || block.type === 'toolResult') &&
+          Array.isArray(block.content)
+        ) {
+          return block.content
+            .filter((part: any) => part?.type === 'text' && part?.text)
+            .map((part: any) => String(part.text))
+        }
+        return []
+      })
       .join('\n')
     if (text.trim()) return text
   }
-  // Fallback to details serialized
+  // Fallback to top-level text/body/message fields.
+  const raw = msg as Record<string, unknown>
+  for (const key of ['text', 'body', 'message']) {
+    const value = raw[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  // Then structured details.
   if (msg.details && typeof msg.details === 'object') {
     return JSON.stringify(msg.details, null, 2)
   }

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -158,6 +158,10 @@ export type InlineRenderPlanItem =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; section: InlineToolSection }
 
+export type CompactInlineRenderPlanItem =
+  | { kind: 'text'; text: string }
+  | { kind: 'tools'; sections: Array<InlineToolSection> }
+
 export function buildInlineToolRenderPlan(
   message: ChatMessage,
   toolSections: Array<InlineToolSection>,
@@ -198,6 +202,32 @@ export function buildInlineToolRenderPlan(
   }
 
   return plan
+}
+
+export function compactInlineToolRenderPlan(
+  plan: Array<InlineRenderPlanItem>,
+): Array<CompactInlineRenderPlanItem> {
+  const compactPlan: Array<CompactInlineRenderPlanItem> = []
+  let pendingToolSections: Array<InlineToolSection> = []
+
+  const flushTools = () => {
+    if (pendingToolSections.length === 0) return
+    compactPlan.push({ kind: 'tools', sections: pendingToolSections })
+    pendingToolSections = []
+  }
+
+  for (const item of plan) {
+    if (item.kind === 'tool') {
+      pendingToolSections.push(item.section)
+      continue
+    }
+
+    flushTools()
+    compactPlan.push(item)
+  }
+
+  flushTools()
+  return compactPlan
 }
 
 function extractToolResultText(msg: ChatMessage | undefined): string {
@@ -1404,8 +1434,6 @@ function InlineToolSectionItem({
   const hasInputData =
     toolSection.input && Object.keys(toolSection.input).length > 0
   const hasOutputData = !!(toolSection.outputText || toolSection.errorText)
-  // Always expandable — show args, output, or at minimum the tool name/state
-  const hasExpandableContent = true
 
   return (
     <div>
@@ -1452,11 +1480,9 @@ function InlineToolSectionItem({
           {isRunning && (
             <span className="size-1.5 rounded-full animate-pulse bg-indigo-500" />
           )}
-          {hasExpandableContent && (
-            <span className="text-[8px] opacity-30 ml-0.5">
-              {open ? '▾' : '▸'}
-            </span>
-          )}
+          <span className="text-[8px] opacity-30 ml-0.5">
+            {open ? '▾' : '▸'}
+          </span>
         </div>
         {isRunning && (
           <div className="px-2.5 pb-1.5 text-[10px] text-primary-400">
@@ -1577,11 +1603,78 @@ function InlineToolSectionItem({
 function ToolCallGroup({
   toolSections,
   expandAll,
+  isStreaming,
 }: {
   toolSections: Array<InlineToolSection>
   expandAll?: boolean
   isStreaming?: boolean
 }) {
+  const [open, setOpen] = useState(Boolean(expandAll))
+  useEffect(() => {
+    if (expandAll) setOpen(true)
+  }, [expandAll])
+
+  if (toolSections.length > 1) {
+    const runningCount = toolSections.filter((section) => section.state === 'input-available' || section.state === 'input-streaming').length
+    const errorCount = toolSections.filter((section) => section.state === 'output-error').length
+    const doneCount = toolSections.length - runningCount - errorCount
+    const labels = Array.from(new Set(toolSections.map((section) => formatToolDisplayLabel(section.type, section.input))))
+    const visibleLabels = labels.slice(0, 3).join(', ')
+    const overflowLabel = labels.length > 3 ? ` +${labels.length - 3} more` : ''
+    const statusLabel =
+      runningCount > 0
+        ? `${runningCount} running`
+        : errorCount > 0
+          ? `${errorCount} failed`
+          : `${doneCount} done`
+
+    return (
+      <div className="my-3 w-full max-w-[min(100%,700px)] border-l-2 border-primary-200/60 pl-3">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-primary-600 hover:bg-primary-50/70"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="font-mono font-semibold text-ink">Tool activity</span>
+          <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] tabular-nums text-primary-600">
+            {toolSections.length} calls
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[10px] opacity-60">
+            {visibleLabels}
+            {overflowLabel}
+          </span>
+          <span
+            className={cn(
+              'shrink-0 text-[10px] tabular-nums',
+              errorCount > 0
+                ? 'text-red-500'
+                : runningCount > 0 || isStreaming
+                  ? 'text-indigo-500'
+                  : 'text-green-600',
+            )}
+          >
+            {statusLabel}
+          </span>
+          <span className="shrink-0 text-[9px] opacity-40">
+            {open ? '▾' : '▸'}
+          </span>
+        </button>
+        {open && (
+          <div className="mt-2 flex flex-col gap-2.5">
+            {toolSections.map((toolSection, index) => (
+              <InlineToolSectionItem
+                key={toolSection.key || `${toolSection.type}-${index}`}
+                toolSection={toolSection}
+                index={index}
+                forceOpen={expandAll}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2.5 my-3 w-full max-w-[min(100%,700px)]">
       {toolSections.map((toolSection, index) => (
@@ -1694,8 +1787,8 @@ function MessageItemComponent({
   }, [])
 
   // Simulate streaming is only active while words are still being revealed
-  const totalWords = countWords(displayText)
-  const revealComplete = revealedWordCount >= totalWords && totalWords > 0
+  const displayWordCount = countWords(displayText)
+  const revealComplete = revealedWordCount >= displayWordCount && displayWordCount > 0
   const effectiveIsStreaming =
     remoteStreamingActive || (_simulateStreaming && !revealComplete)
   const assistantDisplayText = effectiveIsStreaming ? revealedText : displayText
@@ -1705,7 +1798,7 @@ function MessageItemComponent({
   )
 
   useEffect(() => {
-    const totalWords = countWords(displayText)
+    const nextTotalWords = countWords(displayText)
     const previousText = previousTextRef.current
     const previousLength = previousTextLengthRef.current
     const textGrew =
@@ -1713,7 +1806,7 @@ function MessageItemComponent({
       displayText.startsWith(previousText)
     const textChanged = displayText !== previousText
 
-    targetWordCountRef.current = totalWords
+    targetWordCountRef.current = nextTotalWords
     previousTextRef.current = displayText
     previousTextLengthRef.current = displayText.length
 
@@ -1722,12 +1815,12 @@ function MessageItemComponent({
         window.clearInterval(revealTimerRef.current)
         revealTimerRef.current = null
       }
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
     if (textChanged && !textGrew) {
-      setRevealedWordCount(totalWords)
+      setRevealedWordCount(nextTotalWords)
       return
     }
 
@@ -1736,25 +1829,25 @@ function MessageItemComponent({
     }
 
     // Don't start animation if already fully revealed
-    setRevealedWordCount((currentWordCount) => {
-      if (currentWordCount >= totalWords) {
-        return currentWordCount
+    setRevealedWordCount((wordCount) => {
+      if (wordCount >= nextTotalWords) {
+        return wordCount
       }
 
       function tick() {
-        setRevealedWordCount((currentWordCount) => {
+        setRevealedWordCount((visibleWordCount) => {
           const targetWordCount = targetWordCountRef.current
-          if (currentWordCount >= targetWordCount) {
+          if (visibleWordCount >= targetWordCount) {
             if (revealTimerRef.current !== null) {
               window.clearInterval(revealTimerRef.current)
               revealTimerRef.current = null
             }
-            return currentWordCount
+            return visibleWordCount
           }
 
           const nextWordCount = Math.min(
             targetWordCount,
-            currentWordCount + WORDS_PER_TICK,
+            visibleWordCount + WORDS_PER_TICK,
           )
 
           if (
@@ -1770,7 +1863,7 @@ function MessageItemComponent({
       }
 
       revealTimerRef.current = window.setInterval(tick, TICK_INTERVAL_MS)
-      return currentWordCount
+      return wordCount
     })
   }, [displayText, effectiveIsStreaming])
 
@@ -1996,6 +2089,10 @@ function MessageItemComponent({
   const inlineRenderPlan = useMemo(
     () => buildInlineToolRenderPlan(message, finalToolSections),
     [message, finalToolSections],
+  )
+  const compactInlineRenderPlan = useMemo(
+    () => compactInlineToolRenderPlan(inlineRenderPlan),
+    [inlineRenderPlan],
   )
   const hasToolCalls = finalToolSections.length > 0
   const shouldRenderMessageBubble =
@@ -2322,11 +2419,11 @@ function MessageItemComponent({
             )}
             {!isUser && hasToolCalls && (
               <div className="flex flex-col gap-2">
-                {inlineRenderPlan.map((item, index) =>
-                  item.kind === 'tool' ? (
+                {compactInlineRenderPlan.map((item, index) =>
+                  item.kind === 'tools' ? (
                     <ToolCallGroup
-                      key={item.section.key || `tool-${index}`}
-                      toolSections={[item.section]}
+                      key={item.sections.map((section) => section.key).join(':') || `tools-${index}`}
+                      toolSections={item.sections}
                       expandAll={expandAllToolSections}
                       isStreaming={effectiveIsStreaming}
                     />
@@ -2341,11 +2438,6 @@ function MessageItemComponent({
                             'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                             effectiveIsStreaming && 'chat-streaming-content',
                           )}
-                          style={
-                            isUser
-                              ? { color: 'var(--chat-user-foreground)' }
-                              : undefined
-                          }
                         >
                           {item.text}
                         </MessageContent>
@@ -2370,11 +2462,6 @@ function MessageItemComponent({
                         'text-primary-900 bg-transparent w-full text-pretty transition-all duration-100',
                         effectiveIsStreaming && 'chat-streaming-content',
                       )}
-                      style={
-                        isUser
-                          ? { color: 'var(--chat-user-foreground)' }
-                          : undefined
-                      }
                     >
                       {assistantDisplayText}
                     </MessageContent>

--- a/src/screens/chat/components/message-timestamp.tsx
+++ b/src/screens/chat/components/message-timestamp.tsx
@@ -1,3 +1,5 @@
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
+
 type MessageTimestampProps = {
   timestamp: number
 }
@@ -10,14 +12,14 @@ function isSameDay(a: Date, b: Date): boolean {
   )
 }
 
-function formatShort(timestamp: number): string {
+function formatShort(timestamp: number, use24HourTime: boolean): string {
   const date = new Date(timestamp)
   const now = new Date()
   if (isSameDay(date, now)) {
     return new Intl.DateTimeFormat('en-US', {
       hour: 'numeric',
       minute: '2-digit',
-      hour12: true,
+      hour12: !use24HourTime,
     }).format(date)
   }
 
@@ -27,22 +29,24 @@ function formatShort(timestamp: number): string {
   }).format(date)
 }
 
-function formatFull(timestamp: number): string {
-  const value = new Intl.DateTimeFormat('en-US', {
+function formatFull(timestamp: number, use24HourTime: boolean): string {
+  return new Intl.DateTimeFormat('en-US', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
-    hour12: true,
+    hour12: !use24HourTime,
   }).format(new Date(timestamp))
-  return value
 }
 
 export function MessageTimestamp({ timestamp }: MessageTimestampProps) {
-  const shortLabel = formatShort(timestamp)
-  const fullLabel = formatFull(timestamp)
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
+  const shortLabel = formatShort(timestamp, use24HourTime)
+  const fullLabel = formatFull(timestamp, use24HourTime)
 
   return (
     <span

--- a/src/screens/chat/components/sidebar/session-item.tsx
+++ b/src/screens/chat/components/sidebar/session-item.tsx
@@ -18,6 +18,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from '@/components/ui/menu'
+import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 
 type SessionItemProps = {
   session: SessionMeta
@@ -34,21 +35,24 @@ const dayFormatter = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
 })
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: '2-digit',
-})
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-function formatSessionTimestamp(timestamp?: number | null): string {
+function formatSessionTimestamp(
+  timestamp: number | undefined | null,
+  use24HourTime: boolean,
+): string {
   if (!timestamp) return ''
   const date = new Date(timestamp)
   const now = new Date()
   const sameDay = date.toDateString() === now.toDateString()
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: !use24HourTime,
+  })
   return (sameDay ? timeFormatter : dayFormatter).format(date)
 }
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isUuidLike(value: string): boolean {
   return UUID_PATTERN.test(value.trim())
@@ -102,6 +106,9 @@ function SessionItemComponent({
   onRename,
   onDelete,
 }: SessionItemProps) {
+  const use24HourTime = useChatSettingsStore(
+    (state) => state.settings.use24HourTime,
+  )
   const isGenerating = session.titleStatus === 'generating'
   const isError = session.titleStatus === 'error'
   const baseTitle = getSessionDisplayTitle(session, isGenerating)
@@ -117,11 +124,11 @@ function SessionItemComponent({
       return session.titleError || 'Could not generate a title'
     }
     const parts: Array<string> = []
-    const formatted = formatSessionTimestamp(updatedAt)
+    const formatted = formatSessionTimestamp(updatedAt, use24HourTime)
     if (formatted) parts.push(formatted)
     if (session.friendlyId) parts.push(getFriendlyIdLabel(session.friendlyId))
     return parts.join(' • ')
-  }, [isError, session.friendlyId, session.titleError, updatedAt])
+  }, [isError, session.friendlyId, session.titleError, updatedAt, use24HourTime])
 
   return (
     <Link

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -7,7 +7,7 @@ export type ToolCallContent = {
 }
 
 export type ToolResultContent = {
-  type: 'toolResult'
+  type: 'toolResult' | 'tool_result'
   toolCallId?: string
   toolName?: string
   content?: Array<{ type?: string; text?: string }>
@@ -27,7 +27,11 @@ export type ThinkingContent = {
   thinkingSignature?: string
 }
 
-export type MessageContent = TextContent | ToolCallContent | ThinkingContent
+export type MessageContent =
+  | TextContent
+  | ToolCallContent
+  | ToolResultContent
+  | ThinkingContent
 
 export type ChatAttachment = {
   id?: string

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -144,7 +144,10 @@ export function findToolResultForCall(
   messages: Array<ChatMessage>,
 ): ChatMessage | undefined {
   return messages.find(
-    (msg) => msg.role === 'toolResult' && msg.toolCallId === toolCallId,
+    (msg) =>
+      ['toolResult', 'toolresult', 'tool_result', 'tool'].includes(
+        String(msg.role || ''),
+      ) && msg.toolCallId === toolCallId,
   )
 }
 

--- a/src/screens/profiles/profiles-screen.tsx
+++ b/src/screens/profiles/profiles-screen.tsx
@@ -178,8 +178,9 @@ export function ProfilesScreen() {
     }
   }, [createOpen, wizardStep, allModels.length, fetchAllModels])
 
+  const profileNamePattern = /^[a-z0-9][a-z0-9_-]{0,63}$/
   const nameValid =
-    /^[A-Za-z0-9_-]+$/.test(newProfileName.trim()) &&
+    profileNamePattern.test(newProfileName.trim()) &&
     newProfileName.trim() !== 'default'
 
   function resetWizard() {
@@ -542,7 +543,7 @@ export function ProfilesScreen() {
                   />
                   {newProfileName.trim() && !nameValid ? (
                     <p className="text-xs text-red-500">
-                      Use letters, numbers, underscores, or hyphens. Cannot be
+                      Use lowercase letters, numbers, underscores, or hyphens. Cannot be
                       &quot;default&quot;.
                     </p>
                   ) : newProfileName.trim() && nameValid ? (
@@ -788,9 +789,9 @@ export function ProfilesScreen() {
                 autoFocus
               />
               {renameValue.trim() &&
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim()) && (
+                !profileNamePattern.test(renameValue.trim()) && (
                   <p className="text-xs text-red-500">
-                    Use letters, numbers, underscores, or hyphens.
+                    Use lowercase letters, numbers, underscores, or hyphens.
                   </p>
                 )}
             </div>
@@ -812,7 +813,7 @@ export function ProfilesScreen() {
               disabled={
                 !renameTarget ||
                 !renameValue.trim() ||
-                !/^[A-Za-z0-9_-]+$/.test(renameValue.trim())
+                !profileNamePattern.test(renameValue.trim())
               }
             >
               Rename

--- a/src/screens/swarm2/swarm2-kanban-board.test.ts
+++ b/src/screens/swarm2/swarm2-kanban-board.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getKanbanBackendPresentation } from './swarm2-kanban-board'
+
+describe('Swarm2 Kanban backend presentation', () => {
+  it('keeps the initial backend state quiet and non-committal while auto-detecting', () => {
+    expect(getKanbanBackendPresentation(null)).toMatchObject({
+      badgeLabel: 'Detecting board',
+      badgeTone: 'unknown',
+      toastTitle: 'Detecting Swarm Board backend',
+    })
+  })
+
+  it('presents detected Kanban as the default shared board, not a backend demo', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'hermes',
+      label: 'Hermes Kanban',
+      detected: true,
+      writable: true,
+      details: 'Canonical storage detected',
+      path: '/tmp/kanban.db',
+    })).toMatchObject({
+      badgeLabel: 'Shared board',
+      badgeTone: 'hermes',
+      toastTitle: 'Board connected',
+      toastBody: 'Cards and status changes are using the canonical Kanban store.',
+      title: 'Canonical storage detected',
+    })
+  })
+
+  it('presents local storage as an automatic fallback, not a manual control', () => {
+    expect(getKanbanBackendPresentation({
+      id: 'local',
+      label: 'Local board',
+      detected: true,
+      writable: true,
+      details: 'Using local Swarm board JSON store.',
+      path: '/tmp/swarm2-kanban.json',
+    })).toMatchObject({
+      badgeLabel: 'Local fallback',
+      badgeTone: 'local',
+      toastTitle: 'Using local Swarm Board',
+      toastBody: 'Using local Swarm board JSON store.',
+    })
+  })
+})

--- a/src/screens/swarm2/swarm2-kanban-board.tsx
+++ b/src/screens/swarm2/swarm2-kanban-board.tsx
@@ -1,0 +1,433 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { cn } from '@/lib/utils'
+
+type KanbanLane = 'backlog' | 'ready' | 'running' | 'review' | 'blocked' | 'done'
+
+type SwarmKanbanCard = {
+  id: string
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: KanbanLane
+  missionId: string | null
+  reportPath: string | null
+  createdBy: string
+  createdAt: number
+  updatedAt: number
+}
+
+type KanbanWorker = {
+  id: string
+  displayName?: string | null
+  role?: string | null
+}
+
+type KanbanBackendMeta = {
+  id: 'local' | 'hermes'
+  label: string
+  detected: boolean
+  writable: boolean
+  details?: string | null
+  path?: string | null
+}
+
+type KanbanResponse = {
+  cards?: Array<SwarmKanbanCard>
+  backend?: KanbanBackendMeta
+}
+
+type Swarm2KanbanBoardProps = {
+  workers: Array<KanbanWorker>
+  latestMission?: { id: string; title: string; state: string } | null
+  selectedWorkerId?: string | null
+  onSelectWorker?: (workerId: string) => void
+  onOpenRouter?: () => void
+  className?: string
+}
+
+type KanbanBackendPresentation = {
+  badgeLabel: string
+  badgeTone: 'hermes' | 'local' | 'unknown'
+  toastTitle: string
+  toastBody: string
+  title: string | undefined
+}
+
+export function getKanbanBackendPresentation(backend: KanbanBackendMeta | null | undefined): KanbanBackendPresentation {
+  if (!backend) {
+    return {
+      badgeLabel: 'Detecting board',
+      badgeTone: 'unknown',
+      toastTitle: 'Detecting Swarm Board backend',
+      toastBody: 'Checking Hermes Kanban before falling back locally.',
+      title: undefined,
+    }
+  }
+  if (backend.id === 'hermes' && backend.detected) {
+    return {
+      badgeLabel: 'Shared board',
+      badgeTone: 'hermes',
+      toastTitle: 'Board connected',
+      toastBody: 'Cards and status changes are using the canonical Kanban store.',
+      title: backend.details ?? backend.path ?? 'Canonical Kanban store detected',
+    }
+  }
+  return {
+    badgeLabel: 'Local fallback',
+    badgeTone: 'local',
+    toastTitle: 'Using local Swarm Board',
+    toastBody: backend.details || 'Hermes Kanban is not available yet. Cards stay local and the board will switch automatically when Hermes storage is detected.',
+    title: backend.details ?? backend.path ?? 'Local Swarm Board fallback',
+  }
+}
+
+const LANES: Array<{ id: KanbanLane; label: string; hint: string }> = [
+  { id: 'backlog', label: 'Backlog', hint: 'Captured, not committed' },
+  { id: 'ready', label: 'Ready', hint: 'Spec clear, safe to dispatch' },
+  { id: 'running', label: 'Running', hint: 'Worker executing' },
+  { id: 'review', label: 'Review', hint: 'Needs peer/human check' },
+  { id: 'blocked', label: 'Blocked', hint: 'Needs input or dependency' },
+  { id: 'done', label: 'Done', hint: 'Accepted / archived' },
+]
+
+const LANE_TONE: Record<KanbanLane, string> = {
+  backlog: 'border-slate-400/40 bg-slate-500/10 text-slate-700',
+  ready: 'border-blue-400/40 bg-blue-500/10 text-blue-700',
+  running: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-700',
+  review: 'border-violet-400/40 bg-violet-500/10 text-violet-700',
+  blocked: 'border-red-400/40 bg-red-500/10 text-red-700',
+  done: 'border-green-400/40 bg-green-500/10 text-green-700',
+}
+
+async function fetchKanbanCards(): Promise<{ cards: Array<SwarmKanbanCard>; backend: KanbanBackendMeta | null }> {
+  const res = await fetch('/api/swarm-kanban')
+  if (!res.ok) throw new Error(`Kanban request failed: ${res.status}`)
+  const data = (await res.json()) as KanbanResponse
+  return {
+    cards: Array.isArray(data.cards) ? data.cards : [],
+    backend: data.backend ?? null,
+  }
+}
+
+async function createKanbanCard(input: {
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: KanbanLane
+  missionId: string | null
+}): Promise<SwarmKanbanCard> {
+  const res = await fetch('/api/swarm-kanban', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban create failed: ${res.status}`)
+  return data.card
+}
+
+async function updateKanbanCard(id: string, updates: Partial<SwarmKanbanCard>): Promise<SwarmKanbanCard> {
+  const res = await fetch('/api/swarm-kanban', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, ...updates }),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || data?.ok === false) throw new Error(data?.error || `Kanban update failed: ${res.status}`)
+  return data.card
+}
+
+function splitCriteria(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+}
+
+function workerLabel(workers: Array<KanbanWorker>, workerId: string | null): string {
+  if (!workerId) return 'Unassigned'
+  const worker = workers.find((item) => item.id === workerId)
+  return worker?.displayName || workerId
+}
+
+export function Swarm2KanbanBoard({
+  workers,
+  latestMission,
+  selectedWorkerId,
+  onSelectWorker,
+  onOpenRouter,
+  className,
+}: Swarm2KanbanBoardProps) {
+  const queryClient = useQueryClient()
+  const [composerOpen, setComposerOpen] = useState(false)
+  const [draftTitle, setDraftTitle] = useState('')
+  const [draftSpec, setDraftSpec] = useState('')
+  const [draftCriteria, setDraftCriteria] = useState('')
+  const [draftWorker, setDraftWorker] = useState(selectedWorkerId ?? '')
+  const [draftReviewer, setDraftReviewer] = useState('')
+  const [draftStatus, setDraftStatus] = useState<KanbanLane>('backlog')
+  const [linkLatestMission, setLinkLatestMission] = useState(Boolean(latestMission))
+  const [backendToast, setBackendToast] = useState<KanbanBackendPresentation | null>(null)
+  const lastToastedBackendKey = useRef<string | null>(null)
+
+  const query = useQuery({
+    queryKey: ['swarm2', 'kanban'],
+    queryFn: fetchKanbanCards,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  })
+
+  const backend = query.data?.backend ?? null
+  const backendPresentation = useMemo(() => getKanbanBackendPresentation(backend), [backend])
+
+  useEffect(() => {
+    if (!backend) return
+    const backendKey = `${backend.id}:${backend.detected ? 'detected' : 'fallback'}:${backend.path ?? ''}`
+    if (lastToastedBackendKey.current === backendKey) return
+    lastToastedBackendKey.current = backendKey
+
+    const storageKey = 'swarm2-kanban-backend-toast'
+    if (typeof window !== 'undefined') {
+      const lastSessionToast = window.sessionStorage.getItem(storageKey)
+      if (lastSessionToast === backendKey) return
+      window.sessionStorage.setItem(storageKey, backendKey)
+    }
+
+    const nextToast = getKanbanBackendPresentation(backend)
+    setBackendToast(nextToast)
+    const timeout = window.setTimeout(() => setBackendToast(null), 4_500)
+    return () => window.clearTimeout(timeout)
+  }, [backend])
+
+  const createMutation = useMutation({
+    mutationFn: () => createKanbanCard({
+      title: draftTitle.trim(),
+      spec: draftSpec.trim(),
+      acceptanceCriteria: splitCriteria(draftCriteria),
+      assignedWorker: draftWorker || null,
+      reviewer: draftReviewer || null,
+      status: draftStatus,
+      missionId: linkLatestMission ? latestMission?.id ?? null : null,
+    }),
+    onSuccess: async () => {
+      setDraftTitle('')
+      setDraftSpec('')
+      setDraftCriteria('')
+      setDraftWorker(selectedWorkerId ?? '')
+      setDraftReviewer('')
+      setDraftStatus('backlog')
+      setComposerOpen(false)
+      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: Partial<SwarmKanbanCard> }) => updateKanbanCard(id, updates),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['swarm2', 'kanban'] })
+    },
+  })
+
+  const cardsByLane = useMemo(() => {
+    const map = new Map<KanbanLane, Array<SwarmKanbanCard>>()
+    for (const lane of LANES) map.set(lane.id, [])
+    for (const card of query.data?.cards ?? []) {
+      const bucket = map.get(card.status) ?? map.get('backlog')!
+      bucket.push(card)
+    }
+    return map
+  }, [query.data])
+
+  const total = query.data?.cards.length ?? 0
+  const reviewCount = cardsByLane.get('review')?.length ?? 0
+  const blockedCount = cardsByLane.get('blocked')?.length ?? 0
+
+  return (
+    <section className={cn('rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-[0_24px_80px_var(--theme-shadow)]', className)}>
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Manual planning</div>
+          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Swarm Board</h2>
+          <p className="mt-1 max-w-3xl text-xs leading-relaxed text-[var(--theme-muted-2)]">
+            Auto-detects the shared Kanban store by default; if it is unavailable, cards stay in a local fallback. Dispatch stays explicit through Router.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--theme-muted)]">
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{total} cards</span>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-full border px-2 py-1 font-medium',
+              backendPresentation.badgeTone === 'hermes'
+                ? 'border-violet-400/40 bg-violet-500/10 text-violet-700'
+                : backendPresentation.badgeTone === 'local'
+                  ? 'border-amber-400/40 bg-amber-500/10 text-amber-700'
+                  : 'border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-muted)]',
+            )}
+            title={backendPresentation.title}
+            aria-live="polite"
+          >
+            <span className={cn(
+              'h-1.5 w-1.5 rounded-full',
+              backendPresentation.badgeTone === 'hermes' ? 'bg-violet-500' : backendPresentation.badgeTone === 'local' ? 'bg-amber-500' : 'bg-[var(--theme-muted)]',
+            )} />
+            {backendPresentation.badgeLabel}
+          </span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{reviewCount} review</span>
+          <span className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1">{blockedCount} blocked</span>
+          <button
+            type="button"
+            onClick={() => {
+              setDraftWorker(selectedWorkerId ?? '')
+              setLinkLatestMission(Boolean(latestMission))
+              setComposerOpen((open) => !open)
+            }}
+            className="rounded-full bg-[var(--theme-accent)] px-3 py-1.5 font-semibold text-primary-950 hover:bg-[var(--theme-accent-strong)]"
+          >
+            New card
+          </button>
+        </div>
+      </div>
+
+      {backendToast ? (
+        <div className="fixed right-4 top-4 z-50 max-w-sm rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-3 text-sm text-[var(--theme-text)] shadow-[0_18px_60px_var(--theme-shadow)]" role="status" aria-live="polite">
+          <div className="flex items-start gap-3">
+            <span className={cn(
+              'mt-1 h-2 w-2 shrink-0 rounded-full',
+              backendToast.badgeTone === 'hermes' ? 'bg-violet-500' : backendToast.badgeTone === 'local' ? 'bg-amber-500' : 'bg-[var(--theme-muted)]',
+            )} />
+            <div>
+              <div className="font-semibold">{backendToast.toastTitle}</div>
+              <div className="mt-1 text-xs leading-relaxed text-[var(--theme-muted-2)]">{backendToast.toastBody}</div>
+            </div>
+            <button type="button" onClick={() => setBackendToast(null)} className="ml-1 rounded-full px-1.5 text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" aria-label="Dismiss backend notice">×</button>
+          </div>
+        </div>
+      ) : null}
+
+      {composerOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4 py-6 backdrop-blur-sm">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_30px_100px_var(--theme-shadow)]">
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Manual planning</div>
+                <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">New board card</h3>
+                <p className="mt-1 text-xs text-[var(--theme-muted-2)]">Spec work before routing it to an agent. Dispatch stays explicit through Router.</p>
+              </div>
+              <button type="button" onClick={() => setComposerOpen(false)} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-1.5 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]">Close</button>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Title</span>
+                <input value={draftTitle} onChange={(event) => setDraftTitle(event.target.value)} placeholder="e.g. Review board UX safety" className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Spec</span>
+                <textarea value={draftSpec} onChange={(event) => setDraftSpec(event.target.value)} rows={4} placeholder="Short task spec / context" className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs md:col-span-2">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Acceptance criteria</span>
+                <textarea value={draftCriteria} onChange={(event) => setDraftCriteria(event.target.value)} rows={3} placeholder="One per line" className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none" />
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Assigned worker</span>
+                <select value={draftWorker} onChange={(event) => setDraftWorker(event.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  <option value="">Unassigned</option>
+                  {workers.map((worker) => <option key={worker.id} value={worker.id}>{worker.displayName || worker.id}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Reviewer</span>
+                <select value={draftReviewer} onChange={(event) => setDraftReviewer(event.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  <option value="">Unassigned</option>
+                  {workers.map((worker) => <option key={worker.id} value={worker.id}>{worker.displayName || worker.id}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs">
+                <span className="mb-1 block font-semibold text-[var(--theme-muted)]">Status</span>
+                <select value={draftStatus} onChange={(event) => setDraftStatus(event.target.value as KanbanLane)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none">
+                  {LANES.map((lane) => <option key={lane.id} value={lane.id}>{lane.label}</option>)}
+                </select>
+              </label>
+              <label className="flex items-center gap-2 self-end rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-xs text-[var(--theme-muted)]">
+                <input type="checkbox" checked={linkLatestMission} disabled={!latestMission} onChange={(event) => setLinkLatestMission(event.target.checked)} />
+                Link latest mission{latestMission ? `: ${latestMission.title}` : ''}
+              </label>
+              {createMutation.error ? <div className="rounded-xl border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-700 md:col-span-2">{createMutation.error.message}</div> : null}
+              <div className="flex justify-end gap-2 md:col-span-2">
+                <button type="button" onClick={() => setComposerOpen(false)} className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-xs font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)]">Cancel</button>
+                <button type="button" disabled={!draftTitle.trim() || createMutation.isPending} onClick={() => void createMutation.mutateAsync()} className="rounded-xl bg-[var(--theme-accent)] px-3 py-2 text-xs font-semibold text-primary-950 disabled:opacity-50">{createMutation.isPending ? 'Saving…' : 'Create card'}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {query.isError ? (
+        <div className="rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-700">Kanban failed to load: {query.error.message}</div>
+      ) : query.isPending ? (
+        <div className="mb-3 rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-muted)]">
+          Loading board cards and backend source…
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-3 2xl:grid-cols-6">
+        {LANES.map((lane) => {
+          const laneCards = cardsByLane.get(lane.id) ?? []
+          return (
+            <div key={lane.id} className="min-h-64 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-2">
+              <div className="mb-2 flex items-center justify-between gap-2 px-1">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]', LANE_TONE[lane.id])}>{lane.label}</span>
+                    <span className="text-[10px] text-[var(--theme-muted)]">{laneCards.length}</span>
+                  </div>
+                  <div className="mt-1 text-[10px] text-[var(--theme-muted)]">{lane.hint}</div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                {query.isPending ? (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-3 text-xs text-[var(--theme-muted)]">Waiting for source…</div>
+                ) : laneCards.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-[var(--theme-border)] p-3 text-xs text-[var(--theme-muted)]">Empty</div>
+                ) : laneCards.map((card) => (
+                  <article key={card.id} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 text-left shadow-sm">
+                    <div className="text-sm font-semibold leading-snug text-[var(--theme-text)]">{card.title}</div>
+                    {card.spec ? <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-[var(--theme-muted-2)]">{card.spec}</p> : null}
+                    {card.acceptanceCriteria.length ? (
+                      <ul className="mt-2 space-y-1 text-[11px] text-[var(--theme-muted)]">
+                        {card.acceptanceCriteria.slice(0, 3).map((item, index) => <li key={`${card.id}-ac-${index}`}>✓ {item}</li>)}
+                        {card.acceptanceCriteria.length > 3 ? <li>+{card.acceptanceCriteria.length - 3} more</li> : null}
+                      </ul>
+                    ) : null}
+                    <div className="mt-3 space-y-1 text-[10px] text-[var(--theme-muted)]">
+                      <div>Owner: <span className="font-semibold text-[var(--theme-text)]">{workerLabel(workers, card.assignedWorker)}</span></div>
+                      <div>Reviewer: <span className="font-semibold text-[var(--theme-text)]">{workerLabel(workers, card.reviewer)}</span></div>
+                      {card.missionId ? <div className="truncate" title={card.missionId}>Mission: {card.missionId}</div> : null}
+                      {card.reportPath ? <div className="truncate" title={card.reportPath}>Report: {card.reportPath}</div> : null}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {card.assignedWorker ? (
+                        <button type="button" onClick={() => onSelectWorker?.(card.assignedWorker!)} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Open worker</button>
+                      ) : null}
+                      {card.status !== 'running' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'running' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Run</button> : null}
+                      {card.status !== 'review' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'review' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Review</button> : null}
+                      {card.status !== 'done' ? <button type="button" onClick={() => updateMutation.mutate({ id: card.id, updates: { status: 'done' } })} className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-muted)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]">Done</button> : null}
+                      {onOpenRouter ? <button type="button" onClick={onOpenRouter} className="rounded-full border border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] px-2 py-1 text-[10px] font-semibold text-[var(--theme-accent-strong)]">Router</button> : null}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/server/company-os-store.ts
+++ b/src/server/company-os-store.ts
@@ -1,0 +1,840 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { getHermesRoot } from './hermes-paths'
+
+const execFileAsync = promisify(execFile)
+
+export type CompanyOsTask = {
+  title: string
+  description: string
+  status: 'active' | 'waiting' | 'someday' | 'done'
+  tags: Array<string>
+  priority: string | null
+}
+
+export type CompanyOsDocument = {
+  title: string
+  filename: string
+  body: string
+  excerpt: string
+}
+
+export type CompanyOsInvoice = {
+  file: string
+  status: 'outstanding' | 'done' | 'needs-proof' | 'review'
+  source: string
+}
+
+export type CompanyOsAsset = {
+  id: string
+  title: string
+  kind: 'pricing' | 'media-kit' | 'proposal' | 'tax' | 'contract' | 'invoice' | 'site' | 'brand'
+  file: string
+  path: string
+  note: string
+}
+
+export type CompanyOsLead = {
+  id: number | string
+  title: string
+  businessName: string | null
+  listId: string | null
+  priority: string | null
+  estimatedValue: string | null
+  draftStatus: string | null
+  updatedAt: string | null
+}
+
+export type CompanyOsKanbanAction = {
+  id: number | string
+  title: string
+  businessName: string | null
+  stage: string | null
+  priority: string | null
+  draftStatus: string | null
+  updatedAt: string | null
+  lane: string
+  urgency: 'p0' | 'p1' | 'p2'
+  reason: string
+  recommendedAction: string
+  publicAsset: string | null
+  assetIds: Array<string>
+}
+
+export type CompanyOsSignal = {
+  kind: string
+  subject?: string
+  from?: string
+  title?: string
+  url?: string
+  threadId?: string
+  messageId?: string
+  gmailUrl?: string
+  timestamp?: string
+  updatedAt?: string
+  summary: string
+  needs?: string
+  thread?: {
+    status: string
+    latestAction: string
+    messages: Array<{
+      id: string
+      from: string
+      to?: Array<string>
+      cc?: Array<string>
+      timestamp?: string
+      subject?: string
+      body: string
+      attachments?: Array<string>
+    }>
+  }
+}
+
+export type CompanyOsLiveOps = {
+  sources: Array<{
+    name: string
+    status: 'connected' | 'snapshot' | 'missing' | 'error'
+    count: number
+    note: string
+  }>
+  invoices: Array<CompanyOsInvoice>
+  invoiceCounts: Record<string, number>
+  assets: Array<CompanyOsAsset>
+  supabase: {
+    ok: boolean
+    count: number
+    stages: Record<string, number>
+    priorities: Record<string, number>
+    draftStatuses: Record<string, number>
+    hotLeads: Array<CompanyOsLead>
+    invoiceLeads: Array<CompanyOsLead>
+    kanbanActions: Array<CompanyOsKanbanAction>
+    error?: string
+  }
+  emailSignals: Array<CompanyOsSignal>
+  driveSignals: Array<CompanyOsSignal>
+}
+
+export type CompanyOsSnapshot = {
+  slug: string
+  name: string
+  idea: string
+  audience: string
+  status: string
+  rules: Array<string>
+  tasks: Array<CompanyOsTask>
+  documents: Array<CompanyOsDocument>
+  log: string
+  siteHtml: string
+  workspacePath: string
+  liveOps: CompanyOsLiveOps
+  updatedAt: string
+}
+
+export type CompanyOsGmailRefreshResult = {
+  ok: boolean
+  count: number
+  path: string
+  message: string
+}
+
+const SECTION_STATUS: Record<string, CompanyOsTask['status']> = {
+  active: 'active',
+  'waiting on': 'waiting',
+  someday: 'someday',
+  done: 'done',
+}
+
+function companyRoot(): string {
+  return path.join(getHermesRoot(), 'company-os')
+}
+
+function safeSlug(value: string | null): string {
+  return (value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+}
+
+function firstHeading(markdown: string, fallback: string): string {
+  const match = markdown.match(/^#\s+(.+)$/m)
+  return match?.[1]?.trim() || fallback
+}
+
+function section(markdown: string, heading: string): string {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(
+    `^##\\s+${escaped}\\s*$\\n?([\\s\\S]*?)(?=\\n##\\s+|$)`,
+    'im',
+  )
+  return regex.exec(markdown)?.[1]?.trim() || ''
+}
+
+function linesFromSection(markdown: string, heading: string): Array<string> {
+  return section(markdown, heading)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.replace(/^-\s+/, '').trim())
+}
+
+function parseTasks(markdown: string): Array<CompanyOsTask> {
+  const tasks: Array<CompanyOsTask> = []
+  let current: CompanyOsTask['status'] = 'active'
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trim()
+    const heading = /^##\s+(.+)$/.exec(line)?.[1]?.trim().toLowerCase()
+    if (heading && SECTION_STATUS[heading]) {
+      current = SECTION_STATUS[heading]
+      continue
+    }
+
+    const taskMatch = /^-\s+\[[ xX]\]\s+\*\*(.+?)\*\*\s+-\s+(.+)$/.exec(line)
+    if (!taskMatch) continue
+
+    const title = taskMatch[1].trim()
+    const rest = taskMatch[2].trim()
+    const tags = Array.from(rest.matchAll(/`([^`]+)`/g)).map((match) => match[1])
+    const priority = tags.find((tag) => /^p\d$/i.test(tag)) ?? null
+    const description = rest.replace(/\s*`[^`]+`/g, '').trim()
+
+    tasks.push({
+      title,
+      description,
+      status: current,
+      tags: tags.filter((tag) => tag !== priority),
+      priority,
+    })
+  }
+
+  return tasks
+}
+
+function excerpt(markdown: string): string {
+  return markdown
+    .replace(/^#+\s+/gm, '')
+    .replace(/[*_`#>-]/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .slice(0, 220)
+}
+
+async function readIfExists(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+async function readJsonIfExists<T>(filePath: string, fallback: T): Promise<T> {
+  const content = await readIfExists(filePath)
+  if (!content) return fallback
+  try {
+    return JSON.parse(content) as T
+  } catch {
+    return fallback
+  }
+}
+
+async function listFilesRecursively(root: string): Promise<Array<string>> {
+  async function walk(dir: string): Promise<Array<string>> {
+    let entries: Array<import('node:fs').Dirent> = []
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true })
+    } catch {
+      return []
+    }
+
+    const nested = await Promise.all(
+      entries.map(async (entry) => {
+        const absolute = path.join(dir, entry.name)
+        if (entry.isDirectory()) return walk(absolute)
+        if (!entry.isFile()) return []
+        return [absolute]
+      }),
+    )
+    return nested.flat()
+  }
+
+  return walk(root)
+}
+
+function basenameWithParent(filePath: string, root: string): string {
+  return path.relative(root, filePath).replaceAll(path.sep, '/')
+}
+
+async function readInvoiceFiles(): Promise<Array<CompanyOsInvoice>> {
+  const root = path.join(getUserDesktopPath(), 'UNALIGNED', 'INVOICES')
+  const outstandingRoot = path.join(root, 'OUTSTANDING')
+  const doneRoot = path.join(root, 'DONE')
+
+  const [outstanding, done] = await Promise.all([
+    listFilesRecursively(outstandingRoot),
+    listFilesRecursively(doneRoot),
+  ])
+
+  const invoices: Array<CompanyOsInvoice> = [
+    ...outstanding.map((filePath) => ({
+      file: basenameWithParent(filePath, outstandingRoot),
+      status: filePath.includes('NOT CONFIRMED BUT CONFIRMED')
+        ? ('needs-proof' as const)
+        : ('outstanding' as const),
+      source: 'Desktop/UNALIGNED/INVOICES/OUTSTANDING',
+    })),
+    ...done.map((filePath) => ({
+      file: basenameWithParent(filePath, doneRoot),
+      status: 'done' as const,
+      source: 'Desktop/UNALIGNED/INVOICES/DONE',
+    })),
+  ]
+
+  return invoices.filter((invoice) => /\.(pdf|html|docx?)$/i.test(invoice.file))
+}
+
+function countBy<T extends string>(items: Array<T>): Record<string, number> {
+  return items.reduce<Record<string, number>>((counts, item) => {
+    counts[item] = (counts[item] ?? 0) + 1
+    return counts
+  }, {})
+}
+
+function getUserDesktopPath(): string {
+  return path.join(process.env.HOME || process.env.USERPROFILE || '', 'Desktop')
+}
+
+const ASSET_CATALOG: Array<{
+  id: string
+  title: string
+  kind: CompanyOsAsset['kind']
+  relativePath: string
+  note: string
+}> = [
+  {
+    id: 'partnership-packages',
+    title: 'Unaligned Partnership Packages',
+    kind: 'pricing',
+    relativePath: 'MASTER FILES/docs/Unaligned_Partnership_Packages.pdf',
+    note: 'Primary package/rate asset for sales follow-ups.',
+  },
+  {
+    id: 'sponsorship-pricing',
+    title: 'Unaligned Sponsorship Pricing',
+    kind: 'pricing',
+    relativePath: 'MASTER FILES/docs/Unaligned_Sponsorship_Pricing.html',
+    note: 'HTML pricing reference for rate-sent and negotiation cards.',
+  },
+  {
+    id: 'sponsor-program',
+    title: 'Sponsor Program',
+    kind: 'proposal',
+    relativePath: 'MASTER FILES/docs/SponsorProgram.pdf',
+    note: 'Program-level sponsor overview.',
+  },
+  {
+    id: 'media-kit',
+    title: 'Unaligned Media Kit',
+    kind: 'media-kit',
+    relativePath: 'SAM FILES/UNALIGNED/UnalignedMediaKit.pdf',
+    note: 'Audience and credibility proof for new leads.',
+  },
+  {
+    id: 'stats',
+    title: 'Unaligned Stats',
+    kind: 'media-kit',
+    relativePath: 'SAM FILES/UNALIGNED/UnalignedStats.png',
+    note: 'Fast visual proof point for sponsor replies.',
+  },
+  {
+    id: 'w9',
+    title: 'Unaligned W9',
+    kind: 'tax',
+    relativePath: 'SAM FILES/UNALIGNED/UnalignedW9.pdf',
+    note: 'Tax/admin document for procurement and payment setup.',
+  },
+  {
+    id: 'ein',
+    title: 'Unaligned EIN',
+    kind: 'tax',
+    relativePath: 'SAM FILES/UNALIGNED/UnalignedEIN.jpg',
+    note: 'Business identity proof; review before sharing.',
+  },
+  {
+    id: 'contract',
+    title: 'Unaligned Contract',
+    kind: 'contract',
+    relativePath: 'SAM FILES/UNALIGNED/Unaligned Contract.docx',
+    note: 'Contract template/reference; do not send without review.',
+  },
+  {
+    id: 'public-site',
+    title: 'Unaligned Public Site',
+    kind: 'site',
+    relativePath: 'MASTER FILES/index.html',
+    note: 'Public-facing website currently built for Unaligned.',
+  },
+  {
+    id: 'logo',
+    title: 'Unaligned Logo',
+    kind: 'brand',
+    relativePath: 'MASTER FILES/unaligned_logo.png',
+    note: 'Brand asset for decks and one-pagers.',
+  },
+]
+
+async function readSalesAssets(): Promise<Array<CompanyOsAsset>> {
+  const root = path.join(getUserDesktopPath(), 'UNALIGNED')
+  const assets = await Promise.all(
+    ASSET_CATALOG.map(async (asset) => {
+      const absolute = path.join(root, asset.relativePath)
+      try {
+        const stat = await fs.stat(absolute)
+        if (!stat.isFile()) return null
+      } catch {
+        return null
+      }
+
+      return {
+        id: asset.id,
+        title: asset.title,
+        kind: asset.kind,
+        file: asset.relativePath,
+        path: absolute,
+        note: asset.note,
+      }
+    }),
+  )
+
+  return assets.filter((asset): asset is CompanyOsAsset => Boolean(asset))
+}
+
+function extractPythonString(source: string, name: string): string | null {
+  const match = new RegExp(`${name}\\s*=\\s*"([^"]+)"`).exec(source)
+  return match?.[1] ?? null
+}
+
+function normalizeLead(card: Record<string, unknown>): CompanyOsLead {
+  return {
+    id: typeof card.id === 'number' || typeof card.id === 'string' ? card.id : '',
+    title: typeof card.title === 'string' ? card.title : 'Untitled lead',
+    businessName:
+      typeof card.business_name === 'string' && card.business_name
+        ? card.business_name
+        : null,
+    listId: typeof card.list_id === 'string' ? card.list_id : null,
+    priority: typeof card.priority === 'string' ? card.priority : null,
+    estimatedValue:
+      typeof card.estimated_value === 'string' && card.estimated_value
+        ? card.estimated_value
+        : null,
+    draftStatus:
+      typeof card.draft_reply_status === 'string' && card.draft_reply_status
+        ? card.draft_reply_status
+        : null,
+    updatedAt: typeof card.updated_at === 'string' ? card.updated_at : null,
+  }
+}
+
+function textField(card: Record<string, unknown>, field: string): string {
+  const value = card[field]
+  return typeof value === 'string' ? value : ''
+}
+
+function daysSince(value: string | null): number | null {
+  if (!value) return null
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return null
+  return Math.floor((Date.now() - timestamp) / 86_400_000)
+}
+
+function publicAssetForCard(stage: string, haystack: string): string | null {
+  if (/invoice|paid|payment/i.test(haystack)) return 'Invoice / payment proof'
+  if (/rate|pricing|sponsor|partnership/i.test(haystack) || stage === 'rates-sent') {
+    return 'Unaligned sponsorship pricing / partnership package'
+  }
+  if (/media|kit|robert|scoble/i.test(haystack)) return 'Unaligned media kit'
+  return null
+}
+
+function assetIdsForCard(stage: string, haystack: string): Array<string> {
+  if (/invoice|paid|payment|procurement|vendor|w-?9|tax/i.test(haystack)) {
+    return ['w9', 'ein', 'contract']
+  }
+  if (/rate|pricing|sponsor|partnership/i.test(haystack) || stage === 'rates-sent') {
+    return ['partnership-packages', 'sponsorship-pricing', 'sponsor-program']
+  }
+  if (/media|kit|robert|scoble|audience|stats/i.test(haystack)) {
+    return ['media-kit', 'stats', 'public-site']
+  }
+  return ['media-kit', 'partnership-packages']
+}
+
+function normalizeKanbanAction(
+  card: Record<string, unknown>,
+): CompanyOsKanbanAction | null {
+  const lead = normalizeLead(card)
+  const stage = lead.listId || 'unknown'
+  const draftStatus = lead.draftStatus || 'unknown'
+  const priority = lead.priority || 'unknown'
+  const haystack = [
+    stage,
+    priority,
+    draftStatus,
+    lead.title,
+    lead.businessName || '',
+    textField(card, 'description'),
+    textField(card, 'intent'),
+  ].join(' ')
+  const staleDays = daysSince(lead.updatedAt)
+  const activeStage = !['dead-leads', 'done', 'paid-out', 'trash'].includes(stage)
+
+  if (/invoice|paid|payment/i.test(haystack) || stage === 'invoice-sent') {
+    return {
+      ...lead,
+      stage,
+      draftStatus,
+      lane: 'money watchlist',
+      urgency: 'p0',
+      reason: 'Kanban card looks tied to invoice, payment, or paid status.',
+      recommendedAction:
+        'Match this card against local invoices and email history, then draft a payment/status follow-up for approval.',
+      publicAsset: publicAssetForCard(stage, haystack),
+      assetIds: assetIdsForCard(stage, haystack),
+    }
+  }
+
+  if (
+    ['drafted', 'pending'].includes(draftStatus) &&
+    ['rates-sent', 'negotiating', 'engaged', 'first-touch'].includes(stage)
+  ) {
+    return {
+      ...lead,
+      stage,
+      draftStatus,
+      lane: 'reply review',
+      urgency: priority === 'hot' ? 'p1' : 'p2',
+      reason: `Draft status is ${draftStatus} while the deal is still active.`,
+      recommendedAction:
+        'Review the saved draft, attach the right Unaligned asset if useful, and decide whether to send or rewrite.',
+      publicAsset: publicAssetForCard(stage, haystack),
+      assetIds: assetIdsForCard(stage, haystack),
+    }
+  }
+
+  if (
+    priority === 'hot' &&
+    ['rates-sent', 'negotiating', 'engaged', 'first-touch'].includes(stage)
+  ) {
+    return {
+      ...lead,
+      stage,
+      draftStatus,
+      lane: 'hot lead',
+      urgency: 'p1',
+      reason: `Hot lead currently sits in ${stage}.`,
+      recommendedAction:
+        'Confirm owner, last touch, and next ask; prepare a concise follow-up for approval.',
+      publicAsset: publicAssetForCard(stage, haystack),
+      assetIds: assetIdsForCard(stage, haystack),
+    }
+  }
+
+  if (activeStage && staleDays !== null && staleDays >= 14) {
+    return {
+      ...lead,
+      stage,
+      draftStatus,
+      lane: 'stale rescue',
+      urgency: priority === 'hot' ? 'p1' : 'p2',
+      reason: `No card update in ${staleDays} days.`,
+      recommendedAction:
+        'Check whether the thread is still alive, then either draft a rescue follow-up or mark the card for cleanup.',
+      publicAsset: publicAssetForCard(stage, haystack),
+      assetIds: assetIdsForCard(stage, haystack),
+    }
+  }
+
+  return null
+}
+
+function actionRank(action: CompanyOsKanbanAction): number {
+  const urgencyRank = { p0: 0, p1: 10, p2: 20 }[action.urgency]
+  const laneRank =
+    action.lane === 'money watchlist'
+      ? 0
+      : action.lane === 'reply review'
+        ? 1
+        : action.lane === 'hot lead'
+          ? 2
+          : 3
+  return urgencyRank + laneRank
+}
+
+async function readSupabaseLeads(): Promise<CompanyOsLiveOps['supabase']> {
+  const configPath = path.join(
+    process.env.HOME || '',
+    'Documents',
+    'Codex',
+    '2026-05-07',
+    'i-need-you-to-set-up',
+    'review-UNALIGNED',
+    'daily_gmail_sync.py',
+  )
+  const source = await readIfExists(configPath)
+  const url = extractPythonString(source, 'SUPABASE_URL')
+  const key = extractPythonString(source, 'SUPABASE_KEY')
+  if (!url || !key) {
+    return {
+      ok: false,
+      count: 0,
+      stages: {},
+      priorities: {},
+      draftStatuses: {},
+      hotLeads: [],
+      invoiceLeads: [],
+      kanbanActions: [],
+      error: 'Supabase URL/key not found in local Unaligned pipeline config.',
+    }
+  }
+
+  try {
+    const response = await fetch(`${url}/rest/v1/cards?select=*&limit=500`, {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+      },
+    })
+    if (!response.ok) {
+      return {
+        ok: false,
+        count: 0,
+        stages: {},
+        priorities: {},
+        draftStatuses: {},
+        hotLeads: [],
+        invoiceLeads: [],
+        kanbanActions: [],
+        error: `Supabase returned ${response.status}`,
+      }
+    }
+
+    const cards = (await response.json()) as Array<Record<string, unknown>>
+    const stages = countBy(cards.map((card) => String(card.list_id || 'unknown')))
+    const priorities = countBy(cards.map((card) => String(card.priority || 'unknown')))
+    const draftStatuses = countBy(
+      cards.map((card) => String(card.draft_reply_status || 'unknown')),
+    )
+    const hotLeads = cards
+      .filter((card) => card.priority === 'hot')
+      .slice(0, 8)
+      .map(normalizeLead)
+    const invoiceLeads = cards
+      .filter((card) => {
+        const haystack = `${card.list_id || ''} ${card.title || ''} ${card.description || ''} ${card.intent || ''}`
+        return /invoice|paid|payment/i.test(haystack)
+      })
+      .slice(0, 8)
+      .map(normalizeLead)
+    const kanbanActions = cards
+      .map(normalizeKanbanAction)
+      .filter((action): action is CompanyOsKanbanAction => Boolean(action))
+      .sort((left, right) => actionRank(left) - actionRank(right))
+      .slice(0, 12)
+
+    return {
+      ok: true,
+      count: cards.length,
+      stages,
+      priorities,
+      draftStatuses,
+      hotLeads,
+      invoiceLeads,
+      kanbanActions,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      count: 0,
+      stages: {},
+      priorities: {},
+      draftStatuses: {},
+      hotLeads: [],
+      invoiceLeads: [],
+      kanbanActions: [],
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+async function readLiveOps(workspacePath: string): Promise<CompanyOsLiveOps> {
+  const [invoices, assets, supabase, emailSnapshot, driveSnapshot] = await Promise.all([
+    readInvoiceFiles(),
+    readSalesAssets(),
+    readSupabaseLeads(),
+    readJsonIfExists<{ signals?: Array<CompanyOsSignal> }>(
+      path.join(workspacePath, 'live', 'email-signals.json'),
+      { signals: [] },
+    ),
+    readJsonIfExists<{ files?: Array<CompanyOsSignal> }>(
+      path.join(workspacePath, 'live', 'drive-signals.json'),
+      { files: [] },
+    ),
+  ])
+
+  return {
+    sources: [
+      {
+        name: 'Desktop UNALIGNED invoices',
+        status: invoices.length ? 'connected' : 'missing',
+        count: invoices.length,
+        note: 'Read from local invoice folders.',
+      },
+      {
+        name: 'Supabase cards',
+        status: supabase.ok ? 'connected' : 'error',
+        count: supabase.count,
+        note: supabase.ok ? 'Read-only live card summary.' : supabase.error || 'Unavailable.',
+      },
+      {
+        name: 'Unaligned sales assets',
+        status: assets.length ? 'connected' : 'missing',
+        count: assets.length,
+        note: 'Read from local website, media kit, pricing, tax, and proposal files.',
+      },
+      {
+        name: 'Gmail signals',
+        status: emailSnapshot.signals?.length ? 'snapshot' : 'missing',
+        count: emailSnapshot.signals?.length ?? 0,
+        note: 'Readonly Gmail snapshot; refresh from the dashboard.',
+      },
+      {
+        name: 'Google Drive signals',
+        status: driveSnapshot.files?.length ? 'snapshot' : 'missing',
+        count: driveSnapshot.files?.length ?? 0,
+        note: 'Connector snapshot; refresh manually from Drive search.',
+      },
+    ],
+    invoices,
+    invoiceCounts: countBy(invoices.map((invoice) => invoice.status)),
+    assets,
+    supabase,
+    emailSignals: emailSnapshot.signals ?? [],
+    driveSignals: driveSnapshot.files ?? [],
+  }
+}
+
+export async function refreshCompanyOsGmailSnapshot(
+  requestedSlug: string | null,
+): Promise<CompanyOsGmailRefreshResult> {
+  const slugs = await listCompanySlugs()
+  const slug = safeSlug(requestedSlug) || slugs[0]
+  if (!slug || !slugs.includes(slug)) {
+    throw new Error('No Company OS workspace found')
+  }
+
+  const scriptPath = path.join(
+    process.cwd(),
+    'scripts',
+    'company_os_gmail_snapshot.py',
+  )
+
+  const { stdout, stderr } = await execFileAsync(
+    'python3',
+    [scriptPath, '--slug', slug],
+    {
+      timeout: 120_000,
+      maxBuffer: 1024 * 1024 * 4,
+    },
+  )
+
+  const lastLine = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1)
+  if (!lastLine) {
+    throw new Error(stderr.trim() || 'Gmail refresh did not return a result')
+  }
+
+  const result = JSON.parse(lastLine) as { ok?: boolean; count?: number; path?: string }
+  if (!result.ok) {
+    throw new Error(stderr.trim() || 'Gmail refresh failed')
+  }
+
+  return {
+    ok: true,
+    count: result.count ?? 0,
+    path: result.path || '',
+    message: `Refreshed ${result.count ?? 0} Gmail thread${result.count === 1 ? '' : 's'}.`,
+  }
+}
+
+async function listCompanySlugs(): Promise<Array<string>> {
+  try {
+    const entries = await fs.readdir(companyRoot(), { withFileTypes: true })
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => safeSlug(entry.name))
+      .filter(Boolean)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+export async function readCompanyOsSnapshot(
+  requestedSlug: string | null,
+): Promise<CompanyOsSnapshot | null> {
+  const slugs = await listCompanySlugs()
+  const slug = safeSlug(requestedSlug) || slugs[0]
+  if (!slug || !slugs.includes(slug)) return null
+
+  const workspacePath = path.join(companyRoot(), slug)
+  const [company, tasksMarkdown, log, siteHtml] = await Promise.all([
+    readIfExists(path.join(workspacePath, 'COMPANY.md')),
+    readIfExists(path.join(workspacePath, 'TASKS.md')),
+    readIfExists(path.join(workspacePath, 'LOG.md')),
+    readIfExists(path.join(workspacePath, 'site', 'index.html')),
+  ])
+
+  const documentsDir = path.join(workspacePath, 'documents')
+  const documentFiles = await fs
+    .readdir(documentsDir)
+    .catch(() => [] as Array<string>)
+  const documents = await Promise.all(
+    documentFiles
+      .filter((filename) => filename.endsWith('.md'))
+      .sort()
+      .map(async (filename) => {
+        const body = await readIfExists(path.join(documentsDir, filename))
+        return {
+          title: firstHeading(body, filename.replace(/\.md$/, '')),
+          filename,
+          body,
+          excerpt: excerpt(body),
+        }
+      }),
+  )
+
+  return {
+    slug,
+    name: firstHeading(company, slug),
+    idea: section(company, 'Idea'),
+    audience: section(company, 'Audience'),
+    status: section(company, 'Current Status'),
+    rules: linesFromSection(company, 'Rules'),
+    tasks: parseTasks(tasksMarkdown),
+    documents,
+    log,
+    siteHtml,
+    workspacePath,
+    liveOps: await readLiveOps(workspacePath),
+    updatedAt: new Date().toISOString(),
+  }
+}

--- a/src/server/hermes-paths.ts
+++ b/src/server/hermes-paths.ts
@@ -1,0 +1,58 @@
+import { homedir } from 'node:os'
+import { dirname, join, normalize, sep } from 'node:path'
+
+function isProfilesChild(pathValue: string): boolean {
+  const parts = normalize(pathValue).split(sep).filter(Boolean)
+  return parts.length >= 2 && parts.at(-2) === 'profiles'
+}
+
+function isProfileHome(pathValue: string): boolean {
+  const parts = normalize(pathValue).split(sep).filter(Boolean)
+  return parts.length >= 3 && parts.at(-3) === 'profiles' && parts.at(-1) === 'home'
+}
+
+function hermesRootFromProfile(pathValue: string): string | null {
+  if (isProfilesChild(pathValue)) {
+    return dirname(dirname(pathValue))
+  }
+  if (isProfileHome(pathValue)) {
+    return dirname(dirname(dirname(pathValue)))
+  }
+  return null
+}
+
+export function getHermesRoot(): string {
+  const envHome = process.env.HERMES_HOME || process.env.CLAUDE_HOME
+  if (envHome) {
+    const profileRoot = hermesRootFromProfile(envHome)
+    if (profileRoot) return profileRoot
+    return envHome
+  }
+
+  const osHome = homedir()
+  const profileRoot = hermesRootFromProfile(osHome)
+  if (profileRoot) return profileRoot
+  return join(osHome, '.hermes')
+}
+
+export function getProfilesDir(): string {
+  return join(getHermesRoot(), 'profiles')
+}
+
+export function getWorkspaceHermesHome(): string {
+  return getHermesRoot()
+}
+
+export function getProfileHermesHome(profileId: string): string {
+  return join(getProfilesDir(), profileId)
+}
+
+export function getUserHomeForHermesRoot(): string {
+  const root = getHermesRoot()
+  if (root.endsWith(`${sep}.hermes`)) return dirname(root)
+  return homedir()
+}
+
+export function getLocalBinDir(): string {
+  return join(getUserHomeForHermesRoot(), '.local', 'bin')
+}

--- a/src/server/integration-detection.test.ts
+++ b/src/server/integration-detection.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { detectHonchoIntegration } from './integration-detection'
+
+const tempDirs: Array<string> = []
+
+function tempHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honcho-detect-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('detectHonchoIntegration', () => {
+  it('keeps Honcho disabled when no local presence or config exists', () => {
+    const homeDir = tempHome()
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('not-detected')
+    expect(status.available).toBe(false)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects local Honcho presence without enabling unsafe use', () => {
+    const homeDir = tempHome()
+    fs.mkdirSync(path.join(homeDir, '.honcho'), { recursive: true })
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('detected-unconfigured')
+    expect(status.available).toBe(true)
+    expect(status.configured).toBe(false)
+    expect(status.safeToUse).toBe(false)
+  })
+
+  it('detects Honcho config from OpenClaw env/config without exposing secret values', () => {
+    const homeDir = tempHome()
+    const openClawHome = path.join(homeDir, '.openclaw')
+    fs.mkdirSync(openClawHome, { recursive: true })
+    fs.writeFileSync(path.join(openClawHome, '.env'), 'HONCHO_API_KEY=secret-value\n')
+    fs.writeFileSync(path.join(openClawHome, 'config.yaml'), 'honcho:\n  enabled: true\n')
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome,
+      claudeHome: path.join(homeDir, '.claude'),
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.configured).toBe(true)
+    expect(status.safeToUse).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-env' && source.configured)).toBe(true)
+    expect(status.sources.some((source) => source.id === 'openclaw-config' && source.configured)).toBe(true)
+    expect(JSON.stringify(status)).not.toContain('secret-value')
+  })
+
+  it('detects Claude honcho.json as a configured Honcho source', () => {
+    const homeDir = tempHome()
+    const claudeHome = path.join(homeDir, '.claude')
+    fs.mkdirSync(claudeHome, { recursive: true })
+    fs.writeFileSync(path.join(claudeHome, 'honcho.json'), JSON.stringify({ appId: 'workspace', baseUrl: 'http://localhost:8787' }))
+
+    const status = detectHonchoIntegration({
+      env: {},
+      homeDir,
+      openClawHome: path.join(homeDir, '.openclaw'),
+      claudeHome,
+      hermesHome: path.join(homeDir, '.hermes'),
+      now: 1,
+    })
+
+    expect(status.mode).toBe('ready')
+    expect(status.sources.some((source) => source.id === 'claude-honcho-json' && source.configured)).toBe(true)
+  })
+})

--- a/src/server/integration-detection.ts
+++ b/src/server/integration-detection.ts
@@ -1,0 +1,257 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import YAML from 'yaml'
+
+export type HonchoDetectionSource = {
+  id: string
+  label: string
+  path?: string
+  present: boolean
+  configured: boolean
+  details: string
+}
+
+export type HonchoIntegrationStatus = {
+  id: 'honcho'
+  label: 'Honcho memory'
+  available: boolean
+  configured: boolean
+  safeToUse: boolean
+  mode: 'ready' | 'detected-unconfigured' | 'not-detected'
+  summary: string
+  sources: Array<HonchoDetectionSource>
+  checkedAt: number
+}
+
+type DetectHonchoOptions = {
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+  openClawHome?: string
+  claudeHome?: string
+  hermesHome?: string
+  now?: number
+}
+
+const HONCHO_ENV_KEYS = [
+  'HONCHO_API_KEY',
+  'HONCHO_APP_ID',
+  'HONCHO_BASE_URL',
+  'HONCHO_URL',
+  'HONCHO_ENVIRONMENT',
+] as const
+
+const HONCHO_CONFIG_KEYS = [
+  'enabled',
+  'api_key',
+  'apiKey',
+  'app_id',
+  'appId',
+  'url',
+  'base_url',
+  'baseUrl',
+] as const
+
+function expandHome(value: string, homeDir: string): string {
+  if (value === '~') return homeDir
+  if (value.startsWith('~/')) return path.join(homeDir, value.slice(2))
+  return value
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readYaml(filePath: string): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null
+    const parsed = YAML.parse(fs.readFileSync(filePath, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readEnvFile(filePath: string): Record<string, string> {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const env: Record<string, string> = {}
+    for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      env[key] = value
+    }
+    return env
+  } catch {
+    return {}
+  }
+}
+
+function hasOwnTruthy(record: Record<string, unknown> | null | undefined, keys: ReadonlyArray<string>): boolean {
+  if (!record) return false
+  return keys.some((key) => {
+    const value = record[key]
+    return typeof value === 'string' ? Boolean(value.trim()) : Boolean(value)
+  })
+}
+
+function objectAt(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
+  const value = record?.[key]
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function envConfigured(env: Record<string, string | undefined>): boolean {
+  return HONCHO_ENV_KEYS.some((key) => Boolean(env[key]?.trim()))
+}
+
+function configHasHoncho(record: Record<string, unknown> | null): boolean {
+  const honchoConfig = objectAt(record, 'honcho')
+  const memoryConfig = objectAt(record, 'memory')
+  const integrationsConfig = objectAt(record, 'integrations')
+  const integrationsHoncho = objectAt(integrationsConfig, 'honcho')
+  const provider = String(memoryConfig?.provider ?? '').toLowerCase()
+
+  return (
+    hasOwnTruthy(honchoConfig, HONCHO_CONFIG_KEYS) ||
+    (provider.includes('honcho') && hasOwnTruthy(memoryConfig, ['provider', 'honcho'])) ||
+    hasOwnTruthy(integrationsHoncho, HONCHO_CONFIG_KEYS)
+  )
+}
+
+function fileSource(id: string, label: string, filePath: string, configured: boolean, details: string): HonchoDetectionSource {
+  return {
+    id,
+    label,
+    path: filePath,
+    present: fs.existsSync(filePath),
+    configured,
+    details,
+  }
+}
+
+export function detectHonchoIntegration(options: DetectHonchoOptions = {}): HonchoIntegrationStatus {
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? os.homedir()
+  const openClawHome = expandHome(options.openClawHome ?? env.OPENCLAW_HOME ?? path.join(homeDir, '.openclaw'), homeDir)
+  const claudeHome = expandHome(options.claudeHome ?? env.CLAUDE_HOME ?? path.join(homeDir, '.claude'), homeDir)
+  const hermesHome = expandHome(options.hermesHome ?? env.HERMES_HOME ?? path.join(homeDir, '.hermes'), homeDir)
+
+  const processEnvConfigured = envConfigured(env)
+
+  const openClawEnvPath = path.join(openClawHome, '.env')
+  const openClawEnvConfigured = envConfigured(readEnvFile(openClawEnvPath))
+
+  const openClawConfigPath = path.join(openClawHome, 'config.yaml')
+  const openClawConfigConfigured = configHasHoncho(readYaml(openClawConfigPath))
+
+  const claudeHonchoPath = path.join(claudeHome, 'honcho.json')
+  const claudeHonchoConfigured = hasOwnTruthy(readJson(claudeHonchoPath), HONCHO_CONFIG_KEYS)
+
+  // Legacy/compatibility signals stay read-only and only contribute to detection.
+  const hermesEnvPath = path.join(hermesHome, '.env')
+  const hermesEnvConfigured = envConfigured(readEnvFile(hermesEnvPath))
+  const hermesConfigPath = path.join(hermesHome, 'config.yaml')
+  const hermesConfigConfigured = configHasHoncho(readYaml(hermesConfigPath))
+
+  const localDirs = [
+    path.join(homeDir, '.honcho'),
+    path.join(homeDir, '.config', 'honcho'),
+    path.join(openClawHome, 'honcho'),
+    path.join(claudeHome, 'honcho'),
+    path.join(hermesHome, 'honcho'),
+  ]
+
+  const sources: Array<HonchoDetectionSource> = [
+    {
+      id: 'process-env',
+      label: 'Process environment',
+      present: processEnvConfigured,
+      configured: processEnvConfigured,
+      details: processEnvConfigured ? 'Honcho env var present in process environment.' : 'No Honcho env var in process environment.',
+    },
+    fileSource(
+      'openclaw-env',
+      'OpenClaw .env',
+      openClawEnvPath,
+      openClawEnvConfigured,
+      openClawEnvConfigured ? 'Honcho env var present in OpenClaw .env.' : 'No Honcho env var in OpenClaw .env.',
+    ),
+    fileSource(
+      'openclaw-config',
+      'OpenClaw config.yaml',
+      openClawConfigPath,
+      openClawConfigConfigured,
+      openClawConfigConfigured ? 'Honcho keys found in OpenClaw config.' : 'No Honcho keys found in OpenClaw config.',
+    ),
+    fileSource(
+      'claude-honcho-json',
+      'Claude honcho.json',
+      claudeHonchoPath,
+      claudeHonchoConfigured,
+      claudeHonchoConfigured ? 'Claude Honcho config file has usable keys.' : 'No Claude Honcho config file with usable keys.',
+    ),
+    fileSource(
+      'hermes-env',
+      'Hermes .env compatibility',
+      hermesEnvPath,
+      hermesEnvConfigured,
+      hermesEnvConfigured ? 'Honcho env var present in Hermes .env.' : 'No Honcho env var in Hermes .env.',
+    ),
+    fileSource(
+      'hermes-config',
+      'Hermes config.yaml compatibility',
+      hermesConfigPath,
+      hermesConfigConfigured,
+      hermesConfigConfigured ? 'Honcho keys found in Hermes config.' : 'No Honcho keys found in Hermes config.',
+    ),
+    ...localDirs.map((dir) => ({
+      id: `dir:${dir}`,
+      label: path.basename(dir) || dir,
+      path: dir,
+      present: fs.existsSync(dir),
+      configured: false,
+      details: fs.existsSync(dir) ? 'Local Honcho directory exists; configuration still needs verification.' : 'Directory not found.',
+    })),
+  ]
+
+  const configured = sources.some((source) => source.configured)
+  const present = configured || sources.some((source) => source.present)
+  const mode: HonchoIntegrationStatus['mode'] = configured
+    ? 'ready'
+    : present
+      ? 'detected-unconfigured'
+      : 'not-detected'
+
+  return {
+    id: 'honcho',
+    label: 'Honcho memory',
+    available: present,
+    configured,
+    safeToUse: configured,
+    mode,
+    summary: configured
+      ? 'Honcho memory configuration detected. Workspace can safely gate Honcho-backed features behind explicit user action.'
+      : present
+        ? 'Honcho presence detected, but no usable config/token was found. Honcho-backed features remain disabled.'
+        : 'Honcho not detected. Optional Honcho-backed memory features remain hidden/disabled.',
+    sources,
+    checkedAt: options.now ?? Date.now(),
+  }
+}

--- a/src/server/jobs-profile-resolution.test.ts
+++ b/src/server/jobs-profile-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJobsProfileSearch,
+  resolveJobsProfile,
+  sanitizeProfileName,
+} from './jobs-profile-resolution'
+
+describe('sanitizeProfileName', () => {
+  it('accepts simple profile names', () => {
+    expect(sanitizeProfileName('aurora')).toBe('aurora')
+    expect(sanitizeProfileName(' swarm6 ')).toBe('swarm6')
+  })
+
+  it('rejects empty and path-like values', () => {
+    expect(sanitizeProfileName('')).toBeNull()
+    expect(sanitizeProfileName('   ')).toBeNull()
+    expect(sanitizeProfileName('../etc')).toBeNull()
+    expect(sanitizeProfileName('a/b')).toBeNull()
+    expect(sanitizeProfileName('a\\b')).toBeNull()
+  })
+})
+
+describe('resolveJobsProfile', () => {
+  it('prefers explicit ?profile= query param', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?profile=query-one')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'query-one',
+    )
+  })
+
+  it('falls back to HERMES_PROFILE env var', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, 'env-one', () => 'file-one')).toBe(
+      'env-one',
+    )
+  })
+
+  it('falls back to file-backed active profile when env is absent', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'file-one')).toBe('file-one')
+  })
+
+  it('ignores the default sentinel from active_profile', () => {
+    const url = new URL('http://localhost/api/hermes-jobs')
+    expect(resolveJobsProfile(url, null, () => 'default')).toBeNull()
+  })
+})
+
+describe('buildJobsProfileSearch', () => {
+  it('adds the resolved profile while preserving other params', () => {
+    const url = new URL('http://localhost/api/hermes-jobs?limit=10')
+    expect(buildJobsProfileSearch(url, 'aurora')).toBe(
+      '?limit=10&profile=aurora',
+    )
+  })
+
+  it('replaces any inbound profile query with the resolved profile', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', 'new')).toBe(
+      '?limit=10&profile=new',
+    )
+  })
+
+  it('drops profile from the query when no resolved profile exists', () => {
+    expect(buildJobsProfileSearch('?profile=old&limit=10', null)).toBe(
+      '?limit=10',
+    )
+  })
+})

--- a/src/server/jobs-profile-resolution.ts
+++ b/src/server/jobs-profile-resolution.ts
@@ -1,0 +1,55 @@
+import { getActiveProfileName } from './profiles-browser'
+
+export function sanitizeProfileName(
+  name: string | null | undefined,
+): string | null {
+  if (!name) return null
+  const trimmed = String(name).trim()
+  if (!trimmed) return null
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('..')
+  ) {
+    return null
+  }
+  return trimmed
+}
+
+export function resolveJobsProfile(
+  url: URL,
+  envProfile = process.env.HERMES_PROFILE,
+  activeProfileResolver: () => string = getActiveProfileName,
+): string | null {
+  const fromQuery = sanitizeProfileName(url.searchParams.get('profile'))
+  if (fromQuery) return fromQuery
+
+  const fromEnv = sanitizeProfileName(envProfile)
+  if (fromEnv) return fromEnv
+
+  try {
+    const fromFile = sanitizeProfileName(activeProfileResolver())
+    if (fromFile && fromFile !== 'default') return fromFile
+  } catch {
+    // ignore file-backed profile lookup failures
+  }
+
+  return null
+}
+
+export function buildJobsProfileSearch(
+  urlOrSearch: URL | string,
+  profile: string | null,
+): string {
+  const sourceSearch =
+    typeof urlOrSearch === 'string' ? urlOrSearch : urlOrSearch.search
+  const params = new URLSearchParams(
+    sourceSearch.startsWith('?') ? sourceSearch.slice(1) : sourceSearch,
+  )
+
+  params.delete('profile')
+  if (profile) params.set('profile', profile)
+
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}

--- a/src/server/kanban-backend.test.ts
+++ b/src/server/kanban-backend.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+async function loadKanbanBackend(options?: {
+  existsSync?: (path: string) => boolean
+  execFileSync?: (command: string, args?: string[]) => string
+}) {
+  vi.doMock('./swarm-kanban-store', () => ({
+    SWARM_KANBAN_FILE: '/tmp/swarm2-kanban.json',
+    createSwarmKanbanCard: vi.fn((input) => ({
+      id: 'local-1',
+      title: input.title,
+      spec: input.spec ?? '',
+      acceptanceCriteria: input.acceptanceCriteria ?? [],
+      assignedWorker: input.assignedWorker ?? null,
+      reviewer: input.reviewer ?? null,
+      status: input.status ?? 'backlog',
+      missionId: input.missionId ?? null,
+      reportPath: input.reportPath ?? null,
+      createdBy: input.createdBy ?? 'swarm2-kanban',
+      createdAt: 1,
+      updatedAt: 1,
+    })),
+    listSwarmKanbanCards: vi.fn(() => [{
+      id: 'local-1',
+      title: 'Local task',
+      spec: '',
+      acceptanceCriteria: [],
+      assignedWorker: null,
+      reviewer: null,
+      status: 'backlog',
+      missionId: null,
+      reportPath: null,
+      createdBy: 'local',
+      createdAt: 1,
+      updatedAt: 1,
+    }]),
+    updateSwarmKanbanCard: vi.fn((cardId, updates) => ({
+      id: cardId,
+      title: updates.title ?? 'Local task',
+      spec: updates.spec ?? '',
+      acceptanceCriteria: [],
+      assignedWorker: updates.assignedWorker ?? null,
+      reviewer: null,
+      status: updates.status ?? 'backlog',
+      missionId: null,
+      reportPath: null,
+      createdBy: 'local',
+      createdAt: 1,
+      updatedAt: 2,
+    })),
+  }))
+
+  vi.doMock('node:fs', () => ({
+    existsSync: vi.fn((path: string) => options?.existsSync?.(path) ?? false),
+  }))
+
+  vi.doMock('node:child_process', () => ({
+    execFileSync: vi.fn((command: string, args?: string[]) => options?.execFileSync?.(command, args) ?? ''),
+  }))
+
+  return import('./kanban-backend')
+}
+
+describe('kanban-backend', () => {
+  it('auto-detect prefers Hermes backend when Hermes CLI and canonical storage are present', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const sqliteCalls: Array<{ command: string; args?: string[] }> = []
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db' || target === '/Users/aurora/.hermes/kanban',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        if (command === 'sqlite3') {
+          sqliteCalls.push({ command, args })
+          return JSON.stringify([
+            {
+              id: 't_12345678',
+              title: 'Hermes task',
+              body: 'Backed by sqlite',
+              status: 'running',
+              assignee: 'swarm2',
+              created_at: 1777527540,
+              updated_at: 1777527644,
+            },
+          ])
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      writable: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+
+    const cards = mod.listKanbanCards()
+    expect(cards).toHaveLength(1)
+    expect(cards[0]).toMatchObject({
+      id: 't_12345678',
+      title: 'Hermes task',
+      status: 'running',
+      assignedWorker: 'swarm2',
+      createdBy: 'hermes-kanban',
+    })
+    expect(sqliteCalls[0]?.args?.[0]).toBe('/Users/aurora/.hermes/kanban.db')
+  })
+
+  it('auto-detect uses Hermes storage directly when the CLI is unavailable', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') throw new Error('not found')
+        if (command === 'sqlite3') {
+          return JSON.stringify([
+            {
+              id: 't_direct',
+              title: 'Direct Hermes task',
+              body: '',
+              status: 'ready',
+              assignee: null,
+              created_at: 1777527540,
+              updated_at: 1777527644,
+            },
+          ])
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      writable: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+    expect(mod.getKanbanBackendMeta().details).toContain('direct local storage access')
+    expect(mod.listKanbanCards()[0]).toMatchObject({ id: 't_direct', status: 'ready' })
+  })
+
+  it('resolves canonical Kanban paths from CLAUDE_HOME profile homes too', async () => {
+    vi.stubEnv('CLAUDE_HOME', '/Users/aurora/.hermes/profiles/swarm5/home')
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') throw new Error('not found')
+        if (command === 'sqlite3') return '[]'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'hermes',
+      detected: true,
+      path: '/Users/aurora/.hermes/kanban.db',
+    })
+  })
+
+  it('auto-detect falls back to local when canonical Hermes storage is missing', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const mod = await loadKanbanBackend({
+      existsSync: () => false,
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    expect(mod.getKanbanBackendMeta()).toMatchObject({
+      id: 'local',
+      detected: true,
+      writable: true,
+      path: '/tmp/swarm2-kanban.json',
+    })
+    expect(mod.listKanbanCards()[0]?.id).toBe('local-1')
+  })
+
+  it('creates and updates Hermes tasks through canonical kanban.db path', async () => {
+    vi.stubEnv('HERMES_HOME', '/Users/aurora/.hermes/profiles/swarm2')
+    const sqliteCalls: string[] = []
+    let readCount = 0
+    const mod = await loadKanbanBackend({
+      existsSync: (target) => target === '/Users/aurora/.hermes/kanban.db' || target === '/Users/aurora/.hermes/kanban',
+      execFileSync: (command, args = []) => {
+        if (command === 'which' && args[0] === 'hermes') return '/Users/aurora/.local/bin/hermes\n'
+        if (command === '/Users/aurora/.local/bin/hermes' && args[0] === '--version') return 'hermes 1.0.0\n'
+        if (command === 'sqlite3') {
+          sqliteCalls.push(args.join(' '))
+          const sql = args[2] ?? ''
+          if (sql.includes('where id =')) {
+            readCount += 1
+            return JSON.stringify([
+              {
+                id: 't_deadbeef',
+                title: readCount === 1 ? 'Created Hermes task' : 'Updated Hermes task',
+                body: 'Task body',
+                status: readCount === 1 ? 'queued' : 'done',
+                assignee: 'swarm6',
+                created_at: 1777527540,
+                updated_at: 1777527644,
+              },
+            ])
+          }
+          return '[]'
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`)
+      },
+    })
+
+    const created = mod.createKanbanCard({ title: 'Created Hermes task', spec: 'Task body', assignedWorker: 'swarm6', status: 'backlog' })
+    const updated = mod.updateKanbanCard('t_deadbeef', { title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
+
+    expect(created).toMatchObject({ id: 't_deadbeef', title: 'Created Hermes task', status: 'backlog', assignedWorker: 'swarm6', createdBy: 'hermes-kanban' })
+    expect(updated).toMatchObject({ id: 't_deadbeef', title: 'Updated Hermes task', status: 'done', assignedWorker: 'swarm6' })
+    expect(sqliteCalls.every((call) => call.startsWith('/Users/aurora/.hermes/kanban.db '))).toBe(true)
+    expect(sqliteCalls.some((call) => call.includes('insert into tasks'))).toBe(true)
+    expect(sqliteCalls.some((call) => call.includes('update tasks set'))).toBe(true)
+  })
+})

--- a/src/server/kanban-backend.ts
+++ b/src/server/kanban-backend.ts
@@ -1,0 +1,347 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { getHermesRoot, getWorkspaceHermesHome } from './hermes-paths'
+import {
+  SWARM_KANBAN_FILE,
+  type CreateSwarmKanbanCardInput,
+  createSwarmKanbanCard,
+  listSwarmKanbanCards,
+  type SwarmKanbanCard,
+  updateSwarmKanbanCard,
+  type UpdateSwarmKanbanCardInput,
+} from './swarm-kanban-store'
+
+export type KanbanBackendId = 'local' | 'hermes'
+
+export type KanbanBackendMeta = {
+  id: KanbanBackendId
+  label: string
+  detected: boolean
+  writable: boolean
+  details?: string | null
+  path?: string | null
+}
+
+type KanbanBackend = {
+  meta(): KanbanBackendMeta
+  list(): SwarmKanbanCard[]
+  create(input: CreateSwarmKanbanCardInput): SwarmKanbanCard
+  update(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null
+}
+
+type HermesTaskRow = {
+  id: string
+  title: string
+  body?: string | null
+  status?: string | null
+  assignee?: string | null
+  created_at?: number | string | null
+  updated_at?: number | string | null
+}
+
+type HermesDetection = {
+  available: boolean
+  cliPath?: string | null
+  dbPath: string
+  workspacePath: string
+  reason?: string
+}
+
+function env(name: string): string | null {
+  const value = process.env[name]
+  return value && value.trim() ? value.trim() : null
+}
+
+function hermesProfileRoot(): string {
+  return getWorkspaceHermesHome()
+}
+
+function hermesDbPath(): string {
+  return path.join(getHermesRoot(), 'kanban.db')
+}
+
+function hermesWorkspacePath(): string {
+  return path.join(getHermesRoot(), 'kanban')
+}
+
+function hermesCliPath(): string | null {
+  try {
+    const output = execFileSync('which', ['hermes'], { encoding: 'utf8', timeout: 5_000 }).trim()
+    return output || null
+  } catch {
+    return null
+  }
+}
+
+function checkHermesCli(): { ok: boolean; path?: string | null; reason?: string } {
+  const cli = hermesCliPath()
+  if (!cli) return { ok: false, reason: 'hermes CLI not found on PATH' }
+  try {
+    execFileSync(cli, ['--version'], { encoding: 'utf8', timeout: 10_000, env: { ...process.env, HERMES_HOME: hermesProfileRoot() } })
+    return { ok: true, path: cli }
+  } catch (error) {
+    return { ok: false, path: cli, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+function detectHermesKanban(): HermesDetection {
+  const dbPath = hermesDbPath()
+  const workspacePath = hermesWorkspacePath()
+  const hasDb = fs.existsSync(dbPath)
+  const hasWorkspace = fs.existsSync(workspacePath)
+
+  if (!hasDb && !hasWorkspace) {
+    return {
+      available: false,
+      cliPath: null,
+      dbPath,
+      workspacePath,
+      reason: 'Hermes Kanban storage not found; using the local Swarm Board fallback.',
+    }
+  }
+
+  const cli = checkHermesCli()
+  return {
+    available: true,
+    cliPath: cli.ok ? cli.path ?? null : null,
+    dbPath,
+    workspacePath,
+    reason: cli.ok ? undefined : 'Hermes Kanban storage detected; CLI unavailable, using direct local storage access.',
+  }
+}
+
+function sqliteQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+function runSqlite(dbPath: string, sql: string): string {
+  return execFileSync('sqlite3', [dbPath, '-json', sql], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  }).trim()
+}
+
+function readHermesTasks(): HermesTaskRow[] {
+  const detection = detectHermesKanban()
+  if (!detection.available) return []
+  const query = [
+    'select',
+    'id,',
+    'title,',
+    'body,',
+    'status,',
+    'assignee,',
+    'created_at,',
+    'coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at',
+    'from tasks',
+    'order by created_at desc, id desc;',
+  ].join(' ')
+  const raw = runSqlite(detection.dbPath, query)
+  const parsed = raw ? (JSON.parse(raw) as HermesTaskRow[]) : []
+  return Array.isArray(parsed) ? parsed : []
+}
+
+function readHermesTask(taskId: string): HermesTaskRow | null {
+  const detection = detectHermesKanban()
+  if (!detection.available) return null
+  const raw = runSqlite(
+    detection.dbPath,
+    `select id, title, body, status, assignee, created_at, coalesce(last_heartbeat_at, completed_at, started_at, created_at) as updated_at from tasks where id = ${sqliteQuote(taskId)} limit 1;`,
+  )
+  const parsed = raw ? (JSON.parse(raw) as HermesTaskRow[]) : []
+  return Array.isArray(parsed) && parsed[0] ? parsed[0] : null
+}
+
+function normalizeTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? value : Math.round(value * 1000)
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const asNum = Number(value)
+    if (Number.isFinite(asNum)) return normalizeTimestamp(asNum)
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return Date.now()
+}
+
+function mapHermesStatus(status: string | null | undefined): SwarmKanbanCard['status'] {
+  switch ((status ?? '').toLowerCase()) {
+    case 'queued':
+    case 'todo':
+    case 'triage':
+      return 'backlog'
+    case 'ready':
+      return 'ready'
+    case 'running':
+    case 'claimed':
+    case 'in_progress':
+      return 'running'
+    case 'review':
+      return 'review'
+    case 'blocked':
+      return 'blocked'
+    case 'done':
+    case 'complete':
+    case 'completed':
+      return 'done'
+    default:
+      return 'backlog'
+  }
+}
+
+function mapBoardStatus(status: SwarmKanbanCard['status'] | null | undefined): string {
+  switch (status) {
+    case 'backlog':
+      return 'queued'
+    case 'ready':
+      return 'ready'
+    case 'running':
+      return 'running'
+    case 'review':
+      return 'review'
+    case 'blocked':
+      return 'blocked'
+    case 'done':
+      return 'done'
+    default:
+      return 'queued'
+  }
+}
+
+function hermesTaskToCard(task: HermesTaskRow): SwarmKanbanCard {
+  const createdAt = normalizeTimestamp(task.created_at)
+  const updatedAt = normalizeTimestamp(task.updated_at ?? task.created_at)
+  return {
+    id: task.id,
+    title: task.title,
+    spec: task.body ?? '',
+    acceptanceCriteria: [],
+    assignedWorker: task.assignee ?? null,
+    reviewer: null,
+    status: mapHermesStatus(task.status),
+    missionId: null,
+    reportPath: null,
+    createdBy: 'hermes-kanban',
+    createdAt,
+    updatedAt,
+  }
+}
+
+const localBackend: KanbanBackend = {
+  meta() {
+    return {
+      id: 'local',
+      label: 'Local board',
+      detected: true,
+      writable: true,
+      path: SWARM_KANBAN_FILE,
+      details: 'Using local Swarm board JSON store.',
+    }
+  },
+  list() {
+    return listSwarmKanbanCards()
+  },
+  create(input) {
+    return createSwarmKanbanCard(input)
+  },
+  update(cardId, updates) {
+    return updateSwarmKanbanCard(cardId, updates)
+  },
+}
+
+const hermesBackend: KanbanBackend = {
+  meta() {
+    const detection = detectHermesKanban()
+    return {
+      id: 'hermes',
+      label: 'Hermes Kanban',
+      detected: detection.available,
+      writable: detection.available,
+      path: fs.existsSync(detection.dbPath) ? detection.dbPath : null,
+      details: detection.available
+        ? detection.reason ?? `Hermes Kanban storage detected (${detection.cliPath ?? 'direct sqlite'}, ${detection.dbPath})`
+        : detection.reason ?? 'Hermes Kanban not detected.',
+    }
+  },
+  list() {
+    return readHermesTasks().map(hermesTaskToCard)
+  },
+  create(input) {
+    const detection = detectHermesKanban()
+    if (!detection.available) throw new Error(detection.reason ?? 'Hermes Kanban not detected')
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const taskId = `t_${randomUUID().replace(/-/g, '').slice(0, 8)}`
+    const status = mapBoardStatus(input.status ?? 'backlog')
+    const statements = [
+      'insert into tasks (',
+      'id, title, body, assignee, status, priority, created_by, created_at, workspace_kind, workspace_path',
+      ') values (',
+      [
+        sqliteQuote(taskId),
+        sqliteQuote(input.title.trim()),
+        sqliteQuote((input.spec ?? '').trim()),
+        input.assignedWorker?.trim() ? sqliteQuote(input.assignedWorker.trim()) : 'NULL',
+        sqliteQuote(status),
+        '0',
+        sqliteQuote(input.createdBy?.trim() || 'swarm2-kanban'),
+        String(nowSeconds),
+        sqliteQuote('scratch'),
+        sqliteQuote(path.join(detection.workspacePath, 'workspaces', taskId)),
+      ].join(', '),
+      ');',
+    ].join(' ')
+    runSqlite(detection.dbPath, statements)
+    const created = readHermesTask(taskId)
+    if (!created) throw new Error(`Created Hermes task ${taskId} but could not read it back`)
+    return hermesTaskToCard(created)
+  },
+  update(cardId, updates) {
+    const detection = detectHermesKanban()
+    if (!detection.available) return null
+    const assignments: string[] = []
+    if (typeof updates.title === 'string' && updates.title.trim()) assignments.push(`title = ${sqliteQuote(updates.title.trim())}`)
+    if (typeof updates.spec === 'string') assignments.push(`body = ${sqliteQuote(updates.spec)}`)
+    if (updates.assignedWorker !== undefined) assignments.push(`assignee = ${updates.assignedWorker?.trim() ? sqliteQuote(updates.assignedWorker.trim()) : 'NULL'}`)
+    if (updates.status) {
+      const status = mapBoardStatus(updates.status)
+      assignments.push(`status = ${sqliteQuote(status)}`)
+      if (status === 'running') assignments.push(`started_at = coalesce(started_at, ${Math.floor(Date.now() / 1000)})`)
+      if (status === 'done') assignments.push(`completed_at = ${Math.floor(Date.now() / 1000)}`)
+      if (status !== 'done') assignments.push('completed_at = NULL')
+    }
+    if (assignments.length === 0) {
+      const current = readHermesTask(cardId)
+      return current ? hermesTaskToCard(current) : null
+    }
+    runSqlite(detection.dbPath, `update tasks set ${assignments.join(', ')} where id = ${sqliteQuote(cardId)};`)
+    const updated = readHermesTask(cardId)
+    return updated ? hermesTaskToCard(updated) : null
+  },
+}
+
+export function resolveKanbanBackend(): KanbanBackend {
+  const preference = (env('HERMES_KANBAN_BACKEND') ?? 'auto').toLowerCase()
+  if (preference === 'local') return localBackend
+  const hermesMeta = hermesBackend.meta()
+  if (preference === 'hermes') return hermesMeta.detected ? hermesBackend : localBackend
+  return hermesMeta.detected ? hermesBackend : localBackend
+}
+
+export function getKanbanBackendMeta(): KanbanBackendMeta {
+  return resolveKanbanBackend().meta()
+}
+
+export function listKanbanCards(): SwarmKanbanCard[] {
+  return resolveKanbanBackend().list()
+}
+
+export function createKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
+  return resolveKanbanBackend().create(input)
+}
+
+export function updateKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
+  return resolveKanbanBackend().update(cardId, updates)
+}

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -137,7 +137,10 @@ export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(results, workspaceRoot, path.join(workspaceRoot, 'MEMORY.md'))
+  for (const subdir of ['memory', 'memories']) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, subdir))
+  }
 
   results.sort(compareMemoryFiles)
   return results

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -3,13 +3,15 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listProfiles } from './profiles-browser'
+import { listProfiles, renameProfile } from './profiles-browser'
 
-describe('listProfiles', () => {
+describe('profiles-browser integration', () => {
   let tempHome: string
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-workspace-profiles-'))
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-'),
+    )
     vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
   })
 
@@ -24,16 +26,126 @@ describe('listProfiles', () => {
     const namedProfileRoot = path.join(profilesRoot, 'jarvis')
 
     fs.mkdirSync(namedProfileRoot, { recursive: true })
-    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'jarvis\n', 'utf-8')
-    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: default-model\n', 'utf-8')
-    fs.writeFileSync(path.join(namedProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'jarvis\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'model: default-model\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(namedProfileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
 
     const profiles = listProfiles()
     const names = profiles.map((profile) => profile.name)
 
     expect(names).toContain('default')
     expect(names).toContain('jarvis')
-    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(false)
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(true)
+    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(
+      false,
+    )
+    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(
+      true,
+    )
+  })
+
+  it('renames a profile and rewrites local/global stale references', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+    const newProfileRoot = path.join(profilesRoot, 'dr_kwon')
+
+    fs.mkdirSync(path.join(oldProfileRoot, 'skills', 'demo-skill'), {
+      recursive: true,
+    })
+    fs.mkdirSync(path.join(hermesRoot, 'team', 'handoffs'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'alan\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'SOUL.md'),
+      '<!-- Profile: alan (Primary: gpt-5.4) -->\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'config.yaml'),
+      'mcp:\n  command: ~/.hermes/profiles/alan/openbb-env/bin/openbb-mcp\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(oldProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+      `Path: ${hermesRoot}/profiles/alan/data\n`,
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'sharedPath: ~/.hermes/profiles/alan/shared\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team-agents.md'),
+      'Agent alan owns this lane\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+      'handoff from alan with ~/.hermes/profiles/alan/path\n',
+      'utf-8',
+    )
+
+    const renamed = renameProfile('alan', 'dr_kwon')
+
+    expect(renamed.name).toBe('dr_kwon')
+    expect(fs.existsSync(oldProfileRoot)).toBe(false)
+    expect(fs.existsSync(newProfileRoot)).toBe(true)
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8'),
+    ).toBe('dr_kwon\n')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'SOUL.md'), 'utf-8'),
+    ).toContain('Profile: dr_kwon')
+    expect(
+      fs.readFileSync(path.join(newProfileRoot, 'config.yaml'), 'utf-8'),
+    ).toContain('~/.hermes/profiles/dr_kwon/openbb-env/bin/openbb-mcp')
+    expect(
+      fs.readFileSync(
+        path.join(newProfileRoot, 'skills', 'demo-skill', 'SKILL.md'),
+        'utf-8',
+      ),
+    ).toContain(`${hermesRoot}/profiles/dr_kwon/data`)
+    expect(fs.readFileSync(path.join(hermesRoot, 'config.yaml'), 'utf-8')).toContain(
+      '~/.hermes/profiles/dr_kwon/shared',
+    )
+    expect(
+      fs.readFileSync(path.join(hermesRoot, 'team-agents.md'), 'utf-8'),
+    ).toContain('Agent alan owns this lane')
+    expect(
+      fs.readFileSync(
+        path.join(hermesRoot, 'team', 'handoffs', 'alan-to-mira.md'),
+        'utf-8',
+      ),
+    ).toContain('~/.hermes/profiles/dr_kwon/path')
+  })
+
+  it('rejects new profile names that the Hermes CLI would reject', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const oldProfileRoot = path.join(profilesRoot, 'alan')
+
+    fs.mkdirSync(oldProfileRoot, { recursive: true })
+
+    expect(() => renameProfile('alan', 'Dr_Kwon')).toThrow(
+      /Invalid profile name/i,
+    )
   })
 })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -27,6 +28,23 @@ export type ProfileDetail = {
   skillsDir?: string
 }
 
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const TEXT_REWRITE_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.jsonl',
+  '.toml',
+  '.env',
+  '.plist',
+  '.sh',
+  '.js',
+  '.ts',
+  '.tsx',
+])
+
 function getHermesRoot(): string {
   return path.join(os.homedir(), '.hermes')
 }
@@ -45,8 +63,14 @@ function getActiveProfilePath(): string {
  */
 function validateProfileName(name: string): string {
   const trimmed = validateProfileIdentifier(name)
-  if (trimmed === 'default')
+  if (trimmed === 'default') {
     throw new Error('Default profile cannot be modified here')
+  }
+  if (!PROFILE_NAME_RE.test(trimmed)) {
+    throw new Error(
+      "Invalid profile name. Use lowercase letters, numbers, underscores, or hyphens, and start with a letter or number.",
+    )
+  }
   return trimmed
 }
 
@@ -252,7 +276,7 @@ export function readProfile(name: string): ProfileDetail {
   const profilePath =
     normalized === 'default'
       ? getHermesRoot()
-      : path.join(getProfilesRoot(), validateProfileName(normalized))
+      : path.join(getProfilesRoot(), validateProfileIdentifier(normalized))
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   const configPath = path.join(profilePath, 'config.yaml')
   const envPath = path.join(profilePath, '.env')
@@ -279,7 +303,7 @@ export function setActiveProfile(name: string): void {
     if (fs.existsSync(activePath)) fs.unlinkSync(activePath)
     return
   }
-  const normalized = validateProfileName(trimmed)
+  const normalized = validateProfileIdentifier(trimmed)
   const profilePath = path.join(getProfilesRoot(), normalized)
   if (!fs.existsSync(profilePath)) throw new Error('Profile not found')
   fs.mkdirSync(getHermesRoot(), { recursive: true })
@@ -405,14 +429,138 @@ export function updateProfileConfig(
   return readProfile(normalized)
 }
 
+function replaceTextReferences(
+  input: string,
+  oldName: string,
+  newName: string,
+): string {
+  const escapedOld = oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const absoluteProfileOld = `${getHermesRoot()}/profiles/${oldName}`
+  const absoluteProfileNew = `${getHermesRoot()}/profiles/${newName}`
+
+  return input
+    .replaceAll(absoluteProfileOld, absoluteProfileNew)
+    .replaceAll(`~/.hermes/profiles/${oldName}`, `~/.hermes/profiles/${newName}`)
+    .replaceAll(`profiles/${oldName}/`, `profiles/${newName}/`)
+    .replaceAll(`ai.hermes.gateway-${oldName}`, `ai.hermes.gateway-${newName}`)
+    .replace(
+      new RegExp(`(<!--\\s*Profile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+    .replace(
+      new RegExp(`(\\bProfile:\\s*)${escapedOld}(\\b)`, 'g'),
+      `$1${newName}$2`,
+    )
+}
+
+function rewriteTextFileIfPresent(
+  filePath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(filePath)) return
+  try {
+    const original = safeReadText(filePath)
+    const updated = replaceTextReferences(original, oldName, newName)
+    if (updated !== original) {
+      fs.writeFileSync(filePath, updated, 'utf-8')
+    }
+  } catch {
+    // ignore non-text or unreadable files
+  }
+}
+
+function rewriteTextFilesRecursive(
+  rootPath: string,
+  oldName: string,
+  newName: string,
+): void {
+  if (!fs.existsSync(rootPath)) return
+  const stack = [rootPath]
+  while (stack.length > 0) {
+    const current = stack.pop() as string
+    let entries: Array<fs.Dirent> = []
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+        continue
+      }
+      if (!TEXT_REWRITE_EXTENSIONS.has(path.extname(entry.name))) continue
+      rewriteTextFileIfPresent(fullPath, oldName, newName)
+    }
+  }
+}
+
+function migrateLaunchAgentProfile(
+  oldName: string,
+  newName: string,
+): void {
+  if (process.platform !== 'darwin') return
+  const launchAgentsDir = path.join(os.homedir(), 'Library', 'LaunchAgents')
+  const oldPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${oldName}.plist`)
+  const newPlist = path.join(launchAgentsDir, `ai.hermes.gateway-${newName}.plist`)
+  if (!fs.existsSync(oldPlist)) return
+
+  rewriteTextFileIfPresent(oldPlist, oldName, newName)
+  try {
+    if (fs.existsSync(newPlist)) fs.rmSync(newPlist, { force: true })
+    fs.renameSync(oldPlist, newPlist)
+  } catch {
+    return
+  }
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  if (uid == null) return
+  try {
+    execFileSync('launchctl', ['bootout', `gui/${uid}`, oldPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootout failures
+  }
+  try {
+    execFileSync('launchctl', ['bootstrap', `gui/${uid}`, newPlist], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // ignore bootstrap failures
+  }
+}
+
+function migrateGlobalProfileReferences(oldName: string, newName: string): void {
+  const hermesRoot = getHermesRoot()
+  const directFiles = [
+    path.join(hermesRoot, 'config.yaml'),
+    path.join(hermesRoot, 'SOUL.md'),
+    path.join(hermesRoot, 'team-agents.md'),
+    path.join(hermesRoot, 'team', 'cron.md'),
+    path.join(hermesRoot, 'team', 'day-30-runbook.md'),
+  ]
+  for (const filePath of directFiles) {
+    rewriteTextFileIfPresent(filePath, oldName, newName)
+  }
+  rewriteTextFilesRecursive(path.join(hermesRoot, 'team', 'handoffs'), oldName, newName)
+}
+
 export function renameProfile(oldName: string, newName: string): ProfileDetail {
-  const from = validateProfileName(oldName)
+  const from = validateProfileIdentifier(oldName)
   const to = validateProfileName(newName)
   const fromPath = path.join(getProfilesRoot(), from)
   const toPath = path.join(getProfilesRoot(), to)
   if (!fs.existsSync(fromPath)) throw new Error('Profile not found')
   if (fs.existsSync(toPath)) throw new Error('Target profile already exists')
+
   fs.renameSync(fromPath, toPath)
+  rewriteTextFilesRecursive(toPath, from, to)
+  migrateGlobalProfileReferences(from, to)
+  migrateLaunchAgentProfile(from, to)
+
   if (getActiveProfileName() === from) {
     fs.writeFileSync(getActiveProfilePath(), `${to}\n`, 'utf-8')
   }

--- a/src/server/swarm-kanban-store.ts
+++ b/src/server/swarm-kanban-store.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export const SWARM_KANBAN_LANES = ['backlog', 'ready', 'running', 'review', 'blocked', 'done'] as const
+export type SwarmKanbanLane = (typeof SWARM_KANBAN_LANES)[number]
+
+export type SwarmKanbanCard = {
+  id: string
+  title: string
+  spec: string
+  acceptanceCriteria: string[]
+  assignedWorker: string | null
+  reviewer: string | null
+  status: SwarmKanbanLane
+  missionId: string | null
+  reportPath: string | null
+  createdBy: string
+  createdAt: number
+  updatedAt: number
+}
+
+type SwarmKanbanFile = { cards: SwarmKanbanCard[] }
+
+type ListFilters = {
+  status?: string | null
+  assignedWorker?: string | null
+  reviewer?: string | null
+  missionId?: string | null
+}
+
+export type CreateSwarmKanbanCardInput = {
+  title: string
+  spec?: string
+  acceptanceCriteria?: string[]
+  assignedWorker?: string | null
+  reviewer?: string | null
+  status?: SwarmKanbanLane | null
+  missionId?: string | null
+  reportPath?: string | null
+  createdBy?: string | null
+}
+
+export type UpdateSwarmKanbanCardInput = Partial<Omit<CreateSwarmKanbanCardInput, 'createdBy'>>
+
+const HERMES_HOME = process.env.HERMES_HOME ?? path.join(os.homedir(), '.hermes')
+export const SWARM_KANBAN_FILE = path.join(HERMES_HOME, 'swarm2-kanban.json')
+
+function ensureKanbanFile(): void {
+  fs.mkdirSync(HERMES_HOME, { recursive: true })
+  if (!fs.existsSync(SWARM_KANBAN_FILE)) {
+    fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: [] }, null, 2) + '\n', 'utf-8')
+  }
+}
+
+function readKanbanFile(): SwarmKanbanFile {
+  ensureKanbanFile()
+  try {
+    const raw = fs.readFileSync(SWARM_KANBAN_FILE, 'utf-8').trim()
+    if (!raw) return { cards: [] }
+    const parsed = JSON.parse(raw) as Partial<SwarmKanbanFile>
+    return { cards: Array.isArray(parsed.cards) ? parsed.cards.map(normalizeCard) : [] }
+  } catch {
+    return { cards: [] }
+  }
+}
+
+function writeKanbanFile(data: SwarmKanbanFile): void {
+  ensureKanbanFile()
+  fs.writeFileSync(SWARM_KANBAN_FILE, JSON.stringify({ cards: data.cards.map(normalizeCard) }, null, 2) + '\n', 'utf-8')
+}
+
+function normalizeStatus(value: unknown): SwarmKanbanLane {
+  if (value === 'todo') return 'ready'
+  if (value === 'in_progress' || value === 'doing') return 'running'
+  return SWARM_KANBAN_LANES.includes(value as SwarmKanbanLane) ? (value as SwarmKanbanLane) : 'backlog'
+}
+
+function normalizeCriteria(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+  if (typeof value === 'string') return value.split('\n').map((item) => item.trim()).filter(Boolean)
+  return []
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeCard(card: (Partial<Omit<SwarmKanbanCard, 'status'>> & { id?: string; title?: string; status?: SwarmKanbanLane | string | null })): SwarmKanbanCard {
+  const now = Date.now()
+  return {
+    id: typeof card.id === 'string' && card.id ? card.id : randomUUID(),
+    title: typeof card.title === 'string' && card.title.trim() ? card.title.trim() : 'Untitled task',
+    spec: typeof card.spec === 'string' ? card.spec : '',
+    acceptanceCriteria: normalizeCriteria(card.acceptanceCriteria),
+    assignedWorker: optionalString(card.assignedWorker),
+    reviewer: optionalString(card.reviewer),
+    status: normalizeStatus(card.status),
+    missionId: optionalString(card.missionId),
+    reportPath: optionalString(card.reportPath),
+    createdBy: typeof card.createdBy === 'string' && card.createdBy ? card.createdBy : 'swarm2-kanban',
+    createdAt: typeof card.createdAt === 'number' ? card.createdAt : now,
+    updatedAt: typeof card.updatedAt === 'number' ? card.updatedAt : now,
+  }
+}
+
+export function listSwarmKanbanCards(filters: ListFilters = {}): SwarmKanbanCard[] {
+  let cards = readKanbanFile().cards
+  if (filters.status) cards = cards.filter((card) => card.status === normalizeStatus(filters.status))
+  if (filters.assignedWorker) cards = cards.filter((card) => card.assignedWorker === filters.assignedWorker)
+  if (filters.reviewer) cards = cards.filter((card) => card.reviewer === filters.reviewer)
+  if (filters.missionId) cards = cards.filter((card) => card.missionId === filters.missionId)
+  return [...cards].sort((a, b) => b.updatedAt - a.updatedAt || a.title.localeCompare(b.title))
+}
+
+export function createSwarmKanbanCard(input: CreateSwarmKanbanCardInput): SwarmKanbanCard {
+  const file = readKanbanFile()
+  const now = Date.now()
+  const card = normalizeCard({
+    id: randomUUID(),
+    title: input.title,
+    spec: input.spec,
+    acceptanceCriteria: input.acceptanceCriteria,
+    assignedWorker: input.assignedWorker,
+    reviewer: input.reviewer,
+    status: input.status ?? 'backlog',
+    missionId: input.missionId,
+    reportPath: input.reportPath,
+    createdBy: input.createdBy ?? 'swarm2-kanban',
+    createdAt: now,
+    updatedAt: now,
+  })
+  file.cards.push(card)
+  writeKanbanFile(file)
+  return card
+}
+
+export function updateSwarmKanbanCard(cardId: string, updates: UpdateSwarmKanbanCardInput): SwarmKanbanCard | null {
+  const file = readKanbanFile()
+  const index = file.cards.findIndex((card) => card.id === cardId)
+  if (index === -1) return null
+  const current = normalizeCard(file.cards[index])
+  const next = normalizeCard({
+    ...current,
+    ...updates,
+    id: current.id,
+    createdAt: current.createdAt,
+    createdBy: current.createdBy,
+    title: typeof updates.title === 'string' ? updates.title : current.title,
+    updatedAt: Date.now(),
+  })
+  file.cards[index] = next
+  writeKanbanFile(file)
+  return next
+}

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware'
 
 type WorkspaceState = {
   sidebarCollapsed: boolean
+  sidebarPinned: boolean
   fileExplorerCollapsed: boolean
   chatFocusMode: boolean
   /** Currently active sub-page route (e.g. '/skills', '/channels') — null means chat-only */
@@ -17,6 +18,8 @@ type WorkspaceState = {
   mobileComposerFocused: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
+  toggleSidebarPinned: () => void
+  setSidebarPinned: (pinned: boolean) => void
   toggleFileExplorer: () => void
   setFileExplorerCollapsed: (collapsed: boolean) => void
   toggleChatFocusMode: () => void
@@ -34,6 +37,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set) => ({
       sidebarCollapsed: false,
+      sidebarPinned: false,
       fileExplorerCollapsed: true,
       chatFocusMode: false,
       activeSubPage: null,
@@ -43,8 +47,28 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       mobileKeyboardInset: 0,
       mobileComposerFocused: false,
       toggleSidebar: () =>
-        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+        set((s) => {
+          const nextCollapsed = !s.sidebarCollapsed
+          return {
+            sidebarCollapsed: nextCollapsed,
+            sidebarPinned: nextCollapsed ? false : s.sidebarPinned,
+          }
+        }),
+      setSidebarCollapsed: (collapsed) =>
+        set((s) => ({
+          sidebarCollapsed: collapsed,
+          sidebarPinned: collapsed ? false : s.sidebarPinned,
+        })),
+      toggleSidebarPinned: () =>
+        set((s) => ({
+          sidebarPinned: !s.sidebarPinned,
+          sidebarCollapsed: s.sidebarPinned ? s.sidebarCollapsed : false,
+        })),
+      setSidebarPinned: (pinned) =>
+        set((s) => ({
+          sidebarPinned: pinned,
+          sidebarCollapsed: pinned ? false : s.sidebarCollapsed,
+        })),
       toggleFileExplorer: () =>
         set((s) => ({ fileExplorerCollapsed: !s.fileExplorerCollapsed })),
       setFileExplorerCollapsed: (collapsed) =>
@@ -65,6 +89,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       name: 'hermes-workspace-v1',
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarPinned: state.sidebarPinned,
         fileExplorerCollapsed: state.fileExplorerCollapsed,
         chatPanelOpen: state.chatPanelOpen,
         chatPanelSessionKey: state.chatPanelSessionKey,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1101,7 +1101,11 @@ code {
 [data-theme='hermes-slate'] html,
 [data-theme='hermes-slate'] body,
 [data-theme='hermes-slate'] #root,
-[data-theme='hermes-slate'] .dark {
+[data-theme='hermes-slate'] .dark,
+[data-theme='hermes-codex'] html,
+[data-theme='hermes-codex'] body,
+[data-theme='hermes-codex'] #root,
+[data-theme='hermes-codex'] .dark {
   background-color: var(--theme-bg);
   color: var(--theme-text);
 }
@@ -1126,6 +1130,329 @@ code {
   color: var(--theme-text);
 }
 
+/* ============================================================
+   Hermes Codex — Codex / Claude Code terminal aesthetic
+   Near-black background, JetBrains Mono everywhere, orange accent
+   ============================================================ */
+
+[data-theme='hermes-codex'] {
+  --theme-bg: #0d0d0d;
+  --theme-sidebar: #111111;
+  --theme-panel: #141414;
+  --theme-card: #1a1a1a;
+  --theme-card2: #1e1e1e;
+  --theme-border: #2d2d2d;
+  --theme-border-subtle: #222222;
+  --theme-text: #e5e5e5;
+  --theme-muted: #737373;
+  --theme-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.8);
+  --theme-shadow-2: 0 6px 16px rgba(0, 0, 0, 0.7);
+  --theme-shadow-3: 0 16px 36px rgba(0, 0, 0, 0.8);
+  --theme-glass: rgba(13, 13, 13, 0.92);
+  --theme-focus: #f97316;
+  --theme-accent: #f97316;
+  --theme-accent-secondary: #fb923c;
+  --theme-accent-subtle: rgba(249, 115, 22, 0.1);
+  --theme-accent-border: rgba(249, 115, 22, 0.25);
+  --theme-active: #f97316;
+  --theme-link: #fb923c;
+  --theme-success: #4ade80;
+  --theme-warning: #fbbf24;
+  --theme-danger: #f87171;
+  --theme-stripe: rgba(45, 45, 45, 0.5);
+  --theme-header-bg: #0d0d0d;
+  --theme-header-border: #1f1f1f;
+  /* Messages render without colored bubbles — transparent bg, monospace feel */
+  --chat-user-bg: transparent;
+  --chat-user-border: #2d2d2d;
+  --chat-user-foreground: #e5e5e5;
+  --chat-assistant-bg: transparent;
+  --chat-assistant-border: transparent;
+  --chat-assistant-foreground: #e5e5e5;
+  --composer-bg: #1a1a1a;
+  --composer-border: #2d2d2d;
+  --composer-placeholder: #4a4a4a;
+  --tool-card-bg: #141414;
+  --tool-card-border: #2d2d2d;
+  --tool-card-title: #d4d4d4;
+  --tool-card-muted: #737373;
+  --code-bg: #0d0d0d;
+  --code-border: #2d2d2d;
+  --code-foreground: #d4d4d4;
+  --theme-input: #1a1a1a;
+  /* Monospace font throughout — the Codex/Claude Code feel */
+  --font-chat: 'JetBrains Mono', ui-monospace, 'Cascadia Code', 'Fira Code', Menlo, Consolas, monospace;
+}
+
+/* Codex: override body/html bg */
+[data-theme='hermes-codex'] html,
+[data-theme='hermes-codex'] body,
+[data-theme='hermes-codex'] #root,
+[data-theme='hermes-codex'] .dark {
+  background-color: var(--theme-bg);
+  color: var(--theme-text);
+}
+
+/* Codex: monospace everywhere in the chat feed */
+[data-theme='hermes-codex'] .chat-feed-area,
+[data-theme='hermes-codex'] .chat-feed-area * {
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+  line-height: 1.6 !important;
+}
+
+/* Codex: message item — flat linear feed, no bubble */
+[data-theme='hermes-codex'] .codex-message-user {
+  border-top: 1px solid #1f1f1f;
+  border-bottom: none;
+  padding: 16px 0;
+  background: transparent;
+}
+
+[data-theme='hermes-codex'] .codex-message-assistant {
+  padding: 16px 0;
+  background: transparent;
+}
+
+/* Codex: role prefix labels */
+[data-theme='hermes-codex'] .codex-role-label {
+  font-family: var(--font-chat) !important;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Codex: tool card — minimal border-left stripe style */
+[data-theme='hermes-codex'] .tool-card {
+  border-left: 2px solid #2d2d2d;
+  border-radius: 0;
+  background: #111111;
+  padding: 8px 12px;
+  margin: 4px 0;
+  font-family: var(--font-chat) !important;
+  font-size: 12px !important;
+}
+
+[data-theme='hermes-codex'] .tool-card:hover {
+  border-left-color: #f97316;
+}
+
+/* Codex: thinking block — orange left border */
+[data-theme='hermes-codex'] .thinking-block {
+  border-left: 2px solid rgba(249, 115, 22, 0.4);
+  padding-left: 12px;
+  color: #737373;
+  font-style: italic;
+}
+
+/* Codex: composer input — full-width, terminal style, no pill shape */
+[data-theme='hermes-codex'] .composer-input,
+[data-theme='hermes-codex'] [class*='rounded-3xl'][style*='--composer-border'] {
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+  border-radius: 4px !important;
+  background: var(--composer-bg) !important;
+}
+
+[data-theme='hermes-codex'] textarea[class*='placeholder'] {
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+}
+
+/* Codex: sidebar — ultra minimal */
+[data-theme='hermes-codex'] .sidebar-session-item {
+  font-family: var(--font-chat) !important;
+  font-size: 12px !important;
+  border-radius: 0 !important;
+  padding: 6px 12px !important;
+}
+
+[data-theme='hermes-codex'] .sidebar-session-item.active {
+  background: #1a1a1a !important;
+  border-left: 2px solid #f97316 !important;
+}
+
+/* Codex: scrollbar — near-invisible */
+[data-theme='hermes-codex'] *:hover {
+  scrollbar-color: rgba(255, 255, 255, 0.08) transparent !important;
+}
+
+/* Codex: code blocks — no border, pure terminal */
+[data-theme='hermes-codex'] .code-block {
+  border: 1px solid #1f1f1f !important;
+  border-radius: 2px !important;
+  background: #0d0d0d !important;
+}
+
+/* Codex: hide avatars — terminal UIs don't have profile pics */
+[data-theme='hermes-codex'] img[alt='Hermes'],
+[data-theme='hermes-codex'] img[alt='User avatar'],
+[data-theme='hermes-codex'] [data-chat-message-role] svg[viewBox='0 0 100 100'] {
+  display: none !important;
+}
+
+/* Codex: left-align ALL messages (even user), Codex-style */
+[data-theme='hermes-codex'] [data-chat-message-role='user'] {
+  align-items: flex-start !important;
+}
+
+/* Codex: undo flex-row-reverse on user message rows */
+[data-theme='hermes-codex'] [data-chat-message-role='user'] .flex-row-reverse {
+  flex-direction: row !important;
+}
+
+/* Codex: user bubble — flat, orange left-border accent */
+[data-theme='hermes-codex'] [data-chat-message-bubble='user'] {
+  background: transparent !important;
+  border: none !important;
+  border-left: 2px solid var(--theme-accent) !important;
+  border-radius: 0 !important;
+  padding: 4px 12px !important;
+  color: var(--theme-text) !important;
+  max-width: 100% !important;
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+}
+
+/* Codex: assistant bubble — no background, no border, full width */
+[data-theme='hermes-codex'] [data-chat-message-bubble='assistant'] {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  max-width: 100% !important;
+  padding: 0 !important;
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+}
+
+/* Codex: tool call inline cards — terminal left-border style */
+[data-theme='hermes-codex'] [class*='rounded-xl'][class*='border-primary'] {
+  border-radius: 2px !important;
+  border-left-width: 3px !important;
+}
+
+/* Codex: separator between messages */
+[data-theme='hermes-codex'] [data-chat-message-role] + [data-chat-message-role='user'] {
+  margin-top: 8px;
+  padding-top: 12px;
+  border-top: 1px solid #1a1a1a;
+}
+
+/* Codex: message text — monospace */
+[data-theme='hermes-codex'] [data-chat-message-bubble] p,
+[data-theme='hermes-codex'] [data-chat-message-bubble] li,
+[data-theme='hermes-codex'] [data-chat-message-bubble] span {
+  font-family: var(--font-chat) !important;
+}
+
+/* Codex: status bar at bottom of chat */
+[data-theme='hermes-codex'] .chat-status-bar {
+  background: #111111;
+  border-top: 1px solid #1f1f1f;
+  font-family: var(--font-chat) !important;
+  font-size: 11px;
+  color: #4a4a4a;
+  padding: 4px 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+/* Codex: role label prefix via pseudo-element */
+[data-theme='hermes-codex'] [data-chat-message-role='user']::before {
+  content: 'you';
+  display: block;
+  font-family: var(--font-chat) !important;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--theme-accent);
+  padding: 0 0 4px 0;
+  margin-bottom: 2px;
+}
+
+[data-theme='hermes-codex'] [data-chat-message-role='assistant']::before {
+  content: 'hermes';
+  display: block;
+  font-family: var(--font-chat) !important;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #737373;
+  padding: 0 0 4px 0;
+  margin-bottom: 2px;
+}
+
+/* Codex: cursor blink on active generation */
+@keyframes codex-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+[data-theme='hermes-codex'] .codex-cursor::after {
+  content: '▋';
+  display: inline;
+  animation: codex-cursor 1s step-end infinite;
+  color: #f97316;
+  margin-left: 1px;
+}
+
+/* Codex: header — flush, no gradient */
+[data-theme='hermes-codex'] header,
+[data-theme='hermes-codex'] .chat-header {
+  background: #0d0d0d !important;
+  border-bottom: 1px solid #1f1f1f !important;
+  box-shadow: none !important;
+}
+
+/* Codex: sidebar nav links — monospace, flat */
+[data-theme='hermes-codex'] nav a,
+[data-theme='hermes-codex'] .nav-link {
+  font-family: var(--font-chat) !important;
+  font-size: 12px !important;
+  border-radius: 2px !important;
+}
+
+/* Codex: kill pill shape on composer, make it sharp-cornered */
+[data-theme='hermes-codex'] .rounded-3xl {
+  border-radius: 4px !important;
+}
+
+[data-theme='hermes-codex'] .rounded-2xl {
+  border-radius: 3px !important;
+}
+
+/* Codex: make the composer textarea monospace */
+[data-theme='hermes-codex'] textarea {
+  font-family: var(--font-chat) !important;
+  font-size: 13px !important;
+  line-height: 1.6 !important;
+}
+
+/* Codex: primary token remap */
+[data-theme='hermes-codex'] {
+  --color-primary-50: #111111;
+  --color-primary-100: #1a1a1a;
+  --color-primary-200: #2d2d2d;
+  --color-primary-300: #3d3d3d;
+  --color-primary-400: #737373;
+  --color-primary-500: #737373;
+  --color-primary-600: #a3a3a3;
+  --color-primary-700: #d4d4d4;
+  --color-primary-800: #e5e5e5;
+  --color-primary-900: #f5f5f5;
+  --color-primary-950: #fafafa;
+  --color-surface: #0d0d0d;
+  --color-surface-deep: #0a0a0a;
+  --color-ink: #e5e5e5;
+  --color-accent-400: #fb923c;
+  --color-accent-500: #f97316;
+  --color-accent-600: #ea580c;
+}
+
 /* ── Tailwind primary token remaps for dark themes ─────────────────────
    Maps bg-primary-50, text-primary-900, border-primary-200 etc.
    to theme-appropriate values so ALL existing Tailwind classes work.
@@ -1134,7 +1461,8 @@ code {
 [data-theme='hermes-nous'],
 [data-theme='hermes-official'],
 [data-theme='hermes-classic'],
-[data-theme='hermes-slate'] {
+[data-theme='hermes-slate'],
+[data-theme='hermes-codex'] {
   --color-primary-50: var(--theme-panel);
   --color-primary-100: var(--theme-card);
   --color-primary-200: var(--theme-border);


### PR DESCRIPTION
## What changed

- Adds a new `Company OS Beta` route and navigation entry at `/company-os-beta`.
- Builds the Unaligned operating brief / deal machine view for lead triage, payment state, Robert handoff, and daily action/waiting lists.
- Adds a visible sender selector for Asher, Robert, and Sammy before sending/copying drafts.
- Adds local Company OS APIs for snapshot data, Gmail refresh, and Asher Gmail sending with optional pricing PDF attachment.
- Adds the Gmail snapshot refresh script used by the dashboard.

## Why

The current email/lead flow needed a calmer, more executable operating surface instead of a dark, cluttered thread viewer. This beta tab lets the workflow live separately while it is tested against Unaligned leads, invoices, and Gmail context.

## Validation

- `pnpm build`
- Browser checked `/company-os-beta` for the light operations palette, fixed background, sender switch, and Company OS Beta nav entry.
