### PR TITLE
fix: hydrate Operations system prompt from profile config or SOUL

### DIFF
--- a/src/screens/agents/hooks/use-operations.ts
+++ b/src/screens/agents/hooks/use-operations.ts
@@ -16,6 +16,8 @@ type ClaudeProfileSummary = {
   exists: boolean
   model?: string
   provider?: string
+  description?: string
+  systemPrompt?: string
   skillCount: number
   sessionCount: number
   hasEnv: boolean
@@ -28,6 +30,8 @@ export type GatewayConfigAgent = {
   model: string
   workspace?: string
   agentDir?: string
+  description?: string
+  systemPrompt?: string
 }
 
 export type OperationsAgentMeta = {
@@ -206,6 +210,8 @@ function normalizeAgentList(input: unknown): GatewayConfigAgent[] {
       model: readString(row.model),
       workspace: readString(row.workspace) || undefined,
       agentDir: readString(row.agentDir) || undefined,
+      description: readString(row.description) || undefined,
+      systemPrompt: readString(row.systemPrompt) || undefined,
     })
   }
 
@@ -245,6 +251,8 @@ async function fetchOperationsConfig(): Promise<ConfigPayload> {
     model: profile.model || '',
     workspace: profile.path,
     agentDir: profile.path,
+    description: profile.description || '',
+    systemPrompt: profile.systemPrompt || '',
   }))
   // Default-profile model becomes the operations defaultModel suggestion
   const defaultModel = profiles.find((p) => p.name === 'default')?.model || ''
@@ -307,12 +315,18 @@ async function deleteClaudeProfile(name: string) {
   }
 }
 
-function loadAgentMeta(agentId: string): OperationsAgentMeta {
+function loadAgentMeta(
+  agentId: string,
+  fallback?: Partial<Pick<OperationsAgentMeta, 'description' | 'systemPrompt'>>,
+): OperationsAgentMeta {
+  const fallbackDescription = readString(fallback?.description)
+  const fallbackSystemPrompt = readString(fallback?.systemPrompt)
+
   if (typeof window === 'undefined') {
     return {
       emoji: createFallbackEmoji(agentId),
-      description: '',
-      systemPrompt: '',
+      description: fallbackDescription,
+      systemPrompt: fallbackSystemPrompt,
       color: createFallbackColor(agentId),
       createdAt: new Date().toISOString(),
     }
@@ -323,8 +337,8 @@ function loadAgentMeta(agentId: string): OperationsAgentMeta {
     if (!raw) {
       return {
         emoji: createFallbackEmoji(agentId),
-        description: '',
-        systemPrompt: '',
+        description: fallbackDescription,
+        systemPrompt: fallbackSystemPrompt,
         color: createFallbackColor(agentId),
         createdAt: new Date().toISOString(),
       }
@@ -333,16 +347,16 @@ function loadAgentMeta(agentId: string): OperationsAgentMeta {
     const parsed = JSON.parse(raw) as Partial<OperationsAgentMeta>
     return {
       emoji: readString(parsed.emoji) || createFallbackEmoji(agentId),
-      description: readString(parsed.description),
-      systemPrompt: readString(parsed.systemPrompt),
+      description: readString(parsed.description) || fallbackDescription,
+      systemPrompt: readString(parsed.systemPrompt) || fallbackSystemPrompt,
       color: readString(parsed.color) || createFallbackColor(agentId),
       createdAt: readString(parsed.createdAt) || new Date().toISOString(),
     }
   } catch {
     return {
       emoji: createFallbackEmoji(agentId),
-      description: '',
-      systemPrompt: '',
+      description: fallbackDescription,
+      systemPrompt: fallbackSystemPrompt,
       color: createFallbackColor(agentId),
       createdAt: new Date().toISOString(),
     }
@@ -549,7 +563,10 @@ export function useOperations() {
     const cronJobs = cronJobsQuery.data ?? []
 
     return configAgents.map((agent) => {
-      const meta = loadAgentMeta(agent.id)
+      const meta = loadAgentMeta(agent.id, {
+        description: agent.description,
+        systemPrompt: agent.systemPrompt,
+      })
       const agentSessions = getAgentSessions(agent.id, sessions)
       const latestSession = agentSessions[0] ?? null
       const jobs = getAgentJobs(agent.id, cronJobs)

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -97,4 +97,45 @@ describe('listProfiles', () => {
     updateProfileConfig('builder', { description: null })
     expect(readProfile('builder').description).toBe('')
   })
+
+  it('surfaces system prompt from config or SOUL.md in profile summaries', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const soulProfileRoot = path.join(profilesRoot, 'leelo')
+    const configProfileRoot = path.join(profilesRoot, 'ops')
+
+    fs.mkdirSync(soulProfileRoot, { recursive: true })
+    fs.mkdirSync(configProfileRoot, { recursive: true })
+
+    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: root-model\n', 'utf-8')
+    fs.writeFileSync(path.join(soulProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(soulProfileRoot, 'SOUL.md'),
+      'You are Leelo, executive assistant.',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(configProfileRoot, 'config.yaml'),
+      'model: named-model\nsystem_prompt: Config prompt wins\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(configProfileRoot, 'SOUL.md'),
+      'This should not override config',
+      'utf-8',
+    )
+
+    const profiles = listProfiles()
+
+    expect(profiles.find((profile) => profile.name === 'leelo')?.systemPrompt).toBe(
+      'You are Leelo, executive assistant.',
+    )
+    expect(profiles.find((profile) => profile.name === 'ops')?.systemPrompt).toBe(
+      'Config prompt wins',
+    )
+    expect(readProfile('leelo').systemPrompt).toBe(
+      'You are Leelo, executive assistant.',
+    )
+    expect(readProfile('ops').systemPrompt).toBe('Config prompt wins')
+  })
 })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -11,6 +11,7 @@ export type ProfileSummary = {
   model?: string
   provider?: string
   description?: string
+  systemPrompt?: string
   skillCount: number
   sessionCount: number
   hasEnv: boolean
@@ -23,6 +24,7 @@ export type ProfileDetail = {
   active: boolean
   config: Record<string, unknown>
   description: string
+  systemPrompt: string
   envPath?: string
   hasEnv: boolean
   sessionsDir?: string
@@ -166,6 +168,25 @@ function extractDescription(config: Record<string, unknown>): string {
   }
 
   return ''
+}
+
+function extractSystemPrompt(
+  config: Record<string, unknown>,
+  profilePath: string,
+): string {
+  const configured = config.system_prompt
+  if (typeof configured === 'string' && configured.trim()) {
+    return configured.trim()
+  }
+
+  const soulPath = path.join(profilePath, 'SOUL.md')
+  if (!fs.existsSync(soulPath)) return ''
+
+  try {
+    return safeReadText(soulPath).trim()
+  } catch {
+    return ''
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -327,6 +348,7 @@ export async function readProfileWithFallback(
               ...(match.provider ? { provider: match.provider } : {}),
             },
             description: match.description || '',
+            systemPrompt: '',
             hasEnv: false,
           }
         }
@@ -412,6 +434,7 @@ export function listProfiles(): Array<ProfileSummary> {
         model: modelName,
         provider: providerName,
         description: extractDescription(config) || undefined,
+        systemPrompt: extractSystemPrompt(config, profilePath) || undefined,
         skillCount,
         sessionCount,
         hasEnv: fs.existsSync(envPath),
@@ -453,6 +476,7 @@ export function listProfiles(): Array<ProfileSummary> {
     model: defaultModel,
     provider: defaultProvider,
     description: extractDescription(config) || undefined,
+    systemPrompt: extractSystemPrompt(config, root) || undefined,
     skillCount: countFilesRecursive(
       path.join(root, 'skills'),
       (full) => path.basename(full) === 'SKILL.md',
@@ -491,6 +515,7 @@ export function readProfile(name: string): ProfileDetail {
     active: normalized === active,
     config,
     description: extractDescription(config),
+    systemPrompt: extractSystemPrompt(config, profilePath),
     envPath: fs.existsSync(envPath) ? envPath : undefined,
     hasEnv: fs.existsSync(envPath),
     sessionsDir: fs.existsSync(sessionsDir) ? sessionsDir : undefined,


### PR DESCRIPTION
## Summary
- hydrate the Operations system prompt from profile config when available
- fall back to SOUL.md for existing profiles
- expose the prompt consistently in the Operations UI
- add server coverage for the profile prompt fallback behavior

## Test Plan
- [x] run targeted tests for `src/server/profiles-browser.test.ts`
- [x] verify in Operations UI that an existing profile with SOUL.md shows its prompt correctly