### PR TITLE
fix(chat): don't cancel an active send when New Chat resolves into its session

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1295,7 +1295,19 @@ export function ChatScreen({
       return
     }
     if (navCancelKeyRef.current !== navKey) {
+      const activeSend = activeSendRef.current
+      const isResolvingActiveSend =
+        Boolean(activeSend) &&
+        !isNewChat &&
+        (activeSend?.sessionKey === activeCanonicalKey ||
+          activeSend?.friendlyId === activeFriendlyId)
+
       navCancelKeyRef.current = navKey
+
+      if (isResolvingActiveSend) {
+        return
+      }
+
       cancelStreaming()
     }
   }, [activeCanonicalKey, activeFriendlyId, isNewChat, cancelStreaming])


### PR DESCRIPTION
## Problem

When a New Chat resolves from its temporary state into the real session key, the navigation-change effect in `ChatScreen` treats that internal resolution as a genuine navigation and calls `cancelStreaming()`. The gateway keeps producing a valid stream, but the UI surfaces a false **"Operation interrupted"** (it reproduced far less in incognito, which pointed at UI/session state rather than the gateway).

## Fix

Guard the cancel: when an active send is resolving into the now-active session (matched by `sessionKey` / `friendlyId`), it is not cancelled. Genuine navigations still cancel exactly as before. One focused change in `chat-screen.tsx`.

Found and fixed while running a self-hosted deployment; tool-heavy prompts now complete without the spurious interruption.

Reviewed by bdtsimon