### PR TITLE
fix(gateway): honor HERMES_DASHBOARD_URL in dashboard auto-detect (cross-user session leak)

### DIFF
--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -138,6 +138,33 @@ describe('gateway-capabilities', () => {
     expect(mod.CLAUDE_API).toBe('http://localhost:9000')
   })
 
+  it('does not let dashboard auto-detect override an explicit HERMES_DASHBOARD_URL', async () => {
+    // Regression: autoDetectDashboardUrl() only skipped discovery when
+    // CLAUDE_DASHBOARD_URL was set, ignoring the documented primary var
+    // HERMES_DASHBOARD_URL. With a co-located dashboard answering on the
+    // hard-coded :9119 candidate, the probe overwrote the operator's explicit
+    // URL — in multi-user setups attaching to another user's dashboard and
+    // leaking their session list. The explicit URL must always win.
+    process.env.HERMES_DASHBOARD_URL = 'http://127.0.0.1:9120'
+    // A default-port dashboard is up and would answer the auto-detect probe.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'http://127.0.0.1:9119/api/status') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 })
+      }
+      return new Response(null, { status: 404 })
+    })
+    const mod = await loadMod()
+    await mod.probeGateway({ force: true })
+    // The :9119 auto-detect probe must never have run, and the explicit
+    // :9120 URL must be preserved.
+    expect(
+      fetchMock.mock.calls.some(
+        ([u]) => u === 'http://127.0.0.1:9119/api/status',
+      ),
+    ).toBe(false)
+    expect(mod.CLAUDE_DASHBOARD_URL).toBe('http://127.0.0.1:9120')
+  })
+
   it('getResolvedUrls reports default source when no env or file override', async () => {
     const mod = await loadMod()
     const resolved = mod.getResolvedUrls()

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -757,7 +757,15 @@ async function autoDetectGatewayUrl(): Promise<void> {
 }
 
 async function autoDetectDashboardUrl(): Promise<void> {
-  if (process.env.CLAUDE_DASHBOARD_URL) return
+  // Mirror autoDetectGatewayUrl: skip discovery when the dashboard URL was set
+  // explicitly. HERMES_DASHBOARD_URL is the documented primary var (see the
+  // resolution order at the top of this file); CLAUDE_DASHBOARD_URL is the
+  // legacy alias. Probing only the hard-coded :9119 candidate when
+  // HERMES_DASHBOARD_URL points elsewhere lets a co-located dashboard on the
+  // default port silently override the operator's explicit choice — e.g. in a
+  // multi-user setup it attaches to another user's dashboard and leaks their
+  // session list. Honor both vars so an explicit setting always wins.
+  if (process.env.HERMES_DASHBOARD_URL || process.env.CLAUDE_DASHBOARD_URL) return
 
   const candidates = ['http://127.0.0.1:9119']
   for (const candidate of candidates) {


### PR DESCRIPTION
## What

`autoDetectDashboardUrl()` only skipped discovery when `CLAUDE_DASHBOARD_URL` was set, ignoring **`HERMES_DASHBOARD_URL`** — the documented primary env var (see the resolution order in the file header). When an operator sets `HERMES_DASHBOARD_URL` to a non-default port, the guard did not fire and the probe hit the hard-coded `:9119` candidate. If any dashboard answered there, it silently overwrote the explicit URL.

The sibling `autoDetectGatewayUrl()` already guards on **both** `HERMES_API_URL` and `CLAUDE_API_URL`. This one-line fix mirrors that so an explicit setting always wins.

## Why it matters (real-world bug)

Multi-user setup on one host — two users, each running their own gateway + dashboard on distinct ports:

| User | Gateway | Dashboard |
|------|---------|-----------|
| A    | `:8642` | `:9119`   |
| B    | `:8643` | `:9120`   |

User B's workspace was correctly configured with `HERMES_API_URL=:8643` and `HERMES_DASHBOARD_URL=:9120`. Chat and `/api/ping` correctly reported `:8643`. **But the session list showed user A's sessions.**

Root cause: `autoDetectDashboardUrl()` didn't see `HERMES_DASHBOARD_URL`, ran discovery, hit the hard-coded `:9119` candidate, A's dashboard answered `200`, and B's `CLAUDE_DASHBOARD_URL` got overwritten with A's port. Result: B's workspace rendered A's full session list (titles + previews) — a **cross-user privacy leak** — despite a correct explicit config.

Confirmed empirically: B's workspace node process opened a live TCP connection to `:9119` (A's dashboard) during session listing; after the fix it connects only to B's own `:8643`/`:9120`, and the sidebar shows only B's own sessions.

## Change

```diff
 async function autoDetectDashboardUrl(): Promise<void> {
-  if (process.env.CLAUDE_DASHBOARD_URL) return
+  if (process.env.HERMES_DASHBOARD_URL || process.env.CLAUDE_DASHBOARD_URL) return
```
(plus an explanatory comment)

## Tests

Added a regression test in `src/server/__tests__/gateway-capabilities.test.ts` asserting that when `HERMES_DASHBOARD_URL` is set:
- the `:9119` auto-detect probe never runs, and
- the explicit URL is preserved.

Verified the test **fails on the unpatched code** and passes with the fix. The `gateway-capabilities` suite is fully green (15/15). (Unrelated pre-existing failures in `mcp-presets-store`, `mcp-hub-sources-store`, `i18n`, and the Playwright `e2e/` specs exist on `main` and are untouched by this change.)
