### PR TITLE
fix(theme): declare color tokens in @theme so primary/accent/ink/surface utilities exist

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,48 @@
 /* Tailwind v4 — enable dark: variant on .dark class (set by __root.tsx) */
 @variant dark (&:where(.dark, .dark *));
 
+/* ── Custom color tokens ───────────────────────────────────────────────
+   Tailwind v4 only generates utilities (bg-surface, text-ink,
+   bg-primary-900, bg-accent-500, …) for colors declared in @theme.
+   Without this block, every primary/accent/ink/surface class in the app
+   compiles to no CSS at all: the per-theme remap blocks further down
+   ("Maps bg-primary-50 … so ALL existing Tailwind classes work") set
+   variables that no generated rule ever consumed. Values here are
+   fallbacks — the [data-theme=…] remaps and the .system dark block
+   override them at runtime exactly as originally intended. */
+@theme {
+  --color-surface: var(--theme-bg, oklch(0.11 0.005 80));
+  --color-surface-deep: var(--theme-bg, oklch(0.08 0.005 80));
+  --color-ink: var(--theme-text, oklch(0.95 0.002 80));
+
+  --color-primary-50: var(--theme-panel, oklch(0.14 0.005 80));
+  --color-primary-100: var(--theme-card, oklch(0.18 0.005 80));
+  --color-primary-200: var(--theme-border, oklch(0.26 0.006 80));
+  --color-primary-300: var(--theme-border-subtle, oklch(0.34 0.006 80));
+  --color-primary-400: var(--theme-muted, oklch(0.44 0.006 80));
+  --color-primary-500: var(--theme-muted, oklch(0.55 0.006 80));
+  --color-primary-600: var(--theme-muted, oklch(0.68 0.006 80));
+  --color-primary-700: var(--theme-text, oklch(0.76 0.005 80));
+  --color-primary-800: var(--theme-text, oklch(0.84 0.004 80));
+  --color-primary-900: var(--theme-text, oklch(0.9 0.003 80));
+  --color-primary-950: var(--theme-text, oklch(0.95 0.002 80));
+
+  /* Accent ramp follows Tailwind's 50=lightest → 950=darkest convention,
+     derived from the live theme accent; 400/500/600 defer to the theme
+     vars the remap blocks target. */
+  --color-accent-50: color-mix(in srgb, var(--theme-accent, #8a8f98) 10%, white);
+  --color-accent-100: color-mix(in srgb, var(--theme-accent, #8a8f98) 20%, white);
+  --color-accent-200: color-mix(in srgb, var(--theme-accent, #8a8f98) 35%, white);
+  --color-accent-300: color-mix(in srgb, var(--theme-accent, #8a8f98) 55%, white);
+  --color-accent-400: var(--theme-accent-secondary, var(--theme-accent, #8a8f98));
+  --color-accent-500: var(--theme-accent, #8a8f98);
+  --color-accent-600: var(--theme-accent, #8a8f98);
+  --color-accent-700: color-mix(in srgb, var(--theme-accent, #8a8f98) 70%, black);
+  --color-accent-800: color-mix(in srgb, var(--theme-accent, #8a8f98) 55%, black);
+  --color-accent-900: color-mix(in srgb, var(--theme-accent, #8a8f98) 40%, black);
+  --color-accent-950: color-mix(in srgb, var(--theme-accent, #8a8f98) 25%, black);
+}
+
 :root {
   --tabbar-h: 80px;
   /* Chat content max-width — controlled by Settings > Chat Display (see #89).


### PR DESCRIPTION
## Problem

Tailwind v4 only generates utilities for colors declared in `@theme`, and `src/styles.css` has no `@theme` block — so every custom-color class the app uses (`bg-primary-*`, `bg-accent-*`, `text-ink`, `bg-surface`; 200+ usages across the codebase) currently compiles to **no CSS at all**.

The per-theme remap blocks (whose comment says "Maps bg-primary-50 … so ALL existing Tailwind classes work") set CSS variables that no generated rule ever consumes. Easy to verify on `main`:

```bash
npx vite build
grep -o '\.bg-accent-500\|\.bg-surface\|\.bg-primary-900' dist/client/assets/styles-*.css
```

The only match is a hand-written selector (`.bg-accent-500 .text-white`) that *assumes* the utility exists. The tokens were presumably lost in the Tailwind v4 migration (v3 had them in `tailwind.config`).

## Fix

Declare the tokens in `@theme` with `var(--theme-*)` values, fallbacks taken from the existing `.system` dark block's oklch ramp:

- utilities generate (with opacity-modifier support)
- the existing `[data-theme]` remap blocks finally apply, per their original intent
- `accent-50..950` gets a Tailwind-convention ramp derived from the live `--theme-accent` via `color-mix`, with 400/500/600 deferring to the vars the remaps already target

## Verification

Same grep after the fix finds all utilities generated (`.bg-accent-500` + opacity variants, `.text-ink{color:var(--color-ink)}`, `.bg-primary-900` ×17, …). `vite build` passes.

We've been running the equivalent fix on our fork (heavier UI, 12 themes incl. light variants) — previously-dead styling comes online as designed (accent-filled primary buttons, tinted active tabs) with no layout breakage or light-theme washout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HfHZvXkAT3kAR5eAEEufv