### PR TITLE
fix(models): parse Hermes Agent config schema in model picker

### DIFF
--- a/src/routes/api/__tests__/-models.test.ts
+++ b/src/routes/api/__tests__/-models.test.ts
@@ -127,4 +127,55 @@ describe('models route', () => {
     expect(json.models[0].id).toBe('nest-model')
     expect(json.models[0].provider).toBe('anthropic')
   })
+
+  it('reads Hermes Agent models.default syntax from config', async () => {
+    const envHome = '/mock/profiles/hermes'
+    process.env.CLAUDE_HOME = envHome
+
+    const configYaml =
+      'models:\n  default:\n    provider: deepseek\n    model: deepseek-chat\n'
+    existsSync.mockImplementation((p: string) => p === `${envHome}/config.yaml`)
+    readFileSync.mockImplementation((p: string) => {
+      if (p === `${envHome}/config.yaml`) return configYaml
+      return ''
+    })
+
+    const get = await getHandler()
+    const request = new Request('http://localhost/api/models')
+    const res = await get({ request })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    expect(json.models[0].id).toBe('deepseek-chat')
+    expect(json.models[0].provider).toBe('deepseek')
+  })
+
+  it('reads Hermes Agent array-style providers from config', async () => {
+    const envHome = '/mock/profiles/hermes'
+    process.env.CLAUDE_HOME = envHome
+
+    const configYaml =
+      'providers:\n' +
+      '  - name: deepseek\n' +
+      '    base_url: https://api.deepseek.com/v1\n' +
+      '    models:\n' +
+      '      - deepseek-chat\n' +
+      '      - deepseek-coder\n'
+    existsSync.mockImplementation((p: string) => p === `${envHome}/config.yaml`)
+    readFileSync.mockImplementation((p: string) => {
+      if (p === `${envHome}/config.yaml`) return configYaml
+      return ''
+    })
+
+    const get = await getHandler()
+    const request = new Request('http://localhost/api/models')
+    const res = await get({ request })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    const ids = json.models.map((m: any) => m.id)
+    expect(ids).toContain('deepseek-chat')
+    expect(ids).toContain('deepseek-coder')
+    expect(json.models.find((m: any) => m.id === 'deepseek-chat').provider).toBe('deepseek')
+  })
 })

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -176,6 +176,16 @@ function readClaudeDefaultModel(): ModelEntry | null {
         (config.provider as string) ||
         'unknown'
     }
+    // Hermes Agent schema: models.default.{provider,model}
+    if (!modelId) {
+      const modelsField = config.models
+      if (modelsField && typeof modelsField === 'object') {
+        const modelsObj = modelsField as Record<string, unknown>
+        const defaultBlock = asRecord(modelsObj.default)
+        modelId = readString(defaultBlock.model)
+        provider = readString(defaultBlock.provider) || 'unknown'
+      }
+    }
     if (!modelId) return null
     return { id: modelId, name: modelId, provider }
   } catch {
@@ -325,9 +335,24 @@ function readClaudeConfigCatalog(): Array<ModelEntry> {
       seen.add(entry.id)
     }
 
-    const providers = asRecord(config.providers)
-    for (const [providerId, value] of Object.entries(providers)) {
-      const providerBlock = asRecord(value)
+    // Normalize providers to a uniform list — handles both map (Workspace)
+    // and array (Hermes Agent) schemas.
+    const providersList: Array<{ id: string; block: Record<string, unknown> }> = []
+    const providersRaw = config.providers
+    if (Array.isArray(providersRaw)) {
+      for (const value of providersRaw) {
+        const providerBlock = asRecord(value)
+        const providerId = readString(providerBlock.name) || readString(providerBlock.id) || 'unknown'
+        providersList.push({ id: providerId, block: providerBlock })
+      }
+    } else {
+      const providersMap = asRecord(providersRaw)
+      for (const [providerId, value] of Object.entries(providersMap)) {
+        providersList.push({ id: providerId, block: asRecord(value) })
+      }
+    }
+
+    for (const { id: providerId, block: providerBlock } of providersList) {
       const providerModels = providerBlock.models
       if (Array.isArray(providerModels)) {
         for (const modelEntry of providerModels) {


### PR DESCRIPTION
## Problem

Hermes Agent uses a different `config.yaml` schema than Hermes Workspace:

- `models.default.{provider,model}` instead of `model:` / `model.default:`
- `providers` as an **array** with `name` field instead of a **map**

This caused the model picker to show **empty** when Hermes Agent was the backend and no `models.json` existed. The agent's `/v1/models` endpoint also requires auth (returning 401), so the fallback path failed too.

## Fix

1. `readClaudeDefaultModel()` now falls back to `models.default.{provider,model}`
2. `readClaudeConfigCatalog()` normalizes both array and map `providers`
3. Integration tests added for both schema variants

## Test Plan

- `pnpm vitest run src/routes/api/__tests__/-models.test.ts` → 5/5 pass
- `pnpm vitest run src/routes/api/-models.test.ts` → 2/2 pass
- LSP diagnostics: clean on both changed files

Fixes empty model list when Hermes Agent backend is active.