### PR TITLE
fix(context): use api_call_count for context estimation

### DIFF
--- a/src/routes/api/-context-usage.test.ts
+++ b/src/routes/api/-context-usage.test.ts
@@ -27,6 +27,7 @@ import { getLocalMessages, getLocalSession } from '../../server/local-session-st
 import {
   estimateContextTokensFromCacheRead,
   estimateContextTokensFromMessages,
+  estimateContextTokensFromSessionUsage,
   readContextUsage,
 } from '../../server/context-usage'
 
@@ -337,5 +338,62 @@ describe('context usage estimation', () => {
     expect(messageEstimate).toBeLessThan(cacheEstimate)
     expect(messageEstimate).toBeGreaterThan(1000)
     expect(messageEstimate).toBeLessThan(1200)
+  })
+
+  it('estimates context from average input tokens per API call', () => {
+    const estimate = estimateContextTokensFromSessionUsage(
+      21019,
+      31360,
+      0,
+      9,
+    )
+
+    expect(estimate).toBe(5820)
+  })
+
+  it('sums input, cache_read, and cache_write before averaging', () => {
+    const estimate = estimateContextTokensFromSessionUsage(
+      5000,
+      3000,
+      2000,
+      5,
+    )
+
+    expect(estimate).toBe(2000)
+  })
+
+  it('handles zero API calls by treating as a single call', () => {
+    const estimate = estimateContextTokensFromSessionUsage(
+      10000,
+      0,
+      0,
+      0,
+    )
+
+    expect(estimate).toBe(10000)
+  })
+
+  it('handles missing or NaN token fields as zero', () => {
+    const estimate = estimateContextTokensFromSessionUsage(
+      NaN,
+      NaN,
+      NaN,
+      5,
+    )
+
+    expect(estimate).toBe(0)
+  })
+
+  it('returns near-accurate context for a session with many internal API calls but few user messages', () => {
+    const cacheEstimate = estimateContextTokensFromCacheRead(3881216, 119)
+    const usageEstimate = estimateContextTokensFromSessionUsage(
+      203530,
+      3881216,
+      0,
+      59,
+    )
+
+    expect(usageEstimate).toBeLessThan(cacheEstimate)
+    expect(usageEstimate).toBe(69233)
   })
 })

--- a/src/server/context-usage.ts
+++ b/src/server/context-usage.ts
@@ -126,6 +126,20 @@ export function estimateContextTokensFromCacheRead(
   return Math.ceil((Math.max(0, Number(cacheReadTokens) || 0) / assistantTurns) * 1.2)
 }
 
+export function estimateContextTokensFromSessionUsage(
+  inputTokens: number,
+  cacheReadTokens: number,
+  cacheWriteTokens: number,
+  apiCallCount: number,
+): number {
+  const calls = Math.max(1, Number(apiCallCount) || 0)
+  const totalInput =
+    (Number(inputTokens) || 0) +
+    (Number(cacheReadTokens) || 0) +
+    (Number(cacheWriteTokens) || 0)
+  return Math.ceil(totalInput / calls)
+}
+
 function getContextWindow(model: string): number {
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model]
   for (const [key, value] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
@@ -483,12 +497,22 @@ export async function readContextUsage(
     const model = String(sessionData.model || '')
     const maxTokens = configuredModelContext?.maxTokens || getContextWindow(model)
     const cacheReadTokens = Number(sessionData.cache_read_tokens) || 0
+    const cacheWriteTokens = Number(sessionData.cache_write_tokens) || 0
+    const inputTokens = Number(sessionData.input_tokens) || 0
     const messageCount = Number(sessionData.message_count) || 0
+    const apiCallCount = Number(sessionData.api_call_count) || 0
 
     let usedTokens = 0
     const assistantTurns = Math.max(1, Math.ceil(messageCount / 2))
 
-    if (cacheReadTokens > 0 && assistantTurns > 0) {
+    if (apiCallCount > 0) {
+      usedTokens = estimateContextTokensFromSessionUsage(
+        inputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        apiCallCount,
+      )
+    } else if (cacheReadTokens > 0 && assistantTurns > 0) {
       usedTokens = estimateContextTokensFromCacheRead(cacheReadTokens, messageCount)
     } else if (messageCount > 0) {
       try {


### PR DESCRIPTION
## Bug Description

The `estimateContextTokensFromCacheRead` heuristic divides cumulative `cache_read_tokens` by `ceil(message_count / 2)` to estimate current context size. `message_count` tracks user-visible messages only — it does not count internal tool-use turns. A session with 1 user message and 9 internal API calls uses divisor=1, treating the full cumulative `cache_read_tokens` as "current context."

When combined with a model not being in `MODEL_CONTEXT_WINDOWS` (fallback 200K), this shows 100% context usage after a single prompt. Even with the correct 1M denominator (from the model-info resolution on main), the estimate is inflated up to 9×.

## Root Cause

The Hermes agent accumulates `cache_read_tokens` across all internal API calls (`conversation_loop.py`), but `message_count` only counts user-visible messages. The workspace's de-cumulation divisor is therefore too small.

## Fix

Add `estimateContextTokensFromSessionUsage` which uses `api_call_count` (the actual number of API calls) as the divisor, and sums `input_tokens + cache_read_tokens + cache_write_tokens` (all three token types are cumulative and returned by the dashboard `/api/sessions/{id}` endpoint) for the total input per call.

In `readContextUsage`, prefer the new estimator when `api_call_count > 0`, falling back to the existing cache-read heuristic for backends that don't expose `api_call_count`.

## Changes

- `src/server/context-usage.ts`: Add `estimateContextTokensFromSessionUsage` and update `readContextUsage` to prefer it
- `src/routes/api/-context-usage.test.ts`: 5 new test cases

## Testing

- `npx tsc --noEmit` — no new errors
- `npx vitest run src/routes/api/-context-usage.test.ts` — 14/14 pass
- `npx eslint` on changed files — no new errors

## Impact

From a real Hermes Agent session DB:

| Session | Before | After |
|---|---|---|
| New chat (1 msg, 9 API calls) | 100% | 0.6% |
| Old chat (119 msgs, 59 API calls) | 7.8% | 6.9% |