### PR TITLE
fix(swarm-health): don't count auxiliary-client probes as primary auth failure

### DIFF
--- a/src/routes/api/swarm-health.ts
+++ b/src/routes/api/swarm-health.ts
@@ -139,6 +139,12 @@ export function parseModelAuthEventsFromText(text: string): {
   let fallbackModel: string | null = null
   for (const line of text.split('\n')) {
     if (!line.trim()) continue
+    // Auxiliary client (side-task) provider probes are NOT the worker's primary
+    // model auth. Lines like "agent.auxiliary_client: Auxiliary Nous client
+    // unavailable: no Nous authentication found" or "Auxiliary: marking openrouter
+    // unhealthy (payment / credit error)" must not count as primary-auth failures
+    // (otherwise a Kimi-only worker is falsely flagged BLOCKED). See swarm-health.
+    if (/auxiliary/i.test(line)) continue
     const tsMatch = line.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:,\d{3})?/)
     const ts = tsMatch?.[1] ?? null
     if (authPatterns.some((pattern) => pattern.test(line))) {


### PR DESCRIPTION
## Problem
Swarm worker cards render as `modelAuthStatus: primary-auth-failed` ("blocked") even when the worker is running fine. At worker startup, Hermes's **auxiliary client** (`agent/auxiliary_client.py`, `_resolve_auto`) probes its bundled Nous + OpenRouter backends before the main runtime is set. With only a primary key configured (e.g. `KIMI_API_KEY`), those probes log lines like:

```
Auxiliary Nous client unavailable: no Nous authentication found
```

`parseModelAuthEventsFromText` in `src/routes/api/swarm-health.ts` matched these on `/\bauthentication\b/i` and counted them as **primary** auth errors, flipping the worker to a false "blocked" state.

## Fix
Skip auxiliary-client lines before the auth-pattern check:

```ts
if (/auxiliary/i.test(line)) continue
```

Purely cosmetic surface — dispatch was never gated on auth health (only on `tmuxAvailable`) — but the false badge is misleading.

## Testing
With 3 Kimi-backed workers running, all three now report `authStatus=ready, primaryAuthOk=true, recentAuthErrors=0` instead of `primary-auth-failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)