### PR TITLE
fix(chat): clear streaming state when the stream finishes

### DIFF
--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -414,7 +414,8 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       setState((prev) => ({
         ...prev,
         isStreaming: false,
-        streamingText: finalText,
+        streamingMessageId: null,
+        streamingText: '',
       }))
 
       const message: ChatMessage = {


### PR DESCRIPTION
## Problem

On stream finish the hook left `streamingText` set to the final text and kept `streamingMessageId`, so completed-stream state could leak into the next render — e.g. a first/new-chat reply briefly appearing as separate `p` + `pong` fragments, or stale streaming state lingering.

## Fix

Clear `streamingMessageId` and `streamingText` when the stream ends; the finalized `ChatMessage` is appended separately (unchanged). One-line change in `use-streaming-message.ts`.

Found and fixed while running a self-hosted deployment; a new chat with `reply exactly: pong` now returns a clean `pong`.

Reviewed by bdtsimon