### PR TITLE
Fix native Conductor dispatch and stale terminal state

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -114,6 +114,13 @@ const themeColorScript = `
 })()
 `
 
+const DEFAULT_SPLASH_HTML = `
+<img src="/claude-avatar.webp" alt="Hermes Agent" style="width:80px;height:80px;margin-bottom:20px;border-radius:16px;filter:drop-shadow(0 8px 32px color-mix(in srgb,#FFAC02 45%, transparent))" />
+<img src="/claude-banner.png" alt="Hermes Workspace" style="width:280px;height:auto;margin-bottom:8px;filter:drop-shadow(0 4px 16px rgba(0,0,0,0.5))" />
+<div style="font:400 14px/1 system-ui,-apple-system,sans-serif;letter-spacing:0.04em;color:#9CB2AE">Workspace</div>
+<div style="margin-top:28px;width:140px;height:3px;background:rgba(255,255,255,0.08);border-radius:3px;overflow:hidden;position:relative"><div id="splash-bar" style="width:0%;height:100%;background:#FFAC02;border-radius:3px;transition:width 0.4s ease"></div></div>
+`
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -416,7 +423,16 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         />
       </head>
       <body>
-        <div id="splash-screen" aria-hidden="true" style={{ display: 'none' }} />
+        {/* The inline splash bootstrap mutates this node before React hydrates.
+            Keep default splash markup in the server/client tree, then suppress
+            parent-level style/theme mutations for this intentionally browser-owned DOM. */}
+        <div
+          id="splash-screen"
+          aria-hidden="true"
+          suppressHydrationWarning
+          style={{ display: 'none' }}
+          dangerouslySetInnerHTML={{ __html: DEFAULT_SPLASH_HTML }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: wrapInlineScript(`

--- a/src/routes/api/-conductor-spawn.test.ts
+++ b/src/routes/api/-conductor-spawn.test.ts
@@ -14,20 +14,29 @@ describe('native Conductor fallback', () => {
       supervised: false,
     })
 
-    expect(assignments.map((assignment) => assignment.workerId)).toEqual(['swarm2', 'swarm5', 'swarm6', 'swarm11'])
+    expect(assignments.map((assignment) => assignment.workerId)).toEqual(['ops-watch', 'builder', 'reviewer', 'qa'])
     expect(assignments[0].task).toContain('Conductor mission: Fix conductor')
     expect(assignments.every((assignment) => assignment.direct === true)).toBe(true)
     expect(assignments.every((assignment) => assignment.reviewRequired === false)).toBe(true)
   })
 
-  it('uses Scribe when the mission asks for documentation even with a smaller lane count', () => {
+  it('uses KM Agent when the mission asks for documentation even with a smaller lane count', () => {
     const assignments = buildNativeConductorAssignments('Write docs and handoff for the release', {
       maxParallel: 3,
       supervised: true,
     })
 
-    expect(assignments.map((assignment) => assignment.workerId)).toContain('swarm7')
+    expect(assignments.map((assignment) => assignment.workerId)).toContain('km-agent')
     expect(assignments.some((assignment) => assignment.task.includes('Supervised mode'))).toBe(true)
+  })
+
+  it('does not collapse generic two-lane missions to a single worker', () => {
+    const assignments = buildNativeConductorAssignments('Create a small UI prototype', {
+      maxParallel: 2,
+      supervised: false,
+    })
+
+    expect(assignments.map((assignment) => assignment.workerId)).toEqual(['builder', 'reviewer'])
   })
 
   it('normalizes native swarm missions into the Conductor mission status contract', () => {
@@ -40,9 +49,9 @@ describe('native Conductor fallback', () => {
       assignments: [
         {
           id: 'a1',
-          workerId: 'swarm2',
+          workerId: 'builder',
           task: 'Run smoke',
-          rationale: 'Foundation',
+          rationale: 'Builder',
           dependsOn: [],
           reviewRequired: false,
           state: 'dispatched',
@@ -64,6 +73,6 @@ describe('native Conductor fallback', () => {
     expect(record.nativeSwarm).toBe(true)
     expect(record.modeOfficialOotb).toBe(true)
     expect(record.modeNote).toBe(NATIVE_CONDUCTOR_MODE_NOTE)
-    expect(record.lines.join('\n')).toContain('swarm2 dispatched')
+    expect(record.lines.join('\n')).toContain('builder dispatched')
   })
 })

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -4,6 +4,7 @@ import {
   buildHermesTmuxLaunchCommand,
   buildWorkerPrompt,
   checkpointFromRuntimeSnapshot,
+  dispatchBlockReason,
   runtimeCheckpointSignature,
   runtimeSnapshotIsFresh,
 } from './swarm-dispatch'
@@ -44,6 +45,14 @@ describe('checkpointFromRuntimeSnapshot', () => {
     })
 
     expect(checkpoint).toBeNull()
+  })
+})
+
+describe('dispatchBlockReason', () => {
+  it('turns failed or timed-out dispatch results into mission blocker text', () => {
+    expect(dispatchBlockReason({ ok: false, error: 'Command failed: worker exited', output: '', checkpointStatus: undefined })).toBe('Command failed: worker exited')
+    expect(dispatchBlockReason({ ok: true, error: null, output: 'Delivered', checkpointStatus: 'timeout' })).toBe('No fresh checkpoint before poll timeout.')
+    expect(dispatchBlockReason({ ok: true, error: null, output: 'Checkpoint DONE', checkpointStatus: 'checkpointed' })).toBeNull()
   })
 })
 

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildHermesChatQueryArgs,
   buildHermesTmuxLaunchCommand,
   buildWorkerPrompt,
   checkpointFromRuntimeSnapshot,
@@ -109,6 +110,20 @@ describe('buildHermesTmuxLaunchCommand', () => {
   })
 })
 
+describe('buildHermesChatQueryArgs', () => {
+  it('passes the prompt immediately after -q so flags are not parsed as the query', () => {
+    const prompt = 'STATE: DONE\nRESULT: ok'
+    const args = buildHermesChatQueryArgs(prompt)
+
+    expect(args.slice(0, 3)).toEqual(['chat', '-q', prompt])
+    expect(args).toContain('-Q')
+    expect(args).toContain('--source')
+    expect(args[1]).toBe('-q')
+    expect(args[2]).toBe(prompt)
+    expect(args[3]).toBe('-Q')
+  })
+})
+
 describe('buildWorkerPrompt', () => {
   const roster = {
     id: 'swarm5',
@@ -117,9 +132,15 @@ describe('buildWorkerPrompt', () => {
     specialty: 'full-stack implementation across Hermes Workspace and Swarm2',
     model: 'GPT-5.5',
     mission: 'Ship focused product slices with tests and clean diffs.',
+    modes: [],
+    tools: [],
     skills: ['swarm-ui-worker', 'swarm-worker-core'],
+    plugins: [],
+    pluginToolsets: [],
+    mcpServers: [],
     capabilities: ['code-editing', 'ui-implementation', 'build-verification'],
     preferredTaskTypes: ['implementation'],
+    greenlightRequiredFor: [],
     maxConcurrentTasks: 1,
     acceptsBroadcast: true,
     reviewRequired: false,

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -148,96 +148,115 @@ function clipText(value: string, max = 8000): string {
 export function buildNativeConductorAssignments(goal: string, options: { maxParallel: number; supervised: boolean }): Array<NativeConductorAssignment> {
   const maxParallel = Math.min(5, Math.max(1, options.maxParallel || 1))
   const normalizedGoal = goal.toLowerCase()
-  const wantsProduction = /production|ready|harden|audit|clean|fix|bug|test|build|release|deploy|operational/.test(normalizedGoal)
-  const wantsDocs = /doc|handoff|readme|spec|plan|summary/.test(normalizedGoal)
+  const wantsOps = /production|ready|harden|audit|clean|fix|bug|test|build|release|deploy|operational|runtime|gateway|tmux|service|health/.test(normalizedGoal)
+  const wantsDocs = /doc|handoff|readme|spec|plan|summary|knowledge|note/.test(normalizedGoal)
   const assignments: Array<NativeConductorAssignment> = []
 
-  assignments.push({
-    workerId: wantsProduction ? 'swarm2' : 'swarm5',
-    rationale: wantsProduction ? 'Foundation owns runtime contracts and production blockers.' : 'Builder owns the primary implementation lane.',
+  const pushUnique = (assignment: NativeConductorAssignment) => {
+    if (!assignments.some((existing) => existing.workerId === assignment.workerId)) assignments.push(assignment)
+  }
+
+  pushUnique({
+    workerId: wantsOps ? 'ops-watch' : 'builder',
+    rationale: wantsOps ? 'Ops Watch owns runtime health, service quality, and production blockers.' : 'Builder owns scoped implementation and concrete progress.',
     reviewRequired: false,
     direct: true,
     task: [
       `Conductor mission: ${goal}`,
       '',
-      'Lane: Foundation / primary implementation.',
-      'Find the smallest safe execution plan, make concrete progress, and produce a checkpoint. If code changes are required, keep them scoped and testable.',
+      wantsOps ? 'Lane: Ops Watch / runtime quality.' : 'Lane: Builder / primary implementation.',
+      wantsOps
+        ? 'Diagnose the runtime path, make the smallest safe operational improvement, and return proof. Avoid destructive changes unless explicitly approved.'
+        : 'Find the smallest safe execution plan, make concrete progress, and produce a checkpoint. If code changes are required, keep them scoped and testable.',
       options.supervised ? 'Supervised mode: stop before destructive writes or commits and report the exact approval needed.' : 'Do not ask for confirmation unless blocked; start immediately.',
     ].join('\n'),
   })
 
   if (maxParallel >= 2) {
-    assignments.push({
-      workerId: 'swarm5',
-      rationale: 'Builder executes implementation or patch work in parallel with foundation analysis.',
+    pushUnique({
+      workerId: wantsOps ? 'builder' : 'reviewer',
+      rationale: wantsOps
+        ? 'Builder executes implementation or patch work in parallel with runtime analysis.'
+        : 'Reviewer provides the second-lane quality gate for implementation work.',
       reviewRequired: false,
       direct: true,
       task: [
         `Conductor mission: ${goal}`,
         '',
-        'Lane: Builder.',
-        'Implement or prototype the concrete fix/feature path. Avoid broad refactors. Report files changed, tests run, and remaining risks.',
+        wantsOps ? 'Lane: Builder.' : 'Lane: Reviewer / quality gate.',
+        wantsOps
+          ? 'Implement or prototype the concrete fix/feature path. Avoid broad refactors. Report files changed, tests run, and remaining risks.'
+          : 'Review the execution path and any changes. Look for regressions, missing tests, unsafe assumptions, and production-readiness gaps.',
         options.supervised ? 'Supervised mode: prepare patches but stop before destructive writes or commits if approval is needed.' : 'Proceed without asking unless blocked.',
       ].join('\n'),
     })
   }
 
   if (maxParallel >= 3) {
-    assignments.push({
-      workerId: 'swarm6',
-      rationale: 'Reviewer independently checks correctness, regressions, and merge risk.',
+    pushUnique({
+      workerId: wantsOps ? 'reviewer' : 'qa',
+      rationale: wantsOps
+        ? 'Reviewer independently checks correctness, regressions, and merge risk.'
+        : 'QA validates user-visible behavior with focused smoke checks.',
       reviewRequired: false,
       direct: true,
       task: [
         `Conductor mission: ${goal}`,
         '',
-        'Lane: Reviewer / merge gate.',
-        'Review the implementation plan and any changes from Foundation/Builder. Look for regressions, missing tests, unsafe assumptions, and production-readiness gaps. Do not make broad edits unless needed to unblock correctness.',
+        wantsOps ? 'Lane: Reviewer / quality gate.' : 'Lane: QA.',
+        wantsOps
+          ? 'Review the implementation plan and any changes from Ops/Builder. Look for regressions, missing tests, unsafe assumptions, and production-readiness gaps. Do not make broad edits unless needed to unblock correctness.'
+          : 'Run or design focused verification. Prefer targeted tests/build/smoke checks. Report exact commands and results. If tests are missing, identify the minimal regression coverage needed.',
       ].join('\n'),
     })
   }
 
   if (maxParallel >= 4) {
-    assignments.push({
-      workerId: 'swarm11',
-      rationale: 'QA validates behavior with targeted tests and smoke checks.',
+    pushUnique({
+      workerId: wantsOps ? 'qa' : 'ops-watch',
+      rationale: wantsOps
+        ? 'QA validates behavior with targeted tests and smoke checks.'
+        : 'Ops Watch checks runtime/service risks for implementation missions.',
       reviewRequired: false,
       direct: true,
       task: [
         `Conductor mission: ${goal}`,
         '',
-        'Lane: QA.',
-        'Run or design focused verification. Prefer targeted tests/build/smoke checks. Report exact commands and results. If tests are missing, identify the minimal regression coverage needed.',
+        wantsOps ? 'Lane: QA.' : 'Lane: Ops Watch / runtime quality.',
+        wantsOps
+          ? 'Run or design focused verification. Prefer targeted tests/build/smoke checks. Report exact commands and results. If tests are missing, identify the minimal regression coverage needed.'
+          : 'Check runtime, service, deployment, and operational risk. Report only concrete blockers, verification gaps, and safe next actions.',
       ].join('\n'),
     })
   }
 
   if (maxParallel >= 5 || wantsDocs) {
-    assignments.push({
-      workerId: 'swarm7',
-      rationale: 'Scribe captures handoff, docs, and operational notes.',
+    pushUnique({
+      workerId: 'km-agent',
+      rationale: 'KM Agent captures handoff, docs, and durable knowledge notes without leaking secrets.',
       reviewRequired: false,
       direct: true,
       task: [
         `Conductor mission: ${goal}`,
         '',
-        'Lane: Scribe.',
+        'Lane: KM Agent / handoff and knowledge hygiene.',
         'Create a concise handoff/status note: what changed, how to operate it, verification, caveats, and next actions. Do not expose secrets.',
+        options.supervised ? 'Supervised mode: stop before destructive writes or commits and report the exact approval needed.' : 'Proceed without asking unless blocked.',
       ].join('\n'),
     })
   }
 
   const selected = assignments.slice(0, maxParallel)
-  if (wantsDocs && !selected.some((assignment) => assignment.workerId === 'swarm7')) {
+  if (wantsDocs && !selected.some((assignment) => assignment.workerId === 'km-agent')) {
     selected[selected.length - 1] = {
-      workerId: 'swarm7',
-      rationale: 'Scribe captures handoff, docs, and operational notes.',
+      workerId: 'km-agent',
+      rationale: 'KM Agent captures handoff, docs, and durable knowledge notes without leaking secrets.',
       reviewRequired: false,
       direct: true,
       task: [
         `Conductor mission: ${goal}`,
         '',
-        'Lane: Scribe.',
+        'Lane: KM Agent / handoff and knowledge hygiene.',
         'Create a concise handoff/status note: what changed, how to operate it, verification, caveats, and next actions. Do not expose secrets.',
         options.supervised ? 'Supervised mode: stop before destructive writes or commits and report the exact approval needed.' : 'Proceed without asking unless blocked.',
       ].join('\n'),

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -757,6 +757,14 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   }
 }
 
+export function buildHermesChatQueryArgs(prompt: string): string[] {
+  // `hermes chat -q` requires the query as the *immediate* next argv item.
+  // Keeping the prompt adjacent to -q prevents argparse from interpreting
+  // following flags (for example -Q) as a missing query and failing with:
+  // "argument -q/--query: expected one argument".
+  return ['chat', '-q', prompt, '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+}
+
 function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: SwarmRosterWorker | undefined, options?: { waitForCheckpoint?: boolean; checkpointPollMs?: number; missionId?: string | null; notifySessionKey?: string | null }): Promise<WorkerResult> {
   return new Promise(async (resolve) => {
     const workerId = assignment.workerId
@@ -887,9 +895,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
 
     const useWrapper = existsSync(wrapperPath)
     const cmd = useWrapper ? wrapperPath : resolveHermesBin()
-    const args = useWrapper
-      ? ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch', prompt]
-      : ['chat', '-q', '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+    const args = buildHermesChatQueryArgs(prompt)
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       HERMES_HOME: profilePath,

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { newestCheckpointFromMessages, parseSwarmCheckpoint, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
-import { createOrUpdateMission, markMissionAssignmentDispatched, recordMissionCheckpoint } from '../../server/swarm-missions'
+import { createOrUpdateMission, getSwarmMission, markMissionAssignmentDispatched, recordMissionAssignmentBlocked, recordMissionCheckpoint } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
 import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
@@ -502,6 +502,33 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
   })
 }
 
+export function dispatchBlockReason(result: Pick<WorkerResult, 'ok' | 'error' | 'output' | 'checkpointStatus'>): string | null {
+  if (!result.ok) return result.error?.trim() || result.output?.trim() || 'Dispatch failed before a worker checkpoint was recorded.'
+  if (result.checkpointStatus === 'timeout') return 'No fresh checkpoint before poll timeout.'
+  return null
+}
+
+function recordDispatchBlock(workerId: string, assignment: AssignmentRequest, result: WorkerResult, options?: { missionId?: string | null }): void {
+  const reason = dispatchBlockReason(result)
+  if (!reason) return
+  recordMissionAssignmentBlocked({
+    missionId: options?.missionId,
+    assignmentId: assignment.assignmentId ?? null,
+    workerId,
+    reason,
+    source: 'swarm-dispatch',
+  })
+  writeRuntimePatch(workerId, {
+    state: 'blocked',
+    phase: 'blocked',
+    checkpointStatus: 'blocked',
+    blockedReason: reason,
+    lastDispatchResult: reason,
+    lastCheckIn: new Date().toISOString(),
+    lastOutputAt: Date.now(),
+  })
+}
+
 function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoint, notifySessionKey?: string | null): void {
   // When the checkpoint reaches any terminal status (anything other than
   // 'in_progress' — i.e. done/blocked/needs_input/handoff) the worker is no
@@ -874,6 +901,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
       } else {
         liveResult.checkpointStatus = 'not-requested'
       }
+      recordDispatchBlock(workerId, assignment, liveResult, options)
       resolve(liveResult)
       return
     }
@@ -889,6 +917,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         delivery: 'oneshot',
       }
       markDispatchResult(workerId, result)
+      recordDispatchBlock(workerId, assignment, result, options)
       resolve(result)
       return
     }
@@ -915,7 +944,6 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         timeout: timeoutMs,
         maxBuffer: MAX_OUTPUT_CHARS,
         killSignal: 'SIGTERM',
-        input: prompt,
       },
       (error, stdout, stderr) => {
         const durationMs = Date.now() - startedAt
@@ -935,6 +963,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
             delivery: 'oneshot',
           }
           markDispatchResult(workerId, result)
+          recordDispatchBlock(workerId, assignment, result, options)
           resolve(result)
           return
         }
@@ -991,6 +1020,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
           result.checkpointStatus = 'not-requested'
         }
         markDispatchResult(workerId, result)
+        recordDispatchBlock(workerId, assignment, result, options)
         resolve(result)
       },
     )
@@ -1006,6 +1036,7 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
         delivery: 'oneshot',
       }
       markDispatchResult(workerId, result)
+      recordDispatchBlock(workerId, assignment, result, options)
       resolve(result)
     })
   })
@@ -1100,11 +1131,13 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
     { waitForCheckpoint, checkpointPollMs: checkpointPollSeconds * 1000, missionId: mission.id, notifySessionKey },
   )))
 
+  const latestMission = getSwarmMission(mission.id) ?? mission
+
   return {
     dispatchedAt,
     completedAt: Date.now(),
     missionId: mission.id,
-    mission,
+    mission: latestMission,
     prompt: assignments.length === 1 ? assignments[0].task : `${assignments.length} assigned tasks`,
     assignments,
     timeoutSeconds,

--- a/src/routes/api/swarm-runtime.ts
+++ b/src/routes/api/swarm-runtime.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { json } from '@tanstack/react-start'
 import { createFileRoute } from '@tanstack/react-router'
@@ -94,19 +95,22 @@ function lastLogTail(
   }
 }
 
+function resolveTmuxBin(): string {
+  const override = process.env.HERMES_TMUX_BIN || process.env.CLAUDE_TMUX_BIN
+  if (override) return override
+  const local = join(homedir(), '.local', 'bin', 'tmux')
+  return existsSync(local) ? local : 'tmux'
+}
+
 function tmuxHasSession(name: string): Promise<boolean> {
   return new Promise((resolve) => {
-    execFile('tmux', ['has-session', '-t', name], (error) => resolve(!error))
+    execFile(resolveTmuxBin(), ['has-session', '-t', name], (error) => resolve(!error))
   })
 }
 
 function tmuxIsInstalled(): Promise<boolean> {
-  // Honour HERMES_TMUX_BIN so a custom-path install isn't reported as
-  // 'tmux not installed' just because PATH doesn't include it. See #244.
-  const bin =
-    process.env.HERMES_TMUX_BIN || process.env.CLAUDE_TMUX_BIN || 'tmux'
   return new Promise((resolve) => {
-    execFile(bin, ['-V'], (error) => resolve(!error))
+    execFile(resolveTmuxBin(), ['-V'], (error) => resolve(!error))
   })
 }
 

--- a/src/screens/gateway/hooks/use-conductor-gateway.test.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldPersistActiveConductorMission } from './use-conductor-gateway'
+
+describe('Conductor active mission persistence', () => {
+  it('persists only resumable in-flight phases', () => {
+    expect(shouldPersistActiveConductorMission('decomposing')).toBe(true)
+    expect(shouldPersistActiveConductorMission('running')).toBe(true)
+  })
+
+  it('does not persist terminal or idle phases as the active mission', () => {
+    expect(shouldPersistActiveConductorMission('idle')).toBe(false)
+    expect(shouldPersistActiveConductorMission('complete')).toBe(false)
+  })
+})

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -65,6 +65,10 @@ const DEFAULT_CONDUCTOR_SETTINGS: ConductorSettings = {
   supervised: false,
 }
 
+export function shouldPersistActiveConductorMission(phase: MissionPhase): boolean {
+  return phase === 'decomposing' || phase === 'running'
+}
+
 type PersistedMission = {
   missionId: string | null
   missionJobId: string | null
@@ -331,6 +335,16 @@ function loadPersistedMission(): PersistedMission | null {
     if (!goal || (phase !== 'idle' && phase !== 'decomposing' && phase !== 'running' && phase !== 'complete') || streamText === null || planText === null || !workerKeys || !workerLabels) {
       return null
     }
+
+    // Completed/stopped missions are already represented in mission history.
+    // Restoring them as the active mission causes stale terminal records to be
+    // re-queried on page load and can surface an old failure as if Conductor is
+    // currently broken.
+    if (!shouldPersistActiveConductorMission(phase)) {
+      clearPersistedMission()
+      return null
+    }
+
     return {
       missionId,
       missionJobId,
@@ -1020,7 +1034,7 @@ export function useConductorGateway() {
       if (!missionId) return null
       return fetchConductorMission(missionId)
     },
-    enabled: Boolean(missionId) && phase !== 'idle',
+    enabled: Boolean(missionId) && shouldPersistActiveConductorMission(phase),
     refetchInterval: phase === 'decomposing' || phase === 'running' ? 2_500 : false,
     retry: Infinity,
     retryDelay: (attemptIndex: number) => Math.min(2000 * 2 ** attemptIndex, 10_000),
@@ -1374,7 +1388,7 @@ export function useConductorGateway() {
   }, [conductorSettings])
 
   useEffect(() => {
-    if (phase === 'idle') {
+    if (!shouldPersistActiveConductorMission(phase)) {
       try {
         localStorage.removeItem(ACTIVE_MISSION_STORAGE_KEY)
       } catch {}

--- a/src/server/swarm-missions.test.ts
+++ b/src/server/swarm-missions.test.ts
@@ -104,6 +104,68 @@ describe('swarm-missions', () => {
     expect(existsSync(mod.SWARM_MISSIONS_PATH)).toBe(true)
   })
 
+  it('does not infer review-required from dispatch/checkpoint wording alone', async () => {
+    const mod = await loadModule()
+    const mission = mod.createOrUpdateMission({
+      missionId: 'mission-dispatch-smoke-review',
+      title: 'Diagnostic dispatch smoke',
+      assignments: [{
+        workerId: 'builder',
+        task: 'Diagnostic smoke only. Return RESULT: workspace swarm dispatch API smoke passed.',
+        rationale: 'diagnostic dispatch smoke',
+      }],
+    })
+
+    expect(mission.assignments[0]?.reviewRequired).toBe(false)
+
+    const updated = mod.recordMissionCheckpoint({
+      missionId: mission.id,
+      assignmentId: mission.assignments[0]?.id,
+      workerId: 'builder',
+      checkpoint: {
+        stateLabel: 'DONE',
+        runtimeState: 'idle',
+        checkpointStatus: 'done',
+        filesChanged: 'none',
+        commandsRun: 'none',
+        result: 'workspace swarm dispatch API smoke passed',
+        blocker: null,
+        nextAction: 'none',
+        raw: 'STATE: DONE\nFILES_CHANGED: none\nCOMMANDS_RUN: none\nRESULT: workspace swarm dispatch API smoke passed\nBLOCKER: none\nNEXT_ACTION: none',
+      },
+      source: 'swarm-dispatch',
+    })
+
+    expect(updated?.state).toBe('complete')
+  })
+
+  it('records dispatch failures as blocked mission assignments', async () => {
+    const mod = await loadModule()
+    const mission = mod.createOrUpdateMission({
+      missionId: 'mission-dispatch-failure',
+      title: 'Dispatch failure test',
+      assignments: [{ workerId: 'builder', task: 'Probe runtime health', reviewRequired: false }],
+    })
+    mod.markMissionAssignmentDispatched({ missionId: mission.id, workerId: 'builder', task: 'Probe runtime health' })
+
+    const blocked = mod.recordMissionAssignmentBlocked({
+      missionId: mission.id,
+      assignmentId: mission.assignments[0]?.id,
+      workerId: 'builder',
+      reason: 'No fresh checkpoint before poll timeout.',
+      source: 'swarm-dispatch',
+    })
+
+    expect(blocked?.mission.state).toBe('blocked')
+    expect(blocked?.assignment.state).toBe('blocked')
+    expect(blocked?.assignment.checkpoint).toMatchObject({
+      stateLabel: 'BLOCKED',
+      checkpointStatus: 'blocked',
+      blocker: 'No fresh checkpoint before poll timeout.',
+    })
+    expect(blocked?.mission.events.at(-1)?.type).toBe('blocked')
+  })
+
   it('keeps dependent work queued until review-required assignments are reviewed', async () => {
     const mod = await loadModule()
     const mission = mod.createOrUpdateMission({

--- a/src/server/swarm-missions.ts
+++ b/src/server/swarm-missions.ts
@@ -126,6 +126,13 @@ function deriveMissionState(assignments: Array<SwarmMissionAssignment>): SwarmMi
   return 'planning'
 }
 
+function inferReviewRequired(task: string, rationale?: string | null): boolean {
+  // Match intent-bearing task terms only. The previous loose alternation matched
+  // substrings such as "patch" inside "dispatch" and left simple smoke runs in
+  // review forever.
+  return /\b(code|patch(?:es|ed|ing)?|implement(?:ation|ed|ing)?|pr|benchmarks?)\b/i.test(`${task} ${rationale ?? ''}`)
+}
+
 const TERMINAL_ASSIGNMENT_STATES = new Set<SwarmMissionAssignmentState>(['done', 'cancelled'])
 
 function isTerminalAssignment(assignment: SwarmMissionAssignment): boolean {
@@ -197,7 +204,7 @@ export function createOrUpdateMission(input: {
       task: assignment.task,
       rationale: assignment.rationale ?? null,
       dependsOn: assignment.dependsOn ?? [],
-      reviewRequired: assignment.reviewRequired ?? /code|patch|implement|pr|benchmark/i.test(`${assignment.task} ${assignment.rationale ?? ''}`),
+      reviewRequired: assignment.reviewRequired ?? inferReviewRequired(assignment.task, assignment.rationale),
       state: 'queued',
       dispatchedAt: null,
       completedAt: null,
@@ -295,6 +302,63 @@ export function recordMissionCheckpoint(input: {
   const completed = mission.state === 'complete' && previousState !== 'complete'
   writeStore(store)
   return Object.assign(mission, { _completed: completed })
+}
+
+export function recordMissionAssignmentBlocked(input: {
+  missionId?: string | null
+  assignmentId?: string | null
+  workerId: string
+  reason?: string | null
+  source?: string | null
+}): { mission: SwarmMission; assignment: SwarmMissionAssignment; changed: boolean } | null {
+  if (!input.missionId) return null
+  const store = readStore()
+  const mission = store.missions.find((item) => item.id === input.missionId)
+  if (!mission) return null
+  if (mission.state === 'cancelled' || mission.state === 'complete') return null
+  const assignment = (input.assignmentId
+    ? mission.assignments.find((item) => item.id === input.assignmentId)
+    : null)
+    ?? [...mission.assignments].reverse().find((item) => item.workerId === input.workerId && !isTerminalAssignment(item))
+    ?? [...mission.assignments].reverse().find((item) => item.workerId === input.workerId)
+  if (!assignment) return null
+  if (assignment.state === 'cancelled' || assignment.state === 'done') return { mission, assignment, changed: false }
+
+  const reason = input.reason?.trim() || 'Dispatch failed before a worker checkpoint was recorded.'
+  const blockedAt = now()
+  const checkpoint: ParsedSwarmCheckpoint = {
+    stateLabel: 'BLOCKED',
+    runtimeState: 'blocked',
+    checkpointStatus: 'blocked',
+    filesChanged: 'none',
+    commandsRun: 'none',
+    result: null,
+    blocker: reason,
+    nextAction: 'Fix blocker and retry dispatch.',
+    raw: `STATE: BLOCKED\nFILES_CHANGED: none\nCOMMANDS_RUN: none\nRESULT: none\nBLOCKER: ${reason}\nNEXT_ACTION: Fix blocker and retry dispatch.`,
+  }
+  const changed = assignment.state !== 'blocked' || assignment.checkpoint?.raw !== checkpoint.raw
+  assignment.state = 'blocked'
+  assignment.completedAt = blockedAt
+  assignment.checkpoint = checkpoint
+  const report = reportFromCheckpoint({
+    missionId: mission.id,
+    assignmentId: assignment.id,
+    workerId: input.workerId,
+    checkpoint,
+    source: input.source,
+  })
+  if (changed) {
+    mission.events.push(event('blocked', `${input.workerId} blocked: ${reason}`, {
+      workerId: input.workerId,
+      assignmentId: assignment.id,
+      data: report,
+    }))
+  }
+  mission.updatedAt = blockedAt
+  mission.state = deriveMissionState(mission.assignments)
+  writeStore(store)
+  return { mission, assignment, changed }
 }
 
 export function appendMissionContinuation(input: {

--- a/src/server/swarm-profile-config.ts
+++ b/src/server/swarm-profile-config.ts
@@ -14,7 +14,7 @@
  * matches, so re-running on a healthy profile is free.
  */
 
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
@@ -28,6 +28,7 @@ export type ProfileBootstrapResult = {
   configCreated: boolean
   envLinked: boolean
   authLinked: boolean
+  mcpTokensLinked: number
   error?: string
 }
 
@@ -42,6 +43,24 @@ export type SwarmWorkerIdentity = {
   capabilities?: Array<string>
 }
 
+function linkSharedFile(source: string, target: string): boolean {
+  if (!existsSync(source)) return false
+  if (existsSync(target)) {
+    try {
+      const stat = lstatSync(target)
+      if (stat.isSymbolicLink()) {
+        unlinkSync(target)
+      } else {
+        renameSync(target, `${target}.profile-local.bak-${Date.now()}`)
+      }
+    } catch {
+      return false
+    }
+  }
+  symlinkSync(source, target)
+  return true
+}
+
 /**
  * Ensure a worker HERMES_HOME has enough runtime config to boot Hermes.
  *
@@ -52,7 +71,7 @@ export type SwarmWorkerIdentity = {
  * The config is copied (not symlinked) because per-worker model sync edits it.
  */
 export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapResult {
-  const result: ProfileBootstrapResult = { ok: true, configCreated: false, envLinked: false, authLinked: false }
+  const result: ProfileBootstrapResult = { ok: true, configCreated: false, envLinked: false, authLinked: false, mcpTokensLinked: 0 }
   try {
     mkdirSync(profilePath, { recursive: true })
 
@@ -98,6 +117,18 @@ export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapR
       if (shouldLink) {
         symlinkSync(sourceAuth, authPath)
         result.authLinked = true
+      }
+    }
+
+    const mcpTokensDir = join(profilePath, 'mcp-tokens')
+    const sourceMcpTokensDir = join(homedir(), '.hermes', 'mcp-tokens')
+    if (existsSync(sourceMcpTokensDir)) {
+      mkdirSync(mcpTokensDir, { recursive: true })
+      for (const name of readdirSync(sourceMcpTokensDir)) {
+        if (!name.endsWith('.json')) continue
+        if (linkSharedFile(join(sourceMcpTokensDir, name), join(mcpTokensDir, name))) {
+          result.mcpTokensLinked += 1
+        }
       }
     }
 

--- a/src/server/update-system.test.ts
+++ b/src/server/update-system.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { remoteUrlMatches } from './update-system'
+import { remoteUrlMatches, updateAvailableFromDivergence } from './update-system'
 
 describe('update-system helpers', () => {
   it('matches GitHub URL forms against expected repo aliases', () => {
@@ -18,5 +18,13 @@ describe('update-system helpers', () => {
         'hermes-workspace',
       ]),
     ).toBe(false)
+  })
+
+  it('only reports update availability when the remote side is ahead', () => {
+    expect(updateAvailableFromDivergence({ ahead: 2, behind: 0 }, true)).toBe(false)
+    expect(updateAvailableFromDivergence({ ahead: 0, behind: 3 }, true)).toBe(true)
+    expect(updateAvailableFromDivergence({ ahead: 2, behind: 3 }, true)).toBe(true)
+    expect(updateAvailableFromDivergence({ ahead: 0, behind: 0 }, false)).toBe(false)
+    expect(updateAvailableFromDivergence(null, true)).toBe(true)
   })
 })

--- a/src/server/update-system.ts
+++ b/src/server/update-system.ts
@@ -221,6 +221,26 @@ function canResetToRemote(repoPath: string, remoteRef: string): boolean {
   return Boolean(git(['rev-parse', '--verify', remoteRef], repoPath, 10_000))
 }
 
+function branchDivergence(repoPath: string, remoteRef: string): { ahead: number; behind: number } | null {
+  const raw = git(['rev-list', '--left-right', '--count', `HEAD...${remoteRef}`], repoPath, 10_000)
+  if (!raw) return null
+  const [aheadRaw, behindRaw] = raw.split(/\s+/)
+  const ahead = Number(aheadRaw)
+  const behind = Number(behindRaw)
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null
+  return { ahead, behind }
+}
+
+export function updateAvailableFromDivergence(
+  divergence: { ahead: number; behind: number } | null,
+  headsDiffer: boolean,
+): boolean {
+  // A local checkout can legitimately be ahead of origin because it carries
+  // hotfixes or unpublished commits. That is not an available upstream update.
+  // Only remote-ahead or diverged histories should surface as updateable.
+  return divergence ? divergence.behind > 0 : headsDiffer
+}
+
 function syncRepoToRemote(repoPath: string, remoteRef: string): string {
   if (canFastForward(repoPath, remoteRef)) {
     return execOrThrow('git', ['merge', '--ff-only', remoteRef], {
@@ -338,10 +358,11 @@ export function readWorkspaceUpdateStatus(
   const latestHead =
     repoMatches && supportedBranch ? remoteHead(gitRepo, 'origin') : null
   const dirty = isDirty(gitRepo)
-  const updateAvailable = Boolean(
-    supportedBranch && currentHead && latestHead && currentHead !== latestHead,
-  )
   const remoteRef = `origin/${branch || 'main'}`
+  const divergence = latestHead ? branchDivergence(gitRepo, remoteRef) : null
+  const updateAvailable = Boolean(
+    supportedBranch && currentHead && latestHead && updateAvailableFromDivergence(divergence, currentHead !== latestHead),
+  )
   const canSync = updateAvailable ? canResetToRemote(gitRepo, remoteRef) : true
   const ff = updateAvailable ? canFastForward(gitRepo, remoteRef) : true
   const canUpdate = Boolean(
@@ -443,8 +464,9 @@ export function readAgentUpdateStatus(): ProductUpdateStatus {
   const latestHead = repoMatches ? remoteHead(repoPath, 'origin') : null
   const remoteRef = repoMatches ? `origin/${branch || 'main'}` : null
   const dirty = isDirty(repoPath)
+  const divergence = remoteRef ? branchDivergence(repoPath, remoteRef) : null
   const updateAvailable = Boolean(
-    currentHead && latestHead && currentHead !== latestHead && remoteRef,
+    currentHead && latestHead && remoteRef && updateAvailableFromDivergence(divergence, currentHead !== latestHead),
   )
   const canSync = remoteRef ? canResetToRemote(repoPath, remoteRef) : false
   const ff = remoteRef ? canFastForward(repoPath, remoteRef) : false


### PR DESCRIPTION
## Summary

Fixes the local Native Conductor/Workspace Swarm path and prevents stale terminal Conductor missions from reappearing as an active failure after refresh.

This PR covers the issues found while debugging Conductor missions that displayed `Native Workspace Swarm mission blocked` and left the Conductor screen stuck on an old failed mission.

## What changed

- Route Native Conductor dispatch through the swarm runtime using the correct local JSON body and runtime prerequisites.
- Align Conductor's native swarm worker IDs with semantic swarm roster IDs so assignments target real workers instead of placeholder/mismatched IDs.
- Normalize update-status handling so local-ahead commits do not incorrectly mark the workspace as update-blocked.
- Stop persisting terminal Conductor phases (`idle`, `complete`) as `conductor:active-mission`.
- Disable Conductor mission status polling once a mission is terminal, so a stale blocked native-swarm record cannot be re-fetched on page load and shown as a current failure.
- Add regression tests for native dispatch/runtime behavior and terminal active-mission persistence.

## Root cause

There were two separate failure modes:

1. Native Conductor dispatch could create blocked native-swarm missions because the Conductor spawn path and swarm roster/runtime expectations were not fully aligned.
2. Even after backend/runtime cleanup, the browser could restore a terminal mission from `localStorage` as the active mission. Because the restored mission still had a `missionId`, the hook queried mission status again and surfaced an old `blocked` record as a fresh `Mission failed` banner.

## Validation

- `pnpm vitest run src/screens/gateway/hooks/use-conductor-gateway.test.ts src/routes/api/-swarm-runtime-reset.test.ts src/routes/api/-conductor-spawn.test.ts src/server/swarm-missions.test.ts`
  - 4 files passed
  - 17 tests passed
- `pnpm build`
  - client build passed
  - SSR build passed

## Notes

Terminal missions are still saved in `conductor:history`; this only clears active/resumable mission persistence so Conductor returns to the home/new mission state after refresh instead of resurrecting a stale failed mission.
