### PR TITLE
fix(gateway): POST fallback for /v1/chat/completions probe

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -454,7 +454,24 @@ async function probeChatCompletions(): Promise<boolean> {
     if (getRes.status === 405) return true
     if (getRes.ok) return true
     if (getRes.status === 400 || getRes.status === 422) return true
-    if (getRes.status === 404) return false
+    if (getRes.status === 404) {
+      // Some OpenAI-compatible backends (e.g. `hermes proxy`) only route POST
+      // for /v1/chat/completions and return 404 — not 405 — for GET. Confirm
+      // the endpoint exists with a lightweight POST: an empty body triggers a
+      // validation error (400/422) on a real endpoint and 404 on an absent one.
+      // No tokens are spent because the request fails validation before inference.
+      try {
+        const postRes = await fetch(`${CLAUDE_API}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+          body: '{}',
+          signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+        })
+        return postRes.status !== 404
+      } catch {
+        return false
+      }
+    }
     return true
   } catch {
     return false


### PR DESCRIPTION
## Problem

`probeChatCompletions()` in `src/server/gateway-capabilities.ts` probes the endpoint with a `GET /v1/chat/completions` request and treats a `404` response as "endpoint missing". This causes a false negative when the backend is an OpenAI-compatible proxy that only routes `POST` for this path and returns `404` (not `405`) for any other method.

Concretely, `hermes proxy` exhibits this behaviour: the proxy is fully functional for chat, but the onboarding screen blocks with:

> "Backend is reachable, but /v1/chat/completions is not available yet."

## Fix

When the `GET` probe returns `404`, fall back to a minimal `POST` with an empty body (`{}`). A real endpoint responds with `400` or `422` (validation error — model parameter required) without starting any inference. An absent endpoint returns `404`. This distinguishes "POST-only endpoint" from "endpoint does not exist" without spending any tokens.

## Testing

Verified locally against `hermes proxy` (`stepfun/step-3.7-flash:free` via Nous Portal):

- Before patch: gateway-status showed `chatCompletions: false`, onboarding blocked.
- After patch: gateway-status shows `chatCompletions: true`, chat works normally.
