### PR TITLE
fix(docker): copy pnpm-workspace.yaml before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN corepack enable && apt-get update && apt-get install -y --no-install-recomme
 WORKDIR /app
 
 # Install deps (cache-friendly: copy only manifests first)
-COPY package.json pnpm-lock.yaml* ./
+# NOTE: pnpm-workspace.yaml carries the allowBuilds approvals (electron/esbuild/…);
+# it must be present or pnpm 10+/11 fatally errors on ignored build scripts.
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* .npmrc* ./
 RUN pnpm install --frozen-lockfile
 
 # Copy sources and build


### PR DESCRIPTION
The build stage runs `pnpm install` after copying only `package.json` + `pnpm-lock.yaml`, but the `allowBuilds` approvals (electron, electron-winstaller, esbuild, unrs-resolver) live in `pnpm-workspace.yaml`. Without it, modern pnpm (10+/11 via corepack) treats those as ignored build scripts and aborts the install (`ERR_PNPM_IGNORED_BUILDS`), so a clean-clone `docker build .` fails.

This copies `pnpm-workspace.yaml` (and `.npmrc`) alongside the manifests so the approvals apply.

**Repro:** `docker build .` on a fresh clone with a current corepack pnpm