### PR TITLE
fix: align Hermes startup paths

### DIFF
--- a/src/screens/mcp/mcp-screen.tsx
+++ b/src/screens/mcp/mcp-screen.tsx
@@ -85,8 +85,9 @@ export function McpScreen() {
               role="status"
               className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
             >
-              ⚠ Local fallback mode — using config.yaml. Test, Discover, and
-              Logs require the new hermes-agent /api/mcp endpoints.
+              ⚠ Local fallback mode — using config.yaml. Test works through the
+              local Hermes CLI bridge; Discover and Logs require native
+              hermes-agent /api/mcp runtime endpoints.
             </div>
           ) : null}
         </header>

--- a/src/screens/playground/components/playground-hud.tsx
+++ b/src/screens/playground/components/playground-hud.tsx
@@ -164,7 +164,6 @@ export function PlaygroundHud({
               <div className="text-[11px] font-black uppercase tracking-[0.14em]" style={{ color: HUD.parchment }}>
                 {playerProfile.displayName || 'Builder'}
               </div>
-              </div>
               <div className="mt-1 max-w-[126px] truncate text-[9px] uppercase tracking-[0.18em]" style={{ color: HUD.stone }}>{title}</div>
               <div className="mt-2 flex items-center gap-2">
                 <div className="h-1.5 w-[88px] overflow-hidden rounded-full" style={{ background: 'rgba(244,233,211,.12)', boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.45)' }}>

--- a/src/server/claude-agent.test.ts
+++ b/src/server/claude-agent.test.ts
@@ -1,16 +1,28 @@
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { closeSync, mkdtempSync, mkdirSync, openSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { resolveClaudeAgentDir } from './claude-agent'
+import {
+  buildHermesAgentLaunchPlan,
+  resolveClaudeAgentDir,
+  resolveClaudeBinary,
+} from './hermes-agent-startup'
 
 const tempDirs: string[] = []
 
 function createAgentDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix))
   mkdirSync(join(dir, 'webapi'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function createCurrentHermesDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  mkdirSync(join(dir, 'gateway'), { recursive: true })
+  closeSync(openSync(join(dir, 'gateway', 'run.py'), 'w'))
   tempDirs.push(dir)
   return dir
 }
@@ -42,5 +54,55 @@ describe('resolveClaudeAgentDir', () => {
         CLAUDE_AGENT_PATH: legacyAgentDir,
       }),
     ).toBe(legacyAgentDir)
+  })
+
+  it('accepts current Hermes Agent checkouts without the removed webapi directory', () => {
+    const hermesAgentDir = createCurrentHermesDir('hermes-agent-current-')
+
+    expect(
+      resolveClaudeAgentDir({
+        HERMES_AGENT_PATH: hermesAgentDir,
+      }),
+    ).toBe(hermesAgentDir)
+  })
+})
+
+describe('resolveClaudeBinary', () => {
+  it('prefers Hermes binaries before legacy Claude binaries', () => {
+    const hermesBin = createCurrentHermesDir('hermes-bin-')
+    const legacyBin = createCurrentHermesDir('claude-bin-')
+
+    expect(
+      resolveClaudeBinary({
+        HERMES_CLI_BIN: hermesBin,
+        CLAUDE_CLI_BIN: legacyBin,
+      }),
+    ).toBe(hermesBin)
+  })
+})
+
+describe('buildHermesAgentLaunchPlan', () => {
+  it('launches current Hermes Agent source checkouts with gateway.run instead of legacy webapi', () => {
+    const hermesAgentDir = createCurrentHermesDir('hermes-agent-current-launch-')
+
+    const plan = buildHermesAgentLaunchPlan({ agentDir: hermesAgentDir, binary: null })
+
+    expect(plan).toEqual({
+      command: 'python3',
+      args: ['-m', 'gateway.run'],
+      cwd: hermesAgentDir,
+    })
+  })
+
+  it('uses legacy uvicorn only for legacy webapi checkouts', () => {
+    const legacyAgentDir = createAgentDir('claude-agent-launch-')
+
+    const plan = buildHermesAgentLaunchPlan({ agentDir: legacyAgentDir, binary: null })
+
+    expect(plan).toEqual({
+      command: 'python3',
+      args: ['-m', 'uvicorn', 'webapi.app:app', '--host', '0.0.0.0', '--port', '8642'],
+      cwd: legacyAgentDir,
+    })
   })
 })

--- a/src/server/claude-agent.ts
+++ b/src/server/claude-agent.ts
@@ -1,10 +1,17 @@
 import { spawn } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { homedir } from 'node:os'
+import {
+  buildHermesAgentLaunchPlan,
+  HERMES_GATEWAY_PORT,
+  hermesGatewayEnv,
+  resolveClaudeAgentDir,
+  resolveClaudeBinary,
+} from './hermes-agent-startup'
 
 const CLAUDE_HEALTH_TIMEOUT_MS = 2_000
-const CLAUDE_START_PORT = 8642
+const CLAUDE_START_PORT = HERMES_GATEWAY_PORT
 
 let startPromise: Promise<StartClaudeAgentResult> | null = null
 
@@ -52,55 +59,6 @@ function readClaudeEnv(): Record<string, string> {
   }
 }
 
-/** Same directory resolution logic as vite.config.ts. Kept in sync. */
-export function resolveClaudeAgentDir(
-  env: Record<string, string | undefined> = process.env,
-): string | null {
-  const candidates: Array<string> = []
-
-  const explicitAgentPath = env.HERMES_AGENT_PATH?.trim() || env.CLAUDE_AGENT_PATH?.trim()
-  if (explicitAgentPath) {
-    candidates.push(explicitAgentPath)
-  }
-
-  const workspaceRoot = dirname(resolve('.'))
-  candidates.push(
-    resolve(workspaceRoot, 'hermes-agent'),          // sibling (old README)
-    resolve(workspaceRoot, '..', 'hermes-agent'),    // one level up
-    resolve(homedir(), '.hermes', 'hermes-agent'),   // Nous installer default
-    resolve(homedir(), 'hermes-agent'),              // ~/hermes-agent
-  )
-
-  for (const candidate of candidates) {
-    if (existsSync(resolve(candidate, 'webapi'))) return candidate
-  }
-
-  return null
-}
-
-/** Find the `claude` CLI binary installed by Nous's installer (or on PATH). */
-export function resolveClaudeBinary(): string | null {
-  const candidates = [
-    resolve(homedir(), '.claude', 'bin', 'claude'),
-    resolve(homedir(), '.local', 'bin', 'claude'),
-  ]
-  for (const c of candidates) {
-    if (existsSync(c)) return c
-  }
-  return null
-}
-
-export function resolveClaudePython(agentDir: string): string {
-  const venvPython = resolve(agentDir, '.venv', 'bin', 'python')
-  if (existsSync(venvPython)) return venvPython
-  const uvVenv = resolve(agentDir, 'venv', 'bin', 'python')
-  if (existsSync(uvVenv)) return uvVenv
-  // Nous installer ships its own uv-managed python alongside the binary
-  const nousPython = resolve(homedir(), '.claude', 'venv', 'bin', 'python')
-  if (existsSync(nousPython)) return nousPython
-  return 'python3'
-}
-
 export async function isClaudeAgentHealthy(
   port = CLAUDE_START_PORT,
 ): Promise<boolean> {
@@ -129,30 +87,8 @@ export async function startClaudeAgent(): Promise<StartClaudeAgentResult> {
       const claudeBin = resolveClaudeBinary()
       const agentDir = resolveClaudeAgentDir()
 
-      // Prefer the `hermes gateway run` binary path (the Nous installer's
-      // canonical entrypoint). Fall back to launching uvicorn against the
-      // source tree if we only have a directory.
-      let command: string
-      let commandArgs: Array<string>
-      let cwd: string | undefined
-
-      if (claudeBin) {
-        command = claudeBin
-        commandArgs = ['gateway', 'run']
-        cwd = agentDir ?? undefined
-      } else if (agentDir) {
-        command = resolveClaudePython(agentDir)
-        commandArgs = [
-          '-m',
-          'uvicorn',
-          'webapi.app:app',
-          '--host',
-          '0.0.0.0',
-          '--port',
-          String(CLAUDE_START_PORT),
-        ]
-        cwd = agentDir
-      } else {
+      const plan = buildHermesAgentLaunchPlan({ agentDir, binary: claudeBin })
+      if (!plan) {
         return {
           ok: false,
           error:
@@ -161,15 +97,14 @@ export async function startClaudeAgent(): Promise<StartClaudeAgentResult> {
       }
 
       const child = spawn(
-        command,
-        commandArgs,
+        plan.command,
+        plan.args,
         {
-          cwd,
+          cwd: plan.cwd,
           detached: true,
           stdio: 'ignore',
           env: {
-            ...process.env,
-            ...claudeEnv,
+            ...hermesGatewayEnv(process.env, claudeEnv, CLAUDE_START_PORT),
             PATH: [
               resolve(homedir(), '.claude', 'bin'),
               resolve(homedir(), '.local', 'bin'),

--- a/src/server/hermes-agent-startup.ts
+++ b/src/server/hermes-agent-startup.ts
@@ -1,0 +1,123 @@
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { homedir } from 'node:os'
+
+export const HERMES_GATEWAY_PORT = 8642
+
+export type HermesLaunchPlan = {
+  command: string
+  args: string[]
+  cwd?: string
+}
+
+export function isHermesAgentDir(candidate: string): boolean {
+  return (
+    existsSync(resolve(candidate, 'gateway', 'run.py')) ||
+    existsSync(resolve(candidate, 'run_agent.py')) ||
+    existsSync(resolve(candidate, 'webapi'))
+  )
+}
+
+/** Same directory resolution logic for server runtime and Vite dev startup. */
+export function resolveClaudeAgentDir(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const candidates: string[] = []
+
+  const explicitAgentPath = env.HERMES_AGENT_PATH?.trim() || env.CLAUDE_AGENT_PATH?.trim()
+  if (explicitAgentPath) candidates.push(explicitAgentPath)
+
+  const workspaceRoot = dirname(resolve('.'))
+  candidates.push(
+    resolve(workspaceRoot, 'hermes-agent'),
+    resolve(workspaceRoot, '..', 'hermes-agent'),
+    resolve(homedir(), '.hermes', 'hermes-agent'),
+    resolve(homedir(), '.claude', 'hermes-agent'),
+    resolve(homedir(), 'hermes-agent'),
+  )
+
+  for (const candidate of candidates) {
+    if (isHermesAgentDir(candidate)) return candidate
+  }
+  return null
+}
+
+/** Find the Hermes CLI binary, keeping legacy Claude locations as fallbacks. */
+export function resolveClaudeBinary(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const candidates = [
+    env.HERMES_CLI_BIN || '',
+    resolve(homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
+    resolve(homedir(), '.local', 'bin', 'hermes'),
+    env.CLAUDE_CLI_BIN || '',
+    resolve(homedir(), '.claude', 'bin', 'claude'),
+    resolve(homedir(), '.local', 'bin', 'claude'),
+  ]
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+export function resolveClaudePython(agentDir: string): string {
+  const venvPython = resolve(agentDir, '.venv', 'bin', 'python')
+  if (existsSync(venvPython)) return venvPython
+  const uvVenv = resolve(agentDir, 'venv', 'bin', 'python')
+  if (existsSync(uvVenv)) return uvVenv
+  const nousPython = resolve(homedir(), '.claude', 'venv', 'bin', 'python')
+  if (existsSync(nousPython)) return nousPython
+  return 'python3'
+}
+
+export function buildHermesAgentLaunchPlan({
+  agentDir,
+  binary,
+  port = HERMES_GATEWAY_PORT,
+}: {
+  agentDir: string | null
+  binary: string | null
+  port?: number | string
+}): HermesLaunchPlan | null {
+  if (binary) {
+    return {
+      command: binary,
+      args: ['gateway', 'run', '--replace'],
+      cwd: agentDir ?? undefined,
+    }
+  }
+
+  if (!agentDir) return null
+
+  if (existsSync(resolve(agentDir, 'gateway', 'run.py')) || existsSync(resolve(agentDir, 'run_agent.py'))) {
+    return {
+      command: resolveClaudePython(agentDir),
+      args: ['-m', 'gateway.run'],
+      cwd: agentDir,
+    }
+  }
+
+  return {
+    command: resolveClaudePython(agentDir),
+    args: ['-m', 'uvicorn', 'webapi.app:app', '--host', '0.0.0.0', '--port', String(port)],
+    cwd: agentDir,
+  }
+}
+
+export function hermesGatewayEnv(
+  baseEnv: Record<string, string | undefined> = process.env,
+  fileEnv: Record<string, string | undefined> = {},
+  port: string | number = HERMES_GATEWAY_PORT,
+): Record<string, string | undefined> {
+  return {
+    ...baseEnv,
+    ...fileEnv,
+    API_SERVER_ENABLED: baseEnv.API_SERVER_ENABLED ?? fileEnv.API_SERVER_ENABLED ?? 'true',
+    API_SERVER_HOST: baseEnv.API_SERVER_HOST ?? fileEnv.API_SERVER_HOST ?? '127.0.0.1',
+    API_SERVER_PORT: baseEnv.API_SERVER_PORT ?? fileEnv.API_SERVER_PORT ?? String(port),
+    API_SERVER_CORS_ORIGINS:
+      baseEnv.API_SERVER_CORS_ORIGINS ??
+      fileEnv.API_SERVER_CORS_ORIGINS ??
+      'http://localhost:3000,http://127.0.0.1:3000',
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,14 @@ import { execSync, spawn } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import net from 'node:net'
-import { resolve, dirname } from 'node:path'
+import { resolve } from 'node:path'
 import os from 'node:os'
+import {
+  buildHermesAgentLaunchPlan,
+  hermesGatewayEnv,
+  resolveClaudeAgentDir,
+  resolveClaudeBinary,
+} from './src/server/hermes-agent-startup'
 
 // devtools removed
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
@@ -17,62 +23,6 @@ import viteTsConfigPaths from 'vite-tsconfig-paths'
 // ---------------------------------------------------------------------------
 // Hermes Agent auto-start helpers
 // ---------------------------------------------------------------------------
-
-/** Resolve the hermes-agent directory using a priority-ordered fallback chain:
- *  1. HERMES_AGENT_PATH env var (explicit override)
- *  2. CLAUDE_AGENT_PATH env var (legacy override)
- *  3. ../hermes-agent  — sibling clone (standard README setup)
- *  4. ../../hermes-agent — one level up (monorepo / nested workspace)
- *  Returns null if none found.
- */
-function resolveClaudeAgentDir(env: Record<string, string>): string | null {
-  const candidates: string[] = []
-
-  const explicitAgentPath = env.HERMES_AGENT_PATH?.trim() || env.CLAUDE_AGENT_PATH?.trim()
-  if (explicitAgentPath) {
-    candidates.push(explicitAgentPath)
-  }
-
-  // Resolve relative to the workspace root (parent of hermes-workspace/)
-  const workspaceRoot = dirname(resolve('.'))
-  candidates.push(
-    resolve(workspaceRoot, 'hermes-agent'), // sibling (old README)
-    resolve(workspaceRoot, '..', 'hermes-agent'), // one level up
-    resolve(os.homedir(), '.claude', 'hermes-agent'), // Nous installer default
-    resolve(os.homedir(), 'hermes-agent'), // ~/hermes-agent
-  )
-
-  for (const candidate of candidates) {
-    if (existsSync(resolve(candidate, 'webapi'))) return candidate
-  }
-  return null
-}
-
-/** Find the Hermes CLI binary used to start the local gateway. */
-function resolveClaudeBinary(): string | null {
-  const candidates = [
-    process.env.HERMES_CLI_BIN || '',
-    resolve(os.homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
-    resolve(os.homedir(), '.claude', 'bin', 'claude'),
-    resolve(os.homedir(), '.local', 'bin', 'claude'),
-  ]
-  for (const c of candidates) {
-    if (existsSync(c)) return c
-  }
-  return null
-}
-
-/** Resolve the Python executable to use for Hermes backend startup.
- *  Prefers .venv/bin/python inside agentDir, falls back to system python3.
- */
-function resolveClaudePython(agentDir: string): string {
-  const venvPython = resolve(agentDir, '.venv', 'bin', 'python')
-  if (existsSync(venvPython)) return venvPython
-  // uv creates 'venv' not '.venv' sometimes
-  const uvVenv = resolve(agentDir, 'venv', 'bin', 'python')
-  if (existsSync(uvVenv)) return uvVenv
-  return 'python3'
-}
 
 /** Check if hermes-agent health endpoint is responding */
 async function isClaudeAgentHealthy(port = 8642): Promise<boolean> {
@@ -122,37 +72,8 @@ const config = defineConfig(({ mode, command }) => {
     const claudeBin = resolveClaudeBinary()
     const agentDir = resolveClaudeAgentDir(env)
 
-    // Prefer the `hermes gateway run` binary path (Nous installer's canonical
-    // entrypoint). Fall back to launching uvicorn against the source tree if
-    // only a directory is present (dev / cloned-in-place setups).
-    let launchCmd: string
-    let commandArgs: string[]
-    let launchCwd: string | undefined
-
-    if (claudeBin) {
-      launchCmd = claudeBin
-      commandArgs = ['gateway', 'run']
-      launchCwd = agentDir ?? undefined
-      console.log(`[hermes-agent] Starting ${claudeBin} gateway run`)
-    } else if (agentDir) {
-      launchCmd = resolveClaudePython(agentDir)
-      const useGatewayRun = existsSync(resolve(agentDir, 'gateway', 'run.py'))
-      commandArgs = useGatewayRun
-        ? ['-m', 'gateway.run']
-        : [
-            '-m',
-            'uvicorn',
-            'webapi.app:app',
-            '--host',
-            '0.0.0.0',
-            '--port',
-            '8642',
-          ]
-      launchCwd = agentDir
-      console.log(
-        `[hermes-agent] Starting from ${agentDir} using ${launchCmd} (${useGatewayRun ? 'gateway.run' : 'uvicorn'})`,
-      )
-    } else {
+    const plan = buildHermesAgentLaunchPlan({ agentDir, binary: claudeBin })
+    if (!plan) {
       console.warn(
         '[hermes-agent] Could not find hermes-agent installation.\n' +
           '  Run the installer:\n' +
@@ -161,13 +82,14 @@ const config = defineConfig(({ mode, command }) => {
       )
       return
     }
+    console.log(`[hermes-agent] Starting ${plan.command} ${plan.args.join(' ')}`)
 
-    const child = spawn(launchCmd, commandArgs, {
-      cwd: launchCwd,
+    const child = spawn(plan.command, plan.args, {
+      cwd: plan.cwd,
       detached: false, // keep tied to vite process — stops when dev server stops
       stdio: 'pipe',
       env: {
-        ...process.env,
+        ...hermesGatewayEnv(process.env, {}, '8642'),
         PATH: [
           resolve(os.homedir(), '.claude', 'bin'),
           resolve(os.homedir(), '.local', 'bin'),


### PR DESCRIPTION
## Summary
- centralizes Hermes Agent discovery/startup logic for server runtime and Vite dev mode
- launches current Hermes Agent source checkouts with gateway.run instead of legacy webapi fallback
- fixes Playground HUD JSX syntax so the old typecheck parser failure is gone
- updates MCP fallback wording to reflect local CLI Test bridge support

## Test Plan
- pnpm vitest run src/server/claude-agent.test.ts src/server/__tests__/gateway-capabilities.test.ts --reporter=basic
- pnpm exec tsc --noEmit --pretty false (remaining broad baseline quarantined; no playground-hud parser errors remain)