### PR TITLE
feat: HERMES_MISSION_API_URL to decouple Conductor mission dispatch from the dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,11 @@
 # /api/sessions, the conductor mission API, and the upstream kanban plugin
 # all live on the dashboard, not the gateway.
 # HERMES_DASHBOARD_URL=http://127.0.0.1:9119
+#
+# Optional: point ONLY Conductor mission dispatch (/api/conductor/*) at a separate
+# fleet manager, leaving all other dashboard traffic on HERMES_DASHBOARD_URL.
+# Defaults to HERMES_DASHBOARD_URL when unset, so leaving it blank changes nothing.
+# HERMES_MISSION_API_URL=http://127.0.0.1:9119
 
 # Dashboard session token
 #

--- a/src/routes/api/conductor-spawn.ts
+++ b/src/routes/api/conductor-spawn.ts
@@ -5,7 +5,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
-import { dashboardFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { missionFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
 import { sanitizeConductorMissionGoal } from '../../server/conductor-mission-sanitize'
 import { getSwarmMission, recordMissionCheckpoint  } from '../../server/swarm-missions'
 import { getSwarmProfilePath } from '../../server/swarm-foundation'
@@ -113,7 +113,7 @@ async function createDashboardConductorMission(payload: { name: string; prompt: 
   sessionKey?: string
   error?: string
 }> {
-  const res = await dashboardFetch('/api/conductor/missions', {
+  const res = await missionFetch('/api/conductor/missions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name: payload.name, prompt: payload.prompt }),
@@ -394,7 +394,7 @@ export const Route = createFileRoute('/api/conductor-spawn')({
           return json({ ok: false, error: 'Conductor mission not found in native swarm store and dashboard Conductor API is unavailable' }, { status: 404 })
         }
 
-        const res = await dashboardFetch(`/api/conductor/missions/${encodeURIComponent(missionId)}?lines=${lines}`)
+        const res = await missionFetch(`/api/conductor/missions/${encodeURIComponent(missionId)}?lines=${lines}`)
         const text = await res.text()
         let mission: Record<string, unknown> = {}
         try {

--- a/src/routes/api/conductor-stop.ts
+++ b/src/routes/api/conductor-stop.ts
@@ -3,7 +3,7 @@ import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
 import { deleteSession } from '../../server/claude-api'
-import { dashboardFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { missionFetch, ensureGatewayProbed } from '../../server/gateway-capabilities'
 import { cancelSwarmMission } from '../../server/swarm-missions'
 import { resetSwarmWorkerRuntime } from '../../server/swarm-runtime-reset'
 
@@ -63,7 +63,7 @@ export const Route = createFileRoute('/api/conductor-stop')({
 
             if (capabilities.dashboard.available && capabilities.conductor) {
               try {
-                const res = await dashboardFetch(
+                const res = await missionFetch(
                   `/api/conductor/missions/${encodeURIComponent(missionId)}`,
                   { method: 'DELETE' },
                 )

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -322,16 +322,59 @@ export async function dashboardAuthHeaders(options?: {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-function withDashboardBase(path: string): string {
+function withBase(base: string, path: string): string {
   if (/^https?:\/\//i.test(path)) return path
-  return `${CLAUDE_DASHBOARD_URL}${path.startsWith('/') ? path : `/${path}`}`
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`
+}
+
+function withDashboardBase(path: string): string {
+  return withBase(CLAUDE_DASHBOARD_URL, path)
+}
+
+/**
+ * Base URL for Conductor mission dispatch. Defaults to the dashboard URL, so
+ * when `HERMES_MISSION_API_URL` is unset behavior is identical to before.
+ *
+ * Setting it decouples mission dispatch from the dashboard: an external fleet
+ * manager (e.g. a bridge to a separate orchestrator) can answer the small set of
+ * `/api/conductor/*` calls without having to sit in front of the whole dashboard.
+ * All other dashboard traffic (sessions, skills, config, MCP, …) keeps going to
+ * `HERMES_DASHBOARD_URL` untouched.
+ */
+export function missionApiBase(): string {
+  return normalizeUrl(process.env.HERMES_MISSION_API_URL || '') || CLAUDE_DASHBOARD_URL
+}
+
+function withMissionBase(path: string): string {
+  return withBase(missionApiBase(), path)
 }
 
 export async function dashboardFetch(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
-  const requestPath = withDashboardBase(path)
+  return baseFetch(withDashboardBase(path), init)
+}
+
+/**
+ * Like {@link dashboardFetch}, but targets the mission API base
+ * ({@link missionApiBase}, from `HERMES_MISSION_API_URL`). Used for the
+ * `/api/conductor/*` mission-dispatch calls so they can be pointed at an external
+ * fleet manager independently of the dashboard. Auth is injected the same way, so
+ * the mission endpoint is expected to be dashboard-token compatible (a bridge can
+ * accept or ignore it).
+ */
+export async function missionFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return baseFetch(withMissionBase(path), init)
+}
+
+async function baseFetch(
+  requestPath: string,
+  init: RequestInit = {},
+): Promise<Response> {
   const method = (init.method || 'GET').toUpperCase()
   const doFetch = async (forceToken = false) => {
     const headers = new Headers(init.headers)
@@ -581,7 +624,7 @@ async function probeDashboard(): Promise<{ available: boolean; url: string }> {
 async function probeConductor(dashboardAvailable: boolean): Promise<boolean> {
   if (!dashboardAvailable) return false
   try {
-    const res = await dashboardFetch('/api/conductor/missions', {
+    const res = await missionFetch('/api/conductor/missions', {
       method: 'GET',
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     })


### PR DESCRIPTION
## What
Adds an optional `HERMES_MISSION_API_URL`. When set, only the Conductor mission-dispatch calls (`/api/conductor/*`: probe, create, poll, cancel) target that base; all other dashboard traffic keeps going to `HERMES_DASHBOARD_URL`. When unset it defaults to `HERMES_DASHBOARD_URL`, so existing setups are unchanged (a no-op unless you opt in).

## Why
The Conductor mission API is currently assumed to live on the dashboard (:9119). Teams running a dedicated fleet manager want to answer *just* the mission calls from that service without reverse-proxying the whole dashboard. This turns that into a clean, opt-in seam.

## How
Mirrors the existing `gatewayFetch` / `dashboardFetch` split in `gateway-capabilities.ts`: factor a shared `baseFetch()`, add `missionApiBase()` + `missionFetch()`, and route the four `/api/conductor/*` call sites through it. Documents the var in `.env.example`. No dependency changes.

## Verified
Built the workspace from this branch and ran it with `HERMES_MISSION_API_URL` pointed at a separate service while `HERMES_DASHBOARD_URL` pointed at a real dashboard: only `/api/conductor/*` reached the mission service; every other dashboard call went to the dashboard.

This is the integration seam for [Talaria](https://github.com/PackLedger/talaria), a small MIT bridge that lets hermes-workspace drive a [mission-control](https://github.com/builderz-labs/mission-control) fleet as its orchestration brain