### PR TITLE
fix(docker): build on pnpm 10+ — skip unneeded dep build scripts and drifted lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ WORKDIR /app
 
 # Install deps (cache-friendly: copy only manifests first)
 COPY package.json pnpm-lock.yaml* ./
-RUN pnpm install --frozen-lockfile
+# pnpm 10+ aborts install when deps have unapproved build scripts (ERR_PNPM_IGNORED_BUILDS),
+# and corepack pulls the latest pnpm. The web/server image needs none of those scripts:
+# esbuild ships prebuilt binaries via optionalDependencies and electron is desktop-only.
+# --no-frozen-lockfile also keeps fresh clones building when the lockfile drifts.
+RUN pnpm install --no-frozen-lockfile --ignore-scripts
 
 # Copy sources and build
 COPY . .


### PR DESCRIPTION
## Problem
A fresh Docker build currently fails (#621). On the un-pinned pnpm, two issues compound:

1. corepack pulls the latest pnpm (11.x). pnpm 10+ aborts `pnpm install` with `ERR_PNPM_IGNORED_BUILDS` when dependencies ship build scripts that aren't explicitly approved (`electron`, `electron-winstaller`, `esbuild`, `unrs-resolver`).
2. `--frozen-lockfile` separately breaks fresh clones whenever the lockfile drifts (the motivation behind #620).

So the image never builds end-to-end on a current toolchain.

## Fix
Scope the fix to the image build, where **no dependency build scripts are actually needed**:

- `esbuild` ships its platform binary via `optionalDependencies` (no postinstall required),
- `electron` / `electron-winstaller` are desktop-only and unused in the web/server image.

`--ignore-scripts` is therefore safe here and keeps the web image lean (no pointless Electron download). `--no-frozen-lockfile` keeps fresh clones building when the lockfile drifts.

This complements/supersedes #620, which only drops `--frozen-lockfile`; that change alone still fails at `ERR_PNPM_IGNORED_BUILDS` on pnpm 10+.

## Verification
Builds and runs end-to-end (full `pnpm install` + `pnpm build` + container boot). The previous build failed exactly at:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: electron-winstaller@5.4.0, electron@40.9.3, esbuild@0.27.7, unrs-resolver@1.11.1
```

and succeeds with this change.

Fixes #621.
