### PR TITLE
fix(swarm-dispatch): correct CLI flag order and add missing prompt arg

### DIFF
--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -888,8 +888,8 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
     const useWrapper = existsSync(wrapperPath)
     const cmd = useWrapper ? wrapperPath : resolveHermesBin()
     const args = useWrapper
-      ? ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch', prompt]
-      : ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+      ? ['chat', '-Q', '-q', prompt, '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+      : ['chat', '-Q', '-q', prompt, '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       HERMES_HOME: profilePath,


### PR DESCRIPTION
## Bug Fix

Two bugs in the `runWorker()` function in `swarm-dispatch.ts` prevented swarm workers from receiving their assignments correctly:

### Bug 1: Flag order — `-q` before `-Q`
The CLI expects `-Q` (quiet mode) before `-q` (no-banner). The wrapper path had them reversed, causing the flags to be ignored or misinterpreted.

### Bug 2: Missing `prompt` argument on non-wrapper path
The non-wrapper branch (fallback when no worker wrapper script exists) was missing the `prompt` argument entirely. This meant the worker would start without any task description — effectively a no-op.

### Changes
```diff
- ? ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch', prompt]
- : ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+ ? ['chat', '-Q', '-q', prompt, '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+ : ['chat', '-Q', '-q', prompt, '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
```

### Testing
- Patched locally and confirmed workers receive assignments and execute tasks correctly via the conductor/dispatch path.