### PR TITLE
openclaw-dual-dial: working FaceTime call skill for Hermes

### DIFF
--- a/docs/agent-os.md
+++ b/docs/agent-os.md
@@ -1,0 +1,105 @@
+# Agent OS
+
+A centralized operator layer for Hermes + OpenClaw with n8n as the orchestration default.
+
+## Goals
+
+- queue work in one place
+- route by workflow and risk
+- default stable recurring work to n8n
+- keep Hermes/OpenClaw for reasoning-heavy and UI-fragile steps
+- log every execution
+- surface failures quickly
+- require approval for sensitive workflows
+
+## Implemented now
+
+### Core storage
+
+Persistent JSON-backed store under `~/.hermes/agent-os/store.json` with:
+- tasks
+- workflow registry
+- execution log
+- approvals
+
+### API routes
+
+- `GET/POST /api/agent-os/`
+  - list dashboard/task state
+  - enqueue a task
+- `GET/POST /api/agent-os/dispatch`
+  - inspect dispatchable queue
+  - claim / complete / fail tasks
+- `POST /api/agent-os/tasks/:taskId`
+  - route task
+  - update status
+  - attach n8n execution id
+- `POST /api/agent-os/approvals/:approvalId`
+  - approve or deny sensitive tasks
+- `GET/POST /api/agent-os/workflows`
+  - inspect or upsert workflow registry
+- `GET /api/agent-os/n8n-health`
+  - inspect local n8n MCP env state
+
+### Dashboard
+
+Route: `/agent-os`
+
+Shows:
+- active jobs
+- queued jobs
+- failed jobs
+- awaiting approval
+- last execution
+- next execution
+- recent tasks
+- approval queue
+- workflow registry
+
+### Default routing
+
+- n8n
+  - Morning Briefing
+  - Calendar Scan + Meeting Prep
+  - Inbox Triage
+  - Shopify Monitoring
+- Hermes
+  - Job Pipeline
+  - Rootly Prospect Research
+- OpenClaw
+  - Airbnb Host Automation
+
+### Failure notifications
+
+Failed non-retry tasks emit a best-effort local push through `/api/hermes-push`.
+
+## Immediate blocker status
+
+The n8n API key problem was fixed in the MCP env file at:
+- `~/.config/n8n-mcp/env`
+
+The remaining issue is tool-session connectivity to the n8n MCP bridge, not n8n auth itself.
+Manual MCP initialization against `~/.hermes/mcp-installs/n8n/server.py` succeeds.
+
+## Next implementation steps
+
+1. restore live OpenClaw n8n tool connectivity
+2. inventory live workflows and bind real n8n workflow IDs into registry
+3. add n8n execution polling back into task states
+4. add retry scheduling policy per workflow
+5. build first production workflows:
+   - Morning Briefing
+   - Calendar Scan + Meeting Prep
+   - Inbox Triage
+6. add approval action UI and audit detail
+7. add queue-triggered automatic executor loop
+
+## Definition of done gap
+
+Current state is a working scaffold plus dashboard and queue APIs.
+Still missing for full done:
+- automatic execution loop
+- automatic retry engine
+- n8n execution sync
+- completed first production workflows
+- fully live reporting without manual API calls

--- a/docs/openclaw-dual-route-port-plan.md
+++ b/docs/openclaw-dual-route-port-plan.md
@@ -1,0 +1,80 @@
+# Port plan: dual-route call audio into Hermes's own call stack
+
+Status: **planned** (bridge shipped first — see `skills/openclaw-dual-dial` and
+`scripts/hermes-openclaw-dial`).
+
+## Problem
+
+Hermes places FaceTime Audio calls via `scripts/hermes-phone-call` →
+`facetime-audio-alex --route-on`, which sets the Mac's **input, output, and
+system** audio all to `BlackHole 2ch`. Because uplink (Hermes TTS) and capture
+(caller audio) share one device, FaceTime suppresses the injected mic audio, so
+**the remote caller often cannot hear Hermes**. Hermes also never forces
+FaceTime's Video-menu Microphone/Output — it only sets macOS defaults and hopes
+FaceTime follows.
+
+The openclaw-phone-voice project solved this. Verified working recipe lives in
+`openclaw-phone-voice/CALLING_STATUS.md`. Two ingredients:
+
+1. **Dual-BlackHole routing** — two separate virtual devices, no shared loop:
+   - Hermes TTS → macOS output `BlackHole 2ch` → FaceTime mic = `BlackHole 2ch`
+   - caller → FaceTime output = `BlackHole 16ch` → Hermes capture = `BlackHole 16ch`
+2. **Forcing FaceTime's Video-menu devices** via AppleScript (mic = BlackHole 2ch,
+   output = BlackHole 16ch), re-applied after the Call button is pressed, because
+   FaceTime re-evaluates Continuity devices when the call starts.
+
+The bridge (`hermes-openclaw-dial`) gets the working audio today but runs the
+**openclaw** agent (whisper.cpp + Ollama + `say`), not Hermes's brain. This plan
+puts Hermes's own brain (tools, memory, ElevenLabs voice) on the fixed audio.
+
+## Changes required
+
+### 1. `~/.local/bin/facetime-audio-alex` (private helper)
+
+- Add `--route-on-dual` that:
+  - saves prior input/output/system (as today),
+  - sets macOS **output** = `BlackHole 2ch` (so ElevenLabs playback / TTS reaches
+    the FaceTime mic), leaves input as-is,
+  - forces the FaceTime **Video menu**: Microphone → `BlackHole 2ch` (occurrence 1),
+    Output → `BlackHole 16ch` (occurrence 2), re-applied after `--call`.
+  - The AppleScript occurrence-forcing logic can be lifted from
+    `openclaw-phone-voice/scripts/call_contact.sh` (`force_facetime_devices`).
+- Keep `--route-off` restoring the saved devices.
+
+### 2. `scripts/hermes-phone-call`
+
+- Add a `--dual-route` flag that calls `facetime-audio-alex --route-on-dual`
+  instead of `--route-on`, and re-forces devices after `open_call`.
+- Pass the capture device (`BlackHole 16ch`) through to the voice loop.
+
+### 3. `scripts/hermes_voice_call.py` + `tools/voice_mode`
+
+- Make the recorder capture from an explicit device (`BlackHole 16ch`) rather
+  than the macOS default input. Add an env/arg, e.g. `HERMES_CAPTURE_DEVICE`.
+- Ensure TTS playback (`play_audio_file` / `hermes-speak-live`) targets the macOS
+  default output (`BlackHole 2ch`) so it reaches the FaceTime mic. Confirm
+  ElevenLabs audio is played to that device, not a hardcoded one.
+- Pause capture during TTS playback to avoid the agent transcribing itself
+  (openclaw uses a paused flag around `say`).
+
+### 4. Validation
+
+- No-call smoke test: verify the recorder opens `BlackHole 16ch` and TTS plays to
+  `BlackHole 2ch`.
+- Live call: confirm caller hears Hermes (uplink) and Hermes transcribes the
+  caller (downlink) with no self-echo, then graceful hang-up.
+- Confirm `route-off` restores devices even on crash (trap on EXIT).
+
+## Risk / rollback
+
+- Touches a working production call system and a `0700` private helper. Keep the
+  new path behind `--dual-route` so the existing `--route-on` behavior is
+  untouched; roll back by not passing the flag.
+- The bridge remains available as a fallback the whole time.
+
+## Reference
+
+- Working implementation: `openclaw-phone-voice/scripts/call_contact.sh`
+  (`--dual-route`, `force_facetime_devices`, `set_split_route_audio`) and
+  `voice_agent.py` (`LocalBackend`, device selection, pause-during-TTS).
+- Status/recipe: `openclaw-phone-voice/CALLING_STATUS.md`.

--- a/scripts/hermes-openclaw-dial
+++ b/scripts/hermes-openclaw-dial
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# hermes-openclaw-dial — bridge from Hermes to the proven openclaw dual-route
+# local FaceTime dialer (openclaw-phone-voice/scripts/call_contact.sh).
+#
+# This runs the OPENCLAW voice agent (whisper.cpp + Ollama + macOS `say`), NOT
+# the Hermes brain/tools/ElevenLabs voice. It exists so Hermes can place a call
+# whose audio actually works — caller hears the agent, agent hears the caller —
+# via dual-BlackHole routing (BlackHole 2ch uplink, BlackHole 16ch downlink).
+#
+# See openclaw-phone-voice/CALLING_STATUS.md for the working recipe, and
+# hermes-workspace/docs/openclaw-dual-route-port-plan.md for the deeper port
+# that would put Hermes's own brain on the call with this audio fix.
+set -euo pipefail
+
+OPENCLAW_SCRIPTS="${OPENCLAW_SCRIPTS:-/Users/destrynewiger/openclaw-phone-voice/scripts}"
+if [[ ! -x "$OPENCLAW_SCRIPTS/call_contact.sh" ]]; then
+  found="$(find "$HOME" -maxdepth 6 -type d -path '*openclaw-phone-voice/scripts' 2>/dev/null | head -1 || true)"
+  [[ -n "$found" ]] && OPENCLAW_SCRIPTS="$found"
+fi
+DIALER="$OPENCLAW_SCRIPTS/call_contact.sh"
+if [[ ! -x "$DIALER" ]]; then
+  echo "Cannot find openclaw dialer (call_contact.sh). Set OPENCLAW_SCRIPTS=<path>." >&2
+  exit 1
+fi
+
+number="${HERMES_ALEX_PHONE:-+16502198152}"
+duration="150"
+first_line="Hi, it's your local agent. Ask me anything."
+manual=0
+live=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  hermes-openclaw-dial [--live] [--number +1XXXXXXXXXX] [--duration N]
+                       [--first-line "..."] [--manual-call]
+
+Bridges to the openclaw dual-route local FaceTime dialer. Without --live this is
+a DRY RUN: it prints what it would do and places no call.
+
+Runs the openclaw agent (whisper.cpp + Ollama qwen3:4b-instruct + Samantha voice)
+with --dual-route audio so the caller can actually hear it. This is NOT the
+Hermes brain — no Hermes tools, memory, or ElevenLabs voice.
+
+--manual-call waits for a human to click the green Call button (needs a real
+terminal). Omit it to auto-press the button.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --live) live=1; shift ;;
+    --number) number="$2"; shift 2 ;;
+    --duration) duration="$2"; shift 2 ;;
+    --first-line) first_line="$2"; shift 2 ;;
+    --manual-call) manual=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    +*) number="$1"; shift ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+args=(--dual-route --duration "$duration")
+[[ "$manual" -eq 1 ]] && args+=(--manual-call)
+args+=("$number")
+
+if [[ "$live" -eq 0 ]]; then
+  echo "[dry-run] openclaw dialer: $DIALER"
+  echo "[dry-run] would run: VOICE_AGENT_BACKEND=local VOICE_AGENT_FIRST_LINE='$first_line' \\"
+  echo "            $DIALER ${args[*]}"
+  echo "[dry-run] add --live to place the call to $number."
+  exit 0
+fi
+
+exec env VOICE_AGENT_BACKEND=local \
+  VOICE_AGENT_FIRST_LINE="$first_line" \
+  "$DIALER" "${args[@]}"

--- a/scripts/hermes-openclaw-dial
+++ b/scripts/hermes-openclaw-dial
@@ -28,12 +28,20 @@ duration="150"
 first_line="Hi, it's your local agent. Ask me anything."
 manual=0
 live=0
+# The far end is usually still ringing when the agent's speak timer fires, so
+# repeat the opening line a few times spaced out: whoever answers late still
+# hears it. Verified-working defaults (2026-06-30): greet at 10s, 4 reps, 15s
+# apart. Override with flags or the matching VOICE_AGENT_* env vars.
+greet_after="${VOICE_AGENT_GREET_AFTER:-10}"
+repeats="${VOICE_AGENT_FIRST_LINE_REPEATS:-4}"
+interval="${VOICE_AGENT_FIRST_LINE_INTERVAL:-15}"
 
 usage() {
   cat <<'EOF'
 Usage:
   hermes-openclaw-dial [--live] [--number +1XXXXXXXXXX] [--duration N]
-                       [--first-line "..."] [--manual-call]
+                       [--first-line "..."] [--greet-after N] [--repeats N]
+                       [--interval N] [--manual-call]
 
 Bridges to the openclaw dual-route local FaceTime dialer. Without --live this is
 a DRY RUN: it prints what it would do and places no call.
@@ -53,6 +61,9 @@ while [[ $# -gt 0 ]]; do
     --number) number="$2"; shift 2 ;;
     --duration) duration="$2"; shift 2 ;;
     --first-line) first_line="$2"; shift 2 ;;
+    --greet-after) greet_after="$2"; shift 2 ;;
+    --repeats) repeats="$2"; shift 2 ;;
+    --interval) interval="$2"; shift 2 ;;
     --manual-call) manual=1; shift ;;
     -h|--help) usage; exit 0 ;;
     +*) number="$1"; shift ;;
@@ -66,12 +77,17 @@ args+=("$number")
 
 if [[ "$live" -eq 0 ]]; then
   echo "[dry-run] openclaw dialer: $DIALER"
-  echo "[dry-run] would run: VOICE_AGENT_BACKEND=local VOICE_AGENT_FIRST_LINE='$first_line' \\"
+  echo "[dry-run] would run: VOICE_AGENT_BACKEND=local \\"
+  echo "            VOICE_AGENT_GREET_AFTER=$greet_after VOICE_AGENT_FIRST_LINE_REPEATS=$repeats VOICE_AGENT_FIRST_LINE_INTERVAL=$interval \\"
+  echo "            VOICE_AGENT_FIRST_LINE='$first_line' \\"
   echo "            $DIALER ${args[*]}"
   echo "[dry-run] add --live to place the call to $number."
   exit 0
 fi
 
-exec env VOICE_AGENT_BACKEND=local \
+exec env VOICE_AGENT_BACKEND="${VOICE_AGENT_BACKEND:-local}" \
+  VOICE_AGENT_GREET_AFTER="$greet_after" \
+  VOICE_AGENT_FIRST_LINE_REPEATS="$repeats" \
+  VOICE_AGENT_FIRST_LINE_INTERVAL="$interval" \
   VOICE_AGENT_FIRST_LINE="$first_line" \
   "$DIALER" "${args[@]}"

--- a/skills/openclaw-dual-dial/SKILL.md
+++ b/skills/openclaw-dual-dial/SKILL.md
@@ -42,7 +42,39 @@ scripts/hermes-openclaw-dial --live --manual-call --number +16502198152
 ```
 
 Flags: `--live` (required to actually call), `--number`, `--duration N`
-(seconds, default 150), `--first-line "..."`, `--manual-call`.
+(seconds, default 150), `--first-line "..."`, `--greet-after N` (seconds before
+the agent first speaks, default 10), `--repeats N` (times to repeat the opening
+line, default 4), `--interval N` (seconds between repeats, default 15),
+`--manual-call`.
+
+## Verified-working recipe (2026-06-30)
+
+Confirmed live: the caller heard the agent deliver a spoken message end-to-end.
+The opening line is repeated (`--repeats 4 --interval 15`, first at
+`--greet-after 10`) so a caller who answers a few seconds into the ring still
+hears the whole thing. For a one-way announcement leave the defaults; for a
+two-way chat, drop `--repeats` to 1 so the agent stops talking and starts
+listening sooner.
+
+## Gotchas that silence the call (learned the hard way)
+
+1. **Call a DIFFERENT phone than the Mac's own iPhone.** If `--number` is the
+   iPhone that is physically tethered to this Mac mini (the one macOS shows as
+   `iPhone Microphone` / Continuity), the call is a self-loop and carries no
+   audio — total silence both ways even though it rings. Dial a separate device.
+2. **FaceTime mic must be `BlackHole 2ch`, output `BlackHole 16ch`.** Each
+   BlackHole device is listed in BOTH the Microphone and Output sections of
+   FaceTime's Video menu (mic entry first). The dialer now presses the output
+   device at the correct occurrence; if you ever see the caller hear nothing,
+   check that FaceTime's mic didn't get set to `BlackHole 16ch` by mistake.
+3. **PortAudio `-9986` / "Unspecified Audio Hardware Error" = CoreAudio wedged.**
+   Reset it: `sudo killall coreaudiod` (auto-relaunches in ~1s). If even the
+   default mic won't open after that, the iPhone Continuity link is stuck —
+   reboot the Mac mini.
+4. **Do NOT place rapid back-to-back calls.** Repeated dialing wedges FaceTime
+   and CoreAudio (the pre-kernel-panic pattern). Space calls out; the dialer's
+   health-check will quit/relaunch a wedged FaceTime, but a wedged CoreAudio
+   still needs the reset in #3.
 
 ## Audio routing (dual-route)
 

--- a/skills/openclaw-dual-dial/SKILL.md
+++ b/skills/openclaw-dual-dial/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: openclaw-dual-dial
+description: Place a live FaceTime Audio call whose audio actually works (caller hears the agent, agent hears the caller) by bridging to the proven openclaw dual-route local dialer. Use when Hermes needs to call Destry or a number and Hermes's own call audio is unreliable.
+argument-hint: "phone number and/or first line to say"
+---
+
+# openclaw-dual-dial
+
+Bridge from Hermes to the **openclaw dual-route local FaceTime dialer**
+(`openclaw-phone-voice/scripts/call_contact.sh --dual-route`). This is the call
+path that is verified to work end-to-end: the remote caller hears the agent, the
+agent hears the caller, fully local (whisper.cpp + Ollama), no OpenAI.
+
+## When to use
+
+- Hermes needs to place a FaceTime Audio call and the caller must actually hear
+  the agent. Hermes's native `hermes-phone-call --call-me` routes uplink and
+  capture through the same BlackHole device, which FaceTime suppresses — so the
+  caller often can't hear Hermes. This bridge uses two BlackHole devices and
+  forces FaceTime's Video-menu devices, which fixes that.
+
+## What it is NOT
+
+- This runs the **openclaw** voice agent (whisper.cpp + Ollama `qwen3:4b-instruct`
+  + macOS `say` / Samantha voice). It is **not** the Hermes brain: no Hermes
+  tools, memory, or ElevenLabs voice on the call. For Hermes's own brain on this
+  audio fix, see `docs/openclaw-dual-route-port-plan.md` (the deeper port).
+
+## How to run
+
+```bash
+# Dry run (default, places NO call — prints what it would do):
+scripts/hermes-openclaw-dial --number +16502198152
+
+# Place the call (auto-presses the green Call button):
+scripts/hermes-openclaw-dial --live --number +16502198152 \
+  --first-line "Hi, it's Hermes calling. Can you hear me?"
+
+# If auto-press misses the Call button, use manual mode (needs a real terminal;
+# a human clicks Call, then presses Enter):
+scripts/hermes-openclaw-dial --live --manual-call --number +16502198152
+```
+
+Flags: `--live` (required to actually call), `--number`, `--duration N`
+(seconds, default 150), `--first-line "..."`, `--manual-call`.
+
+## Audio routing (dual-route)
+
+| path | device |
+|---|---|
+| agent speaks → phone | `say` → BlackHole 2ch → FaceTime mic = BlackHole 2ch |
+| phone → agent hears | FaceTime output → BlackHole 16ch → agent capture = BlackHole 16ch |
+
+The dialer saves and restores the Mac's audio devices around the call. After the
+call, the report is in `openclaw-phone-voice/scripts/voice_agent.log`.
+
+## Safety
+
+- Without `--live` it never places a call.
+- Placing a call rings a real phone. Only go `--live` when a call is intended.

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -68,6 +68,13 @@ export const MOBILE_HAMBURGER_NAV_ITEMS = [
     match: (p: string) => p.startsWith('/operations'),
   },
   {
+    id: 'agent-os',
+    label: 'Agent OS',
+    icon: Rocket01Icon,
+    to: '/agent-os',
+    match: (p: string) => p.startsWith('/agent-os'),
+  },
+  {
     id: 'swarm',
     label: 'Swarm',
     icon: UserGroupIcon,

--- a/src/components/mobile-tab-bar.tsx
+++ b/src/components/mobile-tab-bar.tsx
@@ -79,6 +79,13 @@ export const MOBILE_NAV_TABS: Array<TabItem> = [
     match: (p) => p.startsWith('/jobs'),
   },
   {
+    id: 'agent-os',
+    label: 'Agent OS',
+    icon: DashboardSquare01Icon,
+    to: '/agent-os',
+    match: (p) => p.startsWith('/agent-os'),
+  },
+  {
     id: 'swarm',
     label: 'Swarm',
     icon: UserGroupIcon,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,6 +22,8 @@ import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
+import { Route as AgentOsRouteImport } from './routes/agent-os'
+import { Route as AgentCommandCenterRouteImport } from './routes/agent-command-center'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -71,6 +73,7 @@ import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiLocalProvidersRouteImport } from './routes/api/local-providers'
 import { Route as ApiIntegrationsRouteImport } from './routes/api/integrations'
 import { Route as ApiHistoryRouteImport } from './routes/api/history'
+import { Route as ApiHermesPushRouteImport } from './routes/api/hermes-push'
 import { Route as ApiGatewayStatusRouteImport } from './routes/api/gateway-status'
 import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
@@ -89,6 +92,8 @@ import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
 import { Route as ApiAuthCheckRouteImport } from './routes/api/auth-check'
 import { Route as ApiAuthRouteImport } from './routes/api/auth'
 import { Route as ApiArtifactsRouteImport } from './routes/api/artifacts'
+import { Route as ApiAgentCommandCenterRouteImport } from './routes/api/agent-command-center'
+import { Route as ApiAgentOsIndexRouteImport } from './routes/api/agent-os/index'
 import { Route as ApiSwarmMemorySearchRouteImport } from './routes/api/swarm-memory/search'
 import { Route as ApiSkillsUninstallRouteImport } from './routes/api/skills/uninstall'
 import { Route as ApiSkillsToggleRouteImport } from './routes/api/skills/toggle'
@@ -121,8 +126,15 @@ import { Route as ApiClaudeTasksTaskIdRouteImport } from './routes/api/claude-ta
 import { Route as ApiClaudeProxySplatRouteImport } from './routes/api/claude-proxy/$'
 import { Route as ApiClaudeJobsJobIdRouteImport } from './routes/api/claude-jobs.$jobId'
 import { Route as ApiArtifactsArtifactIdRouteImport } from './routes/api/artifacts.$artifactId'
+import { Route as ApiAgentOsWorkflowsRouteImport } from './routes/api/agent-os/workflows'
+import { Route as ApiAgentOsN8nHealthRouteImport } from './routes/api/agent-os/n8n-health'
+import { Route as ApiAgentOsDispatchRouteImport } from './routes/api/agent-os/dispatch'
+import { Route as ApiAgentCommandCenterGithubReposRouteImport } from './routes/api/agent-command-center/github-repos'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
 import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api/sessions/$sessionKey.active-run'
+import { Route as ApiAgentOsTasksTaskIdRouteImport } from './routes/api/agent-os/tasks.$taskId'
+import { Route as ApiAgentOsApprovalsApprovalIdRouteImport } from './routes/api/agent-os/approvals.$approvalId'
+import { Route as ApiAgentCommandCenterApprovalsIdRouteImport } from './routes/api/agent-command-center/approvals.$id'
 
 const TerminalRoute = TerminalRouteImport.update({
   id: '/terminal',
@@ -187,6 +199,16 @@ const DashboardRoute = DashboardRouteImport.update({
 const ConductorRoute = ConductorRouteImport.update({
   id: '/conductor',
   path: '/conductor',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentOsRoute = AgentOsRouteImport.update({
+  id: '/agent-os',
+  path: '/agent-os',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AgentCommandCenterRoute = AgentCommandCenterRouteImport.update({
+  id: '/agent-command-center',
+  path: '/agent-command-center',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SplatRoute = SplatRouteImport.update({
@@ -435,6 +457,11 @@ const ApiHistoryRoute = ApiHistoryRouteImport.update({
   path: '/api/history',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHermesPushRoute = ApiHermesPushRouteImport.update({
+  id: '/api/hermes-push',
+  path: '/api/hermes-push',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiGatewayStatusRoute = ApiGatewayStatusRouteImport.update({
   id: '/api/gateway-status',
   path: '/api/gateway-status',
@@ -523,6 +550,16 @@ const ApiAuthRoute = ApiAuthRouteImport.update({
 const ApiArtifactsRoute = ApiArtifactsRouteImport.update({
   id: '/api/artifacts',
   path: '/api/artifacts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentCommandCenterRoute = ApiAgentCommandCenterRouteImport.update({
+  id: '/api/agent-command-center',
+  path: '/api/agent-command-center',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentOsIndexRoute = ApiAgentOsIndexRouteImport.update({
+  id: '/api/agent-os/',
+  path: '/api/agent-os/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSwarmMemorySearchRoute = ApiSwarmMemorySearchRouteImport.update({
@@ -685,6 +722,27 @@ const ApiArtifactsArtifactIdRoute = ApiArtifactsArtifactIdRouteImport.update({
   path: '/$artifactId',
   getParentRoute: () => ApiArtifactsRoute,
 } as any)
+const ApiAgentOsWorkflowsRoute = ApiAgentOsWorkflowsRouteImport.update({
+  id: '/api/agent-os/workflows',
+  path: '/api/agent-os/workflows',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentOsN8nHealthRoute = ApiAgentOsN8nHealthRouteImport.update({
+  id: '/api/agent-os/n8n-health',
+  path: '/api/agent-os/n8n-health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentOsDispatchRoute = ApiAgentOsDispatchRouteImport.update({
+  id: '/api/agent-os/dispatch',
+  path: '/api/agent-os/dispatch',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentCommandCenterGithubReposRoute =
+  ApiAgentCommandCenterGithubReposRouteImport.update({
+    id: '/github-repos',
+    path: '/github-repos',
+    getParentRoute: () => ApiAgentCommandCenterRoute,
+  } as any)
 const ApiSessionsSessionKeyStatusRoute =
   ApiSessionsSessionKeyStatusRouteImport.update({
     id: '/$sessionKey/status',
@@ -697,10 +755,29 @@ const ApiSessionsSessionKeyActiveRunRoute =
     path: '/$sessionKey/active-run',
     getParentRoute: () => ApiSessionsRoute,
   } as any)
+const ApiAgentOsTasksTaskIdRoute = ApiAgentOsTasksTaskIdRouteImport.update({
+  id: '/api/agent-os/tasks/$taskId',
+  path: '/api/agent-os/tasks/$taskId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentOsApprovalsApprovalIdRoute =
+  ApiAgentOsApprovalsApprovalIdRouteImport.update({
+    id: '/api/agent-os/approvals/$approvalId',
+    path: '/api/agent-os/approvals/$approvalId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAgentCommandCenterApprovalsIdRoute =
+  ApiAgentCommandCenterApprovalsIdRouteImport.update({
+    id: '/approvals/$id',
+    path: '/approvals/$id',
+    getParentRoute: () => ApiAgentCommandCenterRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-command-center': typeof AgentCommandCenterRoute
+  '/agent-os': typeof AgentOsRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -714,6 +791,7 @@ export interface FileRoutesByFullPath {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/api/agent-command-center': typeof ApiAgentCommandCenterRouteWithChildren
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -732,6 +810,7 @@ export interface FileRoutesByFullPath {
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-push': typeof ApiHermesPushRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -779,6 +858,10 @@ export interface FileRoutesByFullPath {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/agent-command-center/github-repos': typeof ApiAgentCommandCenterGithubReposRoute
+  '/api/agent-os/dispatch': typeof ApiAgentOsDispatchRoute
+  '/api/agent-os/n8n-health': typeof ApiAgentOsN8nHealthRoute
+  '/api/agent-os/workflows': typeof ApiAgentOsWorkflowsRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -811,12 +894,18 @@ export interface FileRoutesByFullPath {
   '/api/skills/toggle': typeof ApiSkillsToggleRoute
   '/api/skills/uninstall': typeof ApiSkillsUninstallRoute
   '/api/swarm-memory/search': typeof ApiSwarmMemorySearchRoute
+  '/api/agent-os/': typeof ApiAgentOsIndexRoute
+  '/api/agent-command-center/approvals/$id': typeof ApiAgentCommandCenterApprovalsIdRoute
+  '/api/agent-os/approvals/$approvalId': typeof ApiAgentOsApprovalsApprovalIdRoute
+  '/api/agent-os/tasks/$taskId': typeof ApiAgentOsTasksTaskIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-command-center': typeof AgentCommandCenterRoute
+  '/agent-os': typeof AgentOsRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -829,6 +918,7 @@ export interface FileRoutesByTo {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/api/agent-command-center': typeof ApiAgentCommandCenterRouteWithChildren
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -847,6 +937,7 @@ export interface FileRoutesByTo {
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-push': typeof ApiHermesPushRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -894,6 +985,10 @@ export interface FileRoutesByTo {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat': typeof ChatIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/api/agent-command-center/github-repos': typeof ApiAgentCommandCenterGithubReposRoute
+  '/api/agent-os/dispatch': typeof ApiAgentOsDispatchRoute
+  '/api/agent-os/n8n-health': typeof ApiAgentOsN8nHealthRoute
+  '/api/agent-os/workflows': typeof ApiAgentOsWorkflowsRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -926,6 +1021,10 @@ export interface FileRoutesByTo {
   '/api/skills/toggle': typeof ApiSkillsToggleRoute
   '/api/skills/uninstall': typeof ApiSkillsUninstallRoute
   '/api/swarm-memory/search': typeof ApiSwarmMemorySearchRoute
+  '/api/agent-os': typeof ApiAgentOsIndexRoute
+  '/api/agent-command-center/approvals/$id': typeof ApiAgentCommandCenterApprovalsIdRoute
+  '/api/agent-os/approvals/$approvalId': typeof ApiAgentOsApprovalsApprovalIdRoute
+  '/api/agent-os/tasks/$taskId': typeof ApiAgentOsTasksTaskIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
 }
@@ -933,6 +1032,8 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
+  '/agent-command-center': typeof AgentCommandCenterRoute
+  '/agent-os': typeof AgentOsRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/files': typeof FilesRoute
@@ -946,6 +1047,7 @@ export interface FileRoutesById {
   '/swarm2': typeof Swarm2Route
   '/tasks': typeof TasksRoute
   '/terminal': typeof TerminalRoute
+  '/api/agent-command-center': typeof ApiAgentCommandCenterRouteWithChildren
   '/api/artifacts': typeof ApiArtifactsRouteWithChildren
   '/api/auth': typeof ApiAuthRoute
   '/api/auth-check': typeof ApiAuthCheckRoute
@@ -964,6 +1066,7 @@ export interface FileRoutesById {
   '/api/events': typeof ApiEventsRoute
   '/api/files': typeof ApiFilesRoute
   '/api/gateway-status': typeof ApiGatewayStatusRoute
+  '/api/hermes-push': typeof ApiHermesPushRoute
   '/api/history': typeof ApiHistoryRoute
   '/api/integrations': typeof ApiIntegrationsRoute
   '/api/local-providers': typeof ApiLocalProvidersRoute
@@ -1011,6 +1114,10 @@ export interface FileRoutesById {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/agent-command-center/github-repos': typeof ApiAgentCommandCenterGithubReposRoute
+  '/api/agent-os/dispatch': typeof ApiAgentOsDispatchRoute
+  '/api/agent-os/n8n-health': typeof ApiAgentOsN8nHealthRoute
+  '/api/agent-os/workflows': typeof ApiAgentOsWorkflowsRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1043,6 +1150,10 @@ export interface FileRoutesById {
   '/api/skills/toggle': typeof ApiSkillsToggleRoute
   '/api/skills/uninstall': typeof ApiSkillsUninstallRoute
   '/api/swarm-memory/search': typeof ApiSwarmMemorySearchRoute
+  '/api/agent-os/': typeof ApiAgentOsIndexRoute
+  '/api/agent-command-center/approvals/$id': typeof ApiAgentCommandCenterApprovalsIdRoute
+  '/api/agent-os/approvals/$approvalId': typeof ApiAgentOsApprovalsApprovalIdRoute
+  '/api/agent-os/tasks/$taskId': typeof ApiAgentOsTasksTaskIdRoute
   '/api/sessions/$sessionKey/active-run': typeof ApiSessionsSessionKeyActiveRunRoute
   '/api/sessions/$sessionKey/status': typeof ApiSessionsSessionKeyStatusRoute
 }
@@ -1051,6 +1162,8 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$'
+    | '/agent-command-center'
+    | '/agent-os'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -1064,6 +1177,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/api/agent-command-center'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1082,6 +1196,7 @@ export interface FileRouteTypes {
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
+    | '/api/hermes-push'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1129,6 +1244,10 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/agent-command-center/github-repos'
+    | '/api/agent-os/dispatch'
+    | '/api/agent-os/n8n-health'
+    | '/api/agent-os/workflows'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1161,12 +1280,18 @@ export interface FileRouteTypes {
     | '/api/skills/toggle'
     | '/api/skills/uninstall'
     | '/api/swarm-memory/search'
+    | '/api/agent-os/'
+    | '/api/agent-command-center/approvals/$id'
+    | '/api/agent-os/approvals/$approvalId'
+    | '/api/agent-os/tasks/$taskId'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/$'
+    | '/agent-command-center'
+    | '/agent-os'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -1179,6 +1304,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/api/agent-command-center'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1197,6 +1323,7 @@ export interface FileRouteTypes {
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
+    | '/api/hermes-push'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1244,6 +1371,10 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat'
     | '/settings'
+    | '/api/agent-command-center/github-repos'
+    | '/api/agent-os/dispatch'
+    | '/api/agent-os/n8n-health'
+    | '/api/agent-os/workflows'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1276,12 +1407,18 @@ export interface FileRouteTypes {
     | '/api/skills/toggle'
     | '/api/skills/uninstall'
     | '/api/swarm-memory/search'
+    | '/api/agent-os'
+    | '/api/agent-command-center/approvals/$id'
+    | '/api/agent-os/approvals/$approvalId'
+    | '/api/agent-os/tasks/$taskId'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
   id:
     | '__root__'
     | '/'
     | '/$'
+    | '/agent-command-center'
+    | '/agent-os'
     | '/conductor'
     | '/dashboard'
     | '/files'
@@ -1295,6 +1432,7 @@ export interface FileRouteTypes {
     | '/swarm2'
     | '/tasks'
     | '/terminal'
+    | '/api/agent-command-center'
     | '/api/artifacts'
     | '/api/auth'
     | '/api/auth-check'
@@ -1313,6 +1451,7 @@ export interface FileRouteTypes {
     | '/api/events'
     | '/api/files'
     | '/api/gateway-status'
+    | '/api/hermes-push'
     | '/api/history'
     | '/api/integrations'
     | '/api/local-providers'
@@ -1360,6 +1499,10 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/agent-command-center/github-repos'
+    | '/api/agent-os/dispatch'
+    | '/api/agent-os/n8n-health'
+    | '/api/agent-os/workflows'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1392,6 +1535,10 @@ export interface FileRouteTypes {
     | '/api/skills/toggle'
     | '/api/skills/uninstall'
     | '/api/swarm-memory/search'
+    | '/api/agent-os/'
+    | '/api/agent-command-center/approvals/$id'
+    | '/api/agent-os/approvals/$approvalId'
+    | '/api/agent-os/tasks/$taskId'
     | '/api/sessions/$sessionKey/active-run'
     | '/api/sessions/$sessionKey/status'
   fileRoutesById: FileRoutesById
@@ -1399,6 +1546,8 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
+  AgentCommandCenterRoute: typeof AgentCommandCenterRoute
+  AgentOsRoute: typeof AgentOsRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
   FilesRoute: typeof FilesRoute
@@ -1412,6 +1561,7 @@ export interface RootRouteChildren {
   Swarm2Route: typeof Swarm2Route
   TasksRoute: typeof TasksRoute
   TerminalRoute: typeof TerminalRoute
+  ApiAgentCommandCenterRoute: typeof ApiAgentCommandCenterRouteWithChildren
   ApiArtifactsRoute: typeof ApiArtifactsRouteWithChildren
   ApiAuthRoute: typeof ApiAuthRoute
   ApiAuthCheckRoute: typeof ApiAuthCheckRoute
@@ -1430,6 +1580,7 @@ export interface RootRouteChildren {
   ApiEventsRoute: typeof ApiEventsRoute
   ApiFilesRoute: typeof ApiFilesRoute
   ApiGatewayStatusRoute: typeof ApiGatewayStatusRoute
+  ApiHermesPushRoute: typeof ApiHermesPushRoute
   ApiHistoryRoute: typeof ApiHistoryRoute
   ApiIntegrationsRoute: typeof ApiIntegrationsRoute
   ApiLocalProvidersRoute: typeof ApiLocalProvidersRoute
@@ -1474,6 +1625,9 @@ export interface RootRouteChildren {
   ApiWorkspaceRoute: typeof ApiWorkspaceRoute
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
+  ApiAgentOsDispatchRoute: typeof ApiAgentOsDispatchRoute
+  ApiAgentOsN8nHealthRoute: typeof ApiAgentOsN8nHealthRoute
+  ApiAgentOsWorkflowsRoute: typeof ApiAgentOsWorkflowsRoute
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiKnowledgeConfigRoute: typeof ApiKnowledgeConfigRoute
   ApiKnowledgeGraphRoute: typeof ApiKnowledgeGraphRoute
@@ -1493,6 +1647,9 @@ export interface RootRouteChildren {
   ApiProfilesReadRoute: typeof ApiProfilesReadRoute
   ApiProfilesRenameRoute: typeof ApiProfilesRenameRoute
   ApiProfilesUpdateRoute: typeof ApiProfilesUpdateRoute
+  ApiAgentOsIndexRoute: typeof ApiAgentOsIndexRoute
+  ApiAgentOsApprovalsApprovalIdRoute: typeof ApiAgentOsApprovalsApprovalIdRoute
+  ApiAgentOsTasksTaskIdRoute: typeof ApiAgentOsTasksTaskIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1586,6 +1743,20 @@ declare module '@tanstack/react-router' {
       path: '/conductor'
       fullPath: '/conductor'
       preLoaderRoute: typeof ConductorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agent-os': {
+      id: '/agent-os'
+      path: '/agent-os'
+      fullPath: '/agent-os'
+      preLoaderRoute: typeof AgentOsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/agent-command-center': {
+      id: '/agent-command-center'
+      path: '/agent-command-center'
+      fullPath: '/agent-command-center'
+      preLoaderRoute: typeof AgentCommandCenterRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$': {
@@ -1931,6 +2102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHistoryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/hermes-push': {
+      id: '/api/hermes-push'
+      path: '/api/hermes-push'
+      fullPath: '/api/hermes-push'
+      preLoaderRoute: typeof ApiHermesPushRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/gateway-status': {
       id: '/api/gateway-status'
       path: '/api/gateway-status'
@@ -2055,6 +2233,20 @@ declare module '@tanstack/react-router' {
       path: '/api/artifacts'
       fullPath: '/api/artifacts'
       preLoaderRoute: typeof ApiArtifactsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-command-center': {
+      id: '/api/agent-command-center'
+      path: '/api/agent-command-center'
+      fullPath: '/api/agent-command-center'
+      preLoaderRoute: typeof ApiAgentCommandCenterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-os/': {
+      id: '/api/agent-os/'
+      path: '/api/agent-os'
+      fullPath: '/api/agent-os/'
+      preLoaderRoute: typeof ApiAgentOsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/swarm-memory/search': {
@@ -2281,6 +2473,34 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiArtifactsArtifactIdRouteImport
       parentRoute: typeof ApiArtifactsRoute
     }
+    '/api/agent-os/workflows': {
+      id: '/api/agent-os/workflows'
+      path: '/api/agent-os/workflows'
+      fullPath: '/api/agent-os/workflows'
+      preLoaderRoute: typeof ApiAgentOsWorkflowsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-os/n8n-health': {
+      id: '/api/agent-os/n8n-health'
+      path: '/api/agent-os/n8n-health'
+      fullPath: '/api/agent-os/n8n-health'
+      preLoaderRoute: typeof ApiAgentOsN8nHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-os/dispatch': {
+      id: '/api/agent-os/dispatch'
+      path: '/api/agent-os/dispatch'
+      fullPath: '/api/agent-os/dispatch'
+      preLoaderRoute: typeof ApiAgentOsDispatchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-command-center/github-repos': {
+      id: '/api/agent-command-center/github-repos'
+      path: '/github-repos'
+      fullPath: '/api/agent-command-center/github-repos'
+      preLoaderRoute: typeof ApiAgentCommandCenterGithubReposRouteImport
+      parentRoute: typeof ApiAgentCommandCenterRoute
+    }
     '/api/sessions/$sessionKey/status': {
       id: '/api/sessions/$sessionKey/status'
       path: '/$sessionKey/status'
@@ -2294,6 +2514,27 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/sessions/$sessionKey/active-run'
       preLoaderRoute: typeof ApiSessionsSessionKeyActiveRunRouteImport
       parentRoute: typeof ApiSessionsRoute
+    }
+    '/api/agent-os/tasks/$taskId': {
+      id: '/api/agent-os/tasks/$taskId'
+      path: '/api/agent-os/tasks/$taskId'
+      fullPath: '/api/agent-os/tasks/$taskId'
+      preLoaderRoute: typeof ApiAgentOsTasksTaskIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-os/approvals/$approvalId': {
+      id: '/api/agent-os/approvals/$approvalId'
+      path: '/api/agent-os/approvals/$approvalId'
+      fullPath: '/api/agent-os/approvals/$approvalId'
+      preLoaderRoute: typeof ApiAgentOsApprovalsApprovalIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-command-center/approvals/$id': {
+      id: '/api/agent-command-center/approvals/$id'
+      path: '/approvals/$id'
+      fullPath: '/api/agent-command-center/approvals/$id'
+      preLoaderRoute: typeof ApiAgentCommandCenterApprovalsIdRouteImport
+      parentRoute: typeof ApiAgentCommandCenterRoute
     }
   }
 }
@@ -2313,6 +2554,21 @@ const SettingsRouteChildren: SettingsRouteChildren = {
 const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
   SettingsRouteChildren,
 )
+
+interface ApiAgentCommandCenterRouteChildren {
+  ApiAgentCommandCenterGithubReposRoute: typeof ApiAgentCommandCenterGithubReposRoute
+  ApiAgentCommandCenterApprovalsIdRoute: typeof ApiAgentCommandCenterApprovalsIdRoute
+}
+
+const ApiAgentCommandCenterRouteChildren: ApiAgentCommandCenterRouteChildren = {
+  ApiAgentCommandCenterGithubReposRoute: ApiAgentCommandCenterGithubReposRoute,
+  ApiAgentCommandCenterApprovalsIdRoute: ApiAgentCommandCenterApprovalsIdRoute,
+}
+
+const ApiAgentCommandCenterRouteWithChildren =
+  ApiAgentCommandCenterRoute._addFileChildren(
+    ApiAgentCommandCenterRouteChildren,
+  )
 
 interface ApiArtifactsRouteChildren {
   ApiArtifactsArtifactIdRoute: typeof ApiArtifactsArtifactIdRoute
@@ -2417,6 +2673,8 @@ const ApiSwarmMemoryRouteWithChildren = ApiSwarmMemoryRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
+  AgentCommandCenterRoute: AgentCommandCenterRoute,
+  AgentOsRoute: AgentOsRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
   FilesRoute: FilesRoute,
@@ -2430,6 +2688,7 @@ const rootRouteChildren: RootRouteChildren = {
   Swarm2Route: Swarm2Route,
   TasksRoute: TasksRoute,
   TerminalRoute: TerminalRoute,
+  ApiAgentCommandCenterRoute: ApiAgentCommandCenterRouteWithChildren,
   ApiArtifactsRoute: ApiArtifactsRouteWithChildren,
   ApiAuthRoute: ApiAuthRoute,
   ApiAuthCheckRoute: ApiAuthCheckRoute,
@@ -2448,6 +2707,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiEventsRoute: ApiEventsRoute,
   ApiFilesRoute: ApiFilesRoute,
   ApiGatewayStatusRoute: ApiGatewayStatusRoute,
+  ApiHermesPushRoute: ApiHermesPushRoute,
   ApiHistoryRoute: ApiHistoryRoute,
   ApiIntegrationsRoute: ApiIntegrationsRoute,
   ApiLocalProvidersRoute: ApiLocalProvidersRoute,
@@ -2492,6 +2752,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiWorkspaceRoute: ApiWorkspaceRoute,
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,
+  ApiAgentOsDispatchRoute: ApiAgentOsDispatchRoute,
+  ApiAgentOsN8nHealthRoute: ApiAgentOsN8nHealthRoute,
+  ApiAgentOsWorkflowsRoute: ApiAgentOsWorkflowsRoute,
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiKnowledgeConfigRoute: ApiKnowledgeConfigRoute,
   ApiKnowledgeGraphRoute: ApiKnowledgeGraphRoute,
@@ -2511,6 +2774,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiProfilesReadRoute: ApiProfilesReadRoute,
   ApiProfilesRenameRoute: ApiProfilesRenameRoute,
   ApiProfilesUpdateRoute: ApiProfilesUpdateRoute,
+  ApiAgentOsIndexRoute: ApiAgentOsIndexRoute,
+  ApiAgentOsApprovalsApprovalIdRoute: ApiAgentOsApprovalsApprovalIdRoute,
+  ApiAgentOsTasksTaskIdRoute: ApiAgentOsTasksTaskIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/agent-os.tsx
+++ b/src/routes/agent-os.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { AgentOsScreen } from '@/screens/agent-os/agent-os-screen'
+
+export const Route = createFileRoute('/agent-os')({
+  ssr: false,
+  component: AgentOsRoute,
+})
+
+function AgentOsRoute() {
+  usePageTitle('Agent OS')
+  return <AgentOsScreen />
+}

--- a/src/routes/api/agent-os/approvals.$approvalId.ts
+++ b/src/routes/api/agent-os/approvals.$approvalId.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { decideApproval } from '../../../server/agent-os/store'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/approvals/$approvalId')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const decision = body.decision
+          if (decision !== 'approved' && decision !== 'denied') {
+            return jsonResponse({ error: 'decision must be approved or denied' }, 400)
+          }
+          const approval = decideApproval(
+            params.approvalId,
+            decision,
+            typeof body.decided_by === 'string' ? body.decided_by : 'user',
+            typeof body.note === 'string' ? body.note : null,
+          )
+          if (!approval) return jsonResponse({ error: 'Approval not found' }, 404)
+          return jsonResponse({ approval })
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/agent-os/dispatch.ts
+++ b/src/routes/api/agent-os/dispatch.ts
@@ -1,0 +1,45 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { claimQueuedTask, completeTask, failTask, pendingDispatchQueue } from '../../../server/agent-os/router'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/dispatch')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        return jsonResponse({ queue: pendingDispatchQueue() })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const action = body.action
+          const taskId = typeof body.task_id === 'string' ? body.task_id : null
+          if (!taskId) return jsonResponse({ error: 'task_id required' }, 400)
+          if (action === 'claim') {
+            const task = claimQueuedTask(taskId)
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          if (action === 'complete') {
+            const task = completeTask(taskId, typeof body.message === 'string' ? body.message : 'Task completed successfully.')
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          if (action === 'fail') {
+            const task = await failTask(taskId, typeof body.error === 'string' ? body.error : 'unknown error', body.will_retry === true)
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          return jsonResponse({ error: 'unknown action' }, 400)
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/agent-os/index.ts
+++ b/src/routes/api/agent-os/index.ts
@@ -1,0 +1,55 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  agentOsDashboard,
+  listAgentOsTasks,
+  listApprovals,
+  listExecutionLogs,
+  listWorkflowRegistry,
+} from '../../../server/agent-os/store'
+import { enqueueWorkflowTask } from '../../../server/agent-os/router'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        return jsonResponse({
+          dashboard: agentOsDashboard(),
+          tasks: listAgentOsTasks(),
+          workflows: listWorkflowRegistry(),
+          executions: listExecutionLogs(),
+          approvals: listApprovals(),
+        })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          if (typeof body.title !== 'string' || typeof body.workflow_key !== 'string') {
+            return jsonResponse({ error: 'title and workflow_key are required' }, 400)
+          }
+          const task = enqueueWorkflowTask({
+            title: body.title,
+            description: typeof body.description === 'string' ? body.description : '',
+            workflow_key: body.workflow_key,
+            project: typeof body.project === 'string' ? body.project : null,
+            payload: typeof body.payload === 'object' && body.payload ? (body.payload as Record<string, unknown>) : {},
+            priority: typeof body.priority === 'string' ? (body.priority as 'critical' | 'high' | 'medium' | 'low') : 'medium',
+            created_by: typeof body.created_by === 'string' ? body.created_by : 'user',
+          })
+          return jsonResponse({ task }, 201)
+        } catch (error) {
+          return jsonResponse({ error: error instanceof Error ? error.message : 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/agent-os/n8n-health.ts
+++ b/src/routes/api/agent-os/n8n-health.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/n8n-health')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        const envPath = path.join(os.homedir(), '.config', 'n8n-mcp', 'env')
+        let envSummary = { exists: false, base_url: null as string | null, api_key_present: false, placeholder_key: false }
+        try {
+          const raw = fs.readFileSync(envPath, 'utf-8')
+          envSummary.exists = true
+          for (const line of raw.split(/\r?\n/)) {
+            if (line.startsWith('N8N_BASE_URL=')) envSummary.base_url = line.slice('N8N_BASE_URL='.length)
+            if (line.startsWith('N8N_API_KEY=')) {
+              const key = line.slice('N8N_API_KEY='.length)
+              envSummary.api_key_present = key.length > 0
+              envSummary.placeholder_key = key.includes('REPLACE_ME')
+            }
+          }
+        } catch {}
+        return jsonResponse({ env: envSummary })
+      },
+    },
+  },
+})

--- a/src/routes/api/agent-os/tasks.$taskId.ts
+++ b/src/routes/api/agent-os/tasks.$taskId.ts
@@ -1,0 +1,55 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { routeTask, updateTaskStatus, attachN8nExecution } from '../../../server/agent-os/store'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/tasks/$taskId')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          const action = body.action
+          if (action === 'route') {
+            const route = body.route
+            if (!['n8n', 'hermes', 'openclaw', 'manual'].includes(String(route))) {
+              return jsonResponse({ error: 'invalid route' }, 400)
+            }
+            const task = routeTask(params.taskId, route as 'n8n' | 'hermes' | 'openclaw' | 'manual', {
+              reason: typeof body.reason === 'string' ? body.reason : 'manual route update',
+            })
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          if (action === 'status') {
+            const status = body.status
+            if (!['queued', 'routed', 'running', 'retrying', 'blocked', 'failed', 'completed', 'awaiting_approval'].includes(String(status))) {
+              return jsonResponse({ error: 'invalid status' }, 400)
+            }
+            const task = updateTaskStatus(
+              params.taskId,
+              status as 'queued' | 'routed' | 'running' | 'retrying' | 'blocked' | 'failed' | 'completed' | 'awaiting_approval',
+              typeof body.message === 'string' ? body.message : 'status updated',
+              typeof body.meta === 'object' && body.meta ? (body.meta as Record<string, unknown>) : {},
+            )
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          if (action === 'attach_n8n_execution') {
+            if (typeof body.execution_id !== 'string') return jsonResponse({ error: 'execution_id required' }, 400)
+            const task = attachN8nExecution(params.taskId, body.execution_id, typeof body.workflow_id === 'string' ? body.workflow_id : null)
+            return task ? jsonResponse({ task }) : jsonResponse({ error: 'Task not found' }, 404)
+          }
+          return jsonResponse({ error: 'unknown action' }, 400)
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/agent-os/workflows.ts
+++ b/src/routes/api/agent-os/workflows.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { listWorkflowRegistry, upsertWorkflow } from '../../../server/agent-os/store'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export const Route = createFileRoute('/api/agent-os/workflows')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        return jsonResponse({ workflows: listWorkflowRegistry() })
+      },
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json()) as Record<string, unknown>
+          if (typeof body.key !== 'string' || typeof body.name !== 'string') {
+            return jsonResponse({ error: 'key and name are required' }, 400)
+          }
+          const workflow = upsertWorkflow({
+            key: body.key,
+            name: body.name,
+            description: typeof body.description === 'string' ? body.description : '',
+            mode: typeof body.mode === 'string' ? (body.mode as 'n8n' | 'hybrid' | 'agent') : 'n8n',
+            enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
+            route_default: typeof body.route_default === 'string' ? (body.route_default as 'n8n' | 'hermes' | 'openclaw' | 'manual') : 'n8n',
+            sensitive: typeof body.sensitive === 'boolean' ? body.sensitive : false,
+            risk: typeof body.risk === 'string' ? (body.risk as 'low' | 'medium' | 'high' | 'critical') : 'medium',
+            n8n_workflow_id: typeof body.n8n_workflow_id === 'string' ? body.n8n_workflow_id : null,
+            schedule: typeof body.schedule === 'string' ? body.schedule : null,
+            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+            owners: Array.isArray(body.owners) ? body.owners.filter((owner): owner is string => typeof owner === 'string') : [],
+          })
+          return jsonResponse({ workflow }, 201)
+        } catch {
+          return jsonResponse({ error: 'Invalid request body' }, 400)
+        }
+      },
+    },
+  },
+})

--- a/src/screens/agent-os/agent-os-screen.tsx
+++ b/src/screens/agent-os/agent-os-screen.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+type AgentOsResponse = {
+  dashboard: {
+    counts: {
+      active_jobs: number
+      queued_jobs: number
+      failed_jobs: number
+      awaiting_approval: number
+    }
+    last_execution: { created_at: string; message: string; workflow_key: string } | null
+    next_execution: { next_run_at: string | null; title: string; workflow_name: string } | null
+    recent_tasks: Array<{
+      id: string
+      title: string
+      workflow_name: string
+      status: string
+      route: string
+      priority: string
+      updated_at: string
+      n8n_execution_id: string | null
+    }>
+    approvals: Array<{
+      id: string
+      requested_action: string
+      workflow_key: string
+      risk: string
+      status: string
+      created_at: string
+    }>
+    workflows: Array<{
+      key: string
+      name: string
+      enabled: boolean
+      mode: string
+      schedule: string | null
+      n8n_workflow_id: string | null
+      route_default: string
+    }>
+  }
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return 'unknown'
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return iso
+  const diff = (Date.now() - t) / 1000
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+async function fetchAgentOs(): Promise<AgentOsResponse> {
+  const res = await fetch('/api/agent-os/')
+  if (!res.ok) throw new Error(`Failed to load Agent OS (${res.status})`)
+  return res.json()
+}
+
+function StatCard({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+      <div className="text-xs uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-zinc-100">{value}</div>
+      {hint && <div className="mt-1 text-xs text-zinc-500">{hint}</div>}
+    </div>
+  )
+}
+
+function Chip({ children, tone }: { children: React.ReactNode; tone?: string }) {
+  return <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${tone ?? 'border-zinc-700 bg-zinc-900 text-zinc-300'}`}>{children}</span>
+}
+
+export function AgentOsScreen() {
+  const query = useQuery({
+    queryKey: ['agent-os'],
+    queryFn: fetchAgentOs,
+    refetchInterval: 15_000,
+  })
+
+  const data = query.data?.dashboard
+
+  const grouped = useMemo(() => {
+    const tasks = data?.recent_tasks ?? []
+    return {
+      running: tasks.filter((task) => ['running', 'retrying', 'routed'].includes(task.status)),
+      queued: tasks.filter((task) => task.status === 'queued'),
+      failed: tasks.filter((task) => task.status === 'failed'),
+    }
+  }, [data])
+
+  if (query.isLoading) {
+    return <div className="p-6 text-zinc-400">Loading Agent OS…</div>
+  }
+
+  if (query.error || !data) {
+    return <div className="p-6 text-red-300">{query.error instanceof Error ? query.error.message : 'Failed to load Agent OS'}</div>
+  }
+
+  return (
+    <div className="min-h-full bg-surface text-ink">
+      <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="rounded-2xl border border-zinc-800 bg-zinc-950/60 p-5">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-semibold text-zinc-100">Agent OS</h1>
+              <p className="mt-1 text-sm text-zinc-400">Central queue, orchestration registry, execution logs, approvals, and workflow status.</p>
+            </div>
+            <Chip tone="border-emerald-500/40 bg-emerald-500/10 text-emerald-300">n8n-first orchestration</Chip>
+          </div>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard label="Active jobs" value={data.counts.active_jobs} />
+          <StatCard label="Queued jobs" value={data.counts.queued_jobs} />
+          <StatCard label="Failed jobs" value={data.counts.failed_jobs} />
+          <StatCard label="Awaiting approval" value={data.counts.awaiting_approval} />
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="text-sm font-semibold text-zinc-100">Last execution</h2>
+            {data.last_execution ? (
+              <div className="mt-3 text-sm text-zinc-300">
+                <div>{data.last_execution.workflow_key}</div>
+                <div className="mt-1 text-zinc-400">{data.last_execution.message}</div>
+                <div className="mt-2 text-xs text-zinc-500">{timeAgo(data.last_execution.created_at)}</div>
+              </div>
+            ) : (
+              <div className="mt-3 text-sm text-zinc-500">No executions yet.</div>
+            )}
+          </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h2 className="text-sm font-semibold text-zinc-100">Next execution</h2>
+            {data.next_execution ? (
+              <div className="mt-3 text-sm text-zinc-300">
+                <div>{data.next_execution.title}</div>
+                <div className="mt-1 text-zinc-400">{data.next_execution.workflow_name}</div>
+                <div className="mt-2 text-xs text-zinc-500">{data.next_execution.next_run_at ?? 'not scheduled yet'}</div>
+              </div>
+            ) : (
+              <div className="mt-3 text-sm text-zinc-500">No scheduled executions yet.</div>
+            )}
+          </div>
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-3">
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 xl:col-span-2">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-zinc-100">Recent tasks</h2>
+              <div className="text-xs text-zinc-500">Latest 20</div>
+            </div>
+            <div className="space-y-2">
+              {data.recent_tasks.map((task) => (
+                <div key={task.id} className="rounded border border-zinc-800 bg-zinc-950/60 p-3 text-sm">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-zinc-100">{task.title}</div>
+                      <div className="mt-0.5 text-xs text-zinc-500">{task.workflow_name}</div>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs">
+                      <Chip>{task.status}</Chip>
+                      <Chip>{task.route}</Chip>
+                      <Chip>{task.priority}</Chip>
+                    </div>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between text-xs text-zinc-500">
+                    <span>{timeAgo(task.updated_at)}</span>
+                    <span>{task.n8n_execution_id ? `n8n exec ${task.n8n_execution_id}` : 'no n8n execution yet'}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+              <h2 className="text-sm font-semibold text-zinc-100">Approval queue</h2>
+              <div className="mt-3 space-y-2">
+                {data.approvals.length ? data.approvals.map((approval) => (
+                  <div key={approval.id} className="rounded border border-red-500/30 bg-red-500/5 p-3 text-sm">
+                    <div className="font-medium text-zinc-100">{approval.requested_action}</div>
+                    <div className="mt-1 text-xs text-zinc-400">{approval.workflow_key}</div>
+                    <div className="mt-2 flex items-center justify-between text-xs">
+                      <Chip tone="border-red-500/40 bg-red-500/10 text-red-300">{approval.risk}</Chip>
+                      <span className="text-zinc-500">{timeAgo(approval.created_at)}</span>
+                    </div>
+                  </div>
+                )) : <div className="text-sm text-zinc-500">No pending approvals.</div>}
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+              <h2 className="text-sm font-semibold text-zinc-100">Workflow registry</h2>
+              <div className="mt-3 space-y-2">
+                {data.workflows.map((workflow) => (
+                  <div key={workflow.key} className="rounded border border-zinc-800 bg-zinc-950/60 p-3 text-sm">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="font-medium text-zinc-100">{workflow.name}</div>
+                      <Chip>{workflow.enabled ? 'enabled' : 'disabled'}</Chip>
+                    </div>
+                    <div className="mt-1 text-xs text-zinc-500">{workflow.key}</div>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                      <Chip>{workflow.mode}</Chip>
+                      <Chip>{workflow.route_default}</Chip>
+                      <Chip>{workflow.schedule ?? 'manual'}</Chip>
+                    </div>
+                    <div className="mt-2 text-xs text-zinc-500">{workflow.n8n_workflow_id ? `n8n workflow ${workflow.n8n_workflow_id}` : 'not bound to n8n yet'}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">Running / active</h3>
+            <div className="mt-3 text-sm text-zinc-400">{grouped.running.length} task(s)</div>
+          </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">Queued</h3>
+            <div className="mt-3 text-sm text-zinc-400">{grouped.queued.length} task(s)</div>
+          </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">Failed</h3>
+            <div className="mt-3 text-sm text-zinc-400">{grouped.failed.length} task(s)</div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -761,6 +761,7 @@ function ChatSidebarComponent({
   }
 
   const isDashboardActive = pathname === '/dashboard'
+  const isAgentOsActive = pathname === '/agent-os'
 
   const mainItems: Array<NavItemDef> = [
     {
@@ -818,6 +819,13 @@ function ChatSidebarComponent({
       icon: UserMultipleIcon,
       label: 'Operations',
       active: isOperationsActive,
+    },
+    {
+      kind: 'link',
+      to: '/agent-os',
+      icon: Rocket01Icon,
+      label: 'Agent OS',
+      active: isAgentOsActive,
     },
     {
       kind: 'link',

--- a/src/server/agent-os/README.md
+++ b/src/server/agent-os/README.md
@@ -1,0 +1,47 @@
+# Agent OS
+
+This folder contains the centralized agent operating system scaffolding for Hermes.
+
+## Current components
+
+- `store.ts`
+  - persistent queue, workflow registry, execution logs, approval store
+- `router.ts`
+  - default workflow routing and queue state transitions
+- API routes under `src/routes/api/agent-os/`
+  - create/list tasks
+  - workflow registry
+  - approval decisions
+  - dispatch queue
+  - task status updates
+  - local n8n env health summary
+
+## Current routing defaults
+
+- n8n:
+  - morning-briefing
+  - calendar-scan-meeting-prep
+  - inbox-triage
+  - shopify-monitoring
+- Hermes:
+  - job-pipeline
+  - rootly-prospect-research
+- OpenClaw:
+  - airbnb-host-automation
+
+## Intended execution contract
+
+1. A task is created against a workflow key.
+2. If sensitive, it pauses in `awaiting_approval`.
+3. Otherwise it is auto-routed.
+4. Dispatchers claim queued/routed tasks and mark them `running`.
+5. Executors attach n8n execution IDs or agent run metadata.
+6. Executors mark tasks `completed`, `failed`, or `retrying`.
+7. Dashboard surfaces live counts and recent activity.
+
+## Next steps
+
+- Bind real n8n workflow IDs once API connection is fully restored.
+- Add an execution poller that syncs n8n execution states back into Agent OS tasks.
+- Emit failure notifications to the preferred channel.
+- Add actual approval action forwarding for sensitive external operations.

--- a/src/server/agent-os/notifications.ts
+++ b/src/server/agent-os/notifications.ts
@@ -1,0 +1,28 @@
+export interface AgentOsFailureNotificationInput {
+  taskId: string
+  title: string
+  workflowKey: string
+  error: string
+  route: string
+}
+
+export async function notifyAgentOsFailure(input: AgentOsFailureNotificationInput): Promise<void> {
+  try {
+    await fetch('http://127.0.0.1:8787/api/hermes-push', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: `Agent OS failure: ${input.title} (${input.workflowKey}) on ${input.route}. ${input.error}`,
+        priority: 'high',
+        metadata: {
+          scope: 'agent-os',
+          kind: 'failure',
+          taskId: input.taskId,
+          workflowKey: input.workflowKey,
+        },
+      }),
+    })
+  } catch {
+    // best effort only
+  }
+}

--- a/src/server/agent-os/router.ts
+++ b/src/server/agent-os/router.ts
@@ -1,0 +1,70 @@
+import { createAgentOsTask, listAgentOsTasks, routeTask, updateTaskStatus } from './store'
+import { notifyAgentOsFailure } from './notifications'
+
+export function determineRouteForWorkflow(workflowKey: string): 'n8n' | 'hermes' | 'openclaw' | 'manual' {
+  switch (workflowKey) {
+    case 'morning-briefing':
+    case 'calendar-scan-meeting-prep':
+    case 'inbox-triage':
+    case 'shopify-monitoring':
+      return 'n8n'
+    case 'job-pipeline':
+    case 'rootly-prospect-research':
+      return 'hermes'
+    case 'airbnb-host-automation':
+      return 'openclaw'
+    default:
+      return 'manual'
+  }
+}
+
+export function enqueueWorkflowTask(input: {
+  title: string
+  workflow_key: string
+  description?: string
+  payload?: Record<string, unknown>
+  project?: string | null
+  priority?: 'critical' | 'high' | 'medium' | 'low'
+  created_by?: string
+}) {
+  const task = createAgentOsTask(input)
+  if (task.status === 'awaiting_approval') return task
+  const route = determineRouteForWorkflow(task.workflow_key)
+  routeTask(task.id, route, { auto: true, reason: 'workflow default router' })
+  return task
+}
+
+export function claimQueuedTask(taskId: string) {
+  const task = listAgentOsTasks().find((row) => row.id === taskId)
+  if (!task) return null
+  if (!['queued', 'routed', 'retrying'].includes(task.status)) return task
+  return updateTaskStatus(task.id, 'running', 'Task execution started.', { route: task.route })
+}
+
+export async function failTask(taskId: string, error: string, willRetry = false) {
+  const task = listAgentOsTasks().find((row) => row.id === taskId)
+  const updated = updateTaskStatus(
+    taskId,
+    willRetry ? 'retrying' : 'failed',
+    willRetry ? 'Task failed and scheduled for retry.' : 'Task failed.',
+    { error },
+  )
+  if (updated && !willRetry && task) {
+    await notifyAgentOsFailure({
+      taskId: task.id,
+      title: task.title,
+      workflowKey: task.workflow_key,
+      error,
+      route: task.route,
+    })
+  }
+  return updated
+}
+
+export function completeTask(taskId: string, message = 'Task completed successfully.') {
+  return updateTaskStatus(taskId, 'completed', message)
+}
+
+export function pendingDispatchQueue() {
+  return listAgentOsTasks().filter((task) => ['queued', 'routed', 'retrying'].includes(task.status))
+}

--- a/src/server/agent-os/store.ts
+++ b/src/server/agent-os/store.ts
@@ -1,0 +1,445 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+export type AgentOsTaskStatus = 'queued' | 'routed' | 'running' | 'retrying' | 'blocked' | 'failed' | 'completed' | 'awaiting_approval'
+export type AgentOsPriority = 'critical' | 'high' | 'medium' | 'low'
+export type AgentOsWorkflowMode = 'n8n' | 'hybrid' | 'agent'
+export type AgentOsRisk = 'low' | 'medium' | 'high' | 'critical'
+
+export interface AgentOsTask {
+  id: string
+  title: string
+  description: string
+  workflow_key: string
+  workflow_name: string
+  project: string | null
+  payload: Record<string, unknown>
+  status: AgentOsTaskStatus
+  priority: AgentOsPriority
+  route: 'n8n' | 'hermes' | 'openclaw' | 'manual'
+  retry_count: number
+  max_retries: number
+  last_error: string | null
+  sensitive: boolean
+  approval_id: string | null
+  queued_at: string
+  started_at: string | null
+  completed_at: string | null
+  next_run_at: string | null
+  n8n_workflow_id: string | null
+  n8n_execution_id: string | null
+  created_by: string
+  updated_at: string
+}
+
+export interface WorkflowRegistryEntry {
+  key: string
+  name: string
+  description: string
+  mode: AgentOsWorkflowMode
+  enabled: boolean
+  route_default: 'n8n' | 'hermes' | 'openclaw' | 'manual'
+  sensitive: boolean
+  risk: AgentOsRisk
+  n8n_workflow_id: string | null
+  schedule: string | null
+  tags: string[]
+  owners: string[]
+  created_at: string
+  updated_at: string
+}
+
+export interface ExecutionLogEntry {
+  id: string
+  task_id: string
+  workflow_key: string
+  event: 'queued' | 'routed' | 'started' | 'heartbeat' | 'retrying' | 'approval_requested' | 'approval_resolved' | 'failed' | 'completed'
+  status: AgentOsTaskStatus
+  message: string
+  meta: Record<string, unknown>
+  created_at: string
+}
+
+export interface ApprovalRequest {
+  id: string
+  task_id: string
+  workflow_key: string
+  requested_action: string
+  reason: string
+  risk: AgentOsRisk
+  status: 'pending' | 'approved' | 'denied'
+  created_at: string
+  decided_at: string | null
+  decided_by: string | null
+  note: string | null
+}
+
+interface AgentOsFile {
+  tasks: AgentOsTask[]
+  workflows: WorkflowRegistryEntry[]
+  executions: ExecutionLogEntry[]
+  approvals: ApprovalRequest[]
+}
+
+const HERMES_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
+const DATA_DIR = path.join(HERMES_HOME, 'agent-os')
+const STORE_FILE = path.join(DATA_DIR, 'store.json')
+
+const PRIORITY_WORKFLOWS: Array<Pick<WorkflowRegistryEntry, 'key' | 'name' | 'description' | 'mode' | 'route_default' | 'sensitive' | 'risk' | 'schedule' | 'tags' | 'owners'>> = [
+  {
+    key: 'morning-briefing',
+    name: 'Morning Briefing',
+    description: 'Assemble and deliver the 8am daily briefing across active operating domains.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: '0 8 * * * America/Los_Angeles',
+    tags: ['briefing', 'daily', 'priority'],
+    owners: ['hermes', 'n8n'],
+  },
+  {
+    key: 'calendar-scan-meeting-prep',
+    name: 'Calendar Scan + Meeting Prep',
+    description: 'Scan calendar, identify upcoming events, and create prep artifacts or blocks.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: '*/30 * * * * America/Los_Angeles',
+    tags: ['calendar', 'meeting-prep'],
+    owners: ['hermes', 'n8n'],
+  },
+  {
+    key: 'inbox-triage',
+    name: 'Inbox Triage',
+    description: 'Fetch new messages, triage by rules, and escalate or summarize important items.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: '*/20 * * * * America/Los_Angeles',
+    tags: ['gmail', 'triage'],
+    owners: ['hermes', 'n8n'],
+  },
+  {
+    key: 'job-pipeline',
+    name: 'Job Pipeline',
+    description: 'Aggregate jobs, enrich, score, queue, and hand off browser-heavy apply steps.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: '0 */2 * * * America/Los_Angeles',
+    tags: ['jobs', 'pipeline'],
+    owners: ['hermes', 'openclaw', 'n8n'],
+  },
+  {
+    key: 'airbnb-host-automation',
+    name: 'Airbnb Host Automation',
+    description: 'Manage bookings, calendar handoffs, guest messages, and co-host coordination.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: true,
+    risk: 'high',
+    schedule: 'webhook-or-poll',
+    tags: ['airbnb', 'hosting'],
+    owners: ['hermes', 'openclaw', 'n8n'],
+  },
+  {
+    key: 'shopify-monitoring',
+    name: 'Shopify Monitoring',
+    description: 'Monitor store health, checkout, anomalies, and send threshold-based alerts.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: '*/30 * * * * America/Los_Angeles',
+    tags: ['shopify', 'monitoring'],
+    owners: ['hermes', 'n8n'],
+  },
+  {
+    key: 'rootly-prospect-research',
+    name: 'Rootly Prospect Research',
+    description: 'Gather prospect context, enrich with research, and prepare output packets.',
+    mode: 'hybrid',
+    route_default: 'n8n',
+    sensitive: false,
+    risk: 'medium',
+    schedule: null,
+    tags: ['rootly', 'research'],
+    owners: ['hermes', 'openclaw', 'n8n'],
+  },
+]
+
+function ensureStore(): void {
+  fs.mkdirSync(DATA_DIR, { recursive: true })
+  if (!fs.existsSync(STORE_FILE)) {
+    const now = new Date().toISOString()
+    const workflows: WorkflowRegistryEntry[] = PRIORITY_WORKFLOWS.map((wf) => ({
+      ...wf,
+      enabled: true,
+      n8n_workflow_id: null,
+      created_at: now,
+      updated_at: now,
+    }))
+    const initial: AgentOsFile = { tasks: [], workflows, executions: [], approvals: [] }
+    fs.writeFileSync(STORE_FILE, JSON.stringify(initial, null, 2) + '\n', 'utf-8')
+  }
+}
+
+function readStore(): AgentOsFile {
+  ensureStore()
+  try {
+    return JSON.parse(fs.readFileSync(STORE_FILE, 'utf-8')) as AgentOsFile
+  } catch {
+    ensureStore()
+    return JSON.parse(fs.readFileSync(STORE_FILE, 'utf-8')) as AgentOsFile
+  }
+}
+
+function writeStore(data: AgentOsFile): void {
+  ensureStore()
+  fs.writeFileSync(STORE_FILE, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+}
+
+function logEvent(store: AgentOsFile, entry: Omit<ExecutionLogEntry, 'id' | 'created_at'>): ExecutionLogEntry {
+  const row: ExecutionLogEntry = {
+    id: randomUUID(),
+    created_at: new Date().toISOString(),
+    ...entry,
+  }
+  store.executions.push(row)
+  return row
+}
+
+export function listAgentOsTasks(): AgentOsTask[] {
+  return readStore().tasks.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+}
+
+export function listWorkflowRegistry(): WorkflowRegistryEntry[] {
+  return readStore().workflows.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function listExecutionLogs(limit = 200): ExecutionLogEntry[] {
+  return readStore().executions.sort((a, b) => b.created_at.localeCompare(a.created_at)).slice(0, limit)
+}
+
+export function listApprovals(): ApprovalRequest[] {
+  return readStore().approvals.sort((a, b) => b.created_at.localeCompare(a.created_at))
+}
+
+export function getWorkflow(key: string): WorkflowRegistryEntry | null {
+  return readStore().workflows.find((w) => w.key === key) ?? null
+}
+
+export function createAgentOsTask(input: {
+  title: string
+  description?: string
+  workflow_key: string
+  project?: string | null
+  payload?: Record<string, unknown>
+  priority?: AgentOsPriority
+  created_by?: string
+}): AgentOsTask {
+  const store = readStore()
+  const workflow = store.workflows.find((w) => w.key === input.workflow_key)
+  if (!workflow) throw new Error(`Unknown workflow: ${input.workflow_key}`)
+  const now = new Date().toISOString()
+  const sensitive = workflow.sensitive
+  const status: AgentOsTaskStatus = sensitive ? 'awaiting_approval' : 'queued'
+  const route = workflow.route_default
+  const approvalId = sensitive ? randomUUID() : null
+  const task: AgentOsTask = {
+    id: randomUUID(),
+    title: input.title,
+    description: input.description ?? '',
+    workflow_key: workflow.key,
+    workflow_name: workflow.name,
+    project: input.project ?? null,
+    payload: input.payload ?? {},
+    status,
+    priority: input.priority ?? 'medium',
+    route,
+    retry_count: 0,
+    max_retries: 3,
+    last_error: null,
+    sensitive,
+    approval_id: approvalId,
+    queued_at: now,
+    started_at: null,
+    completed_at: null,
+    next_run_at: null,
+    n8n_workflow_id: workflow.n8n_workflow_id,
+    n8n_execution_id: null,
+    created_by: input.created_by ?? 'user',
+    updated_at: now,
+  }
+  store.tasks.push(task)
+  logEvent(store, {
+    task_id: task.id,
+    workflow_key: task.workflow_key,
+    event: 'queued',
+    status: task.status,
+    message: sensitive ? 'Task queued and awaiting approval.' : 'Task queued.',
+    meta: { route: task.route, priority: task.priority },
+  })
+  if (sensitive && approvalId) {
+    store.approvals.push({
+      id: approvalId,
+      task_id: task.id,
+      workflow_key: task.workflow_key,
+      requested_action: task.title,
+      reason: `Workflow ${workflow.name} is marked sensitive and requires approval before execution.`,
+      risk: workflow.risk,
+      status: 'pending',
+      created_at: now,
+      decided_at: null,
+      decided_by: null,
+      note: null,
+    })
+    logEvent(store, {
+      task_id: task.id,
+      workflow_key: task.workflow_key,
+      event: 'approval_requested',
+      status: 'awaiting_approval',
+      message: 'Approval requested for sensitive task.',
+      meta: { approval_id: approvalId },
+    })
+  }
+  writeStore(store)
+  return task
+}
+
+export function updateTaskStatus(taskId: string, status: AgentOsTaskStatus, message: string, meta: Record<string, unknown> = {}): AgentOsTask | null {
+  const store = readStore()
+  const task = store.tasks.find((t) => t.id === taskId)
+  if (!task) return null
+  task.status = status
+  task.updated_at = new Date().toISOString()
+  if (status === 'running' && !task.started_at) task.started_at = task.updated_at
+  if (status === 'completed' || status === 'failed' || status === 'blocked') task.completed_at = task.updated_at
+  logEvent(store, {
+    task_id: task.id,
+    workflow_key: task.workflow_key,
+    event: status === 'completed' ? 'completed' : status === 'failed' ? 'failed' : status === 'retrying' ? 'retrying' : status === 'running' ? 'started' : 'routed',
+    status,
+    message,
+    meta,
+  })
+  writeStore(store)
+  return task
+}
+
+export function routeTask(taskId: string, route: AgentOsTask['route'], meta: Record<string, unknown> = {}): AgentOsTask | null {
+  const store = readStore()
+  const task = store.tasks.find((t) => t.id === taskId)
+  if (!task) return null
+  task.route = route
+  task.status = 'routed'
+  task.updated_at = new Date().toISOString()
+  logEvent(store, {
+    task_id: task.id,
+    workflow_key: task.workflow_key,
+    event: 'routed',
+    status: 'routed',
+    message: `Task routed to ${route}.`,
+    meta,
+  })
+  writeStore(store)
+  return task
+}
+
+export function attachN8nExecution(taskId: string, executionId: string, workflowId?: string | null): AgentOsTask | null {
+  const store = readStore()
+  const task = store.tasks.find((t) => t.id === taskId)
+  if (!task) return null
+  task.n8n_execution_id = executionId
+  if (workflowId) task.n8n_workflow_id = workflowId
+  task.updated_at = new Date().toISOString()
+  writeStore(store)
+  return task
+}
+
+export function decideApproval(approvalId: string, decision: 'approved' | 'denied', decidedBy: string, note?: string | null): ApprovalRequest | null {
+  const store = readStore()
+  const approval = store.approvals.find((a) => a.id === approvalId)
+  if (!approval) return null
+  approval.status = decision
+  approval.decided_at = new Date().toISOString()
+  approval.decided_by = decidedBy
+  approval.note = note ?? null
+  const task = store.tasks.find((t) => t.id === approval.task_id)
+  if (task) {
+    task.status = decision === 'approved' ? 'queued' : 'blocked'
+    task.updated_at = new Date().toISOString()
+    logEvent(store, {
+      task_id: task.id,
+      workflow_key: task.workflow_key,
+      event: 'approval_resolved',
+      status: task.status,
+      message: decision === 'approved' ? 'Approval granted, task returned to queue.' : 'Approval denied, task blocked.',
+      meta: { approval_id: approvalId, decided_by: decidedBy, note: note ?? null },
+    })
+  }
+  writeStore(store)
+  return approval
+}
+
+export function upsertWorkflow(entry: Partial<WorkflowRegistryEntry> & Pick<WorkflowRegistryEntry, 'key' | 'name'>): WorkflowRegistryEntry {
+  const store = readStore()
+  const now = new Date().toISOString()
+  const existing = store.workflows.find((w) => w.key === entry.key)
+  if (existing) {
+    Object.assign(existing, { ...entry, updated_at: now })
+    writeStore(store)
+    return existing
+  }
+  const created: WorkflowRegistryEntry = {
+    key: entry.key,
+    name: entry.name,
+    description: entry.description ?? '',
+    mode: entry.mode ?? 'n8n',
+    enabled: entry.enabled ?? true,
+    route_default: entry.route_default ?? 'n8n',
+    sensitive: entry.sensitive ?? false,
+    risk: entry.risk ?? 'medium',
+    n8n_workflow_id: entry.n8n_workflow_id ?? null,
+    schedule: entry.schedule ?? null,
+    tags: entry.tags ?? [],
+    owners: entry.owners ?? [],
+    created_at: now,
+    updated_at: now,
+  }
+  store.workflows.push(created)
+  writeStore(store)
+  return created
+}
+
+export function agentOsDashboard() {
+  const store = readStore()
+  const tasks = store.tasks
+  const counts = {
+    active_jobs: tasks.filter((t) => ['running', 'retrying', 'routed'].includes(t.status)).length,
+    queued_jobs: tasks.filter((t) => t.status === 'queued').length,
+    failed_jobs: tasks.filter((t) => t.status === 'failed').length,
+    awaiting_approval: tasks.filter((t) => t.status === 'awaiting_approval').length,
+  }
+  const sortedLogs = [...store.executions].sort((a, b) => b.created_at.localeCompare(a.created_at))
+  const lastExecution = sortedLogs[0] ?? null
+  const nextExecution = [...tasks]
+    .filter((t) => t.next_run_at)
+    .sort((a, b) => (a.next_run_at ?? '').localeCompare(b.next_run_at ?? ''))[0] ?? null
+  return {
+    counts,
+    last_execution: lastExecution,
+    next_execution: nextExecution,
+    workflows: store.workflows,
+    recent_tasks: [...tasks].sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, 20),
+    approvals: store.approvals.filter((a) => a.status === 'pending'),
+  }
+}
+
+export const AGENT_OS_PATHS = { DATA_DIR, STORE_FILE }


### PR DESCRIPTION
Hands Hermes a skill to place a FaceTime Audio call whose audio actually works, bridging to the openclaw dual-route local dialer. Verified live 2026-06-30: caller heard the agent deliver a spoken message end-to-end.

## What's here
- `skills/openclaw-dual-dial/SKILL.md` — verified recipe + the gotchas that silence the call:
  - dial a DIFFERENT phone than the Mac's tethered Continuity iPhone (self-loop = silent)
  - FaceTime mic must be BlackHole 2ch / output BlackHole 16ch (menu-occurrence trap)
  - reset a wedged CoreAudio (`-9986`) with `sudo killall coreaudiod`
  - no rapid back-to-back calls (wedges FaceTime/CoreAudio — pre-panic pattern)
- `scripts/hermes-openclaw-dial` — wrapper; now forwards greet/repeat knobs (`--greet-after`/`--repeats`/`--interval`, defaults 10/4/15) so a late answer still hears the opening line. Dry-run by default; `--live` to dial.

The underlying audio fix (dual-route mic/output occurrence, FaceTime health-check, PortAudio -9986 retry, device pinner) lives in the openclaw-phone-voice repo, which this wrapper calls.

## Note
This branch also carries a pre-existing "Hermes Agent OS scaffold" commit that was already on it — not part of tonight's skill work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)