### PR TITLE
[codex] Stabilize workspace sessions, dashboard, and update status

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@types/three": "0.177.0",
     "@vitejs/plugin-react": "^5.0.4",
     "concurrently": "^8.2.2",
     "electron": "^40.8.2",
@@ -101,5 +102,8 @@
     "vite": "^7.3.2",
     "vitest": "^3.0.5",
     "web-vitals": "^5.1.0"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "4.60.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,13 +28,13 @@ importers:
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-three/drei':
         specifier: ^10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
+        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.177.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
       '@react-three/postprocessing':
         specifier: ^3.0.4
-        version: 3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/three@0.184.0)(react@19.2.4)(three@0.184.0)
+        version: 3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/three@0.177.0)(react@19.2.4)(three@0.184.0)
       '@react-three/rapier':
         specifier: ^2.2.0
         version: 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0)
@@ -70,7 +70,7 @@ importers:
         version: 2.1.1
       ecctrl:
         specifier: ^1.0.97
-        version: 1.0.97(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 1.0.97(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.177.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)(use-sync-external-store@1.6.0(react@19.2.4))
       electron-updater:
         specifier: ^6.6.2
         version: 6.8.3
@@ -186,6 +186,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: 0.177.0
+        version: 0.177.0
       '@vitejs/plugin-react':
         specifier: ^5.0.4
         version: 5.2.0(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -225,6 +228,10 @@ importers:
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
+    optionalDependencies:
+      '@rollup/rollup-darwin-arm64':
+        specifier: 4.60.2
+        version: 4.60.2
 
 packages:
 
@@ -545,14 +552,14 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emoji-mart/data@1.2.1':
     resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
@@ -1683,66 +1690,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1864,24 +1884,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2092,8 +2116,8 @@ packages:
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2303,9 +2327,6 @@ packages:
   '@types/three@0.177.0':
     resolution: {integrity: sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==}
 
-  '@types/three@0.184.0':
-    resolution: {integrity: sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==}
-
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -2429,41 +2450,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2537,10 +2566,6 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
-
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -3568,9 +3593,6 @@ packages:
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -3643,10 +3665,6 @@ packages:
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
-
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -4111,9 +4129,6 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
-  jsonfile@6.2.1:
-    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
-
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -4197,24 +4212,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -4436,9 +4455,6 @@ packages:
 
   meshoptimizer@0.18.1:
     resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
-
-  meshoptimizer@1.1.1:
-    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4846,10 +4862,6 @@ packages:
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
-    engines: {node: '>=10.4.0'}
-
-  plist@3.1.1:
-    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
 
   points-on-curve@0.2.0:
@@ -6654,25 +6666,25 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.5
+      fs-extra: 11.3.4
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.0':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7158,9 +7170,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@oozcitak/dom@2.0.2':
@@ -7807,7 +7819,7 @@ snapshots:
 
   '@react-spring/types@10.0.3': {}
 
-  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)':
+  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.177.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mediapipe/tasks-vision': 0.10.17
@@ -7819,10 +7831,10 @@ snapshots:
       detect-gpu: 5.0.70
       glsl-noise: 0.0.0
       hls.js: 1.6.16
-      maath: 0.10.8(@types/three@0.184.0)(three@0.184.0)
+      maath: 0.10.8(@types/three@0.177.0)(three@0.184.0)
       meshline: 3.3.1(three@0.184.0)
       react: 19.2.4
-      stats-gl: 2.4.2(@types/three@0.184.0)(three@0.184.0)
+      stats-gl: 2.4.2(@types/three@0.177.0)(three@0.184.0)
       stats.js: 0.17.0
       suspend-react: 0.1.3(react@19.2.4)
       three: 0.184.0
@@ -7860,10 +7872,10 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@react-three/postprocessing@3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/three@0.184.0)(react@19.2.4)(three@0.184.0)':
+  '@react-three/postprocessing@3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/three@0.177.0)(react@19.2.4)(three@0.184.0)':
     dependencies:
       '@react-three/fiber': 9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
-      maath: 0.6.0(@types/three@0.184.0)(three@0.184.0)
+      maath: 0.6.0(@types/three@0.177.0)(three@0.184.0)
       n8ao: 1.10.1(postprocessing@6.39.1(three@0.184.0))(three@0.184.0)
       postprocessing: 6.39.1(three@0.184.0)
       react: 19.2.4
@@ -8371,7 +8383,7 @@ snapshots:
 
   '@tweenjs/tween.js@23.1.3': {}
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8623,17 +8635,8 @@ snapshots:
       '@types/stats.js': 0.17.4
       '@types/webxr': 0.5.24
       '@webgpu/types': 0.1.69
-      fflate: 0.8.2
-      meshoptimizer: 0.18.1
-
-  '@types/three@0.184.0':
-    dependencies:
-      '@dimforge/rapier3d-compat': 0.12.0
-      '@tweenjs/tween.js': 23.1.3
-      '@types/stats.js': 0.17.4
-      '@types/webxr': 0.5.24
       fflate: 0.8.3
-      meshoptimizer: 1.1.1
+      meshoptimizer: 0.18.1
 
   '@types/trusted-types@2.0.7': {}
 
@@ -8874,9 +8877,6 @@ snapshots:
   '@webgpu/types@0.1.69': {}
 
   '@xmldom/xmldom@0.8.13': {}
-
-  '@xmldom/xmldom@0.9.10':
-    optional: true
 
   abbrev@4.0.0: {}
 
@@ -9712,7 +9712,7 @@ snapshots:
       ajv: 6.14.0
       crc: 3.8.0
       iconv-corefoundation: 1.1.7
-      plist: 3.1.1
+      plist: 3.1.0
       smart-buffer: 4.2.0
       verror: 1.10.1
     optional: true
@@ -9759,10 +9759,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  ecctrl@1.0.97(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)(use-sync-external-store@1.6.0(react@19.2.4)):
+  ecctrl@1.0.97(@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.177.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@react-three/rapier@2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)(use-sync-external-store@1.6.0(react@19.2.4)):
     dependencies:
       '@react-spring/three': 10.0.3(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0)
-      '@react-three/drei': 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
+      '@react-three/drei': 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.177.0)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
       '@react-three/fiber': 9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
       '@react-three/rapier': 2.2.0(@react-three/fiber@9.6.1(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0))(react@19.2.4)(three@0.184.0)
       '@types/three': 0.177.0
@@ -10174,8 +10174,6 @@ snapshots:
 
   fflate@0.6.10: {}
 
-  fflate@0.8.2: {}
-
   fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
@@ -10247,13 +10245,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
-
-  fs-extra@11.3.5:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -10803,13 +10794,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonfile@6.2.1:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    optional: true
-
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
@@ -10983,14 +10967,14 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  maath@0.10.8(@types/three@0.184.0)(three@0.184.0):
+  maath@0.10.8(@types/three@0.177.0)(three@0.184.0):
     dependencies:
-      '@types/three': 0.184.0
+      '@types/three': 0.177.0
       three: 0.184.0
 
-  maath@0.6.0(@types/three@0.184.0)(three@0.184.0):
+  maath@0.6.0(@types/three@0.177.0)(three@0.184.0):
     dependencies:
-      '@types/three': 0.184.0
+      '@types/three': 0.177.0
       three: 0.184.0
 
   magic-string@0.30.21:
@@ -11240,8 +11224,6 @@ snapshots:
       three: 0.184.0
 
   meshoptimizer@0.18.1: {}
-
-  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -11787,13 +11769,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  plist@3.1.1:
-    dependencies:
-      '@xmldom/xmldom': 0.9.10
-      base64-js: 1.5.1
-      xmlbuilder: 15.1.1
-    optional: true
 
   points-on-curve@0.2.0: {}
 
@@ -12587,9 +12562,9 @@ snapshots:
 
   state-local@1.0.7: {}
 
-  stats-gl@2.4.2(@types/three@0.184.0)(three@0.184.0):
+  stats-gl@2.4.2(@types/three@0.177.0)(three@0.184.0):
     dependencies:
-      '@types/three': 0.184.0
+      '@types/three': 0.177.0
       three: 0.184.0
 
   stats.js@0.17.0: {}

--- a/src/components/prompt-kit/text-shimmer.tsx
+++ b/src/components/prompt-kit/text-shimmer.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { createElement } from 'react'
 import { cn } from '@/lib/utils'
 
 export type TextShimmerProps = {
@@ -20,20 +21,21 @@ export function TextShimmer({
   const dynamicSpread = Math.min(Math.max(spread, 5), 45)
   const Component = as as React.ElementType
 
-  return (
-    <Component
-      className={cn(
+  return createElement(
+    Component,
+    {
+      ...props,
+      className: cn(
         'bg-size-[200%_auto] bg-clip-text font-medium text-transparent',
         'animate-[shimmer_4s_infinite_linear]',
         className,
-      )}
-      style={{
+      ),
+      style: {
+        ...(props.style ?? {}),
         backgroundImage: `linear-gradient(to right, var(--color-primary-600) ${50 - dynamicSpread}%, var(--color-primary-950) 50%, var(--color-primary-600) ${50 + dynamicSpread}%)`,
         animationDuration: `${duration}s`,
-      }}
-      {...props}
-    >
-      {children}
-    </Component>
+      },
+    },
+    children,
   )
 }

--- a/src/components/settings/settings-sidebar.tsx
+++ b/src/components/settings/settings-sidebar.tsx
@@ -5,6 +5,7 @@ export type SettingsNavId =
   | 'connection'
   | 'claude'
   | 'agent'
+  | 'routing'
   | 'voice'
   | 'display'
   | 'appearance'
@@ -18,6 +19,7 @@ export const SETTINGS_NAV_ITEMS: Array<NavItem> = [
   { id: 'connection', label: 'Connection' },
   { id: 'claude', label: 'Model & Provider' },
   { id: 'agent', label: 'Agent Behavior' },
+  { id: 'routing', label: 'Smart Routing' },
   { id: 'voice', label: 'Voice' },
   { id: 'display', label: 'Display' },
   { id: 'appearance', label: 'Appearance' },
@@ -100,8 +102,7 @@ export function SettingsSidebar({ activeId }: { activeId: SettingsNavId }) {
 export function SettingsMobilePills({ activeId }: { activeId: SettingsNavId }) {
   const activeClass =
     'bg-[var(--theme-accent)] text-[var(--theme-bg)] font-semibold'
-  const inactiveClass =
-    'bg-primary-100 text-primary-600 hover:bg-primary-200'
+  const inactiveClass = 'bg-primary-100 text-primary-600 hover:bg-primary-200'
   return (
     <div className="scrollbar-none flex gap-1.5 overflow-x-auto pb-2 md:hidden">
       {SETTINGS_NAV_ITEMS.map((item) => {

--- a/src/components/slash-command-menu.tsx
+++ b/src/components/slash-command-menu.tsx
@@ -36,7 +36,10 @@ export const DEFAULT_SLASH_COMMANDS: Array<SlashCommandDefinition> = [
   { command: '/model', description: 'Show or change the current model' },
   { command: '/save', description: 'Save the current conversation' },
   { command: '/skills', description: 'Browse and manage skills' },
-  { command: '/plugins', description: 'List installed plugins and their status' },
+  {
+    command: '/plugins',
+    description: 'List installed plugins and their status',
+  },
   { command: '/mcp', description: 'Manage MCP servers' },
   { command: '/skin', description: 'Change the display theme' },
   { command: '/help', description: 'Show available commands' },
@@ -63,7 +66,12 @@ export function mergeSlashCommands(
 }
 
 const SlashCommandMenu = forwardRef(function SlashCommandMenu(
-  { open, query, onSelect, commands = DEFAULT_SLASH_COMMANDS }: SlashCommandMenuProps,
+  {
+    open,
+    query,
+    onSelect,
+    commands = DEFAULT_SLASH_COMMANDS,
+  }: SlashCommandMenuProps,
   ref: Ref<SlashCommandMenuHandle>,
 ) {
   const [activeIndex, setActiveIndex] = useState(0)
@@ -170,8 +178,4 @@ const SlashCommandMenu = forwardRef(function SlashCommandMenu(
   )
 })
 
-export {
-  SlashCommandMenu,
-  type SlashCommandDefinition,
-  type SlashCommandMenuHandle,
-}
+export { SlashCommandMenu }

--- a/src/components/terminal/terminal-workspace.tsx
+++ b/src/components/terminal/terminal-workspace.tsx
@@ -461,7 +461,7 @@ export function TerminalWorkspace({
       }
 
       // Flush any remaining buffered writes
-      clearTimeout(flushTimer as ReturnType<typeof setTimeout>)
+      if (flushTimer) clearTimeout(flushTimer)
       flushWrites()
 
       const latestTab = useTerminalPanelStore

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -65,6 +65,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const search = useRouterState({
     select: (state) => state.location.search,
   })
+  const surfaceSearch = search as { embed?: string; mode?: string }
   const isElectron = useMemo(
     () =>
       typeof navigator !== 'undefined' && /Electron/.test(navigator.userAgent),
@@ -187,10 +188,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const activeFriendlyId = chatMatch ? chatMatch[1] : 'main'
   const isOnChatRoute = Boolean(chatMatch) || pathname === '/new'
   const isOnTerminalRoute = pathname.startsWith('/terminal')
-  const isOnPlaygroundRoute = pathname === '/playground' || pathname.startsWith('/playground/')
-  const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
+  const isOnPlaygroundRoute =
+    pathname === '/playground' || pathname.startsWith('/playground/')
+  const isOnHermesWorldLandingRoute =
+    pathname === '/hermes-world' ||
+    pathname.startsWith('/hermes-world/') ||
+    pathname === '/world' ||
+    pathname.startsWith('/world/')
   const isEmbeddedSurface =
-    search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
+    surfaceSearch.embed === '1' ||
+    surfaceSearch.embed === 'true' ||
+    surfaceSearch.mode === 'embed'
   const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
@@ -342,7 +350,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
         <div
           className={cn(
             'grid h-full grid-cols-1 grid-rows-[minmax(0,1fr)] overflow-hidden',
-            hideChatSidebar || isChromeFreeSurface ? 'md:grid-cols-1' : 'md:grid-cols-[auto_1fr]',
+            hideChatSidebar || isChromeFreeSurface
+              ? 'md:grid-cols-1'
+              : 'md:grid-cols-[auto_1fr]',
           )}
         >
           {/* Activity ticker bar */}
@@ -433,11 +443,17 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
           </main>
 
           {/* Chat panel — visible on non-chat routes (but not in HermesWorld, which has its own in-game chat) */}
-          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && <ChatPanel />}
+          {!isOnChatRoute &&
+            !isOnPlaygroundRoute &&
+            !isChromeFreeSurface &&
+            !isMobile && <ChatPanel />}
         </div>
 
         {/* Floating chat toggle — visible on non-chat routes (but not in HermesWorld) */}
-        {!isChromeFreeSurface && !isOnChatRoute && !isOnPlaygroundRoute && !isMobile && <ChatPanelToggle />}
+        {!isChromeFreeSurface &&
+          !isOnChatRoute &&
+          !isOnPlaygroundRoute &&
+          !isMobile && <ChatPanelToggle />}
 
         {showDesktopSidebarBackdrop ? (
           <button
@@ -455,10 +471,15 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
       {!isChromeFreeSurface ? <MobileHamburgerMenu /> : null}
       {!isChromeFreeSurface ? <MobileTabBar /> : null}
-      {!isChromeFreeSurface && !isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
+      {!isChromeFreeSurface &&
+      !isMobile &&
+      !isOnChatRoute &&
+      settings.showSystemMetricsFooter ? (
         <SystemMetricsFooter leftOffsetPx={sidebarCollapsed ? 48 : 300} />
       ) : null}
-      {!isChromeFreeSurface ? <CommandPalette pathname={pathname} sessions={sessions} /> : null}
+      {!isChromeFreeSurface ? (
+        <CommandPalette pathname={pathname} sessions={sessions} />
+      ) : null}
     </>
   )
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -221,7 +221,10 @@ export function wrapInlineScript(source: string): string {
 }
 
 type ServiceWorkerLike = {
-  register: (scriptURL: string, options?: RegistrationOptions) => Promise<unknown>
+  register: (
+    scriptURL: string,
+    options?: RegistrationOptions,
+  ) => Promise<unknown>
 }
 
 type CachesLike = {
@@ -252,13 +255,18 @@ export async function registerAppServiceWorker({
 
 function RootLayout() {
   const { settings } = useSettings()
-  const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
   const isHermesWorldLandingRoute =
     pathname === '/hermes-world' ||
     pathname.startsWith('/hermes-world/') ||
     pathname === '/world' ||
     pathname.startsWith('/world/')
-  const isGameSurfaceRoute = isHermesWorldLandingRoute || pathname === '/playground' || pathname.startsWith('/playground/')
+  const isGameSurfaceRoute =
+    isHermesWorldLandingRoute ||
+    pathname === '/playground' ||
+    pathname.startsWith('/playground/')
   const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(
     null,
   )
@@ -371,10 +379,13 @@ function RootLayout() {
           </WorkspaceShell>
           {!isHermesWorldLandingRoute ? <SearchModal /> : null}
           {/* Keep UsageMeter mounted so search-modal OPEN_USAGE still works even when the pill is hidden by default. */}
-          {!isGameSurfaceRoute ? <UsageMeter visible={settings.showUsageMeter} /> : null}
+          {!isGameSurfaceRoute ? (
+            <UsageMeter visible={settings.showUsageMeter} />
+          ) : null}
           {!isHermesWorldLandingRoute ? <KeyboardShortcutsModal /> : null}
           {!isHermesWorldLandingRoute ? <UpdateCenterNotifier /> : null}
-          {rootSurfaceState.showPostOnboardingOverlays && !isGameSurfaceRoute ? (
+          {rootSurfaceState.showPostOnboardingOverlays &&
+          !isGameSurfaceRoute ? (
             <>
               <MobilePromptTrigger />
               <OnboardingTour />
@@ -416,94 +427,22 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         />
       </head>
       <body>
-        <div id="splash-screen" aria-hidden="true" style={{ display: 'none' }} />
+        <div
+          id="splash-screen"
+          aria-hidden="true"
+          suppressHydrationWarning
+          style={{ display: 'none' }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: wrapInlineScript(`
           (function(){
-            if (location.pathname === '/hermes-world' || location.pathname.indexOf('/hermes-world/') === 0 || location.pathname === '/world' || location.pathname.indexOf('/world/') === 0) return;
-            var d = document.getElementById('splash-screen');
-            if (!d) return;
-            var bg = '#031A1A', txt = '#F8F1E3', muted = '#9CB2AE', accent = '#FFAC02';
-            try {
-              var theme = localStorage.getItem('${THEME_STORAGE_KEY}') || '${DEFAULT_THEME}';
-              if (theme === 'claude-nous') {
-                bg = '#031A1A';
-                txt = '#F8F1E3';
-                muted = '#9CB2AE';
-                accent = '#FFAC02';
-              } else if (theme === 'claude-nous-light') {
-                bg = '#F8FAF8';
-                txt = '#16315F';
-                muted = '#6F7D96';
-                accent = '#2557B7';
-              } else if (theme === 'claude-classic') {
-                bg = '#0d0f12';
-                txt = '#eceff4';
-                muted = '#7f8a96';
-                accent = '#b98a44';
-              } else if (theme === 'claude-official-light') {
-                bg = '#F7F7F1';
-                txt = '#16315F';
-                muted = '#6F7D96';
-                accent = '#2557B7';
-              } else if (theme === 'claude-classic-light') {
-                bg = '#F5F2ED';
-                txt = '#1a1f26';
-                muted = '#6F675E';
-                accent = '#b98a44';
-              } else if (theme === 'claude-slate') {
-                bg = '#0d1117';
-                txt = '#c9d1d9';
-                muted = '#8b949e';
-                accent = '#7eb8f6';
-              } else if (theme === 'claude-slate-light') {
-                bg = '#F6F8FA';
-                txt = '#24292f';
-                muted = '#57606A';
-                accent = '#3b82f6';
-              }
-            } catch(e){}
-
-            var isDark = !['claude-nous-light','claude-official-light','claude-classic-light','claude-slate-light'].includes(theme);
-            var quips = ["Consulting the oracle...","Loading ancient knowledge...","Warming up the messenger...","Calibrating tool chain...","Summoning your agent...","Preparing the workspace...","Bridging realms...","Initializing agent runtime..."];
-            var quip = quips[Math.floor(Math.random() * quips.length)];
-
-            d.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;align-items:center;justify-content:center;background:'+bg+';transition:opacity 0.5s ease;';
-            d.innerHTML = '<img src="/claude-avatar.webp" alt="Hermes Agent" style="width:80px;height:80px;margin-bottom:20px;border-radius:16px;filter:drop-shadow(0 8px 32px color-mix(in srgb,'+accent+' 45%, transparent))" />'
-              + '<img src="'+(isDark ? '/claude-banner.png' : '/claude-banner-light.png')+'" alt="Hermes Workspace" style="width:280px;height:auto;margin-bottom:8px;filter:drop-shadow(0 4px 16px '+(isDark ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.1)')+')" />'
-              + '<div style="font:400 14px/1 system-ui,-apple-system,sans-serif;letter-spacing:0.04em;color:'+muted+'">Workspace</div>'
-              + '<div style="margin-top:28px;width:140px;height:3px;background:'+(isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)')+';border-radius:3px;overflow:hidden;position:relative"><div id=splash-bar style="width:0%;height:100%;background:'+accent+';border-radius:3px;transition:width 0.4s ease"></div></div>';
-
-            var bar = document.getElementById('splash-bar');
-            if (bar) {
-              setTimeout(function(){ bar.style.width='15%' }, 300);
-              setTimeout(function(){ bar.style.width='40%' }, 800);
-              setTimeout(function(){ bar.style.width='65%' }, 1500);
-              setTimeout(function(){ bar.style.width='85%' }, 2500);
-              setTimeout(function(){ bar.style.width='92%' }, 3200);
-            }
-
             window.__dismissSplash = function() {
               var el = document.getElementById('splash-screen');
               if (!el) return;
-              if (bar) bar.style.width = '100%';
-              setTimeout(function(){
-                el.style.opacity = '0';
-                setTimeout(function(){
-                  el.innerHTML = '';
-                  el.style.cssText = 'display:none';
-                }, 500);
-              }, 300);
+              el.innerHTML = '';
+              el.style.cssText = 'display:none';
             };
-            // Fallback: always dismiss after 5s
-            setTimeout(function(){ window.__dismissSplash && window.__dismissSplash(); }, 5000);
-            // Fast dismiss: returning users skip quickly
-            try {
-              if (localStorage.getItem('claude-claude-url') || localStorage.getItem('claude-url')) {
-                setTimeout(function(){ window.__dismissSplash && window.__dismissSplash(); }, 600);
-              }
-            } catch(e) {}
           })()
         `),
           }}

--- a/src/routes/api/dashboard/overview.ts
+++ b/src/routes/api/dashboard/overview.ts
@@ -26,11 +26,13 @@ import {
   type DashboardFetcher,
 } from '../../../server/dashboard-aggregator'
 
-const overviewFetcher: DashboardFetcher = (path) => dashboardFetch(path)
+const overviewFetcher: DashboardFetcher = (path, init) =>
+  dashboardFetch(path, init)
 // Gateway fetcher hits the gateway URL (8645/8642), which is where
 // `/health/detailed` lives. The Hermes Agent confirmed `active_agents`
 // from this endpoint is the canonical “currently running” count.
-const overviewGatewayFetcher: DashboardFetcher = (path) => gatewayFetch(path)
+const overviewGatewayFetcher: DashboardFetcher = (path, init) =>
+  gatewayFetch(path, init)
 
 export const Route = createFileRoute('/api/dashboard/overview')({
   server: {
@@ -44,6 +46,7 @@ export const Route = createFileRoute('/api/dashboard/overview')({
           const days = Number(url.searchParams.get('days') ?? '30')
           const limit = Number(url.searchParams.get('achievements') ?? '3')
           const logsLimit = Number(url.searchParams.get('logs') ?? '24')
+          const includeAnalytics = url.searchParams.get('analytics') === 'true'
           const overview = await buildDashboardOverview({
             fetcher: overviewFetcher,
             gatewayFetcher: overviewGatewayFetcher,
@@ -54,6 +57,7 @@ export const Route = createFileRoute('/api/dashboard/overview')({
               Number.isFinite(logsLimit) && logsLimit > 0
                 ? Math.min(logsLimit, 100)
                 : 24,
+            includeAnalytics,
           })
           return json(overview, {
             headers: {
@@ -61,8 +65,7 @@ export const Route = createFileRoute('/api/dashboard/overview')({
               // upstream), but cache for a few seconds so a noisy client
               // doesn't hammer the dashboard. Stale-while-revalidate keeps
               // the UI snappy while fresh data lands.
-              'Cache-Control':
-                'private, max-age=5, stale-while-revalidate=20',
+              'Cache-Control': 'private, max-age=5, stale-while-revalidate=20',
             },
           })
         } catch (err) {

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -16,7 +16,10 @@ import {
   ensureProviderInConfig,
 } from '../../server/local-provider-discovery'
 
-const CLAUDE_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
+const CLAUDE_HOME =
+  process.env.HERMES_HOME ??
+  process.env.CLAUDE_HOME ??
+  path.join(os.homedir(), '.hermes')
 const MODELS_PATH = path.join(CLAUDE_HOME, 'models.json')
 const CONFIG_PATH = path.join(CLAUDE_HOME, 'config.yaml')
 
@@ -66,16 +69,19 @@ function normalizeModel(entry: unknown): ModelEntry | null {
   }
 }
 
-export function mergeModelEntries(...sources: Array<Array<ModelEntry>>): Array<ModelEntry> {
+export function mergeModelEntries(
+  ...sources: Array<Array<ModelEntry>>
+): Array<ModelEntry> {
   const merged: Array<ModelEntry> = []
   const seen = new Set<string>()
 
   for (const source of sources) {
     for (const model of source) {
       const normalized = normalizeModel(model)
-      if (!normalized || seen.has(normalized.id)) continue
+      const id = normalized?.id
+      if (!normalized || !id || seen.has(id)) continue
       merged.push(normalized)
-      seen.add(normalized.id)
+      seen.add(id)
     }
   }
 
@@ -112,19 +118,33 @@ function readClaudeModelsJson(): Array<ModelEntry> {
 const DEFAULT_ACCEPTED_TIMEOUT_S = 120
 const DEFAULT_HANDOFF_TIMEOUT_S = 300
 
-function readStreamTimeouts(): { streamAcceptedTimeoutMs: number; streamHandoffTimeoutMs: number } {
+function readStreamTimeouts(): {
+  streamAcceptedTimeoutMs: number
+  streamHandoffTimeoutMs: number
+} {
   let acceptedS = DEFAULT_ACCEPTED_TIMEOUT_S
   let handoffS = DEFAULT_HANDOFF_TIMEOUT_S
   try {
     if (fs.existsSync(CONFIG_PATH)) {
       const parsed = YAML.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'))
       const ws =
-        parsed && typeof parsed === 'object' && typeof (parsed as Record<string, unknown>).workspace === 'object'
-          ? ((parsed as Record<string, unknown>).workspace as Record<string, unknown>)
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof (parsed as Record<string, unknown>).workspace === 'object'
+          ? ((parsed as Record<string, unknown>).workspace as Record<
+              string,
+              unknown
+            >)
           : {}
-      if (typeof ws.stream_accepted_timeout === 'number' && ws.stream_accepted_timeout > 0)
+      if (
+        typeof ws.stream_accepted_timeout === 'number' &&
+        ws.stream_accepted_timeout > 0
+      )
         acceptedS = ws.stream_accepted_timeout
-      if (typeof ws.stream_handoff_timeout === 'number' && ws.stream_handoff_timeout > 0)
+      if (
+        typeof ws.stream_handoff_timeout === 'number' &&
+        ws.stream_handoff_timeout > 0
+      )
         handoffS = ws.stream_handoff_timeout
     }
   } catch {
@@ -133,8 +153,14 @@ function readStreamTimeouts(): { streamAcceptedTimeoutMs: number; streamHandoffT
   const envAccepted = parseInt(process.env.STREAM_ACCEPTED_TIMEOUT_MS ?? '', 10)
   const envHandoff = parseInt(process.env.STREAM_HANDOFF_TIMEOUT_MS ?? '', 10)
   return {
-    streamAcceptedTimeoutMs: Number.isFinite(envAccepted) && envAccepted > 0 ? envAccepted : acceptedS * 1000,
-    streamHandoffTimeoutMs: Number.isFinite(envHandoff) && envHandoff > 0 ? envHandoff : handoffS * 1000,
+    streamAcceptedTimeoutMs:
+      Number.isFinite(envAccepted) && envAccepted > 0
+        ? envAccepted
+        : acceptedS * 1000,
+    streamHandoffTimeoutMs:
+      Number.isFinite(envHandoff) && envHandoff > 0
+        ? envHandoff
+        : handoffS * 1000,
   }
 }
 
@@ -217,7 +243,10 @@ export const Route = createFileRoute('/api/models')({
           if (getGatewayCapabilities().models) {
             const hermesModels = await fetchClaudeModels()
             models = mergeModelEntries(models, hermesModels)
-            source = source === 'models.json' ? 'models.json+hermes-agent' : 'hermes-agent'
+            source =
+              source === 'models.json'
+                ? 'models.json+hermes-agent'
+                : 'hermes-agent'
           }
 
           // Merge auto-discovered local models (Ollama, Atomic Chat, etc.)

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -20,6 +20,28 @@ import {
   listLocalSessions,
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
+import { shouldShowInChatSessionList } from '../../server/session-utils'
+
+const SESSION_LIST_TIMEOUT_MS = 1200
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    )
+    promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -40,12 +62,24 @@ export const Route = createFileRoute('/api/sessions')({
         }
 
         try {
-          const sessions = await listSessions(50, 0)
-          const gatewaySessions = sessions.map(toSessionSummary)
+          const url = new URL(request.url)
+          const includeInternal =
+            url.searchParams.get('includeInternal') === 'true'
+          const sessions = await withTimeout(
+            listSessions(50, 0),
+            SESSION_LIST_TIMEOUT_MS,
+          ).catch(() => [])
+          const gatewaySessions = sessions
+            .filter((session) =>
+              includeInternal ? true : shouldShowInChatSessionList(session),
+            )
+            .map(toSessionSummary)
 
           // Merge local portable sessions (Ollama, Atomic Chat, etc.)
           const localSessions = listLocalSessions()
-          const gatewayIds = new Set(gatewaySessions.map((s: any) => s.key || s.id))
+          const gatewayIds = new Set(
+            gatewaySessions.map((s: any) => s.key || s.id),
+          )
           for (const ls of localSessions) {
             if (!gatewayIds.has(ls.id)) {
               gatewaySessions.push({

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -5,11 +5,25 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { newestCheckpointFromMessages, parseSwarmCheckpoint, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import {
+  newestCheckpointFromMessages,
+  parseSwarmCheckpoint,
+  type ParsedSwarmCheckpoint,
+} from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
-import { createOrUpdateMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
-import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
-import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
+import {
+  createOrUpdateMission,
+  markMissionAssignmentDispatched,
+  recordMissionCheckpoint,
+} from '../../server/swarm-missions'
+import {
+  appendSwarmMemoryEvent,
+  buildSwarmStartupSnapshot,
+} from '../../server/swarm-memory'
+import {
+  rosterByWorkerId,
+  type SwarmRosterWorker,
+} from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { ensureSwarmProfileConfig } from '../../server/swarm-profile-config'
 
@@ -68,7 +82,13 @@ type WorkerResult = {
 }
 
 type RuntimeCheckpointSnapshot = {
-  checkpointStatus: 'none' | 'in_progress' | 'done' | 'blocked' | 'handoff' | 'needs_input'
+  checkpointStatus:
+    | 'none'
+    | 'in_progress'
+    | 'done'
+    | 'blocked'
+    | 'handoff'
+    | 'needs_input'
   state: string | null
   lastSummary: string | null
   lastResult: string | null
@@ -160,19 +180,29 @@ function execFileAsync(
   args: Array<string>,
   timeout = 8_000,
   input?: string,
-): Promise<{ ok: true; stdout: string; stderr: string } | { ok: false; error: string }> {
+): Promise<
+  { ok: true; stdout: string; stderr: string } | { ok: false; error: string }
+> {
   return new Promise((resolve) => {
-    const child = execFile(cmd, args, { timeout, maxBuffer: MAX_OUTPUT_CHARS }, (error, stdout, stderr) => {
-      if (error) {
-        resolve({ ok: false, error: stderr?.toString().trim() || error.message })
-        return
-      }
-      resolve({
-        ok: true,
-        stdout: (stdout || '').toString(),
-        stderr: (stderr || '').toString(),
-      })
-    })
+    const child = execFile(
+      cmd,
+      args,
+      { timeout, maxBuffer: MAX_OUTPUT_CHARS },
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve({
+            ok: false,
+            error: stderr?.toString().trim() || error.message,
+          })
+          return
+        }
+        resolve({
+          ok: true,
+          stdout: (stdout || '').toString(),
+          stderr: (stderr || '').toString(),
+        })
+      },
+    )
     if (input !== undefined) {
       child.stdin?.end(input)
     }
@@ -207,7 +237,9 @@ export function buildHermesTmuxLaunchCommand(input: {
     `HERMES_CLI_BIN='${shellEscapeSingle(input.hermesBin)}'`,
     input.ghToken ? `GH_TOKEN='${shellEscapeSingle(input.ghToken)}'` : '',
     input.ghToken ? `GITHUB_TOKEN='${shellEscapeSingle(input.ghToken)}'` : '',
-  ].filter(Boolean).join(' ')
+  ]
+    .filter(Boolean)
+    .join(' ')
   const hermesBin = shellEscapeSingle(input.hermesBin)
 
   // Do not exec the Hermes process. Keeping the parent shell alive means a
@@ -224,12 +256,26 @@ function parseAssignments(value: unknown): Array<AssignmentRequest> {
     const obj = entry as Record<string, unknown>
     const workerId = typeof obj.workerId === 'string' ? obj.workerId.trim() : ''
     const task = typeof obj.task === 'string' ? obj.task.trim() : ''
-    const rationale = typeof obj.rationale === 'string' ? obj.rationale.trim() : undefined
-    const dependsOn = Array.isArray(obj.dependsOn) ? obj.dependsOn.filter((value): value is string => typeof value === 'string' && value.trim().length > 0) : undefined
-    const reviewRequired = typeof obj.reviewRequired === 'boolean' ? obj.reviewRequired : undefined
+    const rationale =
+      typeof obj.rationale === 'string' ? obj.rationale.trim() : undefined
+    const dependsOn = Array.isArray(obj.dependsOn)
+      ? obj.dependsOn.filter(
+          (value): value is string =>
+            typeof value === 'string' && value.trim().length > 0,
+        )
+      : undefined
+    const reviewRequired =
+      typeof obj.reviewRequired === 'boolean' ? obj.reviewRequired : undefined
     const direct = typeof obj.direct === 'boolean' ? obj.direct : undefined
     if (!workerId || !task || !validateWorkerId(workerId)) continue
-    assignments.push({ workerId, task, rationale, dependsOn, reviewRequired, direct })
+    assignments.push({
+      workerId,
+      task,
+      rationale,
+      dependsOn,
+      reviewRequired,
+      direct,
+    })
   }
   return assignments
 }
@@ -238,13 +284,19 @@ function readRuntimeJson(profilePath: string): Record<string, unknown> {
   const runtimePath = join(profilePath, 'runtime.json')
   if (!existsSync(runtimePath)) return {}
   try {
-    return JSON.parse(readFileSync(runtimePath, 'utf8')) as Record<string, unknown>
+    return JSON.parse(readFileSync(runtimePath, 'utf8')) as Record<
+      string,
+      unknown
+    >
   } catch {
     return {}
   }
 }
 
-function writeRuntimePatch(workerId: string, patch: Record<string, unknown>): void {
+function writeRuntimePatch(
+  workerId: string,
+  patch: Record<string, unknown>,
+): void {
   const profilePath = getProfilePath(workerId)
   mkdirSync(profilePath, { recursive: true })
   const runtimePath = join(profilePath, 'runtime.json')
@@ -267,13 +319,21 @@ function cleanRuntimeNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
-function cleanRuntimeCheckpointStatus(value: unknown): RuntimeCheckpointSnapshot['checkpointStatus'] {
-  return value === 'in_progress' || value === 'done' || value === 'blocked' || value === 'handoff' || value === 'needs_input'
+function cleanRuntimeCheckpointStatus(
+  value: unknown,
+): RuntimeCheckpointSnapshot['checkpointStatus'] {
+  return value === 'in_progress' ||
+    value === 'done' ||
+    value === 'blocked' ||
+    value === 'handoff' ||
+    value === 'needs_input'
     ? value
     : 'none'
 }
 
-export function readRuntimeCheckpointSnapshot(profilePath: string): RuntimeCheckpointSnapshot {
+export function readRuntimeCheckpointSnapshot(
+  profilePath: string,
+): RuntimeCheckpointSnapshot {
   const raw = readRuntimeJson(profilePath)
   return {
     checkpointStatus: cleanRuntimeCheckpointStatus(raw.checkpointStatus),
@@ -288,7 +348,9 @@ export function readRuntimeCheckpointSnapshot(profilePath: string): RuntimeCheck
   }
 }
 
-export function runtimeCheckpointSignature(snapshot: RuntimeCheckpointSnapshot): string {
+export function runtimeCheckpointSignature(
+  snapshot: RuntimeCheckpointSnapshot,
+): string {
   return JSON.stringify(snapshot)
 }
 
@@ -298,7 +360,9 @@ function isoToMs(value: string | null): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function stateLabelForRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): ParsedSwarmCheckpoint['stateLabel'] | null {
+function stateLabelForRuntimeSnapshot(
+  snapshot: RuntimeCheckpointSnapshot,
+): ParsedSwarmCheckpoint['stateLabel'] | null {
   switch (snapshot.checkpointStatus) {
     case 'done':
       return 'DONE'
@@ -316,12 +380,21 @@ function stateLabelForRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): Pars
   const state = snapshot.state?.toLowerCase()
   if (state === 'blocked') return 'BLOCKED'
   if (state === 'waiting') return 'NEEDS_INPUT'
-  if (state === 'executing' || state === 'thinking' || state === 'writing' || state === 'reviewing' || state === 'syncing') return 'IN_PROGRESS'
+  if (
+    state === 'executing' ||
+    state === 'thinking' ||
+    state === 'writing' ||
+    state === 'reviewing' ||
+    state === 'syncing'
+  )
+    return 'IN_PROGRESS'
   if (state === 'idle') return 'DONE'
   return null
 }
 
-function runtimeSnapshotHasMeaningfulCheckpoint(snapshot: RuntimeCheckpointSnapshot): boolean {
+function runtimeSnapshotHasMeaningfulCheckpoint(
+  snapshot: RuntimeCheckpointSnapshot,
+): boolean {
   return Boolean(
     snapshot.checkpointRaw ||
     snapshot.lastSummary ||
@@ -331,7 +404,11 @@ function runtimeSnapshotHasMeaningfulCheckpoint(snapshot: RuntimeCheckpointSnaps
   )
 }
 
-export function runtimeSnapshotIsFresh(snapshot: RuntimeCheckpointSnapshot, baselineSignature: string, dispatchedAt: number): boolean {
+export function runtimeSnapshotIsFresh(
+  snapshot: RuntimeCheckpointSnapshot,
+  baselineSignature: string,
+  dispatchedAt: number,
+): boolean {
   const changed = runtimeCheckpointSignature(snapshot) !== baselineSignature
   if (!changed) return false
   const outputAt = snapshot.lastOutputAt
@@ -353,13 +430,18 @@ function formatRuntimeCheckpointRaw(checkpoint: ParsedSwarmCheckpoint): string {
   ].join('\n')
 }
 
-export function checkpointFromRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): ParsedSwarmCheckpoint | null {
+export function checkpointFromRuntimeSnapshot(
+  snapshot: RuntimeCheckpointSnapshot,
+): ParsedSwarmCheckpoint | null {
   if (snapshot.checkpointRaw) {
-    const parsed = newestCheckpointFromMessages([{ role: 'assistant', content: snapshot.checkpointRaw }])
+    const parsed = newestCheckpointFromMessages([
+      { role: 'assistant', content: snapshot.checkpointRaw },
+    ])
     if (parsed) return parsed
   }
   const stateLabel = stateLabelForRuntimeSnapshot(snapshot)
-  if (!stateLabel || !runtimeSnapshotHasMeaningfulCheckpoint(snapshot)) return null
+  if (!stateLabel || !runtimeSnapshotHasMeaningfulCheckpoint(snapshot))
+    return null
   const result = snapshot.lastResult ?? snapshot.lastSummary
   const blocker = snapshot.blockedReason
   const checkpoint: ParsedSwarmCheckpoint = {
@@ -408,9 +490,14 @@ export function buildWorkerPrompt(input: {
   const displayName = roster?.name?.trim() || input.workerId
   const role = roster?.role || 'Worker'
   const humanLabel = `${displayName} — ${role}`
-  const skills = roster?.skills?.length ? roster.skills.join(', ') : 'swarm-worker-core'
-  const capabilities = roster?.capabilities?.length ? roster.capabilities.join(', ') : 'not declared'
-  const mission = roster?.mission || 'Execute assigned swarm tasks and checkpoint progress.'
+  const skills = roster?.skills?.length
+    ? roster.skills.join(', ')
+    : 'swarm-worker-core'
+  const capabilities = roster?.capabilities?.length
+    ? roster.capabilities.join(', ')
+    : 'not declared'
+  const mission =
+    roster?.mission || 'Execute assigned swarm tasks and checkpoint progress.'
   const specialty = roster?.specialty || 'General execution'
 
   let snapshotSection = ''
@@ -468,7 +555,13 @@ export function buildWorkerPrompt(input: {
   return lines.filter(Boolean).join('\n')
 }
 
-function markDispatchStarted(workerId: string, task: string, missionId?: string | null, assignmentId?: string | null, notifySessionKey?: string | null): void {
+function markDispatchStarted(
+  workerId: string,
+  task: string,
+  missionId?: string | null,
+  assignmentId?: string | null,
+  notifySessionKey?: string | null,
+): void {
   const controlMessage = `Dispatched task: ${task.slice(0, 180)}`
   writeRuntimePatch(workerId, {
     state: 'executing',
@@ -485,7 +578,8 @@ function markDispatchStarted(workerId: string, task: string, missionId?: string 
     lastCheckIn: new Date().toISOString(),
     lastSummary: controlMessage,
     lastControlMessage: controlMessage,
-    nextAction: 'Worker should execute and return the required checkpoint format.',
+    nextAction:
+      'Worker should execute and return the required checkpoint format.',
     notifySessionKey: notifySessionKey ?? 'main',
   })
 }
@@ -494,7 +588,9 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
   writeRuntimePatch(workerId, {
     lastDispatchAt: Date.now(),
     lastDispatchMode: result.delivery ?? 'none',
-    lastDispatchResult: result.ok ? result.output.slice(0, 500) : (result.error ?? 'dispatch failed').slice(0, 500),
+    lastDispatchResult: result.ok
+      ? result.output.slice(0, 500)
+      : (result.error ?? 'dispatch failed').slice(0, 500),
     state: result.ok ? 'executing' : 'blocked',
     checkpointStatus: result.ok ? 'in_progress' : 'blocked',
     blockedReason: result.ok ? null : result.error,
@@ -502,7 +598,11 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
   })
 }
 
-function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoint, notifySessionKey?: string | null): void {
+function markCheckpointResult(
+  workerId: string,
+  checkpoint: ParsedSwarmCheckpoint,
+  notifySessionKey?: string | null,
+): void {
   // When the checkpoint reaches any terminal status (anything other than
   // 'in_progress' — i.e. done/blocked/needs_input/handoff) the worker is no
   // longer running this task, so clear currentTask the same way conductor-stop
@@ -522,7 +622,11 @@ function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoin
     lastRealResult: checkpoint.result,
     lastControlMessage: null,
     nextAction: checkpoint.nextAction,
-    blockedReason: checkpoint.stateLabel === 'BLOCKED' || checkpoint.stateLabel === 'NEEDS_INPUT' ? checkpoint.blocker : null,
+    blockedReason:
+      checkpoint.stateLabel === 'BLOCKED' ||
+      checkpoint.stateLabel === 'NEEDS_INPUT'
+        ? checkpoint.blocker
+        : null,
     needsHuman: checkpoint.stateLabel === 'NEEDS_INPUT',
     checkpointRaw: checkpoint.raw,
     checkpointFilesChanged: checkpoint.filesChanged,
@@ -542,9 +646,16 @@ async function waitForFreshCheckpoint(
   const profilePath = getProfilePath(workerId)
   while (Date.now() - started < timeoutMs) {
     const runtimeSnapshot = readRuntimeCheckpointSnapshot(profilePath)
-    if (runtimeSnapshotIsFresh(runtimeSnapshot, baselineRuntimeSignature, dispatchedAt)) {
+    if (
+      runtimeSnapshotIsFresh(
+        runtimeSnapshot,
+        baselineRuntimeSignature,
+        dispatchedAt,
+      )
+    ) {
       const runtimeCheckpoint = checkpointFromRuntimeSnapshot(runtimeSnapshot)
-      if (runtimeCheckpoint && runtimeCheckpoint.raw !== previousRaw) return runtimeCheckpoint
+      if (runtimeCheckpoint && runtimeCheckpoint.raw !== previousRaw)
+        return runtimeCheckpoint
     }
 
     const chat = readWorkerMessages(profilePath, 50)
@@ -574,8 +685,15 @@ function resolveWorkerCwd(workerId: string): string {
   return homedir()
 }
 
-async function captureTmuxPane(tmuxBin: string, sessionName: string): Promise<string> {
-  const captured = await execFileAsync(tmuxBin, ['capture-pane', '-p', '-t', sessionName, '-S', '-200'], 8_000)
+async function captureTmuxPane(
+  tmuxBin: string,
+  sessionName: string,
+): Promise<string> {
+  const captured = await execFileAsync(
+    tmuxBin,
+    ['capture-pane', '-p', '-t', sessionName, '-S', '-200'],
+    8_000,
+  )
   return captured.ok ? captured.stdout.trim() : ''
 }
 
@@ -585,7 +703,12 @@ function redactStartupOutput(output: string): string {
     .replace(/(gh[pousr]_[A-Za-z0-9_]{12,})/g, '[REDACTED]')
 }
 
-async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmuxBin: string; sessionName: string } | { ok: false; error: string }> {
+async function ensureLiveTmuxSession(
+  workerId: string,
+): Promise<
+  | { ok: true; tmuxBin: string; sessionName: string }
+  | { ok: false; error: string }
+> {
   const tmuxBin = resolveTmuxBin()
   if (!tmuxBin) return { ok: false, error: 'tmux not installed' }
 
@@ -616,7 +739,13 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
     return { ok: false, error: started.error }
   }
 
-  const launched = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, launchCommand, 'C-m'])
+  const launched = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    launchCommand,
+    'C-m',
+  ])
   if (!launched.ok) {
     return { ok: false, error: launched.error }
   }
@@ -626,7 +755,10 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
   // surface the real startup failure instead of a later tmux "can't find pane".
   await sleep(1200)
   if (!(await tmuxHasSession(tmuxBin, sessionName))) {
-    return { ok: false, error: `Hermes worker tmux session ${sessionName} exited during startup` }
+    return {
+      ok: false,
+      error: `Hermes worker tmux session ${sessionName} exited during startup`,
+    }
   }
 
   const startupOutput = await captureTmuxPane(tmuxBin, sessionName)
@@ -638,8 +770,12 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
     const logsDir = join(profilePath, 'logs')
     mkdirSync(logsDir, { recursive: true })
     const startupLogPath = join(logsDir, 'swarm-dispatch-startup.log')
-    writeFileSync(startupLogPath, `${new Date().toISOString()} ${sanitizedOutput}
-`, { flag: 'a' })
+    writeFileSync(
+      startupLogPath,
+      `${new Date().toISOString()} ${sanitizedOutput}
+`,
+      { flag: 'a' },
+    )
     return {
       ok: false,
       error: `Hermes worker failed to start in tmux session ${sessionName}. Startup output saved to ${startupLogPath}: ${sanitizedOutput}`,
@@ -649,7 +785,10 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
   return { ok: true, tmuxBin, sessionName }
 }
 
-async function sendPromptToLiveSession(workerId: string, prompt: string): Promise<WorkerResult | null> {
+async function sendPromptToLiveSession(
+  workerId: string,
+  prompt: string,
+): Promise<WorkerResult | null> {
   const startedAt = Date.now()
   const ensured = await ensureLiveTmuxSession(workerId)
   if (!ensured.ok) return null
@@ -661,12 +800,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // reliable for live TUI delivery because it preserves multiline content and
   // avoids key translation/terminal timing issues. Enter submits the composed
   // prompt after paste.
-  const loaded = await execFileAsync(tmuxBin, [
-    'load-buffer',
-    '-b',
-    `swarm-dispatch-${workerId}`,
-    '-',
-  ], 8_000, normalizedPrompt)
+  const loaded = await execFileAsync(
+    tmuxBin,
+    ['load-buffer', '-b', `swarm-dispatch-${workerId}`, '-'],
+    8_000,
+    normalizedPrompt,
+  )
   if (!loaded.ok) {
     return {
       workerId,
@@ -682,7 +821,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // Ensure we are sending a fresh prompt, not appending onto a partially typed
   // line left in the agent TUI. Ctrl-U clears readline-style input in the
   // current prompt without disrupting the session.
-  const cleared = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-u'])
+  const cleared = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-u',
+  ])
   if (!cleared.ok) {
     return {
       workerId,
@@ -720,7 +864,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // to accept Enter; sending a confirmation Enter shortly after the first one
   // prevents the user-visible failure mode where the task sits at the prompt.
   await sleep(2000)
-  const enter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
+  const enter = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-m',
+  ])
   if (!enter.ok) {
     return {
       workerId,
@@ -733,7 +882,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
     }
   }
   await sleep(1000)
-  const confirmEnter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
+  const confirmEnter = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-m',
+  ])
   if (!confirmEnter.ok) {
     return {
       workerId,
@@ -757,7 +911,17 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   }
 }
 
-function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: SwarmRosterWorker | undefined, options?: { waitForCheckpoint?: boolean; checkpointPollMs?: number; missionId?: string | null; notifySessionKey?: string | null }): Promise<WorkerResult> {
+function runWorker(
+  assignment: AssignmentRequest,
+  timeoutMs: number,
+  roster: SwarmRosterWorker | undefined,
+  options?: {
+    waitForCheckpoint?: boolean
+    checkpointPollMs?: number
+    missionId?: string | null
+    notifySessionKey?: string | null
+  },
+): Promise<WorkerResult> {
   return new Promise(async (resolve) => {
     const workerId = assignment.workerId
     const prompt = buildWorkerPrompt({
@@ -772,8 +936,16 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
     const profilePath = getProfilePath(workerId)
     const runtimeBeforeDispatch = readRuntimeCheckpointSnapshot(profilePath)
     const previousRaw = runtimeBeforeDispatch.checkpointRaw
-    const baselineRuntimeSignature = runtimeCheckpointSignature(runtimeBeforeDispatch)
-    markDispatchStarted(workerId, assignment.task, options?.missionId ?? null, assignment.assignmentId ?? null, options?.notifySessionKey ?? 'main')
+    const baselineRuntimeSignature = runtimeCheckpointSignature(
+      runtimeBeforeDispatch,
+    )
+    markDispatchStarted(
+      workerId,
+      assignment.task,
+      options?.missionId ?? null,
+      assignment.assignmentId ?? null,
+      options?.notifySessionKey ?? 'main',
+    )
     if (options?.missionId) {
       markMissionAssignmentDispatched({
         missionId: options.missionId,
@@ -812,7 +984,11 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           options.checkpointPollMs ?? 90_000,
         )
         if (checkpoint) {
-          markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
+          markCheckpointResult(
+            workerId,
+            checkpoint,
+            options?.notifySessionKey ?? 'main',
+          )
           const updatedMission = recordMissionCheckpoint({
             missionId: options?.missionId,
             assignmentId: assignment.assignmentId ?? null,
@@ -822,7 +998,9 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           })
           if (updatedMission?._completed) {
             try {
-              for (const wId of new Set(updatedMission.assignments.map((a) => a.workerId))) {
+              for (const wId of new Set(
+                updatedMission.assignments.map((a) => a.workerId),
+              )) {
                 appendSwarmMemoryEvent({
                   workerId: wId,
                   missionId: updatedMission.id,
@@ -831,7 +1009,9 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
                   summary: `Mission complete: ${updatedMission.title}`,
                 })
               }
-            } catch { /* memory write best-effort */ }
+            } catch {
+              /* memory write best-effort */
+            }
           }
           appendSwarmMemoryEvent({
             workerId,
@@ -887,9 +1067,16 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
 
     const useWrapper = existsSync(wrapperPath)
     const cmd = useWrapper ? wrapperPath : resolveHermesBin()
-    const args = useWrapper
-      ? ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch', prompt]
-      : ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+    const args = [
+      'chat',
+      '-q',
+      '-Q',
+      '--yolo',
+      '--ignore-rules',
+      '--source',
+      'swarm-dispatch',
+      prompt,
+    ]
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       HERMES_HOME: profilePath,
@@ -909,13 +1096,15 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         timeout: timeoutMs,
         maxBuffer: MAX_OUTPUT_CHARS,
         killSignal: 'SIGTERM',
-        input: prompt,
       },
       (error, stdout, stderr) => {
         const durationMs = Date.now() - startedAt
         const stdoutStr = (stdout || '').toString()
         const stderrStr = (stderr || '').toString()
-        const out = stdoutStr.length > MAX_OUTPUT_CHARS ? stdoutStr.slice(-MAX_OUTPUT_CHARS) : stdoutStr
+        const out =
+          stdoutStr.length > MAX_OUTPUT_CHARS
+            ? stdoutStr.slice(-MAX_OUTPUT_CHARS)
+            : stdoutStr
 
         if (error) {
           const code = (error as { code?: number | null }).code ?? null
@@ -945,7 +1134,11 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         if (options?.waitForCheckpoint) {
           const checkpoint = parseSwarmCheckpoint(out)
           if (checkpoint) {
-            markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
+            markCheckpointResult(
+              workerId,
+              checkpoint,
+              options?.notifySessionKey ?? 'main',
+            )
             recordMissionCheckpoint({
               missionId: options?.missionId,
               assignmentId: assignment.assignmentId ?? null,
@@ -958,7 +1151,8 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
               missionId: options?.missionId ?? null,
               assignmentId: assignment.assignmentId ?? null,
               type: 'checkpoint',
-              summary: checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
+              summary:
+                checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
               checkpoint,
               event: {
                 stateLabel: checkpoint.stateLabel,
@@ -1042,23 +1236,47 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
   if (assignments.some((assignment) => assignment.task.length === 0)) {
     throw new SwarmDispatchError('assignment task required')
   }
-  if (assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)) {
-    throw new SwarmDispatchError(`assignment task exceeds ${MAX_PROMPT_CHARS} characters`)
+  if (
+    assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)
+  ) {
+    throw new SwarmDispatchError(
+      `assignment task exceeds ${MAX_PROMPT_CHARS} characters`,
+    )
   }
 
-  const timeoutRaw = typeof body.timeoutSeconds === 'number' ? body.timeoutSeconds : DEFAULT_TIMEOUT_S
-  const timeoutSeconds = Math.max(10, Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)))
+  const timeoutRaw =
+    typeof body.timeoutSeconds === 'number'
+      ? body.timeoutSeconds
+      : DEFAULT_TIMEOUT_S
+  const timeoutSeconds = Math.max(
+    10,
+    Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)),
+  )
   const timeoutMs = timeoutSeconds * 1000
-  const waitForCheckpoint = !(body.waitForCheckpoint === false && body.allowAsync === true)
-  const pollRaw = typeof body.checkpointPollSeconds === 'number' ? body.checkpointPollSeconds : 90
+  const waitForCheckpoint = !(
+    body.waitForCheckpoint === false && body.allowAsync === true
+  )
+  const pollRaw =
+    typeof body.checkpointPollSeconds === 'number'
+      ? body.checkpointPollSeconds
+      : 90
   const checkpointPollSeconds = Math.max(5, Math.min(300, Math.floor(pollRaw)))
-  const notifySessionKey = typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim() ? body.notifySessionKey.trim() : 'main'
+  const notifySessionKey =
+    typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim()
+      ? body.notifySessionKey.trim()
+      : 'main'
 
-  const requestedMissionId = typeof body.missionId === 'string' ? body.missionId.trim() : ''
-  const hasExplicitMissionTitle = typeof body.missionTitle === 'string' && body.missionTitle.trim()
+  const requestedMissionId =
+    typeof body.missionId === 'string' ? body.missionId.trim() : ''
+  const hasExplicitMissionTitle =
+    typeof body.missionTitle === 'string' && body.missionTitle.trim()
   const missionTitle = hasExplicitMissionTitle
     ? (body.missionTitle as string).trim()
-    : requestedMissionId ? '' : assignments.length === 1 ? assignments[0].task.slice(0, 120) : `${assignments.length} assigned tasks`
+    : requestedMissionId
+      ? ''
+      : assignments.length === 1
+        ? assignments[0].task.slice(0, 120)
+        : `${assignments.length} assigned tasks`
   const mission = createOrUpdateMission({
     missionId: requestedMissionId || null,
     title: missionTitle,
@@ -1079,27 +1297,43 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
     }
   }
 
-  const assignmentIdByKey = new Map(mission.assignments.map((item) => [`${item.workerId}\n${item.task}`, item.id]))
+  const assignmentIdByKey = new Map(
+    mission.assignments.map((item) => [
+      `${item.workerId}\n${item.task}`,
+      item.id,
+    ]),
+  )
   assignments = assignments.map((assignment) => ({
     ...assignment,
-    assignmentId: assignmentIdByKey.get(`${assignment.workerId}\n${assignment.task}`),
+    assignmentId: assignmentIdByKey.get(
+      `${assignment.workerId}\n${assignment.task}`,
+    ),
   }))
 
   const dispatchedAt = Date.now()
-  const roster = rosterByWorkerId(assignments.map((assignment) => assignment.workerId))
-  const results = await Promise.all(assignments.map((assignment) => runWorker(
-    assignment,
-    timeoutMs,
-    roster.get(assignment.workerId),
-    { waitForCheckpoint, checkpointPollMs: checkpointPollSeconds * 1000, missionId: mission.id, notifySessionKey },
-  )))
+  const roster = rosterByWorkerId(
+    assignments.map((assignment) => assignment.workerId),
+  )
+  const results = await Promise.all(
+    assignments.map((assignment) =>
+      runWorker(assignment, timeoutMs, roster.get(assignment.workerId), {
+        waitForCheckpoint,
+        checkpointPollMs: checkpointPollSeconds * 1000,
+        missionId: mission.id,
+        notifySessionKey,
+      }),
+    ),
+  )
 
   return {
     dispatchedAt,
     completedAt: Date.now(),
     missionId: mission.id,
     mission,
-    prompt: assignments.length === 1 ? assignments[0].task : `${assignments.length} assigned tasks`,
+    prompt:
+      assignments.length === 1
+        ? assignments[0].task
+        : `${assignments.length} assigned tasks`,
     assignments,
     timeoutSeconds,
     waitForCheckpoint,
@@ -1130,7 +1364,10 @@ export const Route = createFileRoute('/api/swarm-dispatch')({
           if (error instanceof SwarmDispatchError) {
             return json({ error: error.message }, { status: error.status })
           }
-          return json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 })
+          return json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 500 },
+          )
         }
       },
     },

--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -54,13 +54,24 @@ export function resolveWorkerWrapperName(workerId: string, worker?: Pick<SwarmRo
 }
 
 function listSwarmIds(): Array<string> {
+  const ids = new Set<string>()
+
+  // Canonical roster workers are the primary swarm source of truth. Include
+  // semantic workers such as `orchestrator`, `builder`, and `ops-watch` even
+  // though older installs only exposed numbered `swarmN` profiles here.
+  for (const worker of rosterByWorkerId().values()) {
+    const id = (worker.profile || worker.id || '').trim()
+    if (id && isSwarmWorkerId(id)) ids.add(id)
+  }
+
   const dir = getProfilesDir()
-  if (!existsSync(dir)) return []
-  return readdirSync(dir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((name) => isSwarmWorkerId(name))
-    .sort()
+  if (existsSync(dir)) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory() && isSwarmWorkerId(entry.name)) ids.add(entry.name)
+    }
+  }
+
+  return [...ids].sort()
 }
 
 function readWorkerConfig(profilePath: string): { model: string; provider: string } {

--- a/src/routes/api/swarm-lifecycle.ts
+++ b/src/routes/api/swarm-lifecycle.ts
@@ -24,16 +24,29 @@ export const Route = createFileRoute('/api/swarm-lifecycle')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        if (!isAuthenticated(request)) return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        if (!isAuthenticated(request))
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         const url = new URL(request.url)
         const requested = validWorkerId(url.searchParams.get('workerId'))
         const ids = requested ? [requested] : listSwarmWorkerIds()
-        return json({ ok: true, checkedAt: Date.now(), workers: ids.map((id) => getSwarmLifecycleStatus(id)) })
+        return json({
+          ok: true,
+          checkedAt: Date.now(),
+          workers: ids.map((id) => getSwarmLifecycleStatus(id)),
+        })
       },
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        if (!isAuthenticated(request))
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         let body: LifecyclePost
-        try { body = await request.json() as LifecyclePost } catch { return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 }) }
+        try {
+          body = (await request.json()) as LifecyclePost
+        } catch {
+          return json(
+            { ok: false, error: 'Invalid JSON body' },
+            { status: 400 },
+          )
+        }
         const action = typeof body.action === 'string' ? body.action : ''
         const workerIdMaybe = validWorkerId(body.workerId)
         if (action === 'auto-sweep') {
@@ -41,15 +54,21 @@ export const Route = createFileRoute('/api/swarm-lifecycle')({
           const sweep = await autoSweepLifecycle(targets)
           return json({ ok: true, action, sweep })
         }
-        if (!workerIdMaybe) return json({ ok: false, error: 'workerId required' }, { status: 400 })
+        if (!workerIdMaybe)
+          return json(
+            { ok: false, error: 'workerId required' },
+            { status: 400 },
+          )
         const workerId = workerIdMaybe
         if (action === 'request-handoff') {
           const result = await requestWorkerHandoff(workerId)
-          return json({ ok: result.ok, workerId, action, ...result })
+          const { ok, ...rest } = result
+          return json({ ...rest, ok, workerId, action })
         }
         if (action === 'renew') {
           const result = await renewWorker(workerId)
-          return json({ ok: result.ok, workerId, action, ...result })
+          const { ok, ...rest } = result
+          return json({ ...rest, ok, workerId, action })
         }
         if (action === 'notify-handoff-written') {
           notifyHandoffWritten(workerId)

--- a/src/routes/api/swarm-runtime.ts
+++ b/src/routes/api/swarm-runtime.ts
@@ -6,27 +6,32 @@ import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfilesDir } from '../../server/claude-paths'
 import {
-
-
-
-
-
-
-
-
-
-
-
   buildSwarmDispatchMetadata,
   buildSwarmSessionMetadata,
   getSwarmTmuxSessionName,
   getSwarmWrapperPath,
   listSwarmWorkerIds,
-  readSwarmRuntimeFile
+  readSwarmRuntimeFile,
 } from '../../server/swarm-foundation'
-import { formatSwarmWorkerLabel, resolveSwarmWorkerDisplayName, rosterByWorkerId } from '../../server/swarm-roster'
+import {
+  formatSwarmWorkerLabel,
+  resolveSwarmWorkerDisplayName,
+  rosterByWorkerId,
+} from '../../server/swarm-roster'
 import { readSwarmMode, writeSwarmMode } from '../../server/swarm-mode'
-import type {SwarmArtifactMetadata, SwarmBoundary, SwarmCheckpointStatus, SwarmDispatchMetadata, SwarmLifecycleMetadata, SwarmPreviewMetadata, SwarmRuntimeSource, SwarmSessionMetadata, SwarmTaskMetadata, SwarmTerminalKind, SwarmWorkerState} from '../../server/swarm-foundation';
+import type {
+  SwarmArtifactMetadata,
+  SwarmBoundary,
+  SwarmCheckpointStatus,
+  SwarmDispatchMetadata,
+  SwarmLifecycleMetadata,
+  SwarmPreviewMetadata,
+  SwarmRuntimeSource,
+  SwarmSessionMetadata,
+  SwarmTaskMetadata,
+  SwarmTerminalKind,
+  SwarmWorkerState,
+} from '../../server/swarm-foundation'
 
 type RuntimeEntry = {
   workerId: string
@@ -79,9 +84,14 @@ function listWorkerIds(): Array<string> {
 function lastLogTail(
   profilePath: string,
   maxBytes = 4_000,
-): { tail: string | null; lastSessionStartedAt: number | null; logPath: string | null } {
+): {
+  tail: string | null
+  lastSessionStartedAt: number | null
+  logPath: string | null
+} {
   const log = join(profilePath, 'logs', 'agent.log')
-  if (!existsSync(log)) return { tail: null, lastSessionStartedAt: null, logPath: null }
+  if (!existsSync(log))
+    return { tail: null, lastSessionStartedAt: null, logPath: null }
   try {
     const stat = statSync(log)
     const buffer = readFileSync(log, 'utf-8')
@@ -191,8 +201,8 @@ async function buildEntry(
     role: roster?.role || runtime.role,
     specialty: roster?.specialty || null,
     mission: roster?.mission || null,
-    skills: roster.skills.length ? roster.skills : [],
-    capabilities: roster.capabilities.length ? roster.capabilities : [],
+    skills: roster?.skills?.length ? roster.skills : [],
+    capabilities: roster?.capabilities?.length ? roster.capabilities : [],
     source,
     pid: lifecycle.pid,
     startedAt: runtime.startedAt,
@@ -233,7 +243,10 @@ function readPid(profilePath: string): number | null {
   const runtimePath = join(profilePath, 'runtime.json')
   if (!existsSync(runtimePath)) return null
   try {
-    const raw = JSON.parse(readFileSync(runtimePath, 'utf-8')) as Record<string, unknown>
+    const raw = JSON.parse(readFileSync(runtimePath, 'utf-8')) as Record<
+      string,
+      unknown
+    >
     return typeof raw.pid === 'number' ? raw.pid : null
   } catch {
     return null
@@ -249,7 +262,9 @@ export const Route = createFileRoute('/api/swarm-runtime')({
         }
         const ids = listWorkerIds()
         const tmuxAvailable = await tmuxIsInstalled()
-        const entries = await Promise.all(ids.map((id) => buildEntry(id, tmuxAvailable)))
+        const entries = await Promise.all(
+          ids.map((id) => buildEntry(id, tmuxAvailable)),
+        )
         return json({
           checkedAt: Date.now(),
           registryVersion: 1,

--- a/src/routes/reserve/confirm.tsx
+++ b/src/routes/reserve/confirm.tsx
@@ -4,12 +4,15 @@ import { usePageTitle } from '@/hooks/use-page-title'
 
 export const Route = createFileRoute('/reserve/confirm')({
   ssr: false,
+  validateSearch: (search: Record<string, unknown>): { token?: string } => ({
+    token: typeof search.token === 'string' ? search.token : undefined,
+  }),
   component: ReserveConfirmRoute,
 })
 
 function ReserveConfirmRoute() {
   usePageTitle('Confirm HermesWorld reservation')
-  const token = Route.useSearch({ strict: false }).token || ''
+  const token = Route.useSearch().token || ''
   const [state, setState] = useState<{
     status: 'loading' | 'success' | 'error'
     message: string
@@ -22,7 +25,8 @@ function ReserveConfirmRoute() {
     if (!token) {
       setState({
         status: 'error',
-        message: 'Missing confirmation token. Re-open the link from your email.',
+        message:
+          'Missing confirmation token. Re-open the link from your email.',
       })
       return
     }
@@ -63,7 +67,9 @@ function ReserveConfirmRoute() {
               ? 'Confirmation problem.'
               : 'Confirming reservation…'}
         </h1>
-        <p className="mt-4 text-base leading-7 text-[#d7d0bd]/68">{state.message}</p>
+        <p className="mt-4 text-base leading-7 text-[#d7d0bd]/68">
+          {state.message}
+        </p>
         <div className="mt-8 flex flex-wrap gap-3">
           <a
             href="/reserve"

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -21,7 +21,7 @@ import type { LoaderStyle } from '@/hooks/use-chat-settings'
 import type { BrailleSpinnerPreset } from '@/components/ui/braille-spinner'
 import type { ThemeId } from '@/lib/theme'
 import type { SettingsNavId } from '@/components/settings/settings-sidebar'
-import type {LocaleId} from '@/lib/i18n';
+import type { LocaleId } from '@/lib/i18n'
 import { GROQ_STT_MODELS, STT_PROVIDER_OPTIONS } from '@/lib/stt-config'
 import {
   SETTINGS_NAV_ITEMS,
@@ -32,7 +32,7 @@ import { usePageTitle } from '@/hooks/use-page-title'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { useSettings } from '@/hooks/use-settings'
-import { LOCALE_LABELS,  getLocale, setLocale } from '@/lib/i18n'
+import { LOCALE_LABELS, getLocale, setLocale } from '@/lib/i18n'
 import { THEMES, getTheme, isDarkTheme, setTheme } from '@/lib/theme'
 import { cn } from '@/lib/utils'
 import {
@@ -163,7 +163,7 @@ const THEME_PREVIEWS: Record<
     accent: '#b98a44',
     text: '#1a1f26',
   },
-  'matrix': {
+  matrix: {
     bg: '#020804',
     panel: '#07130A',
     border: 'rgba(0,255,65,0.28)',
@@ -184,7 +184,7 @@ const THEME_PREVIEWS: Record<
     accent: '#3b82f6',
     text: '#1F2328',
   },
-  'scifi': {
+  scifi: {
     bg: '#060b18',
     panel: '#0a1628',
     border: '#1a3a5c',
@@ -1022,17 +1022,22 @@ function resolveCustomBaseUrlFromConfig(
   config: Record<string, unknown>,
   activeProvider: string,
 ): string {
-  const providersConfig = config.providers as Record<string, unknown> | undefined
+  const providersConfig = config.providers as
+    | Record<string, unknown>
+    | undefined
   const customBlock = (providersConfig?.manifest || providersConfig?.custom) as
     | Record<string, unknown>
     | undefined
-  let url = typeof customBlock?.base_url === 'string' ? customBlock.base_url.trim() : ''
+  let url =
+    typeof customBlock?.base_url === 'string' ? customBlock.base_url.trim() : ''
   if (!url && Array.isArray(config.custom_providers)) {
     const aid = activeProvider.trim().toLowerCase()
     for (const e of config.custom_providers) {
       if (!e || typeof e !== 'object' || Array.isArray(e)) continue
       const rec = e as Record<string, unknown>
-      const name = String(rec.name ?? '').trim().toLowerCase()
+      const name = String(rec.name ?? '')
+        .trim()
+        .toLowerCase()
       if (name && name === aid && typeof rec.base_url === 'string') {
         url = rec.base_url.trim()
         break
@@ -1063,9 +1068,7 @@ function readFallbackInputsFromConfig(config: Record<string, unknown>): {
   }
 }
 
-function normalizeCustomProviderEntry(
-  entry: Record<string, unknown>,
-): {
+function normalizeCustomProviderEntry(entry: Record<string, unknown>): {
   name: string
   title: string
   base_url: string
@@ -1074,9 +1077,11 @@ function normalizeCustomProviderEntry(
 } {
   const name = typeof entry.name === 'string' ? entry.name.trim() : ''
   const title = typeof entry.title === 'string' ? entry.title.trim() : ''
-  const base_url = typeof entry.base_url === 'string' ? entry.base_url.trim() : ''
+  const base_url =
+    typeof entry.base_url === 'string' ? entry.base_url.trim() : ''
   const api_key = typeof entry.api_key === 'string' ? entry.api_key : undefined
-  const api_mode = typeof entry.api_mode === 'string' ? entry.api_mode : undefined
+  const api_mode =
+    typeof entry.api_mode === 'string' ? entry.api_mode : undefined
   return { name, title, base_url, api_key, api_mode }
 }
 
@@ -1103,11 +1108,15 @@ function entryCoveredByCustomProviderList(
 }
 
 function readManifestBlockBaseUrl(config: Record<string, unknown>): string {
-  const providersConfig = config.providers as Record<string, unknown> | undefined
+  const providersConfig = config.providers as
+    | Record<string, unknown>
+    | undefined
   const customBlock = (providersConfig?.manifest || providersConfig?.custom) as
     | Record<string, unknown>
     | undefined
-  return typeof customBlock?.base_url === 'string' ? customBlock.base_url.trim() : ''
+  return typeof customBlock?.base_url === 'string'
+    ? customBlock.base_url.trim()
+    : ''
 }
 
 function deriveCustomProviderNameFromBaseUrl(url: string): string {
@@ -1123,7 +1132,9 @@ function deriveCustomProviderNameFromBaseUrl(url: string): string {
 /** e.g. Qwen3.6.Eclipse from model filename + URL hostname first label */
 function suggestCustomProviderTitle(model: string, baseUrl: string): string {
   let modelPart = (model || '').trim()
-  const lastSeg = modelPart.includes('/') ? modelPart.split('/').pop() || modelPart : modelPart
+  const lastSeg = modelPart.includes('/')
+    ? modelPart.split('/').pop() || modelPart
+    : modelPart
   modelPart = (lastSeg || 'model').replace(/\.gguf$/i, '')
   const dashIdx = modelPart.indexOf('-')
   if (dashIdx > 0) modelPart = modelPart.slice(0, dashIdx)
@@ -1161,7 +1172,11 @@ function mergeModelForManifestSave(
   modelInputTrimmed: string,
 ): Record<string, unknown> {
   const existing = config.model
-  if (typeof existing === 'object' && existing !== null && !Array.isArray(existing)) {
+  if (
+    typeof existing === 'object' &&
+    existing !== null &&
+    !Array.isArray(existing)
+  ) {
     const o = { ...(existing as Record<string, unknown>) }
     o.provider = 'manifest'
     if (typeof o.default !== 'string' || !o.default.trim()) {
@@ -1362,7 +1377,9 @@ function ClaudeConfigSection({
     data.config,
     data.activeProvider,
   )
-  const customProviderCatalogEntry = data.providers.find((p) => p.id === 'custom')
+  const customProviderCatalogEntry = data.providers.find(
+    (p) => p.id === 'custom',
+  )
   const customApiKeyConfigured = Boolean(customProviderCatalogEntry?.configured)
   const customEndpointConfigured =
     customApiKeyConfigured || Boolean(resolvedCustomBaseUrl)
@@ -1385,7 +1402,11 @@ function ClaudeConfigSection({
 
   const extraManifestNotInList =
     manifestBlockOnlyUrl &&
-    !entryCoveredByCustomProviderList('', manifestBlockOnlyUrl, customProviders) &&
+    !entryCoveredByCustomProviderList(
+      '',
+      manifestBlockOnlyUrl,
+      customProviders,
+    ) &&
     urlNormForDedupe(manifestBlockOnlyUrl) !==
       urlNormForDedupe(primaryConfigBaseUrl || '') &&
     !(
@@ -1404,11 +1425,15 @@ function ClaudeConfigSection({
     const n = name.trim()
     const u = base_url.trim()
     if (!n || !u) {
-      setSaveMessage('Provider id and base URL are both required to save a row.')
+      setSaveMessage(
+        'Provider id and base URL are both required to save a row.',
+      )
       setTimeout(() => setSaveMessage(null), 4000)
       return
     }
-    const others = customProviders.filter((e) => String(e.name ?? '').trim() !== n)
+    const others = customProviders.filter(
+      (e) => String(e.name ?? '').trim() !== n,
+    )
     const prev = customProviders.find((e) => String(e.name ?? '').trim() === n)
     const api_mode =
       prev && typeof prev.api_mode === 'string' && prev.api_mode
@@ -1443,7 +1468,9 @@ function ClaudeConfigSection({
     const title = addCpTitle.trim()
     const url = addCpBaseUrl.trim()
     if (!title) {
-      setSaveMessage('Add a title so you can recognize this endpoint (e.g. Qwen3.6.Eclipse).')
+      setSaveMessage(
+        'Add a title so you can recognize this endpoint (e.g. Qwen3.6.Eclipse).',
+      )
       setTimeout(() => setSaveMessage(null), 4000)
       return
     }
@@ -1465,7 +1492,9 @@ function ClaudeConfigSection({
 
   function saveCurrentToCustomProvidersList() {
     if (!providerInput.trim() || !baseUrlInput.trim()) {
-      setSaveMessage('Enter both provider and base URL in Model & Provider, then try again.')
+      setSaveMessage(
+        'Enter both provider and base URL in Model & Provider, then try again.',
+      )
       setTimeout(() => setSaveMessage(null), 4000)
       return
     }
@@ -1599,8 +1628,9 @@ function ClaudeConfigSection({
                 Fallback model (optional)
               </p>
               <p className="text-xs text-primary-600">
-                Used only if the primary model fails. Keep empty to disable — avoids mixing this
-                up with your main provider (for example OpenRouter only here, local primary above).
+                Used only if the primary model fails. Keep empty to disable —
+                avoids mixing this up with your main provider (for example
+                OpenRouter only here, local primary above).
               </p>
             </div>
             <Button
@@ -1610,14 +1640,18 @@ function ClaudeConfigSection({
               className="shrink-0"
               onClick={() => setShowFallbackRow((v) => !v)}
             >
-              {showFallbackRow ? 'Hide fallback fields' : 'Show fallback fields'}
+              {showFallbackRow
+                ? 'Hide fallback fields'
+                : 'Show fallback fields'}
             </Button>
           </div>
           {showFallbackRow ? (
             <div className="mt-3 space-y-3 border-t border-primary-200 pt-3">
               <div className="grid gap-3 md:grid-cols-2">
                 <label className="space-y-1">
-                  <span className="text-xs font-medium text-primary-600">Fallback provider</span>
+                  <span className="text-xs font-medium text-primary-600">
+                    Fallback provider
+                  </span>
                   <Input
                     value={fallbackProviderInput}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -1628,7 +1662,9 @@ function ClaudeConfigSection({
                   />
                 </label>
                 <label className="space-y-1">
-                  <span className="text-xs font-medium text-primary-600">Fallback model id</span>
+                  <span className="text-xs font-medium text-primary-600">
+                    Fallback model id
+                  </span>
                   <Input
                     value={fallbackModelInput}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -1640,7 +1676,9 @@ function ClaudeConfigSection({
                 </label>
               </div>
               <label className="block space-y-1">
-                <span className="text-xs font-medium text-primary-600">Fallback base URL</span>
+                <span className="text-xs font-medium text-primary-600">
+                  Fallback base URL
+                </span>
                 <Input
                   value={fallbackBaseUrlInput}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -1831,18 +1869,23 @@ function ClaudeConfigSection({
       >
         <div className="space-y-4 rounded-xl border border-primary-200 bg-primary-50/80 p-4">
           <div>
-            <p className="text-sm font-medium text-primary-900">Add custom provider</p>
+            <p className="text-sm font-medium text-primary-900">
+              Add custom provider
+            </p>
             <p className="mt-1 text-xs text-primary-600">
-              <span className="font-medium">Title</span> is for your list only (e.g.{' '}
-              <span className="font-mono">Qwen3.6.Eclipse</span> = model + host).{' '}
-              <span className="font-medium">Provider id</span> is the config name Hermes uses — leave
-              blank to derive a safe id from the title. Optional row API key is stored on this
-              provider entry, not in .env.
+              <span className="font-medium">Title</span> is for your list only
+              (e.g. <span className="font-mono">Qwen3.6.Eclipse</span> = model +
+              host). <span className="font-medium">Provider id</span> is the
+              config name Hermes uses — leave blank to derive a safe id from the
+              title. Optional row API key is stored on this provider entry, not
+              in .env.
             </p>
           </div>
           <div className="grid gap-3 md:grid-cols-2">
             <label className="space-y-1 md:col-span-2">
-              <span className="text-xs font-medium text-primary-600">Title</span>
+              <span className="text-xs font-medium text-primary-600">
+                Title
+              </span>
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                 <Input
                   value={addCpTitle}
@@ -1871,7 +1914,9 @@ function ClaudeConfigSection({
               </div>
             </label>
             <label className="space-y-1">
-              <span className="text-xs font-medium text-primary-600">Provider id (optional)</span>
+              <span className="text-xs font-medium text-primary-600">
+                Provider id (optional)
+              </span>
               <Input
                 value={addCpProviderId}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -1882,7 +1927,9 @@ function ClaudeConfigSection({
               />
             </label>
             <label className="space-y-1">
-              <span className="text-xs font-medium text-primary-600">Base URL</span>
+              <span className="text-xs font-medium text-primary-600">
+                Base URL
+              </span>
               <Input
                 value={addCpBaseUrl}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -1903,7 +1950,10 @@ function ClaudeConfigSection({
                   setAddCpTitle((t) =>
                     t.trim()
                       ? t
-                      : suggestCustomProviderTitle(modelInput, baseUrlInput.trim()),
+                      : suggestCustomProviderTitle(
+                          modelInput,
+                          baseUrlInput.trim(),
+                        ),
                   )
                 }}
               >
@@ -1938,7 +1988,9 @@ function ClaudeConfigSection({
         <div className="overflow-x-auto rounded-xl border border-primary-200 bg-white/90">
           <div className="flex flex-col gap-2 border-b border-primary-200 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-primary-700">
-              <span className="font-medium text-primary-900">Saved &amp; detected endpoints</span>
+              <span className="font-medium text-primary-900">
+                Saved &amp; detected endpoints
+              </span>
               <span className="text-primary-600">
                 {' '}
                 (
@@ -1977,10 +2029,12 @@ function ClaudeConfigSection({
                     colSpan={5}
                     className="px-3 py-4 text-xs leading-relaxed text-primary-600"
                   >
-                    No rows in <span className="font-mono">custom_providers</span> yet, and no
-                    primary base URL or manifest URL was detected. Use{' '}
-                    <span className="font-medium">Add custom provider</span>, or set Model &amp;
-                    Provider and click &quot;Save current model setup to list&quot;.
+                    No rows in{' '}
+                    <span className="font-mono">custom_providers</span> yet, and
+                    no primary base URL or manifest URL was detected. Use{' '}
+                    <span className="font-medium">Add custom provider</span>, or
+                    set Model &amp; Provider and click &quot;Save current model
+                    setup to list&quot;.
                   </td>
                 </tr>
               ) : null}
@@ -1992,7 +2046,9 @@ function ClaudeConfigSection({
                     key={`saved-${key}-${index}`}
                     className="border-b border-primary-100 odd:bg-primary-50/40"
                   >
-                    <td className="px-3 py-2 align-top text-xs text-primary-600">Saved</td>
+                    <td className="px-3 py-2 align-top text-xs text-primary-600">
+                      Saved
+                    </td>
                     <td className="max-w-[160px] px-3 py-2 align-top text-xs font-medium text-primary-900 break-words">
                       {entry.title || '—'}
                     </td>
@@ -2022,7 +2078,11 @@ function ClaudeConfigSection({
                           onClick={() => removeCustomProviderAt(index)}
                           aria-label={`Remove ${entry.name || 'custom provider'}`}
                         >
-                          <HugeiconsIcon icon={Delete02Icon} size={16} strokeWidth={1.5} />
+                          <HugeiconsIcon
+                            icon={Delete02Icon}
+                            size={16}
+                            strokeWidth={1.5}
+                          />
                         </Button>
                       </div>
                     </td>
@@ -2031,9 +2091,14 @@ function ClaudeConfigSection({
               })}
               {extraPrimaryNotInList ? (
                 <tr className="border-b border-primary-100 bg-amber-50/50">
-                  <td className="px-3 py-2 align-top text-xs text-amber-900">Active (not in list)</td>
+                  <td className="px-3 py-2 align-top text-xs text-amber-900">
+                    Active (not in list)
+                  </td>
                   <td className="max-w-[160px] px-3 py-2 align-top text-xs text-primary-800 break-words">
-                    {suggestCustomProviderTitle(modelInput, extraPrimaryNotInList.base_url)}
+                    {suggestCustomProviderTitle(
+                      modelInput,
+                      extraPrimaryNotInList.base_url,
+                    )}
                   </td>
                   <td className="px-3 py-2 align-top font-mono text-xs font-medium text-primary-900">
                     {extraPrimaryNotInList.name}
@@ -2051,7 +2116,9 @@ function ClaudeConfigSection({
                         onClick={() => {
                           setProviderInput(extraPrimaryNotInList.name)
                           setBaseUrlInput(extraPrimaryNotInList.base_url)
-                          void fetchModelsForProvider(extraPrimaryNotInList.name)
+                          void fetchModelsForProvider(
+                            extraPrimaryNotInList.name,
+                          )
                         }}
                       >
                         Apply
@@ -2082,11 +2149,14 @@ function ClaudeConfigSection({
               ) : null}
               {extraManifestNotInList ? (
                 <tr className="border-b border-primary-100 bg-sky-50/50">
-                  <td className="px-3 py-2 align-top text-xs text-sky-900">Manifest block</td>
+                  <td className="px-3 py-2 align-top text-xs text-sky-900">
+                    Manifest block
+                  </td>
                   <td className="max-w-[160px] px-3 py-2 align-top text-xs text-primary-800 break-words">
                     {(() => {
                       try {
-                        const h = new URL(extraManifestNotInList.base_url).hostname
+                        const h = new URL(extraManifestNotInList.base_url)
+                          .hostname
                         const short = h.split('.')[0] || h
                         return `Manifest.${short.charAt(0).toUpperCase()}${short.slice(1).toLowerCase()}`
                       } catch {
@@ -2108,17 +2178,21 @@ function ClaudeConfigSection({
                       disabled={saving}
                       onClick={() => {
                         const u = extraManifestNotInList.base_url
-                        persistCustomProviderRow(deriveCustomProviderNameFromBaseUrl(u), u, {
-                          title: (() => {
-                            try {
-                              const h = new URL(u).hostname
-                              const short = h.split('.')[0] || h
-                              return `Manifest.${short.charAt(0).toUpperCase()}${short.slice(1).toLowerCase()}`
-                            } catch {
-                              return 'Manifest'
-                            }
-                          })(),
-                        })
+                        persistCustomProviderRow(
+                          deriveCustomProviderNameFromBaseUrl(u),
+                          u,
+                          {
+                            title: (() => {
+                              try {
+                                const h = new URL(u).hostname
+                                const short = h.split('.')[0] || h
+                                return `Manifest.${short.charAt(0).toUpperCase()}${short.slice(1).toLowerCase()}`
+                              } catch {
+                                return 'Manifest'
+                              }
+                            })(),
+                          },
+                        )
                       }}
                     >
                       Add to list
@@ -2142,7 +2216,8 @@ function ClaudeConfigSection({
         >
           <div className="flex w-full max-w-sm flex-col gap-1">
             <p className="text-[11px] text-primary-500">
-              Leave blank if unused. Add only when your manifest integration requires this key.
+              Leave blank if unused. Add only when your manifest integration
+              requires this key.
             </p>
             <div className="flex items-center gap-2">
               <div className="flex-1">
@@ -2162,7 +2237,9 @@ function ClaudeConfigSection({
                       onClick={() => {
                         void saveConfig({
                           env: {
-                            CUSTOM_API_KEY: customApiKey.trim() ? customApiKey.trim() : null,
+                            CUSTOM_API_KEY: customApiKey.trim()
+                              ? customApiKey.trim()
+                              : null,
                           },
                         })
                         setEditingCustomKey(false)
@@ -2185,7 +2262,9 @@ function ClaudeConfigSection({
                       style={{ color: 'var(--theme-muted)' }}
                     >
                       {customApiKeyConfigured
-                        ? customProviderCatalogEntry.maskedKeys['CUSTOM_API_KEY'] || 'Set'
+                        ? customProviderCatalogEntry?.maskedKeys?.[
+                            'CUSTOM_API_KEY'
+                          ] || 'Set'
                         : 'Not set'}
                     </span>
                     <Button
@@ -2214,8 +2293,8 @@ function ClaudeConfigSection({
         >
           <div className="flex w-full max-w-sm flex-col gap-1">
             <p className="text-[11px] text-primary-500">
-              This updates <span className="font-mono">providers.manifest</span> only. Primary model
-              base URL stays under Model &amp; Provider.
+              This updates <span className="font-mono">providers.manifest</span>{' '}
+              only. Primary model base URL stays under Model &amp; Provider.
             </p>
             <div className="flex items-center gap-2">
               <div className="flex-1">
@@ -2234,13 +2313,18 @@ function ClaudeConfigSection({
                       onClick={() => {
                         const u = customBaseUrl.trim()
                         if (!u) {
-                          setSaveMessage('Enter a manifest base URL, or cancel.')
+                          setSaveMessage(
+                            'Enter a manifest base URL, or cancel.',
+                          )
                           setTimeout(() => setSaveMessage(null), 3000)
                           return
                         }
                         void saveConfig({
                           config: {
-                            model: mergeModelForManifestSave(data.config, modelInput.trim()),
+                            model: mergeModelForManifestSave(
+                              data.config,
+                              modelInput.trim(),
+                            ),
                             providers: {
                               manifest: {
                                 type: 'openai',
@@ -2634,7 +2718,9 @@ function ClaudeConfigSection({
                 value={(sttGroq.model as string) || GROQ_STT_MODELS[0]}
                 onChange={(e) =>
                   void saveConfig({
-                    config: { stt: { groq: { ...sttGroq, model: e.target.value } } },
+                    config: {
+                      stt: { groq: { ...sttGroq, model: e.target.value } },
+                    },
                   })
                 }
                 className={selectClassName}

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -72,7 +72,7 @@ type ChatComposerAttachment = {
   kind?: 'image' | 'file' | 'audio'
 }
 
-type ThinkingLevel = 'off' | 'low' | 'medium' | 'high'
+type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'adaptive'
 
 type ChatComposerProps = {
   onSubmit: (
@@ -116,6 +116,7 @@ function nextThinkingLevel(level: ThinkingLevel): ThinkingLevel {
   if (level === 'off') return 'low'
   if (level === 'low') return 'medium'
   if (level === 'medium') return 'high'
+  if (level === 'high') return 'adaptive'
   return 'off'
 }
 
@@ -237,7 +238,10 @@ async function fetchInstalledSkills(): Promise<Array<InstalledSkillSummary>> {
 
   return skills
     .map((entry) => {
-      const id = readModelText(entry.id) || readModelText(entry.slug) || readModelText(entry.name)
+      const id =
+        readModelText(entry.id) ||
+        readModelText(entry.slug) ||
+        readModelText(entry.name)
       if (!id) return null
       const name = readModelText(entry.name) || id
       const description = readModelText(entry.description)
@@ -721,7 +725,9 @@ async function readResponseError(response: Response): Promise<string> {
   }
 }
 
-async function fetchCurrentModelFromStatus(sessionKey?: string): Promise<string> {
+async function fetchCurrentModelFromStatus(
+  sessionKey?: string,
+): Promise<string> {
   const controller = new AbortController()
   const timeout = globalThis.setTimeout(() => controller.abort(), 7000)
 
@@ -809,6 +815,7 @@ function thinkingLabel(level: ThinkingLevel): string {
   if (level === 'off') return 'None'
   if (level === 'low') return 'Low'
   if (level === 'medium') return 'Medium'
+  if (level === 'adaptive') return 'Adaptive'
   return 'High'
 }
 
@@ -1158,16 +1165,16 @@ function ChatComposerComponent({
   // model/provider configured in ~/.hermes/config.yaml. Users switch
   // via the model selector or Settings page.
 
-  // When model switches to Claude 4.6 and thinking is 'off', auto-upgrade to medium effort
+  // When model switches to Claude 4.6 and thinking is 'off', auto-upgrade to adaptive effort
   const prevModelRef = useRef('')
   useEffect(() => {
     if (!currentModel || currentModel === prevModelRef.current) return
     prevModelRef.current = currentModel
     if (isClaude46Model(currentModel) && thinkingLevel === 'off') {
       if (onThinkingLevelChange) {
-        onThinkingLevelChange('medium')
+        onThinkingLevelChange('adaptive')
       } else {
-        setInternalThinkingLevel('medium')
+        setInternalThinkingLevel('adaptive')
       }
     }
   }, [currentModel, thinkingLevel, onThinkingLevelChange])
@@ -1302,6 +1309,7 @@ function ChatComposerComponent({
     if (
       !isModelMenuOpen &&
       !isProfileMenuOpen &&
+      !isWorkspaceMenuOpen &&
       !isThinkingMenuOpen &&
       !isControlsMenuOpen
     )
@@ -1311,11 +1319,13 @@ function ChatComposerComponent({
       if (controlsMenuRef.current?.contains(target)) return
       if (modelSelectorRef.current?.contains(target)) return
       if (profileMenuRef.current?.contains(target)) return
+      if (workspaceMenuRef.current?.contains(target)) return
       if (thinkingMenuRef.current?.contains(target)) return
       setIsControlsMenuOpen(false)
       setIsModelMenuOpen(false)
       setIsProviderSwitcherExpanded(false)
       setIsProfileMenuOpen(false)
+      setIsWorkspaceMenuOpen(false)
       setIsThinkingMenuOpen(false)
     }
 
@@ -1326,6 +1336,7 @@ function ChatComposerComponent({
   }, [
     isModelMenuOpen,
     isProfileMenuOpen,
+    isWorkspaceMenuOpen,
     isThinkingMenuOpen,
     isControlsMenuOpen,
   ])
@@ -1696,7 +1707,8 @@ function ChatComposerComponent({
   void _isWebSearchActive // retained for future use / external prop
 
   const sttConfig =
-    (sttConfigQuery.data?.config?.stt as Record<string, unknown> | undefined) || {}
+    (sttConfigQuery.data?.config?.stt as Record<string, unknown> | undefined) ||
+    {}
   const sttProvider =
     typeof sttConfig.provider === 'string' ? sttConfig.provider.trim() : 'local'
   const useRemoteStt = sttProvider === 'groq' || sttProvider === 'openai'
@@ -1706,7 +1718,10 @@ function ChatComposerComponent({
       const normalized = text.trim()
       if (!normalized) return
       setValue((prev) => {
-        const next = prev.trim().length > 0 ? `${prev}${separator}${normalized}` : normalized
+        const next =
+          prev.trim().length > 0
+            ? `${prev}${separator}${normalized}`
+            : normalized
         persistDraft(next)
         return next
       })
@@ -1734,7 +1749,9 @@ function ChatComposerComponent({
         error?: string
       }
       if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error || `Transcription failed (${response.status})`)
+        throw new Error(
+          payload.error || `Transcription failed (${response.status})`,
+        )
       }
       return typeof payload.text === 'string' ? payload.text : ''
     },
@@ -1750,12 +1767,9 @@ function ChatComposerComponent({
       },
       [appendTextToDraft],
     ),
-    onError: useCallback(
-      (error: string) => {
-        toast(error || 'Voice transcription failed', { type: 'error' })
-      },
-      [],
-    ),
+    onError: useCallback((error: string) => {
+      toast(error || 'Voice transcription failed', { type: 'error' })
+    }, []),
   })
 
   // Voice recorder (long-press = voice note)
@@ -2738,6 +2752,7 @@ function ChatComposerComponent({
                       onClick={() => {
                         setIsControlsMenuOpen((open) => !open)
                         setIsProfileMenuOpen(false)
+                        setIsWorkspaceMenuOpen(false)
                         setIsThinkingMenuOpen(false)
                         setIsModelMenuOpen(false)
                       }}
@@ -2759,9 +2774,27 @@ function ChatComposerComponent({
                         <line x1="4" y1="6" x2="20" y2="6" />
                         <line x1="4" y1="12" x2="20" y2="12" />
                         <line x1="4" y1="18" x2="20" y2="18" />
-                        <circle cx="9" cy="6" r="2" fill="currentColor" stroke="none" />
-                        <circle cx="15" cy="12" r="2" fill="currentColor" stroke="none" />
-                        <circle cx="11" cy="18" r="2" fill="currentColor" stroke="none" />
+                        <circle
+                          cx="9"
+                          cy="6"
+                          r="2"
+                          fill="currentColor"
+                          stroke="none"
+                        />
+                        <circle
+                          cx="15"
+                          cy="12"
+                          r="2"
+                          fill="currentColor"
+                          stroke="none"
+                        />
+                        <circle
+                          cx="11"
+                          cy="18"
+                          r="2"
+                          fill="currentColor"
+                          stroke="none"
+                        />
                       </svg>
                       <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
                     </button>
@@ -2779,10 +2812,13 @@ function ChatComposerComponent({
                               type="button"
                               onClick={() => {
                                 setIsProfileMenuOpen((open) => !open)
+                                setIsWorkspaceMenuOpen(false)
                                 setIsThinkingMenuOpen(false)
                                 setIsModelMenuOpen(false)
                               }}
-                              disabled={disabled || profileActivateMutation.isPending}
+                              disabled={
+                                disabled || profileActivateMutation.isPending
+                              }
                               className="inline-flex h-8 max-w-[8rem] items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-primary-800/60"
                               title={
                                 activeProfile
@@ -2790,11 +2826,23 @@ function ChatComposerComponent({
                                   : activeProfileName
                               }
                             >
-                              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                              <svg
+                                width="13"
+                                height="13"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
                                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
                                 <circle cx="12" cy="7" r="4" />
                               </svg>
-                              <span className="truncate">{activeProfileName}</span>
+                              <span className="truncate">
+                                {activeProfileName}
+                              </span>
                               <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
                             </button>
                             {isProfileMenuOpen && (
@@ -2802,18 +2850,119 @@ function ChatComposerComponent({
                                 <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
                                   Agent profile
                                 </div>
-                                {(profilesQuery.data?.profiles ?? []).map((profile) => {
-                                  const selected = profile.name === activeProfileName
+                                {(profilesQuery.data?.profiles ?? []).map(
+                                  (profile) => {
+                                    const selected =
+                                      profile.name === activeProfileName
+                                    return (
+                                      <button
+                                        key={profile.name}
+                                        type="button"
+                                        onClick={() => {
+                                          if (selected) {
+                                            setIsProfileMenuOpen(false)
+                                            return
+                                          }
+                                          profileActivateMutation.mutate(
+                                            profile.name,
+                                          )
+                                        }}
+                                        className={cn(
+                                          'flex w-full flex-col rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                                          selected
+                                            ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                            : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60',
+                                        )}
+                                      >
+                                        <span className="flex items-center gap-2">
+                                          <span className="truncate font-medium">
+                                            {profile.name}
+                                          </span>
+                                          {selected ? (
+                                            <span className="text-[10px] text-accent-500">
+                                              active
+                                            </span>
+                                          ) : null}
+                                        </span>
+                                        {profileMeta(profile) ? (
+                                          <span className="mt-0.5 max-w-[12rem] truncate text-[11px] text-neutral-500">
+                                            {profileMeta(profile)}
+                                          </span>
+                                        ) : null}
+                                      </button>
+                                    )
+                                  },
+                                )}
+                                {profilesQuery.isError ? (
+                                  <div className="px-3 py-2 text-xs text-red-500">
+                                    Failed to load profiles
+                                  </div>
+                                ) : null}
+                              </div>
+                            )}
+                          </div>
+
+                          <div
+                            className="relative flex min-w-0 items-center"
+                            ref={workspaceMenuRef}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsWorkspaceMenuOpen((open) => !open)
+                                setIsProfileMenuOpen(false)
+                                setIsThinkingMenuOpen(false)
+                                setIsModelMenuOpen(false)
+                              }}
+                              disabled={
+                                disabled || workspaceSelectMutation.isPending
+                              }
+                              className="inline-flex h-8 max-w-[10rem] items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-primary-800/60"
+                              title="Workspace context"
+                            >
+                              <svg
+                                width="13"
+                                height="13"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
+                                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+                              </svg>
+                              <span className="truncate">
+                                {workspaceButtonLabel}
+                              </span>
+                              <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
+                            </button>
+                            {isWorkspaceMenuOpen && (
+                              <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[16rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
+                                <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
+                                  Workspace context
+                                </div>
+                                {detectedWorkspacePath ? (
+                                  <div className="mx-2 mb-1 truncate rounded-lg bg-neutral-50 px-2 py-1.5 text-[11px] text-neutral-500 dark:bg-neutral-800/60 dark:text-neutral-400">
+                                    {detectedWorkspacePath}
+                                  </div>
+                                ) : null}
+                                {workspaceEntries.map((workspace) => {
+                                  const selected =
+                                    workspace.path === detectedWorkspacePath
                                   return (
                                     <button
-                                      key={profile.name}
+                                      key={workspace.path}
                                       type="button"
                                       onClick={() => {
                                         if (selected) {
-                                          setIsProfileMenuOpen(false)
+                                          setIsWorkspaceMenuOpen(false)
                                           return
                                         }
-                                        profileActivateMutation.mutate(profile.name)
+                                        workspaceSelectMutation.mutate(
+                                          workspace,
+                                        )
                                       }}
                                       className={cn(
                                         'flex w-full flex-col rounded-lg px-3 py-2 text-left text-sm transition-colors',
@@ -2823,14 +2972,28 @@ function ChatComposerComponent({
                                       )}
                                     >
                                       <span className="flex items-center gap-2">
-                                        <span className="truncate font-medium">{profile.name}</span>
-                                        {selected ? <span className="text-[10px] text-accent-500">active</span> : null}
+                                        <span className="truncate font-medium">
+                                          {workspace.name}
+                                        </span>
+                                        {selected ? (
+                                          <span className="text-[10px] text-accent-500">
+                                            active
+                                          </span>
+                                        ) : null}
                                       </span>
-                                      {profileMeta(profile) ? <span className="mt-0.5 max-w-[12rem] truncate text-[11px] text-neutral-500">{profileMeta(profile)}</span> : null}
+                                      <span className="mt-0.5 max-w-[13rem] truncate text-[11px] text-neutral-500">
+                                        {workspace.path}
+                                      </span>
                                     </button>
                                   )
                                 })}
-                                {profilesQuery.isError ? <div className="px-3 py-2 text-xs text-red-500">Failed to load profiles</div> : null}
+                                <button
+                                  type="button"
+                                  onClick={handleOpenWorkspaceManager}
+                                  className="mt-1 flex w-full items-center rounded-lg px-3 py-2 text-left text-xs font-medium text-accent-600 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-800/60"
+                                >
+                                  Browse workspace files
+                                </button>
                               </div>
                             )}
                           </div>
@@ -2844,6 +3007,7 @@ function ChatComposerComponent({
                               onClick={() => {
                                 setIsThinkingMenuOpen((open) => !open)
                                 setIsProfileMenuOpen(false)
+                                setIsWorkspaceMenuOpen(false)
                                 setIsModelMenuOpen(false)
                               }}
                               className={cn(
@@ -2852,7 +3016,17 @@ function ChatComposerComponent({
                               )}
                               title={`Reasoning effort: ${thinkingLabel(thinkingLevel)}`}
                             >
-                              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                              <svg
+                                width="13"
+                                height="13"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
                                 <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.46 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z" />
                                 <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.46 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z" />
                               </svg>
@@ -2861,12 +3035,15 @@ function ChatComposerComponent({
                             </button>
                             {isThinkingMenuOpen && (
                               <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[10rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
-                                {([
-                                  ['off', 'None'],
-                                  ['low', 'Low'],
-                                  ['medium', 'Medium'],
-                                  ['high', 'High'],
-                                ] as Array<[ThinkingLevel, string]>).map(([level, label]) => (
+                                {(
+                                  [
+                                    ['off', 'None'],
+                                    ['low', 'Low'],
+                                    ['medium', 'Medium'],
+                                    ['high', 'High'],
+                                    ['adaptive', 'Adaptive'],
+                                  ] as Array<[ThinkingLevel, string]>
+                                ).map(([level, label]) => (
                                   <button
                                     key={level}
                                     type="button"
@@ -2879,7 +3056,9 @@ function ChatComposerComponent({
                                     )}
                                   >
                                     <span>{label}</span>
-                                    {thinkingLevel === level ? <span className="h-1.5 w-1.5 rounded-full bg-accent-500" /> : null}
+                                    {thinkingLevel === level ? (
+                                      <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />
+                                    ) : null}
                                   </button>
                                 ))}
                               </div>
@@ -2895,48 +3074,110 @@ function ChatComposerComponent({
                               onClick={() => {
                                 setIsModelMenuOpen((prev) => !prev)
                                 setIsProfileMenuOpen(false)
+                                setIsWorkspaceMenuOpen(false)
                                 setIsThinkingMenuOpen(false)
                               }}
                               disabled={isModelSwitcherDisabled}
                               className="inline-flex h-8 max-w-[9rem] items-center rounded-full bg-primary-100/70 px-2 md:max-w-none md:px-3 text-xs font-medium text-primary-600 hover:bg-primary-200/80 dark:hover:bg-primary-800/60 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
                               title={modelButtonLabel}
                             >
-                              <span className="max-w-[5.5rem] truncate sm:max-w-[8.5rem] md:max-w-[12rem]">{modelButtonLabel}</span>
+                              <span className="max-w-[5.5rem] truncate sm:max-w-[8.5rem] md:max-w-[12rem]">
+                                {modelButtonLabel}
+                              </span>
                             </button>
                             {isModelMenuOpen && (
                               <>
-                                <div className="fixed inset-0 z-[199]" onClick={() => setIsModelMenuOpen(false)} />
+                                <div
+                                  className="fixed inset-0 z-[199]"
+                                  onClick={() => setIsModelMenuOpen(false)}
+                                />
                                 <div className="absolute bottom-full left-0 mb-2 z-[200] w-[min(28rem,calc(100vw-2rem))] min-w-[18rem] origin-bottom-left overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900 animate-in fade-in slide-in-from-bottom-2 duration-150">
                                   <div className="max-h-[20rem] overflow-y-auto overflow-x-hidden p-1">
                                     {(() => {
-                                      const allModels = modelsQuery.data?.models ?? []
-                                      const defaultProvider = modelsQuery.data?.currentProvider ?? ''
+                                      const allModels =
+                                        modelsQuery.data?.models ?? []
+                                      const defaultProvider =
+                                        modelsQuery.data?.currentProvider ?? ''
                                       if (allModels.length === 0) {
-                                        return <div className="p-4 text-center text-sm text-neutral-500">No models available</div>
+                                        return (
+                                          <div className="p-4 text-center text-sm text-neutral-500">
+                                            No models available
+                                          </div>
+                                        )
                                       }
                                       const parsed = allModels.map((m) => {
-                                        const mId = String(typeof m === 'string' ? m : m.id || m.model || m.name || 'unknown')
-                                        const mName = String(typeof m === 'string' ? m : m.name || m.displayName || m.label || m.id || m.model || m)
-                                        const mProvider = typeof m === 'string' ? defaultProvider : ((m as Record<string, unknown>).provider as string) || defaultProvider
-                                        const isLocal = typeof m !== 'string' && (m as Record<string, unknown>).description === 'local'
-                                        return { id: mId, name: mName, provider: mProvider, isLocal }
+                                        const mId = String(
+                                          typeof m === 'string'
+                                            ? m
+                                            : m.id ||
+                                                m.model ||
+                                                m.name ||
+                                                'unknown',
+                                        )
+                                        const mName = String(
+                                          typeof m === 'string'
+                                            ? m
+                                            : m.name ||
+                                                m.displayName ||
+                                                m.label ||
+                                                m.id ||
+                                                m.model ||
+                                                m,
+                                        )
+                                        const mProvider =
+                                          typeof m === 'string'
+                                            ? defaultProvider
+                                            : ((m as Record<string, unknown>)
+                                                .provider as string) ||
+                                              defaultProvider
+                                        const isLocal =
+                                          typeof m !== 'string' &&
+                                          (m as Record<string, unknown>)
+                                            .description === 'local'
+                                        return {
+                                          id: mId,
+                                          name: mName,
+                                          provider: mProvider,
+                                          isLocal,
+                                        }
                                       })
-                                      const pinnedEntries = parsed.filter((e) => isPinned(e.id))
-                                      const unpinnedGroups = new Map<string, typeof parsed>()
+                                      const pinnedEntries = parsed.filter((e) =>
+                                        isPinned(e.id),
+                                      )
+                                      const unpinnedGroups = new Map<
+                                        string,
+                                        typeof parsed
+                                      >()
                                       for (const entry of parsed) {
                                         if (isPinned(entry.id)) continue
-                                        const group = unpinnedGroups.get(entry.provider) ?? []
+                                        const group =
+                                          unpinnedGroups.get(entry.provider) ??
+                                          []
                                         group.push(entry)
-                                        unpinnedGroups.set(entry.provider, group)
+                                        unpinnedGroups.set(
+                                          entry.provider,
+                                          group,
+                                        )
                                       }
-                                      const renderEntry = (entry: (typeof parsed)[0]) => {
-                                        const isActive = entry.id === currentModel || `${defaultProvider}/${entry.id}` === currentModel
+                                      const renderEntry = (
+                                        entry: (typeof parsed)[0],
+                                      ) => {
+                                        const isActive =
+                                          entry.id === currentModel ||
+                                          `${defaultProvider}/${entry.id}` ===
+                                            currentModel
                                         return (
-                                          <div key={entry.id} className="group relative flex items-center">
+                                          <div
+                                            key={entry.id}
+                                            className="group relative flex items-center"
+                                          >
                                             <button
                                               type="button"
                                               onClick={() => {
-                                                handleModelSelect(entry.id, entry.provider || undefined)
+                                                handleModelSelect(
+                                                  entry.id,
+                                                  entry.provider || undefined,
+                                                )
                                                 setIsModelMenuOpen(false)
                                               }}
                                               className={`flex flex-1 items-center gap-2 px-3 py-2.5 text-left text-sm transition-colors ${
@@ -2945,9 +3186,17 @@ function ChatComposerComponent({
                                                   : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/50'
                                               }`}
                                             >
-                                              <span className="flex-1 truncate">{entry.name}</span>
-                                              {entry.isLocal ? <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-700">local</span> : null}
-                                              {isActive ? <span className="h-1.5 w-1.5 rounded-full bg-accent-500" /> : null}
+                                              <span className="flex-1 truncate">
+                                                {entry.name}
+                                              </span>
+                                              {entry.isLocal ? (
+                                                <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-700">
+                                                  local
+                                                </span>
+                                              ) : null}
+                                              {isActive ? (
+                                                <span className="h-1.5 w-1.5 rounded-full bg-accent-500" />
+                                              ) : null}
                                             </button>
                                             <button
                                               type="button"
@@ -2960,9 +3209,24 @@ function ChatComposerComponent({
                                                   ? 'text-accent-500 opacity-80 hover:opacity-100'
                                                   : 'text-neutral-400 opacity-0 group-hover:opacity-60 hover:!opacity-100 hover:text-accent-500'
                                               }`}
-                                              aria-label={isPinned(entry.id) ? `Unpin ${entry.name}` : `Pin ${entry.name}`}
+                                              aria-label={
+                                                isPinned(entry.id)
+                                                  ? `Unpin ${entry.name}`
+                                                  : `Pin ${entry.name}`
+                                              }
                                             >
-                                              <svg width="12" height="12" viewBox="0 0 24 24" fill={isPinned(entry.id) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2">
+                                              <svg
+                                                width="12"
+                                                height="12"
+                                                viewBox="0 0 24 24"
+                                                fill={
+                                                  isPinned(entry.id)
+                                                    ? 'currentColor'
+                                                    : 'none'
+                                                }
+                                                stroke="currentColor"
+                                                strokeWidth="2"
+                                              >
                                                 <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
                                               </svg>
                                             </button>
@@ -2974,7 +3238,15 @@ function ChatComposerComponent({
                                           {pinnedEntries.length > 0 ? (
                                             <div className="mb-1 border-b border-neutral-200 pb-1 dark:border-neutral-700">
                                               <div className="mb-1 flex items-center gap-1 px-3 text-[11px] font-medium uppercase tracking-wider text-neutral-500">
-                                                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" className="text-accent-500">
+                                                <svg
+                                                  width="12"
+                                                  height="12"
+                                                  viewBox="0 0 24 24"
+                                                  fill="currentColor"
+                                                  stroke="currentColor"
+                                                  strokeWidth="2"
+                                                  className="text-accent-500"
+                                                >
                                                   <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7z" />
                                                 </svg>
                                                 <span>Pinned</span>
@@ -2982,12 +3254,18 @@ function ChatComposerComponent({
                                               {pinnedEntries.map(renderEntry)}
                                             </div>
                                           ) : null}
-                                          {Array.from(unpinnedGroups.entries()).sort((a, b) => a[0].localeCompare(b[0])).map(([provider, models]) => (
-                                            <div key={provider}>
-                                              <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400">{provider}</div>
-                                              {models.map(renderEntry)}
-                                            </div>
-                                          ))}
+                                          {Array.from(unpinnedGroups.entries())
+                                            .sort((a, b) =>
+                                              a[0].localeCompare(b[0]),
+                                            )
+                                            .map(([provider, models]) => (
+                                              <div key={provider}>
+                                                <div className="px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wider text-neutral-400">
+                                                  {provider}
+                                                </div>
+                                                {models.map(renderEntry)}
+                                              </div>
+                                            ))}
                                         </>
                                       )
                                     })()}

--- a/src/screens/chat/components/chat-header.tsx
+++ b/src/screens/chat/components/chat-header.tsx
@@ -64,7 +64,7 @@ function formatMobileSessionTitle(rawTitle: string): string {
   return title
 }
 
-type ThinkingLevel = 'off' | 'low' | 'adaptive'
+type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'adaptive'
 
 type ChatHeaderProps = {
   activeTitle: string
@@ -169,7 +169,8 @@ function ChatHeaderComponent({
   void activeToolName
   void isFocusMode
   void onToggleFocusMode // kept for prop compat
-  const showThinkingIndicator = thinkingLevel === 'adaptive'
+  const showThinkingIndicator =
+    thinkingLevel !== 'off' && thinkingLevel !== 'low'
 
   const handleRefresh = useCallback(() => {
     if (!onRefresh) return
@@ -299,7 +300,6 @@ function ChatHeaderComponent({
           </button>
 
           <div className="flex-1" />
-
         </div>
       </div>
     )

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -225,7 +225,8 @@ function NavItem({
               style={
                 item.badge === 'NEW'
                   ? {
-                      background: 'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                      background:
+                        'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
                       color: '#0b1320',
                       boxShadow: '0 0 8px rgba(250,204,21,0.4)',
                       letterSpacing: '0.08em',
@@ -253,8 +254,8 @@ function NavItem({
             <TooltipTrigger
               render={
                 <Link
-                  to={item.to}
-                  search={item.search}
+                  to={item.to as any}
+                  search={item.search as any}
                   hash={item.hash}
                   onClick={handleSelect}
                   className={cls}
@@ -271,8 +272,8 @@ function NavItem({
     }
     return (
       <Link
-        to={item.to}
-        search={item.search}
+        to={item.to as any}
+        search={item.search as any}
         hash={item.hash}
         onClick={handleSelect}
         className={cls}
@@ -547,7 +548,9 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail.section === 'appearance' ? 'appearance' : 'claude')
+      handleOpenSettings(
+        detail.section === 'appearance' ? 'appearance' : 'claude',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -845,7 +848,6 @@ function ChatSidebarComponent({
       label: 'Swarm',
       active: isSwarmActive,
     },
-
   ]
 
   const knowledgeItems: Array<NavItemDef> = [
@@ -1036,41 +1038,41 @@ function ChatSidebarComponent({
       {/* Hide when VITE_HERMESWORLD_ENABLED is explicitly '0' */}
       {!isVisuallyCollapsed &&
         (import.meta as any).env?.VITE_HERMESWORLD_ENABLED !== '0' && (
-        <div className="px-2 pb-2">
-          <Link
-            to="/playground"
-            onClick={() => onSelectSession?.()}
-            className={cn(
-              buttonVariants({ variant: 'ghost', size: 'sm' }),
-              'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
-              isPlaygroundActive &&
-                'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
-            )}
-            data-tour="hermesworld"
-          >
-            <HugeiconsIcon
-              icon={Castle02Icon}
-              size={20}
-              strokeWidth={1.5}
-              className="size-5 shrink-0"
-              style={{ color: '#facc15' }}
-            />
-            <span>HermesWorld</span>
-            <span
-              className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
-              style={{
-                background:
-                  'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
-                color: '#0b1320',
-                boxShadow: '0 0 8px rgba(250,204,21,0.4)',
-                letterSpacing: '0.08em',
-              }}
+          <div className="px-2 pb-2">
+            <Link
+              to="/playground"
+              onClick={() => onSelectSession?.()}
+              className={cn(
+                buttonVariants({ variant: 'ghost', size: 'sm' }),
+                'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
+                isPlaygroundActive &&
+                  'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
+              )}
+              data-tour="hermesworld"
             >
-              NEW
-            </span>
-          </Link>
-        </div>
-      )}
+              <HugeiconsIcon
+                icon={Castle02Icon}
+                size={20}
+                strokeWidth={1.5}
+                className="size-5 shrink-0"
+                style={{ color: '#facc15' }}
+              />
+              <span>HermesWorld</span>
+              <span
+                className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
+                style={{
+                  background:
+                    'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
+                  color: '#0b1320',
+                  boxShadow: '0 0 8px rgba(250,204,21,0.4)',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                NEW
+              </span>
+            </Link>
+          </div>
+        )}
 
       {/* ── Scrollable body: nav + sessions ─────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin flex flex-col">

--- a/src/screens/chat/hooks/use-realtime-chat-history.ts
+++ b/src/screens/chat/hooks/use-realtime-chat-history.ts
@@ -196,7 +196,9 @@ export function useRealtimeChatHistory({
           if (
             msgText.startsWith('Pre-compaction memory flush') ||
             msgText.startsWith('Store durable memories now') ||
-            msgText.startsWith('APPEND new content only and do not overwrite') ||
+            msgText.startsWith(
+              'APPEND new content only and do not overwrite',
+            ) ||
             msgText.startsWith('A subagent task') ||
             msgText.startsWith('[Queued announce messages') ||
             msgText.startsWith('Summarize this naturally for the user') ||
@@ -382,9 +384,9 @@ export function useRealtimeChatHistory({
             const completedAssistant =
               realtimeMessages.length > 0
                 ? (() => {
-                    const last = realtimeMessages[realtimeMessages.length - 1] as
-                      | Record<string, unknown>
-                      | undefined
+                    const last = realtimeMessages[
+                      realtimeMessages.length - 1
+                    ] as Record<string, unknown> | undefined
                     return last?.role === 'assistant' ? last : null
                   })()
                 : null
@@ -394,42 +396,47 @@ export function useRealtimeChatHistory({
             clearCompletedStreaming()
 
             // Background refetch for long-term consistency — doesn't block render
-            queryClient.invalidateQueries({ queryKey: key, refetchType: 'all' }).then(() => {
-              // Re-inject the completed assistant message if compaction dropped it
-              if (completedAssistant) {
-                const refetchData =
-                  queryClient.getQueryData<Record<string, unknown>>(key)
-                const refetchedMessages =
-                  (refetchData?.messages as Array<Record<string, unknown>>) ?? []
-                const assistantTail = (completedAssistant.content ?? completedAssistant.text ?? '')
-                  .toString()
-                  .slice(-64)
-                const alreadyPresent = refetchedMessages.some(
-                  (m) =>
-                    m.role === 'assistant' &&
-                    ((m.content ?? m.text ?? '') as string).toString().slice(-64) === assistantTail,
-                )
-                if (!alreadyPresent) {
-                  appendHistoryMessage(
-                    queryClient,
-                    effectiveFriendlyId,
-                    effectiveSessionKey,
-                    completedAssistant as unknown as import('@/types/chat').ChatMessage,
+            queryClient
+              .invalidateQueries({ queryKey: key, refetchType: 'all' })
+              .then(() => {
+                // Re-inject the completed assistant message if compaction dropped it
+                if (completedAssistant) {
+                  const refetchData =
+                    queryClient.getQueryData<Record<string, unknown>>(key)
+                  const refetchedMessages =
+                    (refetchData?.messages as Array<Record<string, unknown>>) ??
+                    []
+                  const assistantTail = (
+                    completedAssistant.content ??
+                    completedAssistant.text ??
+                    ''
                   )
+                    .toString()
+                    .slice(-64)
+                  const alreadyPresent = refetchedMessages.some(
+                    (m) =>
+                      m.role === 'assistant' &&
+                      ((m.content ?? m.text ?? '') as string)
+                        .toString()
+                        .slice(-64) === assistantTail,
+                  )
+                  if (!alreadyPresent) {
+                    appendHistoryMessage(
+                      queryClient,
+                      effectiveFriendlyId,
+                      effectiveSessionKey,
+                      completedAssistant as ChatMessage,
+                    )
+                  }
                 }
-              }
-            })
+              })
 
             // Check for compaction — significant message count drop
             const newData =
               queryClient.getQueryData<Record<string, unknown>>(key)
             const newCount =
               (newData?.messages as Array<unknown> | undefined)?.length ?? 0
-            if (
-              prevCount > 10 &&
-              newCount > 0 &&
-              newCount < prevCount * 0.6
-            ) {
+            if (prevCount > 10 && newCount > 0 && newCount < prevCount * 0.6) {
               onCompactionEnd?.()
               toast(
                 'Context compacted — older messages were summarized to free up space',

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -35,7 +35,11 @@ type ConductorMissionRecord = {
     workerId: string
     task?: string
     state?: string
-    checkpoint?: { stateLabel?: string; result?: string; nextAction?: string } | null
+    checkpoint?: {
+      stateLabel?: string
+      result?: string
+      nextAction?: string
+    } | null
   }>
 }
 
@@ -167,7 +171,16 @@ export type MissionHistoryEntry = {
 const HISTORY_STORAGE_KEY = 'conductor:history'
 const MAX_HISTORY_ENTRIES = 50
 
-const AGENT_NAMES = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
+const AGENT_NAMES = [
+  'Nova',
+  'Pixel',
+  'Blaze',
+  'Echo',
+  'Sage',
+  'Drift',
+  'Flux',
+  'Volt',
+]
 const AGENT_EMOJIS = ['🤖', '⚡', '🔥', '🌊', '🌿', '💫', '🔮', '⭐']
 
 function getAgentPersona(index: number) {
@@ -179,7 +192,11 @@ function getAgentPersona(index: number) {
 
 function extractTasksFromPlan(planText: string): ConductorTask[] {
   const tasks: ConductorTask[] = []
-  const patterns = [/^\s*(\d+)\.\s+(.+)$/gm, /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm, /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm]
+  const patterns = [
+    /^\s*(\d+)\.\s+(.+)$/gm,
+    /^\s*#{1,3}\s+(?:Step\s+)?(\d+)[.:]\s*(.+)$/gm,
+    /^\s*-\s+\*\*(?:Task\s+)?(\d+)[.:]\s*\*\*\s*(.+)$/gm,
+  ]
 
   const seen = new Set<string>()
   for (const pattern of patterns) {
@@ -211,7 +228,9 @@ function extractTasksFromPlan(planText: string): ConductorTask[] {
 }
 
 function readString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null
 }
 
 function readNumber(value: unknown): number | null {
@@ -235,7 +254,11 @@ function toIso(value: unknown): string | null {
 }
 
 function normalizeMatchText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 function getSessionSearchText(session: GatewaySession): string {
@@ -263,13 +286,16 @@ function sessionMatchesMissionContext(
   missionStartMs: number,
   missionNeedles: string[],
 ): boolean {
-  const createdAt = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
+  const createdAt = toIso(
+    session.createdAt ?? session.startedAt ?? session.updatedAt,
+  )
   if (!createdAt) return false
 
   const createdMs = new Date(createdAt).getTime()
   if (!Number.isFinite(createdMs) || createdMs < missionStartMs) return false
 
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
   if (totalTokens <= 0) return false
 
   const text = normalizeMatchText(getSessionSearchText(session))
@@ -291,20 +317,56 @@ function loadPersistedMission(): PersistedMission | null {
     const missionJobId = readString(parsed.missionJobId)
     const goal = typeof parsed.goal === 'string' ? parsed.goal : null
     const phase = parsed.phase
-    const streamText = typeof parsed.streamText === 'string' ? parsed.streamText : null
-    const planText = typeof parsed.planText === 'string' ? parsed.planText : null
-    const workerKeys = Array.isArray(parsed.workerKeys) ? parsed.workerKeys.filter((value): value is string => typeof value === 'string') : null
-    const workerLabels = Array.isArray(parsed.workerLabels) ? parsed.workerLabels.filter((value): value is string => typeof value === 'string') : null
+    const streamText =
+      typeof parsed.streamText === 'string' ? parsed.streamText : null
+    const planText =
+      typeof parsed.planText === 'string' ? parsed.planText : null
+    const workerKeys = Array.isArray(parsed.workerKeys)
+      ? parsed.workerKeys.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : null
+    const workerLabels = Array.isArray(parsed.workerLabels)
+      ? parsed.workerLabels.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : null
     const workerOutputs =
-      parsed.workerOutputs && typeof parsed.workerOutputs === 'object' && !Array.isArray(parsed.workerOutputs)
-        ? Object.fromEntries(Object.entries(parsed.workerOutputs as Record<string, unknown>).filter((entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'))
+      parsed.workerOutputs &&
+      typeof parsed.workerOutputs === 'object' &&
+      !Array.isArray(parsed.workerOutputs)
+        ? Object.fromEntries(
+            Object.entries(
+              parsed.workerOutputs as Record<string, unknown>,
+            ).filter(
+              (entry): entry is [string, string] =>
+                typeof entry[0] === 'string' && typeof entry[1] === 'string',
+            ),
+          )
         : {}
-    const missionStartedAt = parsed.missionStartedAt === null || parsed.missionStartedAt === undefined ? null : toIso(parsed.missionStartedAt)
+    const missionStartedAt =
+      parsed.missionStartedAt === null || parsed.missionStartedAt === undefined
+        ? null
+        : toIso(parsed.missionStartedAt)
     const isPaused = parsed.isPaused === true
-    const pausedElapsedMs = typeof parsed.pausedElapsedMs === 'number' && Number.isFinite(parsed.pausedElapsedMs) ? Math.max(0, parsed.pausedElapsedMs) : 0
-    const accumulatedPausedMs = typeof parsed.accumulatedPausedMs === 'number' && Number.isFinite(parsed.accumulatedPausedMs) ? Math.max(0, parsed.accumulatedPausedMs) : 0
-    const pauseStartedAt = parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined ? null : toIso(parsed.pauseStartedAt)
-    const completedAt = parsed.completedAt === null || parsed.completedAt === undefined ? null : toIso(parsed.completedAt)
+    const pausedElapsedMs =
+      typeof parsed.pausedElapsedMs === 'number' &&
+      Number.isFinite(parsed.pausedElapsedMs)
+        ? Math.max(0, parsed.pausedElapsedMs)
+        : 0
+    const accumulatedPausedMs =
+      typeof parsed.accumulatedPausedMs === 'number' &&
+      Number.isFinite(parsed.accumulatedPausedMs)
+        ? Math.max(0, parsed.accumulatedPausedMs)
+        : 0
+    const pauseStartedAt =
+      parsed.pauseStartedAt === null || parsed.pauseStartedAt === undefined
+        ? null
+        : toIso(parsed.pauseStartedAt)
+    const completedAt =
+      parsed.completedAt === null || parsed.completedAt === undefined
+        ? null
+        : toIso(parsed.completedAt)
     const tasks = Array.isArray(parsed.tasks)
       ? parsed.tasks
           .map((task): ConductorTask | null => {
@@ -313,7 +375,14 @@ function loadPersistedMission(): PersistedMission | null {
             const id = readString(record.id)
             const title = readString(record.title)
             const status = record.status
-            if (!id || !title || (status !== 'pending' && status !== 'running' && status !== 'complete' && status !== 'failed')) {
+            if (
+              !id ||
+              !title ||
+              (status !== 'pending' &&
+                status !== 'running' &&
+                status !== 'complete' &&
+                status !== 'failed')
+            ) {
               return null
             }
 
@@ -321,14 +390,30 @@ function loadPersistedMission(): PersistedMission | null {
               id,
               title,
               status,
-              workerKey: record.workerKey === null || record.workerKey === undefined ? null : readString(record.workerKey),
-              output: record.output === null || record.output === undefined ? null : readString(record.output),
+              workerKey:
+                record.workerKey === null || record.workerKey === undefined
+                  ? null
+                  : readString(record.workerKey),
+              output:
+                record.output === null || record.output === undefined
+                  ? null
+                  : readString(record.output),
             }
           })
           .filter((task): task is ConductorTask => task !== null)
       : []
 
-    if (!goal || (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') || streamText === null || planText === null || !workerKeys || !workerLabels) {
+    if (
+      !goal ||
+      (phase !== 'idle' &&
+        phase !== 'decomposing' &&
+        phase !== 'running' &&
+        phase !== 'complete') ||
+      streamText === null ||
+      planText === null ||
+      !workerKeys ||
+      !workerLabels
+    ) {
       return null
     }
     return {
@@ -360,11 +445,32 @@ function loadConductorSettings(): ConductorSettings {
     if (!raw) return DEFAULT_CONDUCTOR_SETTINGS
     const parsed = JSON.parse(raw) as Record<string, unknown>
     return {
-      orchestratorModel: typeof parsed.orchestratorModel === 'string' ? parsed.orchestratorModel : DEFAULT_CONDUCTOR_SETTINGS.orchestratorModel,
-      workerModel: typeof parsed.workerModel === 'string' ? parsed.workerModel : DEFAULT_CONDUCTOR_SETTINGS.workerModel,
-      projectsDir: typeof parsed.projectsDir === 'string' ? parsed.projectsDir : DEFAULT_CONDUCTOR_SETTINGS.projectsDir,
-      maxParallel: Math.min(5, Math.max(1, typeof parsed.maxParallel === 'number' && Number.isFinite(parsed.maxParallel) ? Math.round(parsed.maxParallel) : DEFAULT_CONDUCTOR_SETTINGS.maxParallel)),
-      supervised: typeof parsed.supervised === 'boolean' ? parsed.supervised : DEFAULT_CONDUCTOR_SETTINGS.supervised,
+      orchestratorModel:
+        typeof parsed.orchestratorModel === 'string'
+          ? parsed.orchestratorModel
+          : DEFAULT_CONDUCTOR_SETTINGS.orchestratorModel,
+      workerModel:
+        typeof parsed.workerModel === 'string'
+          ? parsed.workerModel
+          : DEFAULT_CONDUCTOR_SETTINGS.workerModel,
+      projectsDir:
+        typeof parsed.projectsDir === 'string'
+          ? parsed.projectsDir
+          : DEFAULT_CONDUCTOR_SETTINGS.projectsDir,
+      maxParallel: Math.min(
+        5,
+        Math.max(
+          1,
+          typeof parsed.maxParallel === 'number' &&
+            Number.isFinite(parsed.maxParallel)
+            ? Math.round(parsed.maxParallel)
+            : DEFAULT_CONDUCTOR_SETTINGS.maxParallel,
+        ),
+      ),
+      supervised:
+        typeof parsed.supervised === 'boolean'
+          ? parsed.supervised
+          : DEFAULT_CONDUCTOR_SETTINGS.supervised,
     }
   } catch {
     return DEFAULT_CONDUCTOR_SETTINGS
@@ -373,7 +479,10 @@ function loadConductorSettings(): ConductorSettings {
 
 function persistConductorSettings(settings: ConductorSettings): void {
   try {
-    globalThis.localStorage?.setItem(CONDUCTOR_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+    globalThis.localStorage?.setItem(
+      CONDUCTOR_SETTINGS_STORAGE_KEY,
+      JSON.stringify(settings),
+    )
   } catch {
     // Ignore persistence failures.
   }
@@ -390,18 +499,32 @@ function loadMissionHistory(): MissionHistoryEntry[] {
       .filter((entry: unknown): entry is MissionHistoryEntry => {
         if (!entry || typeof entry !== 'object') return false
         const e = entry as Record<string, unknown>
-        if (typeof e.id !== 'string' || typeof e.goal !== 'string' || typeof e.startedAt !== 'string') return false
+        if (
+          typeof e.id !== 'string' ||
+          typeof e.goal !== 'string' ||
+          typeof e.startedAt !== 'string'
+        )
+          return false
         if (seen.has(e.id)) return false
         seen.add(e.id)
         return true
       })
       .map((entry) => {
-        const projectPath = (typeof entry.projectPath === 'string' && entry.projectPath.trim()) || extractProjectPath(typeof entry.projectPath === 'string' ? entry.projectPath : '') || null
-        const outputText = typeof entry.outputText === 'string' ? entry.outputText : undefined
-        const streamText = typeof entry.streamText === 'string' ? entry.streamText : undefined
+        const projectPath =
+          (typeof entry.projectPath === 'string' && entry.projectPath.trim()) ||
+          extractProjectPath(
+            typeof entry.projectPath === 'string' ? entry.projectPath : '',
+          ) ||
+          null
+        const outputText =
+          typeof entry.outputText === 'string' ? entry.outputText : undefined
+        const streamText =
+          typeof entry.streamText === 'string' ? entry.streamText : undefined
         const outputPath =
           (typeof entry.outputPath === 'string' && entry.outputPath.trim()) ||
-          extractProjectPath(typeof entry.outputPath === 'string' ? entry.outputPath : '') ||
+          extractProjectPath(
+            typeof entry.outputPath === 'string' ? entry.outputPath : '',
+          ) ||
           projectPath ||
           extractProjectPath(outputText ?? '') ||
           extractProjectPath(streamText ?? '') ||
@@ -426,7 +549,10 @@ function appendMissionHistory(entry: MissionHistoryEntry): void {
     // Deduplicate by id before appending
     const filtered = current.filter((e) => e.id !== entry.id)
     const updated = [entry, ...filtered].slice(0, MAX_HISTORY_ENTRIES)
-    globalThis.localStorage?.setItem(HISTORY_STORAGE_KEY, JSON.stringify(updated))
+    globalThis.localStorage?.setItem(
+      HISTORY_STORAGE_KEY,
+      JSON.stringify(updated),
+    )
   } catch {
     // Ignore persistence failures.
   }
@@ -434,7 +560,10 @@ function appendMissionHistory(entry: MissionHistoryEntry): void {
 
 function persistMission(state: PersistedMission): void {
   try {
-    globalThis.localStorage?.setItem(ACTIVE_MISSION_STORAGE_KEY, JSON.stringify(state))
+    globalThis.localStorage?.setItem(
+      ACTIVE_MISSION_STORAGE_KEY,
+      JSON.stringify(state),
+    )
   } catch {
     // Ignore persistence failures.
   }
@@ -461,27 +590,48 @@ function readContextTokens(session: GatewaySession): number {
     readNumber(session.contextTokens) ??
     readNumber(session.maxTokens) ??
     readNumber(session.contextWindow) ??
-    readNumber(session.usage && typeof session.usage === 'object' ? (session.usage as Record<string, unknown>).contextTokens : null) ??
+    readNumber(
+      session.usage && typeof session.usage === 'object'
+        ? (session.usage as Record<string, unknown>).contextTokens
+        : null,
+    ) ??
     0
   )
 }
 
-function deriveWorkerStatus(session: GatewaySession, updatedAt: string | null): ConductorWorker['status'] {
+function deriveWorkerStatus(
+  session: GatewaySession,
+  updatedAt: string | null,
+): ConductorWorker['status'] {
   const status = readString(session.status)?.toLowerCase()
-  if (status && ['complete', 'completed', 'done', 'success', 'succeeded'].includes(status)) return 'complete'
+  if (
+    status &&
+    ['complete', 'completed', 'done', 'success', 'succeeded'].includes(status)
+  )
+    return 'complete'
   if (status && ['idle', 'waiting', 'sleeping'].includes(status)) return 'idle'
-  if (status && ['error', 'errored', 'failed', 'cancelled', 'canceled', 'killed'].includes(status)) return 'stale'
+  if (
+    status &&
+    ['error', 'errored', 'failed', 'cancelled', 'canceled', 'killed'].includes(
+      status,
+    )
+  )
+    return 'stale'
 
   const updatedMs = updatedAt ? new Date(updatedAt).getTime() : 0
   const staleness = updatedMs > 0 ? Date.now() - updatedMs : 0
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
 
   if (totalTokens > 0 && staleness > 10_000) return 'complete'
   if (staleness > 120_000) return 'stale'
   return 'running'
 }
 
-function workersLookComplete(workers: ConductorWorker[], staleAfterMs: number): boolean {
+function workersLookComplete(
+  workers: ConductorWorker[],
+  staleAfterMs: number,
+): boolean {
   if (workers.length === 0) return false
 
   return workers.every((worker) => {
@@ -525,7 +675,8 @@ function formatDisplayName(session: GatewaySession): string {
 }
 
 function formatTokenUsage(totalTokens: number, contextTokens: number): string {
-  if (contextTokens > 0) return `${totalTokens.toLocaleString()} / ${contextTokens.toLocaleString()} tok`
+  if (contextTokens > 0)
+    return `${totalTokens.toLocaleString()} / ${contextTokens.toLocaleString()} tok`
   return `${totalTokens.toLocaleString()} tok`
 }
 
@@ -533,8 +684,11 @@ function toWorker(session: GatewaySession): ConductorWorker | null {
   const key = readString(session.key)
   if (!key) return null
   const label = readString(session.label) ?? 'worker'
-  const updatedAt = toIso(session.updatedAt ?? session.startedAt ?? session.createdAt)
-  const totalTokens = readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
+  const updatedAt = toIso(
+    session.updatedAt ?? session.startedAt ?? session.createdAt,
+  )
+  const totalTokens =
+    readNumber(session.totalTokens) ?? readNumber(session.tokenCount) ?? 0
   const contextTokens = readContextTokens(session)
 
   return {
@@ -551,7 +705,9 @@ function toWorker(session: GatewaySession): ConductorWorker | null {
   }
 }
 
-function extractHistoryMessageText(message: HistoryMessage | undefined): string {
+function extractHistoryMessageText(
+  message: HistoryMessage | undefined,
+): string {
   if (!message) return ''
   if (typeof message.content === 'string') return message.content
   if (Array.isArray(message.content)) {
@@ -563,7 +719,9 @@ function extractHistoryMessageText(message: HistoryMessage | undefined): string 
   return ''
 }
 
-function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string {
+function getLastAssistantMessage(
+  messages: HistoryMessage[] | undefined,
+): string {
   if (!Array.isArray(messages)) return ''
   // Return the longest assistant message so we prefer the substantive work output.
   let best = ''
@@ -576,12 +734,18 @@ function getLastAssistantMessage(messages: HistoryMessage[] | undefined): string
   return best
 }
 
-function readMissionLines(mission: ConductorMissionRecord | null | undefined): string[] {
+function readMissionLines(
+  mission: ConductorMissionRecord | null | undefined,
+): string[] {
   if (!Array.isArray(mission?.lines)) return []
-  return mission.lines.filter((line): line is string => typeof line === 'string')
+  return mission.lines.filter(
+    (line): line is string => typeof line === 'string',
+  )
 }
 
-function extractSessionIdFromMission(mission: ConductorMissionRecord | null | undefined): string | null {
+function extractSessionIdFromMission(
+  mission: ConductorMissionRecord | null | undefined,
+): string | null {
   const direct = readString(mission?.session_id)
   if (direct) return direct
 
@@ -602,18 +766,37 @@ function formatMissionLog(lines: string[]): string {
 }
 
 function isFailedMissionStatus(status: string | null): boolean {
-  return status === 'failed' || status === 'error' || status === 'errored' || status === 'cancelled' || status === 'canceled'
+  return (
+    status === 'failed' ||
+    status === 'error' ||
+    status === 'errored' ||
+    status === 'cancelled' ||
+    status === 'canceled'
+  )
 }
 
 function isCompletedMissionStatus(status: string | null): boolean {
-  return status === 'completed' || status === 'complete' || status === 'done' || status === 'success'
+  return (
+    status === 'completed' ||
+    status === 'complete' ||
+    status === 'done' ||
+    status === 'success'
+  )
 }
 
-async function fetchConductorMission(missionId: string): Promise<ConductorMissionRecord> {
-  const response = await fetch(`/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`)
-  const payload = (await response.json().catch(() => ({}))) as ConductorMissionResponse
+async function fetchConductorMission(
+  missionId: string,
+): Promise<ConductorMissionRecord> {
+  const response = await fetch(
+    `/api/conductor-spawn?missionId=${encodeURIComponent(missionId)}&lines=400`,
+  )
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ConductorMissionResponse
   if (!response.ok || !payload.ok || !payload.mission) {
-    throw new Error(payload.error || `Failed to load conductor mission ${missionId}`)
+    throw new Error(
+      payload.error || `Failed to load conductor mission ${missionId}`,
+    )
   }
   return payload.mission
 }
@@ -652,8 +835,20 @@ function extractProjectPath(text: string): string | null {
   return null
 }
 
-function buildMissionOutputPath(workers: ConductorWorker[], workerOutputs: Record<string, string>, tasks: ConductorTask[], streamText: string): string | null {
-  const workerOutputTexts = [...Object.values(workerOutputs), ...workers.map((worker) => getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined))].filter(Boolean)
+function buildMissionOutputPath(
+  workers: ConductorWorker[],
+  workerOutputs: Record<string, string>,
+  tasks: ConductorTask[],
+  streamText: string,
+): string | null {
+  const workerOutputTexts = [
+    ...Object.values(workerOutputs),
+    ...workers.map((worker) =>
+      getLastAssistantMessage(
+        worker.raw.messages as HistoryMessage[] | undefined,
+      ),
+    ),
+  ].filter(Boolean)
 
   for (const text of workerOutputTexts) {
     const extractedPath = extractProjectPath(text)
@@ -674,7 +869,9 @@ function buildMissionOutputPath(workers: ConductorWorker[], workerOutputs: Recor
 
 function summarizeWorkers(workers: ConductorWorker[]): string[] {
   return workers.map((worker) => {
-    const output = getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)
+    const output = getLastAssistantMessage(
+      worker.raw.messages as HistoryMessage[] | undefined,
+    )
     const firstLine = output
       .split(/\n+/)
       .map((line) => line.trim())
@@ -693,18 +890,41 @@ function buildCompleteSummary(params: {
   totalTokens: number
   outputPath: string | null
 }): string {
-  const { goal, streamError, missionStartedAt, completedAt, totalWorkers, totalTokens, outputPath } = params
-  const durationMs = Math.max(0, new Date(completedAt).getTime() - new Date(missionStartedAt).getTime())
+  const {
+    goal,
+    streamError,
+    missionStartedAt,
+    completedAt,
+    totalWorkers,
+    totalTokens,
+    outputPath,
+  } = params
+  const durationMs = Math.max(
+    0,
+    new Date(completedAt).getTime() - new Date(missionStartedAt).getTime(),
+  )
   const totalSeconds = Math.floor(durationMs / 1000)
   const hours = Math.floor(totalSeconds / 3600)
   const minutes = Math.floor((totalSeconds % 3600) / 60)
   const seconds = totalSeconds % 60
-  const duration = hours > 0 ? `${hours}h ${minutes}m ${seconds}s` : minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
+  const duration =
+    hours > 0
+      ? `${hours}h ${minutes}m ${seconds}s`
+      : minutes > 0
+        ? `${minutes}m ${seconds}s`
+        : `${seconds}s`
 
-  const lines = [streamError ? `❌ ${streamError}` : '✅ Mission completed successfully', '', `**Goal:** ${goal}`, `**Duration:** ${duration}`]
+  const lines = [
+    streamError ? `❌ ${streamError}` : '✅ Mission completed successfully',
+    '',
+    `**Goal:** ${goal}`,
+    `**Duration:** ${duration}`,
+  ]
 
   if (totalWorkers > 0) {
-    lines.push(`**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`)
+    lines.push(
+      `**Workers:** ${totalWorkers} ran · ${totalTokens.toLocaleString()} tokens`,
+    )
   }
 
   if (outputPath) {
@@ -714,10 +934,19 @@ function buildCompleteSummary(params: {
   return lines.join('\n')
 }
 
-function buildMissionOutputText(workers: ConductorWorker[], workerOutputs: Record<string, string>, streamText: string): string {
+function buildMissionOutputText(
+  workers: ConductorWorker[],
+  workerOutputs: Record<string, string>,
+  streamText: string,
+): string {
   const workerSections = workers
     .map((worker) => {
-      const output = (workerOutputs[worker.key] ?? getLastAssistantMessage(worker.raw.messages as HistoryMessage[] | undefined)).trim()
+      const output = (
+        workerOutputs[worker.key] ??
+        getLastAssistantMessage(
+          worker.raw.messages as HistoryMessage[] | undefined,
+        )
+      ).trim()
       if (!output) return null
       return `### ${worker.displayName}\n\n${output}`
     })
@@ -730,8 +959,13 @@ function buildMissionOutputText(workers: ConductorWorker[], workerOutputs: Recor
   return streamText.trim().slice(0, 5000)
 }
 
-async function fetchWorkerOutput(sessionKey: string, limit = 5): Promise<string> {
-  const response = await fetch(`/api/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=${limit}`)
+async function fetchWorkerOutput(
+  sessionKey: string,
+  limit = 5,
+): Promise<string> {
+  const response = await fetch(
+    `/api/history?sessionKey=${encodeURIComponent(sessionKey)}&limit=${limit}`,
+  )
   const payload = (await response.json().catch(() => ({}))) as HistoryResponse
   if (!response.ok) {
     throw new Error(payload.error || `Failed to load history for ${sessionKey}`)
@@ -746,7 +980,11 @@ function appendStreamEvent(
   update((current) => [...current.slice(-99), event])
 }
 
-function readStreamText(event: string, payload: Record<string, unknown>, currentText: string): string | null {
+function readStreamText(
+  event: string,
+  payload: Record<string, unknown>,
+  currentText: string,
+): string | null {
   if (event !== 'chunk' && event !== 'assistant') return null
   const text =
     readString(payload.delta) ??
@@ -754,7 +992,9 @@ function readStreamText(event: string, payload: Record<string, unknown>, current
     readString(payload.content) ??
     readString(payload.chunk)
   if (!text) return null
-  return payload.fullReplace === true || event === 'assistant' ? text : currentText + text
+  return payload.fullReplace === true || event === 'assistant'
+    ? text
+    : currentText + text
 }
 
 function readDoneMessageText(payload: Record<string, unknown>): string {
@@ -782,7 +1022,10 @@ async function streamPortableConductorMission(params: {
       history: [],
       idempotencyKey: crypto.randomUUID(),
       model: params.model || undefined,
-      locale: typeof window !== 'undefined' ? localStorage.getItem('hermes-workspace-locale') || 'en' : 'en',
+      locale:
+        typeof window !== 'undefined'
+          ? localStorage.getItem('hermes-workspace-locale') || 'en'
+          : 'en',
     }),
     signal: params.signal,
   })
@@ -792,7 +1035,8 @@ async function streamPortableConductorMission(params: {
     throw new Error(text || `Conductor stream failed (${response.status})`)
   }
 
-  let sessionKey = response.headers.get('x-hermes-session-key')?.trim() || params.sessionKey
+  let sessionKey =
+    response.headers.get('x-hermes-session-key')?.trim() || params.sessionKey
   let runId: string | null = null
   let accumulated = ''
   let sawDone = false
@@ -800,7 +1044,8 @@ async function streamPortableConductorMission(params: {
   params.onSessionResolved(sessionKey, runId)
 
   const reader = response.body?.getReader()
-  if (!reader) throw new Error('Conductor stream did not include a response body')
+  if (!reader)
+    throw new Error('Conductor stream did not include a response body')
 
   const decoder = new TextDecoder()
   let buffer = ''
@@ -843,7 +1088,11 @@ async function streamPortableConductorMission(params: {
         runId = readString(payload.runId) ?? runId
         sessionKey = readString(payload.sessionKey) ?? sessionKey
         params.onSessionResolved(sessionKey, runId)
-        params.onStreamEvent({ type: 'started', runId: runId ?? undefined, sessionKey })
+        params.onStreamEvent({
+          type: 'started',
+          runId: runId ?? undefined,
+          sessionKey,
+        })
         continue
       }
 
@@ -870,7 +1119,10 @@ async function streamPortableConductorMission(params: {
       if (event === 'done' || event === 'complete') {
         sawDone = true
         const state = readString(payload.state) ?? undefined
-        const message = readString(payload.errorMessage) ?? readString(payload.message) ?? undefined
+        const message =
+          readString(payload.errorMessage) ??
+          readString(payload.message) ??
+          undefined
         const finalText = readDoneMessageText(payload)
         if (!accumulated && finalText) {
           accumulated = finalText
@@ -897,30 +1149,67 @@ async function streamPortableConductorMission(params: {
 }
 
 export function useConductorGateway() {
-  const [initialMission] = useState<PersistedMission | null>(() => loadPersistedMission())
-  const [missionId, setMissionId] = useState<string | null>(() => initialMission?.missionId ?? null)
-  const [missionJobId, setMissionJobId] = useState<string | null>(() => initialMission?.missionJobId ?? null)
-  const [phase, setPhase] = useState<MissionPhase>(() => initialMission?.phase ?? 'idle')
+  const [initialMission] = useState<PersistedMission | null>(() =>
+    loadPersistedMission(),
+  )
+  const [missionId, setMissionId] = useState<string | null>(
+    () => initialMission?.missionId ?? null,
+  )
+  const [missionJobId, setMissionJobId] = useState<string | null>(
+    () => initialMission?.missionJobId ?? null,
+  )
+  const [phase, setPhase] = useState<MissionPhase>(
+    () => initialMission?.phase ?? 'idle',
+  )
   const [goal, setGoal] = useState(() => initialMission?.goal ?? '')
-  const [orchestratorSessionKey, setOrchestratorSessionKey] = useState<string | null>(() => initialMission?.workerKeys[0] ?? null)
-  const [streamText, setStreamText] = useState(() => initialMission?.streamText ?? '')
+  const [orchestratorSessionKey, setOrchestratorSessionKey] = useState<
+    string | null
+  >(() => initialMission?.workerKeys[0] ?? null)
+  const [streamText, setStreamText] = useState(
+    () => initialMission?.streamText ?? '',
+  )
   const [planText, setPlanText] = useState(() => initialMission?.planText ?? '')
   const [streamEvents, setStreamEvents] = useState<StreamEvent[]>([])
-  const [missionStartedAt, setMissionStartedAt] = useState<string | null>(() => initialMission?.missionStartedAt ?? null)
-  const [isPaused, setIsPaused] = useState(() => initialMission?.isPaused ?? false)
-  const [pausedElapsedMs, setPausedElapsedMs] = useState(() => initialMission?.pausedElapsedMs ?? 0)
-  const [accumulatedPausedMs, setAccumulatedPausedMs] = useState(() => initialMission?.accumulatedPausedMs ?? 0)
-  const [pauseStartedAt, setPauseStartedAt] = useState<string | null>(() => initialMission?.pauseStartedAt ?? null)
-  const [completedAt, setCompletedAt] = useState<string | null>(() => initialMission?.completedAt ?? null)
+  const [missionStartedAt, setMissionStartedAt] = useState<string | null>(
+    () => initialMission?.missionStartedAt ?? null,
+  )
+  const [isPaused, setIsPaused] = useState(
+    () => initialMission?.isPaused ?? false,
+  )
+  const [pausedElapsedMs, setPausedElapsedMs] = useState(
+    () => initialMission?.pausedElapsedMs ?? 0,
+  )
+  const [accumulatedPausedMs, setAccumulatedPausedMs] = useState(
+    () => initialMission?.accumulatedPausedMs ?? 0,
+  )
+  const [pauseStartedAt, setPauseStartedAt] = useState<string | null>(
+    () => initialMission?.pauseStartedAt ?? null,
+  )
+  const [completedAt, setCompletedAt] = useState<string | null>(
+    () => initialMission?.completedAt ?? null,
+  )
   const [streamError, setStreamError] = useState<string | null>(null)
   const [timeoutWarning, setTimeoutWarning] = useState(false)
-  const [missionWorkerKeys, setMissionWorkerKeys] = useState<Set<string>>(() => new Set(initialMission?.workerKeys ?? []))
-  const [missionWorkerLabels, setMissionWorkerLabels] = useState<Set<string>>(() => new Set(initialMission?.workerLabels ?? []))
-  const [workerOutputs, setWorkerOutputs] = useState<Record<string, string>>(() => initialMission?.workerOutputs ?? {})
-  const [tasks, setTasks] = useState<ConductorTask[]>(() => initialMission?.tasks ?? [])
-  const [missionHistory, setMissionHistory] = useState<MissionHistoryEntry[]>(() => loadMissionHistory())
-  const [selectedHistoryEntry, setSelectedHistoryEntry] = useState<MissionHistoryEntry | null>(null)
-  const [conductorSettings, setConductorSettings] = useState<ConductorSettings>(() => loadConductorSettings())
+  const [missionWorkerKeys, setMissionWorkerKeys] = useState<Set<string>>(
+    () => new Set(initialMission?.workerKeys ?? []),
+  )
+  const [missionWorkerLabels, setMissionWorkerLabels] = useState<Set<string>>(
+    () => new Set(initialMission?.workerLabels ?? []),
+  )
+  const [workerOutputs, setWorkerOutputs] = useState<Record<string, string>>(
+    () => initialMission?.workerOutputs ?? {},
+  )
+  const [tasks, setTasks] = useState<ConductorTask[]>(
+    () => initialMission?.tasks ?? [],
+  )
+  const [missionHistory, setMissionHistory] = useState<MissionHistoryEntry[]>(
+    () => loadMissionHistory(),
+  )
+  const [selectedHistoryEntry, setSelectedHistoryEntry] =
+    useState<MissionHistoryEntry | null>(null)
+  const [conductorSettings, setConductorSettings] = useState<ConductorSettings>(
+    () => loadConductorSettings(),
+  )
   const doneRef = useRef(initialMission?.phase === 'complete')
   const seenToolCallRef = useRef(false)
   const historySavedRef = useRef(false)
@@ -933,7 +1222,9 @@ export function useConductorGateway() {
     queryFn: async () => {
       const payload = await fetchSessions()
       const sessions = Array.isArray(payload.sessions) ? payload.sessions : []
-      const missionStartMs = missionStartedAt ? new Date(missionStartedAt).getTime() : 0
+      const missionStartMs = missionStartedAt
+        ? new Date(missionStartedAt).getTime()
+        : 0
       const missionNeedles = buildMissionNeedles(goal)
       return sessions
         .filter((session) => {
@@ -947,25 +1238,47 @@ export function useConductorGateway() {
 
           // Match by worker label pattern
           if (label.startsWith('worker-') || label.startsWith('conductor-')) {
-            if (missionWorkerLabels.size > 0 && missionWorkerLabels.has(label)) {
+            if (
+              missionWorkerLabels.size > 0 &&
+              missionWorkerLabels.has(label)
+            ) {
               return true
             }
             // Match by creation time (workers spawned after mission start)
-            const createdIso = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
-            if (createdIso && missionStartMs && new Date(createdIso).getTime() >= missionStartMs) {
+            const createdIso = toIso(
+              session.createdAt ?? session.startedAt ?? session.updatedAt,
+            )
+            if (
+              createdIso &&
+              missionStartMs &&
+              new Date(createdIso).getTime() >= missionStartMs
+            ) {
               return true
             }
           }
 
           // Match subagent sessions created after mission start
           if (key.includes(':subagent:')) {
-            const createdIso = toIso(session.createdAt ?? session.startedAt ?? session.updatedAt)
-            if (createdIso && missionStartMs && new Date(createdIso).getTime() >= missionStartMs) {
+            const createdIso = toIso(
+              session.createdAt ?? session.startedAt ?? session.updatedAt,
+            )
+            if (
+              createdIso &&
+              missionStartMs &&
+              new Date(createdIso).getTime() >= missionStartMs
+            ) {
               return true
             }
           }
 
-          if (missionStartMs > 0 && sessionMatchesMissionContext(session, missionStartMs, missionNeedles)) {
+          if (
+            missionStartMs > 0 &&
+            sessionMatchesMissionContext(
+              session,
+              missionStartMs,
+              missionNeedles,
+            )
+          ) {
             return true
           }
 
@@ -977,11 +1290,19 @@ export function useConductorGateway() {
           const statusRank = { running: 0, idle: 1, complete: 2, stale: 3 }
           const rankDiff = statusRank[a.status] - statusRank[b.status]
           if (rankDiff !== 0) return rankDiff
-          return new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime()
+          return (
+            new Date(b.updatedAt ?? 0).getTime() -
+            new Date(a.updatedAt ?? 0).getTime()
+          )
         })
     },
     enabled: phase !== 'idle',
-    refetchInterval: phase === 'decomposing' || phase === 'running' || (phase === 'complete' && Object.keys(workerOutputs).length === 0) ? 3_000 : false,
+    refetchInterval:
+      phase === 'decomposing' ||
+      phase === 'running' ||
+      (phase === 'complete' && Object.keys(workerOutputs).length === 0)
+        ? 3_000
+        : false,
   })
 
   const recentSessionsQuery = useQuery({
@@ -994,7 +1315,9 @@ export function useConductorGateway() {
         .filter((session) => {
           const label = readString(session.label) ?? ''
           const key = readString(session.key) ?? ''
-          const updatedAt = toIso(session.updatedAt ?? session.startedAt ?? session.createdAt)
+          const updatedAt = toIso(
+            session.updatedAt ?? session.startedAt ?? session.createdAt,
+          )
           if (!updatedAt) return false
           const isConductorSession =
             label.startsWith('worker-') ||
@@ -1004,8 +1327,12 @@ export function useConductorGateway() {
           return isConductorSession && new Date(updatedAt).getTime() >= cutoff
         })
         .sort((a, b) => {
-          const updatedA = new Date(toIso(a.updatedAt ?? a.startedAt ?? a.createdAt) ?? 0).getTime()
-          const updatedB = new Date(toIso(b.updatedAt ?? b.startedAt ?? b.createdAt) ?? 0).getTime()
+          const updatedA = new Date(
+            toIso(a.updatedAt ?? a.startedAt ?? a.createdAt) ?? 0,
+          ).getTime()
+          const updatedB = new Date(
+            toIso(b.updatedAt ?? b.startedAt ?? b.createdAt) ?? 0,
+          ).getTime()
           return updatedB - updatedA
         })
         .slice(0, 20)
@@ -1021,9 +1348,11 @@ export function useConductorGateway() {
       return fetchConductorMission(missionId)
     },
     enabled: Boolean(missionId) && phase !== 'idle',
-    refetchInterval: phase === 'decomposing' || phase === 'running' ? 2_500 : false,
+    refetchInterval:
+      phase === 'decomposing' || phase === 'running' ? 2_500 : false,
     retry: Infinity,
-    retryDelay: (attemptIndex: number) => Math.min(2000 * 2 ** attemptIndex, 10_000),
+    retryDelay: (attemptIndex: number) =>
+      Math.min(2000 * 2 ** attemptIndex, 10_000),
   })
 
   const sessionWorkers = sessionsQuery.data ?? []
@@ -1033,15 +1362,28 @@ export function useConductorGateway() {
   const swarmAssignments = missionStatusQuery.data?.assignments
   const isNativeSwarm = missionStatusQuery.data?.nativeSwarm === true
   const virtualWorkers = useMemo<ConductorWorker[]>(() => {
-    if (!isNativeSwarm || !swarmAssignments || swarmAssignments.length === 0) return []
-    const missionUpdatedAt = new Date(missionStatusQuery.data?.updatedAt ?? Date.now()).toISOString()
+    if (!isNativeSwarm || !swarmAssignments || swarmAssignments.length === 0)
+      return []
+    const missionUpdatedAt = new Date(
+      missionStatusQuery.data?.updatedAt ?? Date.now(),
+    ).toISOString()
     return swarmAssignments.map((assignment, index) => {
       const workerId = assignment.workerId
       const state = assignment.state ?? 'dispatched'
       const checkpoint = assignment.checkpoint
-      const isComplete = state === 'checkpointed' || state === 'done' || state === 'cancelled'
+      const isComplete =
+        state === 'checkpointed' || state === 'done' || state === 'cancelled'
       const isBlocked = state === 'blocked' || state === 'needs_input'
-      const personaNames = ['Nova', 'Pixel', 'Blaze', 'Echo', 'Sage', 'Drift', 'Flux', 'Volt']
+      const personaNames = [
+        'Nova',
+        'Pixel',
+        'Blaze',
+        'Echo',
+        'Sage',
+        'Drift',
+        'Flux',
+        'Volt',
+      ]
       const persona = personaNames[index % personaNames.length]
       return {
         key: workerId,
@@ -1072,7 +1414,13 @@ export function useConductorGateway() {
     if (sessionWorkers.length > 0) return sessionWorkers
     return virtualWorkers
   }, [sessionWorkers, virtualWorkers])
-  const activeWorkers = useMemo(() => workers.filter((worker) => worker.status === 'running' || worker.status === 'idle'), [workers])
+  const activeWorkers = useMemo(
+    () =>
+      workers.filter(
+        (worker) => worker.status === 'running' || worker.status === 'idle',
+      ),
+    [workers],
+  )
   const hasPersistedMission = initialMission !== null
 
   useEffect(() => {
@@ -1092,15 +1440,25 @@ export function useConductorGateway() {
         next.add(realSessionKey)
         return next
       })
-      setPlanText((current) => (current && !current.startsWith('Conductor mission') ? current : 'Orchestrator session attached. Tracking worker activity...'))
+      setPlanText((current) =>
+        current && !current.startsWith('Conductor mission')
+          ? current
+          : 'Orchestrator session attached. Tracking worker activity...',
+      )
       lastActivityAtRef.current = Date.now()
       setTimeoutWarning(false)
     } else if (phase === 'decomposing' || phase === 'running') {
-      setPlanText((current) => current || `Conductor mission ${status ?? 'running'}. Waiting for Hermes to report the session...`)
+      setPlanText(
+        (current) =>
+          current ||
+          `Conductor mission ${status ?? 'running'}. Waiting for Hermes to report the session...`,
+      )
     }
 
     if (missionLog) {
-      setStreamText((current) => (current === missionLog ? current : missionLog))
+      setStreamText((current) =>
+        current === missionLog ? current : missionLog,
+      )
       lastActivityAtRef.current = Date.now()
       setTimeoutWarning(false)
     }
@@ -1124,14 +1482,24 @@ export function useConductorGateway() {
     if (!missionStartedAt) return 0
     const startedMs = new Date(missionStartedAt).getTime()
     if (!Number.isFinite(startedMs)) return 0
-    const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-    const inFlightPausedMs = isPaused && Number.isFinite(pauseStartedMs) ? Math.max(0, referenceTime - pauseStartedMs) : 0
-    return Math.max(0, referenceTime - startedMs - accumulatedPausedMs - inFlightPausedMs)
+    const pauseStartedMs = pauseStartedAt
+      ? new Date(pauseStartedAt).getTime()
+      : NaN
+    const inFlightPausedMs =
+      isPaused && Number.isFinite(pauseStartedMs)
+        ? Math.max(0, referenceTime - pauseStartedMs)
+        : 0
+    return Math.max(
+      0,
+      referenceTime - startedMs - accumulatedPausedMs - inFlightPausedMs,
+    )
   }
 
   useEffect(() => {
     if (missionWorkerLabels.size === 0 || workers.length === 0) return
-    const matchedKeys = workers.filter((worker) => missionWorkerLabels.has(worker.label)).map((worker) => worker.key)
+    const matchedKeys = workers
+      .filter((worker) => missionWorkerLabels.has(worker.label))
+      .map((worker) => worker.key)
 
     if (matchedKeys.length === 0) return
 
@@ -1180,7 +1548,12 @@ export function useConductorGateway() {
   useEffect(() => {
     if (phase !== 'running' && phase !== 'decomposing') return
 
-    const workerSnapshot = workers.map((worker) => `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`).join('|')
+    const workerSnapshot = workers
+      .map(
+        (worker) =>
+          `${worker.key}:${worker.updatedAt ?? ''}:${worker.totalTokens}:${worker.status}`,
+      )
+      .join('|')
 
     if (workerSnapshot && workerSnapshot !== lastWorkerSnapshotRef.current) {
       lastWorkerSnapshotRef.current = workerSnapshot
@@ -1211,7 +1584,8 @@ export function useConductorGateway() {
   useEffect(() => {
     if (phase !== 'running') return
 
-    const shouldCompleteImmediately = doneRef.current && workersLookComplete(workers, 8_000)
+    const shouldCompleteImmediately =
+      doneRef.current && workersLookComplete(workers, 8_000)
     if (shouldCompleteImmediately) {
       setPhase('complete')
       setCompletedAt((value) => value ?? new Date().toISOString())
@@ -1250,8 +1624,12 @@ export function useConductorGateway() {
     void fetchAll()
 
     // Keep polling while workers are running, OR while we're missing outputs for complete workers
-    const hasRunningWorkers = workers.some((worker) => worker.status === 'running' || worker.status === 'idle')
-    const hasMissingOutputs = workers.some((worker) => worker.status === 'complete' && !workerOutputs[worker.key])
+    const hasRunningWorkers = workers.some(
+      (worker) => worker.status === 'running' || worker.status === 'idle',
+    )
+    const hasMissingOutputs = workers.some(
+      (worker) => worker.status === 'complete' && !workerOutputs[worker.key],
+    )
     if (!hasRunningWorkers && !hasMissingOutputs) {
       return () => {
         cancelled = true
@@ -1291,8 +1669,20 @@ export function useConductorGateway() {
         const worker = workers[index]
         if (!worker) return task
         const workerOutput = workerOutputs[worker.key] ?? null
-        const newStatus: ConductorTask['status'] = worker.status === 'complete' ? 'complete' : worker.status === 'stale' ? 'failed' : worker.status === 'running' ? 'running' : task.status
-        if (task.workerKey === worker.key && task.status === newStatus && task.output === workerOutput) return task
+        const newStatus: ConductorTask['status'] =
+          worker.status === 'complete'
+            ? 'complete'
+            : worker.status === 'stale'
+              ? 'failed'
+              : worker.status === 'running'
+                ? 'running'
+                : task.status
+        if (
+          task.workerKey === worker.key &&
+          task.status === newStatus &&
+          task.output === workerOutput
+        )
+          return task
         return {
           ...task,
           workerKey: worker.key,
@@ -1309,13 +1699,26 @@ export function useConductorGateway() {
   // so the entry gets enriched with actual worker content instead of empty text.
   const historySaveCountRef = useRef(0)
   useEffect(() => {
-    if (phase !== 'complete' || !goal || !completedAt || !missionStartedAt) return
+    if (phase !== 'complete' || !goal || !completedAt || !missionStartedAt)
+      return
 
     const missionHistoryId = `mission-${new Date(missionStartedAt).getTime()}`
-    const outputPath = buildMissionOutputPath(workers, workerOutputs, tasks, streamText)
+    const outputPath = buildMissionOutputPath(
+      workers,
+      workerOutputs,
+      tasks,
+      streamText,
+    )
     const workerSummary = summarizeWorkers(workers)
-    const outputText = buildMissionOutputText(workers, workerOutputs, streamText)
-    const totalTokens = workers.reduce((sum, worker) => sum + worker.totalTokens, 0)
+    const outputText = buildMissionOutputText(
+      workers,
+      workerOutputs,
+      streamText,
+    )
+    const totalTokens = workers.reduce(
+      (sum, worker) => sum + worker.totalTokens,
+      0,
+    )
     const completeSummary = buildCompleteSummary({
       goal,
       streamError,
@@ -1364,10 +1767,22 @@ export function useConductorGateway() {
         return [entry, ...current].slice(0, MAX_HISTORY_ENTRIES)
       })
     } else {
-      setMissionHistory((current) => current.map((e) => (e.id === missionHistoryId ? entry : e)))
+      setMissionHistory((current) =>
+        current.map((e) => (e.id === missionHistoryId ? entry : e)),
+      )
     }
     historySaveCountRef.current += 1
-  }, [phase, goal, completedAt, missionStartedAt, workers, streamError, workerOutputs, tasks, streamText])
+  }, [
+    phase,
+    goal,
+    completedAt,
+    missionStartedAt,
+    workers,
+    streamError,
+    workerOutputs,
+    tasks,
+    streamText,
+  ])
 
   useEffect(() => {
     persistConductorSettings(conductorSettings)
@@ -1456,7 +1871,13 @@ export function useConductorGateway() {
   }
 
   const sendMission = useMutation({
-    mutationFn: async ({ nextGoal, settings }: { nextGoal: string; settings: ConductorSettings }) => {
+    mutationFn: async ({
+      nextGoal,
+      settings,
+    }: {
+      nextGoal: string
+      settings: ConductorSettings
+    }) => {
       const trimmed = nextGoal.trim()
       if (!trimmed) throw new Error('Mission goal required')
       doneRef.current = false
@@ -1524,9 +1945,15 @@ export function useConductorGateway() {
 
       if (result.mode === 'portable' || result.prompt) {
         const prompt = typeof result.prompt === 'string' ? result.prompt : ''
-        if (!prompt.trim()) throw new Error('Portable conductor response did not include a prompt')
+        if (!prompt.trim())
+          throw new Error(
+            'Portable conductor response did not include a prompt',
+          )
 
-        const portableSessionKey = result.sessionKey?.trim() || result.jobName?.trim() || `conductor-${Date.now()}`
+        const portableSessionKey =
+          result.sessionKey?.trim() ||
+          result.jobName?.trim() ||
+          `conductor-${Date.now()}`
         const portableFriendlyId = result.jobName?.trim() || portableSessionKey
         setMissionId(null)
         setMissionJobId(null)
@@ -1537,7 +1964,9 @@ export function useConductorGateway() {
           next.add(portableSessionKey)
           return next
         })
-        setPlanText('Conductor portable mission launched. Streaming orchestrator output...')
+        setPlanText(
+          'Conductor portable mission launched. Streaming orchestrator output...',
+        )
         setPhase('running')
 
         const abortController = new AbortController()
@@ -1606,14 +2035,21 @@ export function useConductorGateway() {
             return next
           })
         }
-        setPlanText(result.assignments?.length
-          ? `Native swarm mission launched with ${result.assignments.length} workers. Watching for swarm activity...`
-          : 'Native swarm mission launched. Decomposing and spawning workers...')
+        setPlanText(
+          result.assignments?.length
+            ? `Native swarm mission launched with ${result.assignments.length} workers. Watching for swarm activity...`
+            : 'Native swarm mission launched. Decomposing and spawning workers...',
+        )
         setPhase('running')
         return
       }
 
-      if (!result.sessionKey && !result.sessionKeyPrefix && !result.missionId && !result.jobId) {
+      if (
+        !result.sessionKey &&
+        !result.sessionKeyPrefix &&
+        !result.missionId &&
+        !result.jobId
+      ) {
         throw new Error(result.error ?? 'Failed to spawn orchestrator')
       }
 
@@ -1640,17 +2076,20 @@ export function useConductorGateway() {
             await new Promise((resolve) => setTimeout(resolve, 1500))
             try {
               const sessionPayload = await fetchSessions()
-              const sessions = Array.isArray(sessionPayload.sessions) ? sessionPayload.sessions : []
+              const sessions = Array.isArray(sessionPayload.sessions)
+                ? sessionPayload.sessions
+                : []
               const match = sessions.find((session) => {
                 const key = typeof session.key === 'string' ? session.key : ''
                 return key.startsWith(prefix)
               })
               if (match && typeof match.key === 'string') {
-                setOrchestratorSessionKey(match.key)
+                const resolvedKey = match.key
+                setOrchestratorSessionKey(resolvedKey)
                 setMissionWorkerKeys((current) => {
                   const next = new Set(current)
-                  next.delete(orchestratorKey)
-                  next.add(match.key as string)
+                  if (orchestratorKey) next.delete(orchestratorKey)
+                  next.add(resolvedKey)
                   return next
                 })
                 return
@@ -1690,7 +2129,13 @@ export function useConductorGateway() {
   }
 
   const pauseAgent = useMutation({
-    mutationFn: async ({ sessionKey, pause }: { sessionKey: string; pause: boolean }) => {
+    mutationFn: async ({
+      sessionKey,
+      pause,
+    }: {
+      sessionKey: string
+      pause: boolean
+    }) => {
       const response = await fetch('/api/agent-pause', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1710,8 +2155,12 @@ export function useConductorGateway() {
         return
       }
 
-      const pauseStartedMs = pauseStartedAt ? new Date(pauseStartedAt).getTime() : NaN
-      const additionalPausedMs = Number.isFinite(pauseStartedMs) ? Math.max(0, now - pauseStartedMs) : 0
+      const pauseStartedMs = pauseStartedAt
+        ? new Date(pauseStartedAt).getTime()
+        : NaN
+      const additionalPausedMs = Number.isFinite(pauseStartedMs)
+        ? Math.max(0, now - pauseStartedMs)
+        : 0
       setAccumulatedPausedMs((current) => current + additionalPausedMs)
       setPauseStartedAt(null)
       setIsPaused(false)
@@ -1722,7 +2171,12 @@ export function useConductorGateway() {
   const stopMission = async () => {
     portableStreamAbortRef.current?.abort()
     portableStreamAbortRef.current = null
-    const sessionKeys = [...new Set([...missionWorkerKeys, ...workers.map((worker) => worker.key)])]
+    const sessionKeys = [
+      ...new Set([
+        ...missionWorkerKeys,
+        ...workers.map((worker) => worker.key),
+      ]),
+    ]
     const missionIds = missionId ? [missionId] : []
 
     try {
@@ -1782,8 +2236,10 @@ export function useConductorGateway() {
     workerOutputs,
     conductorSettings,
     setConductorSettings,
-    sendMission: (nextGoal: string) => sendMission.mutateAsync({ nextGoal, settings: conductorSettings }),
-    pauseAgent: (sessionKey: string, pause: boolean) => pauseAgent.mutateAsync({ sessionKey, pause }),
+    sendMission: (nextGoal: string) =>
+      sendMission.mutateAsync({ nextGoal, settings: conductorSettings }),
+    pauseAgent: (sessionKey: string, pause: boolean) =>
+      pauseAgent.mutateAsync({ sessionKey, pause }),
     isSending: sendMission.isPending,
     isPausing: pauseAgent.isPending,
     resetMission,

--- a/src/screens/playground/components/npc-character.tsx
+++ b/src/screens/playground/components/npc-character.tsx
@@ -1,6 +1,7 @@
-import { GroupProps } from '@react-three/fiber'
 import type { CharacterArchetypeId } from '../lib/character-config'
 import { HERMESWORLD_CHARACTER_ARCHETYPES } from '../lib/character-config'
+
+type GroupProps = React.ComponentProps<'group'>
 
 type NpcCharacterProps = GroupProps & {
   archetypeId: CharacterArchetypeId
@@ -13,10 +14,15 @@ type NpcCharacterProps = GroupProps & {
  * This gives us a clean component boundary so Agora can stop rendering every
  * character ad hoc inside the giant world scene file.
  */
-export function NpcCharacter({ archetypeId, accent, ...props }: NpcCharacterProps) {
+export function NpcCharacter({
+  archetypeId,
+  accent,
+  ...props
+}: NpcCharacterProps) {
   const archetype =
-    HERMESWORLD_CHARACTER_ARCHETYPES.find((entry) => entry.id === archetypeId) ??
-    HERMESWORLD_CHARACTER_ARCHETYPES[0]
+    HERMESWORLD_CHARACTER_ARCHETYPES.find(
+      (entry) => entry.id === archetypeId,
+    ) ?? HERMESWORLD_CHARACTER_ARCHETYPES[0]
 
   const tint = accent ?? inferTint(archetypeId)
 
@@ -28,11 +34,19 @@ export function NpcCharacter({ archetypeId, accent, ...props }: NpcCharacterProp
       </mesh>
       <mesh castShadow position={[0, 1.75, 0]}>
         <sphereGeometry args={[0.22, 20, 20]} />
-        <meshStandardMaterial color="#f1c9a5" roughness={0.72} metalness={0.02} />
+        <meshStandardMaterial
+          color="#f1c9a5"
+          roughness={0.72}
+          metalness={0.02}
+        />
       </mesh>
       <mesh position={[0, 2.2, 0]}>
         <boxGeometry args={[0.84, 0.06, 0.06]} />
-        <meshStandardMaterial color="#d9b35f" emissive="#2c2110" emissiveIntensity={0.14} />
+        <meshStandardMaterial
+          color="#d9b35f"
+          emissive="#2c2110"
+          emissiveIntensity={0.14}
+        />
       </mesh>
     </group>
   )

--- a/src/screens/playground/components/player-character.tsx
+++ b/src/screens/playground/components/player-character.tsx
@@ -1,5 +1,6 @@
-import { GroupProps } from '@react-three/fiber'
 import { HERMESWORLD_CHARACTER_ARCHETYPES } from '../lib/character-config'
+
+type GroupProps = React.ComponentProps<'group'>
 
 const PLAYER_ARCHETYPE = HERMESWORLD_CHARACTER_ARCHETYPES.find(
   (entry) => entry.id === 'player-adventurer',
@@ -17,15 +18,27 @@ export function PlayerCharacter(props: GroupProps) {
     <group {...props}>
       <mesh castShadow receiveShadow position={[0, 0.9, 0]}>
         <capsuleGeometry args={[0.28, 1.1, 6, 12]} />
-        <meshStandardMaterial color="#4b7bec" roughness={0.58} metalness={0.08} />
+        <meshStandardMaterial
+          color="#4b7bec"
+          roughness={0.58}
+          metalness={0.08}
+        />
       </mesh>
       <mesh castShadow position={[0, 1.85, 0]}>
         <sphereGeometry args={[0.24, 24, 24]} />
-        <meshStandardMaterial color="#f1c9a5" roughness={0.72} metalness={0.02} />
+        <meshStandardMaterial
+          color="#f1c9a5"
+          roughness={0.72}
+          metalness={0.02}
+        />
       </mesh>
       <mesh position={[0, 2.35, 0]}>
         <boxGeometry args={[0.9, 0.08, 0.08]} />
-        <meshStandardMaterial color="#d9b35f" emissive="#3a2b11" emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color="#d9b35f"
+          emissive="#3a2b11"
+          emissiveIntensity={0.18}
+        />
       </mesh>
     </group>
   )

--- a/src/screens/playground/components/playground-dialog.tsx
+++ b/src/screens/playground/components/playground-dialog.tsx
@@ -7,7 +7,10 @@ const ASCII_PORTRAIT_CACHE: Record<string, string> = {}
 function useAsciiPortrait(npcId: string | null) {
   const [art, setArt] = useState<string | null>(null)
   useEffect(() => {
-    if (!npcId) { setArt(null); return }
+    if (!npcId) {
+      setArt(null)
+      return
+    }
     const id = npcId
     if (ASCII_PORTRAIT_CACHE[id] !== undefined) {
       setArt(ASCII_PORTRAIT_CACHE[id] || null)
@@ -19,7 +22,10 @@ function useAsciiPortrait(npcId: string | null) {
         ASCII_PORTRAIT_CACHE[id] = t.trim()
         setArt(t.trim() || null)
       })
-      .catch(() => { ASCII_PORTRAIT_CACHE[id] = ''; setArt(null) })
+      .catch(() => {
+        ASCII_PORTRAIT_CACHE[id] = ''
+        setArt(null)
+      })
   }, [npcId])
   return art
 }
@@ -39,7 +45,12 @@ type Props = {
   onChoice?: (npcId: string, choiceId: string) => void
 }
 
-type ChatTurn = { role: 'user' | 'assistant'; content: string; ts: number; fallback?: boolean }
+type ChatTurn = {
+  role: 'user' | 'assistant'
+  content: string
+  ts: number
+  fallback?: boolean
+}
 
 export function PlaygroundDialog({
   npcId,
@@ -77,13 +88,14 @@ export function PlaygroundDialog({
 
   const asciiArt = useAsciiPortrait(npcId)
   if (!npcId) return null
-  const npc = NPC_DIALOG[npcId]
+  const activeNpcId = npcId
+  const npc = NPC_DIALOG[activeNpcId]
   if (!npc) return null
 
   function handleChoice(c: DialogChoice) {
     setReply(c.reply)
     setShowLore(false)
-    onChoice?.(npcId, c.id)
+    onChoice?.(activeNpcId, c.id)
     if (c.completeQuest) onCompleteQuest(c.completeQuest)
     if (c.grantItems?.length) onGrantItems(c.grantItems)
     if (c.grantSkillXp) onGrantSkillXp(c.grantSkillXp)
@@ -106,7 +118,7 @@ export function PlaygroundDialog({
 
   async function askLLM() {
     const text = llmFreeform.trim()
-    if (!text || askingLLM || !npcId) return
+    if (!text || askingLLM || !activeNpcId) return
     inFlight.current?.abort()
     const ctrl = new AbortController()
     inFlight.current = ctrl
@@ -130,7 +142,12 @@ export function PlaygroundDialog({
       })
       if (!r.ok) throw new Error(String(r.status))
       const data = (await r.json()) as { reply: string; fallback?: boolean }
-      const t: ChatTurn = { role: 'assistant', content: data.reply, ts: Date.now(), fallback: data.fallback }
+      const t: ChatTurn = {
+        role: 'assistant',
+        content: data.reply,
+        ts: Date.now(),
+        fallback: data.fallback,
+      }
       setChatLog((p) => [...p, t])
     } catch (e: any) {
       if (e?.name === 'AbortError') return
@@ -142,7 +159,8 @@ export function PlaygroundDialog({
       ]
       const t: ChatTurn = {
         role: 'assistant',
-        content: fallbackLines[Math.floor(Math.random() * fallbackLines.length)],
+        content:
+          fallbackLines[Math.floor(Math.random() * fallbackLines.length)],
         ts: Date.now(),
         fallback: true,
       }
@@ -162,7 +180,8 @@ export function PlaygroundDialog({
       className="pointer-events-auto fixed bottom-[max(132px,env(safe-area-inset-bottom))] left-1/2 z-[80] w-[680px] max-w-[94vw] -translate-x-1/2 overflow-visible rounded-[24px] border-2 text-white shadow-2xl backdrop-blur-xl max-[760px]:bottom-[132px] max-[760px]:max-h-[calc(100vh-190px)] max-[760px]:overflow-y-auto"
       style={{
         borderColor: '#d9b35f',
-        background: 'linear-gradient(180deg, rgba(54,36,16,0.96), rgba(12,8,4,0.97))',
+        background:
+          'linear-gradient(180deg, rgba(54,36,16,0.96), rgba(12,8,4,0.97))',
         boxShadow: `0 0 36px ${npc.color}66, 0 18px 60px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,244,205,.16)`,
       }}
     >
@@ -182,7 +201,10 @@ export function PlaygroundDialog({
           width={56}
           height={56}
           className="rounded-full"
-          style={{ border: `2px solid ${npc.color}`, boxShadow: `0 0 14px ${npc.color}88` }}
+          style={{
+            border: `2px solid ${npc.color}`,
+            boxShadow: `0 0 14px ${npc.color}88`,
+          }}
           onError={(e) => {
             ;(e.currentTarget as HTMLImageElement).src = '/avatars/hermes.png'
           }}
@@ -227,7 +249,14 @@ export function PlaygroundDialog({
       {/* Speech body / chat history */}
       {!showChat ? (
         <div className="px-4 py-4">
-          <SpeechBubble variant="npc" tail="left" accent={npc.color} name={npc.name} portraitSrc={npc.portraitSrc} portraitAlt={npc.portraitAlt}>
+          <SpeechBubble
+            variant="npc"
+            tail="left"
+            accent={npc.color}
+            name={npc.name}
+            portraitSrc={npc.portraitSrc}
+            portraitAlt={npc.portraitAlt}
+          >
             {reply ?? npc.opening}
           </SpeechBubble>
         </div>
@@ -238,7 +267,15 @@ export function PlaygroundDialog({
         >
           {/* Show opening line as an initial assistant turn for context */}
           <div className="mb-3">
-            <SpeechBubble variant="npc" tail="left" accent={npc.color} name={npc.name} portraitSrc={npc.portraitSrc} portraitAlt={npc.portraitAlt} compact>
+            <SpeechBubble
+              variant="npc"
+              tail="left"
+              accent={npc.color}
+              name={npc.name}
+              portraitSrc={npc.portraitSrc}
+              portraitAlt={npc.portraitAlt}
+              compact
+            >
               {reply ?? npc.opening}
             </SpeechBubble>
           </div>
@@ -246,12 +283,25 @@ export function PlaygroundDialog({
             <div key={i} className="mb-2">
               {t.role === 'user' ? (
                 <div className="flex justify-end">
-                  <SpeechBubble variant="player" tail="right" name="You" compact>
+                  <SpeechBubble
+                    variant="player"
+                    tail="right"
+                    name="You"
+                    compact
+                  >
                     {t.content}
                   </SpeechBubble>
                 </div>
               ) : (
-                <SpeechBubble variant={t.fallback ? 'system' : 'npc'} tail="left" accent={npc.color} name={npc.name} portraitSrc={npc.portraitSrc} portraitAlt={npc.portraitAlt} compact>
+                <SpeechBubble
+                  variant={t.fallback ? 'system' : 'npc'}
+                  tail="left"
+                  accent={npc.color}
+                  name={npc.name}
+                  portraitSrc={npc.portraitSrc}
+                  portraitAlt={npc.portraitAlt}
+                  compact
+                >
                   {t.content}
                   {t.fallback && (
                     <span className="ml-2 rounded bg-amber-800/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.18em] text-amber-900/75">
@@ -275,36 +325,39 @@ export function PlaygroundDialog({
 
       {/* Free-form input — opt-in via VITE_PLAYGROUND_LLM_CHAT=1 */}
       {llmEnabled && (
-      <div className="border-t border-white/10 bg-black/45 p-2">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            askLLM()
-          }}
-          className="flex gap-2"
-        >
-          <input
-            value={llmFreeform}
-            onChange={(e) => setLlmFreeform(e.target.value)}
-            onKeyDown={(e) => {
-              // Stop WASD movement keys from being captured by the world.
-              e.stopPropagation()
+        <div className="border-t border-white/10 bg-black/45 p-2">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              askLLM()
             }}
-            placeholder={`Ask ${npc.name} anything…`}
-            disabled={askingLLM}
-            className="flex-1 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-[12px] text-white placeholder:text-white/40 outline-none focus:border-white/30"
-            autoFocus
-          />
-          <button
-            type="submit"
-            disabled={askingLLM || !llmFreeform.trim()}
-            className="rounded-lg border border-white/15 bg-white/10 px-3 py-2 text-[11px] font-bold uppercase tracking-[0.12em] text-white/85 transition hover:bg-white/15 disabled:opacity-40"
-            style={{ borderColor: askingLLM ? '#94a3b8' : npc.color, color: askingLLM ? '#94a3b8' : npc.color }}
+            className="flex gap-2"
           >
-            {askingLLM ? '…' : 'Speak'}
-          </button>
-        </form>
-      </div>
+            <input
+              value={llmFreeform}
+              onChange={(e) => setLlmFreeform(e.target.value)}
+              onKeyDown={(e) => {
+                // Stop WASD movement keys from being captured by the world.
+                e.stopPropagation()
+              }}
+              placeholder={`Ask ${npc.name} anything…`}
+              disabled={askingLLM}
+              className="flex-1 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-[12px] text-white placeholder:text-white/40 outline-none focus:border-white/30"
+              autoFocus
+            />
+            <button
+              type="submit"
+              disabled={askingLLM || !llmFreeform.trim()}
+              className="rounded-lg border border-white/15 bg-white/10 px-3 py-2 text-[11px] font-bold uppercase tracking-[0.12em] text-white/85 transition hover:bg-white/15 disabled:opacity-40"
+              style={{
+                borderColor: askingLLM ? '#94a3b8' : npc.color,
+                color: askingLLM ? '#94a3b8' : npc.color,
+              }}
+            >
+              {askingLLM ? '…' : 'Speak'}
+            </button>
+          </form>
+        </div>
       )}
 
       {/* Choices footer */}
@@ -340,7 +393,10 @@ export function PlaygroundDialog({
             onClick={handleNextLore}
             className="block w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-left text-[12px] text-white/70 transition hover:border-white/30 hover:bg-white/10"
           >
-            <span className="opacity-60">›</span> Tell me more {showLore ? `(${loreIdx % npc.lore.length + 1}/${npc.lore.length})` : ''}
+            <span className="opacity-60">›</span> Tell me more{' '}
+            {showLore
+              ? `(${(loreIdx % npc.lore.length) + 1}/${npc.lore.length})`
+              : ''}
           </button>
           <button
             onClick={onClose}

--- a/src/screens/playground/components/playground-environment.tsx
+++ b/src/screens/playground/components/playground-environment.tsx
@@ -16,7 +16,17 @@ function rng(seed: number) {
 }
 
 /* ── Tree variations ── */
-export function PineTree({ position, scale = 1, color = '#1f8b4f', glow = '#86efac' }: { position: [number, number, number]; scale?: number; color?: string; glow?: string }) {
+export function PineTree({
+  position,
+  scale = 1,
+  color = '#1f8b4f',
+  glow = '#86efac',
+}: {
+  position: [number, number, number]
+  scale?: number
+  color?: string
+  glow?: string
+}) {
   return (
     <group position={position} scale={scale}>
       <mesh castShadow position={[0, 0.55, 0]}>
@@ -29,13 +39,26 @@ export function PineTree({ position, scale = 1, color = '#1f8b4f', glow = '#86ef
       </mesh>
       <mesh castShadow position={[0, 2.15, 0]}>
         <coneGeometry args={[0.6, 1, 8]} />
-        <meshStandardMaterial color={glow} roughness={0.7} emissive={glow} emissiveIntensity={0.08} />
+        <meshStandardMaterial
+          color={glow}
+          roughness={0.7}
+          emissive={glow}
+          emissiveIntensity={0.08}
+        />
       </mesh>
     </group>
   )
 }
 
-export function BroadleafTree({ position, scale = 1, color = '#2bbf6f' }: { position: [number, number, number]; scale?: number; color?: string }) {
+export function BroadleafTree({
+  position,
+  scale = 1,
+  color = '#2bbf6f',
+}: {
+  position: [number, number, number]
+  scale?: number
+  color?: string
+}) {
   return (
     <group position={position} scale={scale}>
       <mesh castShadow position={[0, 0.6, 0]}>
@@ -59,13 +82,26 @@ export function BroadleafTree({ position, scale = 1, color = '#2bbf6f' }: { posi
 }
 
 /* ── Bushes / grass tufts ── */
-export function GrassTuft({ position, color = '#3aa86a', variant = 'cluster' }: { position: [number, number, number]; color?: string; variant?: 'cluster' | 'spike' | 'fern' }) {
+export function GrassTuft({
+  position,
+  color = '#3aa86a',
+  variant = 'cluster',
+}: {
+  position: [number, number, number]
+  color?: string
+  variant?: 'cluster' | 'spike' | 'fern'
+}) {
   if (variant === 'spike') {
     // Skinny tufts of grass blades
     return (
       <group position={position}>
         {[0, 0.5, -0.5, 0.25, -0.25].map((angle, i) => (
-          <mesh key={i} castShadow position={[Math.sin(angle) * 0.08, 0.2, Math.cos(angle) * 0.08]} rotation={[0, angle, 0]}>
+          <mesh
+            key={i}
+            castShadow
+            position={[Math.sin(angle) * 0.08, 0.2, Math.cos(angle) * 0.08]}
+            rotation={[0, angle, 0]}
+          >
             <coneGeometry args={[0.05, 0.42, 4]} />
             <meshStandardMaterial color={color} roughness={0.95} />
           </mesh>
@@ -84,7 +120,11 @@ export function GrassTuft({ position, color = '#3aa86a', variant = 'cluster' }: 
           <coneGeometry args={[0.18, 0.32, 5]} />
           <meshStandardMaterial color={color} roughness={0.9} flatShading />
         </mesh>
-        <mesh castShadow position={[-0.16, 0.13, -0.05]} rotation={[0.3, -0.4, 0]}>
+        <mesh
+          castShadow
+          position={[-0.16, 0.13, -0.05]}
+          rotation={[0.3, -0.4, 0]}
+        >
           <coneGeometry args={[0.18, 0.3, 5]} />
           <meshStandardMaterial color={color} roughness={0.9} flatShading />
         </mesh>
@@ -105,19 +145,47 @@ export function GrassTuft({ position, color = '#3aa86a', variant = 'cluster' }: 
 }
 
 /* ── Soft contact shadow disc (use under characters/props that float) ── */
-export function ContactShadow({ position, radius = 0.55, opacity = 0.45 }: { position: [number, number, number]; radius?: number; opacity?: number }) {
+export function ContactShadow({
+  position,
+  radius = 0.55,
+  opacity = 0.45,
+}: {
+  position: [number, number, number]
+  radius?: number
+  opacity?: number
+}) {
   return (
-    <mesh position={[position[0], position[1] + 0.011, position[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+    <mesh
+      position={[position[0], position[1] + 0.011, position[2]]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
       <circleGeometry args={[radius, 16]} />
-      <meshBasicMaterial color="#000000" transparent opacity={opacity} depthWrite={false} />
+      <meshBasicMaterial
+        color="#000000"
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+      />
     </mesh>
   )
 }
 
 /* ── Rocks ── */
-export function Rock({ position, scale = 1, color = '#6b7280' }: { position: [number, number, number]; scale?: number; color?: string }) {
+export function Rock({
+  position,
+  scale = 1,
+  color = '#6b7280',
+}: {
+  position: [number, number, number]
+  scale?: number
+  color?: string
+}) {
   return (
-    <mesh castShadow position={[position[0], position[1] + 0.18 * scale, position[2]]} scale={scale}>
+    <mesh
+      castShadow
+      position={[position[0], position[1] + 0.18 * scale, position[2]]}
+      scale={scale}
+    >
       <dodecahedronGeometry args={[0.4, 0]} />
       <meshStandardMaterial color={color} roughness={0.9} flatShading />
     </mesh>
@@ -125,7 +193,13 @@ export function Rock({ position, scale = 1, color = '#6b7280' }: { position: [nu
 }
 
 /* ── Stone arch (waypoint marker) ── */
-export function StoneArch({ position, color = '#d7c7a4' }: { position: [number, number, number]; color?: string }) {
+export function StoneArch({
+  position,
+  color = '#d7c7a4',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   return (
     <group position={position}>
       <mesh castShadow position={[-0.7, 1.1, 0]}>
@@ -145,7 +219,17 @@ export function StoneArch({ position, color = '#d7c7a4' }: { position: [number, 
 }
 
 /* ── Static townsfolk silhouette (decoration, not interactive) ── */
-export function Townsfolk({ position, color = '#7c3aed', skin = '#f3d3a3', rotation = 0 }: { position: [number, number, number]; color?: string; skin?: string; rotation?: number }) {
+export function Townsfolk({
+  position,
+  color = '#7c3aed',
+  skin = '#f3d3a3',
+  rotation = 0,
+}: {
+  position: [number, number, number]
+  color?: string
+  skin?: string
+  rotation?: number
+}) {
   return (
     <group position={position} rotation={[0, rotation, 0]}>
       {/* Body */}
@@ -186,7 +270,15 @@ export function Townsfolk({ position, color = '#7c3aed', skin = '#f3d3a3', rotat
 }
 
 /* ── Market stall ── */
-export function MarketStall({ position, color = '#b45309', awningColor = '#dc2626' }: { position: [number, number, number]; color?: string; awningColor?: string }) {
+export function MarketStall({
+  position,
+  color = '#b45309',
+  awningColor = '#dc2626',
+}: {
+  position: [number, number, number]
+  color?: string
+  awningColor?: string
+}) {
   return (
     <group position={position}>
       {/* Counter */}
@@ -207,29 +299,62 @@ export function MarketStall({ position, color = '#b45309', awningColor = '#dc262
         </mesh>
       ))}
       {/* Awning */}
-      <mesh castShadow position={[0, 1.95, 0.05]} rotation={[Math.PI / 8, 0, 0]}>
+      <mesh
+        castShadow
+        position={[0, 1.95, 0.05]}
+        rotation={[Math.PI / 8, 0, 0]}
+      >
         <boxGeometry args={[1.85, 0.06, 1]} />
-        <meshStandardMaterial color={awningColor} roughness={0.6} emissive={awningColor} emissiveIntensity={0.08} />
+        <meshStandardMaterial
+          color={awningColor}
+          roughness={0.6}
+          emissive={awningColor}
+          emissiveIntensity={0.08}
+        />
       </mesh>
       {/* Tiny goods */}
       <mesh position={[-0.4, 1, 0]} castShadow>
         <sphereGeometry args={[0.13, 10, 10]} />
-        <meshStandardMaterial color="#facc15" emissive="#facc15" emissiveIntensity={0.3} />
+        <meshStandardMaterial
+          color="#facc15"
+          emissive="#facc15"
+          emissiveIntensity={0.3}
+        />
       </mesh>
       <mesh position={[0, 1, 0]} castShadow>
         <boxGeometry args={[0.18, 0.18, 0.18]} />
-        <meshStandardMaterial color="#a78bfa" emissive="#a78bfa" emissiveIntensity={0.3} />
+        <meshStandardMaterial
+          color="#a78bfa"
+          emissive="#a78bfa"
+          emissiveIntensity={0.3}
+        />
       </mesh>
       <mesh position={[0.4, 1, 0]} castShadow>
         <octahedronGeometry args={[0.14, 0]} />
-        <meshStandardMaterial color="#22d3ee" emissive="#22d3ee" emissiveIntensity={0.4} />
+        <meshStandardMaterial
+          color="#22d3ee"
+          emissive="#22d3ee"
+          emissiveIntensity={0.4}
+        />
       </mesh>
     </group>
   )
 }
 
 /* ── Building (2-story shrine/villa) ── */
-export function Building({ position, color = '#e8d4a8', roofColor = '#b91c1c', accent = '#fbbf24', sign }: { position: [number, number, number]; color?: string; roofColor?: string; accent?: string; sign?: string }) {
+export function Building({
+  position,
+  color = '#e8d4a8',
+  roofColor = '#b91c1c',
+  accent = '#fbbf24',
+  sign,
+}: {
+  position: [number, number, number]
+  color?: string
+  roofColor?: string
+  accent?: string
+  sign?: string
+}) {
   return (
     <group position={position}>
       {/* Foundation */}
@@ -279,7 +404,11 @@ export function Building({ position, color = '#e8d4a8', roofColor = '#b91c1c', a
       {/* Window glow */}
       <mesh position={[-1.05, 1.5, 0.91]}>
         <boxGeometry args={[0.42, 0.42, 0.05]} />
-        <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.5} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.5}
+        />
       </mesh>
       {/* Window cross */}
       <mesh position={[-1.05, 1.5, 0.94]}>
@@ -292,7 +421,11 @@ export function Building({ position, color = '#e8d4a8', roofColor = '#b91c1c', a
       </mesh>
       <mesh position={[1.05, 1.5, 0.91]}>
         <boxGeometry args={[0.42, 0.42, 0.05]} />
-        <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.5} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.5}
+        />
       </mesh>
       <mesh position={[1.05, 1.5, 0.94]}>
         <boxGeometry args={[0.42, 0.04, 0.01]} />
@@ -311,7 +444,11 @@ export function Building({ position, color = '#e8d4a8', roofColor = '#b91c1c', a
           </mesh>
           <mesh position={[0, 0, 0.04]} rotation={[0.05, 0, 0]}>
             <planeGeometry args={[1.34, 0.26]} />
-            <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.4} />
+            <meshStandardMaterial
+              color={accent}
+              emissive={accent}
+              emissiveIntensity={0.4}
+            />
           </mesh>
         </group>
       )}
@@ -320,13 +457,20 @@ export function Building({ position, color = '#e8d4a8', roofColor = '#b91c1c', a
 }
 
 /* ── Lantern / torch ── */
-export function Lantern({ position, color = '#fbbf24' }: { position: [number, number, number]; color?: string }) {
+export function Lantern({
+  position,
+  color = '#fbbf24',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   const ref = useRef<THREE.Mesh>(null)
   useFrame(({ clock }) => {
     if (!ref.current) return
     const t = clock.getElapsedTime()
     const m = ref.current.material as THREE.MeshStandardMaterial
-    if (m && 'emissiveIntensity' in m) m.emissiveIntensity = 1.6 + Math.sin(t * 5) * 0.3
+    if (m && 'emissiveIntensity' in m)
+      m.emissiveIntensity = 1.6 + Math.sin(t * 5) * 0.3
   })
   return (
     <group position={position}>
@@ -336,15 +480,30 @@ export function Lantern({ position, color = '#fbbf24' }: { position: [number, nu
       </mesh>
       <mesh ref={ref} position={[0, 1.3, 0]}>
         <octahedronGeometry args={[0.14, 0]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.6} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={1.6}
+        />
       </mesh>
-      <pointLight position={[0, 1.3, 0]} color={color} intensity={1.2} distance={4} />
+      <pointLight
+        position={[0, 1.3, 0]}
+        color={color}
+        intensity={1.2}
+        distance={4}
+      />
     </group>
   )
 }
 
 /* ── Banner pole ── */
-export function Banner({ position, color = '#9333ea' }: { position: [number, number, number]; color?: string }) {
+export function Banner({
+  position,
+  color = '#9333ea',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   return (
     <group position={position}>
       <mesh castShadow position={[0, 1.2, 0]}>
@@ -353,14 +512,26 @@ export function Banner({ position, color = '#9333ea' }: { position: [number, num
       </mesh>
       <mesh position={[0.32, 1.6, 0]}>
         <planeGeometry args={[0.5, 0.9]} />
-        <meshStandardMaterial color={color} side={THREE.DoubleSide} roughness={0.5} emissive={color} emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color={color}
+          side={THREE.DoubleSide}
+          roughness={0.5}
+          emissive={color}
+          emissiveIntensity={0.18}
+        />
       </mesh>
     </group>
   )
 }
 
 /* ── Flower ── */
-export function Flower({ position, color = '#fde68a' }: { position: [number, number, number]; color?: string }) {
+export function Flower({
+  position,
+  color = '#fde68a',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   return (
     <group position={position}>
       <mesh castShadow position={[0, 0.12, 0]}>
@@ -369,21 +540,41 @@ export function Flower({ position, color = '#fde68a' }: { position: [number, num
       </mesh>
       <mesh castShadow position={[0, 0.27, 0]}>
         <sphereGeometry args={[0.07, 6, 6]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.25} roughness={0.6} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.25}
+          roughness={0.6}
+        />
       </mesh>
     </group>
   )
 }
 
 /* ── Cluster of small flowers in random positions inside a tile ── */
-export function FlowerPatch({ position, count = 6, palette = ['#fde68a', '#fda4af', '#c4b5fd', '#fef3c7'], seed = 1 }: { position: [number, number, number]; count?: number; palette?: string[]; seed?: number }) {
+export function FlowerPatch({
+  position,
+  count = 6,
+  palette = ['#fde68a', '#fda4af', '#c4b5fd', '#fef3c7'],
+  seed = 1,
+}: {
+  position: [number, number, number]
+  count?: number
+  palette?: string[]
+  seed?: number
+}) {
   const items = useMemo(() => {
-    const r = rng(seed * 17 + Math.floor(position[0] * 13) + Math.floor(position[2] * 7))
+    const r = rng(
+      seed * 17 + Math.floor(position[0] * 13) + Math.floor(position[2] * 7),
+    )
     const out: { pos: [number, number, number]; color: string }[] = []
     for (let i = 0; i < count; i++) {
       const dx = (r() - 0.5) * 1.2
       const dz = (r() - 0.5) * 1.2
-      out.push({ pos: [dx, 0, dz], color: palette[Math.floor(r() * palette.length)] })
+      out.push({
+        pos: [dx, 0, dz],
+        color: palette[Math.floor(r() * palette.length)],
+      })
     }
     return out
   }, [count, palette, seed, position])
@@ -397,18 +588,32 @@ export function FlowerPatch({ position, count = 6, palette = ['#fde68a', '#fda4a
 }
 
 /* ── Log pile (small landscape filler) ── */
-export function LogPile({ position, rotation = 0 }: { position: [number, number, number]; rotation?: number }) {
+export function LogPile({
+  position,
+  rotation = 0,
+}: {
+  position: [number, number, number]
+  rotation?: number
+}) {
   return (
     <group position={position} rotation={[0, rotation, 0]}>
       <mesh castShadow position={[0, 0.12, 0]} rotation={[0, 0, Math.PI / 2]}>
         <cylinderGeometry args={[0.13, 0.13, 0.9, 10]} />
         <meshStandardMaterial color="#7c4a1f" roughness={0.85} />
       </mesh>
-      <mesh castShadow position={[0.04, 0.36, 0]} rotation={[0, 0, Math.PI / 2]}>
+      <mesh
+        castShadow
+        position={[0.04, 0.36, 0]}
+        rotation={[0, 0, Math.PI / 2]}
+      >
         <cylinderGeometry args={[0.12, 0.12, 0.85, 10]} />
         <meshStandardMaterial color="#6b3a18" roughness={0.85} />
       </mesh>
-      <mesh castShadow position={[0.02, 0.58, 0]} rotation={[0, 0, Math.PI / 2]}>
+      <mesh
+        castShadow
+        position={[0.02, 0.58, 0]}
+        rotation={[0, 0, Math.PI / 2]}
+      >
         <cylinderGeometry args={[0.1, 0.1, 0.7, 10]} />
         <meshStandardMaterial color="#7c4a1f" roughness={0.85} />
       </mesh>
@@ -417,10 +622,18 @@ export function LogPile({ position, rotation = 0 }: { position: [number, number,
 }
 
 /* ── Fountain (Agora centerpiece) ── */
-export function Fountain({ position, accent = '#7dd3fc' }: { position: [number, number, number]; accent?: string }) {
+export function Fountain({
+  position,
+  accent = '#7dd3fc',
+}: {
+  position: [number, number, number]
+  accent?: string
+}) {
   const splashRef = useRef<THREE.Mesh>(null)
   const [settings] = useHermesWorldSettings()
-  const safeMotion = settings.accessibility.photosensitiveMode || settings.performance.reducedMotion
+  const safeMotion =
+    settings.accessibility.photosensitiveMode ||
+    settings.performance.reducedMotion
   useFrame(({ clock }) => {
     if (!splashRef.current || safeMotion) return
     const t = clock.getElapsedTime()
@@ -437,7 +650,15 @@ export function Fountain({ position, accent = '#7dd3fc' }: { position: [number, 
       {/* Water surface */}
       <mesh position={[0, 0.37, 0]}>
         <cylinderGeometry args={[1.55, 1.55, 0.06, 24]} />
-        <meshStandardMaterial color={accent} transparent opacity={0.78} emissive={accent} emissiveIntensity={0.35} roughness={0.15} metalness={0.3} />
+        <meshStandardMaterial
+          color={accent}
+          transparent
+          opacity={0.78}
+          emissive={accent}
+          emissiveIntensity={0.35}
+          roughness={0.15}
+          metalness={0.3}
+        />
       </mesh>
       {/* Mid pillar */}
       <mesh castShadow position={[0, 0.78, 0]}>
@@ -455,15 +676,37 @@ export function Fountain({ position, accent = '#7dd3fc' }: { position: [number, 
       {/* Splash plume (animated) */}
       <mesh ref={splashRef} position={[0, 1.55, 0]}>
         <coneGeometry args={[0.18, 0.55, 12, 1, true]} />
-        <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={safeMotion ? 0.22 : 0.7} transparent opacity={safeMotion ? 0.34 : 0.6} side={THREE.DoubleSide} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={safeMotion ? 0.22 : 0.7}
+          transparent
+          opacity={safeMotion ? 0.34 : 0.6}
+          side={THREE.DoubleSide}
+        />
       </mesh>
-      <pointLight position={[0, 1.4, 0]} color={accent} intensity={safeMotion ? 0.45 : 1.4} distance={6} />
+      <pointLight
+        position={[0, 1.4, 0]}
+        color={accent}
+        intensity={safeMotion ? 0.45 : 1.4}
+        distance={6}
+      />
     </group>
   )
 }
 
 /* ── Path tile (dirt strip for roads) ── */
-export function PathStrip({ from, to, width = 1.4, color = '#8a6a3d' }: { from: [number, number]; to: [number, number]; width?: number; color?: string }) {
+export function PathStrip({
+  from,
+  to,
+  width = 1.4,
+  color = '#8a6a3d',
+}: {
+  from: [number, number]
+  to: [number, number]
+  width?: number
+  color?: string
+}) {
   const dx = to[0] - from[0]
   const dz = to[1] - from[1]
   const len = Math.sqrt(dx * dx + dz * dz)
@@ -471,7 +714,11 @@ export function PathStrip({ from, to, width = 1.4, color = '#8a6a3d' }: { from: 
   const cx = (from[0] + to[0]) / 2
   const cz = (from[1] + to[1]) / 2
   return (
-    <mesh receiveShadow position={[cx, 0.015, cz]} rotation={[-Math.PI / 2, 0, -angle]}>
+    <mesh
+      receiveShadow
+      position={[cx, 0.015, cz]}
+      rotation={[-Math.PI / 2, 0, -angle]}
+    >
       <planeGeometry args={[len, width, 1, 1]} />
       <meshStandardMaterial color={color} roughness={1} />
     </mesh>
@@ -479,14 +726,30 @@ export function PathStrip({ from, to, width = 1.4, color = '#8a6a3d' }: { from: 
 }
 
 /* ── Round plaza tile (paved center) ── */
-export function PlazaDisc({ position, radius = 6, color = '#a98a5e' }: { position: [number, number, number]; radius?: number; color?: string }) {
+export function PlazaDisc({
+  position,
+  radius = 6,
+  color = '#a98a5e',
+}: {
+  position: [number, number, number]
+  radius?: number
+  color?: string
+}) {
   return (
     <group position={position}>
-      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.012, 0]}>
+      <mesh
+        receiveShadow
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.012, 0]}
+      >
         <circleGeometry args={[radius, 48]} />
         <meshStandardMaterial color={color} roughness={1} />
       </mesh>
-      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.018, 0]}>
+      <mesh
+        receiveShadow
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.018, 0]}
+      >
         <ringGeometry args={[radius - 0.6, radius - 0.4, 64]} />
         <meshStandardMaterial color="#5a4424" roughness={1} />
       </mesh>
@@ -495,99 +758,363 @@ export function PlazaDisc({ position, radius = 6, color = '#a98a5e' }: { positio
 }
 
 /* ── Enterprise MMO hub landmarks ── */
-export function ClockTower({ position, accent = '#fbbf24' }: { position: [number, number, number]; accent?: string }) {
+export function ClockTower({
+  position,
+  accent = '#fbbf24',
+}: {
+  position: [number, number, number]
+  accent?: string
+}) {
   return (
     <group position={position}>
-      <mesh castShadow receiveShadow position={[0, 0.25, 0]}><cylinderGeometry args={[1.25, 1.4, 0.5, 16]} /><meshStandardMaterial color="#8b7355" roughness={0.8} /></mesh>
-      <mesh castShadow position={[0, 2.2, 0]}><boxGeometry args={[1.25, 3.6, 1.25]} /><meshStandardMaterial color="#e7d2a6" roughness={0.72} /></mesh>
+      <mesh castShadow receiveShadow position={[0, 0.25, 0]}>
+        <cylinderGeometry args={[1.25, 1.4, 0.5, 16]} />
+        <meshStandardMaterial color="#8b7355" roughness={0.8} />
+      </mesh>
+      <mesh castShadow position={[0, 2.2, 0]}>
+        <boxGeometry args={[1.25, 3.6, 1.25]} />
+        <meshStandardMaterial color="#e7d2a6" roughness={0.72} />
+      </mesh>
       {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((rot, i) => (
         <group key={i} rotation={[0, rot, 0]} position={[0, 3.1, 0.64]}>
-          <mesh><circleGeometry args={[0.36, 24]} /><meshStandardMaterial color="#fef3c7" emissive="#fef3c7" emissiveIntensity={0.25} roughness={0.45} /></mesh>
-          <mesh position={[0, 0.08, 0.02]} rotation={[0, 0, -0.5]}><boxGeometry args={[0.04, 0.22, 0.02]} /><meshStandardMaterial color="#1f2937" /></mesh>
-          <mesh position={[0.08, -0.02, 0.03]} rotation={[0, 0, 1.2]}><boxGeometry args={[0.035, 0.2, 0.02]} /><meshStandardMaterial color="#1f2937" /></mesh>
+          <mesh>
+            <circleGeometry args={[0.36, 24]} />
+            <meshStandardMaterial
+              color="#fef3c7"
+              emissive="#fef3c7"
+              emissiveIntensity={0.25}
+              roughness={0.45}
+            />
+          </mesh>
+          <mesh position={[0, 0.08, 0.02]} rotation={[0, 0, -0.5]}>
+            <boxGeometry args={[0.04, 0.22, 0.02]} />
+            <meshStandardMaterial color="#1f2937" />
+          </mesh>
+          <mesh position={[0.08, -0.02, 0.03]} rotation={[0, 0, 1.2]}>
+            <boxGeometry args={[0.035, 0.2, 0.02]} />
+            <meshStandardMaterial color="#1f2937" />
+          </mesh>
         </group>
       ))}
-      <mesh castShadow position={[0, 4.35, 0]} rotation={[0, Math.PI / 4, 0]}><coneGeometry args={[1.15, 1.2, 4]} /><meshStandardMaterial color="#7c2d12" roughness={0.68} /></mesh>
-      <mesh position={[0, 5.05, 0]}><octahedronGeometry args={[0.25, 0]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.1} /></mesh>
-      <pointLight position={[0, 4.7, 0]} color={accent} intensity={1.2} distance={9} />
+      <mesh castShadow position={[0, 4.35, 0]} rotation={[0, Math.PI / 4, 0]}>
+        <coneGeometry args={[1.15, 1.2, 4]} />
+        <meshStandardMaterial color="#7c2d12" roughness={0.68} />
+      </mesh>
+      <mesh position={[0, 5.05, 0]}>
+        <octahedronGeometry args={[0.25, 0]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.1}
+        />
+      </mesh>
+      <pointLight
+        position={[0, 4.7, 0]}
+        color={accent}
+        intensity={1.2}
+        distance={9}
+      />
     </group>
   )
 }
 
-export function Signpost({ position, rotation = 0, color = '#fbbf24' }: { position: [number, number, number]; rotation?: number; color?: string }) {
+export function Signpost({
+  position,
+  rotation = 0,
+  color = '#fbbf24',
+}: {
+  position: [number, number, number]
+  rotation?: number
+  color?: string
+}) {
   return (
     <group position={position} rotation={[0, rotation, 0]}>
-      <mesh castShadow position={[0, 0.65, 0]}><cylinderGeometry args={[0.055, 0.055, 1.3, 8]} /><meshStandardMaterial color="#3f2511" roughness={0.85} /></mesh>
-      <mesh castShadow position={[0.34, 1.08, 0]}><boxGeometry args={[0.75, 0.22, 0.08]} /><meshStandardMaterial color="#8b5a2b" roughness={0.75} /></mesh>
-      <mesh position={[0.34, 1.08, 0.045]}><planeGeometry args={[0.62, 0.12]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.28} /></mesh>
-      <mesh castShadow position={[-0.32, 0.76, 0]}><boxGeometry args={[0.65, 0.2, 0.08]} /><meshStandardMaterial color="#8b5a2b" roughness={0.75} /></mesh>
+      <mesh castShadow position={[0, 0.65, 0]}>
+        <cylinderGeometry args={[0.055, 0.055, 1.3, 8]} />
+        <meshStandardMaterial color="#3f2511" roughness={0.85} />
+      </mesh>
+      <mesh castShadow position={[0.34, 1.08, 0]}>
+        <boxGeometry args={[0.75, 0.22, 0.08]} />
+        <meshStandardMaterial color="#8b5a2b" roughness={0.75} />
+      </mesh>
+      <mesh position={[0.34, 1.08, 0.045]}>
+        <planeGeometry args={[0.62, 0.12]} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.28}
+        />
+      </mesh>
+      <mesh castShadow position={[-0.32, 0.76, 0]}>
+        <boxGeometry args={[0.65, 0.2, 0.08]} />
+        <meshStandardMaterial color="#8b5a2b" roughness={0.75} />
+      </mesh>
     </group>
   )
 }
 
-export function Bench({ position, rotation = 0 }: { position: [number, number, number]; rotation?: number }) {
+export function Bench({
+  position,
+  rotation = 0,
+}: {
+  position: [number, number, number]
+  rotation?: number
+}) {
   return (
     <group position={position} rotation={[0, rotation, 0]}>
-      <mesh castShadow position={[0, 0.38, 0]}><boxGeometry args={[1.25, 0.14, 0.38]} /><meshStandardMaterial color="#7c4a1f" roughness={0.85} /></mesh>
-      <mesh castShadow position={[0, 0.75, -0.19]} rotation={[0.25, 0, 0]}><boxGeometry args={[1.25, 0.12, 0.42]} /><meshStandardMaterial color="#6b3a18" roughness={0.85} /></mesh>
-      {[-0.45, 0.45].map((x) => <mesh key={x} castShadow position={[x, 0.18, 0]}><boxGeometry args={[0.09, 0.36, 0.32]} /><meshStandardMaterial color="#3f2511" roughness={0.9} /></mesh>)}
+      <mesh castShadow position={[0, 0.38, 0]}>
+        <boxGeometry args={[1.25, 0.14, 0.38]} />
+        <meshStandardMaterial color="#7c4a1f" roughness={0.85} />
+      </mesh>
+      <mesh castShadow position={[0, 0.75, -0.19]} rotation={[0.25, 0, 0]}>
+        <boxGeometry args={[1.25, 0.12, 0.42]} />
+        <meshStandardMaterial color="#6b3a18" roughness={0.85} />
+      </mesh>
+      {[-0.45, 0.45].map((x) => (
+        <mesh key={x} castShadow position={[x, 0.18, 0]}>
+          <boxGeometry args={[0.09, 0.36, 0.32]} />
+          <meshStandardMaterial color="#3f2511" roughness={0.9} />
+        </mesh>
+      ))}
     </group>
   )
 }
 
-export function TrainingRing({ position, accent = '#fb7185' }: { position: [number, number, number]; accent?: string }) {
+export function TrainingRing({
+  position,
+  accent = '#fb7185',
+}: {
+  position: [number, number, number]
+  accent?: string
+}) {
   return (
     <group position={position}>
-      <mesh receiveShadow position={[0, 0.018, 0]} rotation={[-Math.PI / 2, 0, 0]}><ringGeometry args={[1.8, 2.15, 48]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.15} roughness={0.65} /></mesh>
-      {[-1.4, 1.4].map((x) => <group key={x} position={[x, 0, 0]}><mesh castShadow position={[0, 0.55, 0]}><cylinderGeometry args={[0.18, 0.22, 1.1, 10]} /><meshStandardMaterial color="#8b5a2b" roughness={0.8} /></mesh><mesh castShadow position={[0, 1.22, 0]}><sphereGeometry args={[0.26, 10, 10]} /><meshStandardMaterial color="#f3d3a3" roughness={0.7} /></mesh><mesh castShadow position={[0, 0.7, 0.32]} rotation={[Math.PI / 2, 0, 0]}><cylinderGeometry args={[0.04, 0.04, 0.8, 8]} /><meshStandardMaterial color="#64748b" metalness={0.4} roughness={0.5} /></mesh></group>)}
+      <mesh
+        receiveShadow
+        position={[0, 0.018, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <ringGeometry args={[1.8, 2.15, 48]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.15}
+          roughness={0.65}
+        />
+      </mesh>
+      {[-1.4, 1.4].map((x) => (
+        <group key={x} position={[x, 0, 0]}>
+          <mesh castShadow position={[0, 0.55, 0]}>
+            <cylinderGeometry args={[0.18, 0.22, 1.1, 10]} />
+            <meshStandardMaterial color="#8b5a2b" roughness={0.8} />
+          </mesh>
+          <mesh castShadow position={[0, 1.22, 0]}>
+            <sphereGeometry args={[0.26, 10, 10]} />
+            <meshStandardMaterial color="#f3d3a3" roughness={0.7} />
+          </mesh>
+          <mesh
+            castShadow
+            position={[0, 0.7, 0.32]}
+            rotation={[Math.PI / 2, 0, 0]}
+          >
+            <cylinderGeometry args={[0.04, 0.04, 0.8, 8]} />
+            <meshStandardMaterial
+              color="#64748b"
+              metalness={0.4}
+              roughness={0.5}
+            />
+          </mesh>
+        </group>
+      ))}
     </group>
   )
 }
 
-export function RaisedDais({ position, accent = '#a78bfa' }: { position: [number, number, number]; accent?: string }) {
+export function RaisedDais({
+  position,
+  accent = '#a78bfa',
+}: {
+  position: [number, number, number]
+  accent?: string
+}) {
   return (
     <group position={position}>
-      <mesh castShadow receiveShadow position={[0, 0.24, 0]}><cylinderGeometry args={[2.4, 2.7, 0.48, 8]} /><meshStandardMaterial color="#9ca3af" roughness={0.78} /></mesh>
-      <mesh receiveShadow position={[0, 0.5, 0]} rotation={[-Math.PI / 2, 0, 0]}><circleGeometry args={[2.2, 32]} /><meshStandardMaterial color="#d7c7a4" roughness={0.7} /></mesh>
-      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => <Lantern key={i} position={[Math.cos(a) * 1.85, 0.48, Math.sin(a) * 1.85]} color={accent} />)}
+      <mesh castShadow receiveShadow position={[0, 0.24, 0]}>
+        <cylinderGeometry args={[2.4, 2.7, 0.48, 8]} />
+        <meshStandardMaterial color="#9ca3af" roughness={0.78} />
+      </mesh>
+      <mesh
+        receiveShadow
+        position={[0, 0.5, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
+        <circleGeometry args={[2.2, 32]} />
+        <meshStandardMaterial color="#d7c7a4" roughness={0.7} />
+      </mesh>
+      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => (
+        <Lantern
+          key={i}
+          position={[Math.cos(a) * 1.85, 0.48, Math.sin(a) * 1.85]}
+          color={accent}
+        />
+      ))}
     </group>
   )
 }
 
-export function CrystalCluster({ position, color = '#a78bfa' }: { position: [number, number, number]; color?: string }) {
+export function CrystalCluster({
+  position,
+  color = '#a78bfa',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   return (
     <group position={position}>
-      {[0, 0.5, -0.45].map((dx, i) => <mesh key={i} castShadow position={[dx, 0.45 + i * 0.18, i === 0 ? 0 : dx * 0.25]} rotation={[0.2, dx, 0.1]}><octahedronGeometry args={[0.35 + i * 0.08, 0]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.85} roughness={0.35} transparent opacity={0.92} /></mesh>)}
-      <pointLight position={[0, 1, 0]} color={color} intensity={1.5} distance={7} />
+      {[0, 0.5, -0.45].map((dx, i) => (
+        <mesh
+          key={i}
+          castShadow
+          position={[dx, 0.45 + i * 0.18, i === 0 ? 0 : dx * 0.25]}
+          rotation={[0.2, dx, 0.1]}
+        >
+          <octahedronGeometry args={[0.35 + i * 0.08, 0]} />
+          <meshStandardMaterial
+            color={color}
+            emissive={color}
+            emissiveIntensity={0.85}
+            roughness={0.35}
+            transparent
+            opacity={0.92}
+          />
+        </mesh>
+      ))}
+      <pointLight
+        position={[0, 1, 0]}
+        color={color}
+        intensity={1.5}
+        distance={7}
+      />
     </group>
   )
 }
 
-export function EnergyCore({ position, color = '#22d3ee' }: { position: [number, number, number]; color?: string }) {
+export function EnergyCore({
+  position,
+  color = '#22d3ee',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   const ref = useRef<THREE.Group>(null)
-  useFrame(({ clock }) => { if (ref.current) ref.current.rotation.y = clock.getElapsedTime() * 0.8 })
+  useFrame(({ clock }) => {
+    if (ref.current) ref.current.rotation.y = clock.getElapsedTime() * 0.8
+  })
   return (
     <group position={position}>
-      <mesh receiveShadow castShadow position={[0, 0.18, 0]}><cylinderGeometry args={[1.3, 1.5, 0.36, 16]} /><meshStandardMaterial color="#1f2937" roughness={0.55} metalness={0.25} /></mesh>
-      <group ref={ref} position={[0, 1.15, 0]}><mesh castShadow><octahedronGeometry args={[0.75, 0]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.3} roughness={0.25} /></mesh><mesh rotation={[Math.PI / 2, 0, 0]}><torusGeometry args={[1.1, 0.035, 10, 48]} /><meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.1} /></mesh></group>
-      <pointLight position={[0, 1.2, 0]} color={color} intensity={2.4} distance={10} />
+      <mesh receiveShadow castShadow position={[0, 0.18, 0]}>
+        <cylinderGeometry args={[1.3, 1.5, 0.36, 16]} />
+        <meshStandardMaterial
+          color="#1f2937"
+          roughness={0.55}
+          metalness={0.25}
+        />
+      </mesh>
+      <group ref={ref} position={[0, 1.15, 0]}>
+        <mesh castShadow>
+          <octahedronGeometry args={[0.75, 0]} />
+          <meshStandardMaterial
+            color={color}
+            emissive={color}
+            emissiveIntensity={1.3}
+            roughness={0.25}
+          />
+        </mesh>
+        <mesh rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[1.1, 0.035, 10, 48]} />
+          <meshStandardMaterial
+            color={color}
+            emissive={color}
+            emissiveIntensity={1.1}
+          />
+        </mesh>
+      </group>
+      <pointLight
+        position={[0, 1.2, 0]}
+        color={color}
+        intensity={2.4}
+        distance={10}
+      />
     </group>
   )
 }
 
-
-type SceneryInstance = { type: string; pos: [number, number, number]; color?: string; scale?: number }
+type SceneryInstance = {
+  type: string
+  pos: [number, number, number]
+  color?: string
+  scale?: number
+  glow?: string
+}
 function InstancedRocks({ items }: { items: SceneryInstance[] }) {
   const ref = useRef<THREE.InstancedMesh>(null)
-  const matrices = useMemo(() => { const dummy = new THREE.Object3D(); return items.map((item, index) => { const scale = item.scale ?? 0.8; dummy.position.set(item.pos[0], item.pos[1] + 0.16 * scale, item.pos[2]); dummy.rotation.set(0.2, index * 0.73, -0.1); dummy.scale.set(scale, scale * (0.7 + (index % 3) * 0.08), scale); dummy.updateMatrix(); return dummy.matrix.clone() }) }, [items])
-  useLayoutEffect(() => { matrices.forEach((matrix, index) => ref.current?.setMatrixAt(index, matrix)); if (ref.current) ref.current.instanceMatrix.needsUpdate = true }, [matrices])
-  return <instancedMesh ref={ref} args={[undefined, undefined, matrices.length]} castShadow={false} receiveShadow frustumCulled><dodecahedronGeometry args={[0.45, 0]} /><meshStandardMaterial color="#667085" roughness={0.82} /></instancedMesh>
+  const matrices = useMemo(() => {
+    const dummy = new THREE.Object3D()
+    return items.map((item, index) => {
+      const scale = item.scale ?? 0.8
+      dummy.position.set(item.pos[0], item.pos[1] + 0.16 * scale, item.pos[2])
+      dummy.rotation.set(0.2, index * 0.73, -0.1)
+      dummy.scale.set(scale, scale * (0.7 + (index % 3) * 0.08), scale)
+      dummy.updateMatrix()
+      return dummy.matrix.clone()
+    })
+  }, [items])
+  useLayoutEffect(() => {
+    matrices.forEach((matrix, index) => ref.current?.setMatrixAt(index, matrix))
+    if (ref.current) ref.current.instanceMatrix.needsUpdate = true
+  }, [matrices])
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[undefined, undefined, matrices.length]}
+      castShadow={false}
+      receiveShadow
+      frustumCulled
+    >
+      <dodecahedronGeometry args={[0.45, 0]} />
+      <meshStandardMaterial color="#667085" roughness={0.82} />
+    </instancedMesh>
+  )
 }
 function InstancedGrassTufts({ items }: { items: SceneryInstance[] }) {
   const ref = useRef<THREE.InstancedMesh>(null)
-  const matrices = useMemo(() => { const dummy = new THREE.Object3D(); return items.map((item, index) => { const scale = 0.65 + (index % 4) * 0.08; dummy.position.set(item.pos[0], item.pos[1] + 0.16, item.pos[2]); dummy.rotation.set(0, index * 0.91, 0); dummy.scale.set(scale, scale, scale); dummy.updateMatrix(); return dummy.matrix.clone() }) }, [items])
-  useLayoutEffect(() => { matrices.forEach((matrix, index) => ref.current?.setMatrixAt(index, matrix)); if (ref.current) ref.current.instanceMatrix.needsUpdate = true }, [matrices])
-  return <instancedMesh ref={ref} args={[undefined, undefined, matrices.length]} castShadow={false} receiveShadow={false} frustumCulled><coneGeometry args={[0.12, 0.55, 5]} /><meshStandardMaterial color="#3aa86a" roughness={0.75} /></instancedMesh>
+  const matrices = useMemo(() => {
+    const dummy = new THREE.Object3D()
+    return items.map((item, index) => {
+      const scale = 0.65 + (index % 4) * 0.08
+      dummy.position.set(item.pos[0], item.pos[1] + 0.16, item.pos[2])
+      dummy.rotation.set(0, index * 0.91, 0)
+      dummy.scale.set(scale, scale, scale)
+      dummy.updateMatrix()
+      return dummy.matrix.clone()
+    })
+  }, [items])
+  useLayoutEffect(() => {
+    matrices.forEach((matrix, index) => ref.current?.setMatrixAt(index, matrix))
+    if (ref.current) ref.current.instanceMatrix.needsUpdate = true
+  }, [matrices])
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[undefined, undefined, matrices.length]}
+      castShadow={false}
+      receiveShadow={false}
+      frustumCulled
+    >
+      <coneGeometry args={[0.12, 0.55, 5]} />
+      <meshStandardMaterial color="#3aa86a" roughness={0.75} />
+    </instancedMesh>
+  )
 }
 
 /* ── Scattered scenery cluster (auto-fills a world) ── */
@@ -595,12 +1122,12 @@ export function ScatteredScenery({
   worldId,
   seed = 1,
 }: {
-  worldId: 'agora' | 'forge' | 'grove' | 'oracle' | 'arena'
+  worldId: 'training' | 'agora' | 'forge' | 'grove' | 'oracle' | 'arena'
   seed?: number
 }) {
   const items = useMemo(() => {
     const r = rng(seed * 100 + worldId.length)
-    const out: { type: string; pos: [number, number, number]; color?: string; scale?: number }[] = []
+    const out: SceneryInstance[] = []
 
     function maybeOnEdge(): [number, number, number] {
       // Place on ring 14-22 from center
@@ -617,74 +1144,220 @@ export function ScatteredScenery({
 
     // Common scenery
     for (let i = 0; i < 20; i++) {
-      out.push({ type: 'rock', pos: farEdge(), scale: 0.5 + r() * 0.8, color: '#6b7280' })
+      out.push({
+        type: 'rock',
+        pos: farEdge(),
+        scale: 0.5 + r() * 0.8,
+        color: '#6b7280',
+      })
     }
     for (let i = 0; i < 30; i++) {
-      out.push({ type: 'grass', pos: maybeOnEdge(), color: worldId === 'forge' ? '#0ea5e9' : worldId === 'oracle' ? '#a78bfa' : '#3aa86a' })
+      out.push({
+        type: 'grass',
+        pos: maybeOnEdge(),
+        color:
+          worldId === 'forge'
+            ? '#0ea5e9'
+            : worldId === 'oracle'
+              ? '#a78bfa'
+              : '#3aa86a',
+      })
     }
 
     if (worldId === 'agora') {
       // Centerpiece fountain + paved plaza
-      out.push({ type: 'plaza', pos: [0, 0, 0], radius: 8, color: '#b89668' } as any)
+      out.push({
+        type: 'plaza',
+        pos: [0, 0, 0],
+        radius: 8,
+        color: '#b89668',
+      } as any)
       out.push({ type: 'fountain', pos: [0, 0, 0], color: '#7dd3fc' })
 
       // Dirt paths radiating to NPC zones / portal / arch
       const pathTargets: [number, number][] = [
-        [12, -6], [-12, -6], [12, 6], [-12, 6], [0, 14], [0, -14],
+        [12, -6],
+        [-12, -6],
+        [12, 6],
+        [-12, 6],
+        [0, 14],
+        [0, -14],
       ]
       for (const t of pathTargets) {
-        out.push({ type: 'path', from: [0, 0], to: t, width: 1.6, color: '#9d7a4a' } as any)
+        out.push({
+          type: 'path',
+          from: [0, 0],
+          to: t,
+          width: 1.6,
+          color: '#9d7a4a',
+        } as any)
       }
 
       // Buildings around the plaza like a small town — signed roles create districts
-      out.push({ type: 'building', pos: [-13, 0, -15], color: '#e8d4a8', roofColor: '#b91c1c', sign: 'Smithy' } as any)
-      out.push({ type: 'building', pos: [13, 0, -15], color: '#f5deb3', roofColor: '#1d4ed8', sign: 'Apothecary' } as any)
-      out.push({ type: 'building', pos: [-17, 0, 9], color: '#deb887', roofColor: '#92400e', sign: 'Inn' } as any)
-      out.push({ type: 'building', pos: [17, 0, 9], color: '#e8d4a8', roofColor: '#b91c1c', sign: 'Bank' } as any)
-      out.push({ type: 'building', pos: [-2, 0, -19], color: '#f3e1bb', roofColor: '#1d4ed8', sign: 'Guild' } as any)
-      out.push({ type: 'building', pos: [2, 0, 18], color: '#f3e1bb', roofColor: '#b91c1c', sign: 'Tavern' } as any)
+      out.push({
+        type: 'building',
+        pos: [-13, 0, -15],
+        color: '#e8d4a8',
+        roofColor: '#b91c1c',
+        sign: 'Smithy',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [13, 0, -15],
+        color: '#f5deb3',
+        roofColor: '#1d4ed8',
+        sign: 'Apothecary',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [-17, 0, 9],
+        color: '#deb887',
+        roofColor: '#92400e',
+        sign: 'Inn',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [17, 0, 9],
+        color: '#e8d4a8',
+        roofColor: '#b91c1c',
+        sign: 'Bank',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [-2, 0, -19],
+        color: '#f3e1bb',
+        roofColor: '#1d4ed8',
+        sign: 'Guild',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [2, 0, 18],
+        color: '#f3e1bb',
+        roofColor: '#b91c1c',
+        sign: 'Tavern',
+      } as any)
 
       // Market street: stalls + merchants behind them
-      const stallSetup: { stall: [number, number, number]; merchant: [number, number, number]; mColor: string; mRot: number; awning: string }[] = [
-        { stall: [-3, 0, 11], merchant: [-3, 0, 11.7], mColor: '#7c3aed', mRot: Math.PI, awning: '#dc2626' },
-        { stall: [3, 0, 11], merchant: [3, 0, 11.7], mColor: '#0891b2', mRot: Math.PI, awning: '#1d4ed8' },
-        { stall: [-5, 0, 13.5], merchant: [-5, 0, 14.2], mColor: '#16a34a', mRot: Math.PI, awning: '#16a34a' },
-        { stall: [5, 0, 13.5], merchant: [5, 0, 14.2], mColor: '#dc2626', mRot: Math.PI, awning: '#7c2d12' },
-        { stall: [-9, 0, -2], merchant: [-9, 0, -1.3], mColor: '#7c2d12', mRot: 0, awning: '#dc2626' },
-        { stall: [9, 0, -2], merchant: [9, 0, -1.3], mColor: '#9333ea', mRot: 0, awning: '#22d3ee' },
+      const stallSetup: {
+        stall: [number, number, number]
+        merchant: [number, number, number]
+        mColor: string
+        mRot: number
+        awning: string
+      }[] = [
+        {
+          stall: [-3, 0, 11],
+          merchant: [-3, 0, 11.7],
+          mColor: '#7c3aed',
+          mRot: Math.PI,
+          awning: '#dc2626',
+        },
+        {
+          stall: [3, 0, 11],
+          merchant: [3, 0, 11.7],
+          mColor: '#0891b2',
+          mRot: Math.PI,
+          awning: '#1d4ed8',
+        },
+        {
+          stall: [-5, 0, 13.5],
+          merchant: [-5, 0, 14.2],
+          mColor: '#16a34a',
+          mRot: Math.PI,
+          awning: '#16a34a',
+        },
+        {
+          stall: [5, 0, 13.5],
+          merchant: [5, 0, 14.2],
+          mColor: '#dc2626',
+          mRot: Math.PI,
+          awning: '#7c2d12',
+        },
+        {
+          stall: [-9, 0, -2],
+          merchant: [-9, 0, -1.3],
+          mColor: '#7c2d12',
+          mRot: 0,
+          awning: '#dc2626',
+        },
+        {
+          stall: [9, 0, -2],
+          merchant: [9, 0, -1.3],
+          mColor: '#9333ea',
+          mRot: 0,
+          awning: '#22d3ee',
+        },
       ]
       for (const s of stallSetup) {
         out.push({ type: 'stall', pos: s.stall, awningColor: s.awning } as any)
-        out.push({ type: 'townsfolk', pos: s.merchant, color: s.mColor, rotation: s.mRot } as any)
+        out.push({
+          type: 'townsfolk',
+          pos: s.merchant,
+          color: s.mColor,
+          rotation: s.mRot,
+        } as any)
       }
 
       // A couple of strolling townsfolk near the fountain for life
-      out.push({ type: 'townsfolk', pos: [-4.5, 0, 4.5], color: '#0ea5e9', rotation: 1.2 } as any)
-      out.push({ type: 'townsfolk', pos: [4.5, 0, -4], color: '#facc15', rotation: -2.1 } as any)
-      out.push({ type: 'townsfolk', pos: [3, 0, 6], color: '#a21caf', rotation: -0.8 } as any)
+      out.push({
+        type: 'townsfolk',
+        pos: [-4.5, 0, 4.5],
+        color: '#0ea5e9',
+        rotation: 1.2,
+      } as any)
+      out.push({
+        type: 'townsfolk',
+        pos: [4.5, 0, -4],
+        color: '#facc15',
+        rotation: -2.1,
+      } as any)
+      out.push({
+        type: 'townsfolk',
+        pos: [3, 0, 6],
+        color: '#a21caf',
+        rotation: -0.8,
+      } as any)
 
       // Lanterns ringing the fountain (ornamental)
       for (let i = 0; i < 8; i++) {
         const ang = (i / 8) * Math.PI * 2 + Math.PI / 8
-        out.push({ type: 'lantern', pos: [Math.cos(ang) * 5.5, 0, Math.sin(ang) * 5.5], color: '#fbbf24' })
+        out.push({
+          type: 'lantern',
+          pos: [Math.cos(ang) * 5.5, 0, Math.sin(ang) * 5.5],
+          color: '#fbbf24',
+        })
       }
 
       // Trees on the outer ring (green band that separates plaza from fog)
       for (let i = 0; i < 26; i++) {
         const ang = r() * Math.PI * 2
         const rad = 18 + r() * 6
-        out.push({ type: r() < 0.5 ? 'pine' : 'broadleaf', pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad], scale: 0.8 + r() * 0.6, color: r() < 0.5 ? '#1f8b4f' : '#2bbf6f', glow: '#86efac' })
+        out.push({
+          type: r() < 0.5 ? 'pine' : 'broadleaf',
+          pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
+          scale: 0.8 + r() * 0.6,
+          color: r() < 0.5 ? '#1f8b4f' : '#2bbf6f',
+          glow: '#86efac',
+        })
       }
       // Flowers and grass tufts in the green band, off the paths
       for (let i = 0; i < 28; i++) {
         const ang = r() * Math.PI * 2
         const rad = 9.5 + r() * 7.5
-        out.push({ type: 'grass', pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad], color: '#3aa86a' })
+        out.push({
+          type: 'grass',
+          pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
+          color: '#3aa86a',
+        })
       }
       for (let i = 0; i < 16; i++) {
         const ang = r() * Math.PI * 2
         const rad = 10 + r() * 7
-        out.push({ type: 'flowerpatch', pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad], count: 6 + Math.floor(r() * 5) } as any)
+        out.push({
+          type: 'flowerpatch',
+          pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
+          count: 6 + Math.floor(r() * 5),
+        } as any)
       }
 
       // A few rocks and a log pile for prop variety
@@ -694,17 +1367,32 @@ export function ScatteredScenery({
       out.push({ type: 'rock', pos: [10, 0, -9], scale: 1.1, color: '#5b6470' })
 
       // Landmark layer: wayfinding, social rest points, vertical centerpieces
-      out.push({ type: 'clocktower', pos: [-7, 0, -14], color: '#fbbf24' } as any)
+      out.push({
+        type: 'clocktower',
+        pos: [-7, 0, -14],
+        color: '#fbbf24',
+      } as any)
       out.push({ type: 'dais', pos: [8, 0, -13], color: '#a78bfa' } as any)
       out.push({ type: 'training', pos: [-12, 0, 3], color: '#fb7185' } as any)
-      out.push({ type: 'signpost', pos: [-4, 0, -7], rotation: 0.8, color: '#fbbf24' } as any)
-      out.push({ type: 'signpost', pos: [5, 0, -7], rotation: -0.6, color: '#7dd3fc' } as any)
+      out.push({
+        type: 'signpost',
+        pos: [-4, 0, -7],
+        rotation: 0.8,
+        color: '#fbbf24',
+      } as any)
+      out.push({
+        type: 'signpost',
+        pos: [5, 0, -7],
+        rotation: -0.6,
+        color: '#7dd3fc',
+      } as any)
       for (const b of [
         { pos: [-3.5, 0, 4.8], rotation: -0.55 },
         { pos: [3.8, 0, 4.7], rotation: 0.55 },
         { pos: [-4.8, 0, -4.2], rotation: 2.5 },
         { pos: [4.8, 0, -4.2], rotation: -2.5 },
-      ]) out.push({ type: 'bench', ...b } as any)
+      ])
+        out.push({ type: 'bench', ...b } as any)
 
       // Original arch + banners
       out.push({ type: 'arch', pos: [0, 0, 18], color: '#d7c7a4' })
@@ -715,24 +1403,68 @@ export function ScatteredScenery({
     if (worldId === 'forge') {
       // Industrial tool district: energy core, workshops, cyan lamps
       out.push({ type: 'energycore', pos: [0, 0, -2], color: '#22d3ee' } as any)
-      out.push({ type: 'building', pos: [-14, 0, -10], color: '#1f2937', roofColor: '#22d3ee', sign: 'Tools' } as any)
-      out.push({ type: 'building', pos: [14, 0, -10], color: '#1f2937', roofColor: '#22d3ee', sign: 'Skills' } as any)
+      out.push({
+        type: 'building',
+        pos: [-14, 0, -10],
+        color: '#1f2937',
+        roofColor: '#22d3ee',
+        sign: 'Tools',
+      } as any)
+      out.push({
+        type: 'building',
+        pos: [14, 0, -10],
+        color: '#1f2937',
+        roofColor: '#22d3ee',
+        sign: 'Skills',
+      } as any)
       out.push({ type: 'dais', pos: [0, 0, 10], color: '#22d3ee' } as any)
-      out.push({ type: 'signpost', pos: [-5, 0, 3], rotation: 0.4, color: '#22d3ee' } as any)
-      out.push({ type: 'signpost', pos: [5, 0, 3], rotation: -0.4, color: '#22d3ee' } as any)
+      out.push({
+        type: 'signpost',
+        pos: [-5, 0, 3],
+        rotation: 0.4,
+        color: '#22d3ee',
+      } as any)
+      out.push({
+        type: 'signpost',
+        pos: [5, 0, 3],
+        rotation: -0.4,
+        color: '#22d3ee',
+      } as any)
       for (let i = 0; i < 8; i++) {
         const ang = (i / 8) * Math.PI * 2
-        out.push({ type: 'lantern', pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6], color: '#22d3ee' })
+        out.push({
+          type: 'lantern',
+          pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6],
+          color: '#22d3ee',
+        })
       }
     }
 
     if (worldId === 'grove') {
-      for (let i = 0; i < 38; i++) out.push({ type: 'pine', pos: maybeOnEdge(), scale: 0.7 + r() * 0.7, color: '#1f8b4f', glow: '#86efac' })
-      for (let i = 0; i < 16; i++) out.push({ type: 'broadleaf', pos: maybeOnEdge(), scale: 0.8 + r() * 0.5, color: '#2bbf6f' })
+      for (let i = 0; i < 38; i++)
+        out.push({
+          type: 'pine',
+          pos: maybeOnEdge(),
+          scale: 0.7 + r() * 0.7,
+          color: '#1f8b4f',
+          glow: '#86efac',
+        })
+      for (let i = 0; i < 16; i++)
+        out.push({
+          type: 'broadleaf',
+          pos: maybeOnEdge(),
+          scale: 0.8 + r() * 0.5,
+          color: '#2bbf6f',
+        })
       for (let i = 0; i < 18; i++) {
         const ang = r() * Math.PI * 2
         const rad = 8 + r() * 8
-        out.push({ type: 'flowerpatch', pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad], count: 5 + Math.floor(r() * 4), palette: ['#86efac', '#fde68a', '#a7f3d0', '#fef3c7'] } as any)
+        out.push({
+          type: 'flowerpatch',
+          pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
+          count: 5 + Math.floor(r() * 4),
+          palette: ['#86efac', '#fde68a', '#a7f3d0', '#fef3c7'],
+        } as any)
       }
       out.push({ type: 'logs', pos: [-5, 0, -3], rotation: 0.2 } as any)
       out.push({ type: 'logs', pos: [4, 0, 5], rotation: -0.6 } as any)
@@ -741,7 +1473,11 @@ export function ScatteredScenery({
       out.push({ type: 'crystals', pos: [-7, 0, 6], color: '#34d399' } as any)
       for (let i = 0; i < 8; i++) {
         const ang = (i / 8) * Math.PI * 2
-        out.push({ type: 'lantern', pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6], color: '#86efac' })
+        out.push({
+          type: 'lantern',
+          pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6],
+          color: '#86efac',
+        })
       }
     }
 
@@ -751,36 +1487,80 @@ export function ScatteredScenery({
       out.push({ type: 'crystals', pos: [4, 0, 5], color: '#c4b5fd' } as any)
       out.push({ type: 'arch', pos: [0, 0, -10], color: '#c4b5fd' })
       out.push({ type: 'arch', pos: [0, 0, 10], color: '#c4b5fd' })
-      out.push({ type: 'signpost', pos: [-6, 0, 0], rotation: 1.2, color: '#a78bfa' } as any)
-      out.push({ type: 'signpost', pos: [6, 0, 0], rotation: -1.2, color: '#c4b5fd' } as any)
+      out.push({
+        type: 'signpost',
+        pos: [-6, 0, 0],
+        rotation: 1.2,
+        color: '#a78bfa',
+      } as any)
+      out.push({
+        type: 'signpost',
+        pos: [6, 0, 0],
+        rotation: -1.2,
+        color: '#c4b5fd',
+      } as any)
       for (let i = 0; i < 8; i++) {
         const ang = (i / 8) * Math.PI * 2
-        out.push({ type: 'lantern', pos: [Math.cos(ang) * 9, 0, Math.sin(ang) * 9], color: '#a78bfa' })
+        out.push({
+          type: 'lantern',
+          pos: [Math.cos(ang) * 9, 0, Math.sin(ang) * 9],
+          color: '#a78bfa',
+        })
       }
-      for (let i = 0; i < 12; i++) out.push({ type: 'broadleaf', pos: farEdge(), scale: 0.6 + r() * 0.5, color: '#5b21b6' })
+      for (let i = 0; i < 12; i++)
+        out.push({
+          type: 'broadleaf',
+          pos: farEdge(),
+          scale: 0.6 + r() * 0.5,
+          color: '#5b21b6',
+        })
     }
 
     if (worldId === 'arena') {
       // Banners + duel ring + champion platform
       out.push({ type: 'training', pos: [0, 0, 0], color: '#fb7185' } as any)
       out.push({ type: 'dais', pos: [0, 0, -10], color: '#fb7185' } as any)
-      out.push({ type: 'signpost', pos: [-7, 0, 5], rotation: 0.6, color: '#fb7185' } as any)
-      out.push({ type: 'signpost', pos: [7, 0, 5], rotation: -0.6, color: '#fb7185' } as any)
+      out.push({
+        type: 'signpost',
+        pos: [-7, 0, 5],
+        rotation: 0.6,
+        color: '#fb7185',
+      } as any)
+      out.push({
+        type: 'signpost',
+        pos: [7, 0, 5],
+        rotation: -0.6,
+        color: '#fb7185',
+      } as any)
       for (let i = 0; i < 10; i++) {
         const ang = (i / 10) * Math.PI * 2
-        out.push({ type: 'banner', pos: [Math.cos(ang) * 11, 0, Math.sin(ang) * 11], color: '#fb7185' })
+        out.push({
+          type: 'banner',
+          pos: [Math.cos(ang) * 11, 0, Math.sin(ang) * 11],
+          color: '#fb7185',
+        })
       }
       for (let i = 0; i < 6; i++) {
         const ang = (i / 6) * Math.PI * 2 + Math.PI / 6
-        out.push({ type: 'lantern', pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6], color: '#fb7185' })
+        out.push({
+          type: 'lantern',
+          pos: [Math.cos(ang) * 6, 0, Math.sin(ang) * 6],
+          color: '#fb7185',
+        })
       }
     }
 
     return out
   }, [worldId, seed])
 
-  const rockItems = useMemo(() => items.filter((it) => it.type === 'rock'), [items])
-  const grassItems = useMemo(() => items.filter((it) => it.type === 'grass'), [items])
+  const rockItems = useMemo(
+    () => items.filter((it) => it.type === 'rock'),
+    [items],
+  )
+  const grassItems = useMemo(
+    () => items.filter((it) => it.type === 'grass'),
+    [items],
+  )
   return (
     <>
       {rockItems.length ? <InstancedRocks items={rockItems} /> : null}
@@ -788,18 +1568,54 @@ export function ScatteredScenery({
       {items.map((it: any, i) => {
         switch (it.type) {
           case 'pine':
-            return <PineTree key={i} position={it.pos} scale={it.scale} color={it.color} />
+            return (
+              <PineTree
+                key={i}
+                position={it.pos}
+                scale={it.scale}
+                color={it.color}
+                glow={it.glow}
+              />
+            )
           case 'broadleaf':
-            return <BroadleafTree key={i} position={it.pos} scale={it.scale} color={it.color} />
+            return (
+              <BroadleafTree
+                key={i}
+                position={it.pos}
+                scale={it.scale}
+                color={it.color}
+              />
+            )
           case 'rock':
           case 'grass':
             return null
           case 'stall':
-            return <MarketStall key={i} position={it.pos} awningColor={it.awningColor} />
+            return (
+              <MarketStall
+                key={i}
+                position={it.pos}
+                awningColor={it.awningColor}
+              />
+            )
           case 'townsfolk':
-            return <Townsfolk key={i} position={it.pos} color={it.color} rotation={it.rotation || 0} />
+            return (
+              <Townsfolk
+                key={i}
+                position={it.pos}
+                color={it.color}
+                rotation={it.rotation || 0}
+              />
+            )
           case 'building':
-            return <Building key={i} position={it.pos} color={it.color} roofColor={it.roofColor} sign={it.sign} />
+            return (
+              <Building
+                key={i}
+                position={it.pos}
+                color={it.color}
+                roofColor={it.roofColor}
+                sign={it.sign}
+              />
+            )
           case 'lantern':
             return <Lantern key={i} position={it.pos} color={it.color} />
           case 'arch':
@@ -809,19 +1625,53 @@ export function ScatteredScenery({
           case 'fountain':
             return <Fountain key={i} position={it.pos} accent={it.color} />
           case 'flowerpatch':
-            return <FlowerPatch key={i} position={it.pos} count={it.count} palette={it.palette} seed={i} />
+            return (
+              <FlowerPatch
+                key={i}
+                position={it.pos}
+                count={it.count}
+                palette={it.palette}
+                seed={i}
+              />
+            )
           case 'logs':
-            return <LogPile key={i} position={it.pos} rotation={it.rotation || 0} />
+            return (
+              <LogPile key={i} position={it.pos} rotation={it.rotation || 0} />
+            )
           case 'plaza':
-            return <PlazaDisc key={i} position={it.pos} radius={it.radius} color={it.color} />
+            return (
+              <PlazaDisc
+                key={i}
+                position={it.pos}
+                radius={it.radius}
+                color={it.color}
+              />
+            )
           case 'path':
-            return <PathStrip key={i} from={it.from} to={it.to} width={it.width} color={it.color} />
+            return (
+              <PathStrip
+                key={i}
+                from={it.from}
+                to={it.to}
+                width={it.width}
+                color={it.color}
+              />
+            )
           case 'clocktower':
             return <ClockTower key={i} position={it.pos} accent={it.color} />
           case 'signpost':
-            return <Signpost key={i} position={it.pos} rotation={it.rotation || 0} color={it.color} />
+            return (
+              <Signpost
+                key={i}
+                position={it.pos}
+                rotation={it.rotation || 0}
+                color={it.color}
+              />
+            )
           case 'bench':
-            return <Bench key={i} position={it.pos} rotation={it.rotation || 0} />
+            return (
+              <Bench key={i} position={it.pos} rotation={it.rotation || 0} />
+            )
           case 'training':
             return <TrainingRing key={i} position={it.pos} accent={it.color} />
           case 'dais':

--- a/src/screens/playground/components/playground-hud.tsx
+++ b/src/screens/playground/components/playground-hud.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Toast, rarityForPlaygroundToast } from './toast'
-import type { PlaygroundRpgState, RewardToast } from '../hooks/use-playground-rpg'
+import type {
+  PlaygroundRpgState,
+  RewardToast,
+} from '../hooks/use-playground-rpg'
 import type { PlaygroundWorldId } from '../lib/playground-rpg'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 
@@ -18,7 +21,9 @@ type HudProps = {
 
 // Fixed positions for known targets (world coords). Used to compute the
 // objective arrow direction from the player's current position.
-const TARGET_POS: Partial<Record<PlaygroundWorldId, Partial<Record<string, [number, number]>>>> = {
+const TARGET_POS: Partial<
+  Record<PlaygroundWorldId, Partial<Record<string, [number, number]>>>
+> = {
   training: {
     athena: [-10.5, 7.2],
     iris: [6.2, 0.4],
@@ -42,10 +47,32 @@ const TARGET_POS: Partial<Record<PlaygroundWorldId, Partial<Record<string, [numb
     shopkeeper: [-3, 9.5],
     'awakening-agora': [-8, -3],
   },
-  forge: { pan: [-4, 0], chronos: [4, 0], 'enter-forge': [0, -7], 'forge-shard': [0, -7] },
-  grove: { pan: [-4, 1], apollo: [4, 0], artemis: [0, -5], 'grove-ritual': [-6, -4], 'song-fragment': [-6, -4] },
-  oracle: { athena: [-3, -2], chronos: [3, -2], eros: [0, 4], 'oracle-riddle': [5, -3] },
-  arena: { nike: [-3, 4], hermes: [3, 4], chronos: [0, -5], 'arena-duel': [0, 0], 'kimi-sigil': [0, 0] },
+  forge: {
+    pan: [-4, 0],
+    chronos: [4, 0],
+    'enter-forge': [0, -7],
+    'forge-shard': [0, -7],
+  },
+  grove: {
+    pan: [-4, 1],
+    apollo: [4, 0],
+    artemis: [0, -5],
+    'grove-ritual': [-6, -4],
+    'song-fragment': [-6, -4],
+  },
+  oracle: {
+    athena: [-3, -2],
+    chronos: [3, -2],
+    eros: [0, 4],
+    'oracle-riddle': [5, -3],
+  },
+  arena: {
+    nike: [-3, 4],
+    hermes: [3, 4],
+    chronos: [0, -5],
+    'arena-duel': [0, 0],
+    'kimi-sigil': [0, 0],
+  },
 }
 
 const HUD = {
@@ -76,11 +103,18 @@ export function PlaygroundHud({
 }: HudProps) {
   const { playerProfile } = state
   const sidebarCollapsed = useWorkspaceStore((s) => s.sidebarCollapsed)
-  const isPublicPlayRoute = typeof window !== 'undefined' && window.location.pathname.includes('/play')
-  const chromeLeft = isPublicPlayRoute ? MOCKUP_LEFT : sidebarCollapsed ? 'min(120px, 9vw)' : '320px'
+  const isPublicPlayRoute =
+    typeof window !== 'undefined' && window.location.pathname.includes('/play')
+  const chromeLeft = isPublicPlayRoute
+    ? MOCKUP_LEFT
+    : sidebarCollapsed
+      ? 'min(120px, 9vw)'
+      : '320px'
   const hudAccent = currentWorld === 'agora' ? HUD.gold : worldAccent
   const coinCount = 128
-  const title = playerProfile.titlesUnlocked.at(-1) || (currentWorld === 'agora' ? 'Agora Initiate' : 'Training Grounds')
+  const title =
+    playerProfile.titlesUnlocked.at(-1) ||
+    (currentWorld === 'agora' ? 'Agora Initiate' : 'Training Grounds')
   const panelBg = `linear-gradient(180deg, rgba(15,22,34,.92), rgba(10,13,18,.84)), radial-gradient(circle at 20% 0%, ${hudAccent}2b, transparent 58%), radial-gradient(circle at 100% 100%, ${HUD.verdigris}35, transparent 62%)`
   const panelShadow = `0 18px 42px rgba(0,0,0,.58), 0 0 0 1px ${HUD.obsidian}, 0 0 28px ${hudAccent}30, inset 0 1px 0 rgba(244,233,211,.18)`
 
@@ -88,11 +122,19 @@ export function PlaygroundHud({
   // Throttled to ~10 Hz so we don't re-render the HUD on every animation frame.
   const [arrowDeg, setArrowDeg] = useState<number | null>(null)
   useEffect(() => {
-    if (!objectiveTarget) { setArrowDeg(null); return }
+    if (!objectiveTarget) {
+      setArrowDeg(null)
+      return
+    }
     const target = TARGET_POS[currentWorld]?.[objectiveTarget]
-    if (!target) { setArrowDeg(null); return }
+    if (!target) {
+      setArrowDeg(null)
+      return
+    }
     const compute = () => {
-      const player = (window as any).__hermesPlaygroundPlayerPos as { x: number; z: number } | undefined
+      const player = (window as any).__hermesPlaygroundPlayerPos as
+        | { x: number; z: number }
+        | undefined
       const px = player?.x ?? 0
       const pz = player?.z ?? 0
       const dx = target[0] - px
@@ -119,8 +161,22 @@ export function PlaygroundHud({
         style={{ left: chromeLeft, top: MOCKUP_TOP }}
       >
         <div className="relative flex items-center gap-2">
-          <ResourceOrb label="HP" v={state.hp} m={state.hpMax} color="#B03A30" fillA="#E05745" fillB="#6C1518" />
-          <ResourceOrb label="MP" v={state.mp} m={state.mpMax} color="#2E6A63" fillA="#5EB8AB" fillB="#133D47" />
+          <ResourceOrb
+            label="HP"
+            v={state.hp}
+            m={state.hpMax}
+            color="#B03A30"
+            fillA="#E05745"
+            fillB="#6C1518"
+          />
+          <ResourceOrb
+            label="MP"
+            v={state.mp}
+            m={state.mpMax}
+            color="#2E6A63"
+            fillA="#5EB8AB"
+            fillB="#133D47"
+          />
         </div>
         <div
           className="hermes-hud-rune-frame relative mt-1 min-w-[184px] rounded-[24px] border px-3 py-2 backdrop-blur-xl"
@@ -146,7 +202,10 @@ export function PlaygroundHud({
                   loading="lazy"
                   decoding="async"
                   className="h-full w-full object-cover"
-                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                  onError={(e) => {
+                    ;(e.currentTarget as HTMLImageElement).style.display =
+                      'none'
+                  }}
                 />
               </div>
               <div
@@ -161,16 +220,45 @@ export function PlaygroundHud({
               </div>
             </div>
             <div className="min-w-0 leading-tight">
-              <div className="text-[11px] font-black uppercase tracking-[0.14em]" style={{ color: HUD.parchment }}>
+              <div
+                className="text-[11px] font-black uppercase tracking-[0.14em]"
+                style={{ color: HUD.parchment }}
+              >
                 {playerProfile.displayName || 'Builder'}
               </div>
+              <div
+                className="mt-1 max-w-[126px] truncate text-[9px] uppercase tracking-[0.18em]"
+                style={{ color: HUD.stone }}
+              >
+                {title}
               </div>
-              <div className="mt-1 max-w-[126px] truncate text-[9px] uppercase tracking-[0.18em]" style={{ color: HUD.stone }}>{title}</div>
               <div className="mt-2 flex items-center gap-2">
-                <div className="h-1.5 w-[88px] overflow-hidden rounded-full" style={{ background: 'rgba(244,233,211,.12)', boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.45)' }}>
-                  <div className="h-full rounded-full" style={{ width: `${levelProgress.pct}%`, background: `linear-gradient(90deg, ${HUD.bronze}, ${HUD.gold})`, boxShadow: `0 0 8px ${hudAccent}88` }} />
+                <div
+                  className="h-1.5 w-[88px] overflow-hidden rounded-full"
+                  style={{
+                    background: 'rgba(244,233,211,.12)',
+                    boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.45)',
+                  }}
+                >
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${levelProgress.pct}%`,
+                      background: `linear-gradient(90deg, ${HUD.bronze}, ${HUD.gold})`,
+                      boxShadow: `0 0 8px ${hudAccent}88`,
+                    }}
+                  />
                 </div>
-                <span className="rounded-full border px-2 py-0.5 text-[10px] font-black" style={{ borderColor: `${HUD.bronze}aa`, color: HUD.parchment, background: 'rgba(10,13,18,.72)' }}>◉ {coinCount}</span>
+                <span
+                  className="rounded-full border px-2 py-0.5 text-[10px] font-black"
+                  style={{
+                    borderColor: `${HUD.bronze}aa`,
+                    color: HUD.parchment,
+                    background: 'rgba(10,13,18,.72)',
+                  }}
+                >
+                  ◉ {coinCount}
+                </span>
               </div>
             </div>
           </div>
@@ -189,7 +277,11 @@ export function PlaygroundHud({
         >
           <div
             className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border"
-            style={{ borderColor: `${hudAccent}99`, background: `linear-gradient(180deg, ${HUD.obsidian}, ${HUD.slate})`, boxShadow: `0 0 14px ${hudAccent}3d, inset 0 0 0 1px rgba(244,233,211,.08)` }}
+            style={{
+              borderColor: `${hudAccent}99`,
+              background: `linear-gradient(180deg, ${HUD.obsidian}, ${HUD.slate})`,
+              boxShadow: `0 0 14px ${hudAccent}3d, inset 0 0 0 1px rgba(244,233,211,.08)`,
+            }}
             title={arrowDeg != null ? 'Pointing toward objective' : 'Objective'}
           >
             <span
@@ -198,25 +290,56 @@ export function PlaygroundHud({
                 color: hudAccent,
                 transform: `rotate(${arrowDeg != null ? arrowDeg - 90 : -45}deg)`,
                 transition: 'transform 220ms cubic-bezier(.2,.8,.2,1)',
-                filter: arrowDeg != null ? `drop-shadow(0 0 6px ${hudAccent})` : undefined,
+                filter:
+                  arrowDeg != null
+                    ? `drop-shadow(0 0 6px ${hudAccent})`
+                    : undefined,
               }}
               aria-hidden
-            >➤</span>
+            >
+              ➤
+            </span>
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <span className="text-[9px] font-black uppercase tracking-[0.2em]" style={{ color: HUD.stone }}>Quest</span>
-              <span className="truncate text-[12px] font-black" style={{ color: hudAccent }}>{activeQuestTitle}</span>
+              <span
+                className="text-[9px] font-black uppercase tracking-[0.2em]"
+                style={{ color: HUD.stone }}
+              >
+                Quest
+              </span>
+              <span
+                className="truncate text-[12px] font-black"
+                style={{ color: hudAccent }}
+              >
+                {activeQuestTitle}
+              </span>
             </div>
-            <div className="truncate text-[11px] leading-snug" style={{ color: HUD.parchment }}>{objectiveLabel}</div>
-            {objectiveHint && <div className="truncate text-[10px]" style={{ color: `${HUD.parchment}99` }}>{objectiveHint}</div>}
+            <div
+              className="truncate text-[11px] leading-snug"
+              style={{ color: HUD.parchment }}
+            >
+              {objectiveLabel}
+            </div>
+            {objectiveHint && (
+              <div
+                className="truncate text-[10px]"
+                style={{ color: `${HUD.parchment}99` }}
+              >
+                {objectiveHint}
+              </div>
+            )}
           </div>
         </div>
       </div>
 
       <div className="hermes-toast-lane pointer-events-none fixed left-1/2 top-[154px] z-[80] flex max-h-[30vh] w-[min(92vw,440px)] -translate-x-1/2 flex-col gap-2 overflow-visible md:top-[96px] md:max-h-[36vh]">
         {toasts.map((toast) => (
-          <Toast key={toast.id} title={toast.title} rarity={rarityForPlaygroundToast(toast.kind)}>
+          <Toast
+            key={toast.id}
+            title={toast.title}
+            rarity={rarityForPlaygroundToast(toast.kind)}
+          >
             {toast.body}
           </Toast>
         ))}
@@ -246,8 +369,15 @@ function ResourceOrb({
   const circumference = 2 * Math.PI * radius
   const offset = circumference * (1 - pct)
   return (
-    <div className="hermes-hud-orb relative" style={{ width: size, height: size }}>
-      <svg width={size} height={size} className="absolute inset-0 rotate-[-90deg]">
+    <div
+      className="hermes-hud-orb relative"
+      style={{ width: size, height: size }}
+    >
+      <svg
+        width={size}
+        height={size}
+        className="absolute inset-0 rotate-[-90deg]"
+      >
         <defs>
           <radialGradient id={`orb-${label}`} cx="36%" cy="28%" r="72%">
             <stop offset="0%" stopColor="#fff7d6" stopOpacity="0.78" />
@@ -255,8 +385,22 @@ function ResourceOrb({
             <stop offset="100%" stopColor={fillB} />
           </radialGradient>
         </defs>
-        <circle cx={size / 2} cy={size / 2} r={radius + 4} stroke={HUD.obsidian} strokeWidth="7" fill={`url(#orb-${label})`} />
-        <circle cx={size / 2} cy={size / 2} r={radius + 4} stroke={HUD.bronze} strokeWidth="2" fill="transparent" />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius + 4}
+          stroke={HUD.obsidian}
+          strokeWidth="7"
+          fill={`url(#orb-${label})`}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius + 4}
+          stroke={HUD.bronze}
+          strokeWidth="2"
+          fill="transparent"
+        />
         <circle
           cx={size / 2}
           cy={size / 2}
@@ -267,14 +411,28 @@ function ResourceOrb({
           strokeDasharray={circumference}
           strokeDashoffset={offset}
           strokeLinecap="round"
-          style={{ filter: `drop-shadow(0 0 7px ${color}cc)`, transition: 'stroke-dashoffset 200ms' }}
+          style={{
+            filter: `drop-shadow(0 0 7px ${color}cc)`,
+            transition: 'stroke-dashoffset 200ms',
+          }}
         />
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center pt-1 text-center">
-        <div className="text-[9px] font-black leading-none tracking-[0.16em]" style={{ color: HUD.parchment, textShadow: '0 1px 3px rgba(0,0,0,.9)' }}>
+        <div
+          className="text-[9px] font-black leading-none tracking-[0.16em]"
+          style={{
+            color: HUD.parchment,
+            textShadow: '0 1px 3px rgba(0,0,0,.9)',
+          }}
+        >
           {label}
         </div>
-        <div className="mt-0.5 text-[12px] font-black leading-none" style={{ color: '#fff', textShadow: '0 1px 4px rgba(0,0,0,.95)' }}>{Math.round(v)}</div>
+        <div
+          className="mt-0.5 text-[12px] font-black leading-none"
+          style={{ color: '#fff', textShadow: '0 1px 4px rgba(0,0,0,.95)' }}
+        >
+          {Math.round(v)}
+        </div>
       </div>
     </div>
   )

--- a/src/screens/playground/components/playground-world-3d.tsx
+++ b/src/screens/playground/components/playground-world-3d.tsx
@@ -4,14 +4,23 @@
  */
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { Html, Sparkles } from '@react-three/drei'
-import { EffectComposer, Bloom, Vignette, ToneMapping } from '@react-three/postprocessing'
+import {
+  EffectComposer,
+  Bloom,
+  Vignette,
+  ToneMapping,
+} from '@react-three/postprocessing'
 import { ToneMappingMode } from 'postprocessing'
 import { useEffect, useMemo, useRef, useState, Suspense } from 'react'
 import * as THREE from 'three'
 import type { PlaygroundWorldId } from '../lib/playground-rpg'
 import { botsFor, type BotProfile } from '../lib/playground-bots'
 import { ScatteredScenery } from './playground-environment'
-import { usePlaygroundMultiplayer, type RemotePlayer as MpRemotePlayer, type IncomingChat } from '../hooks/use-playground-multiplayer'
+import {
+  usePlaygroundMultiplayer,
+  type RemotePlayer as MpRemotePlayer,
+  type IncomingChat,
+} from '../hooks/use-playground-multiplayer'
 import { loadAvatarConfig, type AvatarConfig } from '../lib/avatar-config'
 import { PlaygroundNpcGlb } from './playground-npc-glb'
 import { SpeechBubble } from './speech-bubble'
@@ -44,9 +53,14 @@ function useGlbAvailable(id: string, enabled: boolean): boolean {
       .then((r) => {
         if (cancelled) return
         const ct = r.headers.get('content-type') || ''
-        const isReal = r.ok
-          && !ct.includes('text/html')
-          && (ct.includes('octet-stream') || ct.includes('gltf') || ct.includes('binary') || ct === '' || ct.includes('application/'))
+        const isReal =
+          r.ok &&
+          !ct.includes('text/html') &&
+          (ct.includes('octet-stream') ||
+            ct.includes('gltf') ||
+            ct.includes('binary') ||
+            ct === '' ||
+            ct.includes('application/'))
         _glbPresence.set(url, isReal ? 'present' : 'missing')
         force((n) => n + 1)
       })
@@ -55,7 +69,9 @@ function useGlbAvailable(id: string, enabled: boolean): boolean {
         _glbPresence.set(url, 'missing')
         force((n) => n + 1)
       })
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [cached, enabled, url])
   return enabled && cached === 'present'
 }
@@ -74,7 +90,13 @@ function useAvatarConfig() {
   return cfg
 }
 
-type DecorType = 'training' | 'classical' | 'tech' | 'forest' | 'temple' | 'arena'
+type DecorType =
+  | 'training'
+  | 'classical'
+  | 'tech'
+  | 'forest'
+  | 'temple'
+  | 'arena'
 
 type WorldDef = {
   id: PlaygroundWorldId
@@ -198,8 +220,14 @@ function stoneTileTexture(): THREE.CanvasTexture | null {
       if (Math.random() < 0.25) {
         ctx.strokeStyle = 'rgba(0,0,0,0.18)'
         ctx.beginPath()
-        ctx.moveTo(x * tile + Math.random() * tile, y * tile + Math.random() * tile)
-        ctx.lineTo(x * tile + Math.random() * tile, y * tile + Math.random() * tile)
+        ctx.moveTo(
+          x * tile + Math.random() * tile,
+          y * tile + Math.random() * tile,
+        )
+        ctx.lineTo(
+          x * tile + Math.random() * tile,
+          y * tile + Math.random() * tile,
+        )
         ctx.stroke()
       }
       // Specular highlight on a corner
@@ -240,13 +268,23 @@ function Ground({ world }: { world: WorldDef }) {
   return (
     <group>
       {/* Base grass / terrain */}
-      <mesh receiveShadow position={[0, 0, 0]} rotation={[-Math.PI / 2, 0, 0]} geometry={grassGeo}>
+      <mesh
+        receiveShadow
+        position={[0, 0, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        geometry={grassGeo}
+      >
         <meshStandardMaterial vertexColors roughness={1} metalness={0} />
       </mesh>
       {/* Stone-tile circular plaza under central statue — polygon-offset prevents */}
       {/* z-fighting with the statue inscription ring + Agora accent ring above. */}
       {showPlaza && stoneTex && (
-        <mesh receiveShadow position={[0, 0.008, 0]} rotation={[-Math.PI / 2, 0, 0]} renderOrder={-1}>
+        <mesh
+          receiveShadow
+          position={[0, 0.008, 0]}
+          rotation={[-Math.PI / 2, 0, 0]}
+          renderOrder={-1}
+        >
           <circleGeometry args={[7, 64]} />
           <meshStandardMaterial
             map={stoneTex}
@@ -262,7 +300,13 @@ function Ground({ world }: { world: WorldDef }) {
       {!isAgora && (
         <mesh position={[0, 0.006, 0]} rotation={[-Math.PI / 2, 0, 0]}>
           <ringGeometry args={[18, 24, 80]} />
-          <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={0.12} transparent opacity={0.08} />
+          <meshStandardMaterial
+            color={world.accent}
+            emissive={world.accent}
+            emissiveIntensity={0.12}
+            transparent
+            opacity={0.08}
+          />
         </mesh>
       )}
     </group>
@@ -306,20 +350,61 @@ function Monster({
         castShadow
       >
         <octahedronGeometry args={[0.7, 0]} />
-        <meshStandardMaterial color="#220815" emissive={color} emissiveIntensity={0.8} roughness={0.3} />
+        <meshStandardMaterial
+          color="#220815"
+          emissive={color}
+          emissiveIntensity={0.8}
+          roughness={0.3}
+        />
       </mesh>
       {/* Outer ring */}
       <mesh rotation={[Math.PI / 2, 0, 0]}>
         <torusGeometry args={[1.1, 0.04, 12, 32]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.4} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={1.4}
+        />
       </mesh>
       {/* HP bar */}
       <Html position={[0, 1.6, 0]} center distanceFactor={8}>
-        <div style={{ width: 90, padding: 2, background: 'rgba(0,0,0,0.85)', borderRadius: 4, border: `1px solid ${color}` }}>
-          <div style={{ height: 6, background: '#1f2937', borderRadius: 2, overflow: 'hidden' }}>
-            <div style={{ height: '100%', width: `${hpPct * 100}%`, background: color, transition: 'width 200ms' }} />
+        <div
+          style={{
+            width: 90,
+            padding: 2,
+            background: 'rgba(0,0,0,0.85)',
+            borderRadius: 4,
+            border: `1px solid ${color}`,
+          }}
+        >
+          <div
+            style={{
+              height: 6,
+              background: '#1f2937',
+              borderRadius: 2,
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${hpPct * 100}%`,
+                background: color,
+                transition: 'width 200ms',
+              }}
+            />
           </div>
-          <div style={{ marginTop: 2, fontSize: 9, color: 'white', textAlign: 'center', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+          <div
+            style={{
+              marginTop: 2,
+              fontSize: 9,
+              color: 'white',
+              textAlign: 'center',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+            }}
+          >
             Rogue Model
           </div>
           <div style={{ fontSize: 9, color: '#9ca3af', textAlign: 'center' }}>
@@ -355,7 +440,11 @@ function ClassicalPillars({ world }: { world: WorldDef }) {
           </mesh>
         </group>
       ))}
-      <mesh position={[0, 0.018, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.018, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[3.5, 4, 64]} />
         <meshStandardMaterial
           color={world.accent}
@@ -369,14 +458,40 @@ function ClassicalPillars({ world }: { world: WorldDef }) {
         />
       </mesh>
       {/* Central Hermes statue — plaza centerpiece */}
-      <HermesStatue position={[0, 0, 0]} scale={1.15} accent={world.accent} base="#e6dcc4" />
+      <HermesStatue
+        position={[0, 0, 0]}
+        scale={1.15}
+        accent={world.accent}
+        base="#e6dcc4"
+      />
       {/* Banners along the colonnade entrances */}
-      <HermesBanner position={[-17, 0, -9.5]} rotation={[0, Math.PI / 2, 0]} color={world.accent} />
-      <HermesBanner position={[17, 0, -9.5]} rotation={[0, -Math.PI / 2, 0]} color={world.accent} />
-      <HermesBanner position={[-17, 0, 9.5]} rotation={[0, Math.PI / 2, 0]} color={world.accent} />
-      <HermesBanner position={[17, 0, 9.5]} rotation={[0, -Math.PI / 2, 0]} color={world.accent} />
+      <HermesBanner
+        position={[-17, 0, -9.5]}
+        rotation={[0, Math.PI / 2, 0]}
+        color={world.accent}
+      />
+      <HermesBanner
+        position={[17, 0, -9.5]}
+        rotation={[0, -Math.PI / 2, 0]}
+        color={world.accent}
+      />
+      <HermesBanner
+        position={[-17, 0, 9.5]}
+        rotation={[0, Math.PI / 2, 0]}
+        color={world.accent}
+      />
+      <HermesBanner
+        position={[17, 0, 9.5]}
+        rotation={[0, -Math.PI / 2, 0]}
+        color={world.accent}
+      />
       {/* Braziers around the central statue */}
-      {[[-3.2, -3.2], [3.2, -3.2], [-3.2, 3.2], [3.2, 3.2]].map(([x, z], i) => (
+      {[
+        [-3.2, -3.2],
+        [3.2, -3.2],
+        [-3.2, 3.2],
+        [3.2, 3.2],
+      ].map(([x, z], i) => (
         <Brazier key={i} position={[x, 0, z]} color="#fbbf24" />
       ))}
     </>
@@ -400,28 +515,73 @@ function TechPillars({ world }: { world: WorldDef }) {
         <group key={i} position={pos as [number, number, number]}>
           <mesh castShadow position={[0, 0.9, 0]}>
             <boxGeometry args={[1.6, 1.8, 1.6]} />
-            <meshStandardMaterial color="#0f172a" emissive={world.pillarColor} emissiveIntensity={0.4} roughness={0.3} />
+            <meshStandardMaterial
+              color="#0f172a"
+              emissive={world.pillarColor}
+              emissiveIntensity={0.4}
+              roughness={0.3}
+            />
           </mesh>
           <mesh position={[0, 1.86, 0]}>
             <boxGeometry args={[1.2, 0.05, 1.2]} />
-            <meshStandardMaterial color={world.pillarColor} emissive={world.pillarColor} emissiveIntensity={2} />
+            <meshStandardMaterial
+              color={world.pillarColor}
+              emissive={world.pillarColor}
+              emissiveIntensity={2}
+            />
           </mesh>
         </group>
       ))}
-      <mesh position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.05, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[4, 4.4, 64]} />
-        <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={1} />
+        <meshStandardMaterial
+          color={world.accent}
+          emissive={world.accent}
+          emissiveIntensity={1}
+        />
       </mesh>
-      <ForgeSuperFurnace position={[0, 0, 0]} accent={world.accent} ember="#ff8a3d" />
+      <ForgeSuperFurnace
+        position={[0, 0, 0]}
+        accent={world.accent}
+        ember="#ff8a3d"
+      />
       {/* Cyan-flame Forge braziers */}
-      {[[-5, -5], [5, -5], [-5, 5], [5, 5]].map(([x, z], i) => (
+      {[
+        [-5, -5],
+        [5, -5],
+        [-5, 5],
+        [5, 5],
+      ].map(([x, z], i) => (
         <Brazier key={i} position={[x, 0, z]} color={world.accent} />
       ))}
       {/* Tech-banners with Hermes sigil */}
-      <HermesBanner position={[-9, 0, 0]} rotation={[0, Math.PI / 2, 0]} color={world.accent} cloth="#0a0e1a" />
-      <HermesBanner position={[9, 0, 0]} rotation={[0, -Math.PI / 2, 0]} color={world.accent} cloth="#0a0e1a" />
+      <HermesBanner
+        position={[-9, 0, 0]}
+        rotation={[0, Math.PI / 2, 0]}
+        color={world.accent}
+        cloth="#0a0e1a"
+      />
+      <HermesBanner
+        position={[9, 0, 0]}
+        rotation={[0, -Math.PI / 2, 0]}
+        color={world.accent}
+        cloth="#0a0e1a"
+      />
       {/* Floating data motes — disabled in Photosensitive Mode */}
-      {!photosensitiveMode && <Sparkles count={20} scale={[18, 5, 18]} size={1.8} speed={0.12} color={world.accent} opacity={0.22} />}
+      {!photosensitiveMode && (
+        <Sparkles
+          count={20}
+          scale={[18, 5, 18]}
+          size={1.8}
+          speed={0.12}
+          color={world.accent}
+          opacity={0.22}
+        />
+      )}
     </>
   )
 }
@@ -457,14 +617,27 @@ function ForestDecor({ world }: { world: WorldDef }) {
           </mesh>
           <mesh castShadow position={[0, 2.55, 0]}>
             <coneGeometry args={[0.7, 1.2, 8]} />
-            <meshStandardMaterial color={world.pillarColor} roughness={0.7} emissive={world.pillarColor} emissiveIntensity={0.06} />
+            <meshStandardMaterial
+              color={world.pillarColor}
+              roughness={0.7}
+              emissive={world.pillarColor}
+              emissiveIntensity={0.06}
+            />
           </mesh>
         </group>
       ))}
       {/* Mossy center ring */}
-      <mesh position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.05, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[3, 4, 64]} />
-        <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={0.4} />
+        <meshStandardMaterial
+          color={world.accent}
+          emissive={world.accent}
+          emissiveIntensity={0.4}
+        />
       </mesh>
       <MemoryTree position={[0, 0, 0]} accent={world.accent} />
     </>
@@ -481,30 +654,56 @@ function TempleDecor({ world }: { world: WorldDef }) {
     for (let i = 0; i < 14; i++) {
       const ang = (i / 14) * Math.PI * 2
       const r = 7 + seed(i) * 5
-      out.push([Math.cos(ang) * r, 1.2 + seed(i + 3) * 0.8, Math.sin(ang) * r, 0.6 + seed(i + 7) * 0.5])
+      out.push([
+        Math.cos(ang) * r,
+        1.2 + seed(i + 3) * 0.8,
+        Math.sin(ang) * r,
+        0.6 + seed(i + 7) * 0.5,
+      ])
     }
     return out
   }, [])
   return (
     <>
       {crystals.map(([x, y, z, s], i) => (
-        <FloatCrystal key={i} position={[x, y, z]} scale={s} color={world.pillarColor} />
+        <FloatCrystal
+          key={i}
+          position={[x, y, z]}
+          scale={s}
+          color={world.pillarColor}
+        />
       ))}
       {/* outer ring of low pillars */}
       {Array.from({ length: 12 }).map((_, i) => {
         const ang = (i / 12) * Math.PI * 2
         return (
-          <group key={`p${i}`} position={[Math.cos(ang) * 6, 0, Math.sin(ang) * 6]}>
+          <group
+            key={`p${i}`}
+            position={[Math.cos(ang) * 6, 0, Math.sin(ang) * 6]}
+          >
             <mesh castShadow position={[0, 0.6, 0]}>
               <cylinderGeometry args={[0.25, 0.3, 1.2, 12]} />
-              <meshStandardMaterial color={world.pillarColor} emissive={world.pillarColor} emissiveIntensity={0.2} roughness={0.5} />
+              <meshStandardMaterial
+                color={world.pillarColor}
+                emissive={world.pillarColor}
+                emissiveIntensity={0.2}
+                roughness={0.5}
+              />
             </mesh>
           </group>
         )
       })}
-      <mesh position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.05, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[3.2, 3.6, 64]} />
-        <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={1} />
+        <meshStandardMaterial
+          color={world.accent}
+          emissive={world.accent}
+          emissiveIntensity={1}
+        />
       </mesh>
       <OracleRingTower position={[0, 0, 0]} accent={world.accent} />
       {/* Mystical incense braziers */}
@@ -513,78 +712,281 @@ function TempleDecor({ world }: { world: WorldDef }) {
       <Brazier position={[0, 0, -4]} color="#a78bfa" />
       <Brazier position={[0, 0, 4]} color="#a78bfa" />
       {/* Floating runes — disabled in Photosensitive Mode */}
-      {!photosensitiveMode && <Sparkles count={16} scale={[14, 6, 14]} size={1.9} speed={0.1} color={world.accent} opacity={0.22} />}
+      {!photosensitiveMode && (
+        <Sparkles
+          count={16}
+          scale={[14, 6, 14]}
+          size={1.9}
+          speed={0.1}
+          color={world.accent}
+          opacity={0.22}
+        />
+      )}
     </>
   )
 }
 
-function ForgeSuperFurnace({ position, accent, ember }: { position: [number, number, number]; accent: string; ember: string }) {
+function ForgeSuperFurnace({
+  position,
+  accent,
+  ember,
+}: {
+  position: [number, number, number]
+  accent: string
+  ember: string
+}) {
   const ringRef = useRef<THREE.Group>(null)
   useFrame(({ clock }) => {
-    if (ringRef.current) ringRef.current.rotation.y = clock.getElapsedTime() * 0.35
+    if (ringRef.current)
+      ringRef.current.rotation.y = clock.getElapsedTime() * 0.35
   })
   return (
     <group position={position}>
       <mesh castShadow receiveShadow position={[0, 0.35, 0]}>
         <cylinderGeometry args={[2.1, 2.6, 0.7, 16]} />
-        <meshStandardMaterial color="#1f2937" roughness={0.45} metalness={0.25} emissive={ember} emissiveIntensity={0.12} />
+        <meshStandardMaterial
+          color="#1f2937"
+          roughness={0.45}
+          metalness={0.25}
+          emissive={ember}
+          emissiveIntensity={0.12}
+        />
       </mesh>
       <mesh castShadow position={[0, 1.45, 0]}>
         <cylinderGeometry args={[1.15, 1.45, 2.2, 12]} />
-        <meshStandardMaterial color="#0f172a" roughness={0.38} metalness={0.35} emissive={accent} emissiveIntensity={0.38} />
+        <meshStandardMaterial
+          color="#0f172a"
+          roughness={0.38}
+          metalness={0.35}
+          emissive={accent}
+          emissiveIntensity={0.38}
+        />
       </mesh>
       <mesh position={[0, 2.7, 0]}>
         <coneGeometry args={[1.4, 1.25, 8]} />
-        <meshStandardMaterial color="#2a1420" roughness={0.42} emissive={ember} emissiveIntensity={0.55} />
+        <meshStandardMaterial
+          color="#2a1420"
+          roughness={0.42}
+          emissive={ember}
+          emissiveIntensity={0.55}
+        />
       </mesh>
       <group ref={ringRef} position={[0, 2.05, 0]}>
-        <mesh rotation={[Math.PI / 2, 0, 0]}><torusGeometry args={[2.05, 0.045, 10, 64]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.25} /></mesh>
-        <mesh rotation={[Math.PI / 2, 0, Math.PI / 3]}><torusGeometry args={[1.45, 0.035, 10, 64]} /><meshStandardMaterial color={ember} emissive={ember} emissiveIntensity={1.15} /></mesh>
+        <mesh rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[2.05, 0.045, 10, 64]} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={1.25}
+          />
+        </mesh>
+        <mesh rotation={[Math.PI / 2, 0, Math.PI / 3]}>
+          <torusGeometry args={[1.45, 0.035, 10, 64]} />
+          <meshStandardMaterial
+            color={ember}
+            emissive={ember}
+            emissiveIntensity={1.15}
+          />
+        </mesh>
       </group>
-      {[-1.4, 1.4].map((x) => <mesh key={x} castShadow position={[x, 0.85, 0]}><boxGeometry args={[0.45, 1.25, 0.55]} /><meshStandardMaterial color="#111827" emissive={ember} emissiveIntensity={0.35} /></mesh>)}
-      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => <mesh key={i} position={[Math.cos(a) * 2.8, 0.04, Math.sin(a) * 2.8]} rotation={[-Math.PI / 2, 0, a]}><planeGeometry args={[0.36, 3.4]} /><meshStandardMaterial color={ember} emissive={ember} emissiveIntensity={0.75} transparent opacity={0.55} /></mesh>)}
-      <pointLight position={[0, 2.1, 0]} color={ember} intensity={2.6} distance={13} />
-      <pointLight position={[0, 2.8, 0]} color={accent} intensity={1.8} distance={12} />
+      {[-1.4, 1.4].map((x) => (
+        <mesh key={x} castShadow position={[x, 0.85, 0]}>
+          <boxGeometry args={[0.45, 1.25, 0.55]} />
+          <meshStandardMaterial
+            color="#111827"
+            emissive={ember}
+            emissiveIntensity={0.35}
+          />
+        </mesh>
+      ))}
+      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => (
+        <mesh
+          key={i}
+          position={[Math.cos(a) * 2.8, 0.04, Math.sin(a) * 2.8]}
+          rotation={[-Math.PI / 2, 0, a]}
+        >
+          <planeGeometry args={[0.36, 3.4]} />
+          <meshStandardMaterial
+            color={ember}
+            emissive={ember}
+            emissiveIntensity={0.75}
+            transparent
+            opacity={0.55}
+          />
+        </mesh>
+      ))}
+      <pointLight
+        position={[0, 2.1, 0]}
+        color={ember}
+        intensity={2.6}
+        distance={13}
+      />
+      <pointLight
+        position={[0, 2.8, 0]}
+        color={accent}
+        intensity={1.8}
+        distance={12}
+      />
     </group>
   )
 }
 
-function MemoryTree({ position, accent }: { position: [number, number, number]; accent: string }) {
+function MemoryTree({
+  position,
+  accent,
+}: {
+  position: [number, number, number]
+  accent: string
+}) {
   return (
     <group position={position}>
       <mesh castShadow position={[0, 1.45, 0]}>
         <cylinderGeometry args={[0.42, 0.7, 2.9, 10]} />
-        <meshStandardMaterial color="#5b3a1f" roughness={0.82} emissive={accent} emissiveIntensity={0.08} />
+        <meshStandardMaterial
+          color="#5b3a1f"
+          roughness={0.82}
+          emissive={accent}
+          emissiveIntensity={0.08}
+        />
       </mesh>
-      {[0, 0.8, -0.85, 1.7, -1.7].map((x, i) => <mesh key={i} castShadow position={[x, 3.0 + (i % 2) * 0.25, i === 0 ? 0 : x * 0.18]}><dodecahedronGeometry args={[1.05 - Math.min(i, 2) * 0.12, 0]} /><meshStandardMaterial color={i === 0 ? '#86efac' : '#2bbf6f'} roughness={0.72} emissive={accent} emissiveIntensity={0.12} flatShading /></mesh>)}
-      <mesh position={[0, 4.3, 0]}><octahedronGeometry args={[0.34, 0]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.4} transparent opacity={0.9} /></mesh>
-      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => <mesh key={i} position={[Math.cos(a) * 2.9, 0.05, Math.sin(a) * 2.9]} rotation={[-Math.PI / 2, 0, 0]}><circleGeometry args={[0.22, 18]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.55} transparent opacity={0.55} /></mesh>)}
-      <pointLight position={[0, 3.6, 0]} color={accent} intensity={1.6} distance={12} />
+      {[0, 0.8, -0.85, 1.7, -1.7].map((x, i) => (
+        <mesh
+          key={i}
+          castShadow
+          position={[x, 3.0 + (i % 2) * 0.25, i === 0 ? 0 : x * 0.18]}
+        >
+          <dodecahedronGeometry args={[1.05 - Math.min(i, 2) * 0.12, 0]} />
+          <meshStandardMaterial
+            color={i === 0 ? '#86efac' : '#2bbf6f'}
+            roughness={0.72}
+            emissive={accent}
+            emissiveIntensity={0.12}
+            flatShading
+          />
+        </mesh>
+      ))}
+      <mesh position={[0, 4.3, 0]}>
+        <octahedronGeometry args={[0.34, 0]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.4}
+          transparent
+          opacity={0.9}
+        />
+      </mesh>
+      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => (
+        <mesh
+          key={i}
+          position={[Math.cos(a) * 2.9, 0.05, Math.sin(a) * 2.9]}
+          rotation={[-Math.PI / 2, 0, 0]}
+        >
+          <circleGeometry args={[0.22, 18]} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={0.55}
+            transparent
+            opacity={0.55}
+          />
+        </mesh>
+      ))}
+      <pointLight
+        position={[0, 3.6, 0]}
+        color={accent}
+        intensity={1.6}
+        distance={12}
+      />
     </group>
   )
 }
 
-function OracleRingTower({ position, accent }: { position: [number, number, number]; accent: string }) {
+function OracleRingTower({
+  position,
+  accent,
+}: {
+  position: [number, number, number]
+  accent: string
+}) {
   const ref = useRef<THREE.Group>(null)
   useFrame(({ clock }) => {
     if (ref.current) ref.current.rotation.y = clock.getElapsedTime() * 0.22
   })
   return (
     <group position={position}>
-      <mesh castShadow receiveShadow position={[0, 0.28, 0]}><cylinderGeometry args={[1.9, 2.3, 0.56, 18]} /><meshStandardMaterial color="#312e81" roughness={0.5} emissive={accent} emissiveIntensity={0.18} /></mesh>
-      <mesh castShadow position={[0, 1.55, 0]}><cylinderGeometry args={[0.42, 0.58, 2.4, 12]} /><meshStandardMaterial color="#171032" roughness={0.42} emissive={accent} emissiveIntensity={0.35} /></mesh>
+      <mesh castShadow receiveShadow position={[0, 0.28, 0]}>
+        <cylinderGeometry args={[1.9, 2.3, 0.56, 18]} />
+        <meshStandardMaterial
+          color="#312e81"
+          roughness={0.5}
+          emissive={accent}
+          emissiveIntensity={0.18}
+        />
+      </mesh>
+      <mesh castShadow position={[0, 1.55, 0]}>
+        <cylinderGeometry args={[0.42, 0.58, 2.4, 12]} />
+        <meshStandardMaterial
+          color="#171032"
+          roughness={0.42}
+          emissive={accent}
+          emissiveIntensity={0.35}
+        />
+      </mesh>
       <group ref={ref} position={[0, 3.0, 0]}>
-        <mesh rotation={[Math.PI / 2, 0, 0]}><torusGeometry args={[2.2, 0.045, 12, 72]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.35} /></mesh>
-        <mesh rotation={[0.75, 0, 0]}><torusGeometry args={[1.55, 0.04, 12, 72]} /><meshStandardMaterial color="#c4b5fd" emissive="#c4b5fd" emissiveIntensity={1.2} /></mesh>
-        <mesh rotation={[0, 0, 0.75]}><torusGeometry args={[1.0, 0.035, 12, 64]} /><meshStandardMaterial color="#fef3c7" emissive="#fef3c7" emissiveIntensity={0.95} /></mesh>
-        <mesh><octahedronGeometry args={[0.42, 0]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.8} transparent opacity={0.9} /></mesh>
+        <mesh rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[2.2, 0.045, 12, 72]} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={1.35}
+          />
+        </mesh>
+        <mesh rotation={[0.75, 0, 0]}>
+          <torusGeometry args={[1.55, 0.04, 12, 72]} />
+          <meshStandardMaterial
+            color="#c4b5fd"
+            emissive="#c4b5fd"
+            emissiveIntensity={1.2}
+          />
+        </mesh>
+        <mesh rotation={[0, 0, 0.75]}>
+          <torusGeometry args={[1.0, 0.035, 12, 64]} />
+          <meshStandardMaterial
+            color="#fef3c7"
+            emissive="#fef3c7"
+            emissiveIntensity={0.95}
+          />
+        </mesh>
+        <mesh>
+          <octahedronGeometry args={[0.42, 0]} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={1.8}
+            transparent
+            opacity={0.9}
+          />
+        </mesh>
       </group>
-      <pointLight position={[0, 3, 0]} color={accent} intensity={2.1} distance={13} />
+      <pointLight
+        position={[0, 3, 0]}
+        color={accent}
+        intensity={2.1}
+        distance={13}
+      />
     </group>
   )
 }
 
-function FloatCrystal({ position, scale, color }: { position: [number, number, number]; scale: number; color: string }) {
+function FloatCrystal({
+  position,
+  scale,
+  color,
+}: {
+  position: [number, number, number]
+  scale: number
+  color: string
+}) {
   const ref = useRef<THREE.Mesh>(null)
   const phase = useMemo(() => Math.random() * Math.PI * 2, [])
   useFrame(({ clock }) => {
@@ -596,7 +998,13 @@ function FloatCrystal({ position, scale, color }: { position: [number, number, n
   return (
     <mesh ref={ref} position={position} scale={scale}>
       <octahedronGeometry args={[0.6, 0]} />
-      <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1.6} transparent opacity={0.85} />
+      <meshStandardMaterial
+        color={color}
+        emissive={color}
+        emissiveIntensity={1.6}
+        transparent
+        opacity={0.85}
+      />
     </mesh>
   )
 }
@@ -620,42 +1028,103 @@ function ArenaDecor({ world }: { world: WorldDef }) {
       {seats.map((pos, i) => (
         <mesh key={i} position={[pos[0], pos[1] + 0.3, pos[2]]} castShadow>
           <boxGeometry args={[0.6, 0.6, 0.6]} />
-          <meshStandardMaterial color="#27121a" emissive={world.pillarColor} emissiveIntensity={0.06} roughness={0.5} />
+          <meshStandardMaterial
+            color="#27121a"
+            emissive={world.pillarColor}
+            emissiveIntensity={0.06}
+            roughness={0.5}
+          />
         </mesh>
       ))}
       {/* central duel medallion */}
-      <mesh position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.05, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[2.4, 4.4, 64]} />
-        <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={0.6} />
+        <meshStandardMaterial
+          color={world.accent}
+          emissive={world.accent}
+          emissiveIntensity={0.6}
+        />
       </mesh>
-      <mesh position={[0, 0.07, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[0, 0.07, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <circleGeometry args={[2.15, 48]} />
-        <meshStandardMaterial color="#16070a" emissive={world.accent} emissiveIntensity={0.22} roughness={0.45} />
+        <meshStandardMaterial
+          color="#16070a"
+          emissive={world.accent}
+          emissiveIntensity={0.22}
+          roughness={0.45}
+        />
       </mesh>
-      <pointLight position={[0, 4, 0]} color={world.accent} intensity={2.2} distance={14} />
+      <pointLight
+        position={[0, 4, 0]}
+        color={world.accent}
+        intensity={2.2}
+        distance={14}
+      />
       {/* scoreboard pillars */}
       {[-7, 7].map((x, i) => (
         <group key={i} position={[x, 0, 0]}>
           <mesh castShadow position={[0, 1.4, 0]}>
             <boxGeometry args={[0.6, 2.8, 0.6]} />
-            <meshStandardMaterial color="#0f172a" emissive={world.accent} emissiveIntensity={0.4} />
+            <meshStandardMaterial
+              color="#0f172a"
+              emissive={world.accent}
+              emissiveIntensity={0.4}
+            />
           </mesh>
           <mesh position={[0, 2.5, 0]}>
             <boxGeometry args={[1.6, 0.8, 0.18]} />
-            <meshStandardMaterial color="#0f172a" emissive={world.accent} emissiveIntensity={1.4} />
+            <meshStandardMaterial
+              color="#0f172a"
+              emissive={world.accent}
+              emissiveIntensity={1.4}
+            />
           </mesh>
         </group>
       ))}
       {/* Braziers ringing the duel medallion */}
       {Array.from({ length: 6 }).map((_, i) => {
         const ang = (i / 6) * Math.PI * 2
-        return <Brazier key={`bz${i}`} position={[Math.cos(ang) * 5.2, 0, Math.sin(ang) * 5.2]} color="#fb7185" />
+        return (
+          <Brazier
+            key={`bz${i}`}
+            position={[Math.cos(ang) * 5.2, 0, Math.sin(ang) * 5.2]}
+            color="#fb7185"
+          />
+        )
       })}
       {/* Banners flanking the entrances */}
-      <HermesBanner position={[-9, 0, -9]} rotation={[0, 0.5, 0]} color={world.accent} cloth="#3b0a1c" />
-      <HermesBanner position={[9, 0, -9]} rotation={[0, -0.5, 0]} color={world.accent} cloth="#3b0a1c" />
-      <HermesBanner position={[-9, 0, 9]} rotation={[0, 2.5, 0]} color={world.accent} cloth="#3b0a1c" />
-      <HermesBanner position={[9, 0, 9]} rotation={[0, -2.5, 0]} color={world.accent} cloth="#3b0a1c" />
+      <HermesBanner
+        position={[-9, 0, -9]}
+        rotation={[0, 0.5, 0]}
+        color={world.accent}
+        cloth="#3b0a1c"
+      />
+      <HermesBanner
+        position={[9, 0, -9]}
+        rotation={[0, -0.5, 0]}
+        color={world.accent}
+        cloth="#3b0a1c"
+      />
+      <HermesBanner
+        position={[-9, 0, 9]}
+        rotation={[0, 2.5, 0]}
+        color={world.accent}
+        cloth="#3b0a1c"
+      />
+      <HermesBanner
+        position={[9, 0, 9]}
+        rotation={[0, -2.5, 0]}
+        color={world.accent}
+        cloth="#3b0a1c"
+      />
     </>
   )
 }
@@ -664,7 +1133,10 @@ function TrainingDecor({ world }: { world: WorldDef }) {
   const labels = [
     { text: 'Arrival Circle', pos: [-11, 2.4, 8] as [number, number, number] },
     { text: 'Trainer’s Ring', pos: [-5, 2.4, -4] as [number, number, number] },
-    { text: 'Quartermaster Tent', pos: [-14, 2.4, -10] as [number, number, number] },
+    {
+      text: 'Quartermaster Tent',
+      pos: [-14, 2.4, -10] as [number, number, number],
+    },
     { text: 'Archive Podium', pos: [6, 2.4, 0] as [number, number, number] },
     { text: 'Forge Gate', pos: [14, 2.6, -10] as [number, number, number] },
     { text: 'Hermes Sigil', pos: [0, 4.5, 0] as [number, number, number] },
@@ -677,7 +1149,12 @@ function TrainingDecor({ world }: { world: WorldDef }) {
       <PathRibbon from={[0, 0]} to={[-5, -4]} color="#fb7185" width={1.2} />
       <PathRibbon from={[0, 0]} to={[6, 0]} color="#a78bfa" width={1.08} />
       <PathRibbon from={[0, 0]} to={[14, -10]} color="#22d3ee" width={1.35} />
-      <PathRibbon from={[-5, -4]} to={[-14, -10]} color="#fbbf24" width={1.08} />
+      <PathRibbon
+        from={[-5, -4]}
+        to={[-14, -10]}
+        color="#fbbf24"
+        width={1.08}
+      />
       {/* Hermes statue at the heart of the grounds */}
       <HermesStatue position={[0, 0, 0]} accent={world.accent} />
       {/* Practice dummies + weapon racks around the trainer’s ring */}
@@ -687,11 +1164,27 @@ function TrainingDecor({ world }: { world: WorldDef }) {
       <WeaponRack position={[-9.2, 0, -3.0]} accent={world.accent} />
       <WeaponRack position={[-9.2, 0, -5.6]} accent="#fde68a" />
       {/* Banners flanking the Forge Gate */}
-      <HermesBanner position={[11.6, 0, -10]} rotation={[0, 0.4, 0]} color={world.accent} />
-      <HermesBanner position={[16.4, 0, -10]} rotation={[0, -0.4, 0]} color="#fbbf24" />
+      <HermesBanner
+        position={[11.6, 0, -10]}
+        rotation={[0, 0.4, 0]}
+        color={world.accent}
+      />
+      <HermesBanner
+        position={[16.4, 0, -10]}
+        rotation={[0, -0.4, 0]}
+        color="#fbbf24"
+      />
       {/* Banners by Arrival Circle */}
-      <HermesBanner position={[-13.2, 0, 8]} rotation={[0, 0.6, 0]} color={world.accent} />
-      <HermesBanner position={[-8.8, 0, 8]} rotation={[0, -0.6, 0]} color={world.accent} />
+      <HermesBanner
+        position={[-13.2, 0, 8]}
+        rotation={[0, 0.6, 0]}
+        color={world.accent}
+      />
+      <HermesBanner
+        position={[-8.8, 0, 8]}
+        rotation={[0, -0.6, 0]}
+        color={world.accent}
+      />
       {/* Braziers around the central statue and trainer ring */}
       <Brazier position={[3.2, 0, 3.2]} color="#fbbf24" />
       <Brazier position={[-3.2, 0, 3.2]} color="#fbbf24" />
@@ -699,18 +1192,39 @@ function TrainingDecor({ world }: { world: WorldDef }) {
       <Brazier position={[-3.2, 0, -3.2]} color="#fb923c" />
       <Brazier position={[-2.0, 0, -1.6]} color="#fb7185" />
       <Brazier position={[-8.0, 0, -1.6]} color="#fb7185" />
-      <mesh position={[-11, 0.05, 8]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[-11, 0.05, 8]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[2.4, 3.4, 72]} />
-        <meshStandardMaterial color={world.accent} emissive={world.accent} emissiveIntensity={0.5} />
+        <meshStandardMaterial
+          color={world.accent}
+          emissive={world.accent}
+          emissiveIntensity={0.5}
+        />
       </mesh>
-      <mesh position={[-5, 0.04, -4]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <mesh
+        position={[-5, 0.04, -4]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
         <ringGeometry args={[3, 4.6, 72]} />
-        <meshStandardMaterial color="#fb7185" emissive="#fb7185" emissiveIntensity={0.45} />
+        <meshStandardMaterial
+          color="#fb7185"
+          emissive="#fb7185"
+          emissiveIntensity={0.45}
+        />
       </mesh>
       <group position={[-14, 0, -10]}>
         <mesh castShadow position={[0, 2.2, 0]}>
           <coneGeometry args={[3.2, 4.2, 4]} />
-          <meshStandardMaterial color="#1d4ed8" roughness={0.7} emissive="#22d3ee" emissiveIntensity={0.12} />
+          <meshStandardMaterial
+            color="#1d4ed8"
+            roughness={0.7}
+            emissive="#22d3ee"
+            emissiveIntensity={0.12}
+          />
         </mesh>
         <mesh castShadow position={[0, 0.75, 0]}>
           <cylinderGeometry args={[0.18, 0.18, 1.5, 8]} />
@@ -720,43 +1234,103 @@ function TrainingDecor({ world }: { world: WorldDef }) {
       <group position={[6, 0, 0]}>
         <mesh castShadow position={[0, 0.6, 0]}>
           <cylinderGeometry args={[1.2, 1.6, 1.2, 18]} />
-          <meshStandardMaterial color="#312e81" roughness={0.55} emissive="#a78bfa" emissiveIntensity={0.16} />
+          <meshStandardMaterial
+            color="#312e81"
+            roughness={0.55}
+            emissive="#a78bfa"
+            emissiveIntensity={0.16}
+          />
         </mesh>
         <mesh castShadow position={[0, 1.35, 0]}>
           <boxGeometry args={[1.9, 0.2, 1.2]} />
-          <meshStandardMaterial color="#c4b5fd" emissive="#a78bfa" emissiveIntensity={0.4} />
+          <meshStandardMaterial
+            color="#c4b5fd"
+            emissive="#a78bfa"
+            emissiveIntensity={0.4}
+          />
         </mesh>
       </group>
       <group position={[14, 0, -10]}>
-        <mesh position={[0, 0.04, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <mesh
+          position={[0, 0.04, 0]}
+          rotation={[-Math.PI / 2, 0, 0]}
+          receiveShadow
+        >
           <ringGeometry args={[2.8, 4.6, 72]} />
-          <meshStandardMaterial color="#22d3ee" emissive="#22d3ee" emissiveIntensity={0.28} transparent opacity={0.48} />
+          <meshStandardMaterial
+            color="#22d3ee"
+            emissive="#22d3ee"
+            emissiveIntensity={0.28}
+            transparent
+            opacity={0.48}
+          />
         </mesh>
         <mesh castShadow position={[0, 2.3, 0]}>
           <torusGeometry args={[2.2, 0.18, 18, 64]} />
-          <meshStandardMaterial color="#22d3ee" emissive="#22d3ee" emissiveIntensity={1.75} />
+          <meshStandardMaterial
+            color="#22d3ee"
+            emissive="#22d3ee"
+            emissiveIntensity={1.75}
+          />
         </mesh>
-        <mesh castShadow position={[0, 2.3, -0.08]} rotation={[0, 0, Math.PI / 4]}>
+        <mesh
+          castShadow
+          position={[0, 2.3, -0.08]}
+          rotation={[0, 0, Math.PI / 4]}
+        >
           <torusGeometry args={[1.55, 0.06, 12, 48]} />
-          <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={1.1} transparent opacity={0.9} />
+          <meshStandardMaterial
+            color="#fbbf24"
+            emissive="#fbbf24"
+            emissiveIntensity={1.1}
+            transparent
+            opacity={0.9}
+          />
         </mesh>
         {[-2.8, 2.8].map((x) => (
           <group key={x} position={[x, 0, 0]}>
             <mesh castShadow position={[0, 1.5, 0]}>
               <boxGeometry args={[0.7, 3, 0.7]} />
-              <meshStandardMaterial color="#0f172a" emissive="#22d3ee" emissiveIntensity={0.32} />
+              <meshStandardMaterial
+                color="#0f172a"
+                emissive="#22d3ee"
+                emissiveIntensity={0.32}
+              />
             </mesh>
             <mesh castShadow position={[0, 3.25, 0]}>
               <coneGeometry args={[0.65, 0.85, 4]} />
-              <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={0.45} roughness={0.42} />
+              <meshStandardMaterial
+                color="#fbbf24"
+                emissive="#fbbf24"
+                emissiveIntensity={0.45}
+                roughness={0.42}
+              />
             </mesh>
           </group>
         ))}
-        <pointLight position={[0, 2.5, 0]} color="#22d3ee" intensity={2.4} distance={13} />
+        <pointLight
+          position={[0, 2.5, 0]}
+          color="#22d3ee"
+          intensity={2.4}
+          distance={13}
+        />
       </group>
       {labels.map((label) => (
         <Html key={label.text} position={label.pos} center distanceFactor={12}>
-          <div style={{ padding: '4px 10px', borderRadius: 8, background: 'rgba(0,0,0,0.7)', color: 'white', border: `1px solid ${world.accent}`, fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', whiteSpace: 'nowrap' }}>
+          <div
+            style={{
+              padding: '4px 10px',
+              borderRadius: 8,
+              background: 'rgba(0,0,0,0.7)',
+              color: 'white',
+              border: `1px solid ${world.accent}`,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {label.text}
           </div>
         </Html>
@@ -781,18 +1355,41 @@ function PathRibbon({
   const length = Math.sqrt(dx * dx + dz * dz)
   const angle = Math.atan2(dx, dz)
   return (
-    <group position={[from[0] + dx / 2, 0.018, from[1] + dz / 2]} rotation={[0, angle, 0]}>
+    <group
+      position={[from[0] + dx / 2, 0.018, from[1] + dz / 2]}
+      rotation={[0, angle, 0]}
+    >
       <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
         <planeGeometry args={[width, length]} />
-        <meshStandardMaterial color="#80633d" roughness={0.92} transparent opacity={0.74} polygonOffset polygonOffsetFactor={-1} polygonOffsetUnits={-1} />
+        <meshStandardMaterial
+          color="#80633d"
+          roughness={0.92}
+          transparent
+          opacity={0.74}
+          polygonOffset
+          polygonOffsetFactor={-1}
+          polygonOffsetUnits={-1}
+        />
       </mesh>
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[-width / 2, 0.006, 0]}>
         <planeGeometry args={[0.06, length]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.35} transparent opacity={0.72} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.35}
+          transparent
+          opacity={0.72}
+        />
       </mesh>
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[width / 2, 0.006, 0]}>
         <planeGeometry args={[0.06, length]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.35} transparent opacity={0.72} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.35}
+          transparent
+          opacity={0.72}
+        />
       </mesh>
     </group>
   )
@@ -838,7 +1435,13 @@ function HermesStatue({
       {/* chlamys cape */}
       <mesh castShadow position={[0, 1.62, -0.2]} rotation={[0.18, 0, 0]}>
         <planeGeometry args={[1.0, 1.1]} />
-        <meshStandardMaterial color={accent} side={THREE.DoubleSide} roughness={0.6} emissive={accent} emissiveIntensity={0.12} />
+        <meshStandardMaterial
+          color={accent}
+          side={THREE.DoubleSide}
+          roughness={0.6}
+          emissive={accent}
+          emissiveIntensity={0.12}
+        />
       </mesh>
       {/* head */}
       <mesh castShadow position={[0, 2.32, 0]}>
@@ -848,34 +1451,80 @@ function HermesStatue({
       {/* winged petasos (helmet) */}
       <mesh castShadow position={[0, 2.55, 0]}>
         <coneGeometry args={[0.32, 0.18, 18]} />
-        <meshStandardMaterial color={accent} metalness={0.45} roughness={0.4} emissive={accent} emissiveIntensity={0.35} />
+        <meshStandardMaterial
+          color={accent}
+          metalness={0.45}
+          roughness={0.4}
+          emissive={accent}
+          emissiveIntensity={0.35}
+        />
       </mesh>
       {[-1, 1].map((s) => (
-        <mesh key={s} castShadow position={[s * 0.34, 2.55, 0]} rotation={[0, 0, s * 0.6]}>
+        <mesh
+          key={s}
+          castShadow
+          position={[s * 0.34, 2.55, 0]}
+          rotation={[0, 0, s * 0.6]}
+        >
           <coneGeometry args={[0.08, 0.42, 6]} />
-          <meshStandardMaterial color="#fff5d1" emissive={accent} emissiveIntensity={0.6} roughness={0.4} />
+          <meshStandardMaterial
+            color="#fff5d1"
+            emissive={accent}
+            emissiveIntensity={0.6}
+            roughness={0.4}
+          />
         </mesh>
       ))}
       {/* caduceus staff */}
       <mesh castShadow position={[0.45, 1.6, 0.05]} rotation={[0, 0, -0.05]}>
         <cylinderGeometry args={[0.04, 0.04, 2.2, 8]} />
-        <meshStandardMaterial color={accent} metalness={0.6} roughness={0.3} emissive={accent} emissiveIntensity={0.25} />
+        <meshStandardMaterial
+          color={accent}
+          metalness={0.6}
+          roughness={0.3}
+          emissive={accent}
+          emissiveIntensity={0.25}
+        />
       </mesh>
       <mesh castShadow position={[0.45, 2.74, 0.05]}>
         <torusGeometry args={[0.12, 0.04, 8, 16]} />
-        <meshStandardMaterial color={accent} metalness={0.7} roughness={0.25} emissive={accent} emissiveIntensity={0.55} />
+        <meshStandardMaterial
+          color={accent}
+          metalness={0.7}
+          roughness={0.25}
+          emissive={accent}
+          emissiveIntensity={0.55}
+        />
       </mesh>
       {[-1, 1].map((s) => (
-        <mesh key={s} castShadow position={[0.45 + s * 0.12, 2.78, 0.05]} rotation={[0, 0, s * 0.4]}>
+        <mesh
+          key={s}
+          castShadow
+          position={[0.45 + s * 0.12, 2.78, 0.05]}
+          rotation={[0, 0, s * 0.4]}
+        >
           <coneGeometry args={[0.06, 0.22, 6]} />
-          <meshStandardMaterial color="#fff5d1" emissive={accent} emissiveIntensity={0.6} />
+          <meshStandardMaterial
+            color="#fff5d1"
+            emissive={accent}
+            emissiveIntensity={0.6}
+          />
         </mesh>
       ))}
       {/* winged sandals (small accents at feet) */}
       {[-1, 1].map((s) => (
-        <mesh key={`sandal${s}`} castShadow position={[s * 0.18, 0.7, 0.15]} rotation={[0, 0, s * 0.4]}>
+        <mesh
+          key={`sandal${s}`}
+          castShadow
+          position={[s * 0.18, 0.7, 0.15]}
+          rotation={[0, 0, s * 0.4]}
+        >
           <coneGeometry args={[0.06, 0.18, 6]} />
-          <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.7} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={0.7}
+          />
         </mesh>
       ))}
       {/* base inscription glow ring — polygon-offset to prevent z-fighting with the stone plaza below */}
@@ -932,7 +1581,13 @@ function PracticeDummy({ position }: { position: [number, number, number] }) {
   )
 }
 
-function WeaponRack({ position, accent = '#cbd5e1' }: { position: [number, number, number]; accent?: string }) {
+function WeaponRack({
+  position,
+  accent = '#cbd5e1',
+}: {
+  position: [number, number, number]
+  accent?: string
+}) {
   return (
     <group position={position}>
       {/* frame */}
@@ -953,12 +1608,24 @@ function WeaponRack({ position, accent = '#cbd5e1' }: { position: [number, numbe
       </mesh>
       <mesh castShadow position={[-0.25, 1.7, 0.06]} rotation={[0, 0, 0.06]}>
         <coneGeometry args={[0.05, 0.18, 6]} />
-        <meshStandardMaterial color={accent} metalness={0.6} roughness={0.3} emissive={accent} emissiveIntensity={0.2} />
+        <meshStandardMaterial
+          color={accent}
+          metalness={0.6}
+          roughness={0.3}
+          emissive={accent}
+          emissiveIntensity={0.2}
+        />
       </mesh>
       {/* sword */}
       <mesh castShadow position={[0.0, 0.9, 0.06]} rotation={[0, 0, -0.04]}>
         <boxGeometry args={[0.08, 0.95, 0.04]} />
-        <meshStandardMaterial color={accent} metalness={0.7} roughness={0.25} emissive={accent} emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color={accent}
+          metalness={0.7}
+          roughness={0.25}
+          emissive={accent}
+          emissiveIntensity={0.18}
+        />
       </mesh>
       <mesh castShadow position={[0.0, 0.36, 0.06]}>
         <boxGeometry args={[0.22, 0.07, 0.07]} />
@@ -967,11 +1634,21 @@ function WeaponRack({ position, accent = '#cbd5e1' }: { position: [number, numbe
       {/* shield */}
       <mesh castShadow position={[0.32, 0.85, 0.07]}>
         <cylinderGeometry args={[0.32, 0.32, 0.06, 24]} />
-        <meshStandardMaterial color="#1d4ed8" metalness={0.45} roughness={0.4} emissive="#fbbf24" emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color="#1d4ed8"
+          metalness={0.45}
+          roughness={0.4}
+          emissive="#fbbf24"
+          emissiveIntensity={0.18}
+        />
       </mesh>
       <mesh position={[0.32, 0.85, 0.105]}>
         <torusGeometry args={[0.12, 0.025, 8, 24]} />
-        <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={0.6} />
+        <meshStandardMaterial
+          color="#fbbf24"
+          emissive="#fbbf24"
+          emissiveIntensity={0.6}
+        />
       </mesh>
     </group>
   )
@@ -997,7 +1674,13 @@ function HermesBanner({
       </mesh>
       <mesh castShadow position={[0, 3.05, 0]}>
         <coneGeometry args={[0.12, 0.22, 8]} />
-        <meshStandardMaterial color={color} metalness={0.5} roughness={0.35} emissive={color} emissiveIntensity={0.4} />
+        <meshStandardMaterial
+          color={color}
+          metalness={0.5}
+          roughness={0.35}
+          emissive={color}
+          emissiveIntensity={0.4}
+        />
       </mesh>
       {/* horizontal arm */}
       <mesh castShadow position={[0.45, 2.85, 0]}>
@@ -1007,18 +1690,37 @@ function HermesBanner({
       {/* cloth */}
       <mesh position={[0.45, 1.85, 0]}>
         <planeGeometry args={[0.85, 1.85]} />
-        <meshStandardMaterial color={cloth} side={THREE.DoubleSide} roughness={0.7} emissive={color} emissiveIntensity={0.06} />
+        <meshStandardMaterial
+          color={cloth}
+          side={THREE.DoubleSide}
+          roughness={0.7}
+          emissive={color}
+          emissiveIntensity={0.06}
+        />
       </mesh>
       {/* sigil dot */}
       <mesh position={[0.45, 1.95, 0.01]}>
         <circleGeometry args={[0.18, 18]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.6} side={THREE.DoubleSide} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.6}
+          side={THREE.DoubleSide}
+        />
       </mesh>
       {/* wings on sigil */}
       {[-1, 1].map((s) => (
-        <mesh key={s} position={[0.45 + s * 0.18, 1.97, 0.012]} rotation={[0, 0, s * 0.5]}>
+        <mesh
+          key={s}
+          position={[0.45 + s * 0.18, 1.97, 0.012]}
+          rotation={[0, 0, s * 0.5]}
+        >
           <coneGeometry args={[0.07, 0.16, 6]} />
-          <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.7} />
+          <meshStandardMaterial
+            color={color}
+            emissive={color}
+            emissiveIntensity={0.7}
+          />
         </mesh>
       ))}
     </group>
@@ -1026,7 +1728,13 @@ function HermesBanner({
 }
 
 /* ── Brazier (flame on pillar) ── */
-function Brazier({ position, color = '#fb923c' }: { position: [number, number, number]; color?: string }) {
+function Brazier({
+  position,
+  color = '#fb923c',
+}: {
+  position: [number, number, number]
+  color?: string
+}) {
   const flameRef = useRef<THREE.Mesh>(null)
   useFrame(({ clock }) => {
     if (!flameRef.current) return
@@ -1049,9 +1757,21 @@ function Brazier({ position, color = '#fb923c' }: { position: [number, number, n
       {/* flame */}
       <mesh ref={flameRef} position={[0, 1.7, 0]}>
         <coneGeometry args={[0.25, 0.55, 8]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={2.2} transparent opacity={0.92} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={2.2}
+          transparent
+          opacity={0.92}
+        />
       </mesh>
-      <pointLight position={[0, 1.7, 0]} color={color} intensity={0.9} distance={5} decay={1.5} />
+      <pointLight
+        position={[0, 1.7, 0]}
+        color={color}
+        intensity={0.9}
+        distance={5}
+        decay={1.5}
+      />
     </group>
   )
 }
@@ -1059,17 +1779,28 @@ function Brazier({ position, color = '#fb923c' }: { position: [number, number, n
 /* ── Decor router ── */
 function WorldDecor({ world }: { world: WorldDef }) {
   switch (world.pillarType) {
-    case 'training': return <TrainingDecor world={world} />
-    case 'classical': return <ClassicalPillars world={world} />
-    case 'tech': return <TechPillars world={world} />
-    case 'forest': return <ForestDecor world={world} />
-    case 'temple': return <TempleDecor world={world} />
-    case 'arena': return <ArenaDecor world={world} />
+    case 'training':
+      return <TrainingDecor world={world} />
+    case 'classical':
+      return <ClassicalPillars world={world} />
+    case 'tech':
+      return <TechPillars world={world} />
+    case 'forest':
+      return <ForestDecor world={world} />
+    case 'temple':
+      return <TempleDecor world={world} />
+    case 'arena':
+      return <ArenaDecor world={world} />
   }
 }
 
-
-function NpcAccessories({ role = '', color }: { role?: string; color: string }) {
+function NpcAccessories({
+  role = '',
+  color,
+}: {
+  role?: string
+  color: string
+}) {
   const isTrainer = role === 'trainer' || role === 'nike'
   const isBanker = role === 'banker' || role === 'chronos'
   const isRecruiter = role === 'recruiter' || role === 'athena'
@@ -1082,39 +1813,110 @@ function NpcAccessories({ role = '', color }: { role?: string; color: string }) 
       {/* shoulder silhouette */}
       {(isTrainer || isRecruiter || isBanker || isHermes) && (
         <>
-          <mesh castShadow position={[-0.36, 0.98, 0]} rotation={[0, 0, 0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color={isTrainer || isHermes ? '#94a3b8' : color} metalness={isTrainer || isHermes ? 0.6 : 0.15} roughness={0.42} emissive={color} emissiveIntensity={0.12} /></mesh>
-          <mesh castShadow position={[0.36, 0.98, 0]} rotation={[0, 0, -0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color={isTrainer || isHermes ? '#94a3b8' : color} metalness={isTrainer || isHermes ? 0.6 : 0.15} roughness={0.42} emissive={color} emissiveIntensity={0.12} /></mesh>
+          <mesh castShadow position={[-0.36, 0.98, 0]} rotation={[0, 0, 0.4]}>
+            <boxGeometry args={[0.24, 0.12, 0.2]} />
+            <meshStandardMaterial
+              color={isTrainer || isHermes ? '#94a3b8' : color}
+              metalness={isTrainer || isHermes ? 0.6 : 0.15}
+              roughness={0.42}
+              emissive={color}
+              emissiveIntensity={0.12}
+            />
+          </mesh>
+          <mesh castShadow position={[0.36, 0.98, 0]} rotation={[0, 0, -0.4]}>
+            <boxGeometry args={[0.24, 0.12, 0.2]} />
+            <meshStandardMaterial
+              color={isTrainer || isHermes ? '#94a3b8' : color}
+              metalness={isTrainer || isHermes ? 0.6 : 0.15}
+              roughness={0.42}
+              emissive={color}
+              emissiveIntensity={0.12}
+            />
+          </mesh>
         </>
       )}
       {/* breastplate disc (knights only) */}
       {isKnight && (
         <mesh castShadow position={[0, 0.78, 0.18]}>
           <cylinderGeometry args={[0.18, 0.22, 0.08, 18]} />
-          <meshStandardMaterial color="#cbd5e1" metalness={0.7} roughness={0.3} emissive={color} emissiveIntensity={0.18} />
+          <meshStandardMaterial
+            color="#cbd5e1"
+            metalness={0.7}
+            roughness={0.3}
+            emissive={color}
+            emissiveIntensity={0.18}
+          />
         </mesh>
       )}
       {/* cape/back panel, visible in orbit and screenshots */}
       {(isRecruiter || isBanker || isTavern || isHermes) && (
         <mesh castShadow position={[0, 0.78, -0.2]} rotation={[0.18, 0, 0]}>
           <planeGeometry args={[0.72, 0.9]} />
-          <meshStandardMaterial color={color} side={THREE.DoubleSide} roughness={0.6} emissive={color} emissiveIntensity={isHermes ? 0.18 : 0.08} />
+          <meshStandardMaterial
+            color={color}
+            side={THREE.DoubleSide}
+            roughness={0.6}
+            emissive={color}
+            emissiveIntensity={isHermes ? 0.18 : 0.08}
+          />
         </mesh>
       )}
       {/* hats/crowns so roles read at distance */}
-      {isBanker && <mesh castShadow position={[0, 1.48, 0]}><cylinderGeometry args={[0.2, 0.24, 0.18, 12]} /><meshStandardMaterial color="#fbbf24" metalness={0.45} roughness={0.38} emissive="#fbbf24" emissiveIntensity={0.25} /></mesh>}
-      {isShop && <mesh castShadow position={[0, 1.45, 0]} rotation={[0, 0, 0.2]}><coneGeometry args={[0.28, 0.28, 8]} /><meshStandardMaterial color="#38bdf8" roughness={0.55} emissive="#38bdf8" emissiveIntensity={0.1} /></mesh>}
-      {isTavern && <mesh castShadow position={[0, 1.44, 0]}><torusGeometry args={[0.19, 0.025, 8, 24]} /><meshStandardMaterial color="#f59e0b" roughness={0.5} emissive="#f59e0b" emissiveIntensity={0.2} /></mesh>}
+      {isBanker && (
+        <mesh castShadow position={[0, 1.48, 0]}>
+          <cylinderGeometry args={[0.2, 0.24, 0.18, 12]} />
+          <meshStandardMaterial
+            color="#fbbf24"
+            metalness={0.45}
+            roughness={0.38}
+            emissive="#fbbf24"
+            emissiveIntensity={0.25}
+          />
+        </mesh>
+      )}
+      {isShop && (
+        <mesh castShadow position={[0, 1.45, 0]} rotation={[0, 0, 0.2]}>
+          <coneGeometry args={[0.28, 0.28, 8]} />
+          <meshStandardMaterial
+            color="#38bdf8"
+            roughness={0.55}
+            emissive="#38bdf8"
+            emissiveIntensity={0.1}
+          />
+        </mesh>
+      )}
+      {isTavern && (
+        <mesh castShadow position={[0, 1.44, 0]}>
+          <torusGeometry args={[0.19, 0.025, 8, 24]} />
+          <meshStandardMaterial
+            color="#f59e0b"
+            roughness={0.5}
+            emissive="#f59e0b"
+            emissiveIntensity={0.2}
+          />
+        </mesh>
+      )}
       {/* helmet for Trainer & Recruiter (knight) */}
       {(isTrainer || isRecruiter) && (
         <>
           <mesh castShadow position={[0, 1.46, 0]}>
-            <sphereGeometry args={[0.2, 14, 12, 0, Math.PI * 2, 0, Math.PI / 1.6]} />
-            <meshStandardMaterial color="#94a3b8" metalness={0.7} roughness={0.3} />
+            <sphereGeometry
+              args={[0.2, 14, 12, 0, Math.PI * 2, 0, Math.PI / 1.6]}
+            />
+            <meshStandardMaterial
+              color="#94a3b8"
+              metalness={0.7}
+              roughness={0.3}
+            />
           </mesh>
           {/* plume */}
           <mesh castShadow position={[0, 1.62, -0.04]} rotation={[0.4, 0, 0]}>
             <coneGeometry args={[0.07, 0.32, 8]} />
-            <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.6} />
+            <meshStandardMaterial
+              color={color}
+              emissive={color}
+              emissiveIntensity={0.6}
+            />
           </mesh>
         </>
       )}
@@ -1123,12 +1925,27 @@ function NpcAccessories({ role = '', color }: { role?: string; color: string }) 
         <>
           <mesh castShadow position={[0, 1.5, 0]}>
             <coneGeometry args={[0.24, 0.16, 14]} />
-            <meshStandardMaterial color="#fbbf24" metalness={0.6} roughness={0.3} emissive="#fbbf24" emissiveIntensity={0.5} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              metalness={0.6}
+              roughness={0.3}
+              emissive="#fbbf24"
+              emissiveIntensity={0.5}
+            />
           </mesh>
           {[-1, 1].map((s) => (
-            <mesh key={s} castShadow position={[s * 0.26, 1.5, 0]} rotation={[0, 0, s * 0.6]}>
+            <mesh
+              key={s}
+              castShadow
+              position={[s * 0.26, 1.5, 0]}
+              rotation={[0, 0, s * 0.6]}
+            >
               <coneGeometry args={[0.06, 0.32, 6]} />
-              <meshStandardMaterial color="#fff5d1" emissive="#fbbf24" emissiveIntensity={0.7} />
+              <meshStandardMaterial
+                color="#fff5d1"
+                emissive="#fbbf24"
+                emissiveIntensity={0.7}
+              />
             </mesh>
           ))}
         </>
@@ -1136,29 +1953,75 @@ function NpcAccessories({ role = '', color }: { role?: string; color: string }) 
       {/* sword sheath at hip for knights */}
       {isKnight && (
         <>
-          <mesh castShadow position={[0.34, 0.62, 0.04]} rotation={[0, 0, 0.18]}>
+          <mesh
+            castShadow
+            position={[0.34, 0.62, 0.04]}
+            rotation={[0, 0, 0.18]}
+          >
             <boxGeometry args={[0.06, 0.5, 0.06]} />
             <meshStandardMaterial color="#3f2a18" roughness={0.8} />
           </mesh>
-          <mesh castShadow position={[0.34, 0.92, 0.06]} rotation={[0, 0, 0.18]}>
+          <mesh
+            castShadow
+            position={[0.34, 0.92, 0.06]}
+            rotation={[0, 0, 0.18]}
+          >
             <boxGeometry args={[0.08, 0.18, 0.06]} />
-            <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.4} metalness={0.4} roughness={0.4} />
+            <meshStandardMaterial
+              color={color}
+              emissive={color}
+              emissiveIntensity={0.4}
+              metalness={0.4}
+              roughness={0.4}
+            />
           </mesh>
         </>
       )}
       {/* weapons/tools (existing) */}
-      {isTrainer && <mesh castShadow position={[0.52, 0.82, 0.08]} rotation={[0.1, 0, -0.75]}><boxGeometry args={[0.05, 0.9, 0.05]} /><meshStandardMaterial color="#cbd5e1" metalness={0.6} roughness={0.35} /></mesh>}
-      {isShop && <mesh castShadow position={[-0.48, 0.72, 0.08]} rotation={[0, 0, 0.25]}><boxGeometry args={[0.16, 0.38, 0.08]} /><meshStandardMaterial color="#a16207" roughness={0.8} /></mesh>}
+      {isTrainer && (
+        <mesh
+          castShadow
+          position={[0.52, 0.82, 0.08]}
+          rotation={[0.1, 0, -0.75]}
+        >
+          <boxGeometry args={[0.05, 0.9, 0.05]} />
+          <meshStandardMaterial
+            color="#cbd5e1"
+            metalness={0.6}
+            roughness={0.35}
+          />
+        </mesh>
+      )}
+      {isShop && (
+        <mesh castShadow position={[-0.48, 0.72, 0.08]} rotation={[0, 0, 0.25]}>
+          <boxGeometry args={[0.16, 0.38, 0.08]} />
+          <meshStandardMaterial color="#a16207" roughness={0.8} />
+        </mesh>
+      )}
       {/* Hermes caduceus staff */}
       {isHermes && (
         <>
-          <mesh castShadow position={[-0.5, 0.85, 0.08]} rotation={[0, 0, 0.04]}>
+          <mesh
+            castShadow
+            position={[-0.5, 0.85, 0.08]}
+            rotation={[0, 0, 0.04]}
+          >
             <cylinderGeometry args={[0.03, 0.03, 1.6, 8]} />
-            <meshStandardMaterial color="#fbbf24" metalness={0.7} roughness={0.3} emissive="#fbbf24" emissiveIntensity={0.4} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              metalness={0.7}
+              roughness={0.3}
+              emissive="#fbbf24"
+              emissiveIntensity={0.4}
+            />
           </mesh>
           <mesh castShadow position={[-0.5, 1.6, 0.08]}>
             <torusGeometry args={[0.08, 0.02, 8, 14]} />
-            <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={0.7} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              emissive="#fbbf24"
+              emissiveIntensity={0.7}
+            />
           </mesh>
         </>
       )}
@@ -1194,31 +2057,14 @@ const NPC_AMBIENT_LINES: Record<string, string[]> = {
     'Speed is the soul of an agent.',
     'I deliver — between thought and tool.',
   ],
-  chronos: [
-    'Records outlast the writer.',
-    'Time is the only honest critic.',
-  ],
-  apollo: [
-    'A song carries what code cannot.',
-  ],
-  artemis: [
-    'Track the signal. Ignore the noise.',
-  ],
-  eros: [
-    'Connection is the first protocol.',
-  ],
-  trainer: [
-    'Form. Then power. Then speed.',
-  ],
-  recruiter: [
-    'No one builds alone. Find your party.',
-  ],
-  banker: [
-    'Compound the small wins.',
-  ],
-  tavernkeeper: [
-    'Rest. Trade. Listen.',
-  ],
+  chronos: ['Records outlast the writer.', 'Time is the only honest critic.'],
+  apollo: ['A song carries what code cannot.'],
+  artemis: ['Track the signal. Ignore the noise.'],
+  eros: ['Connection is the first protocol.'],
+  trainer: ['Form. Then power. Then speed.'],
+  recruiter: ['No one builds alone. Find your party.'],
+  banker: ['Compound the small wins.'],
+  tavernkeeper: ['Rest. Trade. Listen.'],
 }
 
 function NPC({
@@ -1248,28 +2094,34 @@ function NPC({
   const base = useMemo(() => new THREE.Vector3(...position), [position])
   const phase = useMemo(() => Math.random() * Math.PI * 2, [])
   const glbId = npcId || avatar
+  const lastNear = useRef(false)
+  const [isNear, setIsNear] = useState(false)
   const hasGlb = useGlbAvailable(glbId, isNear || highlight)
 
   // Ambient speech bubble — cycles every ~12-22s with NPC lore lines.
   const [ambient, setAmbient] = useState<string | null>(null)
   useEffect(() => {
-    const lines = (npcId && NPC_AMBIENT_LINES[npcId]) || NPC_AMBIENT_LINES[avatar] || []
+    const lines =
+      (npcId && NPC_AMBIENT_LINES[npcId]) || NPC_AMBIENT_LINES[avatar] || []
     if (lines.length === 0) return
     let stop = false
     const tick = () => {
       if (stop) return
       const line = lines[Math.floor(Math.random() * lines.length)]
       setAmbient(line)
-      window.setTimeout(() => { if (!stop) setAmbient(null) }, 6000)
+      window.setTimeout(() => {
+        if (!stop) setAmbient(null)
+      }, 6000)
       window.setTimeout(tick, 12000 + Math.random() * 10000)
     }
     // Stagger so all NPCs don't speak in unison.
     const initial = window.setTimeout(tick, 2000 + Math.random() * 8000)
-    return () => { stop = true; window.clearTimeout(initial) }
+    return () => {
+      stop = true
+      window.clearTimeout(initial)
+    }
   }, [npcId, avatar])
 
-  const lastNear = useRef(false)
-  const [isNear, setIsNear] = useState(false)
   useFrame(({ clock }) => {
     if (!ref.current) return
     if (drift) {
@@ -1296,13 +2148,17 @@ function NPC({
   })
 
   return (
-    <group ref={ref} position={position} onPointerDown={(e) => {
-      if (!npcId || !onClickNpc) return
-      e.stopPropagation()
-      const p = ref.current?.position
-      if (!p) return
-      onClickNpc(npcId, [p.x, p.y, p.z])
-    }}>
+    <group
+      ref={ref}
+      position={position}
+      onPointerDown={(e) => {
+        if (!npcId || !onClickNpc) return
+        e.stopPropagation()
+        const p = ref.current?.position
+        if (!p) return
+        onClickNpc(npcId, [p.x, p.y, p.z])
+      }}
+    >
       {/* shadow plate */}
       <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <circleGeometry args={[0.5, 18]} />
@@ -1334,12 +2190,21 @@ function NPC({
           {/* torso (robe) — colored per NPC */}
           <mesh position={[0, 0.7, 0]} castShadow>
             <boxGeometry args={[0.5, 0.55, 0.32]} />
-            <meshStandardMaterial color={color} roughness={0.55} emissive={color} emissiveIntensity={0.15} />
+            <meshStandardMaterial
+              color={color}
+              roughness={0.55}
+              emissive={color}
+              emissiveIntensity={0.15}
+            />
           </mesh>
           {/* belt accent matching player */}
           <mesh position={[0, 0.46, 0]} castShadow>
             <boxGeometry args={[0.52, 0.05, 0.34]} />
-            <meshStandardMaterial color="#fbbf24" metalness={0.4} roughness={0.4} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              metalness={0.4}
+              roughness={0.4}
+            />
           </mesh>
           {/* arms */}
           <mesh position={[0.32, 0.7, 0]} castShadow>
@@ -1370,36 +2235,107 @@ function NPC({
             <meshStandardMaterial color="#fde68a" roughness={0.55} />
           </mesh>
           {/* eyes */}
-          <mesh position={[0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color="#0b1220" /></mesh>
-          <mesh position={[-0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color="#0b1220" /></mesh>
+          <mesh position={[0.085, 1.24, 0.19]}>
+            <sphereGeometry args={[0.025, 8, 8]} />
+            <meshStandardMaterial color="#0b1220" />
+          </mesh>
+          <mesh position={[-0.085, 1.24, 0.19]}>
+            <sphereGeometry args={[0.025, 8, 8]} />
+            <meshStandardMaterial color="#0b1220" />
+          </mesh>
           {/* hair cap */}
           <mesh position={[0, 1.34, -0.02]} castShadow>
-            <sphereGeometry args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]} />
-            <meshStandardMaterial color={color} roughness={0.85} emissive={color} emissiveIntensity={0.18} />
+            <sphereGeometry
+              args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]}
+            />
+            <meshStandardMaterial
+              color={color}
+              roughness={0.85}
+              emissive={color}
+              emissiveIntensity={0.18}
+            />
           </mesh>
           <NpcAccessories role={npcId || avatar} color={color} />
         </>
       )}
       {/* nameplate w/ portrait chip — replaces floating PNG */}
       <Html position={[0, 1.95, 0]} center distanceFactor={8}>
-        <div style={{display:'flex',alignItems:'center',gap:6,padding:'2px 8px 2px 2px',background:'rgba(0,0,0,0.78)',color:'white',borderRadius:14,fontSize:11,fontWeight:600,whiteSpace:'nowrap',border:`1px solid ${color}`,boxShadow:`0 0 8px ${color}55`}}>
-          <img src={`/avatars/${avatar}.png`} alt="" loading="lazy" decoding="async" style={{width:22,height:22,borderRadius:'50%',background:color,objectFit:'cover',border:`1px solid ${color}`}} />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '2px 8px 2px 2px',
+            background: 'rgba(0,0,0,0.78)',
+            color: 'white',
+            borderRadius: 14,
+            fontSize: 11,
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+            border: `1px solid ${color}`,
+            boxShadow: `0 0 8px ${color}55`,
+          }}
+        >
+          <img
+            src={`/avatars/${avatar}.png`}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: color,
+              objectFit: 'cover',
+              border: `1px solid ${color}`,
+            }}
+          />
           <span>{name}</span>
         </div>
       </Html>
       {highlight && (
         <Html position={[0, 2.95, 0]} center distanceFactor={8}>
-          <div style={{ color: '#fef08a', fontSize: 24, textShadow: '0 0 18px rgba(250,204,21,0.8)', animation: 'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite' }}>↓</div>
+          <div
+            style={{
+              color: '#fef08a',
+              fontSize: 24,
+              textShadow: '0 0 18px rgba(250,204,21,0.8)',
+              animation:
+                'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite',
+            }}
+          >
+            ↓
+          </div>
         </Html>
       )}
       {isNear && (
         <Html position={[0, 2.55, 0]} center distanceFactor={8}>
-          <div style={{padding:'4px 10px',background:color,color:'#000',borderRadius:6,fontSize:11,fontWeight:800,whiteSpace:'nowrap',boxShadow:`0 0 12px ${color}`,letterSpacing:'0.1em',textTransform:'uppercase'}}>Press E to talk</div>
+          <div
+            style={{
+              padding: '4px 10px',
+              background: color,
+              color: '#000',
+              borderRadius: 6,
+              fontSize: 11,
+              fontWeight: 800,
+              whiteSpace: 'nowrap',
+              boxShadow: `0 0 12px ${color}`,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Press E to talk
+          </div>
         </Html>
       )}
       {ambient && !isNear && (
         <Html position={[0, 2.7, 0]} center distanceFactor={8}>
-          <SpeechBubble className="hermes-world-bubble" variant="npc" accent={color} compact>
+          <SpeechBubble
+            className="hermes-world-bubble"
+            variant="npc"
+            accent={color}
+            compact
+          >
             {ambient}
           </SpeechBubble>
         </Html>
@@ -1443,38 +2379,96 @@ function Portal({
     const t = clock.getElapsedTime()
     if (ringRef.current) {
       ringRef.current.rotation.y += dt * (locked ? 0.45 : 0.85)
-      const pulse = photosensitiveMode ? 1 : (locked ? 1 + Math.sin(t * 2.1) * 0.05 : 1 + Math.sin(t * 2.6) * 0.03)
+      const pulse = photosensitiveMode
+        ? 1
+        : locked
+          ? 1 + Math.sin(t * 2.1) * 0.05
+          : 1 + Math.sin(t * 2.6) * 0.03
       ringRef.current.scale.setScalar(pulse)
     }
     const dist = playerRef.current.distanceTo(center)
     if (dist < 1.5 && !triggered.current && !locked) {
       triggered.current = true
       onEnter()
-      window.setTimeout(() => { triggered.current = false }, 1200)
+      window.setTimeout(() => {
+        triggered.current = false
+      }, 1200)
     }
   })
   return (
     <group position={position}>
       <mesh ref={ringRef} position={[0, 1.2, 0]}>
         <torusGeometry args={[1.1, 0.08, 16, 64]} />
-        <meshStandardMaterial color={locked ? '#64748b' : color} emissive={locked ? '#334155' : color} emissiveIntensity={locked ? 0.9 : 2.5} />
+        <meshStandardMaterial
+          color={locked ? '#64748b' : color}
+          emissive={locked ? '#334155' : color}
+          emissiveIntensity={locked ? 0.9 : 2.5}
+        />
       </mesh>
-      {!locked && <pointLight position={[0, 1.2, 0]} color={color} intensity={4.8} distance={7} />}
-      {locked && <pointLight position={[0, 1.2, 0]} color="#64748b" intensity={1.2} distance={5} />}
-      {!locked && !photosensitiveMode && <Sparkles count={8} scale={[2.5, 2.5, 2.5]} size={1.7} speed={0.12} color={color} opacity={0.22} />}
+      {!locked && (
+        <pointLight
+          position={[0, 1.2, 0]}
+          color={color}
+          intensity={4.8}
+          distance={7}
+        />
+      )}
+      {locked && (
+        <pointLight
+          position={[0, 1.2, 0]}
+          color="#64748b"
+          intensity={1.2}
+          distance={5}
+        />
+      )}
+      {!locked && !photosensitiveMode && (
+        <Sparkles
+          count={8}
+          scale={[2.5, 2.5, 2.5]}
+          size={1.7}
+          speed={0.12}
+          color={color}
+          opacity={0.22}
+        />
+      )}
       {highlight && (
         <Html position={[0, 3.4, 0]} center distanceFactor={8}>
-          <div style={{ color: '#fef08a', fontSize: 26, textShadow: '0 0 18px rgba(250,204,21,0.8)', animation: 'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite' }}>↓</div>
+          <div
+            style={{
+              color: '#fef08a',
+              fontSize: 26,
+              textShadow: '0 0 18px rgba(250,204,21,0.8)',
+              animation:
+                'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite',
+            }}
+          >
+            ↓
+          </div>
         </Html>
       )}
-      {!photosensitiveMode && !locked && unlockedAtRef.current && Date.now() - unlockedAtRef.current < 2200 && (
-        <mesh position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-          <ringGeometry args={[1.8, 2.5, 48]} />
-          <meshBasicMaterial color={color} transparent opacity={0.42} />
-        </mesh>
-      )}
+      {!photosensitiveMode &&
+        !locked &&
+        unlockedAtRef.current &&
+        Date.now() - unlockedAtRef.current < 2200 && (
+          <mesh position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+            <ringGeometry args={[1.8, 2.5, 48]} />
+            <meshBasicMaterial color={color} transparent opacity={0.42} />
+          </mesh>
+        )}
       <Html position={[0, 2.7, 0]} center distanceFactor={8}>
-        <div style={{padding:'2px 8px',background:'rgba(0,0,0,0.7)',color: locked ? '#cbd5e1' : color,borderRadius:4,fontSize:13,whiteSpace:'nowrap',fontWeight:600}}>{locked ? `${label} · locked` : label}</div>
+        <div
+          style={{
+            padding: '2px 8px',
+            background: 'rgba(0,0,0,0.7)',
+            color: locked ? '#cbd5e1' : color,
+            borderRadius: 4,
+            fontSize: 13,
+            whiteSpace: 'nowrap',
+            fontWeight: 600,
+          }}
+        >
+          {locked ? `${label} · locked` : label}
+        </div>
       </Html>
     </group>
   )
@@ -1507,21 +2501,50 @@ function QuestZone({
     if (dist < 1.6 && !triggered.current) {
       triggered.current = true
       onEnter()
-      window.setTimeout(() => { triggered.current = false }, 2000)
+      window.setTimeout(() => {
+        triggered.current = false
+      }, 2000)
     }
   })
   return (
     <group position={position}>
       <mesh ref={ref} position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <ringGeometry args={[1.2, 1.5, 32]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={1} transparent opacity={0.7} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={1}
+          transparent
+          opacity={0.7}
+        />
       </mesh>
       <Html position={[0, 1.8, 0]} center distanceFactor={8}>
-        <div style={{padding:'2px 6px',background:'rgba(0,0,0,0.6)',color,borderRadius:4,fontSize:11,whiteSpace:'nowrap'}}>✨ {label}</div>
+        <div
+          style={{
+            padding: '2px 6px',
+            background: 'rgba(0,0,0,0.6)',
+            color,
+            borderRadius: 4,
+            fontSize: 11,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          ✨ {label}
+        </div>
       </Html>
       {highlight && (
         <Html position={[0, 2.65, 0]} center distanceFactor={8}>
-          <div style={{ color: '#fef08a', fontSize: 24, textShadow: '0 0 18px rgba(250,204,21,0.8)', animation: 'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite' }}>↓</div>
+          <div
+            style={{
+              color: '#fef08a',
+              fontSize: 24,
+              textShadow: '0 0 18px rgba(250,204,21,0.8)',
+              animation:
+                'hermes-target-arrow var(--hw-flash-rate, 1.5s) ease-in-out infinite',
+            }}
+          >
+            ↓
+          </div>
         </Html>
       )}
     </group>
@@ -1534,9 +2557,31 @@ function useKeyboard() {
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       const t = e.target as HTMLElement | null
-      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.isContentEditable)
+      )
+        return
       const k = e.key.toLowerCase()
-      if (['w','a','s','d','arrowup','arrowdown','arrowleft','arrowright','shift','control',' ','[',']'].includes(k)) {
+      if (
+        [
+          'w',
+          'a',
+          's',
+          'd',
+          'arrowup',
+          'arrowdown',
+          'arrowleft',
+          'arrowright',
+          'shift',
+          'control',
+          ' ',
+          '[',
+          ']',
+        ].includes(k)
+      ) {
         keys.current.add(k)
         e.preventDefault()
       }
@@ -1608,14 +2653,17 @@ function PlayerAndCamera({
       if (jumpStartedAt.current || now - lastJumpAt.current < 600) return
       lastJumpAt.current = now
       jumpStartedAt.current = now
-      try { window.dispatchEvent(new CustomEvent('hermesworld-player-jumped')) } catch {}
+      try {
+        window.dispatchEvent(new CustomEvent('hermesworld-player-jumped'))
+      } catch {}
     }
     const onDash = () => {
       dashUntil.current = Date.now() + 900
     }
     const onJump = () => tryJump()
     const onCrouch = (event: Event) => {
-      mobileCrouch.current = !!(event as CustomEvent<{ active?: boolean }>).detail?.active
+      mobileCrouch.current = !!(event as CustomEvent<{ active?: boolean }>)
+        .detail?.active
     }
     window.addEventListener('hermes-playground-dash', onDash)
     window.addEventListener('hermesworld-mobile-jump', onJump)
@@ -1642,7 +2690,13 @@ function PlayerAndCamera({
     }
     const onDown = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      )
+        return
       // Right/middle: drag immediately. Left: only on the canvas, and only after movement threshold.
       const isCanvas = target?.tagName === 'CANVAS'
       if (e.button === 2 || e.button === 1) {
@@ -1677,7 +2731,10 @@ function PlayerAndCamera({
       // Sensitivity: smaller = slower, larger = faster
       const sens = 0.005
       camYaw.current += dx * sens
-      camPitch.current = Math.max(0.25, Math.min(1.4, camPitch.current + dy * sens))
+      camPitch.current = Math.max(
+        0.25,
+        Math.min(1.4, camPitch.current + dy * sens),
+      )
     }
     const onUp = () => {
       if (dragging) {
@@ -1689,9 +2746,18 @@ function PlayerAndCamera({
     }
     const onWheel = (e: WheelEvent) => {
       const target = e.target as HTMLElement | null
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      )
+        return
       // Only zoom when not over a chat/UI panel — check if event is over canvas-y area
-      camDistance.current = Math.max(6, Math.min(28, camDistance.current + e.deltaY * 0.01))
+      camDistance.current = Math.max(
+        6,
+        Math.min(28, camDistance.current + e.deltaY * 0.01),
+      )
     }
     window.addEventListener('contextmenu', onContext)
     window.addEventListener('mousedown', onDown)
@@ -1722,7 +2788,12 @@ function PlayerAndCamera({
   // Cinematic camera mode — Tab cycles through preset angles useful for filming.
   // ESC returns to default isometric.
   useEffect(() => {
-    const presets: Array<{ yaw: number; pitch: number; distance: number; name: string }> = [
+    const presets: Array<{
+      yaw: number
+      pitch: number
+      distance: number
+      name: string
+    }> = [
       { yaw: Math.PI / 4, pitch: 0.85, distance: 13, name: 'Isometric' },
       { yaw: 0, pitch: 0.55, distance: 9, name: 'Behind-back' },
       { yaw: Math.PI, pitch: 0.6, distance: 9, name: 'Front-face' },
@@ -1733,7 +2804,13 @@ function PlayerAndCamera({
     let idx = 0
     const onKey = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      )
+        return
       if (event.key === 'Tab') {
         event.preventDefault()
         idx = (idx + 1) % presets.length
@@ -1743,7 +2820,11 @@ function PlayerAndCamera({
         camDistance.current = p.distance
         // Tiny ephemeral toast
         try {
-          window.dispatchEvent(new CustomEvent('hermes-playground-camera-preset', { detail: p.name }))
+          window.dispatchEvent(
+            new CustomEvent('hermes-playground-camera-preset', {
+              detail: p.name,
+            }),
+          )
         } catch {}
       }
     }
@@ -1756,13 +2837,18 @@ function PlayerAndCamera({
     // ARROW KEYS = camera orbit (yaw + pitch)
     if (k.has('arrowleft')) camYaw.current -= delta * 1.6
     if (k.has('arrowright')) camYaw.current += delta * 1.6
-    if (k.has('arrowup')) camPitch.current = Math.max(0.45, camPitch.current - delta * 1.2)
-    if (k.has('arrowdown')) camPitch.current = Math.min(1.25, camPitch.current + delta * 1.2)
-    if (k.has('[')) camDistance.current = Math.max(7, camDistance.current - delta * 8)
-    if (k.has(']')) camDistance.current = Math.min(22, camDistance.current + delta * 8)
+    if (k.has('arrowup'))
+      camPitch.current = Math.max(0.45, camPitch.current - delta * 1.2)
+    if (k.has('arrowdown'))
+      camPitch.current = Math.min(1.25, camPitch.current + delta * 1.2)
+    if (k.has('['))
+      camDistance.current = Math.max(7, camDistance.current - delta * 8)
+    if (k.has(']'))
+      camDistance.current = Math.min(22, camDistance.current + delta * 8)
 
     // WASD = walk (relative to camera yaw so feels natural)
-    let dx = 0, dz = 0
+    let dx = 0,
+      dz = 0
     if (k.has('w')) dz -= 1
     if (k.has('s')) dz += 1
     if (k.has('a')) dx -= 1
@@ -1770,10 +2856,16 @@ function PlayerAndCamera({
     const wasdMoving = dx !== 0 || dz !== 0
     if (wasdMoving && moveTargetRef) moveTargetRef.current = null // WASD cancels click-to-walk
     const now = Date.now()
-    if (k.has(' ') && !jumpStartedAt.current && now - lastJumpAt.current >= 600) {
+    if (
+      k.has(' ') &&
+      !jumpStartedAt.current &&
+      now - lastJumpAt.current >= 600
+    ) {
       lastJumpAt.current = now
       jumpStartedAt.current = now
-      try { window.dispatchEvent(new CustomEvent('hermesworld-player-jumped')) } catch {}
+      try {
+        window.dispatchEvent(new CustomEvent('hermesworld-player-jumped'))
+      } catch {}
     }
     if (jumpStartedAt.current) {
       const elapsed = now - jumpStartedAt.current
@@ -1816,8 +2908,16 @@ function PlayerAndCamera({
     }
     isMoving.current = mx !== 0 || mz !== 0
     if (isMoving.current) {
-      positionRef.current.x = THREE.MathUtils.clamp(positionRef.current.x + mx, -bounds.x, bounds.x)
-      positionRef.current.z = THREE.MathUtils.clamp(positionRef.current.z + mz, -bounds.z, bounds.z)
+      positionRef.current.x = THREE.MathUtils.clamp(
+        positionRef.current.x + mx,
+        -bounds.x,
+        bounds.x,
+      )
+      positionRef.current.z = THREE.MathUtils.clamp(
+        positionRef.current.z + mz,
+        -bounds.z,
+        bounds.z,
+      )
       yaw.current = Math.atan2(mx, mz)
       bobT.current += delta * 8
     } else {
@@ -1826,8 +2926,14 @@ function PlayerAndCamera({
     if (groupRef.current) {
       groupRef.current.position.x = positionRef.current.x
       groupRef.current.position.z = positionRef.current.z
-      groupRef.current.position.y = jumpHeight.current + (isMoving.current ? Math.abs(Math.sin(bobT.current)) * 0.08 : 0)
-      groupRef.current.scale.y = THREE.MathUtils.lerp(groupRef.current.scale.y, crouching ? 0.52 : 1, 0.22)
+      groupRef.current.position.y =
+        jumpHeight.current +
+        (isMoving.current ? Math.abs(Math.sin(bobT.current)) * 0.08 : 0)
+      groupRef.current.scale.y = THREE.MathUtils.lerp(
+        groupRef.current.scale.y,
+        crouching ? 0.52 : 1,
+        0.22,
+      )
       groupRef.current.rotation.y = yaw.current
     }
     if (yawOutRef) yawOutRef.current = yaw.current
@@ -1874,22 +2980,14 @@ function PlayerAndCamera({
 
       {/* Feet */}
       <mesh
-        position={[
-          0.16,
-          0.05,
-          isMoving.current ? swing * 0.18 : 0,
-        ]}
+        position={[0.16, 0.05, isMoving.current ? swing * 0.18 : 0]}
         castShadow
       >
         <boxGeometry args={[0.24, 0.1, 0.36]} />
         <meshStandardMaterial color="#1f2937" roughness={0.7} />
       </mesh>
       <mesh
-        position={[
-          -0.16,
-          0.05,
-          isMoving.current ? -swing * 0.18 : 0,
-        ]}
+        position={[-0.16, 0.05, isMoving.current ? -swing * 0.18 : 0]}
         castShadow
       >
         <boxGeometry args={[0.24, 0.1, 0.36]} />
@@ -1899,28 +2997,63 @@ function PlayerAndCamera({
       {/* Torso */}
       <mesh position={[0, 0.9, 0]} castShadow>
         <cylinderGeometry args={[0.24, 0.34, 0.74, 10]} />
-        <meshStandardMaterial color={cfg.outfit} roughness={0.48} emissive={cfg.outfit} emissiveIntensity={0.1} />
+        <meshStandardMaterial
+          color={cfg.outfit}
+          roughness={0.48}
+          emissive={cfg.outfit}
+          emissiveIntensity={0.1}
+        />
       </mesh>
       {/* Knight chest plate — muscled cuirass with sigil disc */}
       <mesh position={[0, 0.96, 0.18]} castShadow>
         <boxGeometry args={[0.46, 0.62, 0.08]} />
-        <meshStandardMaterial color="#cbd5e1" metalness={0.7} roughness={0.3} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color="#cbd5e1"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.18}
+        />
       </mesh>
       <mesh position={[0, 0.98, 0.225]}>
         <cylinderGeometry args={[0.12, 0.12, 0.02, 16]} />
-        <meshStandardMaterial color={gearAccent || cfg.outfitAccent} metalness={0.7} roughness={0.25} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.55} />
+        <meshStandardMaterial
+          color={gearAccent || cfg.outfitAccent}
+          metalness={0.7}
+          roughness={0.25}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.55}
+        />
       </mesh>
       {/* Wings on the chest sigil */}
       {[-1, 1].map((s) => (
-        <mesh key={s} position={[s * 0.13, 0.99, 0.232]} rotation={[0, 0, s * 0.55]}>
+        <mesh
+          key={s}
+          position={[s * 0.13, 0.99, 0.232]}
+          rotation={[0, 0, s * 0.55]}
+        >
           <coneGeometry args={[0.04, 0.12, 6]} />
-          <meshStandardMaterial color="#fff5d1" emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.7} />
+          <meshStandardMaterial
+            color="#fff5d1"
+            emissive={gearAccent || cfg.outfitAccent}
+            emissiveIntensity={0.7}
+          />
         </mesh>
       ))}
       {/* Pauldron stud */}
-      <mesh position={[0, 1.02, 0.16]} castShadow rotation={[Math.PI / 4, 0, Math.PI / 4]}>
+      <mesh
+        position={[0, 1.02, 0.16]}
+        castShadow
+        rotation={[Math.PI / 4, 0, Math.PI / 4]}
+      >
         <boxGeometry args={[0.16, 0.16, 0.16]} />
-        <meshStandardMaterial color={gearAccent || cfg.outfitAccent} metalness={0.42} roughness={0.28} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.28} />
+        <meshStandardMaterial
+          color={gearAccent || cfg.outfitAccent}
+          metalness={0.42}
+          roughness={0.28}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.28}
+        />
       </mesh>
       {/* Pelvis */}
       <mesh position={[0, 0.56, 0]} castShadow>
@@ -1929,16 +3062,31 @@ function PlayerAndCamera({
       </mesh>
       {/* Tasset (skirt of armor strips) */}
       {[-0.18, -0.06, 0.06, 0.18].map((x) => (
-        <mesh key={x} castShadow position={[x, 0.42, 0.16]} rotation={[0.05, 0, 0]}>
+        <mesh
+          key={x}
+          castShadow
+          position={[x, 0.42, 0.16]}
+          rotation={[0.05, 0, 0]}
+        >
           <boxGeometry args={[0.1, 0.22, 0.05]} />
-          <meshStandardMaterial color="#94a3b8" metalness={0.6} roughness={0.4} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.12} />
+          <meshStandardMaterial
+            color="#94a3b8"
+            metalness={0.6}
+            roughness={0.4}
+            emissive={gearAccent || cfg.outfitAccent}
+            emissiveIntensity={0.12}
+          />
         </mesh>
       ))}
 
       {/* Belt accent */}
       <mesh position={[0, 0.62, 0]} castShadow>
         <boxGeometry args={[0.5, 0.07, 0.32]} />
-        <meshStandardMaterial color={gearAccent || cfg.outfitAccent} roughness={0.4} metalness={0.4} />
+        <meshStandardMaterial
+          color={gearAccent || cfg.outfitAccent}
+          roughness={0.4}
+          metalness={0.4}
+        />
       </mesh>
 
       {/* Arms */}
@@ -1960,31 +3108,61 @@ function PlayerAndCamera({
       </mesh>
 
       {/* Hands */}
-      <mesh position={[0.39, 0.58, isMoving.current ? -swing * 0.18 : 0]} castShadow>
+      <mesh
+        position={[0.39, 0.58, isMoving.current ? -swing * 0.18 : 0]}
+        castShadow
+      >
         <sphereGeometry args={[0.1, 12, 12]} />
         <meshStandardMaterial color={cfg.skin} roughness={0.5} />
       </mesh>
-      <mesh position={[-0.39, 0.58, isMoving.current ? swing * 0.18 : 0]} castShadow>
+      <mesh
+        position={[-0.39, 0.58, isMoving.current ? swing * 0.18 : 0]}
+        castShadow
+      >
         <sphereGeometry args={[0.1, 12, 12]} />
         <meshStandardMaterial color={cfg.skin} roughness={0.5} />
       </mesh>
       {/* Gauntlets (forearm armor) */}
       <mesh position={[0.39, 0.7, 0]} castShadow>
         <cylinderGeometry args={[0.085, 0.075, 0.22, 10]} />
-        <meshStandardMaterial color="#94a3b8" metalness={0.7} roughness={0.3} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.18}
+        />
       </mesh>
       <mesh position={[-0.39, 0.7, 0]} castShadow>
         <cylinderGeometry args={[0.085, 0.075, 0.22, 10]} />
-        <meshStandardMaterial color="#94a3b8" metalness={0.7} roughness={0.3} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.18}
+        />
       </mesh>
       {/* Greaves (shin armor) */}
       <mesh position={[0.16, 0.18, 0]} castShadow>
         <boxGeometry args={[0.18, 0.32, 0.2]} />
-        <meshStandardMaterial color="#94a3b8" metalness={0.65} roughness={0.32} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.12} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.65}
+          roughness={0.32}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.12}
+        />
       </mesh>
       <mesh position={[-0.16, 0.18, 0]} castShadow>
         <boxGeometry args={[0.18, 0.32, 0.2]} />
-        <meshStandardMaterial color="#94a3b8" metalness={0.65} roughness={0.32} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.12} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.65}
+          roughness={0.32}
+          emissive={gearAccent || cfg.outfitAccent}
+          emissiveIntensity={0.12}
+        />
       </mesh>
 
       {/* Neck */}
@@ -2015,26 +3193,34 @@ function PlayerAndCamera({
       {/* Hair styles */}
       {cfg.hairStyle === 'short' && (
         <mesh position={[0, 1.56, -0.03]} castShadow>
-          <sphereGeometry args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]} />
+          <sphereGeometry
+            args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]}
+          />
           <meshStandardMaterial color={cfg.hair} roughness={0.85} />
         </mesh>
       )}
       {cfg.hairStyle === 'cap' && (
         <mesh position={[0, 1.58, -0.03]} castShadow>
-          <sphereGeometry args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI * 0.55]} />
+          <sphereGeometry
+            args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI * 0.55]}
+          />
           <meshStandardMaterial color={cfg.hair} roughness={0.85} />
         </mesh>
       )}
-      {cfg.hairStyle === 'long' && (<>
-        <mesh position={[0, 1.56, -0.03]} castShadow>
-          <sphereGeometry args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]} />
-          <meshStandardMaterial color={cfg.hair} roughness={0.85} />
-        </mesh>
-        <mesh position={[0, 1.28, -0.2]} castShadow>
-          <boxGeometry args={[0.44, 0.54, 0.08]} />
-          <meshStandardMaterial color={cfg.hair} roughness={0.85} />
-        </mesh>
-      </>)}
+      {cfg.hairStyle === 'long' && (
+        <>
+          <mesh position={[0, 1.56, -0.03]} castShadow>
+            <sphereGeometry
+              args={[0.255, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]}
+            />
+            <meshStandardMaterial color={cfg.hair} roughness={0.85} />
+          </mesh>
+          <mesh position={[0, 1.28, -0.2]} castShadow>
+            <boxGeometry args={[0.44, 0.54, 0.08]} />
+            <meshStandardMaterial color={cfg.hair} roughness={0.85} />
+          </mesh>
+        </>
+      )}
       {cfg.hairStyle === 'mohawk' && (
         <mesh position={[0, 1.64, 0]} castShadow>
           <boxGeometry args={[0.08, 0.22, 0.42]} />
@@ -2044,82 +3230,205 @@ function PlayerAndCamera({
       {(gearHelmet || cfg.helmet) === 'circlet' && (
         <mesh position={[0, 1.49, 0]} castShadow>
           <torusGeometry args={[0.245, 0.025, 8, 24]} />
-          <meshStandardMaterial color="#fbbf24" metalness={0.8} roughness={0.25} emissive="#facc15" emissiveIntensity={0.4} />
+          <meshStandardMaterial
+            color="#fbbf24"
+            metalness={0.8}
+            roughness={0.25}
+            emissive="#facc15"
+            emissiveIntensity={0.4}
+          />
         </mesh>
       )}
-      {(gearHelmet || cfg.helmet) === 'crown' && (<>
-        <mesh position={[0, 1.49, 0]} castShadow>
-          <torusGeometry args={[0.245, 0.025, 8, 24]} />
-          <meshStandardMaterial color="#fbbf24" metalness={0.8} roughness={0.25} emissive="#facc15" emissiveIntensity={0.4} />
-        </mesh>
-        {[0, Math.PI / 3, -Math.PI / 3, Math.PI * 2 / 3, -Math.PI * 2 / 3, Math.PI].map((a, i) => (
-          <mesh key={i} position={[Math.cos(a) * 0.245, 1.56, Math.sin(a) * 0.245]} castShadow>
-            <coneGeometry args={[0.025, 0.08, 4]} />
-            <meshStandardMaterial color="#fbbf24" metalness={0.8} roughness={0.25} emissive="#facc15" emissiveIntensity={0.4} />
+      {(gearHelmet || cfg.helmet) === 'crown' && (
+        <>
+          <mesh position={[0, 1.49, 0]} castShadow>
+            <torusGeometry args={[0.245, 0.025, 8, 24]} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              metalness={0.8}
+              roughness={0.25}
+              emissive="#facc15"
+              emissiveIntensity={0.4}
+            />
           </mesh>
-        ))}
-      </>)}
+          {[
+            0,
+            Math.PI / 3,
+            -Math.PI / 3,
+            (Math.PI * 2) / 3,
+            (-Math.PI * 2) / 3,
+            Math.PI,
+          ].map((a, i) => (
+            <mesh
+              key={i}
+              position={[Math.cos(a) * 0.245, 1.56, Math.sin(a) * 0.245]}
+              castShadow
+            >
+              <coneGeometry args={[0.025, 0.08, 4]} />
+              <meshStandardMaterial
+                color="#fbbf24"
+                metalness={0.8}
+                roughness={0.25}
+                emissive="#facc15"
+                emissiveIntensity={0.4}
+              />
+            </mesh>
+          ))}
+        </>
+      )}
       {(gearHelmet || cfg.helmet) === 'cap' && (
         <mesh position={[0, 1.62, -0.03]} castShadow>
-          <sphereGeometry args={[0.255, 12, 12, 0, Math.PI * 2, 0, Math.PI * 0.5]} />
-          <meshStandardMaterial color={cfg.outfit} roughness={0.55} emissive={cfg.outfit} emissiveIntensity={0.15} />
+          <sphereGeometry
+            args={[0.255, 12, 12, 0, Math.PI * 2, 0, Math.PI * 0.5]}
+          />
+          <meshStandardMaterial
+            color={cfg.outfit}
+            roughness={0.55}
+            emissive={cfg.outfit}
+            emissiveIntensity={0.15}
+          />
         </mesh>
       )}
-      {(gearHelmet || cfg.helmet) === 'winged' && (<>
-        <mesh position={[0, 1.49, 0]} castShadow>
-          <torusGeometry args={[0.245, 0.025, 8, 24]} />
-          <meshStandardMaterial color="#fbbf24" metalness={0.8} roughness={0.25} emissive="#facc15" emissiveIntensity={0.4} />
-        </mesh>
-        <mesh castShadow position={[0.21, 1.55, -0.02]} rotation={[0, 0, 0.6]}>
-          <coneGeometry args={[0.06, 0.18, 5]} />
-          <meshStandardMaterial color="#fef3c7" emissive="#fde68a" emissiveIntensity={0.35} roughness={0.5} />
-        </mesh>
-        <mesh castShadow position={[-0.21, 1.55, -0.02]} rotation={[0, 0, -0.6]}>
-          <coneGeometry args={[0.06, 0.18, 5]} />
-          <meshStandardMaterial color="#fef3c7" emissive="#fde68a" emissiveIntensity={0.35} roughness={0.5} />
-        </mesh>
-      </>)}
+      {(gearHelmet || cfg.helmet) === 'winged' && (
+        <>
+          <mesh position={[0, 1.49, 0]} castShadow>
+            <torusGeometry args={[0.245, 0.025, 8, 24]} />
+            <meshStandardMaterial
+              color="#fbbf24"
+              metalness={0.8}
+              roughness={0.25}
+              emissive="#facc15"
+              emissiveIntensity={0.4}
+            />
+          </mesh>
+          <mesh
+            castShadow
+            position={[0.21, 1.55, -0.02]}
+            rotation={[0, 0, 0.6]}
+          >
+            <coneGeometry args={[0.06, 0.18, 5]} />
+            <meshStandardMaterial
+              color="#fef3c7"
+              emissive="#fde68a"
+              emissiveIntensity={0.35}
+              roughness={0.5}
+            />
+          </mesh>
+          <mesh
+            castShadow
+            position={[-0.21, 1.55, -0.02]}
+            rotation={[0, 0, -0.6]}
+          >
+            <coneGeometry args={[0.06, 0.18, 5]} />
+            <meshStandardMaterial
+              color="#fef3c7"
+              emissive="#fde68a"
+              emissiveIntensity={0.35}
+              roughness={0.5}
+            />
+          </mesh>
+        </>
+      )}
       {/* Shoulder pads */}
       {(gearCape || cfg.cape) !== 'transparent' && (
         <>
-          <mesh castShadow position={[-0.4, 1.1, -0.02]} rotation={[0.12, 0, 0.4]}>
+          <mesh
+            castShadow
+            position={[-0.4, 1.1, -0.02]}
+            rotation={[0.12, 0, 0.4]}
+          >
             <boxGeometry args={[0.3, 0.16, 0.28]} />
-            <meshStandardMaterial color={gearAccent || cfg.outfitAccent} metalness={0.55} roughness={0.4} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+            <meshStandardMaterial
+              color={gearAccent || cfg.outfitAccent}
+              metalness={0.55}
+              roughness={0.4}
+              emissive={gearAccent || cfg.outfitAccent}
+              emissiveIntensity={0.18}
+            />
           </mesh>
-          <mesh castShadow position={[0.4, 1.1, -0.02]} rotation={[0.12, 0, -0.4]}>
+          <mesh
+            castShadow
+            position={[0.4, 1.1, -0.02]}
+            rotation={[0.12, 0, -0.4]}
+          >
             <boxGeometry args={[0.3, 0.16, 0.28]} />
-            <meshStandardMaterial color={gearAccent || cfg.outfitAccent} metalness={0.55} roughness={0.4} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+            <meshStandardMaterial
+              color={gearAccent || cfg.outfitAccent}
+              metalness={0.55}
+              roughness={0.4}
+              emissive={gearAccent || cfg.outfitAccent}
+              emissiveIntensity={0.18}
+            />
           </mesh>
         </>
       )}
       {/* Cape (optional) */}
       {(gearCape || cfg.cape) !== 'transparent' && (
         <group position={[0, 0.92, -0.24]}>
-          <mesh castShadow position={[-0.12, -0.08, 0]} rotation={[0.28, 0.08, 0.06]}>
+          <mesh
+            castShadow
+            position={[-0.12, -0.08, 0]}
+            rotation={[0.28, 0.08, 0.06]}
+          >
             <planeGeometry args={[0.48, 1.1]} />
-            <meshStandardMaterial color={gearCape || cfg.cape} side={THREE.DoubleSide} roughness={0.55} emissive={gearCape || cfg.cape} emissiveIntensity={0.12} />
+            <meshStandardMaterial
+              color={gearCape || cfg.cape}
+              side={THREE.DoubleSide}
+              roughness={0.55}
+              emissive={gearCape || cfg.cape}
+              emissiveIntensity={0.12}
+            />
           </mesh>
-          <mesh castShadow position={[0.12, -0.08, 0]} rotation={[0.28, -0.08, -0.06]}>
+          <mesh
+            castShadow
+            position={[0.12, -0.08, 0]}
+            rotation={[0.28, -0.08, -0.06]}
+          >
             <planeGeometry args={[0.48, 1.1]} />
-            <meshStandardMaterial color={gearCape || cfg.cape} side={THREE.DoubleSide} roughness={0.55} emissive={gearCape || cfg.cape} emissiveIntensity={0.12} />
+            <meshStandardMaterial
+              color={gearCape || cfg.cape}
+              side={THREE.DoubleSide}
+              roughness={0.55}
+              emissive={gearCape || cfg.cape}
+              emissiveIntensity={0.12}
+            />
           </mesh>
         </group>
       )}
       {/* Weapon */}
-      {(gearWeapon || cfg.weapon) === 'sword' && (<>
-        <mesh castShadow position={[0.52, 0.72, 0.02]} rotation={[0.1, 0, -0.22]}>
-          <boxGeometry args={[0.05, 0.96, 0.05]} />
-          <meshStandardMaterial color="#cbd5e1" metalness={0.85} roughness={0.2} />
-        </mesh>
-        <mesh castShadow position={[0.52, 0.28, 0.02]} rotation={[0.1, 0, -0.22]}>
-          <boxGeometry args={[0.18, 0.06, 0.08]} />
-          <meshStandardMaterial color="#7c2d12" roughness={0.85} />
-        </mesh>
-      </>)}
+      {(gearWeapon || cfg.weapon) === 'sword' && (
+        <>
+          <mesh
+            castShadow
+            position={[0.52, 0.72, 0.02]}
+            rotation={[0.1, 0, -0.22]}
+          >
+            <boxGeometry args={[0.05, 0.96, 0.05]} />
+            <meshStandardMaterial
+              color="#cbd5e1"
+              metalness={0.85}
+              roughness={0.2}
+            />
+          </mesh>
+          <mesh
+            castShadow
+            position={[0.52, 0.28, 0.02]}
+            rotation={[0.1, 0, -0.22]}
+          >
+            <boxGeometry args={[0.18, 0.06, 0.08]} />
+            <meshStandardMaterial color="#7c2d12" roughness={0.85} />
+          </mesh>
+        </>
+      )}
       {(gearWeapon || cfg.weapon) === 'staff' && (
         <mesh castShadow position={[0.5, 0.96, 0.08]} rotation={[0, 0, -0.08]}>
           <cylinderGeometry args={[0.04, 0.04, 1.7, 8]} />
-          <meshStandardMaterial color="#7c4a1f" roughness={0.7} emissive={gearAccent || cfg.outfitAccent} emissiveIntensity={0.18} />
+          <meshStandardMaterial
+            color="#7c4a1f"
+            roughness={0.7}
+            emissive={gearAccent || cfg.outfitAccent}
+            emissiveIntensity={0.18}
+          />
         </mesh>
       )}
       {(gearWeapon || cfg.weapon) === 'bow' && (
@@ -2132,19 +3441,57 @@ function PlayerAndCamera({
         <>
           <mesh position={[0, 0.95, 0.33]} castShadow>
             <octahedronGeometry args={[0.08, 0]} />
-            <meshStandardMaterial color={gearArtifact} emissive={gearArtifact} emissiveIntensity={1.3} roughness={0.18} metalness={0.2} />
+            <meshStandardMaterial
+              color={gearArtifact}
+              emissive={gearArtifact}
+              emissiveIntensity={1.3}
+              roughness={0.18}
+              metalness={0.2}
+            />
           </mesh>
           <mesh position={[0, 0.95, 0.33]} rotation={[Math.PI / 2, 0, 0]}>
             <torusGeometry args={[0.12, 0.012, 8, 24]} />
-            <meshStandardMaterial color={gearArtifact} emissive={gearArtifact} emissiveIntensity={1.1} />
+            <meshStandardMaterial
+              color={gearArtifact}
+              emissive={gearArtifact}
+              emissiveIntensity={1.1}
+            />
           </mesh>
         </>
       )}
 
       {/* nameplate w/ portrait chip — "You" */}
       <Html position={[0, 2.2, 0]} center distanceFactor={8}>
-        <div style={{display:'flex',alignItems:'center',gap:6,padding:'2px 8px 2px 2px',background:'rgba(0,0,0,0.78)',color:'#a7f3d0',borderRadius:14,fontSize:11,fontWeight:700,whiteSpace:'nowrap',border:'1px solid #34d39955',boxShadow:'0 0 8px #34d39933'}}>
-          <img src={`/avatars/${portraitId}.png`} alt="" loading="lazy" decoding="async" style={{width:22,height:22,borderRadius:'50%',background:gearAccent || cfg.outfitAccent,objectFit:'cover',border:'1px solid #34d399'}} />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '2px 8px 2px 2px',
+            background: 'rgba(0,0,0,0.78)',
+            color: '#a7f3d0',
+            borderRadius: 14,
+            fontSize: 11,
+            fontWeight: 700,
+            whiteSpace: 'nowrap',
+            border: '1px solid #34d39955',
+            boxShadow: '0 0 8px #34d39933',
+          }}
+        >
+          <img
+            src={`/avatars/${portraitId}.png`}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: gearAccent || cfg.outfitAccent,
+              objectFit: 'cover',
+              border: '1px solid #34d399',
+            }}
+          />
           <span>{displayName}</span>
         </div>
       </Html>
@@ -2155,19 +3502,29 @@ function PlayerAndCamera({
 }
 
 /** Hermes Summoning skill — a glowing familiar orbits the player for 60s after summon. */
-function SummonedFamiliar({ playerRef }: { playerRef: React.MutableRefObject<THREE.Vector3> }) {
+function SummonedFamiliar({
+  playerRef,
+}: {
+  playerRef: React.MutableRefObject<THREE.Vector3>
+}) {
   const ref = useRef<THREE.Mesh>(null)
   const lightRef = useRef<THREE.PointLight>(null)
-  const [active, setActive] = useState<{ untilTs: number; color: string } | null>(null)
+  const [active, setActive] = useState<{
+    untilTs: number
+    color: string
+  } | null>(null)
   useEffect(() => {
     const onSummon = (ev: Event) => {
-      const detail = (ev as CustomEvent).detail as { durationMs?: number; color?: string } | undefined
+      const detail = (ev as CustomEvent).detail as
+        | { durationMs?: number; color?: string }
+        | undefined
       const dur = detail?.durationMs ?? 60000
       const col = detail?.color ?? '#a78bfa'
       setActive({ untilTs: Date.now() + dur, color: col })
     }
     window.addEventListener('hermes-playground-summon-familiar', onSummon)
-    return () => window.removeEventListener('hermes-playground-summon-familiar', onSummon)
+    return () =>
+      window.removeEventListener('hermes-playground-summon-familiar', onSummon)
   }, [])
   useFrame(({ clock }) => {
     if (!active) return
@@ -2193,16 +3550,30 @@ function SummonedFamiliar({ playerRef }: { playerRef: React.MutableRefObject<THR
     <>
       <mesh ref={ref}>
         <octahedronGeometry args={[0.18, 0]} />
-        <meshStandardMaterial color={active.color} emissive={active.color} emissiveIntensity={1.4 * fade} transparent opacity={0.9 * fade} />
+        <meshStandardMaterial
+          color={active.color}
+          emissive={active.color}
+          emissiveIntensity={1.4 * fade}
+          transparent
+          opacity={0.9 * fade}
+        />
       </mesh>
-      <pointLight ref={lightRef} color={active.color} intensity={1.2 * fade} distance={4} decay={1.5} />
+      <pointLight
+        ref={lightRef}
+        color={active.color}
+        intensity={1.2 * fade}
+        distance={4}
+        decay={1.5}
+      />
     </>
   )
 }
 
 /** Listens for the local player's chat sends and pops a speech bubble over their head. */
 function SelfChatBubble() {
-  const [bubble, setBubble] = useState<{ text: string; ts: number } | null>(null)
+  const [bubble, setBubble] = useState<{ text: string; ts: number } | null>(
+    null,
+  )
   useEffect(() => {
     const onChat = (ev: Event) => {
       const detail = (ev as CustomEvent).detail as string | undefined
@@ -2210,7 +3581,8 @@ function SelfChatBubble() {
       setBubble({ text: detail, ts: Date.now() })
     }
     window.addEventListener('hermes-playground-self-chat-bubble', onChat)
-    return () => window.removeEventListener('hermes-playground-self-chat-bubble', onChat)
+    return () =>
+      window.removeEventListener('hermes-playground-self-chat-bubble', onChat)
   }, [])
   useEffect(() => {
     if (!bubble) return
@@ -2300,27 +3672,46 @@ function BotPlayer({
         <meshBasicMaterial color="black" transparent opacity={0.4} />
       </mesh>
       {/* legs */}
-      <mesh position={[0.13, 0.22, 0]} rotation={[moving.current ? limbSwing * 0.5 : 0, 0, 0]} castShadow>
+      <mesh
+        position={[0.13, 0.22, 0]}
+        rotation={[moving.current ? limbSwing * 0.5 : 0, 0, 0]}
+        castShadow
+      >
         <boxGeometry args={[0.14, 0.44, 0.14]} />
         <meshStandardMaterial color="#1f2a37" roughness={0.6} />
       </mesh>
-      <mesh position={[-0.13, 0.22, 0]} rotation={[moving.current ? -limbSwing * 0.5 : 0, 0, 0]} castShadow>
+      <mesh
+        position={[-0.13, 0.22, 0]}
+        rotation={[moving.current ? -limbSwing * 0.5 : 0, 0, 0]}
+        castShadow
+      >
         <boxGeometry args={[0.14, 0.44, 0.14]} />
         <meshStandardMaterial color="#1f2a37" roughness={0.6} />
       </mesh>
       {/* feet */}
-      <mesh position={[0.13, 0.04, moving.current ? limbSwing * 0.16 : 0]} castShadow>
+      <mesh
+        position={[0.13, 0.04, moving.current ? limbSwing * 0.16 : 0]}
+        castShadow
+      >
         <boxGeometry args={[0.18, 0.07, 0.28]} />
         <meshStandardMaterial color="#0f172a" roughness={0.7} />
       </mesh>
-      <mesh position={[-0.13, 0.04, moving.current ? -limbSwing * 0.16 : 0]} castShadow>
+      <mesh
+        position={[-0.13, 0.04, moving.current ? -limbSwing * 0.16 : 0]}
+        castShadow
+      >
         <boxGeometry args={[0.18, 0.07, 0.28]} />
         <meshStandardMaterial color="#0f172a" roughness={0.7} />
       </mesh>
       {/* torso */}
       <mesh position={[0, 0.7, 0]} castShadow>
         <boxGeometry args={[0.5, 0.55, 0.32]} />
-        <meshStandardMaterial color={bot.color} roughness={0.55} emissive={bot.color} emissiveIntensity={0.15} />
+        <meshStandardMaterial
+          color={bot.color}
+          roughness={0.55}
+          emissive={bot.color}
+          emissiveIntensity={0.15}
+        />
       </mesh>
       {/* belt */}
       <mesh position={[0, 0.46, 0]} castShadow>
@@ -2328,11 +3719,19 @@ function BotPlayer({
         <meshStandardMaterial color="#fbbf24" metalness={0.4} roughness={0.4} />
       </mesh>
       {/* arms */}
-      <mesh position={[0.32, 0.7, 0]} rotation={[moving.current ? -limbSwing * 0.6 : 0, 0, 0.05]} castShadow>
+      <mesh
+        position={[0.32, 0.7, 0]}
+        rotation={[moving.current ? -limbSwing * 0.6 : 0, 0, 0.05]}
+        castShadow
+      >
         <boxGeometry args={[0.13, 0.5, 0.13]} />
         <meshStandardMaterial color={bot.color} roughness={0.55} />
       </mesh>
-      <mesh position={[-0.32, 0.7, 0]} rotation={[moving.current ? limbSwing * 0.6 : 0, 0, -0.05]} castShadow>
+      <mesh
+        position={[-0.32, 0.7, 0]}
+        rotation={[moving.current ? limbSwing * 0.6 : 0, 0, -0.05]}
+        castShadow
+      >
         <boxGeometry args={[0.13, 0.5, 0.13]} />
         <meshStandardMaterial color={bot.color} roughness={0.55} />
       </mesh>
@@ -2356,27 +3755,87 @@ function BotPlayer({
         <meshStandardMaterial color="#fde68a" roughness={0.55} />
       </mesh>
       {/* eyes */}
-      <mesh position={[0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color="#0b1220" /></mesh>
-      <mesh position={[-0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color="#0b1220" /></mesh>
+      <mesh position={[0.085, 1.24, 0.19]}>
+        <sphereGeometry args={[0.025, 8, 8]} />
+        <meshStandardMaterial color="#0b1220" />
+      </mesh>
+      <mesh position={[-0.085, 1.24, 0.19]}>
+        <sphereGeometry args={[0.025, 8, 8]} />
+        <meshStandardMaterial color="#0b1220" />
+      </mesh>
       {/* hair cap (bot) */}
       <mesh position={[0, 1.34, -0.02]} castShadow>
-        <sphereGeometry args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]} />
-        <meshStandardMaterial color={bot.color} roughness={0.85} emissive={bot.color} emissiveIntensity={0.18} />
+        <sphereGeometry
+          args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]}
+        />
+        <meshStandardMaterial
+          color={bot.color}
+          roughness={0.85}
+          emissive={bot.color}
+          emissiveIntensity={0.18}
+        />
       </mesh>
       {/* shoulder pads (bot) */}
-      <mesh castShadow position={[-0.36, 0.96, 0]} rotation={[0, 0, 0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color="#0e7490" metalness={0.45} roughness={0.45} /></mesh>
-      <mesh castShadow position={[0.36, 0.96, 0]} rotation={[0, 0, -0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color="#0e7490" metalness={0.45} roughness={0.45} /></mesh>
+      <mesh castShadow position={[-0.36, 0.96, 0]} rotation={[0, 0, 0.4]}>
+        <boxGeometry args={[0.24, 0.12, 0.2]} />
+        <meshStandardMaterial
+          color="#0e7490"
+          metalness={0.45}
+          roughness={0.45}
+        />
+      </mesh>
+      <mesh castShadow position={[0.36, 0.96, 0]} rotation={[0, 0, -0.4]}>
+        <boxGeometry args={[0.24, 0.12, 0.2]} />
+        <meshStandardMaterial
+          color="#0e7490"
+          metalness={0.45}
+          roughness={0.45}
+        />
+      </mesh>
       {/* nameplate w/ portrait chip */}
       <Html position={[0, 1.95, 0]} center distanceFactor={8}>
-        <div style={{display:'flex',alignItems:'center',gap:6,padding:'2px 8px 2px 2px',background:'rgba(0,0,0,0.78)',color:bot.color,borderRadius:14,fontSize:11,fontWeight:700,whiteSpace:'nowrap',border:`1px solid ${bot.color}55`,boxShadow:`0 0 8px ${bot.color}33`}}>
-          <img src={`/avatars/${bot.avatar}.png`} alt="" loading="lazy" decoding="async" style={{width:22,height:22,borderRadius:'50%',background:bot.color,objectFit:'cover',border:`1px solid ${bot.color}`}} />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '2px 8px 2px 2px',
+            background: 'rgba(0,0,0,0.78)',
+            color: bot.color,
+            borderRadius: 14,
+            fontSize: 11,
+            fontWeight: 700,
+            whiteSpace: 'nowrap',
+            border: `1px solid ${bot.color}55`,
+            boxShadow: `0 0 8px ${bot.color}33`,
+          }}
+        >
+          <img
+            src={`/avatars/${bot.avatar}.png`}
+            alt=""
+            loading="lazy"
+            decoding="async"
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: bot.color,
+              objectFit: 'cover',
+              border: `1px solid ${bot.color}`,
+            }}
+          />
           <span>{bot.name}</span>
         </div>
       </Html>
       {/* chat bubble */}
       {bubbleText && (
         <Html position={[0, 2.6, 0]} center distanceFactor={8}>
-          <SpeechBubble className="hermes-world-bubble" variant="party" accent={bot.color} compact>
+          <SpeechBubble
+            className="hermes-world-bubble"
+            variant="party"
+            accent={bot.color}
+            compact
+          >
             {bubbleText}
           </SpeechBubble>
         </Html>
@@ -2385,22 +3844,78 @@ function BotPlayer({
   )
 }
 
-
 type InteriorId = 'tavern' | 'bank' | 'smithy' | 'inn' | 'apothecary' | 'guild'
 
-const INTERIORS: Record<InteriorId, { title: string; accent: string; keeper: string; keeperNpc: string; keeperAvatar: string; keeperColor: string }> = {
-  tavern: { title: 'The Signal & Satyr Tavern', accent: '#f59e0b', keeper: 'Selene · Tavern Keeper', keeperNpc: 'tavernkeeper', keeperAvatar: 'apollo', keeperColor: '#f59e0b' },
-  bank: { title: 'Midas Memory Bank', accent: '#facc15', keeper: 'Midas · Banker', keeperNpc: 'banker', keeperAvatar: 'chronos', keeperColor: '#facc15' },
-  smithy: { title: 'Promptforge Smithy', accent: '#fb7185', keeper: 'Leonidas · Trainer', keeperNpc: 'trainer', keeperAvatar: 'nike', keeperColor: '#fb7185' },
-  inn: { title: 'Wayfarer Inn', accent: '#86efac', keeper: 'Hestia · Innkeeper', keeperNpc: 'innkeeper', keeperAvatar: 'athena', keeperColor: '#86efac' },
-  apothecary: { title: 'Eros’ Apothecary', accent: '#f472b6', keeper: 'Eros · Apothecary', keeperNpc: 'apothecary', keeperAvatar: 'eros', keeperColor: '#f472b6' },
-  guild: { title: 'Builders’ Guild Hall', accent: '#a78bfa', keeper: 'Cassia · Recruiter', keeperNpc: 'recruiter', keeperAvatar: 'athena', keeperColor: '#a78bfa' },
+const INTERIORS: Record<
+  InteriorId,
+  {
+    title: string
+    accent: string
+    keeper: string
+    keeperNpc: string
+    keeperAvatar: string
+    keeperColor: string
+  }
+> = {
+  tavern: {
+    title: 'The Signal & Satyr Tavern',
+    accent: '#f59e0b',
+    keeper: 'Selene · Tavern Keeper',
+    keeperNpc: 'tavernkeeper',
+    keeperAvatar: 'apollo',
+    keeperColor: '#f59e0b',
+  },
+  bank: {
+    title: 'Midas Memory Bank',
+    accent: '#facc15',
+    keeper: 'Midas · Banker',
+    keeperNpc: 'banker',
+    keeperAvatar: 'chronos',
+    keeperColor: '#facc15',
+  },
+  smithy: {
+    title: 'Promptforge Smithy',
+    accent: '#fb7185',
+    keeper: 'Leonidas · Trainer',
+    keeperNpc: 'trainer',
+    keeperAvatar: 'nike',
+    keeperColor: '#fb7185',
+  },
+  inn: {
+    title: 'Wayfarer Inn',
+    accent: '#86efac',
+    keeper: 'Hestia · Innkeeper',
+    keeperNpc: 'innkeeper',
+    keeperAvatar: 'athena',
+    keeperColor: '#86efac',
+  },
+  apothecary: {
+    title: 'Eros’ Apothecary',
+    accent: '#f472b6',
+    keeper: 'Eros · Apothecary',
+    keeperNpc: 'apothecary',
+    keeperAvatar: 'eros',
+    keeperColor: '#f472b6',
+  },
+  guild: {
+    title: 'Builders’ Guild Hall',
+    accent: '#a78bfa',
+    keeper: 'Cassia · Recruiter',
+    keeperNpc: 'recruiter',
+    keeperAvatar: 'athena',
+    keeperColor: '#a78bfa',
+  },
 }
 
 function matchesObjectiveTarget(current: string | null, candidate: string) {
   if (!current) return false
   if (current === candidate) return true
-  if (current === 'build-demo') return candidate === 'build-demo' || candidate === 'athena' || candidate === 'pan'
+  if (current === 'build-demo')
+    return (
+      candidate === 'build-demo' ||
+      candidate === 'athena' ||
+      candidate === 'pan'
+    )
   return false
 }
 
@@ -2429,17 +3944,38 @@ function DoorTrigger({
     if (dist < 1.25 && !triggered.current) {
       triggered.current = true
       onEnter()
-      window.setTimeout(() => { triggered.current = false }, 1200)
+      window.setTimeout(() => {
+        triggered.current = false
+      }, 1200)
     }
   })
   return (
     <group position={position}>
       <mesh ref={ref} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.06, 0]}>
         <ringGeometry args={[0.72, 0.95, 28]} />
-        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.7} transparent opacity={0.8} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={0.7}
+          transparent
+          opacity={0.8}
+        />
       </mesh>
       <Html position={[0, 1.5, 0]} center distanceFactor={8}>
-        <div style={{padding:'3px 8px',background:'rgba(0,0,0,0.75)',color,borderRadius:6,fontSize:11,fontWeight:800,whiteSpace:'nowrap',border:`1px solid ${color}`}}>Enter {label}</div>
+        <div
+          style={{
+            padding: '3px 8px',
+            background: 'rgba(0,0,0,0.75)',
+            color,
+            borderRadius: 6,
+            fontSize: 11,
+            fontWeight: 800,
+            whiteSpace: 'nowrap',
+            border: `1px solid ${color}`,
+          }}
+        >
+          Enter {label}
+        </div>
       </Html>
     </group>
   )
@@ -2466,55 +4002,198 @@ function InteriorScene({
     <>
       <color attach="background" args={['#08070b']} />
       <fog attach="fog" args={['#08070b', 18, 38]} />
-      <hemisphereLight intensity={0.35} color={'#fff1d0'} groundColor={'#251609'} />
+      <hemisphereLight
+        intensity={0.35}
+        color={'#fff1d0'}
+        groundColor={'#251609'}
+      />
       <ambientLight intensity={0.42} color={'#f4c982'} />
-      <directionalLight castShadow position={[6, 10, 8]} intensity={1.1} color={'#ffe4b5'} shadow-mapSize={[1024, 1024]} />
-      <pointLight position={[0, 3, -2]} color={info.accent} intensity={photosensitiveMode ? 0.8 : 2.1} distance={16} />
+      <directionalLight
+        castShadow
+        position={[6, 10, 8]}
+        intensity={1.1}
+        color={'#ffe4b5'}
+        shadow-mapSize={[1024, 1024]}
+      />
+      <pointLight
+        position={[0, 3, -2]}
+        color={info.accent}
+        intensity={photosensitiveMode ? 0.8 : 2.1}
+        distance={16}
+      />
 
       {/* click-to-walk interior floor catcher */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.007, 0]} onPointerDown={(e) => {
-        e.stopPropagation()
-        const x = THREE.MathUtils.clamp(e.point.x, -8, 8)
-        const z = THREE.MathUtils.clamp(e.point.z, -7, 7)
-        moveTargetRef.current = new THREE.Vector3(x, 0, z)
-        setPingPos([x, 0.05, z])
-        window.setTimeout(() => setPingPos(null), 700)
-      }}>
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.007, 0]}
+        onPointerDown={(e) => {
+          e.stopPropagation()
+          const x = THREE.MathUtils.clamp(e.point.x, -8, 8)
+          const z = THREE.MathUtils.clamp(e.point.z, -7, 7)
+          moveTargetRef.current = new THREE.Vector3(x, 0, z)
+          setPingPos([x, 0.05, z])
+          window.setTimeout(() => setPingPos(null), 700)
+        }}
+      >
         <planeGeometry args={[18, 16, 1, 1]} />
         <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
-      {pingPos && !photosensitiveMode && <mesh position={pingPos} rotation={[-Math.PI / 2, 0, 0]}><ringGeometry args={[0.45, 0.6, 32]} /><meshBasicMaterial color={info.accent} transparent opacity={0.55} /></mesh>}
+      {pingPos && !photosensitiveMode && (
+        <mesh position={pingPos} rotation={[-Math.PI / 2, 0, 0]}>
+          <ringGeometry args={[0.45, 0.6, 32]} />
+          <meshBasicMaterial color={info.accent} transparent opacity={0.55} />
+        </mesh>
+      )}
 
       <InteriorRoom id={id} accent={info.accent} />
-      <NPC npcId={info.keeperNpc} position={[0, 0, -3.8]} avatar={info.keeperAvatar} name={info.keeper} color={info.keeperColor} drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />
+      <NPC
+        npcId={info.keeperNpc}
+        position={[0, 0, -3.8]}
+        avatar={info.keeperAvatar}
+        name={info.keeper}
+        color={info.keeperColor}
+        drift={false}
+        playerRef={playerRef}
+        onNearChange={onNpcNearChange}
+      />
       {id === 'tavern' && (
         <>
-          <NPC npcId="apollo" position={[-4.5, 0, 1.5]} avatar="apollo" name="Apollo · Bard" color="#f59e0b" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />
-          <NPC npcId="iris" position={[4.5, 0, 1.2]} avatar="iris" name="Iris · Messenger" color="#22d3ee" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />
+          <NPC
+            npcId="apollo"
+            position={[-4.5, 0, 1.5]}
+            avatar="apollo"
+            name="Apollo · Bard"
+            color="#f59e0b"
+            drift={false}
+            playerRef={playerRef}
+            onNearChange={onNpcNearChange}
+          />
+          <NPC
+            npcId="iris"
+            position={[4.5, 0, 1.2]}
+            avatar="iris"
+            name="Iris · Messenger"
+            color="#22d3ee"
+            drift={false}
+            playerRef={playerRef}
+            onNearChange={onNpcNearChange}
+          />
         </>
       )}
-      {id === 'bank' && <NPC npcId="chronos" position={[-4.5, 0, 1.2]} avatar="chronos" name="Chronos · Archivist" color="#facc15" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />}
-      {id === 'smithy' && <NPC npcId="pan" position={[4.4, 0, 1.3]} avatar="pan" name="Pan · Toolwright" color="#34d399" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />}
-      {id === 'inn' && <NPC npcId="apollo" position={[4.4, 0, 1.5]} avatar="apollo" name="Apollo · Bard at Rest" color="#f59e0b" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />}
-      {id === 'apothecary' && <NPC npcId="chronos" position={[-4.4, 0, 1.5]} avatar="chronos" name="Chronos · Lab Notes" color="#facc15" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />}
-      {id === 'guild' && <>
-        <NPC npcId="nike" position={[-4.4, 0, 1.5]} avatar="nike" name="Nike · Raid Captain" color="#fb7185" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />
-        <NPC npcId="hermes" position={[4.4, 0, 1.5]} avatar="hermes" name="Hermes · Guildmaster" color="#2dd4bf" drift={false} playerRef={playerRef} onNearChange={onNpcNearChange} />
-      </>}
+      {id === 'bank' && (
+        <NPC
+          npcId="chronos"
+          position={[-4.5, 0, 1.2]}
+          avatar="chronos"
+          name="Chronos · Archivist"
+          color="#facc15"
+          drift={false}
+          playerRef={playerRef}
+          onNearChange={onNpcNearChange}
+        />
+      )}
+      {id === 'smithy' && (
+        <NPC
+          npcId="pan"
+          position={[4.4, 0, 1.3]}
+          avatar="pan"
+          name="Pan · Toolwright"
+          color="#34d399"
+          drift={false}
+          playerRef={playerRef}
+          onNearChange={onNpcNearChange}
+        />
+      )}
+      {id === 'inn' && (
+        <NPC
+          npcId="apollo"
+          position={[4.4, 0, 1.5]}
+          avatar="apollo"
+          name="Apollo · Bard at Rest"
+          color="#f59e0b"
+          drift={false}
+          playerRef={playerRef}
+          onNearChange={onNpcNearChange}
+        />
+      )}
+      {id === 'apothecary' && (
+        <NPC
+          npcId="chronos"
+          position={[-4.4, 0, 1.5]}
+          avatar="chronos"
+          name="Chronos · Lab Notes"
+          color="#facc15"
+          drift={false}
+          playerRef={playerRef}
+          onNearChange={onNpcNearChange}
+        />
+      )}
+      {id === 'guild' && (
+        <>
+          <NPC
+            npcId="nike"
+            position={[-4.4, 0, 1.5]}
+            avatar="nike"
+            name="Nike · Raid Captain"
+            color="#fb7185"
+            drift={false}
+            playerRef={playerRef}
+            onNearChange={onNpcNearChange}
+          />
+          <NPC
+            npcId="hermes"
+            position={[4.4, 0, 1.5]}
+            avatar="hermes"
+            name="Hermes · Guildmaster"
+            color="#2dd4bf"
+            drift={false}
+            playerRef={playerRef}
+            onNearChange={onNpcNearChange}
+          />
+        </>
+      )}
 
       <ExitTrigger playerRef={playerRef} onExit={onExit} accent={info.accent} />
       <InteriorExitButton onExit={onExit} accent={info.accent} />
       <Suspense fallback={null}>
-        <PlayerAndCamera positionRef={playerRef} spawn={[0, 0, 4.7]} moveTargetRef={moveTargetRef} bounds={{ x: 8, z: 7 }} />
+        <PlayerAndCamera
+          positionRef={playerRef}
+          spawn={[0, 0, 4.7]}
+          moveTargetRef={moveTargetRef}
+          bounds={{ x: 8, z: 7 }}
+        />
       </Suspense>
       <Html position={[0, 4.2, -6.8]} center distanceFactor={10}>
-        <div style={{padding:'6px 12px',background:'rgba(0,0,0,0.78)',color:info.accent,border:`1px solid ${info.accent}`,borderRadius:10,fontSize:14,fontWeight:900,whiteSpace:'nowrap',letterSpacing:'0.08em',textTransform:'uppercase'}}>{info.title}</div>
+        <div
+          style={{
+            padding: '6px 12px',
+            background: 'rgba(0,0,0,0.78)',
+            color: info.accent,
+            border: `1px solid ${info.accent}`,
+            borderRadius: 10,
+            fontSize: 14,
+            fontWeight: 900,
+            whiteSpace: 'nowrap',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {info.title}
+        </div>
       </Html>
     </>
   )
 }
 
-function ExitTrigger({ playerRef, onExit, accent }: { playerRef: React.MutableRefObject<THREE.Vector3>; onExit: () => void; accent: string }) {
+function ExitTrigger({
+  playerRef,
+  onExit,
+  accent,
+}: {
+  playerRef: React.MutableRefObject<THREE.Vector3>
+  onExit: () => void
+  accent: string
+}) {
   const triggered = useRef(false)
   const center = useMemo(() => new THREE.Vector3(0, 0, 6.2), [])
   useFrame(() => {
@@ -2522,7 +4201,9 @@ function ExitTrigger({ playerRef, onExit, accent }: { playerRef: React.MutableRe
     if (dist < 1.6 && !triggered.current) {
       triggered.current = true
       onExit()
-      window.setTimeout(() => { triggered.current = false }, 1200)
+      window.setTimeout(() => {
+        triggered.current = false
+      }, 1200)
     }
   })
   return (
@@ -2531,22 +4212,64 @@ function ExitTrigger({ playerRef, onExit, accent }: { playerRef: React.MutableRe
       <mesh
         rotation={[-Math.PI / 2, 0, 0]}
         position={[0, 0.05, 0]}
-        onPointerDown={(e) => { e.stopPropagation(); if (!triggered.current) { triggered.current = true; onExit() } }}
+        onPointerDown={(e) => {
+          e.stopPropagation()
+          if (!triggered.current) {
+            triggered.current = true
+            onExit()
+          }
+        }}
       >
         <ringGeometry args={[0.8, 1.5, 32]} />
-        <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.8} transparent opacity={0.85} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.8}
+          transparent
+          opacity={0.85}
+        />
       </mesh>
       {/* Glowing pillar so you can see the exit from anywhere in the room. */}
       <mesh position={[0, 1.6, 0]}>
         <cylinderGeometry args={[0.08, 0.08, 3, 8]} />
-        <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={1.2} transparent opacity={0.6} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.2}
+          transparent
+          opacity={0.6}
+        />
       </mesh>
-      <pointLight position={[0, 1.6, 0]} color={accent} intensity={1.6} distance={8} />
+      <pointLight
+        position={[0, 1.6, 0]}
+        color={accent}
+        intensity={1.6}
+        distance={8}
+      />
       <Html position={[0, 2.3, 0]} center distanceFactor={8}>
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); if (!triggered.current) { triggered.current = true; onExit() } }}
-          style={{padding:'4px 12px',background:accent,color:'#000',borderRadius:8,fontSize:11,fontWeight:800,whiteSpace:'nowrap',border:'none',cursor:'pointer',boxShadow:`0 0 14px ${accent}`,letterSpacing:'0.1em',textTransform:'uppercase'}}
+          onClick={(e) => {
+            e.stopPropagation()
+            if (!triggered.current) {
+              triggered.current = true
+              onExit()
+            }
+          }}
+          style={{
+            padding: '4px 12px',
+            background: accent,
+            color: '#000',
+            borderRadius: 8,
+            fontSize: 11,
+            fontWeight: 800,
+            whiteSpace: 'nowrap',
+            border: 'none',
+            cursor: 'pointer',
+            boxShadow: `0 0 14px ${accent}`,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+          }}
         >
           → Exit to Agora
         </button>
@@ -2556,7 +4279,13 @@ function ExitTrigger({ playerRef, onExit, accent }: { playerRef: React.MutableRe
 }
 
 /** Always-visible exit button for interiors — fixed in HUD so the user can leave even if the floor trigger fails. */
-function InteriorExitButton({ onExit, accent }: { onExit: () => void; accent: string }) {
+function InteriorExitButton({
+  onExit,
+  accent,
+}: {
+  onExit: () => void
+  accent: string
+}) {
   return (
     <Html fullscreen>
       <button
@@ -2589,22 +4318,61 @@ function InteriorExitButton({ onExit, accent }: { onExit: () => void; accent: st
 }
 
 function InteriorRoom({ id, accent }: { id: InteriorId; accent: string }) {
-  const wallColor = id === 'bank' ? '#1f2937' : id === 'smithy' ? '#281512' : '#2b1d12'
-  const floorColor = id === 'bank' ? '#5b6470' : id === 'smithy' ? '#51301b' : '#6b4528'
+  const wallColor =
+    id === 'bank' ? '#1f2937' : id === 'smithy' ? '#281512' : '#2b1d12'
+  const floorColor =
+    id === 'bank' ? '#5b6470' : id === 'smithy' ? '#51301b' : '#6b4528'
   return (
     <group>
       {/* floor + carpet */}
-      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}><planeGeometry args={[18, 16]} /><meshStandardMaterial color={floorColor} roughness={0.92} /></mesh>
-      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.012, 0]}><planeGeometry args={[5.5, 9]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.06} roughness={0.7} transparent opacity={0.55} /></mesh>
+      <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+        <planeGeometry args={[18, 16]} />
+        <meshStandardMaterial color={floorColor} roughness={0.92} />
+      </mesh>
+      <mesh
+        receiveShadow
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.012, 0]}
+      >
+        <planeGeometry args={[5.5, 9]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.06}
+          roughness={0.7}
+          transparent
+          opacity={0.55}
+        />
+      </mesh>
       {/* walls */}
-      <mesh receiveShadow castShadow position={[0, 2, -8]}><boxGeometry args={[18, 4, 0.35]} /><meshStandardMaterial color={wallColor} roughness={0.78} /></mesh>
-      <mesh receiveShadow castShadow position={[-9, 2, 0]}><boxGeometry args={[0.35, 4, 16]} /><meshStandardMaterial color={wallColor} roughness={0.78} /></mesh>
-      <mesh receiveShadow castShadow position={[9, 2, 0]}><boxGeometry args={[0.35, 4, 16]} /><meshStandardMaterial color={wallColor} roughness={0.78} /></mesh>
-      <mesh receiveShadow castShadow position={[0, 2, 8]}><boxGeometry args={[18, 4, 0.35]} /><meshStandardMaterial color={wallColor} roughness={0.78} /></mesh>
+      <mesh receiveShadow castShadow position={[0, 2, -8]}>
+        <boxGeometry args={[18, 4, 0.35]} />
+        <meshStandardMaterial color={wallColor} roughness={0.78} />
+      </mesh>
+      <mesh receiveShadow castShadow position={[-9, 2, 0]}>
+        <boxGeometry args={[0.35, 4, 16]} />
+        <meshStandardMaterial color={wallColor} roughness={0.78} />
+      </mesh>
+      <mesh receiveShadow castShadow position={[9, 2, 0]}>
+        <boxGeometry args={[0.35, 4, 16]} />
+        <meshStandardMaterial color={wallColor} roughness={0.78} />
+      </mesh>
+      <mesh receiveShadow castShadow position={[0, 2, 8]}>
+        <boxGeometry args={[18, 4, 0.35]} />
+        <meshStandardMaterial color={wallColor} roughness={0.78} />
+      </mesh>
       {/* open door cutout visual */}
-      <mesh position={[0, 1, 7.78]}><boxGeometry args={[2.2, 2.1, 0.08]} /><meshStandardMaterial color="#090909" emissive="#000" /></mesh>
+      <mesh position={[0, 1, 7.78]}>
+        <boxGeometry args={[2.2, 2.1, 0.08]} />
+        <meshStandardMaterial color="#090909" emissive="#000" />
+      </mesh>
       {/* ceiling beams */}
-      {[-6, -3, 0, 3, 6].map((x) => <mesh key={x} castShadow position={[x, 3.92, 0]}><boxGeometry args={[0.22, 0.2, 16]} /><meshStandardMaterial color="#3f2511" roughness={0.8} /></mesh>)}
+      {[-6, -3, 0, 3, 6].map((x) => (
+        <mesh key={x} castShadow position={[x, 3.92, 0]}>
+          <boxGeometry args={[0.22, 0.2, 16]} />
+          <meshStandardMaterial color="#3f2511" roughness={0.8} />
+        </mesh>
+      ))}
 
       {id === 'tavern' && <TavernProps accent={accent} />}
       {id === 'bank' && <BankProps accent={accent} />}
@@ -2617,84 +4385,322 @@ function InteriorRoom({ id, accent }: { id: InteriorId; accent: string }) {
 }
 
 function TavernProps({ accent }: { accent: string }) {
-  return <group>
-    <mesh castShadow position={[0, 0.55, -5.8]}><boxGeometry args={[5.6, 1.1, 1]} /><meshStandardMaterial color="#7c4a1f" roughness={0.8} /></mesh>
-    {[-6, -3, 3, 6].map((x) => <group key={x} position={[x, 0, 2]}><mesh castShadow position={[0, 0.42, 0]}><boxGeometry args={[1.2, 0.18, 1.2]} /><meshStandardMaterial color="#7c4a1f" /></mesh><mesh castShadow position={[0, 0.22, 0]}><cylinderGeometry args={[0.12, 0.16, 0.44, 8]} /><meshStandardMaterial color="#3f2511" /></mesh><mesh castShadow position={[0.75, 0.42, 0.65]}><boxGeometry args={[0.32, 0.85, 0.32]} /><meshStandardMaterial color="#6b3a18" /></mesh></group>)}
-    <mesh castShadow position={[-6.8, 1.2, -6.8]}><boxGeometry args={[2.2, 2.2, 0.35]} /><meshStandardMaterial color="#2b1008" emissive="#ef4444" emissiveIntensity={0.25} /></mesh>
-    <pointLight position={[-6.8, 1.4, -6.4]} color="#f97316" intensity={2.2} distance={8} />
-    <mesh position={[0, 1.5, -7.7]}><boxGeometry args={[2.4, 0.5, 0.08]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.3} /></mesh>
-  </group>
+  return (
+    <group>
+      <mesh castShadow position={[0, 0.55, -5.8]}>
+        <boxGeometry args={[5.6, 1.1, 1]} />
+        <meshStandardMaterial color="#7c4a1f" roughness={0.8} />
+      </mesh>
+      {[-6, -3, 3, 6].map((x) => (
+        <group key={x} position={[x, 0, 2]}>
+          <mesh castShadow position={[0, 0.42, 0]}>
+            <boxGeometry args={[1.2, 0.18, 1.2]} />
+            <meshStandardMaterial color="#7c4a1f" />
+          </mesh>
+          <mesh castShadow position={[0, 0.22, 0]}>
+            <cylinderGeometry args={[0.12, 0.16, 0.44, 8]} />
+            <meshStandardMaterial color="#3f2511" />
+          </mesh>
+          <mesh castShadow position={[0.75, 0.42, 0.65]}>
+            <boxGeometry args={[0.32, 0.85, 0.32]} />
+            <meshStandardMaterial color="#6b3a18" />
+          </mesh>
+        </group>
+      ))}
+      <mesh castShadow position={[-6.8, 1.2, -6.8]}>
+        <boxGeometry args={[2.2, 2.2, 0.35]} />
+        <meshStandardMaterial
+          color="#2b1008"
+          emissive="#ef4444"
+          emissiveIntensity={0.25}
+        />
+      </mesh>
+      <pointLight
+        position={[-6.8, 1.4, -6.4]}
+        color="#f97316"
+        intensity={2.2}
+        distance={8}
+      />
+      <mesh position={[0, 1.5, -7.7]}>
+        <boxGeometry args={[2.4, 0.5, 0.08]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.3}
+        />
+      </mesh>
+    </group>
+  )
 }
 
 function BankProps({ accent }: { accent: string }) {
-  return <group>
-    <mesh castShadow position={[0, 0.75, -5.8]}><boxGeometry args={[6.4, 1.5, 1]} /><meshStandardMaterial color="#374151" metalness={0.25} roughness={0.55} /></mesh>
-    {[-5.5, -3.5, 3.5, 5.5].map((x) => <mesh key={x} castShadow position={[x, 0.65, 1]}><boxGeometry args={[1, 1.3, 1]} /><meshStandardMaterial color="#111827" metalness={0.45} roughness={0.35} /></mesh>)}
-    <mesh castShadow position={[6.9, 1.4, -5.6]}><boxGeometry args={[1.4, 2.4, 0.5]} /><meshStandardMaterial color="#0f172a" metalness={0.55} roughness={0.35} emissive={accent} emissiveIntensity={0.05} /></mesh>
-    <mesh position={[6.9, 1.4, -5.28]}><circleGeometry args={[0.35, 24]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.7} /></mesh>
-  </group>
+  return (
+    <group>
+      <mesh castShadow position={[0, 0.75, -5.8]}>
+        <boxGeometry args={[6.4, 1.5, 1]} />
+        <meshStandardMaterial
+          color="#374151"
+          metalness={0.25}
+          roughness={0.55}
+        />
+      </mesh>
+      {[-5.5, -3.5, 3.5, 5.5].map((x) => (
+        <mesh key={x} castShadow position={[x, 0.65, 1]}>
+          <boxGeometry args={[1, 1.3, 1]} />
+          <meshStandardMaterial
+            color="#111827"
+            metalness={0.45}
+            roughness={0.35}
+          />
+        </mesh>
+      ))}
+      <mesh castShadow position={[6.9, 1.4, -5.6]}>
+        <boxGeometry args={[1.4, 2.4, 0.5]} />
+        <meshStandardMaterial
+          color="#0f172a"
+          metalness={0.55}
+          roughness={0.35}
+          emissive={accent}
+          emissiveIntensity={0.05}
+        />
+      </mesh>
+      <mesh position={[6.9, 1.4, -5.28]}>
+        <circleGeometry args={[0.35, 24]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.7}
+        />
+      </mesh>
+    </group>
+  )
 }
 
 function SmithyProps({ accent }: { accent: string }) {
-  return <group>
-    <mesh castShadow position={[-4.8, 0.55, -4.8]}><boxGeometry args={[2.6, 1.1, 1.4]} /><meshStandardMaterial color="#7c2d12" roughness={0.75} emissive="#f97316" emissiveIntensity={0.18} /></mesh>
-    <pointLight position={[-4.8, 1.3, -4.8]} color="#fb923c" intensity={2.2} distance={8} />
-    <mesh castShadow position={[0, 0.45, -2.2]}><boxGeometry args={[1.35, 0.45, 0.9]} /><meshStandardMaterial color="#64748b" metalness={0.55} roughness={0.4} /></mesh>
-    <mesh castShadow position={[4.7, 0.8, -4.9]}><boxGeometry args={[2.8, 1.6, 0.8]} /><meshStandardMaterial color="#3f2511" roughness={0.85} /></mesh>
-    {[0, 1, 2].map((i) => <mesh key={i} castShadow position={[3.8 + i * 0.55, 1.75, -4.48]} rotation={[0, 0, -0.7]}><boxGeometry args={[0.08, 0.85, 0.08]} /><meshStandardMaterial color={accent} metalness={0.55} roughness={0.36} emissive={accent} emissiveIntensity={0.2} /></mesh>)}
-  </group>
+  return (
+    <group>
+      <mesh castShadow position={[-4.8, 0.55, -4.8]}>
+        <boxGeometry args={[2.6, 1.1, 1.4]} />
+        <meshStandardMaterial
+          color="#7c2d12"
+          roughness={0.75}
+          emissive="#f97316"
+          emissiveIntensity={0.18}
+        />
+      </mesh>
+      <pointLight
+        position={[-4.8, 1.3, -4.8]}
+        color="#fb923c"
+        intensity={2.2}
+        distance={8}
+      />
+      <mesh castShadow position={[0, 0.45, -2.2]}>
+        <boxGeometry args={[1.35, 0.45, 0.9]} />
+        <meshStandardMaterial
+          color="#64748b"
+          metalness={0.55}
+          roughness={0.4}
+        />
+      </mesh>
+      <mesh castShadow position={[4.7, 0.8, -4.9]}>
+        <boxGeometry args={[2.8, 1.6, 0.8]} />
+        <meshStandardMaterial color="#3f2511" roughness={0.85} />
+      </mesh>
+      {[0, 1, 2].map((i) => (
+        <mesh
+          key={i}
+          castShadow
+          position={[3.8 + i * 0.55, 1.75, -4.48]}
+          rotation={[0, 0, -0.7]}
+        >
+          <boxGeometry args={[0.08, 0.85, 0.08]} />
+          <meshStandardMaterial
+            color={accent}
+            metalness={0.55}
+            roughness={0.36}
+            emissive={accent}
+            emissiveIntensity={0.2}
+          />
+        </mesh>
+      ))}
+    </group>
+  )
 }
 
 function InnProps({ accent }: { accent: string }) {
-  return <group>
-    {/* fireplace */}
-    <mesh castShadow position={[-7, 1.2, -6.8]}><boxGeometry args={[2.4, 2.4, 0.4]} /><meshStandardMaterial color="#1f2937" emissive="#f97316" emissiveIntensity={0.35} /></mesh>
-    <pointLight position={[-7, 1.6, -6.4]} color="#fb923c" intensity={2.4} distance={9} />
-    {/* beds */}
-    {[-3, 0, 3].map((x) => <group key={x} position={[x, 0, -5]}>
-      <mesh castShadow position={[0, 0.3, 0]}><boxGeometry args={[1.6, 0.4, 0.9]} /><meshStandardMaterial color="#3f2511" roughness={0.85} /></mesh>
-      <mesh castShadow position={[0, 0.55, -0.05]}><boxGeometry args={[1.5, 0.18, 0.8]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.15} roughness={0.7} /></mesh>
-      <mesh castShadow position={[-0.6, 0.7, 0.05]}><boxGeometry args={[0.3, 0.18, 0.5]} /><meshStandardMaterial color="#fff7ed" /></mesh>
-    </group>)}
-    {/* counter */}
-    <mesh castShadow position={[6.4, 0.55, -5]}><boxGeometry args={[3.2, 1.1, 1]} /><meshStandardMaterial color="#7c4a1f" roughness={0.8} /></mesh>
-  </group>
+  return (
+    <group>
+      {/* fireplace */}
+      <mesh castShadow position={[-7, 1.2, -6.8]}>
+        <boxGeometry args={[2.4, 2.4, 0.4]} />
+        <meshStandardMaterial
+          color="#1f2937"
+          emissive="#f97316"
+          emissiveIntensity={0.35}
+        />
+      </mesh>
+      <pointLight
+        position={[-7, 1.6, -6.4]}
+        color="#fb923c"
+        intensity={2.4}
+        distance={9}
+      />
+      {/* beds */}
+      {[-3, 0, 3].map((x) => (
+        <group key={x} position={[x, 0, -5]}>
+          <mesh castShadow position={[0, 0.3, 0]}>
+            <boxGeometry args={[1.6, 0.4, 0.9]} />
+            <meshStandardMaterial color="#3f2511" roughness={0.85} />
+          </mesh>
+          <mesh castShadow position={[0, 0.55, -0.05]}>
+            <boxGeometry args={[1.5, 0.18, 0.8]} />
+            <meshStandardMaterial
+              color={accent}
+              emissive={accent}
+              emissiveIntensity={0.15}
+              roughness={0.7}
+            />
+          </mesh>
+          <mesh castShadow position={[-0.6, 0.7, 0.05]}>
+            <boxGeometry args={[0.3, 0.18, 0.5]} />
+            <meshStandardMaterial color="#fff7ed" />
+          </mesh>
+        </group>
+      ))}
+      {/* counter */}
+      <mesh castShadow position={[6.4, 0.55, -5]}>
+        <boxGeometry args={[3.2, 1.1, 1]} />
+        <meshStandardMaterial color="#7c4a1f" roughness={0.8} />
+      </mesh>
+    </group>
+  )
 }
 
 function ApothecaryProps({ accent }: { accent: string }) {
-  return <group>
-    {/* shelves of vials */}
-    {[-6, -3, 3, 6].map((x) => <group key={x} position={[x, 0, -6]}>
-      <mesh castShadow position={[0, 1.1, 0]}><boxGeometry args={[1.4, 2.2, 0.5]} /><meshStandardMaterial color="#3f2511" roughness={0.85} /></mesh>
-      {[0.5, 1.05, 1.6].map((y, i) => <mesh key={i} castShadow position={[0, y, 0.28]}><boxGeometry args={[1.3, 0.05, 0.05]} /><meshStandardMaterial color="#7c4a1f" /></mesh>)}
-      {[0.6, 1.15, 1.7].map((y, i) => [-0.4, 0, 0.4].map((vx) => <mesh key={`${i}-${vx}`} castShadow position={[vx, y, 0.3]}><cylinderGeometry args={[0.07, 0.05, 0.22, 8]} /><meshStandardMaterial color={[`#86efac`, `#a78bfa`, `#22d3ee`, `#fbbf24`, `#f472b6`, `#fb7185`][(i + Math.abs(Math.floor(vx))) % 6]} emissive={accent} emissiveIntensity={0.45} transparent opacity={0.85} /></mesh>))}
-    </group>)}
-    {/* counter */}
-    <mesh castShadow position={[0, 0.55, -2.5]}><boxGeometry args={[5, 1.1, 0.9]} /><meshStandardMaterial color="#7c4a1f" roughness={0.8} /></mesh>
-    {/* hanging lantern */}
-    <pointLight position={[0, 3.4, 0]} color={accent} intensity={2.2} distance={9} />
-  </group>
+  return (
+    <group>
+      {/* shelves of vials */}
+      {[-6, -3, 3, 6].map((x) => (
+        <group key={x} position={[x, 0, -6]}>
+          <mesh castShadow position={[0, 1.1, 0]}>
+            <boxGeometry args={[1.4, 2.2, 0.5]} />
+            <meshStandardMaterial color="#3f2511" roughness={0.85} />
+          </mesh>
+          {[0.5, 1.05, 1.6].map((y, i) => (
+            <mesh key={i} castShadow position={[0, y, 0.28]}>
+              <boxGeometry args={[1.3, 0.05, 0.05]} />
+              <meshStandardMaterial color="#7c4a1f" />
+            </mesh>
+          ))}
+          {[0.6, 1.15, 1.7].map((y, i) =>
+            [-0.4, 0, 0.4].map((vx) => (
+              <mesh key={`${i}-${vx}`} castShadow position={[vx, y, 0.3]}>
+                <cylinderGeometry args={[0.07, 0.05, 0.22, 8]} />
+                <meshStandardMaterial
+                  color={
+                    [
+                      `#86efac`,
+                      `#a78bfa`,
+                      `#22d3ee`,
+                      `#fbbf24`,
+                      `#f472b6`,
+                      `#fb7185`,
+                    ][(i + Math.abs(Math.floor(vx))) % 6]
+                  }
+                  emissive={accent}
+                  emissiveIntensity={0.45}
+                  transparent
+                  opacity={0.85}
+                />
+              </mesh>
+            )),
+          )}
+        </group>
+      ))}
+      {/* counter */}
+      <mesh castShadow position={[0, 0.55, -2.5]}>
+        <boxGeometry args={[5, 1.1, 0.9]} />
+        <meshStandardMaterial color="#7c4a1f" roughness={0.8} />
+      </mesh>
+      {/* hanging lantern */}
+      <pointLight
+        position={[0, 3.4, 0]}
+        color={accent}
+        intensity={2.2}
+        distance={9}
+      />
+    </group>
+  )
 }
 
 function GuildProps({ accent }: { accent: string }) {
-  return <group>
-    {/* mission board */}
-    <mesh castShadow position={[0, 1.6, -7.6]}><boxGeometry args={[5, 2.2, 0.18]} /><meshStandardMaterial color="#3f2511" roughness={0.78} /></mesh>
-    {[[-2, 1.9], [0, 1.9], [2, 1.9], [-2, 0.9], [0, 0.9], [2, 0.9]].map(([x, y], i) => <mesh key={i} position={[x, y, -7.5]}><planeGeometry args={[1.4, 0.85]} /><meshStandardMaterial color="#fff7ed" emissive={accent} emissiveIntensity={0.18} /></mesh>)}
-    {/* raid table */}
-    <mesh castShadow position={[0, 0.7, 1]}><cylinderGeometry args={[2, 2, 0.18, 24]} /><meshStandardMaterial color="#7c4a1f" roughness={0.85} /></mesh>
-    <mesh position={[0, 0.81, 1]}><circleGeometry args={[1.85, 32]} /><meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.25} roughness={0.65} transparent opacity={0.7} /></mesh>
-    {/* chairs */}
-    {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => <mesh key={i} castShadow position={[Math.cos(a) * 2.6, 0.45, 1 + Math.sin(a) * 2.6]}><boxGeometry args={[0.7, 0.9, 0.7]} /><meshStandardMaterial color="#3f2511" roughness={0.85} /></mesh>)}
-  </group>
+  return (
+    <group>
+      {/* mission board */}
+      <mesh castShadow position={[0, 1.6, -7.6]}>
+        <boxGeometry args={[5, 2.2, 0.18]} />
+        <meshStandardMaterial color="#3f2511" roughness={0.78} />
+      </mesh>
+      {[
+        [-2, 1.9],
+        [0, 1.9],
+        [2, 1.9],
+        [-2, 0.9],
+        [0, 0.9],
+        [2, 0.9],
+      ].map(([x, y], i) => (
+        <mesh key={i} position={[x, y, -7.5]}>
+          <planeGeometry args={[1.4, 0.85]} />
+          <meshStandardMaterial
+            color="#fff7ed"
+            emissive={accent}
+            emissiveIntensity={0.18}
+          />
+        </mesh>
+      ))}
+      {/* raid table */}
+      <mesh castShadow position={[0, 0.7, 1]}>
+        <cylinderGeometry args={[2, 2, 0.18, 24]} />
+        <meshStandardMaterial color="#7c4a1f" roughness={0.85} />
+      </mesh>
+      <mesh position={[0, 0.81, 1]}>
+        <circleGeometry args={[1.85, 32]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={0.25}
+          roughness={0.65}
+          transparent
+          opacity={0.7}
+        />
+      </mesh>
+      {/* chairs */}
+      {[0, Math.PI / 2, Math.PI, -Math.PI / 2].map((a, i) => (
+        <mesh
+          key={i}
+          castShadow
+          position={[Math.cos(a) * 2.6, 0.45, 1 + Math.sin(a) * 2.6]}
+        >
+          <boxGeometry args={[0.7, 0.9, 0.7]} />
+          <meshStandardMaterial color="#3f2511" roughness={0.85} />
+        </mesh>
+      ))}
+    </group>
+  )
 }
 
 function RemotePlayer({ remote }: { remote: MpRemotePlayer }) {
   const ref = useRef<THREE.Group>(null)
-  const target = useMemo(() => new THREE.Vector3(remote.x, remote.y, remote.z), [])
+  const target = useMemo(
+    () => new THREE.Vector3(remote.x, remote.y, remote.z),
+    [],
+  )
   const targetYaw = useRef(remote.yaw)
   const [pinged, setPinged] = useState(false)
-  useEffect(() => { target.set(remote.x, remote.y, remote.z); targetYaw.current = remote.yaw }, [remote.x, remote.y, remote.z, remote.yaw, target])
+  useEffect(() => {
+    target.set(remote.x, remote.y, remote.z)
+    targetYaw.current = remote.yaw
+  }, [remote.x, remote.y, remote.z, remote.yaw, target])
   useEffect(() => {
     const onPing = (event: Event) => {
       if ((event as CustomEvent<string>).detail !== remote.id) return
@@ -2702,7 +4708,8 @@ function RemotePlayer({ remote }: { remote: MpRemotePlayer }) {
       window.setTimeout(() => setPinged(false), 2000)
     }
     window.addEventListener('hermes-playground-ping-remote', onPing)
-    return () => window.removeEventListener('hermes-playground-ping-remote', onPing)
+    return () =>
+      window.removeEventListener('hermes-playground-ping-remote', onPing)
   }, [remote.id])
   useFrame(() => {
     if (!ref.current) return
@@ -2715,50 +4722,216 @@ function RemotePlayer({ remote }: { remote: MpRemotePlayer }) {
   })
   return (
     <group ref={ref} position={[remote.x, remote.y, remote.z]}>
-      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}><circleGeometry args={[0.5, 18]} /><meshBasicMaterial color="black" transparent opacity={0.4} /></mesh>
-      <mesh position={[0.13, 0.22, 0]} castShadow><boxGeometry args={[0.14, 0.44, 0.14]} /><meshStandardMaterial color="#1f2a37" roughness={0.6} /></mesh>
-      <mesh position={[-0.13, 0.22, 0]} castShadow><boxGeometry args={[0.14, 0.44, 0.14]} /><meshStandardMaterial color="#1f2a37" roughness={0.6} /></mesh>
-      <mesh position={[0, 0.7, 0]} castShadow><boxGeometry args={[0.5, 0.55, 0.32]} /><meshStandardMaterial color={remote.avatar?.outfit || remote.color} roughness={0.55} emissive={remote.avatar?.outfit || remote.color} emissiveIntensity={0.12} /></mesh>
+      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.5, 18]} />
+        <meshBasicMaterial color="black" transparent opacity={0.4} />
+      </mesh>
+      <mesh position={[0.13, 0.22, 0]} castShadow>
+        <boxGeometry args={[0.14, 0.44, 0.14]} />
+        <meshStandardMaterial color="#1f2a37" roughness={0.6} />
+      </mesh>
+      <mesh position={[-0.13, 0.22, 0]} castShadow>
+        <boxGeometry args={[0.14, 0.44, 0.14]} />
+        <meshStandardMaterial color="#1f2a37" roughness={0.6} />
+      </mesh>
+      <mesh position={[0, 0.7, 0]} castShadow>
+        <boxGeometry args={[0.5, 0.55, 0.32]} />
+        <meshStandardMaterial
+          color={remote.avatar?.outfit || remote.color}
+          roughness={0.55}
+          emissive={remote.avatar?.outfit || remote.color}
+          emissiveIntensity={0.12}
+        />
+      </mesh>
       {/* knight cuirass + sigil */}
-      <mesh position={[0, 0.78, 0.18]} castShadow><boxGeometry args={[0.46, 0.5, 0.06]} /><meshStandardMaterial color="#cbd5e1" metalness={0.7} roughness={0.3} emissive={remote.avatar?.outfitAccent || remote.color} emissiveIntensity={0.18} /></mesh>
-      <mesh position={[0, 0.8, 0.215]}><cylinderGeometry args={[0.1, 0.1, 0.018, 16]} /><meshStandardMaterial color={remote.avatar?.outfitAccent || remote.color} metalness={0.7} roughness={0.25} emissive={remote.avatar?.outfitAccent || remote.color} emissiveIntensity={0.55} /></mesh>
-      <mesh castShadow position={[-0.36, 0.96, 0]} rotation={[0, 0, 0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color={remote.avatar?.outfitAccent || '#0e7490'} metalness={0.45} roughness={0.45} /></mesh>
-      <mesh castShadow position={[0.36, 0.96, 0]} rotation={[0, 0, -0.4]}><boxGeometry args={[0.24, 0.12, 0.2]} /><meshStandardMaterial color={remote.avatar?.outfitAccent || '#0e7490'} metalness={0.45} roughness={0.45} /></mesh>
+      <mesh position={[0, 0.78, 0.18]} castShadow>
+        <boxGeometry args={[0.46, 0.5, 0.06]} />
+        <meshStandardMaterial
+          color="#cbd5e1"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={remote.avatar?.outfitAccent || remote.color}
+          emissiveIntensity={0.18}
+        />
+      </mesh>
+      <mesh position={[0, 0.8, 0.215]}>
+        <cylinderGeometry args={[0.1, 0.1, 0.018, 16]} />
+        <meshStandardMaterial
+          color={remote.avatar?.outfitAccent || remote.color}
+          metalness={0.7}
+          roughness={0.25}
+          emissive={remote.avatar?.outfitAccent || remote.color}
+          emissiveIntensity={0.55}
+        />
+      </mesh>
+      <mesh castShadow position={[-0.36, 0.96, 0]} rotation={[0, 0, 0.4]}>
+        <boxGeometry args={[0.24, 0.12, 0.2]} />
+        <meshStandardMaterial
+          color={remote.avatar?.outfitAccent || '#0e7490'}
+          metalness={0.45}
+          roughness={0.45}
+        />
+      </mesh>
+      <mesh castShadow position={[0.36, 0.96, 0]} rotation={[0, 0, -0.4]}>
+        <boxGeometry args={[0.24, 0.12, 0.2]} />
+        <meshStandardMaterial
+          color={remote.avatar?.outfitAccent || '#0e7490'}
+          metalness={0.45}
+          roughness={0.45}
+        />
+      </mesh>
       {/* tasset */}
       {[-0.16, -0.05, 0.05, 0.16].map((x) => (
-        <mesh key={x} castShadow position={[x, 0.42, 0.14]} rotation={[0.04, 0, 0]}><boxGeometry args={[0.09, 0.18, 0.04]} /><meshStandardMaterial color="#94a3b8" metalness={0.6} roughness={0.4} emissive={remote.avatar?.outfitAccent || remote.color} emissiveIntensity={0.1} /></mesh>
+        <mesh
+          key={x}
+          castShadow
+          position={[x, 0.42, 0.14]}
+          rotation={[0.04, 0, 0]}
+        >
+          <boxGeometry args={[0.09, 0.18, 0.04]} />
+          <meshStandardMaterial
+            color="#94a3b8"
+            metalness={0.6}
+            roughness={0.4}
+            emissive={remote.avatar?.outfitAccent || remote.color}
+            emissiveIntensity={0.1}
+          />
+        </mesh>
       ))}
       {/* gauntlets */}
-      <mesh position={[0.36, 0.6, 0]} castShadow><cylinderGeometry args={[0.075, 0.07, 0.18, 10]} /><meshStandardMaterial color="#94a3b8" metalness={0.7} roughness={0.3} emissive={remote.avatar?.outfitAccent || remote.color} emissiveIntensity={0.12} /></mesh>
-      <mesh position={[-0.36, 0.6, 0]} castShadow><cylinderGeometry args={[0.075, 0.07, 0.18, 10]} /><meshStandardMaterial color="#94a3b8" metalness={0.7} roughness={0.3} emissive={remote.avatar?.outfitAccent || remote.color} emissiveIntensity={0.12} /></mesh>
+      <mesh position={[0.36, 0.6, 0]} castShadow>
+        <cylinderGeometry args={[0.075, 0.07, 0.18, 10]} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={remote.avatar?.outfitAccent || remote.color}
+          emissiveIntensity={0.12}
+        />
+      </mesh>
+      <mesh position={[-0.36, 0.6, 0]} castShadow>
+        <cylinderGeometry args={[0.075, 0.07, 0.18, 10]} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.7}
+          roughness={0.3}
+          emissive={remote.avatar?.outfitAccent || remote.color}
+          emissiveIntensity={0.12}
+        />
+      </mesh>
       {/* greaves */}
-      <mesh position={[0.13, 0.16, 0]} castShadow><boxGeometry args={[0.16, 0.28, 0.18]} /><meshStandardMaterial color="#94a3b8" metalness={0.6} roughness={0.35} /></mesh>
-      <mesh position={[-0.13, 0.16, 0]} castShadow><boxGeometry args={[0.16, 0.28, 0.18]} /><meshStandardMaterial color="#94a3b8" metalness={0.6} roughness={0.35} /></mesh>
-      <mesh position={[0, 1.22, 0]} castShadow><sphereGeometry args={[0.22, 16, 16]} /><meshStandardMaterial color={remote.avatar?.skin || '#fde68a'} roughness={0.55} /></mesh>
-      <mesh position={[0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color={remote.avatar?.eyes || '#0b1220'} /></mesh>
-      <mesh position={[-0.085, 1.24, 0.19]}><sphereGeometry args={[0.025, 8, 8]} /><meshStandardMaterial color={remote.avatar?.eyes || '#0b1220'} /></mesh>
-      <mesh position={[0, 1.34, -0.02]} castShadow><sphereGeometry args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]} /><meshStandardMaterial color={remote.avatar?.hair || remote.color} roughness={0.85} /></mesh>
+      <mesh position={[0.13, 0.16, 0]} castShadow>
+        <boxGeometry args={[0.16, 0.28, 0.18]} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.6}
+          roughness={0.35}
+        />
+      </mesh>
+      <mesh position={[-0.13, 0.16, 0]} castShadow>
+        <boxGeometry args={[0.16, 0.28, 0.18]} />
+        <meshStandardMaterial
+          color="#94a3b8"
+          metalness={0.6}
+          roughness={0.35}
+        />
+      </mesh>
+      <mesh position={[0, 1.22, 0]} castShadow>
+        <sphereGeometry args={[0.22, 16, 16]} />
+        <meshStandardMaterial
+          color={remote.avatar?.skin || '#fde68a'}
+          roughness={0.55}
+        />
+      </mesh>
+      <mesh position={[0.085, 1.24, 0.19]}>
+        <sphereGeometry args={[0.025, 8, 8]} />
+        <meshStandardMaterial color={remote.avatar?.eyes || '#0b1220'} />
+      </mesh>
+      <mesh position={[-0.085, 1.24, 0.19]}>
+        <sphereGeometry args={[0.025, 8, 8]} />
+        <meshStandardMaterial color={remote.avatar?.eyes || '#0b1220'} />
+      </mesh>
+      <mesh position={[0, 1.34, -0.02]} castShadow>
+        <sphereGeometry
+          args={[0.235, 14, 14, 0, Math.PI * 2, 0, Math.PI / 2]}
+        />
+        <meshStandardMaterial
+          color={remote.avatar?.hair || remote.color}
+          roughness={0.85}
+        />
+      </mesh>
       {remote.avatar?.cape && remote.avatar.cape !== 'transparent' && (
-        <mesh castShadow position={[0, 0.78, -0.22]} rotation={[0.18, 0, 0]}><planeGeometry args={[0.7, 0.9]} /><meshStandardMaterial color={remote.avatar.cape} side={THREE.DoubleSide} roughness={0.6} /></mesh>
+        <mesh castShadow position={[0, 0.78, -0.22]} rotation={[0.18, 0, 0]}>
+          <planeGeometry args={[0.7, 0.9]} />
+          <meshStandardMaterial
+            color={remote.avatar.cape}
+            side={THREE.DoubleSide}
+            roughness={0.6}
+          />
+        </mesh>
       )}
-      {(!remote.avatar) && (
-        <mesh castShadow position={[0, 0.78, -0.22]} rotation={[0.18, 0, 0]}><planeGeometry args={[0.7, 0.9]} /><meshStandardMaterial color={remote.color} side={THREE.DoubleSide} roughness={0.6} /></mesh>
+      {!remote.avatar && (
+        <mesh castShadow position={[0, 0.78, -0.22]} rotation={[0.18, 0, 0]}>
+          <planeGeometry args={[0.7, 0.9]} />
+          <meshStandardMaterial
+            color={remote.color}
+            side={THREE.DoubleSide}
+            roughness={0.6}
+          />
+        </mesh>
       )}
       <Html position={[0, 1.95, 0]} center distanceFactor={8}>
-        <div style={{display:'flex',alignItems:'center',gap:6,padding:'2px 8px 2px 2px',background:'rgba(0,0,0,0.78)',color:'white',borderRadius:14,fontSize:11,fontWeight:700,whiteSpace:'nowrap',border:`1px solid ${remote.color}`,boxShadow:`0 0 8px ${remote.color}55`,transform: pinged ? 'scale(1.08)' : 'scale(1)', transition: 'transform 180ms ease, box-shadow 180ms ease'}}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '2px 8px 2px 2px',
+            background: 'rgba(0,0,0,0.78)',
+            color: 'white',
+            borderRadius: 14,
+            fontSize: 11,
+            fontWeight: 700,
+            whiteSpace: 'nowrap',
+            border: `1px solid ${remote.color}`,
+            boxShadow: `0 0 8px ${remote.color}55`,
+            transform: pinged ? 'scale(1.08)' : 'scale(1)',
+            transition: 'transform 180ms ease, box-shadow 180ms ease',
+          }}
+        >
           {remote.avatar?.portrait && (
-            <img src={`/avatars/${remote.avatar.portrait}.png`} alt="" loading="lazy" decoding="async" style={{width:22,height:22,borderRadius:'50%',background:remote.color,objectFit:'cover',border:`1px solid ${remote.color}`}} />
+            <img
+              src={`/avatars/${remote.avatar.portrait}.png`}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: '50%',
+                background: remote.color,
+                objectFit: 'cover',
+                border: `1px solid ${remote.color}`,
+              }}
+            />
           )}
           <span>{remote.name}</span>
         </div>
       </Html>
-      {remote.lastChat && remote.lastChatAt && Date.now() - remote.lastChatAt < 5500 && (
-        <Html position={[0, 2.6, 0]} center distanceFactor={8}>
-          <SpeechBubble className="hermes-world-bubble" variant="party" accent={remote.color} compact>
-            {remote.lastChat}
-          </SpeechBubble>
-        </Html>
-      )}
+      {remote.lastChat &&
+        remote.lastChatAt &&
+        Date.now() - remote.lastChatAt < 5500 && (
+          <Html position={[0, 2.6, 0]} center distanceFactor={8}>
+            <SpeechBubble
+              className="hermes-world-bubble"
+              variant="party"
+              accent={remote.color}
+              compact
+            >
+              {remote.lastChat}
+            </SpeechBubble>
+          </Html>
+        )}
     </group>
   )
 }
@@ -2817,11 +4990,19 @@ function Scene({
   const world = WORLDS_3D[worldId]
   const [settings] = useHermesWorldSettings()
   const photosensitiveMode = settings.accessibility.photosensitiveMode
-  const visibleRemotePlayers = useMemo(() => Object.values(remotePlayers).filter((r) => r.world === worldId && (r.interior ?? null) === null), [remotePlayers, worldId])
+  const visibleRemotePlayers = useMemo(
+    () =>
+      Object.values(remotePlayers).filter(
+        (r) => r.world === worldId && (r.interior ?? null) === null,
+      ),
+    [remotePlayers, worldId],
+  )
   const moveTarget = useRef<THREE.Vector3 | null>(null)
   const [pingPos, setPingPos] = useState<[number, number, number] | null>(null)
   const [interior, setInterior] = useState<InteriorId | null>(null)
-  const [outsideSpawn, setOutsideSpawn] = useState<[number, number, number]>([0, 0, 6])
+  const [outsideSpawn, setOutsideSpawn] = useState<[number, number, number]>([
+    0, 0, 6,
+  ])
   const [showObjectiveArrow, setShowObjectiveArrow] = useState(false)
   const pendingNpc = useRef<string | null>(null)
 
@@ -2835,7 +5016,8 @@ function Scene({
     return () => window.clearTimeout(id)
   }, [objectivePulseKey, objectiveTargetId])
 
-  const isHighlighted = (target: string) => showObjectiveArrow && matchesObjectiveTarget(objectiveTargetId, target)
+  const isHighlighted = (target: string) =>
+    showObjectiveArrow && matchesObjectiveTarget(objectiveTargetId, target)
 
   const onClickNpc = (id: string, p: [number, number, number]) => {
     // Walk to ~1.6u in front of NPC then auto-open dialog
@@ -2849,7 +5031,9 @@ function Scene({
     onNpcNearChange(id)
     if (id && pendingNpc.current === id) {
       pendingNpc.current = null
-      try { (window as any).__hermesPlaygroundOpenDialog?.(id) } catch {}
+      try {
+        ;(window as any).__hermesPlaygroundOpenDialog?.(id)
+      } catch {}
     }
   }
 
@@ -2894,13 +5078,23 @@ function Scene({
       )}
       <color attach="background" args={[world.skyColor]} />
       <fog attach="fog" args={[world.skyColor, world.fogNear, world.fogFar]} />
-      <hemisphereLight intensity={0.68} color={world.id === 'forge' ? '#ffd0a3' : '#fff4d6'} groundColor={world.id === 'agora' ? '#3f6b3a' : world.ambient} />
+      <hemisphereLight
+        intensity={0.68}
+        color={world.id === 'forge' ? '#ffd0a3' : '#fff4d6'}
+        groundColor={world.id === 'agora' ? '#3f6b3a' : world.ambient}
+      />
       <ambientLight intensity={0.28} color={world.ambient} />
       <directionalLight
         castShadow
         position={[14, 20, 8]}
         intensity={2.15}
-        color={world.id === 'oracle' ? '#ece7ff' : world.id === 'forge' ? '#ffd3aa' : '#fff1cc'}
+        color={
+          world.id === 'oracle'
+            ? '#ece7ff'
+            : world.id === 'forge'
+              ? '#ffd3aa'
+              : '#fff1cc'
+        }
         shadow-mapSize={[2048, 2048]}
         shadow-camera-left={-30}
         shadow-camera-right={30}
@@ -2917,65 +5111,381 @@ function Scene({
       {/* Ambient atmosphere particles — light-touch for performance */}
       {!photosensitiveMode && (
         <>
-          <Sparkles count={36} scale={[64, 10, 64]} size={2.2} speed={0.08} color={world.accent} opacity={0.28} />
-          <Sparkles count={12} scale={[34, 5, 34]} size={1} speed={0.12} color={'#ffffff'} opacity={0.14} />
+          <Sparkles
+            count={36}
+            scale={[64, 10, 64]}
+            size={2.2}
+            speed={0.08}
+            color={world.accent}
+            opacity={0.28}
+          />
+          <Sparkles
+            count={12}
+            scale={[34, 5, 34]}
+            size={1}
+            speed={0.12}
+            color={'#ffffff'}
+            opacity={0.14}
+          />
         </>
       )}
 
       {/* NPCs per world */}
       {worldId === 'training' && (
         <>
-          <NPC npcId="athena" position={[-10.5, 0, 7.2]} avatar="athena" name="Athena · Guide" color={NPC_COLORS.athena} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} highlight={isHighlighted('athena')} />
-          <NPC npcId="iris" position={[6.2, 0, 0.4]} avatar="iris" name="Iris · Archivist" color={NPC_COLORS.iris} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} highlight={isHighlighted('archive-podium')} />
-          <NPC npcId="pan" position={[11.2, 0, -7.5]} avatar="pan" name="Pan · Forge Guide" color={NPC_COLORS.pan} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} highlight={isHighlighted('build-demo')} />
-          <NPC npcId="nike" position={[-4.8, 0, -4.8]} avatar="nike" name="Leonidas · Trainer" color={NPC_COLORS.nike} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="shopkeeper" position={[-14.5, 0, -10.2]} avatar="iris" name="Dorian · Quartermaster" color={NPC_COLORS.shopkeeper} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} highlight={isHighlighted('training-blade') || isHighlighted('novice-cloak') || isHighlighted('hermes-sigil')} />
+          <NPC
+            npcId="athena"
+            position={[-10.5, 0, 7.2]}
+            avatar="athena"
+            name="Athena · Guide"
+            color={NPC_COLORS.athena}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+            highlight={isHighlighted('athena')}
+          />
+          <NPC
+            npcId="iris"
+            position={[6.2, 0, 0.4]}
+            avatar="iris"
+            name="Iris · Archivist"
+            color={NPC_COLORS.iris}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+            highlight={isHighlighted('archive-podium')}
+          />
+          <NPC
+            npcId="pan"
+            position={[11.2, 0, -7.5]}
+            avatar="pan"
+            name="Pan · Forge Guide"
+            color={NPC_COLORS.pan}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+            highlight={isHighlighted('build-demo')}
+          />
+          <NPC
+            npcId="nike"
+            position={[-4.8, 0, -4.8]}
+            avatar="nike"
+            name="Leonidas · Trainer"
+            color={NPC_COLORS.nike}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="shopkeeper"
+            position={[-14.5, 0, -10.2]}
+            avatar="iris"
+            name="Dorian · Quartermaster"
+            color={NPC_COLORS.shopkeeper}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+            highlight={
+              isHighlighted('training-blade') ||
+              isHighlighted('novice-cloak') ||
+              isHighlighted('hermes-sigil')
+            }
+          />
         </>
       )}
       {worldId === 'agora' && (
         <>
-          <NPC npcId="athena" position={[-5, 0, 2]} avatar="athena" name="Athena · Sage" color={NPC_COLORS.athena} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="apollo" position={[5, 0, 3]} avatar="apollo" name="Apollo · Bard" color={NPC_COLORS.apollo} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="iris" position={[-3, 0, -5]} avatar="iris" name="Iris · Messenger" color={NPC_COLORS.iris} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="nike" position={[6, 0, -4]} avatar="nike" name="Nike · Champion" color={NPC_COLORS.nike} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="shopkeeper" position={[-3, 0, 9.5]} avatar="iris" name="Dorian · Quartermaster" color={NPC_COLORS.shopkeeper} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="trainer" position={[-12, 0, 5.7]} avatar="nike" name="Leonidas · Trainer" color={NPC_COLORS.trainer} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="banker" position={[15.3, 0, 7.5]} avatar="chronos" name="Midas · Banker" color={NPC_COLORS.banker} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="recruiter" position={[-1.2, 0, -15.5]} avatar="athena" name="Cassia · Recruiter" color={NPC_COLORS.recruiter} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="tavernkeeper" position={[2, 0, 15.5]} avatar="apollo" name="Selene · Tavern" color={NPC_COLORS.tavernkeeper} drift={false} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <DoorTrigger position={[2, 0, 16.4]} label="Tavern" color="#f59e0b" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([2, 0, 16.7]); setInterior('tavern') }} />
-          <DoorTrigger position={[15.7, 0, 8.5]} label="Bank" color="#facc15" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([15.7, 0, 8.8]); setInterior('bank') }} />
-          <DoorTrigger position={[-12.7, 0, -13.9]} label="Smithy" color="#fb7185" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([-12.7, 0, -13.5]); setInterior('smithy') }} />
-          <DoorTrigger position={[-16.4, 0, 8.5]} label="Inn" color="#86efac" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([-16.4, 0, 8.8]); setInterior('inn') }} />
-          <DoorTrigger position={[12.7, 0, -13.9]} label="Apothecary" color="#f472b6" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([12.7, 0, -13.5]); setInterior('apothecary') }} />
-          <DoorTrigger position={[-1.2, 0, -19.2]} label="Guild Hall" color="#a78bfa" playerRef={playerPos} onEnter={() => { moveTarget.current = null; setOutsideSpawn([-1.2, 0, -18.7]); setInterior('guild') }} />
+          <NPC
+            npcId="athena"
+            position={[-5, 0, 2]}
+            avatar="athena"
+            name="Athena · Sage"
+            color={NPC_COLORS.athena}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="apollo"
+            position={[5, 0, 3]}
+            avatar="apollo"
+            name="Apollo · Bard"
+            color={NPC_COLORS.apollo}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="iris"
+            position={[-3, 0, -5]}
+            avatar="iris"
+            name="Iris · Messenger"
+            color={NPC_COLORS.iris}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="nike"
+            position={[6, 0, -4]}
+            avatar="nike"
+            name="Nike · Champion"
+            color={NPC_COLORS.nike}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="shopkeeper"
+            position={[-3, 0, 9.5]}
+            avatar="iris"
+            name="Dorian · Quartermaster"
+            color={NPC_COLORS.shopkeeper}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="trainer"
+            position={[-12, 0, 5.7]}
+            avatar="nike"
+            name="Leonidas · Trainer"
+            color={NPC_COLORS.trainer}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="banker"
+            position={[15.3, 0, 7.5]}
+            avatar="chronos"
+            name="Midas · Banker"
+            color={NPC_COLORS.banker}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="recruiter"
+            position={[-1.2, 0, -15.5]}
+            avatar="athena"
+            name="Cassia · Recruiter"
+            color={NPC_COLORS.recruiter}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="tavernkeeper"
+            position={[2, 0, 15.5]}
+            avatar="apollo"
+            name="Selene · Tavern"
+            color={NPC_COLORS.tavernkeeper}
+            drift={false}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <DoorTrigger
+            position={[2, 0, 16.4]}
+            label="Tavern"
+            color="#f59e0b"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([2, 0, 16.7])
+              setInterior('tavern')
+            }}
+          />
+          <DoorTrigger
+            position={[15.7, 0, 8.5]}
+            label="Bank"
+            color="#facc15"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([15.7, 0, 8.8])
+              setInterior('bank')
+            }}
+          />
+          <DoorTrigger
+            position={[-12.7, 0, -13.9]}
+            label="Smithy"
+            color="#fb7185"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([-12.7, 0, -13.5])
+              setInterior('smithy')
+            }}
+          />
+          <DoorTrigger
+            position={[-16.4, 0, 8.5]}
+            label="Inn"
+            color="#86efac"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([-16.4, 0, 8.8])
+              setInterior('inn')
+            }}
+          />
+          <DoorTrigger
+            position={[12.7, 0, -13.9]}
+            label="Apothecary"
+            color="#f472b6"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([12.7, 0, -13.5])
+              setInterior('apothecary')
+            }}
+          />
+          <DoorTrigger
+            position={[-1.2, 0, -19.2]}
+            label="Guild Hall"
+            color="#a78bfa"
+            playerRef={playerPos}
+            onEnter={() => {
+              moveTarget.current = null
+              setOutsideSpawn([-1.2, 0, -18.7])
+              setInterior('guild')
+            }}
+          />
         </>
       )}
       {worldId === 'forge' && (
         <>
-          <NPC npcId="pan" position={[-4, 0, 0]} avatar="pan" name="Pan · Hacker" color={NPC_COLORS.pan} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="chronos" position={[4, 0, 0]} avatar="chronos" name="Chronos · Architect" color={NPC_COLORS.chronos} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
+          <NPC
+            npcId="pan"
+            position={[-4, 0, 0]}
+            avatar="pan"
+            name="Pan · Hacker"
+            color={NPC_COLORS.pan}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="chronos"
+            position={[4, 0, 0]}
+            avatar="chronos"
+            name="Chronos · Architect"
+            color={NPC_COLORS.chronos}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
         </>
       )}
       {worldId === 'grove' && (
         <>
-          <NPC npcId="pan" position={[-4, 0, 1]} avatar="pan" name="Pan · Druid" color={NPC_COLORS.pan} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="apollo" position={[4, 0, 0]} avatar="apollo" name="Apollo · Songkeeper" color={NPC_COLORS.apollo} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="artemis" position={[0, 0, -5]} avatar="artemis" name="Artemis · Tracker" color={NPC_COLORS.artemis} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
+          <NPC
+            npcId="pan"
+            position={[-4, 0, 1]}
+            avatar="pan"
+            name="Pan · Druid"
+            color={NPC_COLORS.pan}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="apollo"
+            position={[4, 0, 0]}
+            avatar="apollo"
+            name="Apollo · Songkeeper"
+            color={NPC_COLORS.apollo}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="artemis"
+            position={[0, 0, -5]}
+            avatar="artemis"
+            name="Artemis · Tracker"
+            color={NPC_COLORS.artemis}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
         </>
       )}
       {worldId === 'oracle' && (
         <>
-          <NPC npcId="athena" position={[-3, 0, -2]} avatar="athena" name="Athena · Oracle" color={NPC_COLORS.athena} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="chronos" position={[3, 0, -2]} avatar="chronos" name="Chronos · Archivist" color={NPC_COLORS.chronos} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="eros" position={[0, 0, 4]} avatar="eros" name="Eros · Whisperer" color={NPC_COLORS.eros} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
+          <NPC
+            npcId="athena"
+            position={[-3, 0, -2]}
+            avatar="athena"
+            name="Athena · Oracle"
+            color={NPC_COLORS.athena}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="chronos"
+            position={[3, 0, -2]}
+            avatar="chronos"
+            name="Chronos · Archivist"
+            color={NPC_COLORS.chronos}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="eros"
+            position={[0, 0, 4]}
+            avatar="eros"
+            name="Eros · Whisperer"
+            color={NPC_COLORS.eros}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
         </>
       )}
       {worldId === 'arena' && (
         <>
-          <NPC npcId="nike" position={[-3, 0, 4]} avatar="nike" name="Nike · Champion" color={NPC_COLORS.nike} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="hermes" position={[3, 0, 4]} avatar="hermes" name="Hermes · Referee" color={NPC_COLORS.hermes} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
-          <NPC npcId="chronos" position={[0, 0, -5]} avatar="chronos" name="Chronos · Bookmaker" color={NPC_COLORS.chronos} playerRef={playerPos} onNearChange={handleNearChange} onClickNpc={onClickNpc} />
+          <NPC
+            npcId="nike"
+            position={[-3, 0, 4]}
+            avatar="nike"
+            name="Nike · Champion"
+            color={NPC_COLORS.nike}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="hermes"
+            position={[3, 0, 4]}
+            avatar="hermes"
+            name="Hermes · Referee"
+            color={NPC_COLORS.hermes}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
+          <NPC
+            npcId="chronos"
+            position={[0, 0, -5]}
+            avatar="chronos"
+            name="Chronos · Bookmaker"
+            color={NPC_COLORS.chronos}
+            playerRef={playerPos}
+            onNearChange={handleNearChange}
+            onClickNpc={onClickNpc}
+          />
         </>
       )}
 
@@ -2993,8 +5503,22 @@ function Scene({
       {/* Quest zones per world */}
       {worldId === 'training' && (
         <>
-          <QuestZone position={[6, 0, 0]} color="#a78bfa" label="Archive Podium" onEnter={() => onQuestZone('archive-podium')} playerRef={playerPos} highlight={isHighlighted('archive-podium')} />
-          <QuestZone position={[14, 0, -10]} color="#22d3ee" label="Forge Gate" onEnter={() => onQuestZone('forge-gate')} playerRef={playerPos} highlight={isHighlighted('forge-gate')} />
+          <QuestZone
+            position={[6, 0, 0]}
+            color="#a78bfa"
+            label="Archive Podium"
+            onEnter={() => onQuestZone('archive-podium')}
+            playerRef={playerPos}
+            highlight={isHighlighted('archive-podium')}
+          />
+          <QuestZone
+            position={[14, 0, -10]}
+            color="#22d3ee"
+            label="Forge Gate"
+            onEnter={() => onQuestZone('forge-gate')}
+            playerRef={playerPos}
+            highlight={isHighlighted('forge-gate')}
+          />
           <Monster
             position={[-4.8, 0.95, -4]}
             color="#f472b6"
@@ -3006,19 +5530,49 @@ function Scene({
         </>
       )}
       {worldId === 'agora' && (
-        <QuestZone position={[-8, 0, -3]} color="#facc15" label="Athena's Scroll" onEnter={() => onQuestZone('awakening-agora')} playerRef={playerPos} />
+        <QuestZone
+          position={[-8, 0, -3]}
+          color="#facc15"
+          label="Athena's Scroll"
+          onEnter={() => onQuestZone('awakening-agora')}
+          playerRef={playerPos}
+        />
       )}
       {worldId === 'forge' && (
-        <QuestZone position={[0, 0, -7]} color="#22d3ee" label="Forge Shard" onEnter={() => onQuestZone('enter-forge')} playerRef={playerPos} />
+        <QuestZone
+          position={[0, 0, -7]}
+          color="#22d3ee"
+          label="Forge Shard"
+          onEnter={() => onQuestZone('enter-forge')}
+          playerRef={playerPos}
+        />
       )}
       {worldId === 'grove' && (
-        <QuestZone position={[-6, 0, -4]} color="#34d399" label="Song of the Grove" onEnter={() => onQuestZone('grove-ritual')} playerRef={playerPos} />
+        <QuestZone
+          position={[-6, 0, -4]}
+          color="#34d399"
+          label="Song of the Grove"
+          onEnter={() => onQuestZone('grove-ritual')}
+          playerRef={playerPos}
+        />
       )}
       {worldId === 'oracle' && (
-        <QuestZone position={[5, 0, -3]} color="#a78bfa" label="Oracle's Riddle" onEnter={() => onQuestZone('oracle-riddle')} playerRef={playerPos} />
+        <QuestZone
+          position={[5, 0, -3]}
+          color="#a78bfa"
+          label="Oracle's Riddle"
+          onEnter={() => onQuestZone('oracle-riddle')}
+          playerRef={playerPos}
+        />
       )}
       {worldId === 'arena' && (
-        <QuestZone position={[0, 0, 0]} color="#fb7185" label="Enter the Duel" onEnter={() => onQuestZone('arena-duel')} playerRef={playerPos} />
+        <QuestZone
+          position={[0, 0, 0]}
+          color="#fb7185"
+          label="Enter the Duel"
+          onEnter={() => onQuestZone('arena-duel')}
+          playerRef={playerPos}
+        />
       )}
 
       <Suspense fallback={null}>
@@ -3043,10 +5597,10 @@ function Scene({
 
       {/* Real remote players */}
       {visibleRemotePlayers.map((remote) => (
-          <Suspense key={remote.id} fallback={null}>
-            <RemotePlayer remote={remote} />
-          </Suspense>
-        ))}
+        <Suspense key={remote.id} fallback={null}>
+          <RemotePlayer remote={remote} />
+        </Suspense>
+      ))}
 
       {/* Online bot players */}
       {bots.map((bot) => (
@@ -3058,12 +5612,13 @@ function Scene({
   )
 }
 
-
 function usePerfDebugEnabled() {
   const [enabled, setEnabled] = useState(false)
   useEffect(() => {
     if (typeof window === 'undefined') return
-    setEnabled(new URLSearchParams(window.location.search).get('debug') === 'perf')
+    setEnabled(
+      new URLSearchParams(window.location.search).get('debug') === 'perf',
+    )
   }, [])
   return enabled
 }
@@ -3071,17 +5626,28 @@ function usePerfDebugEnabled() {
 function DevFpsSampler() {
   const sample = useRef({ last: 0, frames: 0, sum: 0, max: 0, heap: 0 })
   useFrame(({ clock }, delta) => {
-    if (typeof import.meta !== 'undefined' && !(import.meta as any).env?.DEV) return
+    if (typeof import.meta !== 'undefined' && !(import.meta as any).env?.DEV)
+      return
     const now = clock.elapsedTime
     const ms = delta * 1000
     const stats = sample.current
     stats.frames += 1
     stats.sum += ms
     stats.max = Math.max(stats.max, ms)
-    if (typeof performance !== 'undefined' && 'memory' in performance) stats.heap = ((performance as any).memory?.usedJSHeapSize || 0) / 1048576
+    if (typeof performance !== 'undefined' && 'memory' in performance)
+      stats.heap = ((performance as any).memory?.usedJSHeapSize || 0) / 1048576
     if (now - stats.last < 10) return
     const avgFrame = stats.sum / Math.max(1, stats.frames)
-    console.table([{ scope: 'HermesWorld playground', avgFps: Number((1000 / Math.max(1, avgFrame)).toFixed(1)), avgFrameMs: Number(avgFrame.toFixed(2)), p95FrameMsApprox: Number(stats.max.toFixed(2)), jsHeapMb: stats.heap ? Number(stats.heap.toFixed(1)) : 'n/a', samples: stats.frames }])
+    console.table([
+      {
+        scope: 'HermesWorld playground',
+        avgFps: Number((1000 / Math.max(1, avgFrame)).toFixed(1)),
+        avgFrameMs: Number(avgFrame.toFixed(2)),
+        p95FrameMsApprox: Number(stats.max.toFixed(2)),
+        jsHeapMb: stats.heap ? Number(stats.heap.toFixed(1)) : 'n/a',
+        samples: stats.frames,
+      },
+    ])
     sample.current = { last: now, frames: 0, sum: 0, max: 0, heap: stats.heap }
   })
   return null
@@ -3091,7 +5657,14 @@ function PerfDebugOverlay() {
   const enabled = usePerfDebugEnabled()
   const { gl } = useThree()
   const sample = useRef({ last: 0, frames: 0, sum: 0, max: 0 })
-  const [stats, setStats] = useState({ fps: 0, frameMs: 0, maxFrameMs: 0, calls: 0, triangles: 0, heap: 'n/a' as string | number })
+  const [stats, setStats] = useState({
+    fps: 0,
+    frameMs: 0,
+    maxFrameMs: 0,
+    calls: 0,
+    triangles: 0,
+    heap: 'n/a' as string | number,
+  })
 
   useFrame(({ clock }, delta) => {
     if (!enabled) return
@@ -3103,9 +5676,14 @@ function PerfDebugOverlay() {
     current.max = Math.max(current.max, ms)
     if (now - current.last < 0.5) return
     const frameMs = current.sum / Math.max(1, current.frames)
-    const heap = typeof performance !== 'undefined' && 'memory' in performance
-      ? Number((((performance as any).memory?.usedJSHeapSize || 0) / 1048576).toFixed(1))
-      : 'n/a'
+    const heap =
+      typeof performance !== 'undefined' && 'memory' in performance
+        ? Number(
+            (
+              ((performance as any).memory?.usedJSHeapSize || 0) / 1048576
+            ).toFixed(1),
+          )
+        : 'n/a'
     setStats({
       fps: Number((1000 / Math.max(1, frameMs)).toFixed(1)),
       frameMs: Number(frameMs.toFixed(2)),
@@ -3120,8 +5698,37 @@ function PerfDebugOverlay() {
   if (!enabled) return null
   return (
     <Html fullscreen prepend>
-      <div style={{ position: 'fixed', left: 12, top: 12, zIndex: 1000, width: 190, border: '1px solid rgba(94,234,212,.35)', borderRadius: 14, background: 'rgba(2,8,13,.78)', color: '#dffcff', padding: '10px 12px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11, lineHeight: 1.55, pointerEvents: 'none', boxShadow: '0 14px 40px rgba(0,0,0,.35)', backdropFilter: 'blur(10px)' }}>
-        <div style={{ color: '#facc15', fontWeight: 900, letterSpacing: '.12em', textTransform: 'uppercase', marginBottom: 4 }}>Perf debug</div>
+      <div
+        style={{
+          position: 'fixed',
+          left: 12,
+          top: 12,
+          zIndex: 1000,
+          width: 190,
+          border: '1px solid rgba(94,234,212,.35)',
+          borderRadius: 14,
+          background: 'rgba(2,8,13,.78)',
+          color: '#dffcff',
+          padding: '10px 12px',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 11,
+          lineHeight: 1.55,
+          pointerEvents: 'none',
+          boxShadow: '0 14px 40px rgba(0,0,0,.35)',
+          backdropFilter: 'blur(10px)',
+        }}
+      >
+        <div
+          style={{
+            color: '#facc15',
+            fontWeight: 900,
+            letterSpacing: '.12em',
+            textTransform: 'uppercase',
+            marginBottom: 4,
+          }}
+        >
+          Perf debug
+        </div>
         <div>FPS: {stats.fps}</div>
         <div>Frame: {stats.frameMs}ms</div>
         <div>Max: {stats.maxFrameMs}ms</div>
@@ -3188,21 +5795,43 @@ export function PlaygroundWorld3D({
   const [settings] = useHermesWorldSettings()
   const photosensitiveMode = settings.accessibility.photosensitiveMode
   const fallbackBackground = ZONE_FALLBACK_BACKGROUNDS[worldId]
-  const positionForMp = useRef<{ x: number; y: number; z: number } | null>({ x: 0, y: 0, z: 6 })
+  const positionForMp = useRef<{ x: number; y: number; z: number } | null>({
+    x: 0,
+    y: 0,
+    z: 6,
+  })
   // Sync simple position object for multiplayer hook (it doesn't use THREE).
   // Also expose to window so the HUD objective arrow can compute heading.
   useEffect(() => {
     // Sample player position at presence cadence (~5Hz). The hook
     // skip-sends when delta < epsilon, so this is cheap.
-    const isMobile = window.matchMedia?.('(pointer: coarse), (max-width: 760px)').matches ?? false
-    const id = window.setInterval(() => {
-      const p = { x: playerPos.current.x, y: playerPos.current.y, z: playerPos.current.z }
-      positionForMp.current = p
-      ;(window as any).__hermesPlaygroundPlayerPos = p
-    }, isMobile ? Math.ceil(1000 / 30) : Math.ceil(1000 / 60))
+    const isMobile =
+      window.matchMedia?.('(pointer: coarse), (max-width: 760px)').matches ??
+      false
+    const id = window.setInterval(
+      () => {
+        const p = {
+          x: playerPos.current.x,
+          y: playerPos.current.y,
+          z: playerPos.current.z,
+        }
+        positionForMp.current = p
+        ;(window as any).__hermesPlaygroundPlayerPos = p
+      },
+      isMobile ? Math.ceil(1000 / 30) : Math.ceil(1000 / 60),
+    )
     return () => window.clearInterval(id)
   }, [])
-  const { remotePlayers, online, transport, serverCount, sendChat, myName, myColor, selfId } = usePlaygroundMultiplayer({
+  const {
+    remotePlayers,
+    online,
+    transport,
+    serverCount,
+    sendChat,
+    myName,
+    myColor,
+    selfId,
+  } = usePlaygroundMultiplayer({
     world: worldId,
     interior: null,
     positionRef: positionForMp,
@@ -3212,7 +5841,8 @@ export function PlaygroundWorld3D({
   })
   // Expose sendChat + multiplayer info globally so HUD/chat panel can read it.
   useEffect(() => {
-    ;(window as any).__hermesPlaygroundSendChat = (text: string) => sendChat(text)
+    ;(window as any).__hermesPlaygroundSendChat = (text: string) =>
+      sendChat(text)
     ;(window as any).__hermesPlaygroundMpInfo = () => ({
       online,
       transport,
@@ -3225,22 +5855,51 @@ export function PlaygroundWorld3D({
     // Push live count for the HUD chip without polling /stats.
     if (serverCount) {
       ;(window as any).__hermesPlaygroundLiveCount = serverCount
-      window.dispatchEvent(new CustomEvent('hermes-playground-count', { detail: serverCount }))
+      window.dispatchEvent(
+        new CustomEvent('hermes-playground-count', { detail: serverCount }),
+      )
     }
     ;(window as any).__hermesPlaygroundLiveTransport = transport
-    window.dispatchEvent(new CustomEvent('hermes-playground-transport', { detail: transport }))
+    window.dispatchEvent(
+      new CustomEvent('hermes-playground-transport', { detail: transport }),
+    )
     return () => {
-      try { delete (window as any).__hermesPlaygroundSendChat } catch {}
-      try { delete (window as any).__hermesPlaygroundMpInfo } catch {}
+      try {
+        delete (window as any).__hermesPlaygroundSendChat
+      } catch {}
+      try {
+        delete (window as any).__hermesPlaygroundMpInfo
+      } catch {}
     }
-  }, [sendChat, online, transport, myName, myColor, selfId, remotePlayers, serverCount])
+  }, [
+    sendChat,
+    online,
+    transport,
+    myName,
+    myColor,
+    selfId,
+    remotePlayers,
+    serverCount,
+  ])
 
-  const remotePublishRef = useRef<{ sig: string; ts: number; timer: number | null }>({ sig: '', ts: 0, timer: null })
+  const remotePublishRef = useRef<{
+    sig: string
+    ts: number
+    timer: number | null
+  }>({ sig: '', ts: 0, timer: null })
   useEffect(() => {
     if (!onRemotePlayersChange) return
-    const sig = Object.values(remotePlayers).map((player) => `${player.id}:${player.world}:${player.x.toFixed(1)}:${player.z.toFixed(1)}:${player.ts}:${player.lastChatAt ?? 0}`).sort().join('|')
+    const sig = Object.values(remotePlayers)
+      .map(
+        (player) =>
+          `${player.id}:${player.world}:${player.x.toFixed(1)}:${player.z.toFixed(1)}:${player.ts}:${player.lastChatAt ?? 0}`,
+      )
+      .sort()
+      .join('|')
     if (sig === remotePublishRef.current.sig) return
-    const isMobile = typeof window !== 'undefined' && window.matchMedia?.('(pointer: coarse), (max-width: 760px)').matches
+    const isMobile =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(pointer: coarse), (max-width: 760px)').matches
     const minDelay = isMobile ? Math.ceil(1000 / 30) : Math.ceil(1000 / 60)
     const elapsed = Date.now() - remotePublishRef.current.ts
     const publish = () => {
@@ -3251,10 +5910,15 @@ export function PlaygroundWorld3D({
       publish()
       return
     }
-    if (remotePublishRef.current.timer != null) window.clearTimeout(remotePublishRef.current.timer)
-    remotePublishRef.current.timer = window.setTimeout(publish, minDelay - elapsed)
+    if (remotePublishRef.current.timer != null)
+      window.clearTimeout(remotePublishRef.current.timer)
+    remotePublishRef.current.timer = window.setTimeout(
+      publish,
+      minDelay - elapsed,
+    )
     return () => {
-      if (remotePublishRef.current.timer != null) window.clearTimeout(remotePublishRef.current.timer)
+      if (remotePublishRef.current.timer != null)
+        window.clearTimeout(remotePublishRef.current.timer)
       remotePublishRef.current.timer = null
     }
   }, [onRemotePlayersChange, remotePlayers])
@@ -3277,7 +5941,8 @@ export function PlaygroundWorld3D({
           style={{
             position: 'absolute',
             inset: 0,
-            background: 'radial-gradient(circle at 50% 45%, transparent 0%, rgba(5,11,18,.34) 68%, rgba(5,11,18,.78) 100%)',
+            background:
+              'radial-gradient(circle at 50% 45%, transparent 0%, rgba(5,11,18,.34) 68%, rgba(5,11,18,.78) 100%)',
             pointerEvents: 'none',
           }}
         />
@@ -3294,7 +5959,13 @@ export function PlaygroundWorld3D({
         camera={{ position: [10, 12, 10], fov: 45 }}
         // Adaptive DPR: matches device pixel ratio up to 1.5 for crispness on retina,
         // drops to 1 on lower-end devices to keep frame times under 16ms.
-        dpr={[1, Math.min(typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1, 2)]}
+        dpr={[
+          1,
+          Math.min(
+            typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
+            2,
+          ),
+        ]}
         // Render on demand when no animation needed reduces CPU when idle on title screen.
         // Game loop still runs because useFrame components subscribe.
         frameloop="always"
@@ -3313,7 +5984,13 @@ export function PlaygroundWorld3D({
           <DevFpsSampler />
           <PerfDebugOverlay />
           <EffectComposer enableNormalPass={false}>
-            <Bloom mipmapBlur intensity={photosensitiveMode ? 0.18 : 0.78} luminanceThreshold={0.72} luminanceSmoothing={0.35} radius={0.85} />
+            <Bloom
+              mipmapBlur
+              intensity={photosensitiveMode ? 0.18 : 0.78}
+              luminanceThreshold={0.72}
+              luminanceSmoothing={0.35}
+              radius={0.85}
+            />
             <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
             <Vignette eskil={false} offset={0.18} darkness={0.55} />
           </EffectComposer>

--- a/src/screens/playground/hooks/use-playground-rpg.ts
+++ b/src/screens/playground/hooks/use-playground-rpg.ts
@@ -12,12 +12,17 @@ import {
   type PlayerProfile,
   type QuestProgressEntry,
 } from '../lib/playground-rpg'
-import { AVATAR_PRESETS, saveAvatarConfig, type AvatarConfig } from '../lib/avatar-config'
+import {
+  AVATAR_PRESETS,
+  saveAvatarConfig,
+  type AvatarConfig,
+} from '../lib/avatar-config'
 
 export type PlaygroundRpg = ReturnType<typeof usePlaygroundRpg>
 
 export const PLAYGROUND_PROFILE_STORAGE_KEY = 'hermes-playground-player-profile'
-export const PLAYGROUND_DISPLAY_NAME_STORAGE_KEY = 'hermes-playground-display-name'
+export const PLAYGROUND_DISPLAY_NAME_STORAGE_KEY =
+  'hermes-playground-display-name'
 export const PLAYGROUND_LEGACY_NAME_KEY = 'hermes-playground-builder-name'
 
 const STORAGE_KEY = PLAYGROUND_PROFILE_STORAGE_KEY
@@ -56,7 +61,11 @@ const EMPTY_EQUIPPED = {
   artifact: null,
 } satisfies PlayerProfile['equipped']
 
-const STARTER_INVENTORY: PlaygroundItemId[] = ['hermes-sigil', 'training-blade', 'novice-cloak']
+const STARTER_INVENTORY: PlaygroundItemId[] = [
+  'hermes-sigil',
+  'training-blade',
+  'novice-cloak',
+]
 
 function defaultQuestProgress(): Record<string, QuestProgressEntry> {
   return Object.fromEntries(
@@ -113,7 +122,9 @@ function replayTutorialState(prev: PlaygroundRpgState): PlaygroundRpgState {
       equipped: { ...EMPTY_EQUIPPED },
       inventory: [...STARTER_INVENTORY],
       questProgress: defaultQuestProgress(),
-      titlesUnlocked: prev.playerProfile.titlesUnlocked.filter((title) => title !== 'Initiate Builder'),
+      titlesUnlocked: prev.playerProfile.titlesUnlocked.filter(
+        (title) => title !== 'Initiate Builder',
+      ),
       lastZone: 'training',
     },
   }
@@ -123,31 +134,50 @@ function xpForNextLevel(level: number) {
   return 100 + (level - 1) * 75
 }
 
-function normalizeState(raw: Partial<PlaygroundRpgState> | null): PlaygroundRpgState {
+function normalizeState(
+  raw: Partial<PlaygroundRpgState> | null,
+): PlaygroundRpgState {
   const base = defaultState()
   const rawProfile = raw?.playerProfile
-  const completedQuests = Array.isArray(raw?.completedQuests) ? raw.completedQuests : []
-  const legacy = raw as Partial<PlaygroundRpgState & {
-    inventory: PlaygroundItemId[]
-    level: number
-    xp: number
-  }> | null
-  const legacyInventory = Array.isArray(legacy?.inventory) ? legacy.inventory : undefined
-  const legacyLevel = typeof legacy?.level === 'number' ? legacy.level : undefined
+  const completedQuests = Array.isArray(raw?.completedQuests)
+    ? raw.completedQuests
+    : []
+  const legacy = raw as Partial<
+    PlaygroundRpgState & {
+      inventory: PlaygroundItemId[]
+      level: number
+      xp: number
+    }
+  > | null
+  const legacyInventory = Array.isArray(legacy?.inventory)
+    ? legacy.inventory
+    : undefined
+  const legacyLevel =
+    typeof legacy?.level === 'number' ? legacy.level : undefined
   const legacyXp = typeof legacy?.xp === 'number' ? legacy.xp : undefined
 
   const profile: PlayerProfile = {
     ...base.playerProfile,
     ...rawProfile,
     displayName: rawProfile?.displayName ?? '',
-    avatarConfig: { ...base.playerProfile.avatarConfig, ...(rawProfile?.avatarConfig ?? {}) },
+    avatarConfig: {
+      ...base.playerProfile.avatarConfig,
+      ...(rawProfile?.avatarConfig ?? {}),
+    },
     equipped: { ...EMPTY_EQUIPPED, ...(rawProfile?.equipped ?? {}) },
-    inventory: Array.from(new Set(rawProfile?.inventory ?? legacyInventory ?? [])),
-    questProgress: { ...defaultQuestProgress(), ...(rawProfile?.questProgress ?? {}) },
+    inventory: Array.from(
+      new Set(rawProfile?.inventory ?? legacyInventory ?? []),
+    ),
+    questProgress: {
+      ...defaultQuestProgress(),
+      ...(rawProfile?.questProgress ?? {}),
+    },
     level: rawProfile?.level ?? legacyLevel ?? base.playerProfile.level,
     xp: rawProfile?.xp ?? legacyXp ?? base.playerProfile.xp,
     titlesUnlocked: Array.from(new Set(rawProfile?.titlesUnlocked ?? [])),
-    lastZone: rawProfile?.lastZone ?? (completedQuests.includes('training-q1') ? 'agora' : 'training'),
+    lastZone:
+      rawProfile?.lastZone ??
+      (completedQuests.includes('training-q1') ? 'agora' : 'training'),
   }
 
   return {
@@ -155,7 +185,9 @@ function normalizeState(raw: Partial<PlaygroundRpgState> | null): PlaygroundRpgS
     ...raw,
     playerProfile: profile,
     skillXp: { ...base.skillXp, ...(raw?.skillXp ?? {}) },
-    unlockedWorlds: Array.from(new Set(raw?.unlockedWorlds ?? base.unlockedWorlds)),
+    unlockedWorlds: Array.from(
+      new Set(raw?.unlockedWorlds ?? base.unlockedWorlds),
+    ),
     completedQuests: Array.from(new Set(completedQuests)),
   }
 }
@@ -171,20 +203,27 @@ function loadState(): PlaygroundRpgState {
 }
 
 function activeQuestForState(state: PlaygroundRpgState) {
-  return PLAYGROUND_QUESTS.find((quest) => !quest.optional && !state.completedQuests.includes(quest.id))
-    ?? PLAYGROUND_QUESTS.find((quest) => !quest.optional)
+  return (
+    PLAYGROUND_QUESTS.find(
+      (quest) => !quest.optional && !state.completedQuests.includes(quest.id),
+    ) ?? PLAYGROUND_QUESTS.find((quest) => !quest.optional)
+  )
 }
 
-function currentObjectiveForQuest(state: PlaygroundRpgState, quest: PlaygroundQuest | undefined) {
+function currentObjectiveForQuest(
+  state: PlaygroundRpgState,
+  quest: PlaygroundQuest | undefined,
+) {
   if (!quest) return null
   const progress = state.playerProfile.questProgress[quest.id]
-  return quest.objectives.find((objective) => !progress?.completedObjectives.includes(objective.id)) ?? null
+  return (
+    quest.objectives.find(
+      (objective) => !progress?.completedObjectives.includes(objective.id),
+    ) ?? null
+  )
 }
 
-function completeQuestState(
-  prev: PlaygroundRpgState,
-  quest: PlaygroundQuest,
-) {
+function completeQuestState(prev: PlaygroundRpgState, quest: PlaygroundQuest) {
   if (prev.completedQuests.includes(quest.id)) return prev
   const reward = quest.reward
   let xp = prev.playerProfile.xp + reward.xp
@@ -203,11 +242,15 @@ function completeQuestState(
     ? Array.from(new Set([...prev.playerProfile.titlesUnlocked, reward.title]))
     : prev.playerProfile.titlesUnlocked
   const unlockedWorlds = Array.from(
-    new Set([...(prev.unlockedWorlds ?? ['training', 'agora']), ...(reward.unlockWorlds ?? [])]),
+    new Set([
+      ...(prev.unlockedWorlds ?? ['training', 'agora']),
+      ...(reward.unlockWorlds ?? []),
+    ]),
   )
   const skillXp = { ...prev.skillXp }
   for (const [skill, amount] of Object.entries(reward.skillXp ?? {})) {
-    skillXp[skill as PlaygroundSkillId] = (skillXp[skill as PlaygroundSkillId] ?? 0) + (amount ?? 0)
+    skillXp[skill as PlaygroundSkillId] =
+      (skillXp[skill as PlaygroundSkillId] ?? 0) + (amount ?? 0)
   }
 
   return {
@@ -225,7 +268,9 @@ function completeQuestState(
         ...prev.playerProfile.questProgress,
         [quest.id]: {
           completed: true,
-          completedObjectives: quest.objectives.map((objective) => objective.id),
+          completedObjectives: quest.objectives.map(
+            (objective) => objective.id,
+          ),
         },
       },
     },
@@ -239,7 +284,10 @@ export function usePlaygroundRpg() {
   useEffect(() => {
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
-      window.localStorage.setItem(PLAYGROUND_DISPLAY_NAME_STORAGE_KEY, state.playerProfile.displayName)
+      window.localStorage.setItem(
+        PLAYGROUND_DISPLAY_NAME_STORAGE_KEY,
+        state.playerProfile.displayName,
+      )
     } catch {
       // ignore quota/private mode
     }
@@ -284,13 +332,16 @@ export function usePlaygroundRpg() {
     return values
   }, [state.playerProfile.equipped])
 
-  const pushToast = useCallback((kind: ToastKind, title: string, body: string) => {
-    const id = `${Date.now()}-${Math.random()}`
-    setToasts((prev) => [...prev, { id, kind, title, body }])
-    window.setTimeout(() => {
-      setToasts((prev) => prev.filter((toast) => toast.id !== id))
-    }, 3500)
-  }, [])
+  const pushToast = useCallback(
+    (kind: ToastKind, title: string, body: string) => {
+      const id = `${Date.now()}-${Math.random()}`
+      setToasts((prev) => [...prev, { id, kind, title, body }])
+      window.setTimeout(() => {
+        setToasts((prev) => prev.filter((toast) => toast.id !== id))
+      }, 3500)
+    },
+    [],
+  )
 
   const setDisplayName = useCallback((displayName: string) => {
     setState((prev) => ({
@@ -329,64 +380,77 @@ export function usePlaygroundRpg() {
     }))
   }, [])
 
-  const markObjective = useCallback((questId: string, objectiveId: string) => {
-    const quest = PLAYGROUND_QUESTS.find((entry) => entry.id === questId)
-    if (!quest) return
-    let completedQuest: PlaygroundQuest | null = null
-    setState((prev) => {
-      const progress = prev.playerProfile.questProgress[questId] ?? {
-        completed: false,
-        completedObjectives: [],
+  const markObjective = useCallback(
+    (questId: string, objectiveId: string) => {
+      const quest = PLAYGROUND_QUESTS.find((entry) => entry.id === questId)
+      if (!quest) return
+      let completedQuest: PlaygroundQuest | null = null
+      setState((prev) => {
+        const progress = prev.playerProfile.questProgress[questId] ?? {
+          completed: false,
+          completedObjectives: [],
+        }
+        if (progress.completedObjectives.includes(objectiveId)) return prev
+        const completedObjectives = Array.from(
+          new Set([...progress.completedObjectives, objectiveId]),
+        )
+        const next = {
+          ...prev,
+          playerProfile: {
+            ...prev.playerProfile,
+            questProgress: {
+              ...prev.playerProfile.questProgress,
+              [questId]: {
+                completed: progress.completed,
+                completedObjectives,
+              },
+            },
+          },
+        }
+        const complete = quest.objectives.every((objective) =>
+          completedObjectives.includes(objective.id),
+        )
+        if (!complete || prev.completedQuests.includes(quest.id)) return next
+        completedQuest = quest
+        return completeQuestState(next, quest)
+      })
+      const completed = completedQuest as PlaygroundQuest | null
+      if (completed) {
+        pushToast('quest', 'Quest Complete', completed.title)
+        pushToast('xp', '+ XP', `+${completed.reward.xp} XP`)
+        if (completed.reward.items?.length) {
+          for (const itemId of completed.reward.items) {
+            const item = itemById(itemId)
+            if (item) pushToast('item', '+ Item', item.name)
+          }
+        }
+        if (completed.reward.title) {
+          pushToast('title', 'Title Unlocked', completed.reward.title)
+        }
       }
-      if (progress.completedObjectives.includes(objectiveId)) return prev
-      const completedObjectives = Array.from(new Set([...progress.completedObjectives, objectiveId]))
-      const next = {
+    },
+    [pushToast],
+  )
+
+  const grantItems = useCallback(
+    (items: PlaygroundItemId[]) => {
+      if (!items?.length) return
+      setState((prev) => ({
         ...prev,
         playerProfile: {
           ...prev.playerProfile,
-          questProgress: {
-            ...prev.playerProfile.questProgress,
-            [questId]: {
-              completed: progress.completed,
-              completedObjectives,
-            },
-          },
+          inventory: Array.from(
+            new Set([...prev.playerProfile.inventory, ...items]),
+          ),
         },
+      }))
+      for (const itemId of items) {
+        const item = itemById(itemId)
+        if (item) pushToast('item', '+ Item', item.name)
       }
-      const complete = quest.objectives.every((objective) => completedObjectives.includes(objective.id))
-      if (!complete || prev.completedQuests.includes(quest.id)) return next
-      completedQuest = quest
-      return completeQuestState(next, quest)
-    })
-    if (completedQuest) {
-      pushToast('quest', 'Quest Complete', completedQuest.title)
-      pushToast('xp', '+ XP', `+${completedQuest.reward.xp} XP`)
-      if (completedQuest.reward.items?.length) {
-        for (const itemId of completedQuest.reward.items) {
-          const item = itemById(itemId)
-          if (item) pushToast('item', '+ Item', item.name)
-        }
-      }
-      if (completedQuest.reward.title) {
-        pushToast('title', 'Title Unlocked', completedQuest.reward.title)
-      }
-    }
-  }, [pushToast])
-
-  const grantItems = useCallback((items: PlaygroundItemId[]) => {
-    if (!items?.length) return
-    setState((prev) => ({
-      ...prev,
-      playerProfile: {
-        ...prev.playerProfile,
-        inventory: Array.from(new Set([...prev.playerProfile.inventory, ...items])),
-      },
-    }))
-    for (const itemId of items) {
-      const item = itemById(itemId)
-      if (item) pushToast('item', '+ Item', item.name)
-    }
-  }, [pushToast])
+    },
+    [pushToast],
+  )
 
   const grantSkillXp = useCallback(
     (skillXp: Partial<Record<PlaygroundSkillId, number>>) => {
@@ -406,34 +470,37 @@ export function usePlaygroundRpg() {
     markObjective('training-q2', 'open-kit')
   }, [markObjective])
 
-  const equipItem = useCallback((itemId: PlaygroundItemId) => {
-    const item = itemById(itemId)
-    if (!item?.slot) return false
-    setState((prev) => {
-      if (!prev.playerProfile.inventory.includes(itemId)) return prev
-      return {
-        ...prev,
-        playerProfile: {
-          ...prev.playerProfile,
-          equipped: {
-            ...prev.playerProfile.equipped,
-            [item.slot!]: itemId,
+  const equipItem = useCallback(
+    (itemId: PlaygroundItemId) => {
+      const item = itemById(itemId)
+      if (!item?.slot) return false
+      setState((prev) => {
+        if (!prev.playerProfile.inventory.includes(itemId)) return prev
+        return {
+          ...prev,
+          playerProfile: {
+            ...prev.playerProfile,
+            equipped: {
+              ...prev.playerProfile.equipped,
+              [item.slot!]: itemId,
+            },
           },
-        },
+        }
+      })
+      const objectiveId =
+        itemId === 'training-blade'
+          ? 'equip-blade'
+          : itemId === 'novice-cloak'
+            ? 'equip-cloak'
+            : null
+      if (objectiveId) markObjective('training-q2', objectiveId)
+      if (item.accent) {
+        pushToast('item', 'Equipped', item.name)
       }
-    })
-    const objectiveId =
-      itemId === 'training-blade'
-        ? 'equip-blade'
-        : itemId === 'novice-cloak'
-          ? 'equip-cloak'
-          : null
-    if (objectiveId) markObjective('training-q2', objectiveId)
-    if (item.accent) {
-      pushToast('item', 'Equipped', item.name)
-    }
-    return true
-  }, [markObjective, pushToast])
+      return true
+    },
+    [markObjective, pushToast],
+  )
 
   const unequipSlot = useCallback((slot: EquipmentSlot) => {
     setState((prev) => ({
@@ -448,30 +515,38 @@ export function usePlaygroundRpg() {
     }))
   }, [])
 
-  const completeQuest = useCallback((quest: PlaygroundQuest) => {
-    if (!quest) return
-    setState((prev) => completeQuestState(prev, quest))
-    pushToast('quest', 'Quest Complete', quest.title)
-    pushToast('xp', '+ XP', `+${quest.reward.xp} XP`)
-    if (quest.reward.items?.length) {
-      for (const itemId of quest.reward.items) {
-        const item = itemById(itemId)
-        if (item) pushToast('item', '+ Item', item.name)
+  const completeQuest = useCallback(
+    (quest: PlaygroundQuest) => {
+      if (!quest) return
+      setState((prev) => completeQuestState(prev, quest))
+      pushToast('quest', 'Quest Complete', quest.title)
+      pushToast('xp', '+ XP', `+${quest.reward.xp} XP`)
+      if (quest.reward.items?.length) {
+        for (const itemId of quest.reward.items) {
+          const item = itemById(itemId)
+          if (item) pushToast('item', '+ Item', item.name)
+        }
       }
-    }
-    if (quest.reward.title) pushToast('title', 'Title Unlocked', quest.reward.title)
-  }, [pushToast])
+      if (quest.reward.title)
+        pushToast('title', 'Title Unlocked', quest.reward.title)
+    },
+    [pushToast],
+  )
 
-  const completeQuestById = useCallback((questId: string) => {
-    const quest = PLAYGROUND_QUESTS.find((entry) => entry.id === questId)
-    if (quest) completeQuest(quest)
-  }, [completeQuest])
+  const completeQuestById = useCallback(
+    (questId: string) => {
+      const quest = PLAYGROUND_QUESTS.find((entry) => entry.id === questId)
+      if (quest) completeQuest(quest)
+    },
+    [completeQuest],
+  )
 
   const damagePlayer = useCallback((amount: number) => {
     setState((prev) => {
-      const nextHp = amount < 0
-        ? Math.min(prev.hpMax, prev.hp - amount)
-        : Math.max(0, Math.min(prev.hpMax, prev.hp - amount))
+      const nextHp =
+        amount < 0
+          ? Math.min(prev.hpMax, prev.hp - amount)
+          : Math.max(0, Math.min(prev.hpMax, prev.hp - amount))
       return { ...prev, hp: nextHp }
     })
   }, [])
@@ -486,35 +561,38 @@ export function usePlaygroundRpg() {
     return ok
   }, [])
 
-  const recordDefeat = useCallback((xpReward: number, itemDrop?: PlaygroundItemId) => {
-    setState((prev) => {
-      let xp = prev.playerProfile.xp + xpReward
-      let level = prev.playerProfile.level
-      let needed = xpForNextLevel(level)
-      while (xp >= needed) {
-        xp -= needed
-        level += 1
-        needed = xpForNextLevel(level)
+  const recordDefeat = useCallback(
+    (xpReward: number, itemDrop?: PlaygroundItemId) => {
+      setState((prev) => {
+        let xp = prev.playerProfile.xp + xpReward
+        let level = prev.playerProfile.level
+        let needed = xpForNextLevel(level)
+        while (xp >= needed) {
+          xp -= needed
+          level += 1
+          needed = xpForNextLevel(level)
+        }
+        return {
+          ...prev,
+          defeats: prev.defeats + 1,
+          playerProfile: {
+            ...prev.playerProfile,
+            xp,
+            level,
+            inventory: itemDrop
+              ? Array.from(new Set([...prev.playerProfile.inventory, itemDrop]))
+              : prev.playerProfile.inventory,
+          },
+        }
+      })
+      pushToast('xp', '+ XP', `+${xpReward} XP`)
+      if (itemDrop) {
+        const item = itemById(itemDrop)
+        if (item) pushToast('item', '+ Item', item.name)
       }
-      return {
-        ...prev,
-        defeats: prev.defeats + 1,
-        playerProfile: {
-          ...prev.playerProfile,
-          xp,
-          level,
-          inventory: itemDrop
-            ? Array.from(new Set([...prev.playerProfile.inventory, itemDrop]))
-            : prev.playerProfile.inventory,
-        },
-      }
-    })
-    pushToast('xp', '+ XP', `+${xpReward} XP`)
-    if (itemDrop) {
-      const item = itemById(itemDrop)
-      if (item) pushToast('item', '+ Item', item.name)
-    }
-  }, [pushToast])
+    },
+    [pushToast],
+  )
 
   useEffect(() => {
     const id = window.setInterval(() => {

--- a/src/screens/swarm/swarm-screen.tsx
+++ b/src/screens/swarm/swarm-screen.tsx
@@ -7,6 +7,7 @@ import {
   Activity01Icon,
   ChartLineData02Icon,
   ComputerTerminal01Icon,
+  CpuIcon,
   FlashIcon,
   RefreshIcon,
   ViewIcon,
@@ -123,11 +124,19 @@ export function SwarmScreen() {
 
   const swarmMembers = useMemo(() => {
     return [...crew]
-      .filter((member) => isWorkerId(member.id))
+      .filter((member) => {
+        if (!isWorkerId(member.id)) return false
+        const legacyNumberedWorker = /^swarm\d+$/i.test(member.id)
+        // Hide stale numbered swarm profiles by default. The current workspace
+        // roster is semantic (builder/reviewer/ops-watch/etc.); old swarm4/5/7/11
+        // runtime.json files can be weeks old and otherwise pollute Active Swarm.
+        if (legacyNumberedWorker && !roomIds.includes(member.id) && getOnlineStatus(member) !== 'online') return false
+        return true
+      })
       .sort((a, b) => {
         const aSwarm = /^swarm\d+$/i.test(a.id)
         const bSwarm = /^swarm\d+$/i.test(b.id)
-        if (aSwarm !== bSwarm) return aSwarm ? -1 : 1
+        if (aSwarm !== bSwarm) return aSwarm ? 1 : -1
         const rank = (member: CrewMember) => {
           if (roomIds.includes(member.id)) return 0
           const status = getOnlineStatus(member)

--- a/src/screens/swarm2/swarm2-orchestrator-card.tsx
+++ b/src/screens/swarm2/swarm2-orchestrator-card.tsx
@@ -12,7 +12,10 @@ import {
 import { AgentProgress } from '@/components/agent-view/agent-progress'
 import { PixelAvatar } from '@/components/agent-swarm/pixel-avatar'
 import { Button } from '@/components/ui/button'
-import { RouterChat, type DispatchResponse } from '@/components/swarm/router-chat'
+import {
+  RouterChat,
+  type DispatchResponse,
+} from '@/components/swarm/router-chat'
 import { OfficeView } from '@/screens/gateway/components/office-view'
 import type { AgentWorkingRow } from '@/screens/gateway/components/agents-working-panel'
 import type { CrewMember } from '@/hooks/use-crew-status'
@@ -44,14 +47,38 @@ export type Swarm2OrchestratorCardProps = {
   viewMode: 'cards' | 'kanban' | 'runtime' | 'reports'
   onViewModeChange: (mode: 'cards' | 'kanban' | 'runtime' | 'reports') => void
   lanes?: Array<{ role: string; count: number; active: number }>
-  activeAgents?: Array<{ workerId: string; workerName: string; role: string; task: string; progress: number; state: 'working' | 'reviewing' | 'blocked' | 'ready'; age: string }>
+  activeAgents?: Array<{
+    workerId: string
+    workerName: string
+    role: string
+    task: string
+    progress: number
+    state: 'working' | 'reviewing' | 'blocked' | 'ready'
+    age: string
+  }>
   members: Array<CrewMember>
   roomIds: Array<string>
   selectedId: string | null
-  recentUpdates?: Array<{ workerId: string; workerName: string; text: string; age: string; tone: 'idle' | 'active' | 'warning' }>
-  latestMission?: { id: string; title: string; state: string; assignmentCount: number; checkpointedCount: number } | null
+  recentUpdates?: Array<{
+    workerId: string
+    workerName: string
+    text: string
+    age: string
+    tone: 'idle' | 'active' | 'warning'
+  }>
+  latestMission?: {
+    id: string
+    title: string
+    state: string
+    assignmentCount: number
+    checkpointedCount: number
+  } | null
   inboxCounts?: { needsReview: number; blocked: number; ready: number }
-  routerSeed?: { key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null
+  routerSeed?: {
+    key: number
+    prompt: string
+    mode: 'auto' | 'manual' | 'broadcast'
+  } | null
   onOpenRouter: () => void
   onRouterResults?: (response: DispatchResponse) => void
   /**
@@ -123,28 +150,52 @@ export function Swarm2OrchestratorCard({
   const isActive = activeRuntimeCount > 0
   const lensIndex = AGENT_LENSES.findIndex((lens) => lens.id === agentLens)
   const filteredAgents = useMemo(
-    () => activeAgents.filter((agent) => agentLens === 'all' || agent.state === agentLens),
+    () =>
+      activeAgents.filter(
+        (agent) => agentLens === 'all' || agent.state === agentLens,
+      ),
     [activeAgents, agentLens],
   )
   const agentCounts = useMemo(() => {
-    const counts: Record<AgentLens, number> = { all: activeAgents.length, working: 0, reviewing: 0, blocked: 0, ready: 0 }
+    const counts: Record<AgentLens, number> = {
+      all: activeAgents.length,
+      working: 0,
+      reviewing: 0,
+      blocked: 0,
+      ready: 0,
+    }
     for (const agent of activeAgents) counts[agent.state] += 1
     return counts
   }, [activeAgents])
 
-  const agentPageCount = Math.max(1, Math.ceil(filteredAgents.length / AGENT_PAGE_SIZE))
-  const visibleAgents = filteredAgents.slice(agentPage * AGENT_PAGE_SIZE, agentPage * AGENT_PAGE_SIZE + AGENT_PAGE_SIZE)
-  const officeAgents = useMemo<AgentWorkingRow[]>(() => activeAgents.map((agent) => ({
-    id: agent.workerId,
-    name: agent.workerName,
-    modelId: agent.role,
-    status: agent.state === 'blocked' ? 'error' : agent.state === 'ready' ? 'done' : 'active',
-    lastLine: agent.task,
-    lastAt: Date.now(),
-    taskCount: agent.state === 'ready' ? 0 : 1,
-    currentTask: agent.task,
-    roleDescription: agent.role,
-  })), [activeAgents])
+  const agentPageCount = Math.max(
+    1,
+    Math.ceil(filteredAgents.length / AGENT_PAGE_SIZE),
+  )
+  const visibleAgents = filteredAgents.slice(
+    agentPage * AGENT_PAGE_SIZE,
+    agentPage * AGENT_PAGE_SIZE + AGENT_PAGE_SIZE,
+  )
+  const officeAgents = useMemo<AgentWorkingRow[]>(
+    () =>
+      activeAgents.map((agent) => ({
+        id: agent.workerId,
+        name: agent.workerName,
+        modelId: agent.role,
+        status:
+          agent.state === 'blocked'
+            ? 'error'
+            : agent.state === 'ready'
+              ? 'idle'
+              : 'active',
+        lastLine: agent.task,
+        lastAt: Date.now(),
+        taskCount: agent.state === 'ready' ? 0 : 1,
+        currentTask: agent.task,
+        roleDescription: agent.role,
+      })),
+    [activeAgents],
+  )
 
   function cycleAgentPage(delta: -1 | 1) {
     setAgentPage((page) => (page + delta + agentPageCount) % agentPageCount)
@@ -165,12 +216,14 @@ export function Swarm2OrchestratorCard({
       >
         <div className="relative flex flex-col items-center gap-3 text-center">
           <div className="absolute left-0 top-0 flex shrink-0 items-center gap-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-1 shadow-sm">
-            {([
-              ['cards', 'Control'],
-              ['kanban', 'Board'],
-              ['reports', 'Inbox'],
-              ['runtime', 'Runtime'],
-            ] as const).map(([mode, label]) => (
+            {(
+              [
+                ['cards', 'Control'],
+                ['kanban', 'Board'],
+                ['reports', 'Inbox'],
+                ['runtime', 'Runtime'],
+              ] as const
+            ).map(([mode, label]) => (
               <button
                 key={mode}
                 type="button"
@@ -291,7 +344,10 @@ export function Swarm2OrchestratorCard({
                         : 'border-transparent bg-transparent text-[var(--theme-muted)] hover:border-[var(--theme-border)] hover:bg-[var(--theme-card)] hover:text-[var(--theme-text)]',
                     )}
                   >
-                    {lens.label}{lens.id !== 'all' && agentCounts[lens.id] ? ` ${agentCounts[lens.id]}` : ''}
+                    {lens.label}
+                    {lens.id !== 'all' && agentCounts[lens.id]
+                      ? ` ${agentCounts[lens.id]}`
+                      : ''}
                   </button>
                 ))}
               </div>
@@ -299,19 +355,34 @@ export function Swarm2OrchestratorCard({
                 <button
                   type="button"
                   onClick={() => setSwarmCardMode('cards')}
-                  className={cn('rounded-lg px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em]', swarmCardMode === 'cards' ? 'bg-[var(--theme-accent)] text-primary-950' : 'text-[var(--theme-muted)] hover:bg-[var(--theme-bg)] hover:text-[var(--theme-text)]')}
+                  className={cn(
+                    'rounded-lg px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em]',
+                    swarmCardMode === 'cards'
+                      ? 'bg-[var(--theme-accent)] text-primary-950'
+                      : 'text-[var(--theme-muted)] hover:bg-[var(--theme-bg)] hover:text-[var(--theme-text)]',
+                  )}
                 >
                   Active Swarm
                 </button>
                 <button
                   type="button"
                   onClick={() => setSwarmCardMode('office')}
-                  className={cn('rounded-lg px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em]', swarmCardMode === 'office' ? 'bg-[var(--theme-accent)] text-primary-950' : 'text-[var(--theme-muted)] hover:bg-[var(--theme-bg)] hover:text-[var(--theme-text)]')}
+                  className={cn(
+                    'rounded-lg px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.14em]',
+                    swarmCardMode === 'office'
+                      ? 'bg-[var(--theme-accent)] text-primary-950'
+                      : 'text-[var(--theme-muted)] hover:bg-[var(--theme-bg)] hover:text-[var(--theme-text)]',
+                  )}
                 >
                   Office
                 </button>
               </div>
-              <div className={cn('flex items-center justify-center gap-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-1 justify-self-center md:justify-self-end', swarmCardMode === 'office' && 'opacity-40')}>
+              <div
+                className={cn(
+                  'flex items-center justify-center gap-1 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-1 justify-self-center md:justify-self-end',
+                  swarmCardMode === 'office' && 'opacity-40',
+                )}
+              >
                 <button
                   type="button"
                   onClick={() => cycleAgentPage(-1)}
@@ -321,16 +392,23 @@ export function Swarm2OrchestratorCard({
                 >
                   ←
                 </button>
-                <div className="flex items-center gap-1 px-1" aria-label={`Agent page ${Math.min(agentPage + 1, agentPageCount)} of ${agentPageCount}`}>
-                  {Array.from({ length: Math.min(agentPageCount, 5) }).map((_, index) => (
-                    <span
-                      key={index}
-                      className={cn(
-                        'size-1.5 rounded-full',
-                        index === agentPage % 5 ? 'bg-[var(--theme-accent)]' : 'bg-[var(--theme-muted)]/30',
-                      )}
-                    />
-                  ))}
+                <div
+                  className="flex items-center gap-1 px-1"
+                  aria-label={`Agent page ${Math.min(agentPage + 1, agentPageCount)} of ${agentPageCount}`}
+                >
+                  {Array.from({ length: Math.min(agentPageCount, 5) }).map(
+                    (_, index) => (
+                      <span
+                        key={index}
+                        className={cn(
+                          'size-1.5 rounded-full',
+                          index === agentPage % 5
+                            ? 'bg-[var(--theme-accent)]'
+                            : 'bg-[var(--theme-muted)]/30',
+                        )}
+                      />
+                    ),
+                  )}
                 </div>
                 <button
                   type="button"
@@ -348,8 +426,12 @@ export function Swarm2OrchestratorCard({
               <div className="h-[360px] overflow-hidden rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)]">
                 <OfficeView
                   agentRows={officeAgents}
-                  missionRunning={activeAgents.some((agent) => agent.state === 'working' || agent.state === 'reviewing')}
+                  missionRunning={activeAgents.some(
+                    (agent) =>
+                      agent.state === 'working' || agent.state === 'reviewing',
+                  )}
                   onViewOutput={() => undefined}
+                  processType="parallel"
                   containerHeight={360}
                   hideHeader
                 />
@@ -360,28 +442,79 @@ export function Swarm2OrchestratorCard({
                   const isBlocked = agent.state === 'blocked'
                   const isReview = agent.state === 'reviewing'
                   return (
-                    <div key={agent.workerId} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2.5">
+                    <div
+                      key={agent.workerId}
+                      className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2.5"
+                    >
                       <div className="flex items-start gap-2.5">
                         <div className="relative shrink-0">
                           <PixelAvatar
                             size={30}
-                            color={isBlocked ? '#ef4444' : isReview ? '#f59e0b' : '#34d399'}
-                            accentColor={isBlocked ? '#fecaca' : isReview ? '#fde68a' : '#bbf7d0'}
-                            status={isBlocked ? 'failed' : isReview ? 'thinking' : 'running'}
+                            color={
+                              isBlocked
+                                ? '#ef4444'
+                                : isReview
+                                  ? '#f59e0b'
+                                  : '#34d399'
+                            }
+                            accentColor={
+                              isBlocked
+                                ? '#fecaca'
+                                : isReview
+                                  ? '#fde68a'
+                                  : '#bbf7d0'
+                            }
+                            status={
+                              isBlocked
+                                ? 'failed'
+                                : isReview
+                                  ? 'thinking'
+                                  : 'running'
+                            }
                           />
-                          <span className={cn('absolute -bottom-0.5 -right-0.5 size-2 rounded-full border border-[var(--theme-card)]', isBlocked ? 'bg-red-500' : isReview ? 'bg-amber-500' : 'bg-emerald-500 animate-pulse')} />
+                          <span
+                            className={cn(
+                              'absolute -bottom-0.5 -right-0.5 size-2 rounded-full border border-[var(--theme-card)]',
+                              isBlocked
+                                ? 'bg-red-500'
+                                : isReview
+                                  ? 'bg-amber-500'
+                                  : 'bg-emerald-500 animate-pulse',
+                            )}
+                          />
                         </div>
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center justify-between gap-2">
-                            <div className="truncate text-[11px] font-semibold text-[var(--theme-text)]">{agent.workerName}</div>
-                            <div className="shrink-0 text-[9px] text-[var(--theme-muted)]">{agent.age}</div>
+                            <div className="truncate text-[11px] font-semibold text-[var(--theme-text)]">
+                              {agent.workerName}
+                            </div>
+                            <div className="shrink-0 text-[9px] text-[var(--theme-muted)]">
+                              {agent.age}
+                            </div>
                           </div>
-                          <div className="mt-0.5 truncate text-[9px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">{agent.state}</div>
+                          <div className="mt-0.5 truncate text-[9px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                            {agent.state}
+                          </div>
                         </div>
                       </div>
-                      <div className="mt-2 line-clamp-3 text-[10px] leading-snug text-[var(--theme-muted-2)]" title={agent.task}>{agent.task}</div>
+                      <div
+                        className="mt-2 line-clamp-3 text-[10px] leading-snug text-[var(--theme-muted-2)]"
+                        title={agent.task}
+                      >
+                        {agent.task}
+                      </div>
                       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--theme-bg)]">
-                        <div className={cn('h-full rounded-full transition-all', isBlocked ? 'bg-red-500' : isReview ? 'bg-amber-500' : 'bg-[var(--theme-accent)]')} style={{ width: `${agent.progress}%` }} />
+                        <div
+                          className={cn(
+                            'h-full rounded-full transition-all',
+                            isBlocked
+                              ? 'bg-red-500'
+                              : isReview
+                                ? 'bg-amber-500'
+                                : 'bg-[var(--theme-accent)]',
+                          )}
+                          style={{ width: `${agent.progress}%` }}
+                        />
                       </div>
                     </div>
                   )
@@ -389,7 +522,9 @@ export function Swarm2OrchestratorCard({
               </div>
             ) : (
               <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-[11px] text-[var(--theme-muted)]">
-                {activeAgents.length ? `No ${AGENT_LENSES[lensIndex]?.label.toLowerCase() ?? 'matching'} agents right now.` : 'Dispatch a mission to see each worker appear here with progress.'}
+                {activeAgents.length
+                  ? `No ${AGENT_LENSES[lensIndex]?.label.toLowerCase() ?? 'matching'} agents right now.`
+                  : 'Dispatch a mission to see each worker appear here with progress.'}
               </div>
             )}
           </div>

--- a/src/screens/swarm2/swarm2-reports-view.tsx
+++ b/src/screens/swarm2/swarm2-reports-view.tsx
@@ -5,7 +5,13 @@ import { AgentProgress } from '@/components/agent-view/agent-progress'
 import { PixelAvatar } from '@/components/agent-swarm/pixel-avatar'
 import { cn } from '@/lib/utils'
 
-type ReportState = 'all' | 'needs_review' | 'ready' | 'blocked' | 'in_progress' | 'artifact'
+type ReportState =
+  | 'all'
+  | 'needs_review'
+  | 'ready'
+  | 'blocked'
+  | 'in_progress'
+  | 'artifact'
 type ReportLayout = 'board' | 'cards' | 'list'
 
 type RuntimeArtifact = {
@@ -120,6 +126,7 @@ type WorkerReportCard = {
   readyCount: number
   blockedCount: number
   artifactCount: number
+  prUrl: string | null
 }
 
 const STATE_FILTERS: Array<{ id: ReportState; label: string }> = [
@@ -142,7 +149,9 @@ function compact(value: string | null | undefined, max = 180): string {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text
 }
 
-function splitChangedFiles(value: string | null | undefined): Array<RuntimeArtifact> {
+function splitChangedFiles(
+  value: string | null | undefined,
+): Array<RuntimeArtifact> {
   return clean(value, '')
     .split(/\n|,/)
     .map((item) => item.trim())
@@ -157,9 +166,12 @@ function splitChangedFiles(value: string | null | undefined): Array<RuntimeArtif
     }))
 }
 
-function stateForAssignment(assignment: MissionAssignment): Exclude<ReportState, 'all'> {
+function stateForAssignment(
+  assignment: MissionAssignment,
+): Exclude<ReportState, 'all'> {
   const checkpoint = assignment.checkpoint
-  const statusText = `${assignment.state ?? ''} ${checkpoint?.stateLabel ?? ''} ${checkpoint?.checkpointStatus ?? ''}`.toLowerCase()
+  const statusText =
+    `${assignment.state ?? ''} ${checkpoint?.stateLabel ?? ''} ${checkpoint?.checkpointStatus ?? ''}`.toLowerCase()
   if (
     statusText.includes('blocked') ||
     statusText.includes('needs_input') ||
@@ -167,17 +179,42 @@ function stateForAssignment(assignment: MissionAssignment): Exclude<ReportState,
   ) {
     return 'blocked'
   }
-  if (assignment.reviewRequired && ['checkpointed', 'reviewing'].includes(assignment.state ?? '')) return 'needs_review'
-  if (['done', 'complete'].includes(assignment.state ?? '') || statusText.includes('handoff') || statusText.includes('done')) return 'ready'
+  if (
+    assignment.reviewRequired &&
+    ['checkpointed', 'reviewing'].includes(assignment.state ?? '')
+  )
+    return 'needs_review'
+  if (
+    ['done', 'complete'].includes(assignment.state ?? '') ||
+    statusText.includes('handoff') ||
+    statusText.includes('done')
+  )
+    return 'ready'
   return 'in_progress'
 }
 
-function stateForRuntime(entry: RuntimeReportEntry): Exclude<ReportState, 'all'> {
-  const statusText = `${entry.checkpointStatus ?? ''} ${entry.currentTask ?? ''}`.toLowerCase()
-  if (entry.blockedReason || entry.needsHuman || statusText.includes('blocked') || statusText.includes('needs_input')) return 'blocked'
+function stateForRuntime(
+  entry: RuntimeReportEntry,
+): Exclude<ReportState, 'all'> {
+  const statusText =
+    `${entry.checkpointStatus ?? ''} ${entry.currentTask ?? ''}`.toLowerCase()
+  if (
+    entry.blockedReason ||
+    entry.needsHuman ||
+    statusText.includes('blocked') ||
+    statusText.includes('needs_input')
+  )
+    return 'blocked'
   if (statusText.includes('review')) return 'needs_review'
-  if (statusText.includes('done') || statusText.includes('handoff') || entry.lastResult || entry.lastRealResult) return 'ready'
-  if ((entry.artifacts?.length ?? 0) > 0 || (entry.previews?.length ?? 0) > 0) return 'artifact'
+  if (
+    statusText.includes('done') ||
+    statusText.includes('handoff') ||
+    entry.lastResult ||
+    entry.lastRealResult
+  )
+    return 'ready'
+  if ((entry.artifacts?.length ?? 0) > 0 || (entry.previews?.length ?? 0) > 0)
+    return 'artifact'
   return 'in_progress'
 }
 
@@ -203,7 +240,9 @@ export function buildSwarm2ReportRows({
   missions: Array<MissionSummary>
   runtimes: Array<RuntimeReportEntry>
 }): Array<Swarm2ReportRow> {
-  const runtimeByWorker = new Map(runtimes.map((entry) => [entry.workerId, entry]))
+  const runtimeByWorker = new Map(
+    runtimes.map((entry) => [entry.workerId, entry]),
+  )
   const rows: Array<Swarm2ReportRow> = []
 
   for (const mission of missions) {
@@ -225,9 +264,19 @@ export function buildSwarm2ReportRows({
         workerName: runtime?.displayName || workerId,
         state,
         stateLabel: stateLabel(state),
-        updatedAt: assignment.completedAt ?? mission.updatedAt ?? runtime?.lastOutputAt ?? null,
-        summary: compact(checkpoint?.result ?? checkpoint?.blocker ?? checkpoint?.nextAction ?? assignment.task),
-        checkpointStatus: checkpoint?.checkpointStatus ?? checkpoint?.stateLabel ?? null,
+        updatedAt:
+          assignment.completedAt ??
+          mission.updatedAt ??
+          runtime?.lastOutputAt ??
+          null,
+        summary: compact(
+          checkpoint?.result ??
+            checkpoint?.blocker ??
+            checkpoint?.nextAction ??
+            assignment.task,
+        ),
+        checkpointStatus:
+          checkpoint?.checkpointStatus ?? checkpoint?.stateLabel ?? null,
         blocker: checkpoint?.blocker ?? null,
         nextAction: checkpoint?.nextAction ?? null,
         reviewRequired: assignment.reviewRequired === true,
@@ -240,10 +289,17 @@ export function buildSwarm2ReportRows({
           { label: 'Commands run', value: clean(checkpoint?.commandsRun) },
           { label: 'Blocker', value: clean(checkpoint?.blocker) },
           { label: 'Next action', value: clean(checkpoint?.nextAction) },
-          { label: 'Checkpoint', value: clean(checkpoint?.checkpointStatus ?? checkpoint?.stateLabel) },
+          {
+            label: 'Checkpoint',
+            value: clean(
+              checkpoint?.checkpointStatus ?? checkpoint?.stateLabel,
+            ),
+          },
           { label: 'Reviewer', value: clean(assignment.reviewedBy) },
         ],
-        artifacts: inferredArtifacts.length ? inferredArtifacts : runtime?.artifacts ?? [],
+        artifacts: inferredArtifacts.length
+          ? inferredArtifacts
+          : (runtime?.artifacts ?? []),
         previews: runtime?.previews ?? [],
       })
     }
@@ -263,8 +319,19 @@ export function buildSwarm2ReportRows({
     const state = stateForRuntime(runtime)
     rows.push({
       id: `runtime:${runtime.workerId}:${runtime.lastOutputAt ?? runtime.lastSessionStartedAt ?? 'latest'}`,
-      kind: (runtime.artifacts?.length ?? 0) > 0 || (runtime.previews?.length ?? 0) > 0 ? 'artifact' : 'runtime',
-      title: clean(runtime.currentTask ?? runtime.lastRealSummary ?? runtime.lastSummary ?? runtime.lastRealResult ?? runtime.lastResult, 'Runtime output'),
+      kind:
+        (runtime.artifacts?.length ?? 0) > 0 ||
+        (runtime.previews?.length ?? 0) > 0
+          ? 'artifact'
+          : 'runtime',
+      title: clean(
+        runtime.currentTask ??
+          runtime.lastRealSummary ??
+          runtime.lastSummary ??
+          runtime.lastRealResult ??
+          runtime.lastResult,
+        'Runtime output',
+      ),
       missionId: null,
       missionTitle: null,
       assignmentId: null,
@@ -273,7 +340,14 @@ export function buildSwarm2ReportRows({
       state,
       stateLabel: stateLabel(state),
       updatedAt: runtime.lastOutputAt ?? runtime.lastSessionStartedAt ?? null,
-      summary: compact(runtime.blockedReason ?? runtime.lastRealResult ?? runtime.lastResult ?? runtime.lastRealSummary ?? runtime.lastSummary ?? runtime.currentTask),
+      summary: compact(
+        runtime.blockedReason ??
+          runtime.lastRealResult ??
+          runtime.lastResult ??
+          runtime.lastRealSummary ??
+          runtime.lastSummary ??
+          runtime.currentTask,
+      ),
       checkpointStatus: runtime.checkpointStatus ?? null,
       blocker: runtime.blockedReason ?? null,
       nextAction: null,
@@ -288,14 +362,21 @@ export function buildSwarm2ReportRows({
         { label: 'Real result', value: clean(runtime.lastRealResult) },
         { label: 'Blocked reason', value: clean(runtime.blockedReason) },
         { label: 'Checkpoint status', value: clean(runtime.checkpointStatus) },
-        { label: 'Recent log tail', value: compact(runtime.recentLogTail, 900) },
+        {
+          label: 'Recent log tail',
+          value: compact(runtime.recentLogTail, 900),
+        },
       ],
       artifacts: runtime.artifacts ?? [],
       previews: runtime.previews ?? [],
     })
   }
 
-  return rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0) || a.workerId.localeCompare(b.workerId))
+  return rows.sort(
+    (a, b) =>
+      (b.updatedAt ?? 0) - (a.updatedAt ?? 0) ||
+      a.workerId.localeCompare(b.workerId),
+  )
 }
 
 export function buildSwarm2InboxLanes({
@@ -306,10 +387,16 @@ export function buildSwarm2InboxLanes({
   runtimes: Array<RuntimeReportEntry>
 }): Swarm2InboxLanes {
   const rows = buildSwarm2ReportRows({ missions, runtimes })
-  const actionable = rows.filter((row): row is Swarm2InboxItem => {
-    if (row.kind !== 'checkpoint' || !row.missionId) return false
-    return row.state === 'needs_review' || row.state === 'blocked' || row.state === 'ready'
-  }).map((row) => ({ ...row, lane: row.state as Swarm2InboxLaneId }))
+  const actionable = rows
+    .filter((row): row is Swarm2InboxItem => {
+      if (row.kind !== 'checkpoint' || !row.missionId) return false
+      return (
+        row.state === 'needs_review' ||
+        row.state === 'blocked' ||
+        row.state === 'ready'
+      )
+    })
+    .map((row) => ({ ...row, lane: row.state as Swarm2InboxLaneId }))
 
   return {
     needs_review: actionable.filter((row) => row.lane === 'needs_review'),
@@ -360,9 +447,20 @@ function statePriority(state: Exclude<ReportState, 'all'>): number {
 }
 
 function colorForWorker(workerId: string): string {
-  const palette = ['#34d399', '#60a5fa', '#a78bfa', '#f59e0b', '#fb7185', '#22d3ee', '#84cc16', '#f472b6']
+  const palette = [
+    '#34d399',
+    '#60a5fa',
+    '#a78bfa',
+    '#f59e0b',
+    '#fb7185',
+    '#22d3ee',
+    '#84cc16',
+    '#f472b6',
+  ]
   const number = Number.parseInt(workerId.replace(/\D/g, ''), 10)
-  return Number.isFinite(number) && number > 0 ? palette[(number - 1) % palette.length] : palette[0]
+  return Number.isFinite(number) && number > 0
+    ? palette[(number - 1) % palette.length]
+    : palette[0]
 }
 
 function roleFromWorkerId(workerId: string): string {
@@ -383,7 +481,9 @@ function roleFromWorkerId(workerId: string): string {
   }
 }
 
-function buildWorkerReportCards(rows: Array<Swarm2ReportRow>): Array<WorkerReportCard> {
+function buildWorkerReportCards(
+  rows: Array<Swarm2ReportRow>,
+): Array<WorkerReportCard> {
   const grouped = new Map<string, Array<Swarm2ReportRow>>()
   for (const row of rows) {
     const existing = grouped.get(row.workerId)
@@ -391,31 +491,40 @@ function buildWorkerReportCards(rows: Array<Swarm2ReportRow>): Array<WorkerRepor
     else grouped.set(row.workerId, [row])
   }
 
-  return [...grouped.entries()].map(([workerId, workerRows]) => {
-    const sorted = [...workerRows].sort((a, b) => {
+  return [...grouped.entries()]
+    .map(([workerId, workerRows]) => {
+      const sorted = [...workerRows].sort((a, b) => {
+        const stateRank = statePriority(a.state) - statePriority(b.state)
+        if (stateRank !== 0) return stateRank
+        return (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
+      })
+      const latest = sorted[0]
+      return {
+        workerId,
+        workerName: latest.workerName,
+        role: latest.missionTitle ?? roleFromWorkerId(workerId),
+        state: latest.state,
+        stateLabel: latest.stateLabel,
+        latest,
+        rows: sorted,
+        reviewCount: workerRows.filter((row) => row.state === 'needs_review')
+          .length,
+        readyCount: workerRows.filter((row) => row.state === 'ready').length,
+        blockedCount: workerRows.filter((row) => row.state === 'blocked')
+          .length,
+        artifactCount: workerRows.reduce(
+          (sum, row) => sum + row.artifacts.length + row.previews.length,
+          0,
+        ),
+        prUrl:
+          sorted.map((row) => extractPullRequestUrl(row)).find(Boolean) ?? null,
+      }
+    })
+    .sort((a, b) => {
       const stateRank = statePriority(a.state) - statePriority(b.state)
       if (stateRank !== 0) return stateRank
-      return (b.updatedAt ?? 0) - (a.updatedAt ?? 0)
+      return (b.latest.updatedAt ?? 0) - (a.latest.updatedAt ?? 0)
     })
-    const latest = sorted[0]
-    return {
-      workerId,
-      workerName: latest.workerName,
-      role: latest.missionTitle ?? roleFromWorkerId(workerId),
-      state: latest.state,
-      stateLabel: latest.stateLabel,
-      latest,
-      rows: sorted,
-      reviewCount: workerRows.filter((row) => row.state === 'needs_review').length,
-      readyCount: workerRows.filter((row) => row.state === 'ready').length,
-      blockedCount: workerRows.filter((row) => row.state === 'blocked').length,
-      artifactCount: workerRows.reduce((sum, row) => sum + row.artifacts.length + row.previews.length, 0),
-    }
-  }).sort((a, b) => {
-    const stateRank = statePriority(a.state) - statePriority(b.state)
-    if (stateRank !== 0) return stateRank
-    return (b.latest.updatedAt ?? 0) - (a.latest.updatedAt ?? 0)
-  })
 }
 
 function detailValue(row: Swarm2ReportRow, label: string): string | null {
@@ -427,7 +536,10 @@ function cleanDetail(value: string | null | undefined): string | null {
   return text && text !== '—' ? text : null
 }
 
-export function buildBlockedGuidanceTask(row: Swarm2InboxItem, guidance: string): string {
+export function buildBlockedGuidanceTask(
+  row: Swarm2InboxItem,
+  guidance: string,
+): string {
   return [
     guidance.trim(),
     '',
@@ -458,7 +570,10 @@ export function extractPullRequestUrl(row: Swarm2ReportRow): string | null {
   return null
 }
 
-export async function postSwarmDispatch(body: { assignments: Array<{ workerId: string; task: string }> }, fetchImpl: typeof fetch = fetch): Promise<void> {
+export async function postSwarmDispatch(
+  body: { assignments: Array<{ workerId: string; task: string }> },
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
   const res = await fetchImpl('/api/swarm-dispatch', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -470,7 +585,10 @@ export async function postSwarmDispatch(body: { assignments: Array<{ workerId: s
   }
 }
 
-export async function markInboxItemReadyForEric(input: { missionId: string; assignmentId: string }, fetchImpl: typeof fetch = fetch): Promise<void> {
+export async function markInboxItemReadyForEric(
+  input: { missionId: string; assignmentId: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
   const res = await fetchImpl('/api/swarm-missions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -512,7 +630,9 @@ export function Swarm2ReportsView({
   const [missionFilter, setMissionFilter] = useState('all')
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({})
-  const [replyErrors, setReplyErrors] = useState<Record<string, string | null>>({})
+  const [replyErrors, setReplyErrors] = useState<Record<string, string | null>>(
+    {},
+  )
   const [busyId, setBusyId] = useState<string | null>(null)
   const [toastMessage, setToastMessage] = useState<string | null>(null)
 
@@ -522,11 +642,24 @@ export function Swarm2ReportsView({
     return () => window.clearTimeout(timer)
   }, [toastMessage])
 
-  const rows = useMemo(() => buildSwarm2ReportRows({ missions, runtimes }), [missions, runtimes])
-  const inboxLanes = useMemo(() => buildSwarm2InboxLanes({ missions, runtimes }), [missions, runtimes])
-  const workers = useMemo(() => [...new Set(rows.map((row) => row.workerId))].sort(), [rows])
+  const rows = useMemo(
+    () => buildSwarm2ReportRows({ missions, runtimes }),
+    [missions, runtimes],
+  )
+  const inboxLanes = useMemo(
+    () => buildSwarm2InboxLanes({ missions, runtimes }),
+    [missions, runtimes],
+  )
+  const workers = useMemo(
+    () => [...new Set(rows.map((row) => row.workerId))].sort(),
+    [rows],
+  )
   const missionOptions = useMemo(
-    () => missions.map((mission) => ({ id: mission.id, label: mission.title || mission.id })),
+    () =>
+      missions.map((mission) => ({
+        id: mission.id,
+        label: mission.title || mission.id,
+      })),
     [missions],
   )
   const filteredRows = rows.filter((row) => {
@@ -535,7 +668,10 @@ export function Swarm2ReportsView({
     if (missionFilter !== 'all' && row.missionId !== missionFilter) return false
     return true
   })
-  const workerCards = useMemo(() => buildWorkerReportCards(filteredRows), [filteredRows])
+  const workerCards = useMemo(
+    () => buildWorkerReportCards(filteredRows),
+    [filteredRows],
+  )
   const counts = rows.reduce<Record<Exclude<ReportState, 'all'>, number>>(
     (acc, row) => {
       acc[row.state] += 1
@@ -555,23 +691,35 @@ export function Swarm2ReportsView({
   async function sendGuidance(row: Swarm2InboxItem) {
     const guidance = cleanDetail(replyDrafts[row.id])
     if (!guidance) {
-      setReplyErrors((current) => ({ ...current, [row.id]: 'Add guidance before sending.' }))
+      setReplyErrors((current) => ({
+        ...current,
+        [row.id]: 'Add guidance before sending.',
+      }))
       return
     }
     setBusyId(`reply:${row.id}`)
     setReplyErrors((current) => ({ ...current, [row.id]: null }))
     try {
       await postSwarmDispatch({
-        assignments: [{ workerId: row.workerId, task: buildBlockedGuidanceTask(row, guidance) }],
+        assignments: [
+          {
+            workerId: row.workerId,
+            task: buildBlockedGuidanceTask(row, guidance),
+          },
+        ],
       })
       await refreshData()
-      setReplyDrafts((current) => ({ ...current, [row.id]: buildReplyPrefill(row) }))
+      setReplyDrafts((current) => ({
+        ...current,
+        [row.id]: buildReplyPrefill(row),
+      }))
       setExpandedId(null)
       showToast(`Sent to ${row.workerId}`)
     } catch (error) {
       setReplyErrors((current) => ({
         ...current,
-        [row.id]: error instanceof Error ? error.message : 'Failed to send guidance.',
+        [row.id]:
+          error instanceof Error ? error.message : 'Failed to send guidance.',
       }))
     } finally {
       setBusyId(null)
@@ -582,7 +730,9 @@ export function Swarm2ReportsView({
     setBusyId(`review:${row.id}`)
     try {
       await postSwarmDispatch({
-        assignments: [{ workerId: 'swarm6', task: buildReviewerDispatchTask(row) }],
+        assignments: [
+          { workerId: 'swarm6', task: buildReviewerDispatchTask(row) },
+        ],
       })
       await refreshData()
       onRouteToReviewer?.(row)
@@ -590,7 +740,8 @@ export function Swarm2ReportsView({
     } catch (error) {
       setReplyErrors((current) => ({
         ...current,
-        [row.id]: error instanceof Error ? error.message : 'Failed to route reviewer.',
+        [row.id]:
+          error instanceof Error ? error.message : 'Failed to route reviewer.',
       }))
     } finally {
       setBusyId(null)
@@ -601,13 +752,19 @@ export function Swarm2ReportsView({
     if (!row.missionId || !row.assignmentId) return
     setBusyId(`ready:${row.id}`)
     try {
-      await markInboxItemReadyForEric({ missionId: row.missionId, assignmentId: row.assignmentId })
+      await markInboxItemReadyForEric({
+        missionId: row.missionId,
+        assignmentId: row.assignmentId,
+      })
       await refreshData()
       showToast(`Marked ${row.workerId} ready for Eric merge`)
     } catch (error) {
       setReplyErrors((current) => ({
         ...current,
-        [row.id]: error instanceof Error ? error.message : 'Failed to mark ready for Eric.',
+        [row.id]:
+          error instanceof Error
+            ? error.message
+            : 'Failed to mark ready for Eric.',
       }))
     } finally {
       setBusyId(null)
@@ -632,17 +789,27 @@ export function Swarm2ReportsView({
     const disabled = busyId === `reply:${row.id}`
     return (
       <div className="mt-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
-        <label className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]" htmlFor={`guidance-${row.id}`}>
+        <label
+          className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]"
+          htmlFor={`guidance-${row.id}`}
+        >
           Guidance for {row.workerId}
         </label>
         <textarea
           id={`guidance-${row.id}`}
           value={replyDrafts[row.id] ?? buildReplyPrefill(row)}
-          onChange={(event) => setReplyDrafts((current) => ({ ...current, [row.id]: event.target.value }))}
+          onChange={(event) =>
+            setReplyDrafts((current) => ({
+              ...current,
+              [row.id]: event.target.value,
+            }))
+          }
           rows={6}
           className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none"
         />
-        {replyErrors[row.id] ? <div className="mt-2 text-xs text-red-600">{replyErrors[row.id]}</div> : null}
+        {replyErrors[row.id] ? (
+          <div className="mt-2 text-xs text-red-600">{replyErrors[row.id]}</div>
+        ) : null}
         <div className="mt-2 flex justify-end gap-2">
           <button
             type="button"
@@ -671,25 +838,56 @@ export function Swarm2ReportsView({
       : 'rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-xs font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]'
     return (
       <div className="mt-2 flex flex-wrap gap-1.5">
-        <button type="button" aria-label={`Open ${row.workerId} worker`} onClick={() => openWorker(row)} className={buttonClass}>
+        <button
+          type="button"
+          aria-label={`Open ${row.workerId} worker`}
+          onClick={() => openWorker(row)}
+          className={buttonClass}
+        >
           ↗
         </button>
         {row.state === 'blocked' ? (
-          <button type="button" onClick={() => openReply(row)} className={buttonClass}>
+          <button
+            type="button"
+            onClick={() => openReply(row)}
+            className={buttonClass}
+          >
             Guide worker
           </button>
         ) : null}
         {row.state === 'needs_review' ? (
-          <button type="button" onClick={() => void routeToReviewer(row)} className={cn(buttonClass, 'border-amber-400/40 bg-amber-500/10 text-amber-700 hover:bg-amber-500/15')}>
+          <button
+            type="button"
+            onClick={() => void routeToReviewer(row)}
+            className={cn(
+              buttonClass,
+              'border-amber-400/40 bg-amber-500/10 text-amber-700 hover:bg-amber-500/15',
+            )}
+          >
             Route to reviewer
           </button>
         ) : null}
         {row.state === 'ready' && prUrl ? (
           <>
-            <a href={prUrl} target="_blank" rel="noreferrer" className={cn(buttonClass, 'border-emerald-400/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15')}>
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(
+                buttonClass,
+                'border-emerald-400/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15',
+              )}
+            >
               Open PR
             </a>
-            <button type="button" onClick={() => void markReady(row)} className={cn(buttonClass, 'border-emerald-400/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15')}>
+            <button
+              type="button"
+              onClick={() => void markReady(row)}
+              className={cn(
+                buttonClass,
+                'border-emerald-400/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15',
+              )}
+            >
               Mark ready for Eric merge
             </button>
           </>
@@ -698,31 +896,58 @@ export function Swarm2ReportsView({
     )
   }
 
-  function renderInboxLane(lane: Swarm2InboxLaneId, title: string, rowsForLane: Array<Swarm2InboxItem>, emptyText: string) {
+  function renderInboxLane(
+    lane: Swarm2InboxLaneId,
+    title: string,
+    rowsForLane: Array<Swarm2InboxItem>,
+    emptyText: string,
+  ) {
     const laneTone = toneClass(lane)
     return (
       <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
         <div className="flex items-center justify-between gap-2">
-          <div className="text-xs font-semibold text-[var(--theme-text)]">{title}</div>
-          <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', laneTone)}>
+          <div className="text-xs font-semibold text-[var(--theme-text)]">
+            {title}
+          </div>
+          <span
+            className={cn(
+              'rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]',
+              laneTone,
+            )}
+          >
             {rowsForLane.length}
           </span>
         </div>
         <div className="mt-3 space-y-2">
-          {rowsForLane.length ? rowsForLane.slice(0, 4).map((row) => (
-            <div key={`lane:${lane}:${row.id}`} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-2.5">
-              <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-xs font-semibold text-[var(--theme-text)]">{row.title}</div>
-                  <div className="mt-1 text-[11px] text-[var(--theme-muted)]">{row.workerName} · {row.missionTitle ?? row.missionId}</div>
+          {rowsForLane.length ? (
+            rowsForLane.slice(0, 4).map((row) => (
+              <div
+                key={`lane:${lane}:${row.id}`}
+                className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-2.5"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-xs font-semibold text-[var(--theme-text)]">
+                      {row.title}
+                    </div>
+                    <div className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                      {row.workerName} · {row.missionTitle ?? row.missionId}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-[10px] text-[var(--theme-muted)]">
+                    {formatAge(row.updatedAt)}
+                  </div>
                 </div>
-                <div className="shrink-0 text-[10px] text-[var(--theme-muted)]">{formatAge(row.updatedAt)}</div>
+                <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-[var(--theme-muted-2)]">
+                  {row.summary}
+                </p>
+                {renderRowActions(row, true)}
+                {expandedId === `reply:${row.id}`
+                  ? renderReplyComposer(row)
+                  : null}
               </div>
-              <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-[var(--theme-muted-2)]">{row.summary}</p>
-              {renderRowActions(row, true)}
-              {expandedId === `reply:${row.id}` ? renderReplyComposer(row) : null}
-            </div>
-          )) : (
+            ))
+          ) : (
             <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-4 text-xs text-[var(--theme-muted)]">
               {emptyText}
             </div>
@@ -736,16 +961,27 @@ export function Swarm2ReportsView({
     <section className="rounded-[1.5rem] border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-[0_20px_60px_color-mix(in_srgb,var(--theme-shadow)_14%,transparent)]">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Outputs / Reports</div>
-          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Worker reports</h2>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+            Outputs / Reports
+          </div>
+          <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">
+            Worker reports
+          </h2>
           <p className="mt-1 max-w-3xl text-xs text-[var(--theme-muted-2)]">
-            Board for queues, Cards for worker-level scanning, List for dense detail.
+            Board for queues, Cards for worker-level scanning, List for dense
+            detail.
           </p>
         </div>
         <div className="grid grid-cols-3 gap-2 text-center text-[10px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
-          <span className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-2 py-1">Review {counts.needs_review}</span>
-          <span className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-2 py-1">Ready {counts.ready}</span>
-          <span className="rounded-xl border border-red-400/40 bg-red-500/10 px-2 py-1">Blocked {counts.blocked}</span>
+          <span className="rounded-xl border border-amber-400/40 bg-amber-500/10 px-2 py-1">
+            Review {counts.needs_review}
+          </span>
+          <span className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-2 py-1">
+            Ready {counts.ready}
+          </span>
+          <span className="rounded-xl border border-red-400/40 bg-red-500/10 px-2 py-1">
+            Blocked {counts.blocked}
+          </span>
         </div>
       </div>
 
@@ -765,20 +1001,38 @@ export function Swarm2ReportsView({
             {filter.label}
           </button>
         ))}
-        <select value={workerFilter} onChange={(event) => setWorkerFilter(event.target.value)} className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-1.5 text-xs text-[var(--theme-muted)] outline-none">
+        <select
+          value={workerFilter}
+          onChange={(event) => setWorkerFilter(event.target.value)}
+          className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-1.5 text-xs text-[var(--theme-muted)] outline-none"
+        >
           <option value="all">All workers</option>
-          {workers.map((worker) => <option key={worker} value={worker}>{worker}</option>)}
+          {workers.map((worker) => (
+            <option key={worker} value={worker}>
+              {worker}
+            </option>
+          ))}
         </select>
-        <select value={missionFilter} onChange={(event) => setMissionFilter(event.target.value)} className="max-w-xs rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-1.5 text-xs text-[var(--theme-muted)] outline-none">
+        <select
+          value={missionFilter}
+          onChange={(event) => setMissionFilter(event.target.value)}
+          className="max-w-xs rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-1.5 text-xs text-[var(--theme-muted)] outline-none"
+        >
           <option value="all">All missions</option>
-          {missionOptions.map((mission) => <option key={mission.id} value={mission.id}>{mission.label}</option>)}
+          {missionOptions.map((mission) => (
+            <option key={mission.id} value={mission.id}>
+              {mission.label}
+            </option>
+          ))}
         </select>
         <div className="ml-auto flex rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] p-1">
-          {([
-            ['board', 'Board'],
-            ['cards', 'Cards'],
-            ['list', 'List'],
-          ] as const).map(([id, label]) => (
+          {(
+            [
+              ['board', 'Board'],
+              ['cards', 'Cards'],
+              ['list', 'List'],
+            ] as const
+          ).map(([id, label]) => (
             <button
               key={id}
               type="button"
@@ -798,114 +1052,227 @@ export function Swarm2ReportsView({
 
       {layout === 'board' ? (
         <div className="grid gap-3 xl:grid-cols-3">
-          {renderInboxLane('needs_review', 'Needs review', inboxLanes.needs_review, 'Reviewer lane is clear. Route the next completed worker output through swarm6.')}
-          {renderInboxLane('blocked', 'Blocked / needs input', inboxLanes.blocked, 'No blockers waiting on human input.')}
-          {renderInboxLane('ready', 'Ready', inboxLanes.ready, 'Nothing is ready yet.')}
+          {renderInboxLane(
+            'needs_review',
+            'Needs review',
+            inboxLanes.needs_review,
+            'Reviewer lane is clear. Route the next completed worker output through swarm6.',
+          )}
+          {renderInboxLane(
+            'blocked',
+            'Blocked / needs input',
+            inboxLanes.blocked,
+            'No blockers waiting on human input.',
+          )}
+          {renderInboxLane(
+            'ready',
+            'Ready',
+            inboxLanes.ready,
+            'Nothing is ready yet.',
+          )}
         </div>
       ) : layout === 'cards' ? (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {workerCards.length ? workerCards.map((card) => {
-            const expanded = expandedId === `worker:${card.workerId}`
-            const latestInboxItem = {
-              ...card.latest,
-              lane: (card.latest.state === 'blocked' ? 'blocked' : card.latest.state === 'ready' ? 'ready' : 'needs_review') as Swarm2InboxLaneId,
-            }
-            return (
-              <article key={card.workerId} className="rounded-[1.4rem] border border-[var(--theme-border)] border-l-4 border-l-[var(--theme-accent)] bg-[var(--theme-bg)] p-4 shadow-[0_16px_40px_color-mix(in_srgb,var(--theme-shadow)_10%,transparent)]">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-start gap-3 min-w-0 flex-1">
-                    <div className="relative flex size-12 shrink-0 items-center justify-center">
-                      <AgentProgress
-                        value={card.state === 'blocked' ? 30 : card.state === 'needs_review' ? 74 : card.state === 'ready' ? 100 : 58}
-                        status={card.state === 'blocked' ? 'failed' : card.state === 'ready' ? 'done' : card.state === 'needs_review' ? 'thinking' : 'running'}
-                        size={48}
-                        strokeWidth={2.5}
-                        className={card.state === 'blocked' ? 'text-red-500' : card.state === 'needs_review' ? 'text-amber-500' : card.state === 'ready' ? 'text-emerald-500' : 'text-sky-500'}
-                      />
-                      <div className="absolute inset-0 flex items-center justify-center">
-                        <PixelAvatar size={34} color={colorForWorker(card.workerId)} accentColor="#fbbf24" status={card.state === 'blocked' ? 'failed' : card.state === 'ready' ? 'running' : 'idle'} />
+          {workerCards.length ? (
+            workerCards.map((card) => {
+              const expanded = expandedId === `worker:${card.workerId}`
+              const latestInboxItem = {
+                ...card.latest,
+                lane: (card.latest.state === 'blocked'
+                  ? 'blocked'
+                  : card.latest.state === 'ready'
+                    ? 'ready'
+                    : 'needs_review') as Swarm2InboxLaneId,
+              }
+              return (
+                <article
+                  key={card.workerId}
+                  className="rounded-[1.4rem] border border-[var(--theme-border)] border-l-4 border-l-[var(--theme-accent)] bg-[var(--theme-bg)] p-4 shadow-[0_16px_40px_color-mix(in_srgb,var(--theme-shadow)_10%,transparent)]"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-start gap-3 min-w-0 flex-1">
+                      <div className="relative flex size-12 shrink-0 items-center justify-center">
+                        <AgentProgress
+                          value={
+                            card.state === 'blocked'
+                              ? 30
+                              : card.state === 'needs_review'
+                                ? 74
+                                : card.state === 'ready'
+                                  ? 100
+                                  : 58
+                          }
+                          status={
+                            card.state === 'blocked'
+                              ? 'failed'
+                              : card.state === 'ready'
+                                ? 'complete'
+                                : card.state === 'needs_review'
+                                  ? 'thinking'
+                                  : 'running'
+                          }
+                          size={48}
+                          strokeWidth={2.5}
+                          className={
+                            card.state === 'blocked'
+                              ? 'text-red-500'
+                              : card.state === 'needs_review'
+                                ? 'text-amber-500'
+                                : card.state === 'ready'
+                                  ? 'text-emerald-500'
+                                  : 'text-sky-500'
+                          }
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <PixelAvatar
+                            size={34}
+                            color={colorForWorker(card.workerId)}
+                            accentColor="#fbbf24"
+                            status={
+                              card.state === 'blocked'
+                                ? 'failed'
+                                : card.state === 'ready'
+                                  ? 'complete'
+                                  : 'idle'
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => onSelectWorker?.(card.workerId)}
+                            className="truncate text-left text-sm font-semibold text-[var(--theme-text)] hover:text-[var(--theme-accent-strong)]"
+                          >
+                            {card.workerName}
+                          </button>
+                          <span
+                            className={cn(
+                              'rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em]',
+                              toneClass(card.state),
+                            )}
+                          >
+                            {card.stateLabel}
+                          </span>
+                        </div>
+                        <div className="mt-1 text-[10px] text-[var(--theme-muted)]">
+                          {card.role} · {formatAge(card.latest.updatedAt)}
+                        </div>
                       </div>
                     </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <button type="button" onClick={() => onSelectWorker?.(card.workerId)} className="truncate text-left text-sm font-semibold text-[var(--theme-text)] hover:text-[var(--theme-accent-strong)]">
-                          {card.workerName}
-                        </button>
-                        <span className={cn('rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em]', toneClass(card.state))}>{card.stateLabel}</span>
-                      </div>
-                      <div className="mt-1 text-[10px] text-[var(--theme-muted)]">{card.role} · {formatAge(card.latest.updatedAt)}</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => setExpandedId(expanded ? null : `worker:${card.workerId}`)}
-                      className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]"
-                    >
-                      {expanded ? 'Hide reports' : `Open reports (${card.rows.length})`}
-                    </button>
-                    {card.prUrl ? (
-                      <a
-                        href={card.prUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-flex items-center rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
-                      >
-                        ↗
-                      </a>
-                    ) : null}
-                    {(card.state === 'needs_review' || card.state === 'blocked' || card.state === 'ready') ? (
+                    <div className="flex items-center gap-2 shrink-0">
                       <button
                         type="button"
-                        onClick={() => onRouteToReviewer?.(card)}
-                        className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
+                        onClick={() =>
+                          setExpandedId(
+                            expanded ? null : `worker:${card.workerId}`,
+                          )
+                        }
+                        className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]"
                       >
-                        Steer
+                        {expanded
+                          ? 'Hide reports'
+                          : `Open reports (${card.rows.length})`}
                       </button>
-                    ) : null}
-                  </div>
-                </div>
-
-                <h3 className="mt-3 text-center line-clamp-2 text-lg font-semibold leading-tight text-[var(--theme-text)]">{card.latest.title}</h3>
-                <p className="mt-1 text-center text-[11px] text-[var(--theme-muted)]">{card.latest.summary}</p>
-
-                <div className="mt-4 flex flex-wrap gap-1.5 text-center text-[9px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
-                  <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5">Review {card.reviewCount}</div>
-                  <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5">Ready {card.readyCount}</div>
-                  <div className="rounded-xl border border-red-400/30 bg-red-500/10 px-1.5 py-0.5">Blocked {card.blockedCount}</div>
-                  <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-1.5 py-0.5">Files {card.artifactCount}</div>
-                </div>
-
-                {expandedId === `reply:${latestInboxItem.id}` ? renderReplyComposer(latestInboxItem) : null}
-
-                {expanded ? (
-                  <div className="mt-3 space-y-2 border-t border-[var(--theme-border)] pt-3">
-                    {card.rows.slice(0, 4).map((row) => {
-                      const inboxRow = {
-                        ...row,
-                        lane: (row.state === 'blocked' ? 'blocked' : row.state === 'ready' ? 'ready' : 'needs_review') as Swarm2InboxLaneId,
-                      }
-                      return (
-                        <div
-                          key={row.id}
-                          className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3"
+                      {card.prUrl ? (
+                        <a
+                          href={card.prUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
                         >
-                          <div className="flex items-center justify-between gap-2">
-                            <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', toneClass(row.state))}>{row.stateLabel}</span>
-                            <span className="text-[10px] text-[var(--theme-muted)]">{formatAge(row.updatedAt)}</span>
-                          </div>
-                          <div className="mt-2 line-clamp-1 text-xs font-semibold text-[var(--theme-text)]">{row.title}</div>
-                          <div className="mt-1 line-clamp-2 text-[11px] text-[var(--theme-muted-2)]">{row.summary}</div>
-                          {renderRowActions(inboxRow)}
-                          {expandedId === `reply:${row.id}` ? renderReplyComposer(inboxRow) : null}
-                        </div>
-                      )
-                    })}
+                          ↗
+                        </a>
+                      ) : null}
+                      {card.state === 'needs_review' ||
+                      card.state === 'blocked' ||
+                      card.state === 'ready' ? (
+                        <button
+                          type="button"
+                          onClick={() => onRouteToReviewer?.(latestInboxItem)}
+                          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2.5 py-1.5 text-[11px] text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
+                        >
+                          Steer
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
-                ) : null}
-              </article>
-            )
-          }) : (
+
+                  <h3 className="mt-3 text-center line-clamp-2 text-lg font-semibold leading-tight text-[var(--theme-text)]">
+                    {card.latest.title}
+                  </h3>
+                  <p className="mt-1 text-center text-[11px] text-[var(--theme-muted)]">
+                    {card.latest.summary}
+                  </p>
+
+                  <div className="mt-4 flex flex-wrap gap-1.5 text-center text-[9px] uppercase tracking-[0.12em] text-[var(--theme-muted)]">
+                    <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5">
+                      Review {card.reviewCount}
+                    </div>
+                    <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5">
+                      Ready {card.readyCount}
+                    </div>
+                    <div className="rounded-xl border border-red-400/30 bg-red-500/10 px-1.5 py-0.5">
+                      Blocked {card.blockedCount}
+                    </div>
+                    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-1.5 py-0.5">
+                      Files {card.artifactCount}
+                    </div>
+                  </div>
+
+                  {expandedId === `reply:${latestInboxItem.id}`
+                    ? renderReplyComposer(latestInboxItem)
+                    : null}
+
+                  {expanded ? (
+                    <div className="mt-3 space-y-2 border-t border-[var(--theme-border)] pt-3">
+                      {card.rows.slice(0, 4).map((row) => {
+                        const inboxRow = {
+                          ...row,
+                          lane: (row.state === 'blocked'
+                            ? 'blocked'
+                            : row.state === 'ready'
+                              ? 'ready'
+                              : 'needs_review') as Swarm2InboxLaneId,
+                        }
+                        return (
+                          <div
+                            key={row.id}
+                            className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3"
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span
+                                className={cn(
+                                  'rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]',
+                                  toneClass(row.state),
+                                )}
+                              >
+                                {row.stateLabel}
+                              </span>
+                              <span className="text-[10px] text-[var(--theme-muted)]">
+                                {formatAge(row.updatedAt)}
+                              </span>
+                            </div>
+                            <div className="mt-2 line-clamp-1 text-xs font-semibold text-[var(--theme-text)]">
+                              {row.title}
+                            </div>
+                            <div className="mt-1 line-clamp-2 text-[11px] text-[var(--theme-muted-2)]">
+                              {row.summary}
+                            </div>
+                            {renderRowActions(inboxRow)}
+                            {expandedId === `reply:${row.id}`
+                              ? renderReplyComposer(inboxRow)
+                              : null}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ) : null}
+                </article>
+              )
+            })
+          ) : (
             <div className="col-span-full rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] p-8 text-center text-sm text-[var(--theme-muted)]">
               No worker reports match these filters yet.
             </div>
@@ -913,85 +1280,157 @@ export function Swarm2ReportsView({
         </div>
       ) : (
         <div className="space-y-2">
-          {filteredRows.length ? filteredRows.map((row) => {
-            const expanded = expandedId === row.id
-            return (
-              <article key={row.id} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
-                <div
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => setExpandedId(expanded ? null : row.id)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      setExpandedId(expanded ? null : row.id)
-                    }
-                  }}
-                  className="block w-full cursor-pointer text-left"
+          {filteredRows.length ? (
+            filteredRows.map((row) => {
+              const expanded = expandedId === row.id
+              return (
+                <article
+                  key={row.id}
+                  className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3"
                 >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', toneClass(row.state))}>{row.stateLabel}</span>
-                        <span className="text-[11px] text-[var(--theme-muted)]">{row.kind}</span>
-                        {row.checkpointStatus ? <span className="text-[11px] text-[var(--theme-muted)]">{row.checkpointStatus}</span> : null}
-                        {row.reviewRequired ? <span className="rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-700">swarm6 gate</span> : null}
-                        {row.reviewedBy ? <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-700">reviewed by {row.reviewedBy}</span> : null}
-                        <span className="text-[11px] text-[var(--theme-muted)]">{formatAge(row.updatedAt)}</span>
-                      </div>
-                      <h3 className="mt-2 truncate text-sm font-semibold text-[var(--theme-text)]">{row.title}</h3>
-                      <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-[var(--theme-muted-2)]">{row.summary}</p>
-                    </div>
-                    <div className="shrink-0 text-right text-xs text-[var(--theme-muted)]">
-                      <div className="flex flex-wrap justify-end gap-1.5">
-                        <button type="button" onClick={(event) => { event.stopPropagation(); onSelectWorker?.(row.workerId) }} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2 py-1 font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]">
-                          {row.workerName}
-                        </button>
-                        {row.state === 'needs_review' ? (
-                          <button type="button" onClick={(event) => { event.stopPropagation(); onRouteToReviewer?.({ ...row, lane: 'needs_review' }) }} className="rounded-lg border border-amber-400/40 bg-amber-500/10 px-2 py-1 font-medium text-amber-700 hover:bg-amber-500/15">
-                            Route swarm6
-                          </button>
-                        ) : null}
-                      </div>
-                      <div className="mt-1 max-w-[14rem] truncate">{row.missionTitle ?? 'runtime output'}</div>
-                    </div>
-                  </div>
-                </div>
-
-                {expanded ? (
-                  <div className="mt-3 border-t border-[var(--theme-border)] pt-3">
-                    <dl className="grid gap-2 md:grid-cols-2">
-                      {row.details.map((detail) => (
-                        <div key={detail.label} className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
-                          <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">{detail.label}</dt>
-                          <dd className="mt-1 whitespace-pre-wrap text-xs leading-relaxed text-[var(--theme-text)]">{detail.value}</dd>
-                        </div>
-                      ))}
-                    </dl>
-                    {(row.artifacts.length > 0 || row.previews.length > 0) ? (
-                      <div className="mt-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
-                        <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">Artifacts</div>
-                        <div className="flex flex-wrap gap-1.5">
-                          {row.artifacts.map((artifact) => (
-                            <span key={artifact.id} title={artifact.path ?? artifact.label} className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1 text-[10px] text-[var(--theme-muted-2)]">
-                              {artifact.kind}: {artifact.label}
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => setExpandedId(expanded ? null : row.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        setExpandedId(expanded ? null : row.id)
+                      }
+                    }}
+                    className="block w-full cursor-pointer text-left"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className={cn(
+                              'rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]',
+                              toneClass(row.state),
+                            )}
+                          >
+                            {row.stateLabel}
+                          </span>
+                          <span className="text-[11px] text-[var(--theme-muted)]">
+                            {row.kind}
+                          </span>
+                          {row.checkpointStatus ? (
+                            <span className="text-[11px] text-[var(--theme-muted)]">
+                              {row.checkpointStatus}
                             </span>
-                          ))}
-                          {row.previews.map((preview) => (
-                            <a key={preview.id} href={preview.url} target="_blank" rel="noreferrer" className="rounded-full border border-[var(--theme-accent)]/40 bg-[var(--theme-accent-soft)] px-2 py-1 text-[10px] text-[var(--theme-accent-strong)]">
-                              preview: {preview.label}
-                            </a>
-                          ))}
+                          ) : null}
+                          {row.reviewRequired ? (
+                            <span className="rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-700">
+                              swarm6 gate
+                            </span>
+                          ) : null}
+                          {row.reviewedBy ? (
+                            <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
+                              reviewed by {row.reviewedBy}
+                            </span>
+                          ) : null}
+                          <span className="text-[11px] text-[var(--theme-muted)]">
+                            {formatAge(row.updatedAt)}
+                          </span>
+                        </div>
+                        <h3 className="mt-2 truncate text-sm font-semibold text-[var(--theme-text)]">
+                          {row.title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-[var(--theme-muted-2)]">
+                          {row.summary}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right text-xs text-[var(--theme-muted)]">
+                        <div className="flex flex-wrap justify-end gap-1.5">
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              onSelectWorker?.(row.workerId)
+                            }}
+                            className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-2 py-1 font-medium text-[var(--theme-text)] hover:border-[var(--theme-accent)]"
+                          >
+                            {row.workerName}
+                          </button>
+                          {row.state === 'needs_review' ? (
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onRouteToReviewer?.({
+                                  ...row,
+                                  lane: 'needs_review',
+                                })
+                              }}
+                              className="rounded-lg border border-amber-400/40 bg-amber-500/10 px-2 py-1 font-medium text-amber-700 hover:bg-amber-500/15"
+                            >
+                              Route swarm6
+                            </button>
+                          ) : null}
+                        </div>
+                        <div className="mt-1 max-w-[14rem] truncate">
+                          {row.missionTitle ?? 'runtime output'}
                         </div>
                       </div>
-                    ) : null}
+                    </div>
                   </div>
-                ) : null}
-              </article>
-            )
-          }) : (
+
+                  {expanded ? (
+                    <div className="mt-3 border-t border-[var(--theme-border)] pt-3">
+                      <dl className="grid gap-2 md:grid-cols-2">
+                        {row.details.map((detail) => (
+                          <div
+                            key={detail.label}
+                            className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2"
+                          >
+                            <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                              {detail.label}
+                            </dt>
+                            <dd className="mt-1 whitespace-pre-wrap text-xs leading-relaxed text-[var(--theme-text)]">
+                              {detail.value}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                      {row.artifacts.length > 0 || row.previews.length > 0 ? (
+                        <div className="mt-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2">
+                          <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-muted)]">
+                            Artifacts
+                          </div>
+                          <div className="flex flex-wrap gap-1.5">
+                            {row.artifacts.map((artifact) => (
+                              <span
+                                key={artifact.id}
+                                title={artifact.path ?? artifact.label}
+                                className="rounded-full border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1 text-[10px] text-[var(--theme-muted-2)]"
+                              >
+                                {artifact.kind}: {artifact.label}
+                              </span>
+                            ))}
+                            {row.previews.map((preview) => (
+                              <a
+                                key={preview.id}
+                                href={preview.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="rounded-full border border-[var(--theme-accent)]/40 bg-[var(--theme-accent-soft)] px-2 py-1 text-[10px] text-[var(--theme-accent-strong)]"
+                              >
+                                preview: {preview.label}
+                              </a>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </article>
+              )
+            })
+          ) : (
             <div className="rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] p-8 text-center text-sm text-[var(--theme-muted)]">
-              No reports match these filters yet. Checkpoints appear after workers return the required checkpoint format; runtime artifacts appear when workers publish artifacts/previews.
+              No reports match these filters yet. Checkpoints appear after
+              workers return the required checkpoint format; runtime artifacts
+              appear when workers publish artifacts/previews.
             </div>
           )}
         </div>

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -25,7 +25,11 @@ import { Swarm2OrchestratorCard } from './swarm2-orchestrator-card'
 import { Swarm2Wires } from './swarm2-wires'
 import { Swarm2ActivityFeed } from './swarm2-activity-feed'
 import { Swarm2KanbanBoard } from './swarm2-kanban-board'
-import { Swarm2ReportsView, buildSwarm2InboxLanes, type Swarm2InboxItem } from './swarm2-reports-view'
+import {
+  Swarm2ReportsView,
+  buildSwarm2InboxLanes,
+  type Swarm2InboxItem,
+} from './swarm2-reports-view'
 import { RouterChat } from '@/components/swarm/router-chat'
 import { SwarmTerminal } from '@/components/swarm/swarm-terminal'
 import { WorkflowHelpModal } from '@/components/workflow-help-modal'
@@ -44,15 +48,22 @@ const SWARM2_OPERATION_THEME: CSSProperties = {
   ['--theme-muted-2' as string]: 'var(--color-primary-600)',
   ['--theme-accent' as string]: 'var(--color-accent-500)',
   ['--theme-accent-strong' as string]: 'var(--color-accent-600)',
-  ['--theme-accent-soft' as string]: 'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
-  ['--theme-accent-soft-strong' as string]: 'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
-  ['--theme-shadow' as string]: 'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
+  ['--theme-accent-soft' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
+  ['--theme-accent-soft-strong' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
+  ['--theme-shadow' as string]:
+    'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
   ['--theme-danger' as string]: 'var(--color-red-600, #dc2626)',
-  ['--theme-danger-soft' as string]: 'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
-  ['--theme-danger-border' as string]: 'color-mix(in srgb, var(--theme-danger) 35%, white)',
+  ['--theme-danger-soft' as string]:
+    'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
+  ['--theme-danger-border' as string]:
+    'color-mix(in srgb, var(--theme-danger) 35%, white)',
   ['--theme-warning' as string]: 'var(--color-amber-600, #d97706)',
-  ['--theme-warning-soft' as string]: 'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
-  ['--theme-warning-border' as string]: 'color-mix(in srgb, var(--theme-warning) 35%, white)',
+  ['--theme-warning-soft' as string]:
+    'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
+  ['--theme-warning-border' as string]:
+    'color-mix(in srgb, var(--theme-warning) 35%, white)',
 }
 
 export const SWARM2_INFORMATION_HIERARCHY = [
@@ -76,7 +87,8 @@ export const SWARM2_SURFACE_CONTRACT = {
   routerPlacement: 'bottom-center',
   cardInlineChat: true,
   routerDefaultOpen: false,
-  heartbeatOrchestration: 'main-session loop processes checkpoints and prompts review/continue decisions',
+  heartbeatOrchestration:
+    'main-session loop processes checkpoints and prompts review/continue decisions',
 } as const
 
 export const SWARM2_OPERATIONS_REUSE = [
@@ -150,7 +162,9 @@ type RuntimeEntry = {
   cwd: string | null
   phase?: string | null
   lastSummary?: string | null
+  lastRealSummary?: string | null
   lastResult?: string | null
+  lastRealResult?: string | null
   blockedReason?: string | null
   checkpointStatus?: string | null
   state?: string | null
@@ -175,7 +189,6 @@ type HealthData = {
     distinctProviders: Array<string>
   }
 }
-
 
 type SwarmRosterWorker = {
   id: string
@@ -244,64 +257,97 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
   {
     role: 'Orchestrator',
     specialty: 'control-plane state, dispatch, drift detection, escalation',
-    mission: 'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
-    systemPrompt: 'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
-    skills: ['swarm-orchestrator', 'swarm-worker-core', 'swarm-review-learning-loop', 'self-improvement'],
+    mission:
+      'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
+    systemPrompt:
+      'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
+    skills: [
+      'swarm-orchestrator',
+      'swarm-worker-core',
+      'swarm-review-learning-loop',
+      'self-improvement',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Builder',
     specialty: 'full-stack implementation, fast ship cycles',
-    mission: 'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
-    systemPrompt: 'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
+    mission:
+      'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
+    systemPrompt:
+      'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
     skills: ['swarm-worker-core', 'byte-verified-code-review'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Reviewer',
     specialty: 'byte-verified code review, naming + tests + build gate',
-    mission: 'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
-    systemPrompt: 'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
+    mission:
+      'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
+    systemPrompt:
+      'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
+    skills: [
+      'swarm-worker-core',
+      'byte-verified-code-review',
+      'swarm-review-learning-loop',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Triage',
     specialty: 'autonomous PR/issues processor',
-    mission: 'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
-    systemPrompt: 'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
+    mission:
+      'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
+    systemPrompt:
+      'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
+    skills: [
+      'swarm-worker-core',
+      'byte-verified-code-review',
+      'swarm-review-learning-loop',
+    ],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Lab',
     specialty: 'local-model R&D, spec-dec, benchmarking',
-    mission: 'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
-    systemPrompt: 'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
-    skills: ['swarm-worker-core', 'pc1-ollama-gguf-bench', 'swarm-bench-worker'],
+    mission:
+      'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
+    systemPrompt:
+      'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
+    skills: [
+      'swarm-worker-core',
+      'pc1-ollama-gguf-bench',
+      'swarm-bench-worker',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Sage',
     specialty: 'research + scripts + X content + creative briefs',
-    mission: 'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
-    systemPrompt: 'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
+    mission:
+      'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
+    systemPrompt:
+      'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
     skills: ['swarm-worker-core', 'last30days', 'pdf-and-paper-deep-reading'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Scribe',
     specialty: 'docs, skills hygiene, memory curation',
-    mission: 'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
-    systemPrompt: 'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
+    mission:
+      'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
+    systemPrompt:
+      'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
     skills: ['swarm-worker-core', 'last30days', 'creative-writing'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Foundation',
     specialty: 'infra, repair playbook, autopilot wiring',
-    mission: 'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
-    systemPrompt: 'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
+    mission:
+      'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
+    systemPrompt:
+      'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
     skills: ['swarm-worker-core'],
     defaultModel: 'GPT-5.4',
   },
@@ -309,7 +355,8 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
     role: 'QA',
     specialty: 'regression QA, render verification',
     mission: 'Run regression suite on every commit + render. Block bad ships.',
-    systemPrompt: 'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
+    systemPrompt:
+      'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
     skills: ['swarm-worker-core', 'byte-verified-code-review'],
     defaultModel: 'GPT-5.4',
   },
@@ -317,7 +364,8 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
     role: 'Mirror Integrations',
     specialty: 'asset packs, upstream sync',
     mission: 'Generate assets. Watch upstream. Pack integrations.',
-    systemPrompt: 'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
+    systemPrompt:
+      'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
     skills: ['swarm-worker-core', 'claude-promo', 'songwriting-and-ai-music'],
     defaultModel: 'GPT-5.4',
   },
@@ -332,7 +380,9 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
 
 const ROLE_NAMES = ROLE_PRESETS.map((p) => p.role)
 
-async function fetchAvailableModels(): Promise<Array<{ id: string; name: string; provider: string }>> {
+async function fetchAvailableModels(): Promise<
+  Array<{ id: string; name: string; provider: string }>
+> {
   try {
     const res = await fetch('/api/models')
     if (!res.ok) return []
@@ -509,7 +559,8 @@ function withInstantScroll<T>(anchor: HTMLElement | null, fn: () => T): T {
   if (typeof window === 'undefined') return fn()
 
   const targets: HTMLElement[] = []
-  if (document.documentElement instanceof HTMLElement) targets.push(document.documentElement)
+  if (document.documentElement instanceof HTMLElement)
+    targets.push(document.documentElement)
   if (document.body instanceof HTMLElement) targets.push(document.body)
 
   let current: HTMLElement | null = anchor
@@ -518,13 +569,22 @@ function withInstantScroll<T>(anchor: HTMLElement | null, fn: () => T): T {
     current = current.parentElement
   }
 
-  for (const selector of ['main', '[data-slot="content"]', '[data-slot="main"]', '[data-scroll-container]']) {
+  for (const selector of [
+    'main',
+    '[data-slot="content"]',
+    '[data-slot="main"]',
+    '[data-scroll-container]',
+  ]) {
     const node = document.querySelector(selector)
     if (node instanceof HTMLElement) targets.push(node)
   }
 
-  const deduped = [...new Set(targets)].filter((node) => !node.closest('.xterm'))
-  const previous = deduped.map((node) => [node, node.style.scrollBehavior] as const)
+  const deduped = [...new Set(targets)].filter(
+    (node) => !node.closest('.xterm'),
+  )
+  const previous = deduped.map(
+    (node) => [node, node.style.scrollBehavior] as const,
+  )
   for (const [node] of previous) node.style.scrollBehavior = 'auto'
   try {
     return fn()
@@ -555,7 +615,8 @@ function scrollContextToTop(anchor: HTMLElement | null) {
     ]
 
     for (const node of candidates) {
-      if (node instanceof HTMLElement && !node.closest('.xterm')) scrollNodeToTop(node)
+      if (node instanceof HTMLElement && !node.closest('.xterm'))
+        scrollNodeToTop(node)
     }
 
     if (anchor) {
@@ -578,7 +639,9 @@ function scheduleScrollContextToTop(anchor: HTMLElement | null) {
 
   run()
   frames.push(window.requestAnimationFrame(run))
-  frames.push(window.requestAnimationFrame(() => window.requestAnimationFrame(run)))
+  frames.push(
+    window.requestAnimationFrame(() => window.requestAnimationFrame(run)),
+  )
   timers.push(window.setTimeout(run, 0))
   timers.push(window.setTimeout(run, 50))
   timers.push(window.setTimeout(run, 150))
@@ -602,25 +665,56 @@ function relativeTime(ts: number | null | undefined): string {
 
 function progressForRuntime(runtime: RuntimeEntry | undefined): number {
   if (!runtime) return 0
-  if (runtime.checkpointStatus === 'done' || runtime.checkpointStatus === 'handoff') return 100
-  if (runtime.checkpointStatus === 'blocked' || runtime.checkpointStatus === 'needs_input') return 100
+  if (
+    runtime.checkpointStatus === 'done' ||
+    runtime.checkpointStatus === 'handoff'
+  )
+    return 100
+  if (
+    runtime.checkpointStatus === 'blocked' ||
+    runtime.checkpointStatus === 'needs_input'
+  )
+    return 100
   if (!runtime.currentTask?.trim()) return 0
-  const text = `${runtime.phase ?? ''} ${runtime.currentTask ?? ''}`.toLowerCase()
+  const text =
+    `${runtime.phase ?? ''} ${runtime.currentTask ?? ''}`.toLowerCase()
   if (text.includes('review')) return 72
   if (text.includes('test') || text.includes('qa')) return 78
-  if (text.includes('implement') || text.includes('build') || text.includes('patch')) return 64
-  if (text.includes('plan') || text.includes('research') || text.includes('design')) return 48
+  if (
+    text.includes('implement') ||
+    text.includes('build') ||
+    text.includes('patch')
+  )
+    return 64
+  if (
+    text.includes('plan') ||
+    text.includes('research') ||
+    text.includes('design')
+  )
+    return 48
   return 58
 }
 
-function cleanSwarmLabel(rawValue: string, fallback = 'Ready for task', maxLength = 64): string {
+function cleanSwarmLabel(
+  rawValue: string,
+  fallback = 'Ready for task',
+  maxLength = 64,
+): string {
   const raw = rawValue.trim()
   if (!raw) return fallback
-  const lines = raw.split('\n').map((line) => line.trim()).filter(Boolean)
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
   const goalLine = lines.find((line) => /^goal\s*:/i.test(line))
   const selected = goalLine
     ? goalLine.replace(/^goal\s*:\s*/i, '')
-    : lines.find((line) => !/^you are\b/i.test(line) && !/^context\b/i.test(line) && !/^constraints\b/i.test(line)) || lines[0]
+    : lines.find(
+        (line) =>
+          !/^you are\b/i.test(line) &&
+          !/^context\b/i.test(line) &&
+          !/^constraints\b/i.test(line),
+      ) || lines[0]
   const cleaned = selected
     .replace(/^[A-Z][A-Z0-9_ -]{2,}TASK\s*:\s*/i, '')
     .replace(/^DESIGN_ADDENDUM\s*:\s*/i, '')
@@ -634,22 +728,41 @@ function cleanSwarmLabel(rawValue: string, fallback = 'Ready for task', maxLengt
   return compactText(cleaned || raw, maxLength)
 }
 
-function displayTaskTitle(runtime: RuntimeEntry | undefined, fallback: string): string {
+function displayTaskTitle(
+  runtime: RuntimeEntry | undefined,
+  fallback: string,
+): string {
   const realSummary = runtime?.lastRealSummary ?? null
   const realResult = runtime?.lastRealResult ?? null
-  return cleanSwarmLabel(runtime?.blockedReason || runtime?.currentTask || realSummary || runtime?.lastSummary || realResult || runtime?.lastResult || fallback || '', 'Ready for task', 64)
+  return cleanSwarmLabel(
+    runtime?.blockedReason ||
+      runtime?.currentTask ||
+      realSummary ||
+      runtime?.lastSummary ||
+      realResult ||
+      runtime?.lastResult ||
+      fallback ||
+      '',
+    'Ready for task',
+    64,
+  )
 }
 
-
-function formatAssignedModel(model?: string | null, provider?: string | null): string {
+function formatAssignedModel(
+  model?: string | null,
+  provider?: string | null,
+): string {
   const value = `${model || ''} ${provider || ''}`.toLowerCase()
-  if (value.includes('claude-opus-4-7') || value.includes('opus-4-7')) return 'Opus 4.7'
-  if (value.includes('claude-opus-4-6') || value.includes('opus-4-6')) return 'Opus 4.6'
+  if (value.includes('claude-opus-4-7') || value.includes('opus-4-7'))
+    return 'Opus 4.7'
+  if (value.includes('claude-opus-4-6') || value.includes('opus-4-6'))
+    return 'Opus 4.6'
   if (value.includes('gpt-5.5')) return 'GPT-5.5'
   if (value.includes('gpt-5.4')) return 'GPT-5.4'
   if (value.includes('gpt-5.3')) return 'GPT-5.3'
   if (model && model !== 'unknown') return model
-  if (provider && provider !== 'unknown') return provider.replace(/^custom:/, '').replace(/[-_]/g, ' ')
+  if (provider && provider !== 'unknown')
+    return provider.replace(/^custom:/, '').replace(/[-_]/g, ' ')
   return 'Worker'
 }
 
@@ -662,13 +775,37 @@ type ControlPlaneStageProps = {
   selectedLabel: string
   workspaceModel: string | null
   lanes: Array<{ role: string; count: number; active: number }>
-  activeAgents: Array<{ workerId: string; workerName: string; role: string; task: string; progress: number; state: 'working' | 'reviewing' | 'blocked' | 'ready'; age: string }>
-  recentUpdates: Array<{ workerId: string; workerName: string; text: string; age: string; tone: 'idle' | 'active' | 'warning' }>
-  latestMission: { id: string; title: string; state: string; assignmentCount: number; checkpointedCount: number } | null
+  activeAgents: Array<{
+    workerId: string
+    workerName: string
+    role: string
+    task: string
+    progress: number
+    state: 'working' | 'reviewing' | 'blocked' | 'ready'
+    age: string
+  }>
+  recentUpdates: Array<{
+    workerId: string
+    workerName: string
+    text: string
+    age: string
+    tone: 'idle' | 'active' | 'warning'
+  }>
+  latestMission: {
+    id: string
+    title: string
+    state: string
+    assignmentCount: number
+    checkpointedCount: number
+  } | null
   missions: Array<SwarmMissionSummary>
   runtimeEntries: Array<RuntimeEntry>
   inboxCounts: { needsReview: number; blocked: number; ready: number }
-  routerSeed: { key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null
+  routerSeed: {
+    key: number
+    prompt: string
+    mode: 'auto' | 'manual' | 'broadcast'
+  } | null
   onOpenInboxItem: (item: Swarm2InboxItem) => void
   onRouteToReviewer: (item: Swarm2InboxItem) => void
   viewMode: ViewMode
@@ -687,7 +824,11 @@ type ControlPlaneStageProps = {
   onToggleFocusedRuntimeWorker: (workerId: string) => void
   onClearFocusedRuntimeWorker: () => void
   onStartAgentSession: (workerId: string) => void
-  onScrollTmuxSession: (workerId: string, direction: 'up' | 'down', session?: string | null) => void
+  onScrollTmuxSession: (
+    workerId: string,
+    direction: 'up' | 'down',
+    session?: string | null,
+  ) => void
 }
 
 function ControlPlaneStage({
@@ -729,19 +870,22 @@ function ControlPlaneStage({
   const stageRef = useRef<HTMLDivElement | null>(null)
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const workerRefsMap = useRef<Map<string, HTMLElement>>(new Map())
-  const cardSetters = useRef<
-    Map<string, (node: HTMLElement | null) => void>
-  >(new Map())
+  const cardSetters = useRef<Map<string, (node: HTMLElement | null) => void>>(
+    new Map(),
+  )
   const [refsVersion, setRefsVersion] = useState(0)
   const bumpRefsVersion = useCallback(() => {
     setRefsVersion((value) => value + 1)
   }, [])
 
-  const setAnchor = useCallback((node: HTMLDivElement | null) => {
-    if (anchorRef.current === node) return
-    anchorRef.current = node
-    bumpRefsVersion()
-  }, [bumpRefsVersion])
+  const setAnchor = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (anchorRef.current === node) return
+      anchorRef.current = node
+      bumpRefsVersion()
+    },
+    [bumpRefsVersion],
+  )
 
   const setWorkerRef = useCallback(
     (workerId: string) => {
@@ -825,7 +969,12 @@ function ControlPlaneStage({
           className="w-full max-w-5xl"
         />
         <div className="relative w-full pt-3">
-          <div className={cn('relative z-10', viewMode === 'cards' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'cards' ? 'block' : 'hidden',
+            )}
+          >
             <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 min-[1680px]:grid-cols-3">
               {members.length === 0 ? (
                 <div className="col-span-full rounded-[1.5rem] border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-sm text-[var(--theme-muted)]">
@@ -843,8 +992,19 @@ function ControlPlaneStage({
                       checkpointStatus={runtime?.checkpointStatus ?? null}
                       runtimeState={runtime?.state ?? null}
                       recentLines={recentLines(runtime)}
-                      recentOutputAt={runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? null}
-                      recentSummary={runtime?.lastRealSummary ?? runtime?.lastRealResult ?? runtime?.lastSummary ?? runtime?.lastResult ?? runtime?.blockedReason ?? null}
+                      recentOutputAt={
+                        runtime?.lastOutputAt ??
+                        runtime?.lastSessionStartedAt ??
+                        null
+                      }
+                      recentSummary={
+                        runtime?.lastRealSummary ??
+                        runtime?.lastRealResult ??
+                        runtime?.lastSummary ??
+                        runtime?.lastResult ??
+                        runtime?.blockedReason ??
+                        null
+                      }
                       artifacts={runtime?.artifacts ?? []}
                       previews={runtime?.previews ?? []}
                       inRoom={roomIds.includes(member.id)}
@@ -860,14 +1020,30 @@ function ControlPlaneStage({
             </div>
           </div>
 
-          <div className={cn('relative z-10 flex flex-col gap-3', viewMode === 'runtime' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10 flex flex-col gap-3',
+              viewMode === 'runtime' ? 'block' : 'hidden',
+            )}
+          >
             {!tmuxAvailable ? (
               <div className="rounded-xl border border-amber-300/40 bg-amber-300/10 px-4 py-2.5 text-xs text-amber-100">
-                <div className="font-semibold text-amber-50">tmux not installed on this host</div>
-                <div className="mt-1 text-amber-100/80">Spawning a Hermes swarm worker requires tmux. Without it, the worker can start but cannot dispatch tasks (you'll see &lsquo;can't find pane: swarm-&lt;id&gt;&rsquo; errors). Install tmux:</div>
-                <code className="mt-1 inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">brew install tmux</code>{' '}
+                <div className="font-semibold text-amber-50">
+                  tmux not installed on this host
+                </div>
+                <div className="mt-1 text-amber-100/80">
+                  Spawning a Hermes swarm worker requires tmux. Without it, the
+                  worker can start but cannot dispatch tasks (you'll see
+                  &lsquo;can't find pane: swarm-&lt;id&gt;&rsquo; errors).
+                  Install tmux:
+                </div>
+                <code className="mt-1 inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">
+                  brew install tmux
+                </code>{' '}
                 <span className="text-amber-100/60">(macOS) or</span>{' '}
-                <code className="inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">apt install tmux</code>{' '}
+                <code className="inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">
+                  apt install tmux
+                </code>{' '}
                 <span className="text-amber-100/60">(Ubuntu/Debian).</span>
               </div>
             ) : null}
@@ -876,7 +1052,9 @@ function ControlPlaneStage({
                 <span>
                   Focus mode on{' '}
                   <span className="font-semibold text-[var(--theme-text)]">
-                    {members.find((member) => member.id === focusedRuntimeWorkerId)?.displayName || focusedRuntimeWorkerId}
+                    {members.find(
+                      (member) => member.id === focusedRuntimeWorkerId,
+                    )?.displayName || focusedRuntimeWorkerId}
                   </span>
                 </span>
                 <button
@@ -888,10 +1066,16 @@ function ControlPlaneStage({
                 </button>
               </div>
             ) : null}
-            <div className={cn('grid grid-cols-1 gap-3', focusedRuntimeWorkerId ? '' : '2xl:grid-cols-2')}>
+            <div
+              className={cn(
+                'grid grid-cols-1 gap-3',
+                focusedRuntimeWorkerId ? '' : '2xl:grid-cols-2',
+              )}
+            >
               {terminalTargets.length === 0 ? (
                 <div className="rounded-[1.5rem] border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-sm text-[var(--theme-muted)]">
-                  No active workers detected. Select a worker or wire it into the room to mount its terminal.
+                  No active workers detected. Select a worker or wire it into
+                  the room to mount its terminal.
                 </div>
               ) : (
                 terminalTargets.map((member) => {
@@ -904,35 +1088,118 @@ function ControlPlaneStage({
                         ? 'border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] text-[var(--theme-warning)]'
                         : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)]'
                   const titleLabel = member.displayName || member.id
-                  const modelLabel = formatAssignedModel(member.model, member.provider)
+                  const modelLabel = formatAssignedModel(
+                    member.model,
+                    member.provider,
+                  )
                   return (
-                    <div key={member.id} className="overflow-hidden rounded-[1.5rem] border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_20px_60px_color-mix(in_srgb,var(--theme-shadow)_14%,transparent)]">
+                    <div
+                      key={member.id}
+                      className="overflow-hidden rounded-[1.5rem] border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_20px_60px_color-mix(in_srgb,var(--theme-shadow)_14%,transparent)]"
+                    >
                       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--theme-border)] px-3 py-2 text-[11px] text-[var(--theme-muted)]">
                         <span className="inline-flex items-center gap-2 font-semibold text-[var(--theme-text)]">
                           <HugeiconsIcon icon={CpuIcon} size={13} />
                           <span>{titleLabel}</span>
-                          <span className="text-[10px] font-medium text-[var(--theme-muted)]">· {modelLabel}</span>
+                          <span className="text-[10px] font-medium text-[var(--theme-muted)]">
+                            · {modelLabel}
+                          </span>
                         </span>
                         <div className="ml-auto flex items-center gap-1">
                           {runtime?.tmuxAttachable ? (
                             <>
-                              <button type="button" onClick={() => onScrollTmuxSession(member.id, 'up', runtime.tmuxSession)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={`Scroll up in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}>↑</button>
-                              <button type="button" onClick={() => onScrollTmuxSession(member.id, 'down', runtime.tmuxSession)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={`Scroll down in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}>↓</button>
-                              <button type="button" onClick={() => onToggleFocusedRuntimeWorker(member.id)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={focusedRuntimeWorkerId === member.id ? `Exit focus for swarm-${member.id}` : `Focus swarm-${member.id}`}>
-                                {focusedRuntimeWorkerId === member.id ? '⛶' : '⤢'}
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onScrollTmuxSession(
+                                    member.id,
+                                    'up',
+                                    runtime.tmuxSession,
+                                  )
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={`Scroll up in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}
+                              >
+                                ↑
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onScrollTmuxSession(
+                                    member.id,
+                                    'down',
+                                    runtime.tmuxSession,
+                                  )
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={`Scroll down in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}
+                              >
+                                ↓
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onToggleFocusedRuntimeWorker(member.id)
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={
+                                  focusedRuntimeWorkerId === member.id
+                                    ? `Exit focus for swarm-${member.id}`
+                                    : `Focus swarm-${member.id}`
+                                }
+                              >
+                                {focusedRuntimeWorkerId === member.id
+                                  ? '⛶'
+                                  : '⤢'}
                               </button>
                             </>
                           ) : (
-                            <button type="button" disabled={pendingTmux.has(member.id) || !tmuxAvailable} onClick={() => onStartAgentSession(member.id)} className={cn('rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] transition-colors', 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:opacity-90', (pendingTmux.has(member.id) || !tmuxAvailable) && 'cursor-not-allowed opacity-50')} title={tmuxAvailable ? `Start a live agent session in tmux (swarm-${member.id})` : 'tmux is not installed on this host'}>
-                              {pendingTmux.has(member.id) ? 'Starting…' : 'Start agent'}
+                            <button
+                              type="button"
+                              disabled={
+                                pendingTmux.has(member.id) || !tmuxAvailable
+                              }
+                              onClick={() => onStartAgentSession(member.id)}
+                              className={cn(
+                                'rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] transition-colors',
+                                'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:opacity-90',
+                                (pendingTmux.has(member.id) ||
+                                  !tmuxAvailable) &&
+                                  'cursor-not-allowed opacity-50',
+                              )}
+                              title={
+                                tmuxAvailable
+                                  ? `Start a live agent session in tmux (swarm-${member.id})`
+                                  : 'tmux is not installed on this host'
+                              }
+                            >
+                              {pendingTmux.has(member.id)
+                                ? 'Starting…'
+                                : 'Start agent'}
                             </button>
                           )}
                         </div>
-                        <span className={cn('inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]', kindBadgeClass)} title={cmd.command.join(' ')}>
-                          {cmd.kind === 'tmux' ? 'tmux' : cmd.kind === 'log-tail' ? 'logs' : 'shell'}
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]',
+                            kindBadgeClass,
+                          )}
+                          title={cmd.command.join(' ')}
+                        >
+                          {cmd.kind === 'tmux'
+                            ? 'tmux'
+                            : cmd.kind === 'log-tail'
+                              ? 'logs'
+                              : 'shell'}
                         </span>
                       </div>
-                      <SwarmTerminal workerId={member.id} command={cmd.command} cwd={runtime?.cwd ?? undefined} height={420} active={viewMode === 'runtime'} />
+                      <SwarmTerminal
+                        workerId={member.id}
+                        command={cmd.command}
+                        cwd={runtime?.cwd ?? undefined}
+                        height={420}
+                        active={viewMode === 'runtime'}
+                      />
                     </div>
                   )
                 })
@@ -940,7 +1207,12 @@ function ControlPlaneStage({
             </div>
           </div>
 
-          <div className={cn('relative z-10', viewMode === 'kanban' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'kanban' ? 'block' : 'hidden',
+            )}
+          >
             <Swarm2KanbanBoard
               workers={members}
               latestMission={latestMission}
@@ -950,7 +1222,12 @@ function ControlPlaneStage({
             />
           </div>
 
-          <div className={cn('relative z-10', viewMode === 'reports' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'reports' ? 'block' : 'hidden',
+            )}
+          >
             <Swarm2ReportsView
               missions={missions}
               runtimes={runtimeEntries}
@@ -967,8 +1244,6 @@ function ControlPlaneStage({
     </section>
   )
 }
-
-
 
 export const __runtimeTabInternals = {
   commandForRuntime,
@@ -994,7 +1269,11 @@ export function Swarm2Screen() {
   })
   const [viewMode, setViewMode] = useState<ViewMode>('cards')
   const [routerOpen, setRouterOpen] = useState(false)
-  const [routerSeed, setRouterSeed] = useState<{ key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null>(null)
+  const [routerSeed, setRouterSeed] = useState<{
+    key: number
+    prompt: string
+    mode: 'auto' | 'manual' | 'broadcast'
+  } | null>(null)
   const [notificationsOpen, setNotificationsOpen] = useState(false)
   const [addSwarmOpen, setAddSwarmOpen] = useState(false)
   const [addSwarmSaving, setAddSwarmSaving] = useState(false)
@@ -1014,7 +1293,9 @@ export function Swarm2Screen() {
   const [newWorkerMission, setNewWorkerMission] = useState('')
   // Worker IDs whose tmux session is currently being started/stopped via API.
   const [pendingTmux, setPendingTmux] = useState<Set<string>>(new Set())
-  const [focusedRuntimeWorkerId, setFocusedRuntimeWorkerId] = useState<string | null>(null)
+  const [focusedRuntimeWorkerId, setFocusedRuntimeWorkerId] = useState<
+    string | null
+  >(null)
   const topRef = useRef<HTMLDivElement | null>(null)
 
   const runtimeQuery = useQuery({
@@ -1050,31 +1331,26 @@ export function Swarm2Screen() {
         if (!res.ok) {
           const text = await res.text().catch(() => '')
           let parsed: { error?: string } = {}
-          try { parsed = JSON.parse(text) } catch {}
+          try {
+            parsed = JSON.parse(text)
+          } catch {}
           const msg = parsed.error || text || `HTTP ${res.status}`
           if (msg.includes('tmux not installed')) {
-            toast({
-              title: 'tmux not installed',
-              description:
-                `Swarm worker ${workerId} couldn't start because tmux is not installed on this host. Install tmux (‘brew install tmux’ or ‘apt install tmux’) and try again. See #244.`,
-              variant: 'destructive',
-            })
+            toast(
+              `tmux not installed. Swarm worker ${workerId} couldn't start. Install tmux (brew install tmux or apt install tmux) and try again. See #244.`,
+              { type: 'error' },
+            )
           } else {
-            toast({
-              title: `Failed to start ${workerId}`,
-              description: msg,
-              variant: 'destructive',
-            })
+            toast(`Failed to start ${workerId}: ${msg}`, { type: 'error' })
           }
           // eslint-disable-next-line no-console
           console.error('[swarm2] start session failed:', res.status, text)
         }
       } catch (err) {
-        toast({
-          title: `Failed to start ${workerId}`,
-          description: err instanceof Error ? err.message : String(err),
-          variant: 'destructive',
-        })
+        toast(
+          `Failed to start ${workerId}: ${err instanceof Error ? err.message : String(err)}`,
+          { type: 'error' },
+        )
       } finally {
         setPendingTmux((prev) => {
           const next = new Set(prev)
@@ -1114,7 +1390,11 @@ export function Swarm2Screen() {
   )
 
   const scrollTmuxSession = useCallback(
-    async (workerId: string, direction: 'up' | 'down', session?: string | null) => {
+    async (
+      workerId: string,
+      direction: 'up' | 'down',
+      session?: string | null,
+    ) => {
       try {
         const res = await fetch('/api/swarm-tmux-scroll', {
           method: 'POST',
@@ -1135,7 +1415,9 @@ export function Swarm2Screen() {
   )
 
   const toggleFocusedRuntimeWorker = useCallback((workerId: string) => {
-    setFocusedRuntimeWorkerId((current) => (current === workerId ? null : workerId))
+    setFocusedRuntimeWorkerId((current) =>
+      current === workerId ? null : workerId,
+    )
   }, [])
 
   const runtimeByWorker = useMemo(() => {
@@ -1222,7 +1504,6 @@ export function Swarm2Screen() {
     return scheduleScrollContextToTop(topRef.current)
   }, [])
 
-
   const activeRuntimeCount = members.filter((member) =>
     isRuntimeActive(runtimeByWorker.get(member.id)),
   ).length
@@ -1254,7 +1535,10 @@ export function Swarm2Screen() {
     ? autoMountTargets.filter((member) => member.id === focusedRuntimeWorkerId)
     : autoMountTargets
   const rosterLanes = useMemo(() => {
-    const map = new Map<string, { role: string; count: number; active: number }>()
+    const map = new Map<
+      string,
+      { role: string; count: number; active: number }
+    >()
     for (const member of members) {
       const role = member.role || 'Worker'
       const existing = map.get(role) ?? { role, count: 0, active: 0 }
@@ -1262,20 +1546,34 @@ export function Swarm2Screen() {
       if (isRuntimeActive(runtimeByWorker.get(member.id))) existing.active += 1
       map.set(role, existing)
     }
-    return [...map.values()].sort((a, b) => b.active - a.active || b.count - a.count || a.role.localeCompare(b.role))
+    return [...map.values()].sort(
+      (a, b) =>
+        b.active - a.active ||
+        b.count - a.count ||
+        a.role.localeCompare(b.role),
+    )
   }, [members, runtimeByWorker])
   const latestMission = useMemo(() => {
     const mission = missionsQuery.data?.[0]
     if (!mission) return null
     const assignments = mission.assignments ?? []
-    const genericTitle = /^\d+\s+assigned tasks?$/i.test(mission.title.trim()) || /assigned tasks/i.test(mission.title)
-    const firstTask = assignments.find((assignment) => assignment.task?.trim())?.task ?? ''
+    const genericTitle =
+      /^\d+\s+assigned tasks?$/i.test(mission.title.trim()) ||
+      /assigned tasks/i.test(mission.title)
+    const firstTask =
+      assignments.find((assignment) => assignment.task?.trim())?.task ?? ''
     return {
       id: mission.id,
-      title: cleanSwarmLabel(genericTitle ? firstTask : mission.title, 'Swarm mission', 72),
+      title: cleanSwarmLabel(
+        genericTitle ? firstTask : mission.title,
+        'Swarm mission',
+        72,
+      ),
       state: mission.state,
       assignmentCount: assignments.length,
-      checkpointedCount: assignments.filter((assignment) => ['checkpointed', 'done'].includes(assignment.state)).length,
+      checkpointedCount: assignments.filter((assignment) =>
+        ['checkpointed', 'done'].includes(assignment.state),
+      ).length,
     }
   }, [missionsQuery.data])
 
@@ -1284,17 +1582,30 @@ export function Swarm2Screen() {
       .map((member) => {
         const runtime = runtimeByWorker.get(member.id)
         const currentTask = runtime?.currentTask?.trim()
-        const blocked = Boolean(runtime?.blockedReason || runtime?.needsHuman || runtime?.checkpointStatus === 'blocked' || runtime?.checkpointStatus === 'needs_input')
-        const done = runtime?.checkpointStatus === 'done' || runtime?.checkpointStatus === 'handoff'
+        const blocked = Boolean(
+          runtime?.blockedReason ||
+          runtime?.needsHuman ||
+          runtime?.checkpointStatus === 'blocked' ||
+          runtime?.checkpointStatus === 'needs_input',
+        )
+        const done =
+          runtime?.checkpointStatus === 'done' ||
+          runtime?.checkpointStatus === 'handoff'
         if (!currentTask && !blocked) return null
         const state: 'working' | 'reviewing' | 'blocked' | 'ready' = blocked
           ? 'blocked'
           : done
             ? 'ready'
-            : `${runtime?.phase ?? ''} ${currentTask ?? ''}`.toLowerCase().includes('review')
+            : `${runtime?.phase ?? ''} ${currentTask ?? ''}`
+                  .toLowerCase()
+                  .includes('review')
               ? 'reviewing'
               : 'working'
-        const ts = runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? member.lastSessionAt ?? null
+        const ts =
+          runtime?.lastOutputAt ??
+          runtime?.lastSessionStartedAt ??
+          member.lastSessionAt ??
+          null
         return {
           workerId: member.id,
           workerName: member.displayName || member.id,
@@ -1309,7 +1620,11 @@ export function Swarm2Screen() {
       .filter((item): item is NonNullable<typeof item> => Boolean(item))
       .sort((a, b) => {
         const priority = { blocked: 0, reviewing: 1, working: 2, ready: 3 }
-        return priority[a.state] - priority[b.state] || b.ts - a.ts || a.workerId.localeCompare(b.workerId)
+        return (
+          priority[a.state] - priority[b.state] ||
+          b.ts - a.ts ||
+          a.workerId.localeCompare(b.workerId)
+        )
       })
       .map((item) => ({
         workerId: item.workerId,
@@ -1323,7 +1638,11 @@ export function Swarm2Screen() {
   }, [members, runtimeByWorker])
 
   const inboxLanes = useMemo(
-    () => buildSwarm2InboxLanes({ missions: missionsQuery.data ?? [], runtimes: runtimeQuery.data?.entries ?? [] }),
+    () =>
+      buildSwarm2InboxLanes({
+        missions: missionsQuery.data ?? [],
+        runtimes: runtimeQuery.data?.entries ?? [],
+      }),
     [missionsQuery.data, runtimeQuery.data?.entries],
   )
 
@@ -1389,23 +1708,46 @@ export function Swarm2Screen() {
         title: `Mission ${latestMission.state}`,
         body: `${latestMission.checkpointedCount}/${latestMission.assignmentCount} checkpointed · ${latestMission.title}`,
         age: latestMission.id,
-        actionable: latestMission.checkpointedCount < latestMission.assignmentCount,
+        actionable:
+          latestMission.checkpointedCount < latestMission.assignmentCount,
       })
     }
     return laneItems.slice(0, 8)
   }, [inboxLanes, latestMission])
-  const actionableNotificationCount = swarmNotifications.filter((item) => item.actionable).length
+  const actionableNotificationCount = swarmNotifications.filter(
+    (item) => item.actionable,
+  ).length
 
   const recentUpdates = useMemo(() => {
     return members
       .map((member) => {
         const runtime = runtimeByWorker.get(member.id)
-        const ts = runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? member.lastSessionAt ?? null
-        const rawText = runtime?.lastRealSummary ?? runtime?.lastRealResult ?? runtime?.lastSummary ?? runtime?.lastResult ?? runtime?.blockedReason ?? runtime?.currentTask ?? member.lastSessionTitle ?? `Ready in ${member.role || 'worker'} lane`
-        const state = (runtime?.phase || runtime?.currentTask || '').toLowerCase()
+        const ts =
+          runtime?.lastOutputAt ??
+          runtime?.lastSessionStartedAt ??
+          member.lastSessionAt ??
+          null
+        const rawText =
+          runtime?.lastRealSummary ??
+          runtime?.lastRealResult ??
+          runtime?.lastSummary ??
+          runtime?.lastResult ??
+          runtime?.blockedReason ??
+          runtime?.currentTask ??
+          member.lastSessionTitle ??
+          `Ready in ${member.role || 'worker'} lane`
+        const state = (
+          runtime?.phase ||
+          runtime?.currentTask ||
+          ''
+        ).toLowerCase()
         const tone: 'idle' | 'active' | 'warning' = runtime?.blockedReason
           ? 'warning'
-          : (state.includes('review') || state.includes('write') || state.includes('build') || state.includes('implement') || state.includes('active'))
+          : state.includes('review') ||
+              state.includes('write') ||
+              state.includes('build') ||
+              state.includes('implement') ||
+              state.includes('active')
             ? 'active'
             : 'idle'
         return {
@@ -1419,7 +1761,13 @@ export function Swarm2Screen() {
       })
       .sort((a, b) => b.ts - a.ts || a.workerId.localeCompare(b.workerId))
       .slice(0, 3)
-      .map(({ workerId, workerName, text, age, tone }) => ({ workerId, workerName, text, age, tone }))
+      .map(({ workerId, workerName, text, age, tone }) => ({
+        workerId,
+        workerName,
+        text,
+        age,
+        tone,
+      }))
   }, [members, runtimeByWorker])
 
   function toggleRoom(id: string) {
@@ -1431,7 +1779,9 @@ export function Swarm2Screen() {
   }
 
   function openAddSwarm() {
-    const existingIds = new Set((rosterQuery.data ?? []).map((worker) => worker.id))
+    const existingIds = new Set(
+      (rosterQuery.data ?? []).map((worker) => worker.id),
+    )
     let next = 13
     while (existingIds.has(`swarm${next}`)) next += 1
     setNewWorkerId(`swarm${next}`)
@@ -1458,7 +1808,10 @@ export function Swarm2Screen() {
           role: newWorkerRole.trim(),
           specialty: newWorkerSpecialty.trim() || preset?.specialty || '',
           model: newWorkerModel.trim(),
-          mission: newWorkerMission.trim() || preset?.mission || 'Awaiting orchestrator dispatch.',
+          mission:
+            newWorkerMission.trim() ||
+            preset?.mission ||
+            'Awaiting orchestrator dispatch.',
           systemPrompt: preset?.systemPrompt ?? null,
           skills: preset?.skills ?? [],
         }),
@@ -1470,15 +1823,20 @@ export function Swarm2Screen() {
       await rosterQuery.refetch()
       setAddSwarmOpen(false)
     } catch (error) {
-      setAddSwarmError(error instanceof Error ? error.message : 'Failed to save swarm agent')
+      setAddSwarmError(
+        error instanceof Error ? error.message : 'Failed to save swarm agent',
+      )
     } finally {
       setAddSwarmSaving(false)
     }
   }
 
-
   return (
-    <div ref={topRef} className="min-h-full bg-surface text-primary-900" style={SWARM2_OPERATION_THEME}>
+    <div
+      ref={topRef}
+      className="min-h-full bg-surface text-primary-900"
+      style={SWARM2_OPERATION_THEME}
+    >
       <div
         className={cn(
           'mx-auto flex min-h-full max-w-[1680px] flex-col gap-3 px-3 pt-3 sm:px-4 lg:px-5',
@@ -1539,7 +1897,11 @@ export function Swarm2Screen() {
                 aria-label="Swarm notifications"
                 title="Swarm notifications"
               >
-                <HugeiconsIcon icon={AlarmClockIcon} size={17} strokeWidth={1.8} />
+                <HugeiconsIcon
+                  icon={AlarmClockIcon}
+                  size={17}
+                  strokeWidth={1.8}
+                />
                 {actionableNotificationCount > 0 ? (
                   <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
                     {actionableNotificationCount}
@@ -1550,34 +1912,55 @@ export function Swarm2Screen() {
                 <div className="absolute right-0 top-12 z-40 w-[min(28rem,calc(100vw-2rem))] rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 text-left shadow-[0_24px_80px_var(--theme-shadow)]">
                   <div className="mb-2 flex items-center justify-between gap-3">
                     <div>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Swarm updates</div>
-                      <div className="text-xs text-[var(--theme-muted-2)]">Actionable state from canonical mission checkpoints and durable report lanes.</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+                        Swarm updates
+                      </div>
+                      <div className="text-xs text-[var(--theme-muted-2)]">
+                        Actionable state from canonical mission checkpoints and
+                        durable report lanes.
+                      </div>
                     </div>
-                    <button type="button" onClick={() => setNotificationsOpen(false)} className="rounded-lg px-2 py-1 text-xs hover:bg-[var(--theme-card2)]">Close</button>
+                    <button
+                      type="button"
+                      onClick={() => setNotificationsOpen(false)}
+                      className="rounded-lg px-2 py-1 text-xs hover:bg-[var(--theme-card2)]"
+                    >
+                      Close
+                    </button>
                   </div>
                   <div className="max-h-80 space-y-2 overflow-y-auto">
-                    {swarmNotifications.length ? swarmNotifications.map((item) => (
-                      <button
-                        key={item.id}
-                        type="button"
-                        onClick={() => {
-                          if (item.workerId) {
-                            setViewMode('reports')
-                            setSelectedId(item.workerId)
-                            setFocusedRuntimeWorkerId(item.workerId)
-                          }
-                          setNotificationsOpen(false)
-                        }}
-                        className="block w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-left hover:border-[var(--theme-accent)]"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="truncate text-sm font-medium text-[var(--theme-text)]">{item.title}</span>
-                          <span className="shrink-0 text-[10px] text-[var(--theme-muted)]">{item.age}</span>
-                        </div>
-                        <div className="mt-1 truncate text-xs text-[var(--theme-muted-2)]">{item.body}</div>
-                      </button>
-                    )) : (
-                      <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-xs text-[var(--theme-muted)]">No active swarm updates.</div>
+                    {swarmNotifications.length ? (
+                      swarmNotifications.map((item) => (
+                        <button
+                          key={item.id}
+                          type="button"
+                          onClick={() => {
+                            if (item.workerId) {
+                              setViewMode('reports')
+                              setSelectedId(item.workerId)
+                              setFocusedRuntimeWorkerId(item.workerId)
+                            }
+                            setNotificationsOpen(false)
+                          }}
+                          className="block w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-left hover:border-[var(--theme-accent)]"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="truncate text-sm font-medium text-[var(--theme-text)]">
+                              {item.title}
+                            </span>
+                            <span className="shrink-0 text-[10px] text-[var(--theme-muted)]">
+                              {item.age}
+                            </span>
+                          </div>
+                          <div className="mt-1 truncate text-xs text-[var(--theme-muted-2)]">
+                            {item.body}
+                          </div>
+                        </button>
+                      ))
+                    ) : (
+                      <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-xs text-[var(--theme-muted)]">
+                        No active swarm updates.
+                      </div>
                     )}
                   </div>
                 </div>
@@ -1641,8 +2024,12 @@ export function Swarm2Screen() {
             focusedRuntimeWorkerId={focusedRuntimeWorkerId}
             onToggleFocusedRuntimeWorker={toggleFocusedRuntimeWorker}
             onClearFocusedRuntimeWorker={() => setFocusedRuntimeWorkerId(null)}
-            onStartAgentSession={(workerId) => { void startAgentSession(workerId) }}
-            onScrollTmuxSession={(workerId, direction, session) => { void scrollTmuxSession(workerId, direction, session) }}
+            onStartAgentSession={(workerId) => {
+              void startAgentSession(workerId)
+            }}
+            onScrollTmuxSession={(workerId, direction, session) => {
+              void scrollTmuxSession(workerId, direction, session)
+            }}
           />
         </div>
 
@@ -1656,14 +2043,17 @@ export function Swarm2Screen() {
         ) : null}
       </div>
 
-
       {addSwarmOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4 py-6 backdrop-blur-sm">
           <div className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-6 shadow-[0_30px_100px_var(--theme-shadow)]">
             <div className="mb-4 flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-xl font-semibold text-[var(--theme-text)]">Add Swarm Agent</h2>
-                <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Create a new swarm roster entry and configure its identity.</p>
+                <h2 className="text-xl font-semibold text-[var(--theme-text)]">
+                  Add Swarm Agent
+                </h2>
+                <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+                  Create a new swarm roster entry and configure its identity.
+                </p>
               </div>
               <button
                 type="button"
@@ -1675,7 +2065,9 @@ export function Swarm2Screen() {
             </div>
             <div className="grid gap-3 md:grid-cols-2">
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Role preset</span>
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Role preset
+                </span>
                 <select
                   value={newWorkerRole}
                   onChange={(e) => {
@@ -1683,71 +2075,164 @@ export function Swarm2Screen() {
                     setNewWorkerRole(role)
                     const preset = ROLE_PRESETS.find((p) => p.role === role)
                     if (preset && role !== 'Custom') {
-                      if (!newWorkerSpecialty.trim()) setNewWorkerSpecialty(preset.specialty)
-                      if (!newWorkerMission.trim()) setNewWorkerMission(preset.mission)
-                      if (preset.defaultModel && !newWorkerModel.trim()) setNewWorkerModel(preset.defaultModel)
+                      if (!newWorkerSpecialty.trim())
+                        setNewWorkerSpecialty(preset.specialty)
+                      if (!newWorkerMission.trim())
+                        setNewWorkerMission(preset.mission)
+                      if (preset.defaultModel && !newWorkerModel.trim())
+                        setNewWorkerModel(preset.defaultModel)
                     }
                   }}
                   className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
                 >
                   {ROLE_NAMES.map((r) => (
-                    <option key={r} value={r}>{r}</option>
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
                   ))}
                 </select>
                 <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Presets auto-fill specialty, mission, system prompt, and skill stack. Pick “Custom” for a blank slate.
+                  Presets auto-fill specialty, mission, system prompt, and skill
+                  stack. Pick “Custom” for a blank slate.
                 </p>
               </label>
               <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Worker ID</span>
-                <input value={newWorkerId} onChange={(e) => setNewWorkerId(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="swarmN" />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Worker ID
+                </span>
+                <input
+                  value={newWorkerId}
+                  onChange={(e) => setNewWorkerId(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder="swarmN"
+                />
               </label>
               <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Display name</span>
-                <input value={newWorkerName} onChange={(e) => setNewWorkerName(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="e.g. Mirror, Builder" />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Display name
+                </span>
+                <input
+                  value={newWorkerName}
+                  onChange={(e) => setNewWorkerName(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder="e.g. Mirror, Builder"
+                />
               </label>
               <label className="block text-sm md:col-span-2">
                 <span className="mb-1 flex items-center justify-between text-[var(--theme-muted)]">
                   <span>Model</span>
-                  <span className="text-[10px] text-[var(--theme-muted-2)]">{availableModels.length > 0 ? `${availableModels.length} available` : modelsQuery.isLoading ? 'loading…' : '0 found'}</span>
+                  <span className="text-[10px] text-[var(--theme-muted-2)]">
+                    {availableModels.length > 0
+                      ? `${availableModels.length} available`
+                      : modelsQuery.isLoading
+                        ? 'loading…'
+                        : '0 found'}
+                  </span>
                 </span>
                 <input
                   value={newWorkerModel}
                   onChange={(e) => setNewWorkerModel(e.target.value)}
                   list="swarm-add-models"
-                  placeholder={availableModels.length ? 'Search or pick a detected model…' : modelsQuery.isLoading ? 'Loading detected models…' : 'No models detected'}
+                  placeholder={
+                    availableModels.length
+                      ? 'Search or pick a detected model…'
+                      : modelsQuery.isLoading
+                        ? 'Loading detected models…'
+                        : 'No models detected'
+                  }
                   className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
                 />
                 <datalist id="swarm-add-models">
                   {availableModels.map((m) => (
-                    <option key={m.id} value={m.name}>{m.provider}</option>
+                    <option key={m.id} value={m.name}>
+                      {m.provider}
+                    </option>
                   ))}
                 </datalist>
                 <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Searchable picker backed by /api/models, the same source as chat. {modelsQuery.isError ? 'Model discovery errored, so this is empty until refresh.' : 'Start typing to see every detected model from the user’s Hermes config and local providers.'}
+                  Searchable picker backed by /api/models, the same source as
+                  chat.{' '}
+                  {modelsQuery.isError
+                    ? 'Model discovery errored, so this is empty until refresh.'
+                    : 'Start typing to see every detected model from the user’s Hermes config and local providers.'}
                 </p>
               </label>
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Specialty</span>
-                <input value={newWorkerSpecialty} onChange={(e) => setNewWorkerSpecialty(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.specialty || 'short focus area'} />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Specialty
+                </span>
+                <input
+                  value={newWorkerSpecialty}
+                  onChange={(e) => setNewWorkerSpecialty(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder={
+                    ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                      ?.specialty || 'short focus area'
+                  }
+                />
               </label>
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Mission</span>
-                <textarea value={newWorkerMission} onChange={(e) => setNewWorkerMission(e.target.value)} rows={3} className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.mission || 'standing mission for this worker'} />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Mission
+                </span>
+                <textarea
+                  value={newWorkerMission}
+                  onChange={(e) => setNewWorkerMission(e.target.value)}
+                  rows={3}
+                  className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder={
+                    ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                      ?.mission || 'standing mission for this worker'
+                  }
+                />
               </label>
-              {ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt ? (
+              {ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                ?.systemPrompt ? (
                 <div className="md:col-span-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
-                  <div className="mb-1 font-semibold text-[var(--theme-muted)]">System prompt (embedded with role)</div>
-                  <div className="whitespace-pre-wrap leading-relaxed">{ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt}</div>
-                  <div className="mt-2 font-semibold text-[var(--theme-muted)]">Skills loaded</div>
-                  <div className="font-mono">{(ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.skills ?? []).join(', ') || '—'}</div>
+                  <div className="mb-1 font-semibold text-[var(--theme-muted)]">
+                    System prompt (embedded with role)
+                  </div>
+                  <div className="whitespace-pre-wrap leading-relaxed">
+                    {
+                      ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                        ?.systemPrompt
+                    }
+                  </div>
+                  <div className="mt-2 font-semibold text-[var(--theme-muted)]">
+                    Skills loaded
+                  </div>
+                  <div className="font-mono">
+                    {(
+                      ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                        ?.skills ?? []
+                    ).join(', ') || '—'}
+                  </div>
                 </div>
               ) : null}
             </div>
-            {addSwarmError ? <div className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{addSwarmError}</div> : null}
+            {addSwarmError ? (
+              <div className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+                {addSwarmError}
+              </div>
+            ) : null}
             <div className="mt-4 flex items-center justify-end gap-3">
-              <button type="button" onClick={() => setAddSwarmOpen(false)} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]">Cancel</button>
-              <button type="button" disabled={addSwarmSaving || !newWorkerId.trim() || !newWorkerName.trim()} onClick={() => void saveAddSwarm()} className="rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 disabled:opacity-50">{addSwarmSaving ? 'Saving…' : 'Save swarm agent'}</button>
+              <button
+                type="button"
+                onClick={() => setAddSwarmOpen(false)}
+                className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={
+                  addSwarmSaving || !newWorkerId.trim() || !newWorkerName.trim()
+                }
+                onClick={() => void saveAddSwarm()}
+                className="rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 disabled:opacity-50"
+              >
+                {addSwarmSaving ? 'Saving…' : 'Save swarm agent'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/server/dashboard-aggregator.test.ts
+++ b/src/server/dashboard-aggregator.test.ts
@@ -36,6 +36,60 @@ describe('buildDashboardOverview', () => {
     expect(overview.analytics).toBeNull()
   })
 
+  it('does not let slow analytics block the rest of the overview', async () => {
+    let analyticsRequested = false
+    const fetcher: DashboardFetcher = async (path) => {
+      if (path.startsWith('/api/status')) {
+        return jsonResponse({
+          gateway_state: 'running',
+          active_agents: 0,
+          platforms: {},
+        })
+      }
+      if (path.startsWith('/api/analytics/usage')) {
+        analyticsRequested = true
+        return new Promise<Response>(() => undefined)
+      }
+      return new Response('not found', { status: 404 })
+    }
+
+    const overview = await buildDashboardOverview({
+      fetcher,
+      requestTimeoutMs: 5,
+    })
+
+    expect(overview.status?.gatewayState).toBe('running')
+    expect(overview.analytics).toBeNull()
+    expect(analyticsRequested).toBe(true)
+  })
+
+  it('can skip analytics entirely for latency-sensitive callers', async () => {
+    let analyticsRequested = false
+    const fetcher: DashboardFetcher = async (path) => {
+      if (path.startsWith('/api/status')) {
+        return jsonResponse({
+          gateway_state: 'running',
+          active_agents: 0,
+          platforms: {},
+        })
+      }
+      if (path.startsWith('/api/analytics/usage')) {
+        analyticsRequested = true
+        return jsonResponse({ totals: { total_sessions: 999 } })
+      }
+      return new Response('not found', { status: 404 })
+    }
+
+    const overview = await buildDashboardOverview({
+      fetcher,
+      includeAnalytics: false,
+    })
+
+    expect(overview.status?.gatewayState).toBe('running')
+    expect(overview.analytics).toBeNull()
+    expect(analyticsRequested).toBe(false)
+  })
+
   it('parses /api/status into status + platforms', async () => {
     const fetcher = makeFetcher({
       '/api/status': {
@@ -131,9 +185,7 @@ describe('buildDashboardOverview', () => {
       name: 'Daily roll-up',
       lastError: 'connection refused',
     })
-    const cronIncident = overview.incidents.find(
-      (i) => i.id === 'cron-fail-a',
-    )
+    const cronIncident = overview.incidents.find((i) => i.id === 'cron-fail-a')
     expect(cronIncident?.severity).toBe('error')
     expect(cronIncident?.detail).toBe('connection refused')
   })

--- a/src/server/dashboard-aggregator.ts
+++ b/src/server/dashboard-aggregator.ts
@@ -157,7 +157,13 @@ export type DashboardAnalyticsSection = {
   totalSessions: number
   /** API call count over the window. */
   totalApiCalls: number
-  topModels: Array<{ id: string; tokens: number; calls: number; cost: number; sessions: number }>
+  topModels: Array<{
+    id: string
+    tokens: number
+    calls: number
+    cost: number
+    sessions: number
+  }>
   /**
    * Per-day rollup for sparklines. ISO date string + tokens + sessions
    * + cost per day. Always returned, even when empty.
@@ -195,7 +201,10 @@ export type DashboardAnalyticsSection = {
   source: 'analytics' | 'fallback' | 'unavailable'
 }
 
-export type DashboardFetcher = (path: string) => Promise<Response>
+export type DashboardFetcher = (
+  path: string,
+  init?: RequestInit,
+) => Promise<Response>
 
 export type BuildOverviewOptions = {
   /**
@@ -210,6 +219,10 @@ export type BuildOverviewOptions = {
   achievementsLimit?: number
   /** How many log tail lines to surface. Default 24. */
   logsLimit?: number
+  /** Whether to query the expensive dashboard analytics endpoint. Default true. */
+  includeAnalytics?: boolean
+  /** Per-upstream timeout in milliseconds. Default 2500. */
+  requestTimeoutMs?: number
 }
 
 const DEFAULT_OPTIONS = {
@@ -218,18 +231,34 @@ const DEFAULT_OPTIONS = {
   analyticsWindowDays: 30,
   achievementsLimit: 3,
   logsLimit: 24,
+  includeAnalytics: true,
+  requestTimeoutMs: 2500,
 }
 
 async function safeJson<T>(
   fetcher: DashboardFetcher,
   path: string,
+  timeoutMs: number,
 ): Promise<T | null> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<Response>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort()
+      reject(new Error(`dashboard request timed out: ${path}`))
+    }, timeoutMs)
+  })
   try {
-    const res = await fetcher(path)
+    const res = await Promise.race([
+      fetcher(path, { signal: controller.signal }),
+      timeout,
+    ])
     if (!res.ok) return null
     return (await res.json()) as T
   } catch {
     return null
+  } finally {
+    if (timer) clearTimeout(timer)
   }
 }
 
@@ -359,8 +388,7 @@ function normalizeCron(raw: unknown): DashboardCronSection | null {
       failed += 1
       const id = readString(j.id) || readString(j.name) || 'unknown'
       const name = readString(j.name) || id
-      const lastRunAt =
-        typeof j.last_run_at === 'string' ? j.last_run_at : null
+      const lastRunAt = typeof j.last_run_at === 'string' ? j.last_run_at : null
       recentFailures.push({ id, name, lastError, lastRunAt })
     }
     const candidates = [
@@ -413,9 +441,7 @@ function normalizeAchievements(
   if (recentArr.length === 0 && (!all || typeof all !== 'object')) return null
   const recentUnlocks = recentArr
     .map(normalizeAchievementUnlock)
-    .filter(
-      (entry): entry is DashboardAchievementUnlock => entry !== null,
-    )
+    .filter((entry): entry is DashboardAchievementUnlock => entry !== null)
     .slice(0, limit)
 
   let totalUnlocked = 0
@@ -480,7 +506,9 @@ function normalizeSkillsUsage(
       }
     })
     .filter(
-      (e): e is {
+      (
+        e,
+      ): e is {
         skill: string
         totalCount: number
         percentage: number
@@ -489,10 +517,7 @@ function normalizeSkillsUsage(
     )
     .sort((a, b) => b.totalCount - a.totalCount)
     .slice(0, 5)
-  if (
-    !summary &&
-    topSkills.length === 0
-  ) {
+  if (!summary && topSkills.length === 0) {
     return null
   }
   return {
@@ -525,9 +550,7 @@ function normalizeAnalytics(
     totalsRaw?.total_output ?? r.total_output ?? r.output_tokens,
   )
   const cacheReadTokens = readNumber(
-    totalsRaw?.total_cache_read ??
-      r.total_cache_read ??
-      r.cache_read_tokens,
+    totalsRaw?.total_cache_read ?? r.total_cache_read ?? r.cache_read_tokens,
   )
   const reasoningTokens = readNumber(
     totalsRaw?.total_reasoning ?? r.total_reasoning ?? r.reasoning_tokens,
@@ -555,9 +578,7 @@ function normalizeAnalytics(
   // reasoning are exposed separately for the rich UI.
   const fallbackTotal = readNumber(r.total_tokens)
   const totalTokens =
-    inputTokens + outputTokens > 0
-      ? inputTokens + outputTokens
-      : fallbackTotal
+    inputTokens + outputTokens > 0 ? inputTokens + outputTokens : fallbackTotal
 
   const modelsRaw = Array.isArray(r.by_model)
     ? r.by_model
@@ -576,14 +597,19 @@ function normalizeAnalytics(
       const tokensOut = readNumber(e.output_tokens)
       return {
         id,
-        tokens: tokensIn + tokensOut > 0 ? tokensIn + tokensOut : readNumber(e.tokens),
+        tokens:
+          tokensIn + tokensOut > 0
+            ? tokensIn + tokensOut
+            : readNumber(e.tokens),
         calls: readNumber(e.api_calls ?? e.calls ?? e.requests),
         cost: readNumber(e.estimated_cost ?? e.cost),
         sessions: readNumber(e.sessions),
       }
     })
     .filter(
-      (entry): entry is {
+      (
+        entry,
+      ): entry is {
         id: string
         tokens: number
         calls: number
@@ -613,7 +639,9 @@ function normalizeAnalytics(
       }
     })
     .filter(
-      (entry): entry is {
+      (
+        entry,
+      ): entry is {
         day: string
         inputTokens: number
         outputTokens: number
@@ -797,16 +825,12 @@ function computeInsights(
   // glance.
   const ops: Array<string> = []
   if (cron && cron.failed > 0) {
-    ops.push(
-      `${cron.failed} failed cron job${cron.failed === 1 ? '' : 's'}`,
-    )
+    ops.push(`${cron.failed} failed cron job${cron.failed === 1 ? '' : 's'}`)
   }
   if (cron && cron.nextRunAt) {
     const nextMs = Date.parse(cron.nextRunAt)
     if (Number.isFinite(nextMs) && nextMs - Date.now() < -7 * 86_400_000) {
-      ops.push(
-        `${cron.total} stale cron job${cron.total === 1 ? '' : 's'}`,
-      )
+      ops.push(`${cron.total} stale cron job${cron.total === 1 ? '' : 's'}`)
     }
   }
   if (
@@ -998,7 +1022,18 @@ export async function buildDashboardOverview(
   options: BuildOverviewOptions & BuildOverviewExtraFetchers,
 ): Promise<DashboardOverview> {
   const opts = { ...DEFAULT_OPTIONS, ...options }
-  const { fetcher, analyticsWindowDays, achievementsLimit, logsLimit } = opts
+  const {
+    fetcher,
+    analyticsWindowDays,
+    achievementsLimit,
+    logsLimit,
+    includeAnalytics,
+    requestTimeoutMs: rawRequestTimeoutMs,
+  } = opts
+  const requestTimeoutMs =
+    rawRequestTimeoutMs && rawRequestTimeoutMs > 0
+      ? rawRequestTimeoutMs
+      : DEFAULT_OPTIONS.requestTimeoutMs
 
   const [
     statusRaw,
@@ -1010,22 +1045,38 @@ export async function buildDashboardOverview(
     analyticsRaw,
     logsRaw,
   ] = await Promise.all([
-    safeJson<unknown>(fetcher, '/api/status'),
+    safeJson<unknown>(fetcher, '/api/status', requestTimeoutMs),
     options.gatewayFetcher
-      ? safeJson<unknown>(options.gatewayFetcher, '/health/detailed')
+      ? safeJson<unknown>(
+          options.gatewayFetcher,
+          '/health/detailed',
+          requestTimeoutMs,
+        )
       : Promise.resolve(null),
-    safeJson<unknown>(fetcher, '/api/cron/jobs'),
+    safeJson<unknown>(fetcher, '/api/cron/jobs', requestTimeoutMs),
     safeJson<unknown>(
       fetcher,
       `/api/plugins/hermes-achievements/recent-unlocks?limit=${achievementsLimit}`,
+      requestTimeoutMs,
     ),
-    safeJson<unknown>(fetcher, '/api/plugins/hermes-achievements/achievements'),
-    safeJson<unknown>(fetcher, '/api/model/info'),
     safeJson<unknown>(
       fetcher,
-      `/api/analytics/usage?days=${analyticsWindowDays}`,
+      '/api/plugins/hermes-achievements/achievements',
+      requestTimeoutMs,
     ),
-    safeJson<unknown>(fetcher, `/api/logs?lines=${logsLimit}`),
+    safeJson<unknown>(fetcher, '/api/model/info', requestTimeoutMs),
+    includeAnalytics
+      ? safeJson<unknown>(
+          fetcher,
+          `/api/analytics/usage?days=${analyticsWindowDays}`,
+          requestTimeoutMs,
+        )
+      : Promise.resolve(null),
+    safeJson<unknown>(
+      fetcher,
+      `/api/logs?lines=${logsLimit}`,
+      requestTimeoutMs,
+    ),
   ])
 
   const status = normalizeStatus(statusRaw, healthRaw)

--- a/src/server/session-utils.test.ts
+++ b/src/server/session-utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isInternalSession,
+  resolveMainChatSessionId,
+  shouldShowInChatSessionList,
+} from './session-utils'
+
+describe('session-utils', () => {
+  it('hides cron and generated worker sessions from the chat list', () => {
+    expect(
+      shouldShowInChatSessionList({
+        id: 'cron_a34081ba1f47_20260530_130010',
+        title: '[IMPORTANT: The user has invoked the "android-phone-ops" skill',
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldShowInChatSessionList({
+        id: '20260530_024814_f6aad2',
+        title: 'Distill the key insights from this MCTS exploration: BRIEF',
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldShowInChatSessionList({
+        id: '20260530_024657_26d43a',
+        preview: 'PLAN — decide next action: Brief: Troubleshoot this error',
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldShowInChatSessionList({
+        id: '20260530_094037_441fb9',
+        title: 'Return exactly: HERMES_UPDATE_OK',
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps ordinary user sessions visible', () => {
+    expect(
+      isInternalSession({
+        id: '20260530_161000_user_chat',
+        title: 'Onderzoek de lokale Hermes agent installatie',
+        message_count: 4,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not resolve main chat to internal runtime sessions', () => {
+    const id = resolveMainChatSessionId([
+      {
+        id: 'cron_66fa922a6bb7_20260530_120045',
+        title:
+          '[IMPORTANT: The user has invoked the "bounty-income-operation" skill',
+        message_count: 14,
+      },
+      {
+        id: '20260530_024814_8f0090',
+        title: 'Distill the key insights from this MCTS exploration: BRIEF',
+        message_count: 2,
+      },
+      {
+        id: 'session-real',
+        title: 'Fix the deployment pipeline',
+        message_count: 8,
+      },
+    ])
+
+    expect(id).toBe('session-real')
+  })
+})

--- a/src/server/session-utils.ts
+++ b/src/server/session-utils.ts
@@ -12,6 +12,8 @@ type ResolveSessionResult = {
 type SessionLike = {
   id: string
   title?: string | null
+  preview?: string | null
+  source?: string | null
   message_count?: number | null
 }
 
@@ -22,13 +24,48 @@ type PortableMainBindingOptions = {
 }
 
 const SYNTHETIC_SESSION_KEYS = new Set(['main', 'new'])
+const INTERNAL_SESSION_TITLE_PREFIXES = [
+  '[IMPORTANT: The user has invoked the "',
+  'Distill the key insights from this MCTS exploration',
+  'You are running a mental simulation',
+  'You are exploring different reasoning approaches',
+  'PLAN — decide next action:',
+  'MONITOR — assess current dream state:',
+  'EVALUATE — compare current approach vs alternatives:',
+  'Return exactly: HERMES_UPDATE_OK',
+]
 
 export function isInternalSessionKey(id: string): boolean {
   return (
     id.startsWith('cron_') ||
     id.startsWith('cron:') ||
+    id.startsWith('agent:') ||
     id.startsWith('agent:main:ops-')
   )
+}
+
+export function isInternalSessionTitle(
+  value: string | null | undefined,
+): boolean {
+  const text = (value ?? '').trim()
+  if (!text) return false
+  return INTERNAL_SESSION_TITLE_PREFIXES.some((prefix) =>
+    text.startsWith(prefix),
+  )
+}
+
+export function isInternalSession(session: SessionLike): boolean {
+  return (
+    isInternalSessionKey(session.id) ||
+    isInternalSessionTitle(session.title) ||
+    isInternalSessionTitle(session.preview) ||
+    session.source === 'cron' ||
+    session.source === 'ops'
+  )
+}
+
+export function shouldShowInChatSessionList(session: SessionLike): boolean {
+  return !isInternalSession(session)
 }
 
 export function hasRealTitle(session: SessionLike): boolean {
@@ -40,13 +77,13 @@ export function resolveMainChatSessionId(
   sessions: Array<SessionLike>,
 ): string | null {
   const titled = sessions.find(
-    (session) => !isInternalSessionKey(session.id) && hasRealTitle(session),
+    (session) => shouldShowInChatSessionList(session) && hasRealTitle(session),
   )
   const fallback = titled
     ? null
     : sessions.find(
         (session) =>
-          !isInternalSessionKey(session.id) &&
+          shouldShowInChatSessionList(session) &&
           typeof session.message_count === 'number' &&
           session.message_count > 0,
       )
@@ -66,9 +103,7 @@ export function shouldBindMainToPortableSession({
   enhancedChat,
 }: PortableMainBindingOptions): boolean {
   return (
-    (sessionKey ?? '').trim() === 'main' &&
-    dashboardAvailable &&
-    !enhancedChat
+    (sessionKey ?? '').trim() === 'main' && dashboardAvailable && !enhancedChat
   )
 }
 

--- a/src/server/swarm-roster.ts
+++ b/src/server/swarm-roster.ts
@@ -15,7 +15,10 @@ export function isSwarmWorkerId(value: unknown): value is string {
 const WorkerIdSchema = z
   .string()
   .trim()
-  .regex(WORKER_ID_PATTERN, 'worker id must look like swarm13 or a semantic profile id')
+  .regex(
+    WORKER_ID_PATTERN,
+    'worker id must look like swarm13 or a semantic profile id',
+  )
 
 export const SwarmRosterWorkerSchema = z.object({
   id: WorkerIdSchema,
@@ -102,10 +105,16 @@ export function fallbackRoster(ids: Array<string> = []): SwarmRoster {
       specialty: '',
       model: 'Worker',
       mission: 'Awaiting orchestrator dispatch.',
+      modes: [],
+      tools: [],
       skills: [],
+      plugins: [],
+      pluginToolsets: [],
+      mcpServers: [],
       capabilities: [],
       defaultCwd: undefined,
       preferredTaskTypes: [],
+      greenlightRequiredFor: [],
       maxConcurrentTasks: 1,
       acceptsBroadcast: true,
       reviewRequired: false,
@@ -134,7 +143,10 @@ export function writeSwarmRoster(roster: SwarmRoster): void {
   writeFileSync(SWARM_ROSTER_PATH, doc)
 }
 
-export function upsertSwarmRosterWorker(input: SwarmRosterUpsert, ids: Array<string> = []): SwarmRoster {
+export function upsertSwarmRosterWorker(
+  input: SwarmRosterUpsert,
+  ids: Array<string> = [],
+): SwarmRoster {
   const nextWorker = SwarmRosterUpsertSchema.parse(input)
   const current = readSwarmRoster(ids)
   const byId = new Map(current.workers.map((worker) => [worker.id, worker]))
@@ -151,12 +163,21 @@ export function upsertSwarmRosterWorker(input: SwarmRosterUpsert, ids: Array<str
   return next
 }
 
-export function rosterByWorkerId(ids: Array<string> = []): Map<string, SwarmRosterWorker> {
-  return new Map(readSwarmRoster(ids).workers.map((worker) => [worker.id, worker]))
+export function rosterByWorkerId(
+  ids: Array<string> = [],
+): Map<string, SwarmRosterWorker> {
+  return new Map(
+    readSwarmRoster(ids).workers.map((worker) => [worker.id, worker]),
+  )
 }
 
-export function resolveSwarmWorkerDisplayName(workerId: string, worker?: Pick<SwarmRosterWorker, 'name'> | null): string {
-  return worker ? worker.name.trim() || titleCase(workerId) : titleCase(workerId)
+export function resolveSwarmWorkerDisplayName(
+  workerId: string,
+  worker?: Pick<SwarmRosterWorker, 'name'> | null,
+): string {
+  return worker
+    ? worker.name.trim() || titleCase(workerId)
+    : titleCase(workerId)
 }
 
 export function formatSwarmWorkerLabel(
@@ -164,6 +185,8 @@ export function formatSwarmWorkerLabel(
   worker?: Pick<SwarmRosterWorker, 'name' | 'role'> | null,
 ): string {
   const displayName = resolveSwarmWorkerDisplayName(workerId, worker)
-  const role = worker ? worker.role.trim() || defaultRoleFromId(workerId) : defaultRoleFromId(workerId)
+  const role = worker
+    ? worker.role.trim() || defaultRoleFromId(workerId)
+    : defaultRoleFromId(workerId)
   return `${displayName} — ${role}`
 }

--- a/src/server/update-system.test.ts
+++ b/src/server/update-system.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { remoteUrlMatches } from './update-system'
+import {
+  parseGitAheadBehind,
+  parseGitPorcelainPath,
+  remoteUrlMatches,
+} from './update-system'
 
 describe('update-system helpers', () => {
   it('matches GitHub URL forms against expected repo aliases', () => {
@@ -18,5 +22,23 @@ describe('update-system helpers', () => {
         'hermes-workspace',
       ]),
     ).toBe(false)
+  })
+
+  it('parses porcelain paths without dropping the first character', () => {
+    expect(parseGitPorcelainPath(' M src/routes/__root.tsx')).toBe(
+      'src/routes/__root.tsx',
+    )
+    expect(parseGitPorcelainPath('M src/routes/__root.tsx')).toBe(
+      'src/routes/__root.tsx',
+    )
+    expect(parseGitPorcelainPath('?? src/server/session-utils.test.ts')).toBe(
+      'src/server/session-utils.test.ts',
+    )
+  })
+
+  it('parses git ahead/behind counts', () => {
+    expect(parseGitAheadBehind('2\t0')).toEqual({ ahead: 2, behind: 0 })
+    expect(parseGitAheadBehind('0 27')).toEqual({ ahead: 0, behind: 27 })
+    expect(parseGitAheadBehind('nope')).toBeNull()
   })
 })

--- a/src/server/update-system.ts
+++ b/src/server/update-system.ts
@@ -139,6 +139,24 @@ function git(args: Array<string>, cwd: string, timeout = 8_000): string | null {
   return exec('git', args, { cwd, timeout })
 }
 
+function gitRaw(
+  args: Array<string>,
+  cwd: string,
+  timeout = 8_000,
+): string | null {
+  try {
+    const output = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      timeout,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).replace(/\s+$/, '')
+    return output || null
+  } catch {
+    return null
+  }
+}
+
 function realGitRepoPath(path: string | null | undefined): string | null {
   if (!path) return null
   try {
@@ -189,19 +207,25 @@ function isDirty(repoPath: string): boolean {
   return Boolean(git(['status', '--porcelain'], repoPath))
 }
 
+export function parseGitPorcelainPath(line: string): string | null {
+  if (!line.trim()) return null
+  if (line.length >= 4 && line[2] === ' ') {
+    return line.slice(3).trim() || null
+  }
+  return line.replace(/^[^\s]+\s+/, '').trim() || null
+}
+
 /**
  * Return up to `limit` paths from `git status --porcelain` so the UI can
  * tell the user exactly which files are blocking an update. The shape of
  * each entry is the relative path inside the repo (XY status code stripped).
  */
 function listDirtyFiles(repoPath: string, limit = 24): Array<string> {
-  const raw = git(['status', '--porcelain'], repoPath)
+  const raw = gitRaw(['status', '--porcelain'], repoPath)
   if (!raw) return []
   const out: Array<string> = []
   for (const line of raw.split('\n')) {
-    if (!line.trim()) continue
-    // porcelain format: XY <space> path  (path may be quoted with renames)
-    const path = line.slice(3).trim()
+    const path = parseGitPorcelainPath(line)
     if (path) out.push(path)
     if (out.length >= limit) break
   }
@@ -219,6 +243,29 @@ function canFastForward(repoPath: string, remoteRef: string): boolean {
 
 function canResetToRemote(repoPath: string, remoteRef: string): boolean {
   return Boolean(git(['rev-parse', '--verify', remoteRef], repoPath, 10_000))
+}
+
+export function parseGitAheadBehind(
+  raw: string | null,
+): { ahead: number; behind: number } | null {
+  if (!raw) return null
+  const [aheadRaw, behindRaw] = raw.trim().split(/\s+/)
+  const ahead = Number.parseInt(aheadRaw ?? '', 10)
+  const behind = Number.parseInt(behindRaw ?? '', 10)
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null
+  return { ahead, behind }
+}
+
+function readAheadBehind(
+  repoPath: string,
+  remoteRef: string,
+): { ahead: number; behind: number } | null {
+  return parseGitAheadBehind(
+    git(
+      ['rev-list', '--left-right', '--count', `HEAD...${remoteRef}`],
+      repoPath,
+    ),
+  )
 }
 
 function syncRepoToRemote(repoPath: string, remoteRef: string): string {
@@ -338,14 +385,28 @@ export function readWorkspaceUpdateStatus(
   const latestHead =
     repoMatches && supportedBranch ? remoteHead(gitRepo, 'origin') : null
   const dirty = isDirty(gitRepo)
-  const updateAvailable = Boolean(
-    supportedBranch && currentHead && latestHead && currentHead !== latestHead,
-  )
   const remoteRef = `origin/${branch || 'main'}`
+  const aheadBehind =
+    repoMatches && supportedBranch ? readAheadBehind(gitRepo, remoteRef) : null
+  const ahead = aheadBehind?.ahead ?? 0
+  const behind = aheadBehind?.behind ?? 0
+  const localAheadOnly = ahead > 0 && behind === 0
+  const diverged = ahead > 0 && behind > 0
+  const updateAvailable = Boolean(
+    supportedBranch &&
+    currentHead &&
+    latestHead &&
+    (aheadBehind ? behind > 0 : currentHead !== latestHead),
+  )
   const canSync = updateAvailable ? canResetToRemote(gitRepo, remoteRef) : true
   const ff = updateAvailable ? canFastForward(gitRepo, remoteRef) : true
   const canUpdate = Boolean(
-    repoMatches && supportedBranch && updateAvailable && !dirty && canSync,
+    repoMatches &&
+    supportedBranch &&
+    updateAvailable &&
+    !dirty &&
+    canSync &&
+    ff,
   )
 
   return {
@@ -366,22 +427,26 @@ export function readWorkspaceUpdateStatus(
         ? 'unsupported'
         : dirty
           ? 'blocked'
-          : updateAvailable
-            ? canSync
-              ? 'available'
-              : 'blocked'
-            : 'current',
+          : updateAvailable && !ff
+            ? 'blocked'
+            : updateAvailable
+              ? canSync
+                ? 'available'
+                : 'blocked'
+              : 'current',
     reason: !repoMatches
       ? 'Workspace origin remote does not look like hermes-workspace.'
       : !supportedBranch
         ? 'Workspace one-click updates are only enabled on main/master branches.'
         : dirty
           ? 'Workspace checkout has local changes. Commit, stash, or remove the listed files before updating.'
-          : updateAvailable && !canSync
-            ? 'Workspace update could not verify the remote branch ref.'
-            : updateAvailable && !ff
-              ? 'Workspace branch diverged from origin. One-click update will realign to the remote branch.'
-              : null,
+          : diverged
+            ? 'Workspace branch diverged from origin. Rebase or merge local commits before using one-click update.'
+            : updateAvailable && !canSync
+              ? 'Workspace update could not verify the remote branch ref.'
+              : localAheadOnly
+                ? `Workspace has ${ahead} local commit${ahead === 1 ? '' : 's'} ahead of origin; no remote update is pending.`
+                : null,
     blockingFiles: dirty ? listDirtyFiles(gitRepo) : undefined,
     updateMode: 'git-ff',
   }
@@ -405,7 +470,9 @@ export function readAgentUpdateStatus(): ProductUpdateStatus {
   const repoPath = agentRepoPath()
   const repoHermes = repoPath ? join(repoPath, 'venv', 'bin', 'hermes') : null
   const path =
-    repoHermes && existsSync(repoHermes) ? repoHermes : exec('which', ['hermes'])
+    repoHermes && existsSync(repoHermes)
+      ? repoHermes
+      : exec('which', ['hermes'])
   const version =
     (path ? exec(path, ['--version'], { timeout: 10_000 }) : null)?.split(
       '\n',
@@ -443,12 +510,22 @@ export function readAgentUpdateStatus(): ProductUpdateStatus {
   const latestHead = repoMatches ? remoteHead(repoPath, 'origin') : null
   const remoteRef = repoMatches ? `origin/${branch || 'main'}` : null
   const dirty = isDirty(repoPath)
+  const aheadBehind = remoteRef ? readAheadBehind(repoPath, remoteRef) : null
+  const ahead = aheadBehind?.ahead ?? 0
+  const behind = aheadBehind?.behind ?? 0
+  const localAheadOnly = ahead > 0 && behind === 0
+  const diverged = ahead > 0 && behind > 0
   const updateAvailable = Boolean(
-    currentHead && latestHead && currentHead !== latestHead && remoteRef,
+    currentHead &&
+    latestHead &&
+    remoteRef &&
+    (aheadBehind ? behind > 0 : currentHead !== latestHead),
   )
   const canSync = remoteRef ? canResetToRemote(repoPath, remoteRef) : false
   const ff = remoteRef ? canFastForward(repoPath, remoteRef) : false
-  const canUpdate = Boolean(repoMatches && updateAvailable && !dirty && canSync)
+  const canUpdate = Boolean(
+    repoMatches && updateAvailable && !dirty && canSync && ff,
+  )
 
   return {
     id: 'agent',
@@ -466,20 +543,24 @@ export function readAgentUpdateStatus(): ProductUpdateStatus {
       ? 'unsupported'
       : dirty
         ? 'blocked'
-        : updateAvailable && canSync
-          ? 'available'
-          : updateAvailable
-            ? 'blocked'
-            : 'current',
+        : updateAvailable && !ff
+          ? 'blocked'
+          : updateAvailable && canSync
+            ? 'available'
+            : updateAvailable
+              ? 'blocked'
+              : 'current',
     reason: !repoMatches
       ? 'Hermes Agent origin remote does not look like hermes-agent.'
       : dirty
         ? 'Hermes Agent checkout has local changes. Commit, stash, or remove the listed files before updating.'
-        : updateAvailable && !canSync
-          ? 'Hermes Agent update could not verify the remote branch ref.'
-          : updateAvailable && !ff
-            ? 'Hermes Agent branch diverged from origin. One-click update will realign to the remote branch.'
-            : null,
+        : diverged
+          ? 'Hermes Agent branch diverged from origin. Rebase or merge local commits before using one-click update.'
+          : updateAvailable && !canSync
+            ? 'Hermes Agent update could not verify the remote branch ref.'
+            : localAheadOnly
+              ? `Hermes Agent has ${ahead} local commit${ahead === 1 ? '' : 's'} ahead of origin; no remote update is pending.`
+              : null,
     blockingFiles: dirty ? listDirtyFiles(repoPath) : undefined,
     updateMode: 'hermes-update',
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,15 @@
     "prettier.config.js",
     "vite.config.ts"
   ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "electron/server-bundle.cjs",
+    "e2e",
+    "playground-ws-worker",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
 
   "compilerOptions": {
     "target": "ES2022",


### PR DESCRIPTION
## Summary
- hide generated cron/MCTS/worker sessions from the chat session list and fail soft when session listing is slow
- bound dashboard overview upstream calls and skip expensive analytics unless explicitly requested
- make update status safe for ahead/diverged git states and preserve dirty-file paths correctly
- clear stale splash-screen state and restore the TypeScript build across workspace surfaces

## Validation
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/server/update-system.test.ts src/server/session-utils.test.ts src/server/dashboard-aggregator.test.ts src/routes/-root-runtime-guards.test.ts src/screens/swarm2/swarm2-reports-view.test.ts src/screens/swarm2/swarm2-screen.test.ts src/screens/chat/components/chat-composer-context-controls.test.ts
- git diff --check origin/main...HEAD
- local smoke checks for workspace sessions, dashboard overview, update status, and chat sidebar