### PR TITLE
fix(claude-api): accept { messages: [...] } shape in getMessages fallback

### DIFF
--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -203,12 +203,13 @@ export async function getMessages(
   const resp = await claudeGet<{
     items?: Array<ClaudeMessage>
     data?: Array<ClaudeMessage>
+    messages?: Array<ClaudeMessage>
     total?: number
   }>(`/api/sessions/${sessionId}/messages`)
   // Gateway (OpenAI-compat) returns { object: 'list', data: [...] }; dashboard / older
-  // shape uses { items: [...] }. Accept either, and never return undefined (callers
-  // read .length / .map / .slice on this).
-  return resp.items ?? resp.data ?? []
+  // shape uses { items: [...] }; some message endpoints use { messages: [...] }.
+  // Accept any, and never return undefined (callers read .length / .map / .slice).
+  return resp.items ?? resp.data ?? resp.messages ?? []
 }
 
 export async function searchSessions(


### PR DESCRIPTION
Adds a `messages?` field and `?? resp.messages` fallback in `getMessages` so message endpoints returning `{ messages: [...] }` are handled (alongside the existing `items`/`data` shapes), never returning undefined to callers.

Verified: full `pnpm run build` passes (exit 0); tsc clean on the file; no new eslint errors (the line-430 `while(true)` warning is pre-existing on upstream).