### PR TITLE
fix(files): hide duplicate mobile page title in empty-file state

### DIFF
--- a/src/routes/files.tsx
+++ b/src/routes/files.tsx
@@ -293,7 +293,7 @@ function FilesRoute() {
                 </>
               ) : (
                 <>
-                  <h1 className="text-base font-medium md:text-lg">Files</h1>
+                  <h1 className="hidden text-base font-medium md:block md:text-lg">Files</h1>
                   <p className="hidden text-sm text-primary-600 sm:block">
                     Click a file in the sidebar to load it into the editor.
                   </p>


### PR DESCRIPTION
## Problem

On mobile, `/files` shows "Files" twice stacked: the shell's `MobilePageHeader` title, and directly beneath it the route's own empty-state `<h1>Files</h1>`. Duplicated title, wasted vertical space on the smallest viewport.

## Fix

One line: the empty-state `<h1>` is hidden below `md`, using the same breakpoint `MobilePageHeader` itself uses (`md:hidden`), so the two headers swap in sync with no JS or hydration gap. The contextual filename heading shown once a file is open is untouched — it isn't a duplicate.

## Verification

On our fork: before/after screenshots at 375px show the duplicate gone with the toolbar and sidebar-toggle button fully functional; desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HfHZvXkAT3kAR5eAEEufv