### PR TITLE
fix(workspace): make fetchDashboardToken resilient to dashboard 500

### DIFF
--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -173,6 +173,23 @@ describe('gateway-capabilities', () => {
       await expect(mod.fetchDashboardToken()).resolves.toBe('live-token')
       expect(fetchMock.mock.calls.some(([url]) => url === 'http://127.0.0.1:9119/')).toBe(true)
     })
+
+    it('returns an empty token instead of throwing when dashboard root fails', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await loadMod()
+
+      await expect(mod.fetchDashboardToken()).resolves.toBe('')
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[gateway] Dashboard index returned 500 — token unavailable',
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -287,19 +287,35 @@ export async function fetchDashboardToken(options?: {
   dashboardTokenPromise = (async () => {
     // Dashboard injects the session token inline on `/` (root), not on
     // `/index.html` which serves the raw Vite-built HTML without the token.
-    const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
-    if (!res.ok) {
-      throw new Error(`Dashboard index failed: ${res.status}`)
+    // When the dashboard requires auth (302 → /auth/login) or the login page
+    // is broken (500), return empty string so protected API calls degrade
+    // gracefully — the caller already handles 401/non-ok via safeJson.
+    try {
+      const res = await fetch(`${CLAUDE_DASHBOARD_URL}/`, {
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        console.warn(
+          `[gateway] Dashboard index returned ${res.status} — token unavailable`,
+        )
+        return ''
+      }
+      const html = await res.text()
+      const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
+      if (!token) {
+        console.warn(
+          '[gateway] Dashboard session token not found in root HTML',
+        )
+        return ''
+      }
+      dashboardTokenCache = token
+      return token
+    } catch (err) {
+      console.warn(
+        `[gateway] Failed to fetch dashboard token: ${err instanceof Error ? err.message : err}`,
+      )
+      return ''
     }
-    const html = await res.text()
-    const token = html.match(DASHBOARD_TOKEN_REGEX)?.[1]?.trim() || ''
-    if (!token) {
-      throw new Error('Dashboard session token not found in root HTML')
-    }
-    dashboardTokenCache = token
-    return token
   })()
 
   try {


### PR DESCRIPTION
## Problem

`fetchDashboardToken()` in `src/server/gateway-capabilities.ts` scrapes
the dashboard root URL `${CLAUDE_DASHBOARD_URL}/` for an inline session
token. When the dashboard returns a 500 (e.g. while the dashboard server
is restarting, or when `/auth/login` is misconfigured and the
Node-default `fetch` follows a 302 redirect into an unauthenticated
loop), the workspace throws:

```
Error: Dashboard index failed: 500
```

That exception propagates up to `/api/dashboard/overview`, which renders
the user-visible message `Dashboard index failed: 500` in every
protected dashboard call.

## Fix

Replace `throw new Error(...)` with `console.warn(...)` and return
`''` (empty token). Callers already handle empty tokens: `safeJson()`
returns `{}` for non-ok responses, and `dashboardAuthHeaders()`
returns `{}` when no token is present. The fallback path through
`dashboardPasswordLogin()` (when `HERMES_DASHBOARD_BASIC_AUTH_*` is
configured) still runs.

### Diff

```
src/server/gateway-capabilities.ts                | 40 ++++++++++++++++-------
src/server/__tests__/gateway-capabilities.test.ts | 17 ++++++++++
```

## Test plan

```
pnpm exec vitest run src/server/__tests__/gateway-capabilities.test.ts
```

New test case: `returns an empty token instead of throwing when dashboard root fails`
→ mocks a 500 from the root URL, asserts `fetchDashboardToken()`
returns `''` and logs the warning.

## Notes for reviewers

- This PR is intentionally tiny and orthogonal to the cookie-based
  dashboard auth work in #661. It just makes the existing
  HTML-scrape fallback path (still used when `HERMES_DASHBOARD_BASIC_AUTH_*`
  is not configured) more graceful.
- If #661 lands first, this PR's conflict will be in the same area
  of `gateway-capabilities.ts`. Re-evaluating whether the resilience
  change is still needed after #661 is fine — the original 500 case
  may now be impossible in practice (cookie path doesn't hit the
  root URL), in which case this PR can be closed as obsolete.
- Originally part of #683, which has been closed in favor of #661
  and this split-out PR.

Refs: hw-srv3.rocco.me dashboard-token-302 issue reported 2026-07-04
