### PR TITLE
fix(server): accept OpenAI-style list shape for gateway sessions/messages

### DIFF
--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -133,10 +133,15 @@ export async function listSessions(
     const resp = await listDashboardSessions(limit, offset)
     return resp.sessions as Array<ClaudeSession>
   }
-  const resp = await claudeGet<{ items: Array<ClaudeSession>; total: number }>(
-    `/api/sessions?limit=${limit}&offset=${offset}`,
-  )
-  return resp.items
+  const resp = await claudeGet<{
+    items?: Array<ClaudeSession>
+    data?: Array<ClaudeSession>
+    total?: number
+  }>(`/api/sessions?limit=${limit}&offset=${offset}`)
+  // The gateway (OpenAI-compat) returns { object: 'list', data: [...] }, while the
+  // dashboard / older gateway shape uses { items: [...] }. Accept either, and never
+  // return undefined (callers .map over this).
+  return resp.items ?? resp.data ?? []
 }
 
 export async function getSession(sessionId: string): Promise<ClaudeSession> {
@@ -195,10 +200,15 @@ export async function getMessages(
     const resp = await getDashboardSessionMessages(sessionId)
     return resp.messages as Array<ClaudeMessage>
   }
-  const resp = await claudeGet<{ items: Array<ClaudeMessage>; total: number }>(
-    `/api/sessions/${sessionId}/messages`,
-  )
-  return resp.items
+  const resp = await claudeGet<{
+    items?: Array<ClaudeMessage>
+    data?: Array<ClaudeMessage>
+    total?: number
+  }>(`/api/sessions/${sessionId}/messages`)
+  // Gateway (OpenAI-compat) returns { object: 'list', data: [...] }; dashboard / older
+  // shape uses { items: [...] }. Accept either, and never return undefined (callers
+  // read .length / .map / .slice on this).
+  return resp.items ?? resp.data ?? []
 }
 
 export async function searchSessions(


### PR DESCRIPTION
## Problem

When the Hermes Agent gateway runs **without the dashboard** (enhanced-fork mode), `listSessions()` and `getMessages()` call the gateway's `/api/sessions` and `/api/sessions/:id/messages` endpoints. Those return an **OpenAI-style list** — `{ object: "list", data: [...] }` — not the `{ items: [...] }` shape the code assumed.

So `resp.items` was `undefined`, and:
- `/api/sessions` did `undefined.map(...)` → **HTTP 500** `Cannot read properties of undefined (reading 'map')`
- `/api/history` did `undefined.length` → **HTTP 500** `Cannot read properties of undefined (reading 'length')`

In the UI this surfaced as a persistent **"Connection error — Try refreshing or check Settings → Advanced → Hermes"** banner, even though chat itself worked fine (it doesn't depend on the session list).

## Fix

In `src/server/claude-api.ts`, both functions now accept either response shape and never return `undefined`:

```js
return resp.items ?? resp.data ?? []
```

## Testing

Against a live gateway in enhanced-fork mode (no dashboard):
- `GET /api/sessions` → was 500, now **200** with the session list
- `GET /api/history?...` → was 500, now **200** with mapped messages
- `/api/ping`, `/api/models`, `/api/session-status`, `/api/sessions/:id/status`, `/api/sessions/:id/active-run` → unaffected (still 200)

These were the only two `resp.items` sites in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)