### PR TITLE
fix(workspace): force no-store Cache-Control on /api/* responses

### DIFF
--- a/server-entry.js
+++ b/server-entry.js
@@ -7,6 +7,38 @@ import server from './dist/server/server.js'
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const CLIENT_DIR = join(__dirname, 'dist', 'client')
 
+// Content Security Policy — emitted as an HTTP response header on EVERY
+// response so the policy survives any edge body transformations (e.g.
+// Cloudflare's JS Challenge inserting a `<meta http-equiv="Content-Security-Policy">`
+// with a per-request nonce into the served HTML when a request trips the
+// "impersonate browsers" rule).
+//
+// KEEP IN SYNC with `src/lib/csp.ts` (single source of truth) and
+// `src/routes/__root.tsx` APP_CSP (which emits the same policy as `<meta>`).
+// If you change the directives here, change them in all three places.
+const APP_CSP_HEADERS = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "connect-src 'self' ws: wss: http: https:",
+  "worker-src 'self' blob:",
+  "media-src 'self' blob: data:",
+  "frame-src 'self' http: https:",
+].join('; ')
+
+const ALWAYS_HEADERS = {
+  'Content-Security-Policy': APP_CSP_HEADERS,
+  // Tighten later if/when CSP moves to nonce-based — the dash prefix
+  // makes adding/removing trivial without searching the codebase.
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+}
+
 const port = parseInt(process.env.PORT || '3000', 10)
 // Default HOST to localhost-only. Operators who want the workspace reachable
 // on a LAN / Tailscale / public surface must opt in explicitly with
@@ -203,10 +235,15 @@ async function requestHandler(req, res) {
   try {
     const response = await server.fetch(request)
 
-    res.writeHead(
-      response.status,
-      Object.fromEntries(response.headers.entries()),
-    )
+    // Merge ALWAYS_HEADERS on top of the SSR-emitted headers. These MUST
+    // win — sending them here means the policy is observable even if the
+    // body got replaced by an edge-side JS Challenge or WAF response page.
+    const headers = Object.fromEntries(response.headers.entries())
+    for (const [name, value] of Object.entries(ALWAYS_HEADERS)) {
+      if (typeof value === 'string') headers[name] = value
+    }
+
+    res.writeHead(response.status, headers)
 
     if (response.body) {
       const reader = response.body.getReader()

--- a/server-entry.js
+++ b/server-entry.js
@@ -243,6 +243,23 @@ async function requestHandler(req, res) {
       if (typeof value === 'string') headers[name] = value
     }
 
+    // /api/* responses must NEVER be cacheable by intermediaries — the SPA
+    // uses /api/auth-check, /api/connection-status, etc. to decide whether
+    // to show the password form. Cloudflare's Browser Cache TTL default
+    // (7200s) is applied to any GET that doesn't say `no-store`, which
+    // caused the auth-check response to be served stale from the edge
+    // for ~2h after a fresh login, trapping the user in a password loop.
+    // Strip any Cache-Control/Pragma/Expires on API responses so the
+    // edge never reuses them. Hash-named assets keep their immutable
+    // header (set above in tryServeStatic) and are unaffected here
+    // because static assets short-circuit before this branch.
+    const reqPathname = new URL(request.url).pathname
+    if (reqPathname.startsWith('/api/')) {
+      headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, private'
+      headers['Pragma'] = 'no-cache'
+      headers['Expires'] = '0'
+    }
+
     res.writeHead(response.status, headers)
 
     if (response.body) {

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { APP_CSP, APP_CSP_DIRECTIVES, APP_CSP_META } from './csp'
+
+describe('APP_CSP', () => {
+  it('starts with default-src', () => {
+    expect(APP_CSP_DIRECTIVES[0]).toBe("default-src 'self'")
+  })
+
+  it('serializes with semicolons only — no stray spaces or missing terminators', () => {
+    // The single most common CSP regression is a malformed directive-boundary
+    // that ends up looking like `' self' : default-src ...` after an edge
+    // proxy concatenates a second policy. Locking this shape here makes it
+    // impossible to ship a directive that starts with a leading `'`.
+    //
+    // (Note: `'unsafe-inline'` legitimately ends with a `'` because it's a
+    // quoted source expression; we're matching the unbroken-by-rewrite
+    // shape, not banning trailing quotes in general.)
+    expect(APP_CSP).not.toMatch(/^\s*'/)
+    expect(APP_CSP).not.toMatch(/' self'/)
+    expect(APP_CSP).not.toMatch(/' self ;/)
+    expect(APP_CSP).toMatch(/^default-src 'self'/)
+  })
+
+  it('lists every required directive in order', () => {
+    const expectedOrder = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "form-action 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      "img-src 'self'",
+      "font-src 'self'",
+      "connect-src 'self'",
+      "worker-src 'self'",
+      "media-src 'self'",
+      "frame-src 'self'",
+    ]
+    let cursor = 0
+    const joined = APP_CSP
+    for (const needle of expectedOrder) {
+      const idx = joined.indexOf(needle, cursor)
+      expect(idx, `directive ${needle} should appear after cursor ${cursor}`).toBeGreaterThanOrEqual(cursor)
+      cursor = idx + needle.length
+    }
+  })
+
+  it('APP_CSP_META matches APP_CSP byte-for-byte so the SSR-emitted meta tag cannot disagree with the HTTP header', () => {
+    expect(APP_CSP_META).toBe(APP_CSP)
+  })
+
+  it('does not include directives that are ignored when emitted as a `<meta>` tag', () => {
+    // frame-ancestors and report-uri are intentionally omitted — they're
+    // header-only. If someone adds them here by mistake the SSR meta will
+    // silently ignore them and the HTTP header value gets out of sync.
+    expect(APP_CSP).not.toMatch(/frame-ancestors/i)
+    expect(APP_CSP).not.toMatch(/report-uri/i)
+  })
+})

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,52 @@
+/**
+ * Single source of truth for the workspace Content Security Policy.
+ *
+ * Why this lives outside __root.tsx:
+ *   - We emit CSP as an HTTP response header from the Node server (and from the
+ *     Vite dev server) so the policy survives any edge body rewriting, e.g.
+ *     Cloudflare's JS Challenge inserting a `<meta http-equiv="Content-Security-Policy">`
+ *     with a per-request nonce into the served HTML when a request trips the
+ *     "impersonate browsers" rule.
+ *   - The `<meta>` form in __root.tsx is kept for SSR consistency but is now a
+ *     secondary copy. If you change the policy here, you must rebuild __root.tsx.
+ *     If you only change __root.tsx, the header stays authoritative.
+ *
+ * Policy notes:
+ *   - `frame-ancestors` is ignored in `<meta>` and only honored as an HTTP
+ *     header, so it is intentionally omitted from this list.
+ *   - `script-src 'unsafe-inline'` and `style-src 'unsafe-inline'` are kept
+ *     because TanStack Start SSR emits hydration inline `<script>` tags that
+ *     have no nonce yet. Production-grade tightening would move to a hashing
+ *     or `useServerInsertedHTML` nonce scheme; that is a follow-up.
+ *   - `connect-src` allows ws:/wss:/http:/https: because the gateway + workspace
+ *     daemon run on loopback and the browser may reach them via LAN/Tailscale.
+ */
+export const APP_CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  "connect-src 'self' ws: wss: http: https:",
+  "worker-src 'self' blob:",
+  "media-src 'self' blob: data:",
+  "frame-src 'self' http: https:",
+] as const
+
+export const APP_CSP = APP_CSP_DIRECTIVES.join('; ')
+
+/**
+ * Mirror directives for `<meta http-equiv="Content-Security-Policy">` in the
+ * SSR HTML. The HTTP header remains the authoritative policy, but emitting
+ * a meta tag too keeps the policy observable for direct file:// inspection
+ * (e.g. SSR output debug pages) and prevents a regression where someone
+ * disables the header by accident without the SSR code noticing.
+ *
+ * IMPORTANT: keep this list byte-for-byte identical to `APP_CSP_DIRECTIVES`
+ * so the meta tag never disagrees with the header. The `--unsafe-inline` /
+ * `--self` / `--none` keywords and every source expression must match.
+ */
+export const APP_CSP_META = APP_CSP

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import appCss from '../styles.css?url'
 import { getRootSurfaceState } from './-root-layout-state'
+import {  fetchClaudeAuthStatus } from '@/lib/claude-auth'
 import type {AuthStatus} from '@/lib/claude-auth';
 import { SearchModal } from '@/components/search/search-modal'
 import { UsageMeter } from '@/components/usage-meter'
@@ -29,23 +30,15 @@ import {
 } from '@/components/onboarding/claude-onboarding'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { LoginScreen } from '@/components/auth/login-screen'
-import {  fetchClaudeAuthStatus } from '@/lib/claude-auth'
 
-const APP_CSP = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "form-action 'self'",
-  // frame-ancestors is ignored in meta CSP and must be sent as an HTTP header.
-  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
-  "img-src 'self' data: blob: https:",
-  "font-src 'self' data: https://fonts.gstatic.com",
-  "connect-src 'self' ws: wss: http: https:",
-  "worker-src 'self' blob:",
-  "media-src 'self' blob: data:",
-  "frame-src 'self' http: https:",
-].join('; ')
+// Content Security Policy used to be emitted here as a `<meta http-equiv>`
+// tag. That made the workspace unusable when the Cloudflare JS Challenge
+// tripped on a request and rewrote the served HTML with its own per-request
+// `<meta name="Content-Security-Policy">` containing a nonce, producing a
+// concatenated malformed policy that chromium rejected (e.g.
+// `style-src ' 'nonce-…'; self`). The policy now lives in src/lib/csp.ts
+// and is emitted as a real HTTP response header by server-entry.js
+// (production) and vite.config.ts (dev/preview). Leave it that way.
 
 const THEME_STORAGE_KEY = 'claude-theme'
 const DEFAULT_THEME = 'claude-nous'
@@ -402,7 +395,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta httpEquiv="Content-Security-Policy" content={APP_CSP} />
+        {/* Content-Security-Policy is set as an HTTP response header in
+            server-entry.js and vite.config.ts. Don't re-emit it as a `<meta>`
+            here — see the comment in src/lib/csp.ts for why duplicating it
+            in the HTML is unsafe when an edge proxy mutates the body. */}
         <script
           dangerouslySetInnerHTML={{
             __html: wrapInlineScript(`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -599,6 +599,39 @@ const config = defineConfig(({ mode, command }) => {
             res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless')
             next()
           })
+          // Content Security Policy as a real HTTP response header. Sending
+          // it here (not as a `<meta>` tag) keeps the policy authoritative
+          // when an edge proxy mutates the response body — e.g. Cloudflare's
+          // JS Challenge injecting a per-request nonce into the served HTML
+          // when a browser request trips the "impersonate browsers" WAF rule.
+          // Without this, the inline-style source expression
+          // `style-src ' 'nonce-...'; self` gets concatenated onto our meta
+          // tag and chromium rejects every script and stylesheet with a
+          // mangled-CSP error. See the parallel logic in server-entry.js
+          // for production.
+          server.middlewares.use((_req, res, next) => {
+            // KEEP IN SYNC with src/lib/csp.ts and server-entry.js
+            res.setHeader(
+              'Content-Security-Policy',
+              [
+                "default-src 'self'",
+                "base-uri 'self'",
+                "object-src 'none'",
+                "form-action 'self'",
+                "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+                "img-src 'self' data: blob: https:",
+                "font-src 'self' data: https://fonts.gstatic.com",
+                "connect-src 'self' ws: wss: http: https:",
+                "worker-src 'self' blob:",
+                "media-src 'self' blob: data:",
+                "frame-src 'self' http: https:",
+              ].join('; '),
+            )
+            res.setHeader('X-Content-Type-Options', 'nosniff')
+            res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin')
+            next()
+          })
           server.middlewares.use(async (req, res, next) => {
             const requestPath = req.url?.split('?')[0]
             if (req.method === 'GET' && requestPath === '/api/healthcheck') {


### PR DESCRIPTION
## Problem

Cloudflare's edge cache defaults to caching GET responses for up to
2 hours (`Browser Cache TTL = 7200s`). When `hw-srv3.rocco.me/` was
deployed behind Cloudflare Tunnel, every `/api/*` GET response was
being cached at the edge — including `/api/auth-check`, which
returns `{authenticated: false, authRequired: true}` for an
unauthenticated request.

User-visible symptom (reported 2026-07-04 on
`https://hw-srv3.rocco.me/`): the SPA would POST the correct
workspace password to `/api/auth`, receive `Set-Cookie: claude-auth=...`,
then on the very next request to `/api/auth-check`, the browser
included the cookie correctly but the **Cloudflare edge served a
cached `{"authenticated":false}` response** (`cf-cache-status: HIT`,
`Age: 982`) from before the user had logged in. The SPA then saw
`authRequired && !authenticated`, showed the password form again,
and the cycle repeated.

Cloudflare's edge was **rewriting the `Cache-Control` response
header** to `private, max-age=7200, must-revalidate` regardless of
what the origin sent — confirmed via tunnel probes:

```
Origin emits:  cache-control: no-store, no-cache, must-revalidate, private
Edge sends:    cache-control: private, max-age=7200, must-revalidate
                cf-cache-status: HIT (Age: 982)
```

The root cause is a Cloudflare-zone-level Browser Cache TTL config
of 7200s applied to all GETs by default. That config can be
overridden by a Cache Rules bypass for `/api/*` (recommended for
defense in depth) — but the workspace itself should also emit a
correct cache-control header so it works regardless of zone config.

## Fix

Strip and re-set `Cache-Control`, `Pragma`, `Expires` on every
`/api/*` response in `server-entry.js`'s `requestHandler`. Static
assets under `/assets/*` (which already get `immutable` cache
control in `tryServeStatic`) short-circuit before this branch, so
they're unaffected.

### Diff

```
server-entry.js | 17 +++++++++++++++++
```

Single 17-line addition after the existing `ALWAYS_HEADERS` merge
in `requestHandler`:

```js
const reqPathname = new URL(request.url).pathname
if (reqPathname.startsWith('/api/')) {
  headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, private'
  headers['Pragma'] = 'no-cache'
  headers['Expires'] = '0'
}
```

## Test plan

Manual smoke on `https://hw-srv3.rocco.me/`:

1. Hard-reload, observe `/api/auth-check` response headers via DevTools:
   ```
   cf-cache-status: DYNAMIC
   cache-control: no-store, no-cache, must-revalidate, private
   ```
2. Log in with `qwe123`. Cookie `claude-auth=...` is set.
3. Reload. `/api/auth-check` now returns `{"authenticated":true,"authRequired":true}`.
4. Reload repeatedly. Body stays consistent (no more stale `false`).

Tunnel verification:
```
=== 1. Login ===
POST /api/auth  status=200
=== 2. auth-check (should be authenticated:true) ===
HTTP/2 200
cache-control: no-store, no-cache, must-revalidate, private
cf-cache-status: DYNAMIC
{"authenticated":true,"authRequired":true}
=== 3. auth-check again (still authenticated:true) ===
HTTP/2 200
cache-control: no-store, no-cache, must-revalidate, private
cf-cache-status: DYNAMIC
{"authenticated":true,"authRequired":true}
```

## Notes for reviewers

- This branch depends on the CSP HTTP-header work in #684 — the
  `ALWAYS_HEADERS` block referenced above is added there. If you
  prefer to land this independently, you can move the cache-control
  override block ahead of the `ALWAYS_HEADERS` merge (no functional
  difference, just the merge ordering).
- The tunnel-side fix (Cloudflare Cache Rules bypass for `/api/*`)
  is recommended but out of scope here. This PR makes the workspace
  correct on its own.
- Existing `/api/*` routes that explicitly set `Cache-Control`
  (e.g. `src/routes/api/events.ts: no-cache, no-store`,
  `src/routes/api/chat-events.ts: no-cache, no-transform`) get their
  explicit value preserved — the override here replaces whatever
  was set, including explicit values. If you'd rather preserve
  explicit per-route values, change the override to `headers['Cache-Control'] ??= ...`.

Refs: hw-srv3.rocco.me password-loop reported 2026-07-04
