### PR TITLE
fix(metrics): report real CPU utilization and macOS-aware memory

### DIFF
--- a/src/routes/api/system-metrics.ts
+++ b/src/routes/api/system-metrics.ts
@@ -1,5 +1,7 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
+import { setTimeout as delay } from 'node:timers/promises'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
@@ -38,10 +40,30 @@ function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, Math.round(value)))
 }
 
-function readCpu() {
+function cpuTotals() {
+  // Sum busy and idle jiffies across every core. The ratio of busy-delta to
+  // total-delta over a short window is true utilization — unlike load average,
+  // which is a run-queue length (it counts I/O waiters and can exceed 100%).
+  let busy = 0
+  let idle = 0
+  for (const cpu of os.cpus()) {
+    busy += cpu.times.user + cpu.times.nice + cpu.times.sys + cpu.times.irq
+    idle += cpu.times.idle
+  }
+  return { busy, idle }
+}
+
+async function readCpu() {
   const cores = Math.max(1, os.cpus().length)
   const loadAverage1m = os.loadavg()[0] ?? 0
-  const loadPercent = clampPercent((loadAverage1m / cores) * 100)
+
+  const start = cpuTotals()
+  await delay(150)
+  const end = cpuTotals()
+
+  const busyDelta = end.busy - start.busy
+  const totalDelta = busyDelta + (end.idle - start.idle)
+  const loadPercent = totalDelta > 0 ? clampPercent((busyDelta / totalDelta) * 100) : 0
 
   return {
     loadPercent,
@@ -50,11 +72,48 @@ function readCpu() {
   }
 }
 
+// On macOS, os.freemem() reports only truly-free pages (often near zero),
+// because the kernel keeps inactive/speculative/purgeable pages populated as
+// reclaimable cache. Treating that as "used" pins the gauge at ~100%. Parse
+// vm_stat to count reclaimable pages as available, matching how Activity
+// Monitor and `top` present memory pressure.
+function readDarwinAvailableBytes(totalBytes: number): number | null {
+  try {
+    const output = execFileSync('vm_stat', { encoding: 'utf8', timeout: 1000 })
+
+    const pageSizeMatch = output.match(/page size of (\d+) bytes/)
+    const pageSize = pageSizeMatch ? Number(pageSizeMatch[1]) : 4096
+
+    const pageStat = (label: string): number => {
+      const match = output.match(new RegExp(`${label}:\\s+(\\d+)\\.`))
+      return match ? Number(match[1]) : 0
+    }
+
+    const reclaimablePages =
+      pageStat('Pages free') +
+      pageStat('Pages inactive') +
+      pageStat('Pages speculative') +
+      pageStat('Pages purgeable')
+
+    const availableBytes = reclaimablePages * pageSize
+    if (!Number.isFinite(availableBytes) || availableBytes <= 0) return null
+    return Math.min(availableBytes, totalBytes)
+  } catch {
+    return null
+  }
+}
+
 function readMemory() {
   const totalBytes = os.totalmem()
-  const freeBytes = os.freemem()
+
+  const availableBytes =
+    process.platform === 'darwin'
+      ? readDarwinAvailableBytes(totalBytes)
+      : null
+
+  const freeBytes = availableBytes ?? os.freemem()
   const usedBytes = Math.max(0, totalBytes - freeBytes)
-  const usedPercent = clampPercent((usedBytes / totalBytes) * 100)
+  const usedPercent = totalBytes > 0 ? clampPercent((usedBytes / totalBytes) * 100) : 0
 
   return {
     usedBytes,
@@ -99,12 +158,12 @@ export const Route = createFileRoute('/api/system-metrics')({
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
 
-        const caps = await ensureGatewayProbed()
+        const [caps, cpu] = await Promise.all([ensureGatewayProbed(), readCpu()])
         const status = getConnectionStatus()
 
         const body: SystemMetricsResponse = {
           checkedAt: Date.now(),
-          cpu: readCpu(),
+          cpu,
           memory: readMemory(),
           disk: readDisk(),
           hermes: {


### PR DESCRIPTION
## Problem
The system-metrics footer pinned CPU and RAM near 100% on macOS:

- **CPU 100%** — computed as `loadavg / cores * 100`. Load average is a run-queue length (counts I/O waiters and can exceed core count), not CPU utilization, so it clamped to 100% under normal load.
- **RAM ~100% (e.g. 36/36 GB)** — used `os.freemem()`, which on macOS reports only *truly free* pages (often <1 GB) and ignores inactive/speculative/purgeable memory the kernel reclaims on demand.
- **Disk** — was already accurate; left unchanged.

## Fix
- **CPU**: sample `os.cpus()` busy/idle ticks over a 150 ms window and report the real busy ratio. `loadAverage1m` is retained in the payload for reference.
- **RAM**: on darwin, parse `vm_stat` and treat free + inactive + speculative + purgeable pages as *available* (matching Activity Monitor's memory-pressure view). Non-darwin platforms fall back to `os.freemem()`.

Response shape is unchanged, so the footer component needs no changes.

## Verification
Live on a 14-core / 38.7 GB macOS host:
```
CPU  76%   (loadavg 17.08 -> previously clamped to 100%)
RAM  31.5 / 38.7 GB (81%)   <- was 36/36 (99%)
Disk 99%   (accurate, unchanged)
```
`tsc --noEmit` passes.