### PR TITLE
docs: add Hermes Tweet workspace context

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Start here: [docs/swarm/](./docs/swarm/)
 - 📱 **PWA + Tailscale** — Install as a native-feeling app; access from any device on your tailnet
 - ⚙️ **Capability gates** — Features that need upstream endpoints (Conductor) show a clean placeholder instead of failing mid-action
 
+## Companion X/Twitter Workspace
+
+For social monitoring missions, pair Hermes Workspace with
+[Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet). Hermes Tweet can
+collect X/Twitter account, post, or trend context inside Hermes, while Workspace
+keeps the related chat, files, memory, skills, terminal, dashboard, jobs, and
+swarm handoffs in one interface. Hermes Tweet is a third-party project
+maintained by Xquik-dev, not by this repository.
+
 ---
 
 ## 📸 Screenshots


### PR DESCRIPTION
## Summary

- Add a compact Companion X/Twitter Workspace section.
- Explain how Hermes Tweet monitoring context can pair with Workspace chat, files, memory, skills, terminal, dashboard, jobs, and swarm handoffs.
- Keep disclosure explicit that Hermes Tweet is third-party.

## Eligibility

- Target repo is an active Hermes Workspace project.
- License reviewed: MIT.
- Complete paginated PR duplicate check found no existing Hermes Tweet PR in this repository.

## Validation

- `git diff --check`
- Added-line safety scan for broken-link, secret, and forbidden-text patterns
