### PR TITLE
fix: fall back to API_SERVER_KEY from HERMES_HOME/.env for HERMES_API_TOKEN

### DIFF
--- a/electron/prod-server.cjs
+++ b/electron/prod-server.cjs
@@ -1,5 +1,6 @@
 const http = require('http')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 
 const portArg = process.argv.find(
@@ -43,6 +44,32 @@ async function loadServerBuild() {
   return serverModule.default
 }
 
+/**
+ * GUI apps launched from Finder/Dock (macOS) don't inherit shell environment
+ * variables, so HERMES_API_TOKEN is unset even when the gateway requires it.
+ * Fall back to the API_SERVER_KEY the gateway itself reads from
+ * $HERMES_HOME/.env (~/.hermes/.env by default), so the desktop app works
+ * without any shell configuration.
+ */
+function applyApiTokenFileFallback() {
+  if (process.env.HERMES_API_TOKEN) return
+  try {
+    const hermesHome =
+      process.env.HERMES_HOME || path.join(os.homedir(), '.hermes')
+    const envFile = path.join(hermesHome, '.env')
+    if (!fs.existsSync(envFile)) return
+    const match = fs
+      .readFileSync(envFile, 'utf-8')
+      .match(/^\s*API_SERVER_KEY\s*=\s*(.+)\s*$/m)
+    if (!match) return
+    const value = match[1].trim().replace(/^["']|["']$/g, '')
+    if (value) process.env.HERMES_API_TOKEN = value
+  } catch {
+    // Best-effort: fall through silently, requests will just go unauthenticated
+    // exactly as they do today when the variable is missing.
+  }
+}
+
 async function main() {
   process.env.NODE_ENV = process.env.NODE_ENV || 'production'
   process.env.HERMES_WORKSPACE_DESKTOP =
@@ -51,6 +78,9 @@ async function main() {
     process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
   process.env.HERMES_DASHBOARD_URL =
     process.env.HERMES_DASHBOARD_URL || 'http://127.0.0.1:9119'
+  // Must run before loadServerBuild(): parts of the server bundle read
+  // HERMES_API_TOKEN at module load time (e.g. the gateway bearer token).
+  applyApiTokenFileFallback()
 
   const serverBuild = await loadServerBuild()
 


### PR DESCRIPTION
Fixes #613.

## What

GUI apps launched from Finder/Dock on macOS don't inherit shell environment variables, so `HERMES_API_TOKEN` is never set for the desktop workspace — chat silently fails against gateways that have `API_SERVER_KEY` enabled (mandatory since hermes-agent v0.16.0). `launchctl setenv` is unreliable and patching `Info.plist` breaks the ad-hoc signature, so there was no sane way to get the token into the app.

`electron/prod-server.cjs` already defaults `HERMES_API_URL` / `HERMES_DASHBOARD_URL`, but had no fallback for the token.

## Fix

Add `applyApiTokenFileFallback()` to `prod-server.cjs`: when `HERMES_API_TOKEN` is not set, read `API_SERVER_KEY` from `$HERMES_HOME/.env` (defaulting to `~/.hermes/.env`) — the same key, from the same file, the gateway itself reads.

Details:
- Runs **before** `loadServerBuild()`, because parts of the server bundle capture `HERMES_API_TOKEN` at module load time (e.g. the gateway bearer token in `gateway-capabilities.ts`).
- An explicitly set `HERMES_API_TOKEN` always wins — the fallback only fills the gap.
- Respects the `HERMES_HOME` override (same convention the rest of the codebase/tests use).
- Tolerates quotes/whitespace in the `.env` line; on any read/parse failure it falls through silently, leaving behavior exactly as it is today.

## Verification

- `node --check electron/prod-server.cjs` — clean.
- Exercised the exact shipped function against temp `HERMES_HOME` dirs: plain value, quoted value, surrounding whitespace, pre-set env var (not overridden), and missing file (no crash) — all behave as expected.
- `prettier --check` — the only remaining warning on the file is the pre-existing one present on `main` (line endings), unrelated to this change.
