### PR TITLE
Add remote subagent server status runbook and PiBench fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
 
-<img src="./public/claude-avatar.webp" alt="Hermes Workspace" width="80" style="border-radius: 16px" />
+<img src="./public/claude-avatar.webp" alt="Hermes C&C Interface" width="80" style="border-radius: 16px" />
 <!-- avatar filename retained for cache stability — do not rename without coordinated cache-bust -->
 
-# Hermes Workspace
+# Hermes C&C Interface
 
 **Your AI agent's command center — chat, files, memory, skills, and terminal in one place.**
 
@@ -16,7 +16,7 @@
 
 > **v2 — zero-fork.** Clone, don't fork. Runs on vanilla [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) installed via Nous's own installer. Chat, sessions, memory, skills, jobs, MCP, terminal, dashboard, Agent View, and Operations are all in vanilla parity. **Conductor** uses the dashboard mission API when available and falls back to Workspace-native Swarm dispatch (`mode: native-swarm`) when the dashboard endpoint is absent, preserving zero-fork behavior ([#262](https://github.com/outsourc-e/hermes-workspace/issues/262)).
 
-![Hermes Workspace](./docs/screenshots/splash.png)
+![Hermes C&C Interface](./docs/screenshots/splash.png)
 
 </div>
 
@@ -125,8 +125,8 @@ Open http://localhost:3000. That's it.
 If you already have `hermes-agent` installed (via Nous's official installer, a source checkout, systemd, Docker, or another existing setup) and it's serving the gateway at `http://<host>:8642`, you don't need to reinstall anything — just point the workspace at it.
 
 ```bash
-git clone https://github.com/outsourc-e/hermes-workspace.git
-cd hermes-workspace
+git clone https://github.com/blackscience/hermes-c-c-interface.git
+cd hermes-c-c-interface
 pnpm install
 cp .env.example .env
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Start here: [docs/swarm/](./docs/swarm/)
 - 📱 **PWA + Tailscale** — Install as a native-feeling app; access from any device on your tailnet
 - ⚙️ **Capability gates** — Features that need upstream endpoints (Conductor) show a clean placeholder instead of failing mid-action
 
+
+### Remote subagent servers status panel
+
+The pve2 C&C status page at `http://192.168.1.140:9120/` includes a **Remote subagent servers** panel for LAN Hermes helper nodes. It currently tracks:
+
+- `192.168.1.108` / `DietGTX780Ti`
+- `192.168.1.151` / `DietPi`
+
+Both nodes are configured for Ollama Cloud subagent work. The panel exposes `/remote-subagents.json`, per-host JSON endpoints, and a model selector that applies changes to the selected server by running `hermes config set` remotely for both the main `model` block and the `delegation` block. The POST succeeds only after the remote Hermes config is read back and verified.
+
+Verified Ollama Cloud model options in this environment are `qwen3-next:80b`, `glm-4.6:latest`, and `gpt-oss:20b`. See [docs/operations/remote-subagent-servers.md](./docs/operations/remote-subagent-servers.md) for runtime paths, service names, endpoint contracts, and verification commands.
+
 ---
 
 ## 📸 Screenshots

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Start here: [docs/swarm/](./docs/swarm/)
 
 The pve2 C&C status page at `http://192.168.1.140:9120/` includes a **Remote subagent servers** panel for LAN Hermes helper nodes. It currently tracks:
 
-- `192.168.1.108` / `DietGTX780Ti`
+- `192.168.1.219` / `PiBench` (primary/first fallback)
 - `192.168.1.151` / `DietPi`
+- `192.168.1.108` / `DietGTX780Ti`
 
 Both nodes are configured for Ollama Cloud subagent work. The panel exposes `/remote-subagents.json`, per-host JSON endpoints, and a model selector that applies changes to the selected server by running `hermes config set` remotely for both the main `model` block and the `delegation` block. The POST succeeds only after the remote Hermes config is read back and verified.
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ Start here: [docs/swarm/](./docs/swarm/)
 The pve2 C&C status page at `http://192.168.1.140:9120/` includes a **Remote subagent servers** panel for LAN Hermes helper nodes. It currently tracks:
 
 - `192.168.1.219` / `PiBench` (primary/first fallback)
+- `192.168.1.211` / `Pxvirt`
 - `192.168.1.151` / `DietPi`
 - `192.168.1.108` / `DietGTX780Ti`
 
-Both nodes are configured for Ollama Cloud subagent work. The panel exposes `/remote-subagents.json`, per-host JSON endpoints, and a model selector that applies changes to the selected server by running `hermes config set` remotely for both the main `model` block and the `delegation` block. The POST succeeds only after the remote Hermes config is read back and verified.
+All listed nodes are configured for Ollama Cloud subagent work. The panel exposes `/remote-subagents.json`, per-host JSON endpoints, and a model selector that applies changes to the selected server by running `hermes config set` remotely for both the main `model` block and the `delegation` block. The POST succeeds only after the remote Hermes config is read back and verified.
 
 Verified Ollama Cloud model options in this environment are `qwen3-next:80b`, `glm-4.6:latest`, and `gpt-oss:20b`. See [docs/operations/remote-subagent-servers.md](./docs/operations/remote-subagent-servers.md) for runtime paths, service names, endpoint contracts, and verification commands.
 

--- a/docs/operations/remote-subagent-servers.md
+++ b/docs/operations/remote-subagent-servers.md
@@ -1,0 +1,129 @@
+# Remote subagent servers on the Hermes C&C status page
+
+The pve2 Hermes C&C status page at `http://192.168.1.140:9120/` is served by the Python systemd service `hermes-backup-status.service`.
+It includes a **Remote subagent servers** section for LAN Hermes helper nodes and Ollama Cloud model switching.
+
+## Runtime files on pve2
+
+- Status page service: `hermes-backup-status.service`
+- Runtime server file: `/mnt/pve/LocalDir/hermes-critical/pve2/hermes-backup-status-server.py`
+- Installed service path: `/usr/local/lib/hermes-backup-status-server.py`
+- Generic status checker: `/usr/local/sbin/hermes-subagent-status.py`
+- Model selection state: `/etc/hermes-subagent-models.json`
+- Per-host status JSON:
+  - `/var/lib/hermes-subagent-108/status.json`
+  - `/var/lib/hermes-subagent-151/status.json`
+
+The repository keeps source snapshots in `scripts/status-page/` so changes can be reviewed and pushed instead of living only as ad-hoc host files.
+
+## Registered servers
+
+| ID | Host | Name | Role |
+| --- | --- | --- | --- |
+| `108` | `192.168.1.108` | `DietGTX780Ti` | Existing Hermes remote subagent host |
+| `151` | `192.168.1.151` | `DietPi` | Hermes remote subagent host installed on DietPi/Debian 12 |
+
+Both servers are configured to use Ollama Cloud:
+
+```yaml
+model:
+  provider: ollama-cloud
+  default: qwen3-next:80b
+  base_url: ''
+
+delegation:
+  provider: ollama-cloud
+  model: qwen3-next:80b
+  base_url: ''
+  api_key: ''
+  api_mode: chat_completions
+```
+
+`OLLAMA_API_KEY` lives in each host's `/root/.hermes/.env`; do not copy or print secret values in logs or docs.
+
+## Status timers
+
+Each server has its own status timer. The checker probes ping, SSH, Hermes install/config, and an Ollama Cloud chat-completion smoke test.
+
+```bash
+systemctl status hermes-108-subagent-status.timer hermes-151-subagent-status.timer --no-pager
+systemctl start hermes-108-subagent-status.service hermes-151-subagent-status.service
+```
+
+Expected JSON readiness after a healthy run:
+
+```json
+{
+  "ready": true,
+  "summary": "ready",
+  "desired_provider": "ollama-cloud",
+  "desired_model": "qwen3-next:80b",
+  "ssh_ok": true,
+  "hermes_ok": true,
+  "ollama_cloud_ok": true
+}
+```
+
+## HTTP endpoints
+
+- `/remote-subagents.json` returns all registered remote subagent statuses.
+- `/subagent-108.json` returns the DietGTX780Ti status.
+- `/subagent-151.json` returns the DietPi status.
+- `/subagent-status.json` remains backward compatible with the original 108 status.
+- `/set-subagent-model` is a POST endpoint used by the Web UI model selector.
+
+## Verified Ollama Cloud models
+
+The Web UI only offers models that were scanned with the active Ollama Cloud account and verified to answer a Hermes smoke test:
+
+- `qwen3-next:80b`
+- `glm-4.6:latest`
+- `gpt-oss:20b`
+
+Models such as `qwen3:8b` and `glm-4.5:latest` returned HTTP 404 in this environment and should not be offered unless a future scan verifies them.
+
+## Model switching contract
+
+Changing a model in the Web UI must update the selected remote server's live Hermes config, not just local desired state.
+
+For the selected server, `/set-subagent-model` must SSH to the host and run:
+
+```bash
+hermes config set model.provider ollama-cloud
+hermes config set model.default '<model>'
+hermes config set model.base_url ''
+hermes config set delegation.provider ollama-cloud
+hermes config set delegation.model '<model>'
+hermes config set delegation.base_url ''
+hermes config set delegation.api_key ''
+hermes config set delegation.api_mode chat_completions
+```
+
+After applying, the remote command reads back `hermes config` / `config.yaml` and fails unless the selected model/provider are present in both the `model` and `delegation` blocks. A Web UI success response therefore means the remote Hermes config picked up the change.
+
+## Verification checklist after changes
+
+```bash
+python3 -m py_compile /mnt/pve/LocalDir/hermes-critical/pve2/hermes-backup-status-server.py /usr/local/sbin/hermes-subagent-status.py
+systemctl restart hermes-backup-status.service
+systemctl is-active hermes-backup-status.service
+systemctl start hermes-108-subagent-status.service hermes-151-subagent-status.service
+python3 - <<'PY'
+import json, urllib.request
+for path in ['/remote-subagents.json', '/subagent-151.json']:
+    data = json.load(urllib.request.urlopen('http://127.0.0.1:9120' + path, timeout=10))
+    print(path, data if path != '/remote-subagents.json' else data.keys())
+PY
+```
+
+Also verify the LAN UI contains `Remote subagent servers`, both host IPs, all verified model options, and `/set-subagent-model`.
+
+## One-shot helper
+
+`/usr/local/bin/hermes-151-subagent` runs a prompt on the DietPi remote Hermes instance:
+
+```bash
+hermes-151-subagent 'Reply exactly OK'
+```
+
+The helper uses the private DietPi credential env file and refreshes the 151 status checker after the run.

--- a/docs/operations/remote-subagent-servers.md
+++ b/docs/operations/remote-subagent-servers.md
@@ -10,9 +10,10 @@ It includes a **Remote subagent servers** section for LAN Hermes helper nodes an
 - Installed service path: `/usr/local/lib/hermes-backup-status-server.py`
 - Generic status checker: `/usr/local/sbin/hermes-subagent-status.py`
 - Model selection state: `/etc/hermes-subagent-models.json`
-- Per-host status JSON:
-  - `/var/lib/hermes-subagent-108/status.json`
+- Per-host status JSON, in fallback order:
+  - `/var/lib/hermes-subagent-219/status.json`
   - `/var/lib/hermes-subagent-151/status.json`
+  - `/var/lib/hermes-subagent-108/status.json`
 
 The repository keeps source snapshots in `scripts/status-page/` so changes can be reviewed and pushed instead of living only as ad-hoc host files.
 
@@ -20,10 +21,11 @@ The repository keeps source snapshots in `scripts/status-page/` so changes can b
 
 | ID | Host | Name | Role |
 | --- | --- | --- | --- |
-| `108` | `192.168.1.108` | `DietGTX780Ti` | Existing Hermes remote subagent host |
+| `219` | `192.168.1.219` | `PiBench` | Primary/first fallback Hermes remote subagent host; SSH user `blackscience`, commands run with sudo-root for Hermes config |
 | `151` | `192.168.1.151` | `DietPi` | Hermes remote subagent host installed on DietPi/Debian 12 |
+| `108` | `192.168.1.108` | `DietGTX780Ti` | Existing Hermes remote subagent host |
 
-Both servers are configured to use Ollama Cloud:
+All servers are configured to use Ollama Cloud:
 
 ```yaml
 model:
@@ -46,8 +48,8 @@ delegation:
 Each server has its own status timer. The checker probes ping, SSH, Hermes install/config, and an Ollama Cloud chat-completion smoke test.
 
 ```bash
-systemctl status hermes-108-subagent-status.timer hermes-151-subagent-status.timer --no-pager
-systemctl start hermes-108-subagent-status.service hermes-151-subagent-status.service
+systemctl status hermes-219-subagent-status.timer hermes-151-subagent-status.timer hermes-108-subagent-status.timer --no-pager
+systemctl start hermes-219-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
 ```
 
 Expected JSON readiness after a healthy run:
@@ -67,8 +69,9 @@ Expected JSON readiness after a healthy run:
 ## HTTP endpoints
 
 - `/remote-subagents.json` returns all registered remote subagent statuses.
-- `/subagent-108.json` returns the DietGTX780Ti status.
+- `/subagent-219.json` returns the PiBench primary fallback status.
 - `/subagent-151.json` returns the DietPi status.
+- `/subagent-108.json` returns the DietGTX780Ti status.
 - `/subagent-status.json` remains backward compatible with the original 108 status.
 - `/set-subagent-model` is a POST endpoint used by the Web UI model selector.
 
@@ -107,16 +110,16 @@ After applying, the remote command reads back `hermes config` / `config.yaml` an
 python3 -m py_compile /mnt/pve/LocalDir/hermes-critical/pve2/hermes-backup-status-server.py /usr/local/sbin/hermes-subagent-status.py
 systemctl restart hermes-backup-status.service
 systemctl is-active hermes-backup-status.service
-systemctl start hermes-108-subagent-status.service hermes-151-subagent-status.service
+systemctl start hermes-219-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
 python3 - <<'PY'
 import json, urllib.request
-for path in ['/remote-subagents.json', '/subagent-151.json']:
+for path in ['/remote-subagents.json', '/subagent-219.json', '/subagent-151.json', '/subagent-108.json']:
     data = json.load(urllib.request.urlopen('http://127.0.0.1:9120' + path, timeout=10))
     print(path, data if path != '/remote-subagents.json' else data.keys())
 PY
 ```
 
-Also verify the LAN UI contains `Remote subagent servers`, both host IPs, all verified model options, and `/set-subagent-model`.
+Also verify the LAN UI contains `Remote subagent servers`, all registered host IPs, all verified model options, and `/set-subagent-model`.
 
 ## One-shot helper
 

--- a/docs/operations/remote-subagent-servers.md
+++ b/docs/operations/remote-subagent-servers.md
@@ -12,6 +12,7 @@ It includes a **Remote subagent servers** section for LAN Hermes helper nodes an
 - Model selection state: `/etc/hermes-subagent-models.json`
 - Per-host status JSON, in fallback order:
   - `/var/lib/hermes-subagent-219/status.json`
+  - `/var/lib/hermes-subagent-211/status.json`
   - `/var/lib/hermes-subagent-151/status.json`
   - `/var/lib/hermes-subagent-108/status.json`
 
@@ -22,6 +23,7 @@ The repository keeps source snapshots in `scripts/status-page/` so changes can b
 | ID | Host | Name | Role |
 | --- | --- | --- | --- |
 | `219` | `192.168.1.219` | `PiBench` | Primary/first fallback Hermes remote subagent host; SSH user `blackscience`, commands run with sudo-root for Hermes config |
+| `211` | `192.168.1.211` | `Pxvirt` | Proxmox/Pi5 host running Hermes as root with `RPI5_01_*` SSH credentials |
 | `151` | `192.168.1.151` | `DietPi` | Hermes remote subagent host installed on DietPi/Debian 12 |
 | `108` | `192.168.1.108` | `DietGTX780Ti` | Existing Hermes remote subagent host |
 
@@ -48,8 +50,8 @@ delegation:
 Each server has its own status timer. The checker probes ping, SSH, Hermes install/config, and an Ollama Cloud chat-completion smoke test.
 
 ```bash
-systemctl status hermes-219-subagent-status.timer hermes-151-subagent-status.timer hermes-108-subagent-status.timer --no-pager
-systemctl start hermes-219-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
+systemctl status hermes-219-subagent-status.timer hermes-211-subagent-status.timer hermes-151-subagent-status.timer hermes-108-subagent-status.timer --no-pager
+systemctl start hermes-219-subagent-status.service hermes-211-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
 ```
 
 Expected JSON readiness after a healthy run:
@@ -70,6 +72,7 @@ Expected JSON readiness after a healthy run:
 
 - `/remote-subagents.json` returns all registered remote subagent statuses.
 - `/subagent-219.json` returns the PiBench primary fallback status.
+- `/subagent-211.json` returns the Pxvirt status.
 - `/subagent-151.json` returns the DietPi status.
 - `/subagent-108.json` returns the DietGTX780Ti status.
 - `/subagent-status.json` remains backward compatible with the original 108 status.
@@ -110,10 +113,10 @@ After applying, the remote command reads back `hermes config` / `config.yaml` an
 python3 -m py_compile /mnt/pve/LocalDir/hermes-critical/pve2/hermes-backup-status-server.py /usr/local/sbin/hermes-subagent-status.py
 systemctl restart hermes-backup-status.service
 systemctl is-active hermes-backup-status.service
-systemctl start hermes-219-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
+systemctl start hermes-219-subagent-status.service hermes-211-subagent-status.service hermes-151-subagent-status.service hermes-108-subagent-status.service
 python3 - <<'PY'
 import json, urllib.request
-for path in ['/remote-subagents.json', '/subagent-219.json', '/subagent-151.json', '/subagent-108.json']:
+for path in ['/remote-subagents.json', '/subagent-219.json', '/subagent-211.json', '/subagent-151.json', '/subagent-108.json']:
     data = json.load(urllib.request.urlopen('http://127.0.0.1:9120' + path, timeout=10))
     print(path, data if path != '/remote-subagents.json' else data.keys())
 PY

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "hermes-workspace",
+  "name": "hermes-c-c-interface",
   "version": "2.3.0",
-  "description": "Desktop workspace for Hermes Agent — chat, orchestration, and multi-agent coding pipelines",
+  "description": "Hermes C&C Interface \u2014 command-and-control dashboard for Hermes Agent, backups, subagents, and homelab operations",
   "author": "Eric (https://github.com/outsourc-e)",
   "license": "MIT",
   "private": true,

--- a/scripts/status-page/README.md
+++ b/scripts/status-page/README.md
@@ -1,0 +1,24 @@
+# pve2 Hermes C&C status-page scripts
+
+This directory contains repository snapshots of the Python-backed status-page utilities that run on pve2.
+
+Runtime deployment paths:
+
+- `hermes-backup-status-server.py` -> `/mnt/pve/LocalDir/hermes-critical/pve2/hermes-backup-status-server.py` and `/usr/local/lib/hermes-backup-status-server.py`
+- `hermes-subagent-status.py` -> `/usr/local/sbin/hermes-subagent-status.py`
+- `hermes-151-subagent` -> `/usr/local/bin/hermes-151-subagent`
+
+The live service is `hermes-backup-status.service` on port `9120`.
+
+The Remote subagent servers panel tracks:
+
+- `108`: `192.168.1.108` / DietGTX780Ti
+- `151`: `192.168.1.151` / DietPi
+
+The model selector is intentionally constrained to Ollama Cloud models verified with the active account:
+
+- `qwen3-next:80b`
+- `glm-4.6:latest`
+- `gpt-oss:20b`
+
+When a user applies a model in the Web UI, `/set-subagent-model` must update the selected remote host's Hermes config and verify the effective config before returning success. See `../../docs/operations/remote-subagent-servers.md` for the full runbook.

--- a/scripts/status-page/README.md
+++ b/scripts/status-page/README.md
@@ -12,8 +12,9 @@ The live service is `hermes-backup-status.service` on port `9120`.
 
 The Remote subagent servers panel tracks:
 
-- `108`: `192.168.1.108` / DietGTX780Ti
+- `219`: `192.168.1.219` / PiBench
 - `151`: `192.168.1.151` / DietPi
+- `108`: `192.168.1.108` / DietGTX780Ti
 
 The model selector is intentionally constrained to Ollama Cloud models verified with the active account:
 

--- a/scripts/status-page/README.md
+++ b/scripts/status-page/README.md
@@ -13,6 +13,7 @@ The live service is `hermes-backup-status.service` on port `9120`.
 The Remote subagent servers panel tracks:
 
 - `219`: `192.168.1.219` / PiBench
+- `211`: `192.168.1.211` / Pxvirt
 - `151`: `192.168.1.151` / DietPi
 - `108`: `192.168.1.108` / DietGTX780Ti
 

--- a/scripts/status-page/hermes-151-subagent
+++ b/scripts/status-page/hermes-151-subagent
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ENV_PATH=/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/dietpi.env
+STATUS=/usr/local/sbin/hermes-subagent-status.py
+if [ $# -lt 1 ]; then
+  echo "Usage: hermes-151-subagent 'task prompt for the remote subagent'" >&2
+  exit 2
+fi
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 151 >/dev/null || true
+fi
+if [ ! -f "$ENV_PATH" ]; then
+  echo "Missing $ENV_PATH" >&2
+  exit 1
+fi
+set -a
+. "$ENV_PATH"
+set +a
+HOST=${DIETPI_HOST:-192.168.1.151}
+USER=${DIETPI_USER:-root}
+PORT=${DIETPI_PORT:-22}
+STRICT=${HERMES_MASTER_STRICT_HOST_KEY_CHECKING:-accept-new}
+PASSWORD=${DIETPI_PASSWORD:-${HERMES_MASTER_PASSWORD:-}}
+if [ -z "$PASSWORD" ]; then
+  echo "Missing DIETPI_PASSWORD/HERMES_MASTER_PASSWORD in $ENV_PATH" >&2
+  exit 1
+fi
+prompt="$*"
+remote_cmd=$(python3 - "$prompt" <<'PY'
+import shlex, sys
+prompt=sys.argv[1]
+print('export PATH=/usr/local/bin:/root/.local/bin:$PATH; hermes chat -Q -q ' + shlex.quote(prompt))
+PY
+)
+tmp=$(mktemp)
+set +e
+sshpass -p "$PASSWORD" ssh \
+  -o ConnectTimeout=8 \
+  -o BatchMode=no \
+  -o ServerAliveInterval=15 \
+  -o StrictHostKeyChecking="$STRICT" \
+  -p "$PORT" \
+  "$USER@$HOST" "$remote_cmd" 2>&1 | tee "$tmp"
+rc=${PIPESTATUS[0]}
+set -e
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 151 >/dev/null || true
+fi
+rm -f "$tmp"
+exit "$rc"

--- a/scripts/status-page/hermes-211-subagent
+++ b/scripts/status-page/hermes-211-subagent
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ENV_PATH=/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/RPi5_01.env
+STATUS=/usr/local/sbin/hermes-subagent-status.py
+if [ $# -lt 1 ]; then
+  echo "Usage: hermes-211-subagent 'task prompt for the remote subagent'" >&2
+  exit 2
+fi
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 211 >/dev/null || true
+fi
+if [ ! -f "$ENV_PATH" ]; then
+  echo "Missing $ENV_PATH" >&2
+  exit 1
+fi
+set -a
+. "$ENV_PATH"
+set +a
+HOST=${RPI5_01_HOST:-192.168.1.211}
+USER=${RPI5_01_USER:-root}
+PORT=${RPI5_01_PORT:-22}
+STRICT=${HERMES_MASTER_STRICT_HOST_KEY_CHECKING:-accept-new}
+PASSWORD=${RPI5_01_PASSWORD:-${HERMES_MASTER_PASSWORD:-}}
+if [ -z "$PASSWORD" ]; then
+  echo "Missing RPI5_01_PASSWORD/HERMES_MASTER_PASSWORD in $ENV_PATH" >&2
+  exit 1
+fi
+prompt="$*"
+remote_cmd=$(python3 - "$prompt" <<'PY'
+import shlex, sys
+prompt=sys.argv[1]
+print('export PATH=/usr/local/bin:/root/.local/bin:$PATH; hermes chat -Q -q ' + shlex.quote(prompt))
+PY
+)
+tmp=$(mktemp)
+set +e
+sshpass -p "$PASSWORD" ssh \
+  -o ConnectTimeout=8 \
+  -o BatchMode=no \
+  -o ServerAliveInterval=15 \
+  -o StrictHostKeyChecking="$STRICT" \
+  -p "$PORT" \
+  "$USER@$HOST" "$remote_cmd" 2>&1 | tee "$tmp"
+rc=${PIPESTATUS[0]}
+set -e
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 211 >/dev/null || true
+fi
+rm -f "$tmp"
+exit "$rc"

--- a/scripts/status-page/hermes-219-subagent
+++ b/scripts/status-page/hermes-219-subagent
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ENV_PATH=/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/PiBench.env
+STATUS=/usr/local/sbin/hermes-subagent-status.py
+if [ $# -lt 1 ]; then
+  echo "Usage: hermes-219-subagent 'task prompt for the remote subagent'" >&2
+  exit 2
+fi
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 219 >/dev/null || true
+fi
+if [ ! -f "$ENV_PATH" ]; then
+  echo "Missing $ENV_PATH" >&2
+  exit 1
+fi
+set -a
+. "$ENV_PATH"
+set +a
+HOST=${PIBENCH_HOST:-192.168.1.219}
+USER=${PIBENCH_USER:-blackscience}
+PORT=${PIBENCH_PORT:-22}
+STRICT=${HERMES_MASTER_STRICT_HOST_KEY_CHECKING:-accept-new}
+PASSWORD=${PIBENCH_PASSWORD:-${HERMES_MASTER_PASSWORD:-}}
+if [ -z "$PASSWORD" ]; then
+  echo "Missing PIBENCH_PASSWORD/HERMES_MASTER_PASSWORD in $ENV_PATH" >&2
+  exit 1
+fi
+prompt="$*"
+remote_cmd=$(python3 - "$prompt" <<'PY'
+import shlex, sys
+prompt=sys.argv[1]
+print('sudo -H bash -lc ' + shlex.quote('export PATH=/usr/local/bin:/root/.local/bin:$PATH; hermes chat -Q -q ' + shlex.quote(prompt)))
+PY
+)
+tmp=$(mktemp)
+set +e
+sshpass -p "$PASSWORD" ssh \
+  -o ConnectTimeout=8 \
+  -o BatchMode=no \
+  -o ServerAliveInterval=15 \
+  -o StrictHostKeyChecking="$STRICT" \
+  -p "$PORT" \
+  "$USER@$HOST" "$remote_cmd" 2>&1 | tee "$tmp"
+rc=${PIPESTATUS[0]}
+set -e
+if [ -x "$STATUS" ]; then
+  "$STATUS" --server 219 >/dev/null || true
+fi
+rm -f "$tmp"
+exit "$rc"

--- a/scripts/status-page/hermes-backup-status-server.py
+++ b/scripts/status-page/hermes-backup-status-server.py
@@ -33,6 +33,10 @@ HOST_151_IP = os.environ.get("HERMES_151_HOST", "192.168.1.151")
 HOST_151_NAME = os.environ.get("HERMES_151_NAME", "DietPi")
 HOST_151_CRED_ENV = pathlib.Path(os.environ.get("HERMES_151_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/dietpi.env"))
 SUBAGENT_151_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_151_SUBAGENT_STATUS", "/var/lib/hermes-subagent-151/status.json"))
+HOST_219_IP = os.environ.get("HERMES_219_HOST", "192.168.1.219")
+HOST_219_NAME = os.environ.get("HERMES_219_NAME", "PiBench")
+HOST_219_CRED_ENV = pathlib.Path(os.environ.get("HERMES_219_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/PiBench.env"))
+SUBAGENT_219_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_219_SUBAGENT_STATUS", "/var/lib/hermes-subagent-219/status.json"))
 SUBAGENT_MODEL_STATE_PATH = pathlib.Path(os.environ.get("HERMES_SUBAGENT_MODEL_STATE", "/etc/hermes-subagent-models.json"))
 WORKING_OLLAMA_CLOUD_MODELS = [
     {"model": "qwen3-next:80b", "label": "Qwen3 Next 80B (verified OK)"},
@@ -40,8 +44,9 @@ WORKING_OLLAMA_CLOUD_MODELS = [
     {"model": "gpt-oss:20b", "label": "gpt-oss 20B (verified OK)"},
 ]
 SUBAGENT_SERVERS = {
-    "108": {"id": "108", "name": HOST_108_NAME, "ip": HOST_108_IP, "cred_env": HOST_108_CRED_ENV, "status_path": SUBAGENT_STATUS_PATH, "helper": "hermes-108-subagent"},
-    "151": {"id": "151", "name": HOST_151_NAME, "ip": HOST_151_IP, "cred_env": HOST_151_CRED_ENV, "status_path": SUBAGENT_151_STATUS_PATH, "helper": "hermes-151-subagent"},
+    "219": {"id": "219", "name": HOST_219_NAME, "ip": HOST_219_IP, "cred_env": HOST_219_CRED_ENV, "status_path": SUBAGENT_219_STATUS_PATH, "helper": "hermes-219-subagent", "env_prefix": "PIBENCH", "sudo_root": True},
+    "151": {"id": "151", "name": HOST_151_NAME, "ip": HOST_151_IP, "cred_env": HOST_151_CRED_ENV, "status_path": SUBAGENT_151_STATUS_PATH, "helper": "hermes-151-subagent", "env_prefix": "DIETPI"},
+    "108": {"id": "108", "name": HOST_108_NAME, "ip": HOST_108_IP, "cred_env": HOST_108_CRED_ENV, "status_path": SUBAGENT_STATUS_PATH, "helper": "hermes-108-subagent", "env_prefix": "DIETPI"},
 }
 
 CSS = """
@@ -298,17 +303,32 @@ def _read_env_file(path):
         data[k.strip()] = v.strip().strip(chr(34)).strip(chr(39))
     return data
 
+def _env_value(creds, prefix, name, *fallback_keys):
+    if prefix:
+        value = creds.get(f"{prefix}_{name}")
+        if value:
+            return value
+    for key in fallback_keys:
+        value = creds.get(key)
+        if value:
+            return value
+    return ""
+
+
 def _ssh_command_for_server(server_id, remote_script):
     cfg = SUBAGENT_SERVERS.get(str(server_id))
     if not cfg:
         raise RuntimeError(f"Unknown subagent server {server_id}")
     creds = _read_env_file(cfg["cred_env"])
-    host = creds.get("DIETPI_HOST") or creds.get("HERMES_MASTER_HOST") or cfg["ip"]
-    user = creds.get("DIETPI_USER") or creds.get("HERMES_MASTER_USER") or "root"
-    port = creds.get("DIETPI_PORT") or creds.get("HERMES_MASTER_PORT") or "22"
-    password = creds.get("DIETPI_PASSWORD") or creds.get("HERMES_MASTER_PASSWORD") or ""
+    prefix = cfg.get("env_prefix", "")
+    host = _env_value(creds, prefix, "HOST", "DIETPI_HOST", "HERMES_MASTER_HOST") or cfg["ip"]
+    user = _env_value(creds, prefix, "USER", "DIETPI_USER", "HERMES_MASTER_USER") or "root"
+    port = _env_value(creds, prefix, "PORT", "DIETPI_PORT", "HERMES_MASTER_PORT") or "22"
+    password = _env_value(creds, prefix, "PASSWORD", "DIETPI_PASSWORD", "HERMES_MASTER_PASSWORD")
     if not password:
         raise RuntimeError(f"No SSH password found in {cfg['cred_env']}")
+    if cfg.get("sudo_root") and user != "root":
+        remote_script = "sudo -H bash -lc " + shlex.quote(remote_script)
     env = os.environ.copy()
     env["SSHPASS"] = password
     cmd = ["sshpass", "-e", "ssh", "-o", "BatchMode=no", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=6", "-p", str(port), f"{user}@{host}", remote_script]
@@ -982,6 +1002,9 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/subagent-151.json":
             self.send_json(read_subagent_status_for("151"))
             return
+        if path == "/subagent-219.json":
+            self.send_json(read_subagent_status_for("219"))
+            return
         if path == "/cloudflare-ns-status.json":
             self.send_json(read_cloudflare_ns_status())
             return
@@ -1102,8 +1125,8 @@ class Handler(BaseHTTPRequestHandler):
 </section>
 """
         statuses = all_subagent_statuses()
-        subagent_body = "".join(render_subagent_card(sid, statuses[sid]) for sid in sorted(SUBAGENT_SERVERS)) + """
-<p class='muted small'>Verified working Ollama Cloud model scan: <code>qwen3-next:80b</code>, <code>glm-4.6:latest</code>, and <code>gpt-oss:20b</code>. JSON endpoints: <a href='/remote-subagents.json'>/remote-subagents.json</a>, <a href='/subagent-108.json'>/subagent-108.json</a>, <a href='/subagent-151.json'>/subagent-151.json</a>.</p>
+        subagent_body = "".join(render_subagent_card(sid, statuses[sid]) for sid in SUBAGENT_SERVERS) + """
+<p class='muted small'>Verified working Ollama Cloud model scan: <code>qwen3-next:80b</code>, <code>glm-4.6:latest</code>, and <code>gpt-oss:20b</code>. JSON endpoints: <a href='/remote-subagents.json'>/remote-subagents.json</a>, <a href='/subagent-108.json'>/subagent-108.json</a>, <a href='/subagent-151.json'>/subagent-151.json</a>, <a href='/subagent-219.json'>/subagent-219.json</a>.</p>
 """
         subagent_section = collapsible("Remote subagent servers", subagent_body, True)
         def fmt_ns_list(items):

--- a/scripts/status-page/hermes-backup-status-server.py
+++ b/scripts/status-page/hermes-backup-status-server.py
@@ -37,6 +37,10 @@ HOST_219_IP = os.environ.get("HERMES_219_HOST", "192.168.1.219")
 HOST_219_NAME = os.environ.get("HERMES_219_NAME", "PiBench")
 HOST_219_CRED_ENV = pathlib.Path(os.environ.get("HERMES_219_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/PiBench.env"))
 SUBAGENT_219_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_219_SUBAGENT_STATUS", "/var/lib/hermes-subagent-219/status.json"))
+HOST_211_IP = os.environ.get("HERMES_211_HOST", "192.168.1.211")
+HOST_211_NAME = os.environ.get("HERMES_211_NAME", "Pxvirt")
+HOST_211_CRED_ENV = pathlib.Path(os.environ.get("HERMES_211_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/RPi5_01.env"))
+SUBAGENT_211_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_211_SUBAGENT_STATUS", "/var/lib/hermes-subagent-211/status.json"))
 SUBAGENT_MODEL_STATE_PATH = pathlib.Path(os.environ.get("HERMES_SUBAGENT_MODEL_STATE", "/etc/hermes-subagent-models.json"))
 WORKING_OLLAMA_CLOUD_MODELS = [
     {"model": "qwen3-next:80b", "label": "Qwen3 Next 80B (verified OK)"},
@@ -45,6 +49,7 @@ WORKING_OLLAMA_CLOUD_MODELS = [
 ]
 SUBAGENT_SERVERS = {
     "219": {"id": "219", "name": HOST_219_NAME, "ip": HOST_219_IP, "cred_env": HOST_219_CRED_ENV, "status_path": SUBAGENT_219_STATUS_PATH, "helper": "hermes-219-subagent", "env_prefix": "PIBENCH", "sudo_root": True},
+    "211": {"id": "211", "name": HOST_211_NAME, "ip": HOST_211_IP, "cred_env": HOST_211_CRED_ENV, "status_path": SUBAGENT_211_STATUS_PATH, "helper": "hermes-211-subagent", "env_prefix": "RPI5_01"},
     "151": {"id": "151", "name": HOST_151_NAME, "ip": HOST_151_IP, "cred_env": HOST_151_CRED_ENV, "status_path": SUBAGENT_151_STATUS_PATH, "helper": "hermes-151-subagent", "env_prefix": "DIETPI"},
     "108": {"id": "108", "name": HOST_108_NAME, "ip": HOST_108_IP, "cred_env": HOST_108_CRED_ENV, "status_path": SUBAGENT_STATUS_PATH, "helper": "hermes-108-subagent", "env_prefix": "DIETPI"},
 }
@@ -1005,6 +1010,9 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/subagent-219.json":
             self.send_json(read_subagent_status_for("219"))
             return
+        if path == "/subagent-211.json":
+            self.send_json(read_subagent_status_for("211"))
+            return
         if path == "/cloudflare-ns-status.json":
             self.send_json(read_cloudflare_ns_status())
             return
@@ -1126,7 +1134,7 @@ class Handler(BaseHTTPRequestHandler):
 """
         statuses = all_subagent_statuses()
         subagent_body = "".join(render_subagent_card(sid, statuses[sid]) for sid in SUBAGENT_SERVERS) + """
-<p class='muted small'>Verified working Ollama Cloud model scan: <code>qwen3-next:80b</code>, <code>glm-4.6:latest</code>, and <code>gpt-oss:20b</code>. JSON endpoints: <a href='/remote-subagents.json'>/remote-subagents.json</a>, <a href='/subagent-108.json'>/subagent-108.json</a>, <a href='/subagent-151.json'>/subagent-151.json</a>, <a href='/subagent-219.json'>/subagent-219.json</a>.</p>
+<p class='muted small'>Verified working Ollama Cloud model scan: <code>qwen3-next:80b</code>, <code>glm-4.6:latest</code>, and <code>gpt-oss:20b</code>. JSON endpoints: <a href='/remote-subagents.json'>/remote-subagents.json</a>, <a href='/subagent-108.json'>/subagent-108.json</a>, <a href='/subagent-151.json'>/subagent-151.json</a>, <a href='/subagent-219.json'>/subagent-219.json</a>, <a href='/subagent-211.json'>/subagent-211.json</a>.</p>
 """
         subagent_section = collapsible("Remote subagent servers", subagent_body, True)
         def fmt_ns_list(items):

--- a/scripts/status-page/hermes-backup-status-server.py
+++ b/scripts/status-page/hermes-backup-status-server.py
@@ -1,0 +1,1178 @@
+#!/usr/bin/env python3
+import html
+import json
+import os
+import pathlib
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+STATUS_PATH = pathlib.Path(os.environ.get("HERMES_BACKUP_STATUS", "/var/lib/hermes-backup/status.json"))
+BACKUP_ROOT = pathlib.Path(os.environ.get("HERMES_BACKUP_ROOT", "/mnt/qnas-hermes-backups/hermes-pve2"))
+PORT = int(os.environ.get("HERMES_BACKUP_STATUS_PORT", "9120"))
+HOST = os.environ.get("HERMES_BACKUP_STATUS_HOST", "0.0.0.0")
+BACKUP_UNIT = os.environ.get("HERMES_BACKUP_UNIT", "hermes-qnas-backup.service")
+HOST_108_IP = os.environ.get("HERMES_108_HOST", "192.168.1.108")
+HOST_108_NAME = os.environ.get("HERMES_108_NAME", "DietGTX780Ti")
+HOST_108_WAKE_CMD = os.environ.get("HERMES_108_WAKE_CMD", "/usr/local/bin/wake-dietgtx780ti")
+HOST_108_CRED_ENV = pathlib.Path(os.environ.get("HERMES_108_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/hermes_slave.env"))
+HOST_108_SLEEP_WAIT_SECONDS = int(os.environ.get("HERMES_108_SLEEP_WAIT_SECONDS", "90"))
+HOST_108_FAN_CMD = os.environ.get("HERMES_108_FAN_CMD", "/usr/local/sbin/hermes-fan-control")
+SUBAGENT_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_108_SUBAGENT_STATUS", "/var/lib/hermes-subagent-108/status.json"))
+CLOUDFLARE_NS_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_CLOUDFLARE_NS_STATUS", "/var/lib/hermes-cloudflare-ns/status.json"))
+SETTINGS_PATH = pathlib.Path(os.environ.get("HERMES_BACKUP_SETTINGS", "/etc/hermes-qnas-backup-settings.json"))
+ENV_PATH = pathlib.Path(os.environ.get("HERMES_BACKUP_ENV", "/etc/default/hermes-qnas-backup"))
+TIMER_PATH = pathlib.Path(os.environ.get("HERMES_BACKUP_TIMER_UNIT", "/etc/systemd/system/hermes-qnas-backup.timer"))
+DEFAULT_SETTINGS = {"retention_count": 14, "schedule": "*-*-* 03:20:00", "randomized_delay": "20m", "timer_enabled": True}
+APP_TITLE = "Hermes C&C Interface"
+GIT_STATUS_REPO = pathlib.Path(os.environ.get("HERMES_STATUS_GIT_REPO", "/root/hermes-workspace"))
+HOST_151_IP = os.environ.get("HERMES_151_HOST", "192.168.1.151")
+HOST_151_NAME = os.environ.get("HERMES_151_NAME", "DietPi")
+HOST_151_CRED_ENV = pathlib.Path(os.environ.get("HERMES_151_CRED_ENV", "/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/dietpi.env"))
+SUBAGENT_151_STATUS_PATH = pathlib.Path(os.environ.get("HERMES_151_SUBAGENT_STATUS", "/var/lib/hermes-subagent-151/status.json"))
+SUBAGENT_MODEL_STATE_PATH = pathlib.Path(os.environ.get("HERMES_SUBAGENT_MODEL_STATE", "/etc/hermes-subagent-models.json"))
+WORKING_OLLAMA_CLOUD_MODELS = [
+    {"model": "qwen3-next:80b", "label": "Qwen3 Next 80B (verified OK)"},
+    {"model": "glm-4.6:latest", "label": "GLM 4.6 latest (verified OK)"},
+    {"model": "gpt-oss:20b", "label": "gpt-oss 20B (verified OK)"},
+]
+SUBAGENT_SERVERS = {
+    "108": {"id": "108", "name": HOST_108_NAME, "ip": HOST_108_IP, "cred_env": HOST_108_CRED_ENV, "status_path": SUBAGENT_STATUS_PATH, "helper": "hermes-108-subagent"},
+    "151": {"id": "151", "name": HOST_151_NAME, "ip": HOST_151_IP, "cred_env": HOST_151_CRED_ENV, "status_path": SUBAGENT_151_STATUS_PATH, "helper": "hermes-151-subagent"},
+}
+
+CSS = """
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#0b1020;color:#e5e7eb;margin:0;padding:2rem;}
+.card{max-width:960px;margin:auto;background:#111827;border:1px solid #374151;border-radius:16px;padding:1.5rem;box-shadow:0 20px 50px #0008;}
+h1{margin-top:0}.ok{color:#34d399}.bad{color:#f87171}.run{color:#fbbf24}.muted{color:#9ca3af}
+table{border-collapse:collapse;width:100%;margin-top:1rem}td,th{padding:.55rem;border-bottom:1px solid #374151;text-align:left}code{background:#020617;padding:.15rem .35rem;border-radius:6px}a{color:#93c5fd}
+.pill{display:inline-block;padding:.2rem .6rem;border-radius:999px;background:#1f2937}.grid{display:grid;grid-template-columns:180px 1fr;gap:.5rem}.small{font-size:.9rem}
+.actions{margin:1rem 0 1.25rem 0;display:flex;gap:.75rem;align-items:center;flex-wrap:wrap}
+button{background:#2563eb;color:white;border:0;border-radius:10px;padding:.65rem 1rem;font-weight:700;cursor:pointer}button:hover{background:#1d4ed8}button:disabled{background:#374151;color:#9ca3af;cursor:not-allowed}
+button.warn{background:#b45309}button.warn:hover{background:#92400e}
+button.danger{background:#991b1b;padding:.4rem .65rem;font-size:.85rem}button.danger:hover{background:#7f1d1d}
+.delete-form{margin:0}.path-cell{word-break:break-all}.actions-cell{white-space:nowrap}
+.notice{padding:.7rem .9rem;border:1px solid #374151;border-radius:10px;background:#0f172a;margin:.75rem 0}.notice.ok{border-color:#065f46}.notice.bad{border-color:#7f1d1d}
+.host-card{border:1px solid #374151;border-radius:14px;background:#0f172a;padding:1rem;margin:1rem 0 1.25rem 0}.host-head{display:flex;justify-content:space-between;gap:1rem;align-items:center;flex-wrap:wrap}.host-state{display:flex;gap:.55rem;align-items:center}.led{display:inline-block;width:.85rem;height:.85rem;border-radius:999px;background:#6b7280;box-shadow:0 0 12px #6b728055}.led.online{background:#34d399;box-shadow:0 0 16px #34d399cc}.led.offline{background:#ef4444;box-shadow:0 0 16px #ef4444aa}.led.checking{background:#fbbf24;box-shadow:0 0 16px #fbbf24aa}
+.progress-card{border:1px solid #374151;border-radius:14px;background:#0f172a;padding:1rem;margin:1rem 0 1.25rem 0}
+.progress-head{display:flex;justify-content:space-between;gap:1rem;align-items:baseline;margin-bottom:.55rem}
+.progress-track{height:18px;background:#020617;border:1px solid #374151;border-radius:999px;overflow:hidden;position:relative}
+.progress-fill{height:100%;width:0%;border-radius:999px;background:linear-gradient(90deg,#2563eb,#06b6d4,#34d399);transition:width .7s ease;position:relative;overflow:hidden}
+.progress-fill:after{content:"";position:absolute;inset:0;background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.35) 45%,transparent 70%);animation:shine 1.1s linear infinite}
+.progress-fill.indeterminate{width:42%;animation:indeterminate 1.2s ease-in-out infinite}
+.progress-meta{margin-top:.6rem;display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap}
+.stage-list{margin:.7rem 0 0 0;padding-left:1.1rem;color:#9ca3af}.stage-list li.done{color:#34d399}.stage-list li.current{color:#fbbf24;font-weight:700}
+@keyframes shine{from{transform:translateX(-100%)}to{transform:translateX(100%)}}
+@keyframes indeterminate{0%{transform:translateX(-110%)}50%{transform:translateX(80%)}100%{transform:translateX(240%)}}
+.nav{display:flex;gap:.75rem;flex-wrap:wrap;margin:.75rem 0 1rem}.nav a{background:#1f2937;border:1px solid #374151;border-radius:10px;padding:.45rem .7rem;text-decoration:none}.settings-form{display:grid;grid-template-columns:220px 1fr;gap:.75rem;align-items:center}.settings-form input,.model-form select{background:#020617;color:#e5e7eb;border:1px solid #374151;border-radius:8px;padding:.45rem}.settings-form .full{grid-column:1 / -1}.model-form{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;margin-top:.75rem}.model-form select{min-width:260px}.settings-form button{justify-self:start}
+.fan-panel{border-top:1px solid #374151;margin-top:1rem;padding-top:1rem}.fan-row{display:grid;grid-template-columns:150px 1fr 70px;gap:.75rem;align-items:center}.fan-row input[type=range]{width:100%;accent-color:#38bdf8}.fan-readout{display:grid;grid-template-columns:150px 1fr;gap:.35rem .75rem;margin-top:.75rem}
+details.panel{border:1px solid #374151;border-radius:14px;background:#0f172a;margin:1rem 0 1.25rem 0;overflow:hidden}details.panel>summary{list-style:none;cursor:pointer;padding:.85rem 1rem;font-weight:800;display:flex;justify-content:space-between;align-items:center;background:#111827}details.panel>summary::-webkit-details-marker{display:none}details.panel>summary:after{content:"−";color:#9ca3af;font-size:1.15rem}details.panel:not([open])>summary:after{content:"+"}details.panel>.panel-body{padding:1rem}.git-clean{color:#34d399}.git-dirty{color:#fbbf24}.git-bad{color:#f87171}
+"""
+
+SCRIPT = """
+<script>
+const STAGES = [
+  'Starting', 'Mounting QNAS / collecting metadata', 'Backing up SQLite DBs',
+  'Archiving Hermes config/state', 'Backing up snapshot metadata',
+  'Backing up Honcho/Postgres', 'Writing manifest/checksums',
+  'Copying backup set to QNAS', 'Completed'
+];
+function esc(s){return String(s ?? '').replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c]));}
+function renderStages(currentIndex, state){
+  const ol = document.getElementById('stageList');
+  if(!ol) return;
+  ol.innerHTML = STAGES.map((name, i) => {
+    let cls = '';
+    if(state === 'success') cls = 'done';
+    else if(state === 'running' && i < currentIndex) cls = 'done';
+    else if(state === 'running' && i === currentIndex) cls = 'current';
+    return `<li class="${cls}">${esc(name)}</li>`;
+  }).join('');
+}
+async function refreshHost108(){
+  const led = document.getElementById('host108Led');
+  const label = document.getElementById('host108Label');
+  const detail = document.getElementById('host108Detail');
+  const checked = document.getElementById('host108Checked');
+  try{
+    if(led){ led.className = 'led checking'; }
+    if(label) label.textContent = 'checking…';
+    const r = await fetch('/host-108.json?ts=' + Date.now(), {cache:'no-store'});
+    const p = await r.json();
+    const online = !!p.online;
+    if(led){ led.className = 'led ' + (online ? 'online' : 'offline'); }
+    if(label){ label.textContent = online ? 'online' : 'offline'; label.className = online ? 'ok' : 'bad'; }
+    if(detail) detail.textContent = p.summary || '';
+    if(checked) checked.textContent = p.checked_at || '';
+  }catch(e){
+    if(led){ led.className = 'led offline'; }
+    if(label){ label.textContent = 'unknown'; label.className = 'bad'; }
+    if(detail) detail.textContent = 'Could not check host: ' + e;
+  }
+  setTimeout(refreshHost108, 10000);
+}
+async function refreshFan108(){
+  const temp = document.getElementById('fan108Temp');
+  const req = document.getElementById('fan108Requested');
+  const app = document.getElementById('fan108Applied');
+  const rpm = document.getElementById('fan108Rpm');
+  const safety = document.getElementById('fan108Safety');
+  const slider = document.getElementById('fan108Slider');
+  const value = document.getElementById('fan108SliderValue');
+  const detail = document.getElementById('fan108Status');
+  try{
+    const r = await fetch('/fan-108.json?ts=' + Date.now(), {cache:'no-store'});
+    const p = await r.json();
+    if(!p.ok){ throw new Error(p.error || 'fan status failed'); }
+    if(temp) temp.textContent = `${p.cpu_temp_c} °C`;
+    if(req) req.textContent = `${p.requested_percent}%`;
+    if(app) app.textContent = `${p.applied_percent}%`;
+    if(rpm) rpm.textContent = `${p.fan_rpm || 'unknown'} RPM`;
+    if(safety){ safety.textContent = p.safety_active ? 'active — raised above requested speed' : 'idle'; safety.className = p.safety_active ? 'run' : 'ok'; }
+    if(slider && document.activeElement !== slider) slider.value = p.requested_percent;
+    if(value && document.activeElement !== slider) value.textContent = `${p.requested_percent}%`;
+    if(detail) detail.textContent = `Last updated: ${p.updated_at || ''}. Guard clamps speed to keep CPU below 70 °C.`;
+  }catch(e){
+    if(detail) detail.textContent = 'Could not refresh fan status: ' + e;
+  }
+  setTimeout(refreshFan108, 5000);
+}
+async function refreshProgress(){
+  try{
+    const r = await fetch('/progress.json?ts=' + Date.now(), {cache:'no-store'});
+    const p = await r.json();
+    const fill = document.getElementById('progressFill');
+    const pct = document.getElementById('progressPercent');
+    const stage = document.getElementById('progressStage');
+    const details = document.getElementById('progressDetails');
+    const statePill = document.getElementById('statePill');
+    const runId = document.getElementById('runId');
+    const duration = document.getElementById('duration');
+    const size = document.getElementById('size');
+    const btn = document.getElementById('backupButton');
+    const unit = document.getElementById('unitState');
+    const running = p.running || p.state === 'running';
+    if(fill){
+      fill.classList.toggle('indeterminate', running && (p.progress_percent ?? 0) < 10);
+      fill.style.width = Math.max(0, Math.min(100, p.progress_percent || 0)) + '%';
+    }
+    if(pct) pct.textContent = (p.progress_percent ?? 0) + '%';
+    if(stage) stage.textContent = p.stage || p.message || p.state || 'unknown';
+    if(details) details.textContent = p.message || '';
+    if(statePill){ statePill.textContent = p.state || 'unknown'; statePill.className = 'pill ' + (p.state === 'success' ? 'ok' : (p.state === 'failed' || p.state === 'error') ? 'bad' : 'run'); }
+    if(runId) runId.textContent = p.run_id || '';
+    if(duration) duration.textContent = (p.duration_seconds ?? '') + ' seconds';
+    if(size) size.textContent = p.backup_size_human || 'unknown';
+    if(unit) unit.textContent = `${p.unit_active || 'unknown'} / ${p.unit_sub || 'unknown'}`;
+    if(btn){ btn.disabled = running; btn.textContent = running ? 'Backup running…' : 'Back up now'; }
+    renderStages(p.stage_index || 0, p.state || 'unknown');
+    if(running) setTimeout(refreshProgress, 2000);
+    else setTimeout(refreshProgress, 10000);
+  }catch(e){
+    const stage = document.getElementById('progressStage');
+    if(stage) stage.textContent = 'Could not refresh progress: ' + e;
+    setTimeout(refreshProgress, 10000);
+  }
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('backupForm');
+  if(form){
+    form.addEventListener('submit', () => {
+      const btn = document.getElementById('backupButton');
+      const fill = document.getElementById('progressFill');
+      const stage = document.getElementById('progressStage');
+      const pct = document.getElementById('progressPercent');
+      if(btn){ btn.disabled = true; btn.textContent = 'Starting backup…'; }
+      if(fill){ fill.classList.add('indeterminate'); fill.style.width = '12%'; }
+      if(stage) stage.textContent = 'Starting backup request…';
+      if(pct) pct.textContent = 'starting';
+    });
+  }
+  const wakeForm = document.getElementById('wake108Form');
+  if(wakeForm){
+    wakeForm.addEventListener('submit', () => {
+      const btn = document.getElementById('wake108Button');
+      const detail = document.getElementById('host108Detail');
+      if(btn){ btn.disabled = true; btn.textContent = 'Trying Wi-Fi wake…'; }
+      if(detail) detail.textContent = 'Trying Wi-Fi WoWLAN packets for up to 3 minutes. If it does not wake, press the physical side power button.';
+    });
+  }
+  const sleepForm = document.getElementById('sleepWake108Form');
+  if(sleepForm){
+    sleepForm.addEventListener('submit', () => {
+      const btn = document.getElementById('sleepWake108Button');
+      const detail = document.getElementById('host108Detail');
+      if(btn){ btn.disabled = true; btn.textContent = 'Sleeping…'; }
+      if(detail) detail.textContent = 'Requesting deep suspend. Wake this PC with the physical power button.';
+    });
+  }
+  const fanForm = document.getElementById('fan108Form');
+  const fanSlider = document.getElementById('fan108Slider');
+  const fanValue = document.getElementById('fan108SliderValue');
+  if(fanSlider && fanValue){
+    fanSlider.addEventListener('input', () => { fanValue.textContent = `${fanSlider.value}%`; });
+  }
+  if(fanForm){
+    fanForm.addEventListener('submit', () => {
+      const btn = document.getElementById('fan108Button');
+      const detail = document.getElementById('fan108Status');
+      if(btn){ btn.disabled = true; btn.textContent = 'Applying…'; }
+      if(detail) detail.textContent = 'Applying guarded fan speed. Safety guard may raise it if CPU is warm.';
+    });
+  }
+  refreshProgress();
+  refreshHost108();
+  refreshFan108();
+});
+</script>
+"""
+
+STAGE_RULES = [
+    ("failed", 100, 8, "Failed"),
+    ("success", 100, 8, "Completed"),
+    ("copying completed backup set", 88, 7, "Copying backup set to QNAS"),
+    ("writing manifest", 76, 6, "Writing manifest/checksums"),
+    ("honcho", 62, 5, "Backing up Honcho/Postgres"),
+    ("snapshot metadata", 50, 4, "Backing up snapshot metadata"),
+    ("creating hermes config", 38, 3, "Archiving Hermes config/state"),
+    ("sqlite", 26, 2, "Backing up SQLite DBs"),
+    ("qnas mounted", 16, 1, "Mounting QNAS / collecting metadata"),
+    ("starting", 6, 0, "Starting"),
+]
+
+def read_status():
+    if not STATUS_PATH.exists():
+        return {"state":"unknown","message":"No backup status file exists yet.","updated_at":"never"}
+    try:
+        return json.loads(STATUS_PATH.read_text())
+    except Exception as e:
+        return {"state":"error","message":f"Could not read status: {e}","updated_at":"unknown"}
+
+def read_subagent_status():
+    return read_subagent_status_for("108")
+
+def read_subagent_status_for(server_id):
+    cfg = SUBAGENT_SERVERS.get(str(server_id))
+    if not cfg:
+        return {"ready": False, "summary": f"Unknown subagent server {server_id}"}
+    path = cfg["status_path"]
+    if not path.exists():
+        return {"ready": False, "server_id": cfg["id"], "server": cfg["ip"], "name": cfg["name"], "summary": f"No {cfg['ip']} subagent status has been recorded yet."}
+    try:
+        data = json.loads(path.read_text())
+        data.setdefault("server_id", cfg["id"])
+        data.setdefault("server", cfg["ip"])
+        data.setdefault("name", cfg["name"])
+        return data
+    except Exception as e:
+        return {"ready": False, "server_id": cfg["id"], "server": cfg["ip"], "name": cfg["name"], "summary": f"Could not read subagent status: {e}"}
+
+def all_subagent_statuses():
+    return {sid: read_subagent_status_for(sid) for sid in SUBAGENT_SERVERS}
+
+def read_subagent_model_state():
+    try:
+        data = json.loads(SUBAGENT_MODEL_STATE_PATH.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+def write_subagent_model_state(server_id, model):
+    data = read_subagent_model_state()
+    data[str(server_id)] = model
+    SUBAGENT_MODEL_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SUBAGENT_MODEL_STATE_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+def _read_env_file(path):
+    data = {}
+    if not pathlib.Path(path).exists():
+        raise RuntimeError(f"Credential env file not found: {path}")
+    for line in pathlib.Path(path).read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip(chr(34)).strip(chr(39))
+    return data
+
+def _ssh_command_for_server(server_id, remote_script):
+    cfg = SUBAGENT_SERVERS.get(str(server_id))
+    if not cfg:
+        raise RuntimeError(f"Unknown subagent server {server_id}")
+    creds = _read_env_file(cfg["cred_env"])
+    host = creds.get("DIETPI_HOST") or creds.get("HERMES_MASTER_HOST") or cfg["ip"]
+    user = creds.get("DIETPI_USER") or creds.get("HERMES_MASTER_USER") or "root"
+    port = creds.get("DIETPI_PORT") or creds.get("HERMES_MASTER_PORT") or "22"
+    password = creds.get("DIETPI_PASSWORD") or creds.get("HERMES_MASTER_PASSWORD") or ""
+    if not password:
+        raise RuntimeError(f"No SSH password found in {cfg['cred_env']}")
+    env = os.environ.copy()
+    env["SSHPASS"] = password
+    cmd = ["sshpass", "-e", "ssh", "-o", "BatchMode=no", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=6", "-p", str(port), f"{user}@{host}", remote_script]
+    return cmd, env
+
+def set_subagent_model(server_id, model):
+    server_id = str(server_id)
+    model = (model or "").strip()
+    allowed = {m["model"] for m in WORKING_OLLAMA_CLOUD_MODELS}
+    if server_id not in SUBAGENT_SERVERS:
+        return False, f"Unknown subagent server {server_id}."
+    if model not in allowed:
+        return False, f"Model {model!r} is not in the verified Ollama Cloud model list."
+    write_subagent_model_state(server_id, model)
+    quoted_model = shlex.quote(model)
+    remote = f"""
+set -e
+HERMES_BIN=$(command -v hermes || command -v /root/.local/bin/hermes || true)
+if [ -z "$HERMES_BIN" ]; then echo "Hermes is not installed on this server" >&2; exit 20; fi
+"$HERMES_BIN" config set model.provider ollama-cloud
+"$HERMES_BIN" config set model.default {quoted_model}
+"$HERMES_BIN" config set model.base_url ''
+"$HERMES_BIN" config set delegation.provider ollama-cloud
+"$HERMES_BIN" config set delegation.model {quoted_model}
+"$HERMES_BIN" config set delegation.base_url ''
+"$HERMES_BIN" config set delegation.api_key ''
+"$HERMES_BIN" config set delegation.api_mode chat_completions
+CONFIG_PATH=$("$HERMES_BIN" config path)
+MODEL_BLOCK=$(sed -n '/^model:/,/^[^[:space:]]/p' "$CONFIG_PATH")
+DELEGATION_BLOCK=$(sed -n '/^delegation:/,/^[^[:space:]]/p' "$CONFIG_PATH")
+printf '%s\n' "$MODEL_BLOCK" | grep -Fq 'provider: ollama-cloud'
+printf '%s\n' "$MODEL_BLOCK" | grep -Fq "default: {model}"
+printf '%s\n' "$DELEGATION_BLOCK" | grep -Fq 'provider: ollama-cloud'
+printf '%s\n' "$DELEGATION_BLOCK" | grep -Fq "model: {model}"
+printf '%s\n' "$DELEGATION_BLOCK" | grep -Fq 'api_mode: chat_completions'
+echo HERMES_CONFIG_PICKED_UP
+"""
+    try:
+        cmd, env = _ssh_command_for_server(server_id, remote)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=env)
+        if result.returncode != 0:
+            msg = (result.stderr or result.stdout or f"ssh exited {result.returncode}").strip()
+            return False, f"Saved desired model locally, but remote update failed for {SUBAGENT_SERVERS[server_id]['ip']}: {msg}"
+        subprocess.run(["systemctl", "start", f"hermes-{server_id}-subagent-status.service"], capture_output=True, text=True, timeout=5)
+        return True, f"Set {SUBAGENT_SERVERS[server_id]['name']} ({SUBAGENT_SERVERS[server_id]['ip']}) to ollama-cloud / {model}."
+    except Exception as e:
+        return False, f"Saved desired model locally, but remote update failed for {SUBAGENT_SERVERS[server_id]['ip']}: {e}"
+
+def read_cloudflare_ns_status():
+    if not CLOUDFLARE_NS_STATUS_PATH.exists():
+        return {"ok": False, "message": "No Cloudflare/one.com nameserver status has been recorded yet.", "checked_at": "never"}
+    try:
+        return json.loads(CLOUDFLARE_NS_STATUS_PATH.read_text())
+    except Exception as e:
+        return {"ok": False, "message": f"Could not read Cloudflare nameserver status: {e}", "checked_at": "unknown", "errors": [str(e)]}
+
+def list_backups():
+    bdir = BACKUP_ROOT / "backups"
+    rows = []
+    if bdir.is_dir():
+        for p in sorted([x for x in bdir.iterdir() if x.is_dir()], reverse=True)[:20]:
+            try:
+                size = sum(f.stat().st_size for f in p.rglob('*') if f.is_file())
+                mtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(p.stat().st_mtime))
+                rows.append((p.name, size, mtime, str(p)))
+            except Exception:
+                rows.append((p.name, 0, "unknown", str(p)))
+    return rows
+
+def fmt_bytes(n):
+    try: n = float(n)
+    except Exception: return "unknown"
+    for unit in ["B","KB","MB","GB","TB"]:
+        if n < 1024 or unit == "TB": return f"{n:.1f} {unit}"
+        n /= 1024
+
+
+def collapsible(title, body, open=True):
+    open_attr = " open" if open else ""
+    return f"<details class='panel'{open_attr}><summary>{html.escape(title)}</summary><div class='panel-body'>{body}</div></details>"
+
+def _git(args, repo=GIT_STATUS_REPO):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, timeout=3)
+
+def git_status():
+    repo = GIT_STATUS_REPO
+    checked_at = time.strftime('%Y-%m-%d %H:%M:%S %Z')
+    if not repo.exists():
+        return {"ok": False, "repo": str(repo), "checked_at": checked_at, "error": "repository path does not exist"}
+    try:
+        inside = _git(["rev-parse", "--is-inside-work-tree"], repo)
+        if inside.returncode != 0:
+            return {"ok": False, "repo": str(repo), "checked_at": checked_at, "error": "not a git repository"}
+        def out(args, default=""):
+            r = _git(args, repo)
+            return r.stdout.strip() if r.returncode == 0 else default
+        sha = out(["rev-parse", "HEAD"])
+        branch = out(["branch", "--show-current"], "detached") or "detached"
+        remote = out(["config", "--get", f"branch.{branch}.remote"], "origin") or "origin"
+        upstream = out(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+        ahead = behind = 0
+        if upstream:
+            counts = out(["rev-list", "--left-right", "--count", f"HEAD...{upstream}"])
+            parts = counts.split()
+            if len(parts) >= 2:
+                ahead, behind = int(parts[0] or 0), int(parts[1] or 0)
+        dirty = bool(out(["status", "--porcelain"]))
+        return {
+            "ok": True,
+            "repo": str(repo),
+            "branch": branch,
+            "remote": remote,
+            "sha": sha,
+            "short_sha": sha[:8],
+            "subject": out(["log", "-1", "--pretty=%s"]),
+            "author": out(["log", "-1", "--pretty=%an"]),
+            "committed_at": out(["log", "-1", "--pretty=%cI"]),
+            "relative_commit_time": out(["log", "-1", "--pretty=%cr"]),
+            "dirty": dirty,
+            "ahead": ahead,
+            "behind": behind,
+            "checked_at": checked_at,
+        }
+    except Exception as e:
+        return {"ok": False, "repo": str(repo), "checked_at": checked_at, "error": str(e)}
+
+def git_status_section():
+    g = git_status()
+    if not g.get("ok"):
+        body = f"<p class='bad'>Git status unavailable: {html.escape(str(g.get('error','unknown')))}</p><p class='muted small'>Repo: <code>{html.escape(str(g.get('repo','')))}</code></p>"
+        return collapsible("Git commit status", body, True)
+    if g.get("dirty"):
+        state, cls = "dirty worktree", "git-dirty"
+    elif g.get("ahead") and g.get("behind"):
+        state, cls = f"diverged +{g.get('ahead')} / -{g.get('behind')}", "git-dirty"
+    elif g.get("ahead"):
+        state, cls = f"ahead by {g.get('ahead')}", "git-dirty"
+    elif g.get("behind"):
+        state, cls = f"behind by {g.get('behind')}", "git-dirty"
+    else:
+        state, cls = "synced", "git-clean"
+    body = f"""
+<div class='grid small'>
+<div class='muted'>Status</div><div><span class='{cls}'>{html.escape(state)}</span></div>
+<div class='muted'>Commit</div><div><code>{html.escape(str(g.get('short_sha','')))}</code> — {html.escape(str(g.get('subject','')))}</div>
+<div class='muted'>Branch</div><div>{html.escape(str(g.get('branch','')))} / {html.escape(str(g.get('remote','origin')))}</div>
+<div class='muted'>Author</div><div>{html.escape(str(g.get('author','')))}</div>
+<div class='muted'>Committed</div><div>{html.escape(str(g.get('relative_commit_time','')))} ({html.escape(str(g.get('committed_at','')))} )</div>
+<div class='muted'>Checked</div><div>{html.escape(str(g.get('checked_at','')))}</div>
+<div class='muted'>Repo</div><div><code>{html.escape(str(g.get('repo','')))}</code></div>
+</div>
+<p class='muted small'>JSON endpoint: <a href='/git-status.json'>/git-status.json</a></p>
+"""
+    return collapsible("Git commit status", body, True)
+
+def backup_unit_state():
+    try:
+        active = subprocess.run(["systemctl", "is-active", BACKUP_UNIT], capture_output=True, text=True, timeout=5)
+        sub = subprocess.run(["systemctl", "show", BACKUP_UNIT, "--property=SubState", "--value"], capture_output=True, text=True, timeout=5)
+        return active.stdout.strip() or "unknown", sub.stdout.strip() or "unknown"
+    except Exception as e:
+        return "unknown", f"systemctl error: {e}"
+
+def progress_info(status=None):
+    status = dict(status or read_status())
+    unit_active, unit_sub = backup_unit_state()
+    state = status.get("state", "unknown")
+    message = str(status.get("message", ""))
+    running = unit_active in ("active", "activating") or state == "running"
+    haystack = f"{state} {message}".lower()
+    progress, stage_index, stage = (0, 0, "Idle")
+    for needle, pct, idx, label in STAGE_RULES:
+        if needle in haystack:
+            progress, stage_index, stage = pct, idx, label
+            break
+    if running and progress in (0, 100):
+        progress, stage_index, stage = 10, 0, "Starting / waiting for status update"
+    if running and progress < 98:
+        try:
+            elapsed = int(status.get("duration_seconds") or 0)
+            progress = max(progress, min(96, 10 + elapsed // 2))
+        except Exception:
+            pass
+    if state in ("failed", "error"):
+        progress, stage_index, stage = 100, 8, "Failed"
+    if state == "success" and not running:
+        progress, stage_index, stage = 0, 8, "Completed / idle"
+    status.update({
+        "unit_active": unit_active,
+        "unit_sub": unit_sub,
+        "running": running,
+        "progress_percent": int(progress),
+        "stage_index": int(stage_index),
+        "stage": stage,
+        "backup_size_human": fmt_bytes(status.get("backup_bytes", 0)),
+    })
+    return status
+
+def trigger_backup():
+    active, sub = backup_unit_state()
+    if active in ("active", "activating"):
+        return False, f"Backup is already running ({sub})."
+    try:
+        result = subprocess.run(["systemctl", "start", "--no-block", BACKUP_UNIT], capture_output=True, text=True, timeout=10)
+        if result.returncode == 0:
+            return True, f"Backup requested via {BACKUP_UNIT}. Progress will update below."
+        err = (result.stderr or result.stdout or "unknown systemctl error").strip()
+        return False, f"Failed to start backup: {err}"
+    except Exception as e:
+        return False, f"Failed to start backup: {e}"
+
+
+def host_108_status():
+    checked_at = time.strftime('%Y-%m-%d %H:%M:%S %Z')
+    try:
+        result = subprocess.run(["ping", "-c", "1", "-W", "1", HOST_108_IP], capture_output=True, text=True, timeout=3)
+        online = result.returncode == 0
+        if online:
+            summary = f"{HOST_108_NAME} ({HOST_108_IP}) replied to ping."
+        else:
+            raw = (result.stderr or result.stdout or "no ping reply").strip().splitlines()
+            summary = f"{HOST_108_NAME} ({HOST_108_IP}) did not reply to ping: {raw[-1] if raw else 'offline'}"
+        return {"host": HOST_108_NAME, "ip": HOST_108_IP, "online": online, "checked_at": checked_at, "summary": summary}
+    except Exception as e:
+        return {"host": HOST_108_NAME, "ip": HOST_108_IP, "online": False, "checked_at": checked_at, "summary": f"Host check failed: {e}"}
+
+
+def trigger_wake_108():
+    """Send repeated WoL/WoWLAN packets and wait for a useful result.
+
+    Important edge case: after pressing Sleep, the host can still answer ping for
+    a few seconds while the delayed SSH suspend command is pending. If Wake is
+    clicked during that window, returning immediately because ping is currently
+    online is wrong: the host may go to sleep right after the response. So when
+    the host starts online, require it to remain online for a short stable window;
+    if it drops offline, keep sending wake packets until it returns.
+    """
+    outputs = []
+    last_error = ""
+    try:
+        initial = host_108_status()
+        initially_online = bool(initial.get("online"))
+        saw_offline = not initially_online
+        consecutive_online = 0
+        detail = f"Wake packet sent to {HOST_108_NAME} ({HOST_108_IP})."
+
+        # About 180 seconds total. Send a packet batch every 3 seconds and poll in
+        # between. This covers the common “clicked Wake while Sleep is still
+        # settling” Wi-Fi WoWLAN race and gives this flaky Intel Wi-Fi adapter
+        # multiple chances. Deep/S3 WoWLAN on this host is still not guaranteed;
+        # the physical power button remains the reliable wake path.
+        for tick in range(180):
+            if tick % 3 == 0:
+                result = subprocess.run([HOST_108_WAKE_CMD], capture_output=True, text=True, timeout=15)
+                output = (result.stdout or result.stderr or "").strip()
+                if output:
+                    outputs.append(output)
+                    detail = output
+                if result.returncode != 0:
+                    last_error = output or f"Wake command failed with exit {result.returncode}."
+
+            st = host_108_status()
+            if st.get("online"):
+                consecutive_online += 1
+                if saw_offline:
+                    return True, f"Wake packets sent; {HOST_108_NAME} came online. {detail}"
+                if initially_online and consecutive_online >= 10:
+                    return True, f"{HOST_108_NAME} is already online and stayed online after wake packets. {detail}"
+            else:
+                saw_offline = True
+                consecutive_online = 0
+            time.sleep(1)
+
+        if outputs and not last_error:
+            return False, f"Wake packets sent for 180s, but {HOST_108_NAME} has not replied to ping yet. Press the physical side power button. Last sender output: {outputs[-1]}"
+        return False, last_error or f"Wake packets sent for 180s, but {HOST_108_NAME} did not come online. Press the physical side power button."
+    except FileNotFoundError:
+        return False, f"Wake command not found: {HOST_108_WAKE_CMD}"
+    except Exception as e:
+        return False, f"Wake command failed: {e}"
+
+
+def _read_host_108_creds():
+    data = {}
+    if not HOST_108_CRED_ENV.exists():
+        raise RuntimeError(f"Credential env file not found: {HOST_108_CRED_ENV}")
+    for line in HOST_108_CRED_ENV.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"').strip("'")
+    required = ["DIETPI_HOST", "DIETPI_PORT", "DIETPI_USER", "DIETPI_PASSWORD"]
+    missing = [k for k in required if not data.get(k)]
+    if missing:
+        raise RuntimeError(f"Credential env file missing keys: {', '.join(missing)}")
+    return data
+
+
+def _request_host_108_suspend():
+    creds = _read_host_108_creds()
+    env = os.environ.copy()
+    env["SSHPASS"] = creds["DIETPI_PASSWORD"]
+    cmd = [
+        "sshpass", "-e", "ssh",
+        "-o", "BatchMode=no",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=5",
+        "-p", str(creds.get("DIETPI_PORT", "22")),
+        f"{creds['DIETPI_USER']}@{creds['DIETPI_HOST']}",
+        "nohup /usr/local/sbin/hermes-suspend-wifi-wowlan.sh >/dev/null 2>&1 &",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, env=env)
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or f"ssh exited {result.returncode}").strip()
+        raise RuntimeError(msg)
+    return True
+
+
+def _wait_host_108_online(want_online, timeout_seconds, interval=2):
+    deadline = time.time() + timeout_seconds
+    last = None
+    while time.time() < deadline:
+        st = host_108_status()
+        last = st
+        if bool(st.get("online")) == bool(want_online):
+            return True, st
+        time.sleep(interval)
+    return False, last or host_108_status()
+
+
+def trigger_sleep_108():
+    before = host_108_status()
+    if not before.get("online"):
+        return False, f"Refusing sleep because {HOST_108_NAME} ({HOST_108_IP}) is already offline. Press the physical power button to wake it."
+    try:
+        _request_host_108_suspend()
+    except Exception as e:
+        return False, f"Failed to request deep suspend over SSH: {e}"
+    return True, f"Deep sleep requested for {HOST_108_NAME} ({HOST_108_IP}). Fans should spin down; wake it with the physical side power button."
+
+
+def safe_fan_percent(requested_percent, cpu_temp_c):
+    try:
+        requested = int(round(float(requested_percent)))
+    except Exception:
+        requested = 100
+    requested = max(20, min(100, requested))
+    try:
+        temp = float(cpu_temp_c)
+    except Exception:
+        return 100
+    if temp >= 70.0:
+        floor = 100
+    elif temp >= 68.0:
+        floor = 90
+    elif temp >= 65.0:
+        floor = 75
+    elif temp >= 60.0:
+        floor = 55
+    else:
+        floor = 20
+    return max(requested, floor)
+
+
+def parse_remote_fan_json(raw):
+    raw = raw or ""
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            return json.loads(line)
+    return json.loads(raw)
+
+
+def _run_host_108_command(remote_args, timeout=15):
+    creds = _read_host_108_creds()
+    env = os.environ.copy()
+    env["SSHPASS"] = creds["DIETPI_PASSWORD"]
+    cmd = [
+        "sshpass", "-e", "ssh",
+        "-o", "BatchMode=no",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=5",
+        "-p", str(creds.get("DIETPI_PORT", "22")),
+        f"{creds['DIETPI_USER']}@{creds['DIETPI_HOST']}",
+    ] + list(remote_args)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=env)
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or f"ssh exited {result.returncode}").strip()
+        raise RuntimeError(msg)
+    return result.stdout
+
+
+def fan_108_status():
+    try:
+        raw = _run_host_108_command([HOST_108_FAN_CMD, "status"], timeout=20)
+        data = parse_remote_fan_json(raw)
+        if isinstance(data, dict):
+            data.setdefault("ok", True)
+        return data
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+def set_fan_108(percent):
+    try:
+        requested = int(round(float(percent)))
+    except Exception:
+        return False, "Fan speed must be a number between 20 and 100%."
+    if requested < 20 or requested > 100:
+        return False, "Fan speed must be between 20 and 100%."
+    try:
+        raw = _run_host_108_command([HOST_108_FAN_CMD, "set", str(requested)], timeout=20)
+        data = parse_remote_fan_json(raw)
+        if not data.get("ok", False):
+            return False, data.get("error", "Remote fan controller failed")
+        applied = data.get("applied_percent", requested)
+        temp = data.get("cpu_temp_c", "unknown")
+        rpm = data.get("fan_rpm", "unknown")
+        if data.get("safety_active"):
+            return True, f"Requested {requested}% fan, but safety guard applied {applied}% because CPU is {temp} °C. Fan: {rpm} RPM."
+        return True, f"Fan set to {applied}% with CPU at {temp} °C. Fan: {rpm} RPM."
+    except Exception as e:
+        return False, f"Failed to set fan speed: {e}"
+
+
+def _parse_env_file(path=ENV_PATH):
+    data = {}
+    if not path.exists():
+        return data
+    for line in path.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"').strip("'")
+    return data
+
+def _timer_values_from_unit():
+    schedule = DEFAULT_SETTINGS["schedule"]
+    randomized = DEFAULT_SETTINGS["randomized_delay"]
+    enabled = True
+    if TIMER_PATH.exists():
+        for line in TIMER_PATH.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if line.startswith("OnCalendar="):
+                schedule = line.split("=", 1)[1].strip()
+            elif line.startswith("RandomizedDelaySec="):
+                randomized = line.split("=", 1)[1].strip()
+    try:
+        enabled = subprocess.run(["systemctl", "is-enabled", "hermes-qnas-backup.timer"], capture_output=True, text=True, timeout=5).returncode == 0
+    except Exception:
+        enabled = True
+    return schedule, randomized, enabled
+
+def read_settings():
+    settings = dict(DEFAULT_SETTINGS)
+    try:
+        if SETTINGS_PATH.exists():
+            loaded = json.loads(SETTINGS_PATH.read_text())
+            if isinstance(loaded, dict):
+                settings.update(loaded)
+    except Exception:
+        pass
+    env = _parse_env_file()
+    if env.get("RETENTION_COUNT", "").isdigit():
+        settings["retention_count"] = int(env["RETENTION_COUNT"])
+    schedule, randomized, enabled = _timer_values_from_unit()
+    settings.setdefault("schedule", schedule)
+    settings.setdefault("randomized_delay", randomized)
+    # Keep live timer values authoritative unless the JSON was just written with matching keys absent.
+    settings["schedule"] = schedule
+    settings["randomized_delay"] = randomized
+    settings["timer_enabled"] = enabled
+    try:
+        settings["retention_count"] = max(1, min(365, int(settings.get("retention_count", 14))))
+    except Exception:
+        settings["retention_count"] = 14
+    return settings
+
+def validate_calendar(expr):
+    expr = (expr or "").strip()
+    if not expr or len(expr) > 120 or re.search(r"[^A-Za-z0-9*,:/ ._+~=-]", expr):
+        return False, "Schedule contains invalid characters."
+    result = subprocess.run(["systemd-analyze", "calendar", expr], capture_output=True, text=True, timeout=10)
+    if result.returncode != 0:
+        return False, (result.stderr or result.stdout or "Invalid OnCalendar expression").strip()
+    return True, "ok"
+
+def validate_timespan(expr):
+    expr = (expr or "").strip()
+    if not expr:
+        return True, "ok"
+    if len(expr) > 40 or re.search(r"[^A-Za-z0-9 ._-]", expr):
+        return False, "Randomized delay contains invalid characters."
+    result = subprocess.run(["systemd-analyze", "timespan", expr], capture_output=True, text=True, timeout=10)
+    if result.returncode != 0:
+        return False, (result.stderr or result.stdout or "Invalid timespan").strip()
+    return True, "ok"
+
+def save_settings(fields):
+    retention_raw = fields.get("retention_count", [""])[0]
+    schedule = fields.get("schedule", [DEFAULT_SETTINGS["schedule"]])[0].strip()
+    randomized = fields.get("randomized_delay", [DEFAULT_SETTINGS["randomized_delay"]])[0].strip() or "0"
+    timer_enabled = fields.get("timer_enabled", [""])[0] == "1"
+    try:
+        retention_count = int(retention_raw)
+    except Exception:
+        return False, "Backups to keep must be a number."
+    if retention_count < 1 or retention_count > 365:
+        return False, "Backups to keep must be between 1 and 365."
+    ok, msg = validate_calendar(schedule)
+    if not ok:
+        return False, f"Invalid backup schedule: {msg}"
+    ok, msg = validate_timespan(randomized)
+    if not ok:
+        return False, f"Invalid randomized delay: {msg}"
+    settings = {"retention_count": retention_count, "schedule": schedule, "randomized_delay": randomized, "timer_enabled": timer_enabled}
+    SETTINGS_PATH.write_text(json.dumps(settings, indent=2) + "\n")
+    ENV_PATH.write_text(f"RETENTION_COUNT={retention_count}\n")
+    TIMER_PATH.write_text(f"""[Unit]\nDescription=Run Hermes/Honcho QNAS backup on configured schedule\n\n[Timer]\nOnCalendar={schedule}\nRandomizedDelaySec={randomized}\nPersistent=true\nUnit=hermes-qnas-backup.service\n\n[Install]\nWantedBy=timers.target\n""")
+    subprocess.run(["systemctl", "daemon-reload"], check=True, capture_output=True, text=True, timeout=20)
+    if timer_enabled:
+        subprocess.run(["systemctl", "enable", "--now", "hermes-qnas-backup.timer"], check=True, capture_output=True, text=True, timeout=20)
+        subprocess.run(["systemctl", "restart", "hermes-qnas-backup.timer"], check=True, capture_output=True, text=True, timeout=20)
+    else:
+        subprocess.run(["systemctl", "disable", "--now", "hermes-qnas-backup.timer"], check=True, capture_output=True, text=True, timeout=20)
+    return True, "Settings saved. Backup timer updated."
+
+def timer_status_line():
+    try:
+        result = subprocess.run(["systemctl", "list-timers", "--all", "hermes-qnas-backup.timer", "--no-pager", "--no-legend"], capture_output=True, text=True, timeout=5)
+        return (result.stdout or result.stderr or "Timer status unavailable").strip()
+    except Exception as e:
+        return f"Timer status unavailable: {e}"
+
+def render_settings_page(notice_msg="", notice_ok=True):
+    settings = read_settings()
+    checked = " checked" if settings.get("timer_enabled") else ""
+    notice = f"<div class='notice {'ok' if notice_ok else 'bad'}'>{html.escape(notice_msg)}</div>" if notice_msg else ""
+    body = f"""<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(APP_TITLE)} Settings</title><style>{CSS}</style></head><body><div class='card'>
+<h1>{html.escape(APP_TITLE)} Settings</h1>
+<div class='nav'><a href='/'>Status</a><a href='/settings'>Settings</a></div>
+{notice}
+<form class='settings-form' action='/settings' method='post'>
+<label for='retention_count'>Backups to keep</label><input id='retention_count' name='retention_count' type='number' min='1' max='365' value='{html.escape(str(settings.get('retention_count',14)))}' required>
+<label for='schedule'>Backup schedule</label><input id='schedule' name='schedule' value='{html.escape(str(settings.get('schedule',DEFAULT_SETTINGS['schedule'])))}' required>
+<label for='randomized_delay'>Randomized delay</label><input id='randomized_delay' name='randomized_delay' value='{html.escape(str(settings.get('randomized_delay',DEFAULT_SETTINGS['randomized_delay'])))}'>
+<label for='timer_enabled'>Scheduler enabled</label><input id='timer_enabled' name='timer_enabled' type='checkbox' value='1'{checked}>
+<div class='full'><button type='submit'>Save settings</button></div>
+</form>
+<p class='muted small'>Schedule uses systemd OnCalendar syntax, e.g. <code>*-*-* 03:20:00</code> for daily at 03:20 or <code>weekly</code>. Retention keeps the newest N backup folders after each successful backup.</p>
+{collapsible('Current timer', f"<pre class='small'><code>{html.escape(timer_status_line())}</code></pre>", True)}
+</div></body></html>"""
+    out = body.encode()
+    return out
+
+def delete_backup_set(run_id):
+    active, sub = backup_unit_state()
+    if active in ("active", "activating"):
+        return False, f"Refusing to delete while backup is running ({sub})."
+    run_id = (run_id or "").strip()
+    if not re.fullmatch(r"20\d{6}_\d{6}", run_id):
+        return False, "Invalid backup set name."
+    backups_dir = (BACKUP_ROOT / "backups").resolve()
+    target = (backups_dir / run_id).resolve()
+    if backups_dir not in target.parents:
+        return False, "Invalid backup path."
+    if not target.is_dir():
+        return False, f"Backup set {run_id} was not found."
+    try:
+        shutil.rmtree(target)
+        return True, f"Deleted backup set {run_id}."
+    except Exception as e:
+        return False, f"Failed to delete backup set {run_id}: {e}"
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def send_json(self, data):
+        body = json.dumps(data, indent=2).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def redirect_home(self, message=None, ok=True):
+        target = "/"
+        if message:
+            import urllib.parse
+            target += "?" + urllib.parse.urlencode({"ok": "1" if ok else "0", "message": message})
+        self.send_response(303)
+        self.send_header("Location", target)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+
+    def read_post_fields(self):
+        import urllib.parse
+        try:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+        except ValueError:
+            length = 0
+        body = self.rfile.read(min(length, 65536)).decode("utf-8", "replace") if length else ""
+        return urllib.parse.parse_qs(body, keep_blank_values=True)
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/run-backup":
+            ok, message = trigger_backup()
+            self.redirect_home(message, ok)
+            return
+        if path == "/wake-108":
+            ok, message = trigger_wake_108()
+            self.redirect_home(message, ok)
+            return
+        if path == "/sleep-108":
+            ok, message = trigger_sleep_108()
+            self.redirect_home(message, ok)
+            return
+        if path == "/fan-108":
+            fields = self.read_post_fields()
+            ok, message = set_fan_108(fields.get("percent", [""])[0])
+            self.redirect_home(message, ok)
+            return
+        if path == "/set-subagent-model":
+            fields = self.read_post_fields()
+            ok, message = set_subagent_model(fields.get("server", [""])[0], fields.get("model", [""])[0])
+            self.redirect_home(message, ok)
+            return
+        if path == "/delete-backup":
+            fields = self.read_post_fields()
+            run_id = fields.get("run_id", [""])[0]
+            ok, message = delete_backup_set(run_id)
+            self.redirect_home(message, ok)
+            return
+        if path == "/settings":
+            fields = self.read_post_fields()
+            try:
+                ok, message = save_settings(fields)
+            except Exception as e:
+                ok, message = False, f"Failed to save settings: {e}"
+            body = render_settings_page(message, ok)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers(); self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/status.json":
+            self.send_json(read_status())
+            return
+        if path == "/progress.json":
+            self.send_json(progress_info())
+            return
+        if path == "/subagent-status.json":
+            self.send_json(read_subagent_status())
+            return
+        if path == "/remote-subagents.json":
+            self.send_json(all_subagent_statuses())
+            return
+        if path == "/subagent-108.json":
+            self.send_json(read_subagent_status_for("108"))
+            return
+        if path == "/subagent-151.json":
+            self.send_json(read_subagent_status_for("151"))
+            return
+        if path == "/cloudflare-ns-status.json":
+            self.send_json(read_cloudflare_ns_status())
+            return
+        if path == "/git-status.json":
+            self.send_json(git_status())
+            return
+        if path == "/host-108.json":
+            self.send_json(host_108_status())
+            return
+        if path == "/fan-108.json":
+            self.send_json(fan_108_status())
+            return
+        if path == "/settings":
+            body = render_settings_page()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers(); self.wfile.write(body)
+            return
+        if path not in ("/", ""):
+            self.send_error(404)
+            return
+        import urllib.parse
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+        notice_msg = query.get("message", [""])[0]
+        notice_ok = query.get("ok", ["1"])[0] == "1"
+        status = read_status()
+        subagent = read_subagent_status()
+        settings = read_settings()
+        pinfo = progress_info(status)
+        host108 = host_108_status()
+        fan108 = fan_108_status()
+        cfns = read_cloudflare_ns_status()
+        state = pinfo.get("state", "unknown")
+        cls = "ok" if state == "success" else "bad" if state in ("failed","error") else "run"
+        running = pinfo.get("running")
+        rows = list_backups()
+        backup_rows = "".join(
+            f"<tr><td><code>{html.escape(name)}</code></td><td>{fmt_bytes(size)}</td><td>{html.escape(mtime)}</td>"
+            f"<td class='path-cell'><code>{html.escape(path)}</code></td>"
+            f"<td class='actions-cell'><form class='delete-form' action='/delete-backup' method='post' "
+            f"onsubmit=\"return confirm('Delete backup set {html.escape(name)} from QNAS? This cannot be undone.');\">"
+            f"<input type='hidden' name='run_id' value='{html.escape(name)}'>"
+            f"<button class='danger' type='submit'>Delete</button></form></td></tr>"
+            for name,size,mtime,path in rows
+        )
+        notice = f"<div class='notice {'ok' if notice_ok else 'bad'}'>{html.escape(notice_msg)}</div>" if notice_msg else ""
+        sub_cls = "ok" if subagent.get("ready") else "bad"
+        sub_ollama = subagent.get("ollama_cloud", {}) if isinstance(subagent.get("ollama_cloud", {}), dict) else {}
+        host_led_cls = "online" if host108.get("online") else "offline"
+        host_label_cls = "ok" if host108.get("online") else "bad"
+        host_label = "online" if host108.get("online") else "offline"
+        def render_model_options(selected):
+            selected = selected or ""
+            return "".join(
+                f"<option value='{html.escape(item['model'])}'{' selected' if item['model'] == selected else ''}>{html.escape(item['label'])}</option>"
+                for item in WORKING_OLLAMA_CLOUD_MODELS
+            )
+        def render_subagent_card(server_id, status_data):
+            cfg = SUBAGENT_SERVERS[server_id]
+            ready = bool(status_data.get("ready"))
+            cls = "ok" if ready else "bad"
+            current_model = str(status_data.get("desired_model") or read_subagent_model_state().get(server_id) or WORKING_OLLAMA_CLOUD_MODELS[0]["model"])
+            ollama = status_data.get("ollama_cloud", {}) if isinstance(status_data.get("ollama_cloud", {}), dict) else {}
+            helper = cfg.get("helper", "")
+            helper_line = f"<p class='muted small'>Run remote one-shot tasks from pve2 with: <code>{html.escape(helper)} 'your task'</code>.</p>" if helper and not helper.startswith("pending") else "<p class='muted small'>Remote one-shot helper is pending until this host is reachable and Hermes is installed.</p>"
+            extra_controls = ""
+            if server_id == "108":
+                extra_controls = f"""
+  <div class='actions' style='margin:.75rem 0'>
+    <form id='wake108Form' action='/wake-108' method='post'><button id='wake108Button' type='submit'>Try Wi-Fi Wake</button></form>
+    <form id='sleepWake108Form' action='/sleep-108' method='post' onsubmit=\"return confirm('This will put 192.168.1.108 into deep sleep/S3 so fans go down. Wake it with the physical side power button. Continue?');\"><button id='sleepWake108Button' class='warn' type='submit'>Sleep</button></form>
+  </div>
+  <div class='fan-panel'>
+    <h3>Manual CPU fan control</h3>
+    <form id='fan108Form' action='/fan-108' method='post' class='fan-row'>
+      <label for='fan108Slider'>Requested fan</label>
+      <input id='fan108Slider' name='percent' type='range' min='20' max='100' step='1' value='{html.escape(str(fan108.get('requested_percent',100)))}'>
+      <strong id='fan108SliderValue'>{html.escape(str(fan108.get('requested_percent',100)))}%</strong>
+      <span></span><button id='fan108Button' type='submit'>Apply fan speed</button><span></span>
+    </form>
+    <div class='fan-readout small'>
+      <div class='muted'>CPU temp</div><div id='fan108Temp'>{html.escape(str(fan108.get('cpu_temp_c','unknown')))} °C</div>
+      <div class='muted'>Requested</div><div id='fan108Requested'>{html.escape(str(fan108.get('requested_percent','unknown')))}%</div>
+      <div class='muted'>Applied</div><div id='fan108Applied'>{html.escape(str(fan108.get('applied_percent','unknown')))}%</div>
+      <div class='muted'>Fan speed</div><div id='fan108Rpm'>{html.escape(str(fan108.get('fan_rpm','unknown')))} RPM</div>
+      <div class='muted'>Safety guard</div><div id='fan108Safety' class='{'run' if fan108.get('safety_active') else 'ok'}'>{html.escape('active — raised above requested speed' if fan108.get('safety_active') else 'idle')}</div>
+    </div>
+    <p id='fan108Status' class='muted small'>Guarded by <code>hermes-fan-control.service</code>: if CPU reaches 70 °C it forces 100%, with rising safety floors before that.</p>
+  </div>
+"""
+            return f"""
+<section class='host-card' aria-live='polite'>
+  <div class='host-head'>
+    <div>
+      <strong>{html.escape(str(status_data.get('name') or cfg['name']))} / {html.escape(str(status_data.get('server') or cfg['ip']))}</strong>
+      <div class='host-state small'><span class='led {'online' if status_data.get('up') else 'offline'}'></span><span>Status: <span class='{cls}'>{'ready' if ready else 'not ready'}</span></span></div>
+    </div>
+    <div class='small muted'>Last checked: {html.escape(str(status_data.get('checked_at','unknown')))}</div>
+  </div>
+  <p class='muted small'>{html.escape(str(status_data.get('summary','unknown')))}</p>
+  <div class='grid small'>
+    <div class='muted'>Ping</div><div>{html.escape(str(status_data.get('up', False)))}</div>
+    <div class='muted'>SSH</div><div>{html.escape(str(status_data.get('ssh_ok', False)))}</div>
+    <div class='muted'>Hermes</div><div>{html.escape(str(status_data.get('hermes_ok', False)))}</div>
+    <div class='muted'>Ollama Cloud</div><div>{html.escape(str(status_data.get('desired_provider','ollama-cloud')))} / <code>{html.escape(current_model)}</code> usable: {html.escape(str(status_data.get('ollama_cloud_ok', False)))}</div>
+    <div class='muted'>LLM test</div><div>{html.escape(str(ollama.get('content') or ollama.get('error') or ''))} in {html.escape(str(ollama.get('elapsed_seconds','?')))}s</div>
+  </div>
+  <form class='model-form' action='/set-subagent-model' method='post'>
+    <input type='hidden' name='server' value='{html.escape(server_id)}'>
+    <label for='model-{html.escape(server_id)}'>Change model</label>
+    <select id='model-{html.escape(server_id)}' name='model'>{render_model_options(current_model)}</select>
+    <button type='submit'>Apply to this server</button>
+  </form>
+  {helper_line}
+  {extra_controls}
+</section>
+"""
+        statuses = all_subagent_statuses()
+        subagent_body = "".join(render_subagent_card(sid, statuses[sid]) for sid in sorted(SUBAGENT_SERVERS)) + """
+<p class='muted small'>Verified working Ollama Cloud model scan: <code>qwen3-next:80b</code>, <code>glm-4.6:latest</code>, and <code>gpt-oss:20b</code>. JSON endpoints: <a href='/remote-subagents.json'>/remote-subagents.json</a>, <a href='/subagent-108.json'>/subagent-108.json</a>, <a href='/subagent-151.json'>/subagent-151.json</a>.</p>
+"""
+        subagent_section = collapsible("Remote subagent servers", subagent_body, True)
+        def fmt_ns_list(items):
+            vals = items if isinstance(items, list) else []
+            return ", ".join(f"<code>{html.escape(str(x))}</code>" for x in vals) or "<span class='muted'>none</span>"
+        cf_cls = "ok" if cfns.get("ok") else ("run" if cfns.get("onecom_matches_cloudflare_expected") and not cfns.get("cloudflare_zone_active") else "bad")
+        cf_state = "healthy" if cfns.get("ok") else ("waiting for propagation" if cfns.get("onecom_matches_cloudflare_expected") else "needs attention")
+        cf_body = f"""
+<section class='host-card'>
+  <div class='host-head'>
+    <div>
+      <strong>{html.escape(str(cfns.get('domain','nor-soft.no')))}</strong>
+      <div class='host-state small'><span class='led {'online' if cfns.get('ok') else 'checking' if cfns.get('onecom_matches_cloudflare_expected') else 'offline'}'></span><span>Status: <span class='{cf_cls}'>{html.escape(cf_state)}</span></span></div>
+    </div>
+    <div class='small muted'>Last checked: {html.escape(str(cfns.get('checked_at','unknown')))}</div>
+  </div>
+  <p class='muted small'>{html.escape(str(cfns.get('message','')))}</p>
+  <div class='grid small'>
+    <div class='muted'>Cloudflare zone</div><div><code>{html.escape(str(cfns.get('cloudflare_zone_id','unknown')))}</code> / {html.escape(str(cfns.get('cloudflare_zone_status','unknown')))}</div>
+    <div class='muted'>Expected NS</div><div>{fmt_ns_list(cfns.get('expected_nameservers'))}</div>
+    <div class='muted'>one.com NS</div><div>{fmt_ns_list(cfns.get('onecom_nameservers'))}</div>
+    <div class='muted'>one.com matches</div><div>{html.escape(str(cfns.get('onecom_matches_cloudflare_expected', False)))}</div>
+    <div class='muted'>Public 1.1.1.1 NS</div><div>{fmt_ns_list(cfns.get('public_nameservers_1_1_1_1'))}</div>
+    <div class='muted'>Registry trace NS</div><div>{fmt_ns_list(cfns.get('registry_trace_nameservers'))}</div>
+    <div class='muted'>Needs confirmation</div><div>{html.escape(str(cfns.get('needs_user_confirmation', False)))} — no automatic one.com update is performed</div>
+  </div>
+  <p class='muted small'>JSON endpoint: <a href='/cloudflare-ns-status.json'>/cloudflare-ns-status.json</a>. If one.com ever differs from the Cloudflare expected nameservers, the cron watchdog alerts you and waits for explicit confirmation before any update.</p>
+</section>
+"""
+        cf_section = collapsible("Cloudflare / one.com nameserver watchdog", cf_body, True)
+        button_text = "Backup running…" if running else "Back up now"
+        disabled = " disabled" if running else ""
+        body = f"""<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(APP_TITLE)}</title><style>{CSS}</style></head><body><div class='card'>
+<h1>{html.escape(APP_TITLE)}</h1>
+<div class='nav'><a href='/'>Status</a><a href='/settings'>Settings</a></div>
+{notice}
+{git_status_section()}
+{collapsible('Backup status', f'''<form id="backupForm" class="actions" action="/run-backup" method="post"><button id="backupButton" type="submit"{disabled}>{html.escape(button_text)}</button><span class="muted small">Manual trigger: <code>{html.escape(BACKUP_UNIT)}</code> is <span id="unitState">{html.escape(pinfo.get('unit_active','unknown'))} / {html.escape(pinfo.get('unit_sub','unknown'))}</span></span></form>
+<p class="muted small">Retention: keep newest {html.escape(str(settings.get('retention_count',14)))} backups. Scheduler: {html.escape('enabled' if settings.get('timer_enabled') else 'disabled')} at <code>{html.escape(str(settings.get('schedule','')))}</code> ± <code>{html.escape(str(settings.get('randomized_delay','')))}</code>. <a href="/settings">Change settings</a>.</p>
+<section class="progress-card" aria-live="polite">
+  <div class="progress-head"><strong>Backup progress</strong><span id="progressPercent">{pinfo.get('progress_percent',0)}%</span></div>
+  <div class="progress-track"><div id="progressFill" class="progress-fill{' indeterminate' if running and pinfo.get('progress_percent',0) < 10 else ''}" style="width:{pinfo.get('progress_percent',0)}%"></div></div>
+  <div class="progress-meta small"><span id="progressStage">{html.escape(str(pinfo.get('stage','Idle')))}</span><span id="progressDetails" class="muted">{html.escape(str(pinfo.get('message','')))}</span></div>
+  <ol id="stageList" class="stage-list small"></ol>
+</section>
+<p>Status: <span id="statePill" class="pill {cls}">{html.escape(state)}</span></p>
+<div class="grid small">
+<div class="muted">Message</div><div>{html.escape(str(status.get('message','')))}</div>
+<div class="muted">Run ID</div><div><code id="runId">{html.escape(str(status.get('run_id','')))}</code></div>
+<div class="muted">Started</div><div>{html.escape(str(status.get('started_at','')))}</div>
+<div class="muted">Updated</div><div>{html.escape(str(status.get('updated_at','')))}</div>
+<div class="muted">Duration</div><div id="duration">{html.escape(str(status.get('duration_seconds','')))} seconds</div>
+<div class="muted">Destination</div><div><code>{html.escape(str(status.get('destination','')))}</code></div>
+<div class="muted">Size</div><div id="size">{fmt_bytes(status.get('backup_bytes',0))}</div>
+<div class="muted">Log</div><div><code>{html.escape(str(status.get('log_file','')))}</code></div>
+</div>''', True)}
+{subagent_section}
+{cf_section}
+{collapsible('Recent backup sets on QNAS', f'''<table><thead><tr><th>Run</th><th>Size</th><th>Modified</th><th>Path</th><th>Actions</th></tr></thead><tbody>{backup_rows or '<tr><td colspan=5>No backup sets found yet.</td></tr>'}</tbody></table>''', True)}
+<p class='muted'>Progress polls every 2 seconds while running. JSON endpoints: <a href='/status.json'>/status.json</a> and <a href='/progress.json'>/progress.json</a></p>
+</div>{SCRIPT}</body></html>"""
+        out = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(out)))
+        self.end_headers(); self.wfile.write(out)
+
+if __name__ == "__main__":
+    httpd = ThreadingHTTPServer((HOST, PORT), Handler)
+    print(f"Serving Hermes backup status on {HOST}:{PORT}", flush=True)
+    httpd.serve_forever()

--- a/scripts/status-page/hermes-subagent-status.py
+++ b/scripts/status-page/hermes-subagent-status.py
@@ -20,6 +20,13 @@ SERVERS = {
         'env_prefix': 'PIBENCH',
         'sudo_root': True,
     },
+    '211': {
+        'host': '192.168.1.211',
+        'name': 'Pxvirt',
+        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/RPi5_01.env',
+        'out_dir': '/var/lib/hermes-subagent-211',
+        'env_prefix': 'RPI5_01',
+    },
     '151': {
         'host': '192.168.1.151',
         'name': 'DietPi',

--- a/scripts/status-page/hermes-subagent-status.py
+++ b/scripts/status-page/hermes-subagent-status.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import subprocess
+import shlex
 import tempfile
 import time
 from datetime import datetime, timezone
@@ -11,17 +12,27 @@ from datetime import datetime, timezone
 MODEL_STATE_PATH = pathlib.Path('/etc/hermes-subagent-models.json')
 DEFAULT_MODEL = 'qwen3-next:80b'
 SERVERS = {
-    '108': {
-        'host': '192.168.1.108',
-        'name': 'DietGTX780Ti',
-        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/hermes_slave.env',
-        'out_dir': '/var/lib/hermes-subagent-108',
+    '219': {
+        'host': '192.168.1.219',
+        'name': 'PiBench',
+        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/PiBench.env',
+        'out_dir': '/var/lib/hermes-subagent-219',
+        'env_prefix': 'PIBENCH',
+        'sudo_root': True,
     },
     '151': {
         'host': '192.168.1.151',
         'name': 'DietPi',
         'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/dietpi.env',
         'out_dir': '/var/lib/hermes-subagent-151',
+        'env_prefix': 'DIETPI',
+    },
+    '108': {
+        'host': '192.168.1.108',
+        'name': 'DietGTX780Ti',
+        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/hermes_slave.env',
+        'out_dir': '/var/lib/hermes-subagent-108',
+        'env_prefix': 'DIETPI',
     },
 }
 
@@ -66,13 +77,29 @@ def run(cmd, timeout=20):
         return {'ok': False, 'returncode': None, 'stdout': '', 'stderr': str(e), 'elapsed_seconds': round(time.time() - started, 2)}
 
 
-def ssh_cmd(env, remote_script, default_host):
-    host = env.get('DIETPI_HOST') or env.get('HERMES_MASTER_HOST') or default_host
-    user = env.get('DIETPI_USER') or env.get('HERMES_MASTER_USER') or 'root'
-    port = env.get('DIETPI_PORT') or env.get('HERMES_MASTER_PORT') or '22'
+def env_value(env, prefix, name, *fallback_keys):
+    if prefix:
+        val = env.get(f'{prefix}_{name}')
+        if val:
+            return val
+    for key in fallback_keys:
+        val = env.get(key)
+        if val:
+            return val
+    return ''
+
+
+def ssh_cmd(env, remote_script, default_host, cfg=None):
+    cfg = cfg or {}
+    prefix = cfg.get('env_prefix', '')
+    host = env_value(env, prefix, 'HOST', 'DIETPI_HOST', 'HERMES_MASTER_HOST') or default_host
+    user = env_value(env, prefix, 'USER', 'DIETPI_USER', 'HERMES_MASTER_USER') or 'root'
+    port = env_value(env, prefix, 'PORT', 'DIETPI_PORT', 'HERMES_MASTER_PORT') or '22'
     strict = env.get('HERMES_MASTER_STRICT_HOST_KEY_CHECKING', 'accept-new')
     key = env.get('HERMES_MASTER_SSH_KEY', '')
-    password = env.get('DIETPI_PASSWORD') or env.get('HERMES_MASTER_PASSWORD') or ''
+    password = env_value(env, prefix, 'PASSWORD', 'DIETPI_PASSWORD', 'HERMES_MASTER_PASSWORD')
+    if cfg.get('sudo_root') and user != 'root':
+        remote_script = 'sudo -H bash -lc ' + shlex.quote(remote_script)
     cmd = ['sshpass', '-p', password, 'ssh', '-o', 'ConnectTimeout=8', '-o', 'BatchMode=no', '-o', f'StrictHostKeyChecking={strict}', '-p', port]
     if key and pathlib.Path(key).exists():
         cmd += ['-i', key]
@@ -82,12 +109,12 @@ def ssh_cmd(env, remote_script, default_host):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('--server', default='108', choices=sorted(SERVERS))
+    ap.add_argument('--server', default='108', choices=list(SERVERS))
     args = ap.parse_args()
     cfg = SERVERS[args.server]
     model = desired_model(args.server)
     env = load_env(cfg['env_path'])
-    cmd_dummy, has_password, host = ssh_cmd(env, 'true', cfg['host'])
+    cmd_dummy, has_password, host = ssh_cmd(env, 'true', cfg['host'], cfg)
     out_dir = pathlib.Path(cfg['out_dir'])
     out_path = out_dir / 'status.json'
     status = {
@@ -123,7 +150,7 @@ printf 'delegation='; grep -A6 '^delegation:' /root/.hermes/config.yaml 2>/dev/n
 printf '\nmodel='; grep -A5 '^model:' /root/.hermes/config.yaml 2>/dev/null | sed -n '1,6p' | tr '\n' ';'
 printf '\n'
 '''
-        ssh, _, _ = ssh_cmd(env, remote_probe, cfg['host'])
+        ssh, _, _ = ssh_cmd(env, remote_probe, cfg['host'], cfg)
         ssh_result = run(ssh, timeout=25)
         status['ssh_ok'] = ssh_result['ok']
         status['remote_probe'] = ssh_result['stdout'] if ssh_result['ok'] else ssh_result['stderr']
@@ -154,7 +181,7 @@ except Exception as e:
     print(json.dumps({{"ok": False, "model": model, "error": str(e)}}))
 PY
 '''
-        llm_cmd, _, _ = ssh_cmd(env, remote_llm, cfg['host'])
+        llm_cmd, _, _ = ssh_cmd(env, remote_llm, cfg['host'], cfg)
         llm = run(llm_cmd, timeout=70)
         try:
             llm_json = json.loads((llm['stdout'] or '{}').splitlines()[-1]) if llm['stdout'] else {}

--- a/scripts/status-page/hermes-subagent-status.py
+++ b/scripts/status-page/hermes-subagent-status.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+
+MODEL_STATE_PATH = pathlib.Path('/etc/hermes-subagent-models.json')
+DEFAULT_MODEL = 'qwen3-next:80b'
+SERVERS = {
+    '108': {
+        'host': '192.168.1.108',
+        'name': 'DietGTX780Ti',
+        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/hermes_slave.env',
+        'out_dir': '/var/lib/hermes-subagent-108',
+    },
+    '151': {
+        'host': '192.168.1.151',
+        'name': 'DietPi',
+        'env_path': '/mnt/pve/LocalDir/hermes-critical/pve2/hermes-home/private/dietpi.env',
+        'out_dir': '/var/lib/hermes-subagent-151',
+    },
+}
+
+
+def load_env(path):
+    vals = {}
+    p = pathlib.Path(path)
+    if not p.exists():
+        return vals
+    for line in p.read_text(errors='ignore').splitlines():
+        s = line.strip()
+        if not s or s.startswith('#') or '=' not in s:
+            continue
+        k, v = s.split('=', 1)
+        vals[k.strip()] = v.strip().strip('"\'')
+    return vals
+
+
+def desired_model(server_id):
+    env_key = f'HERMES_{server_id}_OLLAMA_MODEL'
+    if os.environ.get(env_key):
+        return os.environ[env_key]
+    try:
+        data = json.loads(MODEL_STATE_PATH.read_text())
+        return str(data.get(server_id) or data.get('default') or DEFAULT_MODEL)
+    except Exception:
+        return DEFAULT_MODEL
+
+
+def run(cmd, timeout=20):
+    started = time.time()
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return {
+            'ok': p.returncode == 0,
+            'returncode': p.returncode,
+            'stdout': (p.stdout or '').strip()[-4000:],
+            'stderr': (p.stderr or '').strip()[-1200:],
+            'elapsed_seconds': round(time.time() - started, 2),
+        }
+    except Exception as e:
+        return {'ok': False, 'returncode': None, 'stdout': '', 'stderr': str(e), 'elapsed_seconds': round(time.time() - started, 2)}
+
+
+def ssh_cmd(env, remote_script, default_host):
+    host = env.get('DIETPI_HOST') or env.get('HERMES_MASTER_HOST') or default_host
+    user = env.get('DIETPI_USER') or env.get('HERMES_MASTER_USER') or 'root'
+    port = env.get('DIETPI_PORT') or env.get('HERMES_MASTER_PORT') or '22'
+    strict = env.get('HERMES_MASTER_STRICT_HOST_KEY_CHECKING', 'accept-new')
+    key = env.get('HERMES_MASTER_SSH_KEY', '')
+    password = env.get('DIETPI_PASSWORD') or env.get('HERMES_MASTER_PASSWORD') or ''
+    cmd = ['sshpass', '-p', password, 'ssh', '-o', 'ConnectTimeout=8', '-o', 'BatchMode=no', '-o', f'StrictHostKeyChecking={strict}', '-p', port]
+    if key and pathlib.Path(key).exists():
+        cmd += ['-i', key]
+    cmd += [f'{user}@{host}', remote_script]
+    return cmd, bool(password), host
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--server', default='108', choices=sorted(SERVERS))
+    args = ap.parse_args()
+    cfg = SERVERS[args.server]
+    model = desired_model(args.server)
+    env = load_env(cfg['env_path'])
+    cmd_dummy, has_password, host = ssh_cmd(env, 'true', cfg['host'])
+    out_dir = pathlib.Path(cfg['out_dir'])
+    out_path = out_dir / 'status.json'
+    status = {
+        'checked_at': datetime.now(timezone.utc).isoformat(),
+        'server_id': args.server,
+        'server': host,
+        'name': cfg['name'],
+        'role': 'Hermes remote subagent host',
+        'desired_provider': 'ollama-cloud',
+        'desired_model': model,
+        'up': False,
+        'ssh_ok': False,
+        'hermes_ok': False,
+        'ollama_cloud_ok': False,
+        'ready': False,
+        'summary': 'not checked',
+    }
+
+    ping = run(['ping', '-c', '1', '-W', '1', host], timeout=4)
+    status['ping_ok'] = ping['ok']
+    status['up'] = ping['ok']
+
+    if not has_password:
+        status['summary'] = f'{host} ping={ping["ok"]}; missing SSH credentials on 192.168.1.140'
+    else:
+        remote_probe = r'''
+set -o pipefail
+printf 'hostname='; hostname -f 2>/dev/null || hostname
+printf 'whoami='; whoami
+printf 'hermes='; command -v hermes || command -v /root/.local/bin/hermes || true
+printf 'hermes_version='; (/root/.local/bin/hermes --version 2>/dev/null || hermes --version 2>/dev/null || true) | head -1
+printf 'delegation='; grep -A6 '^delegation:' /root/.hermes/config.yaml 2>/dev/null | sed -n '1,7p' | tr '\n' ';' | sed -E 's/api_key: .*/api_key: [REDACTED]/'
+printf '\nmodel='; grep -A5 '^model:' /root/.hermes/config.yaml 2>/dev/null | sed -n '1,6p' | tr '\n' ';'
+printf '\n'
+'''
+        ssh, _, _ = ssh_cmd(env, remote_probe, cfg['host'])
+        ssh_result = run(ssh, timeout=25)
+        status['ssh_ok'] = ssh_result['ok']
+        status['remote_probe'] = ssh_result['stdout'] if ssh_result['ok'] else ssh_result['stderr']
+        status['hermes_ok'] = ssh_result['ok'] and 'hermes=' in ssh_result['stdout'] and ('/hermes' in ssh_result['stdout'] or 'hermes_version=' in ssh_result['stdout'])
+
+        remote_llm = f'''
+set -a; . /root/.hermes/.env 2>/dev/null || true; set +a
+python3 - <<'PY'
+import os,json,urllib.request,urllib.error,time
+model={model!r}
+body=json.dumps({{"model":model,"messages":[{{"role":"system","content":"Answer only the exact requested token."}},{{"role":"user","content":"Reply exactly OK"}}],"stream":False,"max_tokens":16}}).encode()
+req=urllib.request.Request("https://ollama.com/v1/chat/completions",data=body,headers={{"Authorization":"Bearer "+os.environ.get("OLLAMA_API_KEY",""),"Content-Type":"application/json"}})
+try:
+    t=time.time()
+    with urllib.request.urlopen(req,timeout=45) as r:
+        txt=r.read().decode("utf-8","replace")
+        http_status=r.status
+    data=json.loads(txt)
+    choices=data.get("choices",[])
+    msg=choices[0].get("message",{{}}) if choices else {{}}
+    content=(msg.get("content") or "").strip()
+    reasoning=(msg.get("reasoning") or msg.get("thinking") or "").strip()
+    ok = bool(http_status == 200 and choices and msg)
+    print(json.dumps({{"ok": ok, "model": model, "http_status": http_status, "content": content[:80], "reasoning_present": bool(reasoning), "elapsed_seconds": round(time.time()-t,2)}}))
+except urllib.error.HTTPError as e:
+    print(json.dumps({{"ok": False, "model": model, "http_status": e.code, "error": e.read().decode("utf-8","replace")[:240]}}))
+except Exception as e:
+    print(json.dumps({{"ok": False, "model": model, "error": str(e)}}))
+PY
+'''
+        llm_cmd, _, _ = ssh_cmd(env, remote_llm, cfg['host'])
+        llm = run(llm_cmd, timeout=70)
+        try:
+            llm_json = json.loads((llm['stdout'] or '{}').splitlines()[-1]) if llm['stdout'] else {}
+        except Exception:
+            llm_json = {'ok': False, 'error': llm['stdout'] or llm['stderr']}
+        status['ollama_cloud'] = llm_json
+        status['ollama_cloud_ok'] = bool(llm_json.get('ok'))
+        status['ready'] = bool(status['up'] and status['ssh_ok'] and status['hermes_ok'] and status['ollama_cloud_ok'])
+        status['summary'] = 'ready' if status['ready'] else 'not ready: ' + ', '.join(k for k in ['up','ssh_ok','hermes_ok','ollama_cloud_ok'] if not status.get(k))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix='status.', suffix='.json', dir=str(out_dir))
+    with os.fdopen(fd, 'w') as f:
+        json.dump(status, f, indent=2)
+        f.write('\n')
+    os.replace(tmp, out_path)
+    print(json.dumps({k: status[k] for k in ['server','ready','summary','desired_provider','desired_model']}, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -334,7 +334,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
                 className="text-[13px] font-medium select-none"
                 style={{ color: 'var(--theme-accent, #B98A44)' }}
               >
-                Hermes
+                Hermes C&amp;C Interface
               </span>
             </div>
             {/* Right spacer to balance */}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -90,6 +90,7 @@ import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
 import { Route as ApiHermesTasksRouteImport } from './routes/api/hermes-tasks'
 import { Route as ApiHermesConfigRouteImport } from './routes/api/hermes-config'
+import { Route as ApiGitStatusRouteImport } from './routes/api/git-status'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiGatewayReprobeRouteImport } from './routes/api/gateway-reprobe'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
@@ -576,6 +577,11 @@ const ApiHermesConfigRoute = ApiHermesConfigRouteImport.update({
   path: '/api/hermes-config',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiGitStatusRoute = ApiGitStatusRouteImport.update({
+  id: '/api/git-status',
+  path: '/api/git-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
@@ -1026,6 +1032,7 @@ export interface FileRoutesByFullPath {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/git-status': typeof ApiGitStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/history': typeof ApiHistoryRoute
@@ -1187,6 +1194,7 @@ export interface FileRoutesByTo {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/git-status': typeof ApiGitStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/history': typeof ApiHistoryRoute
@@ -1350,6 +1358,7 @@ export interface FileRoutesById {
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-reprobe': typeof ApiGatewayReprobeRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/git-status': typeof ApiGitStatusRoute
   '/api/hermes-config': typeof ApiHermesConfigRoute
   '/api/hermes-tasks': typeof ApiHermesTasksRouteWithChildren
   '/api/history': typeof ApiHistoryRoute
@@ -1514,6 +1523,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/git-status'
     | '/api/hermes-config'
     | '/api/hermes-tasks'
     | '/api/history'
@@ -1675,6 +1685,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/git-status'
     | '/api/hermes-config'
     | '/api/hermes-tasks'
     | '/api/history'
@@ -1837,6 +1848,7 @@ export interface FileRouteTypes {
     | '/api/files'
     | '/api/gateway-reprobe'
     | '/api/gateway-status'
+    | '/api/git-status'
     | '/api/hermes-config'
     | '/api/hermes-tasks'
     | '/api/history'
@@ -2000,6 +2012,7 @@ export interface RootRouteChildren {
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayReprobeRoute: typeof ApiGatewayReprobeRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiGitStatusRoute: typeof ApiGitStatusRoute
   ApiHermesConfigRoute: typeof ApiHermesConfigRoute
   ApiHermesTasksRoute: typeof ApiHermesTasksRouteWithChildren
   ApiHistoryRoute: typeof ApiHistoryRoute
@@ -2652,6 +2665,13 @@ declare module '@tanstack/react-router' {
       path: '/api/hermes-config'
       fullPath: '/api/hermes-config'
       preLoaderRoute: typeof ApiHermesConfigRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/git-status': {
+      id: '/api/git-status'
+      path: '/api/git-status'
+      fullPath: '/api/git-status'
+      preLoaderRoute: typeof ApiGitStatusRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/gateway-status': {
@@ -3469,6 +3489,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayReprobeRoute: ApiGatewayReprobeRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiGitStatusRoute: ApiGitStatusRoute,
   ApiHermesConfigRoute: ApiHermesConfigRoute,
   ApiHermesTasksRoute: ApiHermesTasksRouteWithChildren,
   ApiHistoryRoute: ApiHistoryRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -134,7 +134,7 @@ export const Route = createRootRoute({
           'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-visual',
       },
       {
-        title: 'Hermes Workspace',
+        title: 'Hermes C&C Interface',
       },
       {
         name: 'description',

--- a/src/routes/api/-claude-update.test.ts
+++ b/src/routes/api/-claude-update.test.ts
@@ -2,17 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { createRemoteStatus, remoteUrlMatchesExpectedRepo } from './claude-update'
 
 describe('claude update repo gating', () => {
-  it('matches Claude workspace repo aliases', () => {
-    expect(remoteUrlMatchesExpectedRepo('https://github.com/example/hermes-workspace.git', ['hermes-workspace'])).toBe(true)
+  it('matches Hermes C&C Interface repo aliases', () => {
+    expect(remoteUrlMatchesExpectedRepo('https://github.com/blackscience/hermes-c-c-interface.git', ['hermes-c-c-interface'])).toBe(true)
+    expect(remoteUrlMatchesExpectedRepo('git@github.com:blackscience/hermes-c-c-interface.git', ['blackscience/hermes-c-c-interface'])).toBe(true)
     expect(remoteUrlMatchesExpectedRepo('git@github.com:outsourc-e/hermes-workspace.git', ['outsourc-e/hermes-workspace'])).toBe(true)
   })
 
   it('blocks update availability for wrong remote repos even when heads differ', () => {
     const status = createRemoteStatus({
       name: 'origin',
-      label: 'Hermes Workspace',
-      expectedRepo: 'hermes-workspace',
-      aliases: ['hermes-workspace'],
+      label: 'Hermes C&C Interface',
+      expectedRepo: 'hermes-c-c-interface',
+      aliases: ['hermes-c-c-interface'],
       url: 'https://github.com/example/not-workspace.git',
       currentHead: 'local',
       remoteHead: 'remote',
@@ -20,7 +21,7 @@ describe('claude update repo gating', () => {
 
     expect(status.repoMatches).toBe(false)
     expect(status.updateAvailable).toBe(false)
-    expect(status.error).toContain('expected hermes-workspace')
+    expect(status.error).toContain('expected hermes-c-c-interface')
   })
 
   it('allows update availability only for the expected repo with a newer remote head', () => {

--- a/src/routes/api/claude-update.ts
+++ b/src/routes/api/claude-update.ts
@@ -30,9 +30,9 @@ type RemoteDefinition = {
 export const UPDATE_REMOTE_DEFINITIONS: Array<RemoteDefinition> = [
   {
     name: 'origin',
-    label: 'Hermes Workspace',
-    expectedRepo: 'hermes-workspace',
-    aliases: ['claude-workspace', 'hermes-workspace', 'outsourc-e/hermes-workspace'],
+    label: 'Hermes C&C Interface',
+    expectedRepo: 'hermes-c-c-interface',
+    aliases: ['claude-workspace', 'hermes-workspace', 'hermes-c-c-interface', 'blackscience/hermes-c-c-interface', 'outsourc-e/hermes-workspace'],
   },
   {
     name: 'upstream',
@@ -144,7 +144,7 @@ export const Route = createFileRoute('/api/claude-update')({
           ok: true,
           checkedAt: Date.now(),
           app: {
-            name: 'Hermes Workspace',
+            name: 'Hermes C&C Interface',
             version: pkgVersion(),
             branch,
             currentHead,

--- a/src/routes/api/git-status.ts
+++ b/src/routes/api/git-status.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process'
+import * as path from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+
+const REPO_ROOT = path.resolve(process.env.HERMES_WORKSPACE_REPO || process.cwd())
+
+function git(args: Array<string>): string {
+  return execFileSync('git', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 2500,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function safeGit(args: Array<string>): string | null {
+  try {
+    return git(args)
+  } catch {
+    return null
+  }
+}
+
+function parseAheadBehind(): { ahead: number; behind: number } {
+  const upstream = safeGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
+  if (!upstream) return { ahead: 0, behind: 0 }
+  const counts = safeGit(['rev-list', '--left-right', '--count', `HEAD...${upstream}`])
+  if (!counts) return { ahead: 0, behind: 0 }
+  const [aheadRaw, behindRaw] = counts.split(/\s+/)
+  return {
+    ahead: Number(aheadRaw) || 0,
+    behind: Number(behindRaw) || 0,
+  }
+}
+
+export const Route = createFileRoute('/api/git-status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const sha = git(['rev-parse', 'HEAD'])
+          const branch = safeGit(['branch', '--show-current']) || 'detached'
+          const remote = safeGit(['config', '--get', `branch.${branch}.remote`])
+          const status = safeGit(['status', '--porcelain']) ?? ''
+          const { ahead, behind } = parseAheadBehind()
+
+          return Response.json({
+            ok: true,
+            repo: REPO_ROOT,
+            branch,
+            shortSha: sha.slice(0, 8),
+            sha,
+            subject: git(['log', '-1', '--pretty=%s']),
+            author: git(['log', '-1', '--pretty=%an']),
+            committedAt: git(['log', '-1', '--pretty=%cI']),
+            relativeCommitTime: git(['log', '-1', '--pretty=%cr']),
+            dirty: status.length > 0,
+            ahead,
+            behind,
+            remote,
+            checkedAt: Date.now(),
+          })
+        } catch (error) {
+          return Response.json(
+            {
+              ok: false,
+              repo: REPO_ROOT,
+              branch: 'unknown',
+              shortSha: '',
+              sha: '',
+              subject: '',
+              author: '',
+              committedAt: '',
+              relativeCommitTime: '',
+              dirty: false,
+              ahead: 0,
+              behind: 0,
+              remote: null,
+              checkedAt: Date.now(),
+              error: error instanceof Error ? error.message : String(error),
+            },
+            { status: 200 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/screens/dashboard/components/git-status-card.tsx
+++ b/src/screens/dashboard/components/git-status-card.tsx
@@ -1,0 +1,100 @@
+import { useQuery } from '@tanstack/react-query'
+
+type GitStatusResponse = {
+  ok: boolean
+  repo: string
+  branch: string
+  shortSha: string
+  sha: string
+  subject: string
+  author: string
+  committedAt: string
+  relativeCommitTime: string
+  dirty: boolean
+  ahead: number
+  behind: number
+  remote: string | null
+  checkedAt: number
+  error?: string
+}
+
+function statusLabel(data: GitStatusResponse | undefined): string {
+  if (!data) return 'Checking'
+  if (!data.ok) return 'Unavailable'
+  if (data.dirty) return 'Dirty worktree'
+  if (data.ahead > 0 && data.behind > 0) return `Diverged +${data.ahead}/-${data.behind}`
+  if (data.ahead > 0) return `Ahead by ${data.ahead}`
+  if (data.behind > 0) return `Behind by ${data.behind}`
+  return 'Synced'
+}
+
+function statusColor(data: GitStatusResponse | undefined): string {
+  if (!data) return 'var(--theme-muted)'
+  if (!data.ok) return 'var(--theme-danger)'
+  if (data.dirty || data.ahead > 0 || data.behind > 0) return 'var(--theme-warning)'
+  return 'var(--theme-success)'
+}
+
+export function GitStatusCard() {
+  const query = useQuery<GitStatusResponse>({
+    queryKey: ['dashboard', 'git-status'],
+    queryFn: async () => {
+      const res = await fetch('/api/git-status', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`git-status ${res.status}`)
+      return (await res.json()) as GitStatusResponse
+    },
+    staleTime: 10_000,
+    refetchInterval: 30_000,
+    retry: 1,
+  })
+
+  const data = query.data
+  const label = query.isError ? 'Unavailable' : statusLabel(data)
+  const color = query.isError ? 'var(--theme-danger)' : statusColor(data)
+
+  return (
+    <div className="h-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted">
+            Git Commit
+          </p>
+          <h3 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">
+            {data?.shortSha ?? '—'}
+          </h3>
+        </div>
+        <span
+          className="rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]"
+          style={{
+            borderColor: `color-mix(in srgb, ${color} 42%, var(--theme-border))`,
+            background: `color-mix(in srgb, ${color} 12%, transparent)`,
+            color,
+          }}
+        >
+          {label}
+        </span>
+      </div>
+
+      <div className="space-y-2 text-xs text-muted">
+        <p className="line-clamp-2 text-sm text-[var(--theme-text)]">
+          {query.isError ? 'Could not read repository status.' : data?.subject ?? 'Loading commit status…'}
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="rounded-lg bg-[var(--theme-card2)] px-2 py-1.5">
+            <div className="text-[10px] uppercase tracking-[0.12em] opacity-70">Branch</div>
+            <div className="truncate text-[var(--theme-text)]">{data?.branch ?? '—'}</div>
+          </div>
+          <div className="rounded-lg bg-[var(--theme-card2)] px-2 py-1.5">
+            <div className="text-[10px] uppercase tracking-[0.12em] opacity-70">Remote</div>
+            <div className="truncate text-[var(--theme-text)]">{data?.remote ?? 'origin'}</div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-[11px]">
+          <span>author: {data?.author ?? '—'}</span>
+          <span>committed: {data?.relativeCommitTime ?? '—'}</span>
+          {data ? <span>checked: {new Date(data.checkedAt).toLocaleTimeString()}</span> : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/dashboard/components/widget-shell.tsx
+++ b/src/screens/dashboard/components/widget-shell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import {
   WIDGET_CATALOG,
   type DashboardLayout,
@@ -6,19 +6,9 @@ import {
 } from '@/screens/dashboard/lib/use-dashboard-layout'
 
 /**
- * Wraps a dashboard widget so it participates in edit mode without
- * the widget itself needing to know edit state exists.
- *
- * Behavior:
- * - When `layout.editMode` is true: shows a subtle dashed outline +
- *   an X button in the top-right corner that hides the widget. The
- *   widget body remains interactive so the operator can still see
- *   what they're toggling.
- * - When edit mode is off: renders children unchanged (zero overhead
- *   layout-wise; the wrapper is just a passthrough div).
- *
- * If the widget is hidden (`!layout.isVisible(id)`), this returns
- * null in both modes — restoration happens through the EditPanel.
+ * Wraps a dashboard widget so it participates in edit mode and can be
+ * collapsed without fully hiding it. Collapsed state is per-widget and
+ * persisted in localStorage so operators can fit more status on one page.
  */
 export function WidgetShell({
   id,
@@ -33,16 +23,69 @@ export function WidgetShell({
 
   const meta = WIDGET_CATALOG.find((w) => w.id === id)
   const canHide = meta?.hideable ?? true
+  const storageKey = `dashboard.widget.collapsed.${id}`
+  const [collapsed, setCollapsed] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem(storageKey) === '1'
+  })
 
-  if (!layout.editMode) {
-    // Plain passthrough. Wrapping in a fragment-equivalent div would
-    // change the flexbox layout above us, so we skip the wrapper.
-    return <>{children}</>
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(storageKey, collapsed ? '1' : '0')
+  }, [collapsed, storageKey])
+
+  const collapseButton = (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        setCollapsed((value) => !value)
+      }}
+      className="absolute top-2 z-20 inline-flex h-6 items-center justify-center rounded-full border px-2 text-[11px] font-semibold uppercase tracking-[0.12em] shadow-sm transition-all hover:scale-105"
+      style={{
+        right: layout.editMode && canHide ? 30 : 8,
+        background: 'var(--theme-card)',
+        color: 'var(--theme-muted)',
+        borderColor: 'var(--theme-border)',
+      }}
+      title={`${collapsed ? 'Expand' : 'Collapse'} ${meta?.label ?? id}`}
+      aria-label={`${collapsed ? 'Expand' : 'Collapse'} widget ${meta?.label ?? id}`}
+    >
+      {collapsed ? '＋' : '－'}
+    </button>
+  )
+
+  if (collapsed) {
+    return (
+      <div
+        className="relative rounded-xl border px-4 py-3"
+        style={{
+          background: 'var(--theme-card)',
+          borderColor: 'var(--theme-border)',
+        }}
+      >
+        <div className="pr-16">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted">
+            {meta?.label ?? id}
+          </div>
+          <div className="mt-1 text-xs text-muted">
+            Collapsed — click + to expand.
+          </div>
+        </div>
+        {collapseButton}
+      </div>
+    )
   }
 
-  // Use `h-full` on the edit-mode wrapper so children that opted
-  // into `flex-1`/`h-full` (e.g. Sessions Intelligence post iter 013)
-  // still expand correctly when the dashboard is in edit mode.
+  if (!layout.editMode) {
+    return (
+      <div className="relative h-full">
+        {children}
+        {collapseButton}
+      </div>
+    )
+  }
+
   return (
     <div className="relative h-full">
       <div
@@ -57,6 +100,7 @@ export function WidgetShell({
         }}
       />
       <div className="relative h-full">{children}</div>
+      {collapseButton}
       {canHide ? (
         <button
           type="button"
@@ -64,7 +108,7 @@ export function WidgetShell({
             e.stopPropagation()
             layout.hide(id)
           }}
-          className="absolute -right-2 -top-2 z-10 inline-flex size-6 items-center justify-center rounded-full text-[14px] font-bold leading-none shadow-md transition-transform hover:scale-110"
+          className="absolute -right-2 -top-2 z-20 inline-flex size-6 items-center justify-center rounded-full text-[14px] font-bold leading-none shadow-md transition-transform hover:scale-110"
           style={{
             background: 'var(--theme-card)',
             color: 'var(--theme-danger)',

--- a/src/screens/dashboard/dashboard-screen.tsx
+++ b/src/screens/dashboard/dashboard-screen.tsx
@@ -29,6 +29,7 @@ import { CacheEfficiencyCard } from './components/cache-efficiency-card'
 import { CostLedgerCard } from './components/cost-ledger-card'
 import { EditModePanel } from './components/edit-mode-panel'
 import { HeroMetrics } from './components/hero-metrics'
+import { GitStatusCard } from './components/git-status-card'
 import { LogsTailCard } from './components/logs-tail-card'
 import { OperatorTipCard } from './components/operator-tip-card'
 import { OpsStrip } from './components/ops-strip'
@@ -920,7 +921,7 @@ export function DashboardScreen() {
                 lineHeight: 1.1,
               }}
             >
-              Hermes Workspace
+              Hermes C&amp;C Interface
             </h1>
           </div>
         </div>
@@ -1171,6 +1172,9 @@ export function DashboardScreen() {
             stretch the rail to match Sessions Intelligence height so
             we don't get the dangling gap Eric flagged in iter 007. */}
         <div className="flex min-h-full flex-col gap-3 lg:col-span-4">
+          <WidgetShell id="git_status" layout={layout}>
+            <GitStatusCard />
+          </WidgetShell>
           <WidgetShell id="achievements" layout={layout}>
             <AchievementsCard
               achievements={overview?.achievements ?? null}

--- a/src/screens/dashboard/lib/use-dashboard-layout.ts
+++ b/src/screens/dashboard/lib/use-dashboard-layout.ts
@@ -11,6 +11,7 @@ const STORAGE_KEY = 'dashboard.layout.v1'
  * can group them sensibly in the picker UI.
  */
 export type WidgetId =
+  | 'git_status'
   | 'analytics_chart'
   | 'top_models'
   | 'provider_mix'
@@ -35,6 +36,13 @@ export type WidgetMeta = {
 }
 
 export const WIDGET_CATALOG: ReadonlyArray<WidgetMeta> = [
+  {
+    id: 'git_status',
+    label: 'Git status',
+    description: 'Current commit, branch, and push/drift status for this workspace repo.',
+    column: 'rail',
+    hideable: true,
+  },
   {
     id: 'analytics_chart',
     label: 'Analytics chart',


### PR DESCRIPTION
## Summary
- Document the pve2 C&C `:9120` Remote subagent servers panel and Ollama Cloud model-switching contract.
- Add `192.168.1.219` / PiBench as the first/primary remote subagent fallback ahead of DietPi and DietGTX780Ti.
- Add status-page checker/server support for per-host credential prefixes, sudo-root execution, `/subagent-219.json`, and the `hermes-219-subagent` helper.

## Verification
- `python3 -m py_compile` passed for the status-page server and checker scripts.
- `hermes-backup-status.service` restarted and is active on pve2.
- `hermes-219-subagent-status.timer`, `hermes-151-subagent-status.timer`, and `hermes-108-subagent-status.timer` are active.
- `http://127.0.0.1:9120/remote-subagents.json` returns order `219`, `151`, `108`, all `ready: true`.
- `/set-subagent-model` was exercised on 219 with `qwen3-next:80b` and returned success.

Note: fork branch was pushed from 192.168.1.140 because the blackscience token has push access to the fork but read-only access to `outsourc-e/hermes-workspace`.