### PR TITLE
perf(bundle): lazy-load ChatPanel — eager entry chunk −40%

### DIFF
--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -29,7 +29,13 @@ import { useChatSessions } from '@/screens/chat/hooks/use-chat-sessions'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { SIDEBAR_TOGGLE_EVENT } from '@/hooks/use-global-shortcuts'
 import { useSwipeNavigation } from '@/hooks/use-swipe-navigation'
-import { ChatPanel } from '@/components/chat-panel'
+// Lazy: ChatPanel statically imports ChatScreen and with it the chat
+// markdown pipeline; keeping it out of the eager entry means non-chat
+// routes stop paying for chat at first paint. The chat route itself
+// already lazy-loads ChatScreen through its own boundary.
+const ChatPanel = lazy(() =>
+  import('@/components/chat-panel').then((m) => ({ default: m.ChatPanel })),
+)
 import { ChatPanelToggle } from '@/components/chat-panel-toggle'
 import { LoginScreen } from '@/components/auth/login-screen'
 import { MobileTabBar } from '@/components/mobile-tab-bar'
@@ -435,7 +441,11 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
           </main>
 
           {/* Chat panel — visible on non-chat routes (but not in HermesWorld, which has its own in-game chat) */}
-          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && <ChatPanel />}
+          {!isOnChatRoute && !isOnPlaygroundRoute && !isChromeFreeSurface && !isMobile && (
+            <Suspense fallback={null}>
+              <ChatPanel />
+            </Suspense>
+          )}
         </div>
 
         {/* Floating chat toggle — visible on non-chat routes (but not in HermesWorld) */}


### PR DESCRIPTION
## Problem

The eager client entry (`main-*.js`) is **2,253 KB minified (683 KB gzip)** — downloaded and parsed on every route before first render.

Sourcemap analysis shows the largest avoidable contributor is the chat screen plus its markdown pipeline (react-markdown/micromark, `parse5` via rehype-raw, shiki core, marked). The chat *route* already lazy-loads `ChatScreen` through its own boundary — but `workspace-shell.tsx` statically imports `ChatPanel`, and `chat-panel.tsx` statically imports `ChatScreen`. That single static path forces all of it into the eager entry for every route, chat or not.

## Fix

One `lazy()` + `<Suspense fallback={null}>` boundary around `ChatPanel` in the shell — the same pattern the shell already uses for `TerminalWorkspace`. Desktop non-chat routes fetch the panel chunk in the background after first paint; the chat route is unaffected.

## Result

```
main-*.js  2,253.35 kB → 1,342.55 kB minified   (−40%)
gzip         683.15 kB →   413.32 kB on the wire
```

`tsc` error count unchanged from baseline. We run the same change on our fork (same shell architecture, heavier app) with live smoke tests: non-chat routes render, the chat route renders with a working composer, zero page errors.

Related fixes from the same review session: #673, #674, #675, #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HfHZvXkAT3kAR5eAEEufv