### PR TITLE
fix(sessions): persist renames in dashboard-without-enhancedChat mode

### DIFF
--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -20,6 +20,7 @@ import {
   listLocalSessions,
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
+import { dashboardFetch } from '../../server/gateway-capabilities'
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -226,19 +227,61 @@ export const Route = createFileRoute('/api/sessions')({
           }
 
           if (capabilities.dashboard.available && !capabilities.enhancedChat) {
-            return json({
-              ok: true,
-              sessionKey,
-              entry: {
-                key: sessionKey,
-                id: sessionKey,
-                title: label || sessionKey,
-                label: label || sessionKey,
-                derivedTitle: label || sessionKey,
-                updatedAt: Date.now(),
-              },
-              updated: false,
-            })
+            // Persist the rename through the dashboard session API instead of
+            // reporting a fake success. This branch previously returned
+            // `ok: true, updated: false` without saving anything, so any
+            // rename in dashboard-without-enhancedChat mode silently vanished
+            // and the session kept its raw first-message title on the native
+            // dashboard. PATCH /api/sessions/{id} resolves friendly ids too.
+            try {
+              const res = await dashboardFetch(
+                `/api/sessions/${encodeURIComponent(sessionKey)}`,
+                {
+                  method: 'PATCH',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ title: label ?? '' }),
+                },
+              )
+              const data = (await res.json().catch(() => ({}))) as Record<
+                string,
+                unknown
+              >
+              if (!res.ok) {
+                return json(
+                  {
+                    ok: false,
+                    error:
+                      typeof data.detail === 'string'
+                        ? data.detail
+                        : 'Rename failed',
+                  },
+                  { status: res.status },
+                )
+              }
+              const savedTitle =
+                typeof data.title === 'string' && data.title
+                  ? data.title
+                  : label || sessionKey
+              return json({
+                ok: true,
+                sessionKey,
+                entry: {
+                  key: sessionKey,
+                  id: sessionKey,
+                  title: savedTitle,
+                  label: savedTitle,
+                  derivedTitle: savedTitle,
+                  updatedAt: Date.now(),
+                },
+                updated: true,
+                source: 'dashboard',
+              })
+            } catch {
+              return json(
+                { ok: false, error: 'Agent dashboard unreachable' },
+                { status: 502 },
+              )
+            }
           }
 
           const session = await updateSession(sessionKey, {


### PR DESCRIPTION
## Problem

In the `PATCH /api/sessions` handler, when the gateway reports `capabilities.dashboard.available && !capabilities.enhancedChat`, the branch returned:

```js
return json({ ok: true, /* … */ updated: false })
```

…without persisting anything. A rename in that mode **looks** like it succeeded (the UI gets `ok: true`), but nothing reaches the agent — the session keeps its raw first-message title on the native dashboard, and re-opening the list shows the old name.

## Fix

Persist the rename through the existing `dashboardFetch` helper — `PATCH /api/sessions/{id}` (which resolves friendly ids too) — surface a real error when the dashboard rejects it, and echo the saved title back to the client (`updated: true`).

Single-concern, no new dependencies: it reuses `dashboardFetch` from `server/gateway-capabilities` and mirrors the shape the other PATCH branches already return.

## Notes

- The `updateSession()` path (full `enhancedChat`) and the local-session path are unchanged.
- On failure the client now gets `{ ok: false }` with the dashboard's `detail` (or a 502 when the dashboard is unreachable) instead of a false success.

Reviewed by bdtsimon

🤖 Generated with [Claude Code](https://claude.com/claude-code)