### PR TITLE
Persist model selection per chat session

### DIFF
--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -13,13 +13,14 @@ import {
   toSessionSummary,
   updateSession,
 } from '../../server/claude-api'
-import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 import {
   deleteLocalSession,
   getLocalSession,
   listLocalSessions,
+  updateLocalSessionModel,
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -192,6 +193,8 @@ export const Route = createFileRoute('/api/sessions')({
             typeof body.friendlyId === 'string' ? body.friendlyId.trim() : ''
           const label =
             typeof body.label === 'string' ? body.label.trim() : undefined
+          const model =
+            typeof body.model === 'string' ? body.model.trim() : undefined
           const sessionKey = rawSessionKey || rawFriendlyId
 
           if (!sessionKey) {
@@ -204,6 +207,8 @@ export const Route = createFileRoute('/api/sessions')({
           const localSession = getLocalSession(sessionKey)
           if (localSession) {
             if (label) updateLocalSessionTitle(sessionKey, label)
+            if (model !== undefined) updateLocalSessionModel(sessionKey, model)
+            const updatedLocalSession = getLocalSession(sessionKey) ?? localSession
             return json({
               ok: true,
               sessionKey,
@@ -214,10 +219,10 @@ export const Route = createFileRoute('/api/sessions')({
                 title: label || sessionKey,
                 label: label || sessionKey,
                 derivedTitle: label || sessionKey,
-                startedAt: localSession.createdAt,
+                startedAt: updatedLocalSession.createdAt,
                 updatedAt: Date.now(),
-                message_count: localSession.messageCount,
-                model: localSession.model,
+                message_count: updatedLocalSession.messageCount,
+                model: updatedLocalSession.model,
                 source: 'local',
               },
               updated: true,
@@ -236,13 +241,16 @@ export const Route = createFileRoute('/api/sessions')({
                 label: label || sessionKey,
                 derivedTitle: label || sessionKey,
                 updatedAt: Date.now(),
+                model: model || undefined,
               },
               updated: false,
+              modelApplied: Boolean(model),
             })
           }
 
           const session = await updateSession(sessionKey, {
             title: label,
+            ...(model !== undefined ? { model } : {}),
           })
 
           return json({

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -67,6 +67,7 @@ import {
   CHAT_RUN_COMMAND_EVENT,
   CHAT_SUBMIT_SELECTION_EVENT,
 } from './chat-events'
+import { _localModelOverride } from './local-model-override'
 import type {
   ChatRunCommandDetail,
   ChatSubmitSelectionDetail,
@@ -112,9 +113,6 @@ import { useResearchCard } from '@/hooks/use-research-card'
 import { useTapDebug } from '@/hooks/use-tap-debug'
 import { useChatMode } from '@/hooks/use-chat-mode'
 import {  useChatActivityStore } from '@/stores/chat-activity-store'
-
-export let _localModelOverride = ''
-export function setLocalModelOverride(model: string) { _localModelOverride = model }
 
 type ChatScreenProps = {
   activeFriendlyId: string
@@ -1057,8 +1055,14 @@ export function ChatScreen({
     return models.map((m: any) => m.id).filter((id: string) => id)
   }, [modelsQuery.data])
 
+  const modelSessionKey = isNewChat
+    ? undefined
+    : forcedSessionKey || resolvedSessionKey || activeCanonicalKey || activeSessionKey
+  const persistedSessionModel = useSessionModelStore((s) =>
+    s.getModel(modelSessionKey),
+  )
   const gatewayModel = currentModelQuery.data || ''
-  const currentModel = _localModelOverride || gatewayModel
+  const currentModel = _localModelOverride || persistedSessionModel || gatewayModel
 
   // Ref so sendMessage can always read latest thinkingLevel without being in deps
   const thinkingLevelRef = useRef<ThinkingLevel>(thinkingLevel)

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -1138,11 +1138,38 @@ function ChatComposerComponent({
       }
       setModelNotice(null)
       const resolved = getResolvedModelKey(model, provider)
-      // Per-session, browser-local persistence. No global config write —
-      // picking a model here only affects this chat. The actual model is
-      // passed on each request via the chat-completion `model` field.
+      // Model choice belongs to the session. Persist it through /api/sessions
+      // and keep a local cache only so the picker/send path updates instantly.
       if (normalizedSessionKey) {
+        // Persist to the backend session so reloads, browser changes, and
+        // other clients hydrate from the chat itself. The local Zustand store
+        // is only an immediate UI/send-path cache, never the source of truth.
         setPersistedSessionModel(normalizedSessionKey, resolved)
+        void fetch('/api/sessions', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionKey: normalizedSessionKey,
+            model: resolved,
+          }),
+        })
+          .then(async (response) => {
+            if (!response.ok) throw new Error(await readResponseError(response))
+            await Promise.all([
+              queryClient.invalidateQueries({ queryKey: ['chat', 'sessions'] }),
+              queryClient.invalidateQueries({
+                queryKey: ['claude', 'session-status-model'],
+              }),
+            ])
+          })
+          .catch((error: unknown) => {
+            toast(
+              `Model saved for this browser, but session persistence failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              { type: 'error' },
+            )
+          })
       }
       setIsModelMenuOpen(false)
     },
@@ -1150,6 +1177,7 @@ function ChatComposerComponent({
       gatewayModeQuery.data,
       sessionKey,
       setPersistedSessionModel,
+      queryClient,
       zeroForkModelInfoFlags,
     ],
   )

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -22,6 +22,7 @@ import {
   getSessionMessages as getDashboardSessionMessages,
   listSessions as listDashboardSessions,
   searchSessions as searchDashboardSessions,
+  setSessionModel as setDashboardSessionModel,
   updateSession as updateDashboardSession,
 } from './claude-dashboard-api'
 
@@ -172,11 +173,28 @@ export async function createSession(opts?: {
 
 export async function updateSession(
   sessionId: string,
-  updates: { title?: string },
+  updates: { title?: string; model?: string | null },
 ): Promise<ClaudeSession> {
   if (getCapabilities().dashboard.available) {
-    const resp = await updateDashboardSession(sessionId, updates)
-    return resp.session as ClaudeSession
+    let session: ClaudeSession | null = null
+    if (typeof updates.title === 'string') {
+      const resp = await updateDashboardSession(sessionId, { title: updates.title })
+      session = resp.session as ClaudeSession
+    }
+    if (typeof updates.model === 'string') {
+      const modelValue = updates.model.trim()
+      if (modelValue) {
+        const slashIndex = modelValue.indexOf('/')
+        const provider = slashIndex > 0 ? modelValue.slice(0, slashIndex) : undefined
+        const model = slashIndex > 0 ? modelValue.slice(slashIndex + 1) : modelValue
+        const resp = await setDashboardSessionModel(sessionId, {
+          model,
+          ...(provider ? { provider } : {}),
+        })
+        session = (resp.session as ClaudeSession | undefined) ?? session
+      }
+    }
+    return session ?? getSession(sessionId)
   }
   const resp = await claudePatch<{ session: ClaudeSession }>(
     `/api/sessions/${sessionId}`,

--- a/src/server/claude-dashboard-api.ts
+++ b/src/server/claude-dashboard-api.ts
@@ -169,6 +169,17 @@ export async function updateSession(
   })
 }
 
+export async function setSessionModel(
+  id: string,
+  body: { model: string; provider?: string },
+): Promise<{ session?: DashboardSession; ok?: boolean }> {
+  return dashboardJson(`/api/hermes/sessions/${encodeURIComponent(id)}/model`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
 export async function forkSession(
   id: string,
 ): Promise<{ session: DashboardSession; forked_from: string }> {

--- a/src/server/local-session-store.test.ts
+++ b/src/server/local-session-store.test.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalCwd = process.cwd()
+let tempDir: string | null = null
+
+async function loadStore() {
+  tempDir = mkdtempSync(join(tmpdir(), 'hermes-local-session-store-'))
+  process.chdir(tempDir)
+  vi.resetModules()
+  return import('./local-session-store')
+}
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+  tempDir = null
+})
+
+describe('local-session-store', () => {
+  it('persists model updates on the session without touching other sessions', async () => {
+    const store = await loadStore()
+
+    store.ensureLocalSession('session-a', 'openai/gpt-5.5')
+    store.ensureLocalSession('session-b', 'anthropic/claude-sonnet-4-5')
+
+    store.updateLocalSessionModel('session-a', 'zai/glm-4.6')
+
+    expect(store.getLocalSession('session-a')?.model).toBe('zai/glm-4.6')
+    expect(store.getLocalSession('session-b')?.model).toBe(
+      'anthropic/claude-sonnet-4-5',
+    )
+  })
+
+  it('clears a local session model when given a blank value', async () => {
+    const store = await loadStore()
+
+    store.ensureLocalSession('session-a', 'openai/gpt-5.5')
+    store.updateLocalSessionModel('session-a', '   ')
+
+    expect(store.getLocalSession('session-a')?.model).toBeNull()
+  })
+})

--- a/src/server/local-session-store.ts
+++ b/src/server/local-session-store.ts
@@ -95,6 +95,18 @@ export function updateLocalSessionTitle(
   }
 }
 
+export function updateLocalSessionModel(
+  sessionId: string,
+  model: string | null,
+): void {
+  const session = store.sessions[sessionId]
+  if (session) {
+    session.model = model && model.trim().length > 0 ? model.trim() : null
+    session.updatedAt = Date.now()
+    saveToDisk()
+  }
+}
+
 export function touchLocalSession(sessionId: string): void {
   const session = store.sessions[sessionId]
   if (session) session.updatedAt = Date.now()


### PR DESCRIPTION
## Summary
- persist chat model selection through the backend session instead of browser-only state
- use Hermes Studio's `/api/hermes/sessions/{id}/model` endpoint for dashboard-backed sessions
- keep a local session-store model updater for gateway/local fallback sessions
- hydrate the send path from the per-session model store so selected chat models are actually used after reloads

## Verification
- `node --import tsx .tmp-verify-local-session-store.ts` → `local-session-store model persistence verified`
- `npx eslint src/server/local-session-store.test.ts` → passed
- `node --import tsx -e "await import('./src/server/claude-dashboard-api.ts'); await import('./src/server/claude-api.ts'); await import('./src/routes/api/sessions.ts'); console.log('server modules import ok'); process.exit(0)"` → `server modules import ok`
- `git diff --check` → passed

## Known existing blockers while verifying
- `npx vitest run src/server/local-session-store.test.ts` and `npm run build` both crashed with `Bus error (core dumped)` in this WSL worktree after dependency install.
- `npx tsc --noEmit --pretty false` reports many existing repo-wide type/dependency errors unrelated to this patch.

Authored-by: Zephyr (AI Assistant) <raaisalpwardana+zephyr@gmail.com>
