### PR TITLE
Fix dashboard fallback auth in profile browsing (#499 regression)

### DIFF
--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -198,15 +198,6 @@ function getDashboardUrl(): string | undefined {
   return url || undefined
 }
 
-function getDashboardToken(): string | undefined {
-  return (
-    process.env.HERMES_API_TOKEN?.trim() ||
-    process.env.CLAUDE_API_TOKEN?.trim() ||
-    process.env.CLAUDE_DASHBOARD_TOKEN?.trim() ||
-    undefined
-  )
-}
-
 async function fetchDashboardProfiles(): Promise<{
   profiles: Array<ProfileSummary>
   activeProfile: string
@@ -215,12 +206,13 @@ async function fetchDashboardProfiles(): Promise<{
   if (!dashboardUrl) return null
 
   try {
-    const token = getDashboardToken()
-    const headers: Record<string, string> = {}
-    if (token) headers['Authorization'] = `Bearer ${token}`
-
-    const response = await fetch(`${dashboardUrl}/api/profiles`, {
-      headers,
+    // The dashboard's /api/profiles route only accepts its ephemeral
+    // per-boot session token (scraped from its root HTML), not a static
+    // bearer token — dashboardFetch() already implements that scrape/retry
+    // dance (see gateway-capabilities.ts) and is the same helper the
+    // skills/toggle-skill dashboard proxies use.
+    const { dashboardFetch } = await import('./gateway-capabilities')
+    const response = await dashboardFetch('/api/profiles', {
       signal: AbortSignal.timeout(5000),
     })
     if (!response.ok) return null
@@ -314,12 +306,8 @@ export async function readProfileWithFallback(
   const dashboardUrl = getDashboardUrl()
   if (dashboardUrl) {
     try {
-      const token = getDashboardToken()
-      const headers: Record<string, string> = {}
-      if (token) headers['Authorization'] = `Bearer ${token}`
-
-      const response = await fetch(`${dashboardUrl}/api/profiles`, {
-        headers,
+      const { dashboardFetch } = await import('./gateway-capabilities')
+      const response = await dashboardFetch('/api/profiles', {
         signal: AbortSignal.timeout(5000),
       })
       if (response.ok) {


### PR DESCRIPTION
## Summary

#499 ("Profile UI in split-host deployments returns empty list") was closed by #520, which added a dashboard-API fallback to `profiles-browser.ts`. That fallback authenticates against the dashboard's `/api/profiles` route using a static bearer token (`HERMES_API_TOKEN` / `CLAUDE_API_TOKEN` / `CLAUDE_DASHBOARD_TOKEN`). The dashboard's `/api/profiles` route does not accept static bearer tokens — it only recognizes its own ephemeral per-boot session token (scraped from the dashboard's root HTML). So the fallback request always gets a 401 and silently degrades back to the (empty) local filesystem read, meaning #499 is not actually fixed for the scenario it describes.

Confirmed this on a real split-host deployment: `hermes-workspace` container with no `/data/hermes` mount, `HERMES_DASHBOARD_URL` pointed at a working dashboard — `/api/profiles/list` returned only the synthetic `default` profile until this fix, then returned all real profiles afterward.

## Fix

`fetchDashboardProfiles()` and `readProfileWithFallback()` now use `dashboardFetch()` from `gateway-capabilities.ts` — the same ephemeral-token scrape/retry helper `skills.ts` and `toggle-skill.ts` already use for their own dashboard-proxied routes — instead of the hand-rolled static-token fetch. Removed the now-unused `getDashboardToken()`.

## Test plan

- [x] Manually verified against a real split-host deployment: `POST /api/auth` login + `GET /api/profiles/list` now returns all configured profiles (previously only `default`) with correct model/provider/skillCount/hasEnv metadata.
- [ ] No existing automated test covers the dashboard-fallback path; happy to add one if maintainers want it scoped into this PR.
