### PR TITLE
fix(sessions): fall back to gateway when dashboard create is unavailable

### DIFF
--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -154,18 +154,33 @@ export async function getSession(sessionId: string): Promise<ClaudeSession> {
   return resp.session
 }
 
+function shouldFallbackFromDashboardCreateSession(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /Hermes Agent dashboard \/api\/sessions: (404|405|501)\b/.test(
+    message,
+  )
+}
+
 export async function createSession(opts?: {
   id?: string
   title?: string
   model?: string
 }): Promise<ClaudeSession> {
+  const body = opts || {}
   if (getCapabilities().dashboard.available) {
-    const resp = await createDashboardSession(opts || {})
-    return resp.session as ClaudeSession
+    try {
+      const resp = await createDashboardSession(body)
+      return resp.session as ClaudeSession
+    } catch (err) {
+      if (!shouldFallbackFromDashboardCreateSession(err)) throw err
+      console.warn(
+        '[claude-api] dashboard session creation unavailable; falling back to gateway /api/sessions',
+      )
+    }
   }
   const resp = await claudePost<{ session: ClaudeSession }>(
     '/api/sessions',
-    opts || {},
+    body,
   )
   return resp.session
 }


### PR DESCRIPTION
## Summary

When Workspace detects a dashboard but its session-create endpoint is not implemented (404/405/501), fall back to the gateway `POST /api/sessions` path instead of making session creation fail. Other dashboard errors still propagate.

This keeps split-host and partially wired dashboard deployments usable while preserving strict failure handling for unexpected errors.

## Verification

- `git diff --check origin/main...HEAD`
- `pnpm run build`
- `pnpm exec vitest run src/server/__tests__/gateway-capabilities.test.ts` (16 passed)

No live service or active checkout was changed.