### PR TITLE
fix: isolate Hermes home in model tests

### DIFF
--- a/src/routes/api/__tests__/-models.test.ts
+++ b/src/routes/api/__tests__/-models.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../../server/local-provider-discovery', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  delete process.env.HERMES_HOME
   delete process.env.CLAUDE_HOME
 })
 

--- a/src/server/__tests__/local-provider-discovery.test.ts
+++ b/src/server/__tests__/local-provider-discovery.test.ts
@@ -22,6 +22,7 @@ vi.mock('node:fs', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  delete process.env.HERMES_HOME
   delete process.env.CLAUDE_HOME
 })
 


### PR DESCRIPTION
## Summary
- clear HERMES_HOME in affected test beforeEach hooks so tests do not read the caller's real Hermes profile
- preserves existing CLAUDE_HOME cleanup

## Verification
- pnpm vitest run src/server/__tests__/local-provider-discovery.test.ts src/routes/api/__tests__/-models.test.ts
- pnpm test
- pnpm build