### PR TITLE
fix: count profile sessions from Hermes state db

### DIFF
--- a/src/server/__tests__/profiles-browser-state-db.test.ts
+++ b/src/server/__tests__/profiles-browser-state-db.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+
+type SqliteDatabaseSync = {
+  exec: (sql: string) => void
+  close: () => void
+}
+
+type NodeSqliteModule = {
+  DatabaseSync: new (path: string) => SqliteDatabaseSync
+}
+
+function loadNodeSqlite(): NodeSqliteModule | undefined {
+  try {
+    return require('node:sqlite') as NodeSqliteModule
+  } catch {
+    return undefined
+  }
+}
+
+const sqlite = loadNodeSqlite()
+const describeWithSqlite = sqlite ? describe : describe.skip
+
+let hermesHome: string
+
+beforeEach(() => {
+  hermesHome = fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-profiles-'))
+  process.env.HERMES_HOME = hermesHome
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.HERMES_HOME
+  fs.rmSync(hermesHome, { recursive: true, force: true })
+})
+
+describeWithSqlite('profiles-browser state.db session counts', () => {
+  it('counts sessions from profile state.db before falling back to legacy session files', async () => {
+    const profilePath = path.join(hermesHome, 'profiles', 'agent')
+    fs.mkdirSync(profilePath, { recursive: true })
+    fs.writeFileSync(path.join(profilePath, 'config.yaml'), 'model:\n  default: gpt-5.5\n')
+
+    const db = new sqlite!.DatabaseSync(path.join(profilePath, 'state.db'))
+    db.exec('create table sessions (id text primary key)')
+    db.exec("insert into sessions (id) values ('one'), ('two'), ('three')")
+    db.close()
+
+    const mod = await import('../profiles-browser')
+    const profile = mod.listProfiles().find((entry) => entry.name === 'agent')
+
+    expect(profile?.sessionCount).toBe(3)
+  })
+})

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,7 +1,21 @@
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 import YAML from 'yaml'
+
+const require = createRequire(import.meta.url)
+
+type SqliteDatabaseSync = {
+  prepare: (sql: string) => {
+    get: () => Record<string, unknown> | undefined
+  }
+  close: () => void
+}
+
+type NodeSqliteModule = {
+  DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => SqliteDatabaseSync
+}
 
 export type ProfileSummary = {
   name: string
@@ -141,6 +155,41 @@ function countFilesRecursive(
     }
   }
   return count
+}
+
+function countLegacySessionFiles(sessionsDir: string): number {
+  return countFilesRecursive(sessionsDir, (full) =>
+    /\.(jsonl|json|sqlite|db)$/i.test(full),
+  )
+}
+
+function countSessionsFromStateDb(profilePath: string): number | undefined {
+  const dbPath = path.join(profilePath, 'state.db')
+  if (!fs.existsSync(dbPath)) return undefined
+
+  let db: SqliteDatabaseSync | undefined
+  try {
+    const sqlite = require('node:sqlite') as NodeSqliteModule
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true })
+    const row = db.prepare('select count(*) as count from sessions').get()
+    const count = row?.count
+    return typeof count === 'number' ? count : undefined
+  } catch {
+    return undefined
+  } finally {
+    try {
+      db?.close()
+    } catch {
+      // Ignore close failures; session counting should not break profile listing.
+    }
+  }
+}
+
+function countProfileSessions(profilePath: string): number {
+  return (
+    countSessionsFromStateDb(profilePath) ??
+    countLegacySessionFiles(path.join(profilePath, 'sessions'))
+  )
 }
 
 function latestMtime(paths: Array<string>): string | undefined {
@@ -406,9 +455,6 @@ export function listProfiles(): Array<ProfileSummary> {
         skillsDir,
         (full) => path.basename(full) === 'SKILL.md',
       )
-      const sessionCount = countFilesRecursive(sessionsDir, (full) =>
-        /\.(jsonl|json|sqlite|db)$/i.test(full),
-      )
       // Resolve model/provider from nested or flat config structure
       let modelName: string | undefined
       let providerName: string | undefined
@@ -436,7 +482,7 @@ export function listProfiles(): Array<ProfileSummary> {
         description: extractDescription(config) || undefined,
         systemPrompt: extractSystemPrompt(config, profilePath) || undefined,
         skillCount,
-        sessionCount,
+        sessionCount: countProfileSessions(profilePath),
         hasEnv: fs.existsSync(envPath),
         updatedAt: latestMtime([
           profilePath,
@@ -481,9 +527,7 @@ export function listProfiles(): Array<ProfileSummary> {
       path.join(root, 'skills'),
       (full) => path.basename(full) === 'SKILL.md',
     ),
-    sessionCount: countFilesRecursive(path.join(root, 'sessions'), (full) =>
-      /\.(jsonl|json|sqlite|db)$/i.test(full),
-    ),
+    sessionCount: countProfileSessions(root),
     hasEnv: fs.existsSync(path.join(root, '.env')),
     updatedAt: latestMtime([root, path.join(root, 'config.yaml')]),
   })


### PR DESCRIPTION
## Summary
- Count Workspace profile sessions from each profile's Hermes `state.db` first.
- Keep legacy session-file counting as a fallback for older layouts or runtimes without `node:sqlite`.
- Add a focused test that creates a profile `state.db` and verifies the profile card count.

## Why
Hermes now stores profile sessions primarily in `~/.hermes/profiles/<name>/state.db`. Workspace profile cards were only counting legacy files under `sessions/`, which made active profiles display `0` sessions when no legacy files existed.

## Tests
- `pnpm test src/server/__tests__/profiles-browser-state-db.test.ts src/server/__tests__/profiles-browser.test.ts`
- `pnpm build`
