### PR TITLE
Fix Hermes Workspace zero-fork chat responses

### DIFF
--- a/docs/head-office-recovery.md
+++ b/docs/head-office-recovery.md
@@ -1,0 +1,44 @@
+# Hermes Head Office Recovery Notes
+
+Current working route as of 2026-05-28:
+
+- Telegram and Workspace use Hermes gateway on `127.0.0.1:8642`.
+- Hermes model config uses ChatGPT/Codex subscription through the Codex CLI app-server runtime:
+  - `model.provider: openai-codex`
+  - `model.default: gpt-5.5`
+  - `model.openai_runtime: codex_app_server`
+- Codex CLI must be installed and logged in with ChatGPT:
+  - `codex login status` should print `Logged in using ChatGPT`.
+- Workspace `.env` must include:
+  - `HERMES_API_URL=http://127.0.0.1:8642`
+  - `HERMES_API_TOKEN=<matches API_SERVER_KEY>`
+- Hermes `.env` must include:
+  - `API_SERVER_ENABLED=true`
+  - `API_SERVER_KEY=<same token>`
+
+## Health Check
+
+Run this on the VPS:
+
+```bash
+cd /root/hermes-workspace
+scripts/head-office-health.sh
+```
+
+Expected final line:
+
+```text
+OK: Head Office is operational
+```
+
+## Important Fix
+
+`src/routes/api/send-stream.ts` uses the gateway non-streaming `/v1/chat/completions` path for Workspace zero-fork chat, then emits one Workspace SSE chunk. This avoids the empty-response/hanging behavior observed from the gateway streaming path while preserving the browser chat UI.
+
+## Recovery Order
+
+1. Confirm Codex is logged in: `codex login status`.
+2. Confirm gateway health: `curl -sS http://127.0.0.1:8642/health`.
+3. Confirm Workspace dev server is running in tmux target `ui`.
+4. Run `scripts/head-office-health.sh`.
+5. Only restart the gateway if health on `:8642` fails. Preserve Telegram as the working control channel whenever possible.

--- a/docs/head-office-recovery.md
+++ b/docs/head-office-recovery.md
@@ -42,3 +42,25 @@ OK: Head Office is operational
 3. Confirm Workspace dev server is running in tmux target `ui`.
 4. Run `scripts/head-office-health.sh`.
 5. Only restart the gateway if health on `:8642` fails. Preserve Telegram as the working control channel whenever possible.
+
+
+## Autopilot Watchdog
+
+The VPS runs a cron watchdog every 5 minutes:
+
+```bash
+cd /root/hermes-workspace
+scripts/head-office-watchdog.sh
+```
+
+Logs are written to:
+
+```text
+/root/.hermes/logs/head-office-watchdog.log
+```
+
+The watchdog runs `scripts/head-office-health.sh`. If health fails, it restarts only the affected runtime:
+
+- Gateway failures restart the `gateway` tmux session with `hermes gateway run`.
+- Workspace UI failures restart the `ui` tmux session with `pnpm dev`.
+- If gateway is healthy but end-to-end Workspace chat fails, it restarts Workspace UI first to preserve Telegram as the control channel.

--- a/docs/head-office-recovery.md
+++ b/docs/head-office-recovery.md
@@ -73,3 +73,8 @@ The watchdog usually runs cheap HTTP/login checks. Deep checks run `scripts/head
 - Gateway failures restart the `gateway` tmux session with `hermes gateway run`.
 - Workspace UI failures restart the `ui` tmux session with `pnpm dev`.
 - If gateway is healthy but end-to-end Workspace chat fails, it restarts Workspace UI first to preserve Telegram as the control channel.
+
+
+## Cadence Review
+
+The current recommended cadence is cheap light checks every 5 minutes and deep model-backed checks daily plus after failures. If the system remains stable for a week, switch the scheduled deep check to weekly to reduce subscription usage further.

--- a/docs/head-office-recovery.md
+++ b/docs/head-office-recovery.md
@@ -46,11 +46,20 @@ OK: Head Office is operational
 
 ## Autopilot Watchdog
 
-The VPS runs a cron watchdog every 5 minutes:
+The VPS runs a cheap cron watchdog every 5 minutes:
 
 ```bash
 cd /root/hermes-workspace
-scripts/head-office-watchdog.sh
+scripts/head-office-watchdog.sh light
+```
+
+The light check does not call the model. It verifies gateway health, Workspace HTTP availability, and Codex login status.
+
+A deep model-backed health check runs once per day and after recovery attempts:
+
+```bash
+cd /root/hermes-workspace
+scripts/head-office-watchdog.sh deep
 ```
 
 Logs are written to:
@@ -59,7 +68,7 @@ Logs are written to:
 /root/.hermes/logs/head-office-watchdog.log
 ```
 
-The watchdog runs `scripts/head-office-health.sh`. If health fails, it restarts only the affected runtime:
+The watchdog usually runs cheap HTTP/login checks. Deep checks run `scripts/head-office-health.sh` once per day or after failures. If health fails, it restarts only the affected runtime:
 
 - Gateway failures restart the `gateway` tmux session with `hermes gateway run`.
 - Workspace UI failures restart the `ui` tmux session with `pnpm dev`.

--- a/docs/head-office-recovery.md
+++ b/docs/head-office-recovery.md
@@ -78,3 +78,40 @@ The watchdog usually runs cheap HTTP/login checks. Deep checks run `scripts/head
 ## Cadence Review
 
 The current recommended cadence is cheap light checks every 5 minutes and deep model-backed checks daily plus after failures. If the system remains stable for a week, switch the scheduled deep check to weekly to reduce subscription usage further.
+
+
+## Model Routing
+
+Current cost-control routing:
+
+- Main Atlas/Hermes model remains `gpt-5.5` through `openai-codex` with `model.openai_runtime: codex_app_server`.
+- Lightweight auxiliary tasks use GitHub Copilot `gpt-4o-mini`:
+  - compression
+  - skills_hub
+  - approval
+  - mcp
+  - title_generation
+  - triage_specifier
+  - kanban_decomposer
+  - profile_describer
+  - curator
+- Fallback chain includes Copilot `gpt-4o-mini` after the main Codex route.
+
+This reduces ChatGPT/Codex usage for side tasks while keeping Codex/5.5 as the primary reasoning/coding route. Vision and web extraction remain `auto` until dedicated provider keys are configured.
+
+Verify auxiliary routing without changing config:
+
+```bash
+cd /usr/local/lib/hermes-agent
+/usr/local/lib/hermes-agent/venv/bin/python - <<'PYCHECK'
+from agent.auxiliary_client import get_text_auxiliary_client
+client, model = get_text_auxiliary_client("title_generation")
+print(model)
+PYCHECK
+```
+
+Expected model:
+
+```text
+gpt-4o-mini
+```

--- a/scripts/head-office-health.sh
+++ b/scripts/head-office-health.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-/root/hermes-workspace}"
+HERMES_HOME="${HERMES_HOME:-/root/.hermes}"
+cd "$ROOT"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "OK: $*"
+}
+
+echo "== Hermes Head Office health =="
+
+command -v codex >/dev/null 2>&1 || fail "codex CLI not on PATH"
+codex login status >/tmp/hermes-codex-status.$$ 2>&1 || fail "codex login status failed: $(cat /tmp/hermes-codex-status.$$)"
+grep -q "Logged in using ChatGPT" /tmp/hermes-codex-status.$$ || fail "codex is not logged in using ChatGPT: $(cat /tmp/hermes-codex-status.$$)"
+rm -f /tmp/hermes-codex-status.$$
+pass "Codex CLI logged in via ChatGPT"
+
+grep -q "provider: openai-codex" "$HERMES_HOME/config.yaml" || fail "Hermes provider is not openai-codex"
+grep -q "default: gpt-5.5" "$HERMES_HOME/config.yaml" || fail "Hermes default model is not gpt-5.5"
+grep -q "openai_runtime: codex_app_server" "$HERMES_HOME/config.yaml" || fail "Hermes is not using codex_app_server runtime"
+pass "Hermes model config points at ChatGPT/Codex subscription runtime"
+
+grep -q "^API_SERVER_ENABLED=true" "$HERMES_HOME/.env" || fail "API_SERVER_ENABLED=true missing in $HERMES_HOME/.env"
+TOKEN="$(grep "^HERMES_API_TOKEN=" "$ROOT/.env" 2>/dev/null | cut -d= -f2- || true)"
+[ -n "$TOKEN" ] || fail "HERMES_API_TOKEN missing in $ROOT/.env"
+pass "Workspace API token is configured"
+
+curl -fsS http://127.0.0.1:8642/health >/tmp/hermes-health.$$ || fail "Hermes gateway health check failed on :8642"
+grep -q "hermes-agent" /tmp/hermes-health.$$ || fail "Unexpected gateway health payload: $(cat /tmp/hermes-health.$$)"
+rm -f /tmp/hermes-health.$$
+pass "Hermes gateway is healthy on :8642"
+
+completion="$(timeout 60s curl -fsS -X POST http://127.0.0.1:8642/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data '{"model":"hermes-agent","messages":[{"role":"user","content":"reply exactly HEALTH_OK"}],"stream":false}' || true)"
+echo "$completion" | grep -q "HEALTH_OK" || fail "Gateway completion test did not return HEALTH_OK: $completion"
+pass "Hermes gateway completion route returns text"
+
+stream="$(timeout 90s curl -fsS -N -X POST http://127.0.0.1:3000/api/send-stream \
+  -H "Content-Type: application/json" \
+  --data '{"message":"reply exactly WORKSPACE_OK","sessionKey":"health-check"}' || true)"
+echo "$stream" | grep -q "event: chunk" || fail "Workspace stream emitted no chunk: $stream"
+echo "$stream" | grep -q "WORKSPACE_OK" || fail "Workspace stream did not return WORKSPACE_OK: $stream"
+pass "Hermes Workspace chat route returns text"
+
+pass "Head Office is operational"

--- a/scripts/head-office-watchdog.sh
+++ b/scripts/head-office-watchdog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-/root/hermes-workspace}"
+HERMES_HOME="${HERMES_HOME:-/root/.hermes}"
+LOG_DIR="$HERMES_HOME/logs"
+LOCK_FILE="/tmp/hermes-head-office-watchdog.lock"
+HEALTH_SCRIPT="$ROOT/scripts/head-office-health.sh"
+mkdir -p "$LOG_DIR"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+run_health() {
+  cd "$ROOT"
+  "$HEALTH_SCRIPT"
+}
+
+ensure_tmux_session() {
+  local name="$1"
+  if ! tmux has-session -t "$name" 2>/dev/null; then
+    tmux new-session -d -s "$name"
+  fi
+}
+
+restart_workspace_ui() {
+  log "recovery: restarting Workspace UI tmux session ui"
+  ensure_tmux_session ui
+  tmux send-keys -t ui C-c
+  sleep 1
+  tmux send-keys -t ui 'cd /root/hermes-workspace && pnpm dev' Enter
+}
+
+restart_gateway() {
+  log "recovery: restarting Hermes gateway in tmux session gateway"
+  ensure_tmux_session gateway
+  tmux send-keys -t gateway C-c
+  sleep 2
+  tmux send-keys -t gateway 'hermes gateway run' Enter
+}
+
+with_lock() {
+  flock -n 9 || {
+    log "skip: watchdog already running"
+    exit 0
+  }
+
+  local health_out
+  health_out="$(mktemp)"
+  if run_health >"$health_out" 2>&1; then
+    log "healthy: Head Office operational"
+    rm -f "$health_out"
+    exit 0
+  fi
+
+  log "unhealthy: initial health check failed"
+  sed 's/^/[health] /' "$health_out"
+
+  local gateway_ok=0
+  if curl -fsS http://127.0.0.1:8642/health >/dev/null 2>&1; then
+    gateway_ok=1
+  fi
+
+  local workspace_ok=0
+  if curl -fsS http://127.0.0.1:3000/chat >/dev/null 2>&1; then
+    workspace_ok=1
+  fi
+
+  if [ "$gateway_ok" -ne 1 ]; then
+    restart_gateway
+    sleep 25
+  fi
+
+  if [ "$workspace_ok" -ne 1 ]; then
+    restart_workspace_ui
+    sleep 15
+  fi
+
+  # If both ports were up but the end-to-end health failed, prefer restarting
+  # Workspace first. Gateway/Telegram is the primary control channel, so touch
+  # it only when its own health endpoint or completion route fails.
+  if [ "$gateway_ok" -eq 1 ] && [ "$workspace_ok" -eq 1 ]; then
+    local token
+    token="$(grep '^HERMES_API_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2- || true)"
+    if [ -n "$token" ] && timeout 45s curl -fsS -X POST http://127.0.0.1:8642/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $token" \
+      --data '{"model":"hermes-agent","messages":[{"role":"user","content":"reply exactly WATCHDOG_OK"}],"stream":false}' | grep -q WATCHDOG_OK; then
+      restart_workspace_ui
+      sleep 15
+    else
+      restart_gateway
+      sleep 25
+    fi
+  fi
+
+  if run_health >"$health_out" 2>&1; then
+    log "recovered: Head Office operational"
+    rm -f "$health_out"
+    exit 0
+  fi
+
+  log "failed: recovery attempted but health still fails"
+  sed 's/^/[health] /' "$health_out"
+  rm -f "$health_out"
+  exit 1
+}
+
+with_lock 9>"$LOCK_FILE"

--- a/scripts/head-office-watchdog.sh
+++ b/scripts/head-office-watchdog.sh
@@ -6,15 +6,25 @@ HERMES_HOME="${HERMES_HOME:-/root/.hermes}"
 LOG_DIR="$HERMES_HOME/logs"
 LOCK_FILE="/tmp/hermes-head-office-watchdog.lock"
 HEALTH_SCRIPT="$ROOT/scripts/head-office-health.sh"
+MODE="${1:-light}"
 mkdir -p "$LOG_DIR"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }
 
-run_health() {
+run_deep_health() {
   cd "$ROOT"
   "$HEALTH_SCRIPT"
+}
+
+run_light_health() {
+  curl -fsS http://127.0.0.1:8642/health >/dev/null
+  curl -fsS http://127.0.0.1:3000/chat >/dev/null
+  command -v codex >/dev/null
+  local codex_status
+  codex_status="$(codex login status 2>&1)"
+  echo "$codex_status" | grep -q "Logged in using ChatGPT"
 }
 
 ensure_tmux_session() {
@@ -48,13 +58,23 @@ with_lock() {
 
   local health_out
   health_out="$(mktemp)"
-  if run_health >"$health_out" 2>&1; then
-    log "healthy: Head Office operational"
-    rm -f "$health_out"
-    exit 0
+
+  if [ "$MODE" = "deep" ]; then
+    if run_deep_health >"$health_out" 2>&1; then
+      log "healthy: deep Head Office health passed"
+      rm -f "$health_out"
+      exit 0
+    fi
+    log "unhealthy: deep health check failed"
+  else
+    if run_light_health >"$health_out" 2>&1; then
+      log "healthy: light checks passed"
+      rm -f "$health_out"
+      exit 0
+    fi
+    log "unhealthy: light checks failed; starting recovery"
   fi
 
-  log "unhealthy: initial health check failed"
   sed 's/^/[health] /' "$health_out"
 
   local gateway_ok=0
@@ -77,28 +97,24 @@ with_lock() {
     sleep 15
   fi
 
-  # If both ports were up but the end-to-end health failed, prefer restarting
-  # Workspace first. Gateway/Telegram is the primary control channel, so touch
-  # it only when its own health endpoint or completion route fails.
-  if [ "$gateway_ok" -eq 1 ] && [ "$workspace_ok" -eq 1 ]; then
-    local token
-    token="$(grep '^HERMES_API_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2- || true)"
-    if [ -n "$token" ] && timeout 45s curl -fsS -X POST http://127.0.0.1:8642/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer $token" \
-      --data '{"model":"hermes-agent","messages":[{"role":"user","content":"reply exactly WATCHDOG_OK"}],"stream":false}' | grep -q WATCHDOG_OK; then
-      restart_workspace_ui
-      sleep 15
-    else
-      restart_gateway
-      sleep 25
-    fi
-  fi
-
-  if run_health >"$health_out" 2>&1; then
-    log "recovered: Head Office operational"
+  # Only spend model usage after a failure/recovery attempt, to verify the
+  # full path is truly back. Normal 5-minute checks are cheap HTTP checks.
+  if run_deep_health >"$health_out" 2>&1; then
+    log "recovered: deep Head Office health passed"
     rm -f "$health_out"
     exit 0
+  fi
+
+  # If ports were up but deep health failed, restart Workspace first to preserve
+  # Telegram as the control channel, then verify once more.
+  if [ "$gateway_ok" -eq 1 ] && [ "$workspace_ok" -eq 1 ]; then
+    restart_workspace_ui
+    sleep 15
+    if run_deep_health >"$health_out" 2>&1; then
+      log "recovered: Workspace restart restored deep health"
+      rm -f "$health_out"
+      exit 0
+    fi
   fi
 
   log "failed: recovery attempted but health still fails"

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -384,6 +384,7 @@ export const Route = createFileRoute('/api/send-stream')({
         let persistedRunReady: Promise<unknown> | null = null
         let unregisterTimer: ReturnType<typeof setTimeout> | null = null
         let streamTimeoutTimer: ReturnType<typeof setTimeout> | null = null
+        let keepaliveTimer: ReturnType<typeof setInterval> | null = null
         let heartbeatTimer: ReturnType<typeof setInterval> | null = null
         const abortController = new AbortController()
         let closeStream = () => {
@@ -417,7 +418,6 @@ export const Route = createFileRoute('/api/send-stream')({
 
         const stream = new ReadableStream({
           async start(controller) {
-            let heartbeatTimer: ReturnType<typeof setInterval> | null = null
             let lastClientEventAt = Date.now()
             const enqueueRaw = (payload: string) => {
               if (streamClosed) return
@@ -436,7 +436,7 @@ export const Route = createFileRoute('/api/send-stream')({
             // lightweight recognized event periodically so public Workspace chats
             // do not sit at "Thinking…" until the frontend reports failure.
             enqueueRaw(`: ${' '.repeat(2048)}\n\n`)
-            heartbeatTimer = setInterval(() => {
+            keepaliveTimer = setInterval(() => {
               if (streamClosed) return
               if (Date.now() - lastClientEventAt < 10_000) return
               // Heartbeat to keep Cloudflare/Access from culling the SSE stream.
@@ -450,6 +450,10 @@ export const Route = createFileRoute('/api/send-stream')({
             closeStream = () => {
               if (streamClosed) return
               streamClosed = true
+              if (keepaliveTimer) {
+                clearInterval(keepaliveTimer)
+                keepaliveTimer = null
+              }
               if (heartbeatTimer) {
                 clearInterval(heartbeatTimer)
                 heartbeatTimer = null
@@ -461,10 +465,6 @@ export const Route = createFileRoute('/api/send-stream')({
               if (streamTimeoutTimer) {
                 clearTimeout(streamTimeoutTimer)
                 streamTimeoutTimer = null
-              }
-              if (heartbeatTimer) {
-                clearInterval(heartbeatTimer)
-                heartbeatTimer = null
               }
               if (activeRunId) {
                 unregisterActiveSendRun(activeRunId)
@@ -718,80 +718,31 @@ export const Route = createFileRoute('/api/send-stream')({
                     }
                   }
 
-                  const stream = await openaiChat(portableMessages, {
+                  const responseText = await openaiChat(portableMessages, {
                     model: localBaseUrl ? bareModel : (typeof body.model === 'string' ? body.model : undefined),
                     temperature:
                       typeof body.temperature === 'number'
                         ? body.temperature
                         : undefined,
                     signal: abortController.signal,
-                    stream: true,
+                    stream: false,
                     sessionId: portableSessionKey,
                     baseUrl: localBaseUrl,
                   })
 
-                  let thinking = ''
-                  let toolEventCount = 0
-                  for await (const chunk of stream) {
-                    if (chunk.type === 'reasoning') {
-                      thinking += chunk.text
-                      persistActiveRun((runSessionKey, activeId) =>
-                        setRunThinking(runSessionKey, activeId, thinking),
-                      )
-                      sendEvent('thinking', {
-                        text: thinking,
-                        sessionKey: portableSessionKey,
-                        runId,
-                      })
-                    } else if (chunk.type === 'tool') {
-                      // Prefer the gateway's stable tool_call_id so 'running'
-                      // and 'completed' events for the same call collapse to
-                      // one card row. Fall back to a synthetic id only when
-                      // the upstream payload lacks one (older Hermes builds).
-                      toolEventCount += 1
-                      const toolCallId =
-                        chunk.toolCallId ||
-                        `${runId}:${chunk.name}:${toolEventCount}`
-                      // Map upstream status -> internal phase. 'running'
-                      // arrives at tool start; 'completed' at finish.
-                      // Missing status (back-compat path) is treated as a
-                      // one-shot 'calling' to mirror the previous behavior.
-                      const phase =
-                        chunk.status === 'completed'
-                          ? 'complete'
-                          : chunk.status === 'running'
-                            ? 'calling'
-                            : 'start'
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: toolCallId,
-                          name: chunk.name || 'tool',
-                          phase,
-                          preview: chunk.label,
-                        }),
-                      )
-                      sendEvent('tool', {
-                        phase,
-                        name: chunk.name,
-                        toolCallId,
-                        preview: chunk.label,
-                        sessionKey: portableSessionKey,
-                        runId,
-                      })
-                    } else {
-                      accumulated += chunk.text
-                      persistActiveRun((runSessionKey, activeId) =>
-                        appendRunText(runSessionKey, activeId, accumulated, {
-                          replace: true,
-                        }),
-                      )
-                      sendEvent('chunk', {
-                        text: accumulated,
-                        fullReplace: true,
-                        sessionKey: portableSessionKey,
-                        runId,
-                      })
-                    }
+                  accumulated = responseText
+                  if (accumulated) {
+                    persistActiveRun((runSessionKey, activeId) =>
+                      appendRunText(runSessionKey, activeId, accumulated, {
+                        replace: true,
+                      }),
+                    )
+                    sendEvent('chunk', {
+                      text: accumulated,
+                      fullReplace: true,
+                      sessionKey: portableSessionKey,
+                      runId,
+                    })
                   }
 
                   // Persist assistant response to local session store


### PR DESCRIPTION
## Summary
- Fix Workspace zero-fork chat by using the working Hermes gateway non-streaming completion path and emitting the response as a Workspace SSE chunk.
- Split keepalive and heartbeat SSE timers so one interval does not overwrite the other.
- Add a Head Office health check script and recovery notes for the current ChatGPT/Codex subscription runtime setup.

## Verification
- scripts/head-office-health.sh
- Manual Workspace browser test replied from /root/hermes-workspace.