### PR TITLE
i18n(agent-bus): translate Agent Bus panel from pt-BR to English

### DIFF
--- a/src/screens/agents/components/agent-bus-panel.tsx
+++ b/src/screens/agents/components/agent-bus-panel.tsx
@@ -54,14 +54,14 @@ type ActionState =
 
 const initialActionState: ActionState = {
   status: 'idle',
-  message: 'Acoes seguras ficam registradas no Agent Bus.',
+  message: 'Safe actions are logged in the Agent Bus.',
 }
 
 function formatDate(value?: string): string {
-  if (!value) return 'sem leitura'
+  if (!value) return 'no reading'
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
-  return new Intl.DateTimeFormat('pt-BR', {
+  return new Intl.DateTimeFormat('en-US', {
     day: '2-digit',
     month: '2-digit',
     hour: '2-digit',
@@ -70,17 +70,17 @@ function formatDate(value?: string): string {
 }
 
 function firstLine(value?: string): string {
-  return String(value || '').split('\n').find(Boolean) || 'sem detalhe'
+  return String(value || '').split('\n').find(Boolean) || 'no detail'
 }
 
 function missionTitle(mission: AgentBusMission): string {
   if (mission.mission_type === 'handoff') {
-    return `${mission.source_agent || 'agente'} -> ${mission.target || 'agente'}`
+    return `${mission.source_agent || 'agent'} -> ${mission.target || 'agent'}`
   }
   if (mission.mission_type === 'thumbnail') {
     return `Thumbnail ${mission.target || ''}`.trim()
   }
-  return mission.mission_type || 'Missao'
+  return mission.mission_type || 'Mission'
 }
 
 function StatTile({
@@ -122,10 +122,10 @@ export function AgentBusPanel() {
       const response = await fetch('/api/agent-bus', {
         headers: { Accept: 'application/json' },
       })
-      if (!response.ok) throw new Error(`Agent Bus respondeu HTTP ${response.status}`)
+      if (!response.ok) throw new Error(`Agent Bus responded HTTP ${response.status}`)
       setData((await response.json()) as AgentBusPayload)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Falha ao carregar Agent Bus')
+      setError(err instanceof Error ? err.message : 'Failed to load Agent Bus')
     } finally {
       setLoading(false)
     }
@@ -144,7 +144,7 @@ export function AgentBusPanel() {
   const visibleIssues = useMemo(() => issues.slice(0, 5), [issues])
 
   async function runAction(body: Record<string, unknown>, successMessage: string) {
-    setAction({ status: 'running', message: 'Executando acao segura...' })
+    setAction({ status: 'running', message: 'Running safe action...' })
     try {
       const response = await fetch('/api/agent-bus', {
         method: 'POST',
@@ -160,7 +160,7 @@ export function AgentBusPanel() {
     } catch (err) {
       setAction({
         status: 'error',
-        message: err instanceof Error ? err.message : 'Acao falhou',
+        message: err instanceof Error ? err.message : 'Action failed',
       })
     }
   }
@@ -173,20 +173,20 @@ export function AgentBusPanel() {
             Agent Bus
           </p>
           <h2 className="mt-1 text-lg font-semibold text-[var(--theme-text)]">
-            Estado da Tropa
+            Fleet Status
           </h2>
           <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
-            Leitura do Scumbag, missões e pendências operacionais do Hermes.
+            Scumbag reading, Hermes missions and operational pending items.
           </p>
         </div>
         <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-muted)]">
-          Última leitura: {formatDate(data?.status?.checked_at)}
+          Last reading: {formatDate(data?.status?.checked_at)}
         </div>
       </div>
 
       {loading ? (
         <div className="mt-5 rounded-2xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-8 text-center text-sm text-[var(--theme-muted)]">
-          Carregando Agent Bus...
+          Loading Agent Bus...
         </div>
       ) : error ? (
         <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-900">
@@ -198,16 +198,16 @@ export function AgentBusPanel() {
             <StatTile label="total" value={summary.total ?? 0} />
             <StatTile label="online" value={summary.up ?? 0} tone="good" />
             <StatTile label="down" value={summary.down ?? 0} tone={(summary.down ?? 0) > 0 ? 'bad' : 'good'} />
-            <StatTile label="sem endpoint" value={summary.no_endpoint ?? 0} tone={(summary.no_endpoint ?? 0) > 0 ? 'warn' : 'good'} />
-            <StatTile label="fora op." value={summary.non_operational ?? 0} tone={(summary.non_operational ?? 0) > 0 ? 'warn' : 'good'} />
-            <StatTile label="eventos" value={events.length || summary.events || 0} tone={events.length > 0 ? 'bad' : 'good'} />
+            <StatTile label="no endpoint" value={summary.no_endpoint ?? 0} tone={(summary.no_endpoint ?? 0) > 0 ? 'warn' : 'good'} />
+            <StatTile label="non-op." value={summary.non_operational ?? 0} tone={(summary.non_operational ?? 0) > 0 ? 'warn' : 'good'} />
+            <StatTile label="events" value={events.length || summary.events || 0} tone={events.length > 0 ? 'bad' : 'good'} />
           </div>
 
           <div className="mt-5 grid grid-cols-1 gap-4 xl:grid-cols-[1.1fr_0.9fr]">
             <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
               <div className="flex items-center justify-between gap-3">
-                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Pendências vivas</h3>
-                <span className="text-xs text-[var(--theme-muted)]">{issues.length} itens</span>
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Open issues</h3>
+                <span className="text-xs text-[var(--theme-muted)]">{issues.length} items</span>
               </div>
               <div className="mt-3 space-y-2">
                 {visibleIssues.length ? (
@@ -221,7 +221,7 @@ export function AgentBusPanel() {
                           {agent.name || agent.id}
                         </span>
                         <span className="text-xs text-[var(--theme-muted)]">
-                          {agent.status_config || 'sem status'} / {agent.health || 'sem health'}
+                          {agent.status_config || 'no status'} / {agent.health || 'no health'}
                         </span>
                       </div>
                       {agent.error ? (
@@ -231,7 +231,7 @@ export function AgentBusPanel() {
                   ))
                 ) : (
                   <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-5 text-sm text-[var(--theme-muted)]">
-                    Nenhum agente operacional caído agora.
+                    No operational agent down right now.
                   </div>
                 )}
               </div>
@@ -239,8 +239,8 @@ export function AgentBusPanel() {
 
             <div className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
               <div className="flex items-center justify-between gap-3">
-                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Últimas missões</h3>
-                <span className="text-xs text-[var(--theme-muted)]">{missions.length} registros</span>
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Recent missions</h3>
+                <span className="text-xs text-[var(--theme-muted)]">{missions.length} records</span>
               </div>
               <div className="mt-3 space-y-2">
                 {missions.slice(0, 5).map((mission, index) => (
@@ -257,13 +257,13 @@ export function AgentBusPanel() {
                       </span>
                     </div>
                     <p className="mt-1 line-clamp-2 text-xs text-[var(--theme-muted)]">
-                      {mission.brief || mission.reason || 'missão registrada'}
+                      {mission.brief || mission.reason || 'mission recorded'}
                     </p>
                   </div>
                 ))}
                 {!missions.length ? (
                   <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-5 text-sm text-[var(--theme-muted)]">
-                    Nenhuma missão registrada ainda.
+                    No missions recorded yet.
                   </div>
                 ) : null}
               </div>
@@ -273,42 +273,42 @@ export function AgentBusPanel() {
           <div className="mt-5 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div>
-                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Ações seguras</h3>
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">Safe actions</h3>
                 <p className="mt-1 text-xs text-[var(--theme-muted)]">
-                  Sem restart, sem WhatsApp e sem gasto pago automático.
+                  No restart, no WhatsApp, no automatic paid spend.
                 </p>
               </div>
               <div className="flex flex-wrap gap-2">
                 <button
                   type="button"
-                  onClick={() => runAction({ action: 'sync-roadmap' }, 'Roadmap sincronizado com eventos atuais.')}
+                  onClick={() => runAction({ action: 'sync-roadmap' }, 'Roadmap synced with current events.')}
                   className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
                 >
-                  Sincronizar Roadmap
+                  Sync Roadmap
                 </button>
                 <button
                   type="button"
                   onClick={() =>
                     runAction(
                       { action: 'thumbnail-mission', target: 'vini' },
-                      'Missão de thumbnail do Vini registrada.',
+                      'Vini thumbnail mission recorded.',
                     )
                   }
                   className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
                 >
-                  Missão Thumbnail Vini
+                  Vini Thumbnail Mission
                 </button>
                 <button
                   type="button"
                   onClick={() =>
                     runAction(
                       { action: 'handoff-mission', source: 'dona-helena', target: 'larissinha' },
-                      'Handoff Dona Helena -> Larissinha registrado.',
+                      'Handoff Dona Helena -> Larissinha recorded.',
                     )
                   }
                   className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] transition-colors hover:bg-[var(--theme-card2)]"
                 >
-                  Handoff Helena para Larissinha
+                  Handoff Helena to Larissinha
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## What

The **Agent Bus operations panel** (`src/screens/agents/components/agent-bus-panel.tsx`, added in #477) has all of its UI strings hardcoded in Brazilian Portuguese. It is the only Portuguese-localized component under `src/` — every other screen in the app is in English — so it renders inconsistently for English users.

This PR translates all visible strings to English.

## Changes

- All visible UI text translated to English (headings, labels, empty states, button labels, status/loading/error messages).
- Date formatting locale changed `pt-BR` → `en-US` to match.
- **No behavior changes.** Props, state, fetch logic, action payloads, and target identifiers (`sync-roadmap`, `thumbnail-mission`, `handoff-mission`, and targets `vini` / `dona-helena` / `larissinha`) are all left exactly as-is — only the human-readable strings changed.

Diff is one file, 33 insertions / 33 deletions.

## Notes

Kept the scope strictly to translation so it stays trivially reviewable. If maintainers would prefer these strings routed through an i18n layer instead of hardcoded English, happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)