### PR TITLE
feat: add safe Workspace queue execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ build
 
 # Environment variables
 .env
+.env.*
+!.env.example
 .env.local
 .env.*.local
 

--- a/docs/plans/2026-05-22-executive-queue-spec-v0.1.md
+++ b/docs/plans/2026-05-22-executive-queue-spec-v0.1.md
@@ -1,0 +1,598 @@
+# Executive Queue Spec v0.1
+
+> **For Hermes:** Use this as the product/spec source for the first Executive Queue implementation. Use `subagent-driven-development` if implementing task-by-task.
+
+**Goal:** Build a cross-domain control layer where delegated work from voice, Telegram, email, meetings, crons, Hermes Workspace, and agents is captured, triaged, approved, executed, and reviewed.
+
+**Architecture:** Local JSON is the execution source of truth. Notion is the human command center after triage. Hermes Workspace is the live cockpit for triage, approvals, queue views, and dispatch. Voice Lab should create the first real queue item locally from its delegation handoff.
+
+**Tech Stack:** Hermes Workspace V2, TypeScript, TanStack Start routes, local JSON under the Executive profile, future Notion sync.
+
+---
+
+## Core Principle
+
+Executive Queue is not a todo list.
+
+It is a decision-and-delegation control layer.
+
+It answers:
+
+- What does Tim want done?
+- Who owns it?
+- What context is required?
+- What can Executive do without approval?
+- What needs Tim before action?
+- What is the current state?
+
+## Default Posture
+
+- New items start in **Triage**.
+- Triage mode is **Judgment**.
+- Executive may prepare freely.
+- Execution must obey approval gates.
+- Every item must be traceable to its source.
+- Every item must have exactly one accountable owner.
+- Done requires a result summary.
+
+## Storage Model
+
+### Local JSON
+
+Local JSON is the machine source of truth.
+
+It stores:
+
+- raw captures
+- triage attempts
+- full source transcript/reference
+- audit trail
+- diagnostics
+- execution metadata
+- queue item record
+- sync state
+
+Recommended path:
+
+```text
+~/.hermes/profiles/executive/executive-queue/items/YYYY-MM-DD/{itemId}.json
+~/.hermes/profiles/executive/executive-queue/index.jsonl
+```
+
+### Notion
+
+Notion is the human command center.
+
+It stores cleaned operating view fields only after triage:
+
+- Proposed
+- Queued
+- In Progress
+- Blocked
+- Done
+
+Also sync High-risk Triage items if they need visibility or Tim approval.
+
+Do not sync raw captures to Notion.
+
+### Hermes Workspace
+
+Hermes Workspace is the live cockpit.
+
+It should show:
+
+- Inbox/Triage
+- Active Queue
+- Approvals
+- Blocked
+- Done history
+- item detail
+- source transcript
+- audit trail
+- dispatch owner controls
+
+## Statuses
+
+### Triage
+
+Captured, but not fully classified.
+
+Needs owner, priority, risk, approval level, confidence, and next action.
+
+### Proposed
+
+Executive knows what should happen, but needs Tim approval before starting.
+
+### Queued
+
+Approved or safe enough to start under standing rules.
+
+### In Progress
+
+An owner is actively working the item.
+
+### Blocked
+
+Cannot move forward without missing info, access, timing, dependency, or approval.
+
+### Done
+
+Outcome delivered and result summary captured.
+
+### Archived
+
+No longer relevant, duplicate, stale, or intentionally dropped.
+
+## Status Transitions
+
+- Triage can move to Proposed, Queued, Blocked, or Archived.
+- Proposed can move to Queued, Blocked, or Archived.
+- Queued can move to In Progress, Blocked, Done, or Archived.
+- In Progress can move to Blocked, Done, or Queued.
+- Blocked can move back to Triage, Proposed, Queued, or Archived.
+- Done can only move to Archived or reopen to Triage.
+- Archived can only reopen to Triage.
+
+## Done Rule
+
+An item cannot move to Done unless it has:
+
+- result summary
+- completed timestamp
+- completed by
+- artifact links or file paths, if relevant
+
+If Notion sets status to Done without result summary, local sync should convert it to Blocked.
+
+Blocked reason:
+
+```text
+Done requires result summary.
+```
+
+## Priorities
+
+- **P0:** urgent now. Drop other work.
+- **P1:** important today.
+- **P2:** important this week.
+- **P3:** useful someday or backlog.
+
+Rule:
+
+Executive may downgrade priority when confidence is low. Executive should not upgrade priority without clear evidence or Tim instruction.
+
+## Triage Mode
+
+Triage mode is **Judgment**.
+
+Executive moves low-risk items forward automatically, but pauses for high-risk, irreversible, external-facing, financial, system-level, identity-sensitive, or ministry-sensitive actions.
+
+## Risk Levels
+
+### Low
+
+- internal-only
+- reversible
+- no money
+- no external communication
+- no system/config changes
+- no sensitive personal data
+
+### Medium
+
+- shared docs
+- calendar holds
+- draft emails
+- Notion updates
+- categorization decisions
+- reversible, but could confuse people if wrong
+
+### High
+
+- external communication
+- spending money
+- publishing
+- production/config changes
+- secrets/credentials
+- legal or HR implications
+- pastoral sensitivity
+- financial consequences
+- minors
+- private family matters
+
+Special rule:
+
+Restored pastoral/staff-sensitive items are High risk by default.
+
+This includes:
+
+- pastoral care
+- staff conflict
+- HR-like issues
+- member discipline
+- confidential family details
+- minors
+- sensitive counseling
+- church finances
+- public church communication
+
+## Approval Levels
+
+### Auto
+
+Executive can act without asking.
+
+Examples:
+
+- summarize
+- classify
+- tag
+- extract tasks
+- draft content
+- research public info
+- search local non-secret files
+- create local notes/specs/plans
+- update local queue metadata
+- run safe read-only diagnostics
+- prepare proposed changes without applying them
+
+### Ask Before External
+
+Executive can prepare, but must ask before:
+
+- sending email/text
+- contacting people
+- posting
+- publishing
+- updating shared docs people rely on
+
+### Ask Before Spend
+
+Executive can research or draft, but must ask before:
+
+- purchases
+- subscriptions
+- paid API usage
+- paid transcription
+- ad spend
+- paid credits
+
+### Ask Before System Change
+
+Executive can inspect and propose, but must ask before:
+
+- config changes
+- restarts
+- deploys
+- permissions
+- secrets
+- production data changes
+- launchd changes
+- Docker changes
+- cron changes
+
+### Manual Only
+
+Executive should not act directly. It can advise or prepare instructions.
+
+## Prepare vs Execute Rule
+
+Executive may prepare freely.
+
+Executive may research, draft, plan, summarize, classify, and prepare next actions without asking. It must respect approval gates before external, financial, system, sensitive, or irreversible execution.
+
+## Approval Workflow
+
+Default approval is single-action approval.
+
+Executive should present button-style options by default:
+
+- Approve this action
+- Hold
+- Edit
+- Manual only
+- Broader approval
+
+Rules:
+
+- Approval applies only to the specific next action shown.
+- Broader approval is valid only if Tim explicitly chooses or says it.
+- Approval record must capture approved by, approved at, approved scope, approved action, channel, expiration if any, and notes.
+
+## Domains
+
+- AI Ops
+- Restored
+- Travel Multiplier
+- Personal
+- Finance
+- Code
+- Research
+- Email
+- Calendar
+- Meetings
+- Home
+- Health
+
+Family items go under Personal unless clearly Home, Calendar, Health, or Finance.
+
+Domain decides context. Owner decides accountability.
+
+## Owners
+
+Owners are specific named owners only.
+
+Allowed owners:
+
+- Executive
+- Restored COS
+- TM COS
+- Personal COS
+- Coding Agent
+- Research Agent
+- Finance CFO
+- Email Assistant
+- Calendar Assistant
+- Meeting Notes Agent
+- Voice Lab
+- Tim
+- Human: [Name]
+
+Rule:
+
+Every queue item has exactly one accountable owner.
+
+Supporting agents can be recorded later, but one owner is responsible.
+
+## Owner Reassignment
+
+During Triage, Executive may assign or reassign owner automatically.
+
+No Tim approval needed.
+
+After Triage, owner changes require Tim approval unless there is a clear operational reason:
+
+- agent failure
+- blocked access
+- wrong domain
+- duplicate item
+- unavailable owner
+
+Audit trail required:
+
+- original owner
+- new owner
+- reason
+- timestamp
+- changed by
+
+## Confidence
+
+Confidence is Low, Medium, or High.
+
+### High
+
+Executive can clearly classify owner, risk, approval, and next action.
+
+### Medium
+
+Reasonable classification, but one or two assumptions.
+
+### Low
+
+Missing context or meaningful ambiguity.
+
+Action rules:
+
+- High confidence + Low risk + Auto approval can move from Triage to Queued automatically.
+- High confidence + Medium risk + Ask Before External can move from Triage to Queued when the next action is internal prep.
+- Medium confidence can move to Proposed or Blocked, depending on risk.
+- Low confidence stays in Triage or Blocked with one clarifying question.
+
+## Auto-Queue Rule
+
+An item may move Triage → Queued automatically when:
+
+- confidence is High
+- next action is internal prep
+- approval level is Auto or Ask Before External
+- no immediate external action, spend, system change, or sensitive Restored/personal issue
+
+Medium risk can auto-queue if the next action is internal prep.
+
+## Source Types
+
+- Voice Lab
+- Telegram
+- Email
+- Calendar
+- Meeting Notes
+- Cron
+- Manual
+- Hermes Workspace
+- Notion
+- GitHub
+- Monarch
+- Google Drive
+
+Every item stores:
+
+- source type
+- source ID
+- source timestamp
+- short excerpt
+- full reference link/path
+
+Queue item stays readable. Full context must be retrievable.
+
+## Notion Sync
+
+Only sync items after triage.
+
+Sync to Notion when item becomes:
+
+- Proposed
+- Queued
+- In Progress
+- Blocked
+- Done
+
+Also sync High-risk Triage items if they need visibility or Tim approval.
+
+### Local → Notion
+
+- title
+- outcome
+- status
+- priority
+- domain
+- owner
+- risk level
+- approval level
+- confidence
+- next action
+- due date
+- source type
+- source excerpt
+- result summary
+- blocked reason
+- local reference path
+
+### Notion → Local
+
+Safe fields only:
+
+- status
+- priority
+- owner
+- due date
+- notes
+- blocked reason
+
+### Notion Display-Only
+
+- risk level
+- approval level
+- confidence
+- source type
+- source excerpt
+- local reference path
+
+### Local-Only
+
+- full transcript
+- diagnostics
+- raw logs
+- execution internals
+- audit trail
+- sensitive context
+
+Risk level and approval level are not editable from Notion. They can only be changed through Hermes Workspace or Executive tooling with audit trail.
+
+## Queue Item Schema v0.1
+
+```json
+{
+  "id": "eq_...",
+  "title": "",
+  "outcome": "",
+  "status": "Triage",
+  "priority": "P1",
+  "domain": "AI Ops",
+  "owner": "Executive",
+  "riskLevel": "Low",
+  "approvalLevel": "Auto",
+  "confidence": "High",
+  "source": {
+    "type": "Voice Lab",
+    "id": "",
+    "timestamp": "",
+    "excerpt": "",
+    "fullReference": ""
+  },
+  "context": "",
+  "constraints": [],
+  "nextAction": "",
+  "blockedReason": "",
+  "resultSummary": "",
+  "createdAt": "",
+  "updatedAt": "",
+  "dueAt": "",
+  "completedAt": "",
+  "completedBy": "",
+  "auditTrail": [],
+  "sync": {
+    "notionPageId": "",
+    "lastSyncedAt": "",
+    "lastSyncStatus": "not_synced"
+  }
+}
+```
+
+## Triage Output Contract
+
+Every triage pass must produce:
+
+```json
+{
+  "title": "",
+  "outcome": "",
+  "domain": "Travel Multiplier",
+  "owner": "TM COS",
+  "priority": "P1",
+  "riskLevel": "Medium",
+  "approvalLevel": "Ask Before External",
+  "confidence": "High",
+  "nextAction": "Draft the webinar outline and offer bridge.",
+  "autoQueue": true,
+  "reasoning": "Internal prep only. External sending/publishing still requires approval."
+}
+```
+
+## First MVP Implementation
+
+Build local JSON first. Do not build Notion first.
+
+MVP scope:
+
+1. Local JSON queue store
+   - create item
+   - update item
+   - list items
+   - append audit event
+
+2. Voice Lab → Queue
+   - Send to Executive Queue creates a real queue item locally from the delegation object
+
+3. Hermes Workspace Queue page
+   - Triage
+   - Active
+   - Blocked
+   - Done
+   - item detail
+
+4. Notion sync later
+   - after local queue behavior is proven
+   - sync only after triage
+
+## Acceptance Criteria for MVP
+
+- Voice Lab can create one real Executive Queue item locally.
+- The item starts as Triage unless auto-queue criteria are satisfied.
+- The queue item stores source excerpt and full local source reference.
+- The queue item has exactly one accountable owner.
+- The queue item includes risk, approval level, confidence, priority, next action, and audit trail.
+- Hermes Workspace can list queue items by status.
+- Moving an item to Done without result summary fails or converts to Blocked with reason.
+- High-risk Restored pastoral/staff-sensitive items do not auto-queue.
+- Tests cover queue item creation, auto-queue rule, Done rule, and source reference preservation.
+
+## Implementation Notes
+
+Use strict TDD for production code:
+
+1. Write failing tests for schema validation and queue creation.
+2. Implement minimal local JSON store.
+3. Add Voice Lab queue creation endpoint.
+4. Add Workspace queue UI after API behavior is verified.
+5. Add Notion sync only after local behavior is stable.

--- a/docs/plans/2026-06-04-x-bookmark-ai-intake-system.md
+++ b/docs/plans/2026-06-04-x-bookmark-ai-intake-system.md
@@ -1,0 +1,152 @@
+# X Bookmark AI Intake System Implementation Plan
+
+> **For Hermes:** Use test-driven-development and workspace repo verification for implementation.
+
+**Goal:** Turn Tim's X bookmarks into an actionable AI-development intake system with review digest, article extraction metadata, AI Ops upgrade radar, capture inbox prototype, and Travel Multiplier AI Search audit artifact.
+
+**Architecture:** Keep this local and read-only. Build deterministic Workspace APIs over the existing X bookmark cache first, using keyword/source classification and review-state files. Avoid new paid services, publishing, Notion writes, cross-profile writes, or automatic high-credit pagination.
+
+**Tech Stack:** Hermes Workspace, TanStack Start route APIs, TypeScript utilities, Vitest, local JSON stores under `~/.hermes/profiles/ai-dev/workspace/x-bookmark-intake/`.
+
+---
+
+## Safe autonomous scope
+
+Allowed without more approval:
+
+- Read existing X bookmark cache.
+- Add local Workspace APIs and read-only UI surfaces.
+- Create local artifacts under the ai-dev profile and Workspace repo.
+- Run tests, lint, build, restart Workspace.
+- Perform at most one small verification fetch if needed.
+
+Blocked without explicit approval:
+
+- Spending money or intentionally burning large X API credits.
+- Sending/publishing content.
+- Writing Notion source-of-truth pages.
+- Modifying other Hermes profiles' identity, memory, crons, tools, or gateway setup.
+- Installing paid tools or exposing public network routes.
+- Pushing git commits remote.
+
+## Tasks
+
+### Task 1: Add deterministic review utility
+
+**Objective:** Classify cached bookmarks into Tim-actionable buckets and produce a digest/radar summary.
+
+**Files:**
+
+- Modify: `src/routes/api/x-bookmarks/-x-bookmarks-utils.ts`
+- Modify test: `src/routes/api/x-bookmarks/-x-bookmarks-utils.test.ts`
+
+**Behavior:**
+
+- Input: cached bookmark records.
+- Output: `useNow`, `teach`, `packageSell`, `watch`, `reject`, plus upgrade radar items.
+- Include source URL, author, claim, rationale, recommended action, approval needed.
+- Prefer deterministic classification. No LLM dependency.
+
+**Verification:**
+
+- `pnpm vitest run src/routes/api/x-bookmarks/-x-bookmarks-utils.test.ts`
+
+### Task 2: Add review API
+
+**Objective:** Serve the digest from Workspace.
+
+**Files:**
+
+- Create: `src/routes/api/x-bookmarks/review.ts`
+
+**Behavior:**
+
+- Requires Workspace auth.
+- Reads cache.
+- Returns digest, source counts, article-wrapper count, reviewed-state summary.
+
+### Task 3: Add article extraction metadata
+
+**Objective:** Detect X Article wrappers and mark which need full extraction.
+
+**Files:**
+
+- Modify utilities and review API.
+
+**Behavior:**
+
+- Detect `x.com/i/article/*` links.
+- Include `articleUrl`, `articleStatus: pending/extracted/unavailable`.
+- Do not claim full article text unless extracted.
+
+### Task 4: Add AI Ops Upgrade Radar UI
+
+**Objective:** Make the digest visible in Workspace.
+
+**Files:**
+
+- Create: `src/routes/x-bookmark-review.tsx`
+
+**Behavior:**
+
+- Shows top recommendations and grouped bookmark items.
+- Labels verified vs partial article-wrapper items.
+- Shows approval gates.
+
+### Task 5: Add review-state guardrails
+
+**Objective:** Prevent the same bookmark from resurfacing forever.
+
+**Files:**
+
+- Utility functions in `-x-bookmarks-utils.ts`
+- API route for marking reviewed can be read-only/design-only unless approval is given for mutating controls.
+
+**Behavior:**
+
+- Store state locally in `bookmark-review-state.json`.
+- For now, surface counts and IDs. Actual UI mutation can stay disabled if not needed.
+
+### Task 6: Create Tim Capture Inbox prototype artifact
+
+**Objective:** Local prototype spec and starter JSON schema for voice/text capture routing.
+
+**Files:**
+
+- Create local artifact under `~/.hermes/profiles/ai-dev/workspace/x-bookmark-intake/tim-capture-inbox-prototype.md`
+
+**Behavior:**
+
+- Defines capture categories, routing rules, and approval gates.
+
+### Task 7: Create Travel Multiplier AI Search audit artifact
+
+**Objective:** Local, ready-to-use audit template based on bookmark signals.
+
+**Files:**
+
+- Create local artifact under `~/.hermes/profiles/ai-dev/workspace/x-bookmark-intake/travel-multiplier-ai-search-audit-template.md`
+
+**Behavior:**
+
+- One-page audit workflow for a Travel Multiplier page.
+- Uses public/page inputs when available.
+- Does not publish or edit live content.
+
+### Task 8: Verify and restart
+
+**Commands:**
+
+- `pnpm vitest run src/routes/api/x-bookmarks/-x-bookmarks-utils.test.ts`
+- `pnpm exec eslint src/routes/api/x-bookmarks/-x-bookmarks-utils.ts src/routes/api/x-bookmarks/review.ts src/routes/x-bookmark-review.tsx`
+- `pnpm build`
+- `launchctl kickstart -k gui/$(id -u)/ai.hermes.workspace`
+- Smoke test `/x-bookmark-review` locally and over Tailscale.
+
+## Done criteria
+
+- Review digest API works from current cache without spending more X credits.
+- Workspace review route loads.
+- Local capture inbox and AI search audit artifacts exist.
+- Tests/lint/build pass for touched files.
+- Final report names remaining blockers, especially full X Article extraction limitations.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
+    "@elevenlabs/client": "^1.9.0",
     "@hugeicons/core-free-icons": "^3.1.1",
     "@hugeicons/react": "^1.1.4",
     "@lobehub/icons": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@elevenlabs/client':
+        specifier: ^1.9.0
+        version: 1.9.0(@types/dom-mediacapture-record@1.0.22)
       '@hugeicons/core-free-icons':
         specifier: ^3.1.1
         version: 3.3.0
@@ -433,6 +436,9 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
+
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
@@ -544,6 +550,12 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@elevenlabs/client@1.9.0':
+    resolution: {integrity: sha512-czkbwUv7n18DoH5L9YdAKr0ATlcPSYNxhVQTfnFvAUdijvWfhwn8Ct0WHbPxX1oGwH6s1hMbPPAK+CUURHyowg==}
+
+  '@elevenlabs/types@0.14.0':
+    resolution: {integrity: sha512-CfpxFyNtTq9Iwm1/Hfxk+FK0QlFgsHpXcNM9jMPYrjP/kAYMFi9rgFoosdJcBGYbgkvzUL7hwT9I6WzHyNyxDg==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -903,6 +915,12 @@ packages:
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.42.2':
+    resolution: {integrity: sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==}
 
   '@lobehub/emojilib@1.0.0':
     resolution: {integrity: sha512-s9KnjaPjsEefaNv150G3aifvB+J3P4eEKG+epY9zDPS2BeB6+V2jELWqAZll+nkogMaVovjEE813z3V751QwGw==}
@@ -1683,66 +1701,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1864,24 +1895,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2215,6 +2250,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
@@ -2429,41 +2467,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3514,6 +3560,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4054,6 +4104,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
@@ -4197,24 +4250,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -4244,6 +4301,11 @@ packages:
   lit@3.3.3:
     resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
+  livekit-client@2.16.1:
+    resolution: {integrity: sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4263,6 +4325,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5391,6 +5457,13 @@ packages:
   scrollparent@2.1.0:
     resolution: {integrity: sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==}
 
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
@@ -5754,6 +5827,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-debounce@4.0.0:
+    resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
+
   ts-declaration-location@1.0.7:
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
@@ -5802,6 +5878,9 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typescript-eslint@8.57.0:
     resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
@@ -6061,6 +6140,10 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  webrtc-adapter@9.0.5:
+    resolution: {integrity: sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -6503,6 +6586,8 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bufbuild/protobuf@1.10.1': {}
+
   '@chevrotain/types@11.1.2': {}
 
   '@csstools/color-helpers@6.0.2': {}
@@ -6660,6 +6745,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  '@elevenlabs/client@1.9.0(@types/dom-mediacapture-record@1.0.22)':
+    dependencies:
+      '@elevenlabs/types': 0.14.0
+      livekit-client: 2.16.1(@types/dom-mediacapture-record@1.0.22)
+    transitivePeerDependencies:
+      - '@types/dom-mediacapture-record'
+
+  '@elevenlabs/types@0.14.0': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -6966,6 +7060,12 @@ snapshots:
   '@lit/reactive-element@2.1.2':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.42.2':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
 
   '@lobehub/emojilib@1.0.0': {}
 
@@ -8533,6 +8633,8 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/dom-mediacapture-record@1.0.22': {}
 
   '@types/draco3d@1.4.10': {}
 
@@ -10124,6 +10226,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -10736,6 +10840,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
@@ -10933,6 +11039,20 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.3
 
+  livekit-client@2.16.1(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.42.2
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.2.3
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      ts-debounce: 4.0.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.5
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -10946,6 +11066,8 @@ snapshots:
   lodash@4.17.23: {}
 
   lodash@4.18.1: {}
+
+  loglevel@1.9.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -12475,6 +12597,10 @@ snapshots:
 
   scrollparent@2.1.0: {}
 
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
+
   semver-compare@1.0.0: {}
 
   semver@5.7.2: {}
@@ -12801,6 +12927,8 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-debounce@4.0.0: {}
+
   ts-declaration-location@1.0.7(typescript@5.9.3):
     dependencies:
       picomatch: 4.0.4
@@ -12841,6 +12969,10 @@ snapshots:
     optional: true
 
   type-fest@4.41.0: {}
+
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 7.8.2
 
   typescript-eslint@8.57.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -13140,6 +13272,10 @@ snapshots:
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  webrtc-adapter@9.0.5:
+    dependencies:
+      sdp: 3.2.2
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/scripts/-x-article-browser-login-utils.test.ts
+++ b/scripts/-x-article-browser-login-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  brokerFieldCommandArgs,
+  isXLoginTemporarilyLimited,
+  shouldAttemptBrokerLogin,
+  summarizeBrokerCredentialCheck,
+} from './-x-article-browser-login-utils'
+
+describe('x article browser login utils', () => {
+  it('attempts broker login only for X login-wall extraction failures', () => {
+    expect(
+      shouldAttemptBrokerLogin(
+        'Dedicated browser profile is not logged into X.',
+      ),
+    ).toBe(true)
+    expect(shouldAttemptBrokerLogin('Sign in to X to continue')).toBe(true)
+    expect(shouldAttemptBrokerLogin('Article unavailable')).toBe(false)
+    expect(shouldAttemptBrokerLogin(undefined)).toBe(false)
+  })
+
+  it('builds restricted broker field commands without embedding secrets', () => {
+    expect(brokerFieldCommandArgs('username')).toEqual([
+      '/Users/hermes/.hermes/profiles/ai-dev/scripts/op_hermes_broker.py',
+      'get-field',
+      'x-tim',
+      'username',
+    ])
+    expect(brokerFieldCommandArgs('password')).toEqual([
+      '/Users/hermes/.hermes/profiles/ai-dev/scripts/op_hermes_broker.py',
+      'get-field',
+      'x-tim',
+      'password',
+    ])
+  })
+
+  it('summarizes credential checks without exposing values', () => {
+    expect(
+      summarizeBrokerCredentialCheck('tim@example.com', 'secret-password'),
+    ).toEqual({
+      usernamePresent: true,
+      passwordPresent: true,
+      usernameLength: 15,
+      passwordLength: 15,
+    })
+  })
+
+  it('detects X temporary login throttling', () => {
+    expect(
+      isXLoginTemporarilyLimited(
+        'We’ve temporarily limited your login. Please try again later.',
+      ),
+    ).toBe(true)
+    expect(isXLoginTemporarilyLimited('Sign in to X')).toBe(false)
+  })
+})

--- a/scripts/-x-article-browser-login-utils.ts
+++ b/scripts/-x-article-browser-login-utils.ts
@@ -1,0 +1,41 @@
+export type BrokerField = 'username' | 'password'
+
+export type BrokerCredentialSummary = {
+  usernamePresent: boolean
+  passwordPresent: boolean
+  usernameLength: number
+  passwordLength: number
+}
+
+const BROKER_SCRIPT =
+  '/Users/hermes/.hermes/profiles/ai-dev/scripts/op_hermes_broker.py'
+const BROKER_ALIAS = 'x-tim'
+
+export function shouldAttemptBrokerLogin(error?: string): boolean {
+  if (!error) return false
+  const normalized = error.toLowerCase()
+  return (
+    normalized.includes('not logged into x') ||
+    normalized.includes('sign in to x')
+  )
+}
+
+export function isXLoginTemporarilyLimited(bodyText: string): boolean {
+  return /temporarily limited your login/i.test(bodyText)
+}
+
+export function brokerFieldCommandArgs(field: BrokerField): Array<string> {
+  return [BROKER_SCRIPT, 'get-field', BROKER_ALIAS, field]
+}
+
+export function summarizeBrokerCredentialCheck(
+  username: string,
+  password: string,
+): BrokerCredentialSummary {
+  return {
+    usernamePresent: username.trim().length > 0,
+    passwordPresent: password.trim().length > 0,
+    usernameLength: username.trim().length,
+    passwordLength: password.trim().length,
+  }
+}

--- a/scripts/seed-executive-blitz-queue.py
+++ b/scripts/seed-executive-blitz-queue.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Seed Tim's Executive Queue with durable, approval-ready backlog items.
+
+This is intentionally local-only. It does not contact people, change Motion,
+write finance records, or mutate Notion beyond normal Activity Log elsewhere.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+QUEUE_ROOT = Path('/Users/hermes/.hermes/profiles/executive/executive-queue')
+TODAY = datetime.now(timezone.utc).astimezone().isoformat()
+DATE_DIR = TODAY[:10]
+ITEMS_DIR = QUEUE_ROOT / 'items' / DATE_DIR
+
+ALLOWED_DOMAINS = {
+    'AI Ops', 'Restored', 'Travel Multiplier', 'Personal', 'Finance', 'Code',
+    'Research', 'Email', 'Calendar', 'Meetings', 'Home', 'Health',
+}
+ALLOWED_OWNERS = {
+    'Executive', 'Restored COS', 'TM COS', 'Personal COS', 'Coding Agent',
+    'Research Agent', 'Finance CFO', 'Email Assistant', 'Calendar Assistant',
+    'Meeting Notes Agent', 'Voice Lab', 'Tim',
+}
+
+def slug(value: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '-', value.lower()).strip('-')[:58]
+
+RAW_ITEMS = [
+    {
+        'title': 'Rate first canonical AI Learning output',
+        'outcome': 'AI Learning keeps surfacing useful, weekly agent-roadmap decisions instead of becoming another ignored digest.',
+        'status': 'Proposed', 'priority': 'P1', 'domain': 'AI Ops', 'owner': 'Executive',
+        'riskLevel': 'Low', 'approvalLevel': 'Manual Only', 'confidence': 'High',
+        'source_id': 'active-queue-ai-learning-canonical',
+        'excerpt': 'Active queue item: first Executive AI Learning Agent output needs Tim review.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-3',
+        'context': 'First canonical run completed and produced ranked recommendations. Tuning should happen after Tim reaction, not before.',
+        'constraints': ['No paid transcription without approval.'],
+        'nextAction': 'Open the latest AI Learning report and choose: looks good, needs tuning, or not useful.',
+    },
+    {
+        'title': 'Approve Operating KB extraction batch',
+        'outcome': 'Turn the metadata inventory into useful cross-domain operating knowledge without reading everything blindly.',
+        'status': 'Proposed', 'priority': 'P1', 'domain': 'AI Ops', 'owner': 'Executive',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before System Change', 'confidence': 'High',
+        'source_id': 'active-queue-operating-kb-inventory',
+        'excerpt': 'Inventory found 100 Drive candidate documents and 40 TM email candidate threads. Tim needs to approve Phase 2 extraction.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-15',
+        'context': 'Metadata-first inventory is complete. No full docs or full emails were read in that phase.',
+        'constraints': ['Do not save memory or create skills until extracted facts are reviewed.'],
+        'nextAction': 'Approve a first extraction batch, such as top 5 Restored and top 5 Travel Multiplier sources.',
+    },
+    {
+        'title': 'Draft Communion ministry lunch response',
+        'outcome': 'Sunday lunch and communion ministry agenda items get handled before they bury Tim.',
+        'status': 'Proposed', 'priority': 'P1', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'High',
+        'source_id': 'reliability-queue-communion-thread',
+        'excerpt': 'Superhuman inbox thread about shut-ins, meals, and centralized process.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#queue-review-snapshot-2026-05-29',
+        'context': 'Email was in inbox and marked important in the queue review snapshot.',
+        'constraints': ['Draft only. No external reply without Tim approval.'],
+        'nextAction': 'Restored COS reads the thread and drafts a concise response or agenda for Tim approval.',
+    },
+    {
+        'title': 'Review Judy pastoral follow-up',
+        'outcome': 'A sensitive pastoral follow-up does not disappear in the inbox.',
+        'status': 'Proposed', 'priority': 'P1', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'High', 'approvalLevel': 'Manual Only', 'confidence': 'High',
+        'source_id': 'reliability-queue-judy-pastoral-email',
+        'excerpt': 'Judy pastoral follow-up email was marked important and private enough to treat as high risk.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#queue-review-snapshot-2026-05-29',
+        'context': 'Queue review identified this as pastoral/private. Summary and reply should be handled carefully.',
+        'constraints': ['No sensitive note or external reply without Tim approval.'],
+        'nextAction': 'Restored COS prepares a short private summary for Tim only.',
+    },
+    {
+        'title': 'Recover baptism candidate follow-up',
+        'outcome': 'A Restored people task gets scheduled instead of staying due and unscheduled.',
+        'status': 'Triage', 'priority': 'P1', 'domain': 'Restored', 'owner': 'Executive',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'High',
+        'source_id': 'reliability-queue-baptism-motion',
+        'excerpt': 'Motion scan found Baptism candidate follow-up due with no scheduled time.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#queue-review-snapshot-2026-05-29',
+        'context': 'Read-only scan only. External contact requires approval.',
+        'constraints': ['Respect Friday protection. Ask before contacting people.'],
+        'nextAction': 'Check if the Motion task is still open, then schedule a recovery block or draft contact for approval.',
+    },
+    {
+        'title': 'Decide Saturday overload plan',
+        'outcome': 'Tim gets a realistic Saturday instead of 315 minutes of stacked work by inertia.',
+        'status': 'Proposed', 'priority': 'P1', 'domain': 'Personal', 'owner': 'Executive',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before System Change', 'confidence': 'High',
+        'source_id': 'reliability-queue-saturday-overload',
+        'excerpt': 'Motion scan showed 5 Saturday tasks totaling 315 minutes across finance, Restored, sermon prep, and TM.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#queue-review-snapshot-2026-05-29',
+        'context': 'This is exactly the kind of capacity conflict the Executive layer should surface.',
+        'constraints': ['Do not move external hard deadlines without Tim approval.'],
+        'nextAction': 'Rank the Saturday tasks and propose what to keep, move, or drop.',
+    },
+    {
+        'title': 'Prepare elder onboarding packet',
+        'outcome': 'Elder onboarding prep becomes a reviewable packet instead of scattered tasks.',
+        'status': 'Queued', 'priority': 'P2', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'High',
+        'source_id': 'reliability-queue-elder-onboarding-packet',
+        'excerpt': 'Motion scan found three Elder Onboarding Prep tasks due June 4.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#queue-review-snapshot-2026-05-29',
+        'context': 'Safe local prep is allowed. External sharing requires approval.',
+        'constraints': ['Draft locally. Ask before sharing.'],
+        'nextAction': 'Draft the onboarding outline and meeting plan for Tim review.',
+    },
+    {
+        'title': 'Review next Finance Watcher report',
+        'outcome': 'Every dollar tracking improves without making noisy or unsafe automatic finance writes.',
+        'status': 'Queued', 'priority': 'P1', 'domain': 'Finance', 'owner': 'Finance CFO',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before System Change', 'confidence': 'High',
+        'source_id': 'active-queue-finance-watcher-tuned-report',
+        'excerpt': 'Finance Watcher prompts now require completeness status, unresolved count, source tracing blockers, and no writes without approval.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-4',
+        'context': 'Sunday and Wednesday Finance Watcher prompts were updated after Tim clarified every dollar must be tracked accurately.',
+        'constraints': ['No finance writes without explicit approval.'],
+        'nextAction': 'Inspect the next natural Finance Watcher artifact and approve only high-confidence ready items.',
+    },
+    {
+        'title': 'Resolve AI transcript backfill blockers',
+        'outcome': 'AI Learning has full transcripts rather than partial summaries or inaccessible queued items.',
+        'status': 'Proposed', 'priority': 'P2', 'domain': 'AI Ops', 'owner': 'Executive',
+        'riskLevel': 'Low', 'approvalLevel': 'Manual Only', 'confidence': 'High',
+        'source_id': 'reliability-queue-transcript-backfill',
+        'excerpt': 'Transcript backfill still reports missing or unacceptable transcripts. No paid transcription used.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/reports/reliability-queue-2026-05-29/reliability_queue_report.json',
+        'context': 'Tim has stated partial/summary/queued/inaccessible transcripts are unacceptable and paid transcription requires approval.',
+        'constraints': ['Ask before paid transcription. No partial transcripts.'],
+        'nextAction': 'Prepare a short list of blocked transcript candidates and ask which are worth paid/manual recovery.',
+    },
+    {
+        'title': 'Tune Travel Multiplier weekly review sources',
+        'outcome': 'TM lane surfaces profit and system-protection moves, not silent empty reports.',
+        'status': 'Triage', 'priority': 'P2', 'domain': 'Travel Multiplier', 'owner': 'TM COS',
+        'riskLevel': 'Medium', 'approvalLevel': 'Auto', 'confidence': 'Medium',
+        'source_id': 'active-queue-tm-weekly-review-coverage',
+        'excerpt': 'First real TM weekly review returned silent because live sources were too thin.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-7',
+        'context': 'TM needs profit/system lane coverage so inconsistency does not cripple the business.',
+        'constraints': ['No customer contact or public changes without approval.'],
+        'nextAction': 'Identify the next two TM live sources or explicit TM tasks the weekly review should monitor.',
+    },
+    {
+        'title': 'Scope broader referral link monitoring',
+        'outcome': 'TM protects core affiliate revenue links beyond the existing referrals page watcher.',
+        'status': 'Proposed', 'priority': 'P2', 'domain': 'Travel Multiplier', 'owner': 'TM COS',
+        'riskLevel': 'Low', 'approvalLevel': 'Ask Before System Change', 'confidence': 'High',
+        'source_id': 'active-queue-referral-link-monitoring-scope',
+        'excerpt': 'Current watcher checks Travel Multiplier referrals page. Broader card-program monitoring is a separate scope.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-10',
+        'context': 'Existing deterministic watcher is healthy, but broader monitoring could catch program-page changes.',
+        'constraints': ['Do not edit TM cron or scripts without approval.'],
+        'nextAction': 'Decide whether to scope broader card-program monitoring beyond the referral page.',
+    },
+    {
+        'title': 'Decide Voice Bridge production hardening',
+        'outcome': 'Voice Lab moves from prototype to reliable production only if it is worth the operational cost.',
+        'status': 'Proposed', 'priority': 'P2', 'domain': 'AI Ops', 'owner': 'Executive',
+        'riskLevel': 'High', 'approvalLevel': 'Ask Before System Change', 'confidence': 'High',
+        'source_id': 'active-queue-voice-bridge-hardening',
+        'excerpt': 'Live Speech Engine browser bridge works, but uses temporary Cloudflare quick tunnels and background process.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-11',
+        'context': 'Gateway/process restarts and public tunnels are gated. Local readiness prep is safe.',
+        'constraints': ['No public tunnels, launchd services, or restarts without approval.'],
+        'nextAction': 'Choose whether to harden Voice Lab now, keep it as prototype, or defer.',
+    },
+    {
+        'title': 'Run Four-Lane output quality check',
+        'outcome': 'The operating cadence actually protects AI Learning, Restored, Finance, and TM instead of just existing on paper.',
+        'status': 'Queued', 'priority': 'P1', 'domain': 'AI Ops', 'owner': 'Executive',
+        'riskLevel': 'Low', 'approvalLevel': 'Auto', 'confidence': 'High',
+        'source_id': 'active-queue-four-lane-quality-check',
+        'excerpt': 'Four-Lane Operating System is built and awaiting natural-run quality check.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-1',
+        'context': 'Tuesday Executive Queue, Wednesday Finance, Thursday AI Learning, and Monday TM outputs should be checked before tuning.',
+        'constraints': ['Do not overbuild scoring. Tune after real outputs.'],
+        'nextAction': 'Review each natural output and mark useful, noisy, missing, or action-worthy.',
+    },
+    {
+        'title': 'Make Motion queue compensation real',
+        'outcome': 'Motion becomes Tim’s executive-function operating system, not just a passive task list.',
+        'status': 'Queued', 'priority': 'P1', 'domain': 'Personal', 'owner': 'Executive',
+        'riskLevel': 'Medium', 'approvalLevel': 'Auto', 'confidence': 'High',
+        'source_id': 'active-queue-motion-operating-system',
+        'excerpt': 'Executive has Full Motion ops for clear low-risk task/deadline management.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-2',
+        'context': 'Executive may create, update, schedule, and reschedule clear low-risk Motion tasks. Sensitive or external commitments are gated.',
+        'constraints': ['No Friday work. Ask before deletes, external hard deadlines, or sensitive decisions.'],
+        'nextAction': 'Use Motion scans to turn overload and unscheduled work into approval-ready moves.',
+    },
+    {
+        'title': 'Review Product Pass monitor output',
+        'outcome': 'Lenny/Product Pass AI tool monitoring turns into concrete experiments or rejections.',
+        'status': 'Triage', 'priority': 'P3', 'domain': 'AI Ops', 'owner': 'Research Agent',
+        'riskLevel': 'Low', 'approvalLevel': 'Auto', 'confidence': 'Medium',
+        'source_id': 'four-lane-product-pass-monitor',
+        'excerpt': 'Lenny Product Pass AI tool monitor runs Mondays and is part of AI Learning visibility.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/four-lane-operating-system/reports/status-snapshot-2026-06-01.json',
+        'context': 'This should feed the AI Learning lane only when it creates a decision or experiment.',
+        'constraints': ['No paid tool adoption without approval.'],
+        'nextAction': 'Pull latest Product Pass monitor output and propose one adopt/test/reject decision.',
+    },
+    {
+        'title': 'Review Meeting Follow-Up drafts',
+        'outcome': 'Granola-derived follow-ups do not pile up without Tim seeing draftable next actions.',
+        'status': 'Triage', 'priority': 'P2', 'domain': 'Meetings', 'owner': 'Meeting Notes Agent',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'Medium',
+        'source_id': 'cron-meeting-follow-up-drafts',
+        'excerpt': 'Meeting Follow-Up Drafts cron runs Monday through Thursday and Saturday at 4:30 PM.',
+        'fullReference': 'cron:3e39f6f7dc1a',
+        'context': 'Drafts are useful only if they become approval-ready replies or Motion tasks.',
+        'constraints': ['No sending without approval.'],
+        'nextAction': 'Open the latest follow-up artifact and surface only drafts that need Tim approval.',
+    },
+    {
+        'title': 'Blitz Executive inbox review leftovers',
+        'outcome': 'Inbox action items become approvals, drafts, or archived noise instead of staying invisible.',
+        'status': 'Triage', 'priority': 'P1', 'domain': 'Email', 'owner': 'Email Assistant',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'Medium',
+        'source_id': 'cron-executive-inbox-review',
+        'excerpt': 'Executive Inbox Review runs daily at 8:25 AM and should produce action items.',
+        'fullReference': 'cron:afba478b85e6',
+        'context': 'Email scans should report inbox emails and create drafts for approval rather than hiding behind ok statuses.',
+        'constraints': ['Never send without approval.'],
+        'nextAction': 'Read latest inbox review output and turn remaining inbox actions into queue cards.',
+    },
+    {
+        'title': 'Decide Chase Paze nudge',
+        'outcome': 'Travel card optimization either gets completed or stops consuming reminder cycles.',
+        'status': 'Proposed', 'priority': 'P3', 'domain': 'Travel Multiplier', 'owner': 'TM COS',
+        'riskLevel': 'Low', 'approvalLevel': 'Manual Only', 'confidence': 'Medium',
+        'source_id': 'active-queue-chase-paze-nudge',
+        'excerpt': 'Chase Paze 10x setup nudge was marked Later.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-5',
+        'context': 'This is not urgent, but it is a small money-optimization loose end.',
+        'constraints': ['Do not spend or apply without Tim.'],
+        'nextAction': 'Choose complete now, keep nudging, or kill the reminder.',
+    },
+    {
+        'title': 'Convert elder onboarding email draft',
+        'outcome': 'The strong elder onboarding inbox draft becomes a usable packet and meeting plan.',
+        'status': 'Queued', 'priority': 'P2', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Medium', 'approvalLevel': 'Ask Before External', 'confidence': 'High',
+        'source_id': 'active-queue-elder-onboarding-email',
+        'excerpt': 'Strong draft exists in Tim inbox and likely needs conversion into usable elder onboarding packet.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-6',
+        'context': 'This is related to but distinct from the Motion packet task.',
+        'constraints': ['No external sharing without Tim approval.'],
+        'nextAction': 'Find the inbox draft and convert it into a structured packet outline.',
+    },
+    {
+        'title': 'Recheck Restored Morning Brief quality',
+        'outcome': 'Restored morning brief repairs are verified by useful output, not merely ok status.',
+        'status': 'Queued', 'priority': 'P2', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Low', 'approvalLevel': 'Auto', 'confidence': 'Medium',
+        'source_id': 'active-queue-mcp-reliability-scorecard',
+        'excerpt': 'Approved repairs completed. Watch next natural Restored Morning Brief and Finance Watcher runs.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-13',
+        'context': 'The reliability lesson was that last_status ok is not enough.',
+        'constraints': ['Do read-only verification unless a fresh failure needs repair approval.'],
+        'nextAction': 'Inspect next Restored Morning Brief output and confirm it contains useful data.',
+    },
+    {
+        'title': 'Prepare Tim Morris onboarding SOP later pack',
+        'outcome': 'Tim Morris operations ideas are parked as a batch instead of rediscovered repeatedly.',
+        'status': 'Triage', 'priority': 'P4', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Low', 'approvalLevel': 'Auto', 'confidence': 'Medium',
+        'source_id': 'active-queue-tim-morris-sop',
+        'excerpt': 'Tim Morris: On and Off Boarding SOP was chosen Later.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-8',
+        'context': 'Bring back only when reviewing elder/governance ops.',
+        'constraints': ['Do not distract current queue unless Tim asks for governance ops.'],
+        'nextAction': 'Keep parked and batch with volunteer recognition when Restored systems review starts.',
+    },
+    {
+        'title': 'Prepare volunteer recognition later pack',
+        'outcome': 'Volunteer systems idea is preserved without cluttering active priorities.',
+        'status': 'Triage', 'priority': 'P4', 'domain': 'Restored', 'owner': 'Restored COS',
+        'riskLevel': 'Low', 'approvalLevel': 'Auto', 'confidence': 'Medium',
+        'source_id': 'active-queue-volunteer-recognition',
+        'excerpt': 'Tim Morris: Volunteer Recognition Program was chosen Later.',
+        'fullReference': '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/active-queue.md#item-9',
+        'context': 'Bring back only when reviewing volunteer systems or Tim Morris agenda.',
+        'constraints': ['Do not distract active priorities.'],
+        'nextAction': 'Keep parked until Restored volunteer systems review.',
+    },
+]
+
+assert len(RAW_ITEMS) >= 20
+
+ITEMS_DIR.mkdir(parents=True, mode=0o700, exist_ok=True)
+QUEUE_ROOT.mkdir(parents=True, mode=0o700, exist_ok=True)
+
+# Archive obsolete smoke-test item so it stops poisoning the operating picture.
+archived = 0
+for path in (QUEUE_ROOT / 'items').rglob('*.json'):
+    try:
+        item = json.loads(path.read_text())
+    except Exception:
+        continue
+    if item.get('id') == 'eq_20260522_status-approval-smoke' or 'smoke test' in item.get('title', '').lower():
+        if item.get('status') != 'Archived':
+            item['status'] = 'Archived'
+            item['updatedAt'] = TODAY
+            item.setdefault('auditTrail', []).append({
+                'action': 'archived',
+                'actor': 'Executive Backlog Compiler',
+                'timestamp': TODAY,
+                'from': 'In Progress',
+                'to': 'Archived',
+                'note': 'Archived obsolete smoke-test item so the Command Center reflects real work.',
+            })
+            path.write_text(json.dumps(item, indent=2) + '\n')
+            archived += 1
+
+existing_ids = set()
+if (QUEUE_ROOT / 'items').exists():
+    for path in (QUEUE_ROOT / 'items').rglob('*.json'):
+        try:
+            existing_ids.add(json.loads(path.read_text()).get('id'))
+        except Exception:
+            pass
+
+created = 0
+updated = 0
+for raw in RAW_ITEMS:
+    domain = raw['domain'] if raw['domain'] in ALLOWED_DOMAINS else 'AI Ops'
+    owner = raw['owner'] if raw['owner'] in ALLOWED_OWNERS else 'Executive'
+    item_id = 'eq_blitz_' + slug(raw['source_id'])
+    local_path = ITEMS_DIR / f'{item_id}.json'
+    record = {
+        'schemaVersion': 1,
+        'id': item_id,
+        'title': raw['title'],
+        'outcome': raw['outcome'],
+        'status': raw['status'],
+        'priority': raw['priority'],
+        'domain': domain,
+        'owner': owner,
+        'riskLevel': raw['riskLevel'],
+        'approvalLevel': raw['approvalLevel'],
+        'confidence': raw['confidence'],
+        'source': {
+            'type': 'Voice Lab',
+            'id': raw['source_id'],
+            'timestamp': TODAY,
+            'excerpt': raw['excerpt'],
+            'fullReference': raw['fullReference'],
+        },
+        'context': raw['context'],
+        'constraints': raw['constraints'],
+        'nextAction': raw['nextAction'],
+        'blockedReason': '',
+        'resultSummary': '',
+        'createdAt': TODAY,
+        'updatedAt': TODAY,
+        'dueAt': '',
+        'completedAt': '',
+        'completedBy': '',
+        'auditTrail': [{
+            'action': 'created',
+            'actor': 'Executive Backlog Compiler',
+            'timestamp': TODAY,
+            'note': 'Seeded from durable active queue and reliability queue sources so Workspace is blitz-ready.',
+        }],
+        'sync': {
+            'notionPageId': '',
+            'lastSyncedAt': '',
+            'lastSyncStatus': 'not_synced',
+        },
+        'localPath': str(local_path),
+    }
+    if item_id in existing_ids:
+        # Preserve any Tim-updated status/result while refreshing metadata only if file exists.
+        try:
+            old_path = next((QUEUE_ROOT / 'items').rglob(f'{item_id}.json'))
+            old = json.loads(old_path.read_text())
+            for key in ['status', 'blockedReason', 'resultSummary', 'completedAt', 'completedBy', 'auditTrail', 'createdAt']:
+                record[key] = old.get(key, record[key])
+            record['updatedAt'] = TODAY
+            record['localPath'] = str(old_path)
+            old_path.write_text(json.dumps(record, indent=2) + '\n')
+            updated += 1
+        except StopIteration:
+            local_path.write_text(json.dumps(record, indent=2) + '\n')
+            created += 1
+    else:
+        local_path.write_text(json.dumps(record, indent=2) + '\n')
+        with (QUEUE_ROOT / 'index.jsonl').open('a') as f:
+            f.write(json.dumps({
+                'id': record['id'],
+                'status': record['status'],
+                'priority': record['priority'],
+                'owner': record['owner'],
+                'updatedAt': record['updatedAt'],
+                'localPath': record['localPath'],
+            }) + '\n')
+        created += 1
+
+print(json.dumps({'created': created, 'updated': updated, 'archived': archived, 'total_seed_items': len(RAW_ITEMS)}, indent=2))

--- a/scripts/x-article-browser-extractor.ts
+++ b/scripts/x-article-browser-extractor.ts
@@ -1,0 +1,463 @@
+import { execFile } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { promisify } from 'node:util'
+import { chromium } from 'playwright'
+
+import {
+  createBrowserXArticleExtraction,
+  isBrowserXLoginWallText,
+  mergeXArticleExtractions,
+  profileHome,
+  readBookmarkCache,
+  readXArticleExtractionCache,
+  writeXArticleExtractionCache,
+  xArticleBrowserProfilePath,
+  xArticleBrowserRunPath,
+  xArticleIdFromUrl,
+  xArticleUrl,
+} from '../src/routes/api/x-bookmarks/-x-bookmarks-utils'
+import {
+  brokerFieldCommandArgs,
+  isXLoginTemporarilyLimited,
+  shouldAttemptBrokerLogin,
+} from './-x-article-browser-login-utils'
+
+import type { XArticleExtraction } from '../src/routes/api/x-bookmarks/-x-bookmarks-utils'
+import type { Page } from 'playwright'
+
+const execFileAsync = promisify(execFile)
+
+type RunSummary = {
+  ok: boolean
+  mode: 'setup-login' | 'extract'
+  startedAt: string
+  finishedAt: string
+  profilePath: string
+  totalArticleCandidates: number
+  attempted: number
+  extracted: number
+  unavailable: number
+  error: number
+  remaining: number
+  items: Array<
+    Pick<
+      XArticleExtraction,
+      | 'articleId'
+      | 'articleUrl'
+      | 'sourceTweetId'
+      | 'status'
+      | 'title'
+      | 'excerpt'
+      | 'extractedAt'
+      | 'method'
+      | 'error'
+    >
+  >
+  errorMessage?: string
+}
+
+function argValue(name: string, fallback = ''): string {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  return process.argv[index + 1] || fallback
+}
+
+function hasArg(name: string): boolean {
+  return process.argv.includes(name)
+}
+
+function limitFromArgs(): number {
+  const raw = Number(argValue('--limit', '10'))
+  if (!Number.isFinite(raw)) return 10
+  return Math.min(Math.max(Math.floor(raw), 1), 50)
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as T
+  } catch {
+    return null
+  }
+}
+
+async function writeRunSummary(summary: RunSummary): Promise<void> {
+  const path = xArticleBrowserRunPath(profileHome())
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  await writeFile(path, `${JSON.stringify(summary, null, 2)}\n`, {
+    mode: 0o600,
+  })
+}
+
+async function readBrokerField(
+  field: 'username' | 'password',
+): Promise<string> {
+  const [command, ...args] = brokerFieldCommandArgs(field)
+  const result = await execFileAsync(command, args, {
+    timeout: 45_000,
+    maxBuffer: 1024 * 128,
+  })
+  const value = result.stdout.trim()
+  if (!value) throw new Error(`1Password broker returned empty ${field}.`)
+  return value
+}
+
+async function clickFirstVisible(
+  page: Page,
+  selectors: Array<string>,
+): Promise<boolean> {
+  for (const selector of selectors) {
+    const locator = page.locator(selector).first()
+    if (await locator.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await locator.click()
+      return true
+    }
+  }
+  return false
+}
+
+async function fillFirstVisible(
+  page: Page,
+  selectors: Array<string>,
+  value: string,
+): Promise<boolean> {
+  let filled = false
+  for (const selector of selectors) {
+    const locator = page.locator(selector)
+    const count = await locator.count().catch(() => 0)
+    for (let index = 0; index < count; index += 1) {
+      const candidate = locator.nth(index)
+      if (await candidate.isVisible({ timeout: 1_000 }).catch(() => false)) {
+        await candidate.fill(value)
+        filled = true
+      }
+    }
+  }
+  return filled
+}
+
+async function completeXLoginWithBroker(page: Page): Promise<void> {
+  const username = await readBrokerField('username')
+  const password = await readBrokerField('password')
+
+  await page.goto('https://x.com/i/flow/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  })
+  await page
+    .waitForLoadState('networkidle', { timeout: 20_000 })
+    .catch(() => undefined)
+
+  const filledUsername = await fillFirstVisible(
+    page,
+    [
+      'input[name="username_or_email"]',
+      'input[autocomplete="username"]',
+      'input[autocomplete="username webauthn"]',
+      'input[name="text"]',
+      'input[type="text"]',
+    ],
+    username,
+  )
+  if (!filledUsername)
+    throw new Error('Could not find X username field for broker login.')
+
+  await clickFirstVisible(page, [
+    'div[role="button"]:has-text("Next")',
+    'button:has-text("Next")',
+  ])
+  await page.waitForTimeout(1_500)
+
+  const challengeVisible = await page
+    .locator(
+      'text=/Enter your phone number or username|Enter your email|Enter your username/i',
+    )
+    .first()
+    .isVisible({ timeout: 2_000 })
+    .catch(() => false)
+  if (challengeVisible) {
+    await fillFirstVisible(
+      page,
+      [
+        'input[data-testid="ocfEnterTextTextInput"]',
+        'input[name="text"]',
+        'input[type="text"]',
+      ],
+      username,
+    )
+    await clickFirstVisible(page, [
+      'div[role="button"]:has-text("Next")',
+      'button:has-text("Next")',
+    ])
+    await page.waitForTimeout(1_500)
+  }
+
+  const filledPassword = await fillFirstVisible(
+    page,
+    [
+      'input[name="password"]',
+      'input[autocomplete="current-password"]',
+      'input[type="password"]',
+    ],
+    password,
+  )
+  if (!filledPassword)
+    throw new Error('Could not find X password field for broker login.')
+
+  await clickFirstVisible(page, [
+    'div[data-testid="LoginForm_Login_Button"]',
+    'button:text-is("Log in")',
+    'div[role="button"]:has-text("Log in")',
+    'button:text-is("Continue")',
+  ])
+  await page
+    .getByRole('button', { name: /^Continue$/ })
+    .first()
+    .click({ timeout: 2_000 })
+    .catch(() => undefined)
+  await page.keyboard.press('Enter').catch(() => undefined)
+  await page
+    .waitForLoadState('networkidle', { timeout: 30_000 })
+    .catch(() => undefined)
+  await page.waitForTimeout(3_000)
+
+  const bodyText = await page
+    .locator('body')
+    .innerText({ timeout: 10_000 })
+    .catch(() => '')
+  if (isXLoginTemporarilyLimited(bodyText)) {
+    throw new Error(
+      'X temporarily limited broker login attempts. Wait before retrying browser login automation.',
+    )
+  }
+  if (isBrowserXLoginWallText(bodyText)) {
+    throw new Error(
+      'Broker login submitted, but X still shows a login wall or challenge.',
+    )
+  }
+}
+
+async function setupLogin(): Promise<void> {
+  const startedAt = new Date().toISOString()
+  const profilePath = xArticleBrowserProfilePath(profileHome())
+  await mkdir(profilePath, { recursive: true, mode: 0o700 })
+  const context = await chromium.launchPersistentContext(profilePath, {
+    headless: false,
+    viewport: { width: 1280, height: 900 },
+  })
+  const page = context.pages()[0] || (await context.newPage())
+  await page.goto('https://x.com/home', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  })
+  console.log(
+    'Opened dedicated X Article browser profile. Log into X in that browser window, then return here.',
+  )
+  console.log(
+    'Waiting up to 10 minutes. The session will be reused by autonomous extraction.',
+  )
+  await page.waitForTimeout(10 * 60 * 1000)
+  await context.close()
+  await writeRunSummary({
+    ok: true,
+    mode: 'setup-login',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    profilePath,
+    totalArticleCandidates: 0,
+    attempted: 0,
+    extracted: 0,
+    unavailable: 0,
+    error: 0,
+    remaining: 0,
+    items: [],
+  })
+}
+
+async function extractVisibleArticleText(
+  pageUrl: string,
+  sourceTweetId: string,
+  extractedAt: string,
+): Promise<XArticleExtraction> {
+  const profilePath = xArticleBrowserProfilePath(profileHome())
+  const context = await chromium.launchPersistentContext(profilePath, {
+    headless: true,
+    viewport: { width: 1280, height: 900 },
+  })
+  try {
+    const page = context.pages()[0] || (await context.newPage())
+    await page.goto(pageUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    await page
+      .waitForLoadState('networkidle', { timeout: 20_000 })
+      .catch(() => undefined)
+    await page.waitForTimeout(2_000)
+    let currentUrl = page.url()
+    let title = await page.title().catch(() => '')
+    let bodyText = await page
+      .locator('body')
+      .innerText({ timeout: 10_000 })
+      .catch(() => '')
+    let needsLogin = isBrowserXLoginWallText(bodyText)
+    if (
+      needsLogin &&
+      shouldAttemptBrokerLogin(
+        'Dedicated browser profile is not logged into X.',
+      )
+    ) {
+      await completeXLoginWithBroker(page)
+      await page.goto(pageUrl, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60_000,
+      })
+      await page
+        .waitForLoadState('networkidle', { timeout: 20_000 })
+        .catch(() => undefined)
+      await page.waitForTimeout(2_000)
+      currentUrl = page.url()
+      title = await page.title().catch(() => '')
+      bodyText = await page
+        .locator('body')
+        .innerText({ timeout: 10_000 })
+        .catch(() => '')
+      needsLogin = isBrowserXLoginWallText(bodyText)
+    }
+    return createBrowserXArticleExtraction({
+      articleUrl: currentUrl.includes('/i/article/') ? currentUrl : pageUrl,
+      sourceTweetId,
+      title: title.replace(/\s*\/ X$/, ''),
+      text: needsLogin ? '' : bodyText,
+      extractedAt,
+      error: needsLogin
+        ? 'Dedicated browser profile is not logged into X.'
+        : undefined,
+    })
+  } catch (err) {
+    return createBrowserXArticleExtraction({
+      articleUrl: pageUrl,
+      sourceTweetId,
+      text: '',
+      extractedAt,
+      error:
+        err instanceof Error
+          ? err.message
+          : 'Unknown logged-in browser extraction error.',
+    })
+  } finally {
+    await context.close()
+  }
+}
+
+async function runExtraction(): Promise<void> {
+  const startedAt = new Date().toISOString()
+  const profilePath = xArticleBrowserProfilePath(profileHome())
+  await mkdir(profilePath, { recursive: true, mode: 0o700 })
+  const limit = limitFromArgs()
+  const force = hasArg('--force')
+  const cache = await readBookmarkCache()
+  if (!cache) throw new Error('No X bookmark cache exists yet.')
+  const existing = await readXArticleExtractionCache()
+  const existingIds = new Set(
+    (existing?.items || [])
+      .filter((item) => item.status === 'extracted')
+      .map((item) => item.articleId),
+  )
+  const articleCandidates = cache.items
+    .map((item) => ({ item, articleUrl: xArticleUrl(item) }))
+    .filter(({ articleUrl }) => Boolean(articleUrl))
+  const targets = articleCandidates
+    .filter(
+      ({ articleUrl }) =>
+        force || !existingIds.has(xArticleIdFromUrl(articleUrl)),
+    )
+    .slice(0, limit)
+
+  const extractedAt = new Date().toISOString()
+  const items: Array<XArticleExtraction> = []
+  for (const target of targets) {
+    items.push(
+      await extractVisibleArticleText(
+        target.articleUrl,
+        target.item.id,
+        extractedAt,
+      ),
+    )
+  }
+  const merged = mergeXArticleExtractions({ existing, extractedAt, items })
+  await writeXArticleExtractionCache(merged)
+  const counts = {
+    extracted: items.filter((item) => item.status === 'extracted').length,
+    unavailable: items.filter((item) => item.status === 'unavailable').length,
+    error: items.filter((item) => item.status === 'error').length,
+  }
+  const remaining = Math.max(
+    articleCandidates.filter(
+      ({ articleUrl }) =>
+        !new Set(
+          merged.items
+            .filter((item) => item.status === 'extracted')
+            .map((item) => item.articleId),
+        ).has(xArticleIdFromUrl(articleUrl)),
+    ).length,
+    0,
+  )
+  const summary: RunSummary = {
+    ok: true,
+    mode: 'extract',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    profilePath,
+    totalArticleCandidates: articleCandidates.length,
+    attempted: items.length,
+    extracted: counts.extracted,
+    unavailable: counts.unavailable,
+    error: counts.error,
+    remaining,
+    items: items.map((item) => ({
+      articleId: item.articleId,
+      articleUrl: item.articleUrl,
+      sourceTweetId: item.sourceTweetId,
+      status: item.status,
+      title: item.title,
+      excerpt: item.excerpt,
+      extractedAt: item.extractedAt,
+      method: item.method,
+      error: item.error,
+    })),
+  }
+  await writeRunSummary(summary)
+  console.log(JSON.stringify(summary, null, 2))
+}
+
+async function main() {
+  try {
+    if (hasArg('--setup-login')) {
+      await setupLogin()
+    } else {
+      await runExtraction()
+    }
+  } catch (err) {
+    const summary: RunSummary = {
+      ok: false,
+      mode: hasArg('--setup-login') ? 'setup-login' : 'extract',
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      profilePath: xArticleBrowserProfilePath(profileHome()),
+      totalArticleCandidates: 0,
+      attempted: 0,
+      extracted: 0,
+      unavailable: 0,
+      error: 1,
+      remaining: 0,
+      items: [],
+      errorMessage:
+        err instanceof Error
+          ? err.message
+          : 'Unknown X Article browser extractor failure.',
+    }
+    await writeRunSummary(summary)
+    console.error(JSON.stringify(summary, null, 2))
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -6,6 +6,7 @@ import {
   Cancel01Icon,
   Castle02Icon,
   Chat01Icon,
+  CheckListIcon,
   Clock01Icon,
   CommandLineIcon,
   DashboardSquare01Icon,
@@ -70,6 +71,13 @@ export const MOBILE_HAMBURGER_NAV_ITEMS = [
     icon: Rocket01Icon,
     to: '/conductor',
     match: (p: string) => p.startsWith('/conductor'),
+  },
+  {
+    id: 'executive-queue',
+    label: 'Executive Queue',
+    icon: CheckListIcon,
+    to: '/executive-queue',
+    match: (p: string) => p.startsWith('/executive-queue'),
   },
   {
     id: 'operations',

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -21,11 +21,13 @@ import {
   useState,
 } from 'react'
 import { useNavigate, useRouterState } from '@tanstack/react-router'
-import { fetchClaudeAuthStatus, type AuthStatus } from '@/lib/claude-auth'
+import { useQuery } from '@tanstack/react-query'
+import type { SessionMeta } from '@/screens/chat/types'
+import type { AuthStatus } from '@/lib/claude-auth'
 import { cn } from '@/lib/utils'
 import { ConnectionStartupScreen } from '@/components/connection-startup-screen'
 import { ChatSidebar } from '@/screens/chat/components/chat-sidebar'
-import { useChatSessions } from '@/screens/chat/hooks/use-chat-sessions'
+import { chatQueryKeys } from '@/screens/chat/chat-queries'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { SIDEBAR_TOGGLE_EVENT } from '@/hooks/use-global-shortcuts'
 import { useSwipeNavigation } from '@/hooks/use-swipe-navigation'
@@ -39,7 +41,7 @@ import { MobilePageHeader } from '@/components/mobile-page-header'
 import { MobileTerminalInput } from '@/components/terminal/mobile-terminal-input'
 import { ClaudeReconnectBanner } from '@/components/claude-reconnect-banner'
 import { useMobileKeyboard } from '@/hooks/use-mobile-keyboard'
-import { SystemMetricsFooter } from '@/components/system-metrics-footer'
+// System metrics footer removed — not used in Hermes Workspace
 import { CommandPalette } from '@/components/command-palette'
 import { useSettings } from '@/hooks/use-settings'
 // ActivityTicker moved to dashboard-only (too noisy for global header)
@@ -50,8 +52,20 @@ const TerminalWorkspace = lazy(() =>
   })),
 )
 
+type SessionsListResponse = Array<SessionMeta>
 export const DESKTOP_SIDEBAR_BACKDROP_CLASS =
   'fixed left-0 bottom-0 top-[var(--titlebar-h,0px)] w-[300px] z-10 bg-black/10 backdrop-blur-[1px]'
+
+async function fetchSessions(): Promise<SessionsListResponse> {
+  const res = await fetch('/api/sessions')
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const data = await res.json()
+  return Array.isArray(data?.sessions)
+    ? data.sessions
+    : Array.isArray(data)
+      ? data
+      : []
+}
 
 type WorkspaceShellProps = {
   children?: React.ReactNode
@@ -61,9 +75,6 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const navigate = useNavigate()
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
-  })
-  const search = useRouterState({
-    select: (state) => state.location.search,
   })
   const isElectron = useMemo(
     () =>
@@ -98,13 +109,15 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (path.startsWith('/files')) return 2
     if (path.startsWith('/terminal')) return 3
     if (path.startsWith('/jobs')) return 4
-    if (path === '/swarm' || path.startsWith('/swarm2')) return 5
-    if (path.startsWith('/echo-studio')) return 5
-    if (path.startsWith('/memory')) return 6
-    if (path.startsWith('/skills')) return 7
-    if (path.startsWith('/mcp')) return 8
-    if (path.startsWith('/profiles')) return 9
-    if (path.startsWith('/settings')) return 10
+    if (path.startsWith('/agent-surfaces')) return 5
+    if (path.startsWith('/x-bookmarks')) return 6
+    if (path.startsWith('/learning-loop')) return 7
+    if (path.startsWith('/conductor')) return 8
+    if (path.startsWith('/operations')) return 9
+    if (path.startsWith('/memory')) return 10
+    if (path.startsWith('/skills')) return 11
+    if (path.startsWith('/profiles')) return 12
+    if (path.startsWith('/settings')) return 13
     return -1
   }, [])
 
@@ -125,59 +138,19 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     setConnectionVerified(true)
   }, [])
 
-  // Fallback startup verification in the shell itself.
-  // This prevents a bad loading loop if the splash component gets stuck even
-  // though /api/auth-check or /api/connection-status are already healthy.
-  useEffect(() => {
-    if (typeof window === 'undefined' || connectionVerified) return
-    let cancelled = false
-
-    const verify = async () => {
-      try {
-        const status = await fetchClaudeAuthStatus(3000)
-        if (cancelled) return
-        setAuthStatus(status)
-        setConnectionVerified(true)
-        return
-      } catch {
-        // Fall through to connection-status as a looser readiness signal.
-      }
-
-      try {
-        const res = await fetch('/api/connection-status', { cache: 'no-store' })
-        if (!res.ok || cancelled) return
-        const data = (await res.json()) as {
-          ok?: boolean
-          chatReady?: boolean
-          modelConfigured?: boolean
-        }
-        if (data?.ok || (data?.chatReady && data?.modelConfigured)) {
-          setAuthStatus({ authenticated: true, authRequired: false })
-          setConnectionVerified(true)
-        }
-      } catch {
-        // Keep the startup screen if both checks fail.
-      }
-    }
-
-    void verify()
-    return () => {
-      cancelled = true
-    }
-  }, [connectionVerified])
-
   // Derive active session from URL
   const mobilePageTitle = (() => {
     if (pathname.startsWith('/terminal')) return 'Terminal'
     if (pathname.startsWith('/files')) return 'Files'
     if (pathname.startsWith('/jobs')) return 'Jobs'
+    if (pathname.startsWith('/agent-surfaces')) return 'Agent Surfaces'
+    if (pathname.startsWith('/x-bookmarks')) return 'X Bookmark Intake'
+    if (pathname.startsWith('/learning-loop')) return 'Learning Loop'
+    if (pathname.startsWith('/executive-queue')) return 'Executive Queue'
     if (pathname.startsWith('/conductor')) return 'Conductor'
     if (pathname.startsWith('/operations')) return 'Operations'
-    if (pathname.startsWith('/swarm2') || pathname === '/swarm') return 'Swarm'
-    if (pathname.startsWith('/echo-studio')) return 'Echo Studio'
     if (pathname.startsWith('/memory')) return 'Memory'
     if (pathname.startsWith('/skills')) return 'Skills'
-    if (pathname.startsWith('/mcp')) return 'MCP'
     if (pathname.startsWith('/profiles')) return 'Profiles'
     if (pathname.startsWith('/settings')) return 'Settings'
     if (pathname.startsWith('/debug')) return 'Debug'
@@ -189,28 +162,30 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const activeFriendlyId = chatMatch ? chatMatch[1] : 'main'
   const isOnChatRoute = Boolean(chatMatch) || pathname === '/new'
   const isOnTerminalRoute = pathname.startsWith('/terminal')
-  const isOnPlaygroundRoute = pathname === '/playground' || pathname.startsWith('/playground/')
-  const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
-  const isEmbeddedSurface =
-    search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
-  const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =
-    !isChromeFreeSurface && !isMobile && !isOnChatRoute && !sidebarCollapsed
+    !isMobile && !isOnChatRoute && !sidebarCollapsed
 
-  const isNewChat = activeFriendlyId === 'new'
-
-  // Sessions state — shared semantic source for sidebar and chat header
-  const {
-    sessions,
-    sessionsLoading,
-    sessionsFetching,
-    sessionsError,
-    refetchSessions,
-  } = useChatSessions({
-    activeFriendlyId,
-    isNewChat,
+  // Sessions query — shared across sidebar and chat
+  const sessionsQuery = useQuery({
+    queryKey: chatQueryKeys.sessions,
+    queryFn: fetchSessions,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
   })
+
+  const sessions = sessionsQuery.data ?? []
+  const sessionsLoading = sessionsQuery.isLoading
+  const sessionsFetching = sessionsQuery.isFetching
+  const sessionsError = sessionsQuery.isError
+    ? sessionsQuery.error instanceof Error
+      ? sessionsQuery.error.message
+      : 'Failed to load sessions'
+    : null
+
+  const refetchSessions = useCallback(() => {
+    void sessionsQuery.refetch()
+  }, [sessionsQuery])
 
   const startNewChat = useCallback(() => {
     setCreatingSession(true)
@@ -290,13 +265,6 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
       window.removeEventListener(SIDEBAR_TOGGLE_EVENT, handleToggleEvent)
   }, [isMobile, setSidebarCollapsed, toggleSidebar])
 
-  // Public/launch surfaces should behave like normal web pages, not app-shell panes.
-  // This keeps /hermes-world and /world scrollable at the document level and avoids
-  // local-only workspace chrome for X/GitHub traffic.
-  if (isChromeFreeSurface) {
-    return <>{children}</>
-  }
-
   // Show login screen if auth is required and not authenticated
   if (authState.authRequired && !authState.authenticated) {
     return <LoginScreen />
@@ -344,12 +312,12 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
         <div
           className={cn(
             'grid h-full grid-cols-1 grid-rows-[minmax(0,1fr)] overflow-hidden',
-            hideChatSidebar || isChromeFreeSurface ? 'md:grid-cols-1' : 'md:grid-cols-[auto_1fr]',
+            hideChatSidebar ? 'md:grid-cols-1' : 'md:grid-cols-[auto_1fr]',
           )}
         >
           {/* Activity ticker bar */}
           {/* Persistent sidebar */}
-          {!isChromeFreeSurface && !isMobile && !hideChatSidebar && (
+          {!isMobile && !hideChatSidebar && (
             <div className="relative z-30">
               <ChatSidebar
                 sessions={sessions}
@@ -377,12 +345,11 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
               'h-full min-h-0 min-w-0 overflow-x-hidden bg-[var(--theme-bg)] relative',
               isOnChatRoute ? 'overflow-hidden' : 'overflow-y-auto',
               isMobile && !isOnChatRoute
-                ? 'pb-[calc(var(--tabbar-h,80px)+0.5rem)]'
+                ? 'pb-[calc(var(--tabbar-h,0px)+0.5rem)]'
                 : !isMobile &&
-                    !isChromeFreeSurface &&
                     !isOnChatRoute &&
                     settings.showSystemMetricsFooter
-                  ? 'pb-7'
+                  ? 'pb-[calc(1.5rem+1.75rem)]'
                   : '',
             ].join(' ')}
             data-tour="chat-area"
@@ -417,8 +384,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
             <div
               className={[
-                'page-transition flex flex-col',
-                isChromeFreeSurface ? 'min-h-full' : 'h-full',
+                'page-transition h-full flex flex-col',
                 slideClass,
                 isOnTerminalRoute ? 'hidden' : '',
               ]
@@ -426,7 +392,6 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 .join(' ')}
             >
               {isMobile &&
-                !isChromeFreeSurface &&
                 !isOnChatRoute &&
                 !isOnTerminalRoute &&
                 mobilePageTitle && <MobilePageHeader title={mobilePageTitle} />}
@@ -434,12 +399,12 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
             </div>
           </main>
 
-          {/* Chat panel — visible on non-chat routes (but not in HermesWorld, which has its own in-game chat) */}
-          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && <ChatPanel />}
+          {/* Chat panel — visible on non-chat routes */}
+          {!isOnChatRoute && !isMobile && <ChatPanel />}
         </div>
 
-        {/* Floating chat toggle — visible on non-chat routes (but not in HermesWorld) */}
-        {!isChromeFreeSurface && !isOnChatRoute && !isOnPlaygroundRoute && !isMobile && <ChatPanelToggle />}
+        {/* Floating chat toggle — visible on non-chat routes */}
+        {!isOnChatRoute && !isMobile && <ChatPanelToggle />}
 
         {showDesktopSidebarBackdrop ? (
           <button
@@ -455,12 +420,9 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
         ) : null}
       </div>
 
-      {!isChromeFreeSurface ? <MobileHamburgerMenu /> : null}
-      {!isChromeFreeSurface ? <MobileTabBar /> : null}
-      {!isChromeFreeSurface && !isMobile && !isOnChatRoute && settings.showSystemMetricsFooter ? (
-        <SystemMetricsFooter leftOffsetPx={sidebarCollapsed ? 48 : 300} />
-      ) : null}
-      {!isChromeFreeSurface ? <CommandPalette pathname={pathname} sessions={sessions} /> : null}
+      <MobileHamburgerMenu />
+      {/* System metrics footer removed */}
+      <CommandPalette pathname={pathname} sessions={sessions} />
     </>
   )
 }

--- a/src/features/agent-surfaces/agent-surface-renderer.tsx
+++ b/src/features/agent-surfaces/agent-surface-renderer.tsx
@@ -1,0 +1,409 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type {
+  AgentSurface,
+  AgentSurfaceAction,
+  AgentSurfaceBlock,
+  AgentSurfaceTone,
+} from './types'
+import { cn } from '@/lib/utils'
+
+type AgentSurfaceRendererProps = {
+  surface: AgentSurface
+  onAction?: (action: AgentSurfaceAction, block: AgentSurfaceBlock) => void
+}
+
+const toneClasses: Record<AgentSurfaceTone, string> = {
+  neutral:
+    'border-[var(--theme-border)] bg-[var(--theme-card)] text-[var(--theme-muted)]',
+  success: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
+  warning: 'border-amber-400/30 bg-amber-400/10 text-amber-300',
+  danger: 'border-red-400/30 bg-red-400/10 text-red-300',
+  info: 'border-sky-400/30 bg-sky-400/10 text-sky-300',
+}
+
+const riskClasses = {
+  Low: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
+  Medium: 'border-amber-400/30 bg-amber-400/10 text-amber-300',
+  High: 'border-red-400/30 bg-red-400/10 text-red-300',
+}
+
+const confidenceLabels = {
+  verified: 'Verified fact',
+  informed_judgment: 'Informed judgment',
+  speculative: 'Speculative bet',
+}
+
+function Pill({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <span
+      className={cn(
+        'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+function SurfaceActionButton({
+  action,
+  block,
+  onAction,
+}: {
+  action: AgentSurfaceAction
+  block: AgentSurfaceBlock
+  onAction?: (action: AgentSurfaceAction, block: AgentSurfaceBlock) => void
+}) {
+  const intent =
+    action.kind === 'approve' || action.kind === 'run' ? 'primary' : 'secondary'
+  const label = action.requiresApproval ? `${action.label} *` : action.label
+
+  if (action.href) {
+    return (
+      <a
+        href={action.href}
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          'rounded-xl border px-3 py-2 text-xs font-semibold transition',
+          intent === 'primary'
+            ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/10 text-ink hover:bg-[var(--theme-accent)]/20'
+            : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:border-[var(--theme-accent)] hover:text-ink',
+        )}
+      >
+        {label}
+      </a>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onAction?.(action, block)}
+      className={cn(
+        'rounded-xl border px-3 py-2 text-xs font-semibold transition',
+        intent === 'primary'
+          ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/10 text-ink hover:bg-[var(--theme-accent)]/20'
+          : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:border-[var(--theme-accent)] hover:text-ink',
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+function DecisionCard({
+  block,
+  onAction,
+}: {
+  block: Extract<AgentSurfaceBlock, { type: 'decision_card' }>
+  onAction?: (action: AgentSurfaceAction, block: AgentSurfaceBlock) => void
+}) {
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+            Decision
+          </p>
+          <h2 className="mt-1 text-xl font-semibold text-ink">{block.title}</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {block.priority ? (
+            <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+              {block.priority}
+            </Pill>
+          ) : null}
+          {block.risk ? (
+            <Pill className={riskClasses[block.risk]}>{block.risk} risk</Pill>
+          ) : null}
+          {block.status ? (
+            <Pill className="border-sky-400/30 bg-sky-400/10 text-sky-300">
+              {block.status}
+            </Pill>
+          ) : null}
+        </div>
+      </div>
+      <p className="mt-4 text-base leading-relaxed text-ink">
+        {block.recommendation}
+      </p>
+      {block.why ? (
+        <p className="mt-3 text-sm leading-relaxed text-[var(--theme-muted)]">
+          Why: {block.why}
+        </p>
+      ) : null}
+      {block.owner ? (
+        <p className="mt-3 text-xs text-[var(--theme-muted)]">
+          Owner: <span className="text-ink">{block.owner}</span>
+        </p>
+      ) : null}
+      {block.actions?.length ? (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {block.actions.map((action) => (
+            <SurfaceActionButton
+              key={action.id}
+              action={action}
+              block={block}
+              onAction={onAction}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function ApprovalAction({
+  block,
+  onAction,
+}: {
+  block: Extract<AgentSurfaceBlock, { type: 'approval_action' }>
+  onAction?: (action: AgentSurfaceAction, block: AgentSurfaceBlock) => void
+}) {
+  return (
+    <section className="rounded-3xl border border-amber-400/25 bg-amber-400/5 p-5">
+      <p className="text-xs uppercase tracking-[0.18em] text-amber-300">
+        Approval gate
+      </p>
+      <h2 className="mt-1 text-lg font-semibold text-ink">{block.title}</h2>
+      <p className="mt-3 text-sm leading-relaxed text-[var(--theme-muted)]">
+        {block.prompt}
+      </p>
+      {block.approvalNote ? (
+        <p className="mt-3 rounded-2xl border border-amber-400/20 bg-amber-400/10 p-3 text-xs text-amber-200">
+          {block.approvalNote}
+        </p>
+      ) : null}
+      <div className="mt-4 flex flex-wrap gap-2">
+        {block.actions.map((action) => (
+          <SurfaceActionButton
+            key={action.id}
+            action={action}
+            block={block}
+            onAction={onAction}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function EvidenceLink({
+  block,
+}: {
+  block: Extract<AgentSurfaceBlock, { type: 'evidence_link' }>
+}) {
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+            Evidence
+          </p>
+          <a
+            href={block.url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-1 block text-lg font-semibold text-ink hover:text-[var(--theme-accent)]"
+          >
+            {block.title}
+          </a>
+        </div>
+        {block.confidence ? (
+          <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+            {confidenceLabels[block.confidence]}
+          </Pill>
+        ) : null}
+      </div>
+      {block.source ? (
+        <p className="mt-2 text-xs text-[var(--theme-muted)]">{block.source}</p>
+      ) : null}
+      {block.excerpt ? (
+        <blockquote className="mt-4 border-l-2 border-[var(--theme-accent)] pl-4 text-sm leading-relaxed text-[var(--theme-muted)]">
+          {block.excerpt}
+        </blockquote>
+      ) : null}
+    </section>
+  )
+}
+
+function Checklist({
+  block,
+}: {
+  block: Extract<AgentSurfaceBlock, { type: 'checklist' }>
+}) {
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+      <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+        Checklist
+      </p>
+      <h2 className="mt-1 text-lg font-semibold text-ink">{block.title}</h2>
+      <div className="mt-4 space-y-3">
+        {block.items.map((item) => (
+          <div
+            key={item.id}
+            className="flex gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3"
+          >
+            <span
+              className={cn(
+                'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-xs',
+                item.done
+                  ? 'border-emerald-400/40 bg-emerald-400/10 text-emerald-300'
+                  : 'border-[var(--theme-border)] text-[var(--theme-muted)]',
+              )}
+            >
+              {item.done ? '✓' : '•'}
+            </span>
+            <div>
+              <p className="text-sm font-medium text-ink">{item.label}</p>
+              {item.detail ? (
+                <p className="mt-1 text-xs leading-relaxed text-[var(--theme-muted)]">
+                  {item.detail}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function StatusItem({
+  block,
+}: {
+  block: Extract<AgentSurfaceBlock, { type: 'status_item' }>
+}) {
+  return (
+    <section
+      className={cn(
+        'rounded-3xl border p-5',
+        toneClasses[block.tone ?? 'neutral'],
+      )}
+    >
+      <p className="text-xs uppercase tracking-[0.18em] opacity-80">
+        {block.label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold text-ink">{block.value}</p>
+      {block.detail ? (
+        <p className="mt-2 text-sm leading-relaxed opacity-85">
+          {block.detail}
+        </p>
+      ) : null}
+    </section>
+  )
+}
+
+function SurfaceBlock({
+  block,
+  onAction,
+}: {
+  block: AgentSurfaceBlock
+  onAction?: (action: AgentSurfaceAction, block: AgentSurfaceBlock) => void
+}) {
+  switch (block.type) {
+    case 'decision_card':
+      return <DecisionCard block={block} onAction={onAction} />
+    case 'approval_action':
+      return <ApprovalAction block={block} onAction={onAction} />
+    case 'evidence_link':
+      return <EvidenceLink block={block} />
+    case 'checklist':
+      return <Checklist block={block} />
+    case 'status_item':
+      return <StatusItem block={block} />
+  }
+}
+
+export function AgentSurfaceRenderer({
+  surface,
+  onAction,
+}: AgentSurfaceRendererProps) {
+  const generatedAt = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(surface.generatedAt))
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-4 py-6 text-ink md:px-8 lg:px-10">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="rounded-[2rem] border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-sm md:p-8">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.22em] text-[var(--theme-muted)]">
+                Agent Surface
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                {surface.title}
+              </h1>
+              {surface.description ? (
+                <p className="mt-3 max-w-3xl text-sm leading-relaxed text-[var(--theme-muted)] md:text-base">
+                  {surface.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-xs text-[var(--theme-muted)]">
+              <div>
+                Schema: <span className="text-ink">{surface.schema}</span>
+              </div>
+              <div>
+                Generated: <span className="text-ink">{generatedAt}</span>
+              </div>
+              <div>
+                Agent: <span className="text-ink">{surface.source.agent}</span>
+              </div>
+            </div>
+          </div>
+        </header>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-4">
+            {surface.blocks
+              .filter((block) => block.type !== 'status_item')
+              .map((block) => (
+                <SurfaceBlock
+                  key={block.id}
+                  block={block}
+                  onAction={onAction}
+                />
+              ))}
+          </div>
+          <aside className="space-y-4">
+            {surface.blocks
+              .filter((block) => block.type === 'status_item')
+              .map((block) => (
+                <SurfaceBlock
+                  key={block.id}
+                  block={block}
+                  onAction={onAction}
+                />
+              ))}
+            <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+                Workflow
+              </p>
+              <p className="mt-2 text-sm text-ink">{surface.source.workflow}</p>
+              {surface.source.profile ? (
+                <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                  Profile: {surface.source.profile}
+                </p>
+              ) : null}
+              <p className="mt-4 text-xs leading-relaxed text-[var(--theme-muted)]">
+                * Approval-marked actions are visual only in this pilot. Live
+                side effects need explicit wiring and approval gates.
+              </p>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/agent-surfaces/sample-surface.test.ts
+++ b/src/features/agent-surfaces/sample-surface.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createSampleAgentSurface } from './sample-surface'
+
+describe('createSampleAgentSurface', () => {
+  it('creates a stable v1 surface with the five starter block types', () => {
+    const surface = createSampleAgentSurface(
+      new Date('2026-06-03T17:12:23.000Z'),
+    )
+
+    expect(surface.schema).toBe('hermes.agent_surface.v1')
+    expect(surface.generatedAt).toBe('2026-06-03T17:12:23.000Z')
+    expect(surface.source.workflow).toBe('AI Learning Review')
+    expect(surface.blocks.map((block) => block.type)).toEqual([
+      'status_item',
+      'decision_card',
+      'approval_action',
+      'checklist',
+      'evidence_link',
+    ])
+  })
+})

--- a/src/features/agent-surfaces/sample-surface.ts
+++ b/src/features/agent-surfaces/sample-surface.ts
@@ -1,0 +1,119 @@
+import type { AgentSurface } from './types'
+
+export function createSampleAgentSurface(now = new Date()): AgentSurface {
+  return {
+    schema: 'hermes.agent_surface.v1',
+    id: 'ai-learning-review-pilot',
+    title: 'AI Learning Review Surface',
+    description:
+      'A first reusable surface contract for turning dense agent output into decision cards, approval actions, evidence, checklists, and status items.',
+    generatedAt: now.toISOString(),
+    source: {
+      agent: 'AI Dev Guru',
+      workflow: 'AI Learning Review',
+      profile: 'ai-dev',
+    },
+    blocks: [
+      {
+        type: 'status_item',
+        id: 'surface-contract',
+        label: 'Surface contract',
+        value: 'v1 ready',
+        tone: 'success',
+        detail:
+          'Agents can emit the same JSON shape and Workspace can render it without bespoke UI for every workflow.',
+      },
+      {
+        type: 'decision_card',
+        id: 'pilot-ai-learning',
+        title: 'Use AI Learning as the first generative UI pilot',
+        recommendation:
+          'Render weekly AI Learning as an interactive review board before wiring higher-risk workflows.',
+        why: 'It is dense, recurring, low-risk, teachable, and already fits Tim’s HTML artifact pattern.',
+        owner: 'AI Dev Guru',
+        priority: 'P1',
+        risk: 'Low',
+        status: 'Proposed',
+        actions: [
+          {
+            id: 'approve-pilot',
+            label: 'Approve pilot',
+            kind: 'approve',
+            description:
+              'Authorize wiring a real AI Learning run into this surface contract.',
+            requiresApproval: true,
+          },
+          {
+            id: 'hold-pilot',
+            label: 'Hold',
+            kind: 'hold',
+            description:
+              'Keep the renderer available but do not connect live workflows yet.',
+          },
+        ],
+      },
+      {
+        type: 'approval_action',
+        id: 'next-wire-ai-learning',
+        title: 'Next implementation gate',
+        prompt:
+          'Wire the next AI Learning output to emit hermes.agent_surface.v1 JSON alongside the Telegram summary.',
+        approvalNote:
+          'This is intentionally approval-gated because it changes workflow output shape, not because it sends public content.',
+        actions: [
+          {
+            id: 'draft-integration-plan',
+            label: 'Draft integration plan',
+            kind: 'draft',
+            description:
+              'Prepare the exact files and cron prompt changes for review.',
+          },
+          {
+            id: 'run-sample-only',
+            label: 'Run sample only',
+            kind: 'run',
+            description:
+              'Keep using mock/sample data until the contract is reviewed.',
+          },
+        ],
+      },
+      {
+        type: 'checklist',
+        id: 'surface-rules',
+        title: 'Renderer rules',
+        items: [
+          {
+            id: 'fixed-contract',
+            label: 'Use one stable JSON contract for the long tail',
+            done: true,
+            detail: 'This is the declarative pattern from the article.',
+          },
+          {
+            id: 'controlled-top-flows',
+            label: 'Upgrade top workflows to controlled components later',
+            done: false,
+            detail:
+              'Executive approvals and finance exceptions deserve exact components.',
+          },
+          {
+            id: 'no-open-default',
+            label: 'Do not use raw model-generated HTML as the default',
+            done: true,
+            detail:
+              'Open-ended HTML is useful only for disposable visualizations.',
+          },
+        ],
+      },
+      {
+        type: 'evidence_link',
+        id: 'source-x-article',
+        title: 'Source idea: Generative UI Is the New Frontend',
+        url: 'https://x.com/Saboo_Shubham_/status/2062220865643982875',
+        source: 'X Article by Shubham Saboo',
+        excerpt:
+          'Controlled for exact flows. Declarative for the long tail. Open-ended for disposable visualizations.',
+        confidence: 'verified',
+      },
+    ],
+  }
+}

--- a/src/features/agent-surfaces/types.ts
+++ b/src/features/agent-surfaces/types.ts
@@ -1,0 +1,96 @@
+export type AgentSurfaceTone =
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'info'
+
+export type AgentSurfaceAction = {
+  id: string
+  label: string
+  kind: 'approve' | 'hold' | 'draft' | 'run' | 'open' | 'copy'
+  description?: string
+  href?: string
+  command?: string
+  requiresApproval?: boolean
+}
+
+export type AgentSurfaceDecisionCard = {
+  type: 'decision_card'
+  id: string
+  title: string
+  recommendation: string
+  why?: string
+  owner?: string
+  priority?: 'P0' | 'P1' | 'P2' | 'P3'
+  risk?: 'Low' | 'Medium' | 'High'
+  status?:
+    | 'Proposed'
+    | 'Approved'
+    | 'Queued'
+    | 'In Progress'
+    | 'Blocked'
+    | 'Done'
+  actions?: Array<AgentSurfaceAction>
+}
+
+export type AgentSurfaceApprovalAction = {
+  type: 'approval_action'
+  id: string
+  title: string
+  prompt: string
+  actions: Array<AgentSurfaceAction>
+  approvalNote?: string
+}
+
+export type AgentSurfaceEvidenceLink = {
+  type: 'evidence_link'
+  id: string
+  title: string
+  url: string
+  source?: string
+  excerpt?: string
+  confidence?: 'verified' | 'informed_judgment' | 'speculative'
+}
+
+export type AgentSurfaceChecklist = {
+  type: 'checklist'
+  id: string
+  title: string
+  items: Array<{
+    id: string
+    label: string
+    done?: boolean
+    detail?: string
+  }>
+}
+
+export type AgentSurfaceStatusItem = {
+  type: 'status_item'
+  id: string
+  label: string
+  value: string
+  tone?: AgentSurfaceTone
+  detail?: string
+}
+
+export type AgentSurfaceBlock =
+  | AgentSurfaceDecisionCard
+  | AgentSurfaceApprovalAction
+  | AgentSurfaceEvidenceLink
+  | AgentSurfaceChecklist
+  | AgentSurfaceStatusItem
+
+export type AgentSurface = {
+  schema: 'hermes.agent_surface.v1'
+  id: string
+  title: string
+  description?: string
+  generatedAt: string
+  source: {
+    agent: string
+    workflow: string
+    profile?: string
+  }
+  blocks: Array<AgentSurfaceBlock>
+}

--- a/src/features/learning-loop/types.ts
+++ b/src/features/learning-loop/types.ts
@@ -1,0 +1,37 @@
+export type LearningLoopItemKind = 'memory' | 'skill'
+
+export type LearningLoopReviewStatus = 'new' | 'recent' | 'stable'
+
+export type LearningLoopRiskLevel = 'low' | 'medium' | 'high'
+
+export type LearningLoopReviewItem = {
+  id: string
+  kind: LearningLoopItemKind
+  profile: string
+  name: string
+  relativePath: string
+  updatedAt: string
+  ageHours: number
+  status: LearningLoopReviewStatus
+  risk: LearningLoopRiskLevel
+  reviewFlags: Array<string>
+  summary: string
+  details?: string
+}
+
+export type LearningLoopReview = {
+  ok: boolean
+  generatedAt: string
+  windowHours: number
+  profiles: Array<string>
+  items: Array<LearningLoopReviewItem>
+  counts: {
+    total: number
+    memory: number
+    skill: number
+    highRisk: number
+    mediumRisk: number
+    reviewNeeded: number
+  }
+  error?: string
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,8 +9,11 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as XBookmarksRouteImport } from './routes/x-bookmarks'
+import { Route as XBookmarkReviewRouteImport } from './routes/x-bookmark-review'
 import { Route as WorldRouteImport } from './routes/world'
 import { Route as VtCapitalRouteImport } from './routes/vt-capital'
+import { Route as VoiceLabRouteImport } from './routes/voice-lab'
 import { Route as TerminalRouteImport } from './routes/terminal'
 import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as Swarm2RouteImport } from './routes/swarm2'
@@ -23,14 +26,17 @@ import { Route as PlaygroundRouteImport } from './routes/playground'
 import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as McpRouteImport } from './routes/mcp'
+import { Route as LearningLoopRouteImport } from './routes/learning-loop'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
+import { Route as ExecutiveQueueRouteImport } from './routes/executive-queue'
 import { Route as EchoStudioRouteImport } from './routes/echo-studio'
 import { Route as EarlyAccessRouteImport } from './routes/early-access'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
 import { Route as AgoraRouteImport } from './routes/agora'
+import { Route as AgentSurfacesRouteImport } from './routes/agent-surfaces'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -40,6 +46,7 @@ import { Route as ReserveConfirmRouteImport } from './routes/reserve/confirm'
 import { Route as ChatSessionKeyRouteImport } from './routes/chat/$sessionKey'
 import { Route as ApiWorkspaceRouteImport } from './routes/api/workspace'
 import { Route as ApiVtCapitalRouteImport } from './routes/api/vt-capital'
+import { Route as ApiVoiceLabLedgerRouteImport } from './routes/api/voice-lab-ledger'
 import { Route as ApiTranscribeRouteImport } from './routes/api/transcribe'
 import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-stream'
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
@@ -67,6 +74,7 @@ import { Route as ApiSwarmCheckpointRouteImport } from './routes/api/swarm-check
 import { Route as ApiSwarmChatRouteImport } from './routes/api/swarm-chat'
 import { Route as ApiStartClaudeRouteImport } from './routes/api/start-claude'
 import { Route as ApiStartAgentRouteImport } from './routes/api/start-agent'
+import { Route as ApiSourceCoverageRouteImport } from './routes/api/source-coverage'
 import { Route as ApiSkillsRouteImport } from './routes/api/skills'
 import { Route as ApiSessionsRouteImport } from './routes/api/sessions'
 import { Route as ApiSessionStatusRouteImport } from './routes/api/session-status'
@@ -93,7 +101,11 @@ import { Route as ApiHermesConfigRouteImport } from './routes/api/hermes-config'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
+import { Route as ApiExecutiveQueueNotionSyncRouteImport } from './routes/api/executive-queue-notion-sync'
+import { Route as ApiExecutiveQueueExecutionRouteImport } from './routes/api/executive-queue-execution'
+import { Route as ApiExecutiveQueueRouteImport } from './routes/api/executive-queue'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
+import { Route as ApiElevenlabsTokenRouteImport } from './routes/api/elevenlabs-token'
 import { Route as ApiCrewStatusRouteImport } from './routes/api/crew-status'
 import { Route as ApiContextUsageRouteImport } from './routes/api/context-usage'
 import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection-status'
@@ -112,6 +124,13 @@ import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiArtifactsRouteImport } from './routes/api/artifacts'
 import { Route as ApiAgentBusRouteImport } from './routes/api/agent-bus'
+import { Route as ApiXBookmarksStatusRouteImport } from './routes/api/x-bookmarks/status'
+import { Route as ApiXBookmarksReviewRouteImport } from './routes/api/x-bookmarks/review'
+import { Route as ApiXBookmarksImportArticleRouteImport } from './routes/api/x-bookmarks/import-article'
+import { Route as ApiXBookmarksFetchRouteImport } from './routes/api/x-bookmarks/fetch'
+import { Route as ApiXBookmarksExtractArticlesRouteImport } from './routes/api/x-bookmarks/extract-articles'
+import { Route as ApiXBookmarksCallbackRouteImport } from './routes/api/x-bookmarks/callback'
+import { Route as ApiXBookmarksAuthorizeRouteImport } from './routes/api/x-bookmarks/authorize'
 import { Route as ApiUpdateWorkspaceRouteImport } from './routes/api/update/workspace'
 import { Route as ApiUpdateStatusRouteImport } from './routes/api/update/status'
 import { Route as ApiUpdateAgentRouteImport } from './routes/api/update/agent'
@@ -147,6 +166,7 @@ import { Route as ApiMcpHubSearchRouteImport } from './routes/api/mcp/hub-search
 import { Route as ApiMcpDiscoverRouteImport } from './routes/api/mcp/discover'
 import { Route as ApiMcpConfigureRouteImport } from './routes/api/mcp/configure'
 import { Route as ApiMcpNameRouteImport } from './routes/api/mcp/$name'
+import { Route as ApiLearningLoopReviewRouteImport } from './routes/api/learning-loop/review'
 import { Route as ApiKnowledgeSyncRouteImport } from './routes/api/knowledge/sync'
 import { Route as ApiKnowledgeSearchRouteImport } from './routes/api/knowledge/search'
 import { Route as ApiKnowledgeReadRouteImport } from './routes/api/knowledge/read'
@@ -163,6 +183,7 @@ import { Route as ApiClaudeTasksTaskIdRouteImport } from './routes/api/claude-ta
 import { Route as ApiClaudeProxySplatRouteImport } from './routes/api/claude-proxy/$'
 import { Route as ApiClaudeJobsJobIdRouteImport } from './routes/api/claude-jobs.$jobId'
 import { Route as ApiArtifactsArtifactIdRouteImport } from './routes/api/artifacts.$artifactId'
+import { Route as ApiAgentSurfacesSampleRouteImport } from './routes/api/agent-surfaces/sample'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
 import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api/sessions/$sessionKey.active-run'
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
@@ -170,6 +191,16 @@ import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
 import { Route as ApiRunsSessionKeyRunIdAbandonRouteImport } from './routes/api/runs/$sessionKey.$runId.abandon'
 
+const XBookmarksRoute = XBookmarksRouteImport.update({
+  id: '/x-bookmarks',
+  path: '/x-bookmarks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const XBookmarkReviewRoute = XBookmarkReviewRouteImport.update({
+  id: '/x-bookmark-review',
+  path: '/x-bookmark-review',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const WorldRoute = WorldRouteImport.update({
   id: '/world',
   path: '/world',
@@ -178,6 +209,11 @@ const WorldRoute = WorldRouteImport.update({
 const VtCapitalRoute = VtCapitalRouteImport.update({
   id: '/vt-capital',
   path: '/vt-capital',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const VoiceLabRoute = VoiceLabRouteImport.update({
+  id: '/voice-lab',
+  path: '/voice-lab',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TerminalRoute = TerminalRouteImport.update({
@@ -240,6 +276,11 @@ const McpRoute = McpRouteImport.update({
   path: '/mcp',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LearningLoopRoute = LearningLoopRouteImport.update({
+  id: '/learning-loop',
+  path: '/learning-loop',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JobsRoute = JobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
@@ -253,6 +294,11 @@ const HermesWorldRoute = HermesWorldRouteImport.update({
 const FilesRoute = FilesRouteImport.update({
   id: '/files',
   path: '/files',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ExecutiveQueueRoute = ExecutiveQueueRouteImport.update({
+  id: '/executive-queue',
+  path: '/executive-queue',
   getParentRoute: () => rootRouteImport,
 } as any)
 const EchoStudioRoute = EchoStudioRouteImport.update({
@@ -278,6 +324,11 @@ const ConductorRoute = ConductorRouteImport.update({
 const AgoraRoute = AgoraRouteImport.update({
   id: '/agora',
   path: '/agora',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentSurfacesRoute = AgentSurfacesRouteImport.update({
+  id: '/agent-surfaces',
+  path: '/agent-surfaces',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -323,6 +374,11 @@ const ApiWorkspaceRoute = ApiWorkspaceRouteImport.update({
 const ApiVtCapitalRoute = ApiVtCapitalRouteImport.update({
   id: '/api/vt-capital',
   path: '/api/vt-capital',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiVoiceLabLedgerRoute = ApiVoiceLabLedgerRouteImport.update({
+  id: '/api/voice-lab-ledger',
+  path: '/api/voice-lab-ledger',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiTranscribeRoute = ApiTranscribeRouteImport.update({
@@ -461,6 +517,11 @@ const ApiStartAgentRoute = ApiStartAgentRouteImport.update({
   path: '/api/start-agent',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSourceCoverageRoute = ApiSourceCoverageRouteImport.update({
+  id: '/api/source-coverage',
+  path: '/api/source-coverage',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSkillsRoute = ApiSkillsRouteImport.update({
   id: '/api/skills',
   path: '/api/skills',
@@ -591,9 +652,31 @@ const ApiFilesRoute = ApiFilesRouteImport.update({
   path: '/api/files',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiExecutiveQueueNotionSyncRoute =
+  ApiExecutiveQueueNotionSyncRouteImport.update({
+    id: '/api/executive-queue-notion-sync',
+    path: '/api/executive-queue-notion-sync',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiExecutiveQueueExecutionRoute =
+  ApiExecutiveQueueExecutionRouteImport.update({
+    id: '/api/executive-queue-execution',
+    path: '/api/executive-queue-execution',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiExecutiveQueueRoute = ApiExecutiveQueueRouteImport.update({
+  id: '/api/executive-queue',
+  path: '/api/executive-queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiEventsRoute = ApiEventsRouteImport.update({
   id: '/api/events',
   path: '/api/events',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiElevenlabsTokenRoute = ApiElevenlabsTokenRouteImport.update({
+  id: '/api/elevenlabs-token',
+  path: '/api/elevenlabs-token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiCrewStatusRoute = ApiCrewStatusRouteImport.update({
@@ -684,6 +767,43 @@ const ApiArtifactsRoute = ApiArtifactsRouteImport.update({
 const ApiAgentBusRoute = ApiAgentBusRouteImport.update({
   id: '/api/agent-bus',
   path: '/api/agent-bus',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiXBookmarksStatusRoute = ApiXBookmarksStatusRouteImport.update({
+  id: '/api/x-bookmarks/status',
+  path: '/api/x-bookmarks/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiXBookmarksReviewRoute = ApiXBookmarksReviewRouteImport.update({
+  id: '/api/x-bookmarks/review',
+  path: '/api/x-bookmarks/review',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiXBookmarksImportArticleRoute =
+  ApiXBookmarksImportArticleRouteImport.update({
+    id: '/api/x-bookmarks/import-article',
+    path: '/api/x-bookmarks/import-article',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiXBookmarksFetchRoute = ApiXBookmarksFetchRouteImport.update({
+  id: '/api/x-bookmarks/fetch',
+  path: '/api/x-bookmarks/fetch',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiXBookmarksExtractArticlesRoute =
+  ApiXBookmarksExtractArticlesRouteImport.update({
+    id: '/api/x-bookmarks/extract-articles',
+    path: '/api/x-bookmarks/extract-articles',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiXBookmarksCallbackRoute = ApiXBookmarksCallbackRouteImport.update({
+  id: '/api/x-bookmarks/callback',
+  path: '/api/x-bookmarks/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiXBookmarksAuthorizeRoute = ApiXBookmarksAuthorizeRouteImport.update({
+  id: '/api/x-bookmarks/authorize',
+  path: '/api/x-bookmarks/authorize',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiUpdateWorkspaceRoute = ApiUpdateWorkspaceRouteImport.update({
@@ -861,6 +981,11 @@ const ApiMcpNameRoute = ApiMcpNameRouteImport.update({
   path: '/$name',
   getParentRoute: () => ApiMcpRoute,
 } as any)
+const ApiLearningLoopReviewRoute = ApiLearningLoopReviewRouteImport.update({
+  id: '/api/learning-loop/review',
+  path: '/api/learning-loop/review',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiKnowledgeSyncRoute = ApiKnowledgeSyncRouteImport.update({
   id: '/api/knowledge/sync',
   path: '/api/knowledge/sync',
@@ -944,6 +1069,11 @@ const ApiArtifactsArtifactIdRoute = ApiArtifactsArtifactIdRouteImport.update({
   path: '/$artifactId',
   getParentRoute: () => ApiArtifactsRoute,
 } as any)
+const ApiAgentSurfacesSampleRoute = ApiAgentSurfacesSampleRouteImport.update({
+  id: '/api/agent-surfaces/sample',
+  path: '/api/agent-surfaces/sample',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSessionsSessionKeyStatusRoute =
   ApiSessionsSessionKeyStatusRouteImport.update({
     id: '/$sessionKey/status',
@@ -982,14 +1112,17 @@ const ApiRunsSessionKeyRunIdAbandonRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-surfaces': typeof AgentSurfacesRoute
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
   '/echo-studio': typeof EchoStudioRoute
+  '/executive-queue': typeof ExecutiveQueueRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
+  '/learning-loop': typeof LearningLoopRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -1002,8 +1135,11 @@ export interface FileRoutesByFullPath {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/voice-lab': typeof VoiceLabRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/x-bookmark-review': typeof XBookmarkReviewRoute
+  '/x-bookmarks': typeof XBookmarksRoute
   '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1022,7 +1158,11 @@ export interface FileRoutesByFullPath {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/elevenlabs-token': typeof ApiElevenlabsTokenRoute
   '/api/events': typeof ApiEventsRoute
+  '/api/executive-queue': typeof ApiExecutiveQueueRoute
+  '/api/executive-queue-execution': typeof ApiExecutiveQueueExecutionRoute
+  '/api/executive-queue-notion-sync': typeof ApiExecutiveQueueNotionSyncRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -1049,6 +1189,7 @@ export interface FileRoutesByFullPath {
   '/api/session-status': typeof ApiSessionStatusRoute
   '/api/sessions': typeof ApiSessionsRouteWithChildren
   '/api/skills': typeof ApiSkillsRouteWithChildren
+  '/api/source-coverage': typeof ApiSourceCoverageRoute
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
@@ -1076,6 +1217,7 @@ export interface FileRoutesByFullPath {
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
   '/api/transcribe': typeof ApiTranscribeRoute
+  '/api/voice-lab-ledger': typeof ApiVoiceLabLedgerRoute
   '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
@@ -1083,6 +1225,7 @@ export interface FileRoutesByFullPath {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/agent-surfaces/sample': typeof ApiAgentSurfacesSampleRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1099,6 +1242,7 @@ export interface FileRoutesByFullPath {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/learning-loop/review': typeof ApiLearningLoopReviewRoute
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1134,6 +1278,13 @@ export interface FileRoutesByFullPath {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/x-bookmarks/authorize': typeof ApiXBookmarksAuthorizeRoute
+  '/api/x-bookmarks/callback': typeof ApiXBookmarksCallbackRoute
+  '/api/x-bookmarks/extract-articles': typeof ApiXBookmarksExtractArticlesRoute
+  '/api/x-bookmarks/fetch': typeof ApiXBookmarksFetchRoute
+  '/api/x-bookmarks/import-article': typeof ApiXBookmarksImportArticleRoute
+  '/api/x-bookmarks/review': typeof ApiXBookmarksReviewRoute
+  '/api/x-bookmarks/status': typeof ApiXBookmarksStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1144,14 +1295,17 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-surfaces': typeof AgentSurfacesRoute
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
   '/echo-studio': typeof EchoStudioRoute
+  '/executive-queue': typeof ExecutiveQueueRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
+  '/learning-loop': typeof LearningLoopRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -1163,8 +1317,11 @@ export interface FileRoutesByTo {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/voice-lab': typeof VoiceLabRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/x-bookmark-review': typeof XBookmarkReviewRoute
+  '/x-bookmarks': typeof XBookmarksRoute
   '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1183,7 +1340,11 @@ export interface FileRoutesByTo {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/elevenlabs-token': typeof ApiElevenlabsTokenRoute
   '/api/events': typeof ApiEventsRoute
+  '/api/executive-queue': typeof ApiExecutiveQueueRoute
+  '/api/executive-queue-execution': typeof ApiExecutiveQueueExecutionRoute
+  '/api/executive-queue-notion-sync': typeof ApiExecutiveQueueNotionSyncRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -1210,6 +1371,7 @@ export interface FileRoutesByTo {
   '/api/session-status': typeof ApiSessionStatusRoute
   '/api/sessions': typeof ApiSessionsRouteWithChildren
   '/api/skills': typeof ApiSkillsRouteWithChildren
+  '/api/source-coverage': typeof ApiSourceCoverageRoute
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
@@ -1237,6 +1399,7 @@ export interface FileRoutesByTo {
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
   '/api/transcribe': typeof ApiTranscribeRoute
+  '/api/voice-lab-ledger': typeof ApiVoiceLabLedgerRoute
   '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
@@ -1244,6 +1407,7 @@ export interface FileRoutesByTo {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat': typeof ChatIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/api/agent-surfaces/sample': typeof ApiAgentSurfacesSampleRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1260,6 +1424,7 @@ export interface FileRoutesByTo {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/learning-loop/review': typeof ApiLearningLoopReviewRoute
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1295,6 +1460,13 @@ export interface FileRoutesByTo {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/x-bookmarks/authorize': typeof ApiXBookmarksAuthorizeRoute
+  '/api/x-bookmarks/callback': typeof ApiXBookmarksCallbackRoute
+  '/api/x-bookmarks/extract-articles': typeof ApiXBookmarksExtractArticlesRoute
+  '/api/x-bookmarks/fetch': typeof ApiXBookmarksFetchRoute
+  '/api/x-bookmarks/import-article': typeof ApiXBookmarksImportArticleRoute
+  '/api/x-bookmarks/review': typeof ApiXBookmarksReviewRoute
+  '/api/x-bookmarks/status': typeof ApiXBookmarksStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1306,14 +1478,17 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-surfaces': typeof AgentSurfacesRoute
   '/agora': typeof AgoraRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
   '/echo-studio': typeof EchoStudioRoute
+  '/executive-queue': typeof ExecutiveQueueRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jobs': typeof JobsRoute
+  '/learning-loop': typeof LearningLoopRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
   '/operations': typeof OperationsRoute
@@ -1326,8 +1501,11 @@ export interface FileRoutesById {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/voice-lab': typeof VoiceLabRoute
   '/vt-capital': typeof VtCapitalRoute
   '/world': typeof WorldRoute
+  '/x-bookmark-review': typeof XBookmarkReviewRoute
+  '/x-bookmarks': typeof XBookmarksRoute
   '/api/agent-bus': typeof ApiAgentBusRoute
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
@@ -1346,7 +1524,11 @@ export interface FileRoutesById {
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/crew-status': typeof ApiCrewStatusRoute
+  '/api/elevenlabs-token': typeof ApiElevenlabsTokenRoute
   '/api/events': typeof ApiEventsRoute
+  '/api/executive-queue': typeof ApiExecutiveQueueRoute
+  '/api/executive-queue-execution': typeof ApiExecutiveQueueExecutionRoute
+  '/api/executive-queue-notion-sync': typeof ApiExecutiveQueueNotionSyncRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
@@ -1373,6 +1555,7 @@ export interface FileRoutesById {
   '/api/session-status': typeof ApiSessionStatusRoute
   '/api/sessions': typeof ApiSessionsRouteWithChildren
   '/api/skills': typeof ApiSkillsRouteWithChildren
+  '/api/source-coverage': typeof ApiSourceCoverageRoute
   '/api/start-agent': typeof ApiStartAgentRoute
   '/api/start-claude': typeof ApiStartClaudeRoute
   '/api/swarm-chat': typeof ApiSwarmChatRoute
@@ -1400,6 +1583,7 @@ export interface FileRoutesById {
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
   '/api/terminal-stream': typeof ApiTerminalStreamRoute
   '/api/transcribe': typeof ApiTranscribeRoute
+  '/api/voice-lab-ledger': typeof ApiVoiceLabLedgerRoute
   '/api/vt-capital': typeof ApiVtCapitalRoute
   '/api/workspace': typeof ApiWorkspaceRoute
   '/chat/$sessionKey': typeof ChatSessionKeyRoute
@@ -1407,6 +1591,7 @@ export interface FileRoutesById {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/agent-surfaces/sample': typeof ApiAgentSurfacesSampleRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1423,6 +1608,7 @@ export interface FileRoutesById {
   '/api/knowledge/read': typeof ApiKnowledgeReadRoute
   '/api/knowledge/search': typeof ApiKnowledgeSearchRoute
   '/api/knowledge/sync': typeof ApiKnowledgeSyncRoute
+  '/api/learning-loop/review': typeof ApiLearningLoopReviewRoute
   '/api/mcp/$name': typeof ApiMcpNameRouteWithChildren
   '/api/mcp/configure': typeof ApiMcpConfigureRoute
   '/api/mcp/discover': typeof ApiMcpDiscoverRoute
@@ -1458,6 +1644,13 @@ export interface FileRoutesById {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/x-bookmarks/authorize': typeof ApiXBookmarksAuthorizeRoute
+  '/api/x-bookmarks/callback': typeof ApiXBookmarksCallbackRoute
+  '/api/x-bookmarks/extract-articles': typeof ApiXBookmarksExtractArticlesRoute
+  '/api/x-bookmarks/fetch': typeof ApiXBookmarksFetchRoute
+  '/api/x-bookmarks/import-article': typeof ApiXBookmarksImportArticleRoute
+  '/api/x-bookmarks/review': typeof ApiXBookmarksReviewRoute
+  '/api/x-bookmarks/status': typeof ApiXBookmarksStatusRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1470,14 +1663,17 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$'
+    | '/agent-surfaces'
     | '/agora'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
     | '/echo-studio'
+    | '/executive-queue'
     | '/files'
     | '/hermes-world'
     | '/jobs'
+    | '/learning-loop'
     | '/mcp'
     | '/memory'
     | '/operations'
@@ -1490,8 +1686,11 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/voice-lab'
     | '/vt-capital'
     | '/world'
+    | '/x-bookmark-review'
+    | '/x-bookmarks'
     | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
@@ -1510,7 +1709,11 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/elevenlabs-token'
     | '/api/events'
+    | '/api/executive-queue'
+    | '/api/executive-queue-execution'
+    | '/api/executive-queue-notion-sync'
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
@@ -1537,6 +1740,7 @@ export interface FileRouteTypes {
     | '/api/session-status'
     | '/api/sessions'
     | '/api/skills'
+    | '/api/source-coverage'
     | '/api/start-agent'
     | '/api/start-claude'
     | '/api/swarm-chat'
@@ -1564,6 +1768,7 @@ export interface FileRouteTypes {
     | '/api/terminal-resize'
     | '/api/terminal-stream'
     | '/api/transcribe'
+    | '/api/voice-lab-ledger'
     | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
@@ -1571,6 +1776,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/agent-surfaces/sample'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1587,6 +1793,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/learning-loop/review'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1622,6 +1829,13 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/x-bookmarks/authorize'
+    | '/api/x-bookmarks/callback'
+    | '/api/x-bookmarks/extract-articles'
+    | '/api/x-bookmarks/fetch'
+    | '/api/x-bookmarks/import-article'
+    | '/api/x-bookmarks/review'
+    | '/api/x-bookmarks/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1632,14 +1846,17 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$'
+    | '/agent-surfaces'
     | '/agora'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
     | '/echo-studio'
+    | '/executive-queue'
     | '/files'
     | '/hermes-world'
     | '/jobs'
+    | '/learning-loop'
     | '/mcp'
     | '/memory'
     | '/operations'
@@ -1651,8 +1868,11 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/voice-lab'
     | '/vt-capital'
     | '/world'
+    | '/x-bookmark-review'
+    | '/x-bookmarks'
     | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
@@ -1671,7 +1891,11 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/elevenlabs-token'
     | '/api/events'
+    | '/api/executive-queue'
+    | '/api/executive-queue-execution'
+    | '/api/executive-queue-notion-sync'
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
@@ -1698,6 +1922,7 @@ export interface FileRouteTypes {
     | '/api/session-status'
     | '/api/sessions'
     | '/api/skills'
+    | '/api/source-coverage'
     | '/api/start-agent'
     | '/api/start-claude'
     | '/api/swarm-chat'
@@ -1725,6 +1950,7 @@ export interface FileRouteTypes {
     | '/api/terminal-resize'
     | '/api/terminal-stream'
     | '/api/transcribe'
+    | '/api/voice-lab-ledger'
     | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
@@ -1732,6 +1958,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat'
     | '/settings'
+    | '/api/agent-surfaces/sample'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1748,6 +1975,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/learning-loop/review'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1783,6 +2011,13 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/x-bookmarks/authorize'
+    | '/api/x-bookmarks/callback'
+    | '/api/x-bookmarks/extract-articles'
+    | '/api/x-bookmarks/fetch'
+    | '/api/x-bookmarks/import-article'
+    | '/api/x-bookmarks/review'
+    | '/api/x-bookmarks/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1793,14 +2028,17 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$'
+    | '/agent-surfaces'
     | '/agora'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
     | '/echo-studio'
+    | '/executive-queue'
     | '/files'
     | '/hermes-world'
     | '/jobs'
+    | '/learning-loop'
     | '/mcp'
     | '/memory'
     | '/operations'
@@ -1813,8 +2051,11 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/voice-lab'
     | '/vt-capital'
     | '/world'
+    | '/x-bookmark-review'
+    | '/x-bookmarks'
     | '/api/agent-bus'
     | '/api/artifacts'
     | '/api/auth'
@@ -1833,7 +2074,11 @@ export interface FileRouteTypes {
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/crew-status'
+    | '/api/elevenlabs-token'
     | '/api/events'
+    | '/api/executive-queue'
+    | '/api/executive-queue-execution'
+    | '/api/executive-queue-notion-sync'
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
@@ -1860,6 +2105,7 @@ export interface FileRouteTypes {
     | '/api/session-status'
     | '/api/sessions'
     | '/api/skills'
+    | '/api/source-coverage'
     | '/api/start-agent'
     | '/api/start-claude'
     | '/api/swarm-chat'
@@ -1887,6 +2133,7 @@ export interface FileRouteTypes {
     | '/api/terminal-resize'
     | '/api/terminal-stream'
     | '/api/transcribe'
+    | '/api/voice-lab-ledger'
     | '/api/vt-capital'
     | '/api/workspace'
     | '/chat/$sessionKey'
@@ -1894,6 +2141,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/agent-surfaces/sample'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1910,6 +2158,7 @@ export interface FileRouteTypes {
     | '/api/knowledge/read'
     | '/api/knowledge/search'
     | '/api/knowledge/sync'
+    | '/api/learning-loop/review'
     | '/api/mcp/$name'
     | '/api/mcp/configure'
     | '/api/mcp/discover'
@@ -1945,6 +2194,13 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/x-bookmarks/authorize'
+    | '/api/x-bookmarks/callback'
+    | '/api/x-bookmarks/extract-articles'
+    | '/api/x-bookmarks/fetch'
+    | '/api/x-bookmarks/import-article'
+    | '/api/x-bookmarks/review'
+    | '/api/x-bookmarks/status'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1956,14 +2212,17 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  AgentSurfacesRoute: typeof AgentSurfacesRoute
   AgoraRoute: typeof AgoraRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
   EarlyAccessRoute: typeof EarlyAccessRoute
   EchoStudioRoute: typeof EchoStudioRoute
+  ExecutiveQueueRoute: typeof ExecutiveQueueRoute
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
   JobsRoute: typeof JobsRoute
+  LearningLoopRoute: typeof LearningLoopRoute
   McpRoute: typeof McpRoute
   MemoryRoute: typeof MemoryRoute
   OperationsRoute: typeof OperationsRoute
@@ -1976,8 +2235,11 @@ export interface RootRouteChildren {
   Swarm2Route: typeof Swarm2Route
   TasksRoute: typeof TasksRoute
   TerminalRoute: typeof TerminalRoute
+  VoiceLabRoute: typeof VoiceLabRoute
   VtCapitalRoute: typeof VtCapitalRoute
   WorldRoute: typeof WorldRoute
+  XBookmarkReviewRoute: typeof XBookmarkReviewRoute
+  XBookmarksRoute: typeof XBookmarksRoute
   ApiAgentBusRoute: typeof ApiAgentBusRoute
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
@@ -1996,7 +2258,11 @@ export interface RootRouteChildren {
   ApiConnectionStatusRoute: typeof ApiConnectionStatusRoute
   ApiContextUsageRoute: typeof ApiContextUsageRoute
   ApiCrewStatusRoute: typeof ApiCrewStatusRoute
+  ApiElevenlabsTokenRoute: typeof ApiElevenlabsTokenRoute
   ApiEventsRoute: typeof ApiEventsRoute
+  ApiExecutiveQueueRoute: typeof ApiExecutiveQueueRoute
+  ApiExecutiveQueueExecutionRoute: typeof ApiExecutiveQueueExecutionRoute
+  ApiExecutiveQueueNotionSyncRoute: typeof ApiExecutiveQueueNotionSyncRoute
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
@@ -2023,6 +2289,7 @@ export interface RootRouteChildren {
   ApiSessionStatusRoute: typeof ApiSessionStatusRoute
   ApiSessionsRoute: typeof ApiSessionsRouteWithChildren
   ApiSkillsRoute: typeof ApiSkillsRouteWithChildren
+  ApiSourceCoverageRoute: typeof ApiSourceCoverageRoute
   ApiStartAgentRoute: typeof ApiStartAgentRoute
   ApiStartClaudeRoute: typeof ApiStartClaudeRoute
   ApiSwarmChatRoute: typeof ApiSwarmChatRoute
@@ -2050,10 +2317,12 @@ export interface RootRouteChildren {
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
   ApiTerminalStreamRoute: typeof ApiTerminalStreamRoute
   ApiTranscribeRoute: typeof ApiTranscribeRoute
+  ApiVoiceLabLedgerRoute: typeof ApiVoiceLabLedgerRoute
   ApiVtCapitalRoute: typeof ApiVtCapitalRoute
   ApiWorkspaceRoute: typeof ApiWorkspaceRoute
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
+  ApiAgentSurfacesSampleRoute: typeof ApiAgentSurfacesSampleRoute
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiDashboardOverviewRoute: typeof ApiDashboardOverviewRoute
   ApiExternalMemoryCandidatesRoute: typeof ApiExternalMemoryCandidatesRoute
@@ -2066,6 +2335,7 @@ export interface RootRouteChildren {
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
+  ApiLearningLoopReviewRoute: typeof ApiLearningLoopReviewRoute
   ApiModelInfoRoute: typeof ApiModelInfoRoute
   ApiOauthDeviceCodeRoute: typeof ApiOauthDeviceCodeRoute
   ApiOauthPollTokenRoute: typeof ApiOauthPollTokenRoute
@@ -2082,11 +2352,32 @@ export interface RootRouteChildren {
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
   ApiUpdateWorkspaceRoute: typeof ApiUpdateWorkspaceRoute
+  ApiXBookmarksAuthorizeRoute: typeof ApiXBookmarksAuthorizeRoute
+  ApiXBookmarksCallbackRoute: typeof ApiXBookmarksCallbackRoute
+  ApiXBookmarksExtractArticlesRoute: typeof ApiXBookmarksExtractArticlesRoute
+  ApiXBookmarksFetchRoute: typeof ApiXBookmarksFetchRoute
+  ApiXBookmarksImportArticleRoute: typeof ApiXBookmarksImportArticleRoute
+  ApiXBookmarksReviewRoute: typeof ApiXBookmarksReviewRoute
+  ApiXBookmarksStatusRoute: typeof ApiXBookmarksStatusRoute
   ApiRunsSessionKeyRunIdAbandonRoute: typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/x-bookmarks': {
+      id: '/x-bookmarks'
+      path: '/x-bookmarks'
+      fullPath: '/x-bookmarks'
+      preLoaderRoute: typeof XBookmarksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/x-bookmark-review': {
+      id: '/x-bookmark-review'
+      path: '/x-bookmark-review'
+      fullPath: '/x-bookmark-review'
+      preLoaderRoute: typeof XBookmarkReviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/world': {
       id: '/world'
       path: '/world'
@@ -2099,6 +2390,13 @@ declare module '@tanstack/react-router' {
       path: '/vt-capital'
       fullPath: '/vt-capital'
       preLoaderRoute: typeof VtCapitalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/voice-lab': {
+      id: '/voice-lab'
+      path: '/voice-lab'
+      fullPath: '/voice-lab'
+      preLoaderRoute: typeof VoiceLabRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/terminal': {
@@ -2185,6 +2483,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof McpRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/learning-loop': {
+      id: '/learning-loop'
+      path: '/learning-loop'
+      fullPath: '/learning-loop'
+      preLoaderRoute: typeof LearningLoopRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/jobs': {
       id: '/jobs'
       path: '/jobs'
@@ -2204,6 +2509,13 @@ declare module '@tanstack/react-router' {
       path: '/files'
       fullPath: '/files'
       preLoaderRoute: typeof FilesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/executive-queue': {
+      id: '/executive-queue'
+      path: '/executive-queue'
+      fullPath: '/executive-queue'
+      preLoaderRoute: typeof ExecutiveQueueRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/echo-studio': {
@@ -2239,6 +2551,13 @@ declare module '@tanstack/react-router' {
       path: '/agora'
       fullPath: '/agora'
       preLoaderRoute: typeof AgoraRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agent-surfaces': {
+      id: '/agent-surfaces'
+      path: '/agent-surfaces'
+      fullPath: '/agent-surfaces'
+      preLoaderRoute: typeof AgentSurfacesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$': {
@@ -2302,6 +2621,13 @@ declare module '@tanstack/react-router' {
       path: '/api/vt-capital'
       fullPath: '/api/vt-capital'
       preLoaderRoute: typeof ApiVtCapitalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/voice-lab-ledger': {
+      id: '/api/voice-lab-ledger'
+      path: '/api/voice-lab-ledger'
+      fullPath: '/api/voice-lab-ledger'
+      preLoaderRoute: typeof ApiVoiceLabLedgerRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/transcribe': {
@@ -2493,6 +2819,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiStartAgentRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/source-coverage': {
+      id: '/api/source-coverage'
+      path: '/api/source-coverage'
+      fullPath: '/api/source-coverage'
+      preLoaderRoute: typeof ApiSourceCoverageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/skills': {
       id: '/api/skills'
       path: '/api/skills'
@@ -2675,11 +3008,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiFilesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/executive-queue-notion-sync': {
+      id: '/api/executive-queue-notion-sync'
+      path: '/api/executive-queue-notion-sync'
+      fullPath: '/api/executive-queue-notion-sync'
+      preLoaderRoute: typeof ApiExecutiveQueueNotionSyncRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/executive-queue-execution': {
+      id: '/api/executive-queue-execution'
+      path: '/api/executive-queue-execution'
+      fullPath: '/api/executive-queue-execution'
+      preLoaderRoute: typeof ApiExecutiveQueueExecutionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/executive-queue': {
+      id: '/api/executive-queue'
+      path: '/api/executive-queue'
+      fullPath: '/api/executive-queue'
+      preLoaderRoute: typeof ApiExecutiveQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/events': {
       id: '/api/events'
       path: '/api/events'
       fullPath: '/api/events'
       preLoaderRoute: typeof ApiEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/elevenlabs-token': {
+      id: '/api/elevenlabs-token'
+      path: '/api/elevenlabs-token'
+      fullPath: '/api/elevenlabs-token'
+      preLoaderRoute: typeof ApiElevenlabsTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/crew-status': {
@@ -2806,6 +3167,55 @@ declare module '@tanstack/react-router' {
       path: '/api/agent-bus'
       fullPath: '/api/agent-bus'
       preLoaderRoute: typeof ApiAgentBusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/status': {
+      id: '/api/x-bookmarks/status'
+      path: '/api/x-bookmarks/status'
+      fullPath: '/api/x-bookmarks/status'
+      preLoaderRoute: typeof ApiXBookmarksStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/review': {
+      id: '/api/x-bookmarks/review'
+      path: '/api/x-bookmarks/review'
+      fullPath: '/api/x-bookmarks/review'
+      preLoaderRoute: typeof ApiXBookmarksReviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/import-article': {
+      id: '/api/x-bookmarks/import-article'
+      path: '/api/x-bookmarks/import-article'
+      fullPath: '/api/x-bookmarks/import-article'
+      preLoaderRoute: typeof ApiXBookmarksImportArticleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/fetch': {
+      id: '/api/x-bookmarks/fetch'
+      path: '/api/x-bookmarks/fetch'
+      fullPath: '/api/x-bookmarks/fetch'
+      preLoaderRoute: typeof ApiXBookmarksFetchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/extract-articles': {
+      id: '/api/x-bookmarks/extract-articles'
+      path: '/api/x-bookmarks/extract-articles'
+      fullPath: '/api/x-bookmarks/extract-articles'
+      preLoaderRoute: typeof ApiXBookmarksExtractArticlesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/callback': {
+      id: '/api/x-bookmarks/callback'
+      path: '/api/x-bookmarks/callback'
+      fullPath: '/api/x-bookmarks/callback'
+      preLoaderRoute: typeof ApiXBookmarksCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/x-bookmarks/authorize': {
+      id: '/api/x-bookmarks/authorize'
+      path: '/api/x-bookmarks/authorize'
+      fullPath: '/api/x-bookmarks/authorize'
+      preLoaderRoute: typeof ApiXBookmarksAuthorizeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/update/workspace': {
@@ -3053,6 +3463,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiMcpNameRouteImport
       parentRoute: typeof ApiMcpRoute
     }
+    '/api/learning-loop/review': {
+      id: '/api/learning-loop/review'
+      path: '/api/learning-loop/review'
+      fullPath: '/api/learning-loop/review'
+      preLoaderRoute: typeof ApiLearningLoopReviewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/knowledge/sync': {
       id: '/api/knowledge/sync'
       path: '/api/knowledge/sync'
@@ -3164,6 +3581,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/artifacts/$artifactId'
       preLoaderRoute: typeof ApiArtifactsArtifactIdRouteImport
       parentRoute: typeof ApiArtifactsRoute
+    }
+    '/api/agent-surfaces/sample': {
+      id: '/api/agent-surfaces/sample'
+      path: '/api/agent-surfaces/sample'
+      fullPath: '/api/agent-surfaces/sample'
+      preLoaderRoute: typeof ApiAgentSurfacesSampleRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/sessions/$sessionKey/status': {
       id: '/api/sessions/$sessionKey/status'
@@ -3425,14 +3849,17 @@ const ApiHermesworldReservationsRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  AgentSurfacesRoute: AgentSurfacesRoute,
   AgoraRoute: AgoraRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
   EarlyAccessRoute: EarlyAccessRoute,
   EchoStudioRoute: EchoStudioRoute,
+  ExecutiveQueueRoute: ExecutiveQueueRoute,
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
   JobsRoute: JobsRoute,
+  LearningLoopRoute: LearningLoopRoute,
   McpRoute: McpRoute,
   MemoryRoute: MemoryRoute,
   OperationsRoute: OperationsRoute,
@@ -3445,8 +3872,11 @@ const rootRouteChildren: RootRouteChildren = {
   Swarm2Route: Swarm2Route,
   TasksRoute: TasksRoute,
   TerminalRoute: TerminalRoute,
+  VoiceLabRoute: VoiceLabRoute,
   VtCapitalRoute: VtCapitalRoute,
   WorldRoute: WorldRoute,
+  XBookmarkReviewRoute: XBookmarkReviewRoute,
+  XBookmarksRoute: XBookmarksRoute,
   ApiAgentBusRoute: ApiAgentBusRoute,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
@@ -3465,7 +3895,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiConnectionStatusRoute: ApiConnectionStatusRoute,
   ApiContextUsageRoute: ApiContextUsageRoute,
   ApiCrewStatusRoute: ApiCrewStatusRoute,
+  ApiElevenlabsTokenRoute: ApiElevenlabsTokenRoute,
   ApiEventsRoute: ApiEventsRoute,
+  ApiExecutiveQueueRoute: ApiExecutiveQueueRoute,
+  ApiExecutiveQueueExecutionRoute: ApiExecutiveQueueExecutionRoute,
+  ApiExecutiveQueueNotionSyncRoute: ApiExecutiveQueueNotionSyncRoute,
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
@@ -3492,6 +3926,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSessionStatusRoute: ApiSessionStatusRoute,
   ApiSessionsRoute: ApiSessionsRouteWithChildren,
   ApiSkillsRoute: ApiSkillsRouteWithChildren,
+  ApiSourceCoverageRoute: ApiSourceCoverageRoute,
   ApiStartAgentRoute: ApiStartAgentRoute,
   ApiStartClaudeRoute: ApiStartClaudeRoute,
   ApiSwarmChatRoute: ApiSwarmChatRoute,
@@ -3519,10 +3954,12 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,
   ApiTerminalStreamRoute: ApiTerminalStreamRoute,
   ApiTranscribeRoute: ApiTranscribeRoute,
+  ApiVoiceLabLedgerRoute: ApiVoiceLabLedgerRoute,
   ApiVtCapitalRoute: ApiVtCapitalRoute,
   ApiWorkspaceRoute: ApiWorkspaceRoute,
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,
+  ApiAgentSurfacesSampleRoute: ApiAgentSurfacesSampleRoute,
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiDashboardOverviewRoute: ApiDashboardOverviewRoute,
   ApiExternalMemoryCandidatesRoute: ApiExternalMemoryCandidatesRoute,
@@ -3535,6 +3972,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
+  ApiLearningLoopReviewRoute: ApiLearningLoopReviewRoute,
   ApiModelInfoRoute: ApiModelInfoRoute,
   ApiOauthDeviceCodeRoute: ApiOauthDeviceCodeRoute,
   ApiOauthPollTokenRoute: ApiOauthPollTokenRoute,
@@ -3551,6 +3989,13 @@ const rootRouteChildren: RootRouteChildren = {
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,
   ApiUpdateWorkspaceRoute: ApiUpdateWorkspaceRoute,
+  ApiXBookmarksAuthorizeRoute: ApiXBookmarksAuthorizeRoute,
+  ApiXBookmarksCallbackRoute: ApiXBookmarksCallbackRoute,
+  ApiXBookmarksExtractArticlesRoute: ApiXBookmarksExtractArticlesRoute,
+  ApiXBookmarksFetchRoute: ApiXBookmarksFetchRoute,
+  ApiXBookmarksImportArticleRoute: ApiXBookmarksImportArticleRoute,
+  ApiXBookmarksReviewRoute: ApiXBookmarksReviewRoute,
+  ApiXBookmarksStatusRoute: ApiXBookmarksStatusRoute,
   ApiRunsSessionKeyRunIdAbandonRoute: ApiRunsSessionKeyRunIdAbandonRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/agent-surfaces.tsx
+++ b/src/routes/agent-surfaces.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import type {
+  AgentSurface,
+  AgentSurfaceAction,
+  AgentSurfaceBlock,
+} from '@/features/agent-surfaces/types'
+import { AgentSurfaceRenderer } from '@/features/agent-surfaces/agent-surface-renderer'
+import { createSampleAgentSurface } from '@/features/agent-surfaces/sample-surface'
+import { usePageTitle } from '@/hooks/use-page-title'
+
+type AgentSurfaceResponse = {
+  ok: boolean
+  surface?: AgentSurface
+  error?: string
+}
+
+async function fetchSampleSurface(): Promise<AgentSurface> {
+  const response = await fetch('/api/agent-surfaces/sample')
+  const data = (await response.json()) as AgentSurfaceResponse
+  if (!response.ok || data.ok === false || !data.surface) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data.surface
+}
+
+export const Route = createFileRoute('/agent-surfaces')({
+  ssr: false,
+  component: AgentSurfacesRoute,
+})
+
+function AgentSurfacesRoute() {
+  usePageTitle('Agent Surfaces')
+  const [lastAction, setLastAction] = useState<string | null>(null)
+  const fallbackSurface = useMemo(() => createSampleAgentSurface(), [])
+  const surfaceQuery = useQuery({
+    queryKey: ['agent-surfaces', 'sample'],
+    queryFn: fetchSampleSurface,
+    staleTime: 60_000,
+  })
+
+  const surface = surfaceQuery.data ?? fallbackSurface
+
+  function handleAction(action: AgentSurfaceAction, block: AgentSurfaceBlock) {
+    setLastAction(`${action.label} on ${block.id}`)
+  }
+
+  return (
+    <div className="relative min-h-full">
+      {surfaceQuery.isError ? (
+        <div className="mx-auto max-w-6xl px-4 pt-4 text-xs text-amber-300 md:px-8 lg:px-10">
+          API sample failed, rendering local fallback:{' '}
+          {surfaceQuery.error instanceof Error
+            ? surfaceQuery.error.message
+            : 'Unknown error'}
+        </div>
+      ) : null}
+      {lastAction ? (
+        <div className="sticky top-0 z-10 border-b border-[var(--theme-border)] bg-[var(--theme-card)]/95 px-4 py-2 text-xs text-[var(--theme-muted)] backdrop-blur md:px-8 lg:px-10">
+          Visual-only action captured:{' '}
+          <span className="text-ink">{lastAction}</span>
+        </div>
+      ) : null}
+      <AgentSurfaceRenderer surface={surface} onAction={handleAction} />
+    </div>
+  )
+}

--- a/src/routes/api/-executive-queue-execution.test.ts
+++ b/src/routes/api/-executive-queue-execution.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  conciseTelegramBody,
+  dispatchQueueWorkerInBackground,
+  isMissingSessionError,
+  queueExecutionSessionTitle,
+  resultTextFromPayload,
+} from './executive-queue-execution'
+
+describe('Executive Queue execution session handling', () => {
+  it('treats dashboard 404 Session not found errors as missing sessions', () => {
+    const error = new Error(
+      'Hermes dashboard /api/sessions/executive-command-center-smoke-safety-filter: 404 {"detail":"Session not found"}',
+    )
+
+    expect(
+      isMissingSessionError(
+        error,
+        'executive-command-center-smoke-safety-filter',
+      ),
+    ).toBe(true)
+  })
+
+  it('does not swallow unrelated dashboard errors', () => {
+    const error = new Error(
+      'Hermes dashboard /api/sessions/executive-command-center: 500 {"detail":"Database unavailable"}',
+    )
+
+    expect(isMissingSessionError(error, 'executive-command-center')).toBe(false)
+  })
+
+  it('keeps the default session title stable and makes smoke-test session titles unique', () => {
+    expect(queueExecutionSessionTitle('executive-command-center')).toBe(
+      'Executive Command Center',
+    )
+    expect(
+      queueExecutionSessionTitle('executive-command-center-smoke-session-404-fixed'),
+    ).toBe('Executive Command Center: smoke-session-404-fixed')
+  })
+
+  it('extracts assistant content from Hermes chat completion payloads instead of raw JSON', () => {
+    const text = resultTextFromPayload({
+      object: 'hermes.session.chat.completion',
+      session_id: '20260606_095234_38d673',
+      message: {
+        role: 'assistant',
+        content: 'Done.\n\nReal result:\nFound 1 approval-needed draft.',
+      },
+      usage: {
+        input_tokens: 677524,
+        output_tokens: 6148,
+        total_tokens: 683672,
+      },
+    })
+
+    expect(text).toBe('Done.\n\nReal result:\nFound 1 approval-needed draft.')
+    expect(text).not.toContain('hermes.session.chat.completion')
+    expect(text).not.toContain('input_tokens')
+  })
+
+  it('trims noisy verification and artifact sections from Telegram updates', () => {
+    const body = conciseTelegramBody(
+      'Done.\\n\\nReal result:\\nFound 1 approval-needed draft.\\n\\nVerification output:\\napproval_receipt_mode: draft_only\\n\\nArtifacts created:\\n/path/to/report.md',
+    )
+
+    expect(body).toContain('Found 1 approval-needed draft.')
+    expect(body).not.toContain('Verification output')
+    expect(body).not.toContain('Artifacts created')
+    expect(body).not.toContain('/path/to/report.md')
+  })
+
+  it('trims pilot-style verified details and artifact paths from Telegram updates', () => {
+    const body = conciseTelegramBody(
+      'Done.\\nReal result: PASS with one watch item.\\nVerified:\\nrecords reviewed: 8\\nroute check: sendTelegramStatus true\\nArtifacts:\\nMD: /Users/hermes/.hermes/profiles/executive/workspaces/report.md',
+    )
+
+    expect(body).toContain('PASS with one watch item.')
+    expect(body).not.toContain('records reviewed')
+    expect(body).not.toContain('route check')
+    expect(body).not.toContain('/Users/hermes')
+  })
+
+  it('keeps draft-only started updates short and hides approval receipt paths', async () => {
+    let releaseChat: (value: Record<string, unknown>) => void = () => undefined
+    const chatPromise = new Promise<Record<string, unknown>>((resolve) => {
+      releaseChat = resolve
+    })
+    const statuses: Array<{ status: string; subject: string; body: string }> = []
+    const timers: Array<number> = []
+
+    const accepted = await dispatchQueueWorkerInBackground(
+      {
+        item: {
+          id: 'eq_noise_regression',
+          title: 'Noise regression item',
+          nextAction:
+            'Review a long next action that should not be pasted into Telegram with receipt paths.',
+        },
+        record: {
+          id: 'qexec_noise_regression',
+          prompt: 'Slow worker prompt',
+        },
+        approvalReceiptPath: '/Users/hermes/.hermes/profiles/executive/executive-queue/approval-receipts/2026-06-06/qreceipt.json',
+        mode: 'draft_only',
+        sessionKey: 'executive-command-center',
+        now: () => '2026-06-06T15:00:00.000Z',
+      },
+      {
+        sendTelegramStatus: (status) => {
+          statuses.push({
+            status: status.status,
+            subject: status.subject,
+            body: status.body,
+          })
+          return Promise.resolve()
+        },
+        sendChat: () => chatPromise,
+        updateExecutionRecord: () => Promise.resolve(),
+        updateQueueStatus: () => Promise.resolve(),
+        setTimeout: (_callback, ms) => {
+          timers.push(ms)
+          return undefined
+        },
+        clearTimeout: () => undefined,
+      },
+    )
+
+    expect(accepted.completionPending).toBe(true)
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0]).toMatchObject({
+      status: 'started',
+      subject: 'Workspace started: Noise regression item',
+    })
+    expect(statuses[0]?.body).toContain('Draft-only')
+    expect(statuses[0]?.body).not.toContain('Approval receipt')
+    expect(statuses[0]?.body).not.toContain('/Users/hermes')
+    expect(timers).toEqual([600_000])
+
+    releaseChat({ message: { content: 'Done cleanly.' } })
+    await accepted.completion
+  })
+
+  it('starts worker dispatch without waiting for chat completion', async () => {
+    let releaseChat: (value: Record<string, unknown>) => void = () => undefined
+    const chatPromise = new Promise<Record<string, unknown>>((resolve) => {
+      releaseChat = resolve
+    })
+    const events: Array<string> = []
+
+    const accepted = await dispatchQueueWorkerInBackground(
+      {
+        item: {
+          id: 'eq_timeout_regression',
+          title: 'Timeout regression item',
+          nextAction: 'Run a slow worker safely.',
+        },
+        record: {
+          id: 'qexec_timeout_regression',
+          prompt: 'Slow worker prompt',
+        },
+        approvalReceiptPath: '/tmp/qreceipt-timeout-regression.json',
+        mode: 'draft_only',
+        sessionKey: 'executive-command-center',
+        now: () => '2026-06-06T15:00:00.000Z',
+      },
+      {
+        sendTelegramStatus: (status) => {
+          events.push(status.status)
+          return Promise.resolve()
+        },
+        sendChat: () => chatPromise,
+        updateExecutionRecord: () => Promise.resolve(),
+        updateQueueStatus: () => Promise.resolve(),
+        setTimeout: () => undefined,
+        clearTimeout: () => undefined,
+      },
+    )
+
+    expect(accepted.completionPending).toBe(true)
+    expect(events).toEqual(['started'])
+
+    releaseChat({ message: { content: 'Done cleanly.' } })
+    await accepted.completion
+
+    expect(events).toEqual(['started', 'completed'])
+  })
+})

--- a/src/routes/api/-executive-queue-notion-sync-utils.test.ts
+++ b/src/routes/api/-executive-queue-notion-sync-utils.test.ts
@@ -1,0 +1,222 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import { createQueueItemFromVoiceLab, readQueueItemById, transitionQueueItem, writeQueueItem } from './-executive-queue-utils'
+import {
+  applyApprovedNotionSync,
+  buildNotionSyncProposal,
+  createNotionSyncProposal,
+  filterNotionSyncEligibleItems,
+} from './-executive-queue-notion-sync-utils'
+
+describe('Executive Queue Notion proposal sync', () => {
+  it('excludes raw Triage and Archived items from Notion proposal sync', () => {
+    const triage = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-triage',
+      ledgerPath: '/tmp/voice-triage.json',
+      delegation: {
+        outcome: '',
+        owner: 'Executive',
+        context: 'Ambiguous raw capture.',
+        constraints: [],
+        nextAction: '',
+        approvalRequired: true,
+      },
+    })
+    const queued = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    const archived = { ...queued, id: 'archived-item', status: 'Archived' as const }
+
+    const eligible = filterNotionSyncEligibleItems([triage, queued, archived])
+
+    expect(eligible.map((item) => item.id)).toEqual([queued.id])
+  })
+
+  it('builds proposal-only Notion rows without mutating queue item sync state', () => {
+    const item = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep only. Public copy requires Tim approval.',
+        constraints: ['No publishing without Tim approval.'],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    const inProgress = transitionQueueItem(item, {
+      status: 'In Progress',
+      actor: 'Executive',
+      now: '2026-05-22T21:10:00.000Z',
+    })
+
+    const proposal = buildNotionSyncProposal({
+      items: [inProgress],
+      now: '2026-05-22T21:15:00.000Z',
+      actor: 'Executive',
+      mode: 'proposal_only',
+    })
+
+    expect(proposal.mode).toBe('proposal_only')
+    expect(proposal.wouldCreate).toHaveLength(1)
+    expect(proposal.wouldUpdate).toHaveLength(0)
+    expect(proposal.wouldSkip).toHaveLength(0)
+    expect(proposal.wouldDelete).toHaveLength(0)
+    expect(proposal.warnings).toContain('Proposal only: no Notion pages were created, updated, archived, or deleted.')
+    expect(proposal.wouldCreate[0]?.queueItemId).toBe(inProgress.id)
+    expect(proposal.wouldCreate[0]?.notionProperties.Name.title[0]?.text.content).toBe(inProgress.title)
+    expect(proposal.wouldCreate[0]?.notionProperties.Status.select.name).toBe('In Progress')
+    expect(proposal.wouldCreate[0]?.notionProperties.Risk.select.name).toBe('Medium')
+    expect(proposal.wouldCreate[0]?.notionProperties.Approval.select.name).toBe('Auto')
+    expect(inProgress.sync.lastSyncStatus).toBe('not_synced')
+  })
+
+  it('persists proposal snapshots locally for review', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-notion-sync-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    await writeQueueItem({ ...item, status: 'Queued' }, root)
+
+    const proposal = await createNotionSyncProposal({
+      root,
+      now: '2026-05-22T21:20:00.000Z',
+      actor: 'Executive',
+      mode: 'proposal_only',
+    })
+
+    expect(proposal.persistedPath).toContain('notion-sync-proposals')
+    const saved = JSON.parse(await readFile(proposal.persistedPath, 'utf-8')) as { id: string; wouldCreate: Array<unknown> }
+    expect(saved.id).toBe(proposal.id)
+    expect(saved.wouldCreate).toHaveLength(1)
+  })
+
+  it('rejects live Notion sync without exact approval text', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-notion-sync-gate-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    await writeQueueItem({ ...item, status: 'Queued' }, root)
+    const proposal = await createNotionSyncProposal({
+      root,
+      now: '2026-05-22T21:20:00.000Z',
+      actor: 'Executive',
+      mode: 'proposal_only',
+    })
+
+    await expect(
+      applyApprovedNotionSync({
+        root,
+        now: '2026-05-22T21:25:00.000Z',
+        actor: 'Executive',
+        databaseId: 'database-id',
+        approval: {
+          proposalId: proposal.id,
+          proposalPath: proposal.persistedPath,
+          approvedBy: 'Tim',
+          approvalText: 'yes',
+          expectedCreates: proposal.wouldCreate.length,
+          expectedUpdates: proposal.wouldUpdate.length,
+        },
+        notionClient: (async () => Promise.resolve({ id: 'should-not-run' })),
+      }),
+    ).rejects.toThrow('APPROVE NOTION SYNC')
+  })
+
+  it('applies approved create operations and records sync state without deletes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-notion-sync-apply-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    await writeQueueItem({ ...item, status: 'Queued' }, root)
+    const proposal = await createNotionSyncProposal({
+      root,
+      now: '2026-05-22T21:20:00.000Z',
+      actor: 'Executive',
+      mode: 'proposal_only',
+    })
+    const calls: Array<{ path: string; method: string; body: Record<string, unknown> }> = []
+
+    const result = await applyApprovedNotionSync({
+      root,
+      now: '2026-05-22T21:25:00.000Z',
+      actor: 'Executive',
+      databaseId: 'database-id',
+      approval: {
+        proposalId: proposal.id,
+        proposalPath: proposal.persistedPath,
+        approvedBy: 'Tim',
+        approvalText: 'APPROVE NOTION SYNC',
+        expectedCreates: proposal.wouldCreate.length,
+        expectedUpdates: proposal.wouldUpdate.length,
+      },
+      notionClient: (async (call) => Promise.resolve((() => {
+        calls.push(call)
+        return { id: 'notion-page-1' }
+      })())),
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.path).toBe('/pages')
+    expect(calls[0]?.method).toBe('POST')
+    expect(calls[0]?.body.parent).toEqual({ database_id: 'database-id' })
+    expect(result.created).toEqual([{ operation: 'create', queueItemId: item.id, notionPageId: 'notion-page-1', title: item.title }])
+    expect(result.deleted).toEqual([])
+    expect(result.persistedPath).toContain('notion-sync-results')
+
+    const updated = await readQueueItemById(item.id, root)
+    expect(updated?.sync.notionPageId).toBe('notion-page-1')
+    expect(updated?.sync.lastSyncStatus).toBe('synced')
+    expect(updated?.auditTrail.some((entry) => entry.action === 'notion_synced')).toBe(true)
+  })
+})

--- a/src/routes/api/-executive-queue-notion-sync-utils.ts
+++ b/src/routes/api/-executive-queue-notion-sync-utils.ts
@@ -1,0 +1,445 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { listQueueItems, readQueueItemById, writeQueueItem } from './-executive-queue-utils'
+import type { ExecutiveQueueItem } from './-executive-queue-utils'
+
+export type NotionSyncMode = 'proposal_only' | 'apply_approved'
+
+export type NotionRichTextProperty = {
+  rich_text: Array<{ text: { content: string } }>
+}
+
+export type NotionSelectProperty = {
+  select: { name: string }
+}
+
+export type NotionTitleProperty = {
+  title: Array<{ text: { content: string } }>
+}
+
+export type NotionUrlProperty = {
+  url: string | null
+}
+
+export type NotionDateProperty = {
+  date: { start: string } | null
+}
+
+export type ExecutiveQueueNotionProperties = {
+  Name: NotionTitleProperty
+  Status: NotionSelectProperty
+  Priority: NotionSelectProperty
+  Domain: NotionSelectProperty
+  Owner: NotionSelectProperty
+  Risk: NotionSelectProperty
+  Approval: NotionSelectProperty
+  Outcome: NotionRichTextProperty
+  'Next Action': NotionRichTextProperty
+  Context: NotionRichTextProperty
+  Constraints: NotionRichTextProperty
+  Source: NotionRichTextProperty
+  'Queue Item ID': NotionRichTextProperty
+  'Local Path': NotionRichTextProperty
+  'Source Reference': NotionUrlProperty
+  'Created At': NotionDateProperty
+  'Updated At': NotionDateProperty
+}
+
+export type NotionSyncOperation = {
+  operation: 'create' | 'update'
+  queueItemId: string
+  title: string
+  reason: string
+  notionPageId: string
+  notionProperties: ExecutiveQueueNotionProperties
+}
+
+export type NotionSyncSkippedItem = {
+  queueItemId: string
+  title: string
+  reason: string
+}
+
+export type ExecutiveQueueNotionSyncProposal = {
+  schemaVersion: 1
+  id: string
+  mode: NotionSyncMode
+  actor: string
+  generatedAt: string
+  eligibleCount: number
+  totalCount: number
+  wouldCreate: Array<NotionSyncOperation>
+  wouldUpdate: Array<NotionSyncOperation>
+  wouldSkip: Array<NotionSyncSkippedItem>
+  wouldDelete: Array<never>
+  warnings: Array<string>
+  persistedPath: string
+}
+
+export type BuildNotionSyncProposalInput = {
+  items: Array<ExecutiveQueueItem>
+  now: string
+  actor: string
+  mode: 'proposal_only'
+}
+
+export type CreateNotionSyncProposalInput = {
+  root?: string
+  now: string
+  actor: string
+  mode: 'proposal_only'
+}
+
+export type NotionWriteResult = {
+  operation: 'create' | 'update'
+  queueItemId: string
+  notionPageId: string
+  title: string
+}
+
+export type NotionSyncApproval = {
+  proposalId: string
+  proposalPath: string
+  approvedBy: string
+  approvalText: string
+  expectedCreates: number
+  expectedUpdates: number
+}
+
+export type NotionHttpClient = (input: { path: string; method: 'POST' | 'PATCH'; body: Record<string, unknown> }) => Promise<Record<string, unknown>>
+
+export type ApplyApprovedNotionSyncInput = {
+  root?: string
+  now: string
+  actor: string
+  databaseId?: string
+  approval: NotionSyncApproval
+  notionClient?: NotionHttpClient
+}
+
+export type ExecutiveQueueNotionSyncApplyResult = {
+  schemaVersion: 1
+  mode: 'apply_approved'
+  actor: string
+  appliedAt: string
+  proposalId: string
+  proposalPath: string
+  created: Array<NotionWriteResult>
+  updated: Array<NotionWriteResult>
+  skipped: Array<NotionSyncSkippedItem>
+  deleted: Array<never>
+  warnings: Array<string>
+  persistedPath: string
+}
+
+function defaultRoot(): string {
+  return join(process.env.HERMES_HOME || join(process.env.HOME || '/Users/hermes', '.hermes', 'profiles', 'executive'), 'executive-queue')
+}
+
+function clampText(value: string, max = 1900): string {
+  const text = value.trim()
+  if (text.length <= max) return text
+  return `${text.slice(0, max - 1).trimEnd()}…`
+}
+
+function richText(value: string): NotionRichTextProperty {
+  return { rich_text: [{ text: { content: clampText(value) } }] }
+}
+
+function title(value: string): NotionTitleProperty {
+  return { title: [{ text: { content: clampText(value || 'Untitled Executive Queue item', 1900) } }] }
+}
+
+function select(value: string): NotionSelectProperty {
+  return { select: { name: value || 'None' } }
+}
+
+function date(value: string): NotionDateProperty {
+  return value ? { date: { start: value } } : { date: null }
+}
+
+function sourceUrl(value: string): NotionUrlProperty {
+  if (/^https?:\/\//i.test(value)) return { url: value }
+  return { url: null }
+}
+
+function proposalId(now: string): string {
+  return `notion_sync_proposal_${now.replace(/[^0-9]/g, '').slice(0, 14)}`
+}
+
+function proposalPath(root: string, now: string, id: string): string {
+  return join(root, 'notion-sync-proposals', now.slice(0, 10), `${id}.json`)
+}
+
+function applyResultPath(root: string, now: string, syncProposalId: string): string {
+  return join(root, 'notion-sync-results', now.slice(0, 10), `${syncProposalId}-apply-${now.replace(/[^0-9]/g, '').slice(0, 14)}.json`)
+}
+
+function getNotionToken(): string {
+  const token = process.env.NOTION_API_KEY || process.env.NOTION_TOKEN
+  if (!token) throw new Error('Missing Notion API token. Set NOTION_API_KEY or NOTION_TOKEN in local secure config, not chat.')
+  return token
+}
+
+function getDatabaseId(inputDatabaseId?: string): string {
+  const databaseId = inputDatabaseId || process.env.EXECUTIVE_QUEUE_NOTION_DATABASE_ID || process.env.NOTION_EXECUTIVE_QUEUE_DATABASE_ID
+  if (!databaseId) throw new Error('Missing Executive Queue Notion database ID. Set EXECUTIVE_QUEUE_NOTION_DATABASE_ID in local secure config.')
+  return databaseId
+}
+
+function extractNotionPageId(response: Record<string, unknown>): string {
+  const id = response.id
+  if (typeof id !== 'string' || !id.trim()) throw new Error('Notion response did not include a page id.')
+  return id
+}
+
+async function defaultNotionClient(input: { path: string; method: 'POST' | 'PATCH'; body: Record<string, unknown> }): Promise<Record<string, unknown>> {
+  const response = await fetch(`https://api.notion.com/v1${input.path}`, {
+    method: input.method,
+    headers: {
+      Authorization: `Bearer ${getNotionToken()}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28',
+    },
+    body: JSON.stringify(input.body),
+  })
+  const text = await response.text()
+  const data = text ? (JSON.parse(text) as Record<string, unknown>) : {}
+  if (!response.ok) {
+    const message = typeof data.message === 'string' ? data.message : `Notion API failed with ${response.status}`
+    throw new Error(message)
+  }
+  return data
+}
+
+export function filterNotionSyncEligibleItems(items: Array<ExecutiveQueueItem>): Array<ExecutiveQueueItem> {
+  return items.filter((item) => item.status !== 'Triage' && item.status !== 'Archived')
+}
+
+export function buildNotionProperties(item: ExecutiveQueueItem): ExecutiveQueueNotionProperties {
+  return {
+    Name: title(item.title),
+    Status: select(item.status),
+    Priority: select(item.priority),
+    Domain: select(item.domain),
+    Owner: select(item.owner),
+    Risk: select(item.riskLevel),
+    Approval: select(item.approvalLevel),
+    Outcome: richText(item.outcome),
+    'Next Action': richText(item.nextAction),
+    Context: richText(item.context),
+    Constraints: richText(item.constraints.join('\n')),
+    Source: richText(`${item.source.type}: ${item.source.id}\n${item.source.excerpt}`),
+    'Queue Item ID': richText(item.id),
+    'Local Path': richText(item.localPath),
+    'Source Reference': sourceUrl(item.source.fullReference),
+    'Created At': date(item.createdAt),
+    'Updated At': date(item.updatedAt),
+  }
+}
+
+export function buildNotionSyncProposal(input: BuildNotionSyncProposalInput): ExecutiveQueueNotionSyncProposal {
+  const eligible = filterNotionSyncEligibleItems(input.items)
+  const skipped = input.items
+    .filter((item) => item.status === 'Triage' || item.status === 'Archived')
+    .map((item) => ({
+      queueItemId: item.id,
+      title: item.title,
+      reason: item.status === 'Triage' ? 'Raw Triage capture is not synced to Notion.' : 'Archived items are not synced or deleted in proposal-only mode.',
+    }))
+
+  const wouldCreate: Array<NotionSyncOperation> = []
+  const wouldUpdate: Array<NotionSyncOperation> = []
+
+  for (const item of eligible) {
+    const operation: NotionSyncOperation = {
+      operation: item.sync.notionPageId ? 'update' : 'create',
+      queueItemId: item.id,
+      title: item.title,
+      reason: item.sync.notionPageId ? 'Existing Notion page would be updated from local JSON.' : 'Triaged local queue item has no Notion page yet.',
+      notionPageId: item.sync.notionPageId,
+      notionProperties: buildNotionProperties(item),
+    }
+    if (operation.operation === 'update') wouldUpdate.push(operation)
+    else wouldCreate.push(operation)
+  }
+
+  const id = proposalId(input.now)
+  return {
+    schemaVersion: 1,
+    id,
+    mode: input.mode,
+    actor: input.actor,
+    generatedAt: input.now,
+    eligibleCount: eligible.length,
+    totalCount: input.items.length,
+    wouldCreate,
+    wouldUpdate,
+    wouldSkip: skipped,
+    wouldDelete: [],
+    warnings: [
+      'Proposal only: no Notion pages were created, updated, archived, or deleted.',
+      'Local JSON remains the source of truth. Notion is a proposed human command-center mirror.',
+      'Risk and approval fields are exported for visibility only and should not be editable from Notion.',
+    ],
+    persistedPath: '',
+  }
+}
+
+export async function persistNotionSyncProposal(
+  proposal: ExecutiveQueueNotionSyncProposal,
+  root?: string,
+): Promise<ExecutiveQueueNotionSyncProposal> {
+  const queueRoot = root ?? defaultRoot()
+  const persistedPath = proposalPath(queueRoot, proposal.generatedAt, proposal.id)
+  const record = { ...proposal, persistedPath }
+  await mkdir(join(queueRoot, 'notion-sync-proposals', proposal.generatedAt.slice(0, 10)), { recursive: true, mode: 0o700 })
+  await writeFile(persistedPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+  return record
+}
+
+export async function createNotionSyncProposal(
+  input: CreateNotionSyncProposalInput,
+): Promise<ExecutiveQueueNotionSyncProposal> {
+  const items = await listQueueItems({ root: input.root, includeArchived: true })
+  const proposal = buildNotionSyncProposal({
+    items,
+    now: input.now,
+    actor: input.actor,
+    mode: input.mode,
+  })
+  return persistNotionSyncProposal(proposal, input.root)
+}
+
+async function readProposal(path: string): Promise<ExecutiveQueueNotionSyncProposal> {
+  const proposal = JSON.parse(await readFile(path, 'utf-8')) as ExecutiveQueueNotionSyncProposal
+  if (proposal.mode !== 'proposal_only') throw new Error('Only proposal_only snapshots can be applied.')
+  return proposal
+}
+
+function assertApprovedProposal(proposal: ExecutiveQueueNotionSyncProposal, approval: NotionSyncApproval): void {
+  if (approval.approvalText !== 'APPROVE NOTION SYNC') {
+    throw new Error('Live Notion sync requires approvalText exactly: APPROVE NOTION SYNC')
+  }
+  if (!approval.approvedBy.trim()) throw new Error('Live Notion sync requires approvedBy.')
+  if (approval.proposalId !== proposal.id) throw new Error('Approval proposalId does not match proposal snapshot.')
+  if (approval.proposalPath !== proposal.persistedPath) throw new Error('Approval proposalPath does not match proposal snapshot.')
+  if (approval.expectedCreates !== proposal.wouldCreate.length) throw new Error('Approved create count does not match proposal snapshot.')
+  if (approval.expectedUpdates !== proposal.wouldUpdate.length) throw new Error('Approved update count does not match proposal snapshot.')
+  if (proposal.wouldDelete.length > 0) throw new Error('Notion deletes are permanently disabled for Executive Queue sync.')
+}
+
+async function updateQueueItemNotionSync(input: {
+  root?: string
+  queueItemId: string
+  notionPageId: string
+  now: string
+  actor: string
+}): Promise<void> {
+  const item = await readQueueItemById(input.queueItemId, input.root)
+  if (!item) throw new Error(`Queue item not found after Notion write: ${input.queueItemId}`)
+  await writeQueueItem(
+    {
+      ...item,
+      updatedAt: input.now,
+      sync: {
+        ...item.sync,
+        notionPageId: input.notionPageId,
+        lastSyncedAt: input.now,
+        lastSyncStatus: 'synced',
+      },
+      auditTrail: [
+        ...item.auditTrail,
+        {
+          action: 'notion_synced',
+          actor: input.actor,
+          timestamp: input.now,
+          note: `Synced to Notion page ${input.notionPageId}`,
+        },
+      ],
+    },
+    input.root,
+  )
+}
+
+async function persistApplyResult(
+  result: ExecutiveQueueNotionSyncApplyResult,
+  root?: string,
+): Promise<ExecutiveQueueNotionSyncApplyResult> {
+  const queueRoot = root ?? defaultRoot()
+  const persistedPath = applyResultPath(queueRoot, result.appliedAt, result.proposalId)
+  const record = { ...result, persistedPath }
+  await mkdir(join(queueRoot, 'notion-sync-results', result.appliedAt.slice(0, 10)), { recursive: true, mode: 0o700 })
+  await writeFile(persistedPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+  return record
+}
+
+export async function applyApprovedNotionSync(input: ApplyApprovedNotionSyncInput): Promise<ExecutiveQueueNotionSyncApplyResult> {
+  const proposal = await readProposal(input.approval.proposalPath)
+  assertApprovedProposal(proposal, input.approval)
+  const databaseId = getDatabaseId(input.databaseId)
+  const notionClient = input.notionClient ?? defaultNotionClient
+  const created: Array<NotionWriteResult> = []
+  const updated: Array<NotionWriteResult> = []
+
+  for (const operation of proposal.wouldCreate) {
+    const response = await notionClient({
+      path: '/pages',
+      method: 'POST',
+      body: {
+        parent: { database_id: databaseId },
+        properties: operation.notionProperties,
+      },
+    })
+    const notionPageId = extractNotionPageId(response)
+    created.push({ operation: 'create', queueItemId: operation.queueItemId, notionPageId, title: operation.title })
+    await updateQueueItemNotionSync({
+      root: input.root,
+      queueItemId: operation.queueItemId,
+      notionPageId,
+      now: input.now,
+      actor: input.actor,
+    })
+  }
+
+  for (const operation of proposal.wouldUpdate) {
+    if (!operation.notionPageId) throw new Error(`Cannot update Notion without page id for ${operation.queueItemId}`)
+    const response = await notionClient({
+      path: `/pages/${operation.notionPageId}`,
+      method: 'PATCH',
+      body: { properties: operation.notionProperties },
+    })
+    const notionPageId = extractNotionPageId(response)
+    updated.push({ operation: 'update', queueItemId: operation.queueItemId, notionPageId, title: operation.title })
+    await updateQueueItemNotionSync({
+      root: input.root,
+      queueItemId: operation.queueItemId,
+      notionPageId,
+      now: input.now,
+      actor: input.actor,
+    })
+  }
+
+  return persistApplyResult(
+    {
+      schemaVersion: 1,
+      mode: 'apply_approved',
+      actor: input.actor,
+      appliedAt: input.now,
+      proposalId: proposal.id,
+      proposalPath: proposal.persistedPath,
+      created,
+      updated,
+      skipped: proposal.wouldSkip,
+      deleted: [],
+      warnings: [
+        'Live Notion sync was approval-gated by proposal id, proposal path, exact approval text, and expected operation counts.',
+        'No Notion pages were deleted or archived.',
+        'Local JSON remains the machine source of truth.',
+      ],
+      persistedPath: '',
+    },
+    input.root,
+  )
+}

--- a/src/routes/api/-executive-queue-utils.test.ts
+++ b/src/routes/api/-executive-queue-utils.test.ts
@@ -1,0 +1,503 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyQueueApproval,
+  buildQueueExecutionPrompt,
+  createQueueApprovalReceipt,
+  createQueueExecutionRecord,
+  createQueueItemFromVoiceLab,
+  groupQueueItemsForBoard,
+  listQueueItems,
+  transitionQueueItem,
+  updateQueueItemStatus,
+  writeQueueItem,
+} from './-executive-queue-utils'
+
+describe('Executive Queue local store', () => {
+  it('creates a real queue item from a Voice Lab delegation handoff', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-'))
+
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-123',
+      ledgerPath: '/tmp/voice-123.json',
+      delegation: {
+        outcome:
+          'prepare my May 28 Travel Multiplier webinar so attendees believe travel hacking is real and buy the course',
+        owner: 'TM COS',
+        context:
+          'Tim asked for webinar prep. Executive recommended TM COS. Needs approval before publishing or sending anything.',
+        constraints: ['No side effects without explicit confirmation.'],
+        nextAction: 'Draft the webinar outline and offer bridge',
+        approvalRequired: true,
+      },
+      review: {
+        summary: 'Latest Executive turn: Decision: delegate this to TM COS.',
+        decisions: ['Decision: delegate this to TM COS.'],
+        followUpActions: [
+          'Next action: draft the webinar outline and offer bridge.',
+        ],
+        openQuestions: ['No open questions detected.'],
+        needsApproval: [
+          'Needs approval before publishing or sending anything.',
+        ],
+      },
+    })
+
+    expect(item.status).toBe('Queued')
+    expect(item.priority).toBe('P1')
+    expect(item.domain).toBe('Travel Multiplier')
+    expect(item.owner).toBe('TM COS')
+    expect(item.riskLevel).toBe('Medium')
+    expect(item.approvalLevel).toBe('Ask Before External')
+    expect(item.confidence).toBe('High')
+    expect(item.source).toMatchObject({
+      type: 'Voice Lab',
+      id: 'voice-123',
+      timestamp: '2026-05-22T21:00:00.000Z',
+      fullReference: '/tmp/voice-123.json',
+    })
+    expect(item.source.excerpt).toContain(
+      'prepare my May 28 Travel Multiplier webinar',
+    )
+    expect(item.nextAction).toBe('Draft the webinar outline and offer bridge')
+    expect(item.auditTrail[0]).toMatchObject({
+      action: 'created',
+      actor: 'Voice Lab',
+    })
+    expect(
+      item.auditTrail.some((event) => event.action === 'auto_queued'),
+    ).toBe(true)
+
+    const saved = await readFile(item.localPath, 'utf-8')
+    expect(JSON.parse(saved)).toMatchObject({ id: item.id, status: 'Queued' })
+  })
+
+  it('blocks Done transitions without a result summary', () => {
+    const item = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-456',
+      ledgerPath: '/tmp/voice-456.json',
+      delegation: {
+        outcome: 'research safe travel hacking examples',
+        owner: 'Research Agent',
+        context: 'Internal research request.',
+        constraints: [],
+        nextAction: 'Find three public proof examples',
+        approvalRequired: false,
+      },
+    })
+
+    const transitioned = transitionQueueItem(item, {
+      status: 'Done',
+      actor: 'Tim',
+      now: '2026-05-22T21:05:00.000Z',
+    })
+
+    expect(transitioned.status).toBe('Blocked')
+    expect(transitioned.blockedReason).toBe('Done requires result summary.')
+    expect(transitioned.completedAt).toBe('')
+  })
+
+  it('preserves result summary when moving to Done', () => {
+    const item = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-789',
+      ledgerPath: '/tmp/voice-789.json',
+      delegation: {
+        outcome: 'draft webinar outline',
+        owner: 'TM COS',
+        context: 'Internal prep request.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+
+    const transitioned = transitionQueueItem(item, {
+      status: 'Done',
+      resultSummary: 'Draft outline saved locally.',
+      actor: 'TM COS',
+      now: '2026-05-22T21:10:00.000Z',
+    })
+
+    expect(transitioned.status).toBe('Done')
+    expect(transitioned.resultSummary).toBe('Draft outline saved locally.')
+    expect(transitioned.completedAt).toBe('2026-05-22T21:10:00.000Z')
+    expect(transitioned.completedBy).toBe('TM COS')
+  })
+
+  it('lists queue items from the local JSON store newest first and excludes archived by default', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-list-'))
+    const first = createQueueItemFromVoiceLab.sync({
+      root,
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-first',
+      ledgerPath: '/tmp/voice-first.json',
+      delegation: {
+        outcome: 'draft internal command center outline',
+        owner: 'Executive',
+        context: 'Internal prep request.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    const second = createQueueItemFromVoiceLab.sync({
+      root,
+      now: '2026-05-22T22:00:00.000Z',
+      conversationId: 'voice-second',
+      ledgerPath: '/tmp/voice-second.json',
+      delegation: {
+        outcome: 'draft internal command center review',
+        owner: 'Executive',
+        context: 'Internal prep request.',
+        constraints: [],
+        nextAction: 'Draft review',
+        approvalRequired: false,
+      },
+    })
+    const archived = {
+      ...first,
+      id: 'eq_20260522_archived',
+      status: 'Archived' as const,
+      updatedAt: '2026-05-22T23:00:00.000Z',
+      localPath: join(root, 'items', '2026-05-22', 'eq_20260522_archived.json'),
+    }
+
+    await writeQueueItem(first, root)
+    await writeQueueItem(second, root)
+    await writeQueueItem(archived, root)
+
+    const items = await listQueueItems({ root })
+
+    expect(items.map((item) => item.id)).toEqual([second.id, first.id])
+    expect(items.every((item) => item.status !== 'Archived')).toBe(true)
+  })
+
+  it('groups queue items into Executive Queue board columns', () => {
+    const triage = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-triage',
+      ledgerPath: '/tmp/voice-triage.json',
+      delegation: {
+        outcome: '',
+        owner: 'Executive',
+        context: 'Ambiguous request.',
+        constraints: [],
+        nextAction: '',
+        approvalRequired: true,
+      },
+    })
+    const queued = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:05:00.000Z',
+      conversationId: 'voice-queued',
+      ledgerPath: '/tmp/voice-queued.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+    const blocked = transitionQueueItem(queued, {
+      status: 'Blocked',
+      actor: 'Executive',
+      now: '2026-05-22T21:10:00.000Z',
+      blockedReason: 'Waiting on Tim approval.',
+    })
+
+    const grouped = groupQueueItemsForBoard([queued, blocked, triage])
+
+    expect(grouped.Triage).toHaveLength(1)
+    expect(grouped.Queued).toHaveLength(1)
+    expect(grouped.Blocked).toHaveLength(1)
+    expect(grouped.Done).toHaveLength(0)
+  })
+
+  it('persists status transitions to the local JSON record', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-transition-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-transition',
+      ledgerPath: '/tmp/voice-transition.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Internal prep.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: false,
+      },
+    })
+
+    const updated = await updateQueueItemStatus({
+      root,
+      id: item.id,
+      status: 'In Progress',
+      actor: 'Executive',
+      now: '2026-05-22T21:15:00.000Z',
+    })
+
+    expect(updated.status).toBe('In Progress')
+    expect(updated.auditTrail.at(-1)).toMatchObject({
+      action: 'status_changed',
+      actor: 'Executive',
+      from: 'Queued',
+      to: 'In Progress',
+    })
+    const saved = JSON.parse(await readFile(updated.localPath, 'utf-8')) as {
+      status: string
+    }
+    expect(saved.status).toBe('In Progress')
+  })
+
+  it('approves a single queue action and moves it into progress with audit trail', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-approval-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-approval',
+      ledgerPath: '/tmp/voice-approval.json',
+      delegation: {
+        outcome: 'prepare May 28 Travel Multiplier webinar',
+        owner: 'TM COS',
+        context: 'Needs approval before publishing or sending anything.',
+        constraints: [],
+        nextAction: 'Draft outline',
+        approvalRequired: true,
+      },
+    })
+
+    const approved = await applyQueueApproval({
+      root,
+      id: item.id,
+      decision: 'approve_action',
+      actor: 'Tim',
+      now: '2026-05-22T21:20:00.000Z',
+      note: 'Approve this action only.',
+    })
+
+    expect(approved.status).toBe('In Progress')
+    expect(approved.auditTrail.at(-1)).toMatchObject({
+      action: 'approval_granted',
+      actor: 'Tim',
+      from: 'Queued',
+      to: 'In Progress',
+      note: 'Approve this action only.',
+    })
+  })
+
+  it('builds a single-action execution prompt from a queue item', () => {
+    const item = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-execute-prompt',
+      ledgerPath: '/tmp/voice-execute-prompt.json',
+      delegation: {
+        outcome: 'draft internal Command Center execution notes',
+        owner: 'Executive',
+        context: 'Tim approved local preparation only.',
+        constraints: ['Do not send messages.', 'Do not spend money.'],
+        nextAction: 'Draft the implementation note',
+        approvalRequired: true,
+      },
+    })
+
+    const prompt = buildQueueExecutionPrompt(item, {
+      mode: 'draft_only',
+      actor: 'Tim',
+      note: 'Keep this local.',
+    })
+
+    expect(prompt).toContain('Execution mode: draft_only')
+    expect(prompt).toContain(
+      'Queue item: draft internal Command Center execution notes',
+    )
+    expect(prompt).toContain('Next action: Draft the implementation note')
+    expect(prompt).toContain('Approval scope: single queue item only')
+    expect(prompt).toContain('Do not send messages.')
+    expect(prompt).toContain('Keep this local.')
+    expect(prompt).toContain('Worker safety filter: raw Codex')
+    expect(prompt).toContain(
+      'The Workspace API sends this as plain Telegram status/completion text.',
+    )
+    expect(prompt).not.toContain('wrap this final report in an HTML artifact')
+  })
+
+  it('builds a Telegram explanation prompt without approving or executing the item', () => {
+    const item = createQueueItemFromVoiceLab.sync({
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-explain-prompt',
+      ledgerPath: '/tmp/voice-explain-prompt.json',
+      delegation: {
+        outcome: 'approve operating knowledge base extraction batch',
+        owner: 'Executive',
+        context: 'Tim is not sure what the approval means.',
+        constraints: ['No execution before approval.'],
+        nextAction:
+          'Explain what the extraction batch means and what approval would allow',
+        approvalRequired: true,
+      },
+    })
+
+    const prompt = buildQueueExecutionPrompt(item, {
+      mode: 'explain_more',
+      actor: 'Tim',
+      note: 'Explain before approval.',
+    })
+
+    expect(prompt).toContain('Execution mode: explain_more')
+    expect(prompt).toContain(
+      'Do not approve, execute, mutate, or mark this queue item in progress.',
+    )
+    expect(prompt).toContain('Write a concise Telegram reply to Tim')
+    expect(prompt).toContain(
+      'Queue item: approve operating knowledge base extraction batch',
+    )
+    expect(prompt).toContain('Explain before approval.')
+  })
+
+  it('persists an execution dispatch record with audit metadata', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-execution-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-05-22T21:00:00.000Z',
+      conversationId: 'voice-execute-record',
+      ledgerPath: '/tmp/voice-execute-record.json',
+      delegation: {
+        outcome: 'draft local Command Center execution notes',
+        owner: 'Executive',
+        context: 'Local prep request.',
+        constraints: ['No external side effects.'],
+        nextAction: 'Draft the notes',
+        approvalRequired: true,
+      },
+    })
+
+    const record = await createQueueExecutionRecord({
+      root,
+      item,
+      mode: 'approve_and_run',
+      actor: 'Tim',
+      now: '2026-05-22T21:25:00.000Z',
+      note: 'Run this now.',
+      sessionKey: 'executive-command-center',
+    })
+
+    expect(record).toMatchObject({
+      itemId: item.id,
+      mode: 'approve_and_run',
+      actor: 'Tim',
+      note: 'Run this now.',
+      sessionKey: 'executive-command-center',
+      status: 'dispatched',
+    })
+    expect(record.prompt).toContain(item.title)
+    expect(record.localPath).toContain('executions')
+    const saved = JSON.parse(await readFile(record.localPath, 'utf-8')) as {
+      itemId: string
+      mode: string
+    }
+    expect(saved).toMatchObject({ itemId: item.id, mode: 'approve_and_run' })
+  })
+
+  it('persists an approval receipt before approval-triggered execution', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-receipt-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-06-02T23:40:00.000Z',
+      conversationId: 'voice-receipt',
+      ledgerPath: '/tmp/voice-receipt.json',
+      delegation: {
+        outcome: 'run a safe AI Ops follow-through check',
+        owner: 'Executive',
+        context: 'Approval came from Workspace Command Center.',
+        constraints: ['No external side effects.'],
+        nextAction: 'Run the bounded check',
+        approvalRequired: true,
+      },
+    })
+
+    const receipt = await createQueueApprovalReceipt({
+      root,
+      item,
+      mode: 'approve_and_run',
+      actor: 'Tim',
+      now: '2026-06-02T23:45:00.000Z',
+      note: 'Approve and run',
+      sessionKey: 'executive-command-center',
+      sourceReference: {
+        sessionId: 'telegram-session-1',
+        messageId: 'message-123',
+      },
+    })
+
+    expect(receipt).toMatchObject({
+      itemId: item.id,
+      itemTitle: item.title,
+      mode: 'approve_and_run',
+      actor: 'Tim',
+      approvedPhrase: 'Approve and run',
+      sourceChannel: 'Workspace',
+      status: 'captured',
+    })
+    expect(receipt.normalizedScope).toContain('one Executive Queue item only')
+    expect(receipt.forbiddenSideEffects.join('\n')).toContain(
+      'No broad interpretation',
+    )
+    expect(receipt.localPath).toContain('approval-receipts')
+    const saved = JSON.parse(await readFile(receipt.localPath, 'utf-8')) as {
+      id: string
+      itemId: string
+    }
+    expect(saved).toMatchObject({ id: receipt.id, itemId: item.id })
+  })
+
+  it('links execution records and prompts to approval receipts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'executive-queue-receipt-link-'))
+    const item = await createQueueItemFromVoiceLab({
+      root,
+      now: '2026-06-02T23:40:00.000Z',
+      conversationId: 'voice-receipt-link',
+      ledgerPath: '/tmp/voice-receipt-link.json',
+      delegation: {
+        outcome: 'draft safe approval receipt notes',
+        owner: 'Executive',
+        context: 'Local prep request.',
+        constraints: ['No external side effects.'],
+        nextAction: 'Draft local notes',
+        approvalRequired: true,
+      },
+    })
+    const receipt = await createQueueApprovalReceipt({
+      root,
+      item,
+      mode: 'draft_only',
+      actor: 'Tim',
+      now: '2026-06-02T23:45:00.000Z',
+      sessionKey: 'executive-command-center',
+    })
+
+    const record = await createQueueExecutionRecord({
+      root,
+      item,
+      mode: 'draft_only',
+      actor: 'Tim',
+      now: '2026-06-02T23:46:00.000Z',
+      sessionKey: 'executive-command-center',
+      approvalReceipt: receipt,
+    })
+
+    expect(record.approvalReceiptId).toBe(receipt.id)
+    expect(record.approvalReceiptPath).toBe(receipt.localPath)
+    expect(record.prompt).toContain(`Approval receipt: ${receipt.localPath}`)
+  })
+})

--- a/src/routes/api/-executive-queue-utils.ts
+++ b/src/routes/api/-executive-queue-utils.ts
@@ -1,0 +1,984 @@
+import { randomUUID } from 'node:crypto'
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+} from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { DelegationHandoff, VoiceReview } from './-voice-lab-ledger-utils'
+
+export type QueueStatus =
+  | 'Triage'
+  | 'Proposed'
+  | 'Queued'
+  | 'In Progress'
+  | 'Blocked'
+  | 'Done'
+  | 'Archived'
+export type QueuePriority = 'P0' | 'P1' | 'P2' | 'P3'
+export type QueueRiskLevel = 'Low' | 'Medium' | 'High'
+export type QueueApprovalLevel =
+  | 'Auto'
+  | 'Ask Before External'
+  | 'Ask Before Spend'
+  | 'Ask Before System Change'
+  | 'Manual Only'
+export type QueueConfidence = 'Low' | 'Medium' | 'High'
+export type QueueDomain =
+  | 'AI Ops'
+  | 'Restored'
+  | 'Travel Multiplier'
+  | 'Personal'
+  | 'Finance'
+  | 'Code'
+  | 'Research'
+  | 'Email'
+  | 'Calendar'
+  | 'Meetings'
+  | 'Home'
+  | 'Health'
+
+export type QueueOwner =
+  | 'Executive'
+  | 'Restored COS'
+  | 'TM COS'
+  | 'Personal COS'
+  | 'Coding Agent'
+  | 'Research Agent'
+  | 'Finance CFO'
+  | 'Email Assistant'
+  | 'Calendar Assistant'
+  | 'Meeting Notes Agent'
+  | 'Voice Lab'
+  | 'Tim'
+  | `Human: ${string}`
+
+export type QueueAuditEvent = {
+  action: string
+  actor: string
+  timestamp: string
+  note?: string
+  from?: string
+  to?: string
+}
+
+export type ExecutiveQueueItem = {
+  schemaVersion: 1
+  id: string
+  title: string
+  outcome: string
+  status: QueueStatus
+  priority: QueuePriority
+  domain: QueueDomain
+  owner: QueueOwner
+  riskLevel: QueueRiskLevel
+  approvalLevel: QueueApprovalLevel
+  confidence: QueueConfidence
+  source: {
+    type: 'Voice Lab'
+    id: string
+    timestamp: string
+    excerpt: string
+    fullReference: string
+  }
+  context: string
+  constraints: Array<string>
+  nextAction: string
+  blockedReason: string
+  resultSummary: string
+  createdAt: string
+  updatedAt: string
+  dueAt: string
+  completedAt: string
+  completedBy: string
+  auditTrail: Array<QueueAuditEvent>
+  sync: {
+    notionPageId: string
+    lastSyncedAt: string
+    lastSyncStatus: 'not_synced' | 'synced' | 'error'
+  }
+  localPath: string
+}
+
+export type QueueBoardColumn =
+  | 'Triage'
+  | 'Proposed'
+  | 'Queued'
+  | 'In Progress'
+  | 'Blocked'
+  | 'Done'
+export const QUEUE_BOARD_COLUMNS: Array<QueueBoardColumn> = [
+  'Triage',
+  'Proposed',
+  'Queued',
+  'In Progress',
+  'Blocked',
+  'Done',
+]
+
+export type ListQueueItemsInput = {
+  root?: string
+  includeArchived?: boolean
+  status?: QueueStatus
+  owner?: QueueOwner
+  domain?: QueueDomain
+}
+
+type CreateQueueItemFromVoiceLabInput = {
+  root?: string
+  now: string
+  conversationId: string
+  ledgerPath: string
+  delegation: DelegationHandoff
+  review?: VoiceReview
+}
+
+type TransitionQueueItemInput = {
+  status: QueueStatus
+  actor: string
+  now: string
+  resultSummary?: string
+  blockedReason?: string
+}
+
+export type QueueApprovalDecision =
+  | 'approve_action'
+  | 'hold'
+  | 'manual_only'
+  | 'broader_approval'
+
+type PersistedTransitionQueueItemInput = TransitionQueueItemInput & {
+  root?: string
+  id: string
+}
+
+type ApplyQueueApprovalInput = {
+  root?: string
+  id: string
+  decision: QueueApprovalDecision
+  actor: string
+  now: string
+  note?: string
+}
+
+export type QueueExecutionMode =
+  | 'approve_and_run'
+  | 'draft_only'
+  | 'explain_more'
+
+export type QueueExecutionRecord = {
+  schemaVersion: 1
+  id: string
+  itemId: string
+  itemTitle: string
+  mode: QueueExecutionMode
+  actor: string
+  timestamp: string
+  note: string
+  sessionKey: string
+  approvalReceiptId?: string
+  approvalReceiptPath?: string
+  status: 'dispatched' | 'completed' | 'error'
+  prompt: string
+  localPath: string
+  completedAt?: string
+  resultSummary?: string
+  error?: string
+  runId?: string | null
+}
+
+export type QueueApprovalReceipt = {
+  schemaVersion: 1
+  id: string
+  itemId: string
+  itemTitle: string
+  mode: Exclude<QueueExecutionMode, 'explain_more'>
+  actor: string
+  timestamp: string
+  approvedPhrase: string
+  normalizedScope: string
+  sourceChannel: string
+  sourceReference: {
+    sessionId: string
+    messageId: string
+    fallbackReference: string
+  }
+  riskLevel: QueueRiskLevel
+  approvalLevel: QueueApprovalLevel
+  sessionKey: string
+  authorizedSideEffects: Array<string>
+  forbiddenSideEffects: Array<string>
+  expectedTimSurface: string
+  rawWorkerOutputPolicy: string
+  status: 'captured'
+  localPath: string
+}
+
+type BuildQueueExecutionPromptInput = {
+  mode: QueueExecutionMode
+  actor: string
+  note?: string
+}
+
+type CreateQueueExecutionRecordInput = BuildQueueExecutionPromptInput & {
+  root?: string
+  item: ExecutiveQueueItem
+  now: string
+  sessionKey: string
+  approvalReceipt?: QueueApprovalReceipt
+}
+
+type CreateQueueApprovalReceiptInput = {
+  root?: string
+  item: ExecutiveQueueItem
+  mode: Exclude<QueueExecutionMode, 'explain_more'>
+  actor: string
+  now: string
+  note?: string
+  sessionKey: string
+  approvedPhrase?: string
+  sourceChannel?: string
+  sourceReference?: Partial<QueueApprovalReceipt['sourceReference']>
+}
+
+function slugId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48)
+}
+
+function createId(input: CreateQueueItemFromVoiceLabInput): string {
+  return `eq_${input.now.slice(0, 10).replace(/-/g, '')}_${slugId(input.conversationId)}`
+}
+
+function defaultRoot(): string {
+  return join(
+    process.env.HERMES_HOME ||
+      join(
+        process.env.HOME || '/Users/hermes',
+        '.hermes',
+        'profiles',
+        'executive',
+      ),
+    'executive-queue',
+  )
+}
+
+function cleanSentence(value: string): string {
+  return value.trim().replace(/[.!?]+$/, '')
+}
+
+function titleFromOutcome(outcome: string): string {
+  const cleaned = cleanSentence(outcome)
+  if (/may 28|webinar|travel multiplier/i.test(cleaned))
+    return 'Prepare May 28 Travel Multiplier webinar'
+  return cleaned.slice(0, 80) || 'Untitled Executive Queue item'
+}
+
+function domainFromInput(input: CreateQueueItemFromVoiceLabInput): QueueDomain {
+  const text = `${input.delegation.outcome} ${input.delegation.context}`
+  if (/travel multiplier|webinar|travel hacking|course/i.test(text))
+    return 'Travel Multiplier'
+  if (/restored|church|pastor|staff|pco|planning center/i.test(text))
+    return 'Restored'
+  if (/monarch|receipt|expensify|budget|transaction/i.test(text))
+    return 'Finance'
+  if (/code|bug|build|deploy|github|repo/i.test(text)) return 'Code'
+  if (/research|find|scan|current facts/i.test(text)) return 'Research'
+  if (/email|inbox|reply/i.test(text)) return 'Email'
+  if (/calendar|schedule|meeting time/i.test(text)) return 'Calendar'
+  return 'AI Ops'
+}
+
+function ownerFromDelegation(owner: string, domain: QueueDomain): QueueOwner {
+  const normalized = owner.trim().toLowerCase()
+  if (normalized.includes('tm cos') || normalized.includes('sales webinar'))
+    return 'TM COS'
+  if (normalized.includes('restored')) return 'Restored COS'
+  if (normalized.includes('personal')) return 'Personal COS'
+  if (normalized.includes('coding')) return 'Coding Agent'
+  if (normalized.includes('research')) return 'Research Agent'
+  if (normalized.includes('finance')) return 'Finance CFO'
+  if (normalized.includes('email')) return 'Email Assistant'
+  if (normalized.includes('calendar')) return 'Calendar Assistant'
+  if (normalized.includes('meeting')) return 'Meeting Notes Agent'
+  if (normalized.includes('tim')) return 'Tim'
+  if (domain === 'Travel Multiplier') return 'TM COS'
+  if (domain === 'Restored') return 'Restored COS'
+  return 'Executive'
+}
+
+function riskFromInput(
+  input: CreateQueueItemFromVoiceLabInput,
+  domain: QueueDomain,
+): QueueRiskLevel {
+  const fullText = `${input.delegation.outcome} ${input.delegation.context} ${input.delegation.nextAction}`
+  const nextAction = input.delegation.nextAction
+  if (
+    domain === 'Restored' &&
+    /pastoral|staff|conflict|care|minor|discipline|counsel/i.test(fullText)
+  )
+    return 'High'
+  if (
+    /spend|purchase|deploy|restart|secret|credential|production|config/i.test(
+      fullText,
+    )
+  )
+    return 'High'
+  if (/send|publish|post|contact|external/i.test(nextAction)) return 'High'
+  if (
+    /shared|notion|calendar|draft|categor|approval|publish|send/i.test(fullText)
+  )
+    return 'Medium'
+  if (input.delegation.approvalRequired) return 'Medium'
+  return 'Low'
+}
+
+function approvalFromRisk(
+  input: CreateQueueItemFromVoiceLabInput,
+  riskLevel: QueueRiskLevel,
+): QueueApprovalLevel {
+  const text = `${input.delegation.outcome} ${input.delegation.context} ${input.delegation.nextAction}`
+  if (/spend|purchase|subscription|paid|credits|ad spend/i.test(text))
+    return 'Ask Before Spend'
+  if (
+    /deploy|restart|config|secret|credential|production|launchd|docker|cron/i.test(
+      text,
+    )
+  )
+    return 'Ask Before System Change'
+  if (
+    /send|publish|post|contact|external|shared docs?|before publishing|before sending/i.test(
+      text,
+    )
+  )
+    return 'Ask Before External'
+  if (riskLevel === 'High') return 'Manual Only'
+  if (input.delegation.approvalRequired) return 'Ask Before External'
+  return 'Auto'
+}
+
+function priorityFromInput(
+  input: CreateQueueItemFromVoiceLabInput,
+): QueuePriority {
+  const text = `${input.delegation.outcome} ${input.delegation.context}`
+  if (/urgent|now|drop other work/i.test(text)) return 'P0'
+  if (/today|may 28|webinar/i.test(text)) return 'P1'
+  if (/this week/i.test(text)) return 'P2'
+  return 'P3'
+}
+
+function canAutoQueue(
+  item: Pick<
+    ExecutiveQueueItem,
+    'confidence' | 'riskLevel' | 'approvalLevel' | 'nextAction' | 'domain'
+  >,
+): boolean {
+  const internalPrep =
+    /draft|prepare|research|summarize|outline|review|classify|plan/i.test(
+      item.nextAction,
+    )
+  if (item.confidence !== 'High') return false
+  if (!internalPrep) return false
+  if (item.domain === 'Restored' && item.riskLevel === 'High') return false
+  if (item.riskLevel === 'High') return false
+  return (
+    item.approvalLevel === 'Auto' ||
+    item.approvalLevel === 'Ask Before External'
+  )
+}
+
+function buildLocalPath(root: string, now: string, id: string): string {
+  return join(root, 'items', now.slice(0, 10), `${id}.json`)
+}
+
+function isQueueItem(value: unknown): value is ExecutiveQueueItem {
+  if (!value || typeof value !== 'object') return false
+  const item = value as Partial<ExecutiveQueueItem>
+  return (
+    item.schemaVersion === 1 &&
+    typeof item.id === 'string' &&
+    typeof item.title === 'string'
+  )
+}
+
+function matchesListFilter(
+  item: ExecutiveQueueItem,
+  input: ListQueueItemsInput,
+): boolean {
+  if (!input.includeArchived && item.status === 'Archived') return false
+  if (input.status && item.status !== input.status) return false
+  if (input.owner && item.owner !== input.owner) return false
+  if (input.domain && item.domain !== input.domain) return false
+  return true
+}
+
+export function groupQueueItemsForBoard(
+  items: Array<ExecutiveQueueItem>,
+): Record<QueueBoardColumn, Array<ExecutiveQueueItem>> {
+  const grouped: Record<QueueBoardColumn, Array<ExecutiveQueueItem>> = {
+    Triage: [],
+    Proposed: [],
+    Queued: [],
+    'In Progress': [],
+    Blocked: [],
+    Done: [],
+  }
+
+  for (const item of items) {
+    if (item.status === 'Archived') continue
+    if (item.status in grouped)
+      grouped[item.status as QueueBoardColumn].push(item)
+  }
+
+  return grouped
+}
+
+export async function listQueueItems(
+  input: ListQueueItemsInput = {},
+): Promise<Array<ExecutiveQueueItem>> {
+  const root = input.root ?? defaultRoot()
+  const itemsRoot = join(root, 'items')
+  const items: Array<ExecutiveQueueItem> = []
+
+  let dateDirs: Array<string>
+  try {
+    dateDirs = await readdir(itemsRoot)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT')
+      return []
+    throw error
+  }
+
+  for (const dateDir of dateDirs) {
+    const dir = join(itemsRoot, dateDir)
+    let files: Array<string>
+    try {
+      files = await readdir(dir)
+    } catch {
+      continue
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue
+      try {
+        const parsed = JSON.parse(
+          await readFile(join(dir, file), 'utf-8'),
+        ) as unknown
+        if (isQueueItem(parsed) && matchesListFilter(parsed, input))
+          items.push(parsed)
+      } catch {
+        continue
+      }
+    }
+  }
+
+  const priorityWeight: Record<string, number> = {
+    P0: 0,
+    P1: 1,
+    P2: 2,
+    P3: 3,
+    P4: 4,
+  }
+  const statusWeight: Record<string, number> = {
+    Proposed: 0,
+    Triage: 1,
+    Queued: 2,
+    'In Progress': 3,
+    Blocked: 4,
+    Done: 8,
+    Archived: 9,
+  }
+
+  return items.sort((a, b) => {
+    const activeA = a.status === 'Done' || a.status === 'Archived' ? 1 : 0
+    const activeB = b.status === 'Done' || b.status === 'Archived' ? 1 : 0
+    if (activeA !== activeB) return activeA - activeB
+
+    const priority =
+      (priorityWeight[a.priority] ?? 9) - (priorityWeight[b.priority] ?? 9)
+    if (priority !== 0) return priority
+
+    const status = (statusWeight[a.status] ?? 9) - (statusWeight[b.status] ?? 9)
+    if (status !== 0) return status
+
+    return b.updatedAt.localeCompare(a.updatedAt)
+  })
+}
+
+export function buildQueueItemFromVoiceLab(
+  input: CreateQueueItemFromVoiceLabInput,
+): ExecutiveQueueItem {
+  const root = input.root ?? defaultRoot()
+  const id = createId(input)
+  const domain = domainFromInput(input)
+  const owner = ownerFromDelegation(input.delegation.owner, domain)
+  const riskLevel = riskFromInput(input, domain)
+  const approvalLevel = approvalFromRisk(input, riskLevel)
+  const priority = priorityFromInput(input)
+  const confidence: QueueConfidence =
+    input.delegation.outcome && input.delegation.nextAction ? 'High' : 'Low'
+  const sourceExcerpt = input.delegation.outcome.slice(0, 280)
+  const baseItem: ExecutiveQueueItem = {
+    schemaVersion: 1,
+    id,
+    title: titleFromOutcome(input.delegation.outcome),
+    outcome: cleanSentence(input.delegation.outcome),
+    status: 'Triage',
+    priority,
+    domain,
+    owner,
+    riskLevel,
+    approvalLevel,
+    confidence,
+    source: {
+      type: 'Voice Lab',
+      id: input.conversationId,
+      timestamp: input.now,
+      excerpt: sourceExcerpt,
+      fullReference: input.ledgerPath,
+    },
+    context: input.delegation.context,
+    constraints: input.delegation.constraints,
+    nextAction: cleanSentence(input.delegation.nextAction),
+    blockedReason: '',
+    resultSummary: '',
+    createdAt: input.now,
+    updatedAt: input.now,
+    dueAt: '',
+    completedAt: '',
+    completedBy: '',
+    auditTrail: [
+      {
+        action: 'created',
+        actor: 'Voice Lab',
+        timestamp: input.now,
+        note:
+          input.review?.summary ?? 'Created from Voice Lab delegation handoff.',
+      },
+    ],
+    sync: {
+      notionPageId: '',
+      lastSyncedAt: '',
+      lastSyncStatus: 'not_synced',
+    },
+    localPath: buildLocalPath(root, input.now, id),
+  }
+
+  if (!canAutoQueue(baseItem)) return baseItem
+
+  return {
+    ...baseItem,
+    status: 'Queued',
+    auditTrail: [
+      ...baseItem.auditTrail,
+      {
+        action: 'auto_queued',
+        actor: 'Executive',
+        timestamp: input.now,
+        from: 'Triage',
+        to: 'Queued',
+        note: 'High confidence internal prep under allowed approval level.',
+      },
+    ],
+  }
+}
+
+export function transitionQueueItem(
+  item: ExecutiveQueueItem,
+  input: TransitionQueueItemInput,
+): ExecutiveQueueItem {
+  if (input.status === 'Done' && !input.resultSummary?.trim()) {
+    return {
+      ...item,
+      status: 'Blocked',
+      blockedReason: 'Done requires result summary.',
+      updatedAt: input.now,
+      auditTrail: [
+        ...item.auditTrail,
+        {
+          action: 'blocked',
+          actor: input.actor,
+          timestamp: input.now,
+          from: item.status,
+          to: 'Blocked',
+          note: 'Done requires result summary.',
+        },
+      ],
+    }
+  }
+
+  return {
+    ...item,
+    status: input.status,
+    resultSummary: input.resultSummary?.trim() ?? item.resultSummary,
+    blockedReason:
+      input.blockedReason?.trim() ??
+      (input.status === 'Blocked' ? item.blockedReason : ''),
+    completedAt: input.status === 'Done' ? input.now : item.completedAt,
+    completedBy: input.status === 'Done' ? input.actor : item.completedBy,
+    updatedAt: input.now,
+    auditTrail: [
+      ...item.auditTrail,
+      {
+        action: 'status_changed',
+        actor: input.actor,
+        timestamp: input.now,
+        from: item.status,
+        to: input.status,
+      },
+    ],
+  }
+}
+
+export async function writeQueueItem(
+  item: ExecutiveQueueItem,
+  root?: string,
+): Promise<ExecutiveQueueItem> {
+  const queueRoot = root ?? defaultRoot()
+  const localPath =
+    item.localPath || buildLocalPath(queueRoot, item.createdAt, item.id)
+  const record = { ...item, localPath }
+  await mkdir(join(queueRoot, 'items', item.createdAt.slice(0, 10)), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await writeFile(localPath, `${JSON.stringify(record, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  await appendFile(
+    join(queueRoot, 'index.jsonl'),
+    `${JSON.stringify({ id: record.id, status: record.status, priority: record.priority, owner: record.owner, updatedAt: record.updatedAt, localPath })}\n`,
+    { mode: 0o600 },
+  )
+  return record
+}
+
+export async function readQueueItemById(
+  id: string,
+  root?: string,
+): Promise<ExecutiveQueueItem | null> {
+  const items = await listQueueItems({ root, includeArchived: true })
+  return items.find((item) => item.id === id) ?? null
+}
+
+export async function updateQueueItemStatus(
+  input: PersistedTransitionQueueItemInput,
+): Promise<ExecutiveQueueItem> {
+  const item = await readQueueItemById(input.id, input.root)
+  if (!item) throw new Error(`Queue item not found: ${input.id}`)
+  const updated = transitionQueueItem(item, input)
+  return writeQueueItem(updated, input.root)
+}
+
+export async function applyQueueApproval(
+  input: ApplyQueueApprovalInput,
+): Promise<ExecutiveQueueItem> {
+  const item = await readQueueItemById(input.id, input.root)
+  if (!item) throw new Error(`Queue item not found: ${input.id}`)
+
+  const note = input.note?.trim()
+  const next = (() => {
+    if (input.decision === 'approve_action') {
+      return {
+        ...item,
+        status: 'In Progress' as const,
+        updatedAt: input.now,
+        auditTrail: [
+          ...item.auditTrail,
+          {
+            action: 'approval_granted',
+            actor: input.actor,
+            timestamp: input.now,
+            from: item.status,
+            to: 'In Progress',
+            note: note || 'Approved this action only.',
+          },
+        ],
+      }
+    }
+
+    if (input.decision === 'broader_approval') {
+      return {
+        ...item,
+        status: 'In Progress' as const,
+        updatedAt: input.now,
+        auditTrail: [
+          ...item.auditTrail,
+          {
+            action: 'broader_approval_granted',
+            actor: input.actor,
+            timestamp: input.now,
+            from: item.status,
+            to: 'In Progress',
+            note: note || 'Broader approval granted for this queue item.',
+          },
+        ],
+      }
+    }
+
+    if (input.decision === 'manual_only') {
+      return {
+        ...item,
+        status: 'Proposed' as const,
+        approvalLevel: 'Manual Only' as const,
+        updatedAt: input.now,
+        auditTrail: [
+          ...item.auditTrail,
+          {
+            action: 'manual_only_set',
+            actor: input.actor,
+            timestamp: input.now,
+            from: item.status,
+            to: 'Proposed',
+            note: note || 'Manual only mode set from approval controls.',
+          },
+        ],
+      }
+    }
+
+    return {
+      ...item,
+      status: 'Blocked' as const,
+      blockedReason: note || 'Held from Executive Queue approval controls.',
+      updatedAt: input.now,
+      auditTrail: [
+        ...item.auditTrail,
+        {
+          action: 'approval_held',
+          actor: input.actor,
+          timestamp: input.now,
+          from: item.status,
+          to: 'Blocked',
+          note: note || 'Held from Executive Queue approval controls.',
+        },
+      ],
+    }
+  })()
+
+  return writeQueueItem(next, input.root)
+}
+
+export function buildQueueExecutionPrompt(
+  item: ExecutiveQueueItem,
+  input: BuildQueueExecutionPromptInput,
+): string {
+  const note = input.note?.trim()
+  const approvalReceipt =
+    'approvalReceipt' in input
+      ? (input.approvalReceipt as QueueApprovalReceipt | undefined)
+      : undefined
+  const constraints = item.constraints.length
+    ? item.constraints.map((constraint) => `- ${constraint}`).join('\n')
+    : '- No extra constraints recorded.'
+
+  return [
+    "You are Executive operating from Tim Walker's Workspace Command Center.",
+    '',
+    `Execution mode: ${input.mode}`,
+    input.mode === 'explain_more'
+      ? 'Approval scope: explanation only. Do not approve, execute, mutate, or mark this queue item in progress.'
+      : 'Approval scope: single queue item only. Do not treat this as broader approval.',
+    input.mode === 'explain_more'
+      ? 'Side-effect rule: Write a concise Telegram reply to Tim that explains what this item is, why it matters, what approval would allow, what risks exist, and 2-3 good questions he can ask before deciding.'
+      : input.mode === 'draft_only'
+        ? 'Side-effect rule: prepare local drafts and analysis only. Do not send, publish, spend, schedule, restart services, or contact people.'
+        : 'Side-effect rule: execute only the queue item below. If the work requires sending, publishing, spending, calendar commitments, people decisions, or broader system changes beyond the named item, stop and ask Tim.',
+    '',
+    `Queue item: ${item.title}`,
+    `Queue ID: ${item.id}`,
+    `Priority: ${item.priority}`,
+    `Domain: ${item.domain}`,
+    `Owner: ${item.owner}`,
+    `Risk: ${item.riskLevel}`,
+    `Approval level: ${item.approvalLevel}`,
+    `Outcome: ${item.outcome}`,
+    `Context: ${item.context || 'None'}`,
+    `Next action: ${item.nextAction || 'Needs triage'}`,
+    approvalReceipt
+      ? `Approval receipt: ${approvalReceipt.localPath}`
+      : 'Approval receipt: none recorded for this execution mode.',
+    '',
+    'Constraints:',
+    constraints,
+    '',
+    note ? `Tim's note: ${note}` : "Tim's note: none.",
+    '',
+    'Worker safety filter: raw Codex, Kanban, or other worker output must stay behind Executive synthesis. Do not paste raw worker logs to Tim unless Tim explicitly asks for the raw execution record.',
+    'Approval phrase rule: generic Approve or Approve and Run cannot authorize multiple unrelated side effects. Stay inside the single queue item and receipt.',
+    'Delivery requirement: your final response must be a concise, ready-to-read execution report. Include the real result, verification output, artifact paths created, and whether any follow-up approval is needed. The Workspace API sends this as plain Telegram status/completion text. Do not create routine HTML status cards unless the deliverable itself is a dense review artifact.',
+  ].join('\n')
+}
+
+function authorizedSideEffectsForReceipt(
+  input: CreateQueueApprovalReceiptInput,
+): Array<string> {
+  if (input.mode === 'draft_only') {
+    return [
+      'Prepare local drafts, analysis, and artifacts for this single queue item.',
+      'Report concise status and completion back to Tim.',
+    ]
+  }
+
+  return [
+    'Execute only this single queue item within its recorded risk and approval boundaries.',
+    'Create local artifacts needed to prove the result.',
+    'Report concise status and completion back to Tim.',
+  ]
+}
+
+function forbiddenSideEffectsForReceipt(): Array<string> {
+  return [
+    'No external messages unless this exact queue item explicitly authorizes sending.',
+    'No spending or paid services unless this exact queue item explicitly authorizes spend.',
+    'No calendar commitments unless this exact queue item explicitly authorizes scheduling.',
+    'No people decisions, Restored pastoral decisions, or sensitive domain decisions.',
+    'No cron, launchd, Docker, gateway, Workspace, dashboard, config, credential, or production-system changes unless this exact queue item explicitly authorizes them.',
+    'No broad interpretation of a generic Approve reply beyond the immediately preceding explicit action.',
+  ]
+}
+
+export async function createQueueApprovalReceipt(
+  input: CreateQueueApprovalReceiptInput,
+): Promise<QueueApprovalReceipt> {
+  const queueRoot = input.root ?? defaultRoot()
+  const id = `qreceipt_${input.now.slice(0, 10).replace(/-/g, '')}_${randomUUID()}`
+  const localPath = join(
+    queueRoot,
+    'approval-receipts',
+    input.now.slice(0, 10),
+    `${id}.json`,
+  )
+  const approvedPhrase =
+    input.approvedPhrase?.trim() ||
+    input.note?.trim() ||
+    (input.mode === 'draft_only' ? 'Draft Only' : 'Approve and Run')
+  const record: QueueApprovalReceipt = {
+    schemaVersion: 1,
+    id,
+    itemId: input.item.id,
+    itemTitle: input.item.title,
+    mode: input.mode,
+    actor: input.actor,
+    timestamp: input.now,
+    approvedPhrase,
+    normalizedScope: `Approval authorizes ${input.mode} for one Executive Queue item only: ${input.item.title}`,
+    sourceChannel: input.sourceChannel?.trim() || 'Workspace',
+    sourceReference: {
+      sessionId: input.sourceReference?.sessionId?.trim() || '',
+      messageId: input.sourceReference?.messageId?.trim() || '',
+      fallbackReference:
+        input.sourceReference?.fallbackReference?.trim() ||
+        'Workspace Executive Queue execution control',
+    },
+    riskLevel: input.item.riskLevel,
+    approvalLevel: input.item.approvalLevel,
+    sessionKey: input.sessionKey,
+    authorizedSideEffects: authorizedSideEffectsForReceipt(input),
+    forbiddenSideEffects: forbiddenSideEffectsForReceipt(),
+    expectedTimSurface:
+      'Plain Telegram lifecycle updates plus one concise completion report.',
+    rawWorkerOutputPolicy:
+      'Hidden behind Executive synthesis unless Tim asks for the raw execution record.',
+    status: 'captured',
+    localPath,
+  }
+
+  await mkdir(join(queueRoot, 'approval-receipts', input.now.slice(0, 10)), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await writeFile(localPath, `${JSON.stringify(record, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  await appendFile(
+    join(queueRoot, 'approval-receipts.jsonl'),
+    `${JSON.stringify({ id: record.id, itemId: record.itemId, mode: record.mode, actor: record.actor, timestamp: record.timestamp, sourceChannel: record.sourceChannel, localPath })}\n`,
+    { mode: 0o600 },
+  )
+  return record
+}
+
+export async function createQueueExecutionRecord(
+  input: CreateQueueExecutionRecordInput,
+): Promise<QueueExecutionRecord> {
+  const queueRoot = input.root ?? defaultRoot()
+  const id = `qexec_${input.now.slice(0, 10).replace(/-/g, '')}_${randomUUID()}`
+  const localPath = join(
+    queueRoot,
+    'executions',
+    input.now.slice(0, 10),
+    `${id}.json`,
+  )
+  const record: QueueExecutionRecord = {
+    schemaVersion: 1,
+    id,
+    itemId: input.item.id,
+    itemTitle: input.item.title,
+    mode: input.mode,
+    actor: input.actor,
+    timestamp: input.now,
+    note: input.note?.trim() ?? '',
+    sessionKey: input.sessionKey,
+    approvalReceiptId: input.approvalReceipt?.id,
+    approvalReceiptPath: input.approvalReceipt?.localPath,
+    status: 'dispatched',
+    prompt: buildQueueExecutionPrompt(input.item, input),
+    localPath,
+  }
+
+  await mkdir(join(queueRoot, 'executions', input.now.slice(0, 10)), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await writeFile(localPath, `${JSON.stringify(record, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  await appendFile(
+    join(queueRoot, 'executions.jsonl'),
+    `${JSON.stringify({ id: record.id, itemId: record.itemId, mode: record.mode, actor: record.actor, timestamp: record.timestamp, sessionKey: record.sessionKey, localPath })}\n`,
+    { mode: 0o600 },
+  )
+  return record
+}
+
+export async function updateQueueExecutionRecord(
+  record: QueueExecutionRecord,
+  patch: Partial<
+    Pick<
+      QueueExecutionRecord,
+      'status' | 'completedAt' | 'resultSummary' | 'error' | 'runId'
+    >
+  >,
+): Promise<QueueExecutionRecord> {
+  const existing = JSON.parse(
+    await readFile(record.localPath, 'utf8'),
+  ) as QueueExecutionRecord
+  const updated: QueueExecutionRecord = {
+    ...existing,
+    ...patch,
+  }
+  await writeFile(record.localPath, `${JSON.stringify(updated, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  return updated
+}
+
+async function createQueueItemFromVoiceLabAsync(
+  input: CreateQueueItemFromVoiceLabInput,
+): Promise<ExecutiveQueueItem> {
+  const item = buildQueueItemFromVoiceLab(input)
+  return writeQueueItem(item, input.root)
+}
+
+export const createQueueItemFromVoiceLab = Object.assign(
+  createQueueItemFromVoiceLabAsync,
+  {
+    sync: buildQueueItemFromVoiceLab,
+  },
+)

--- a/src/routes/api/-voice-lab-ledger-utils.test.ts
+++ b/src/routes/api/-voice-lab-ledger-utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildVoiceLedgerRecord } from './-voice-lab-ledger-utils'
+
+describe('buildVoiceLedgerRecord', () => {
+  it('creates a delegation handoff from a voice conversation', () => {
+    const record = buildVoiceLedgerRecord({
+      conversationId: 'voice-test',
+      sessionKey: 'session-test',
+      status: 'ended',
+      updatedAt: '2026-05-22T20:00:00.000Z',
+      turns: [
+        {
+          id: '1',
+          role: 'tim',
+          text: 'I need someone to prepare my May 28 Travel Multiplier webinar so attendees believe travel hacking is real and buy the course.',
+          timestamp: '2026-05-22T19:59:00.000Z',
+        },
+        {
+          id: '2',
+          role: 'executive',
+          text: 'Decision: delegate this to the sales webinar prep workflow. Next action: draft the webinar outline and offer bridge. Needs approval before publishing or sending anything.',
+          timestamp: '2026-05-22T20:00:00.000Z',
+        },
+      ],
+      elevenLabsLog: ['connected'],
+    })
+
+    expect(record.review.summary).toContain('sales webinar prep workflow')
+    expect(record.review.decisions).toContain('Decision: delegate this to the sales webinar prep workflow.')
+    expect(record.review.followUpActions).toContain('Next action: draft the webinar outline and offer bridge.')
+    expect(record.review.openQuestions).toContain('No open questions detected.')
+    expect(record.review.needsApproval).toContain('Needs approval before publishing or sending anything.')
+    expect(record.delegation).toMatchObject({
+      outcome: 'prepare my May 28 Travel Multiplier webinar so attendees believe travel hacking is real and buy the course',
+      owner: 'sales webinar prep workflow',
+      nextAction: 'draft the webinar outline and offer bridge',
+      approvalRequired: true,
+    })
+    expect(record.delegation.context).toContain('May 28 Travel Multiplier webinar')
+    expect(record.delegation.constraints).toContain('No side effects without explicit confirmation.')
+  })
+})

--- a/src/routes/api/-voice-lab-ledger-utils.ts
+++ b/src/routes/api/-voice-lab-ledger-utils.ts
@@ -1,0 +1,182 @@
+const MAX_TURNS = 400
+const MAX_TEXT_LENGTH = 20_000
+const MAX_LOG_LINES = 80
+
+export type VoiceTurn = {
+  id: string
+  role: 'tim' | 'executive' | 'system'
+  text: string
+  timestamp?: string
+}
+
+export type DelegationHandoff = {
+  outcome: string
+  owner: string
+  context: string
+  constraints: Array<string>
+  nextAction: string
+  approvalRequired: boolean
+}
+
+export type VoiceReview = {
+  summary: string
+  decisions: Array<string>
+  followUpActions: Array<string>
+  openQuestions: Array<string>
+  needsApproval: Array<string>
+}
+
+type BuildVoiceLedgerRecordInput = {
+  conversationId: string
+  sessionKey: string
+  status: string
+  updatedAt: string
+  turns: unknown
+  elevenLabsLog: unknown
+}
+
+export function readString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value.trim() : fallback
+}
+
+export function normalizeTurns(value: unknown): Array<VoiceTurn> {
+  if (!Array.isArray(value)) return []
+
+  const turns: Array<VoiceTurn> = []
+  for (const entry of value.slice(-MAX_TURNS)) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const role = record.role
+    if (role !== 'tim' && role !== 'executive' && role !== 'system') continue
+    const text = readString(record.text).slice(0, MAX_TEXT_LENGTH)
+    if (!text) continue
+    turns.push({
+      id: readString(record.id, `${Date.now()}-${turns.length}`),
+      role,
+      text,
+      timestamp: readString(record.timestamp) || undefined,
+    })
+  }
+  return turns
+}
+
+export function normalizeLog(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((line) => readString(line).slice(0, 1_000))
+    .filter(Boolean)
+    .slice(-MAX_LOG_LINES)
+}
+
+export function buildSummary(turns: Array<VoiceTurn>): string {
+  const meaningful = turns.filter((turn) => turn.role !== 'system')
+  if (meaningful.length === 0) return 'No user conversation captured yet.'
+  const executiveDecision = [...meaningful]
+    .reverse()
+    .find((turn) => turn.role === 'executive' && /\b(decision|delegate|next action|workflow|agent)\b/i.test(turn.text))
+  const last = executiveDecision ?? meaningful[meaningful.length - 1]
+  return `Latest ${last.role === 'tim' ? 'Tim' : 'Executive'} turn: ${last.text.slice(0, 240)}`
+}
+
+export function extractLines(turns: Array<VoiceTurn>, patterns: Array<RegExp>): Array<string> {
+  const lines: Array<string> = []
+  for (const turn of turns) {
+    if (turn.role === 'system') continue
+    const sentences = turn.text.split(/(?<=[.!?])\s+/)
+    for (const sentence of sentences) {
+      const clean = sentence.trim()
+      if (!clean) continue
+      if (patterns.some((pattern) => pattern.test(clean))) lines.push(clean.slice(0, 500))
+    }
+  }
+  return Array.from(new Set(lines)).slice(-8)
+}
+
+function stripTrailingPunctuation(value: string): string {
+  return value.trim().replace(/[.!?]+$/, '')
+}
+
+function extractOutcome(turns: Array<VoiceTurn>): string {
+  const timTurn = turns.find((turn) => turn.role === 'tim' && /\b(i need|prepare|build|create|draft)\b/i.test(turn.text))
+  if (!timTurn) return 'No delegation outcome detected yet.'
+  const match = timTurn.text.match(/I need(?: someone)? to (.+?)(?:\.|$)/i)
+  return stripTrailingPunctuation(match?.[1] ?? timTurn.text.slice(0, 180))
+}
+
+function extractOwner(decisions: Array<string>): string {
+  const decision = decisions.find((line) => /delegate/i.test(line))
+  const match = decision?.match(/delegate (?:this|it)?\s*to (.+?)(?:\.|$)/i)
+  return stripTrailingPunctuation(match?.[1] ?? 'Executive').replace(/^the\s+/i, '')
+}
+
+function extractNextAction(followUpActions: Array<string>): string {
+  const action = followUpActions.find((line) => /next action/i.test(line)) ?? followUpActions.at(-1)
+  const match = action?.match(/next action:\s*(.+?)(?:\.|$)/i)
+  return stripTrailingPunctuation(match?.[1] ?? action ?? 'Review the transcript and choose the next action')
+}
+
+function extractOpenQuestions(turns: Array<VoiceTurn>): Array<string> {
+  const questions = extractLines(turns, [/\?$/, /\b(open question|need to know|clarify)\b/i])
+  return questions.length ? questions : ['No open questions detected.']
+}
+
+function extractNeedsApproval(turns: Array<VoiceTurn>): Array<string> {
+  const approvals = extractLines(turns, [/\b(needs approval|approval required|confirm before|before publishing|before sending)\b/i])
+  return approvals.length ? approvals : ['No approval blockers detected.']
+}
+
+function buildDelegation(input: {
+  turns: Array<VoiceTurn>
+  decisions: Array<string>
+  followUpActions: Array<string>
+  needsApproval: Array<string>
+}): DelegationHandoff {
+  const context = input.turns
+    .filter((turn) => turn.role !== 'system')
+    .map((turn) => `${turn.role === 'tim' ? 'Tim' : 'Executive'}: ${turn.text}`)
+    .join('\n')
+    .slice(0, 2_000)
+
+  return {
+    outcome: extractOutcome(input.turns),
+    owner: extractOwner(input.decisions),
+    context,
+    constraints: ['No side effects without explicit confirmation.'],
+    nextAction: extractNextAction(input.followUpActions),
+    approvalRequired: input.needsApproval.some((line) => !/No approval blockers/i.test(line)),
+  }
+}
+
+export function buildVoiceLedgerRecord(input: BuildVoiceLedgerRecordInput) {
+  const turns = normalizeTurns(input.turns)
+  const elevenLabsLog = normalizeLog(input.elevenLabsLog)
+  const decisions = extractLines(turns, [/\b(decision|decide|decided|we should|the right move)\b/i])
+  const followUpActions = extractLines(turns, [/\b(next step|next action|follow up|delegate|task|action|confirm|approval)\b/i])
+  const openQuestions = extractOpenQuestions(turns)
+  const needsApproval = extractNeedsApproval(turns)
+  const review: VoiceReview = {
+    summary: buildSummary(turns),
+    decisions,
+    followUpActions,
+    openQuestions,
+    needsApproval,
+  }
+
+  return {
+    schemaVersion: 2,
+    source: 'workspace-voice-lab',
+    conversationId: input.conversationId,
+    sessionKey: input.sessionKey,
+    status: input.status,
+    updatedAt: input.updatedAt,
+    summary: review.summary,
+    decisions,
+    followUpActions,
+    review,
+    delegation: buildDelegation({ turns, decisions, followUpActions, needsApproval }),
+    turns,
+    diagnostics: {
+      elevenLabsLog,
+    },
+  }
+}

--- a/src/routes/api/-worker-safety-filter.test.ts
+++ b/src/routes/api/-worker-safety-filter.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  evaluateQueueExecutionSafety,
+  evaluateWorkerSurfaceItem,
+  sanitizeSourceCoverageSnapshot,
+} from './-worker-safety-filter'
+import type { ExecutiveQueueItem } from './-executive-queue-utils'
+
+function queueItem(
+  overrides: Partial<ExecutiveQueueItem> = {},
+): ExecutiveQueueItem {
+  return {
+    schemaVersion: 1,
+    id: 'eq_safe_low_risk',
+    title: 'Draft local Codex safety notes',
+    outcome: 'Local notes are drafted.',
+    status: 'Queued',
+    priority: 'P1',
+    domain: 'AI Ops',
+    owner: 'Executive',
+    riskLevel: 'Low',
+    approvalLevel: 'Auto',
+    confidence: 'High',
+    source: {
+      type: 'Voice Lab',
+      id: 'voice-safe',
+      timestamp: '2026-06-06T13:00:00.000Z',
+      excerpt: 'Draft local safety notes.',
+      fullReference: '/tmp/voice-safe.json',
+    },
+    context: 'Local-only prep.',
+    constraints: ['No external side effects.'],
+    nextAction: 'Draft local notes',
+    blockedReason: '',
+    resultSummary: '',
+    createdAt: '2026-06-06T13:00:00.000Z',
+    updatedAt: '2026-06-06T13:00:00.000Z',
+    dueAt: '',
+    completedAt: '',
+    completedBy: '',
+    auditTrail: [],
+    sync: {
+      notionPageId: '',
+      lastSyncedAt: '',
+      lastSyncStatus: 'not_synced',
+    },
+    localPath: '/tmp/eq_safe_low_risk.json',
+    ...overrides,
+  }
+}
+
+describe('worker safety filter contracts', () => {
+  it('allows verified local source coverage summaries without raw bodies', () => {
+    const decision = evaluateWorkerSurfaceItem({
+      surface: 'source_coverage',
+      action: 'local_report',
+      source: { type: 'local_artifact', id: 'snapshot.json', status: 'verified' },
+      title: 'Source coverage ready',
+    })
+
+    expect(decision.verdict).toBe('allow')
+    expect(decision.timFacing).toBe(true)
+  })
+
+  it('suppresses teammate-owned Motion work before it reaches Tim-facing cards', () => {
+    const decision = evaluateWorkerSurfaceItem({
+      surface: 'motion',
+      action: 'queue_proposal',
+      owner: 'Morris',
+      ownership: 'teammate',
+      source: { type: 'motion_snapshot', id: 'motion-1', status: 'verified' },
+      title: 'Follow up teammate task',
+    })
+
+    expect(decision.verdict).toBe('suppress')
+    expect(decision.timFacing).toBe(false)
+    expect(decision.reasons).toContain('motion_ownership_not_tim_clear')
+  })
+
+  it('suppresses partial Reader transcript items instead of marking them ready', () => {
+    const decision = evaluateWorkerSurfaceItem({
+      surface: 'reader_transcript',
+      action: 'queue_proposal',
+      fullTranscriptVerified: false,
+      source: { type: 'reader', id: 'reader-1', status: 'partial' },
+      title: 'AI podcast summary',
+    })
+
+    expect(decision.verdict).toBe('suppress')
+    expect(decision.reasons).toContain('full_transcript_not_verified')
+  })
+
+  it('gates X or bookmark recommendations that become monetization actions', () => {
+    const decision = evaluateWorkerSurfaceItem({
+      surface: 'x_research',
+      action: 'queue_proposal',
+      recommendationType: 'package',
+      source: { type: 'x_bookmark', id: 'bookmark-1', status: 'verified' },
+      title: 'Package this as a Travel Multiplier offer',
+    })
+
+    expect(decision.verdict).toBe('gate')
+    expect(decision.reasons).toContain(
+      'external_or_monetization_recommendation_needs_approval',
+    )
+  })
+
+  it('blocks raw worker output and credential-looking text from Tim-facing surfaces', () => {
+    const rawDecision = evaluateWorkerSurfaceItem({
+      surface: 'telegram_summary',
+      action: 'summarize',
+      rawWorkerOutput: true,
+      source: { type: 'codex_output', id: 'worker-1', status: 'verified' },
+      title: 'Raw Codex dump',
+    })
+    const secretDecision = evaluateWorkerSurfaceItem({
+      surface: 'telegram_summary',
+      action: 'summarize',
+      body: 'worker printed api_key: placeholder',
+      source: { type: 'codex_output', id: 'worker-2', status: 'verified' },
+      title: 'Unsafe worker log',
+    })
+
+    expect(rawDecision.verdict).toBe('suppress')
+    expect(secretDecision.verdict).toBe('deny')
+  })
+
+  it('allows draft-only execution for a sourced local queue item', () => {
+    const decision = evaluateQueueExecutionSafety({
+      item: queueItem(),
+      mode: 'draft_only',
+      approvedPhrase: 'Draft local notes only',
+    })
+
+    expect(decision.verdict).toBe('allow')
+    expect(decision.timFacing).toBe(true)
+  })
+
+  it('gates draft-only queue execution unless the item is low-risk Auto local prep', () => {
+    const medium = evaluateQueueExecutionSafety({
+      item: queueItem({
+        id: 'eq_medium_draft',
+        riskLevel: 'Medium',
+        approvalLevel: 'Auto',
+      }),
+      mode: 'draft_only',
+      approvedPhrase: 'Draft only',
+    })
+    const manual = evaluateQueueExecutionSafety({
+      item: queueItem({
+        id: 'eq_manual_draft',
+        riskLevel: 'Low',
+        approvalLevel: 'Manual Only',
+      }),
+      mode: 'draft_only',
+      approvedPhrase: 'Draft only',
+    })
+
+    expect(medium.verdict).toBe('gate')
+    expect(medium.reasons).toContain('draft_only_requires_low_risk_auto_item')
+    expect(manual.verdict).toBe('gate')
+    expect(manual.reasons).toContain('draft_only_requires_low_risk_auto_item')
+  })
+
+  it('gates draft-only execution for people, Motion, calendar, sends, money, and system changes', () => {
+    const gated = [
+      queueItem({ id: 'people', title: 'Draft people decision memo' }),
+      queueItem({ id: 'motion', title: 'Draft Motion task cleanup' }),
+      queueItem({ id: 'calendar', title: 'Draft calendar invite', domain: 'Calendar' }),
+      queueItem({ id: 'send', title: 'Draft and send email', domain: 'Email' }),
+      queueItem({ id: 'money', title: 'Draft money reimbursement', domain: 'Finance' }),
+      queueItem({ id: 'system', title: 'Draft system restart plan', domain: 'Code' }),
+    ].map((item) =>
+      evaluateQueueExecutionSafety({
+        item,
+        mode: 'draft_only',
+        approvedPhrase: 'Draft only',
+      }),
+    )
+
+    expect(gated.every((decision) => decision.verdict === 'gate')).toBe(true)
+    expect(gated.flatMap((decision) => decision.reasons)).toContain(
+      'draft_only_touches_approval_gated_surface',
+    )
+  })
+
+  it('blocks generic approve-and-run for high-risk or external queue work', () => {
+    const decision = evaluateQueueExecutionSafety({
+      item: queueItem({
+        id: 'eq_high_risk_email',
+        title: 'Send donor follow-up email',
+        domain: 'Email',
+        riskLevel: 'High',
+        approvalLevel: 'Ask Before External',
+        context: 'External email send.',
+        nextAction: 'Send the email',
+      }),
+      mode: 'approve_and_run',
+      approvedPhrase: 'Approve',
+    })
+
+    expect(decision.verdict).toBe('gate')
+    expect(decision.reasons).toContain('generic_approve_cannot_authorize_execution')
+    expect(decision.reasons).toContain('high_risk_queue_item_requires_manual_gate')
+  })
+
+  it('requires an exact item-scoped phrase for medium-risk approve-and-run', () => {
+    const item = queueItem({
+      id: 'eq_medium_workspace',
+      title: 'Run workspace worker check',
+      riskLevel: 'Medium',
+      approvalLevel: 'Ask Before System Change',
+      context: 'Could touch Workspace execution routes.',
+      nextAction: 'Run the bounded route check',
+    })
+
+    const generic = evaluateQueueExecutionSafety({
+      item,
+      mode: 'approve_and_run',
+      approvedPhrase: 'Approve and Run',
+    })
+    const scoped = evaluateQueueExecutionSafety({
+      item,
+      mode: 'approve_and_run',
+      approvedPhrase: 'RUN-eq_medium_workspace',
+    })
+
+    expect(generic.verdict).toBe('gate')
+    expect(scoped.verdict).toBe('allow')
+  })
+
+  it('redacts source coverage snapshots to safe summary fields only', () => {
+    const sanitized = sanitizeSourceCoverageSnapshot({
+      generated_at: '2026-06-06T00:00:00Z',
+      sources: {
+        motion: {
+          available: true,
+          tim_owned_count: 3,
+          raw_task_titles: ['private raw task title'],
+        },
+        reader: {
+          acceptable_full_transcripts: 4,
+          token: 'do-not-return',
+          failure_reason_counts: { partial: 1 },
+        },
+      },
+      raw_private_body: 'do-not-return',
+    })
+
+    expect(JSON.stringify(sanitized)).not.toContain('private raw task title')
+    expect(JSON.stringify(sanitized)).not.toContain('do-not-return')
+    expect(sanitized).toMatchObject({
+      generated_at: '2026-06-06T00:00:00Z',
+      sources: {
+        motion: { available: true, tim_owned_count: 3 },
+        reader: {
+          acceptable_full_transcripts: 4,
+          failure_reason_counts: { partial: 1 },
+        },
+      },
+    })
+  })
+})

--- a/src/routes/api/-worker-safety-filter.ts
+++ b/src/routes/api/-worker-safety-filter.ts
@@ -1,0 +1,390 @@
+import type {
+  ExecutiveQueueItem,
+  QueueExecutionMode,
+} from './-executive-queue-utils'
+
+export type SafetyVerdict = 'allow' | 'gate' | 'suppress' | 'deny'
+
+export type WorkerSafetyDecision = {
+  verdict: SafetyVerdict
+  reasons: Array<string>
+  timFacing: boolean
+  requiredApprovalPhrase?: string
+}
+
+export type WorkerSurfaceItem = {
+  surface:
+    | 'source_coverage'
+    | 'motion'
+    | 'granola'
+    | 'reader_transcript'
+    | 'x_research'
+    | 'bookmark_research'
+    | 'executive_queue'
+    | 'kanban'
+    | 'heavy_lift'
+    | 'workspace_approval'
+    | 'telegram_summary'
+    | 'agent_surface'
+  action: string
+  source?: {
+    type?: string
+    id?: string
+    status?: 'verified' | 'partial' | 'failed' | 'unavailable'
+  }
+  title?: string
+  body?: string
+  owner?: string
+  ownership?: 'tim_clear' | 'teammate' | 'ambiguous' | 'unassigned'
+  confidential?: boolean
+  sensitivePeopleIssue?: boolean
+  fullTranscriptVerified?: boolean
+  recommendationType?: 'sell' | 'package' | 'pilot_offer' | 'outbound' | 'internal'
+  rawWorkerOutput?: boolean
+  riskClasses?: Array<string>
+  sideEffects?: Array<string>
+  approvalPhrase?: string
+  expectedApprovalPhrase?: string
+  approvalReceiptId?: string
+  href?: string
+}
+
+type QueueExecutionSafetyInput = {
+  item: ExecutiveQueueItem
+  mode: QueueExecutionMode
+  approvedPhrase?: string
+}
+
+const HIGH_RISK_CLASSES = new Set([
+  'finance_write',
+  'external_communication',
+  'pastoral_private_people',
+  'system_change',
+  'credential_or_secret',
+  'public_publishing',
+  'cron_change',
+  'money_movement',
+  'calendar_commitment',
+  'motion_mutation',
+])
+
+const SIDE_EFFECT_ACTIONS = new Set([
+  'send_email',
+  'send_text',
+  'publish',
+  'create_cron',
+  'update_cron',
+  'restart_gateway',
+  'repair_oauth',
+  'write_monarch',
+  'move_money',
+  'change_motion_task',
+  'create_calendar_commitment',
+  'launch_worker',
+  'approve_and_run',
+])
+
+const SAFE_INTERNAL_ACTIONS = new Set([
+  'summarize',
+  'draft',
+  'classify',
+  'local_report',
+  'queue_proposal',
+  'read_only_research',
+])
+
+const QUEUE_DRAFT_ONLY_GATED_PATTERN = /\b(people|personnel|staffing|pastoral|counsel|motion|calendar|schedule|invite|send|email|text|message|publish|post|money|spend|payment|reimburse|monarch|finance|tax|budget|system|restart|deploy|config|credential|secret|token|oauth|cron|launchd|docker)\b/i
+
+const SECRET_PATTERNS = [
+  /api[_-]?key\s*[:=]/i,
+  /bearer\s+[a-z0-9._-]{8,}/i,
+  /refresh[_-]?token/i,
+  /auth\.json|\.env|credential/i,
+]
+
+const SOURCE_COVERAGE_SAFE_KEYS = new Set([
+  'available',
+  'generated_at',
+  'items_last_30_days_scanned',
+  'estimated_ai_relevant_items',
+  'x_bookmarks_30_days',
+  'unique_x_accounts_30_days',
+  'reader_action_summary',
+  'recent_notes_scanned',
+  'eligible_notes_parsed',
+  'skipped_confidential_or_sensitive',
+  'action_summary',
+  'task_count',
+  'ownership_counts',
+  'tim_owned_count',
+  'teammate_owned_count',
+  'ambiguous_unassigned_count',
+  'unscheduled_count',
+  'items_checked',
+  'acceptable_full_transcripts',
+  'unacceptable_transcripts',
+  'failure_reason_counts',
+])
+
+function decision(
+  verdict: SafetyVerdict,
+  reasons: Array<string>,
+  timFacing: boolean,
+  requiredApprovalPhrase?: string,
+): WorkerSafetyDecision {
+  return {
+    verdict,
+    reasons: [...new Set(reasons)].sort(),
+    timFacing,
+    ...(requiredApprovalPhrase ? { requiredApprovalPhrase } : {}),
+  }
+}
+
+function containsSecretLikeText(text: string): boolean {
+  return SECRET_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+function isGenericApproval(phrase: string | undefined): boolean {
+  const normalized = phrase?.trim().toLowerCase()
+  return !normalized || ['approve', 'approved', 'yes', 'ok', 'go', 'approve and run'].includes(normalized)
+}
+
+function hasSpecificApproval(input: {
+  approvalPhrase?: string
+  expectedApprovalPhrase?: string
+}): boolean {
+  const phrase = input.approvalPhrase?.trim()
+  const expected = input.expectedApprovalPhrase?.trim()
+  return Boolean(phrase && expected && phrase === expected && !isGenericApproval(phrase))
+}
+
+function itemText(item: WorkerSurfaceItem): string {
+  return [item.title, item.body].filter(Boolean).join(' ')
+}
+
+export function evaluateWorkerSurfaceItem(
+  item: WorkerSurfaceItem,
+): WorkerSafetyDecision {
+  if (item.rawWorkerOutput) {
+    return decision(
+      'suppress',
+      ['raw_worker_output_requires_executive_synthesis'],
+      false,
+    )
+  }
+
+  if (containsSecretLikeText(itemText(item))) {
+    return decision('deny', ['secret_or_credential_like_text'], false)
+  }
+
+  const reasons: Array<string> = []
+  const source = item.source
+
+  if (!source?.type || !source.id) reasons.push('missing_source_link')
+  if (
+    source?.status &&
+    ['partial', 'failed', 'unavailable'].includes(source.status)
+  ) {
+    reasons.push('source_not_verified')
+  }
+
+  if (item.surface === 'motion') {
+    if (item.owner && item.owner !== 'Tim') reasons.push('motion_non_tim_owned_suppressed')
+    if (['teammate', 'ambiguous', 'unassigned'].includes(item.ownership ?? '')) {
+      reasons.push('motion_ownership_not_tim_clear')
+    }
+  }
+
+  if (item.surface === 'granola') {
+    if (item.confidential || item.sensitivePeopleIssue) {
+      reasons.push('granola_sensitive_or_confidential')
+    }
+    if (item.ownership !== 'tim_clear') {
+      reasons.push('granola_ownership_not_tim_clear')
+    }
+  }
+
+  if (item.surface === 'reader_transcript' && !item.fullTranscriptVerified) {
+    reasons.push('full_transcript_not_verified')
+  }
+
+  if (
+    (item.surface === 'x_research' || item.surface === 'bookmark_research') &&
+    ['sell', 'package', 'pilot_offer', 'outbound'].includes(
+      item.recommendationType ?? '',
+    )
+  ) {
+    reasons.push('external_or_monetization_recommendation_needs_approval')
+  }
+
+  if (
+    ['kanban', 'heavy_lift', 'workspace_approval', 'telegram_summary'].includes(
+      item.surface,
+    )
+  ) {
+    if (SIDE_EFFECT_ACTIONS.has(item.action) && !item.approvalReceiptId) {
+      reasons.push('agent_surface_missing_approval_receipt')
+    }
+    if (item.href && !item.href.startsWith('/') && !item.href.startsWith('https://')) {
+      reasons.push('unsafe_href')
+    }
+  }
+
+  if ((item.sideEffects?.length ?? 0) > 1 && isGenericApproval(item.approvalPhrase)) {
+    reasons.push('generic_approve_cannot_authorize_multiple_side_effects')
+  }
+
+  if (item.riskClasses?.some((riskClass) => HIGH_RISK_CLASSES.has(riskClass))) {
+    reasons.push('high_risk_class_requires_gate')
+  }
+
+  if (SIDE_EFFECT_ACTIONS.has(item.action)) {
+    if (hasSpecificApproval(item) && reasons.length === 0) {
+      return decision('allow', ['specific_approval_present'], true)
+    }
+    if (!hasSpecificApproval(item)) {
+      reasons.push('side_effect_requires_specific_approval_phrase')
+    }
+    return decision('gate', reasons, true, item.expectedApprovalPhrase)
+  }
+
+  if (!SAFE_INTERNAL_ACTIONS.has(item.action)) {
+    reasons.push('unknown_action_defaults_to_gate')
+  }
+
+  const suppressReasons = new Set([
+    'missing_source_link',
+    'source_not_verified',
+    'motion_non_tim_owned_suppressed',
+    'motion_ownership_not_tim_clear',
+    'granola_sensitive_or_confidential',
+    'granola_ownership_not_tim_clear',
+    'full_transcript_not_verified',
+  ])
+
+  if (reasons.some((reason) => suppressReasons.has(reason))) {
+    return decision('suppress', reasons, false)
+  }
+
+  if (reasons.length > 0) return decision('gate', reasons, true)
+
+  return decision('allow', ['safe_internal_item'], true)
+}
+
+function queueText(item: ExecutiveQueueItem): string {
+  return [
+    item.title,
+    item.outcome,
+    item.context,
+    item.nextAction,
+    ...item.constraints,
+  ].join(' ')
+}
+
+function expectedQueuePhrase(item: ExecutiveQueueItem): string {
+  return `RUN-${item.id}`
+}
+
+export function evaluateQueueExecutionSafety(
+  input: QueueExecutionSafetyInput,
+): WorkerSafetyDecision {
+  const reasons: Array<string> = []
+
+  if (!input.item.source.id) {
+    reasons.push('missing_source_link')
+  }
+
+  if (containsSecretLikeText(queueText(input.item))) {
+    return decision('deny', ['secret_or_credential_like_text'], false)
+  }
+
+  if (input.mode === 'explain_more') {
+    return reasons.length
+      ? decision('suppress', reasons, false)
+      : decision('allow', ['explanation_only'], true)
+  }
+
+  if (input.mode === 'draft_only') {
+    if (input.item.riskLevel !== 'Low' || input.item.approvalLevel !== 'Auto') {
+      reasons.push('draft_only_requires_low_risk_auto_item')
+    }
+    if (input.item.status !== 'Queued' && input.item.status !== 'In Progress') {
+      reasons.push('draft_only_requires_active_queue_item')
+    }
+    if (input.item.domain === 'Calendar' || input.item.domain === 'Finance') {
+      reasons.push('draft_only_touches_approval_gated_surface')
+    }
+    if (
+      input.item.owner === 'Finance CFO' ||
+      input.item.owner === 'Calendar Assistant'
+    ) {
+      reasons.push('draft_only_touches_approval_gated_surface')
+    }
+    if (QUEUE_DRAFT_ONLY_GATED_PATTERN.test(queueText(input.item))) {
+      reasons.push('draft_only_touches_approval_gated_surface')
+    }
+    return reasons.length
+      ? decision('gate', reasons, true)
+      : decision('allow', ['draft_only_local_execution'], true)
+  }
+
+  const requiredPhrase = expectedQueuePhrase(input.item)
+
+  if (isGenericApproval(input.approvedPhrase)) {
+    reasons.push('generic_approve_cannot_authorize_execution')
+  }
+
+  if (input.item.riskLevel === 'High') {
+    reasons.push('high_risk_queue_item_requires_manual_gate')
+  }
+
+  if (
+    input.item.riskLevel === 'Medium' ||
+    input.item.approvalLevel !== 'Auto'
+  ) {
+    if (input.approvedPhrase?.trim() !== requiredPhrase) {
+      reasons.push('item_scoped_approval_phrase_required')
+    }
+  }
+
+  if (input.item.approvalLevel === 'Manual Only') {
+    reasons.push('manual_only_item_cannot_auto_execute')
+  }
+
+  if (reasons.length > 0) {
+    return decision('gate', reasons, true, requiredPhrase)
+  }
+
+  return decision('allow', ['safe_approve_and_run_execution'], true)
+}
+
+function sanitizeObject(value: unknown, allowArbitraryKeys = false): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+
+  const result: Record<string, unknown> = {}
+  for (const [key, nested] of Object.entries(value)) {
+    if (!allowArbitraryKeys && !SOURCE_COVERAGE_SAFE_KEYS.has(key)) continue
+    const nestedAllowsArbitraryKeys = key === 'failure_reason_counts'
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      result[key] = sanitizeObject(nested, nestedAllowsArbitraryKeys)
+    } else {
+      result[key] = nested
+    }
+  }
+  return result
+}
+
+export function sanitizeSourceCoverageSnapshot(
+  snapshot: Record<string, unknown>,
+): Record<string, unknown> {
+  const safe: Record<string, unknown> = {}
+  if (typeof snapshot.generated_at === 'string') safe.generated_at = snapshot.generated_at
+
+  const sources = snapshot.sources
+  if (sources && typeof sources === 'object' && !Array.isArray(sources)) {
+    safe.sources = Object.fromEntries(
+      Object.entries(sources).map(([name, value]) => [name, sanitizeObject(value)]),
+    )
+  }
+  return safe
+}

--- a/src/routes/api/agent-surfaces/sample.ts
+++ b/src/routes/api/agent-surfaces/sample.ts
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { createSampleAgentSurface } from '../../../features/agent-surfaces/sample-surface'
+
+export const Route = createFileRoute('/api/agent-surfaces/sample')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        return json({ ok: true, surface: createSampleAgentSurface() })
+      },
+    },
+  },
+})

--- a/src/routes/api/elevenlabs-token.ts
+++ b/src/routes/api/elevenlabs-token.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+export const Route = createFileRoute('/api/elevenlabs-token')({
+  server: {
+    handlers: {
+      GET: async () => {
+        try {
+          const response = await fetch('http://127.0.0.1:3192/api/token', {
+            cache: 'no-store',
+          })
+
+          if (!response.ok) {
+            return json(
+              {
+                ok: false,
+                error: `Voice bridge token server returned ${response.status}`,
+              },
+              { status: 503 },
+            )
+          }
+
+          const data = (await response.json()) as { token?: string }
+          if (!data.token) {
+            return json(
+              { ok: false, error: 'Voice bridge token server returned no token' },
+              { status: 503 },
+            )
+          }
+
+          return json({ ok: true, token: data.token })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Voice bridge token server unavailable',
+            },
+            { status: 503 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/executive-queue-execution.ts
+++ b/src/routes/api/executive-queue-execution.ts
@@ -1,0 +1,538 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { createSession, getSession, sendChat } from '../../server/claude-api'
+import { resolveSessionKey } from '../../server/session-utils'
+import {
+  applyQueueApproval,
+  createQueueApprovalReceipt,
+  createQueueExecutionRecord,
+  readQueueItemById,
+  updateQueueExecutionRecord,
+  updateQueueItemStatus,
+} from './-executive-queue-utils'
+import { evaluateQueueExecutionSafety } from './-worker-safety-filter'
+import type {
+  ExecutiveQueueItem,
+  QueueExecutionMode,
+  QueueExecutionRecord,
+} from './-executive-queue-utils'
+import type { WorkerSafetyDecision } from './-worker-safety-filter'
+
+function readString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value.trim() : fallback
+}
+
+function readExecutionMode(value: unknown): QueueExecutionMode | null {
+  if (
+    value === 'approve_and_run' ||
+    value === 'draft_only' ||
+    value === 'explain_more'
+  )
+    return value
+  return null
+}
+
+const execFileAsync = promisify(execFile)
+
+const HERMES_HOME =
+  process.env.HERMES_HOME || '/Users/hermes/.hermes/profiles/executive'
+
+function readNestedString(
+  record: Record<string, unknown>,
+  path: Array<string>,
+): string {
+  let current: unknown = record
+  for (const key of path) {
+    if (!current || typeof current !== 'object') return ''
+    current = (current as Record<string, unknown>)[key]
+  }
+  return typeof current === 'string' ? current.trim() : ''
+}
+
+export function resultTextFromPayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return String(payload ?? '')
+  const record = payload as Record<string, unknown>
+  for (const path of [
+    ['final_response'],
+    ['response'],
+    ['message', 'content'],
+    ['message'],
+    ['content'],
+    ['text'],
+  ]) {
+    const value = readNestedString(record, path)
+    if (value) return value
+  }
+  return ''
+}
+
+export function conciseTelegramBody(body: string, maxLength = 500): string {
+  const normalized = body
+    .replace(/\\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  const stopSections = [
+    'Verification output:',
+    'Artifacts created:',
+    'Artifacts:',
+    'Verified:',
+    'Verification:',
+    'JSON read-back:',
+    'Source checked:',
+    'Safety:',
+  ]
+  const kept: Array<string> = []
+  for (const line of normalized) {
+    if (stopSections.some((section) => line.startsWith(section))) break
+    if (line.startsWith('{') || line.startsWith('"object":')) continue
+    kept.push(line)
+  }
+
+  const text = kept.join('\n').trim() || 'Done.'
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength - 22).trimEnd()}\n…trimmed for Telegram.`
+}
+
+async function sendTelegramStatus(input: {
+  itemTitle: string
+  itemId: string
+  executionId: string
+  status: 'started' | 'running' | 'completed' | 'error' | 'explanation'
+  timestamp: string
+  sessionKey: string
+  body: string
+  error?: string
+  subject: string
+}): Promise<void> {
+  const message = `${input.subject}\n\n${conciseTelegramBody(input.body)}`.trim()
+  await execFileAsync('hermes', ['send', '--to', 'telegram', message], {
+    env: {
+      ...process.env,
+      HERMES_HOME,
+    },
+    timeout: 30_000,
+    maxBuffer: 256 * 1024,
+  })
+}
+
+type WorkerDispatchStatusInput = Parameters<typeof sendTelegramStatus>[0]
+
+type WorkerDispatchInput = {
+  item: Pick<ExecutiveQueueItem, 'id' | 'title' | 'nextAction'>
+  record: Pick<QueueExecutionRecord, 'id' | 'prompt'> & {
+    localPath?: string
+  }
+  approvalReceiptPath?: string
+  mode: QueueExecutionMode
+  sessionKey: string
+  now?: () => string
+}
+
+type WorkerTimer = Parameters<typeof clearTimeout>[0]
+
+type WorkerDispatchDeps = {
+  sendTelegramStatus?: (input: WorkerDispatchStatusInput) => Promise<void>
+  sendChat?: (
+    sessionKey: string,
+    body: { message: string },
+  ) => Promise<Record<string, unknown>>
+  updateExecutionRecord?: (
+    patch: Partial<QueueExecutionRecord>,
+  ) => Promise<void>
+  updateQueueStatus?: (input: {
+    status: 'Done' | 'Blocked'
+    resultSummary?: string
+    blockedReason?: string
+    actor: string
+    now: string
+  }) => Promise<void>
+  setTimeout?: (callback: () => void, ms: number) => WorkerTimer
+  clearTimeout?: (timer: WorkerTimer) => void
+}
+
+export type WorkerDispatchAccepted = {
+  completionPending: true
+  startedDelivered: boolean
+  runningDelivered: boolean
+  completion: Promise<void>
+}
+
+export async function dispatchQueueWorkerInBackground(
+  input: WorkerDispatchInput,
+  deps: WorkerDispatchDeps = {},
+): Promise<WorkerDispatchAccepted> {
+  const now = input.now ?? (() => new Date().toISOString())
+  const sendStatus = deps.sendTelegramStatus ?? sendTelegramStatus
+  const chat = deps.sendChat ?? sendChat
+  const updateExecution =
+    deps.updateExecutionRecord ??
+    (async (patch) => {
+      if (input.record.localPath) {
+        await updateQueueExecutionRecord(input.record as QueueExecutionRecord, patch)
+      }
+    })
+  const updateStatus =
+    deps.updateQueueStatus ??
+    (async (statusInput) => {
+      await updateQueueItemStatus({
+        id: input.item.id,
+        status: statusInput.status,
+        actor: statusInput.actor,
+        now: statusInput.now,
+        resultSummary: statusInput.resultSummary,
+        blockedReason: statusInput.blockedReason,
+      })
+    })
+  const schedule = deps.setTimeout ?? setTimeout
+  const cancelTimer = deps.clearTimeout ?? clearTimeout
+
+  await sendStatus({
+    itemTitle: input.item.title,
+    itemId: input.item.id,
+    executionId: input.record.id,
+    status: 'started',
+    timestamp: now(),
+    sessionKey: input.sessionKey,
+    subject: `Workspace started: ${input.item.title}`,
+    body:
+      input.mode === 'draft_only'
+        ? 'Draft-only. I’ll message again when it is done, blocked, or still running after 10 minutes.'
+        : 'Running now. I’ll message again when it is done, blocked, or still running after 10 minutes.',
+  })
+
+  let runningDelivered = false
+  const runningTimer = schedule(() => {
+    void sendStatus({
+      itemTitle: input.item.title,
+      itemId: input.item.id,
+      executionId: input.record.id,
+      status: 'running',
+      timestamp: now(),
+      sessionKey: input.sessionKey,
+      subject: `Workspace still running: ${input.item.title}`,
+      body: 'Still running after 10 minutes. I’ll keep going and report when it is done or blocked.',
+    })
+      .then(() => {
+        runningDelivered = true
+      })
+      .catch(() => undefined)
+  }, 600_000)
+
+  const completion = (async () => {
+    try {
+      const result = await chat(input.sessionKey, { message: input.record.prompt })
+      cancelTimer(runningTimer)
+      const resultSummary = resultTextFromPayload(result)
+      await updateExecution({
+        status: 'completed',
+        completedAt: now(),
+        resultSummary,
+        runId: typeof result.run_id === 'string' ? result.run_id : null,
+      })
+      await updateStatus({
+        status: 'Done',
+        actor: 'Executive Queue Worker',
+        now: now(),
+        resultSummary: resultSummary || 'Worker completed from Workspace.',
+      })
+      await sendStatus({
+        itemTitle: input.item.title,
+        itemId: input.item.id,
+        executionId: input.record.id,
+        status: 'completed',
+        timestamp: now(),
+        sessionKey: input.sessionKey,
+        subject: `Workspace done: ${input.item.title}`,
+        body: resultSummary,
+      })
+    } catch (error) {
+      cancelTimer(runningTimer)
+      const message =
+        error instanceof Error ? error.message : 'Failed to dispatch queue execution'
+      await updateExecution({
+        status: 'error',
+        completedAt: now(),
+        error: message,
+      }).catch(() => undefined)
+      await updateStatus({
+        status: 'Blocked',
+        actor: 'Executive Queue Worker',
+        now: now(),
+        blockedReason: message,
+      }).catch(() => undefined)
+      await sendStatus({
+        itemTitle: input.item.title,
+        itemId: input.item.id,
+        executionId: input.record.id,
+        status: 'error',
+        timestamp: now(),
+        sessionKey: input.sessionKey,
+        subject: `Workspace blocked: ${input.item.title}`,
+        body: message,
+        error: message,
+      }).catch(() => undefined)
+    }
+  })()
+
+  void completion.catch(() => undefined)
+
+  return {
+    completionPending: true,
+    startedDelivered: true,
+    runningDelivered,
+    completion,
+  }
+}
+
+async function buildExplanation(prompt: string): Promise<string> {
+  const env = {
+    ...process.env,
+    HERMES_HOME,
+  }
+  const { stdout } = await execFileAsync('hermes', ['-z', prompt], {
+    env,
+    timeout: 180_000,
+    maxBuffer: 1024 * 1024,
+  })
+  const message = stdout.trim()
+  if (!message)
+    throw new Error('Explanation agent produced no Telegram message.')
+  return message
+}
+
+export function isMissingSessionError(
+  error: unknown,
+  sessionKey: string,
+): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  const normalizedSessionKey = sessionKey.toLowerCase()
+  return (
+    message.includes('session_not_found') ||
+    message.includes(`session not found: ${normalizedSessionKey}`) ||
+    (message.includes('/api/sessions/') &&
+      message.includes(normalizedSessionKey) &&
+      message.includes('404') &&
+      message.includes('session not found'))
+  )
+}
+
+export function queueExecutionSessionTitle(sessionKey: string): string {
+  if (sessionKey === 'executive-command-center') return 'Executive Command Center'
+  return `Executive Command Center: ${sessionKey.replace(/^executive-command-center-/, '')}`
+}
+
+async function ensureQueueExecutionSession(sessionKey: string): Promise<void> {
+  try {
+    await getSession(sessionKey)
+    return
+  } catch (error) {
+    if (!isMissingSessionError(error, sessionKey)) throw error
+  }
+
+  try {
+    await createSession({
+      id: sessionKey,
+      title: queueExecutionSessionTitle(sessionKey),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!message.toLowerCase().includes('session_exists')) throw error
+  }
+}
+function safetyGateResponse(decision: WorkerSafetyDecision) {
+  return json(
+    {
+      ok: false,
+      error: 'Execution blocked by worker safety filter',
+      safetyDecision: decision,
+    },
+    { status: 403 },
+  )
+}
+
+export const Route = createFileRoute('/api/executive-queue-execution')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const payload = (await request.json()) as Record<string, unknown>
+          const id = readString(payload.id)
+          if (!id)
+            return json({ ok: false, error: 'id is required' }, { status: 400 })
+
+          const mode = readExecutionMode(payload.mode)
+          if (!mode)
+            return json(
+              { ok: false, error: 'valid execution mode is required' },
+              { status: 400 },
+            )
+
+          const actor = readString(payload.actor, 'Tim')
+          const note = readString(payload.note)
+          const now = new Date().toISOString()
+          const { sessionKey } = await resolveSessionKey({
+            rawSessionKey: readString(
+              payload.sessionKey,
+              'executive-command-center',
+            ),
+            friendlyId: 'executive-command-center',
+            defaultKey: 'executive-command-center',
+          })
+          await ensureQueueExecutionSession(sessionKey)
+
+          if (mode === 'explain_more') {
+            const item = await readQueueItemById(id)
+            if (!item)
+              return json(
+                { ok: false, error: `Queue item not found: ${id}` },
+                { status: 404 },
+              )
+            const safetyDecision = evaluateQueueExecutionSafety({
+              item,
+              mode,
+              approvedPhrase: note,
+            })
+            if (safetyDecision.verdict !== 'allow') {
+              return safetyGateResponse(safetyDecision)
+            }
+
+            const record = await createQueueExecutionRecord({
+              item,
+              mode,
+              actor,
+              now,
+              note: note || 'Explain this queue item before approval.',
+              sessionKey,
+            })
+            const explanation = await buildExplanation(record.prompt)
+            await sendTelegramStatus({
+              itemTitle: item.title,
+              itemId: item.id,
+              executionId: record.id,
+              status: 'explanation',
+              timestamp: now,
+              sessionKey,
+              subject: `Executive Queue explanation ready: ${item.title}`,
+              body: explanation,
+            })
+            const delivery = { ok: true, delivered: true, artifactPath: null }
+            return json({
+              ok: true,
+              item,
+              execution: record,
+              delivery,
+              sessionKey,
+            })
+          }
+
+          const item = await readQueueItemById(id)
+          if (!item)
+            return json(
+              { ok: false, error: `Queue item not found: ${id}` },
+              { status: 404 },
+            )
+
+          const safetyDecision = evaluateQueueExecutionSafety({
+            item,
+            mode,
+            approvedPhrase: note,
+          })
+          if (safetyDecision.verdict !== 'allow') {
+            return safetyGateResponse(safetyDecision)
+          }
+
+          const approved =
+            item.status === 'In Progress'
+              ? item
+              : await applyQueueApproval({
+                  id,
+                  decision: 'approve_action',
+                  actor,
+                  now,
+                  note:
+                    note ||
+                    (mode === 'draft_only'
+                      ? 'Approved draft-only execution from Command Center.'
+                      : 'Approved and initiated from Command Center.'),
+                })
+          const reloadedItem = await readQueueItemById(approved.id)
+          if (!reloadedItem)
+            return json(
+              { ok: false, error: 'approved queue item could not be reloaded' },
+              { status: 500 },
+            )
+
+          const approvalReceipt = await createQueueApprovalReceipt({
+            item: reloadedItem,
+            mode,
+            actor,
+            now,
+            note,
+            sessionKey,
+            approvedPhrase:
+              note ||
+              (mode === 'draft_only' ? 'Draft Only' : 'Approve and Run'),
+            sourceChannel: 'Workspace',
+            sourceReference: {
+              fallbackReference: 'Workspace Executive Queue execution control',
+            },
+          })
+
+          const record = await createQueueExecutionRecord({
+            item: reloadedItem,
+            mode,
+            actor,
+            now,
+            note,
+            sessionKey,
+            approvalReceipt,
+          })
+
+          const delivery = await dispatchQueueWorkerInBackground({
+            item: reloadedItem,
+            record,
+            approvalReceiptPath: approvalReceipt.localPath,
+            mode,
+            sessionKey,
+          })
+          return json(
+            {
+              ok: true,
+              accepted: true,
+              item: reloadedItem,
+              execution: record,
+              sessionKey,
+              delivery: {
+                startedArtifactPath: null,
+                runningArtifactPath: null,
+                completedArtifactPath: null,
+                startedDelivered: delivery.startedDelivered,
+                runningDelivered: delivery.runningDelivered,
+                completedDelivered: false,
+                completionPending: true,
+              },
+            },
+            { status: 202 },
+          )
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to dispatch queue execution',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/executive-queue-notion-sync.ts
+++ b/src/routes/api/executive-queue-notion-sync.ts
@@ -1,0 +1,71 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { applyApprovedNotionSync, createNotionSyncProposal } from './-executive-queue-notion-sync-utils'
+import type { NotionSyncApproval } from './-executive-queue-notion-sync-utils'
+
+function readString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function readNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : -1
+}
+
+function readApproval(value: unknown): NotionSyncApproval {
+  const approval = value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+  return {
+    proposalId: readString(approval.proposalId),
+    proposalPath: readString(approval.proposalPath),
+    approvedBy: readString(approval.approvedBy),
+    approvalText: readString(approval.approvalText),
+    expectedCreates: readNumber(approval.expectedCreates),
+    expectedUpdates: readNumber(approval.expectedUpdates),
+  }
+}
+
+export const Route = createFileRoute('/api/executive-queue-notion-sync')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>
+          const mode = readString(payload.mode, 'proposal_only')
+          if (mode === 'proposal_only') {
+            const proposal = await createNotionSyncProposal({
+              now: new Date().toISOString(),
+              actor: readString(payload.actor, 'Executive Queue'),
+              mode: 'proposal_only',
+            })
+            return json({ ok: true, proposal })
+          }
+
+          if (mode === 'apply_approved') {
+            const result = await applyApprovedNotionSync({
+              now: new Date().toISOString(),
+              actor: readString(payload.actor, 'Executive Queue'),
+              approval: readApproval(payload.approval),
+            })
+            return json({ ok: true, result })
+          }
+
+          return json(
+            {
+              ok: false,
+              error: 'Unsupported Notion sync mode. Use proposal_only or apply_approved.',
+            },
+            { status: 400 },
+          )
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : 'Failed to run Notion sync request',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/executive-queue.ts
+++ b/src/routes/api/executive-queue.ts
@@ -1,0 +1,129 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import {
+  applyQueueApproval,
+  groupQueueItemsForBoard,
+  listQueueItems,
+  updateQueueItemStatus,
+} from './-executive-queue-utils'
+import type { QueueApprovalDecision, QueueDomain, QueueOwner, QueueStatus } from './-executive-queue-utils'
+
+function readQueueStatus(value: string | null): QueueStatus | undefined {
+  if (
+    value === 'Triage' ||
+    value === 'Proposed' ||
+    value === 'Queued' ||
+    value === 'In Progress' ||
+    value === 'Blocked' ||
+    value === 'Done' ||
+    value === 'Archived'
+  ) {
+    return value
+  }
+  return undefined
+}
+
+function readQueueOwner(value: string | null): QueueOwner | undefined {
+  return value?.trim() ? (value as QueueOwner) : undefined
+}
+
+function readQueueDomain(value: string | null): QueueDomain | undefined {
+  return value?.trim() ? (value as QueueDomain) : undefined
+}
+
+function readString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function readStatusValue(value: unknown): QueueStatus | null {
+  return readQueueStatus(typeof value === 'string' ? value : null) ?? null
+}
+
+function readApprovalDecision(value: unknown): QueueApprovalDecision | null {
+  if (
+    value === 'approve_action' ||
+    value === 'hold' ||
+    value === 'manual_only' ||
+    value === 'broader_approval'
+  ) {
+    return value
+  }
+  return null
+}
+
+export const Route = createFileRoute('/api/executive-queue')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        try {
+          const url = new URL(request.url)
+          const items = await listQueueItems({
+            includeArchived: url.searchParams.get('include_archived') === 'true',
+            status: readQueueStatus(url.searchParams.get('status')),
+            owner: readQueueOwner(url.searchParams.get('owner')),
+            domain: readQueueDomain(url.searchParams.get('domain')),
+          })
+          const grouped = groupQueueItemsForBoard(items)
+          return json({ ok: true, items, grouped, total: items.length })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : 'Failed to load Executive Queue',
+            },
+            { status: 500 },
+          )
+        }
+      },
+      PATCH: async ({ request }) => {
+        try {
+          const payload = (await request.json()) as Record<string, unknown>
+          const id = readString(payload.id)
+          if (!id) return json({ ok: false, error: 'id is required' }, { status: 400 })
+
+          const actor = readString(payload.actor, 'Executive Queue')
+          const now = new Date().toISOString()
+          const action = readString(payload.action)
+
+          if (action === 'transition') {
+            const status = readStatusValue(payload.status)
+            if (!status) return json({ ok: false, error: 'valid status is required' }, { status: 400 })
+            const item = await updateQueueItemStatus({
+              id,
+              status,
+              actor,
+              now,
+              resultSummary: readString(payload.resultSummary),
+              blockedReason: readString(payload.blockedReason),
+            })
+            return json({ ok: true, item })
+          }
+
+          if (action === 'approval') {
+            const decision = readApprovalDecision(payload.decision)
+            if (!decision) return json({ ok: false, error: 'valid approval decision is required' }, { status: 400 })
+            const item = await applyQueueApproval({
+              id,
+              decision,
+              actor,
+              now,
+              note: readString(payload.note),
+            })
+            return json({ ok: true, item })
+          }
+
+          return json({ ok: false, error: 'valid action is required' }, { status: 400 })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : 'Failed to update Executive Queue item',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/learning-loop/review.ts
+++ b/src/routes/api/learning-loop/review.ts
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { buildLearningLoopReview } from '../../../server/learning-loop-review'
+
+export const Route = createFileRoute('/api/learning-loop/review')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const windowHours = Number(url.searchParams.get('windowHours') ?? 168)
+
+        return json(
+          buildLearningLoopReview(
+            Number.isFinite(windowHours) && windowHours > 0 ? windowHours : 168,
+          ),
+        )
+      },
+    },
+  },
+})

--- a/src/routes/api/source-coverage.ts
+++ b/src/routes/api/source-coverage.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises'
+
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { sanitizeSourceCoverageSnapshot } from './-worker-safety-filter'
+
+const SOURCE_COVERAGE_PATH =
+  '/Users/hermes/.hermes/profiles/executive/workspaces/executive-orchestrator/reports/ai-stack-sprint-2026-06-05/source-coverage-snapshot.json'
+
+export const Route = createFileRoute('/api/source-coverage')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const raw = await readFile(SOURCE_COVERAGE_PATH, 'utf8')
+          const snapshot = sanitizeSourceCoverageSnapshot(
+            JSON.parse(raw) as Record<string, unknown>,
+          )
+          return json({ ok: true, snapshot })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to load source coverage snapshot',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/voice-lab-ledger.ts
+++ b/src/routes/api/voice-lab-ledger.ts
@@ -1,0 +1,98 @@
+import { appendFile, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { createQueueItemFromVoiceLab } from './-executive-queue-utils'
+import { buildVoiceLedgerRecord, readString } from './-voice-lab-ledger-utils'
+
+type VoiceLabLedgerRequest = {
+  conversationId?: unknown
+  sessionKey?: unknown
+  status?: unknown
+  turns?: unknown
+  elevenLabsLog?: unknown
+  createQueueItem?: unknown
+}
+
+function sanitizeId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 96) || `voice-${Date.now()}`
+}
+
+function profileHome(): string {
+  return process.env.HERMES_HOME || join(process.env.HOME || '/Users/hermes', '.hermes', 'profiles', 'executive')
+}
+
+export const Route = createFileRoute('/api/voice-lab-ledger')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const payload = (await request.json()) as VoiceLabLedgerRequest
+          const conversationId = sanitizeId(readString(payload.conversationId))
+          const sessionKey = readString(payload.sessionKey, 'new')
+          const status = readString(payload.status, 'active')
+          const now = new Date()
+          const date = now.toISOString().slice(0, 10)
+          const dir = join(profileHome(), 'voice-conversations', 'voice-lab', date)
+          const filePath = join(dir, `${conversationId}.json`)
+          const indexPath = join(profileHome(), 'voice-conversations', 'voice-lab', 'index.jsonl')
+
+          const record = buildVoiceLedgerRecord({
+            conversationId,
+            sessionKey,
+            status,
+            updatedAt: now.toISOString(),
+            turns: payload.turns,
+            elevenLabsLog: payload.elevenLabsLog,
+          })
+
+          await mkdir(dir, { recursive: true, mode: 0o700 })
+          await mkdir(join(profileHome(), 'voice-conversations', 'voice-lab'), {
+            recursive: true,
+            mode: 0o700,
+          })
+          await writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+          await appendFile(
+            indexPath,
+            `${JSON.stringify({ conversationId, sessionKey, status, updatedAt: record.updatedAt, filePath })}\n`,
+            { mode: 0o600 },
+          )
+
+          const queueItem =
+            payload.createQueueItem === true
+              ? await createQueueItemFromVoiceLab({
+                  now: now.toISOString(),
+                  conversationId,
+                  ledgerPath: filePath,
+                  delegation: record.delegation,
+                  review: record.review,
+                })
+              : null
+
+          return json({
+            ok: true,
+            conversationId,
+            filePath,
+            turnCount: record.turns.length,
+            summary: record.summary,
+            decisions: record.decisions,
+            followUpActions: record.followUpActions,
+            review: record.review,
+            delegation: record.delegation,
+            queueItem,
+          })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error: error instanceof Error ? error.message : 'Failed to save voice ledger',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/-x-bookmarks-utils.test.ts
+++ b/src/routes/api/x-bookmarks/-x-bookmarks-utils.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  X_BOOKMARK_SCOPES,
+  buildXArticleCaptureBookmarklet,
+  buildXBookmarkAuthorizeUrl,
+  createBrowserXArticleExtraction,
+  createManualXArticleExtraction,
+  createXBookmarkReviewDigest,
+  createXBookmarkStatus,
+  draftContentStateToPlainText,
+  fetchXArticleExtraction,
+  isBrowserXLoginWallText,
+  mergeBookmarkCache,
+  normalizeBrowserExtractedArticleText,
+  normalizeXBookmarkTweets,
+  redactXBookmarkTokenState,
+  xArticleBrowserProfilePath,
+} from './-x-bookmarks-utils'
+
+describe('X Bookmark Intake utilities', () => {
+  it('builds a safe X Article capture bookmarklet for logged-in browser extraction', () => {
+    const bookmarklet = buildXArticleCaptureBookmarklet()
+
+    expect(bookmarklet.startsWith('javascript:')).toBe(true)
+    expect(decodeURIComponent(bookmarklet)).toContain(
+      'navigator.clipboard.writeText',
+    )
+    expect(decodeURIComponent(bookmarklet)).toContain('x-article-clipboard-v1')
+    expect(decodeURIComponent(bookmarklet)).toContain('document.body.innerText')
+    expect(bookmarklet).not.toContain('cookie')
+    expect(bookmarklet).not.toContain('localStorage')
+    expect(bookmarklet).not.toContain('token')
+  })
+
+  it('reports read-only setup state without exposing secrets', () => {
+    const status = createXBookmarkStatus({
+      clientId: 'client-123',
+      redirectUri: 'http://127.0.0.1:3002/api/x-bookmarks/callback',
+      tokenState: {
+        accessToken: 'secret-access-token',
+        refreshToken: 'secret-refresh-token',
+        expiresAt: '2026-06-05T00:00:00.000Z',
+        scope: 'bookmark.read tweet.read users.read',
+        userId: '12345',
+        username: 'tim',
+        updatedAt: '2026-06-04T20:00:00.000Z',
+      },
+    })
+
+    expect(status.configured).toBe(true)
+    expect(status.authenticated).toBe(true)
+    expect(status.mode).toBe('read-only')
+    expect(status.scopes).toEqual(X_BOOKMARK_SCOPES)
+    expect(JSON.stringify(status)).not.toContain('secret-access-token')
+    expect(JSON.stringify(status)).not.toContain('secret-refresh-token')
+    expect(status.token).toEqual({
+      hasAccessToken: true,
+      hasRefreshToken: true,
+      expiresAt: '2026-06-05T00:00:00.000Z',
+      scope: 'bookmark.read tweet.read users.read',
+      userId: '12345',
+      username: 'tim',
+      updatedAt: '2026-06-04T20:00:00.000Z',
+    })
+  })
+
+  it('builds the X OAuth authorize URL with PKCE and read-only bookmark scopes', () => {
+    const url = buildXBookmarkAuthorizeUrl({
+      clientId: 'client-123',
+      redirectUri: 'http://127.0.0.1:3002/api/x-bookmarks/callback',
+      state: 'state-abc',
+      codeChallenge: 'challenge-xyz',
+    })
+
+    expect(url.origin).toBe('https://x.com')
+    expect(url.pathname).toBe('/i/oauth2/authorize')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('client_id')).toBe('client-123')
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'http://127.0.0.1:3002/api/x-bookmarks/callback',
+    )
+    expect(url.searchParams.get('state')).toBe('state-abc')
+    expect(url.searchParams.get('code_challenge')).toBe('challenge-xyz')
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('scope')).toBe(
+      'bookmark.read tweet.read users.read offline.access',
+    )
+  })
+
+  it('normalizes bookmark tweets into safe local cache records', () => {
+    const records = normalizeXBookmarkTweets(
+      {
+        data: [
+          {
+            id: '111',
+            text: 'AI agents are becoming product surfaces',
+            created_at: '2026-06-04T19:00:00.000Z',
+            author_id: '42',
+            public_metrics: { like_count: 10, retweet_count: 2 },
+            attachments: { media_keys: ['media-1'] },
+            entities: { urls: [{ expanded_url: 'https://example.com/post' }] },
+          },
+        ],
+        includes: {
+          users: [{ id: '42', username: 'builder', name: 'Builder' }],
+          media: [
+            {
+              media_key: 'media-1',
+              type: 'video',
+              url: 'https://video.example/file.mp4',
+            },
+          ],
+        },
+        meta: { result_count: 1, next_token: 'next-page' },
+      },
+      '2026-06-04T20:00:00.000Z',
+    )
+
+    expect(records.nextToken).toBe('next-page')
+    expect(records.items).toEqual([
+      {
+        id: '111',
+        url: 'https://x.com/builder/status/111',
+        text: 'AI agents are becoming product surfaces',
+        createdAt: '2026-06-04T19:00:00.000Z',
+        capturedAt: '2026-06-04T20:00:00.000Z',
+        author: { id: '42', username: 'builder', name: 'Builder' },
+        metrics: { like_count: 10, retweet_count: 2 },
+        externalUrls: ['https://example.com/post'],
+        media: [
+          {
+            mediaKey: 'media-1',
+            type: 'video',
+            url: 'https://video.example/file.mp4',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('merges fetched bookmark pages with existing cache, dedupes, and identifies likely-new bookmarks', () => {
+    const existing = {
+      fetchedAt: '2026-06-04T13:00:00.000Z',
+      nextToken: 'old-next',
+      items: [
+        {
+          id: 'old-1',
+          url: 'https://x.com/builder/status/old-1',
+          text: 'Already cached',
+          createdAt: '2026-06-04T12:00:00.000Z',
+          capturedAt: '2026-06-04T13:00:00.000Z',
+          author: { id: '42', username: 'builder', name: 'Builder' },
+          metrics: {},
+          externalUrls: [],
+          media: [],
+        },
+      ],
+    }
+    const fetched = [
+      {
+        id: 'new-1',
+        url: 'https://x.com/builder/status/new-1',
+        text: 'New cached bookmark',
+        createdAt: '2026-06-04T14:00:00.000Z',
+        capturedAt: '2026-06-04T15:00:00.000Z',
+        author: { id: '42', username: 'builder', name: 'Builder' },
+        metrics: {},
+        externalUrls: [],
+        media: [],
+      },
+      {
+        id: 'old-1',
+        url: 'https://x.com/builder/status/old-1',
+        text: 'Already cached with fresher capture',
+        createdAt: '2026-06-04T12:00:00.000Z',
+        capturedAt: '2026-06-04T15:00:00.000Z',
+        author: { id: '42', username: 'builder', name: 'Builder' },
+        metrics: { like_count: 1 },
+        externalUrls: [],
+        media: [],
+      },
+    ]
+
+    const merged = mergeBookmarkCache({
+      existing,
+      fetchedAt: '2026-06-04T15:00:00.000Z',
+      nextToken: 'new-next',
+      fetched,
+    })
+
+    expect(merged.nextToken).toBe('new-next')
+    expect(merged.items.map((item) => item.id)).toEqual(['new-1', 'old-1'])
+    expect(merged.likelyNewItems.map((item) => item.id)).toEqual(['new-1'])
+    expect(merged.items.find((item) => item.id === 'old-1')?.text).toBe(
+      'Already cached with fresher capture',
+    )
+  })
+
+  it('builds an actionable AI review digest from cached bookmarks', () => {
+    const digest = createXBookmarkReviewDigest([
+      {
+        id: 'memory-1',
+        url: 'https://x.com/OpenAI/status/memory-1',
+        text: 'ChatGPT memory now lets you review and steer what it remembers across conversations.',
+        createdAt: '2026-06-04T16:00:00.000Z',
+        capturedAt: '2026-06-04T21:00:00.000Z',
+        author: { id: '1', username: 'OpenAI', name: 'OpenAI' },
+        metrics: { bookmark_count: 1000 },
+        externalUrls: ['https://openai.com/index/chatgpt-memory-dreaming/'],
+        media: [],
+      },
+      {
+        id: 'seo-1',
+        url: 'https://x.com/timsoulo/status/seo-1',
+        text: 'AI search optimization studies show best X listicles are cited by AI chatbots.',
+        createdAt: '2026-06-04T16:00:00.000Z',
+        capturedAt: '2026-06-04T21:00:00.000Z',
+        author: { id: '2', username: 'timsoulo', name: 'Tim Soulo' },
+        metrics: { bookmark_count: 6000 },
+        externalUrls: [],
+        media: [],
+      },
+      {
+        id: 'article-1',
+        url: 'https://x.com/dickiebush/status/article-1',
+        text: 'https://t.co/example',
+        createdAt: '2026-06-04T16:00:00.000Z',
+        capturedAt: '2026-06-04T21:00:00.000Z',
+        author: { id: '3', username: 'dickiebush', name: 'Dickie Bush' },
+        metrics: { bookmark_count: 371 },
+        externalUrls: ['http://x.com/i/article/2062493314012889088'],
+        media: [],
+      },
+    ])
+
+    expect(digest.total).toBe(3)
+    expect(digest.articleWrapperCount).toBe(1)
+    expect(digest.groups.useNow.some((item) => item.id === 'memory-1')).toBe(
+      true,
+    )
+    expect(digest.groups.packageSell.some((item) => item.id === 'seo-1')).toBe(
+      true,
+    )
+    expect(digest.articleCandidates[0]).toMatchObject({
+      id: 'article-1',
+      articleStatus: 'pending',
+    })
+    expect(
+      digest.radar.some((item) => item.title === 'Memory and context quality'),
+    ).toBe(true)
+  })
+
+  it('uses extracted X Article text in the review digest when available', () => {
+    const digest = createXBookmarkReviewDigest(
+      [
+        {
+          id: 'article-1',
+          url: 'https://x.com/dickiebush/status/article-1',
+          text: 'https://t.co/example',
+          createdAt: '2026-06-04T16:00:00.000Z',
+          capturedAt: '2026-06-04T21:00:00.000Z',
+          author: { id: '3', username: 'dickiebush', name: 'Dickie Bush' },
+          metrics: { bookmark_count: 371 },
+          externalUrls: ['http://x.com/i/article/2062493314012889088'],
+          media: [],
+        },
+      ],
+      '2026-06-04T22:00:00.000Z',
+      [
+        {
+          articleId: '2062493314012889088',
+          articleUrl: 'http://x.com/i/article/2062493314012889088',
+          sourceTweetId: 'article-1',
+          status: 'extracted',
+          title: 'How to build better AI workflows',
+          text: 'Long article body about agents and systems.',
+          excerpt: 'Long article body about agents and systems.',
+          extractedAt: '2026-06-04T22:00:00.000Z',
+          method: 'x-web-graphql',
+        },
+      ],
+    )
+
+    expect(digest.articleCandidates[0]).toMatchObject({
+      id: 'article-1',
+      articleStatus: 'extracted',
+      articleTitle: 'How to build better AI workflows',
+      articleExcerpt: 'Long article body about agents and systems.',
+      claim: 'How to build better AI workflows',
+    })
+  })
+
+  it('creates manual X Article imports without storing browser cookies or tokens', () => {
+    const extraction = createManualXArticleExtraction({
+      articleUrl: 'https://x.com/i/article/2062493314012889088',
+      sourceTweetId: 'article-1',
+      title: ' Manual fallback title ',
+      text: ' First paragraph from a logged-in browser copy.\r\n\r\nSecond paragraph with enough context to classify. ',
+      importedAt: '2026-06-04T23:00:00.000Z',
+    })
+
+    expect(extraction).toMatchObject({
+      articleId: '2062493314012889088',
+      sourceTweetId: 'article-1',
+      status: 'extracted',
+      title: 'Manual fallback title',
+      text: 'First paragraph from a logged-in browser copy.\n\nSecond paragraph with enough context to classify.',
+      excerpt:
+        'First paragraph from a logged-in browser copy. Second paragraph with enough context to classify.',
+      method: 'manual-import',
+    })
+    expect(JSON.stringify(extraction)).not.toContain('cookie')
+    expect(JSON.stringify(extraction)).not.toContain('token')
+  })
+
+  it('normalizes logged-in browser article text without X navigation chrome', () => {
+    const text = normalizeBrowserExtractedArticleText(`
+Home
+Explore
+Notifications
+Useful AI Article
+By Builder
+First paragraph about agent workflows.
+Like
+Share
+First paragraph about agent workflows.
+Second paragraph with implementation details.
+Privacy Policy
+`)
+
+    expect(text).toBe(
+      'Useful AI Article\nBy Builder\nFirst paragraph about agent workflows.\nSecond paragraph with implementation details.',
+    )
+  })
+
+  it('detects X login walls so autonomous runs do not save sign-in pages as articles', () => {
+    expect(
+      isBrowserXLoginWallText(
+        "See what's happening\nSelect an option below:\nContinue with phone\nContinue with Apple\nor\nEmail or username\nBy continuing, you agree to our Terms of Service",
+      ),
+    ).toBe(true)
+    expect(
+      isBrowserXLoginWallText(
+        'Useful Article Title\nFirst paragraph with real body text.\nSecond paragraph.',
+      ),
+    ).toBe(false)
+  })
+
+  it('creates autonomous browser X Article extractions as local text-only records', () => {
+    const extraction = createBrowserXArticleExtraction({
+      articleUrl: 'https://x.com/i/article/2062493314012889088',
+      sourceTweetId: 'article-1',
+      title: ' Browser extracted title ',
+      text: ' First paragraph from the logged-in browser.\nSecond paragraph from the DOM. ',
+      extractedAt: '2026-06-05T00:00:00.000Z',
+    })
+
+    expect(extraction).toMatchObject({
+      articleId: '2062493314012889088',
+      sourceTweetId: 'article-1',
+      status: 'extracted',
+      title: 'Browser extracted title',
+      text: 'First paragraph from the logged-in browser.\nSecond paragraph from the DOM.',
+      method: 'logged-in-browser',
+    })
+    expect(JSON.stringify(extraction)).not.toContain('cookie')
+    expect(JSON.stringify(extraction)).not.toContain('token')
+  })
+
+  it('keeps the autonomous browser profile inside the local X bookmark store', () => {
+    expect(xArticleBrowserProfilePath('/profile-root')).toBe(
+      '/profile-root/workspace/x-bookmark-intake/browser-profile',
+    )
+  })
+
+  it('converts X Article Draft.js content blocks to readable text', () => {
+    expect(
+      draftContentStateToPlainText({
+        blocks: [
+          { text: 'First paragraph.' },
+          { text: '' },
+          { text: 'Second paragraph.' },
+        ],
+      }),
+    ).toBe('First paragraph.\n\nSecond paragraph.')
+  })
+
+  it('extracts an X Article body through the web GraphQL flow without exposing tokens', async () => {
+    const calls: Array<string> = []
+    const fetcher = async (input: RequestInfo | URL) => {
+      await Promise.resolve()
+      const url = String(input)
+      calls.push(url)
+      if (url === 'https://x.com/i/article/1') {
+        return new Response(
+          '<script src="https://abs.twimg.com/responsive-web/client-web/main.abc123.js"></script>',
+        )
+      }
+      if (
+        url === 'https://abs.twimg.com/responsive-web/client-web/main.abc123.js'
+      ) {
+        return new Response('const token = "Bearer PUBLIC_TOKEN"')
+      }
+      if (url === 'https://api.twitter.com/1.1/guest/activate.json') {
+        return new Response(JSON.stringify({ guest_token: 'guest-token' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (
+        url.startsWith(
+          'https://twitter.com/i/api/graphql/8-OHhj8-KCAHUP8XjPaAYQ/ArticleEntityResultByRestId',
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              article_result_by_rest_id: {
+                result: {
+                  title: 'Useful X Article',
+                  content_state: {
+                    blocks: [
+                      { text: 'Paragraph one.' },
+                      { text: 'Paragraph two.' },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        )
+      }
+      return new Response('not found', { status: 404 })
+    }
+
+    const extraction = await fetchXArticleExtraction({
+      articleUrl: 'https://x.com/i/article/2062493314012889088',
+      sourceTweetId: 'tweet-1',
+      fetchedAt: '2026-06-04T22:00:00.000Z',
+      fetcher: fetcher as typeof fetch,
+    })
+
+    expect(extraction).toMatchObject({
+      articleId: '2062493314012889088',
+      status: 'extracted',
+      title: 'Useful X Article',
+      text: 'Paragraph one.\n\nParagraph two.',
+      excerpt: 'Paragraph one. Paragraph two.',
+    })
+    expect(
+      calls.some((url) => url.includes('ArticleEntityResultByRestId')),
+    ).toBe(true)
+    expect(JSON.stringify(extraction)).not.toContain('PUBLIC_TOKEN')
+    expect(JSON.stringify(extraction)).not.toContain('guest-token')
+  })
+
+  it('redacts persisted OAuth token state for API responses', () => {
+    expect(
+      redactXBookmarkTokenState({
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        expiresAt: '2026-06-05T00:00:00.000Z',
+        updatedAt: '2026-06-04T20:00:00.000Z',
+      }),
+    ).toEqual({
+      hasAccessToken: true,
+      hasRefreshToken: true,
+      expiresAt: '2026-06-05T00:00:00.000Z',
+      scope: '',
+      userId: '',
+      username: '',
+      updatedAt: '2026-06-04T20:00:00.000Z',
+    })
+  })
+})

--- a/src/routes/api/x-bookmarks/-x-bookmarks-utils.ts
+++ b/src/routes/api/x-bookmarks/-x-bookmarks-utils.ts
@@ -1,0 +1,1230 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export const X_BOOKMARK_SCOPES = [
+  'bookmark.read',
+  'tweet.read',
+  'users.read',
+] as const
+export const X_BOOKMARK_OAUTH_SCOPES = [
+  ...X_BOOKMARK_SCOPES,
+  'offline.access',
+] as const
+
+export function buildXArticleCaptureBookmarklet(): string {
+  const script = `(() => {
+  const clean = (value) => String(value || '').replace(/\\s+$/g, '').trim();
+  const lines = clean(document.body.innerText).split('\\n').map((line) => line.trim()).filter(Boolean);
+  const skip = new Set(['Home', 'Explore', 'Notifications', 'Messages', 'Grok', 'Bookmarks', 'Jobs', 'Communities', 'Premium', 'Verified Orgs', 'Profile', 'More', 'Post', 'Reply', 'Repost', 'Like', 'Share', 'Terms of Service', 'Privacy Policy']);
+  const text = lines.filter((line, index, list) => !skip.has(line) && list.indexOf(line) === index).join('\\n');
+  const title = clean(document.querySelector('h1')?.innerText || document.title.replace(/\\s*\\/ X$/, ''));
+  const payload = { source: 'x-article-clipboard-v1', capturedAt: new Date().toISOString(), articleUrl: location.href, title, text };
+  navigator.clipboard.writeText(JSON.stringify(payload, null, 2)).then(() => alert('X Article text copied. Paste it into Hermes Workspace.'), () => prompt('Copy this X Article payload', JSON.stringify(payload, null, 2)));
+})()`
+  return `javascript:${encodeURIComponent(script)}`
+}
+
+export type XBookmarkTokenState = {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: string
+  scope?: string
+  userId?: string
+  username?: string
+  updatedAt?: string
+}
+
+export type XBookmarkRedactedTokenState = {
+  hasAccessToken: boolean
+  hasRefreshToken: boolean
+  expiresAt: string
+  scope: string
+  userId: string
+  username: string
+  updatedAt: string
+}
+
+export type XBookmarkStatus = {
+  configured: boolean
+  authenticated: boolean
+  mode: 'read-only'
+  clientIdConfigured: boolean
+  redirectUri: string
+  scopes: ReadonlyArray<string>
+  token: XBookmarkRedactedTokenState | null
+  missing: Array<string>
+  nextStep: string
+}
+
+export type XBookmarkOAuthState = {
+  state: string
+  codeVerifier: string
+  redirectUri: string
+  createdAt: string
+}
+
+export type XBookmarkRecord = {
+  id: string
+  url: string
+  text: string
+  createdAt: string
+  capturedAt: string
+  author: {
+    id: string
+    username: string
+    name: string
+  }
+  metrics: Record<string, number>
+  externalUrls: Array<string>
+  media: Array<{
+    mediaKey: string
+    type: string
+    url: string
+  }>
+}
+
+type XTweet = {
+  id?: string
+  text?: string
+  created_at?: string
+  author_id?: string
+  public_metrics?: Record<string, number>
+  attachments?: { media_keys?: Array<string> }
+  entities?: { urls?: Array<{ expanded_url?: string; url?: string }> }
+}
+
+type XUser = {
+  id?: string
+  username?: string
+  name?: string
+}
+
+type XMedia = {
+  media_key?: string
+  type?: string
+  url?: string
+  preview_image_url?: string
+}
+
+type XBookmarksApiResponse = {
+  data?: Array<XTweet>
+  includes?: {
+    users?: Array<XUser>
+    media?: Array<XMedia>
+  }
+  meta?: {
+    result_count?: number
+    next_token?: string
+  }
+}
+
+export function profileHome(): string {
+  return (
+    process.env.HERMES_HOME ||
+    join(process.env.HOME || '/Users/hermes', '.hermes', 'profiles', 'ai-dev')
+  )
+}
+
+export function xBookmarkStoreRoot(root = profileHome()): string {
+  return join(root, 'workspace', 'x-bookmark-intake')
+}
+
+export function xBookmarkTokenPath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'token-state.json')
+}
+
+export function xBookmarkOAuthStatePath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'oauth-state.json')
+}
+
+export function xBookmarkCachePath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'bookmarks-cache.json')
+}
+
+export function xArticleExtractionCachePath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'x-article-extractions.json')
+}
+
+export function xArticleBrowserProfilePath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'browser-profile')
+}
+
+export function xArticleBrowserRunPath(root = profileHome()): string {
+  return join(xBookmarkStoreRoot(root), 'browser-extraction-run.json')
+}
+
+export function configuredClientId(): string {
+  return (
+    process.env.X_BOOKMARKS_CLIENT_ID ||
+    process.env.X_OAUTH_CLIENT_ID ||
+    ''
+  ).trim()
+}
+
+export function configuredClientSecret(): string {
+  return (
+    process.env.X_BOOKMARKS_CLIENT_SECRET ||
+    process.env.X_OAUTH_CLIENT_SECRET ||
+    ''
+  ).trim()
+}
+
+export function defaultRedirectUri(requestUrl?: string): string {
+  if (process.env.X_BOOKMARKS_REDIRECT_URI?.trim())
+    return process.env.X_BOOKMARKS_REDIRECT_URI.trim()
+  if (requestUrl) {
+    const url = new URL(requestUrl)
+    url.pathname = '/api/x-bookmarks/callback'
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  }
+  return 'http://127.0.0.1:3002/api/x-bookmarks/callback'
+}
+
+export function redactXBookmarkTokenState(
+  tokenState: XBookmarkTokenState | null | undefined,
+): XBookmarkRedactedTokenState | null {
+  if (!tokenState) return null
+  return {
+    hasAccessToken: Boolean(tokenState.accessToken),
+    hasRefreshToken: Boolean(tokenState.refreshToken),
+    expiresAt: tokenState.expiresAt || '',
+    scope: tokenState.scope || '',
+    userId: tokenState.userId || '',
+    username: tokenState.username || '',
+    updatedAt: tokenState.updatedAt || '',
+  }
+}
+
+export function createXBookmarkStatus(input: {
+  clientId?: string
+  redirectUri: string
+  tokenState?: XBookmarkTokenState | null
+}): XBookmarkStatus {
+  const clientIdConfigured = Boolean(input.clientId?.trim())
+  const token = redactXBookmarkTokenState(input.tokenState)
+  const authenticated = Boolean(token?.hasAccessToken)
+  const missing: Array<string> = []
+  if (!clientIdConfigured) missing.push('X_BOOKMARKS_CLIENT_ID')
+  if (!authenticated) missing.push('X OAuth authorization')
+
+  return {
+    configured: clientIdConfigured && authenticated,
+    authenticated,
+    mode: 'read-only',
+    clientIdConfigured,
+    redirectUri: input.redirectUri,
+    scopes: X_BOOKMARK_SCOPES,
+    token,
+    missing,
+    nextStep: !clientIdConfigured
+      ? 'Create an X Developer app with this callback URL, then set X_BOOKMARKS_CLIENT_ID locally.'
+      : authenticated
+        ? 'Ready to fetch bookmarked posts read-only.'
+        : 'Start OAuth authorization from Workspace and approve the read-only bookmark scopes.',
+  }
+}
+
+export function buildXBookmarkAuthorizeUrl(input: {
+  clientId: string
+  redirectUri: string
+  state: string
+  codeChallenge: string
+}): URL {
+  const url = new URL('https://x.com/i/oauth2/authorize')
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', input.clientId)
+  url.searchParams.set('redirect_uri', input.redirectUri)
+  url.searchParams.set('scope', X_BOOKMARK_OAUTH_SCOPES.join(' '))
+  url.searchParams.set('state', input.state)
+  url.searchParams.set('code_challenge', input.codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  return url
+}
+
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(48).toString('base64url')
+  const challenge = createHash('sha256').update(verifier).digest('base64url')
+  return { verifier, challenge }
+}
+
+export function createOAuthStateValue(): string {
+  return randomBytes(24).toString('base64url')
+}
+
+export async function readTokenState(
+  root = profileHome(),
+): Promise<XBookmarkTokenState | null> {
+  try {
+    const raw = await readFile(xBookmarkTokenPath(root), 'utf-8')
+    return JSON.parse(raw) as XBookmarkTokenState
+  } catch {
+    return null
+  }
+}
+
+export async function writeTokenState(
+  tokenState: XBookmarkTokenState,
+  root = profileHome(),
+): Promise<void> {
+  const path = xBookmarkTokenPath(root)
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  await writeFile(path, `${JSON.stringify(tokenState, null, 2)}\n`, {
+    mode: 0o600,
+  })
+}
+
+export async function readOAuthState(
+  root = profileHome(),
+): Promise<XBookmarkOAuthState | null> {
+  try {
+    const raw = await readFile(xBookmarkOAuthStatePath(root), 'utf-8')
+    return JSON.parse(raw) as XBookmarkOAuthState
+  } catch {
+    return null
+  }
+}
+
+export async function writeOAuthState(
+  oauthState: XBookmarkOAuthState,
+  root = profileHome(),
+): Promise<void> {
+  const path = xBookmarkOAuthStatePath(root)
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  await writeFile(path, `${JSON.stringify(oauthState, null, 2)}\n`, {
+    mode: 0o600,
+  })
+}
+
+export type XBookmarkCache = {
+  fetchedAt: string
+  nextToken: string
+  items: Array<XBookmarkRecord>
+}
+
+export type XBookmarkCacheMerge = XBookmarkCache & {
+  likelyNewItems: Array<XBookmarkRecord>
+}
+
+export async function writeBookmarkCache(
+  input: XBookmarkCache & { root?: string },
+): Promise<string> {
+  const path = xBookmarkCachePath(input.root)
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  await writeFile(
+    path,
+    `${JSON.stringify({ fetchedAt: input.fetchedAt, nextToken: input.nextToken, items: input.items }, null, 2)}\n`,
+    { mode: 0o600 },
+  )
+  return path
+}
+
+export async function readBookmarkCache(
+  root = profileHome(),
+): Promise<XBookmarkCache | null> {
+  try {
+    const raw = await readFile(xBookmarkCachePath(root), 'utf-8')
+    return JSON.parse(raw) as XBookmarkCache
+  } catch {
+    return null
+  }
+}
+
+export function mergeBookmarkCache(input: {
+  existing?: XBookmarkCache | null
+  fetchedAt: string
+  nextToken: string
+  fetched: Array<XBookmarkRecord>
+}): XBookmarkCacheMerge {
+  const existingIds = new Set(
+    (input.existing?.items || []).map((item) => item.id),
+  )
+  const likelyNewItems = input.fetched.filter(
+    (item) => item.id && !existingIds.has(item.id),
+  )
+  const byId = new Map<string, XBookmarkRecord>()
+
+  for (const item of [...input.fetched, ...(input.existing?.items || [])]) {
+    if (!item.id || byId.has(item.id)) continue
+    byId.set(item.id, item)
+  }
+
+  return {
+    fetchedAt: input.fetchedAt,
+    nextToken: input.nextToken,
+    items: Array.from(byId.values()),
+    likelyNewItems,
+  }
+}
+
+export type XBookmarkReviewBucket =
+  | 'useNow'
+  | 'teach'
+  | 'packageSell'
+  | 'watch'
+  | 'reject'
+
+export type XArticleExtractionStatus =
+  | 'pending'
+  | 'extracted'
+  | 'unavailable'
+  | 'error'
+  | 'none'
+
+export type XArticleExtraction = {
+  articleId: string
+  articleUrl: string
+  sourceTweetId: string
+  status: Exclude<XArticleExtractionStatus, 'pending' | 'none'>
+  title: string
+  text: string
+  excerpt: string
+  extractedAt: string
+  method: 'x-web-graphql' | 'manual-import' | 'logged-in-browser'
+  error?: string
+}
+
+export type XArticleExtractionCache = {
+  updatedAt: string
+  items: Array<XArticleExtraction>
+}
+
+export type XBookmarkReviewItem = XBookmarkRecord & {
+  bucket: XBookmarkReviewBucket
+  claim: string
+  whyItMatters: string
+  recommendedAction: string
+  approvalNeeded: boolean
+  articleUrl: string
+  articleStatus: XArticleExtractionStatus
+  articleTitle: string
+  articleExcerpt: string
+  articleExtractedAt: string
+  matchedSignals: Array<string>
+}
+
+export type XBookmarkRadarItem = {
+  title: string
+  why: string
+  nextAction: string
+  count: number
+  approvalNeeded: boolean
+  sourceIds: Array<string>
+}
+
+export type XBookmarkReviewDigest = {
+  generatedAt: string
+  total: number
+  articleWrapperCount: number
+  topAuthors: Array<{ username: string; count: number }>
+  groups: Record<XBookmarkReviewBucket, Array<XBookmarkReviewItem>>
+  radar: Array<XBookmarkRadarItem>
+  articleCandidates: Array<XBookmarkReviewItem>
+}
+
+function includesAny(text: string, terms: Array<string>): boolean {
+  return terms.some((term) => text.includes(term))
+}
+
+export function xArticleUrl(item: XBookmarkRecord): string {
+  return item.externalUrls.find((url) => /x\.com\/i\/article\//.test(url)) || ''
+}
+
+export function xArticleIdFromUrl(articleUrl: string): string {
+  return articleUrl.match(/x\.com\/i\/article\/(\d+)/)?.[1] || ''
+}
+
+function conciseClaim(
+  item: XBookmarkRecord,
+  extraction?: XArticleExtraction,
+): string {
+  if (extraction?.status === 'extracted' && extraction.title)
+    return extraction.title.slice(0, 220)
+  const text = item.text.replace(/\s+/g, ' ').trim()
+  if (text && !/^https:\/\/t\.co\//.test(text)) return text.slice(0, 220)
+  const article = xArticleUrl(item)
+  return article
+    ? `X Article from @${item.author.username}`
+    : `Saved post from @${item.author.username}`
+}
+
+function classifyBookmark(
+  item: XBookmarkRecord,
+): Pick<
+  XBookmarkReviewItem,
+  | 'bucket'
+  | 'whyItMatters'
+  | 'recommendedAction'
+  | 'approvalNeeded'
+  | 'matchedSignals'
+> {
+  const text =
+    `${item.text} ${item.externalUrls.join(' ')} ${item.author.username}`.toLowerCase()
+  const matchedSignals: Array<string> = []
+
+  if (
+    includesAny(text, [
+      'hermes',
+      'dashboard',
+      'workspace',
+      'memory',
+      'skill',
+      'agent',
+      'obsidian',
+      'second brain',
+      'capture',
+    ])
+  ) {
+    matchedSignals.push('ai-ops')
+  }
+  if (
+    includesAny(text, [
+      'seo',
+      'search',
+      'ai overview',
+      'google',
+      'rank',
+      'content gap',
+      'reviews',
+    ])
+  ) {
+    matchedSignals.push('ai-search')
+  }
+  if (
+    includesAny(text, [
+      'sell',
+      'service',
+      'revenue',
+      'startup',
+      'client',
+      'agency',
+      'product',
+      'codex sites',
+      'sites',
+    ])
+  ) {
+    matchedSignals.push('packaging')
+  }
+  if (
+    includesAny(text, [
+      'prompt',
+      'carousel',
+      'podcast',
+      'teach',
+      'training',
+      'workflow',
+    ])
+  ) {
+    matchedSignals.push('teachable')
+  }
+
+  if (
+    matchedSignals.includes('ai-search') ||
+    matchedSignals.includes('packaging')
+  ) {
+    return {
+      bucket: 'packageSell',
+      whyItMatters:
+        'This points toward a monetizable workflow or Travel Multiplier/consulting asset.',
+      recommendedAction:
+        'Convert into a one-page pilot, offer, SOP, or audit before saving more examples.',
+      approvalNeeded: false,
+      matchedSignals,
+    }
+  }
+
+  if (matchedSignals.includes('ai-ops')) {
+    return {
+      bucket: 'useNow',
+      whyItMatters:
+        'This can improve Tim’s Hermes setup, memory quality, source capture, or agent operating system.',
+      recommendedAction:
+        'Turn into a local Workspace/system upgrade proposal with source link and approval gate.',
+      approvalNeeded: false,
+      matchedSignals,
+    }
+  }
+
+  if (matchedSignals.includes('teachable')) {
+    return {
+      bucket: 'teach',
+      whyItMatters:
+        'This can become staff training, a repeatable prompt, or a reusable playbook.',
+      recommendedAction:
+        'Package the underlying workflow into a teachable template.',
+      approvalNeeded: false,
+      matchedSignals,
+    }
+  }
+
+  if (/^https:\/\/t\.co\//.test(item.text.trim()) && !xArticleUrl(item)) {
+    return {
+      bucket: 'watch',
+      whyItMatters:
+        'The bookmark has too little visible text to safely act on without opening the source.',
+      recommendedAction:
+        'Extract the linked source before using it for decisions.',
+      approvalNeeded: false,
+      matchedSignals,
+    }
+  }
+
+  return {
+    bucket: 'watch',
+    whyItMatters:
+      'Potentially useful, but not enough signal for immediate action.',
+    recommendedAction:
+      'Keep as watch material unless it recurs in other sources.',
+    approvalNeeded: false,
+    matchedSignals,
+  }
+}
+
+function buildRadar(
+  items: Array<XBookmarkReviewItem>,
+): Array<XBookmarkRadarItem> {
+  const specs: Array<{
+    signal: string
+    title: string
+    why: string
+    nextAction: string
+  }> = [
+    {
+      signal: 'ai-ops',
+      title: 'Memory and context quality',
+      why: 'Bookmarks repeatedly point to Hermes, memory, skills, second brain, and agent operating-system improvements.',
+      nextAction:
+        'Build source-backed review surfaces before adding more autonomous behavior.',
+    },
+    {
+      signal: 'ai-search',
+      title: 'AI Search and agent-facing content',
+      why: 'Multiple saves point to AI search, AI Overview visibility, SEO context, and agent recommendation surfaces.',
+      nextAction:
+        'Pilot a one-page Travel Multiplier AI Search Readiness Audit.',
+    },
+    {
+      signal: 'packaging',
+      title: 'Packageable AI workflows',
+      why: 'Saved items include services, productized workflows, Codex Sites, and client-facing systems.',
+      nextAction:
+        'Extract repeatable workflows into offers, SOPs, and training assets.',
+    },
+    {
+      signal: 'teachable',
+      title: 'Teach/reproduce queue',
+      why: 'Several saves are prompts, carousels, podcast synthesis, and workflow templates.',
+      nextAction:
+        'Turn the best examples into short playbooks for Tim, staff, or future training.',
+    },
+  ]
+
+  return specs
+    .map((spec) => {
+      const matches = items.filter((item) =>
+        item.matchedSignals.includes(spec.signal),
+      )
+      return {
+        title: spec.title,
+        why: spec.why,
+        nextAction: spec.nextAction,
+        count: matches.length,
+        approvalNeeded: false,
+        sourceIds: matches.slice(0, 8).map((item) => item.id),
+      }
+    })
+    .filter((item) => item.count > 0)
+    .sort((a, b) => b.count - a.count)
+}
+
+export function createXBookmarkReviewDigest(
+  records: Array<XBookmarkRecord>,
+  generatedAt = new Date().toISOString(),
+  articleExtractions: Array<XArticleExtraction> = [],
+): XBookmarkReviewDigest {
+  const groups: Record<XBookmarkReviewBucket, Array<XBookmarkReviewItem>> = {
+    useNow: [],
+    teach: [],
+    packageSell: [],
+    watch: [],
+    reject: [],
+  }
+  const extractionByArticleId = new Map(
+    articleExtractions.map((item) => [item.articleId, item]),
+  )
+
+  const reviewItems = records.map((item) => {
+    const classification = classifyBookmark(item)
+    const articleUrl = xArticleUrl(item)
+    const articleId = xArticleIdFromUrl(articleUrl)
+    const extraction = articleId
+      ? extractionByArticleId.get(articleId)
+      : undefined
+    return {
+      ...item,
+      ...classification,
+      claim: conciseClaim(item, extraction),
+      articleUrl,
+      articleStatus: articleUrl ? extraction?.status || 'pending' : 'none',
+      articleTitle: extraction?.title || '',
+      articleExcerpt: extraction?.excerpt || '',
+      articleExtractedAt: extraction?.extractedAt || '',
+    } satisfies XBookmarkReviewItem
+  })
+
+  for (const item of reviewItems) groups[item.bucket].push(item)
+
+  const authorCounts = new Map<string, number>()
+  for (const item of records)
+    authorCounts.set(
+      item.author.username,
+      (authorCounts.get(item.author.username) || 0) + 1,
+    )
+
+  return {
+    generatedAt,
+    total: records.length,
+    articleWrapperCount: reviewItems.filter((item) => item.articleUrl).length,
+    topAuthors: Array.from(authorCounts.entries())
+      .map(([username, count]) => ({ username, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 12),
+    groups,
+    radar: buildRadar(reviewItems),
+    articleCandidates: reviewItems.filter((item) => item.articleUrl),
+  }
+}
+
+export async function readXArticleExtractionCache(
+  root = profileHome(),
+): Promise<XArticleExtractionCache | null> {
+  try {
+    const raw = await readFile(xArticleExtractionCachePath(root), 'utf-8')
+    return JSON.parse(raw) as XArticleExtractionCache
+  } catch {
+    return null
+  }
+}
+
+export async function writeXArticleExtractionCache(
+  input: XArticleExtractionCache & { root?: string },
+): Promise<string> {
+  const path = xArticleExtractionCachePath(input.root)
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  await writeFile(
+    path,
+    `${JSON.stringify({ updatedAt: input.updatedAt, items: input.items }, null, 2)}\n`,
+    { mode: 0o600 },
+  )
+  return path
+}
+
+export function mergeXArticleExtractions(input: {
+  existing?: XArticleExtractionCache | null
+  extractedAt: string
+  items: Array<XArticleExtraction>
+}): XArticleExtractionCache {
+  const byArticleId = new Map<string, XArticleExtraction>()
+  for (const item of [...(input.existing?.items || []), ...input.items]) {
+    if (!item.articleId) continue
+    byArticleId.set(item.articleId, item)
+  }
+  return {
+    updatedAt: input.extractedAt,
+    items: Array.from(byArticleId.values()),
+  }
+}
+
+export function draftContentStateToPlainText(contentState: unknown): string {
+  if (!contentState || typeof contentState !== 'object') return ''
+  const blocks = (contentState as { blocks?: Array<{ text?: unknown }> }).blocks
+  if (!Array.isArray(blocks)) return ''
+  return blocks
+    .map((block) => (typeof block.text === 'string' ? block.text.trim() : ''))
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+function extractionExcerpt(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, 500)
+}
+
+export function isBrowserXLoginWallText(rawText: string): boolean {
+  const text = rawText.replace(/\s+/g, ' ').toLowerCase()
+  const loginSignals = [
+    "see what's happening",
+    'select an option below',
+    'continue with phone',
+    'continue with apple',
+    'email or username',
+    'by continuing, you agree to our terms of service',
+  ]
+  return loginSignals.filter((signal) => text.includes(signal)).length >= 2
+}
+
+export function normalizeBrowserExtractedArticleText(rawText: string): string {
+  const skip = new Set([
+    'Home',
+    'Explore',
+    'Notifications',
+    'Messages',
+    'Grok',
+    'Bookmarks',
+    'Jobs',
+    'Communities',
+    'Premium',
+    'Verified Orgs',
+    'Profile',
+    'More',
+    'Post',
+    'Reply',
+    'Repost',
+    'Like',
+    'Share',
+    'Terms of Service',
+    'Privacy Policy',
+  ])
+  const seen = new Set<string>()
+  return rawText
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => {
+      if (!line || skip.has(line) || seen.has(line)) return false
+      seen.add(line)
+      return true
+    })
+    .join('\n')
+    .trim()
+}
+
+export function createBrowserXArticleExtraction(input: {
+  articleUrl: string
+  sourceTweetId: string
+  title?: string
+  text: string
+  extractedAt?: string
+  error?: string
+}): XArticleExtraction {
+  const articleId = xArticleIdFromUrl(input.articleUrl)
+  const text = normalizeBrowserExtractedArticleText(input.text)
+  return {
+    articleId,
+    articleUrl: input.articleUrl,
+    sourceTweetId: input.sourceTweetId,
+    status: text ? 'extracted' : 'unavailable',
+    title: (input.title || '').replace(/\s+/g, ' ').trim(),
+    text,
+    excerpt: extractionExcerpt(text),
+    extractedAt: input.extractedAt || new Date().toISOString(),
+    method: 'logged-in-browser',
+    error: text
+      ? undefined
+      : input.error ||
+        'Logged-in browser extraction did not find article body text.',
+  }
+}
+
+export function createManualXArticleExtraction(input: {
+  articleUrl: string
+  sourceTweetId: string
+  title?: string
+  text: string
+  importedAt?: string
+}): XArticleExtraction {
+  const articleId = xArticleIdFromUrl(input.articleUrl)
+  const text = input.text.replace(/\r\n/g, '\n').trim()
+  return {
+    articleId,
+    articleUrl: input.articleUrl,
+    sourceTweetId: input.sourceTweetId,
+    status: text ? 'extracted' : 'unavailable',
+    title: (input.title || '').replace(/\s+/g, ' ').trim(),
+    text,
+    excerpt: extractionExcerpt(text),
+    extractedAt: input.importedAt || new Date().toISOString(),
+    method: 'manual-import',
+    error: text
+      ? undefined
+      : 'Manual import did not include article body text.',
+  }
+}
+
+function fallbackXArticleExtraction(input: {
+  articleId: string
+  articleUrl: string
+  sourceTweetId: string
+  extractedAt: string
+  status: 'unavailable' | 'error'
+  error?: string
+}): XArticleExtraction {
+  return {
+    articleId: input.articleId,
+    articleUrl: input.articleUrl,
+    sourceTweetId: input.sourceTweetId,
+    status: input.status,
+    title: '',
+    text: '',
+    excerpt: '',
+    extractedAt: input.extractedAt,
+    method: 'x-web-graphql',
+    error: input.error,
+  }
+}
+
+function findPublicBearerToken(scriptText: string): string {
+  return scriptText.match(/Bearer ([A-Za-z0-9%._-]+)/)?.[1] || ''
+}
+
+async function fetchText(
+  fetcher: typeof fetch,
+  url: string,
+  init?: RequestInit,
+): Promise<string> {
+  const response = await fetcher(url, init)
+  if (!response.ok)
+    throw new Error(`HTTP ${response.status} from ${new URL(url).host}`)
+  return response.text()
+}
+
+async function fetchPublicBearer(fetcher: typeof fetch): Promise<string> {
+  const html = await fetchText(fetcher, 'https://x.com/i/article/1', {
+    headers: { 'User-Agent': 'Mozilla/5.0' },
+  })
+  const mainScript = html.match(
+    /https:\/\/abs\.twimg\.com\/responsive-web\/client-web\/main\.[^"']+\.js/,
+  )?.[0]
+  if (!mainScript)
+    throw new Error(
+      'Could not locate X main script for public bearer token discovery.',
+    )
+  const scriptText = await fetchText(fetcher, mainScript, {
+    headers: { 'User-Agent': 'Mozilla/5.0' },
+  })
+  const bearer = findPublicBearerToken(scriptText)
+  if (!bearer)
+    throw new Error('Could not locate X public bearer token in main script.')
+  return bearer
+}
+
+async function fetchGuestToken(
+  fetcher: typeof fetch,
+  bearer: string,
+): Promise<string> {
+  const endpoints = [
+    'https://api.twitter.com/1.1/guest/activate.json',
+    'https://api.x.com/1.1/guest/activate.json',
+  ]
+  let lastError = ''
+  for (const endpoint of endpoints) {
+    const response = await fetcher(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'User-Agent': 'Mozilla/5.0',
+      },
+    })
+    if (!response.ok) {
+      lastError = `HTTP ${response.status} from ${new URL(endpoint).host}`
+      continue
+    }
+    const data = (await response.json()) as { guest_token?: string }
+    if (data.guest_token) return data.guest_token
+    lastError = `No guest token from ${new URL(endpoint).host}`
+  }
+  throw new Error(`X guest token activation failed: ${lastError}`)
+}
+
+function articleFromGraphqlResult(input: {
+  articleId: string
+  articleUrl: string
+  sourceTweetId: string
+  extractedAt: string
+  payload: unknown
+}): XArticleExtraction | null {
+  const result = (
+    input.payload as {
+      data?: { article_result_by_rest_id?: { result?: unknown } }
+    }
+  ).data?.article_result_by_rest_id?.result as
+    | { title?: string; content_state?: unknown }
+    | undefined
+  const title = typeof result?.title === 'string' ? result.title.trim() : ''
+  const text = draftContentStateToPlainText(result?.content_state)
+  if (!title && !text) return null
+  return {
+    articleId: input.articleId,
+    articleUrl: input.articleUrl,
+    sourceTweetId: input.sourceTweetId,
+    status: 'extracted',
+    title,
+    text,
+    excerpt: extractionExcerpt(text),
+    extractedAt: input.extractedAt,
+    method: 'x-web-graphql',
+  }
+}
+
+export async function fetchXArticleExtraction(input: {
+  articleUrl: string
+  sourceTweetId: string
+  fetchedAt?: string
+  fetcher?: typeof fetch
+}): Promise<XArticleExtraction> {
+  const articleId = xArticleIdFromUrl(input.articleUrl)
+  const extractedAt = input.fetchedAt || new Date().toISOString()
+  if (!articleId) {
+    return fallbackXArticleExtraction({
+      articleId: '',
+      articleUrl: input.articleUrl,
+      sourceTweetId: input.sourceTweetId,
+      extractedAt,
+      status: 'unavailable',
+      error: 'No X Article ID found in URL.',
+    })
+  }
+
+  const fetcher = input.fetcher || fetch
+  try {
+    const bearer = await fetchPublicBearer(fetcher)
+    const guestToken = await fetchGuestToken(fetcher, bearer)
+    const variables = JSON.stringify({ articleEntityId: articleId })
+    const features = JSON.stringify({
+      profile_label_improvements_pcf_label_in_post_enabled: true,
+      responsive_web_profile_redirect_enabled: true,
+      rweb_tipjar_consumption_enabled: true,
+      verified_phone_label_enabled: false,
+      responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+      responsive_web_graphql_timeline_navigation_enabled: true,
+    })
+    const url = new URL(
+      'https://twitter.com/i/api/graphql/8-OHhj8-KCAHUP8XjPaAYQ/ArticleEntityResultByRestId',
+    )
+    url.searchParams.set('variables', variables)
+    url.searchParams.set('features', features)
+
+    const response = await fetcher(url, {
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'User-Agent': 'Mozilla/5.0',
+        'x-guest-token': guestToken,
+        'x-twitter-active': 'yes',
+        'x-twitter-client-language': 'en',
+      },
+    })
+    if (!response.ok) {
+      return fallbackXArticleExtraction({
+        articleId,
+        articleUrl: input.articleUrl,
+        sourceTweetId: input.sourceTweetId,
+        extractedAt,
+        status: response.status === 404 ? 'unavailable' : 'error',
+        error:
+          response.status === 404
+            ? 'X web GraphQL did not expose this article to guest extraction. Logged-in web cookies may be required.'
+            : `X Article GraphQL failed with HTTP ${response.status}`,
+      })
+    }
+    const payload = await response.json()
+    return (
+      articleFromGraphqlResult({
+        articleId,
+        articleUrl: input.articleUrl,
+        sourceTweetId: input.sourceTweetId,
+        extractedAt,
+        payload,
+      }) ||
+      fallbackXArticleExtraction({
+        articleId,
+        articleUrl: input.articleUrl,
+        sourceTweetId: input.sourceTweetId,
+        extractedAt,
+        status: 'unavailable',
+        error:
+          'X returned no article body. The article may require logged-in web cookies or may be unavailable.',
+      })
+    )
+  } catch (err) {
+    return fallbackXArticleExtraction({
+      articleId,
+      articleUrl: input.articleUrl,
+      sourceTweetId: input.sourceTweetId,
+      extractedAt,
+      status: 'error',
+      error:
+        err instanceof Error
+          ? err.message
+          : 'Unknown X Article extraction error.',
+    })
+  }
+}
+
+export function normalizeXBookmarkTweets(
+  response: XBookmarksApiResponse,
+  capturedAt: string,
+): {
+  items: Array<XBookmarkRecord>
+  nextToken: string
+} {
+  const usersById = new Map(
+    (response.includes?.users || []).map((user) => [user.id || '', user]),
+  )
+  const mediaByKey = new Map(
+    (response.includes?.media || []).map((media) => [
+      media.media_key || '',
+      media,
+    ]),
+  )
+
+  const items = (response.data || [])
+    .filter((tweet) => Boolean(tweet.id))
+    .map((tweet) => {
+      const author = usersById.get(tweet.author_id || '')
+      const username = author?.username || 'unknown'
+      const media = (tweet.attachments?.media_keys || [])
+        .map((key) => mediaByKey.get(key))
+        .filter((item): item is XMedia => Boolean(item))
+        .map((item) => ({
+          mediaKey: item.media_key || '',
+          type: item.type || '',
+          url: item.url || item.preview_image_url || '',
+        }))
+
+      return {
+        id: tweet.id || '',
+        url: `https://x.com/${username}/status/${tweet.id}`,
+        text: tweet.text || '',
+        createdAt: tweet.created_at || '',
+        capturedAt,
+        author: {
+          id: author?.id || tweet.author_id || '',
+          username,
+          name: author?.name || '',
+        },
+        metrics: tweet.public_metrics || {},
+        externalUrls: (tweet.entities?.urls || [])
+          .map((item) => item.expanded_url || item.url || '')
+          .filter(Boolean),
+        media,
+      }
+    })
+
+  return { items, nextToken: response.meta?.next_token || '' }
+}
+
+export async function exchangeCodeForToken(input: {
+  clientId: string
+  clientSecret?: string
+  code: string
+  codeVerifier: string
+  redirectUri: string
+  now?: string
+}): Promise<XBookmarkTokenState> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  }
+  if (input.clientSecret) {
+    headers.Authorization = `Basic ${Buffer.from(`${input.clientId}:${input.clientSecret}`).toString('base64')}`
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    code_verifier: input.codeVerifier,
+    client_id: input.clientId,
+  })
+
+  const response = await fetch('https://api.twitter.com/2/oauth2/token', {
+    method: 'POST',
+    headers,
+    body,
+  })
+  const data = (await response.json()) as {
+    access_token?: string
+    refresh_token?: string
+    expires_in?: number
+    scope?: string
+    error?: string
+    error_description?: string
+  }
+
+  if (!response.ok || !data.access_token) {
+    throw new Error(
+      data.error_description ||
+        data.error ||
+        `X token exchange failed with HTTP ${response.status}`,
+    )
+  }
+
+  const nowMs = input.now ? Date.parse(input.now) : Date.now()
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || '',
+    expiresAt: data.expires_in
+      ? new Date(nowMs + data.expires_in * 1000).toISOString()
+      : '',
+    scope: data.scope || '',
+    updatedAt: new Date(nowMs).toISOString(),
+  }
+}
+
+export async function fetchAuthenticatedUser(
+  accessToken: string,
+): Promise<{ userId: string; username: string }> {
+  const response = await fetch(
+    'https://api.twitter.com/2/users/me?user.fields=username',
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+  const data = (await response.json()) as {
+    data?: { id?: string; username?: string }
+    error?: string
+  }
+  if (!response.ok)
+    throw new Error(
+      data.error || `X user lookup failed with HTTP ${response.status}`,
+    )
+  return { userId: data.data?.id || '', username: data.data?.username || '' }
+}
+
+export async function fetchXBookmarks(input: {
+  userId: string
+  accessToken: string
+  maxResults?: number
+  paginationToken?: string
+}): Promise<XBookmarksApiResponse> {
+  const url = new URL(
+    `https://api.twitter.com/2/users/${input.userId}/bookmarks`,
+  )
+  url.searchParams.set('max_results', String(input.maxResults || 10))
+  url.searchParams.set(
+    'tweet.fields',
+    'attachments,author_id,created_at,entities,public_metrics',
+  )
+  url.searchParams.set('expansions', 'author_id,attachments.media_keys')
+  url.searchParams.set('user.fields', 'name,username')
+  url.searchParams.set('media.fields', 'type,url,preview_image_url')
+  if (input.paginationToken)
+    url.searchParams.set('pagination_token', input.paginationToken)
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${input.accessToken}` },
+  })
+  const data = (await response.json()) as XBookmarksApiResponse & {
+    error?: string
+    detail?: string
+    title?: string
+  }
+  if (!response.ok)
+    throw new Error(
+      data.detail ||
+        data.title ||
+        data.error ||
+        `X bookmarks fetch failed with HTTP ${response.status}`,
+    )
+  return data
+}

--- a/src/routes/api/x-bookmarks/authorize.ts
+++ b/src/routes/api/x-bookmarks/authorize.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  buildXBookmarkAuthorizeUrl,
+  configuredClientId,
+  createOAuthStateValue,
+  createPkcePair,
+  defaultRedirectUri,
+  writeOAuthState,
+} from './-x-bookmarks-utils'
+
+export const Route = createFileRoute('/api/x-bookmarks/authorize')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const clientId = configuredClientId()
+        if (!clientId) {
+          return json(
+            {
+              ok: false,
+              error: 'X_BOOKMARKS_CLIENT_ID is not configured locally.',
+            },
+            { status: 400 },
+          )
+        }
+
+        const redirectUri = defaultRedirectUri(request.url)
+        const state = createOAuthStateValue()
+        const pkce = createPkcePair()
+        await writeOAuthState({
+          state,
+          codeVerifier: pkce.verifier,
+          redirectUri,
+          createdAt: new Date().toISOString(),
+        })
+
+        const authorizeUrl = buildXBookmarkAuthorizeUrl({
+          clientId,
+          redirectUri,
+          state,
+          codeChallenge: pkce.challenge,
+        })
+
+        return json({
+          ok: true,
+          authorizeUrl: authorizeUrl.toString(),
+          redirectUri,
+          mode: 'read-only',
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/callback.ts
+++ b/src/routes/api/x-bookmarks/callback.ts
@@ -1,0 +1,82 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import {
+  configuredClientId,
+  configuredClientSecret,
+  exchangeCodeForToken,
+  fetchAuthenticatedUser,
+  readOAuthState,
+  writeTokenState,
+} from './-x-bookmarks-utils'
+
+function htmlResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  })
+}
+
+export const Route = createFileRoute('/api/x-bookmarks/callback')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url)
+        const code = url.searchParams.get('code') || ''
+        const state = url.searchParams.get('state') || ''
+        const error = url.searchParams.get('error') || ''
+
+        if (error) {
+          return htmlResponse(
+            `<h1>X Bookmark Intake authorization failed</h1><p>${error}</p>`,
+            400,
+          )
+        }
+        if (!code || !state) {
+          return htmlResponse(
+            '<h1>X Bookmark Intake authorization failed</h1><p>Missing OAuth code or state.</p>',
+            400,
+          )
+        }
+
+        const oauthState = await readOAuthState()
+        if (!oauthState || oauthState.state !== state) {
+          return htmlResponse(
+            '<h1>X Bookmark Intake authorization failed</h1><p>OAuth state did not match. Start again from Workspace.</p>',
+            400,
+          )
+        }
+
+        const clientId = configuredClientId()
+        if (!clientId) {
+          return htmlResponse(
+            '<h1>X Bookmark Intake authorization failed</h1><p>X_BOOKMARKS_CLIENT_ID is not configured locally.</p>',
+            400,
+          )
+        }
+
+        try {
+          const tokenState = await exchangeCodeForToken({
+            clientId,
+            clientSecret: configuredClientSecret(),
+            code,
+            codeVerifier: oauthState.codeVerifier,
+            redirectUri: oauthState.redirectUri,
+          })
+          const user = await fetchAuthenticatedUser(
+            tokenState.accessToken || '',
+          )
+          await writeTokenState({ ...tokenState, ...user })
+          return htmlResponse(
+            '<h1>X Bookmark Intake connected</h1><p>You can close this tab and return to Workspace.</p>',
+          )
+        } catch (err) {
+          return htmlResponse(
+            `<h1>X Bookmark Intake authorization failed</h1><p>${err instanceof Error ? err.message : 'Unknown OAuth error'}</p>`,
+            500,
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/extract-articles.ts
+++ b/src/routes/api/x-bookmarks/extract-articles.ts
@@ -1,0 +1,109 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  fetchXArticleExtraction,
+  mergeXArticleExtractions,
+  readBookmarkCache,
+  readXArticleExtractionCache,
+  writeXArticleExtractionCache,
+  xArticleIdFromUrl,
+  xArticleUrl,
+} from './-x-bookmarks-utils'
+
+type ExtractRequest = {
+  limit?: unknown
+  force?: unknown
+}
+
+function readLimit(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 10
+  return Math.min(Math.max(Math.floor(value), 1), 50)
+}
+
+export const Route = createFileRoute('/api/x-bookmarks/extract-articles')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        let payload: ExtractRequest = {}
+        try {
+          payload = (await request.json()) as ExtractRequest
+        } catch {
+          payload = {}
+        }
+
+        const cache = await readBookmarkCache()
+        if (!cache) {
+          return json(
+            { ok: false, error: 'No X bookmark cache exists yet.' },
+            { status: 400 },
+          )
+        }
+
+        const existing = await readXArticleExtractionCache()
+        const existingIds = new Set(
+          (existing?.items || []).map((item) => item.articleId),
+        )
+        const limit = readLimit(payload.limit)
+        const force = payload.force === true
+        const articleCandidates = cache.items
+          .map((item) => ({ item, articleUrl: xArticleUrl(item) }))
+          .filter(({ articleUrl }) => Boolean(articleUrl))
+        const targets = articleCandidates
+          .filter(
+            ({ articleUrl }) =>
+              force || !existingIds.has(xArticleIdFromUrl(articleUrl)),
+          )
+          .slice(0, limit)
+
+        const extractedAt = new Date().toISOString()
+        const extracted = []
+        for (const target of targets) {
+          extracted.push(
+            await fetchXArticleExtraction({
+              articleUrl: target.articleUrl,
+              sourceTweetId: target.item.id,
+              fetchedAt: extractedAt,
+            }),
+          )
+        }
+
+        const merged = mergeXArticleExtractions({
+          existing,
+          extractedAt,
+          items: extracted,
+        })
+        const cachePath = await writeXArticleExtractionCache(merged)
+
+        return json({
+          ok: true,
+          extractedAt,
+          totalArticleCandidates: articleCandidates.length,
+          attempted: extracted.length,
+          cachedCount: merged.items.length,
+          remaining: Math.max(
+            articleCandidates.length - merged.items.length,
+            0,
+          ),
+          counts: {
+            extracted: merged.items.filter(
+              (item) => item.status === 'extracted',
+            ).length,
+            unavailable: merged.items.filter(
+              (item) => item.status === 'unavailable',
+            ).length,
+            error: merged.items.filter((item) => item.status === 'error')
+              .length,
+          },
+          cachePath,
+          items: extracted,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/fetch.ts
+++ b/src/routes/api/x-bookmarks/fetch.ts
@@ -1,0 +1,102 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  fetchXBookmarks,
+  mergeBookmarkCache,
+  normalizeXBookmarkTweets,
+  readBookmarkCache,
+  readTokenState,
+  writeBookmarkCache,
+} from './-x-bookmarks-utils'
+
+type FetchRequest = {
+  maxResults?: unknown
+  paginationToken?: unknown
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readMaxResults(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 100
+  return Math.min(Math.max(Math.floor(value), 5), 100)
+}
+
+export const Route = createFileRoute('/api/x-bookmarks/fetch')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const tokenState = await readTokenState()
+        if (!tokenState?.accessToken || !tokenState.userId) {
+          return json(
+            {
+              ok: false,
+              error: 'X Bookmark Intake is not authenticated yet.',
+            },
+            { status: 400 },
+          )
+        }
+
+        let payload: FetchRequest = {}
+        try {
+          payload = (await request.json()) as FetchRequest
+        } catch {
+          payload = {}
+        }
+
+        try {
+          const capturedAt = new Date().toISOString()
+          const existingCache = await readBookmarkCache()
+          const response = await fetchXBookmarks({
+            userId: tokenState.userId,
+            accessToken: tokenState.accessToken,
+            maxResults: readMaxResults(payload.maxResults),
+            paginationToken: readString(payload.paginationToken),
+          })
+          const normalized = normalizeXBookmarkTweets(response, capturedAt)
+          const merged = mergeBookmarkCache({
+            existing: existingCache,
+            fetchedAt: capturedAt,
+            nextToken: normalized.nextToken,
+            fetched: normalized.items,
+          })
+          const cachePath = await writeBookmarkCache({
+            fetchedAt: merged.fetchedAt,
+            nextToken: merged.nextToken,
+            items: merged.items,
+          })
+
+          return json({
+            ok: true,
+            fetchedAt: capturedAt,
+            count: normalized.items.length,
+            cacheCount: merged.items.length,
+            likelyNewCount: merged.likelyNewItems.length,
+            nextToken: normalized.nextToken,
+            cachePath,
+            items: normalized.items,
+            likelyNewItems: merged.likelyNewItems,
+          })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error:
+                err instanceof Error
+                  ? err.message
+                  : 'Failed to fetch X bookmarks',
+            },
+            { status: 502 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/import-article.ts
+++ b/src/routes/api/x-bookmarks/import-article.ts
@@ -1,0 +1,116 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  createManualXArticleExtraction,
+  mergeXArticleExtractions,
+  readBookmarkCache,
+  readXArticleExtractionCache,
+  writeXArticleExtractionCache,
+  xArticleUrl,
+} from './-x-bookmarks-utils'
+
+type ImportRequest = {
+  sourceTweetId?: unknown
+  articleUrl?: unknown
+  title?: unknown
+  text?: unknown
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export const Route = createFileRoute('/api/x-bookmarks/import-article')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        let payload: ImportRequest = {}
+        try {
+          payload = (await request.json()) as ImportRequest
+        } catch {
+          return json(
+            { ok: false, error: 'Invalid JSON payload.' },
+            { status: 400 },
+          )
+        }
+
+        const sourceTweetId = textValue(payload.sourceTweetId)
+        const bodyText = textValue(payload.text)
+        const title = textValue(payload.title)
+        if (!sourceTweetId)
+          return json(
+            { ok: false, error: 'sourceTweetId is required.' },
+            { status: 400 },
+          )
+        if (bodyText.length < 40)
+          return json(
+            {
+              ok: false,
+              error: 'Article body text must be at least 40 characters.',
+            },
+            { status: 400 },
+          )
+
+        const cache = await readBookmarkCache()
+        if (!cache)
+          return json(
+            { ok: false, error: 'No X bookmark cache exists yet.' },
+            { status: 400 },
+          )
+
+        const source = cache.items.find((item) => item.id === sourceTweetId)
+        if (!source)
+          return json(
+            {
+              ok: false,
+              error: 'sourceTweetId was not found in the bookmark cache.',
+            },
+            { status: 404 },
+          )
+
+        const articleUrl = textValue(payload.articleUrl) || xArticleUrl(source)
+        if (!articleUrl)
+          return json(
+            { ok: false, error: 'No X Article URL found for this source.' },
+            { status: 400 },
+          )
+
+        const importedAt = new Date().toISOString()
+        const extraction = createManualXArticleExtraction({
+          articleUrl,
+          sourceTweetId,
+          title,
+          text: bodyText,
+          importedAt,
+        })
+        if (!extraction.articleId)
+          return json(
+            { ok: false, error: 'Invalid X Article URL.' },
+            { status: 400 },
+          )
+
+        const existing = await readXArticleExtractionCache()
+        const merged = mergeXArticleExtractions({
+          existing,
+          extractedAt: importedAt,
+          items: [extraction],
+        })
+        const cachePath = await writeXArticleExtractionCache(merged)
+
+        return json({
+          ok: true,
+          importedAt,
+          cachePath,
+          item: extraction,
+          cachedCount: merged.items.length,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/review.ts
+++ b/src/routes/api/x-bookmarks/review.ts
@@ -1,0 +1,55 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  createXBookmarkReviewDigest,
+  readBookmarkCache,
+  readXArticleExtractionCache,
+} from './-x-bookmarks-utils'
+
+export const Route = createFileRoute('/api/x-bookmarks/review')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const cache = await readBookmarkCache()
+        const articleExtractions = await readXArticleExtractionCache()
+        if (!cache) {
+          return json({
+            ok: true,
+            cache: null,
+            digest: createXBookmarkReviewDigest(
+              [],
+              undefined,
+              articleExtractions?.items || [],
+            ),
+          })
+        }
+
+        const digest = createXBookmarkReviewDigest(
+          cache.items,
+          undefined,
+          articleExtractions?.items || [],
+        )
+        return json({
+          ok: true,
+          cache: {
+            fetchedAt: cache.fetchedAt,
+            count: cache.items.length,
+            nextToken: cache.nextToken,
+          },
+          digest,
+          limitations: [
+            'X returns post createdAt, not bookmark save time.',
+            'X Article extraction uses X web GraphQL and records extracted, unavailable, or error status per article.',
+            'Digest classification is deterministic and source-backed, not a substitute for final human judgment.',
+          ],
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/x-bookmarks/status.ts
+++ b/src/routes/api/x-bookmarks/status.ts
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  configuredClientId,
+  createXBookmarkStatus,
+  defaultRedirectUri,
+  readBookmarkCache,
+  readTokenState,
+} from './-x-bookmarks-utils'
+
+export const Route = createFileRoute('/api/x-bookmarks/status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const tokenState = await readTokenState()
+        const cache = await readBookmarkCache()
+        return json({
+          ok: true,
+          status: createXBookmarkStatus({
+            clientId: configuredClientId(),
+            redirectUri: defaultRedirectUri(request.url),
+            tokenState,
+          }),
+          cache: cache
+            ? {
+                fetchedAt: cache.fetchedAt,
+                count: cache.items.length,
+                nextToken: cache.nextToken,
+                sample: cache.items.slice(0, 5),
+              }
+            : null,
+        })
+      },
+    },
+  },
+})

--- a/src/routes/executive-queue.tsx
+++ b/src/routes/executive-queue.tsx
@@ -1,0 +1,818 @@
+'use client'
+
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  ExecutiveQueueItem,
+  QueueApprovalDecision,
+  QueueBoardColumn,
+  QueueExecutionMode,
+  QueueStatus,
+} from './api/-executive-queue-utils'
+import type { ExecutiveQueueNotionSyncProposal } from './api/-executive-queue-notion-sync-utils'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { cn } from '@/lib/utils'
+import { toast } from '@/components/ui/toast'
+
+type ExecutiveQueueResponse = {
+  ok: boolean
+  items: Array<ExecutiveQueueItem>
+  grouped: Record<QueueBoardColumn, Array<ExecutiveQueueItem>>
+  total: number
+  error?: string
+}
+
+const BOARD_COLUMNS: Array<QueueBoardColumn> = [
+  'Triage',
+  'Proposed',
+  'Queued',
+  'In Progress',
+  'Blocked',
+  'Done',
+]
+
+const COLUMN_HELP: Record<QueueBoardColumn, string> = {
+  Triage: 'Needs judgment',
+  Proposed: 'Needs approval',
+  Queued: 'Ready for owner',
+  'In Progress': 'Being worked',
+  Blocked: 'Waiting',
+  Done: 'Result captured',
+}
+
+const RISK_STYLES = {
+  Low: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
+  Medium: 'border-amber-400/30 bg-amber-400/10 text-amber-300',
+  High: 'border-red-400/30 bg-red-400/10 text-red-300',
+}
+
+type QueueUpdateInput =
+  | {
+      id: string
+      action: 'transition'
+      status: QueueStatus
+      resultSummary?: string
+      blockedReason?: string
+    }
+  | {
+      id: string
+      action: 'approval'
+      decision: QueueApprovalDecision
+      note?: string
+    }
+
+type QueueUpdateResponse = {
+  ok: boolean
+  item?: ExecutiveQueueItem
+  error?: string
+}
+
+type QueueExecutionInput = {
+  id: string
+  mode: QueueExecutionMode
+  note?: string
+}
+
+type QueueExecutionResponse = {
+  ok: boolean
+  item?: ExecutiveQueueItem
+  execution?: { id: string; localPath: string }
+  runId?: string | null
+  sessionKey?: string
+  delivery?: { delivered?: boolean }
+  error?: string
+}
+
+type NotionApplyResult = {
+  mode: 'apply_approved'
+  created: Array<unknown>
+  updated: Array<unknown>
+  skipped: Array<unknown>
+  deleted: Array<never>
+  persistedPath: string
+}
+
+type NotionSyncResponse = {
+  ok: boolean
+  proposal?: ExecutiveQueueNotionSyncProposal
+  result?: NotionApplyResult
+  error?: string
+}
+
+async function fetchExecutiveQueue(): Promise<ExecutiveQueueResponse> {
+  const response = await fetch('/api/executive-queue')
+  const data = (await response.json()) as ExecutiveQueueResponse
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data
+}
+
+async function updateExecutiveQueue(
+  input: QueueUpdateInput,
+): Promise<ExecutiveQueueItem> {
+  const response = await fetch('/api/executive-queue', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...input, actor: 'Tim' }),
+  })
+  const data = (await response.json()) as QueueUpdateResponse
+  if (!response.ok || data.ok === false || !data.item) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data.item
+}
+
+async function executeExecutiveQueueItem(
+  input: QueueExecutionInput,
+): Promise<QueueExecutionResponse> {
+  const response = await fetch('/api/executive-queue-execution', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...input, actor: 'Tim' }),
+  })
+  const data = (await response.json()) as QueueExecutionResponse
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data
+}
+
+async function createNotionSyncProposalFromQueue(): Promise<ExecutiveQueueNotionSyncProposal> {
+  const response = await fetch('/api/executive-queue-notion-sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ actor: 'Tim', mode: 'proposal_only' }),
+  })
+  const data = (await response.json()) as NotionSyncResponse
+  if (!response.ok || data.ok === false || !data.proposal) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data.proposal
+}
+
+async function applyApprovedNotionSyncProposal(
+  proposal: ExecutiveQueueNotionSyncProposal,
+): Promise<NotionApplyResult> {
+  const approvalText =
+    window.prompt('Type exactly: APPROVE NOTION SYNC')?.trim() ?? ''
+  const response = await fetch('/api/executive-queue-notion-sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      actor: 'Tim',
+      mode: 'apply_approved',
+      approval: {
+        proposalId: proposal.id,
+        proposalPath: proposal.persistedPath,
+        approvedBy: 'Tim',
+        approvalText,
+        expectedCreates: proposal.wouldCreate.length,
+        expectedUpdates: proposal.wouldUpdate.length,
+      },
+    }),
+  })
+  const data = (await response.json()) as NotionSyncResponse
+  if (!response.ok || data.ok === false || !data.result) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data.result
+}
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-2xl border border-primary-200 bg-primary-50/70 px-4 py-3">
+      <div className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold text-ink">{value}</div>
+    </div>
+  )
+}
+
+function Pill({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <span
+      className={cn(
+        'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+function QueueCard({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: ExecutiveQueueItem
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'w-full rounded-2xl border bg-[var(--theme-card)] p-3 text-left transition hover:border-[var(--theme-accent)] hover:bg-[var(--theme-hover)]',
+        selected
+          ? 'border-[var(--theme-accent)]'
+          : 'border-[var(--theme-border)]',
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold leading-snug text-ink">
+          {item.title}
+        </h3>
+        <Pill className="shrink-0 border-[var(--theme-border)] text-[var(--theme-muted)]">
+          {item.priority}
+        </Pill>
+      </div>
+      <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+        {item.outcome}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+          {item.owner}
+        </Pill>
+        <Pill className={RISK_STYLES[item.riskLevel]}>{item.riskLevel}</Pill>
+      </div>
+      <div className="mt-3 text-xs text-[var(--theme-muted)]">
+        Next:{' '}
+        <span className="text-ink">{item.nextAction || 'Needs triage'}</span>
+      </div>
+    </button>
+  )
+}
+
+function ActionButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: ReactNode
+  onClick: () => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-xs font-medium text-[var(--theme-muted)] transition hover:border-[var(--theme-accent)] hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {children}
+    </button>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+      <div className="text-[11px] uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-sm text-ink">{value || 'None'}</div>
+    </div>
+  )
+}
+
+function QueueDetail({
+  item,
+  onApproval,
+  onExecute,
+  onTransition,
+  updating,
+}: {
+  item: ExecutiveQueueItem | null
+  onApproval: (
+    item: ExecutiveQueueItem,
+    decision: QueueApprovalDecision,
+    note?: string,
+  ) => void
+  onExecute: (
+    item: ExecutiveQueueItem,
+    mode: QueueExecutionMode,
+    note?: string,
+  ) => void
+  onTransition: (item: ExecutiveQueueItem, status: QueueStatus) => void
+  updating: boolean
+}) {
+  if (!item) {
+    return (
+      <aside className="rounded-2xl border border-primary-200 bg-primary-50/70 p-5 text-sm text-[var(--theme-muted)]">
+        Select an item to inspect owner, risk, approval gate, source, and next
+        action.
+      </aside>
+    )
+  }
+
+  return (
+    <aside className="rounded-2xl border border-primary-200 bg-primary-50/80 p-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+          {item.status}
+        </Pill>
+        <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+          {item.domain}
+        </Pill>
+        <Pill className={RISK_STYLES[item.riskLevel]}>
+          {item.riskLevel} risk
+        </Pill>
+      </div>
+      <h2 className="mt-4 text-xl font-semibold text-ink">{item.title}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-[var(--theme-muted)]">
+        {item.outcome}
+      </p>
+
+      <div className="mt-5 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+          Execution controls
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-[var(--theme-muted)]">
+          Approve only changes queue state. Approve and run dispatches this one
+          item to Executive.
+        </p>
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <ActionButton
+            disabled={updating}
+            onClick={() =>
+              onApproval(
+                item,
+                'approve_action',
+                'Approved only. Do not run automatically.',
+              )
+            }
+          >
+            Approve only
+          </ActionButton>
+          <ActionButton
+            disabled={updating}
+            onClick={() =>
+              onExecute(
+                item,
+                'approve_and_run',
+                'Approved and run this queue item now.',
+              )
+            }
+          >
+            Approve and run
+          </ActionButton>
+          <ActionButton
+            disabled={updating}
+            onClick={() =>
+              onExecute(
+                item,
+                'draft_only',
+                'Approved local draft-only prep. No external side effects.',
+              )
+            }
+          >
+            Draft only
+          </ActionButton>
+          <ActionButton
+            disabled={updating}
+            onClick={() =>
+              onExecute(
+                item,
+                'explain_more',
+                'Explain this queue item before approval.',
+              )
+            }
+          >
+            Explain more
+          </ActionButton>
+          <ActionButton
+            disabled={updating}
+            onClick={() => {
+              const reason = window
+                .prompt('Why are we holding this item?')
+                ?.trim()
+              if (!reason) return
+              onApproval(item, 'hold', reason)
+            }}
+          >
+            Hold
+          </ActionButton>
+          <ActionButton
+            disabled={updating}
+            onClick={() =>
+              onApproval(item, 'manual_only', 'Manual only mode set by Tim.')
+            }
+          >
+            Manual only
+          </ActionButton>
+        </div>
+        <details className="mt-3">
+          <summary className="cursor-pointer text-xs font-medium text-[var(--theme-muted)]">
+            Advanced approval
+          </summary>
+          <div className="mt-2">
+            <ActionButton
+              disabled={updating}
+              onClick={() =>
+                onApproval(
+                  item,
+                  'broader_approval',
+                  'Broader approval granted by Tim.',
+                )
+              }
+            >
+              Broader approval
+            </ActionButton>
+          </div>
+        </details>
+      </div>
+
+      <div className="mt-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+          Status transitions
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {BOARD_COLUMNS.map((status) => (
+            <ActionButton
+              key={status}
+              disabled={updating || item.status === status}
+              onClick={() => onTransition(item, status)}
+            >
+              {status}
+            </ActionButton>
+          ))}
+          <ActionButton
+            disabled={updating || item.status === 'Archived'}
+            onClick={() => onTransition(item, 'Archived')}
+          >
+            Archive
+          </ActionButton>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3">
+        <DetailRow label="Owner" value={item.owner} />
+        <DetailRow label="Approval" value={item.approvalLevel} />
+        <DetailRow label="Next action" value={item.nextAction} />
+        <DetailRow label="Blocked reason" value={item.blockedReason} />
+        <DetailRow label="Result" value={item.resultSummary} />
+        <DetailRow
+          label="Source"
+          value={`${item.source.type}: ${item.source.id}`}
+        />
+      </div>
+
+      <div className="mt-5 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+          Source excerpt
+        </div>
+        <p className="mt-2 text-sm leading-relaxed text-ink">
+          {item.source.excerpt || item.context || 'No excerpt captured.'}
+        </p>
+      </div>
+    </aside>
+  )
+}
+
+function ExecutiveQueueRoute() {
+  usePageTitle('Executive Queue')
+  const queryClient = useQueryClient()
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [notionProposal, setNotionProposal] =
+    useState<ExecutiveQueueNotionSyncProposal | null>(null)
+  const [notionApplyResult, setNotionApplyResult] =
+    useState<NotionApplyResult | null>(null)
+
+  const queueQuery = useQuery({
+    queryKey: ['executive-queue'],
+    queryFn: fetchExecutiveQueue,
+    refetchInterval: 20_000,
+    placeholderData: keepPreviousData,
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: updateExecutiveQueue,
+    onSuccess: (item) => {
+      setSelectedId(item.id)
+      void queryClient.invalidateQueries({ queryKey: ['executive-queue'] })
+      toast('Executive Queue updated')
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error
+          ? error.message
+          : 'Failed to update Executive Queue',
+        { type: 'error' },
+      )
+    },
+  })
+
+  const executionMutation = useMutation({
+    mutationFn: executeExecutiveQueueItem,
+    onSuccess: (result) => {
+      if (result.item?.id) setSelectedId(result.item.id)
+      void queryClient.invalidateQueries({ queryKey: ['executive-queue'] })
+      if (result.delivery?.delivered) {
+        toast('Explanation sent to Telegram')
+      } else if (result.execution) {
+        const target = result.runId
+          ? `run ${result.runId}`
+          : (result.sessionKey ?? result.execution.id)
+        toast(`Queue item dispatched: ${target}`)
+      } else {
+        toast('Queue execution requested')
+      }
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error
+          ? error.message
+          : 'Failed to dispatch queue item',
+        { type: 'error' },
+      )
+    },
+  })
+
+  const notionSyncMutation = useMutation({
+    mutationFn: createNotionSyncProposalFromQueue,
+    onSuccess: (proposal) => {
+      setNotionProposal(proposal)
+      setNotionApplyResult(null)
+      toast(
+        `Notion proposal created: ${proposal.eligibleCount} eligible item${proposal.eligibleCount === 1 ? '' : 's'}`,
+      )
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error
+          ? error.message
+          : 'Failed to create Notion sync proposal',
+        { type: 'error' },
+      )
+    },
+  })
+
+  const notionApplyMutation = useMutation({
+    mutationFn: applyApprovedNotionSyncProposal,
+    onSuccess: (result) => {
+      setNotionApplyResult(result)
+      void queryClient.invalidateQueries({ queryKey: ['executive-queue'] })
+      toast(
+        `Notion sync applied: ${result.created.length} created, ${result.updated.length} updated`,
+      )
+    },
+    onError: (error) => {
+      toast(
+        error instanceof Error
+          ? error.message
+          : 'Failed to apply approved Notion sync',
+        { type: 'error' },
+      )
+    },
+  })
+
+  const handleApproval = (
+    item: ExecutiveQueueItem,
+    decision: QueueApprovalDecision,
+    note?: string,
+  ) => {
+    updateMutation.mutate({ id: item.id, action: 'approval', decision, note })
+  }
+
+  const handleExecute = (
+    item: ExecutiveQueueItem,
+    mode: QueueExecutionMode,
+    note?: string,
+  ) => {
+    executionMutation.mutate({ id: item.id, mode, note })
+  }
+
+  const handleTransition = (item: ExecutiveQueueItem, status: QueueStatus) => {
+    const resultSummary =
+      status === 'Done'
+        ? window.prompt('Result summary required to mark Done')?.trim()
+        : undefined
+    if (status === 'Done' && !resultSummary) return
+    const blockedReason =
+      status === 'Blocked'
+        ? window.prompt('Why is this blocked?')?.trim()
+        : undefined
+    updateMutation.mutate({
+      id: item.id,
+      action: 'transition',
+      status,
+      resultSummary,
+      blockedReason,
+    })
+  }
+
+  const items = queueQuery.data?.items ?? []
+  const grouped = queueQuery.data?.grouped
+  const selectedItem = useMemo(() => {
+    if (!items.length) return null
+    const activeItems = items.filter(
+      (item) => item.status !== 'Done' && item.status !== 'Archived',
+    )
+    const selectedById = items.find((item) => item.id === selectedId)
+    if (selectedById) return selectedById
+    if (activeItems.length) return activeItems[0]
+    return items[0]
+  }, [items, selectedId])
+
+  const activeCount = items.filter(
+    (item) => item.status !== 'Done' && item.status !== 'Archived',
+  ).length
+  const blockedCount = items.filter((item) => item.status === 'Blocked').length
+  const approvalCount = items.filter(
+    (item) =>
+      item.status !== 'Done' &&
+      item.status !== 'Archived' &&
+      (item.status === 'Proposed' || item.approvalLevel !== 'Auto'),
+  ).length
+
+  return (
+    <div className="min-h-full overflow-y-auto bg-surface text-ink">
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
+        <header className="rounded-2xl border border-primary-200 bg-primary-50/85 p-5 backdrop-blur-xl">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-ink">
+                Executive Queue
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm leading-relaxed text-[var(--theme-muted)]">
+                Control layer for delegated work. Local JSON is the source of
+                truth. Notion and Workspace mirror what is safe to operate.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void queueQuery.refetch()}
+                className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-sm text-[var(--theme-muted)] transition hover:border-[var(--theme-accent)] hover:text-ink"
+              >
+                Refresh
+              </button>
+              <button
+                type="button"
+                disabled={notionSyncMutation.isPending}
+                onClick={() => notionSyncMutation.mutate()}
+                className="rounded-xl border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-sm font-medium text-amber-200 transition hover:border-amber-300 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {notionSyncMutation.isPending
+                  ? 'Preparing…'
+                  : 'Prepare Notion sync proposal'}
+              </button>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard label="Total" value={items.length} />
+            <StatCard label="Active" value={activeCount} />
+            <StatCard label="Approvals" value={approvalCount} />
+            <StatCard label="Blocked" value={blockedCount} />
+          </div>
+        </header>
+
+        {queueQuery.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {queueQuery.error instanceof Error
+              ? queueQuery.error.message
+              : 'Failed to load Executive Queue'}
+          </div>
+        ) : null}
+
+        {notionProposal ? (
+          <section className="rounded-2xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <h2 className="font-semibold text-amber-50">
+                  Notion sync proposal
+                </h2>
+                <p className="mt-1 text-amber-100/80">
+                  No Notion pages changed yet. Proposed creates:{' '}
+                  {notionProposal.wouldCreate.length}. Proposed updates:{' '}
+                  {notionProposal.wouldUpdate.length}. Skipped:{' '}
+                  {notionProposal.wouldSkip.length}.
+                </p>
+                <p className="mt-1 text-xs text-amber-100/70">
+                  Saved locally: {notionProposal.persistedPath}
+                </p>
+                <p className="mt-1 text-xs text-amber-100/70">
+                  Live apply requires exact typed phrase plus proposal
+                  id/path/count matching on the server.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Pill className="border-amber-300/40 text-amber-100">
+                  Approval gated
+                </Pill>
+                <button
+                  type="button"
+                  disabled={notionApplyMutation.isPending}
+                  onClick={() => notionApplyMutation.mutate(notionProposal)}
+                  className="rounded-xl border border-red-400/40 bg-red-400/10 px-3 py-2 text-xs font-semibold text-red-100 transition hover:border-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {notionApplyMutation.isPending
+                    ? 'Applying…'
+                    : 'Apply approved sync'}
+                </button>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        {notionApplyResult ? (
+          <section className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-4 text-sm text-emerald-100">
+            <h2 className="font-semibold text-emerald-50">
+              Approved Notion sync applied
+            </h2>
+            <p className="mt-1 text-emerald-100/80">
+              Created: {notionApplyResult.created.length}. Updated:{' '}
+              {notionApplyResult.updated.length}. Skipped:{' '}
+              {notionApplyResult.skipped.length}. Deleted:{' '}
+              {notionApplyResult.deleted.length}.
+            </p>
+            <p className="mt-1 text-xs text-emerald-100/70">
+              Saved result: {notionApplyResult.persistedPath}
+            </p>
+          </section>
+        ) : null}
+
+        <div className="grid gap-5 xl:grid-cols-[1fr_380px]">
+          <section className="overflow-x-auto rounded-2xl border border-primary-200 bg-primary-50/40 p-3">
+            <div className="grid min-w-[1180px] grid-cols-6 gap-3">
+              {BOARD_COLUMNS.map((column) => {
+                const columnItems = grouped?.[column] ?? []
+                return (
+                  <div
+                    key={column}
+                    className="flex min-h-[480px] flex-col rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)]/60"
+                  >
+                    <div className="border-b border-[var(--theme-border)] p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <h2 className="text-sm font-semibold text-ink">
+                          {column}
+                        </h2>
+                        <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+                          {columnItems.length}
+                        </Pill>
+                      </div>
+                      <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                        {COLUMN_HELP[column]}
+                      </p>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2 p-2">
+                      {queueQuery.isLoading ? (
+                        <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 text-xs text-[var(--theme-muted)]">
+                          Loading…
+                        </div>
+                      ) : columnItems.length ? (
+                        columnItems.map((item) => (
+                          <QueueCard
+                            key={item.id}
+                            item={item}
+                            selected={selectedItem?.id === item.id}
+                            onSelect={() => setSelectedId(item.id)}
+                          />
+                        ))
+                      ) : (
+                        <div className="rounded-2xl border border-dashed border-[var(--theme-border)] p-3 text-xs text-[var(--theme-muted)]">
+                          No items
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </section>
+
+          <QueueDetail
+            item={selectedItem}
+            onApproval={handleApproval}
+            onExecute={handleExecute}
+            onTransition={handleTransition}
+            updating={updateMutation.isPending || executionMutation.isPending}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/executive-queue')({
+  ssr: false,
+  component: ExecutiveQueueRoute,
+})

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,9 +2,9 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   ssr: false,
-  beforeLoad: function redirectToChat() {
+  beforeLoad: function redirectToDashboard() {
     throw redirect({
-      to: '/chat' as string,
+      to: '/dashboard' as string,
       replace: true,
     })
   },

--- a/src/routes/learning-loop.tsx
+++ b/src/routes/learning-loop.tsx
@@ -1,0 +1,325 @@
+'use client'
+
+import { createFileRoute } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  LearningLoopReview,
+  LearningLoopReviewItem,
+} from '@/features/learning-loop/types'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { cn } from '@/lib/utils'
+
+type FilterKind = 'all' | 'memory' | 'skill'
+type FilterRisk = 'all' | 'high' | 'medium' | 'low'
+
+async function fetchLearningLoopReview(): Promise<LearningLoopReview> {
+  const response = await fetch('/api/learning-loop/review?windowHours=168')
+  const data = (await response.json()) as LearningLoopReview
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data
+}
+
+export const Route = createFileRoute('/learning-loop')({
+  ssr: false,
+  component: LearningLoopRoute,
+})
+
+function riskClass(risk: LearningLoopReviewItem['risk']) {
+  if (risk === 'high') return 'border-red-400/30 bg-red-400/10 text-red-300'
+  if (risk === 'medium')
+    return 'border-amber-400/30 bg-amber-400/10 text-amber-300'
+  return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300'
+}
+
+function kindClass(kind: LearningLoopReviewItem['kind']) {
+  return kind === 'memory'
+    ? 'border-sky-400/30 bg-sky-400/10 text-sky-300'
+    : 'border-violet-400/30 bg-violet-400/10 text-violet-300'
+}
+
+function formatAge(ageHours: number) {
+  if (ageHours < 1) return 'Just now'
+  if (ageHours < 24) return `${ageHours}h ago`
+  return `${Math.round(ageHours / 24)}d ago`
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
+function Pill({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <span
+      className={cn(
+        'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+function MetricCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number | string
+  tone?: 'danger' | 'warning' | 'info'
+}) {
+  const toneClass =
+    tone === 'danger'
+      ? 'border-red-400/25 bg-red-400/10'
+      : tone === 'warning'
+        ? 'border-amber-400/25 bg-amber-400/10'
+        : tone === 'info'
+          ? 'border-sky-400/25 bg-sky-400/10'
+          : 'border-[var(--theme-border)] bg-[var(--theme-card)]'
+
+  return (
+    <section className={cn('rounded-3xl border p-5', toneClass)}>
+      <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+        {label}
+      </p>
+      <p className="mt-2 text-3xl font-semibold text-ink">{value}</p>
+    </section>
+  )
+}
+
+function ReviewItemCard({ item }: { item: LearningLoopReviewItem }) {
+  return (
+    <article className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap gap-2">
+            <Pill className={kindClass(item.kind)}>{item.kind}</Pill>
+            <Pill className={riskClass(item.risk)}>{item.risk} risk</Pill>
+            <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+              {item.profile}
+            </Pill>
+            <Pill className="border-[var(--theme-border)] text-[var(--theme-muted)]">
+              {item.status}
+            </Pill>
+          </div>
+          <h2 className="mt-3 break-words text-lg font-semibold text-ink">
+            {item.name}
+          </h2>
+          <p className="mt-1 break-all text-xs text-[var(--theme-muted)]">
+            {item.relativePath}
+          </p>
+        </div>
+        <div className="shrink-0 text-right text-xs text-[var(--theme-muted)]">
+          <div className="text-ink">{formatAge(item.ageHours)}</div>
+          <div>{formatDate(item.updatedAt)}</div>
+        </div>
+      </div>
+
+      <p className="mt-4 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-sm leading-relaxed text-[var(--theme-muted)]">
+        {item.summary}
+      </p>
+
+      {item.reviewFlags.length ? (
+        <div className="mt-4 space-y-2">
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+            Review flags
+          </p>
+          <ul className="space-y-2">
+            {item.reviewFlags.map((flag) => (
+              <li
+                key={flag}
+                className="flex gap-2 text-xs leading-relaxed text-[var(--theme-muted)]"
+              >
+                <span className="mt-1 size-1.5 shrink-0 rounded-full bg-[var(--theme-accent)]" />
+                <span>{flag}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-xs font-semibold text-[var(--theme-muted)] transition hover:border-[var(--theme-accent)] hover:text-ink"
+          onClick={() => {
+            void navigator.clipboard.writeText(item.relativePath)
+          }}
+        >
+          Copy path
+        </button>
+        <button
+          type="button"
+          className="rounded-xl border border-[var(--theme-border)] px-3 py-2 text-xs font-semibold text-[var(--theme-muted)] opacity-70"
+          disabled
+          title="Live review actions are intentionally not wired yet"
+        >
+          Mark reviewed, coming next
+        </button>
+      </div>
+    </article>
+  )
+}
+
+function EmptyState() {
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-center">
+      <p className="text-lg font-semibold text-ink">
+        No recent learning-loop changes found.
+      </p>
+      <p className="mt-2 text-sm text-[var(--theme-muted)]">
+        This read-only pilot watches recent memory and skill file changes across
+        Hermes profiles.
+      </p>
+    </section>
+  )
+}
+
+function LearningLoopRoute() {
+  usePageTitle('Learning Loop')
+  const [kindFilter, setKindFilter] = useState<FilterKind>('all')
+  const [riskFilter, setRiskFilter] = useState<FilterRisk>('all')
+  const reviewQuery = useQuery({
+    queryKey: ['learning-loop-review'],
+    queryFn: fetchLearningLoopReview,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+
+  const review = reviewQuery.data
+  const filteredItems = useMemo(() => {
+    const items = review?.items ?? []
+    return items.filter((item) => {
+      if (kindFilter !== 'all' && item.kind !== kindFilter) return false
+      if (riskFilter !== 'all' && item.risk !== riskFilter) return false
+      return true
+    })
+  }, [kindFilter, review?.items, riskFilter])
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-4 py-6 text-ink md:px-8 lg:px-10">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="rounded-[2rem] border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-sm md:p-8">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.22em] text-[var(--theme-muted)]">
+                Hermes learning loop
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-ink md:text-4xl">
+                Memory and Skill Change Review
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-relaxed text-[var(--theme-muted)] md:text-base">
+                Read-only surface for seeing what Hermes recently learned, which
+                profile it affects, and what needs human review before learning
+                becomes invisible system drift.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-amber-400/25 bg-amber-400/10 p-3 text-xs leading-relaxed text-amber-200">
+              Safe pilot: no writes, no undo, no profile changes.
+              <br />
+              Live controls stay gated until approved.
+            </div>
+          </div>
+        </header>
+
+        {reviewQuery.isError ? (
+          <section className="rounded-3xl border border-red-400/25 bg-red-400/10 p-5 text-sm text-red-200">
+            Failed to load learning-loop review:{' '}
+            {reviewQuery.error instanceof Error
+              ? reviewQuery.error.message
+              : 'Unknown error'}
+          </section>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+          <MetricCard
+            label="Recent changes"
+            value={review?.counts.total ?? '…'}
+            tone="info"
+          />
+          <MetricCard
+            label="Review needed"
+            value={review?.counts.reviewNeeded ?? '…'}
+            tone="warning"
+          />
+          <MetricCard
+            label="High risk"
+            value={review?.counts.highRisk ?? '…'}
+            tone="danger"
+          />
+          <MetricCard label="Memory" value={review?.counts.memory ?? '…'} />
+          <MetricCard label="Skills" value={review?.counts.skill ?? '…'} />
+        </div>
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-sm text-[var(--theme-muted)]">
+              Window: last {review?.windowHours ?? 168} hours
+              {review ? ` across ${review.profiles.length} profiles` : ''}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(['all', 'memory', 'skill'] as const).map((filter) => (
+                <button
+                  key={filter}
+                  type="button"
+                  onClick={() => setKindFilter(filter)}
+                  className={cn(
+                    'rounded-xl border px-3 py-2 text-xs font-semibold transition',
+                    kindFilter === filter
+                      ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/10 text-ink'
+                      : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-ink',
+                  )}
+                >
+                  {filter}
+                </button>
+              ))}
+              {(['all', 'high', 'medium', 'low'] as const).map((filter) => (
+                <button
+                  key={filter}
+                  type="button"
+                  onClick={() => setRiskFilter(filter)}
+                  className={cn(
+                    'rounded-xl border px-3 py-2 text-xs font-semibold transition',
+                    riskFilter === filter
+                      ? 'border-[var(--theme-accent)] bg-[var(--theme-accent)]/10 text-ink'
+                      : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-ink',
+                  )}
+                >
+                  {filter} risk
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <div className="space-y-4">
+          {reviewQuery.isLoading ? (
+            <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-center text-sm text-[var(--theme-muted)]">
+              Loading learning-loop changes…
+            </section>
+          ) : filteredItems.length ? (
+            filteredItems.map((item) => (
+              <ReviewItemCard key={item.id} item={item} />
+            ))
+          ) : (
+            <EmptyState />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/voice-lab.tsx
+++ b/src/routes/voice-lab.tsx
@@ -1,0 +1,831 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Conversation } from '@elevenlabs/client'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+  }
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike
+
+type SpeechRecognitionLike = {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  start: () => void
+  stop: () => void
+  abort: () => void
+  onstart: (() => void) | null
+  onend: (() => void) | null
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+}
+
+type SpeechRecognitionErrorEventLike = {
+  error?: string
+  message?: string
+}
+
+type SpeechRecognitionEventLike = {
+  resultIndex: number
+  results: ArrayLike<{
+    isFinal: boolean
+    0: { transcript: string }
+  }>
+}
+
+type VoiceTurn = {
+  id: string
+  role: 'tim' | 'executive' | 'system'
+  text: string
+  timestamp: string
+}
+
+type VoiceLedgerResponse = {
+  ok?: boolean
+  conversationId?: string
+  filePath?: string
+  turnCount?: number
+  summary?: string
+  decisions?: Array<string>
+  followUpActions?: Array<string>
+  review?: VoiceReview
+  delegation?: DelegationHandoff
+  queueItem?: ExecutiveQueueResponse['item'] | null
+  error?: string
+}
+
+type VoiceReview = {
+  summary: string
+  decisions: Array<string>
+  followUpActions: Array<string>
+  openQuestions: Array<string>
+  needsApproval: Array<string>
+}
+
+type ExecutiveQueueResponse = {
+  ok?: boolean
+  item?: {
+    id: string
+    title: string
+    status: string
+    priority: string
+    owner: string
+    localPath: string
+  }
+  error?: string
+}
+
+type DelegationHandoff = {
+  outcome: string
+  owner: string
+  context: string
+  constraints: Array<string>
+  nextAction: string
+  approvalRequired: boolean
+}
+
+type StreamEvent = {
+  event: string
+  data: Record<string, unknown>
+}
+
+type ElevenLabsConversationSession = {
+  endSession: () => Promise<void>
+}
+
+type ElevenLabsTokenResponse = {
+  ok?: boolean
+  token?: string
+  error?: string
+}
+
+const EXECUTIVE_DELEGATION_SYSTEM_PROMPT = [
+  'You are Executive, Tim Walker\'s cross-domain chief of staff.',
+  'This is a browser voice prototype for AI ops agent delegation while Tim may be driving.',
+  'Keep responses short, spoken-first, and safe for audio.',
+  'Ask one question at a time unless Tim clearly asks you to summarize or decide.',
+  'Push toward a clear delegated next action.',
+  'For every work request, classify the right workflow or agent, state why, and name the next action.',
+  'Do not execute side effects unless Tim explicitly confirms. Draft or queue by default.',
+  'Current prototype test case: prepare Tim\'s May 28 Travel Multiplier webinar.',
+].join('\n')
+
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null {
+  if (typeof window === 'undefined') return null
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function parseSseEvents(buffer: string): { events: Array<StreamEvent>; rest: string } {
+  const parts = buffer.split('\n\n')
+  const rest = parts.pop() ?? ''
+  const events: Array<StreamEvent> = []
+
+  for (const part of parts) {
+    const lines = part.split('\n')
+    const eventLine = lines.find((line) => line.startsWith('event:'))
+    const dataLines = lines.filter((line) => line.startsWith('data:'))
+    const event = eventLine?.replace(/^event:\s*/, '').trim() || 'message'
+    const dataRaw = dataLines.map((line) => line.replace(/^data:\s*/, '')).join('\n')
+    if (!dataRaw) continue
+    try {
+      const data = JSON.parse(dataRaw) as Record<string, unknown>
+      events.push({ event, data })
+    } catch {
+      events.push({ event, data: { text: dataRaw } })
+    }
+  }
+
+  return { events, rest }
+}
+
+function getStreamText(event: StreamEvent): string {
+  if (event.event !== 'chunk') return ''
+  const text = event.data.text
+  return typeof text === 'string' ? text : ''
+}
+
+function stopSpeaking() {
+  if (typeof window === 'undefined') return
+  window.speechSynthesis.cancel()
+}
+
+function speak(text: string) {
+  if (typeof window === 'undefined') return
+  if (!('speechSynthesis' in window)) return
+  stopSpeaking()
+  const utterance = new SpeechSynthesisUtterance(text)
+  utterance.rate = 1.02
+  utterance.pitch = 0.95
+  utterance.volume = 1
+  window.speechSynthesis.speak(utterance)
+}
+
+async function getElevenLabsToken(): Promise<string> {
+  const response = await fetch('/api/elevenlabs-token', { cache: 'no-store' })
+  const data = (await response.json().catch(() => ({}))) as ElevenLabsTokenResponse
+  if (!response.ok || !data.token) {
+    throw new Error(data.error || `ElevenLabs token request failed: ${response.status}`)
+  }
+  return data.token
+}
+
+async function saveVoiceLedger(payload: {
+  conversationId: string
+  sessionKey: string
+  status: 'active' | 'ended'
+  turns: Array<VoiceTurn>
+  elevenLabsLog: Array<string>
+  createQueueItem?: boolean
+}): Promise<VoiceLedgerResponse> {
+  const response = await fetch('/api/voice-lab-ledger', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = (await response.json().catch(() => ({}))) as VoiceLedgerResponse
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error || `Voice ledger save failed: ${response.status}`)
+  }
+  return data
+}
+
+function readElevenLabsTranscript(message: unknown): { role: 'tim' | 'executive' | 'system'; text: string } | null {
+  if (!message || typeof message !== 'object') return null
+  const record = message as Record<string, unknown>
+  const rawText = record.message ?? record.text ?? record.transcript
+  const text = typeof rawText === 'string' ? rawText.trim() : ''
+  if (!text) return null
+
+  const rawSource = String(record.source ?? record.role ?? record.type ?? '').toLowerCase()
+  if (rawSource.includes('user') || rawSource.includes('human')) return { role: 'tim', text }
+  if (rawSource.includes('agent') || rawSource.includes('assistant')) return { role: 'executive', text }
+  return { role: 'system', text }
+}
+
+function buildEndOfSessionWrapUp(result: VoiceLedgerResponse, reason: string): string {
+  const lines = [reason, 'Transcript saved.']
+  if (result.summary) lines.push(`Wrap-up: ${result.summary}`)
+  if (result.followUpActions?.length) {
+    lines.push(`Next action: ${result.followUpActions[result.followUpActions.length - 1]}`)
+  }
+  return lines.join('\n')
+}
+
+export const Route = createFileRoute('/voice-lab')({
+  ssr: false,
+  component: VoiceLabRoute,
+})
+
+function VoiceLabRoute() {
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const elevenLabsConversationRef = useRef<ElevenLabsConversationSession | null>(null)
+  const turnsRef = useRef<Array<VoiceTurn>>([])
+  const sessionKeyRef = useRef('new')
+  const elevenLabsLogRef = useRef<Array<string>>([])
+  const finalizedRef = useRef(false)
+  const [turns, setTurns] = useState<Array<VoiceTurn>>(() => [
+    {
+      id: 'intro',
+      role: 'system',
+      text: 'Prototype goal: talk to Executive in the browser, interrupt naturally, and leave with a delegated next action.',
+      timestamp: new Date().toISOString(),
+    },
+  ])
+  const [isListening, setIsListening] = useState(false)
+  const [isThinking, setIsThinking] = useState(false)
+  const [interimTranscript, setInterimTranscript] = useState('')
+  const [draftText, setDraftText] = useState('')
+  const [error, setError] = useState('')
+  const [sessionKey, setSessionKey] = useState('new')
+  const [conversationId] = useState(() => `voice-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  const [ledgerStatus, setLedgerStatus] = useState('Not saved yet')
+  const [ledgerPath, setLedgerPath] = useState('')
+  const [latestLedgerReview, setLatestLedgerReview] = useState<VoiceLedgerResponse | null>(null)
+  const [queueStatus, setQueueStatus] = useState('Not queued yet')
+  const [elevenLabsStatus, setElevenLabsStatus] = useState<'idle' | 'connecting' | 'connected' | 'error'>('idle')
+  const [elevenLabsError, setElevenLabsError] = useState('')
+  const [elevenLabsLog, setElevenLabsLog] = useState<Array<string>>([])
+
+  const supportsSpeechRecognition = useMemo(
+    () => typeof window !== 'undefined' && Boolean(getSpeechRecognitionConstructor()),
+    [],
+  )
+
+  useEffect(() => {
+    turnsRef.current = turns
+  }, [turns])
+
+  useEffect(() => {
+    sessionKeyRef.current = sessionKey
+  }, [sessionKey])
+
+  useEffect(() => {
+    elevenLabsLogRef.current = elevenLabsLog
+  }, [elevenLabsLog])
+
+  const appendTurn = useCallback((turn: Omit<VoiceTurn, 'id' | 'timestamp'>) => {
+    setTurns((current) => [
+      ...current,
+      {
+        ...turn,
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        timestamp: new Date().toISOString(),
+      },
+    ])
+  }, [])
+
+  const appendElevenLabsLog = useCallback((message: string) => {
+    setElevenLabsLog((current) => [
+      ...current.slice(-8),
+      `${new Date().toLocaleTimeString()} ${message}`,
+    ])
+  }, [])
+
+  const updateStreamingExecutiveTurn = useCallback((text: string) => {
+    setTurns((current) => {
+      const last = current[current.length - 1]
+      if (last.role === 'executive' && last.id === 'streaming') {
+        return [...current.slice(0, -1), { ...last, text }]
+      }
+      return [...current, { id: 'streaming', role: 'executive', text, timestamp: new Date().toISOString() }]
+    })
+  }, [])
+
+  const finalizeStreamingExecutiveTurn = useCallback(() => {
+    setTurns((current) => {
+      const last = current[current.length - 1]
+      if (last.id !== 'streaming') return current
+      return [
+        ...current.slice(0, -1),
+        { ...last, id: `${Date.now()}-${Math.random().toString(16).slice(2)}` },
+      ]
+    })
+  }, [])
+
+  const sendToExecutive = useCallback(
+    async (message: string) => {
+      const cleanMessage = message.trim()
+      if (!cleanMessage || isThinking) return
+      setError('')
+      setDraftText('')
+      setInterimTranscript('')
+      appendTurn({ role: 'tim', text: cleanMessage })
+      setIsThinking(true)
+
+      const controller = new AbortController()
+      abortRef.current = controller
+      let assistantText = ''
+
+      try {
+        const response = await fetch('/api/send-stream', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          signal: controller.signal,
+          body: JSON.stringify({
+            sessionKey,
+            message: cleanMessage,
+            thinking: EXECUTIVE_DELEGATION_SYSTEM_PROMPT,
+          }),
+        })
+
+        if (!response.ok) {
+          throw new Error(await response.text())
+        }
+        if (!response.body) throw new Error('No response stream returned')
+
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        for (;;) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const parsed = parseSseEvents(buffer)
+          buffer = parsed.rest
+
+          for (const event of parsed.events) {
+            if (event.event === 'started') {
+              const nextSessionKey = event.data.sessionKey
+              if (typeof nextSessionKey === 'string' && nextSessionKey.trim()) {
+                setSessionKey(nextSessionKey)
+              }
+            }
+            if (event.event === 'error') {
+              const streamErrorMessage = event.data.message
+              throw new Error(typeof streamErrorMessage === 'string' ? streamErrorMessage : 'Stream error')
+            }
+            const nextText = getStreamText(event)
+            if (nextText) {
+              const fullReplace = event.data.fullReplace === true
+              assistantText = fullReplace ? nextText : `${assistantText}${nextText}`
+              updateStreamingExecutiveTurn(assistantText)
+            }
+          }
+        }
+
+        finalizeStreamingExecutiveTurn()
+        if (assistantText.trim()) speak(assistantText.trim())
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          appendTurn({ role: 'system', text: 'Interrupted.' })
+        } else {
+          setError(getErrorMessage(err))
+        }
+      } finally {
+        setIsThinking(false)
+        abortRef.current = null
+      }
+    },
+    [appendTurn, finalizeStreamingExecutiveTurn, isThinking, sessionKey, updateStreamingExecutiveTurn],
+  )
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop()
+    setIsListening(false)
+  }, [])
+
+  const startListening = useCallback(() => {
+    setError('')
+    stopSpeaking()
+    abortRef.current?.abort()
+
+    const Recognition = getSpeechRecognitionConstructor()
+    if (!Recognition) {
+      setError('This browser does not support SpeechRecognition. Use Chrome or Edge for this prototype.')
+      return
+    }
+
+    const recognition = new Recognition()
+    recognitionRef.current = recognition
+    recognition.continuous = false
+    recognition.interimResults = true
+    recognition.lang = 'en-US'
+
+    let finalTranscript = ''
+    recognition.onstart = () => setIsListening(true)
+    recognition.onend = () => {
+      setIsListening(false)
+      setInterimTranscript('')
+      const transcript = finalTranscript.trim()
+      if (transcript) void sendToExecutive(transcript)
+    }
+    recognition.onerror = (event) => {
+      setIsListening(false)
+      setError(event.message || event.error || 'Speech recognition failed')
+    }
+    recognition.onresult = (event) => {
+      let interim = ''
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results[index]
+        const transcript = result[0].transcript
+        if (result.isFinal) finalTranscript += transcript
+        else interim += transcript
+      }
+      setInterimTranscript(interim.trim())
+    }
+
+    recognition.start()
+  }, [sendToExecutive])
+
+  const finalizeVoiceSession = useCallback(
+    async (reason: string) => {
+      if (finalizedRef.current) return
+      finalizedRef.current = true
+      setLedgerStatus('Saving final transcript...')
+      try {
+        const result = await saveVoiceLedger({
+          conversationId,
+          sessionKey: sessionKeyRef.current,
+          status: 'ended',
+          turns: turnsRef.current,
+          elevenLabsLog: elevenLabsLogRef.current,
+        })
+        setLedgerStatus(`Session ended. Transcript saved (${result.turnCount ?? turnsRef.current.length} turns)`)
+        if (result.filePath) setLedgerPath(result.filePath)
+        setLatestLedgerReview(result)
+        appendTurn({ role: 'system', text: buildEndOfSessionWrapUp(result, reason) })
+      } catch (nextError) {
+        const message = getErrorMessage(nextError)
+        setLedgerStatus(`Final save failed: ${message}`)
+        appendTurn({ role: 'system', text: `${reason}\nTranscript save failed: ${message}` })
+      }
+    },
+    [appendTurn, conversationId],
+  )
+
+  const stopElevenLabsLive = useCallback(async () => {
+    const conversation = elevenLabsConversationRef.current
+    elevenLabsConversationRef.current = null
+    if (conversation) {
+      await conversation.endSession()
+    }
+    setElevenLabsStatus('idle')
+    appendElevenLabsLog('ElevenLabs live session stopped.')
+    await finalizeVoiceSession('Session ended by Tim.')
+  }, [appendElevenLabsLog, finalizeVoiceSession])
+
+  const startElevenLabsLive = useCallback(async () => {
+    finalizedRef.current = false
+    setElevenLabsError('')
+    setLedgerStatus('Live session active. Saving transcript...')
+    setElevenLabsStatus('connecting')
+    stopSpeaking()
+    abortRef.current?.abort()
+    recognitionRef.current?.abort()
+    setIsListening(false)
+    setIsThinking(false)
+
+    try {
+      appendElevenLabsLog('Requesting microphone permission...')
+      await navigator.mediaDevices.getUserMedia({ audio: true })
+      appendElevenLabsLog('Requesting ElevenLabs token...')
+      const token = await getElevenLabsToken()
+      appendElevenLabsLog('Starting Speech Engine session...')
+      const conversation = (await Conversation.startSession({
+        conversationToken: token,
+        onConnect: () => {
+          setElevenLabsStatus('connected')
+          appendElevenLabsLog('Connected. Start talking naturally.')
+        },
+        onDisconnect: () => {
+          elevenLabsConversationRef.current = null
+          setElevenLabsStatus('idle')
+          appendElevenLabsLog('Disconnected.')
+          void finalizeVoiceSession('ElevenLabs live session ended.')
+        },
+        onError: (nextError: Error | string) => {
+          const message = nextError instanceof Error ? nextError.message : String(nextError)
+          setElevenLabsStatus('error')
+          setElevenLabsError(message)
+          appendElevenLabsLog(`Error: ${message}`)
+        },
+        onModeChange: (mode: unknown) => appendElevenLabsLog(`Mode: ${JSON.stringify(mode)}`),
+        onMessage: (message: unknown) => {
+          appendElevenLabsLog(`Event: ${JSON.stringify(message)}`)
+          const transcript = readElevenLabsTranscript(message)
+          if (transcript) appendTurn(transcript)
+        },
+      })) as ElevenLabsConversationSession
+      elevenLabsConversationRef.current = conversation
+    } catch (nextError) {
+      const message = getErrorMessage(nextError)
+      setElevenLabsStatus('error')
+      setElevenLabsError(message)
+      appendElevenLabsLog(`Failed: ${message}`)
+    }
+  }, [appendElevenLabsLog, appendTurn, finalizeVoiceSession])
+
+  const interrupt = useCallback(() => {
+    stopSpeaking()
+    void stopElevenLabsLive()
+    abortRef.current?.abort()
+    recognitionRef.current?.abort()
+    setIsListening(false)
+    setIsThinking(false)
+    appendTurn({ role: 'system', text: 'Interrupted. Start speaking again when ready.' })
+  }, [appendTurn, stopElevenLabsLive])
+
+  useEffect(() => {
+    if (finalizedRef.current) return undefined
+    const timeout = window.setTimeout(() => {
+      void saveVoiceLedger({
+        conversationId,
+        sessionKey,
+        status: elevenLabsStatus === 'connected' || isListening || isThinking ? 'active' : 'ended',
+        turns,
+        elevenLabsLog,
+      })
+        .then((result) => {
+          setLedgerStatus(`Saved ${result.turnCount ?? turns.length} turns`)
+          if (result.filePath) setLedgerPath(result.filePath)
+          setLatestLedgerReview(result)
+        })
+        .catch((nextError) => setLedgerStatus(`Save failed: ${getErrorMessage(nextError)}`))
+    }, 700)
+
+    return () => window.clearTimeout(timeout)
+  }, [conversationId, elevenLabsLog, elevenLabsStatus, isListening, isThinking, sessionKey, turns])
+
+  const queueDelegation = useCallback(async () => {
+    setQueueStatus('Saving delegation handoff...')
+    try {
+      const result = await saveVoiceLedger({
+        conversationId,
+        sessionKey: sessionKeyRef.current,
+        status: 'ended',
+        turns: turnsRef.current,
+        elevenLabsLog: elevenLabsLogRef.current,
+        createQueueItem: true,
+      })
+      setLatestLedgerReview(result)
+      const queueItem = result.queueItem
+      setQueueStatus(`Queued: ${queueItem?.title ?? 'Executive Queue item'} (${queueItem?.status ?? 'saved'})`)
+      if (queueItem?.localPath) setLedgerPath(queueItem.localPath)
+    } catch (nextError) {
+      setQueueStatus(`Queue failed: ${getErrorMessage(nextError)}`)
+    }
+  }, [conversationId])
+
+  useEffect(() => {
+    return () => {
+      stopSpeaking()
+      recognitionRef.current?.abort()
+      abortRef.current?.abort()
+      void elevenLabsConversationRef.current?.endSession()
+      elevenLabsConversationRef.current = null
+    }
+  }, [])
+
+  const statusText = isListening
+    ? 'Listening. Stop when done.'
+    : isThinking
+      ? 'Executive is thinking.'
+      : 'Ready.'
+
+  return (
+    <main className="min-h-screen bg-primary-950 text-primary-50">
+      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="rounded-3xl border border-primary-800 bg-primary-900/80 p-5 shadow-2xl shadow-black/20">
+          <p className="text-sm uppercase tracking-[0.28em] text-accent-300">Executive Voice Lab</p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+            Browser voice delegation prototype
+          </h1>
+          <p className="mt-3 max-w-3xl text-base leading-7 text-primary-200">
+            Test: talk to Executive, interrupt naturally, and leave with a clear delegated next action.
+          </p>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-3xl border border-primary-800 bg-primary-900/70 p-5">
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={elevenLabsStatus === 'connected' ? stopElevenLabsLive : startElevenLabsLive}
+                disabled={elevenLabsStatus === 'connecting'}
+                className="rounded-full bg-accent-400 px-6 py-3 text-base font-semibold text-primary-950 transition hover:bg-accent-300 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {elevenLabsStatus === 'connected'
+                  ? 'Stop ElevenLabs live'
+                  : elevenLabsStatus === 'connecting'
+                    ? 'Connecting...'
+                    : 'Start ElevenLabs live'}
+              </button>
+              <button
+                type="button"
+                onClick={isListening ? stopListening : startListening}
+                disabled={isThinking && !isListening}
+                className="rounded-full border border-primary-700 px-5 py-3 text-base font-semibold text-primary-100 transition hover:bg-primary-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isListening ? 'Stop and send browser voice' : 'Browser voice fallback'}
+              </button>
+              <button
+                type="button"
+                onClick={interrupt}
+                className="rounded-full border border-red-300/50 px-5 py-3 text-base font-semibold text-red-100 transition hover:bg-red-500/10"
+              >
+                Interrupt
+              </button>
+              <span className="rounded-full bg-primary-800 px-4 py-2 text-sm text-primary-200">
+                ElevenLabs: {elevenLabsStatus}
+              </span>
+              <span className="rounded-full bg-primary-800 px-4 py-2 text-sm text-primary-200">
+                Fallback: {statusText}
+              </span>
+            </div>
+
+            <div className="mt-4 rounded-2xl border border-accent-300/20 bg-accent-300/10 p-4 text-sm leading-6 text-primary-100">
+              <p className="font-semibold text-accent-200">Recommended test mode</p>
+              <p className="mt-1">
+                Use ElevenLabs live first. It handles real turn-taking, audio output, and natural interruption.
+                Browser voice remains here as a fallback baseline.
+              </p>
+            </div>
+
+            {elevenLabsError ? (
+              <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 p-4 text-sm text-red-100">
+                {elevenLabsError}
+              </div>
+            ) : null}
+
+            {elevenLabsLog.length ? (
+              <div className="mt-4 max-h-48 overflow-y-auto rounded-2xl bg-primary-950 p-4 font-mono text-xs leading-5 text-primary-300">
+                {elevenLabsLog.map((line) => (
+                  <p key={line}>{line}</p>
+                ))}
+              </div>
+            ) : null}
+
+            {!supportsSpeechRecognition ? (
+              <div className="mt-4 rounded-2xl border border-amber-400/40 bg-amber-400/10 p-4 text-sm text-amber-100">
+                Browser speech recognition is unavailable. Use Chrome or Edge for hands-free input.
+              </div>
+            ) : null}
+
+            {interimTranscript ? (
+              <div className="mt-4 rounded-2xl border border-accent-300/30 bg-accent-300/10 p-4 text-primary-100">
+                <p className="text-xs uppercase tracking-[0.2em] text-accent-200">Hearing</p>
+                <p className="mt-2 text-lg">{interimTranscript}</p>
+              </div>
+            ) : null}
+
+            <form
+              className="mt-5 flex gap-3"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void sendToExecutive(draftText)
+              }}
+            >
+              <input
+                value={draftText}
+                onChange={(event) => setDraftText(event.target.value)}
+                placeholder="Fallback text input"
+                className="min-w-0 flex-1 rounded-2xl border border-primary-700 bg-primary-950 px-4 py-3 text-primary-50 outline-none placeholder:text-primary-500 focus:border-accent-300"
+              />
+              <button
+                type="submit"
+                disabled={!draftText.trim() || isThinking}
+                className="rounded-2xl bg-primary-100 px-5 py-3 font-semibold text-primary-950 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Send
+              </button>
+            </form>
+
+            {error ? (
+              <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 p-4 text-sm text-red-100">
+                {error}
+              </div>
+            ) : null}
+          </div>
+
+          <aside className="rounded-3xl border border-primary-800 bg-primary-900/70 p-5">
+            <h2 className="text-lg font-semibold">Prototype rules</h2>
+            <ul className="mt-4 space-y-3 text-sm leading-6 text-primary-200">
+              <li>• One question at a time.</li>
+              <li>• Spoken-first responses.</li>
+              <li>• Delegation decision before execution.</li>
+              <li>• No side effects without explicit confirmation.</li>
+            </ul>
+            <div className="mt-5 rounded-2xl bg-primary-950 p-4 text-sm text-primary-300">
+              <p>
+                Session: <span className="font-mono text-primary-100">{sessionKey}</span>
+              </p>
+              <p className="mt-2">
+                Voice ledger: <span className="text-primary-100">{ledgerStatus}</span>
+              </p>
+              {ledgerPath ? (
+                <p className="mt-2 break-all font-mono text-xs text-primary-400">{ledgerPath}</p>
+              ) : null}
+            </div>
+          </aside>
+        </section>
+
+        {latestLedgerReview?.review || latestLedgerReview?.delegation ? (
+          <section className="rounded-3xl border border-accent-300/30 bg-primary-900/80 p-5">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-sm uppercase tracking-[0.24em] text-accent-300">Post-session review</p>
+                <h2 className="mt-2 text-2xl font-semibold">Executive delegation handoff</h2>
+              </div>
+              <button
+                type="button"
+                onClick={queueDelegation}
+                className="rounded-full bg-accent-400 px-5 py-3 text-sm font-semibold text-primary-950 transition hover:bg-accent-300"
+              >
+                Send to Executive Queue
+              </button>
+            </div>
+
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+              <div className="rounded-2xl bg-primary-950 p-4">
+                <h3 className="font-semibold text-primary-50">Review</h3>
+                <p className="mt-3 text-sm leading-6 text-primary-200">
+                  {latestLedgerReview.review?.summary ?? latestLedgerReview.summary}
+                </p>
+                <ReviewList label="Decisions" items={latestLedgerReview.review?.decisions ?? []} />
+                <ReviewList label="Follow-up actions" items={latestLedgerReview.review?.followUpActions ?? []} />
+                <ReviewList label="Open questions" items={latestLedgerReview.review?.openQuestions ?? []} />
+                <ReviewList label="Needs approval" items={latestLedgerReview.review?.needsApproval ?? []} />
+              </div>
+
+              {latestLedgerReview.delegation ? (
+                <div className="rounded-2xl border border-accent-300/20 bg-accent-300/10 p-4">
+                  <h3 className="font-semibold text-accent-100">Delegation object</h3>
+                  <dl className="mt-3 space-y-3 text-sm leading-6 text-primary-100">
+                    <div>
+                      <dt className="text-primary-400">Outcome</dt>
+                      <dd>{latestLedgerReview.delegation.outcome}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-primary-400">Owner / agent</dt>
+                      <dd>{latestLedgerReview.delegation.owner}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-primary-400">Next action</dt>
+                      <dd>{latestLedgerReview.delegation.nextAction}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-primary-400">Approval required</dt>
+                      <dd>{latestLedgerReview.delegation.approvalRequired ? 'Yes' : 'No'}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-primary-400">Queue status</dt>
+                      <dd>{queueStatus}</dd>
+                    </div>
+                  </dl>
+                </div>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="flex-1 rounded-3xl border border-primary-800 bg-primary-900/70 p-5">
+          <h2 className="text-lg font-semibold">Conversation</h2>
+          <div className="mt-4 flex flex-col gap-3">
+            {turns.map((turn) => (
+              <article
+                key={turn.id}
+                className={
+                  turn.role === 'tim'
+                    ? 'ml-auto max-w-[85%] rounded-3xl bg-accent-300 p-4 text-primary-950'
+                    : turn.role === 'executive'
+                      ? 'mr-auto max-w-[85%] rounded-3xl bg-primary-800 p-4 text-primary-50'
+                      : 'mx-auto max-w-[90%] rounded-2xl border border-primary-800 bg-primary-950 p-3 text-sm text-primary-300'
+                }
+              >
+                <p className="mb-1 text-xs font-semibold uppercase tracking-[0.18em] opacity-70">
+                  {turn.role === 'tim' ? 'Tim' : turn.role === 'executive' ? 'Executive' : 'System'}
+                </p>
+                <p className="whitespace-pre-wrap leading-7">{turn.text}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function ReviewList({ label, items }: { label: string; items: Array<string> }) {
+  if (!items.length) return null
+  return (
+    <div className="mt-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary-400">{label}</p>
+      <ul className="mt-2 space-y-2 text-sm leading-6 text-primary-200">
+        {items.map((item) => (
+          <li key={item}>• {item}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/routes/x-bookmark-review.tsx
+++ b/src/routes/x-bookmark-review.tsx
@@ -1,0 +1,587 @@
+'use client'
+
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { usePageTitle } from '@/hooks/use-page-title'
+
+type ReviewBucket = 'useNow' | 'teach' | 'packageSell' | 'watch' | 'reject'
+
+type ReviewItem = {
+  id: string
+  url: string
+  text: string
+  bucket: ReviewBucket
+  claim: string
+  whyItMatters: string
+  recommendedAction: string
+  approvalNeeded: boolean
+  articleUrl: string
+  articleStatus: 'pending' | 'extracted' | 'unavailable' | 'error' | 'none'
+  articleTitle: string
+  articleExcerpt: string
+  articleExtractedAt: string
+  matchedSignals: Array<string>
+  author: { username: string; name: string }
+  metrics: Record<string, number>
+}
+
+type RadarItem = {
+  title: string
+  why: string
+  nextAction: string
+  count: number
+  approvalNeeded: boolean
+  sourceIds: Array<string>
+}
+
+type ReviewResponse = {
+  ok: boolean
+  error?: string
+  cache: null | { fetchedAt: string; count: number; nextToken: string }
+  digest: {
+    generatedAt: string
+    total: number
+    articleWrapperCount: number
+    topAuthors: Array<{ username: string; count: number }>
+    groups: Record<ReviewBucket, Array<ReviewItem>>
+    radar: Array<RadarItem>
+    articleCandidates: Array<ReviewItem>
+  }
+  limitations?: Array<string>
+}
+
+async function loadReview(): Promise<ReviewResponse> {
+  const response = await fetch('/api/x-bookmarks/review')
+  const data = (await response.json()) as ReviewResponse
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+async function extractArticles(): Promise<{
+  ok: boolean
+  attempted: number
+  counts: { extracted: number; unavailable: number; error: number }
+}> {
+  const response = await fetch('/api/x-bookmarks/extract-articles', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ limit: 50 }),
+  })
+  const data = (await response.json()) as {
+    ok: boolean
+    error?: string
+    attempted: number
+    counts: { extracted: number; unavailable: number; error: number }
+  }
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+async function importArticle(input: {
+  sourceTweetId: string
+  articleUrl: string
+  title: string
+  text: string
+}): Promise<{ ok: boolean; item: ReviewItem }> {
+  const response = await fetch('/api/x-bookmarks/import-article', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const data = (await response.json()) as {
+    ok: boolean
+    error?: string
+    item: ReviewItem
+  }
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+export const Route = createFileRoute('/x-bookmark-review')({
+  ssr: false,
+  component: XBookmarkReviewRoute,
+})
+
+const bucketLabels: Record<ReviewBucket, string> = {
+  useNow: 'Use now',
+  teach: 'Teach / reproduce',
+  packageSell: 'Package / sell',
+  watch: 'Watch',
+  reject: 'Reject',
+}
+
+function XBookmarkReviewRoute() {
+  usePageTitle('X Bookmark Review')
+  const [selectedArticleId, setSelectedArticleId] = useState('')
+  const [manualTitle, setManualTitle] = useState('')
+  const [manualText, setManualText] = useState('')
+  const [capturedJson, setCapturedJson] = useState('')
+  const [captureMessage, setCaptureMessage] = useState('')
+  const reviewQuery = useQuery({
+    queryKey: ['x-bookmarks', 'review'],
+    queryFn: loadReview,
+  })
+  const extractMutation = useMutation({
+    mutationFn: extractArticles,
+    onSuccess: () => reviewQuery.refetch(),
+  })
+  const importMutation = useMutation({
+    mutationFn: importArticle,
+    onSuccess: () => {
+      setManualTitle('')
+      setManualText('')
+      reviewQuery.refetch()
+    },
+  })
+  const digest = reviewQuery.data?.digest
+  const importCandidates = (digest?.articleCandidates || []).filter(
+    (item) => item.articleStatus !== 'extracted',
+  )
+  const selectedArticle =
+    importCandidates.find((item) => item.id === selectedArticleId) ||
+    ({
+      id: '',
+      articleUrl: '',
+      claim: '',
+      articleStatus: 'pending',
+      author: { username: '', name: '' },
+    } as ReviewItem)
+
+  function submitManualImport() {
+    if (!selectedArticle.id) return
+    importMutation.mutate({
+      sourceTweetId: selectedArticle.id,
+      articleUrl: selectedArticle.articleUrl,
+      title: manualTitle,
+      text: manualText,
+    })
+  }
+
+  function applyCapturedArticlePayload() {
+    setCaptureMessage('')
+    let payload: { articleUrl?: unknown; title?: unknown; text?: unknown } = {}
+    try {
+      payload = JSON.parse(capturedJson) as {
+        articleUrl?: unknown
+        title?: unknown
+        text?: unknown
+      }
+    } catch {
+      setCaptureMessage('Capture payload was not valid JSON.')
+      return
+    }
+    const articleUrl =
+      typeof payload.articleUrl === 'string' ? payload.articleUrl.trim() : ''
+    const title = typeof payload.title === 'string' ? payload.title.trim() : ''
+    const text = typeof payload.text === 'string' ? payload.text.trim() : ''
+    if (!articleUrl || text.length < 40) {
+      setCaptureMessage(
+        'Capture payload needs an articleUrl and at least 40 characters of text.',
+      )
+      return
+    }
+    const normalizedArticleUrl = articleUrl
+      .replace(/^https?:\/\//, '')
+      .replace(/\/$/, '')
+    const match = importCandidates.find(
+      (item) =>
+        item.articleUrl.replace(/^https?:\/\//, '').replace(/\/$/, '') ===
+        normalizedArticleUrl,
+    )
+    if (match) setSelectedArticleId(match.id)
+    setManualTitle(title)
+    setManualText(text)
+    setCaptureMessage(
+      match
+        ? 'Captured article applied. Review it, then import.'
+        : 'Captured text applied. Select the matching article, then import.',
+    )
+  }
+
+  function copyCaptureBookmarklet() {
+    const script = `(() => {
+  const clean = (value) => String(value || '').replace(/\\s+$/g, '').trim();
+  const lines = clean(document.body.innerText).split('\\n').map((line) => line.trim()).filter(Boolean);
+  const skip = new Set(['Home', 'Explore', 'Notifications', 'Messages', 'Grok', 'Bookmarks', 'Jobs', 'Communities', 'Premium', 'Verified Orgs', 'Profile', 'More', 'Post', 'Reply', 'Repost', 'Like', 'Share', 'Terms of Service', 'Privacy Policy']);
+  const text = lines.filter((line, index, list) => !skip.has(line) && list.indexOf(line) === index).join('\\n');
+  const title = clean(document.querySelector('h1')?.innerText || document.title.replace(/\\s*\\/ X$/, ''));
+  const payload = { source: 'x-article-clipboard-v1', capturedAt: new Date().toISOString(), articleUrl: location.href, title, text };
+  navigator.clipboard.writeText(JSON.stringify(payload, null, 2)).then(() => alert('X Article text copied. Paste it into Hermes Workspace.'), () => prompt('Copy this X Article payload', JSON.stringify(payload, null, 2)));
+})()`
+    void navigator.clipboard.writeText(
+      `javascript:${encodeURIComponent(script)}`,
+    )
+    setCaptureMessage(
+      'Bookmarklet copied. Save it as a browser bookmark, then run it on an open X Article page.',
+    )
+  }
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-4 py-6 text-[var(--theme-fg)] md:px-8 lg:px-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-muted)]">
+            AI Dev intake
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold text-ink">
+            X Bookmark Review Digest
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--theme-muted)]">
+            Turns Tim's latest cached X bookmarks into AI setup upgrades,
+            teachable workflows, packaging ideas, and watch items. Read-only. No
+            publishing, no sending, no new X fetch.
+          </p>
+        </header>
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-ink">
+                X Article Extraction
+              </h2>
+              <p className="mt-1 text-sm text-[var(--theme-muted)]">
+                Extracts pending X Article wrapper posts into a local cache.
+                This uses X web GraphQL, not a bookmark fetch.
+              </p>
+              {extractMutation.data ? (
+                <p className="mt-2 text-sm text-[var(--theme-muted)]">
+                  Last run: {extractMutation.data.attempted} attempted.
+                  Extracted {extractMutation.data.counts.extracted}. Unavailable{' '}
+                  {extractMutation.data.counts.unavailable}. Errors{' '}
+                  {extractMutation.data.counts.error}.
+                </p>
+              ) : null}
+              {extractMutation.isError ? (
+                <p className="mt-2 text-sm text-red-200">
+                  Extraction failed:{' '}
+                  {extractMutation.error instanceof Error
+                    ? extractMutation.error.message
+                    : 'Unknown error'}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={() => extractMutation.mutate()}
+              disabled={extractMutation.isPending}
+              className="rounded-full border border-blue-400/40 bg-blue-500/10 px-4 py-2 text-sm font-semibold text-blue-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {extractMutation.isPending
+                ? 'Extracting…'
+                : 'Extract pending articles'}
+            </button>
+          </div>
+
+          <div className="mt-5 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+            <h3 className="text-sm font-semibold text-ink">
+              Manual logged-in fallback
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-[var(--theme-muted)]">
+              If X blocks guest extraction, open the article while logged in,
+              copy the body text, and import it here. This stores article text
+              only, not browser cookies, tokens, or passwords.
+            </p>
+            <div className="mt-4 rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h4 className="text-sm font-semibold text-amber-100">
+                    Logged-in capture helper
+                  </h4>
+                  <p className="mt-1 text-sm leading-6 text-amber-100/80">
+                    Copy this bookmarklet, save it as a browser bookmark, open
+                    an X Article while logged in, then click the bookmark. It
+                    copies the visible full article text as JSON for import
+                    here.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={copyCaptureBookmarklet}
+                  className="rounded-full border border-amber-300/40 bg-amber-300/10 px-4 py-2 text-sm font-semibold text-amber-100"
+                >
+                  Copy capture bookmarklet
+                </button>
+              </div>
+              <label className="mt-3 block text-sm text-amber-100/80">
+                Captured JSON from X Article page
+                <textarea
+                  value={capturedJson}
+                  onChange={(event) => setCapturedJson(event.target.value)}
+                  placeholder='Paste the JSON copied by the bookmarklet, then click "Apply captured text".'
+                  rows={4}
+                  className="mt-1 w-full rounded-xl border border-amber-300/30 bg-[var(--theme-bg)] px-3 py-2 text-sm leading-6 text-[var(--theme-fg)]"
+                />
+              </label>
+              <div className="mt-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <p className="text-xs text-amber-100/70">
+                  No X browser credentials are collected. Only visible title,
+                  URL, and article text are copied.
+                </p>
+                <button
+                  type="button"
+                  onClick={applyCapturedArticlePayload}
+                  disabled={!capturedJson.trim()}
+                  className="rounded-full border border-amber-300/40 bg-amber-300/10 px-4 py-2 text-sm font-semibold text-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Apply captured text
+                </button>
+              </div>
+              {captureMessage ? (
+                <p className="mt-2 text-sm text-amber-100">{captureMessage}</p>
+              ) : null}
+            </div>
+            <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+              <label className="text-sm text-[var(--theme-muted)]">
+                Article
+                <select
+                  value={selectedArticle.id}
+                  onChange={(event) => setSelectedArticleId(event.target.value)}
+                  className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-fg)]"
+                >
+                  {importCandidates.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      @{item.author.username} · {item.articleStatus} ·{' '}
+                      {item.claim.slice(0, 80)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {selectedArticle.id ? (
+                <a
+                  href={selectedArticle.articleUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-full border border-[var(--theme-border)] px-4 py-2 text-center text-sm text-blue-300 hover:underline"
+                >
+                  Open article
+                </a>
+              ) : null}
+            </div>
+            <label className="mt-3 block text-sm text-[var(--theme-muted)]">
+              Title, optional
+              <input
+                value={manualTitle}
+                onChange={(event) => setManualTitle(event.target.value)}
+                placeholder="Paste the article title"
+                className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-fg)]"
+              />
+            </label>
+            <label className="mt-3 block text-sm text-[var(--theme-muted)]">
+              Article body
+              <textarea
+                value={manualText}
+                onChange={(event) => setManualText(event.target.value)}
+                placeholder="Paste article body text copied from a logged-in X browser session. Minimum 40 characters."
+                rows={6}
+                className="mt-1 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm leading-6 text-[var(--theme-fg)]"
+              />
+            </label>
+            <div className="mt-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <p className="text-xs text-[var(--theme-muted)]">
+                Pending/manual candidates: {importCandidates.length}
+              </p>
+              <button
+                type="button"
+                onClick={submitManualImport}
+                disabled={
+                  !selectedArticle.id ||
+                  manualText.trim().length < 40 ||
+                  importMutation.isPending
+                }
+                className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {importMutation.isPending
+                  ? 'Importing…'
+                  : 'Import copied article text'}
+              </button>
+            </div>
+            {importMutation.isSuccess ? (
+              <p className="mt-2 text-sm text-emerald-200">
+                Manual article text imported and review digest refreshed.
+              </p>
+            ) : null}
+            {importMutation.isError ? (
+              <p className="mt-2 text-sm text-red-200">
+                Import failed:{' '}
+                {importMutation.error instanceof Error
+                  ? importMutation.error.message
+                  : 'Unknown error'}
+              </p>
+            ) : null}
+          </div>
+        </section>
+
+        {reviewQuery.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Review failed:{' '}
+            {reviewQuery.error instanceof Error
+              ? reviewQuery.error.message
+              : 'Unknown error'}
+          </div>
+        ) : null}
+
+        <section className="grid gap-4 md:grid-cols-4">
+          <Stat label="Cached bookmarks" value={String(digest?.total ?? '…')} />
+          <Stat
+            label="X Article wrappers"
+            value={String(digest?.articleWrapperCount ?? '…')}
+          />
+          <Stat
+            label="Use now"
+            value={String(digest?.groups.useNow.length ?? '…')}
+          />
+          <Stat
+            label="Package / sell"
+            value={String(digest?.groups.packageSell.length ?? '…')}
+          />
+        </section>
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+          <h2 className="text-xl font-semibold text-ink">
+            AI Ops Upgrade Radar
+          </h2>
+          <div className="mt-4 grid gap-3">
+            {(digest?.radar || []).map((item) => (
+              <article
+                key={item.title}
+                className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="font-semibold text-ink">{item.title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-[var(--theme-muted)]">
+                      {item.why}
+                    </p>
+                    <p className="mt-2 text-sm text-ink">
+                      Next: {item.nextAction}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-[var(--theme-border)] px-3 py-1 text-xs text-[var(--theme-muted)]">
+                    {item.count} sources
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        {(
+          ['useNow', 'packageSell', 'teach', 'watch'] as Array<ReviewBucket>
+        ).map((bucket) => (
+          <section
+            key={bucket}
+            className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6"
+          >
+            <h2 className="text-xl font-semibold text-ink">
+              {bucketLabels[bucket]}
+            </h2>
+            <div className="mt-4 grid gap-3">
+              {(digest?.groups[bucket] || []).slice(0, 12).map((item) => (
+                <ReviewCard key={item.id} item={item} />
+              ))}
+              {digest && digest.groups[bucket].length === 0 ? (
+                <p className="text-sm text-[var(--theme-muted)]">
+                  No items in this bucket.
+                </p>
+              ) : null}
+            </div>
+          </section>
+        ))}
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+          <h2 className="text-xl font-semibold text-ink">Known limitations</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-[var(--theme-muted)]">
+            {(reviewQuery.data?.limitations || []).map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-ink">{value}</div>
+    </div>
+  )
+}
+
+function ReviewCard({ item }: { item: ReviewItem }) {
+  return (
+    <article className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="text-sm font-semibold text-ink">
+            @{item.author.username}
+          </div>
+          <p className="mt-2 text-sm leading-6 text-[var(--theme-fg)]">
+            {item.claim}
+          </p>
+        </div>
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-blue-300 hover:underline"
+        >
+          Open source
+        </a>
+      </div>
+      <p className="mt-3 text-sm text-[var(--theme-muted)]">
+        Why: {item.whyItMatters}
+      </p>
+      <p className="mt-2 text-sm text-ink">Action: {item.recommendedAction}</p>
+      {item.articleExcerpt ? (
+        <p className="mt-3 text-sm leading-6 text-[var(--theme-fg)]">
+          Article: {item.articleExcerpt}
+        </p>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {item.matchedSignals.map((signal) => (
+          <span
+            key={signal}
+            className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-xs text-[var(--theme-muted)]"
+          >
+            {signal}
+          </span>
+        ))}
+        {item.articleUrl ? <ArticleBadge item={item} /> : null}
+      </div>
+    </article>
+  )
+}
+
+function ArticleBadge({ item }: { item: ReviewItem }) {
+  const labels: Record<ReviewItem['articleStatus'], string> = {
+    extracted: 'X Article extracted',
+    pending: 'X Article extraction pending',
+    unavailable: 'X Article unavailable',
+    error: 'X Article extraction error',
+    none: '',
+  }
+  const classes: Record<ReviewItem['articleStatus'], string> = {
+    extracted: 'border-emerald-400/40 text-emerald-200',
+    pending: 'border-amber-400/40 text-amber-200',
+    unavailable: 'border-zinc-400/40 text-zinc-200',
+    error: 'border-red-400/40 text-red-200',
+    none: 'border-[var(--theme-border)] text-[var(--theme-muted)]',
+  }
+  if (item.articleStatus === 'none') return null
+  return (
+    <span
+      className={`rounded-full border px-2 py-1 text-xs ${classes[item.articleStatus]}`}
+    >
+      {labels[item.articleStatus]}
+    </span>
+  )
+}

--- a/src/routes/x-bookmarks.tsx
+++ b/src/routes/x-bookmarks.tsx
@@ -1,0 +1,391 @@
+'use client'
+
+import { createFileRoute } from '@tanstack/react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { usePageTitle } from '@/hooks/use-page-title'
+
+type XBookmarkStatusResponse = {
+  ok: boolean
+  error?: string
+  status?: {
+    configured: boolean
+    authenticated: boolean
+    mode: 'read-only'
+    clientIdConfigured: boolean
+    redirectUri: string
+    scopes: Array<string>
+    token: null | {
+      hasAccessToken: boolean
+      hasRefreshToken: boolean
+      expiresAt: string
+      scope: string
+      userId: string
+      username: string
+      updatedAt: string
+    }
+    missing: Array<string>
+    nextStep: string
+  }
+  cache?: null | {
+    fetchedAt: string
+    count: number
+    nextToken: string
+    sample: Array<XBookmarkItem>
+  }
+}
+
+type XBookmarkItem = {
+  id: string
+  url: string
+  text: string
+  createdAt: string
+  capturedAt: string
+  author: { id: string; username: string; name: string }
+  metrics: Record<string, number>
+  externalUrls: Array<string>
+  media: Array<{ mediaKey: string; type: string; url: string }>
+}
+
+type AuthorizeResponse = {
+  ok: boolean
+  authorizeUrl?: string
+  redirectUri?: string
+  error?: string
+}
+
+type FetchResponse = {
+  ok: boolean
+  error?: string
+  fetchedAt?: string
+  count?: number
+  cacheCount?: number
+  likelyNewCount?: number
+  nextToken?: string
+  cachePath?: string
+  items?: Array<XBookmarkItem>
+  likelyNewItems?: Array<XBookmarkItem>
+}
+
+async function loadStatus(): Promise<XBookmarkStatusResponse> {
+  const response = await fetch('/api/x-bookmarks/status')
+  const data = (await response.json()) as XBookmarkStatusResponse
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+async function startAuthorization(): Promise<AuthorizeResponse> {
+  const response = await fetch('/api/x-bookmarks/authorize', { method: 'POST' })
+  const data = (await response.json()) as AuthorizeResponse
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+async function fetchBookmarks(): Promise<FetchResponse> {
+  const response = await fetch('/api/x-bookmarks/fetch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ maxResults: 100 }),
+  })
+  const data = (await response.json()) as FetchResponse
+  if (!response.ok || data.ok === false)
+    throw new Error(data.error || `HTTP ${response.status}`)
+  return data
+}
+
+export const Route = createFileRoute('/x-bookmarks')({
+  ssr: false,
+  component: XBookmarksRoute,
+})
+
+function XBookmarksRoute() {
+  usePageTitle('X Bookmark Intake')
+  const statusQuery = useQuery({
+    queryKey: ['x-bookmarks', 'status'],
+    queryFn: loadStatus,
+  })
+  const authorizeMutation = useMutation({
+    mutationFn: startAuthorization,
+    onSuccess: (data) => {
+      if (data.authorizeUrl) window.location.assign(data.authorizeUrl)
+    },
+  })
+  const fetchMutation = useMutation({
+    mutationFn: fetchBookmarks,
+    onSuccess: () => statusQuery.refetch(),
+  })
+
+  const status = statusQuery.data?.status
+  const cache = statusQuery.data?.cache
+  const fetchedItems = fetchMutation.data?.items
+  const likelyNewItems = fetchMutation.data?.likelyNewItems || []
+  const visibleItems =
+    likelyNewItems.length > 0
+      ? likelyNewItems
+      : fetchedItems && fetchedItems.length > 0
+        ? fetchedItems
+        : cache?.sample || []
+  const listTitle =
+    likelyNewItems.length > 0
+      ? 'Likely-new bookmarks since last fetch'
+      : 'Latest cached bookmarks'
+  const authorizeUrl = authorizeMutation.data?.authorizeUrl
+
+  return (
+    <div className="min-h-full bg-[var(--theme-bg)] px-4 py-6 text-[var(--theme-fg)] md:px-8 lg:px-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--theme-muted)]">
+                AI Learning intake
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold text-ink">
+                X Bookmark Intake
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--theme-muted)]">
+                Read-only prototype for pulling Tim's bookmarked X posts into a
+                local Workspace cache. No posting, liking, deleting, DMs,
+                follows, or public actions.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm">
+              <div className="text-[var(--theme-muted)]">Mode</div>
+              <div className="mt-1 font-semibold text-ink">Read-only</div>
+            </div>
+          </div>
+        </header>
+
+        {statusQuery.isError ? (
+          <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            Status failed:{' '}
+            {statusQuery.error instanceof Error
+              ? statusQuery.error.message
+              : 'Unknown error'}
+          </div>
+        ) : null}
+
+        <section className="grid gap-4 lg:grid-cols-3">
+          <StatusCard
+            label="Developer app"
+            value={
+              status?.clientIdConfigured ? 'Configured' : 'Missing client ID'
+            }
+            good={Boolean(status?.clientIdConfigured)}
+          />
+          <StatusCard
+            label="OAuth"
+            value={status?.authenticated ? 'Connected' : 'Not connected'}
+            good={Boolean(status?.authenticated)}
+          />
+          <StatusCard
+            label="Local cache"
+            value={cache ? `${cache.count} bookmarks` : 'No cache yet'}
+            good={Boolean(cache)}
+          />
+        </section>
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+          <h2 className="text-xl font-semibold text-ink">Setup</h2>
+          <div className="mt-4 grid gap-4 lg:grid-cols-[1fr_auto] lg:items-start">
+            <div className="space-y-3 text-sm text-[var(--theme-muted)]">
+              <p>{status?.nextStep || 'Loading setup state...'}</p>
+              <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+                <div className="text-xs uppercase tracking-[0.18em]">
+                  Callback URL for X Developer app
+                </div>
+                <code className="mt-2 block overflow-x-auto text-xs text-ink">
+                  {status?.redirectUri || 'Loading...'}
+                </code>
+              </div>
+              <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+                <div className="text-xs uppercase tracking-[0.18em]">
+                  Requested scopes
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(
+                    status?.scopes || [
+                      'bookmark.read',
+                      'tweet.read',
+                      'users.read',
+                    ]
+                  ).map((scope) => (
+                    <span
+                      key={scope}
+                      className="rounded-full border border-[var(--theme-border)] px-3 py-1 text-xs text-ink"
+                    >
+                      {scope}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                disabled={
+                  !status?.clientIdConfigured || authorizeMutation.isPending
+                }
+                onClick={() => authorizeMutation.mutate()}
+                className="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-[var(--theme-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {authorizeMutation.isPending
+                  ? 'Starting OAuth...'
+                  : 'Connect X read-only'}
+              </button>
+              <button
+                type="button"
+                disabled={!status?.authenticated || fetchMutation.isPending}
+                onClick={() => fetchMutation.mutate()}
+                className="rounded-xl border border-[var(--theme-border)] px-5 py-3 text-sm font-semibold text-ink disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {fetchMutation.isPending
+                  ? 'Fetching...'
+                  : 'Fetch latest 100 bookmarks'}
+              </button>
+              <button
+                type="button"
+                onClick={() => statusQuery.refetch()}
+                className="rounded-xl border border-[var(--theme-border)] px-5 py-3 text-sm text-[var(--theme-muted)]"
+              >
+                Refresh status
+              </button>
+            </div>
+          </div>
+          {authorizeMutation.isError ? (
+            <ErrorNote error={authorizeMutation.error} />
+          ) : null}
+          {authorizeUrl ? (
+            <div className="mt-4 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4 text-sm text-[var(--theme-muted)]">
+              <div className="font-semibold text-ink">Manual fallback</div>
+              <p className="mt-1">
+                If X login loops, copy this authorization URL and paste it into
+                a browser where x.com is already logged in.
+              </p>
+              <code className="mt-2 block max-h-28 overflow-auto break-all rounded-xl border border-[var(--theme-border)] p-3 text-xs text-ink">
+                {authorizeUrl}
+              </code>
+            </div>
+          ) : null}
+          {fetchMutation.isError ? (
+            <ErrorNote error={fetchMutation.error} />
+          ) : null}
+          {fetchMutation.data ? (
+            <div className="mt-4 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4 text-sm text-[var(--theme-muted)]">
+              <div className="font-semibold text-ink">Fetch summary</div>
+              <p className="mt-1">
+                Fetched {fetchMutation.data.count ?? 0} bookmarks, found{' '}
+                {fetchMutation.data.likelyNewCount ?? 0} likely-new, cache now
+                has {fetchMutation.data.cacheCount ?? cache?.count ?? 0} deduped
+                bookmarks.
+              </p>
+            </div>
+          ) : null}
+          {fetchMutation.data?.cachePath ? (
+            <p className="mt-4 text-xs text-[var(--theme-muted)]">
+              Cached locally at {fetchMutation.data.cachePath}
+            </p>
+          ) : null}
+        </section>
+
+        <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-6">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-ink">{listTitle}</h2>
+              <p className="mt-1 text-sm text-[var(--theme-muted)]">
+                {cache?.fetchedAt
+                  ? `Last fetched ${cache.fetchedAt}`
+                  : 'Nothing fetched yet.'}
+              </p>
+            </div>
+            {cache?.nextToken ? (
+              <span className="text-xs text-[var(--theme-muted)]">
+                More pages available
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-5 grid gap-3">
+            {visibleItems.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-[var(--theme-border)] p-6 text-sm text-[var(--theme-muted)]">
+                Connect X, then fetch bookmarks to populate the local cache.
+              </div>
+            ) : (
+              visibleItems.map((item) => (
+                <BookmarkCard key={item.id} item={item} />
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function StatusCard({
+  label,
+  value,
+  good,
+}: {
+  label: string
+  value: string
+  good: boolean
+}) {
+  return (
+    <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="text-xs uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+        {label}
+      </div>
+      <div
+        className={
+          good
+            ? 'mt-2 font-semibold text-emerald-300'
+            : 'mt-2 font-semibold text-amber-300'
+        }
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function ErrorNote({ error }: { error: unknown }) {
+  return (
+    <div className="mt-4 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-200">
+      {error instanceof Error ? error.message : 'Action failed'}
+    </div>
+  )
+}
+
+function BookmarkCard({ item }: { item: XBookmarkItem }) {
+  return (
+    <article className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm font-semibold text-ink">
+          @{item.author.username}
+        </div>
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-blue-300 hover:underline"
+        >
+          Open on X
+        </a>
+      </div>
+      <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--theme-fg)]">
+        {item.text}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-[var(--theme-muted)]">
+        <span>{item.createdAt || 'No date'}</span>
+        {item.media.length > 0 ? (
+          <span>{item.media.length} media item(s)</span>
+        ) : null}
+        {item.externalUrls.length > 0 ? (
+          <span>{item.externalUrls.length} external link(s)</span>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -4,15 +4,13 @@ import {
   ArrowLeft01Icon,
   ArrowRight01Icon,
   BrainIcon,
-  Building01Icon,
-  Castle02Icon,
+  ChartRelationshipIcon,
   Chat01Icon,
   CheckListIcon,
   Clock01Icon,
   ComputerTerminal01Icon,
   DashboardSquare01Icon,
   File01Icon,
-  McpServerIcon,
   MessageMultiple01Icon,
   Moon02Icon,
   PencilEdit02Icon,
@@ -73,27 +71,27 @@ function ThemeToggleMini() {
   // Detect dark/light from actual data-theme attribute
   const currentDataTheme =
     typeof document !== 'undefined'
-      ? document.documentElement.getAttribute('data-theme') || 'claude-nous'
-      : 'claude-nous'
+      ? document.documentElement.getAttribute('data-theme') || 'hermes-nous'
+      : 'hermes-nous'
   const isDark = !currentDataTheme.endsWith('-light')
 
   // Map between dark and light counterparts — must include all theme families
   const LIGHT_DARK_PAIRS: Record<string, string> = {
-    'claude-nous': 'claude-nous-light',
-    'claude-nous-light': 'claude-nous',
-    'claude-official': 'claude-official-light',
-    'claude-official-light': 'claude-official',
-    'claude-classic': 'claude-classic-light',
-    'claude-classic-light': 'claude-classic',
-    'claude-slate': 'claude-slate-light',
-    'claude-slate-light': 'claude-slate',
+    'hermes-nous': 'hermes-nous-light',
+    'hermes-nous-light': 'hermes-nous',
+    'hermes-official': 'hermes-official-light',
+    'hermes-official-light': 'hermes-official',
+    'hermes-classic': 'hermes-classic-light',
+    'hermes-classic-light': 'hermes-classic',
+    'hermes-slate': 'hermes-slate-light',
+    'hermes-slate-light': 'hermes-slate',
   }
 
   return (
     <button
       type="button"
       onClick={() => {
-        // Fall back to current family rather than dropping the user into claude-official
+        // Fall back to current family rather than dropping the user into hermes-official
         const nextDataTheme =
           LIGHT_DARK_PAIRS[currentDataTheme] ||
           (isDark
@@ -162,7 +160,7 @@ export async function fetchWorkspaceStats(): Promise<WorkspaceStats | null> {
   }
 }
 
-export async function fetchWorkspaceProjectShortcuts(): Promise<Array<never>> {
+export function fetchWorkspaceProjectShortcuts(): Array<never> {
   return []
 }
 
@@ -220,19 +218,7 @@ function NavItem({
             {item.label}
           </span>
           {item.badge && item.badge !== 'error-dot' ? (
-            <span
-              className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
-              style={
-                item.badge === 'NEW'
-                  ? {
-                      background: 'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
-                      color: '#0b1320',
-                      boxShadow: '0 0 8px rgba(250,204,21,0.4)',
-                      letterSpacing: '0.08em',
-                    }
-                  : undefined
-              }
-            >
+            <span className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full border border-primary-700 bg-primary-900 px-2 py-0.5 text-[10px] font-semibold leading-none text-primary-300">
               {item.badge}
             </span>
           ) : null}
@@ -331,7 +317,7 @@ function NavItem({
 
 // ── Last-visited route tracking ─────────────────────────────────────────
 
-const LAST_ROUTE_KEY = 'claude-sidebar-last-route'
+const LAST_ROUTE_KEY = 'hermes-sidebar-last-route'
 
 function getLastRoute(section: string): string | null {
   try {
@@ -547,7 +533,9 @@ function ChatSidebarComponent({
   useEffect(() => {
     function handleOpenSettingsEvent(event: Event) {
       const detail = (event as CustomEvent<ChatOpenSettingsDetail>).detail
-      handleOpenSettings(detail.section === 'appearance' ? 'appearance' : 'claude')
+      handleOpenSettings(
+        detail.section === 'appearance' ? 'appearance' : 'hermes',
+      )
     }
 
     window.addEventListener(CHAT_OPEN_SETTINGS_EVENT, handleOpenSettingsEvent)
@@ -576,20 +564,17 @@ function ChatSidebarComponent({
     pathname === '/new' || pathname.startsWith('/chat/new')
   const _isSettingsActive = pathname === '/settings'
   const isSkillsActive = pathname === '/skills'
-  const isMcpActive = pathname === '/mcp'
   const isFilesActive = pathname === '/files'
-  const isPlaygroundActive = pathname === '/playground'
-  const isAgoraActive = pathname === '/agora'
   const isTerminalActive = pathname === '/terminal'
   const isJobsActive = pathname === '/jobs'
   const isMemoryActive = pathname === '/memory'
   const isTasksActive = pathname === '/tasks'
+  const isAgentSurfacesActive = pathname === '/agent-surfaces'
+  const isXBookmarksActive = pathname === '/x-bookmarks'
+  const isLearningLoopActive = pathname === '/learning-loop'
+  const isExecutiveQueueActive = pathname === '/executive-queue'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
-  const isSwarmActive = pathname === '/swarm' || pathname === '/swarm2'
-  const echoStudioEnabled = useSettingsStore(
-    (state) => state.settings.experimentalEchoStudio,
-  )
   const mainRoutes = ['/chat', '/new', '/files', '/terminal']
   const knowledgeRoutes = ['/memory', '/skills']
   const systemRoutes = ['/settings', '/logs']
@@ -611,15 +596,15 @@ function ChatSidebarComponent({
 
   // Collapsible section states
   const [mainExpanded, toggleMain] = usePersistedBool(
-    'claude-sidebar-main-expanded',
+    'hermes-sidebar-main-expanded',
     true,
   )
   const [knowledgeExpanded, toggleKnowledge] = usePersistedBool(
-    'claude-sidebar-knowledge-expanded',
+    'hermes-sidebar-knowledge-expanded',
     true,
   )
   const [_systemExpanded, _toggleSystem] = usePersistedBool(
-    'claude-sidebar-system-expanded',
+    'hermes-sidebar-system-expanded',
     false,
   )
 
@@ -798,7 +783,6 @@ function ChatSidebarComponent({
       label: t('nav.chat'),
       active: isChatActive,
     },
-
     {
       kind: 'link',
       to: '/files',
@@ -824,8 +808,36 @@ function ChatSidebarComponent({
       kind: 'link',
       to: '/tasks',
       icon: CheckListIcon,
-      label: 'Tasks',
+      label: t('nav.tasks'),
       active: isTasksActive,
+    },
+    {
+      kind: 'link',
+      to: '/agent-surfaces',
+      icon: ChartRelationshipIcon,
+      label: 'Agent Surfaces',
+      active: isAgentSurfacesActive,
+    },
+    {
+      kind: 'link',
+      to: '/x-bookmarks',
+      icon: Search01Icon,
+      label: 'X Bookmarks',
+      active: isXBookmarksActive,
+    },
+    {
+      kind: 'link',
+      to: '/learning-loop',
+      icon: BrainIcon,
+      label: 'Learning Loop',
+      active: isLearningLoopActive,
+    },
+    {
+      kind: 'link',
+      to: '/executive-queue',
+      icon: CheckListIcon,
+      label: 'Executive Queue',
+      active: isExecutiveQueueActive,
     },
     {
       kind: 'link',
@@ -837,29 +849,10 @@ function ChatSidebarComponent({
     {
       kind: 'link',
       to: '/operations',
-      icon: UserMultipleIcon,
+      icon: UserGroupIcon,
       label: 'Operations',
       active: isOperationsActive,
     },
-    {
-      kind: 'link',
-      to: '/swarm',
-      icon: UserGroupIcon,
-      label: 'Swarm',
-      active: isSwarmActive,
-    },
-    ...(echoStudioEnabled
-      ? [
-          {
-            kind: 'link' as const,
-            to: '/echo-studio',
-            icon: DashboardSquare01Icon,
-            label: 'Echo Studio',
-            active: pathname.startsWith('/echo-studio'),
-          },
-        ]
-      : []),
-
   ]
 
   const knowledgeItems: Array<NavItemDef> = [
@@ -877,13 +870,6 @@ function ChatSidebarComponent({
       label: t('nav.skills'),
       active: isSkillsActive,
       dataTour: 'skills',
-    },
-    {
-      kind: 'link',
-      to: '/mcp',
-      icon: McpServerIcon,
-      label: 'MCP',
-      active: isMcpActive,
     },
     {
       kind: 'link',
@@ -951,8 +937,8 @@ function ChatSidebarComponent({
                 )}
               >
                 <img
-                  src="/claude-avatar.webp"
-                  alt="Hermes Agent"
+                  src="/hermes-avatar.webp"
+                  alt="Hermes"
                   className="size-6 rounded-lg"
                 />
                 <span
@@ -1042,46 +1028,6 @@ function ChatSidebarComponent({
               className="size-5 shrink-0"
             />
             <span>New Session</span>
-          </Link>
-        </div>
-      )}
-
-      {/* ── HermesWorld featured link (gold castle, NEW badge) ────── */}
-      {/* Hide when VITE_HERMESWORLD_ENABLED is explicitly '0' */}
-      {!isVisuallyCollapsed &&
-        (import.meta as any).env?.VITE_HERMESWORLD_ENABLED !== '0' && (
-        <div className="px-2 pb-2">
-          <Link
-            to="/playground"
-            onClick={() => onSelectSession?.()}
-            className={cn(
-              buttonVariants({ variant: 'ghost', size: 'sm' }),
-              'group w-full justify-start gap-2.5 px-3 py-2 text-primary-900 hover:bg-primary-200 dark:hover:bg-primary-800',
-              isPlaygroundActive &&
-                'bg-accent-500/10 text-accent-500 hover:bg-accent-50 dark:hover:bg-accent-900/300/15',
-            )}
-            data-tour="hermesworld"
-          >
-            <HugeiconsIcon
-              icon={Castle02Icon}
-              size={20}
-              strokeWidth={1.5}
-              className="size-5 shrink-0"
-              style={{ color: '#facc15' }}
-            />
-            <span>HermesWorld</span>
-            <span
-              className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none"
-              style={{
-                background:
-                  'linear-gradient(180deg, #fde68a 0%, #fbbf24 50%, #d4a017 100%)',
-                color: '#0b1320',
-                boxShadow: '0 0 8px rgba(250,204,21,0.4)',
-                letterSpacing: '0.08em',
-              }}
-            >
-              NEW
-            </span>
           </Link>
         </div>
       )}
@@ -1209,7 +1155,7 @@ function ChatSidebarComponent({
             <MenuContent side="top" align="start" className="min-w-[200px]">
               <MenuItem
                 onClick={function onOpenSettings() {
-                  handleOpenSettings('claude')
+                  handleOpenSettings('hermes')
                 }}
                 className="justify-between"
               >
@@ -1230,7 +1176,7 @@ function ChatSidebarComponent({
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
-                onClick={() => handleOpenSettings('claude')}
+                onClick={() => handleOpenSettings('hermes')}
                 className="shrink-0 rounded-lg p-1.5 text-primary-400 hover:bg-primary-200 dark:hover:bg-neutral-800 hover:text-primary-600 dark:hover:text-neutral-300 transition-colors"
                 aria-label="Settings"
               >

--- a/src/screens/dashboard/-command-center-utils.test.ts
+++ b/src/screens/dashboard/-command-center-utils.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getStartHereQueueState,
+  isSafeDraftOnlyQueueItem,
+  selectSafeDraftOnlyQueueItem,
+} from './-command-center-utils'
+import type { ExecutiveQueueItem } from '@/routes/api/-executive-queue-utils'
+
+function queueItem(overrides: Partial<ExecutiveQueueItem>): ExecutiveQueueItem {
+  return {
+    schemaVersion: 1,
+    id: overrides.id ?? 'item',
+    title: overrides.title ?? 'Untitled item',
+    outcome: overrides.outcome ?? 'Move work forward',
+    status: overrides.status ?? 'Queued',
+    priority: overrides.priority ?? 'P2',
+    domain: overrides.domain ?? 'AI Ops',
+    owner: overrides.owner ?? 'Executive',
+    riskLevel: overrides.riskLevel ?? 'Medium',
+    approvalLevel: overrides.approvalLevel ?? 'Ask Before System Change',
+    confidence: overrides.confidence ?? 'High',
+    source: overrides.source ?? {
+      type: 'Voice Lab',
+      id: 'source',
+      timestamp: '2026-06-02T10:00:00.000Z',
+      excerpt: 'source excerpt',
+      fullReference: 'source ref',
+    },
+    context: overrides.context ?? 'Context',
+    constraints: overrides.constraints ?? [],
+    nextAction: overrides.nextAction ?? 'Next action',
+    blockedReason: overrides.blockedReason ?? '',
+    resultSummary: overrides.resultSummary ?? '',
+    createdAt: overrides.createdAt ?? '2026-06-02T10:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-06-02T10:00:00.000Z',
+    dueAt: overrides.dueAt ?? '',
+    completedAt: overrides.completedAt ?? '',
+    completedBy: overrides.completedBy ?? '',
+    auditTrail: overrides.auditTrail ?? [],
+    sync: overrides.sync ?? {
+      notionPageId: '',
+      lastSyncedAt: '',
+      lastSyncStatus: 'not_synced',
+    },
+    localPath: overrides.localPath ?? '',
+  }
+}
+
+describe('getStartHereQueueState', () => {
+  it('elevates broken Gmail access as a critical exception before normal approval work', () => {
+    const state = getStartHereQueueState([
+      queueItem({
+        id: 'approval-p1',
+        title: 'Approve normal P1 system cleanup',
+        status: 'Queued',
+        priority: 'P1',
+        domain: 'AI Ops',
+        approvalLevel: 'Ask Before System Change',
+        riskLevel: 'Medium',
+      }),
+      queueItem({
+        id: 'gmail-broken',
+        title: 'Broken Gmail access',
+        outcome: 'Restore Superhuman/Gmail access so inbox scans and finance receipt searches are trustworthy',
+        status: 'Blocked',
+        priority: 'P0',
+        domain: 'Email',
+        owner: 'Email Assistant',
+        riskLevel: 'High',
+        approvalLevel: 'Ask Before System Change',
+        nextAction: 'Verify Superhuman MCP auth status and prepare repair steps without requesting secrets in chat',
+        blockedReason: 'Superhuman MCP search failed with auth/access error',
+      }),
+    ])
+
+    expect(state.primaryMode).toBe('Repair')
+    expect(state.primaryItem?.id).toBe('gmail-broken')
+    expect(state.primaryCta).toBe('Open critical exception')
+    expect(state.criticalExceptionItems.map((item) => item.id)).toEqual(['gmail-broken'])
+  })
+
+  it('does not treat ordinary blocked work as a critical system exception', () => {
+    const state = getStartHereQueueState([
+      queueItem({
+        id: 'calendar-blocked',
+        title: 'Waiting on Tim calendar decision',
+        status: 'Blocked',
+        priority: 'P1',
+        domain: 'Calendar',
+        blockedReason: 'Waiting on Tim to choose a time',
+      }),
+    ])
+
+    expect(state.primaryMode).toBe('Unblock')
+    expect(state.criticalExceptionItems).toEqual([])
+  })
+
+  it('starts with actionable approval work before higher-priority blocked or in-progress items', () => {
+    const state = getStartHereQueueState([
+      queueItem({
+        id: 'blocked-p1',
+        title: 'Blocked P1 should not be first',
+        status: 'Blocked',
+        priority: 'P1',
+        blockedReason: 'Waiting on Tim calendar decision',
+      }),
+      queueItem({
+        id: 'in-progress-p1',
+        title: 'In progress P1 should not be first',
+        status: 'In Progress',
+        priority: 'P1',
+      }),
+      queueItem({
+        id: 'actionable-p2',
+        title: 'Actionable P2 approval',
+        status: 'Queued',
+        priority: 'P2',
+        approvalLevel: 'Ask Before System Change',
+      }),
+    ])
+
+    expect(state.primaryMode).toBe('Decide')
+    expect(state.primaryItem?.id).toBe('actionable-p2')
+    expect(state.primaryCta).toBe('Open approvals')
+  })
+
+  it('uses blitz-ready queued work before blocked work when no approval decision is ready', () => {
+    const state = getStartHereQueueState([
+      queueItem({
+        id: 'blocked-p1',
+        title: 'Blocked P1',
+        status: 'Blocked',
+        priority: 'P1',
+        approvalLevel: 'Auto',
+      }),
+      queueItem({
+        id: 'auto-queued-p2',
+        title: 'Auto queued P2',
+        status: 'Queued',
+        priority: 'P2',
+        approvalLevel: 'Auto',
+        riskLevel: 'Low',
+        context: 'Local draft-only prep.',
+        constraints: ['No external side effects.'],
+        nextAction: 'Draft local notes',
+      }),
+    ])
+
+    expect(state.primaryMode).toBe('Blitz')
+    expect(state.primaryItem?.id).toBe('auto-queued-p2')
+    expect(state.primaryCta).toBe('Start safe draft')
+  })
+
+  it('selects only low-risk queued draft-only work and skips cancelled or parked items', () => {
+    const safe = queueItem({
+      id: 'safe-local-draft',
+      title: 'Draft local AI Ops note',
+      status: 'Queued',
+      priority: 'P2',
+      riskLevel: 'Low',
+      approvalLevel: 'Auto',
+      domain: 'AI Ops',
+      context: 'Internal local prep only.',
+      constraints: ['Draft only. No external side effects.'],
+      nextAction: 'Draft the local note',
+    })
+    const parked = queueItem({
+      id: 'parked-low-risk',
+      title: 'Parked local draft',
+      status: 'Parked' as ExecutiveQueueItem['status'],
+      riskLevel: 'Low',
+      approvalLevel: 'Auto',
+    })
+    const cancelled = queueItem({
+      id: 'cancelled-low-risk',
+      title: 'Cancelled local draft',
+      status: 'Cancelled' as ExecutiveQueueItem['status'],
+      riskLevel: 'Low',
+      approvalLevel: 'Auto',
+    })
+
+    expect(isSafeDraftOnlyQueueItem(safe)).toBe(true)
+    expect(isSafeDraftOnlyQueueItem(parked)).toBe(false)
+    expect(isSafeDraftOnlyQueueItem(cancelled)).toBe(false)
+    expect(selectSafeDraftOnlyQueueItem([parked, cancelled, safe])?.id).toBe(
+      'safe-local-draft',
+    )
+  })
+
+  it('keeps people, Motion, calendar, sends, money, and system changes out of safe draft selection', () => {
+    const riskyItems = [
+      queueItem({ id: 'people', title: 'Draft people decision memo', domain: 'Personal' }),
+      queueItem({ id: 'motion', title: 'Clean up Motion tasks', domain: 'AI Ops' }),
+      queueItem({ id: 'calendar', title: 'Draft calendar scheduling plan', domain: 'Calendar' }),
+      queueItem({ id: 'send', title: 'Draft and send follow-up email', domain: 'Email' }),
+      queueItem({ id: 'money', title: 'Draft reimbursement and money checklist', domain: 'Finance' }),
+      queueItem({ id: 'system', title: 'Draft Workspace restart steps', domain: 'Code' }),
+    ].map((item) => ({
+      ...item,
+      status: 'Queued' as const,
+      priority: 'P2' as const,
+      riskLevel: 'Low' as const,
+      approvalLevel: 'Auto' as const,
+      context: 'Looks local but touches a gated surface.',
+      nextAction: item.title,
+    }))
+
+    expect(riskyItems.every((item) => !isSafeDraftOnlyQueueItem(item))).toBe(true)
+    expect(selectSafeDraftOnlyQueueItem(riskyItems)).toBeNull()
+  })
+})

--- a/src/screens/dashboard/-command-center-utils.ts
+++ b/src/screens/dashboard/-command-center-utils.ts
@@ -1,0 +1,179 @@
+import type { ExecutiveQueueItem } from '@/routes/api/-executive-queue-utils'
+
+export const ACTIVE_QUEUE_STATUSES = new Set(['Triage', 'Proposed', 'Queued', 'In Progress', 'Blocked'])
+export const PRIORITY_WEIGHT: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 }
+export const DOMAIN_ORDER = ['Restored', 'Finance', 'Travel Multiplier', 'Personal', 'AI Ops', 'Meetings', 'Email']
+
+export type StartHereMode = 'Repair' | 'Decide' | 'Unblock' | 'Blitz' | 'Check'
+
+export type StartHereQueueState = {
+  activeItems: Array<ExecutiveQueueItem>
+  criticalExceptionItems: Array<ExecutiveQueueItem>
+  approvalItems: Array<ExecutiveQueueItem>
+  blockedItems: Array<ExecutiveQueueItem>
+  blitzItems: Array<ExecutiveQueueItem>
+  safeDraftOnlyItems: Array<ExecutiveQueueItem>
+  safeDraftOnlyItem: ExecutiveQueueItem | null
+  inProgressItems: Array<ExecutiveQueueItem>
+  primaryItem: ExecutiveQueueItem | null
+  primaryMode: StartHereMode
+  primaryCta: string
+  topLine: string
+}
+
+function isTerminalStatus(item: ExecutiveQueueItem): boolean {
+  const status = String(item.status).toLowerCase()
+  return ['done', 'archived', 'cancelled', 'canceled', 'parked'].includes(status)
+}
+
+function isParkedOrCancelled(item: ExecutiveQueueItem): boolean {
+  const status = String(item.status).toLowerCase()
+  const text = [item.title, item.context, item.blockedReason, item.resultSummary]
+    .join(' ')
+    .toLowerCase()
+  return (
+    ['cancelled', 'canceled', 'parked'].includes(status) ||
+    /\b(cancelled|canceled|parked)\b/.test(text)
+  )
+}
+
+function isActionableNow(item: ExecutiveQueueItem): boolean {
+  return !isTerminalStatus(item) && item.status !== 'Blocked' && item.status !== 'In Progress'
+}
+
+function needsTimDecision(item: ExecutiveQueueItem): boolean {
+  return isActionableNow(item) && (item.status === 'Proposed' || item.approvalLevel !== 'Auto')
+}
+
+const CRITICAL_FAILURE_PATTERN = /\b(broken|failed|failure|down|offline|unavailable|expired|unauthorized|auth|access|credential|secret|token|mcp)\b/i
+const CRITICAL_SERVICE_PATTERN = /\b(gmail|superhuman|monarch|telegram|delivery|gateway|dashboard|api|cron|watchdog|calendar|finance)\b/i
+
+function isCriticalException(item: ExecutiveQueueItem): boolean {
+  if (isTerminalStatus(item)) return false
+
+  const text = [
+    item.title,
+    item.outcome,
+    item.context,
+    item.nextAction,
+    item.blockedReason,
+    item.source.excerpt,
+  ].join(' ')
+  if (!CRITICAL_FAILURE_PATTERN.test(text) || !CRITICAL_SERVICE_PATTERN.test(text)) return false
+
+  const severePriority = item.priority === 'P0' || item.priority === 'P1'
+  const elevatedRisk = item.riskLevel === 'High' || item.approvalLevel === 'Ask Before System Change' || item.approvalLevel === 'Manual Only'
+  const impairedWorkflow = item.status === 'Blocked' || item.status === 'Proposed' || item.status === 'Triage'
+  const criticalDomain = item.domain === 'AI Ops' || item.domain === 'Email' || item.domain === 'Finance' || item.domain === 'Calendar'
+
+  return severePriority && elevatedRisk && impairedWorkflow && criticalDomain
+}
+
+export function sortQueueItems(items: Array<ExecutiveQueueItem>): Array<ExecutiveQueueItem> {
+  return [...items].sort((a, b) => {
+    const priority = (PRIORITY_WEIGHT[a.priority] ?? 9) - (PRIORITY_WEIGHT[b.priority] ?? 9)
+    if (priority !== 0) return priority
+    const aTime = Date.parse(a.updatedAt || a.createdAt || '') || 0
+    const bTime = Date.parse(b.updatedAt || b.createdAt || '') || 0
+    return bTime - aTime
+  })
+}
+
+const GATED_DRAFT_TEXT_PATTERN = /\b(people|personnel|staffing|pastoral|counsel|motion|calendar|schedule|invite|send|email|text|message|publish|post|money|spend|payment|reimburse|monarch|finance|tax|budget|system|restart|deploy|config|credential|secret|token|oauth|cron|launchd|docker)\b/i
+const SAFE_DRAFT_TEXT_PATTERN = /\b(draft|summarize|summary|classify|research|review|analy[sz]e|outline|local|notes?|report)\b/i
+
+export function isSafeDraftOnlyQueueItem(item: ExecutiveQueueItem): boolean {
+  const text = [
+    item.title,
+    item.outcome,
+    item.context,
+    item.nextAction,
+    item.blockedReason,
+    ...item.constraints,
+  ].join(' ')
+
+  if (isParkedOrCancelled(item)) return false
+  if (item.status !== 'Queued') return false
+  if (item.riskLevel !== 'Low') return false
+  if (item.approvalLevel !== 'Auto') return false
+  if (item.domain === 'Calendar' || item.domain === 'Finance') return false
+  if (item.owner === 'Finance CFO' || item.owner === 'Calendar Assistant') return false
+  if (GATED_DRAFT_TEXT_PATTERN.test(text)) return false
+  return SAFE_DRAFT_TEXT_PATTERN.test(text)
+}
+
+export function selectSafeDraftOnlyQueueItem(
+  items: Array<ExecutiveQueueItem>,
+): ExecutiveQueueItem | null {
+  return sortQueueItems(items.filter(isSafeDraftOnlyQueueItem))[0] ?? null
+}
+
+export function getStartHereQueueState(items: Array<ExecutiveQueueItem>): StartHereQueueState {
+  const activeItems = sortQueueItems(items.filter((item) => ACTIVE_QUEUE_STATUSES.has(item.status)))
+  const criticalExceptionItems = sortQueueItems(activeItems.filter(isCriticalException))
+  const approvalItems = sortQueueItems(items.filter(needsTimDecision))
+  const blockedItems = sortQueueItems(items.filter((item) => item.status === 'Blocked'))
+  const safeDraftOnlyItems = sortQueueItems(items.filter(isSafeDraftOnlyQueueItem))
+  const safeDraftOnlyItem = safeDraftOnlyItems[0] ?? null
+  const blitzItems = safeDraftOnlyItems
+  const inProgressItems = activeItems.filter((item) => item.status === 'In Progress')
+
+  const primaryItem = (() => {
+    if (criticalExceptionItems.length) return criticalExceptionItems[0]
+    if (approvalItems.length) return approvalItems[0]
+    if (blitzItems.length) return blitzItems[0]
+    if (blockedItems.length) return blockedItems[0]
+    return null
+  })()
+
+  const primaryMode: StartHereMode = criticalExceptionItems.length
+    ? 'Repair'
+    : approvalItems.length
+    ? 'Decide'
+    : blitzItems.length
+      ? 'Blitz'
+      : blockedItems.length
+        ? 'Unblock'
+        : 'Check'
+
+  const primaryCta = primaryMode === 'Repair'
+    ? 'Open critical exception'
+    : primaryMode === 'Decide'
+    ? 'Open approvals'
+    : primaryMode === 'Blitz'
+      ? 'Start safe draft'
+      : primaryMode === 'Unblock'
+        ? 'Open blocked item'
+        : 'Open queue'
+
+  const topLine = (() => {
+    if (criticalExceptionItems.length) {
+      return `${criticalExceptionItems.length} critical exception${criticalExceptionItems.length === 1 ? '' : 's'} need fast attention. Start with ${criticalExceptionItems[0].title}.`
+    }
+    if (approvalItems.length) {
+      return `${approvalItems.length} actionable decision${approvalItems.length === 1 ? '' : 's'} ready. Start with ${approvalItems[0].title}.`
+    }
+    if (blitzItems.length) {
+      return `${blitzItems.length} active queue item${blitzItems.length === 1 ? '' : 's'} are ready to move. Start with ${blitzItems[0].title}.`
+    }
+    if (blockedItems.length) {
+      return `${blockedItems.length} item${blockedItems.length === 1 ? '' : 's'} are blocked. Start with ${blockedItems[0].title}.`
+    }
+    return 'No active queue items are loaded. This should be unusual.'
+  })()
+
+  return {
+    activeItems,
+    criticalExceptionItems,
+    approvalItems,
+    blockedItems,
+    blitzItems,
+    safeDraftOnlyItems,
+    safeDraftOnlyItem,
+    inProgressItems,
+    primaryItem,
+    primaryMode,
+    primaryCta,
+    topLine,
+  }
+}

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -1,531 +1,406 @@
-import {
-  BubbleChatAddIcon,
-  CheckmarkCircle02Icon,
-  ConsoleIcon,
-  Edit02Icon,
-  Moon02Icon,
-  PuzzleIcon,
-  Settings02Icon,
-  Sun02Icon,
-} from '@hugeicons/core-free-icons'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
-import { AchievementsCard } from './components/achievements-card'
-import { ActiveModelKpi } from './components/active-model-kpi'
-import { AnalyticsChartCard } from './components/analytics-chart-card'
-import { AttentionMarquee } from './components/attention-marquee'
-import { CacheEfficiencyCard } from './components/cache-efficiency-card'
-import { CostLedgerCard } from './components/cost-ledger-card'
-import { EditModePanel } from './components/edit-mode-panel'
-import { HeroMetrics } from './components/hero-metrics'
-import { LogsTailCard } from './components/logs-tail-card'
-import { OperatorTipCard } from './components/operator-tip-card'
-import { OpsStrip } from './components/ops-strip'
-import { ProviderMixCard } from './components/provider-mix-card'
-import { SessionsIntelligenceCard } from './components/sessions-intelligence-card'
-import { SkillsUsageCard } from './components/skills-usage-card'
-import { TokenMixHourCard } from './components/token-mix-hour-card'
-import { TopModelsCard } from './components/top-models-card'
-import { VelocityCard } from './components/velocity-card'
-import { WidgetShell } from './components/widget-shell'
-import { normalizeDashboardSessionsPayload } from './lib/sessions-query'
-import { useDashboardLayout } from './lib/use-dashboard-layout'
-import type { SessionRowData } from './components/sessions-intelligence-card'
-import type { AnalyticsPeriod } from './components/analytics-chart-card'
+  DOMAIN_ORDER,
+  getStartHereQueueState,
+  sortQueueItems,
+} from './-command-center-utils'
 import type { ReactNode } from 'react'
-import type { ClaudeSession } from '@/server/claude-api'
-import type { DashboardOverview } from '@/server/dashboard-aggregator'
-import { getUnavailableReason } from '@/lib/feature-gates'
+import type {
+  ExecutiveQueueItem,
+  QueueBoardColumn,
+} from '@/routes/api/-executive-queue-utils'
 import { cn } from '@/lib/utils'
-import { applyTheme, useSettingsStore } from '@/hooks/use-settings'
+import { toast } from '@/components/ui/toast'
 import { openHamburgerMenu } from '@/components/mobile-hamburger-menu'
-import { useFeatureAvailable } from '@/hooks/use-feature-available'
 
-// `IconSvgObject` isn't exported from @hugeicons/react; reuse the
-// inferred type from a real icon import for prop typing.
-type HugeIcon = typeof Settings02Icon
-
-// ── Helpers ──────────────────────────────────────────────────────
-
-function timeAgo(ts: number): string {
-  const diff = Date.now() / 1000 - ts
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
+type ExecutiveQueueResponse = {
+  ok: boolean
+  items: Array<ExecutiveQueueItem>
+  grouped: Record<QueueBoardColumn, Array<ExecutiveQueueItem>>
+  total: number
+  error?: string
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
+type QueueExecutionMode = 'approve_and_run' | 'draft_only' | 'explain_more'
+
+type QueueMutationResponse = {
+  ok: boolean
+  item?: ExecutiveQueueItem
+  error?: string
 }
 
-function themeColor(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  const value = getComputedStyle(document.documentElement)
-    .getPropertyValue(name)
-    .trim()
-  return value || fallback
+type QueueExecutionResponse = QueueMutationResponse & {
+  execution?: { id: string; sessionKey: string; mode?: QueueExecutionMode }
+  runId?: string | null
+  sessionKey?: string
 }
 
-function alpha(color: string, amount: number): string {
-  const pct = Math.max(0, Math.min(100, Math.round(amount * 100)))
-  return `color-mix(in srgb, ${color} ${pct}%, transparent)`
+type GatewayStatusResponse = {
+  gateway?: { available?: boolean; url?: string }
+  dashboard?: { available?: boolean; url?: string }
+  mode?: string
+  capabilities?: Record<string, boolean | { available?: boolean }>
+  error?: string
 }
 
-function readDashboardPalette() {
-  return {
-    accent: themeColor('--theme-accent', '#6366f1'),
-    accentSecondary: themeColor('--theme-accent-secondary', '#8b5cf6'),
-    success: themeColor('--theme-success', '#22c55e'),
-    warning: themeColor('--theme-warning', '#f59e0b'),
-    danger: themeColor('--theme-danger', '#ef4444'),
-    muted: themeColor('--theme-muted', '#6b7280'),
-    border: themeColor('--theme-border', '#333333'),
-    card: themeColor('--theme-card', '#1a1a2e'),
-    text: themeColor('--theme-text', '#e5e7eb'),
-  }
-}
-
-function useDashboardPalette() {
-  const [palette, setPalette] = useState(readDashboardPalette)
-
-  useEffect(() => {
-    if (typeof document === 'undefined') return undefined
-    const refresh = () => setPalette(readDashboardPalette())
-    refresh()
-    const observer = new MutationObserver(refresh)
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme', 'style', 'class'],
-    })
-    return () => observer.disconnect()
-  }, [])
-
-  return palette
-}
-
-// ── Glass Card ───────────────────────────────────────────────────
-
-function GlassCard({
-  title,
-  titleRight,
-  accentColor,
-  noPadding,
-  className,
-  children,
-}: {
+type JobLike = {
+  id?: string
+  name?: string
   title?: string
-  titleRight?: ReactNode
-  accentColor?: string
-  noPadding?: boolean
-  className?: string
+  enabled?: boolean
+  last_status?: string
+  lastStatus?: string
+  status?: string
+  next_run?: string
+  nextRun?: string
+  schedule?: string
+}
+
+type JobsResponse = {
+  jobs?: Array<JobLike>
+  items?: Array<JobLike>
+  error?: string
+}
+
+type SessionLike = {
+  id?: string
+  key?: string
+  title?: string
+  label?: string
+  derivedTitle?: string
+  startedAt?: number
+  started_at?: number
+  updatedAt?: number
+  updated_at?: number
+}
+
+type SessionsResponse = {
+  sessions?: Array<SessionLike>
+}
+
+type MotionAction = {
+  taskId?: string
+  name?: string
+  workspace?: string
+  dueDateET?: string
+  scheduledStartET?: string | null
+  priority?: string
+  deadlineType?: string
+  ownership?: string
+  riskLevel?: string
+  actionType?: string
+  safety?: string
+  reason?: string
+}
+
+type ReaderAction = {
+  title?: string
+  author?: string
+  source?: string
+  source_url?: string
+  contentType?: string
+  score?: number
+  actionType?: string
+  safety?: string
+  reason?: string
+  failureReason?: string
+  nextAction?: string
+  handle?: string
+  saves?: number
+  examples?: Array<ReaderAction>
+}
+
+type GranolaAction = {
+  noteId?: string
+  noteTitle?: string
+  createdAt?: string
+  domain?: string
+  heading?: string
+  text?: string
+  actionType?: string
+  safety?: string
+  reason?: string
+}
+
+type AiOpsIntakeQueueItem = {
+  id?: string
+  source?: string
+  sourceType?: string
+  sourceId?: string | null
+  title?: string
+  detail?: string
+  actionType?: string
+  nextAction?: string
+  owner?: string
+  domain?: string
+  priority?: string
+  riskLevel?: string
+  gate?: string
+  safety?: string
+  createdAt?: string | null
+  sourceUrl?: string | null
+  reason?: string
+}
+
+type SourceCoverageSource = {
+  available?: boolean
+  items_last_30_days_scanned?: number
+  estimated_ai_relevant_items?: number
+  x_bookmarks_30_days?: number
+  reader_action_summary?: {
+    readyForAiLearningCount?: number
+    freshReadyCount?: number
+    xWatchlistCandidateCount?: number
+    transcriptFailureCount?: number
+  }
+  reader_actions?: {
+    readyForAiLearning?: Array<ReaderAction>
+    freshReady?: Array<ReaderAction>
+    xWatchlistCandidates?: Array<ReaderAction>
+    transcriptFailures?: Array<ReaderAction>
+  }
+  content_type_counts?: Record<string, number>
+  ai_relevant_type_counts?: Record<string, number>
+  task_count?: number
+  unscheduled_count?: number
+  due_today_count?: number
+  tim_owned_count?: number
+  teammate_owned_count?: number
+  ambiguous_unassigned_count?: number
+  tim_owned_unscheduled_count?: number
+  ownership_counts?: Record<string, number>
+  action_summary?: {
+    actionCandidateCount?: number
+    needsTimDecisionCount?: number
+    followUpCandidateCount?: number
+    ownershipClarificationCount?: number
+    assignedActionCandidateCount?: number
+    safeWriteCount?: number
+    approvalRequiredCount?: number
+    suppressedCount?: number
+  }
+  motion_actions?: {
+    safeWriteActions?: Array<MotionAction>
+    approvalRequired?: Array<MotionAction>
+    suppressedItems?: Array<MotionAction>
+  }
+  recent_notes_scanned?: number
+  eligible_notes_parsed?: number
+  skipped_confidential_or_sensitive?: number
+  fetch_errors?: number
+  domain_counts?: Record<string, number>
+  granola_actions?: {
+    needsTimDecision?: Array<GranolaAction>
+    followUpCandidates?: Array<GranolaAction>
+    ownershipClarifications?: Array<GranolaAction>
+    assignedActionCandidates?: Array<GranolaAction>
+  }
+  summary?: {
+    totalItemCount?: number
+    topItemCount?: number
+    needsTimDecisionCount?: number
+    safeAgentWorkCount?: number
+    approvalRequiredCount?: number
+    recoveryRequiredCount?: number
+    reviewOwnerCount?: number
+    learnFromThisCount?: number
+    draftFollowUpCount?: number
+    suppressedAuditCount?: number
+    sourceCounts?: Record<string, number>
+    ownerCounts?: Record<string, number>
+    actionCounts?: Record<string, number>
+    gateCounts?: Record<string, number>
+    riskCounts?: Record<string, number>
+  }
+  topItems?: Array<AiOpsIntakeQueueItem>
+  notes_returned_first_page?: number
+  recent_notes_36h_first_page?: number
+  items_checked?: number
+  acceptable_full_transcripts?: number
+  unacceptable_transcripts?: number
+  tim_notice_required?: boolean
+  error?: string
+}
+
+type SourceCoverageResponse = {
+  ok: boolean
+  snapshot?: {
+    generated_at?: string
+    sources?: Partial<Record<string, SourceCoverageSource>>
+  }
+  error?: string
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  const data = (await response.json().catch(() => ({}))) as T
+  if (!response.ok) {
+    const maybeError = data as { error?: string }
+    throw new Error(maybeError.error ?? `HTTP ${response.status}`)
+  }
+  return data
+}
+
+async function holdQueueItem(
+  id: string,
+  note: string,
+): Promise<ExecutiveQueueItem> {
+  const response = await fetch('/api/executive-queue', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id,
+      action: 'approval',
+      decision: 'hold',
+      note,
+      actor: 'Tim',
+    }),
+  })
+  const data = (await response
+    .json()
+    .catch(() => ({}))) as QueueMutationResponse
+  if (!response.ok || data.ok === false || !data.item) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data.item
+}
+
+async function executeQueueItem(
+  id: string,
+  mode: QueueExecutionMode,
+  note: string,
+): Promise<QueueExecutionResponse> {
+  const response = await fetch('/api/executive-queue-execution', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id,
+      mode,
+      note,
+      actor: 'Tim',
+      sessionKey: 'executive-command-center',
+    }),
+  })
+  const data = (await response
+    .json()
+    .catch(() => ({}))) as QueueExecutionResponse
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error ?? `HTTP ${response.status}`)
+  }
+  return data
+}
+
+function priorityTone(
+  priority: string,
+): 'neutral' | 'good' | 'warn' | 'danger' | 'accent' {
+  if (priority === 'P0') return 'danger'
+  if (priority === 'P1') return 'warn'
+  if (priority === 'P2') return 'accent'
+  return 'neutral'
+}
+
+function statusTone(
+  status: string,
+): 'neutral' | 'good' | 'warn' | 'danger' | 'accent' {
+  if (status === 'Blocked') return 'danger'
+  if (status === 'Proposed' || status === 'Triage') return 'warn'
+  if (status === 'In Progress') return 'accent'
+  if (status === 'Queued') return 'good'
+  return 'neutral'
+}
+
+function formatTimestamp(value?: string | number): string {
+  if (!value) return 'No time set'
+  const date =
+    typeof value === 'number'
+      ? new Date(value > 10_000_000_000 ? value : value * 1000)
+      : new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function getSessionTime(session: SessionLike): number {
+  const raw =
+    session.updatedAt ??
+    session.updated_at ??
+    session.startedAt ??
+    session.started_at ??
+    0
+  return raw > 10_000_000_000 ? raw : raw * 1000
+}
+
+function Badge({
+  children,
+  tone = 'neutral',
+}: {
   children: ReactNode
+  tone?: 'neutral' | 'good' | 'warn' | 'danger' | 'accent'
 }) {
   return (
-    <div
-      className={cn(
-        'relative flex flex-col overflow-hidden rounded-xl border transition-colors',
-        className,
-      )}
-      style={{
-        background: 'var(--theme-card)',
-        borderColor: 'var(--theme-border)',
-      }}
-    >
-      {accentColor && (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-0 h-[2px]"
-          style={{
-            background: `linear-gradient(90deg, ${accentColor}, ${accentColor}50, transparent)`,
-          }}
-        />
-      )}
-      {title && (
-        <div className="flex items-center justify-between px-5 pt-4 pb-0">
-          <h3 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted">
-            {title}
-          </h3>
-          {titleRight}
-        </div>
-      )}
-      <div className={cn('flex-1', noPadding ? '' : 'px-5 pb-4 pt-3')}>
-        {children}
-      </div>
-    </div>
-  )
-}
-
-function EnhancedBadge({ label = 'Enhanced API' }: { label?: string }) {
-  return (
     <span
-      className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]"
-      style={{
-        border: `1px solid ${themeColor('--theme-accent-border', 'rgba(245, 158, 11, 0.28)')}`,
-        background: themeColor('--theme-accent-subtle', 'rgba(245, 158, 11, 0.12)'),
-        color: themeColor('--theme-accent', '#f59e0b'),
-      }}
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+        tone === 'good' &&
+          'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
+        tone === 'warn' && 'border-amber-400/30 bg-amber-400/10 text-amber-200',
+        tone === 'danger' && 'border-red-400/30 bg-red-400/10 text-red-200',
+        tone === 'accent' &&
+          'border-[var(--theme-accent-border)] bg-[var(--theme-accent)]/10 text-[var(--theme-accent)]',
+        tone === 'neutral' &&
+          'border-[var(--theme-border)] text-[var(--theme-muted)]',
+      )}
     >
-      {label}
+      {children}
     </span>
   )
 }
 
-function UnavailableWidget({
+function Panel({
   title,
-  description,
+  eyebrow,
+  children,
+  action,
 }: {
   title: string
-  description: string
+  eyebrow?: string
+  children: ReactNode
+  action?: ReactNode
 }) {
   return (
-    <GlassCard
-      title={title}
-      titleRight={<EnhancedBadge />}
-      accentColor={themeColor('--theme-warning', '#f59e0b')}
-      className="h-full"
-    >
-      <div className="flex h-full min-h-[180px] items-center justify-center rounded-lg border border-dashed border-[var(--theme-border)] bg-[var(--theme-card2)] px-4 text-center">
-        <p className="text-sm text-muted">{description}</p>
-      </div>
-    </GlassCard>
-  )
-}
-
-// ── Metric Tile ──────────────────────────────────────────────────
-
-function MetricTile({
-  label,
-  value,
-  sub,
-  icon,
-  accentColor,
-}: {
-  label: string
-  value: string
-  sub?: string
-  icon: string
-  accentColor: string
-}) {
-  return (
-    <GlassCard accentColor={accentColor}>
-      <div className="flex items-start justify-between">
-        <div className="flex flex-col gap-0.5">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted">
-            {label}
-          </div>
-          <div className="text-2xl font-bold tabular-nums text-ink">
-            {value}
-          </div>
-          {sub && <div className="text-[11px] text-muted">{sub}</div>}
+    <section className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)]/85 p-4 shadow-sm backdrop-blur">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          {eyebrow ? (
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              {eyebrow}
+            </div>
+          ) : null}
+          <h2 className="mt-1 text-base font-semibold text-ink">{title}</h2>
         </div>
-        <div
-          className="flex size-8 items-center justify-center rounded-lg text-base"
-          style={{ background: `${accentColor}15` }}
-        >
-          {icon}
-        </div>
+        {action}
       </div>
-    </GlassCard>
+      {children}
+    </section>
   )
 }
 
-// ── Activity Chart ───────────────────────────────────────────────
-
-function ActivityChart({
-  sessions,
-  palette,
-}: {
-  sessions: Array<ClaudeSession>
-  palette: ReturnType<typeof readDashboardPalette>
-}) {
-  const chartData = useMemo(() => {
-    const dayMap = new Map<string, { sessions: number; messages: number }>()
-    const now = Date.now() / 1000
-    for (let i = 13; i >= 0; i--) {
-      const d = new Date((now - i * 86400) * 1000)
-      const key = d.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-      })
-      dayMap.set(key, { sessions: 0, messages: 0 })
-    }
-    for (const s of sessions) {
-      if (!s.started_at) continue
-      const d = new Date(s.started_at * 1000)
-      const key = d.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-      })
-      const entry = dayMap.get(key)
-      if (entry) {
-        entry.sessions += 1
-        entry.messages += s.message_count ?? 0
-      }
-    }
-    const all = Array.from(dayMap.entries()).map(([date, data]) => ({
-      date,
-      ...data,
-    }))
-    let firstActive = all.findIndex((d) => d.sessions > 0 || d.messages > 0)
-    if (firstActive > 0) firstActive = Math.max(0, firstActive - 1)
-    return firstActive > 0 ? all.slice(firstActive) : all
-  }, [sessions])
-
-  return (
-    <GlassCard
-      title="Activity"
-      titleRight={<span className="text-[10px] text-muted">14 days</span>}
-      accentColor={palette.accent}
-      className="h-full"
-    >
-      <div className="h-[200px] w-full -ml-2">
-        <ResponsiveContainer width="100%" height="100%">
-          <AreaChart
-            data={chartData}
-            margin={{ top: 8, right: 32, left: -16, bottom: 0 }}
-          >
-            <defs>
-              <linearGradient id="g-sessions" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={palette.accent} stopOpacity={0.3} />
-                <stop offset="100%" stopColor={palette.accent} stopOpacity={0} />
-              </linearGradient>
-              <linearGradient id="g-messages" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={palette.success} stopOpacity={0.2} />
-                <stop offset="100%" stopColor={palette.success} stopOpacity={0} />
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke={palette.border} opacity={0.45} />
-            <XAxis
-              dataKey="date"
-              tick={{ fontSize: 10, fill: palette.muted }}
-              axisLine={false}
-              tickLine={false}
-            />
-            <YAxis
-              yAxisId="left"
-              tick={{ fontSize: 10, fill: palette.success }}
-              axisLine={false}
-              tickLine={false}
-              allowDecimals={false}
-              width={28}
-            />
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tick={{ fontSize: 10, fill: palette.accent }}
-              axisLine={false}
-              tickLine={false}
-              allowDecimals={false}
-              width={28}
-            />
-            <Tooltip
-              contentStyle={{
-                background: palette.card,
-                border: `1px solid ${palette.border}`,
-                borderRadius: '8px',
-                fontSize: '11px',
-              }}
-              labelStyle={{ color: palette.muted, fontSize: '10px' }}
-            />
-            <Area
-              yAxisId="left"
-              type="monotone"
-              dataKey="messages"
-              stroke={palette.success}
-              fill="url(#g-messages)"
-              strokeWidth={1.5}
-              dot={false}
-            />
-            <Area
-              yAxisId="right"
-              type="monotone"
-              dataKey="sessions"
-              stroke={palette.accent}
-              fill="url(#g-sessions)"
-              strokeWidth={2}
-              dot={false}
-            />
-          </AreaChart>
-        </ResponsiveContainer>
-      </div>
-      <div className="mt-2 flex items-center gap-5 text-[10px] text-muted">
-        <span className="flex items-center gap-1.5">
-          <span className="size-2 rounded-full" style={{ background: palette.accent }} />
-          Sessions
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="size-2 rounded-full" style={{ background: palette.success }} />
-          Messages
-        </span>
-      </div>
-    </GlassCard>
-  )
-}
-
-// ── Skills Widget ────────────────────────────────────────────────
-
-function SkillsWidget({
-  palette,
-  onOpen,
-  usage,
-}: {
-  palette: ReturnType<typeof readDashboardPalette>
-  onOpen: () => void
-  usage: DashboardOverview['skillsUsage']
-}) {
-  const skillsAvailable = useFeatureAvailable('skills')
-  const skillsQuery = useQuery({
-    queryKey: ['claude-skills'],
-    queryFn: async () => {
-      const res = await fetch('/api/skills?tab=installed&limit=200&summary=search')
-      if (!res.ok) return []
-      const data = await res.json()
-      return (data?.skills ?? []) as Array<Record<string, unknown>>
-    },
-    staleTime: 30_000,
-    enabled: skillsAvailable,
-  })
-
-  const skills = skillsQuery.data ?? []
-
-  if (!skillsAvailable) {
-    return (
-      <UnavailableWidget
-        title="Skills"
-        description={getUnavailableReason('skills')}
-      />
-    )
-  }
-
-  // Summary view per Hermes Agent feedback: 'don’t enumerate, summarise.'
-  // Prefer real usage signal from /api/analytics/usage when present
-  // (counts what the agent *actually used*, not just what's installed).
-  const installed = skills.length
-  const enabled = skills.filter((s) => s.enabled !== false).length
-  const usedThisWindow = usage?.distinctSkills ?? null
-  const topUsed = usage?.topSkills[0]
-  const topInstalled =
-    skills.find((s) => s.enabled !== false) ?? skills.at(0)
-  const topName = topUsed?.skill ?? String(topInstalled?.name ?? '—')
-
-  return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className="group relative flex w-full flex-col gap-1.5 overflow-hidden rounded-xl border px-4 py-3 text-left transition-colors hover:bg-[var(--theme-card)]/80"
-      style={{
-        background: 'var(--theme-card)',
-        borderColor: 'var(--theme-border)',
-      }}
-    >
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 h-[2px]"
-        style={{
-          background: `linear-gradient(90deg, ${palette.warning}, ${palette.warning}50, transparent)`,
-        }}
-      />
-      <div className="flex items-center justify-between">
-        <h3
-          className="text-[10px] font-semibold uppercase tracking-[0.18em]"
-          style={{ color: 'var(--theme-muted)' }}
-        >
-          Skills
-        </h3>
-        <span
-          className="font-mono text-[9px] uppercase tracking-[0.15em]"
-          style={{ color: 'var(--theme-muted)' }}
-        >
-          manage →
-        </span>
-      </div>
-      <div
-        className="font-mono text-2xl font-bold tabular-nums leading-none"
-        style={{ color: 'var(--theme-text)' }}
-      >
-        {installed}
-      </div>
-      <div
-        className="font-mono text-[10px] uppercase tracking-[0.1em]"
-        style={{ color: 'var(--theme-muted)' }}
-      >
-        {installed === 0
-          ? 'no skills installed'
-          : usedThisWindow !== null && usedThisWindow > 0
-            ? `${enabled} enabled · ${usedThisWindow} used · top: ${topName}`
-            : `${enabled} enabled · top: ${topName}`}
-      </div>
-    </button>
-  )
-}
-
-// ── Secondary action (smaller, monochrome) ─────────────────────
-
-function SecondaryAction({
-  label,
-  icon,
+function ActionButton({
+  children,
   onClick,
-  disabled,
+  primary = false,
+  disabled = false,
 }: {
-  label: string
-  icon: HugeIcon
+  children: ReactNode
   onClick: () => void
+  primary?: boolean
   disabled?: boolean
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className="group inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-semibold uppercase tracking-[0.05em] transition-all hover:scale-[1.015] hover:bg-[var(--theme-card)]/70 hover:text-[var(--theme-text)] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
-      style={{
-        borderColor: 'var(--theme-border)',
-        color: 'var(--theme-muted)',
-        background:
-          'linear-gradient(135deg, color-mix(in srgb, var(--theme-card) 80%, transparent), transparent)',
-      }}
-    >
-      <HugeiconsIcon
-        icon={icon}
-        size={14}
-        strokeWidth={1.6}
-        className="transition-colors group-hover:text-[var(--theme-accent)]"
-      />
-      <span>{label}</span>
-    </button>
-  )
-}
-
-// ── Quick Action ─────────────────────────────────────────────────
-
-function QuickAction({
-  label,
-  icon,
-  onClick,
-  accentColor,
-  disabled,
-  badge,
-}: {
-  label: string
-  icon: string
-  onClick: () => void
-  accentColor: string
-  disabled?: boolean
-  badge?: string
 }) {
   return (
     <button
@@ -533,670 +408,1187 @@ function QuickAction({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        'relative overflow-hidden flex min-h-12 w-full items-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium transition-all',
-        'border-[var(--theme-border)] bg-[var(--theme-card)] text-left',
-        disabled
-          ? 'cursor-not-allowed opacity-60'
-          : 'hover:border-[var(--theme-accent-border)] hover:scale-[1.01] active:scale-[0.99]',
+        'rounded-xl border px-3 py-2 text-sm font-medium transition active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50',
+        primary
+          ? 'border-[var(--theme-accent-border)] bg-[var(--theme-accent)] text-white hover:brightness-110'
+          : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-ink hover:border-[var(--theme-accent-border)]',
       )}
     >
-      <div
-        className="flex size-7 shrink-0 items-center justify-center rounded-md text-sm"
-        style={{ background: `${accentColor}18` }}
-      >
-        {icon}
-      </div>
-      <span
-        className="min-w-0 flex-1 text-xs font-semibold"
-        style={{ color: 'var(--theme-text)' }}
-      >
-        {label}
-      </span>
-      {badge ? (
-        <span className="ml-auto shrink-0 rounded-full border border-amber-300 bg-amber-100 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-amber-700">
-          {badge}
-        </span>
-      ) : null}
-      <div
-        className="absolute bottom-0 left-0 right-0 h-[2px]"
-        style={{
-          background: `linear-gradient(90deg, ${accentColor}, transparent)`,
-        }}
-      />
+      {children}
     </button>
   )
 }
 
-// ── Session Row (minimal) ────────────────────────────────────────
-
-function SessionRow({
-  session,
-  maxTokens,
+function QueueRow({
+  item,
   onClick,
-  palette,
+  dense = false,
 }: {
-  session: ClaudeSession
-  maxTokens: number
+  item: ExecutiveQueueItem
   onClick: () => void
-  palette: ReturnType<typeof readDashboardPalette>
+  dense?: boolean
 }) {
-  const tokens = (session.input_tokens ?? 0) + (session.output_tokens ?? 0)
-  const msgs = session.message_count ?? 0
-  const tools = session.tool_call_count ?? 0
-  const barWidth = maxTokens > 0 ? Math.max(1, (tokens / maxTokens) * 100) : 0
-
+  const riskTone =
+    item.riskLevel === 'High'
+      ? 'danger'
+      : item.riskLevel === 'Medium'
+        ? 'warn'
+        : 'good'
   return (
     <button
       type="button"
       onClick={onClick}
-      className="w-full text-left px-4 py-2.5 rounded-lg hover:bg-[var(--theme-card2)] transition-colors group"
+      className={cn(
+        'w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] text-left transition hover:border-[var(--theme-accent-border)]',
+        dense ? 'p-2.5' : 'p-3',
+      )}
     >
-      <div className="flex items-center gap-2 mb-1">
-        <span className="text-[13px] font-medium text-ink truncate flex-1 group-hover:text-ink">
-          {session.title || session.id}
-        </span>
-        <span className="text-[10px] tabular-nums text-muted shrink-0">
-          {session.started_at ? timeAgo(session.started_at) : ''}
-        </span>
-      </div>
-      <div className="mb-1.5 flex items-center gap-2 text-[10px] text-neutral-500">
-        {session.model && (
-          <span
-            className="rounded px-1.5 py-0.5 font-mono text-[9px] font-medium"
-            style={{
-              background: alpha(palette.accent, 0.1),
-              color: palette.accent,
-            }}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold leading-snug text-ink">
+            {item.title}
+          </div>
+          <p
+            className={cn(
+              'mt-1 text-xs leading-relaxed text-[var(--theme-muted)]',
+              dense ? 'line-clamp-1' : 'line-clamp-2',
+            )}
           >
-            {session.model}
-          </span>
-        )}
-        <span>{msgs} msgs</span>
-        {tools > 0 && <span>{tools} tools</span>}
-        {tokens > 0 && <span>{formatNumber(tokens)} tok</span>}
+            {item.nextAction || item.outcome}
+          </p>
+        </div>
+        <Badge tone={priorityTone(item.priority)}>{item.priority}</Badge>
       </div>
-      <div className="h-[3px] rounded-full w-full bg-[var(--theme-border)] overflow-hidden">
-        <div
-          className="h-full rounded-full transition-all duration-700"
-          style={{
-            width: `${barWidth}%`,
-            background: `linear-gradient(90deg, ${palette.accent}, ${palette.accentSecondary})`,
-          }}
-        />
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <Badge tone={statusTone(item.status)}>{item.status}</Badge>
+        <Badge tone={riskTone}>{item.riskLevel} risk</Badge>
+        <Badge>{item.owner}</Badge>
       </div>
     </button>
   )
 }
 
-// ── Main Dashboard ───────────────────────────────────────────────
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card2)] p-4 text-sm text-[var(--theme-muted)]">
+      {text}
+    </div>
+  )
+}
 
 export function DashboardScreen() {
   const navigate = useNavigate()
-  const skillsAvailable = useFeatureAvailable('skills')
-  const sessionsQuery = useQuery({
-    // Use a dedicated query key — NOT chatQueryKeys.sessions — to avoid
-    // cache collisions with the chat sidebar which fetches fewer sessions
-    // and overwrites the dashboard's larger dataset.
-    // Also use the workspace proxy (/api/sessions) rather than the server-side
-    // listSessions() — the latter calls the gateway via CLAUDE_API which is
-    // only available server-side and returns nothing when called from the client.
-    // Do not gate this direct proof behind /api/gateway-status. That probe can
-    // be stale/loading while /api/sessions already works, which made the
-    // dashboard show a bogus “Enhanced API required” warning even though
-    // sessions were healthy.
-    queryKey: ['dashboard', 'sessions'],
-    queryFn: async () => {
-      const res = await fetch('/api/sessions?limit=200&offset=0')
-      if (!res.ok) {
-        throw new Error(`Sessions API returned HTTP ${res.status}`)
-      }
-      const data = await res.json()
-      return normalizeDashboardSessionsPayload(data)
-    },
+  const queryClient = useQueryClient()
+
+  const queueQuery = useQuery({
+    queryKey: ['command-center', 'executive-queue'],
+    queryFn: () => fetchJson<ExecutiveQueueResponse>('/api/executive-queue'),
+    staleTime: 10_000,
+    refetchInterval: 20_000,
+  })
+
+  const gatewayQuery = useQuery({
+    queryKey: ['command-center', 'gateway-status'],
+    queryFn: () => fetchJson<GatewayStatusResponse>('/api/gateway-status'),
     staleTime: 10_000,
     refetchInterval: 30_000,
-    retry: 1,
   })
 
-  const sessionsResult = sessionsQuery.data
+  const jobsQuery = useQuery({
+    queryKey: ['command-center', 'jobs'],
+    queryFn: () => fetchJson<JobsResponse>('/api/hermes-jobs'),
+    staleTime: 20_000,
+    refetchInterval: 60_000,
+  })
 
-  // Raw rows from the sessions endpoint. Used both for hero stats
-  // (count/tokens) and for the SessionsIntelligenceCard below.
-  const rawSessions = sessionsResult?.sessions ?? []
-  const sessionsUnavailable = Boolean(sessionsResult?.unavailable)
-  const sessionsUnavailableMessage =
-    sessionsResult?.message ?? getUnavailableReason('sessions')
+  const sessionsQuery = useQuery({
+    queryKey: ['command-center', 'sessions'],
+    queryFn: () =>
+      fetchJson<SessionsResponse>('/api/sessions?limit=8&offset=0'),
+    staleTime: 20_000,
+    refetchInterval: 60_000,
+  })
 
-  // Adapter shape kept for the legacy fallbacks that still reference
-  // ClaudeSession (HeroMetrics fallback path, etc.).
-  const sessions = useMemo(
-    () =>
-      rawSessions.map((s) => ({
-        id: (s.key ?? s.id) as string,
-        started_at: s.startedAt ? (s.startedAt as number) / 1000 : undefined,
-        message_count: (s.message_count as number | undefined) ?? 0,
-        tool_call_count: (s.tool_call_count as number | undefined) ?? 0,
-        input_tokens: (s.tokenCount as number | undefined) ?? 0,
-        output_tokens: 0,
-      })) as Array<ClaudeSession>,
-    [rawSessions],
-  )
-
-  // Enriched rows for the Sessions Intelligence card. Keeps the rich
-  // fields (`derivedTitle`, `kind`, `status`, `source`, `updatedAt`,
-  // etc.) the legacy adapter dropped.
-  const sessionRows: Array<SessionRowData> = useMemo(
-    () =>
-      [...rawSessions]
-        .sort(
-          (a, b) =>
-            ((b.updatedAt as number | undefined) ??
-              (b.startedAt as number | undefined) ??
-              0) -
-            ((a.updatedAt as number | undefined) ??
-              (a.startedAt as number | undefined) ??
-              0),
-        )
-        .slice(0, 12)
-        .map((s) => ({
-          key: String(s.key ?? s.id ?? ''),
-          title:
-            (s.derivedTitle as string | undefined) ||
-            (s.title as string | undefined) ||
-            (s.preview as string | undefined) ||
-            String(s.key ?? ''),
-          kind: String(s.kind ?? 'chat'),
-          status: String(s.status ?? ''),
-          source: (s.source as string | undefined) ?? null,
-          model: (s.model as string | undefined) ?? null,
-          messageCount:
-            ((s.messageCount as number | undefined) ??
-              (s.message_count as number | undefined) ??
-              0),
-          toolCallCount:
-            ((s.toolCallCount as number | undefined) ??
-              (s.tool_call_count as number | undefined) ??
-              0),
-          tokenCount:
-            ((s.tokenCount as number | undefined) ??
-              (s.totalTokens as number | undefined) ??
-              0),
-          startedAt: (s.startedAt as number | undefined) ?? null,
-          updatedAt: (s.updatedAt as number | undefined) ?? null,
-        })),
-    [rawSessions],
-  )
-
-  const stats = useMemo(() => {
-    let totalMessages = 0,
-      totalToolCalls = 0,
-      totalTokens = 0
-    for (const s of sessions) {
-      totalMessages += s.message_count ?? 0
-      totalToolCalls += s.tool_call_count ?? 0
-      totalTokens += (s.input_tokens ?? 0) + (s.output_tokens ?? 0)
-    }
-    return {
-      totalSessions: sessions.length,
-      totalMessages,
-      totalToolCalls,
-      totalTokens,
-    }
-  }, [sessions])
-
-  const recentSessions = useMemo(
-    () =>
-      [...sessions]
-        .sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0))
-        .slice(0, 6),
-    [sessions],
-  )
-
-  const maxTokens = useMemo(() => {
-    let max = 0
-    for (const s of recentSessions) {
-      const t = (s.input_tokens ?? 0) + (s.output_tokens ?? 0)
-      if (t > max) max = t
-    }
-    return max
-  }, [recentSessions])
-
-  // Skills count for the SkillsUsageCard sub-text. Cheap query, used
-  // only for the "X of Y used" microcopy.
-  const skillsCountQuery = useQuery({
-    queryKey: ['dashboard', 'skills-count'],
-    queryFn: async () => {
-      const res = await fetch(
-        '/api/skills?tab=installed&limit=200&summary=search',
-      )
-      if (!res.ok) return 0
-      const data = (await res.json()) as {
-        skills?: Array<unknown>
-      }
-      return data.skills?.length ?? 0
-    },
+  const sourceCoverageQuery = useQuery({
+    queryKey: ['command-center', 'source-coverage'],
+    queryFn: () => fetchJson<SourceCoverageResponse>('/api/source-coverage'),
     staleTime: 60_000,
-    enabled: skillsAvailable,
+    refetchInterval: 120_000,
   })
-  const skillsInstalled = skillsCountQuery.data ?? 0
 
-  // Per-user widget visibility + edit-mode state (localStorage backed).
-  const layout = useDashboardLayout()
-
-  // Period selector for analytics; persists across navigation via
-  // localStorage so refreshes don't reset the operator's preference.
-  const [period, setPeriod] = useState<AnalyticsPeriod>(() => {
-    if (typeof window === 'undefined') return 30
-    const stored = window.localStorage.getItem('dashboard.analyticsPeriod')
-    const n = Number(stored)
-    if (n === 7 || n === 14 || n === 30) return n
-    return 30
-  })
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(
-        'dashboard.analyticsPeriod',
-        String(period),
+  const executionMutation = useMutation({
+    mutationFn: ({
+      id,
+      mode,
+      note,
+    }: {
+      id: string
+      mode: QueueExecutionMode
+      note: string
+    }) => executeQueueItem(id, mode, note),
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['command-center', 'executive-queue'],
+      })
+      const mode = result.execution?.mode
+      if (mode === 'explain_more') {
+        toast('Explanation requested. Watch Telegram for the answer.', {
+          type: 'success',
+        })
+        return
+      }
+      toast(
+        result.sessionKey
+          ? `Execution dispatched to ${result.sessionKey}.`
+          : 'Execution dispatched.',
+        { type: 'success' },
       )
-    }
-  }, [period])
-
-  // Aggregate dashboard overview — surfaces the data the native
-  // Hermes dashboard exposes (status, platforms, cron, achievements,
-  // model info, analytics) in a single round trip with per-section
-  // graceful fallbacks. Each card renders only when its slice resolves.
-  const overviewQuery = useQuery<DashboardOverview>({
-    queryKey: ['dashboard', 'overview', period],
-    queryFn: async () => {
-      // achievements=5 (instead of 3) gives the Achievements rail
-      // card enough vertical mass to fill the gap below Top Models.
-      const res = await fetch(
-        `/api/dashboard/overview?days=${period}&achievements=5`,
-      )
-      if (!res.ok) throw new Error(`overview ${res.status}`)
-      return (await res.json()) as DashboardOverview
     },
-    staleTime: 5_000,
-    refetchInterval: 30_000,
+    onError: (error) => {
+      toast(
+        error instanceof Error ? error.message : 'Execution dispatch failed.',
+        { type: 'error' },
+      )
+    },
   })
-  const overview = overviewQuery.data ?? null
 
-  const palette = useDashboardPalette()
-
-  const updateSettings = useSettingsStore((state) => state.updateSettings)
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof document === 'undefined') return true
-    const dt = document.documentElement.getAttribute('data-theme') || ''
-    return !dt.endsWith('-light')
+  const holdMutation = useMutation({
+    mutationFn: ({ id, note }: { id: string; note: string }) =>
+      holdQueueItem(id, note),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['command-center', 'executive-queue'],
+      })
+      toast('Queue item held.', { type: 'success' })
+    },
+    onError: (error) => {
+      toast(error instanceof Error ? error.message : 'Hold failed.', {
+        type: 'error',
+      })
+    },
   })
+
+  const items = queueQuery.data?.items ?? []
+  const startHereState = useMemo(() => getStartHereQueueState(items), [items])
+  const {
+    activeItems,
+    criticalExceptionItems,
+    approvalItems,
+    blockedItems,
+    blitzItems,
+    safeDraftOnlyItem,
+    inProgressItems,
+    primaryItem,
+    primaryMode,
+    primaryCta,
+    topLine: queueTopLine,
+  } = startHereState
+  const laneCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const item of activeItems)
+      counts.set(item.domain, (counts.get(item.domain) ?? 0) + 1)
+    return [...counts.entries()].sort((a, b) => {
+      const aIndex = DOMAIN_ORDER.indexOf(a[0])
+      const bIndex = DOMAIN_ORDER.indexOf(b[0])
+      return (
+        (aIndex === -1 ? 99 : aIndex) - (bIndex === -1 ? 99 : bIndex) ||
+        b[1] - a[1]
+      )
+    })
+  }, [activeItems])
+  const jobs = jobsQuery.data?.jobs ?? jobsQuery.data?.items ?? []
+  const sourceCoverage = sourceCoverageQuery.data?.snapshot?.sources ?? {}
+  const aiOpsIntakeQueue = sourceCoverage.ai_ops_intake_queue
+  const aiOpsIntakeSummary = aiOpsIntakeQueue?.summary
+  const aiOpsIntakeItems = aiOpsIntakeQueue?.topItems ?? []
+  const readerCoverage = sourceCoverage.reader_readwise
+  const readerActionSummary = readerCoverage?.reader_action_summary
+  const readerActions = readerCoverage?.reader_actions
+  const readerReadyActions = readerActions?.readyForAiLearning ?? []
+  const readerFreshActions = readerActions?.freshReady ?? []
+  const readerXWatchlistCandidates = readerActions?.xWatchlistCandidates ?? []
+  const readerTranscriptFailures = readerActions?.transcriptFailures ?? []
+  const transcriptCoverage = sourceCoverage.ai_learning_transcripts
+  const granolaCoverage = sourceCoverage.granola
+  const granolaActionSummary = granolaCoverage?.action_summary
+  const granolaActions = granolaCoverage?.granola_actions
+  const granolaNeedsDecision = granolaActions?.needsTimDecision ?? []
+  const granolaFollowUps = granolaActions?.followUpCandidates ?? []
+  const granolaOwnershipClarifications =
+    granolaActions?.ownershipClarifications ?? []
+  const granolaAssignedActions = granolaActions?.assignedActionCandidates ?? []
+  const motionCoverage = sourceCoverage.motion
+  const motionActionSummary = motionCoverage?.action_summary
+  const motionActions = motionCoverage?.motion_actions
+  const motionSafeWriteActions = motionActions?.safeWriteActions ?? []
+  const motionApprovalRequiredActions = motionActions?.approvalRequired ?? []
+  const motionSuppressedItems = motionActions?.suppressedItems ?? []
+  const sourceCoverageGeneratedAt =
+    sourceCoverageQuery.data?.snapshot?.generated_at
+  const sourceCoverageProblems = [
+    readerCoverage && !readerCoverage.available ? 'Reader unavailable' : null,
+    readerActionSummary?.readyForAiLearningCount
+      ? 'Reader actions ready'
+      : null,
+    readerActionSummary?.transcriptFailureCount
+      ? 'Reader transcript gaps'
+      : null,
+    transcriptCoverage?.tim_notice_required ? 'Transcript gaps' : null,
+    granolaCoverage && !granolaCoverage.available
+      ? 'Granola unavailable'
+      : null,
+    granolaActionSummary?.needsTimDecisionCount
+      ? 'Granola Tim decisions'
+      : null,
+    granolaActionSummary?.followUpCandidateCount ? 'Granola follow-ups' : null,
+    motionCoverage && !motionCoverage.available ? 'Motion unavailable' : null,
+    motionActionSummary?.safeWriteCount ? 'Motion write actions ready' : null,
+    motionActionSummary?.approvalRequiredCount
+      ? 'Motion ownership review'
+      : null,
+    aiOpsIntakeSummary?.needsTimDecisionCount
+      ? 'Unified queue Tim decisions'
+      : null,
+    aiOpsIntakeSummary?.recoveryRequiredCount
+      ? 'Unified queue recovery work'
+      : null,
+    aiOpsIntakeSummary?.approvalRequiredCount
+      ? 'Unified queue approvals'
+      : null,
+  ].filter(Boolean)
+  const failedJobs = jobs.filter((job) =>
+    String(job.last_status ?? job.lastStatus ?? job.status ?? '')
+      .toLowerCase()
+      .includes('fail'),
+  )
+  const enabledJobs = jobs.filter((job) => job.enabled !== false)
+  const recentSessions = (sessionsQuery.data?.sessions ?? [])
+    .slice()
+    .sort((a, b) => getSessionTime(b) - getSessionTime(a))
+    .slice(0, 5)
+
+  const gatewayOnline = Boolean(gatewayQuery.data?.gateway?.available)
+  const dashboardOnline = Boolean(gatewayQuery.data?.dashboard?.available)
+  const gatewayStatusLoaded = Boolean(gatewayQuery.data)
+  const systemExceptions = [
+    ...(gatewayStatusLoaded && !gatewayOnline
+      ? [
+          {
+            id: 'gateway-offline',
+            title: 'Hermes gateway offline',
+            detail:
+              'Telegram command surface and Workspace backend access may be impaired.',
+            target: '/dashboard' as const,
+          },
+        ]
+      : []),
+    ...(gatewayStatusLoaded && !dashboardOnline
+      ? [
+          {
+            id: 'dashboard-limited',
+            title: 'Dashboard API limited',
+            detail:
+              'Sessions, skills, config, and Command Center context may be incomplete.',
+            target: '/dashboard' as const,
+          },
+        ]
+      : []),
+    ...failedJobs.slice(0, 5).map((job, index) => ({
+      id: job.id ?? `failed-job-${index}`,
+      title: job.name ?? job.title ?? job.id ?? 'Unnamed failed job',
+      detail:
+        'Scheduled work reported a failure. Inspect before trusting the workflow.',
+      target: '/jobs' as const,
+    })),
+  ]
+  const criticalExceptionCount =
+    criticalExceptionItems.length + systemExceptions.length
+  const needsDecisionCount = approvalItems.length
+  const needsUnblockCount = blockedItems.length
+  const activeCount = activeItems.length
+
+  const topLine =
+    !primaryItem && systemExceptions.length
+      ? `${systemExceptions.length} system exception${systemExceptions.length === 1 ? '' : 's'} need repair before the operating picture is trustworthy.`
+      : queueTopLine
+
+  const mutationPending = executionMutation.isPending || holdMutation.isPending
+  const canRunPrimarySafeDraft =
+    primaryMode === 'Blitz' &&
+    Boolean(primaryItem) &&
+    safeDraftOnlyItem?.id === primaryItem?.id
+  const runPrimaryItem = (mode: QueueExecutionMode) => {
+    if (!primaryItem || mutationPending) return
+    if (mode !== 'explain_more' && !canRunPrimarySafeDraft) {
+      toast('This item needs Tim approval before Workspace can run it.', {
+        type: 'error',
+      })
+      return
+    }
+    const defaultNote =
+      mode === 'explain_more'
+        ? 'Explain what this is before I approve.'
+        : 'Draft only. No external side effects.'
+    const promptLabel =
+      mode === 'explain_more'
+        ? 'Optional question for Executive to answer in Telegram:'
+        : 'Optional execution note for Executive:'
+    const note = window.prompt(promptLabel, defaultNote)
+    if (note === null) return
+    executionMutation.mutate({ id: primaryItem.id, mode, note })
+  }
+  const holdPrimaryItem = () => {
+    if (!primaryItem || mutationPending) return
+    const note = window.prompt(
+      'Why should this be held?',
+      primaryItem.blockedReason || 'Held by Tim from Command Center.',
+    )
+    if (!note?.trim()) return
+    holdMutation.mutate({ id: primaryItem.id, note })
+  }
 
   return (
-    <div className="min-h-full">
-      {/* Floating mobile nav: hamburger left, theme toggle right */}
-      <div className="md:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-2 h-12" style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}>
+    <div className="min-h-full bg-surface text-ink">
+      <div
+        className="md:hidden fixed top-0 left-0 right-0 z-50 flex h-12 items-center justify-between px-2"
+        style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+      >
         <button
           type="button"
           aria-label="Open navigation menu"
           onClick={openHamburgerMenu}
-          className="flex items-center justify-center w-11 h-11 rounded-xl active:bg-white/10 transition-colors touch-manipulation"
+          className="flex h-11 w-11 items-center justify-center rounded-xl transition active:bg-white/10"
         >
-          <svg width="20" height="16" viewBox="0 0 20 16" fill="none" className="opacity-70" style={{ color: 'var(--color-ink, #111)' }}>
-            <path d="M1 1.5H19M1 8H19M1 14.5H13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          <svg
+            width="20"
+            height="16"
+            viewBox="0 0 20 16"
+            fill="none"
+            className="opacity-70"
+            style={{ color: 'var(--color-ink, #111)' }}
+          >
+            <path
+              d="M1 1.5H19M1 8H19M1 14.5H13"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
           </svg>
         </button>
-        <button
-          type="button"
-          aria-label="Toggle theme"
-          onClick={() => {
-            const LIGHT_DARK_PAIRS: Record<string, string> = {
-              'claude-nous': 'claude-nous-light',
-              'claude-nous-light': 'claude-nous',
-              'claude-official': 'claude-official-light',
-              'claude-official-light': 'claude-official',
-              'claude-classic': 'claude-classic-light',
-              'claude-classic-light': 'claude-classic',
-              'claude-slate': 'claude-slate-light',
-              'claude-slate-light': 'claude-slate',
-            }
-            const cur = document.documentElement.getAttribute('data-theme') || 'claude-official'
-            const nextDataTheme = LIGHT_DARK_PAIRS[cur] || (isDark ? 'claude-official-light' : 'claude-official')
-            import('@/lib/theme').then(({ setTheme }) => { setTheme(nextDataTheme as any) })
-            const nextMode = nextDataTheme.endsWith('-light') ? 'light' : 'dark'
-            applyTheme(nextMode)
-            updateSettings({ theme: nextMode })
-            setIsDark(nextMode === 'dark')
-          }}
-          className="flex items-center justify-center w-11 h-11 rounded-xl active:bg-white/10 transition-colors touch-manipulation"
-          style={{ color: 'var(--theme-muted)' }}
-        >
-          <HugeiconsIcon icon={isDark ? Sun02Icon : Moon02Icon} size={20} strokeWidth={1.5} />
-        </button>
+        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+          Command Center
+        </span>
+        <div className="h-11 w-11" />
       </div>
-      <div className="px-4 pt-14 md:pt-4 py-4 md:px-8 md:py-6 lg:px-10 space-y-5 pb-28">
-      {/* ── Header: brand lockup left, action cluster right.
-           Iteration 010: dropped redundant "Dashboard" eyebrow (the
-           page IS the dashboard); promoted "Hermes Workspace" to
-           the primary heading at a larger weight. Logo bumped from
-           36px → 44px and gets a soft accent glow + ring so the
-           lockup commands the left side instead of feeling like
-           filler before the action cluster. Kept anchored left
-           (not centered) on purpose: ops dashboards put brand left
-           + actions right because that's the spatial hierarchy
-           operators expect (Linear, Vercel, Datadog all do this). */}
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex items-center gap-3">
-          <span
-            className="relative inline-flex shrink-0 items-center justify-center rounded-xl border"
-            style={{
-              width: 44,
-              height: 44,
-              borderColor:
-                'color-mix(in srgb, var(--theme-accent) 35%, var(--theme-border))',
-              background:
-                'linear-gradient(135deg, color-mix(in srgb, var(--theme-accent) 14%, var(--theme-card)), var(--theme-card))',
-              boxShadow:
-                '0 0 0 4px color-mix(in srgb, var(--theme-accent) 6%, transparent)',
-            }}
-          >
-            <img
-              src="/claude-avatar.webp"
-              alt="Hermes Workspace logo"
-              className="size-8 rounded-md"
-              style={{ background: 'transparent' }}
-            />
-          </span>
-          {/* Iter 011: dropped the 'Operator console · vX.Y.Z'
-              eyebrow. The gateway version is already on the OpsStrip
-              (♦ GATEWAY V0.12.0), so the eyebrow was duplicating it.
-              Single bold lockup feels cleaner; vertical centering on
-              the lockup matches the height of the action cluster on
-              the right so they don't visually drift. */}
-          <div className="flex flex-col justify-center">
-            <h1
-              className="text-2xl font-bold tracking-tight"
-              style={{
-                color: 'var(--theme-text)',
-                letterSpacing: '-0.015em',
-                lineHeight: 1.1,
-              }}
+
+      <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 px-4 pb-28 pt-16 md:px-8 md:py-6 lg:px-10">
+        <header className="overflow-hidden rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 md:p-6">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-4xl">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--theme-accent)]">
+                Executive Command Center
+              </div>
+              <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink md:text-5xl">
+                What does Tim need to know, decide, or unblock right now?
+              </h1>
+              <p className="mt-4 text-base leading-relaxed text-[var(--theme-muted)] md:text-lg">
+                {topLine}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <ActionButton
+                primary
+                onClick={() => navigate({ to: '/executive-queue' })}
+              >
+                Review Queue
+              </ActionButton>
+              <ActionButton onClick={() => navigate({ to: '/jobs' })}>
+                Check Jobs
+              </ActionButton>
+              <ActionButton
+                onClick={() =>
+                  navigate({
+                    to: '/chat/$sessionKey',
+                    params: { sessionKey: 'new' },
+                  })
+                }
+              >
+                Start Chat
+              </ActionButton>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          <div className="rounded-2xl border border-red-400/30 bg-red-400/10 p-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-red-200">
+              Critical exceptions
+            </div>
+            <div className="mt-2 text-3xl font-semibold text-ink">
+              {criticalExceptionCount}
+            </div>
+            <p className="mt-1 text-xs text-[var(--theme-muted)]">
+              Broken access or system failure
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              Needs decision
+            </div>
+            <div className="mt-2 text-3xl font-semibold text-ink">
+              {needsDecisionCount}
+            </div>
+            <p className="mt-1 text-xs text-[var(--theme-muted)]">
+              Approval-gated items
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              Blocked
+            </div>
+            <div className="mt-2 text-3xl font-semibold text-ink">
+              {needsUnblockCount}
+            </div>
+            <p className="mt-1 text-xs text-[var(--theme-muted)]">
+              Waiting on a constraint
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              Blitz-ready
+            </div>
+            <div className="mt-2 text-3xl font-semibold text-ink">
+              {blitzItems.length}
+            </div>
+            <p className="mt-1 text-xs text-[var(--theme-muted)]">
+              Ready to pick up now
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+              System
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              <Badge tone={gatewayOnline ? 'good' : 'danger'}>
+                Gateway {gatewayOnline ? 'online' : 'offline'}
+              </Badge>
+              <Badge tone={dashboardOnline ? 'good' : 'warn'}>
+                Dashboard {dashboardOnline ? 'online' : 'limited'}
+              </Badge>
+              <Badge tone={failedJobs.length ? 'danger' : 'good'}>
+                {failedJobs.length} failed jobs
+              </Badge>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 rounded-3xl border border-[var(--theme-accent-border)] bg-[var(--theme-accent)]/10 p-4 md:grid-cols-[1fr_auto] md:items-center md:p-5">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge
+                tone={
+                  primaryMode === 'Repair'
+                    ? 'danger'
+                    : primaryMode === 'Decide'
+                      ? 'warn'
+                      : primaryMode === 'Unblock'
+                        ? 'danger'
+                        : primaryMode === 'Blitz'
+                          ? 'accent'
+                          : 'neutral'
+                }
+              >
+                Start here: {primaryMode}
+              </Badge>
+              {primaryItem ? (
+                <Badge tone={priorityTone(primaryItem.priority)}>
+                  {primaryItem.priority}
+                </Badge>
+              ) : null}
+              {primaryItem ? <Badge>{primaryItem.domain}</Badge> : null}
+            </div>
+            <h2 className="mt-3 text-xl font-semibold text-ink md:text-2xl">
+              {primaryItem
+                ? primaryItem.title
+                : 'Load or create Executive Queue work'}
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-[var(--theme-muted)]">
+              {primaryItem
+                ? primaryItem.nextAction || primaryItem.outcome
+                : 'The Command Center is healthy, but it has no active work loaded. Check the queue source before assuming there is nothing to move.'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 md:justify-end">
+            {primaryItem ? (
+              <>
+                {canRunPrimarySafeDraft ? (
+                  <ActionButton
+                    primary
+                    disabled={mutationPending}
+                    onClick={() => runPrimaryItem('draft_only')}
+                  >
+                    {mutationPending ? 'Working…' : 'Run Safe Draft'}
+                  </ActionButton>
+                ) : null}
+                <ActionButton
+                  disabled={mutationPending}
+                  onClick={() => runPrimaryItem('explain_more')}
+                >
+                  Explain More
+                </ActionButton>
+                <ActionButton
+                  disabled={mutationPending || !canRunPrimarySafeDraft}
+                  onClick={() => runPrimaryItem('draft_only')}
+                >
+                  Draft Only
+                </ActionButton>
+                <ActionButton
+                  disabled={mutationPending}
+                  onClick={holdPrimaryItem}
+                >
+                  Hold
+                </ActionButton>
+              </>
+            ) : null}
+            <ActionButton
+              disabled={mutationPending}
+              onClick={() => navigate({ to: '/executive-queue' })}
             >
-              Hermes Workspace
-            </h1>
+              {primaryCta}
+            </ActionButton>
+            <ActionButton
+              disabled={mutationPending}
+              onClick={() =>
+                navigate({
+                  to: '/chat/$sessionKey',
+                  params: { sessionKey: 'new' },
+                })
+              }
+            >
+              Ask Executive
+            </ActionButton>
           </div>
-        </div>
-        {/* Action row: hierarchy per Hermes Agent review.
-           New Chat is primary (full button + accent), Terminal +
-           Skills are secondary, Settings collapses to icon-only. */}
-        <div className="flex w-full flex-wrap items-center gap-2 lg:justify-end lg:max-w-xl">
-          <button
-            type="button"
-            onClick={() =>
-              navigate({
-                to: '/chat/$sessionKey',
-                params: { sessionKey: 'new' },
-              })
-            }
-            className="group relative inline-flex items-center gap-2 overflow-hidden rounded-lg px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.05em] transition-all hover:scale-[1.02] active:scale-[0.99] sm:px-3.5 sm:py-2 sm:text-sm"
-            style={{
-              background: `linear-gradient(135deg, ${palette.accent}, ${palette.accentSecondary})`,
-              color: 'var(--theme-on-accent, white)',
-              boxShadow: `0 6px 18px -8px ${palette.accent}aa, inset 0 1px 0 0 rgba(255,255,255,0.18)`,
-            }}
-          >
-            <span
-              aria-hidden
-              className="pointer-events-none absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100"
-              style={{
-                background:
-                  'linear-gradient(135deg, rgba(255,255,255,0.15), transparent 60%)',
-              }}
-            />
-            <HugeiconsIcon
-              icon={BubbleChatAddIcon}
-              size={16}
-              strokeWidth={1.8}
-            />
-            <span>New Chat</span>
-          </button>
-          <SecondaryAction
-            label="Terminal"
-            icon={ConsoleIcon}
-            onClick={() => navigate({ to: '/terminal' })}
-          />
-          <SecondaryAction
-            label="Skills"
-            icon={PuzzleIcon}
-            onClick={() => navigate({ to: '/skills' })}
-            disabled={!skillsAvailable}
-          />
-          {/* Edit toggle: enters "layout edit mode" where each widget
-              shows an X button and a banner appears for re-adding
-              hidden widgets. Persisted to localStorage. */}
-          <button
-            type="button"
-            aria-label={layout.editMode ? 'Done editing layout' : 'Edit layout'}
-            title={layout.editMode ? 'Done editing layout' : 'Edit layout'}
-            onClick={layout.toggleEdit}
-            className="inline-flex size-9 items-center justify-center rounded-lg border transition-all hover:scale-[1.05] hover:bg-[var(--theme-card)]/70"
-            style={{
-              borderColor: layout.editMode
-                ? 'var(--theme-accent)'
-                : 'var(--theme-border)',
-              background: layout.editMode
-                ? 'color-mix(in srgb, var(--theme-accent) 14%, transparent)'
-                : 'linear-gradient(135deg, color-mix(in srgb, var(--theme-card) 80%, transparent), transparent)',
-              color: layout.editMode
-                ? 'var(--theme-accent)'
-                : 'var(--theme-muted)',
-            }}
-          >
-            <HugeiconsIcon
-              icon={layout.editMode ? CheckmarkCircle02Icon : Edit02Icon}
-              size={15}
-              strokeWidth={1.7}
-            />
-          </button>
-          <button
-            type="button"
-            aria-label="Settings"
-            title="Settings"
-            onClick={() => navigate({ to: '/settings', search: {} })}
-            className="inline-flex size-9 items-center justify-center rounded-lg border transition-all hover:scale-[1.05] hover:bg-[var(--theme-card)]/70 hover:text-[var(--theme-text)]"
-            style={{
-              borderColor: 'var(--theme-border)',
-              color: 'var(--theme-muted)',
-              background:
-                'linear-gradient(135deg, color-mix(in srgb, var(--theme-card) 80%, transparent), transparent)',
-            }}
-          >
-            <HugeiconsIcon
-              icon={Settings02Icon}
-              size={15}
-              strokeWidth={1.7}
-            />
-          </button>
-        </div>
-      </div>
+        </section>
 
-      {/* ── Attention marquee ──
-           Iteration 008: lifted *out* of the OpsStrip into its own
-           dedicated row above it. Fixed Eric's 'feels cluttered'
-           concern by giving the ticker its own visual chamber
-           (warning gradient, separated border) so it doesn't blend
-           into the gateway/version/cron line below it. */}
-      {(overview?.incidents.length ?? 0) > 0 ? (
-        <AttentionMarquee overview={overview ?? null} />
-      ) : null}
-
-      {/* ── Ops strip (gateway + version drift + platforms + cron pulse). ── */}
-      <OpsStrip
-        status={overview?.status ?? null}
-        cron={overview?.cron ?? null}
-        kanban={overview?.kanban ?? null}
-        platforms={overview?.platforms ?? []}
-      />
-
-      {/* ── Hero Metrics: 3 analytics tiles + Active Model KPI in slot 4 ── */}
-      <HeroMetrics
-        analytics={overview?.analytics ?? null}
-        fallback={{
-          sessions: stats.totalSessions,
-          messages: stats.totalMessages,
-          toolCalls: stats.totalToolCalls,
-          tokens: stats.totalTokens,
-        }}
-        extraTile={
-          <ActiveModelKpi
-            modelInfo={overview?.modelInfo ?? null}
-            analytics={overview?.analytics ?? null}
-          />
-        }
-      />
-
-      {/* ── Edit-mode banner (only renders when toggled). ── */}
-      <EditModePanel layout={layout} />
-
-      {/* ── Analytics chart (left) + Top models / Provider mix / Cache
-           efficiency stacked on the right. The right-side stack now
-           occupies the full vertical of the chart so we don't get the
-           floating-card empty-space Eric flagged in iter 008. ── */}
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
-        {layout.isVisible('analytics_chart') ? (
-          <div className="lg:col-span-8">
-            <WidgetShell id="analytics_chart" layout={layout}>
-              <AnalyticsChartCard
-                analytics={overview?.analytics ?? null}
-                insights={overview?.insights ?? []}
-                period={period}
-                onPeriodChange={setPeriod}
-                loading={overviewQuery.isFetching}
+        <Panel
+          eyebrow="Critical"
+          title="Critical exceptions"
+          action={
+            <Badge tone={criticalExceptionCount ? 'danger' : 'good'}>
+              {criticalExceptionCount}
+            </Badge>
+          }
+        >
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {criticalExceptionCount === 0 ? (
+              <EmptyState text="No broken access or system-failure exceptions are elevated right now." />
+            ) : null}
+            {criticalExceptionItems.slice(0, 6).map((item) => (
+              <QueueRow
+                key={item.id}
+                item={item}
+                dense
+                onClick={() => navigate({ to: '/executive-queue' })}
               />
-            </WidgetShell>
+            ))}
+            {systemExceptions.map((exception) => (
+              <button
+                key={exception.id}
+                type="button"
+                onClick={() => navigate({ to: exception.target })}
+                className="w-full rounded-xl border border-red-400/25 bg-red-400/10 p-3 text-left transition hover:border-red-300/60"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold leading-snug text-red-100">
+                      {exception.title}
+                    </div>
+                    <p className="mt-1 text-xs leading-relaxed text-red-100/75">
+                      {exception.detail}
+                    </p>
+                  </div>
+                  <Badge tone="danger">Repair</Badge>
+                </div>
+              </button>
+            ))}
           </div>
-        ) : null}
-        {layout.isVisible('top_models') ||
-        layout.isVisible('provider_mix') ||
-        layout.isVisible('cache_efficiency') ||
-        layout.isVisible('velocity') ||
-        layout.isVisible('cost_ledger') ? (
-          <div
-            className={
-              layout.isVisible('analytics_chart')
-                ? 'flex flex-col gap-3 lg:col-span-4'
-                : 'flex flex-col gap-3 lg:col-span-12'
-            }
-          >
-            {layout.isVisible('top_models') ? (
-              <WidgetShell id="top_models" layout={layout}>
-                <TopModelsCard analytics={overview?.analytics ?? null} />
-              </WidgetShell>
-            ) : null}
-            {layout.isVisible('cache_efficiency') ? (
-              <WidgetShell id="cache_efficiency" layout={layout}>
-                <CacheEfficiencyCard
-                  analytics={overview?.analytics ?? null}
-                />
-              </WidgetShell>
-            ) : null}
-            {layout.isVisible('provider_mix') ? (
-              <WidgetShell id="provider_mix" layout={layout}>
-                <ProviderMixCard analytics={overview?.analytics ?? null} />
-              </WidgetShell>
-            ) : null}
-            {layout.isVisible('velocity') ? (
-              <WidgetShell id="velocity" layout={layout}>
-                <VelocityCard analytics={overview?.analytics ?? null} />
-              </WidgetShell>
-            ) : null}
-            {layout.isVisible('cost_ledger') ? (
-              <WidgetShell id="cost_ledger" layout={layout}>
-                <CostLedgerCard
-                  analytics={overview?.analytics ?? null}
-                />
-              </WidgetShell>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
+        </Panel>
 
-      {/* ── Primary content: Sessions Intelligence (replaces 14d Activity) + side rail ──
-           Iteration 006 layout per Eric:
-           - Attention now rides the OpsStrip marquee, not the rail.
-           - Achievements moved up to sit beside Top Models would push the chart out
-             of place; instead it now lives at the *top* of the side rail since the
-             rail itself is right of the chart, which produces the same visual order.
-           - Logs default off; still toggleable from edit mode for power users. */}
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
-        {/* Iter 013 main column order: Operator Tip first (compact),
-            then Sessions Intelligence (the bottom anchor that grows
-            to fill the column to match the side rail height), then
-            optional Logs Tail at the bottom for power users in edit
-            mode. The column itself is `min-h-full flex` so the
-            child Sessions card's `flex-1` actually expands. */}
-        <div className="flex min-h-full flex-col gap-3 lg:col-span-8">
-          {layout.isVisible('operator_tip') ? (
-            <WidgetShell id="operator_tip" layout={layout}>
-              <OperatorTipCard overview={overview ?? null} />
-            </WidgetShell>
-          ) : null}
-          {layout.isVisible('sessions_intelligence') ? (
-            <div className="flex min-h-0 flex-1 flex-col">
-              <WidgetShell id="sessions_intelligence" layout={layout}>
-                {sessionsQuery.isError || sessionsUnavailable ? (
-                  <UnavailableWidget
-                    title="Recent Sessions"
-                    description={
-                      sessionsQuery.isError
-                        ? getUnavailableReason('sessions')
-                        : sessionsUnavailableMessage
+        <Panel
+          eyebrow="Blitz"
+          title="Loaded queue: next work waiting for Tim"
+          action={
+            <Badge tone={blitzItems.length ? 'accent' : 'warn'}>
+              {blitzItems.length} ready
+            </Badge>
+          }
+        >
+          <div className="mb-3 flex flex-wrap gap-1.5">
+            {laneCounts.map(([domain, count]) => (
+              <Badge key={domain} tone="neutral">
+                {domain}: {count}
+              </Badge>
+            ))}
+          </div>
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {queueQuery.isLoading ? (
+              <EmptyState text="Loading the loaded queue…" />
+            ) : null}
+            {queueQuery.isError ? (
+              <EmptyState
+                text={
+                  queueQuery.error instanceof Error
+                    ? queueQuery.error.message
+                    : 'Executive Queue failed to load.'
+                }
+              />
+            ) : null}
+            {!queueQuery.isLoading &&
+            !queueQuery.isError &&
+            blitzItems.length === 0 ? (
+              <EmptyState text="No blitz-ready work is loaded. Check the queue source." />
+            ) : null}
+            {blitzItems.slice(0, 12).map((item) => (
+              <QueueRow
+                key={item.id}
+                item={item}
+                dense
+                onClick={() => navigate({ to: '/executive-queue' })}
+              />
+            ))}
+          </div>
+        </Panel>
+
+        <div className="grid gap-5 xl:grid-cols-[1.15fr_0.85fr]">
+          <div className="flex flex-col gap-5">
+            <Panel
+              eyebrow="Decide"
+              title="Items waiting on Tim"
+              action={
+                <Badge tone={needsDecisionCount ? 'warn' : 'good'}>
+                  {needsDecisionCount}
+                </Badge>
+              }
+            >
+              <div className="grid gap-3">
+                {queueQuery.isLoading ? (
+                  <EmptyState text="Loading Executive Queue…" />
+                ) : null}
+                {queueQuery.isError ? (
+                  <EmptyState
+                    text={
+                      queueQuery.error instanceof Error
+                        ? queueQuery.error.message
+                        : 'Executive Queue failed to load.'
                     }
                   />
-                ) : (
-                  <SessionsIntelligenceCard sessions={sessionRows} />
-                )}
-              </WidgetShell>
-            </div>
-          ) : null}
-          {layout.isVisible('logs_tail') ? (
-            <WidgetShell id="logs_tail" layout={layout}>
-              <LogsTailCard logs={overview?.logs ?? null} />
-            </WidgetShell>
-          ) : null}
-        </div>
-        {/* Side rail. Achievements is now first (sits beside Top Models
-            visually since the rail is right of the chart row + sessions),
-            then Skills, then the rhythm card. Mix & rhythm is the unique
-            chart in this column — keeping it.
-            `min-h-full` + the trailing `flex-1` rhythm card together
-            stretch the rail to match Sessions Intelligence height so
-            we don't get the dangling gap Eric flagged in iter 007. */}
-        <div className="flex min-h-full flex-col gap-3 lg:col-span-4">
-          <WidgetShell id="achievements" layout={layout}>
-            <AchievementsCard
-              achievements={overview?.achievements ?? null}
-            />
-          </WidgetShell>
-          <WidgetShell id="skills_usage" layout={layout}>
-            <SkillsUsageCard
-              usage={overview?.skillsUsage ?? null}
-              installedCount={skillsInstalled}
-              onOpen={() => navigate({ to: '/skills' })}
-            />
-          </WidgetShell>
-          {/* `flex-1` here pushes the rhythm card to consume any
-              remaining vertical space so the rail's bottom aligns
-              with Sessions Intelligence. The card itself uses
-              h-full + flex-1 to honor the stretch. */}
-          <div className="flex min-h-0 flex-1 flex-col">
-            <WidgetShell id="mix_rhythm" layout={layout}>
-              <TokenMixHourCard
-                analytics={overview?.analytics ?? null}
-                sessions={sessionRows}
-              />
-            </WidgetShell>
+                ) : null}
+                {!queueQuery.isLoading &&
+                !queueQuery.isError &&
+                approvalItems.length === 0 ? (
+                  <EmptyState text="No approval-gated item is waiting. Keep moving." />
+                ) : null}
+                {approvalItems.slice(0, 4).map((item) => (
+                  <QueueRow
+                    key={item.id}
+                    item={item}
+                    onClick={() => navigate({ to: '/executive-queue' })}
+                  />
+                ))}
+              </div>
+            </Panel>
+
+            <Panel
+              eyebrow="Unblock"
+              title="Blocked work"
+              action={
+                <Badge tone={needsUnblockCount ? 'danger' : 'good'}>
+                  {needsUnblockCount}
+                </Badge>
+              }
+            >
+              <div className="grid gap-3">
+                {blockedItems.length === 0 ? (
+                  <EmptyState text="Nothing is blocked in the Executive Queue." />
+                ) : null}
+                {blockedItems.slice(0, 3).map((item) => (
+                  <QueueRow
+                    key={item.id}
+                    item={item}
+                    onClick={() => navigate({ to: '/executive-queue' })}
+                  />
+                ))}
+              </div>
+            </Panel>
+          </div>
+
+          <div className="flex flex-col gap-5">
+            <Panel eyebrow="Know" title="Operating picture">
+              <div className="grid gap-3">
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Source coverage
+                    </span>
+                    <Badge
+                      tone={sourceCoverageProblems.length ? 'warn' : 'good'}
+                    >
+                      {sourceCoverageProblems.length
+                        ? `${sourceCoverageProblems.length} watch`
+                        : 'Covered'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Reader:{' '}
+                    {readerCoverage?.items_last_30_days_scanned ?? 'unknown'}{' '}
+                    items, {readerActionSummary?.readyForAiLearningCount ?? 0}{' '}
+                    ready. Transcripts:{' '}
+                    {transcriptCoverage?.acceptable_full_transcripts ?? 0}/
+                    {transcriptCoverage?.items_checked ?? 0} full. Granola:{' '}
+                    {granolaCoverage?.eligible_notes_parsed ??
+                      granolaCoverage?.recent_notes_36h_first_page ??
+                      'unknown'}{' '}
+                    parsed, {granolaActionSummary?.followUpCandidateCount ?? 0}{' '}
+                    follow-ups. Motion:{' '}
+                    {motionCoverage?.task_count ?? 'unknown'} tasks,{' '}
+                    {motionCoverage?.tim_owned_count ?? 0} Tim-owned,{' '}
+                    {motionActionSummary?.safeWriteCount ?? 0} safe writes
+                    ready.
+                  </p>
+                  {sourceCoverageGeneratedAt ? (
+                    <p className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                      Snapshot: {formatTimestamp(sourceCoverageGeneratedAt)}
+                    </p>
+                  ) : null}
+                  {sourceCoverageProblems.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {sourceCoverageProblems.map((problem) => (
+                        <Badge key={String(problem)} tone="warn">
+                          {problem}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-accent-border)] bg-[var(--theme-accent)]/10 p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Unified AI Ops Intake Queue
+                    </span>
+                    <Badge
+                      tone={
+                        aiOpsIntakeSummary?.needsTimDecisionCount
+                          ? 'warn'
+                          : aiOpsIntakeSummary?.recoveryRequiredCount
+                            ? 'danger'
+                            : aiOpsIntakeSummary?.safeAgentWorkCount
+                              ? 'accent'
+                              : 'good'
+                      }
+                    >
+                      {aiOpsIntakeSummary?.totalItemCount ?? 0} items
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Tim decisions:{' '}
+                    {aiOpsIntakeSummary?.needsTimDecisionCount ?? 0}. Safe agent
+                    work: {aiOpsIntakeSummary?.safeAgentWorkCount ?? 0}.
+                    Recoveries: {aiOpsIntakeSummary?.recoveryRequiredCount ?? 0}
+                    . Owner checks: {aiOpsIntakeSummary?.reviewOwnerCount ?? 0}.
+                    Learning intake:{' '}
+                    {aiOpsIntakeSummary?.learnFromThisCount ?? 0}.
+                  </p>
+                  {aiOpsIntakeItems.length ? (
+                    <div className="mt-3 grid gap-2">
+                      {aiOpsIntakeItems.slice(0, 5).map((queueItem) => (
+                        <div
+                          key={queueItem.id ?? queueItem.title}
+                          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="line-clamp-1 text-xs font-semibold text-ink">
+                                {queueItem.title ?? 'AI Ops intake item'}
+                              </div>
+                              <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-[var(--theme-muted)]">
+                                {queueItem.nextAction ?? queueItem.detail}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 flex-col items-end gap-1">
+                              <Badge
+                                tone={priorityTone(queueItem.priority ?? 'P3')}
+                              >
+                                {queueItem.priority ?? 'P3'}
+                              </Badge>
+                              <Badge tone="neutral">
+                                {queueItem.source ?? 'Source'}
+                              </Badge>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState text="No unified intake items are loaded. Re-run the AI Ops intake queue script after source scans." />
+                  )}
+                  <p className="mt-2 text-[11px] text-[var(--theme-muted)]">
+                    Read-only. Sending, spending, calendar commitments, people
+                    decisions, Motion writes, and subscriptions stay
+                    approval-gated.
+                  </p>
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Reader action layer
+                    </span>
+                    <Badge
+                      tone={
+                        readerTranscriptFailures.length
+                          ? 'warn'
+                          : readerReadyActions.length
+                            ? 'accent'
+                            : 'good'
+                      }
+                    >
+                      {readerReadyActions.length
+                        ? `${readerReadyActions.length} ready`
+                        : 'Clear'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Scanned:{' '}
+                    {readerCoverage?.items_last_30_days_scanned ?? 'unknown'}.
+                    AI-relevant:{' '}
+                    {readerCoverage?.estimated_ai_relevant_items ?? 0}. Fresh:{' '}
+                    {readerActionSummary?.freshReadyCount ?? 0}. X watchlist:{' '}
+                    {readerActionSummary?.xWatchlistCandidateCount ?? 0}.
+                    Transcript failures:{' '}
+                    {readerActionSummary?.transcriptFailureCount ?? 0}.
+                  </p>
+                  {readerReadyActions.length ? (
+                    <div className="mt-3 grid gap-2">
+                      {readerReadyActions.slice(0, 3).map((action) => (
+                        <div
+                          key={action.source_url ?? action.title}
+                          className="rounded-lg border border-[var(--theme-accent-border)] bg-[var(--theme-accent)]/10 px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="line-clamp-1 text-xs font-semibold text-ink">
+                                {action.title ?? 'Untitled Reader item'}
+                              </div>
+                              <p className="mt-1 text-[11px] leading-relaxed text-[var(--theme-muted)]">
+                                {action.reason ??
+                                  'Ready for AI Learning filter.'}
+                              </p>
+                            </div>
+                            <Badge tone="accent">
+                              {action.contentType ?? 'Reader'}
+                            </Badge>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                  {readerTranscriptFailures.length ? (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {readerTranscriptFailures.slice(0, 4).map((failure) => (
+                        <Badge
+                          key={failure.source_url ?? failure.title}
+                          tone="warn"
+                        >
+                          Transcript: {failure.title ?? 'Reader item'}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                  {readerXWatchlistCandidates.length ? (
+                    <p className="mt-2 text-[11px] text-[var(--theme-muted)]">
+                      {readerXWatchlistCandidates.length} X accounts have enough
+                      repeated saves to consider for monitoring. Verify claims
+                      before acting.
+                    </p>
+                  ) : null}
+                  {readerFreshActions.length ? (
+                    <p className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                      {readerFreshActions.length} fresh items are ready from the
+                      last 7 days.
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Granola action layer
+                    </span>
+                    <Badge
+                      tone={
+                        granolaNeedsDecision.length
+                          ? 'warn'
+                          : granolaFollowUps.length
+                            ? 'accent'
+                            : 'good'
+                      }
+                    >
+                      {granolaNeedsDecision.length
+                        ? `${granolaNeedsDecision.length} decision`
+                        : granolaFollowUps.length
+                          ? `${granolaFollowUps.length} follow-up`
+                          : 'Clear'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Scanned: {granolaCoverage?.recent_notes_scanned ?? 0}.
+                    Parsed: {granolaCoverage?.eligible_notes_parsed ?? 0}.
+                    Skipped sensitive:{' '}
+                    {granolaCoverage?.skipped_confidential_or_sensitive ?? 0}.
+                    Candidates:{' '}
+                    {granolaActionSummary?.actionCandidateCount ?? 0}. Ownership
+                    checks:{' '}
+                    {granolaActionSummary?.ownershipClarificationCount ?? 0}.
+                  </p>
+                  {granolaNeedsDecision.length ? (
+                    <div className="mt-3 grid gap-2">
+                      {granolaNeedsDecision.slice(0, 3).map((action) => (
+                        <div
+                          key={`${action.noteId}-${action.text}`}
+                          className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="line-clamp-1 text-xs font-semibold text-ink">
+                                {action.text ?? 'Granola decision candidate'}
+                              </div>
+                              <p className="mt-1 text-[11px] leading-relaxed text-[var(--theme-muted)]">
+                                {action.noteTitle ?? 'Meeting note'}
+                              </p>
+                            </div>
+                            <Badge tone="warn">Review</Badge>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                  {granolaFollowUps.length ? (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {granolaFollowUps.slice(0, 4).map((action) => (
+                        <Badge
+                          key={`${action.noteId}-${action.text}`}
+                          tone="accent"
+                        >
+                          Follow-up: {action.noteTitle ?? 'Meeting'}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                  {granolaAssignedActions.length ? (
+                    <p className="mt-2 text-[11px] text-[var(--theme-muted)]">
+                      {granolaAssignedActions.length} assigned-action candidates
+                      are visible for review before writing tasks.
+                    </p>
+                  ) : null}
+                  {granolaOwnershipClarifications.length ? (
+                    <p className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                      {granolaOwnershipClarifications.length} items need owner
+                      or wording clarification before side effects.
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Motion action layer
+                    </span>
+                    <Badge
+                      tone={
+                        motionSafeWriteActions.length
+                          ? 'accent'
+                          : motionApprovalRequiredActions.length
+                            ? 'warn'
+                            : 'good'
+                      }
+                    >
+                      {motionSafeWriteActions.length
+                        ? `${motionSafeWriteActions.length} safe write`
+                        : motionApprovalRequiredActions.length
+                          ? `${motionApprovalRequiredActions.length} review`
+                          : 'Clear'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Tim-owned: {motionCoverage?.tim_owned_count ?? 0}. Safe
+                    writes: {motionActionSummary?.safeWriteCount ?? 0}. Approval
+                    required: {motionActionSummary?.approvalRequiredCount ?? 0}.
+                    Suppressed teammate/ambiguous:{' '}
+                    {motionActionSummary?.suppressedCount ?? 0}.
+                  </p>
+                  {motionSafeWriteActions.length ? (
+                    <div className="mt-3 grid gap-2">
+                      {motionSafeWriteActions.slice(0, 3).map((action) => (
+                        <div
+                          key={action.taskId ?? action.name}
+                          className="rounded-lg border border-[var(--theme-accent-border)] bg-[var(--theme-accent)]/10 px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="line-clamp-1 text-xs font-semibold text-ink">
+                                {action.name ?? 'Unnamed Motion task'}
+                              </div>
+                              <p className="mt-1 text-[11px] leading-relaxed text-[var(--theme-muted)]">
+                                {action.reason ?? 'Safe Motion write is ready.'}
+                              </p>
+                            </div>
+                            <Badge tone="accent">Ready</Badge>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                  {motionApprovalRequiredActions.length ? (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {motionApprovalRequiredActions
+                        .slice(0, 4)
+                        .map((action) => (
+                          <Badge key={action.taskId ?? action.name} tone="warn">
+                            Review: {action.name ?? 'Motion task'}
+                          </Badge>
+                        ))}
+                    </div>
+                  ) : null}
+                  {motionSuppressedItems.length ? (
+                    <p className="mt-2 text-[11px] text-[var(--theme-muted)]">
+                      {motionSuppressedItems.length} teammate-owned items are
+                      visible but suppressed from Tim-owned alerts.
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Hermes backend
+                    </span>
+                    <Badge
+                      tone={gatewayOnline && dashboardOnline ? 'good' : 'warn'}
+                    >
+                      {gatewayOnline && dashboardOnline ? 'Ready' : 'Check'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    Gateway: {gatewayOnline ? 'online' : 'offline'}. Dashboard
+                    API: {dashboardOnline ? 'online' : 'limited'}. Mode:{' '}
+                    {gatewayQuery.data?.mode ?? 'unknown'}.
+                  </p>
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      Scheduled work
+                    </span>
+                    <Badge tone={failedJobs.length ? 'danger' : 'good'}>
+                      {failedJobs.length
+                        ? `${failedJobs.length} failed`
+                        : 'Healthy'}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed text-[var(--theme-muted)]">
+                    {enabledJobs.length || jobs.length} jobs visible.{' '}
+                    {jobsQuery.isError
+                      ? jobsQuery.error instanceof Error
+                        ? jobsQuery.error.message
+                        : 'Jobs failed to load.'
+                      : 'Failure count is based on latest reported status.'}
+                  </p>
+                  {failedJobs.length ? (
+                    <div className="mt-3 grid gap-2">
+                      {failedJobs.slice(0, 3).map((job, index) => (
+                        <button
+                          key={job.id ?? index}
+                          type="button"
+                          onClick={() => navigate({ to: '/jobs' })}
+                          className="rounded-lg border border-red-400/20 bg-red-400/10 px-3 py-2 text-left text-xs text-red-100"
+                        >
+                          {job.name ?? job.title ?? job.id ?? 'Unnamed job'}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-ink">
+                      In progress
+                    </span>
+                    <Badge tone={inProgressItems.length ? 'accent' : 'neutral'}>
+                      {inProgressItems.length}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 grid gap-2">
+                    {inProgressItems.slice(0, 3).map((item) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => navigate({ to: '/executive-queue' })}
+                        className="text-left text-xs leading-relaxed text-[var(--theme-muted)] hover:text-ink"
+                      >
+                        {item.title}
+                      </button>
+                    ))}
+                    {!inProgressItems.length ? (
+                      <p className="text-xs text-[var(--theme-muted)]">
+                        No queue item is marked In Progress.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </Panel>
+
+            <Panel eyebrow="Resume" title="Recent threads">
+              <div className="grid gap-2">
+                {sessionsQuery.isLoading ? (
+                  <EmptyState text="Loading recent sessions…" />
+                ) : null}
+                {!sessionsQuery.isLoading && recentSessions.length === 0 ? (
+                  <EmptyState text="No recent sessions found." />
+                ) : null}
+                {recentSessions.map((session) => {
+                  const key = session.key ?? session.id ?? 'main'
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() =>
+                        navigate({
+                          to: '/chat/$sessionKey',
+                          params: { sessionKey: key },
+                        })
+                      }
+                      className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] p-3 text-left transition hover:border-[var(--theme-accent-border)]"
+                    >
+                      <div className="line-clamp-1 text-sm font-medium text-ink">
+                        {session.title ??
+                          session.label ??
+                          session.derivedTitle ??
+                          key}
+                      </div>
+                      <div className="mt-1 text-xs text-[var(--theme-muted)]">
+                        {formatTimestamp(getSessionTime(session))}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            </Panel>
           </div>
         </div>
-      </div>
       </div>
     </div>
   )

--- a/src/server/learning-loop-review.ts
+++ b/src/server/learning-loop-review.ts
@@ -1,0 +1,306 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+import type { Dirent } from 'node:fs'
+import type {
+  LearningLoopReview,
+  LearningLoopReviewItem,
+  LearningLoopReviewStatus,
+  LearningLoopRiskLevel,
+} from '@/features/learning-loop/types'
+
+const DEFAULT_WINDOW_HOURS = 168
+const MAX_ITEMS = 80
+const MAX_EXCERPT_CHARS = 220
+const SECRET_PATTERN =
+  /(api[_-]?key|token|secret|password|credential|bearer|private[_-]?key)/i
+const HIGH_RISK_PROFILE_PATTERN = /^(executive|restored|tm-cos|personal)$/
+
+function getHermesRoot() {
+  const configuredHome = process.env.HERMES_HOME || join(homedir(), '.hermes')
+  const parent = dirname(configuredHome)
+  if (parent.endsWith('/profiles')) return dirname(parent)
+  return configuredHome
+}
+
+function safeStat(path: string) {
+  try {
+    return statSync(path)
+  } catch {
+    return null
+  }
+}
+
+function safeRead(path: string) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function listDirectories(path: string) {
+  try {
+    return readdirSync(path, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((left, right) => left.localeCompare(right))
+  } catch {
+    return []
+  }
+}
+
+function walkFiles(root: string, predicate: (path: string) => boolean) {
+  const files: Array<string> = []
+  const stack = [root]
+
+  while (stack.length) {
+    const current = stack.pop()
+    if (!current) continue
+    let entries: Array<Dirent>
+    try {
+      entries = readdirSync(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      const path = join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git') continue
+        stack.push(path)
+      } else if (entry.isFile() && predicate(path)) {
+        files.push(path)
+      }
+    }
+  }
+
+  return files
+}
+
+function hoursSince(dateMs: number, nowMs: number) {
+  return Math.max(0, Math.round((nowMs - dateMs) / 36_000 / 10))
+}
+
+function classifyStatus(ageHours: number): LearningLoopReviewStatus {
+  if (ageHours <= 24) return 'new'
+  if (ageHours <= DEFAULT_WINDOW_HOURS) return 'recent'
+  return 'stable'
+}
+
+function firstMeaningfulLine(content: string) {
+  const line = content
+    .split('\n')
+    .map((entry) => entry.trim())
+    .find(
+      (entry) => entry && !entry.startsWith('---') && !entry.startsWith('#'),
+    )
+  if (!line) return 'No readable summary found.'
+  if (SECRET_PATTERN.test(line))
+    return 'Content hidden because it may contain credential-like text.'
+  return line.length > MAX_EXCERPT_CHARS
+    ? `${line.slice(0, MAX_EXCERPT_CHARS - 1)}…`
+    : line
+}
+
+function skillTitle(content: string, fallback: string) {
+  const frontmatterName = content.match(/^name:\s*(.+)$/m)?.[1]?.trim()
+  if (frontmatterName) return frontmatterName
+  const heading = content.match(/^#\s+(.+)$/m)?.[1]?.trim()
+  return heading || fallback
+}
+
+function skillDescription(content: string) {
+  const frontmatterDescription = content
+    .match(/^description:\s*(.+)$/m)?.[1]
+    ?.trim()
+  if (frontmatterDescription) return frontmatterDescription
+  return firstMeaningfulLine(content)
+}
+
+function riskForItem(args: {
+  kind: 'memory' | 'skill'
+  profile: string
+  path: string
+  content: string
+  ageHours: number
+}): { risk: LearningLoopRiskLevel; flags: Array<string> } {
+  const flags: Array<string> = []
+  let score = 0
+
+  if (args.ageHours <= 24) {
+    flags.push('Changed in the last 24 hours')
+    score += 1
+  }
+  if (HIGH_RISK_PROFILE_PATTERN.test(args.profile)) {
+    flags.push('Affects a domain/profile with approval boundaries')
+    score += 1
+  }
+  if (args.kind === 'memory') {
+    flags.push('Persistent memory changes influence future agent behavior')
+    score += 1
+  }
+  if (args.kind === 'skill') {
+    flags.push('Skill changes can alter repeatable workflows')
+    score += 1
+  }
+  if (SECRET_PATTERN.test(args.content) || SECRET_PATTERN.test(args.path)) {
+    flags.push('Credential-like wording detected, content preview suppressed')
+    score += 2
+  }
+
+  return {
+    risk: score >= 4 ? 'high' : score >= 2 ? 'medium' : 'low',
+    flags,
+  }
+}
+
+function profileRoots() {
+  const hermesRoot = getHermesRoot()
+  const profilesRoot = join(hermesRoot, 'profiles')
+  const profileNames = listDirectories(profilesRoot)
+
+  if (profileNames.length === 0) {
+    return [{ profile: 'default', root: hermesRoot }]
+  }
+
+  return profileNames.map((profile) => ({
+    profile,
+    root: join(profilesRoot, profile),
+  }))
+}
+
+function collectMemoryItems(profile: string, root: string, nowMs: number) {
+  const memoryRoots = ['memories', 'memory']
+    .map((name) => join(root, name))
+    .filter((path) => existsSync(path))
+  const directMemoryFiles = ['MEMORY.md', 'USER.md']
+    .map((name) => join(root, name))
+    .filter((path) => existsSync(path))
+  const files = [
+    ...directMemoryFiles,
+    ...memoryRoots.flatMap((path) =>
+      walkFiles(path, (file) => /\.(md|txt|json)$/i.test(file)),
+    ),
+  ]
+
+  return files
+    .map((path): LearningLoopReviewItem | null => {
+      const stats = safeStat(path)
+      if (!stats) return null
+      const content = safeRead(path)
+      const ageHours = hoursSince(stats.mtimeMs, nowMs)
+      const risk = riskForItem({
+        kind: 'memory',
+        profile,
+        path,
+        content,
+        ageHours,
+      })
+      const suppressPreview =
+        SECRET_PATTERN.test(content) || SECRET_PATTERN.test(path)
+
+      return {
+        id: `memory:${profile}:${relative(root, path)}`,
+        kind: 'memory',
+        profile,
+        name: path.endsWith('USER.md')
+          ? 'User profile memory'
+          : path.endsWith('MEMORY.md')
+            ? 'Agent memory'
+            : relative(root, path),
+        relativePath: relative(root, path),
+        updatedAt: new Date(stats.mtimeMs).toISOString(),
+        ageHours,
+        status: classifyStatus(ageHours),
+        risk: risk.risk,
+        reviewFlags: risk.flags,
+        summary: suppressPreview
+          ? 'Preview hidden because this file may contain credential-like text.'
+          : firstMeaningfulLine(content),
+      }
+    })
+    .filter((item): item is LearningLoopReviewItem => item !== null)
+}
+
+function collectSkillItems(profile: string, root: string, nowMs: number) {
+  const skillsRoot = join(root, 'skills')
+  if (!existsSync(skillsRoot)) return []
+
+  return walkFiles(skillsRoot, (file) => file.endsWith('/SKILL.md'))
+    .map((path): LearningLoopReviewItem | null => {
+      const stats = safeStat(path)
+      if (!stats) return null
+      const content = safeRead(path)
+      const relativePath = relative(root, path)
+      const fallbackName = relative(skillsRoot, path).replace(
+        /\/SKILL\.md$/,
+        '',
+      )
+      const ageHours = hoursSince(stats.mtimeMs, nowMs)
+      const risk = riskForItem({
+        kind: 'skill',
+        profile,
+        path,
+        content,
+        ageHours,
+      })
+      const suppressPreview =
+        SECRET_PATTERN.test(content) || SECRET_PATTERN.test(path)
+
+      return {
+        id: `skill:${profile}:${relativePath}`,
+        kind: 'skill',
+        profile,
+        name: skillTitle(content, fallbackName),
+        relativePath,
+        updatedAt: new Date(stats.mtimeMs).toISOString(),
+        ageHours,
+        status: classifyStatus(ageHours),
+        risk: risk.risk,
+        reviewFlags: risk.flags,
+        summary: suppressPreview
+          ? 'Preview hidden because this skill may contain credential-like text.'
+          : skillDescription(content),
+      }
+    })
+    .filter((item): item is LearningLoopReviewItem => item !== null)
+}
+
+export function buildLearningLoopReview(
+  windowHours = DEFAULT_WINDOW_HOURS,
+): LearningLoopReview {
+  const now = new Date()
+  const nowMs = now.getTime()
+  const roots = profileRoots()
+  const items = roots
+    .flatMap(({ profile, root }) => [
+      ...collectMemoryItems(profile, root, nowMs),
+      ...collectSkillItems(profile, root, nowMs),
+    ])
+    .filter((item) => item.ageHours <= windowHours)
+    .sort(
+      (left, right) =>
+        new Date(right.updatedAt).getTime() -
+        new Date(left.updatedAt).getTime(),
+    )
+    .slice(0, MAX_ITEMS)
+
+  return {
+    ok: true,
+    generatedAt: now.toISOString(),
+    windowHours,
+    profiles: roots.map((entry) => entry.profile),
+    items,
+    counts: {
+      total: items.length,
+      memory: items.filter((item) => item.kind === 'memory').length,
+      skill: items.filter((item) => item.kind === 'skill').length,
+      highRisk: items.filter((item) => item.risk === 'high').length,
+      mediumRisk: items.filter((item) => item.risk === 'medium').length,
+      reviewNeeded: items.filter(
+        (item) => item.risk !== 'low' || item.status === 'new',
+      ).length,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Workspace worker safety filtering for queue execution.
- Blocks unsafe/high-risk queue items before launching Codex or worker runs.
- Adds safe queue execution behavior, async worker dispatch, concise Telegram status updates, and prerequisite Executive Command Center queue surfaces.
- Adds X bookmark intake, Learning Loop, Voice Lab, and Agent Surfaces routes included in the prerequisite feature stack.

## Verification
- `pnpm exec vitest run src/routes/api/-worker-safety-filter.test.ts src/routes/api/-executive-queue-execution.test.ts src/screens/dashboard/-command-center-utils.test.ts` passed: 3 files, 25 tests.
- Targeted ESLint on changed safety/queue/dashboard files passed.
- `pnpm run build` passed.

## Notes
- Branch was rebuilt as one clean commit on current upstream `main` so this PR is mergeable.
- Full repo test run still has unrelated existing MCP/chat test failures outside this PR scope.
- This PR is from a fork because `timmit687` has read-only access to `outsourc-e/hermes-workspace`.
