### PR TITLE
chore: add CODEOWNERS for auth, security, CI/CD, Docker paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,60 @@
+# CODEOWNERS — Hermes Workspace
+#
+# This file defines code ownership for automated review routing.
+# Owners are automatically requested for review when a PR touches their paths.
+#
+# Last matching pattern wins.  Use GitHub usernames or @org/team names.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# ── Auth & authentication middleware ──────────────────────────────────────
+/src/server/auth-middleware.ts       @outsourc-e
+/src/server/auth-middleware.test.ts  @outsourc-e
+
+# ── Security: rate limiter, security policy, security CI ─────────────────
+/src/server/rate-limit.ts            @outsourc-e
+/src/server/rate-limit.test.ts       @outsourc-e
+/SECURITY.md                         @outsourc-e
+/.github/workflows/security.yml      @outsourc-e
+
+# ── CI/CD workflows (all) ────────────────────────────────────────────────
+/.github/workflows/                  @outsourc-e
+
+# ── Docker & container configs ───────────────────────────────────────────
+/Dockerfile                          @outsourc-e
+/docker-compose.yml                  @outsourc-e
+/docker-compose.dev.yml              @outsourc-e
+/docker/                             @outsourc-e
+/.dockerignore                       @outsourc-e
+/.devcontainer/                      @outsourc-e
+
+# ── Server-side infrastructure (all) ─────────────────────────────────────
+/src/server/                         @outsourc-e
+
+# ── Nix packaging & flake ────────────────────────────────────────────────
+/flake.nix                           @outsourc-e
+/flake.lock                          @outsourc-e
+/nix/                                @outsourc-e
+
+# ── Root config & infrastructure ─────────────────────────────────────────
+/package.json                        @outsourc-e
+/pnpm-lock.yaml                      @outsourc-e
+/pnpm-workspace.yaml                 @outsourc-e
+/tsconfig.json                       @outsourc-e
+/vite.config.ts                      @outsourc-e
+/wrangler.jsonc                      @outsourc-e
+/eslint.config.js                    @outsourc-e
+/prettier.config.js                  @outsourc-e
+/electron-builder.config.cjs         @outsourc-e
+
+# ── Electron (desktop app) ───────────────────────────────────────────────
+/electron/                           @outsourc-e
+
+# ── Server entry point ───────────────────────────────────────────────────
+/server-entry.js                     @outsourc-e
+
+# ── Install & bootstrap ──────────────────────────────────────────────────
+/install.sh                          @outsourc-e
+/.env.example                        @outsourc-e
+
+# ── GitHub Actions directory (non-workflow files) ────────────────────────
+/.github/                            @outsourc-e

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,10 @@
 # ── Auth & authentication middleware ──────────────────────────────────────
 /src/server/auth-middleware.ts       @outsourc-e
 /src/server/auth-middleware.test.ts  @outsourc-e
+/src/routes/api/auth.ts              @outsourc-e
+/src/routes/api/auth-check.ts        @outsourc-e
+/src/routes/api/oauth.device-code.ts @outsourc-e
+/src/routes/api/oauth.poll-token.ts  @outsourc-e
 
 # ── Security: rate limiter, security policy, security CI ─────────────────
 /src/server/rate-limit.ts            @outsourc-e


### PR DESCRIPTION
## Summary

Add `.github/CODEOWNERS` to hermes-workspace to enable automatic review routing.

## Coverage

- **Auth middleware & routes** — `auth-middleware.ts`, `auth.ts`, `auth-check.ts`, OAuth device-code and poll-token endpoints
- **Security config** — rate limiter, SECURITY.md, security CI workflow
- **CI/CD workflows** — all `.github/workflows/` files
- **Docker configs** — Dockerfile, docker-compose files, docker/ directory, .dockerignore, .devcontainer
- **Server infrastructure** — all `/src/server/` code
- **Nix packaging** — flake.nix, flake.lock, nix/ directory
- **Root config** — package.json, pnpm configs, tsconfig, vite, wrangler, eslint, prettier, electron-builder
- **Electron** — electron/ directory
- **Install/bootstrap** — install.sh, .env.example

Ownership assigned to @outsourc-e (primary maintainer).

Fixes compliance finding from security audit: no CODEOWNERS file in hermes-workspace.