### PR TITLE
Implement worker spine adapter

### DIFF
--- a/src/server/worker-spine/adapter-fixtures.test.ts
+++ b/src/server/worker-spine/adapter-fixtures.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { requiredUnsafeMarkers, workerSpineAdapterFixtures } from './adapter-fixtures'
+
+describe('workerSpineAdapterFixtures', () => {
+  it('uses unique fake queue IDs and fixed timestamps', () => {
+    const fixtures = Object.values(workerSpineAdapterFixtures)
+    const ids = fixtures.map((fixture) => fixture.queueItemId)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(fixtures.every((fixture) => fixture.nowIso === '2026-06-06T12:00:00.000Z')).toBe(true)
+    expect(fixtures.every((fixture) => fixture.queueItemId?.startsWith('fake-queue-'))).toBe(true)
+  })
+
+  it('does not contain real credential-shaped content', () => {
+    const serialized = JSON.stringify(workerSpineAdapterFixtures).toLowerCase()
+
+    expect(serialized).not.toContain('sk-')
+    expect(serialized).not.toContain('bearer ')
+    expect(serialized).not.toContain('/users/hermes')
+    expect(serialized).not.toContain('auth.json')
+    expect(serialized).not.toContain('.env')
+  })
+
+  it('declares required fake unsafe markers', () => {
+    expect(requiredUnsafeMarkers).toEqual([
+      'FAKE_TOKEN_SHOULD_NOT_RENDER',
+      'FAKE_AUTH_HEADER_SHOULD_NOT_RENDER',
+      'FAKE_COOKIE_SHOULD_NOT_RENDER',
+      'FAKE_ENV_PATH_SHOULD_NOT_RENDER',
+      'FAKE_AUTH_JSON_PATH_SHOULD_NOT_RENDER',
+      'FAKE_STACK_TRACE_SHOULD_NOT_RENDER',
+      'FAKE_RAW_PROMPT_SHOULD_NOT_RENDER',
+      'FAKE_RAW_COMPLETION_SHOULD_NOT_RENDER',
+      'FAKE_PRIVATE_BODY_SHOULD_NOT_RENDER',
+      'FAKE_LONG_LOG_SHOULD_NOT_RENDER',
+    ])
+  })
+})

--- a/src/server/worker-spine/adapter-fixtures.ts
+++ b/src/server/worker-spine/adapter-fixtures.ts
@@ -1,0 +1,118 @@
+import type { WorkerQueueInput } from './adapter'
+
+const nowIso = '2026-06-06T12:00:00.000Z'
+
+function baseFixture(
+  queueItemId: string,
+  overrides: Partial<WorkerQueueInput>,
+): WorkerQueueInput {
+  return {
+    queueItemId,
+    title: 'Safe worker task',
+    instruction: 'Complete safe local work only.',
+    requestedBy: 'executive',
+    source: 'fixture',
+    domain: 'coding',
+    riskLevel: 'low',
+    approvalReceiptId: null,
+    dryRun: true,
+    sourceRefs: [{ label: 'Fake source', uri: 'fixture://source', safeToShow: true }],
+    nowIso,
+    ...overrides,
+  }
+}
+
+export const safeCodingTask = baseFixture('fake-queue-safe-coding', {
+  title: 'Implement adapter branch',
+  instruction: 'Build a local worker spine adapter with fake-only ports.',
+})
+
+export const safeResearchTask = baseFixture('fake-queue-safe-research', {
+  title: 'Summarize safe source',
+  instruction: 'Summarize fake public source only.',
+  domain: 'research',
+})
+
+export const blockedUnknownTask = baseFixture('fake-queue-blocked-unknown', {
+  title: 'Do unknown risky thing',
+  instruction: 'Ambiguous work with unknown owner.',
+  domain: 'unknown',
+})
+
+export const needsTimExternalSend = baseFixture('fake-queue-needs-tim-send', {
+  title: 'Send external message',
+  instruction: 'Send this external message now.',
+  riskLevel: 'high',
+})
+
+export const missingCredentialNeedsTimLocalSetup = baseFixture(
+  'fake-queue-missing-credential',
+  {
+    title: 'Connect missing credential source',
+    instruction: 'Use missing credential to continue.',
+    riskLevel: 'high',
+  },
+)
+
+export const missingSourceExecutiveEscalation = baseFixture(
+  'fake-queue-missing-source',
+  {
+    title: 'Use missing source',
+    instruction: 'Need a source that is not available to this worker.',
+    domain: 'research',
+  },
+)
+
+export const unsafeOutputRejected = baseFixture('fake-queue-unsafe-output', {
+  title: 'Unsafe output regression',
+  instruction: 'Return unsafe fake markers only in worker output.',
+})
+
+export const routineDryRunNotLogged = baseFixture('fake-queue-routine-dry-run', {
+  title: 'Routine empty check',
+  instruction: 'Run routine empty check with no meaningful outcome.',
+  source: 'cron',
+})
+
+export const completedWithSafeArtifact = baseFixture('fake-queue-safe-artifact', {
+  title: 'Create safe artifact label',
+  instruction: 'Create a fake safe artifact reference.',
+})
+
+export const activityLogWritePending = baseFixture('fake-queue-log-pending', {
+  title: 'Meaningful completion to log',
+  instruction: 'Complete meaningful local work.',
+})
+
+export const activityLogWriteSkipped = baseFixture('fake-queue-log-skipped', {
+  title: 'Skip routine log',
+  instruction: 'Routine dry run should not log.',
+  source: 'cron',
+})
+
+export const workerSpineAdapterFixtures = {
+  safeCodingTask,
+  safeResearchTask,
+  blockedUnknownTask,
+  needsTimExternalSend,
+  missingCredentialNeedsTimLocalSetup,
+  missingSourceExecutiveEscalation,
+  unsafeOutputRejected,
+  routineDryRunNotLogged,
+  completedWithSafeArtifact,
+  activityLogWritePending,
+  activityLogWriteSkipped,
+}
+
+export const requiredUnsafeMarkers = [
+  'FAKE_TOKEN_SHOULD_NOT_RENDER',
+  'FAKE_AUTH_HEADER_SHOULD_NOT_RENDER',
+  'FAKE_COOKIE_SHOULD_NOT_RENDER',
+  'FAKE_ENV_PATH_SHOULD_NOT_RENDER',
+  'FAKE_AUTH_JSON_PATH_SHOULD_NOT_RENDER',
+  'FAKE_STACK_TRACE_SHOULD_NOT_RENDER',
+  'FAKE_RAW_PROMPT_SHOULD_NOT_RENDER',
+  'FAKE_RAW_COMPLETION_SHOULD_NOT_RENDER',
+  'FAKE_PRIVATE_BODY_SHOULD_NOT_RENDER',
+  'FAKE_LONG_LOG_SHOULD_NOT_RENDER',
+] as const

--- a/src/server/worker-spine/adapter.test.ts
+++ b/src/server/worker-spine/adapter.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { runWorkerSpineAdapter } from './adapter'
+import {
+  blockedUnknownTask,
+  missingCredentialNeedsTimLocalSetup,
+  missingSourceExecutiveEscalation,
+  needsTimExternalSend,
+  routineDryRunNotLogged,
+  safeCodingTask,
+  unsafeOutputRejected,
+} from './adapter-fixtures'
+import { createFakeWorkerSpinePorts } from './ports'
+import type { WorkerQueueInput } from './adapter'
+
+function makeInput(overrides: Partial<WorkerQueueInput> = {}): WorkerQueueInput {
+  return {
+    queueItemId: 'fake-queue-1',
+    title: 'Draft safe local plan',
+    instruction: 'Create a safe implementation plan only.',
+    requestedBy: 'executive',
+    source: 'fixture',
+    domain: 'coding',
+    riskLevel: 'low',
+    approvalReceiptId: null,
+    dryRun: true,
+    sourceRefs: [{ label: 'Fake source', uri: 'fixture://source', safeToShow: true }],
+    nowIso: '2026-06-06T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('runWorkerSpineAdapter', () => {
+  it('rejects invalid queue input safely', async () => {
+    const result = await runWorkerSpineAdapter({
+      input: makeInput({ title: '', instruction: '' }),
+      ports: createFakeWorkerSpinePorts(),
+    })
+
+    expect(result.decision.status).toBe('blocked')
+    expect(result.safeResponse.safeSummary).toBe('Worker request is missing required safe input.')
+    expect(JSON.stringify(result)).not.toContain('undefined')
+  })
+
+  it('completes a safe fake coding task without live side-effect ports', async () => {
+    const ports = createFakeWorkerSpinePorts()
+    const result = await runWorkerSpineAdapter({ input: safeCodingTask, ports })
+
+    expect(result.decision.status).toBe('completed')
+    expect(result.decision.ok).toBe(true)
+    expect(result.record.id).toMatch(/^fake-exec-/)
+    expect(result.safeResponse.safeSummary).toBe('Safe worker result completed.')
+    expect(result.safeResponse.safeNextPrompt).toBe('Review worker result')
+    expect(result.telegramSummary?.kind).toBe('completion')
+    expect(result.activityLogDecision?.state).toBe('pending')
+    expect(ports.dispatchCalls).toHaveLength(1)
+    expect(result.safeResponse).not.toHaveProperty('rawOutput')
+  })
+
+  it('blocks unknown work before dispatch', async () => {
+    const ports = createFakeWorkerSpinePorts()
+    const result = await runWorkerSpineAdapter({ input: blockedUnknownTask, ports })
+
+    expect(result.decision.status).toBe('blocked')
+    expect(result.decision.safeSummary).toBe('Worker request blocked until Executive reviews routing.')
+    expect(result.decision.requiresTimApproval).toBe(false)
+    expect(ports.dispatchCalls).toHaveLength(0)
+  })
+
+  it('requires Tim approval for external send intent without dispatching', async () => {
+    const ports = createFakeWorkerSpinePorts()
+    const result = await runWorkerSpineAdapter({ input: needsTimExternalSend, ports })
+
+    expect(result.decision.status).toBe('needs_tim')
+    expect(result.decision.requiresTimApproval).toBe(true)
+    expect(result.decision.approvalPrompt).toBe('Approval needed: external send. Risk: public outbound action. Reply: `Approve external send`')
+    expect(ports.dispatchCalls).toHaveLength(0)
+  })
+
+  it('uses local credential setup language when credentials are missing', async () => {
+    const result = await runWorkerSpineAdapter({
+      input: missingCredentialNeedsTimLocalSetup,
+      ports: createFakeWorkerSpinePorts(),
+    })
+
+    expect(result.decision.status).toBe('needs_tim')
+    expect(result.safeResponse.safeSummary).toBe('Access needed before this worker can continue.')
+    expect(result.decision.approvalPrompt).toBe('Access needed: connect the required source locally. Next prompt: `Set up source access`')
+  })
+
+  it('escalates missing source to Executive first', async () => {
+    const result = await runWorkerSpineAdapter({
+      input: missingSourceExecutiveEscalation,
+      ports: createFakeWorkerSpinePorts(),
+    })
+
+    expect(result.decision.status).toBe('blocked')
+    expect(result.safeResponse.safeSummary).toBe('Missing source. Executive should check available tools before asking Tim.')
+    expect(result.decision.requiresTimApproval).toBe(false)
+  })
+
+  it('does not log routine dry-run checks', async () => {
+    const result = await runWorkerSpineAdapter({
+      input: routineDryRunNotLogged,
+      ports: createFakeWorkerSpinePorts(),
+    })
+
+    expect(result.decision.status).toBe('completed')
+    expect(result.activityLogDecision?.state).toBe('not_needed')
+    expect(result.telegramSummary?.shouldDeliver).toBe(false)
+  })
+
+  it('fails closed when fake unsafe worker output is returned', async () => {
+    const ports = createFakeWorkerSpinePorts({
+      candidateOutput: {
+        status: 'completed',
+        summary: 'FAKE_TOKEN_SHOULD_NOT_RENDER FAKE_STACK_TRACE_SHOULD_NOT_RENDER',
+        nextPrompt: 'Unsafe prompt',
+        artifactRefs: [],
+      },
+    })
+    const result = await runWorkerSpineAdapter({ input: unsafeOutputRejected, ports })
+    const serialized = JSON.stringify(result)
+
+    expect(result.decision.status).toBe('failed')
+    expect(result.safeResponse.safeSummary).toBe('Worker output failed safety validation.')
+    expect(serialized).not.toContain('FAKE_TOKEN_SHOULD_NOT_RENDER')
+    expect(serialized).not.toContain('FAKE_STACK_TRACE_SHOULD_NOT_RENDER')
+  })
+
+  it('does not call optional delivery or log write ports in dry run', async () => {
+    const telegramCalls: Array<unknown> = []
+    const activityLogCalls: Array<unknown> = []
+    const ports = createFakeWorkerSpinePorts()
+    ports.deliverTelegram = (summary) => {
+      telegramCalls.push(summary)
+      return Promise.resolve({ ok: true })
+    }
+    ports.writeActivityLog = (draft) => {
+      activityLogCalls.push(draft)
+      return Promise.resolve({ ok: true, pageId: 'fake-notion-page-1' })
+    }
+
+    await runWorkerSpineAdapter({ input: safeCodingTask, ports })
+
+    expect(telegramCalls).toHaveLength(0)
+    expect(activityLogCalls).toHaveLength(0)
+  })
+})

--- a/src/server/worker-spine/adapter.ts
+++ b/src/server/worker-spine/adapter.ts
@@ -1,0 +1,378 @@
+import type {
+  WorkerActivityLogDraft,
+  WorkerCandidateOutput,
+  WorkerContextPacket,
+  WorkerExecutionRecord,
+  WorkerSpinePorts,
+  WorkerTelegramSummary,
+} from './ports'
+
+export type WorkerId =
+  | 'executive'
+  | 'codex'
+  | 'research'
+  | 'qa'
+  | 'personal_cfo'
+  | 'restored_cos'
+  | 'tm_cos'
+
+export interface WorkerQueueInput {
+  queueItemId: string | null
+  title: string
+  instruction: string
+  requestedBy: 'tim' | 'executive' | 'workspace' | 'cron' | 'system'
+  source: 'executive_queue' | 'manual' | 'cron' | 'api' | 'fixture'
+  domain:
+    | 'executive'
+    | 'coding'
+    | 'research'
+    | 'finance'
+    | 'restored'
+    | 'travel_multiplier'
+    | 'personal'
+    | 'unknown'
+  riskLevel: 'low' | 'medium' | 'high'
+  approvalReceiptId: string | null
+  dryRun: boolean
+  sourceRefs: Array<{
+    label: string
+    uri: string
+    safeToShow: boolean
+  }>
+  nowIso: string
+}
+
+export interface WorkerSpineDecision {
+  ok: boolean
+  status: 'blocked' | 'needs_tim' | 'queued' | 'running' | 'completed' | 'failed'
+  executionRecordId: string
+  workerId: WorkerId | null
+  routingDecisionId: string | null
+  escalationPacketId: string | null
+  contextPacketId: string | null
+  safeSummary: string
+  safeNextPrompt: string | null
+  requiresTimApproval: boolean
+  approvalPrompt: string | null
+}
+
+export interface WorkerOutputValidationResult {
+  status: 'pass' | 'fail'
+  safeSummary: string
+  safeNextPrompt: string | null
+}
+
+export interface WorkerActivityLogDecision {
+  state: 'not_needed' | 'pending' | 'logged' | 'failed'
+  shouldWrite: boolean
+  draft: WorkerActivityLogDraft | null
+}
+
+export interface WorkerExecutionSafeResponse {
+  ok: boolean
+  status: WorkerSpineDecision['status']
+  executionRecordId: string
+  safeSummary: string
+  safeNextPrompt: string | null
+  safeArtifactRefs: Array<{ label: string; uri: string; safeToShow: true }>
+  safeSourceRefs: Array<{ label: string; uri: string; safeToShow: true }>
+  requiresTimApproval: boolean
+  approvalPrompt: string | null
+}
+
+export interface WorkerSpineResult {
+  decision: WorkerSpineDecision
+  record: WorkerExecutionRecord
+  validation: WorkerOutputValidationResult | null
+  telegramSummary: WorkerTelegramSummary | null
+  activityLogDecision: WorkerActivityLogDecision | null
+  safeResponse: WorkerExecutionSafeResponse
+}
+
+export async function runWorkerSpineAdapter(args: {
+  input: WorkerQueueInput
+  ports: WorkerSpinePorts
+}): Promise<WorkerSpineResult> {
+  const { input, ports } = args
+  const inputProblem = validateWorkerQueueInput(input)
+  if (inputProblem) {
+    return blockedResult(input, 'Worker request is missing required safe input.', input.nowIso)
+  }
+
+  if (input.domain === 'unknown') {
+    return blockedResult(
+      input,
+      'Worker request blocked until Executive reviews routing.',
+      input.nowIso,
+    )
+  }
+
+  if (isMissingSource(input)) {
+    return blockedResult(
+      input,
+      'Missing source. Executive should check available tools before asking Tim.',
+      input.nowIso,
+    )
+  }
+
+  if (isMissingCredential(input)) {
+    return needsTimResult(
+      input,
+      'Access needed before this worker can continue.',
+      'Access needed: connect the required source locally. Next prompt: `Set up source access`',
+    )
+  }
+
+  if (requiresApproval(input)) {
+    return needsTimResult(
+      input,
+      'Worker request needs Tim approval before dispatch.',
+      'Approval needed: external send. Risk: public outbound action. Reply: `Approve external send`',
+    )
+  }
+
+  const record = makeRecord(input, 'running', 'Worker request is running safely.')
+  const context: WorkerContextPacket = {
+    id: `fake-context-${safeId(input.queueItemId ?? input.title)}`,
+    title: sanitizeText(input.title, 'Worker task'),
+    instruction: sanitizeText(input.instruction, 'Safe worker instruction'),
+    dryRun: input.dryRun,
+  }
+  const candidateOutput = await ports.dispatchWorker(context)
+  const validation = validateWorkerOutput(candidateOutput)
+  if (validation.status === 'fail') {
+    const failedRecord = {
+      ...record,
+      status: 'failed' as const,
+      safeSummary: 'Worker output failed safety validation.',
+      updatedAt: input.nowIso,
+    }
+    await ports.persistRecord(failedRecord)
+    return resultFromParts({
+      decision: makeDecision({
+        input,
+        status: 'failed',
+        ok: false,
+        summary: 'Worker output failed safety validation.',
+        nextPrompt: 'Regenerate safe output',
+        workerId: routeWorkerId(input),
+        contextPacketId: context.id,
+      }),
+      record: failedRecord,
+      validation,
+      telegramSummary: { kind: 'failure', shouldDeliver: true, message: 'Failed safely. Worker output failed safety validation.' },
+      activityLogDecision: { state: 'failed', shouldWrite: false, draft: null },
+    })
+  }
+
+  const completedRecord = {
+    ...record,
+    status: 'completed' as const,
+    safeSummary: validation.safeSummary,
+    updatedAt: input.nowIso,
+  }
+  await ports.persistRecord(completedRecord)
+  const routine = isRoutine(input)
+  return resultFromParts({
+    decision: makeDecision({
+      input,
+      status: 'completed',
+      ok: true,
+      summary: validation.safeSummary,
+      nextPrompt: validation.safeNextPrompt,
+      workerId: routeWorkerId(input),
+      contextPacketId: context.id,
+    }),
+    record: completedRecord,
+    validation,
+    telegramSummary: routine
+      ? { kind: 'silent', shouldDeliver: false, message: null }
+      : { kind: 'completion', shouldDeliver: true, message: `Done. ${validation.safeSummary}` },
+    activityLogDecision: routine
+      ? { state: 'not_needed', shouldWrite: false, draft: null }
+      : {
+          state: 'pending',
+          shouldWrite: true,
+          draft: {
+            action: sanitizeText(input.title, 'Completed worker task'),
+            details: validation.safeSummary,
+          },
+        },
+  })
+}
+
+function validateWorkerQueueInput(input: WorkerQueueInput): string | null {
+  if (!input.title.trim() || !input.instruction.trim()) return 'missing_input'
+  if (!input.nowIso.trim()) return 'missing_time'
+  return null
+}
+
+function validateWorkerOutput(output: WorkerCandidateOutput): WorkerOutputValidationResult {
+  const combined = JSON.stringify(output)
+  if (containsUnsafe(combined)) {
+    return {
+      status: 'fail',
+      safeSummary: 'Worker output failed safety validation.',
+      safeNextPrompt: 'Regenerate safe output',
+    }
+  }
+  return {
+    status: 'pass',
+    safeSummary: sanitizeText(output.summary, 'Safe worker result completed.'),
+    safeNextPrompt: output.nextPrompt ? sanitizeText(output.nextPrompt, 'Review worker result') : null,
+  }
+}
+
+function resultFromParts(args: {
+  decision: WorkerSpineDecision
+  record: WorkerExecutionRecord
+  validation: WorkerOutputValidationResult | null
+  telegramSummary: WorkerTelegramSummary | null
+  activityLogDecision: WorkerActivityLogDecision | null
+}): WorkerSpineResult {
+  const safeResponse = buildSafeResponse(args.decision)
+  return { ...args, safeResponse }
+}
+
+function blockedResult(input: WorkerQueueInput, summary: string, nowIso: string): WorkerSpineResult {
+  const record = makeRecord(input, 'blocked', summary, nowIso)
+  return resultFromParts({
+    decision: makeDecision({
+      input,
+      status: 'blocked',
+      ok: false,
+      summary,
+      nextPrompt: 'Review worker routing',
+      workerId: null,
+      escalationPacketId: `fake-escalation-${safeId(input.queueItemId ?? input.title)}`,
+    }),
+    record,
+    validation: null,
+    telegramSummary: { kind: 'blocked', shouldDeliver: true, message: `Blocked. ${summary}` },
+    activityLogDecision: { state: 'not_needed', shouldWrite: false, draft: null },
+  })
+}
+
+function needsTimResult(input: WorkerQueueInput, summary: string, approvalPrompt: string): WorkerSpineResult {
+  const record = makeRecord(input, 'needs_tim', summary)
+  const decision = makeDecision({
+    input,
+    status: 'needs_tim',
+    ok: false,
+    summary,
+    nextPrompt: 'Review approval request',
+    workerId: null,
+    escalationPacketId: `fake-escalation-${safeId(input.queueItemId ?? input.title)}`,
+    requiresTimApproval: true,
+    approvalPrompt,
+  })
+  return resultFromParts({
+    decision,
+    record,
+    validation: null,
+    telegramSummary: { kind: 'needs_tim', shouldDeliver: true, message: approvalPrompt },
+    activityLogDecision: { state: 'pending', shouldWrite: true, draft: { action: 'Review worker approval', details: summary } },
+  })
+}
+
+function makeDecision(args: {
+  input: WorkerQueueInput
+  status: WorkerSpineDecision['status']
+  ok: boolean
+  summary: string
+  nextPrompt: string | null
+  workerId: WorkerId | null
+  escalationPacketId?: string | null
+  contextPacketId?: string | null
+  requiresTimApproval?: boolean
+  approvalPrompt?: string | null
+}): WorkerSpineDecision {
+  return {
+    ok: args.ok,
+    status: args.status,
+    executionRecordId: executionRecordId(args.input),
+    workerId: args.workerId,
+    routingDecisionId: `fake-routing-${safeId(args.input.queueItemId ?? args.input.title)}`,
+    escalationPacketId: args.escalationPacketId ?? null,
+    contextPacketId: args.contextPacketId ?? null,
+    safeSummary: args.summary,
+    safeNextPrompt: args.nextPrompt,
+    requiresTimApproval: args.requiresTimApproval ?? false,
+    approvalPrompt: args.approvalPrompt ?? null,
+  }
+}
+
+function makeRecord(
+  input: WorkerQueueInput,
+  status: WorkerExecutionRecord['status'],
+  safeSummary: string,
+  nowIso = input.nowIso,
+): WorkerExecutionRecord {
+  return {
+    id: executionRecordId(input),
+    status,
+    queueItemId: input.queueItemId,
+    title: sanitizeText(input.title, 'Worker task'),
+    safeSummary,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  }
+}
+
+function buildSafeResponse(decision: WorkerSpineDecision): WorkerExecutionSafeResponse {
+  return {
+    ok: decision.ok,
+    status: decision.status,
+    executionRecordId: decision.executionRecordId,
+    safeSummary: decision.safeSummary,
+    safeNextPrompt: decision.safeNextPrompt,
+    safeArtifactRefs: [],
+    safeSourceRefs: [],
+    requiresTimApproval: decision.requiresTimApproval,
+    approvalPrompt: decision.approvalPrompt,
+  }
+}
+
+function requiresApproval(input: WorkerQueueInput): boolean {
+  const text = `${input.title} ${input.instruction}`.toLowerCase()
+  return input.riskLevel === 'high' && text.includes('send') && !input.approvalReceiptId
+}
+
+function isMissingCredential(input: WorkerQueueInput): boolean {
+  return `${input.title} ${input.instruction}`.toLowerCase().includes('credential')
+}
+
+function isMissingSource(input: WorkerQueueInput): boolean {
+  return `${input.title} ${input.instruction}`.toLowerCase().includes('missing source')
+}
+
+function isRoutine(input: WorkerQueueInput): boolean {
+  const text = `${input.title} ${input.instruction}`.toLowerCase()
+  return input.source === 'cron' || text.includes('routine empty check')
+}
+
+function routeWorkerId(input: WorkerQueueInput): WorkerId {
+  if (input.domain === 'research') return 'research'
+  if (input.domain === 'finance') return 'personal_cfo'
+  if (input.domain === 'restored') return 'restored_cos'
+  if (input.domain === 'travel_multiplier') return 'tm_cos'
+  if (input.domain === 'coding') return 'codex'
+  return 'executive'
+}
+
+function executionRecordId(input: WorkerQueueInput): string {
+  return `fake-exec-${safeId(input.queueItemId ?? input.title)}`
+}
+
+function safeId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'worker'
+}
+
+function sanitizeText(value: string, fallback: string): string {
+  if (!value.trim() || containsUnsafe(value)) return fallback
+  return value.trim()
+}
+
+function containsUnsafe(value: string): boolean {
+  return /FAKE_(TOKEN|AUTH_HEADER|COOKIE|ENV_PATH|AUTH_JSON_PATH|STACK_TRACE|RAW_PROMPT|RAW_COMPLETION|PRIVATE_BODY|LONG_LOG)_SHOULD_NOT_RENDER/i.test(value)
+}

--- a/src/server/worker-spine/ports.test.ts
+++ b/src/server/worker-spine/ports.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { createFakeWorkerSpinePorts } from './ports'
+
+describe('createFakeWorkerSpinePorts', () => {
+  it('persists records without mutation', async () => {
+    const ports = createFakeWorkerSpinePorts()
+    const record = { id: 'fake-exec-1', status: 'completed' as const }
+
+    await expect(ports.persistRecord(record)).resolves.toBe(record)
+  })
+
+  it('returns deterministic fake worker output', async () => {
+    const ports = createFakeWorkerSpinePorts()
+
+    await expect(ports.dispatchWorker({ id: 'fake-context-1' })).resolves.toMatchObject({
+      status: 'completed',
+      summary: 'Safe worker result completed.',
+      nextPrompt: 'Review worker result',
+    })
+  })
+
+  it('does not install live side-effect ports by default', () => {
+    const ports = createFakeWorkerSpinePorts()
+
+    expect(ports.deliverTelegram).toBeUndefined()
+    expect(ports.writeActivityLog).toBeUndefined()
+  })
+})

--- a/src/server/worker-spine/ports.ts
+++ b/src/server/worker-spine/ports.ts
@@ -1,0 +1,80 @@
+export type WorkerCandidateOutputStatus = 'completed' | 'failed'
+
+export interface WorkerCandidateOutput {
+  status: WorkerCandidateOutputStatus
+  summary: string
+  nextPrompt: string | null
+  artifactRefs: Array<{ label: string; uri: string; safeToShow: boolean }>
+}
+
+export interface WorkerExecutionRecord {
+  id: string
+  status: 'blocked' | 'needs_tim' | 'queued' | 'running' | 'completed' | 'failed'
+  queueItemId: string | null
+  title: string
+  safeSummary: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WorkerContextPacket {
+  id: string
+  title: string
+  instruction: string
+  dryRun: boolean
+}
+
+export interface WorkerActivityLogDraft {
+  action: string
+  details: string
+}
+
+export interface WorkerTelegramSummary {
+  kind: 'silent' | 'completion' | 'blocked' | 'needs_tim' | 'failure'
+  shouldDeliver: boolean
+  message: string | null
+}
+
+export interface WorkerSpinePorts {
+  dispatchWorker: (context: WorkerContextPacket) => Promise<WorkerCandidateOutput>
+  persistRecord: (record: WorkerExecutionRecord) => Promise<WorkerExecutionRecord>
+  writeActivityLog?: (
+    draft: WorkerActivityLogDraft,
+  ) => Promise<{ ok: true; pageId: string } | { ok: false; safeReason: string }>
+  deliverTelegram?: (
+    summary: WorkerTelegramSummary,
+  ) => Promise<{ ok: true } | { ok: false; safeReason: string }>
+}
+
+export interface FakeWorkerSpinePorts extends WorkerSpinePorts {
+  dispatchCalls: Array<WorkerContextPacket>
+  persistCalls: Array<WorkerExecutionRecord>
+}
+
+export const defaultFakeWorkerOutput: WorkerCandidateOutput = {
+  status: 'completed',
+  summary: 'Safe worker result completed.',
+  nextPrompt: 'Review worker result',
+  artifactRefs: [],
+}
+
+export function createFakeWorkerSpinePorts(options: {
+  candidateOutput?: WorkerCandidateOutput
+} = {}): FakeWorkerSpinePorts {
+  const dispatchCalls: Array<WorkerContextPacket> = []
+  const persistCalls: Array<WorkerExecutionRecord> = []
+  const candidateOutput = options.candidateOutput ?? defaultFakeWorkerOutput
+
+  return {
+    dispatchCalls,
+    persistCalls,
+    dispatchWorker(context) {
+      dispatchCalls.push(context)
+      return Promise.resolve(candidateOutput)
+    },
+    persistRecord(record) {
+      persistCalls.push(record)
+      return Promise.resolve(record)
+    },
+  }
+}

--- a/src/server/worker-spine/pr600-seam.test.ts
+++ b/src/server/worker-spine/pr600-seam.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildWorkerQueueInputFromPr600Request, toPr600SafeResponse } from './pr600-seam'
+import { runWorkerSpineAdapter } from './adapter'
+import { createFakeWorkerSpinePorts } from './ports'
+
+describe('PR 600 seam helpers', () => {
+  it('maps a queue execution request into normalized worker input', () => {
+    const input = buildWorkerQueueInputFromPr600Request({
+      queueItemId: 'fake-queue-pr600',
+      taskTitle: 'Draft adapter plan',
+      taskInstruction: 'Build only local files.',
+      requestedBy: 'workspace',
+      approvalReceiptId: null,
+      dryRun: true,
+    }, '2026-06-06T12:00:00.000Z')
+
+    expect(input).toMatchObject({
+      queueItemId: 'fake-queue-pr600',
+      title: 'Draft adapter plan',
+      requestedBy: 'workspace',
+      source: 'executive_queue',
+      dryRun: true,
+    })
+  })
+
+  it('converts adapter output into route-safe response without raw internals', async () => {
+    const input = buildWorkerQueueInputFromPr600Request({
+      queueItemId: 'fake-queue-pr600',
+      taskTitle: 'Draft adapter plan',
+      taskInstruction: 'Build only local files.',
+      requestedBy: 'workspace',
+      approvalReceiptId: null,
+      dryRun: true,
+    }, '2026-06-06T12:00:00.000Z')
+    const result = await runWorkerSpineAdapter({ input, ports: createFakeWorkerSpinePorts() })
+    const safeResponse = toPr600SafeResponse(result)
+
+    expect(safeResponse.status).toBe('completed')
+    expect(safeResponse.safeSummary).toBe('Safe worker result completed.')
+    expect(JSON.stringify(safeResponse)).not.toContain('taskInstruction')
+    expect(JSON.stringify(safeResponse)).not.toContain('raw')
+  })
+})

--- a/src/server/worker-spine/pr600-seam.ts
+++ b/src/server/worker-spine/pr600-seam.ts
@@ -1,0 +1,55 @@
+import type {
+  WorkerExecutionSafeResponse,
+  WorkerQueueInput,
+  WorkerSpineResult,
+} from './adapter'
+
+export interface Pr600QueueExecutionRequest {
+  queueItemId: string | null
+  taskTitle: string
+  taskInstruction: string
+  requestedBy: 'tim' | 'executive' | 'workspace' | 'cron'
+  approvalReceiptId: string | null
+  dryRun?: boolean
+}
+
+export function buildWorkerQueueInputFromPr600Request(
+  request: Pr600QueueExecutionRequest,
+  nowIso: string,
+): WorkerQueueInput {
+  return {
+    queueItemId: request.queueItemId,
+    title: request.taskTitle,
+    instruction: request.taskInstruction,
+    requestedBy: request.requestedBy,
+    source: 'executive_queue',
+    domain: inferDomain(request.taskTitle, request.taskInstruction),
+    riskLevel: inferRisk(request.taskTitle, request.taskInstruction),
+    approvalReceiptId: request.approvalReceiptId,
+    dryRun: request.dryRun ?? true,
+    sourceRefs: [],
+    nowIso,
+  }
+}
+
+export function toPr600SafeResponse(
+  result: WorkerSpineResult,
+): WorkerExecutionSafeResponse {
+  return result.safeResponse
+}
+
+function inferDomain(title: string, instruction: string): WorkerQueueInput['domain'] {
+  const text = `${title} ${instruction}`.toLowerCase()
+  if (text.includes('research')) return 'research'
+  if (text.includes('finance') || text.includes('money')) return 'finance'
+  if (text.includes('restored') || text.includes('church')) return 'restored'
+  if (text.includes('travel multiplier') || text.includes('tm ')) return 'travel_multiplier'
+  if (text.includes('code') || text.includes('build') || text.includes('implement')) return 'coding'
+  return 'executive'
+}
+
+function inferRisk(title: string, instruction: string): WorkerQueueInput['riskLevel'] {
+  const text = `${title} ${instruction}`.toLowerCase()
+  if (/(send|publish|spend|delete|restart|merge|credential|calendar)/.test(text)) return 'high'
+  return 'low'
+}

--- a/src/server/worker-spine/smoke-runner.test.ts
+++ b/src/server/worker-spine/smoke-runner.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { runWorkerSpineSmoke } from './smoke-runner'
+
+describe('runWorkerSpineSmoke', () => {
+  it('runs fake-only adapter scenarios and returns safe pass summary', async () => {
+    const result = await runWorkerSpineSmoke()
+    const serialized = JSON.stringify(result)
+
+    expect(result.ok).toBe(true)
+    expect(result.summary).toBe('Worker Spine Adapter Smoke: PASS')
+    expect(result.scenariosPassed).toBeGreaterThanOrEqual(5)
+    expect(result.scenariosFailed).toBe(0)
+    expect(result.unsafeMarkersAbsent).toBe(true)
+    expect(serialized).not.toContain('FAKE_TOKEN_SHOULD_NOT_RENDER')
+    expect(serialized).not.toContain('FAKE_STACK_TRACE_SHOULD_NOT_RENDER')
+    expect(serialized).not.toContain('FAKE_RAW_PROMPT_SHOULD_NOT_RENDER')
+  })
+})

--- a/src/server/worker-spine/smoke-runner.ts
+++ b/src/server/worker-spine/smoke-runner.ts
@@ -1,0 +1,74 @@
+import { runWorkerSpineAdapter } from './adapter'
+import {
+  blockedUnknownTask,
+  missingCredentialNeedsTimLocalSetup,
+  needsTimExternalSend,
+  requiredUnsafeMarkers,
+  routineDryRunNotLogged,
+  safeCodingTask,
+  unsafeOutputRejected,
+} from './adapter-fixtures'
+import { createFakeWorkerSpinePorts } from './ports'
+
+export interface WorkerSpineSmokeResult {
+  ok: boolean
+  summary: string
+  scenariosPassed: number
+  scenariosFailed: number
+  unsafeMarkersAbsent: boolean
+  surfacesVerified: Array<string>
+}
+
+export async function runWorkerSpineSmoke(): Promise<WorkerSpineSmokeResult> {
+  const scenarios = [
+    { input: safeCodingTask, expectedStatus: 'completed' },
+    { input: blockedUnknownTask, expectedStatus: 'blocked' },
+    { input: needsTimExternalSend, expectedStatus: 'needs_tim' },
+    { input: missingCredentialNeedsTimLocalSetup, expectedStatus: 'needs_tim' },
+    { input: routineDryRunNotLogged, expectedStatus: 'completed' },
+  ] as const
+
+  let passed = 0
+  let failed = 0
+  const serializedResults: Array<string> = []
+
+  for (const scenario of scenarios) {
+    const result = await runWorkerSpineAdapter({
+      input: scenario.input,
+      ports: createFakeWorkerSpinePorts(),
+    })
+    serializedResults.push(JSON.stringify(result))
+    if (result.decision.status === scenario.expectedStatus) passed += 1
+    else failed += 1
+  }
+
+  const unsafeResult = await runWorkerSpineAdapter({
+    input: unsafeOutputRejected,
+    ports: createFakeWorkerSpinePorts({
+      candidateOutput: {
+        status: 'completed',
+        summary: 'FAKE_TOKEN_SHOULD_NOT_RENDER FAKE_RAW_PROMPT_SHOULD_NOT_RENDER',
+        nextPrompt: 'unsafe',
+        artifactRefs: [],
+      },
+    }),
+  })
+  serializedResults.push(JSON.stringify(unsafeResult))
+  if (unsafeResult.decision.status === 'failed') passed += 1
+  else failed += 1
+
+  const combined = serializedResults.join('\n')
+  const unsafeMarkersAbsent = requiredUnsafeMarkers.every(
+    (marker) => !combined.includes(marker),
+  )
+  if (!unsafeMarkersAbsent) failed += 1
+
+  return {
+    ok: failed === 0,
+    summary: failed === 0 ? 'Worker Spine Adapter Smoke: PASS' : 'Worker Spine Adapter Smoke: FAIL',
+    scenariosPassed: passed,
+    scenariosFailed: failed,
+    unsafeMarkersAbsent,
+    surfacesVerified: ['adapter', 'record', 'safeResponse', 'telegramSummary', 'activityLogDecision'],
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a standalone Worker Spine adapter seam for safe queue execution
- Adds fake-only side-effect ports, deterministic fixtures, and unsafe-output validation
- Adds PR #600 mapping helpers and a smoke runner for lifecycle verification

## Test Plan
- pnpm exec vitest run src/server/worker-spine/adapter.test.ts src/server/worker-spine/ports.test.ts src/server/worker-spine/adapter-fixtures.test.ts src/server/worker-spine/pr600-seam.test.ts src/server/worker-spine/smoke-runner.test.ts
- pnpm exec eslint src/server/worker-spine
- pnpm build

## Notes
- Opened from fork because timmit687 does not have direct push permission to outsourc-e/hermes-workspace.
- No live Telegram, Notion, credential, or worker side effects are wired yet. Ports are fake-only by default.
