### PR TITLE
fix(terminal): keep mobile input bar above the bottom tab bar

### DIFF
--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -392,7 +392,13 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
               className="flex flex-col"
               style={{
                 position: 'absolute',
-                inset: 0,
+                top: 0,
+                left: 0,
+                right: 0,
+                // inset:0 would extend through main's tab-bar padding (abspos resolves
+                // against the padding box), putting the mobile input bar behind the
+                // fixed tab bar. --tabbar-h is live: 0px whenever the bar hides.
+                bottom: isMobile ? 'var(--tabbar-h, 80px)' : 0,
                 visibility: isOnTerminalRoute ? 'visible' : 'hidden',
                 pointerEvents: isOnTerminalRoute ? 'auto' : 'none',
                 zIndex: isOnTerminalRoute ? 1 : -1,


### PR DESCRIPTION
## Problem

On mobile, the terminal's input bar renders underneath the fixed bottom tab bar, making it hard or impossible to use.

Root cause: `<main>` reserves tab-bar space with `pb-[calc(var(--tabbar-h,80px)+0.5rem)]`, but the persistent terminal container inside it is `position: absolute; inset: 0` — and absolute positioning resolves against the **padding box**, so the container extends straight through that reserved padding. `MobileTerminalInput`, as the container's last flex child, lands exactly under the z-80 tab bar.

## Fix

The container's `bottom` becomes `var(--tabbar-h, 80px)` on mobile (desktop keeps `bottom: 0`). Since `MobileTabBar` maintains `--tabbar-h` live — setting it to `0px` whenever the bar hides, e.g. while the keyboard is open — the input bar automatically drops flush to the bottom in that case.

## Verification

On our fork (identical shell structure): measured at 375×812, the input bar's bottom edge moves from overlapping the tab bar to 20px clear of its top (input bottom y=718 vs tab bar top y=738), and typing into the input works against a live session. Desktop terminal renders identically. tsc error count unchanged from baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HfHZvXkAT3kAR5eAEEufv