### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -231,7 +231,7 @@ const PROVIDER_CARDS: Array<{
     id: 'minimax',
     name: 'MiniMax',
     logo: '/providers/minimax.png',
-    models: ['MiniMax-M2.5', 'MiniMax-M2.5-Lightning'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-Lightning'],
     authType: 'api_key',
     envKey: 'MINIMAX_API_KEY',
   },

--- a/src/lib/format-model-name.ts
+++ b/src/lib/format-model-name.ts
@@ -29,6 +29,7 @@ const MODEL_MAP: Record<string, string> = {
   'gemini-2.0-flash': 'Gemini 2.0 Flash',
   'gemini-2.5-pro': 'Gemini 2.5 Pro',
   'gemini-2.5-flash': 'Gemini 2.5 Flash',
+  'MiniMax-M3': 'MiniMax M3',
   'MiniMax-M2.7': 'MiniMax M2.7',
   'MiniMax-M2.7-Lightning': 'MiniMax M2.7 Lightning',
 }

--- a/src/screens/gateway/components/config-wizards.tsx
+++ b/src/screens/gateway/components/config-wizards.tsx
@@ -243,6 +243,7 @@ export const PROVIDER_COMMON_MODELS: Record<string, Array<{ value: string; label
     { value: 'fireworks/accounts/fireworks/models/qwen2p5-72b-instruct', label: 'Qwen 2.5 72B' },
   ],
   minimax: [
+    { value: 'minimax/MiniMax-M3', label: 'MiniMax M3' },
     { value: 'minimax/MiniMax-M2.7', label: 'MiniMax M2.7' },
     { value: 'minimax/MiniMax-M2.7-Lightning', label: 'MiniMax M2.7 Lightning' },
   ],

--- a/src/screens/gateway/components/hub-constants.tsx
+++ b/src/screens/gateway/components/hub-constants.tsx
@@ -53,7 +53,7 @@ export const MODEL_PRESET_MAP: Record<string, string> = {
   sonnet: 'anthropic/claude-sonnet-4-6',
   codex: 'openai/gpt-5.3-codex',
   flash: 'google/gemini-2.5-flash',
-  minimax: 'minimax/MiniMax-M2.7',
+  minimax: 'minimax/MiniMax-M3',
 }
 
 export type GatewayModelEntry = {

--- a/src/screens/gateway/components/team-panel.tsx
+++ b/src/screens/gateway/components/team-panel.tsx
@@ -21,7 +21,7 @@ export const MODEL_PRESETS = [
   { id: 'sonnet', label: 'Claude Sonnet 4.6', desc: 'Fast & capable — Anthropic' },
   { id: 'codex', label: 'GPT-5 Codex', desc: 'Code specialist — OpenAI' },
   { id: 'flash', label: 'Gemini 2.5 Flash', desc: 'Quick & cheap — Google' },
-  { id: 'minimax', label: 'MiniMax M2.7', desc: 'Cost efficient — MiniMax' },
+  { id: 'minimax', label: 'MiniMax M3', desc: 'Cost efficient — MiniMax' },
   { id: 'pc1-coder', label: 'PC1 Coder (97 TPS)', desc: 'Qwen3-Coder 30B · Local · RTX 4090' },
   { id: 'pc1-planner', label: 'PC1 Planner (175 TPS)', desc: 'Qwen3-30B Sonnet Distill MoE · Local · RTX 4090' },
   { id: 'pc1-critic', label: 'PC1 Critic (83 TPS)', desc: 'Qwen3-14B Opus Distill · Local · RTX 4090' },

--- a/src/server/swarm-model-resolver.ts
+++ b/src/server/swarm-model-resolver.ts
@@ -58,6 +58,9 @@ export function resolveSwarmModelLabel(
   }
 
   // MiniMax
+  if (/^minimax(?:\s*m)?\s*3$|^minimax m?3$/.test(normalized)) {
+    return { provider: 'minimax', default: 'MiniMax-M3' }
+  }
   if (/^minimax(?:\s*m)?\s*2\.7$|^minimax m?2\.7$/.test(normalized)) {
     return { provider: 'minimax', default: 'MiniMax-M2.7' }
   }


### PR DESCRIPTION
## Summary
Upgrade the MiniMax model configuration to ship `MiniMax-M3` as the new default while keeping `MiniMax-M2.7` (and the Lightning variant) available as fallbacks.

## Changes
- Add `MiniMax-M3` to the model selection list and friendly-name map
- Set `MiniMax-M3` as the default in the gateway hub preset
- Surface `MiniMax-M3` first in the gateway config wizard picker
- Update the team panel preset label to `MiniMax M3`
- Teach the swarm model resolver to map roster labels like `MiniMax M3` / `minimax 3` to `MiniMax-M3`
- Drop the lingering `MiniMax-M2.5` / `MiniMax-M2.5-Lightning` entries in the settings dialog provider card (these slipped back in after #233 during the custom-endpoint refactor)

## Why
MiniMax-M3 is the new flagship MiniMax model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Defaulting to M3 means new users land on the latest model, while M2.7 remains explicitly selectable for anyone who has tuned configs against it.

## Testing
- `vitest run src/server/swarm-model-resolver.test.ts` — 7/7 pass
- `vitest run src/routes/api/-swarm-health.test.ts` — pass (M2.7 fallback log assertions still match by design)
- `tsc --noEmit` — no new errors introduced (the existing `playground-hud.tsx` parse errors on `main` are unrelated and unchanged)