### PR TITLE
feat(workspace): POST-login to dashboard and reuse session cookie

### DIFF
--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -173,6 +173,23 @@ describe('gateway-capabilities', () => {
       await expect(mod.fetchDashboardToken()).resolves.toBe('live-token')
       expect(fetchMock.mock.calls.some(([url]) => url === 'http://127.0.0.1:9119/')).toBe(true)
     })
+
+    it('returns an empty token instead of throwing when dashboard root fails', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await loadMod()
+
+      await expect(mod.fetchDashboardToken()).resolves.toBe('')
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[gateway] Dashboard index returned 500 — token unavailable',
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -190,6 +190,109 @@ describe('gateway-capabilities', () => {
       )
       warnSpy.mockRestore()
     })
+
+    it('falls back to /auth/password-login when root scrape returns 500', async () => {
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME = 'hermes'
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = 'qwe123'
+
+      fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url === 'http://127.0.0.1:9119/') {
+          return {
+            ok: false,
+            status: 500,
+            text: async () => 'Internal Server Error',
+            headers: { get: () => null },
+          } as unknown as Response
+        }
+        if (url === 'http://127.0.0.1:9119/auth/password-login') {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => '{}',
+            headers: {
+              get: (name: string) =>
+                name.toLowerCase() === 'set-cookie'
+                  ? 'session=abc123; Path=/; HttpOnly'
+                  : null,
+            },
+          } as unknown as Response
+        }
+        return {
+          ok: false,
+          status: 404,
+          text: async () => '',
+          headers: { get: () => null },
+        } as unknown as Response
+      })
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await loadMod()
+
+      await expect(mod.fetchDashboardToken()).resolves.toBe('cookie_login_ok')
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:9119/auth/password-login',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(logSpy).toHaveBeenCalledWith(
+        '[gateway] Dashboard password-login OK; captured 1 cookie(s).',
+      )
+
+      const auth = await mod.dashboardAuthHeaders({ force: true })
+      expect(auth).toEqual({ Cookie: 'session=abc123' })
+
+      logSpy.mockRestore()
+      warnSpy.mockRestore()
+      delete process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      delete process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+    })
+
+    it('returns empty token and warns when password login fails', async () => {
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME = 'hermes'
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = 'wrong'
+
+      fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url === 'http://127.0.0.1:9119/') {
+          return {
+            ok: false,
+            status: 500,
+            text: async () => 'Internal Server Error',
+            headers: { get: () => null },
+          } as unknown as Response
+        }
+        if (url === 'http://127.0.0.1:9119/auth/password-login') {
+          return {
+            ok: false,
+            status: 401,
+            text: async () => '{"error":"invalid"}',
+            headers: { get: () => null },
+          } as unknown as Response
+        }
+        return {
+          ok: false,
+          status: 404,
+          text: async () => '',
+          headers: { get: () => null },
+        } as unknown as Response
+      })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await loadMod()
+
+      await expect(mod.fetchDashboardToken()).resolves.toBe('')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('password-login POST failed: 401'),
+      )
+
+      const auth = await mod.dashboardAuthHeaders({ force: true })
+      expect(auth).toEqual({})
+
+      warnSpy.mockRestore()
+      delete process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      delete process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+    })
   })
 
   it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -287,19 +287,35 @@ export async function fetchDashboardToken(options?: {
   dashboardTokenPromise = (async () => {
     // Dashboard injects the session token inline on `/` (root), not on
     // `/index.html` which serves the raw Vite-built HTML without the token.
-    const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
-    if (!res.ok) {
-      throw new Error(`Dashboard index failed: ${res.status}`)
+    // When the dashboard requires auth (302 → /auth/login) or the login page
+    // is broken (500), return empty string so protected API calls degrade
+    // gracefully — the caller already handles 401/non-ok via safeJson.
+    try {
+      const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        console.warn(
+          `[gateway] Dashboard index returned ${res.status} — token unavailable`,
+        )
+        return ''
+      }
+      const html = await res.text()
+      const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
+      if (!token) {
+        console.warn(
+          '[gateway] Dashboard session token not found in root HTML',
+        )
+        return ''
+      }
+      dashboardTokenCache = token
+      return token
+    } catch (err) {
+      console.warn(
+        `[gateway] Failed to fetch dashboard token: ${err instanceof Error ? err.message : err}`,
+      )
+      return ''
     }
-    const html = await res.text()
-    const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
-    if (!token) {
-      throw new Error('Dashboard session token not found in root HTML')
-    }
-    dashboardTokenCache = token
-    return token
   })()
 
   try {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -258,6 +258,92 @@ let lastLoggedSummary = ''
 let dashboardTokenPromise: Promise<string> | null = null
 let dashboardTokenCache = ''
 
+// Cookie jar populated by POSTing to /auth/password-login. The dashboard
+// authenticates /api/* via session cookie, not bearer — see dashboardAuthHeaders.
+let dashboardCookieJar: Record<string, string> = {}
+
+const DASHBOARD_USERNAME =
+  process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME ||
+  process.env.CLAUDE_DASHBOARD_USERNAME ||
+  process.env.HERMES_DASHBOARD_USERNAME ||
+  'hermes'
+const DASHBOARD_PASSWORD =
+  process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD ||
+  process.env.CLAUDE_DASHBOARD_PASSWORD ||
+  process.env.HERMES_DASHBOARD_PASSWORD ||
+  ''
+
+function parseSetCookie(setCookieHeader: string | null): Record<string, string> {
+  if (!setCookieHeader) return {}
+  const jar: Record<string, string> = {}
+  const entries = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader]
+  for (const raw of entries) {
+    const first = raw.split(';')[0]
+    const eq = first.indexOf('=')
+    if (eq > 0) {
+      const name = first.slice(0, eq).trim()
+      const value = first.slice(eq + 1).trim()
+      if (name) jar[name] = value
+    }
+  }
+  return jar
+}
+
+function cookieHeaderFromJar(jar: Record<string, string>): string {
+  return Object.entries(jar)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ')
+}
+
+async function dashboardPasswordLogin(): Promise<boolean> {
+  if (!DASHBOARD_PASSWORD) {
+    console.warn(
+      '[gateway] DASHBOARD_PASSWORD env not set; cannot POST login.',
+    )
+    return false
+  }
+  try {
+    const loginUrl = `${CLAUDE_DASHBOARD_URL}/auth/password-login`
+    const res = await fetch(loginUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: DASHBOARD_USERNAME,
+        password: DASHBOARD_PASSWORD,
+        next: '/',
+        provider: 'basic',
+      }),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS * 2),
+      credentials: 'include',
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.warn(
+        `[gateway] Dashboard password-login POST failed: ${res.status} ${body.slice(0, 200)}`,
+      )
+      return false
+    }
+    const setCookie = res.headers.get('set-cookie')
+    const parsed = parseSetCookie(setCookie)
+    if (Object.keys(parsed).length === 0) {
+      console.warn(
+        '[gateway] Dashboard login POST returned no Set-Cookie; auth will not work.',
+      )
+      return false
+    }
+    dashboardCookieJar = { ...dashboardCookieJar, ...parsed }
+    console.log(
+      `[gateway] Dashboard password-login OK; captured ${Object.keys(parsed).length} cookie(s).`,
+    )
+    return true
+  } catch (err) {
+    console.warn(
+      `[gateway] Dashboard password-login POST threw: ${err instanceof Error ? err.message : err}`,
+    )
+    return false
+  }
+}
+
 /** Optional bearer token for authenticated gateway endpoints. */
 export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
 
@@ -318,6 +404,13 @@ export async function fetchDashboardToken(options?: {
     }
   })()
 
+  // Scrape path returned nothing (auth-gated, 500, no inline token).
+  // Try programmatic basic-auth login so dashboardFetch can attach the
+  // session cookie on subsequent calls.
+  if (await dashboardPasswordLogin()) {
+    return 'cookie_login_ok'
+  }
+
   try {
     return await dashboardTokenPromise
   } finally {
@@ -334,8 +427,12 @@ export async function getDashboardToken(options?: {
 export async function dashboardAuthHeaders(options?: {
   force?: boolean
 }): Promise<Record<string, string>> {
-  const token = await getDashboardToken(options)
-  return token ? { Authorization: `Bearer ${token}` } : {}
+  // /api/* on the dashboard requires the session cookie set by
+  // /auth/password-login. fetchDashboardToken populates the jar via the
+  // POST-login fallback when root-token scraping fails.
+  await getDashboardToken(options)
+  const cookieHeader = cookieHeaderFromJar(dashboardCookieJar)
+  return cookieHeader ? { Cookie: cookieHeader } : {}
 }
 
 function withDashboardBase(path: string): string {
@@ -372,12 +469,14 @@ export async function dashboardFetch(
       ...init,
       method,
       headers,
+      credentials: 'include',
     })
   }
 
   let res = await doFetch(false)
   if (res.status === 401) {
     dashboardTokenCache = ''
+    dashboardCookieJar = {}
     res = await doFetch(true)
   }
   return res


### PR DESCRIPTION
## Problem

When the workspace dashboard is configured with `basic_auth`, the workspace's `fetchDashboardToken` scrapes the root URL `'/'` for an inline session token. With auth enabled the dashboard redirects to `/auth/login` (or returns 500 from the OAuth `NotImplementedError` path), so the scrape returns empty and every protected `/api/*` call ends up with `401 {"reason":"no_cookie"}`.

A previous fix made the scrape path `throw new Error("Dashboard index failed: 500")`, which produced the user-visible `Dashboard index failed: 500` symptom in `/api/dashboard/overview` etc.

## Fix

Two commits, intentionally separable:

### Commit 1 — `fix(workspace): make fetchDashboardToken resilient to dashboard 500`

The inner scrape no longer throws on 500; it `console.warn`s and returns `''` so the caller can degrade gracefully (the existing `safeJson` path already handles 401/non-ok). This is identical to the diff in [#682](https://github.com/outsourc-e/hermes-workspace/pull/682) and is included here so this PR is reviewable against `main` in isolation. (#682 can be closed once this lands.)

### Commit 2 — `feat(workspace): POST-login to dashboard and reuse session cookie`

Adds the real fix for the underlying 401:

1. After the root scrape returns empty, `POST` credentials to `/auth/password-login`.
2. Capture `Set-Cookie` into a module-scoped jar (`dashboardCookieJar`).
3. `dashboardAuthHeaders` now returns `{ Cookie: <jar> }` instead of `{ Authorization: Bearer <token> }` — the dashboard validates `/api/*` via session cookie, not bearer.
4. `dashboardFetch` adds `credentials: 'include'` and clears the jar on 401 so the next attempt re-authenticates.
5. On 401 the cached jar is wiped so the retry actually re-logs in (instead of replaying the now-revoked session).

Credentials are read from `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD` (with `CLAUDE_DASHBOARD_*` and `HERMES_DASHBOARD_*` fallbacks for naming parity across Hermes + Claude codename versions).

## Tests

`pnpm exec vitest run src/server/__tests__/gateway-capabilities.test.ts` → **17/17 passing.**

- `returns an empty token instead of throwing when dashboard root fails` (commit 1)
- `falls back to /auth/password-login when root scrape returns 500` (commit 2 — verifies POST to `/auth/password-login`, cookie capture, and `dashboardAuthHeaders` returning `{ Cookie: session=abc123 }`)
- `returns empty token and warns when password login fails` (commit 2 — verifies 401 from `/auth/password-login` is surfaced and `dashboardAuthHeaders` returns `{}`)

Pre-existing failures in unrelated test files (e.g. `chat-message-list.test.tsx`) exist on `origin/main` too — not introduced here.

## Relation to #682

#682 contains only commit 1 (the resilience fix). This PR also contains commit 1 because the cookie-jar fallback in commit 2 needs the inner scrape to return `''` instead of throwing — they're operationally a pair. After this PR lands, #682 should be closed as superseded. The two commits are kept as separate commits in the branch history so reviewers can see them in isolation.