### PR TITLE
fix(models): opt-in workspace.hide_default_model_in_picker to hide default model from picker

### DIFF
--- a/src/routes/api/__tests__/-models.test.ts
+++ b/src/routes/api/__tests__/-models.test.ts
@@ -107,6 +107,33 @@ describe('models route', () => {
     expect(json.models[0].provider).toBe('nous')
   })
 
+  it('hides the default model from the picker when workspace.hide_default_model_in_picker is set', async () => {
+    const envHome = '/mock/profiles/jarvis'
+    process.env.CLAUDE_HOME = envHome
+
+    const configYaml =
+      'model: jarvis-model\nprovider: nous\nworkspace:\n  hide_default_model_in_picker: true\n'
+    const modelsJson = '[{"model":"x","provider":"y"}]'
+    existsSync.mockImplementation((p: string) => {
+      return p === `${envHome}/models.json` || p === `${envHome}/config.yaml`
+    })
+    readFileSync.mockImplementation((p: string) => {
+      if (p === `${envHome}/config.yaml`) return configYaml
+      if (p === `${envHome}/models.json`) return modelsJson
+      return ''
+    })
+
+    const get = await getHandler()
+    const request = new Request('http://localhost/api/models')
+    const res = await get({ request })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    // default model is NOT injected; only the real models.json entry remains
+    expect(json.models.some((m: { id: string }) => m.id === 'jarvis-model')).toBe(false)
+    expect(json.models.map((m: { id: string }) => m.id)).toEqual(['x'])
+  })
+
   it('reads nested model object syntax from config using YAML.parse', async () => {
     const envHome = '/mock/profiles/jarvis'
     process.env.CLAUDE_HOME = envHome

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -184,6 +184,22 @@ function readClaudeDefaultModel(): ModelEntry | null {
 }
 
 /**
+ * Opt-out flag: when `workspace.hide_default_model_in_picker: true` is set in
+ * config.yaml, the configured default model is not injected as a standalone
+ * picker entry. Defaults to false (preserve historical "default first").
+ */
+function readHideDefaultModelInPicker(): boolean {
+  try {
+    if (!fs.existsSync(CONFIG_PATH)) return false
+    const parsed = YAML.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'))
+    const ws = asRecord(asRecord(parsed).workspace)
+    return ws.hide_default_model_in_picker === true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Read providers.*.models (+ provider default model) and model_aliases
  * from ~/.hermes/config.yaml so the picker reflects the user's full Hermes
  * catalog, not just /v1/models + models.json + local discovery. Fix for #569.
@@ -419,9 +435,17 @@ export const Route = createFileRoute('/api/models')({
           let models = readClaudeModelsJson()
           let source = 'models.json'
 
-          // Ensure the default model from config.yaml is always first
+          // Ensure the default model from config.yaml is always first.
+          //
+          // Opt-out: when `workspace.hide_default_model_in_picker: true` is set
+          // in config.yaml, the default model is NOT injected as a standalone
+          // picker entry. This is for stacks where the top-level `model:` is the
+          // agent's upstream working model (e.g. anthropic/claude-opus-4-8 served
+          // via the gateway's own `hermes-agent` entry), where surfacing it adds
+          // a confusing provider-less ("unknown") duplicate. Default behaviour
+          // (inject + first) is unchanged.
           const defaultModel = readClaudeDefaultModel()
-          if (defaultModel) {
+          if (defaultModel && !readHideDefaultModelInPicker()) {
             models = models.filter((m) => m.id !== defaultModel.id)
             models.unshift(defaultModel)
           }


### PR DESCRIPTION
## What

Add an opt-in config flag `workspace.hide_default_model_in_picker` (default `false`). When set to `true` in `config.yaml`, the configured top-level default `model:` is **not** injected as a standalone entry in `/api/models`.

## Why

On stacks where the top-level `model:` is the agent's *upstream* working model (e.g. `anthropic/claude-opus-4-8` reached via the gateway's own `hermes-agent` entry), surfacing it in the picker creates a confusing provider-less ("unknown") duplicate of `hermes-agent`. The flag lets such deployments hide it without affecting the agent's model.

## Behaviour

- Default (flag unset/false): unchanged — default model is injected and listed first.
- Flag true: default model is skipped in the picker only.

## Tests

`src/routes/api/__tests__/-models.test.ts` — added a case asserting the default model is not injected when the flag is set; existing default-first tests remain green (4/4 pass locally via vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)