### PR TITLE
[codex] Add Hermes runs approval flow

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -168,6 +168,8 @@ import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
 import { Route as ApiMcpNameLogsRouteImport } from './routes/api/mcp/$name.logs'
 import { Route as ApiHermesworldReservationsConfirmRouteImport } from './routes/api/hermesworld/reservations/confirm'
+import { Route as ApiApprovalsApprovalIdDenyRouteImport } from './routes/api/approvals/$approvalId/deny'
+import { Route as ApiApprovalsApprovalIdApproveRouteImport } from './routes/api/approvals/$approvalId/approve'
 import { Route as ApiRunsSessionKeyRunIdAbandonRouteImport } from './routes/api/runs/$sessionKey.$runId.abandon'
 
 const WorldRoute = WorldRouteImport.update({
@@ -972,6 +974,18 @@ const ApiHermesworldReservationsConfirmRoute =
     path: '/confirm',
     getParentRoute: () => ApiHermesworldReservationsRoute,
   } as any)
+const ApiApprovalsApprovalIdDenyRoute =
+  ApiApprovalsApprovalIdDenyRouteImport.update({
+    id: '/api/approvals/$approvalId/deny',
+    path: '/api/approvals/$approvalId/deny',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiApprovalsApprovalIdApproveRoute =
+  ApiApprovalsApprovalIdApproveRouteImport.update({
+    id: '/api/approvals/$approvalId/approve',
+    path: '/api/approvals/$approvalId/approve',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiRunsSessionKeyRunIdAbandonRoute =
   ApiRunsSessionKeyRunIdAbandonRouteImport.update({
     id: '/api/runs/$sessionKey/$runId/abandon',
@@ -1134,6 +1148,8 @@ export interface FileRoutesByFullPath {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/approvals/$approvalId/approve': typeof ApiApprovalsApprovalIdApproveRoute
+  '/api/approvals/$approvalId/deny': typeof ApiApprovalsApprovalIdDenyRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1295,6 +1311,8 @@ export interface FileRoutesByTo {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/approvals/$approvalId/approve': typeof ApiApprovalsApprovalIdApproveRoute
+  '/api/approvals/$approvalId/deny': typeof ApiApprovalsApprovalIdDenyRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1458,6 +1476,8 @@ export interface FileRoutesById {
   '/api/update/agent': typeof ApiUpdateAgentRoute
   '/api/update/status': typeof ApiUpdateStatusRoute
   '/api/update/workspace': typeof ApiUpdateWorkspaceRoute
+  '/api/approvals/$approvalId/approve': typeof ApiApprovalsApprovalIdApproveRoute
+  '/api/approvals/$approvalId/deny': typeof ApiApprovalsApprovalIdDenyRoute
   '/api/hermesworld/reservations/confirm': typeof ApiHermesworldReservationsConfirmRoute
   '/api/mcp/$name/logs': typeof ApiMcpNameLogsRoute
   '/api/mcp/hub-sources/$id': typeof ApiMcpHubSourcesIdRoute
@@ -1622,6 +1642,8 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/approvals/$approvalId/approve'
+    | '/api/approvals/$approvalId/deny'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1783,6 +1805,8 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/approvals/$approvalId/approve'
+    | '/api/approvals/$approvalId/deny'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -1945,6 +1969,8 @@ export interface FileRouteTypes {
     | '/api/update/agent'
     | '/api/update/status'
     | '/api/update/workspace'
+    | '/api/approvals/$approvalId/approve'
+    | '/api/approvals/$approvalId/deny'
     | '/api/hermesworld/reservations/confirm'
     | '/api/mcp/$name/logs'
     | '/api/mcp/hub-sources/$id'
@@ -2082,6 +2108,8 @@ export interface RootRouteChildren {
   ApiUpdateAgentRoute: typeof ApiUpdateAgentRoute
   ApiUpdateStatusRoute: typeof ApiUpdateStatusRoute
   ApiUpdateWorkspaceRoute: typeof ApiUpdateWorkspaceRoute
+  ApiApprovalsApprovalIdApproveRoute: typeof ApiApprovalsApprovalIdApproveRoute
+  ApiApprovalsApprovalIdDenyRoute: typeof ApiApprovalsApprovalIdDenyRoute
   ApiRunsSessionKeyRunIdAbandonRoute: typeof ApiRunsSessionKeyRunIdAbandonRoute
 }
 
@@ -3200,6 +3228,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiHermesworldReservationsConfirmRouteImport
       parentRoute: typeof ApiHermesworldReservationsRoute
     }
+    '/api/approvals/$approvalId/deny': {
+      id: '/api/approvals/$approvalId/deny'
+      path: '/api/approvals/$approvalId/deny'
+      fullPath: '/api/approvals/$approvalId/deny'
+      preLoaderRoute: typeof ApiApprovalsApprovalIdDenyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/approvals/$approvalId/approve': {
+      id: '/api/approvals/$approvalId/approve'
+      path: '/api/approvals/$approvalId/approve'
+      fullPath: '/api/approvals/$approvalId/approve'
+      preLoaderRoute: typeof ApiApprovalsApprovalIdApproveRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/runs/$sessionKey/$runId/abandon': {
       id: '/api/runs/$sessionKey/$runId/abandon'
       path: '/api/runs/$sessionKey/$runId/abandon'
@@ -3551,6 +3593,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiUpdateAgentRoute: ApiUpdateAgentRoute,
   ApiUpdateStatusRoute: ApiUpdateStatusRoute,
   ApiUpdateWorkspaceRoute: ApiUpdateWorkspaceRoute,
+  ApiApprovalsApprovalIdApproveRoute: ApiApprovalsApprovalIdApproveRoute,
+  ApiApprovalsApprovalIdDenyRoute: ApiApprovalsApprovalIdDenyRoute,
   ApiRunsSessionKeyRunIdAbandonRoute: ApiRunsSessionKeyRunIdAbandonRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -163,6 +163,7 @@ import { Route as ApiClaudeTasksTaskIdRouteImport } from './routes/api/claude-ta
 import { Route as ApiClaudeProxySplatRouteImport } from './routes/api/claude-proxy/$'
 import { Route as ApiClaudeJobsJobIdRouteImport } from './routes/api/claude-jobs.$jobId'
 import { Route as ApiArtifactsArtifactIdRouteImport } from './routes/api/artifacts.$artifactId'
+import { Route as ApiApprovalsPendingRouteImport } from './routes/api/approvals/pending'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
 import { Route as ApiSessionsSessionKeyActiveRunRouteImport } from './routes/api/sessions/$sessionKey.active-run'
 import { Route as ApiMcpHubSourcesIdRouteImport } from './routes/api/mcp/hub-sources.$id'
@@ -946,6 +947,11 @@ const ApiArtifactsArtifactIdRoute = ApiArtifactsArtifactIdRouteImport.update({
   path: '/$artifactId',
   getParentRoute: () => ApiArtifactsRoute,
 } as any)
+const ApiApprovalsPendingRoute = ApiApprovalsPendingRouteImport.update({
+  id: '/api/approvals/pending',
+  path: '/api/approvals/pending',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSessionsSessionKeyStatusRoute =
   ApiSessionsSessionKeyStatusRouteImport.update({
     id: '/$sessionKey/status',
@@ -1097,6 +1103,7 @@ export interface FileRoutesByFullPath {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/approvals/pending': typeof ApiApprovalsPendingRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1260,6 +1267,7 @@ export interface FileRoutesByTo {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat': typeof ChatIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/api/approvals/pending': typeof ApiApprovalsPendingRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1425,6 +1433,7 @@ export interface FileRoutesById {
   '/settings/providers': typeof SettingsProvidersRoute
   '/chat/': typeof ChatIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/approvals/pending': typeof ApiApprovalsPendingRoute
   '/api/artifacts/$artifactId': typeof ApiArtifactsArtifactIdRoute
   '/api/claude-jobs/$jobId': typeof ApiClaudeJobsJobIdRoute
   '/api/claude-proxy/$': typeof ApiClaudeProxySplatRoute
@@ -1591,6 +1600,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/approvals/pending'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1754,6 +1764,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat'
     | '/settings'
+    | '/api/approvals/pending'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -1918,6 +1929,7 @@ export interface FileRouteTypes {
     | '/settings/providers'
     | '/chat/'
     | '/settings/'
+    | '/api/approvals/pending'
     | '/api/artifacts/$artifactId'
     | '/api/claude-jobs/$jobId'
     | '/api/claude-proxy/$'
@@ -2080,6 +2092,7 @@ export interface RootRouteChildren {
   ApiWorkspaceRoute: typeof ApiWorkspaceRoute
   ChatSessionKeyRoute: typeof ChatSessionKeyRoute
   ChatIndexRoute: typeof ChatIndexRoute
+  ApiApprovalsPendingRoute: typeof ApiApprovalsPendingRoute
   ApiClaudeProxySplatRoute: typeof ApiClaudeProxySplatRoute
   ApiDashboardOverviewRoute: typeof ApiDashboardOverviewRoute
   ApiExternalMemoryCandidatesRoute: typeof ApiExternalMemoryCandidatesRoute
@@ -3193,6 +3206,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiArtifactsArtifactIdRouteImport
       parentRoute: typeof ApiArtifactsRoute
     }
+    '/api/approvals/pending': {
+      id: '/api/approvals/pending'
+      path: '/api/approvals/pending'
+      fullPath: '/api/approvals/pending'
+      preLoaderRoute: typeof ApiApprovalsPendingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/sessions/$sessionKey/status': {
       id: '/api/sessions/$sessionKey/status'
       path: '/$sessionKey/status'
@@ -3565,6 +3585,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiWorkspaceRoute: ApiWorkspaceRoute,
   ChatSessionKeyRoute: ChatSessionKeyRoute,
   ChatIndexRoute: ChatIndexRoute,
+  ApiApprovalsPendingRoute: ApiApprovalsPendingRoute,
   ApiClaudeProxySplatRoute: ApiClaudeProxySplatRoute,
   ApiDashboardOverviewRoute: ApiDashboardOverviewRoute,
   ApiExternalMemoryCandidatesRoute: ApiExternalMemoryCandidatesRoute,

--- a/src/routes/api/-send-stream-final-output.test.ts
+++ b/src/routes/api/-send-stream-final-output.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldPreferFinalOutput } from './send-stream'
+
+describe('shouldPreferFinalOutput', () => {
+  it('prefers a formatted final output over compact streamed deltas for the same text', () => {
+    const compact =
+      'NichtnurGeschwindigkeit.EinSwarmbringtdreiArtenvonVorteilen:1.Geschwindigkeit2.Qualität3.Kontext-Hygiene'
+    const formatted =
+      'Nicht nur Geschwindigkeit. Ein Swarm bringt drei Arten von Vorteilen:\n\n1. Geschwindigkeit\n2. Qualität\n3. Kontext-Hygiene'
+
+    expect(shouldPreferFinalOutput(compact, formatted)).toBe(true)
+  })
+
+  it('does not replace streamed text with unrelated final output', () => {
+    expect(
+      shouldPreferFinalOutput(
+        'Die aktuelle Antwort ist schon lesbar.',
+        'Ein anderer finaler Text.',
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/routes/api/approvals/$approvalId/approve.ts
+++ b/src/routes/api/approvals/$approvalId/approve.ts
@@ -3,6 +3,24 @@ import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../../server/auth-middleware'
 import { submitHermesRunApproval } from '../../../../server/hermes-runs-api'
 
+type ApprovalChoice = 'once' | 'session' | 'always'
+
+async function readApprovalChoice(request: Request): Promise<ApprovalChoice> {
+  try {
+    const body = (await request.json()) as { choice?: unknown }
+    if (
+      body.choice === 'once' ||
+      body.choice === 'session' ||
+      body.choice === 'always'
+    ) {
+      return body.choice
+    }
+  } catch {
+    // Empty / non-JSON body keeps the historical one-shot approval behavior.
+  }
+  return 'once'
+}
+
 export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
   server: {
     handlers: {
@@ -12,14 +30,21 @@ export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
         }
         const approvalId = params.approvalId?.trim()
         if (!approvalId) {
-          return json({ ok: false, error: 'approvalId required' }, { status: 400 })
+          return json(
+            { ok: false, error: 'approvalId required' },
+            { status: 400 },
+          )
         }
         try {
-          await submitHermesRunApproval(approvalId, 'once')
+          const choice = await readApprovalChoice(request)
+          await submitHermesRunApproval(approvalId, choice)
           return json({ ok: true })
         } catch (err) {
           return json(
-            { ok: false, error: err instanceof Error ? err.message : String(err) },
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
             { status: 502 },
           )
         }

--- a/src/routes/api/approvals/$approvalId/approve.ts
+++ b/src/routes/api/approvals/$approvalId/approve.ts
@@ -2,6 +2,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../../server/auth-middleware'
 import { submitHermesRunApproval } from '../../../../server/hermes-runs-api'
+import {
+  clearPendingSessionApproval,
+  rememberSessionApprovalForRun,
+} from '../../../../server/session-approval-store'
 
 type ApprovalChoice = 'once' | 'session' | 'always'
 
@@ -38,6 +42,11 @@ export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
         try {
           const choice = await readApprovalChoice(request)
           await submitHermesRunApproval(approvalId, choice)
+          if (choice === 'session') {
+            await rememberSessionApprovalForRun(approvalId)
+          } else {
+            await clearPendingSessionApproval(approvalId)
+          }
           return json({ ok: true })
         } catch (err) {
           return json(

--- a/src/routes/api/approvals/$approvalId/approve.ts
+++ b/src/routes/api/approvals/$approvalId/approve.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../../server/auth-middleware'
+import { submitHermesRunApproval } from '../../../../server/hermes-runs-api'
+
+export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const approvalId = params.approvalId?.trim()
+        if (!approvalId) {
+          return json({ ok: false, error: 'approvalId required' }, { status: 400 })
+        }
+        try {
+          await submitHermesRunApproval(approvalId, 'once')
+          return json({ ok: true })
+        } catch (err) {
+          return json(
+            { ok: false, error: err instanceof Error ? err.message : String(err) },
+            { status: 502 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/approvals/$approvalId/deny.ts
+++ b/src/routes/api/approvals/$approvalId/deny.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../../server/auth-middleware'
 import { submitHermesRunApproval } from '../../../../server/hermes-runs-api'
+import { clearPendingSessionApproval } from '../../../../server/session-approval-store'
 
 export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
   server: {
@@ -16,6 +17,7 @@ export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
         }
         try {
           await submitHermesRunApproval(approvalId, 'deny')
+          await clearPendingSessionApproval(approvalId)
           return json({ ok: true })
         } catch (err) {
           return json(

--- a/src/routes/api/approvals/$approvalId/deny.ts
+++ b/src/routes/api/approvals/$approvalId/deny.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../../../server/auth-middleware'
+import { submitHermesRunApproval } from '../../../../server/hermes-runs-api'
+
+export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
+  server: {
+    handlers: {
+      POST: async ({ request, params }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const approvalId = params.approvalId?.trim()
+        if (!approvalId) {
+          return json({ ok: false, error: 'approvalId required' }, { status: 400 })
+        }
+        try {
+          await submitHermesRunApproval(approvalId, 'deny')
+          return json({ ok: true })
+        } catch (err) {
+          return json(
+            { ok: false, error: err instanceof Error ? err.message : String(err) },
+            { status: 502 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/approvals/pending.ts
+++ b/src/routes/api/approvals/pending.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../../server/auth-middleware'
+import { listPendingSessionApprovals } from '../../../server/session-approval-store'
+
+export const Route = createFileRoute('/api/approvals/pending')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        const url = new URL(request.url)
+        const sessionKeys = url.searchParams.getAll('sessionKey')
+        const pending = await listPendingSessionApprovals({ sessionKeys })
+        return json({ ok: true, pending })
+      },
+    },
+  },
+})

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -17,8 +17,16 @@ import {
   upsertRunToolCall,
 } from '../../server/run-store'
 import { getChatMode } from '../../server/gateway-capabilities'
-import { appendLocalMessage, ensureLocalSession, getLocalMessages, touchLocalSession } from '../../server/local-session-store'
-import { getDiscoveredModels, getLocalProviderDef } from '../../server/local-provider-discovery'
+import {
+  appendLocalMessage,
+  ensureLocalSession,
+  getLocalMessages,
+  touchLocalSession,
+} from '../../server/local-session-store'
+import {
+  getDiscoveredModels,
+  getLocalProviderDef,
+} from '../../server/local-provider-discovery'
 import { openaiChat } from '../../server/openai-compat-api'
 import {
   HermesRunStartError,
@@ -40,7 +48,10 @@ import {
   collectSyntheticLiveToolEvents,
   createSyntheticLiveToolTracker,
 } from './-send-stream-live-tools'
-import type {OpenAICompatContentPart, OpenAICompatMessage} from '../../server/openai-compat-api';
+import type {
+  OpenAICompatContentPart,
+  OpenAICompatMessage,
+} from '../../server/openai-compat-api'
 // Claude agent runs can take 5+ minutes with complex tool chains
 const SEND_STREAM_RUN_TIMEOUT_MS = 600_000
 const SESSION_BOOTSTRAP_KEYS = new Set(['main', 'new'])
@@ -262,6 +273,40 @@ function parseJsonIfPossible(value: unknown): unknown {
   return value
 }
 
+function compactTextSignature(value: string): string {
+  return value.trim().replace(/\s+/g, '')
+}
+
+function readabilityScore(value: string): number {
+  const whitespaceCount = (value.match(/\s/g) ?? []).length
+  const sentenceBreakCount = (value.match(/[.!?]\s/g) ?? []).length
+  const listBreakCount = (value.match(/\n\s*(?:[-*]|\d+\.)\s/g) ?? []).length
+  return whitespaceCount + sentenceBreakCount * 4 + listBreakCount * 8
+}
+
+export function shouldPreferFinalOutput(
+  currentText: string,
+  finalOutput: string,
+): boolean {
+  const current = currentText.trim()
+  const final = finalOutput.trim()
+  if (!final) return false
+  if (!current) return true
+  if (final === current) return false
+
+  const currentSignature = compactTextSignature(current)
+  const finalSignature = compactTextSignature(final)
+  if (
+    currentSignature.length >= 40 &&
+    currentSignature === finalSignature &&
+    readabilityScore(final) > readabilityScore(current)
+  ) {
+    return true
+  }
+
+  return false
+}
+
 function getToolArgs(data: Record<string, unknown>): unknown {
   const toolCall = readRecord(data.tool_call)
   const toolFunction = readRecord(toolCall?.function)
@@ -357,10 +402,14 @@ export const Route = createFileRoute('/api/send-stream')({
         let chatMode = getChatMode()
         let localBaseUrl: string | undefined
         const requestModel = typeof body.model === 'string' ? body.model : ''
-        const bareModel = requestModel.includes('/') ? requestModel.split('/').slice(1).join('/') : requestModel
+        const bareModel = requestModel.includes('/')
+          ? requestModel.split('/').slice(1).join('/')
+          : requestModel
         if (requestModel) {
           const discoveredModels = getDiscoveredModels()
-          const localMatch = discoveredModels.find((m) => m.id === requestModel || m.id === bareModel)
+          const localMatch = discoveredModels.find(
+            (m) => m.id === requestModel || m.id === bareModel,
+          )
           if (localMatch) {
             const providerDef = getLocalProviderDef(localMatch.provider)
             if (providerDef) {
@@ -384,6 +433,7 @@ export const Route = createFileRoute('/api/send-stream')({
         const encoder = new TextEncoder()
         let streamClosed = false
         let activeRunId: string | null = null
+        const activeSendRunIds = new Set<string>()
         let activeRunSessionKey: string | null = null
         let persistedRunReady: Promise<unknown> | null = null
         let unregisterTimer: ReturnType<typeof setTimeout> | null = null
@@ -420,12 +470,17 @@ export const Route = createFileRoute('/api/send-stream')({
             persistActiveRun((runSessionKey, activeId) =>
               markRunStatus(runSessionKey, activeId, 'handoff'),
             )
-            unregisterActiveSendRun(activeRunId)
+            for (const runIdToUnregister of activeSendRunIds) {
+              unregisterActiveSendRun(runIdToUnregister)
+            }
+            activeSendRunIds.clear()
             activeRunId = null
           }
           closeStream()
         }
-        request.signal.addEventListener('abort', () => handleAbort(), { once: true })
+        request.signal.addEventListener('abort', () => handleAbort(), {
+          once: true,
+        })
 
         const persistRunStarted = (
           runId: string | undefined,
@@ -505,7 +560,10 @@ export const Route = createFileRoute('/api/send-stream')({
                 streamTimeoutTimer = null
               }
               if (activeRunId) {
-                unregisterActiveSendRun(activeRunId)
+                for (const runIdToUnregister of activeSendRunIds) {
+                  unregisterActiveSendRun(runIdToUnregister)
+                }
+                activeSendRunIds.clear()
                 activeRunId = null
               }
               abortController.abort()
@@ -522,7 +580,10 @@ export const Route = createFileRoute('/api/send-stream')({
             // Every 10s we also forward the last known activity so the UI can
             // show meaningful progress instead of a static "Thinking…".
             heartbeatTimer = setInterval(() => {
-              sendEvent('heartbeat', { timestamp: Date.now(), activity: lastActivity })
+              sendEvent('heartbeat', {
+                timestamp: Date.now(),
+                activity: lastActivity,
+              })
             }, 10_000)
 
             try {
@@ -531,7 +592,10 @@ export const Route = createFileRoute('/api/send-stream')({
                 const portableSessionKey = sessionKey
 
                 // Ensure session exists (user message appended after building history)
-                ensureLocalSession(portableSessionKey, typeof body.model === 'string' ? body.model : undefined)
+                ensureLocalSession(
+                  portableSessionKey,
+                  typeof body.model === 'string' ? body.model : undefined,
+                )
                 const portableFriendlyId =
                   resolvedFriendlyId ||
                   requestedFriendlyId ||
@@ -541,10 +605,14 @@ export const Route = createFileRoute('/api/send-stream')({
 
                 activeRunId = runId
                 registerActiveSendRun(runId)
+                activeSendRunIds.add(runId)
                 persistRunStarted(runId, portableSessionKey, portableFriendlyId)
                 unregisterTimer = setTimeout(() => {
                   if (activeRunId) {
-                    unregisterActiveSendRun(activeRunId)
+                    for (const runIdToUnregister of activeSendRunIds) {
+                      unregisterActiveSendRun(runIdToUnregister)
+                    }
+                    activeSendRunIds.clear()
                     activeRunId = null
                   }
                 }, SEND_STREAM_RUN_TIMEOUT_MS)
@@ -562,10 +630,17 @@ export const Route = createFileRoute('/api/send-stream')({
                     attachments,
                   )
                   // Inject locale preference so the agent responds in the user's language
-                  const locale = typeof body.locale === 'string' ? body.locale.trim() : ''
-                  const localeSystemMsg: Array<OpenAICompatMessage> = locale && locale !== 'en'
-                    ? [{ role: 'system', content: `Respond in ${locale === 'es' ? 'Spanish' : locale === 'fr' ? 'French' : locale === 'zh' ? 'Chinese' : locale === 'de' ? 'German' : locale === 'ja' ? 'Japanese' : locale === 'ko' ? 'Korean' : locale === 'pt' ? 'Portuguese' : locale === 'ru' ? 'Russian' : locale === 'ar' ? 'Arabic' : 'English'}. The user's interface is set to this language.` }]
-                    : []
+                  const locale =
+                    typeof body.locale === 'string' ? body.locale.trim() : ''
+                  const localeSystemMsg: Array<OpenAICompatMessage> =
+                    locale && locale !== 'en'
+                      ? [
+                          {
+                            role: 'system',
+                            content: `Respond in ${locale === 'es' ? 'Spanish' : locale === 'fr' ? 'French' : locale === 'zh' ? 'Chinese' : locale === 'de' ? 'German' : locale === 'ja' ? 'Japanese' : locale === 'ko' ? 'Korean' : locale === 'pt' ? 'Portuguese' : locale === 'ru' ? 'Russian' : locale === 'ar' ? 'Arabic' : 'English'}. The user's interface is set to this language.`,
+                          },
+                        ]
+                      : []
                   // Load persisted history for this session, then append user message.
                   // When the gateway can bind portable chat to a server-side session
                   // via X-Hermes-Session-Id, replaying the entire local transcript on
@@ -580,7 +655,8 @@ export const Route = createFileRoute('/api/send-stream')({
                   appendLocalMessage(portableSessionKey, {
                     id: crypto.randomUUID(),
                     role: 'user',
-                    content: typeof body.message === 'string' ? body.message : '',
+                    content:
+                      typeof body.message === 'string' ? body.message : '',
                     timestamp: Date.now(),
                   })
                   const effectiveHistory = selectPortableConversationHistory(
@@ -617,24 +693,39 @@ export const Route = createFileRoute('/api/send-stream')({
                         input: scopedMessage,
                         conversationHistory: effectiveHistory,
                         model:
-                          typeof body.model === 'string' ? body.model : undefined,
+                          typeof body.model === 'string'
+                            ? body.model
+                            : undefined,
                         sessionId: portableSessionKey,
                         signal: abortController.signal,
                       })
                       for await (const ev of runStream) {
                         if (ev.kind === 'started') {
-                          // Workspace already emitted and persisted its own
-                          // UI runId above. Keep Hermes' run_id only inside
-                          // approval payloads so store writes keep targeting
-                          // the active Workspace run.
+                          // Keep Workspace's runId as the UI/persistence id,
+                          // but register Hermes' run_id as an active alias so
+                          // chat-events suppresses the same response when it
+                          // arrives from the gateway bus/history path.
+                          registerActiveSendRun(ev.runId)
+                          activeSendRunIds.add(ev.runId)
+                          sendEvent('run_ids', {
+                            runId,
+                            runIds: [runId, ev.runId],
+                            sessionKey: portableSessionKey,
+                            friendlyId: portableFriendlyId,
+                          })
                           continue
                         }
                         if (ev.kind === 'text.delta') {
                           accumulated += ev.delta
                           persistActiveRun((runSessionKey, activeId) =>
-                            appendRunText(runSessionKey, activeId, accumulated, {
-                              replace: true,
-                            }),
+                            appendRunText(
+                              runSessionKey,
+                              activeId,
+                              accumulated,
+                              {
+                                replace: true,
+                              },
+                            ),
                           )
                           sendEvent('chunk', {
                             text: accumulated,
@@ -707,12 +798,20 @@ export const Route = createFileRoute('/api/send-stream')({
                           continue
                         }
                         if (ev.kind === 'completed') {
-                          if (!accumulated && ev.output) {
+                          if (
+                            ev.output &&
+                            shouldPreferFinalOutput(accumulated, ev.output)
+                          ) {
                             accumulated = ev.output
                             persistActiveRun((runSessionKey, activeId) =>
-                              appendRunText(runSessionKey, activeId, accumulated, {
-                                replace: true,
-                              }),
+                              appendRunText(
+                                runSessionKey,
+                                activeId,
+                                accumulated,
+                                {
+                                  replace: true,
+                                },
+                              ),
                             )
                             sendEvent('chunk', {
                               text: accumulated,
@@ -777,7 +876,9 @@ export const Route = createFileRoute('/api/send-stream')({
                         input: scopedMessage,
                         conversationHistory: effectiveHistory,
                         model:
-                          typeof body.model === 'string' ? body.model : undefined,
+                          typeof body.model === 'string'
+                            ? body.model
+                            : undefined,
                         sessionId: portableSessionKey,
                         signal: abortController.signal,
                       })
@@ -807,7 +908,7 @@ export const Route = createFileRoute('/api/send-stream')({
                           })
                           const argsForCard =
                             ev.args && typeof ev.args === 'object'
-                              ? (ev.args)
+                              ? ev.args
                               : undefined
                           persistActiveRun((runSessionKey, activeId) =>
                             upsertRunToolCall(runSessionKey, activeId, {
@@ -842,7 +943,7 @@ export const Route = createFileRoute('/api/send-stream')({
                           const state = toolStateByCallId.get(ev.callId)
                           const argsForCard =
                             state?.args && typeof state.args === 'object'
-                              ? (state.args)
+                              ? state.args
                               : undefined
                           const name = state?.name || 'tool'
                           persistActiveRun((runSessionKey, activeId) =>
@@ -892,7 +993,9 @@ export const Route = createFileRoute('/api/send-stream')({
                         message: {
                           role: 'assistant',
                           content: [
-                            ...(thinking ? [{ type: 'thinking', thinking }] : []),
+                            ...(thinking
+                              ? [{ type: 'thinking', thinking }]
+                              : []),
                             { type: 'text', text: accumulated },
                           ],
                         },
@@ -913,7 +1016,11 @@ export const Route = createFileRoute('/api/send-stream')({
                   }
 
                   const stream = await openaiChat(portableMessages, {
-                    model: localBaseUrl ? bareModel : (typeof body.model === 'string' ? body.model : undefined),
+                    model: localBaseUrl
+                      ? bareModel
+                      : typeof body.model === 'string'
+                        ? body.model
+                        : undefined,
                     temperature:
                       typeof body.temperature === 'number'
                         ? body.temperature
@@ -1017,7 +1124,12 @@ export const Route = createFileRoute('/api/send-stream')({
                   if (!streamClosed) {
                     const errorMessage = normalizeClaudeErrorMessage(err)
                     persistActiveRun((runSessionKey, activeId) =>
-                      markRunStatus(runSessionKey, activeId, 'error', errorMessage),
+                      markRunStatus(
+                        runSessionKey,
+                        activeId,
+                        'error',
+                        errorMessage,
+                      ),
                     )
                     sendEvent('error', {
                       message: errorMessage,
@@ -1154,497 +1266,504 @@ export const Route = createFileRoute('/api/send-stream')({
                   } catch {
                     // Best-effort polling; ignore transient errors.
                   }
-                  await new Promise((r) =>
-                    setTimeout(r, livePollIntervalMs),
-                  )
+                  await new Promise((r) => setTimeout(r, livePollIntervalMs))
                 }
               })()
 
               try {
                 await streamChat(
-                sessionKey,
-                {
-                  message: scopedMessage,
-                  model:
-                    typeof body.model === 'string' ? body.model : undefined,
-                  system_message: thinking,
-                  attachments: attachments || undefined,
-                },
-                {
-                  signal: abortController.signal,
-                  async onEvent({ event, data }) {
-                    const sessionKeyFromEvent =
-                      typeof data.session_id === 'string' &&
-                      data.session_id.trim()
-                        ? data.session_id
-                        : sessionKey
-                    const runId =
-                      typeof data.run_id === 'string' && data.run_id.trim()
-                        ? data.run_id
-                        : (activeRunId ?? undefined)
+                  sessionKey,
+                  {
+                    message: scopedMessage,
+                    model:
+                      typeof body.model === 'string' ? body.model : undefined,
+                    system_message: thinking,
+                    attachments: attachments || undefined,
+                  },
+                  {
+                    signal: abortController.signal,
+                    async onEvent({ event, data }) {
+                      const sessionKeyFromEvent =
+                        typeof data.session_id === 'string' &&
+                        data.session_id.trim()
+                          ? data.session_id
+                          : sessionKey
+                      const runId =
+                        typeof data.run_id === 'string' && data.run_id.trim()
+                          ? data.run_id
+                          : (activeRunId ?? undefined)
 
-                    if (runId && !activeRunId) {
-                      activeRunId = runId
-                      registerActiveSendRun(runId)
-                      persistRunStarted(
-                        runId,
-                        sessionKeyFromEvent,
-                        sessionKeyFromEvent,
-                      )
-                      unregisterTimer = setTimeout(() => {
-                        if (activeRunId) {
-                          unregisterActiveSendRun(activeRunId)
-                          activeRunId = null
-                        }
-                      }, SEND_STREAM_RUN_TIMEOUT_MS)
-                    }
-
-                    if (!startedSent && runId) {
-                      startedSent = true
-                      sendEvent('started', {
-                        runId,
-                        sessionKey: sessionKeyFromEvent,
-                        friendlyId: sessionKeyFromEvent,
-                      })
-                      lastActivity = 'Processing your message...'
-                    }
-
-                    if (event === 'run.started') {
-                      const userMessage =
-                        data.user_message &&
-                        typeof data.user_message === 'object'
-                          ? (data.user_message as Record<string, unknown>)
-                          : null
-                      if (userMessage) {
-                        skipPublish ||
-                          publishChatEvent('user_message', {
-                            message: {
-                              id: userMessage.id,
-                              role: userMessage.role ?? 'user',
-                              content: [
-                                {
-                                  type: 'text',
-                                  text:
-                                    typeof userMessage.content === 'string'
-                                      ? userMessage.content
-                                      : '',
-                                },
-                              ],
-                            },
-                            sessionKey: sessionKeyFromEvent,
-                            source: 'claude',
-                            runId,
-                          })
-                      }
-                      return
-                    }
-
-                    if (event === 'message.started') {
-                      const message =
-                        data.message && typeof data.message === 'object'
-                          ? (data.message as Record<string, unknown>)
-                          : {}
-                      const translated = {
-                        message: {
-                          id: message.id,
-                          role: 'assistant',
-                          content: [],
-                        },
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      sendEvent('message', translated)
-                      skipPublish || publishChatEvent('message', translated)
-                      return
-                    }
-
-                    if (event === 'assistant.completed') {
-                      // Send full content as a chunk — covers cases where
-                      // deltas were missed or response was too short for streaming
-                      const content =
-                        typeof data.content === 'string' ? data.content : ''
-                      if (content) {
-                        persistActiveRun((runSessionKey, activeId) =>
-                          appendRunText(runSessionKey, activeId, content, {
-                            replace: true,
-                          }),
+                      if (runId && !activeRunId) {
+                        activeRunId = runId
+                        registerActiveSendRun(runId)
+                        activeSendRunIds.add(runId)
+                        persistRunStarted(
+                          runId,
+                          sessionKeyFromEvent,
+                          sessionKeyFromEvent,
                         )
+                        unregisterTimer = setTimeout(() => {
+                          if (activeRunId) {
+                            for (const runIdToUnregister of activeSendRunIds) {
+                              unregisterActiveSendRun(runIdToUnregister)
+                            }
+                            activeSendRunIds.clear()
+                            activeRunId = null
+                          }
+                        }, SEND_STREAM_RUN_TIMEOUT_MS)
+                      }
+
+                      if (!startedSent && runId) {
+                        startedSent = true
+                        sendEvent('started', {
+                          runId,
+                          sessionKey: sessionKeyFromEvent,
+                          friendlyId: sessionKeyFromEvent,
+                        })
+                        lastActivity = 'Processing your message...'
+                      }
+
+                      if (event === 'run.started') {
+                        const userMessage =
+                          data.user_message &&
+                          typeof data.user_message === 'object'
+                            ? (data.user_message as Record<string, unknown>)
+                            : null
+                        if (userMessage) {
+                          skipPublish ||
+                            publishChatEvent('user_message', {
+                              message: {
+                                id: userMessage.id,
+                                role: userMessage.role ?? 'user',
+                                content: [
+                                  {
+                                    type: 'text',
+                                    text:
+                                      typeof userMessage.content === 'string'
+                                        ? userMessage.content
+                                        : '',
+                                  },
+                                ],
+                              },
+                              sessionKey: sessionKeyFromEvent,
+                              source: 'claude',
+                              runId,
+                            })
+                        }
+                        return
+                      }
+
+                      if (event === 'message.started') {
+                        const message =
+                          data.message && typeof data.message === 'object'
+                            ? (data.message as Record<string, unknown>)
+                            : {}
                         const translated = {
-                          text: content,
-                          fullReplace: true,
+                          message: {
+                            id: message.id,
+                            role: 'assistant',
+                            content: [],
+                          },
                           sessionKey: sessionKeyFromEvent,
                           runId,
                         }
-                        sendEvent('chunk', translated)
-                        skipPublish || publishChatEvent('chunk', translated)
+                        sendEvent('message', translated)
+                        skipPublish || publishChatEvent('message', translated)
+                        return
                       }
-                      return
-                    }
 
-                    if (event === 'assistant.delta') {
-                      const delta =
-                        typeof data.delta === 'string' ? data.delta : ''
-                      if (!delta) return
-                      persistActiveRun((runSessionKey, activeId) =>
-                        appendRunText(runSessionKey, activeId, delta),
-                      )
-                      const translated = {
-                        text: delta,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
+                      if (event === 'assistant.completed') {
+                        // Send full content as a chunk — covers cases where
+                        // deltas were missed or response was too short for streaming
+                        const content =
+                          typeof data.content === 'string' ? data.content : ''
+                        if (content) {
+                          persistActiveRun((runSessionKey, activeId) =>
+                            appendRunText(runSessionKey, activeId, content, {
+                              replace: true,
+                            }),
+                          )
+                          const translated = {
+                            text: content,
+                            fullReplace: true,
+                            sessionKey: sessionKeyFromEvent,
+                            runId,
+                          }
+                          sendEvent('chunk', translated)
+                          skipPublish || publishChatEvent('chunk', translated)
+                        }
+                        return
                       }
-                      sendEvent('chunk', translated)
-                      skipPublish || publishChatEvent('chunk', translated)
-                      return
-                    }
 
-                    if (
-                      event === 'tool.pending' ||
-                      event === 'tool.started' ||
-                      event === 'tool.calling' ||
-                      event === 'tool.running'
-                    ) {
-                      const toolName = getToolName(data)
-                      const preview =
-                        typeof data.preview === 'string'
-                          ? data.preview
-                          : undefined
-                      const translated = {
-                        phase:
-                          event === 'tool.pending' || event === 'tool.started'
-                            ? 'start'
-                            : 'calling',
-                        name: toolName,
-                        toolCallId: getToolCallId(data, runId, toolName),
-                        args: getToolArgs(data),
-                        preview,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId,
-                          name: toolName,
-                          phase: translated.phase,
-                          args: translated.args,
-                          preview,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      lastActivity = `Running: ${toolName.replace(/_/g, ' ')}`
-                      return
-                    }
-
-                    if (event === 'tool.progress') {
-                      const delta = readString(data.delta)
-                      const toolName = getToolName(data)
-                      if (toolName === '_thinking' || toolName === 'tool') {
+                      if (event === 'assistant.delta') {
+                        const delta =
+                          typeof data.delta === 'string' ? data.delta : ''
                         if (!delta) return
                         persistActiveRun((runSessionKey, activeId) =>
-                          setRunThinking(runSessionKey, activeId, delta),
+                          appendRunText(runSessionKey, activeId, delta),
                         )
                         const translated = {
                           text: delta,
                           sessionKey: sessionKeyFromEvent,
                           runId,
                         }
-                        sendEvent('thinking', translated)
-                        skipPublish || publishChatEvent('thinking', translated)
-                        lastActivity = delta.length > 60 ? delta.slice(0, 60) + '...' : delta
+                        sendEvent('chunk', translated)
+                        skipPublish || publishChatEvent('chunk', translated)
                         return
                       }
-                      const translated = {
-                        phase: 'calling',
-                        name: toolName,
-                        toolCallId: getToolCallId(data, runId, toolName),
-                        args: getToolArgs(data),
-                        result: delta || undefined,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId,
+
+                      if (
+                        event === 'tool.pending' ||
+                        event === 'tool.started' ||
+                        event === 'tool.calling' ||
+                        event === 'tool.running'
+                      ) {
+                        const toolName = getToolName(data)
+                        const preview =
+                          typeof data.preview === 'string'
+                            ? data.preview
+                            : undefined
+                        const translated = {
+                          phase:
+                            event === 'tool.pending' || event === 'tool.started'
+                              ? 'start'
+                              : 'calling',
                           name: toolName,
-                          phase: 'calling',
-                          args: translated.args,
-                          result: translated.result,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      return
-                    }
-
-                    if (event === 'tool.completed') {
-                      const toolName = getToolName(data)
-                      const resultPreview = getToolResultPreview(data)
-                      const translated = {
-                        phase: 'complete',
-                        name: toolName,
-                        toolCallId: getToolCallId(data, runId, toolName),
-                        args: getToolArgs(data),
-                        result: resultPreview.slice(0, 4000),
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId,
-                          name: toolName,
-                          phase: 'complete',
-                          args: translated.args,
-                          result: translated.result,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      lastActivity = `Completed: ${toolName.replace(/_/g, ' ')}`
-                      return
-                    }
-
-                    if (event === 'artifact.created') {
-                      const artifact =
-                        data.artifact && typeof data.artifact === 'object'
-                          ? (data.artifact as Record<string, unknown>)
-                          : {}
-                      const translated = {
-                        name: readString(data.tool_name) || 'artifact',
-                        title:
-                          readString(artifact.title) ||
-                          readString(data.title) ||
-                          'Artifact created',
-                        kind:
-                          readString(artifact.kind) ||
-                          readString(data.kind) ||
-                          'artifact',
-                        path:
-                          readString(artifact.path) || readString(data.path) || '',
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      sendEvent('artifact', translated)
-                      skipPublish || publishChatEvent('artifact', translated)
-                      return
-                    }
-
-                    if (event === 'memory.updated') {
-                      const translated = {
-                        phase: 'complete',
-                        name: 'memory',
-                        toolCallId: readString(data.tool_call_id) || undefined,
-                        result:
-                          readString(data.message) ||
-                          `Updated ${readString(data.target) || 'memory'}`,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId || `${runId || 'run'}:memory`,
-                          name: 'memory',
-                          phase: 'complete',
-                          result: translated.result,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      return
-                    }
-
-                    if (event === 'skill.loaded') {
-                      const skill =
-                        data.skill && typeof data.skill === 'object'
-                          ? (data.skill as Record<string, unknown>)
-                          : {}
-                      const translated = {
-                        phase: 'complete',
-                        name: 'skill',
-                        toolCallId: readString(data.tool_call_id) || undefined,
-                        result:
-                          readString(skill.name) ||
-                          readString(data.skill_name) ||
-                          'Skill loaded',
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId || `${runId || 'run'}:skill`,
-                          name: 'skill',
-                          phase: 'complete',
-                          result: translated.result,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      return
-                    }
-
-                    if (event === 'tool.failed') {
-                      const errorMessage =
-                        readString(
-                          (data.error as Record<string, unknown> | undefined)
-                            ?.message,
-                        ) || readString(data.message)
-                      const toolName = getToolName(data)
-                      const translated = {
-                        phase: 'error',
-                        name: toolName,
-                        toolCallId: getToolCallId(data, runId, toolName),
-                        result: errorMessage,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        upsertRunToolCall(runSessionKey, activeId, {
-                          id: translated.toolCallId,
-                          name: toolName,
-                          phase: 'error',
-                          result: translated.result,
-                        }),
-                      )
-                      sendEvent('tool', translated)
-                      skipPublish || publishChatEvent('tool', translated)
-                      return
-                    }
-
-                    if (event === 'error') {
-                      const errorMessage =
-                        readString(
-                          (data.error as Record<string, unknown> | undefined)
-                            ?.message,
-                        ) ||
-                        readString(data.message) ||
-                        'Hermes stream error'
-                      persistActiveRun((runSessionKey, activeId) =>
-                        markRunStatus(
-                          runSessionKey,
-                          activeId,
-                          'error',
-                          errorMessage,
-                        ),
-                      )
-                      sendEvent('error', {
-                        message: errorMessage,
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
-                      })
-                      closeStream()
-                      return
-                    }
-
-                    if (event === 'run.completed') {
-                      // Backfill tool calls from session history.
-                      // Hermes Agent currently does not stream tool.* events
-                      // reliably, but it persists tool calls on the assistant
-                      // message. Fetch the latest assistant message and emit
-                      // synthetic 'tool' events for each tool call so the
-                      // Workspace UI can render the Activity card.
-                      try {
-                        const sid =
-                          readString(data.session_id) ||
-                          sessionKeyFromEvent ||
-                          ''
-                        if (sid) {
-                          let persistedMessages: Array<
-                            Record<string, unknown>
-                          > = []
-                          try {
-                            persistedMessages =
-                              (await getSessionMessagesFromAgent(
-                                sid,
-                              )) as unknown as Array<Record<string, unknown>>
-                          } catch {
-                            persistedMessages = []
-                          }
-                          // Walk back to the most recent assistant message in
-                          // this run; tool_calls are siblings on it. Also
-                          // collect tool_result entries that immediately
-                          // follow it so we can pair input/output.
-                          // Use the per-run baseline so we never read tool
-                          // calls from a previous turn.
-                          const sliceFrom = Math.max(
-                            0,
-                            Math.min(
-                              liveBaselineCount,
-                              Math.max(0, persistedMessages.length - 1),
-                            ),
-                          )
-                          const recent = persistedMessages.slice(
-                            sliceFrom,
-                          )
-                          let lastAssistantIndex = -1
-                          for (let i = recent.length - 1; i >= 0; i--) {
-                            const m = recent[i]
-                            if (m && m.role === 'assistant') {
-                              lastAssistantIndex = i
-                              break
-                            }
-                          }
-                          if (lastAssistantIndex >= 0) {
-                            const lastAssistant = recent[
-                              lastAssistantIndex
-                            ]
-                            const rawToolCalls = (lastAssistant.tool_calls ??
-                              (lastAssistant as any).toolCalls) as
-                              | Array<Record<string, unknown>>
-                              | undefined
-                            const toolCalls =
-                              Array.isArray(rawToolCalls) && rawToolCalls.length
-                                ? rawToolCalls
-                                : []
-
-                            const syntheticEvents = collectSyntheticLiveToolEvents({
-                              messages: recent,
-                              tracker: syntheticLiveToolTracker,
-                              sessionKey: sessionKeyFromEvent,
-                              runId,
-                            })
-                            for (const synthetic of syntheticEvents) {
-                              persistActiveRun(
-                                (runSessionKey, activeId) =>
-                                  upsertRunToolCall(
-                                    runSessionKey,
-                                    activeId,
-                                    {
-                                      id: synthetic.toolCallId,
-                                      name: synthetic.name,
-                                      phase: synthetic.phase,
-                                      args: synthetic.args,
-                                      result: synthetic.result,
-                                    },
-                                  ),
-                              )
-                              sendEvent('tool', synthetic)
-                              skipPublish ||
-                                publishChatEvent('tool', synthetic)
-                            }
-                          }
+                          toolCallId: getToolCallId(data, runId, toolName),
+                          args: getToolArgs(data),
+                          preview,
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
                         }
-                      } catch (err) {
-                        // Backfill is best-effort; don't fail the run.
-                        console.warn(
-                          '[send-stream] tool backfill failed:',
-                          err,
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id: translated.toolCallId,
+                            name: toolName,
+                            phase: translated.phase,
+                            args: translated.args,
+                            preview,
+                          }),
                         )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        lastActivity = `Running: ${toolName.replace(/_/g, ' ')}`
+                        return
                       }
 
-                      const translated = {
-                        state: 'complete',
-                        sessionKey: sessionKeyFromEvent,
-                        runId,
+                      if (event === 'tool.progress') {
+                        const delta = readString(data.delta)
+                        const toolName = getToolName(data)
+                        if (toolName === '_thinking' || toolName === 'tool') {
+                          if (!delta) return
+                          persistActiveRun((runSessionKey, activeId) =>
+                            setRunThinking(runSessionKey, activeId, delta),
+                          )
+                          const translated = {
+                            text: delta,
+                            sessionKey: sessionKeyFromEvent,
+                            runId,
+                          }
+                          sendEvent('thinking', translated)
+                          skipPublish ||
+                            publishChatEvent('thinking', translated)
+                          lastActivity =
+                            delta.length > 60
+                              ? delta.slice(0, 60) + '...'
+                              : delta
+                          return
+                        }
+                        const translated = {
+                          phase: 'calling',
+                          name: toolName,
+                          toolCallId: getToolCallId(data, runId, toolName),
+                          args: getToolArgs(data),
+                          result: delta || undefined,
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id: translated.toolCallId,
+                            name: toolName,
+                            phase: 'calling',
+                            args: translated.args,
+                            result: translated.result,
+                          }),
+                        )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        return
                       }
-                      persistActiveRun((runSessionKey, activeId) =>
-                        markRunStatus(runSessionKey, activeId, 'complete'),
-                      )
-                      sendEvent('done', translated)
-                      skipPublish || publishChatEvent('done', translated)
-                      closeStream()
-                    }
+
+                      if (event === 'tool.completed') {
+                        const toolName = getToolName(data)
+                        const resultPreview = getToolResultPreview(data)
+                        const translated = {
+                          phase: 'complete',
+                          name: toolName,
+                          toolCallId: getToolCallId(data, runId, toolName),
+                          args: getToolArgs(data),
+                          result: resultPreview.slice(0, 4000),
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id: translated.toolCallId,
+                            name: toolName,
+                            phase: 'complete',
+                            args: translated.args,
+                            result: translated.result,
+                          }),
+                        )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        lastActivity = `Completed: ${toolName.replace(/_/g, ' ')}`
+                        return
+                      }
+
+                      if (event === 'artifact.created') {
+                        const artifact =
+                          data.artifact && typeof data.artifact === 'object'
+                            ? (data.artifact as Record<string, unknown>)
+                            : {}
+                        const translated = {
+                          name: readString(data.tool_name) || 'artifact',
+                          title:
+                            readString(artifact.title) ||
+                            readString(data.title) ||
+                            'Artifact created',
+                          kind:
+                            readString(artifact.kind) ||
+                            readString(data.kind) ||
+                            'artifact',
+                          path:
+                            readString(artifact.path) ||
+                            readString(data.path) ||
+                            '',
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        sendEvent('artifact', translated)
+                        skipPublish || publishChatEvent('artifact', translated)
+                        return
+                      }
+
+                      if (event === 'memory.updated') {
+                        const translated = {
+                          phase: 'complete',
+                          name: 'memory',
+                          toolCallId:
+                            readString(data.tool_call_id) || undefined,
+                          result:
+                            readString(data.message) ||
+                            `Updated ${readString(data.target) || 'memory'}`,
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id:
+                              translated.toolCallId ||
+                              `${runId || 'run'}:memory`,
+                            name: 'memory',
+                            phase: 'complete',
+                            result: translated.result,
+                          }),
+                        )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        return
+                      }
+
+                      if (event === 'skill.loaded') {
+                        const skill =
+                          data.skill && typeof data.skill === 'object'
+                            ? (data.skill as Record<string, unknown>)
+                            : {}
+                        const translated = {
+                          phase: 'complete',
+                          name: 'skill',
+                          toolCallId:
+                            readString(data.tool_call_id) || undefined,
+                          result:
+                            readString(skill.name) ||
+                            readString(data.skill_name) ||
+                            'Skill loaded',
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id:
+                              translated.toolCallId ||
+                              `${runId || 'run'}:skill`,
+                            name: 'skill',
+                            phase: 'complete',
+                            result: translated.result,
+                          }),
+                        )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        return
+                      }
+
+                      if (event === 'tool.failed') {
+                        const errorMessage =
+                          readString(
+                            (data.error as Record<string, unknown> | undefined)
+                              ?.message,
+                          ) || readString(data.message)
+                        const toolName = getToolName(data)
+                        const translated = {
+                          phase: 'error',
+                          name: toolName,
+                          toolCallId: getToolCallId(data, runId, toolName),
+                          result: errorMessage,
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          upsertRunToolCall(runSessionKey, activeId, {
+                            id: translated.toolCallId,
+                            name: toolName,
+                            phase: 'error',
+                            result: translated.result,
+                          }),
+                        )
+                        sendEvent('tool', translated)
+                        skipPublish || publishChatEvent('tool', translated)
+                        return
+                      }
+
+                      if (event === 'error') {
+                        const errorMessage =
+                          readString(
+                            (data.error as Record<string, unknown> | undefined)
+                              ?.message,
+                          ) ||
+                          readString(data.message) ||
+                          'Hermes stream error'
+                        persistActiveRun((runSessionKey, activeId) =>
+                          markRunStatus(
+                            runSessionKey,
+                            activeId,
+                            'error',
+                            errorMessage,
+                          ),
+                        )
+                        sendEvent('error', {
+                          message: errorMessage,
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        })
+                        closeStream()
+                        return
+                      }
+
+                      if (event === 'run.completed') {
+                        // Backfill tool calls from session history.
+                        // Hermes Agent currently does not stream tool.* events
+                        // reliably, but it persists tool calls on the assistant
+                        // message. Fetch the latest assistant message and emit
+                        // synthetic 'tool' events for each tool call so the
+                        // Workspace UI can render the Activity card.
+                        try {
+                          const sid =
+                            readString(data.session_id) ||
+                            sessionKeyFromEvent ||
+                            ''
+                          if (sid) {
+                            let persistedMessages: Array<
+                              Record<string, unknown>
+                            > = []
+                            try {
+                              persistedMessages =
+                                (await getSessionMessagesFromAgent(
+                                  sid,
+                                )) as unknown as Array<Record<string, unknown>>
+                            } catch {
+                              persistedMessages = []
+                            }
+                            // Walk back to the most recent assistant message in
+                            // this run; tool_calls are siblings on it. Also
+                            // collect tool_result entries that immediately
+                            // follow it so we can pair input/output.
+                            // Use the per-run baseline so we never read tool
+                            // calls from a previous turn.
+                            const sliceFrom = Math.max(
+                              0,
+                              Math.min(
+                                liveBaselineCount,
+                                Math.max(0, persistedMessages.length - 1),
+                              ),
+                            )
+                            const recent = persistedMessages.slice(sliceFrom)
+                            let lastAssistantIndex = -1
+                            for (let i = recent.length - 1; i >= 0; i--) {
+                              const m = recent[i]
+                              if (m && m.role === 'assistant') {
+                                lastAssistantIndex = i
+                                break
+                              }
+                            }
+                            if (lastAssistantIndex >= 0) {
+                              const lastAssistant = recent[lastAssistantIndex]
+                              const rawToolCalls = (lastAssistant.tool_calls ??
+                                (lastAssistant as any).toolCalls) as
+                                | Array<Record<string, unknown>>
+                                | undefined
+                              const toolCalls =
+                                Array.isArray(rawToolCalls) &&
+                                rawToolCalls.length
+                                  ? rawToolCalls
+                                  : []
+
+                              const syntheticEvents =
+                                collectSyntheticLiveToolEvents({
+                                  messages: recent,
+                                  tracker: syntheticLiveToolTracker,
+                                  sessionKey: sessionKeyFromEvent,
+                                  runId,
+                                })
+                              for (const synthetic of syntheticEvents) {
+                                persistActiveRun((runSessionKey, activeId) =>
+                                  upsertRunToolCall(runSessionKey, activeId, {
+                                    id: synthetic.toolCallId,
+                                    name: synthetic.name,
+                                    phase: synthetic.phase,
+                                    args: synthetic.args,
+                                    result: synthetic.result,
+                                  }),
+                                )
+                                sendEvent('tool', synthetic)
+                                skipPublish ||
+                                  publishChatEvent('tool', synthetic)
+                              }
+                            }
+                          }
+                        } catch (err) {
+                          // Backfill is best-effort; don't fail the run.
+                          console.warn(
+                            '[send-stream] tool backfill failed:',
+                            err,
+                          )
+                        }
+
+                        const translated = {
+                          state: 'complete',
+                          sessionKey: sessionKeyFromEvent,
+                          runId,
+                        }
+                        persistActiveRun((runSessionKey, activeId) =>
+                          markRunStatus(runSessionKey, activeId, 'complete'),
+                        )
+                        sendEvent('done', translated)
+                        skipPublish || publishChatEvent('done', translated)
+                        closeStream()
+                      }
+                    },
                   },
-                },
                 )
               } finally {
                 // Stop the mid-run tool poller and let it drain.

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -20,6 +20,10 @@ import { getChatMode } from '../../server/gateway-capabilities'
 import { appendLocalMessage, ensureLocalSession, getLocalMessages, touchLocalSession } from '../../server/local-session-store'
 import { getDiscoveredModels, getLocalProviderDef } from '../../server/local-provider-discovery'
 import { openaiChat } from '../../server/openai-compat-api'
+import {
+  HermesRunStartError,
+  streamHermesRun,
+} from '../../server/hermes-runs-api'
 import { streamResponses } from '../../server/responses-api'
 import { selectPortableConversationHistory } from '../../server/portable-history'
 import {
@@ -605,6 +609,157 @@ export const Route = createFileRoute('/api/send-stream')({
                   // openaiChat path.
                   const useResponsesApi =
                     process.env.HERMES_USE_RESPONSES === '1' && !localBaseUrl
+                  const useRunsApi =
+                    process.env.HERMES_USE_RUNS !== '0' && !localBaseUrl
+                  if (useRunsApi) {
+                    try {
+                      const runStream = streamHermesRun({
+                        input: scopedMessage,
+                        conversationHistory: effectiveHistory,
+                        model:
+                          typeof body.model === 'string' ? body.model : undefined,
+                        sessionId: portableSessionKey,
+                        signal: abortController.signal,
+                      })
+                      for await (const ev of runStream) {
+                        if (ev.kind === 'started') {
+                          // Workspace already emitted and persisted its own
+                          // UI runId above. Keep Hermes' run_id only inside
+                          // approval payloads so store writes keep targeting
+                          // the active Workspace run.
+                          continue
+                        }
+                        if (ev.kind === 'text.delta') {
+                          accumulated += ev.delta
+                          persistActiveRun((runSessionKey, activeId) =>
+                            appendRunText(runSessionKey, activeId, accumulated, {
+                              replace: true,
+                            }),
+                          )
+                          sendEvent('chunk', {
+                            text: accumulated,
+                            fullReplace: true,
+                            sessionKey: portableSessionKey,
+                            runId,
+                          })
+                          continue
+                        }
+                        if (ev.kind === 'reasoning') {
+                          persistActiveRun((runSessionKey, activeId) =>
+                            setRunThinking(runSessionKey, activeId, ev.text),
+                          )
+                          sendEvent('thinking', {
+                            text: ev.text,
+                            sessionKey: portableSessionKey,
+                            runId,
+                          })
+                          continue
+                        }
+                        if (ev.kind === 'tool.started') {
+                          persistActiveRun((runSessionKey, activeId) =>
+                            upsertRunToolCall(runSessionKey, activeId, {
+                              id: ev.callId,
+                              name: ev.name,
+                              phase: 'calling',
+                              preview: ev.preview,
+                            }),
+                          )
+                          sendEvent('tool', {
+                            phase: 'calling',
+                            name: ev.name,
+                            toolCallId: ev.callId,
+                            preview: ev.preview,
+                            sessionKey: portableSessionKey,
+                            runId,
+                          })
+                          lastActivity = `Running: ${ev.name.replace(/_/g, ' ')}`
+                          continue
+                        }
+                        if (ev.kind === 'tool.completed') {
+                          persistActiveRun((runSessionKey, activeId) =>
+                            upsertRunToolCall(runSessionKey, activeId, {
+                              id: ev.callId,
+                              name: ev.name,
+                              phase: ev.error ? 'error' : 'complete',
+                            }),
+                          )
+                          sendEvent('tool', {
+                            phase: ev.error ? 'error' : 'complete',
+                            name: ev.name,
+                            toolCallId: ev.callId,
+                            sessionKey: portableSessionKey,
+                            runId,
+                          })
+                          lastActivity = `Completed: ${ev.name.replace(/_/g, ' ')}`
+                          continue
+                        }
+                        if (ev.kind === 'approval.request') {
+                          sendEvent('approval', {
+                            ...ev.approval,
+                            sessionKey: portableSessionKey,
+                            source: 'agent',
+                          })
+                          lastActivity = 'Waiting for approval...'
+                          continue
+                        }
+                        if (ev.kind === 'approval.responded') {
+                          lastActivity = 'Approval received; resuming...'
+                          continue
+                        }
+                        if (ev.kind === 'completed') {
+                          if (!accumulated && ev.output) {
+                            accumulated = ev.output
+                            persistActiveRun((runSessionKey, activeId) =>
+                              appendRunText(runSessionKey, activeId, accumulated, {
+                                replace: true,
+                              }),
+                            )
+                            sendEvent('chunk', {
+                              text: accumulated,
+                              fullReplace: true,
+                              sessionKey: portableSessionKey,
+                              runId,
+                            })
+                          }
+                          break
+                        }
+                        if (ev.kind === 'failed') {
+                          throw new Error(ev.error)
+                        }
+                      }
+                      appendLocalMessage(portableSessionKey, {
+                        id: crypto.randomUUID(),
+                        role: 'assistant',
+                        content: accumulated,
+                        timestamp: Date.now(),
+                      })
+                      touchLocalSession(portableSessionKey)
+                      persistActiveRun((runSessionKey, activeId) =>
+                        markRunStatus(runSessionKey, activeId, 'complete'),
+                      )
+                      sendEvent('done', {
+                        state: 'complete',
+                        sessionKey: portableSessionKey,
+                        runId,
+                        message: {
+                          role: 'assistant',
+                          content: [{ type: 'text', text: accumulated }],
+                        },
+                      })
+                      closeStream()
+                      return
+                    } catch (err) {
+                      if (!(err instanceof HermesRunStartError)) {
+                        throw err
+                      }
+                      console.warn(
+                        '[send-stream] /v1/runs path unavailable, falling back:',
+                        err,
+                      )
+                      accumulated = ''
+                    }
+                  }
+
                   if (useResponsesApi) {
                     const thinking = ''
                     // Track tool calls by callId so a `tool.completed`

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -12,6 +12,7 @@ import {
 import {
   appendRunText,
   createPersistedRun,
+  addRunLifecycleEvent,
   markRunStatus,
   setRunThinking,
   upsertRunToolCall,
@@ -31,7 +32,14 @@ import { openaiChat } from '../../server/openai-compat-api'
 import {
   HermesRunStartError,
   streamHermesRun,
+  submitHermesRunApproval,
 } from '../../server/hermes-runs-api'
+import {
+  clearPendingSessionApproval,
+  markSessionApprovalRuleUsed,
+  registerPendingSessionApproval,
+  shouldAutoApproveSessionApproval,
+} from '../../server/session-approval-store'
 import { streamResponses } from '../../server/responses-api'
 import { selectPortableConversationHistory } from '../../server/portable-history'
 import {
@@ -785,6 +793,46 @@ export const Route = createFileRoute('/api/send-stream')({
                           continue
                         }
                         if (ev.kind === 'approval.request') {
+                          await registerPendingSessionApproval({
+                            runId,
+                            sessionKey: portableSessionKey,
+                            approval: ev.approval,
+                          })
+                          if (
+                            await shouldAutoApproveSessionApproval({
+                              sessionKey: portableSessionKey,
+                              approval: ev.approval,
+                            })
+                          ) {
+                            try {
+                              await submitHermesRunApproval(runId, 'once')
+                              await clearPendingSessionApproval(runId)
+                              await markSessionApprovalRuleUsed({
+                                sessionKey: portableSessionKey,
+                                approval: ev.approval,
+                              })
+                              persistActiveRun((runSessionKey, activeId) =>
+                                addRunLifecycleEvent(runSessionKey, activeId, {
+                                  text: 'Session approval auto-approved',
+                                  emoji: '🔓',
+                                  timestamp: Date.now(),
+                                  isError: false,
+                                }),
+                              )
+                              sendEvent('tool', {
+                                phase: 'complete',
+                                name: 'approval',
+                                result: 'Session approval auto-approved',
+                                sessionKey: portableSessionKey,
+                                runId,
+                              })
+                              lastActivity = 'Session approval auto-approved; resuming...'
+                              continue
+                            } catch {
+                              lastActivity =
+                                'Session auto-approval failed; waiting for approval...'
+                            }
+                          }
                           sendEvent('approval', {
                             ...ev.approval,
                             sessionKey: portableSessionKey,

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -133,6 +133,63 @@ function readApprovalSubmitId(payload: Record<string, unknown>): string {
   )
 }
 
+type ServerPendingApproval = {
+  runId?: unknown
+  sessionKey?: unknown
+  actionLabel?: unknown
+  requestedAt?: unknown
+}
+
+function mergePendingApprovals(
+  localApprovals: Array<ApprovalRequest>,
+  serverApprovals: Array<ApprovalRequest>,
+): Array<ApprovalRequest> {
+  const merged = new Map<string, ApprovalRequest>()
+  for (const approval of localApprovals) {
+    merged.set(approval.gatewayApprovalId || approval.id, approval)
+  }
+  for (const approval of serverApprovals) {
+    merged.set(approval.gatewayApprovalId || approval.id, approval)
+  }
+  return [...merged.values()].sort((a, b) => b.requestedAt - a.requestedAt)
+}
+
+async function fetchServerPendingApprovals(): Promise<Array<ApprovalRequest>> {
+  const response = await fetch('/api/approvals/pending')
+  if (!response.ok) return []
+  const payload = (await response.json()) as {
+    pending?: Array<ServerPendingApproval>
+  }
+  return (payload.pending ?? []).flatMap((entry) => {
+    if (typeof entry.runId !== 'string' || !entry.runId.trim()) return []
+    const sessionKey =
+      typeof entry.sessionKey === 'string' && entry.sessionKey.trim()
+        ? entry.sessionKey.trim()
+        : 'Agent'
+    const action =
+      typeof entry.actionLabel === 'string' && entry.actionLabel.trim()
+        ? entry.actionLabel.trim()
+        : 'Tool call requires approval'
+    const requestedAt =
+      typeof entry.requestedAt === 'number' && Number.isFinite(entry.requestedAt)
+        ? entry.requestedAt
+        : Date.now()
+    return [
+      {
+        id: `server-${entry.runId}`,
+        agentId: sessionKey,
+        agentName: 'Agent',
+        action,
+        context: '',
+        requestedAt,
+        status: 'pending' as const,
+        source: 'agent' as const,
+        gatewayApprovalId: entry.runId,
+      },
+    ]
+  })
+}
+
 type ChatScreenProps = {
   activeFriendlyId: string
   isNewChat?: boolean
@@ -852,13 +909,27 @@ export function ChatScreen({
   }, [clearCompletedStreaming, waitingForResponse])
 
   useEffect(() => {
-    function checkApprovals() {
-      const all = loadApprovals()
-      setPendingApprovals(all.filter((entry) => entry.status === 'pending'))
+    let cancelled = false
+
+    async function checkApprovals() {
+      const localPending = loadApprovals().filter(
+        (entry) => entry.status === 'pending',
+      )
+      let serverPending: Array<ApprovalRequest> = []
+      try {
+        serverPending = await fetchServerPendingApprovals()
+      } catch {
+        serverPending = []
+      }
+      if (cancelled) return
+      setPendingApprovals(mergePendingApprovals(localPending, serverPending))
     }
-    checkApprovals()
-    const id = window.setInterval(checkApprovals, 2000)
-    return () => window.clearInterval(id)
+    void checkApprovals()
+    const id = window.setInterval(() => void checkApprovals(), 1000)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
   }, [])
 
   const resolvePendingApproval = useCallback(

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -853,7 +853,11 @@ export function ChatScreen({
   }, [])
 
   const resolvePendingApproval = useCallback(
-    async (approval: ApprovalRequest, status: 'approved' | 'denied') => {
+    async (
+      approval: ApprovalRequest,
+      status: 'approved' | 'denied',
+      choice: 'once' | 'session' = 'once',
+    ) => {
       const nextApprovals = loadApprovals().map((entry) => {
         if (entry.id !== approval.id) return entry
         return {
@@ -873,7 +877,14 @@ export function ChatScreen({
           ? `/api/approvals/${approval.gatewayApprovalId}/approve`
           : `/api/approvals/${approval.gatewayApprovalId}/deny`
       try {
-        await fetch(endpoint, { method: 'POST' })
+        await fetch(endpoint, {
+          method: 'POST',
+          headers:
+            status === 'approved'
+              ? { 'Content-Type': 'application/json' }
+              : undefined,
+          body: status === 'approved' ? JSON.stringify({ choice }) : undefined,
+        })
       } catch {
         // Local resolution still succeeds when API endpoint is unavailable.
       }
@@ -2941,11 +2952,28 @@ export function ChatScreen({
                       <button
                         type="button"
                         onClick={() => {
-                          void resolvePendingApproval(approval, 'approved')
+                          void resolvePendingApproval(
+                            approval,
+                            'approved',
+                            'once',
+                          )
                         }}
                         className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-600"
                       >
                         Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void resolvePendingApproval(
+                            approval,
+                            'approved',
+                            'session',
+                          )
+                        }}
+                        className="rounded-lg border border-emerald-200 bg-white px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800/50 dark:bg-emerald-900/10 dark:text-emerald-300 dark:hover:bg-emerald-900/30"
+                      >
+                        Session
                       </button>
                       <button
                         type="button"

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -117,6 +117,22 @@ export function setLocalModelOverride(model: string) {
   _localModelOverride = model
 }
 
+function readStringPayload(value: unknown): string {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : ''
+}
+
+function readApprovalSubmitId(payload: Record<string, unknown>): string {
+  return (
+    readStringPayload(payload.runId) ||
+    readStringPayload(payload.run_id) ||
+    readStringPayload(payload.approvalRunId) ||
+    readStringPayload(payload.approvalId) ||
+    readStringPayload(payload.id)
+  )
+}
+
 type ChatScreenProps = {
   activeFriendlyId: string
   isNewChat?: boolean
@@ -722,14 +738,7 @@ export function ChatScreen({
       setPendingGeneration(true)
     }, []),
     onApprovalRequest: useCallback((payload: Record<string, unknown>) => {
-      const approvalId =
-        typeof payload.id === 'string'
-          ? payload.id
-          : typeof payload.approvalId === 'string'
-            ? payload.approvalId
-            : typeof payload.approvalId === 'string'
-              ? payload.approvalId
-              : ''
+      const approvalId = readApprovalSubmitId(payload)
 
       const currentApprovals = loadApprovals()
       if (
@@ -858,6 +867,35 @@ export function ChatScreen({
       status: 'approved' | 'denied',
       choice: 'once' | 'session' = 'once',
     ) => {
+      if (approval.gatewayApprovalId) {
+        const endpoint =
+          status === 'approved'
+            ? `/api/approvals/${approval.gatewayApprovalId}/approve`
+            : `/api/approvals/${approval.gatewayApprovalId}/deny`
+        try {
+          const response = await fetch(endpoint, {
+            method: 'POST',
+            headers:
+              status === 'approved'
+                ? { 'Content-Type': 'application/json' }
+                : undefined,
+            body:
+              status === 'approved' ? JSON.stringify({ choice }) : undefined,
+          })
+          if (!response.ok) {
+            const text = await response.text().catch(() => '')
+            throw new Error(text || `Approval failed with ${response.status}`)
+          }
+        } catch (error) {
+          showErrorToast(
+            error instanceof Error
+              ? error.message
+              : 'Approval konnte nicht gesendet werden.',
+          )
+          return
+        }
+      }
+
       const nextApprovals = loadApprovals().map((entry) => {
         if (entry.id !== approval.id) return entry
         return {
@@ -870,24 +908,6 @@ export function ChatScreen({
       setPendingApprovals(
         nextApprovals.filter((entry) => entry.status === 'pending'),
       )
-      if (!approval.gatewayApprovalId) return
-
-      const endpoint =
-        status === 'approved'
-          ? `/api/approvals/${approval.gatewayApprovalId}/approve`
-          : `/api/approvals/${approval.gatewayApprovalId}/deny`
-      try {
-        await fetch(endpoint, {
-          method: 'POST',
-          headers:
-            status === 'approved'
-              ? { 'Content-Type': 'application/json' }
-              : undefined,
-          body: status === 'approved' ? JSON.stringify({ choice }) : undefined,
-        })
-      } catch {
-        // Local resolution still succeeds when API endpoint is unavailable.
-      }
     },
     [],
   )
@@ -1218,14 +1238,7 @@ export function ChatScreen({
       [queryClient],
     ),
     onApprovalRequest: useCallback((payload: Record<string, unknown>) => {
-      const approvalId =
-        typeof payload.id === 'string'
-          ? payload.id
-          : typeof payload.approvalId === 'string'
-            ? payload.approvalId
-            : typeof payload.runId === 'string'
-              ? payload.runId
-              : ''
+      const approvalId = readApprovalSubmitId(payload)
 
       const currentApprovals = loadApprovals()
       if (

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1177,6 +1177,68 @@ export function ChatScreen({
       },
       [queryClient],
     ),
+    onApprovalRequest: useCallback((payload: Record<string, unknown>) => {
+      const approvalId =
+        typeof payload.id === 'string'
+          ? payload.id
+          : typeof payload.approvalId === 'string'
+            ? payload.approvalId
+            : typeof payload.runId === 'string'
+              ? payload.runId
+              : ''
+
+      const currentApprovals = loadApprovals()
+      if (
+        approvalId &&
+        currentApprovals.some((entry) => {
+          return entry.status === 'pending' && entry.gatewayApprovalId === approvalId
+        })
+      ) {
+        setPendingApprovals(
+          currentApprovals.filter((entry) => entry.status === 'pending'),
+        )
+        return
+      }
+
+      const actionValue = payload.action ?? payload.tool ?? payload.command
+      const action =
+        typeof actionValue === 'string'
+          ? actionValue
+          : actionValue
+            ? JSON.stringify(actionValue)
+            : 'Tool call requires approval'
+      const contextValue = payload.context ?? payload.input ?? payload.args ?? payload.description
+      const context =
+        typeof contextValue === 'string'
+          ? contextValue
+          : contextValue
+            ? JSON.stringify(contextValue)
+            : ''
+      const agentNameValue =
+        payload.agentName ?? payload.agent ?? payload.source
+      const agentName =
+        typeof agentNameValue === 'string' && agentNameValue.trim().length > 0
+          ? agentNameValue
+          : 'Agent'
+      const agentIdValue =
+        payload.agentId ?? payload.sessionKey ?? payload.source
+      const agentId =
+        typeof agentIdValue === 'string' && agentIdValue.trim().length > 0
+          ? agentIdValue
+          : 'claude'
+
+      addApproval({
+        agentId,
+        agentName,
+        action,
+        context,
+        source: 'agent',
+        gatewayApprovalId: approvalId || undefined,
+      })
+      setPendingApprovals(
+        loadApprovals().filter((entry) => entry.status === 'pending'),
+      )
+    }, []),
     onComplete: useCallback((message: ChatMessage) => {
       const activeSend = activeSendRef.current
       if (activeSend?.clientId) {

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -18,12 +18,11 @@ import {
   textFromMessage,
 } from './utils'
 import {
-  
   advanceStickyStreamingText,
   createOptimisticMessage,
   createResponseWaitSnapshot,
   isTerminalActiveRunStatus,
-  shouldClearWaitingForAssistantMessage
+  shouldClearWaitingForAssistantMessage,
 } from './chat-screen-utils'
 import {
   appendHistoryMessage,
@@ -71,7 +70,7 @@ import type {
   ChatRunCommandDetail,
   ChatSubmitSelectionDetail,
 } from './chat-events'
-import type {ResponseWaitSnapshot} from './chat-screen-utils';
+import type { ResponseWaitSnapshot } from './chat-screen-utils'
 import type {
   ChatComposerAttachment,
   ChatComposerHandle,
@@ -80,7 +79,7 @@ import type {
 } from './components/chat-composer'
 import type { ApprovalRequest } from '@/screens/gateway/lib/approvals-store'
 import type { ChatAttachment, ChatMessage, SessionMeta } from './types'
-import type {AgentActivity} from '@/stores/chat-activity-store';
+import type { AgentActivity } from '@/stores/chat-activity-store'
 import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { playChatComplete } from '@/lib/sounds'
 import {
@@ -111,10 +110,12 @@ import { useResearchCard } from '@/hooks/use-research-card'
 // MOBILE_TAB_BAR_OFFSET removed — tab bar always hidden in chat
 import { useTapDebug } from '@/hooks/use-tap-debug'
 import { useChatMode } from '@/hooks/use-chat-mode'
-import {  useChatActivityStore } from '@/stores/chat-activity-store'
+import { useChatActivityStore } from '@/stores/chat-activity-store'
 
 export let _localModelOverride = ''
-export function setLocalModelOverride(model: string) { _localModelOverride = model }
+export function setLocalModelOverride(model: string) {
+  _localModelOverride = model
+}
 
 type ChatScreenProps = {
   activeFriendlyId: string
@@ -170,6 +171,10 @@ function normalizeMessageValue(value: unknown): string {
   if (typeof value !== 'string') return ''
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : ''
+}
+
+function compactAssistantTextKey(text: string): string {
+  return text.replace(/\s+/g, '')
 }
 
 function getPortableHistoryContent(message: ChatMessage): string {
@@ -509,7 +514,13 @@ export function ChatScreen({
     if (typeof window === 'undefined') return 'low'
     const key = `claude-thinking-${activeFriendlyId || 'new'}`
     const stored = window.sessionStorage.getItem(key)
-    if (stored === 'off' || stored === 'low' || stored === 'medium' || stored === 'high' || stored === 'adaptive')
+    if (
+      stored === 'off' ||
+      stored === 'low' ||
+      stored === 'medium' ||
+      stored === 'high' ||
+      stored === 'adaptive'
+    )
       return stored
     return 'low'
   })
@@ -519,7 +530,8 @@ export function ChatScreen({
   useEffect(() => {
     if (typeof window === 'undefined') return
     const key = `claude-thinking-${activeFriendlyId || 'new'}`
-    thinkingInitializedByUserRef.current = window.sessionStorage.getItem(key) !== null
+    thinkingInitializedByUserRef.current =
+      window.sessionStorage.getItem(key) !== null
   }, [activeFriendlyId])
   const { alertOpen, alertThreshold, alertPercent, dismissAlert } =
     useContextAlert()
@@ -662,7 +674,8 @@ export function ChatScreen({
   // If so, re-set waitingForResponse in the store so the UI shows the spinner.
   useActiveRunCheck({
     sessionKey: resolvedSessionKey ?? '',
-    enabled: !isNewChat && Boolean(resolvedSessionKey) && historyQuery.isSuccess,
+    enabled:
+      !isNewChat && Boolean(resolvedSessionKey) && historyQuery.isSuccess,
     onCheckComplete: useCallback(() => {
       setActiveRunCheckDone(true)
     }, []),
@@ -688,9 +701,9 @@ export function ChatScreen({
       : isNewChat
         ? 'new'
         : resolvedSessionKey ||
-        sessionKeyForHistory ||
-        activeCanonicalKey ||
-        'main',
+          sessionKeyForHistory ||
+          activeCanonicalKey ||
+          'main',
     friendlyId: portableChatFriendlyId,
     historyMessages,
     portableMode: isPortableMode,
@@ -722,7 +735,9 @@ export function ChatScreen({
       if (
         approvalId &&
         currentApprovals.some((entry) => {
-          return entry.status === 'pending' && entry.gatewayApprovalId === approvalId
+          return (
+            entry.status === 'pending' && entry.gatewayApprovalId === approvalId
+          )
         })
       ) {
         setPendingApprovals(
@@ -912,10 +927,7 @@ export function ChatScreen({
     // hasn't processed the user's POST yet, the optimistic message vanishes.
     const historySessionKey = isPortableMode
       ? 'main'
-      : activeSessionKey ||
-        sessionKeyForHistory ||
-        resolvedSessionKey ||
-        'main'
+      : activeSessionKey || sessionKeyForHistory || resolvedSessionKey || 'main'
     const reInjectOptimistic = snapshotOptimisticUserMessages(
       queryClient,
       portableChatFriendlyId,
@@ -1005,7 +1017,8 @@ export function ChatScreen({
     ],
     queryFn: async () => {
       try {
-        const statusSessionKey = resolvedSessionKey || activeFriendlyId || 'main'
+        const statusSessionKey =
+          resolvedSessionKey || activeFriendlyId || 'main'
         const query = statusSessionKey
           ? `?sessionKey=${encodeURIComponent(statusSessionKey)}`
           : ''
@@ -1037,11 +1050,22 @@ export function ChatScreen({
       try {
         const res = await fetch('/api/hermes-config')
         if (!res.ok) return 'low'
-        const data = await res.json() as { config?: Record<string, unknown> }
+        const data = (await res.json()) as { config?: Record<string, unknown> }
         const agentSection = data?.config?.agent
-        if (agentSection && typeof agentSection === 'object' && !Array.isArray(agentSection)) {
-          const effort = (agentSection as Record<string, unknown>).reasoning_effort
-          if (effort === 'off' || effort === 'low' || effort === 'medium' || effort === 'high') return effort
+        if (
+          agentSection &&
+          typeof agentSection === 'object' &&
+          !Array.isArray(agentSection)
+        ) {
+          const effort = (agentSection as Record<string, unknown>)
+            .reasoning_effort
+          if (
+            effort === 'off' ||
+            effort === 'low' ||
+            effort === 'medium' ||
+            effort === 'high'
+          )
+            return effort
         }
         return 'low'
       } catch {
@@ -1093,7 +1117,12 @@ export function ChatScreen({
     if (thinkingInitializedByUserRef.current) return
     const configEffort = reasoningEffortQuery.data
     if (!configEffort) return
-    if (configEffort === 'off' || configEffort === 'low' || configEffort === 'medium' || configEffort === 'high') {
+    if (
+      configEffort === 'off' ||
+      configEffort === 'low' ||
+      configEffort === 'medium' ||
+      configEffort === 'high'
+    ) {
       setThinkingLevel(configEffort)
     }
   }, [reasoningEffortQuery.data])
@@ -1191,7 +1220,9 @@ export function ChatScreen({
       if (
         approvalId &&
         currentApprovals.some((entry) => {
-          return entry.status === 'pending' && entry.gatewayApprovalId === approvalId
+          return (
+            entry.status === 'pending' && entry.gatewayApprovalId === approvalId
+          )
         })
       ) {
         setPendingApprovals(
@@ -1207,7 +1238,8 @@ export function ChatScreen({
           : actionValue
             ? JSON.stringify(actionValue)
             : 'Tool call requires approval'
-      const contextValue = payload.context ?? payload.input ?? payload.args ?? payload.description
+      const contextValue =
+        payload.context ?? payload.input ?? payload.args ?? payload.description
       const context =
         typeof contextValue === 'string'
           ? contextValue
@@ -1239,36 +1271,39 @@ export function ChatScreen({
         loadApprovals().filter((entry) => entry.status === 'pending'),
       )
     }, []),
-    onComplete: useCallback((message: ChatMessage) => {
-      const activeSend = activeSendRef.current
-      if (activeSend?.clientId) {
-        updateHistoryMessageByClientIdEverywhere(
-          queryClient,
-          activeSend.clientId,
-          (message) => ({
-            ...message,
-            status: 'done',
-          }),
-        )
-      }
-      if (activeSend?.sessionKey) {
-        persistRecoveryMessage(activeSend.sessionKey, message)
-        clearPendingSendForSession(
-          activeSend.sessionKey,
-          activeSend.friendlyId,
-        )
-      }
-      activeSendRef.current = null
-      refreshHistoryRef.current()
-      setSending(false)
-      // Clear waitingForResponse so ThinkingBubble hides and message renders
-      streamFinish()
-      // Play notification sound if the user opted in (Settings → Chat).
-      // Read directly from the store to avoid re-creating this callback on every settings change.
-      if (useChatSettingsStore.getState().settings.soundOnChatComplete) {
-        playChatComplete()
-      }
-    }, [queryClient, streamFinish]),
+    onComplete: useCallback(
+      (message: ChatMessage) => {
+        const activeSend = activeSendRef.current
+        if (activeSend?.clientId) {
+          updateHistoryMessageByClientIdEverywhere(
+            queryClient,
+            activeSend.clientId,
+            (message) => ({
+              ...message,
+              status: 'done',
+            }),
+          )
+        }
+        if (activeSend?.sessionKey) {
+          persistRecoveryMessage(activeSend.sessionKey, message)
+          clearPendingSendForSession(
+            activeSend.sessionKey,
+            activeSend.friendlyId,
+          )
+        }
+        activeSendRef.current = null
+        refreshHistoryRef.current()
+        setSending(false)
+        // Clear waitingForResponse so ThinkingBubble hides and message renders
+        streamFinish()
+        // Play notification sound if the user opted in (Settings → Chat).
+        // Read directly from the store to avoid re-creating this callback on every settings change.
+        if (useChatSettingsStore.getState().settings.soundOnChatComplete) {
+          playChatComplete()
+        }
+      },
+      [queryClient, streamFinish],
+    ),
     onError: useCallback(
       (messageText: string) => {
         const activeSend = activeSendRef.current
@@ -1372,10 +1407,12 @@ export function ChatScreen({
     activeRealtimeStreamingText,
     activeIsRealtimeStreaming,
   )
-  const stickyStreamingTextRef = useRef<{ runId: string | null; text: string }>({
-    runId: null,
-    text: '',
-  })
+  const stickyStreamingTextRef = useRef<{ runId: string | null; text: string }>(
+    {
+      runId: null,
+      text: '',
+    },
+  )
   stickyStreamingTextRef.current = advanceStickyStreamingText({
     isStreaming: activeIsRealtimeStreaming,
     runId: streamingRunId ?? null,
@@ -1428,6 +1465,7 @@ export function ChatScreen({
 
     const seen = new Set<string>()
     const seenByText = new Map<string, ChatMessage>()
+    const seenByCompactAssistantText = new Map<string, ChatMessage>()
     const dedupedSet = new Set<ChatMessage>()
     for (const msg of sortedForDedup) {
       const raw = msg as Record<string, unknown>
@@ -1466,6 +1504,24 @@ export function ChatScreen({
         }
         if (!existingTextMatch) {
           seenByText.set(textKey, msg)
+        }
+
+        if (msg.role === 'assistant') {
+          const compactText = compactAssistantTextKey(text)
+          if (compactText.length >= 80) {
+            const compactKey = `assistant:compact-text:${compactText}`
+            const existingCompactTextMatch =
+              seenByCompactAssistantText.get(compactKey)
+            if (
+              existingCompactTextMatch &&
+              shouldCollapseTextDuplicate(existingCompactTextMatch, msg)
+            ) {
+              continue
+            }
+            if (!existingCompactTextMatch) {
+              seenByCompactAssistantText.set(compactKey, msg)
+            }
+          }
         }
       }
 
@@ -1511,11 +1567,12 @@ export function ChatScreen({
       // message is potentially the same response — match by text overlap
       if (streamingText.length > 0) {
         const msgText = textFromMessage(msg).trim()
-        if (msgText.length > 0 && (
-          msgText === streamingText ||
-          msgText.startsWith(streamingText) ||
-          streamingText.startsWith(msgText)
-        )) {
+        if (
+          msgText.length > 0 &&
+          (msgText === streamingText ||
+            msgText.startsWith(streamingText) ||
+            streamingText.startsWith(msgText))
+        ) {
           return true
         }
       }
@@ -1523,10 +1580,15 @@ export function ChatScreen({
       // calls as the streaming placeholder, it's the same response
       if (streamToolCalls.length > 0) {
         const msgContent = Array.isArray(msg.content) ? msg.content : []
-        const msgToolCalls = msgContent.filter((p: any) => p.type === 'toolCall')
-        if (msgToolCalls.length > 0 && msgToolCalls.length === streamToolCalls.length) {
+        const msgToolCalls = msgContent.filter(
+          (p: any) => p.type === 'toolCall',
+        )
+        if (
+          msgToolCalls.length > 0 &&
+          msgToolCalls.length === streamToolCalls.length
+        ) {
           return streamToolCalls.every((stc: any) =>
-            msgToolCalls.some((mtc: any) => mtc.name === stc.name)
+            msgToolCalls.some((mtc: any) => mtc.name === stc.name),
           )
         }
       }
@@ -1683,9 +1745,9 @@ export function ChatScreen({
   }, [suggestion, resolvedSessionKey, dismiss])
 
   // Sync chat activity to global store for sidebar orchestrator avatar
-  const setLocalActivity = useChatActivityStore(
-    (s) => s.setLocalActivity,
-  ) as (next: AgentActivity) => void
+  const setLocalActivity = useChatActivityStore((s) => s.setLocalActivity) as (
+    next: AgentActivity,
+  ) => void
   useEffect(() => {
     if (liveToolActivity.length > 0) {
       setLocalActivity('tool-use')

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -78,6 +78,7 @@ type UseStreamingMessageOptions = {
   onError?: (error: string) => void
   onThinking?: (thinking: string) => void
   onTool?: (tool: unknown) => void
+  onApprovalRequest?: (approval: Record<string, unknown>) => void
   onMessageAccepted?: (
     sessionKey: string,
     friendlyId: string,
@@ -101,6 +102,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
     onError,
     onThinking,
     onTool,
+    onApprovalRequest,
     onMessageAccepted,
     onAbort,
     onSessionResolved,
@@ -626,6 +628,16 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
           onTool?.(payload)
           break
         }
+        case 'approval': {
+          markActivity()
+          pushActivity({
+            type: 'tool_call',
+            time: new Date().toLocaleTimeString(),
+            text: 'Waiting for approval',
+          })
+          onApprovalRequest?.(payload)
+          break
+        }
         case 'artifact': {
           markActivity()
           const title =
@@ -780,6 +792,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       finishStream,
       markFailed,
       onStarted,
+      onApprovalRequest,
       onSessionResolved,
       onThinking,
       onTool,

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -677,6 +677,8 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
             text: 'Waiting for approval',
           })
           onApprovalRequest?.(payload)
+          lifecyclePhaseRef.current = 'handoff'
+          schedulePostAcceptanceTimeout('handoff')
           break
         }
         case 'artifact': {
@@ -842,6 +844,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       processStoreEvent,
       pushTargetText,
       registerSendStreamRun,
+      schedulePostAcceptanceTimeout,
       transitionToHandoff,
     ],
   )

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -125,6 +125,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
   const finishedRef = useRef(false)
   const thinkingRef = useRef<string>('')
   const activeRunIdRef = useRef<string | null>(null)
+  const activeRunAliasIdsRef = useRef<Set<string>>(new Set())
   const delayedUnregisterTimerRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
@@ -175,6 +176,10 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       unregisterSendStreamRun(activeRunIdRef.current)
       activeRunIdRef.current = null
     }
+    for (const runId of activeRunAliasIdsRef.current) {
+      unregisterSendStreamRun(runId)
+    }
+    activeRunAliasIdsRef.current.clear()
   }, [unregisterSendStreamRun])
 
   const resetActiveStreamState = useCallback(
@@ -399,12 +404,16 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         clearTimeout(delayedUnregisterTimerRef.current)
         delayedUnregisterTimerRef.current = null
       }
-      const completedRunId = activeRunIdRef.current
-      if (completedRunId) {
+      const completedRunIds = new Set(activeRunAliasIdsRef.current)
+      if (activeRunIdRef.current) completedRunIds.add(activeRunIdRef.current)
+      activeRunAliasIdsRef.current.clear()
+      if (completedRunIds.size > 0) {
         activeRunIdRef.current = null
         delayedUnregisterTimerRef.current = setTimeout(() => {
           delayedUnregisterTimerRef.current = null
-          unregisterSendStreamRun(completedRunId)
+          for (const completedRunId of completedRunIds) {
+            unregisterSendStreamRun(completedRunId)
+          }
         }, 5000)
       }
 
@@ -448,7 +457,6 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         typeof window !== 'undefined' &&
         window.localStorage?.getItem('hermes:debug:sse') === '1'
       ) {
-         
         console.log(
           '[hermes-sse]',
           event,
@@ -460,7 +468,12 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
 
       // hb_signal/keepalive events from server: just mark activity, never let them
       // surface as user-visible thinking or tool rows.
-      if (event === 'hb_signal' || event === 'heartbeat' || event === 'keepalive' || event === 'ping') {
+      if (
+        event === 'hb_signal' ||
+        event === 'heartbeat' ||
+        event === 'keepalive' ||
+        event === 'ping'
+      ) {
         markActivity()
         return
       }
@@ -498,6 +511,16 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
             activeRunIdRef.current = runId
             registerSendStreamRun(runId)
           }
+          const runIds = Array.isArray(payload.runIds)
+            ? payload.runIds.filter(
+                (value): value is string =>
+                  typeof value === 'string' && value.trim().length > 0,
+              )
+            : []
+          for (const aliasRunId of runIds) {
+            activeRunAliasIdsRef.current.add(aliasRunId)
+            registerSendStreamRun(aliasRunId)
+          }
           markActivity()
           pushActivity({
             type: 'assistant_start',
@@ -512,6 +535,24 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
             transport: 'send-stream',
           })
           onStarted?.({ runId: runId ?? null })
+          break
+        }
+        case 'run_ids': {
+          const runIds = Array.isArray(payload.runIds)
+            ? payload.runIds.filter(
+                (value): value is string =>
+                  typeof value === 'string' && value.trim().length > 0,
+              )
+            : []
+          const runId =
+            typeof payload.runId === 'string' && payload.runId.trim()
+              ? payload.runId.trim()
+              : undefined
+          if (runId) runIds.push(runId)
+          for (const aliasRunId of runIds) {
+            activeRunAliasIdsRef.current.add(aliasRunId)
+            registerSendStreamRun(aliasRunId)
+          }
           break
         }
         case 'assistant': {
@@ -768,7 +809,8 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
         }
         case 'heartbeat': {
           markActivity()
-          const activity = (payload as { activity?: string | null }).activity ?? null
+          const activity =
+            (payload as { activity?: string | null }).activity ?? null
           useChatStore.getState().setHeartbeatActivity(activity)
           break
         }

--- a/src/server/chat-event-bus.ts
+++ b/src/server/chat-event-bus.ts
@@ -38,11 +38,19 @@ function broadcast(event: string, data: Record<string, unknown>): void {
   }
 }
 
+function getEventRunId(data: Record<string, unknown>): string | undefined {
+  return typeof data.runId === 'string'
+    ? data.runId
+    : typeof data.run_id === 'string'
+      ? data.run_id
+      : undefined
+}
+
 export function publishChatEvent(
   event: string,
   data: Record<string, unknown>,
 ): void {
-  const runId = typeof data.runId === 'string' ? data.runId : undefined
+  const runId = getEventRunId(data)
   if (hasActiveSendRun(runId)) return
   broadcast(event, data)
 }
@@ -64,14 +72,12 @@ export function subscribeToChatEvents(
     ? (event) => {
         const eventSessionKey = event.data.sessionKey as string | undefined
         if (eventSessionKey && eventSessionKey !== sessionKeyFilter) return
-        const runId =
-          typeof event.data.runId === 'string' ? event.data.runId : undefined
+        const runId = getEventRunId(event.data)
         if (hasActiveSendRun(runId)) return
         subscriber(event)
       }
     : (event) => {
-        const runId =
-          typeof event.data.runId === 'string' ? event.data.runId : undefined
+        const runId = getEventRunId(event.data)
         if (hasActiveSendRun(runId)) return
         subscriber(event)
       }

--- a/src/server/hermes-runs-api.test.ts
+++ b/src/server/hermes-runs-api.test.ts
@@ -41,7 +41,7 @@ describe('streamHermesRun', () => {
       .mockResolvedValueOnce(
         createStreamResponse([
           'data: {"event":"message.delta","run_id":"run_123","delta":"Hello"}\n\n',
-          'data: {"event":"approval.request","run_id":"run_123","command":"rm -rf /tmp/demo","description":"destructive command"}\n\n',
+          'data: {"event":"approval.request","run_id":"run_123","id":"approval_456","command":"rm -rf /tmp/demo","description":"destructive command"}\n\n',
           'data: {"event":"approval.responded","run_id":"run_123","choice":"once"}\n\n',
           'data: {"event":"run.completed","run_id":"run_123","output":"Hello"}\n\n',
         ]),
@@ -80,8 +80,10 @@ describe('streamHermesRun', () => {
       kind: 'approval.request',
       runId: 'run_123',
       approval: expect.objectContaining({
-        id: 'run_123',
+        id: 'approval_456',
         approvalId: 'run_123',
+        approvalRunId: 'run_123',
+        requestApprovalId: 'approval_456',
         runId: 'run_123',
         command: 'rm -rf /tmp/demo',
         description: 'destructive command',

--- a/src/server/hermes-runs-api.test.ts
+++ b/src/server/hermes-runs-api.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  submitHermesRunApproval,
-  streamHermesRun,
-} from './hermes-runs-api'
+import { submitHermesRunApproval, streamHermesRun } from './hermes-runs-api'
 
 function createStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder()
@@ -95,16 +92,18 @@ describe('streamHermesRun', () => {
 
 describe('submitHermesRunApproval', () => {
   it('posts the approval choice to the run approval endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await submitHermesRunApproval('run_123', 'deny')
+    await submitHermesRunApproval('run_123', 'session')
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://127.0.0.1:8642/v1/runs/run_123/approval',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ choice: 'deny' }),
+        body: JSON.stringify({ choice: 'session' }),
       }),
     )
   })

--- a/src/server/hermes-runs-api.test.ts
+++ b/src/server/hermes-runs-api.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  submitHermesRunApproval,
+  streamHermesRun,
+} from './hermes-runs-api'
+
+function createStreamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk))
+        }
+        controller.close()
+      },
+    }),
+    {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    },
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  delete process.env.HERMES_API_TOKEN
+  delete process.env.CLAUDE_API_TOKEN
+})
+
+describe('streamHermesRun', () => {
+  it('starts a run and normalizes approval request events', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ run_id: 'run_123', status: 'started' }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        createStreamResponse([
+          'data: {"event":"message.delta","run_id":"run_123","delta":"Hello"}\n\n',
+          'data: {"event":"approval.request","run_id":"run_123","command":"rm -rf /tmp/demo","description":"destructive command"}\n\n',
+          'data: {"event":"approval.responded","run_id":"run_123","choice":"once"}\n\n',
+          'data: {"event":"run.completed","run_id":"run_123","output":"Hello"}\n\n',
+        ]),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const events = []
+    for await (const event of streamHermesRun({
+      input: 'hello',
+      conversationHistory: [{ role: 'user', content: 'previous' }],
+      sessionId: 'main',
+      model: 'hermes-agent',
+    })) {
+      events.push(event)
+    }
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://127.0.0.1:8642/v1/runs',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          input: 'hello',
+          conversation_history: [{ role: 'user', content: 'previous' }],
+          model: 'hermes-agent',
+          session_id: 'main',
+        }),
+      }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://127.0.0.1:8642/v1/runs/run_123/events',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(events).toContainEqual({
+      kind: 'approval.request',
+      runId: 'run_123',
+      approval: expect.objectContaining({
+        id: 'run_123',
+        approvalId: 'run_123',
+        runId: 'run_123',
+        command: 'rm -rf /tmp/demo',
+        description: 'destructive command',
+      }),
+    })
+  })
+})
+
+describe('submitHermesRunApproval', () => {
+  it('posts the approval choice to the run approval endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await submitHermesRunApproval('run_123', 'deny')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:8642/v1/runs/run_123/approval',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ choice: 'deny' }),
+      }),
+    )
+  })
+})

--- a/src/server/hermes-runs-api.ts
+++ b/src/server/hermes-runs-api.ts
@@ -1,0 +1,234 @@
+import { CLAUDE_API } from './gateway-capabilities'
+import { getBearerToken } from './openai-compat-api'
+
+export type HermesRunEvent =
+  | { kind: 'started'; runId: string }
+  | { kind: 'text.delta'; delta: string; runId: string }
+  | { kind: 'tool.started'; runId: string; callId: string; name: string; preview?: string }
+  | { kind: 'tool.completed'; runId: string; callId: string; name: string; error?: boolean }
+  | { kind: 'reasoning'; runId: string; text: string }
+  | { kind: 'approval.request'; runId: string; approval: Record<string, unknown> }
+  | { kind: 'approval.responded'; runId: string; choice: string }
+  | { kind: 'completed'; runId: string; output: string }
+  | { kind: 'failed'; runId: string; error: string }
+
+export type HermesRunRequest = {
+  input: string
+  conversationHistory?: Array<{ role: string; content: string }>
+  instructions?: string
+  model?: string
+  sessionId?: string
+  signal?: AbortSignal
+}
+
+export class HermesRunStartError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'HermesRunStartError'
+  }
+}
+
+const authHeaders = (): Record<string, string> => {
+  const bearer = getBearerToken()
+  return bearer ? { Authorization: `Bearer ${bearer}` } : {}
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function parseSseData(rawEvent: string): Array<Record<string, unknown>> {
+  const payloads: Array<Record<string, unknown>> = []
+  const dataLines: Array<string> = []
+  for (const line of rawEvent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('data:')) dataLines.push(trimmed.slice(5).trim())
+  }
+  for (const payload of dataLines) {
+    if (!payload || payload === '[DONE]') continue
+    try {
+      const parsed = JSON.parse(payload) as unknown
+      const record = readRecord(parsed)
+      if (record) payloads.push(record)
+    } catch {
+      // Ignore malformed or comment-only SSE frames.
+    }
+  }
+  return payloads
+}
+
+function normalizeRunEvent(event: Record<string, unknown>): HermesRunEvent | null {
+  const eventName = readString(event.event)
+  const runId = readString(event.run_id) || readString(event.runId)
+  if (!eventName || !runId) return null
+
+  if (eventName === 'message.delta') {
+    const delta = readString(event.delta)
+    return delta ? { kind: 'text.delta', runId, delta } : null
+  }
+  if (eventName === 'tool.started') {
+    const name = readString(event.tool) || readString(event.name) || 'tool'
+    const callId =
+      readString(event.tool_call_id) ||
+      readString(event.call_id) ||
+      readString(event.id) ||
+      `${runId}:${name}`
+    return {
+      kind: 'tool.started',
+      runId,
+      callId,
+      name,
+      preview: readString(event.preview) || undefined,
+    }
+  }
+  if (eventName === 'tool.completed') {
+    const name = readString(event.tool) || readString(event.name) || 'tool'
+    const callId =
+      readString(event.tool_call_id) ||
+      readString(event.call_id) ||
+      readString(event.id) ||
+      `${runId}:${name}`
+    return {
+      kind: 'tool.completed',
+      runId,
+      callId,
+      name,
+      error: event.error === true,
+    }
+  }
+  if (eventName === 'reasoning.available') {
+    const text = readString(event.text)
+    return text ? { kind: 'reasoning', runId, text } : null
+  }
+  if (eventName === 'approval.request') {
+    return {
+      kind: 'approval.request',
+      runId,
+      approval: {
+        ...event,
+        id: readString(event.id) || runId,
+        approvalId: readString(event.approval_id) || readString(event.approvalId) || runId,
+        runId,
+      },
+    }
+  }
+  if (eventName === 'approval.responded') {
+    return {
+      kind: 'approval.responded',
+      runId,
+      choice: readString(event.choice),
+    }
+  }
+  if (eventName === 'run.completed') {
+    return {
+      kind: 'completed',
+      runId,
+      output: readString(event.output),
+    }
+  }
+  if (eventName === 'run.failed') {
+    return {
+      kind: 'failed',
+      runId,
+      error: readString(event.error) || 'Run failed',
+    }
+  }
+  return null
+}
+
+export async function* streamHermesRun(
+  req: HermesRunRequest,
+): AsyncGenerator<HermesRunEvent, void, void> {
+  const headers: Record<string, string> = {
+    ...authHeaders(),
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  }
+  if (req.sessionId) {
+    headers['X-Hermes-Session-Id'] = req.sessionId
+  }
+
+  const body: Record<string, unknown> = {
+    input: req.input,
+  }
+  if (req.conversationHistory) body.conversation_history = req.conversationHistory
+  if (req.instructions) body.instructions = req.instructions
+  if (req.model) body.model = req.model
+  if (req.sessionId) body.session_id = req.sessionId
+
+  const startRes = await fetch(`${CLAUDE_API}/v1/runs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: req.signal,
+  })
+  if (!startRes.ok) {
+    const text = await startRes.text().catch(() => '')
+    throw new HermesRunStartError(`/v1/runs start failed: ${startRes.status} ${text}`)
+  }
+  const started = (await startRes.json()) as { run_id?: string }
+  const runId = readString(started.run_id)
+  if (!runId) {
+    throw new HermesRunStartError('/v1/runs start response did not include run_id')
+  }
+  yield { kind: 'started', runId }
+
+  const eventsRes = await fetch(`${CLAUDE_API}/v1/runs/${encodeURIComponent(runId)}/events`, {
+    method: 'GET',
+    headers: {
+      ...authHeaders(),
+      Accept: 'text/event-stream',
+    },
+    signal: req.signal,
+  })
+  if (!eventsRes.ok) {
+    const text = await eventsRes.text().catch(() => '')
+    throw new Error(`/v1/runs events failed: ${eventsRes.status} ${text}`)
+  }
+
+  const reader = eventsRes.body?.getReader()
+  if (!reader) throw new Error('No response body for /v1/runs events stream')
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+
+    let boundary = buffer.indexOf('\n\n')
+    while (boundary >= 0) {
+      const rawEvent = buffer.slice(0, boundary)
+      buffer = buffer.slice(boundary + 2)
+      for (const payload of parseSseData(rawEvent)) {
+        const normalized = normalizeRunEvent(payload)
+        if (normalized) yield normalized
+      }
+      boundary = buffer.indexOf('\n\n')
+    }
+  }
+}
+
+export async function submitHermesRunApproval(
+  runId: string,
+  choice: 'once' | 'session' | 'always' | 'deny',
+): Promise<void> {
+  const res = await fetch(`${CLAUDE_API}/v1/runs/${encodeURIComponent(runId)}/approval`, {
+    method: 'POST',
+    headers: {
+      ...authHeaders(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ choice }),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`approval response failed: ${res.status} ${text}`)
+  }
+}

--- a/src/server/hermes-runs-api.ts
+++ b/src/server/hermes-runs-api.ts
@@ -107,13 +107,19 @@ function normalizeRunEvent(event: Record<string, unknown>): HermesRunEvent | nul
     return text ? { kind: 'reasoning', runId, text } : null
   }
   if (eventName === 'approval.request') {
+    const requestApprovalId =
+      readString(event.approval_id) ||
+      readString(event.approvalId) ||
+      readString(event.id)
     return {
       kind: 'approval.request',
       runId,
       approval: {
         ...event,
-        id: readString(event.id) || runId,
-        approvalId: readString(event.approval_id) || readString(event.approvalId) || runId,
+        id: requestApprovalId || runId,
+        approvalId: runId,
+        approvalRunId: runId,
+        requestApprovalId: requestApprovalId || undefined,
         runId,
       },
     }

--- a/src/server/session-approval-store.test.ts
+++ b/src/server/session-approval-store.test.ts
@@ -50,4 +50,28 @@ describe('session approval store', () => {
       }),
     ).resolves.toBe(false)
   })
+
+  it('matches command approvals at tool level', async () => {
+    const store = await import('./session-approval-store')
+
+    await store.registerPendingSessionApproval({
+      runId: 'run_456',
+      sessionKey: 'main',
+      approval: {
+        command:
+          "execute_code <<'PY'\nprint('first script')\nPY",
+      },
+    })
+    await store.rememberSessionApprovalForRun('run_456')
+
+    await expect(
+      store.shouldAutoApproveSessionApproval({
+        sessionKey: 'main',
+        approval: {
+          command:
+            "execute_code <<'PY'\nprint('different script')\nPY",
+        },
+      }),
+    ).resolves.toBe(true)
+  })
 })

--- a/src/server/session-approval-store.test.ts
+++ b/src/server/session-approval-store.test.ts
@@ -74,4 +74,30 @@ describe('session approval store', () => {
       }),
     ).resolves.toBe(true)
   })
+
+  it('lists recent pending approvals by session', async () => {
+    const store = await import('./session-approval-store')
+
+    await store.registerPendingSessionApproval({
+      runId: 'run_visible',
+      sessionKey: 'main',
+      approval: { tool: 'execute_code' },
+    })
+    await store.registerPendingSessionApproval({
+      runId: 'run_other',
+      sessionKey: 'other',
+      approval: { tool: 'execute_code' },
+    })
+
+    await expect(
+      store
+        .listPendingSessionApprovals({ sessionKeys: ['main'] })
+        .then((rows) => rows.map((row) => row.runId)),
+    ).resolves.toEqual(['run_visible'])
+    await expect(
+      store
+        .listPendingSessionApprovals()
+        .then((rows) => rows.map((row) => row.runId).sort()),
+    ).resolves.toEqual(['run_other', 'run_visible'])
+  })
 })

--- a/src/server/session-approval-store.test.ts
+++ b/src/server/session-approval-store.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempHome = ''
+
+beforeEach(() => {
+  tempHome = mkdtempSync(path.join(tmpdir(), 'session-approvals-'))
+  process.env.HERMES_HOME = tempHome
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.HERMES_HOME
+  vi.resetModules()
+  if (tempHome) rmSync(tempHome, { recursive: true, force: true })
+  tempHome = ''
+})
+
+describe('session approval store', () => {
+  it('remembers session approval rules by session and action', async () => {
+    const store = await import('./session-approval-store')
+
+    await expect(
+      store.shouldAutoApproveSessionApproval({
+        sessionKey: 'main',
+        approval: { tool: 'execute_code' },
+      }),
+    ).resolves.toBe(false)
+
+    await store.registerPendingSessionApproval({
+      runId: 'run_123',
+      sessionKey: 'main',
+      approval: { tool: 'execute_code' },
+    })
+    await store.rememberSessionApprovalForRun('run_123')
+
+    await expect(
+      store.shouldAutoApproveSessionApproval({
+        sessionKey: 'main',
+        approval: { tool: 'execute_code' },
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      store.shouldAutoApproveSessionApproval({
+        sessionKey: 'other',
+        approval: { tool: 'execute_code' },
+      }),
+    ).resolves.toBe(false)
+  })
+})

--- a/src/server/session-approval-store.ts
+++ b/src/server/session-approval-store.ts
@@ -181,6 +181,28 @@ export async function clearPendingSessionApproval(runId: string): Promise<void> 
   })
 }
 
+export async function listPendingSessionApprovals(options?: {
+  sessionKeys?: Array<string>
+  maxAgeMs?: number
+}): Promise<Array<PendingApproval>> {
+  const store = await readStore()
+  const now = Date.now()
+  const maxAgeMs = options?.maxAgeMs ?? 10 * 60 * 1000
+  const sessionKeys = new Set(
+    (options?.sessionKeys ?? [])
+      .map((sessionKey) => normalizeSessionKey(sessionKey))
+      .filter(Boolean),
+  )
+  const merged = new Map<string, PendingApproval>()
+  for (const row of store.pending) merged.set(row.runId, row)
+  for (const row of pendingApprovals.values()) merged.set(row.runId, row)
+
+  return [...merged.values()]
+    .filter((row) => now - row.requestedAt <= maxAgeMs)
+    .filter((row) => sessionKeys.size === 0 || sessionKeys.has(row.sessionKey))
+    .sort((a, b) => b.requestedAt - a.requestedAt)
+}
+
 export async function markSessionApprovalRuleUsed(input: {
   sessionKey: string
   approval: Record<string, unknown>

--- a/src/server/session-approval-store.ts
+++ b/src/server/session-approval-store.ts
@@ -1,0 +1,202 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { getHermesRoot } from './claude-paths'
+
+type SessionApprovalRule = {
+  sessionKey: string
+  actionKey: string
+  actionLabel: string
+  createdAt: number
+  lastUsedAt?: number
+  useCount?: number
+}
+
+type PendingApproval = {
+  runId: string
+  sessionKey: string
+  actionKey: string
+  actionLabel: string
+  requestedAt: number
+}
+
+type ApprovalStore = {
+  version: 1
+  rules: Array<SessionApprovalRule>
+  pending: Array<PendingApproval>
+}
+
+const STORE_DIR = path.join(getHermesRoot(), 'webui-mvp')
+const STORE_FILE = path.join(STORE_DIR, 'session-approvals.json')
+const pendingApprovals = new Map<string, PendingApproval>()
+let storeQueue: Promise<unknown> = Promise.resolve()
+
+function normalizePart(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function approvalActionLabel(approval: Record<string, unknown>): string {
+  const direct =
+    readString(approval.tool) ||
+    readString(approval.name) ||
+    readString(approval.action) ||
+    readString(approval.command)
+  if (direct) return direct
+
+  const input = readRecord(approval.input) ?? readRecord(approval.args)
+  return (
+    readString(input?.tool) ||
+    readString(input?.name) ||
+    readString(input?.action) ||
+    'tool_call'
+  )
+}
+
+function approvalActionKey(actionLabel: string): string {
+  return normalizePart(actionLabel)
+}
+
+function normalizeSessionKey(sessionKey: string): string {
+  return normalizePart(sessionKey || 'main')
+}
+
+async function readStore(): Promise<ApprovalStore> {
+  try {
+    const raw = await readFile(STORE_FILE, 'utf8')
+    const parsed = JSON.parse(raw) as Partial<ApprovalStore>
+    return {
+      version: 1,
+      rules: Array.isArray(parsed.rules) ? parsed.rules : [],
+      pending: Array.isArray(parsed.pending) ? parsed.pending : [],
+    }
+  } catch {
+    return { version: 1, rules: [], pending: [] }
+  }
+}
+
+async function writeStore(store: ApprovalStore): Promise<void> {
+  await mkdir(STORE_DIR, { recursive: true })
+  const tempPath = `${STORE_FILE}.${process.pid}.${Date.now()}.tmp`
+  await writeFile(tempPath, `${JSON.stringify(store, null, 2)}\n`, 'utf8')
+  await rename(tempPath, STORE_FILE)
+}
+
+function enqueueStoreUpdate<T>(work: () => Promise<T>): Promise<T> {
+  const current = storeQueue.catch(() => undefined).then(work)
+  storeQueue = current.then(
+    () => undefined,
+    () => undefined,
+  )
+  return current
+}
+
+export async function registerPendingSessionApproval(input: {
+  runId: string
+  sessionKey: string
+  approval: Record<string, unknown>
+}): Promise<PendingApproval> {
+  const actionLabel = approvalActionLabel(input.approval)
+  const pending: PendingApproval = {
+    runId: input.runId,
+    sessionKey: normalizeSessionKey(input.sessionKey),
+    actionKey: approvalActionKey(actionLabel),
+    actionLabel,
+    requestedAt: Date.now(),
+  }
+  pendingApprovals.set(input.runId, pending)
+  await enqueueStoreUpdate(async () => {
+    const store = await readStore()
+    const pendingRows = store.pending.filter((row) => row.runId !== input.runId)
+    pendingRows.push(pending)
+    await writeStore({ ...store, pending: pendingRows.slice(-100) })
+  })
+  return pending
+}
+
+export async function shouldAutoApproveSessionApproval(input: {
+  sessionKey: string
+  approval: Record<string, unknown>
+}): Promise<boolean> {
+  const actionLabel = approvalActionLabel(input.approval)
+  const sessionKey = normalizeSessionKey(input.sessionKey)
+  const actionKey = approvalActionKey(actionLabel)
+  const store = await readStore()
+  return store.rules.some(
+    (rule) => rule.sessionKey === sessionKey && rule.actionKey === actionKey,
+  )
+}
+
+export async function rememberSessionApprovalForRun(
+  runId: string,
+): Promise<PendingApproval | null> {
+  return enqueueStoreUpdate(async () => {
+    const store = await readStore()
+    const pending =
+      pendingApprovals.get(runId) ??
+      store.pending.find((row) => row.runId === runId) ??
+      null
+    if (!pending) return null
+
+    const rules = store.rules.filter(
+      (rule) =>
+        rule.sessionKey !== pending.sessionKey ||
+        rule.actionKey !== pending.actionKey,
+    )
+    rules.push({
+      sessionKey: pending.sessionKey,
+      actionKey: pending.actionKey,
+      actionLabel: pending.actionLabel,
+      createdAt: Date.now(),
+    })
+    const nextPending = store.pending.filter((row) => row.runId !== runId)
+    pendingApprovals.delete(runId)
+    await writeStore({
+      version: 1,
+      rules: rules.slice(-200),
+      pending: nextPending.slice(-100),
+    })
+    return pending
+  })
+}
+
+export async function clearPendingSessionApproval(runId: string): Promise<void> {
+  pendingApprovals.delete(runId)
+  await enqueueStoreUpdate(async () => {
+    const store = await readStore()
+    await writeStore({
+      ...store,
+      pending: store.pending.filter((row) => row.runId !== runId),
+    })
+  })
+}
+
+export async function markSessionApprovalRuleUsed(input: {
+  sessionKey: string
+  approval: Record<string, unknown>
+}): Promise<void> {
+  await enqueueStoreUpdate(async () => {
+    const store = await readStore()
+    const sessionKey = normalizeSessionKey(input.sessionKey)
+    const actionKey = approvalActionKey(approvalActionLabel(input.approval))
+    const rules = store.rules.map((rule) =>
+      rule.sessionKey === sessionKey && rule.actionKey === actionKey
+        ? {
+            ...rule,
+            lastUsedAt: Date.now(),
+            useCount: (rule.useCount ?? 0) + 1,
+          }
+        : rule,
+    )
+    await writeStore({ ...store, rules })
+  })
+}

--- a/src/server/session-approval-store.ts
+++ b/src/server/session-approval-store.ts
@@ -46,12 +46,13 @@ function readRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function approvalActionLabel(approval: Record<string, unknown>): string {
+  const command = readString(approval.command)
   const direct =
     readString(approval.tool) ||
     readString(approval.name) ||
-    readString(approval.action) ||
-    readString(approval.command)
+    readString(approval.action)
   if (direct) return direct
+  if (command) return command.split(/\s+/, 1)[0] || command
 
   const input = readRecord(approval.input) ?? readRecord(approval.args)
   return (

--- a/src/stores/chat-store.test.ts
+++ b/src/stores/chat-store.test.ts
@@ -18,6 +18,71 @@ function textMessage(
 }
 
 describe('chat-store history merge ordering', () => {
+  it('deduplicates assistant realtime messages that only differ by whitespace', () => {
+    const sessionKey = 'assistant-whitespace-realtime-session'
+    const readableText = [
+      'Checked. Short status:',
+      '',
+      'Configuration',
+      'Hermes Config: /Users/example/.hermes/config.yaml',
+      'Active model: gpt-5.5',
+      'Gateway: running via launchd',
+      'Telegram: configured',
+      '',
+      'Jobs',
+      'Seven active scheduled jobs are configured and all are active.',
+    ].join('\n')
+    const compactText = readableText.replace(/\s+/g, '')
+    const store = useChatStore.getState()
+
+    store.clearSession(sessionKey)
+    store.processEvent({
+      type: 'message',
+      sessionKey,
+      message: textMessage('readable', 'assistant', readableText, 0),
+    })
+    store.processEvent({
+      type: 'message',
+      sessionKey,
+      message: textMessage('compact', 'assistant', compactText, 1),
+    })
+
+    expect(
+      store.getRealtimeMessages(sessionKey).map((message) => message.id),
+    ).toEqual(['readable'])
+  })
+
+  it('deduplicates history and realtime assistant messages that only differ by whitespace', () => {
+    const sessionKey = 'assistant-whitespace-history-session'
+    const readableText = [
+      'Checked. Short status:',
+      '',
+      'Configuration',
+      'Hermes Config: /Users/example/.hermes/config.yaml',
+      'Active model: gpt-5.5',
+      'Gateway: running via launchd',
+      'Telegram: configured',
+      '',
+      'Jobs',
+      'Seven active scheduled jobs are configured and all are active.',
+    ].join('\n')
+    const compactText = readableText.replace(/\s+/g, '')
+    const store = useChatStore.getState()
+
+    store.clearSession(sessionKey)
+    store.processEvent({
+      type: 'message',
+      sessionKey,
+      message: textMessage('compact', 'assistant', compactText, 1),
+    })
+
+    const merged = store.mergeHistoryMessages(sessionKey, [
+      textMessage('readable', 'assistant', readableText, 0),
+    ])
+
+    expect(merged.map((message) => message.id)).toEqual(['readable'])
+  })
+
   it('preserves persisted history order when messages share a timestamp', () => {
     const messages: Array<ChatMessage> = [
       textMessage('m1', 'user', 'first question', 0),

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -838,7 +838,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           if (
             normalizedMessage.role === 'assistant' &&
             newPlainText.length > 20 &&
-            newPlainText === extractMessageText(existing)
+            assistantTextsMatch(newPlainText, extractMessageText(existing))
           ) {
             return true
           }
@@ -915,8 +915,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           ) {
             const prevEmptyIdx = sessionMessages.findLastIndex(
               (m) =>
-                m.role === 'assistant' &&
-                extractMessageText(m).length === 0,
+                m.role === 'assistant' && extractMessageText(m).length === 0,
             )
             if (prevEmptyIdx >= 0) {
               sessionMessages[prevEmptyIdx] = incomingMessage
@@ -1125,7 +1124,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
             const existingId = getMessageId(existing)
             if (completeId && existingId && completeId === existingId)
               return true
-            if (completeText && completeText === extractMessageText(existing))
+            if (
+              completeText &&
+              assistantTextsMatch(completeText, extractMessageText(existing))
+            )
               return true
             return false
           })
@@ -1145,7 +1147,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
               const existingId = getMessageId(existing)
               if (completeId && existingId && completeId === existingId)
                 return true
-              if (completeText && completeText === extractMessageText(existing))
+              if (
+                completeText &&
+                assistantTextsMatch(completeText, extractMessageText(existing))
+              )
                 return true
               return false
             })
@@ -1243,13 +1248,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       if (histMsg.role === rtMsg.role && rtText) {
         const histText = extractMessageText(histMsg)
-        if (histText === rtText) return true
-        // Streaming realtime text is a prefix of the final server text.
-        // Match either direction to prevent duplicates when the server
-        // returns the complete message after the realtime buffer had a
-        // partial version.
-        if (rtText.length > 0 && histText.length > 0) {
-          if (histText.startsWith(rtText) || rtText.startsWith(histText)) return true
+        if (histMsg.role === 'assistant') {
+          // Streaming realtime text is a prefix of the final server text.
+          // Match either direction to prevent duplicates when the server
+          // returns the complete message after the realtime buffer had a
+          // partial version. Some Hermes Agent history payloads can also lose
+          // whitespace while the realtime payload keeps it, so compare a
+          // whitespace-insensitive signature for substantial assistant output.
+          if (assistantTextsMatch(histText, rtText, { allowPrefix: true })) {
+            return true
+          }
+        } else {
+          if (histText === rtText) return true
+          if (rtText.length > 0 && histText.length > 0) {
+            if (histText.startsWith(rtText) || rtText.startsWith(histText))
+              return true
+          }
         }
       }
 
@@ -1366,6 +1380,34 @@ function extractMessageText(msg: ChatMessage | null | undefined): string {
       return stripFinalTags(val.trim())
   }
   return ''
+}
+
+function compactAssistantTextSignature(text: string): string {
+  return stripFinalTags(text).replace(/\s+/g, '')
+}
+
+function assistantTextsMatch(
+  left: string,
+  right: string,
+  options: { allowPrefix?: boolean } = {},
+): boolean {
+  if (!left || !right) return false
+  if (left === right) return true
+  if (options.allowPrefix && (left.startsWith(right) || right.startsWith(left)))
+    return true
+
+  const compactLeft = compactAssistantTextSignature(left)
+  const compactRight = compactAssistantTextSignature(right)
+
+  // Only use whitespace-insensitive matching for substantial assistant output.
+  // Short strings can collide too easily when all whitespace is removed.
+  if (compactLeft.length < 80 || compactRight.length < 80) return false
+  if (compactLeft === compactRight) return true
+  return Boolean(
+    options.allowPrefix &&
+    (compactLeft.startsWith(compactRight) ||
+      compactRight.startsWith(compactLeft)),
+  )
 }
 
 function ensureAssistantTextContent(msg: ChatMessage): ChatMessage {


### PR DESCRIPTION
## Summary

Adds a Hermes Runs API transport for Workspace chat so tool approval requests can surface as approval cards and be resolved from the Workspace UI.

## Why

The OpenAI-compatible chat-completions path can return an approval-required error, but it does not provide the interactive approval event and approval response flow that Hermes exposes through `/v1/runs`.

## Changes

- Start portable Hermes chat requests through `POST /v1/runs` when available.
- Stream run events from `/v1/runs/{run_id}/events`.
- Convert `approval.request` events into Workspace approval UI events.
- Add approve/deny routes that call `POST /v1/runs/{run_id}/approval`.
- Keep a fallback to the existing path when a run cannot be started.
- Add focused unit coverage for the Runs API helper.

## Validation

- `pnpm exec vitest run src/server/hermes-runs-api.test.ts`
- `pnpm run build`
- Manual local validation with `approvals.mode: manual`: an approval card appeared in Workspace and approval completed the blocked run.

## Attribution

Implementation and validation were assisted by OpenAI Codex.
