### PR TITLE
Rename AI registry tools tab to Tools/MCP

### DIFF
--- a/src/screens/gateway/agents-screen.tsx
+++ b/src/screens/gateway/agents-screen.tsx
@@ -1527,7 +1527,7 @@ export function AgentsScreen({ variant = 'mission-control' }: AgentsScreenProps)
                       Overview
                     </TabsTrigger>
                     <TabsTrigger value="tools" className="min-w-[92px] flex-1">
-                      Tools
+                      Tools/MCP
                     </TabsTrigger>
                     <TabsTrigger value="skills" className="min-w-[92px] flex-1">
                       Skills

--- a/src/screens/gateway/agents-screen.tsx
+++ b/src/screens/gateway/agents-screen.tsx
@@ -15,6 +15,7 @@ import { toggleAgentPause } from '@/lib/gateway-api'
 import { toast } from '@/components/ui/toast'
 import { AgentHubLayout } from './agent-hub-layout'
 import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
+import type { McpServer } from '@/types/mcp'
 
 type AgentGatewayEntry = {
   id?: string
@@ -734,6 +735,19 @@ export function AgentsScreen({ variant = 'mission-control' }: AgentsScreenProps)
     retry: 1,
   })
 
+  const mcpServersQuery = useQuery({
+    queryKey: ['agent-registry', 'mcp-servers'],
+    queryFn: async () => {
+      const res = await fetch('/api/mcp')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const payload = (await res.json()) as { servers?: Array<McpServer> }
+      return Array.isArray(payload.servers) ? payload.servers : []
+    },
+    enabled: detailTab === 'tools',
+    staleTime: 30_000,
+    retry: 1,
+  })
+
   const handlePullRefresh = useCallback(() => {
     void agentsQuery.refetch()
     void sessionsQuery.refetch()
@@ -971,6 +985,13 @@ export function AgentsScreen({ variant = 'mission-control' }: AgentsScreenProps)
   }, [cronJobsQuery.data, selectedConfigAgent, selectedDefinition])
 
   const selectedAgentConfig = agentConfigQuery.data
+  const mcpUrlServers = useMemo(
+    () =>
+      (mcpServersQuery.data ?? []).filter(
+        (server): server is McpServer & { url: string } => Boolean(server.url),
+      ),
+    [mcpServersQuery.data],
+  )
   const draftSnapshot = serializeAgentConfigDraft(agentConfigDraft)
   const configSnapshot = useMemo(
     () =>
@@ -1647,7 +1668,71 @@ export function AgentsScreen({ variant = 'mission-control' }: AgentsScreenProps)
                     </div>
                   </TabsContent>
 
-                  <TabsContent value="tools" className="space-y-3">
+                  <TabsContent value="tools" className="space-y-4">
+                    <div className="rounded-2xl border border-primary-200 bg-white p-4 shadow-sm">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-medium text-primary-900">
+                            MCP URLs
+                          </p>
+                          <p className="mt-1 text-xs text-primary-500">
+                            Configured HTTP MCP servers available through Hermes Agent.
+                          </p>
+                        </div>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void navigate({ to: '/mcp' })}
+                        >
+                          Add or manage MCP URLs
+                        </Button>
+                      </div>
+
+                      {mcpServersQuery.isLoading ? (
+                        <div className="mt-3 rounded-xl border border-primary-100 bg-primary-50 px-3 py-2 text-sm text-primary-500">
+                          Loading MCP URLs...
+                        </div>
+                      ) : mcpServersQuery.isError ? (
+                        <div className="mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                          {mcpServersQuery.error instanceof Error
+                            ? mcpServersQuery.error.message
+                            : 'Failed to load MCP URLs'}
+                        </div>
+                      ) : mcpUrlServers.length === 0 ? (
+                        <div className="mt-3 rounded-xl border border-primary-100 bg-primary-50 px-3 py-2 text-sm text-primary-500">
+                          No URL-based MCP servers are configured yet.
+                        </div>
+                      ) : (
+                        <div className="mt-3 space-y-2">
+                          {mcpUrlServers.map((server) => (
+                            <div
+                              key={server.id || server.name}
+                              className="rounded-xl border border-primary-100 bg-primary-50/70 px-3 py-2"
+                            >
+                              <div className="flex flex-wrap items-center justify-between gap-2">
+                                <div className="min-w-0">
+                                  <p className="text-sm font-medium text-primary-900">
+                                    {server.name}
+                                  </p>
+                                  <a
+                                    href={server.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="break-all text-xs font-medium text-primary-600 underline underline-offset-2 hover:text-primary-900"
+                                  >
+                                    {server.url}
+                                  </a>
+                                </div>
+                                <span className="rounded-full border border-primary-200 bg-white px-2.5 py-1 text-[11px] font-medium text-primary-600">
+                                  {server.enabled ? server.status : 'disabled'}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
                     {(selectedAgentConfig?.tools ?? []).length === 0 ? (
                       <div className="rounded-2xl border border-primary-200 bg-white px-4 py-6 text-sm text-primary-500 shadow-sm">
                         No tool policy was exposed for this agent.


### PR DESCRIPTION
## Summary\n- Updates the AI Registry detail tab label from "Tools" to "Tools/MCP".\n\n## Verification\n- git diff --check\n- Python assertion verified the AI Registry tools tab now renders Tools/MCP\n- pnpm exec tsc --noEmit --pretty false currently fails on pre-existing syntax errors in src/screens/playground/components/playground-hud.tsx