### PR TITLE
fix(workspace): make fetchDashboardToken resilient to dashboard 500

### DIFF
--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -173,6 +173,23 @@ describe('gateway-capabilities', () => {
       await expect(mod.fetchDashboardToken()).resolves.toBe('live-token')
       expect(fetchMock.mock.calls.some(([url]) => url === 'http://127.0.0.1:9119/')).toBe(true)
     })
+
+    it('returns an empty token instead of throwing when dashboard root fails', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await loadMod()
+
+      await expect(mod.fetchDashboardToken()).resolves.toBe('')
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[gateway] Dashboard index returned 500 — token unavailable',
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -287,19 +287,35 @@ export async function fetchDashboardToken(options?: {
   dashboardTokenPromise = (async () => {
     // Dashboard injects the session token inline on `/` (root), not on
     // `/index.html` which serves the raw Vite-built HTML without the token.
-    const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
-    if (!res.ok) {
-      throw new Error(`Dashboard index failed: ${res.status}`)
+    // When the dashboard requires auth (302 → /auth/login) or the login page
+    // is broken (500), return empty string so protected API calls degrade
+    // gracefully — the caller already handles 401/non-ok via safeJson.
+    try {
+      const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        console.warn(
+          `[gateway] Dashboard index returned ${res.status} — token unavailable`,
+        )
+        return ''
+      }
+      const html = await res.text()
+      const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
+      if (!token) {
+        console.warn(
+          '[gateway] Dashboard session token not found in root HTML',
+        )
+        return ''
+      }
+      dashboardTokenCache = token
+      return token
+    } catch (err) {
+      console.warn(
+        `[gateway] Failed to fetch dashboard token: ${err instanceof Error ? err.message : err}`,
+      )
+      return ''
     }
-    const html = await res.text()
-    const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
-    if (!token) {
-      throw new Error('Dashboard session token not found in root HTML')
-    }
-    dashboardTokenCache = token
-    return token
   })()
 
   try {


### PR DESCRIPTION
## Problem

When the Hermes Agent dashboard requires auth (302 → `/auth/login`) and the login page is broken (500), `fetchDashboardToken` throws `Dashboard index failed: 500`. This propagated to the dashboard overview page rendering a hard 500 error instead of gracefully degrading.

## Root Cause

`fetchDashboardToken` in `src/server/gateway-capabilities.ts` fetches the dashboard root URL to scrape the ephemeral session token. When dashboard auth is enabled (redirects `/` → `/auth/login`), and the login page itself returns 500, the token extraction fails with an unhandled throw.

## Fix

Instead of throwing on failure, return an empty string and log a `console.warn`. The callers (`dashboardFetch` → `safeJson`) already handle non-ok/401 responses gracefully by returning `null` per-section. This means the dashboard overview degrades to null sections instead of a hard 500 page.

## Re-application

A local patch is saved at `~/.hermes/patches/hermes-workspace-dashboard-token-500.patch` — can be re-applied with:

```sh
cd ~/hermes-workspace && git apply ~/.hermes/patches/hermes-workspace-dashboard-token-500.patch
```

This is useful after hermes-agent updates fix the underlying dashboard login 500.