### PR TITLE
[verified] fix: make swarm router dispatch nonblocking

### DIFF
--- a/src/components/swarm/router-chat.test.ts
+++ b/src/components/swarm/router-chat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function source(): string {
+  return readFileSync(
+    join(process.cwd(), 'src/components/swarm/router-chat.tsx'),
+    'utf-8',
+  )
+}
+
+describe('RouterChat dispatch request', () => {
+  it('does not block route mission UI while waiting for worker checkpoints', () => {
+    const src = source()
+
+    expect(src).toContain("fetch('/api/swarm-dispatch'")
+    expect(src).toContain('waitForCheckpoint: false')
+    expect(src).not.toContain('checkpointPollSeconds: 90')
+  })
+})

--- a/src/components/swarm/router-chat.tsx
+++ b/src/components/swarm/router-chat.tsx
@@ -178,6 +178,7 @@ export function RouterChat({
           prompt: prompt.trim(),
           workers: eligibleWorkers,
         }),
+        signal: AbortSignal.timeout(120_000),
       })
       if (!res.ok) {
         const text = await res.text()
@@ -241,9 +242,9 @@ export function RouterChat({
         body: JSON.stringify({
           assignments: plan,
           timeoutSeconds: 300,
-          waitForCheckpoint: true,
-          checkpointPollSeconds: 90,
+          waitForCheckpoint: false,
         }),
+        signal: AbortSignal.timeout(60_000),
       })
       if (!res.ok) {
         const text = await res.text()

--- a/src/routes/api/-swarm-decompose.test.ts
+++ b/src/routes/api/-swarm-decompose.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function source(): string {
+  return readFileSync(
+    join(process.cwd(), 'src/routes/api/swarm-decompose.ts'),
+    'utf-8',
+  )
+}
+
+describe('/api/swarm-decompose auth', () => {
+  it('uses runtime bearer token helper for gateway chat completions', () => {
+    const src = source()
+
+    expect(src).toContain(
+      "import { getBearerToken } from '../../server/openai-compat-api'",
+    )
+    expect(src).toContain('const bearer = getBearerToken()')
+    expect(src).toContain(
+      'if (bearer) headers.Authorization = `Bearer ${bearer}`',
+    )
+    expect(src).not.toContain('if (BEARER_TOKEN) headers.Authorization')
+  })
+})

--- a/src/routes/api/swarm-decompose.ts
+++ b/src/routes/api/swarm-decompose.ts
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { BEARER_TOKEN, ensureGatewayProbed, getResolvedUrls } from '../../server/gateway-capabilities'
+import { ensureGatewayProbed, getResolvedUrls } from '../../server/gateway-capabilities'
+import { getBearerToken } from '../../server/openai-compat-api'
 
 type DecomposeRequest = {
   prompt?: unknown
@@ -68,7 +69,8 @@ async function callOrchestrator(prompt: string, workers: WorkerHint[], model: st
   }
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (BEARER_TOKEN) headers.Authorization = `Bearer ${BEARER_TOKEN}`
+  const bearer = getBearerToken()
+  if (bearer) headers.Authorization = `Bearer ${bearer}`
 
   const { gateway } = getResolvedUrls()
   const res = await fetch(`${gateway}/v1/chat/completions`, {


### PR DESCRIPTION
## Summary
- make Router Chat dispatch non-blocking by sending `waitForCheckpoint: false`
- add bounded browser-side timeouts for decompose and dispatch requests
- fix `/api/swarm-decompose` gateway auth to use the runtime bearer token helper
- add regression tests for Router Chat dispatch behavior and swarm-decompose auth wiring

## Test Plan
- `npm -s test -- src/components/swarm/router-chat.test.ts src/routes/api/-swarm-decompose.test.ts src/routes/api/-swarm-dispatch.test.ts`
- Runtime local verification: `POST /api/swarm-decompose` returned `ok: true`, `fallback: false`, and model-generated assignments
- Browser smoke: `/swarm` loaded, Router Chat accepted prompt, Route mission button enabled

## Notes
- `npm run check` is currently blocked by an unrelated baseline syntax error in `src/screens/playground/components/playground-hud.tsx`.
