### PR TITLE
feat: add /api/gateway/agents so the Agents screen shows real agents

### DIFF
--- a/src/routes/api/gateway/agents.ts
+++ b/src/routes/api/gateway/agents.ts
@@ -1,0 +1,41 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { gatewayFetch } from '../../../server/gateway-capabilities'
+
+/**
+ * Agent roster, derived from the gateway's model list (`/v1/models`).
+ *
+ * A Hermes gateway exposes its agent(s) as models. When the gateway is a single
+ * agent this returns that one; when it's a fleet multiplexer (many agents behind
+ * one gateway URL) this returns the whole fleet. Previously the Agents screen had
+ * no data source here and fell back to a hardcoded stub registry.
+ */
+export const Route = createFileRoute('/api/gateway/agents')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          const res = await gatewayFetch('/v1/models')
+          if (!res.ok) return json({ agents: [] })
+          const payload = (await res.json()) as { data?: Array<{ id?: string }> }
+          const models = Array.isArray(payload?.data) ? payload.data : []
+          const agents = models
+            .filter((m) => typeof m.id === 'string' && m.id)
+            .map((m) => ({ id: m.id as string, name: m.id as string, role: 'agent', category: 'fleet' }))
+          return json({
+            agents,
+            defaultId: agents[0]?.id ?? null,
+            mainKey: agents[0]?.id ?? null,
+            scope: 'fleet',
+          })
+        } catch {
+          return json({ agents: [] })
+        }
+      },
+    },
+  },
+})


### PR DESCRIPTION
## What
Adds an `/api/gateway/agents` route. The Agents screen already fetches it, but nothing served it, so it fell back to a hardcoded stub registry. The route reads the gateway's model list (`/v1/models`) and returns each model as an agent.

## Why
- Single-agent gateway → the roster shows that agent.
- Fleet gateway (many agents exposed as models behind one gateway URL) → the roster shows the whole fleet.

Either way the Agents screen reflects what the gateway actually serves instead of a static stub. (The code comment in agents-screen.tsx already anticipated this: "Temporary fallback registry until the gateway exposes a dedicated agent registry schema.")

## How
Mirrors the existing `/api/gateway-status` route: `createFileRoute` + `isAuthenticated` + `gatewayFetch('/v1/models')`, mapping each model id to `{ id, name, role, category }`. No dependency changes; fails soft to an empty list.

## Notes
Read-only roster (the screen's pause/kill controls are a separate concern for gateway-managed agents). Built from this branch; the route compiles and registers (returns 401 unauth as expected).