### PR TITLE
fix: recover dashboard kanban from stale loopback url

### DIFF
--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -138,6 +138,57 @@ describe('gateway-capabilities', () => {
     expect(mod.CLAUDE_API).toBe('http://localhost:9000')
   })
 
+  it('falls back from a stale loopback dashboard env URL to the vanilla dashboard port', async () => {
+    process.env.HERMES_API_URL = 'http://gateway.test'
+    process.env.HERMES_DASHBOARD_URL = 'http://127.0.0.1:8642'
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === 'http://127.0.0.1:8642/api/status') {
+        return new Response('not found', { status: 404 })
+      }
+      if (url === 'http://127.0.0.1:9119/api/status') {
+        return new Response(JSON.stringify({ version: '0.14.0' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://127.0.0.1:9119/') {
+        return new Response("<script>window.__HERMES_SESSION_TOKEN__ = 'test-token'</script>", {
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+      if (url === 'http://127.0.0.1:9119/api/conductor/missions') {
+        return new Response('not found', { status: 404 })
+      }
+      if (url === 'http://127.0.0.1:9119/api/plugins/kanban/board') {
+        return new Response(JSON.stringify({ columns: [] }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://127.0.0.1:9119/api/mcp') {
+        return new Response('not found', { status: 404 })
+      }
+      if (url === 'http://127.0.0.1:9119/api/config') {
+        return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://gateway.test/v1/chat/completions') return new Response('', { status: 405 })
+      if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') return new Response('', { status: 404 })
+      if (url === 'http://gateway.test/api/mcp') return new Response('', { status: 404 })
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    })
+
+    const mod = await loadMod()
+    const caps = await mod.probeGateway({ force: true })
+
+    expect(mod.CLAUDE_DASHBOARD_URL).toBe('http://127.0.0.1:9119')
+    expect(caps.dashboard.available).toBe(true)
+    expect(caps.kanban).toBe(true)
+  })
+
   it('getResolvedUrls reports default source when no env or file override', async () => {
     const mod = await loadMod()
     const resolved = mod.getResolvedUrls()

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -57,6 +57,16 @@ function normalizeUrl(u: string): string {
   return u.trim().replace(/\/+$/, '')
 }
 
+function isLoopbackOrigin(raw: string): boolean {
+  try {
+    const { hostname } = new URL(raw)
+    const normalized = hostname.trim().toLowerCase()
+    return normalized === '127.0.0.1' || normalized === 'localhost' || normalized === '::1' || normalized === '[::1]'
+  } catch {
+    return false
+  }
+}
+
 const _initialOverrides = readOverrides()
 
 export let CLAUDE_API = normalizeUrl(
@@ -655,7 +665,7 @@ const DASHBOARD_BACKED_APIS = new Set([
 
 export function getCapabilityWarningMessage(
   next: GatewayCapabilities,
-  criticalMissing: string[],
+  criticalMissing: Array<string>,
 ): string | null {
   if (criticalMissing.length === 0 || (!next.health && !next.dashboard.available)) {
     return null
@@ -751,21 +761,41 @@ async function autoDetectGatewayUrl(): Promise<void> {
   )
 }
 
+async function dashboardStatusOk(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/status`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+    if (!res.ok) return false
+    const body = (await res.json()) as { version?: string }
+    return Boolean(body.version)
+  } catch {
+    return false
+  }
+}
+
 async function autoDetectDashboardUrl(): Promise<void> {
-  if (process.env.CLAUDE_DASHBOARD_URL) return
+  if (_initialOverrides.claudeDashboardUrl) return
+
+  const hasEnvDashboard = Boolean(
+    process.env.CLAUDE_DASHBOARD_URL || process.env.HERMES_DASHBOARD_URL,
+  )
+
+  if (hasEnvDashboard) {
+    if (await dashboardStatusOk(CLAUDE_DASHBOARD_URL)) return
+    // Common attach-to-existing-agent footgun: users copy the gateway/API
+    // port into HERMES_DASHBOARD_URL (for example 8642/6789). If that stale
+    // value is loopback-only, safely fall back to the vanilla dashboard port.
+    // Do not override remote/Tailscale URLs; those are intentional and may be
+    // temporarily unavailable during startup.
+    if (!isLoopbackOrigin(CLAUDE_DASHBOARD_URL)) return
+  }
 
   const candidates = ['http://127.0.0.1:9119']
   for (const candidate of candidates) {
-    try {
-      const res = await fetch(`${candidate}/api/status`, {
-        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-      })
-      if (res.ok) {
-        CLAUDE_DASHBOARD_URL = candidate
-        return
-      }
-    } catch {
-      // continue
+    if (await dashboardStatusOk(candidate)) {
+      CLAUDE_DASHBOARD_URL = candidate
+      return
     }
   }
 }


### PR DESCRIPTION
## Summary
- Validate configured dashboard URLs before treating them as usable
- Fall back to the default local dashboard port when a stale loopback env URL is configured
- Add regression coverage for HERMES_DASHBOARD_URL pointing at the gateway port

## Test plan
- pnpm vitest run src/server/__tests__/gateway-capabilities.test.ts
- pnpm lint src/server/gateway-capabilities.ts src/server/__tests__/gateway-capabilities.test.ts
- pnpm build

Local config also updated: .env now uses HERMES_DASHBOARD_URL=http://127.0.0.1:9119 and CLAUDE_KANBAN_BACKEND=auto.