### PR TITLE
feat(usage): add Kimi/Moonshot provider to usage panel

### DIFF
--- a/src/server/provider-usage.ts
+++ b/src/server/provider-usage.ts
@@ -1056,6 +1056,109 @@ export async function fetchGeminiUsage(): Promise<ProviderUsageResult> {
   }
 }
 
+// ── Kimi / Moonshot (API Key) ────────────────────────────────────────────────
+
+export async function fetchKimiUsage(): Promise<ProviderUsageResult> {
+  const now = Date.now()
+  const apiKey = (
+    process.env.KIMI_API_KEY ?? process.env.MOONSHOT_API_KEY
+  )?.trim()
+
+  if (!apiKey) {
+    return {
+      provider: 'kimi',
+      displayName: 'Kimi (Moonshot)',
+      status: 'missing_credentials',
+      message: 'Missing KIMI_API_KEY',
+      lines: [],
+      updatedAt: now,
+    }
+  }
+
+  // International (sk-ax…) keys live on api.moonshot.ai; mainland keys on .cn.
+  // Allow override, else probe .ai then fall back to .cn.
+  const override = process.env.MOONSHOT_API_BASE?.trim().replace(/\/+$/, '')
+  const bases = override
+    ? [override]
+    : ['https://api.moonshot.ai', 'https://api.moonshot.cn']
+
+  let lastStatus = 0
+  let lastErr = ''
+  for (const base of bases) {
+    let res: Response
+    try {
+      res = await fetch(`${base}/v1/users/me/balance`, {
+        headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' },
+      })
+    } catch (e) {
+      lastErr = e instanceof Error ? e.message : String(e)
+      continue
+    }
+    if (res.status === 401 || res.status === 403) {
+      lastStatus = res.status
+      continue // wrong region for this key — try next base
+    }
+    if (!res.ok) {
+      lastStatus = res.status
+      continue
+    }
+
+    const payload = (await res.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null
+    const data = (payload?.data ?? payload) as Record<string, unknown> | null
+
+    const available = readNumber(data?.available_balance)
+    const cash = readNumber(data?.cash_balance)
+    const voucher = readNumber(data?.voucher_balance)
+
+    const lines: UsageLine[] = []
+    if (available !== undefined) {
+      lines.push({
+        type: 'text',
+        label: 'Balance',
+        value: `$${available.toFixed(2)}`,
+      })
+    }
+    if (voucher !== undefined && voucher > 0) {
+      lines.push({
+        type: 'text',
+        label: 'Voucher',
+        value: `$${voucher.toFixed(2)}`,
+      })
+    }
+    if (cash !== undefined && (available === undefined || cash !== available)) {
+      lines.push({ type: 'text', label: 'Cash', value: `$${cash.toFixed(2)}` })
+    }
+    if (lines.length === 0) {
+      lines.push({
+        type: 'badge',
+        label: 'Status',
+        value: 'API key active',
+        color: '#10b981',
+      })
+    }
+
+    return {
+      provider: 'kimi',
+      displayName: 'Kimi (Moonshot)',
+      status: 'ok',
+      lines,
+      updatedAt: now,
+    }
+  }
+
+  return {
+    provider: 'kimi',
+    displayName: 'Kimi (Moonshot)',
+    status: lastStatus === 401 || lastStatus === 403 ? 'auth_expired' : 'error',
+    message: lastErr || `HTTP ${lastStatus || 'unreachable'}`,
+    lines: [],
+    updatedAt: now,
+  }
+}
+
 // ── Aggregate ────────────────────────────────────────────────────────────────
 
 const CACHE_TTL_MS = 30_000
@@ -1070,6 +1173,7 @@ export async function getProviderUsage(
   }
 
   const results = await Promise.allSettled([
+    fetchKimiUsage(),
     fetchClaudeUsage(),
     fetchCodexUsage(),
     fetchOpenAIUsage(),
@@ -1079,8 +1183,8 @@ export async function getProviderUsage(
 
   const providers: ProviderUsageResult[] = results.map((r, i) => {
     if (r.status === 'fulfilled') return r.value
-    const names = ['Claude (OAuth)', 'Codex', 'OpenAI', 'OpenRouter', 'Gemini']
-    const ids = ['claude', 'codex', 'openai', 'openrouter', 'gemini']
+    const names = ['Kimi (Moonshot)', 'Claude (OAuth)', 'Codex', 'OpenAI', 'OpenRouter', 'Gemini']
+    const ids = ['kimi', 'claude', 'codex', 'openai', 'openrouter', 'gemini']
     return {
       provider: ids[i],
       displayName: names[i],


### PR DESCRIPTION
## Problem
The provider-usage aggregator (`src/server/provider-usage.ts`) only polls Claude, Codex, OpenAI, OpenRouter, and Gemini. Deployments running on **Kimi (Moonshot)** — which Hermes supports as a model provider (`kimi-coding`) — have no usage card, so the panel shows "failing to fetch usage data" with nothing actionable. This is especially visible on hosts where the Western provider endpoints are unreachable (e.g. mainland-China networks), where every other card errors too.

## Fix
Add `fetchKimiUsage()` and wire it into `getProviderUsage()`:

- Reads `KIMI_API_KEY` (falls back to `MOONSHOT_API_KEY`).
- Fetches `GET /v1/users/me/balance` and surfaces `available_balance` / `voucher_balance` / `cash_balance` as usage lines.
- **Region-aware:** international `sk-ax…` keys authenticate on `api.moonshot.ai`, mainland keys on `api.moonshot.cn`. The provider probes `.ai` then `.cn` (and honours a `MOONSHOT_API_BASE` override), so it works regardless of which key the user has.
- Degrades gracefully to `missing_credentials` (no key) / `auth_expired` (401/403 on all bases) / `error`, matching the existing provider conventions.

No new dependencies; mirrors the existing OpenRouter/Gemini provider patterns.

## Testing
Verified live against a running gateway: with an international key the panel renders **`Kimi (Moonshot) · Balance $58.92 · status ok`**. With no key it shows `missing_credentials` and does not affect other providers (`Promise.allSettled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)