### PR TITLE
[codex] Fix workspace build and chat session persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 allowBuilds:
   electron: true
   electron-winstaller: true

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -21,6 +21,22 @@ import {
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
 
+function toLocalSessionSummary(ls: ReturnType<typeof listLocalSessions>[number]) {
+  return {
+    key: ls.id,
+    id: ls.id,
+    friendlyId: ls.id,
+    title: ls.title || 'Local Chat',
+    label: ls.title || 'Local Chat',
+    derivedTitle: ls.title || 'Local Chat',
+    startedAt: ls.createdAt,
+    updatedAt: ls.updatedAt,
+    message_count: ls.messageCount,
+    model: ls.model,
+    source: 'local',
+  } as any
+}
+
 export const Route = createFileRoute('/api/sessions')({
   server: {
     handlers: {
@@ -29,12 +45,13 @@ export const Route = createFileRoute('/api/sessions')({
         if (!isAuthenticated(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
+        const localSessions = listLocalSessions().map(toLocalSessionSummary)
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.sessions) {
           return json({
             ok: true,
-            sessions: [],
-            source: 'unavailable',
+            sessions: localSessions,
+            source: localSessions.length > 0 ? 'local-fallback' : 'unavailable',
             message: SESSIONS_API_UNAVAILABLE_MESSAGE,
           })
         }
@@ -44,23 +61,10 @@ export const Route = createFileRoute('/api/sessions')({
           const gatewaySessions = sessions.map(toSessionSummary)
 
           // Merge local portable sessions (Ollama, Atomic Chat, etc.)
-          const localSessions = listLocalSessions()
           const gatewayIds = new Set(gatewaySessions.map((s: any) => s.key || s.id))
           for (const ls of localSessions) {
-            if (!gatewayIds.has(ls.id)) {
-              gatewaySessions.push({
-                key: ls.id,
-                id: ls.id,
-                friendlyId: ls.id,
-                title: ls.title || 'Local Chat',
-                label: ls.title || 'Local Chat',
-                derivedTitle: ls.title || 'Local Chat',
-                startedAt: ls.createdAt,
-                updatedAt: ls.updatedAt,
-                message_count: ls.messageCount,
-                model: ls.model,
-                source: 'local',
-              } as any)
+            if (!gatewayIds.has(ls.id) && !gatewayIds.has(ls.key)) {
+              gatewaySessions.push(ls)
             }
           }
 

--- a/src/routes/chat/$sessionKey.tsx
+++ b/src/routes/chat/$sessionKey.tsx
@@ -5,6 +5,7 @@ import {
   moveHistoryMessages,
   reconcileSessionDraft,
 } from '../../screens/chat/chat-queries'
+import { setRecentSession } from '../../screens/chat/pending-send'
 import { ErrorBoundary } from '@/components/error-boundary'
 
 const ChatScreen = lazy(async () => {
@@ -74,6 +75,15 @@ function ChatRoute() {
       ? forcedSession.sessionKey
       : undefined
 
+  useEffect(() => {
+    if (isNewChat || activeFriendlyId === 'main') return
+    try {
+      localStorage.setItem('hermes:last_session_id', activeFriendlyId)
+      localStorage.setItem('claude-last-session', activeFriendlyId)
+      setRecentSession(activeFriendlyId)
+    } catch {}
+  }, [activeFriendlyId, isNewChat])
+
   // Clear history cache when navigating to new chat
   useEffect(() => {
     if (isNewChat) {
@@ -109,6 +119,7 @@ function ChatRoute() {
       })
       // Persist last session for refresh recovery
       try {
+        localStorage.setItem('hermes:last_session_id', payload.friendlyId)
         localStorage.setItem('claude-last-session', payload.friendlyId)
       } catch {}
       navigate({

--- a/src/routes/chat/index.tsx
+++ b/src/routes/chat/index.tsx
@@ -8,7 +8,8 @@ export const Route = createFileRoute('/chat/')({
     try {
       const stored =
         typeof window !== 'undefined'
-          ? localStorage.getItem('claude-last-session')
+          ? localStorage.getItem('hermes:last_session_id') ||
+            localStorage.getItem('claude-last-session')
           : null
       if (stored && stored !== 'main') lastSession = stored
     } catch {}

--- a/src/screens/chat/hooks/use-chat-sessions.ts
+++ b/src/screens/chat/hooks/use-chat-sessions.ts
@@ -85,7 +85,7 @@ export function useChatSessions({
       (session) => session.friendlyId === activeFriendlyId,
     )
 
-    if (!activeAlreadyPresent && (forcedSessionKey || isRecentSession(activeFriendlyId))) {
+    if (!activeAlreadyPresent && !isNewChat) {
       const synthetic = buildSyntheticActiveSession(
         activeFriendlyId,
         forcedSessionKey,
@@ -115,6 +115,7 @@ export function useChatSessions({
     if (isNewChat) return true
     if (forcedSessionKey) return true
     if (isRecentSession(activeFriendlyId)) return true
+    if (activeFriendlyId) return true
     return sessions.some((session) => session.friendlyId === activeFriendlyId)
   }, [activeFriendlyId, forcedSessionKey, isNewChat, sessions])
   const activeSessionKey = activeSession?.key ?? ''


### PR DESCRIPTION
## Summary
- Fix Docker/pnpm build metadata so the Hermes Workspace source lane can build through GitHub/GHCR.
- Persist the active chat session as hermes:last_session_id / claude-last-session.
- Make the session sidebar show local/active sessions instead of incorrectly showing "No sessions yet" when the active chat route exists.

## Why
The production workspace can open direct /chat/<session_id> routes, but the sidebar can still show "No sessions yet. Start a conversation". That means the active route works while the session index/resume state is not synced.

## Validation
- pnpm install --frozen-lockfile passed locally.
- pnpm build passed locally.
- Production deploy was not performed in this PR step.

## Safety
- No /app runtime-container edits.
- No production deploy.
- No docker compose pull/up.
- No secrets touched.