### PR TITLE
fix: generate auto title for default "Local Chat" sessions

### DIFF
--- a/src/screens/chat/hooks/use-auto-session-title.test.ts
+++ b/src/screens/chat/hooks/use-auto-session-title.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { isGenericTitle } from './use-auto-session-title'
+
+describe('isGenericTitle', () => {
+  it('treats empty and placeholder titles as generic', () => {
+    expect(isGenericTitle('')).toBe(true)
+    expect(isGenericTitle('New Session')).toBe(true)
+    expect(isGenericTitle('Untitled')).toBe(true)
+    expect(isGenericTitle('Conversation')).toBe(true)
+  })
+
+  it('treats the default "Local Chat" fallback as generic (#635)', () => {
+    expect(isGenericTitle('Local Chat')).toBe(true)
+    expect(isGenericTitle('local chat')).toBe(true)
+    expect(isGenericTitle('  Local Chat  ')).toBe(true)
+  })
+
+  it('keeps real user-derived titles non-generic', () => {
+    expect(isGenericTitle('Refactor auth middleware')).toBe(false)
+    expect(isGenericTitle('Local development setup notes')).toBe(false)
+  })
+})

--- a/src/screens/chat/hooks/use-auto-session-title.ts
+++ b/src/screens/chat/hooks/use-auto-session-title.ts
@@ -18,11 +18,12 @@ const GENERIC_TITLE_PATTERNS = [
   /^session \d/i,
   /^conversation$/i,
   /^chat$/i,
+  /^local chat$/i,
   /^[0-9a-f]{6,}/i,
   /^\w{8} \(\d{4}-\d{2}-\d{2}\)$/,
 ]
 
-function isGenericTitle(title: string): boolean {
+export function isGenericTitle(title: string): boolean {
   const trimmed = title.trim()
   if (!trimmed || trimmed === 'New Session') return true
   return GENERIC_TITLE_PATTERNS.some((pattern) => pattern.test(trimmed))


### PR DESCRIPTION
Fixes #635

## Bug
Sessions without a title fall back to the label `"Local Chat"` (set in `src/routes/api/sessions.ts`). The `useAutoSessionTitle` hook's `isGenericTitle` check did not recognize `"Local Chat"` as a generic/placeholder title, so `shouldGenerate` returned `false` and automatic title generation never ran. These sessions stayed permanently named "Local Chat" unless renamed by hand. (PR #350, which introduced the fallback label, did not add a matching pattern.)

## Fix
Add `/^local chat$/i` to `GENERIC_TITLE_PATTERNS` in `src/screens/chat/hooks/use-auto-session-title.ts`. Now `isGenericTitle('Local Chat')` is `true`, so the hook generates a title from the first user message after the first assistant response, like every other placeholder title.

`isGenericTitle` is now exported so it can be unit-tested directly.

## Verification
Added `src/screens/chat/hooks/use-auto-session-title.test.ts` covering the new case plus existing placeholder/real-title behavior.

```
npx vitest run src/screens/chat/hooks/use-auto-session-title.test.ts
# Test Files  1 passed (1)
#      Tests  3 passed (3)
```

Ran together with the nearest existing chat tests (`utils.test.ts`, `use-streaming-message.test.ts`): 9 passed.
