### PR TITLE
Add Atlas Cloud provider catalog entry

### DIFF
--- a/src/lib/provider-catalog.ts
+++ b/src/lib/provider-catalog.ts
@@ -97,6 +97,38 @@ export const PROVIDER_CATALOG: Array<ProviderInfo> = [
     ),
   },
   {
+    id: 'atlascloud',
+    name: 'Atlas Cloud',
+    description: 'OpenAI-compatible model access through the Atlas Cloud API.',
+    authTypes: ['api-key'],
+    docsUrl: 'https://www.atlascloud.ai/docs',
+    configExample: JSON.stringify(
+      {
+        auth: {
+          profiles: {
+            'atlascloud:default': {
+              provider: 'atlascloud',
+              apiKey: 'ATLASCLOUD_API_KEY',
+            },
+          },
+        },
+        custom_providers: [
+          {
+            name: 'atlascloud',
+            base_url: 'https://api.atlascloud.ai/v1',
+            api_mode: 'openai',
+          },
+        ],
+        model: {
+          provider: 'atlascloud',
+          default: 'qwen/qwen3.5-flash',
+        },
+      },
+      null,
+      2,
+    ),
+  },
+  {
     id: 'minimax',
     name: 'MiniMax',
     description: 'MiniMax foundation models and multimodal APIs.',

--- a/src/server/hermes-config-migration.test.ts
+++ b/src/server/hermes-config-migration.test.ts
@@ -71,4 +71,35 @@ describe('normalizeHermesConfigState', () => {
       source: 'nested',
     })
   })
+
+  it('recognizes Atlas Cloud API key config and default model', () => {
+    const state = normalizeHermesConfigState({
+      paths,
+      config: {
+        model: { provider: 'atlascloud', default: 'qwen/qwen3.5-flash' },
+        custom_providers: [
+          {
+            name: 'atlascloud',
+            base_url: 'https://api.atlascloud.ai/v1',
+            api_mode: 'openai',
+          },
+        ],
+      },
+      env: { ATLASCLOUD_API_KEY: 'atlas-test-key-123456' },
+      authProfiles: {},
+      localProviders: [],
+      localModels: [],
+    })
+
+    expect(state.activeProvider).toBe('atlascloud')
+    expect(state.activeModel).toBe('qwen/qwen3.5-flash')
+    const atlascloud = state.providers.find((p) => p.id === 'atlascloud')
+    expect(atlascloud?.configured).toBe(true)
+    expect(atlascloud?.authenticated).toBe(true)
+    expect(atlascloud?.isDefault).toBe(true)
+    expect(atlascloud?.authSource).toBe('env')
+    expect(atlascloud?.envKeys).toContain('ATLASCLOUD_API_KEY')
+    expect(atlascloud?.models.map((model) => model.id)).toContain('qwen/qwen3.5-flash')
+    expect(atlascloud?.models.map((model) => model.id)).toContain('deepseek-ai/deepseek-v4-pro')
+  })
 })

--- a/src/server/hermes-config-migration.ts
+++ b/src/server/hermes-config-migration.ts
@@ -88,6 +88,16 @@ export const HERMES_PROVIDER_CATALOG: Array<ProviderDef> = [
   { id: 'openai-codex', name: 'OpenAI Codex', kind: 'oauth', envKeys: [], models: [] },
   { id: 'anthropic', name: 'Anthropic', kind: 'api_key', envKeys: ['ANTHROPIC_API_KEY'], models: [] },
   { id: 'openrouter', name: 'OpenRouter', kind: 'api_key', envKeys: ['OPENROUTER_API_KEY'], models: [] },
+  {
+    id: 'atlascloud',
+    name: 'Atlas Cloud',
+    kind: 'api_key',
+    envKeys: ['ATLASCLOUD_API_KEY'],
+    models: [
+      { id: 'qwen/qwen3.5-flash', name: 'Qwen3.5 Flash' },
+      { id: 'deepseek-ai/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+    ],
+  },
   { id: 'zai', name: 'Z.AI / GLM', kind: 'api_key', envKeys: ['GLM_API_KEY'], models: [] },
   { id: 'kimi-coding', name: 'Kimi', kind: 'api_key', envKeys: ['KIMI_API_KEY'], models: [] },
   { id: 'minimax', name: 'MiniMax', kind: 'api_key', envKeys: ['MINIMAX_API_KEY'], models: [] },


### PR DESCRIPTION
## Summary
- add Atlas Cloud to the provider catalog with an OpenAI-compatible configuration example
- include Atlas Cloud in Hermes config normalization with ATLASCLOUD_API_KEY support
- add focused coverage for Atlas Cloud default model and auth detection

## Validation
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm test src/server/hermes-config-migration.test.ts (4 passed)
- TypeScript syntax check for changed files
- git diff --check
- Atlas Cloud live /v1/models catalog check confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

Note: full pnpm install without --ignore-scripts hung in Electron postinstall locally. Full `pnpm exec tsc --noEmit` currently reports unrelated existing project-wide type errors outside this change.

No README changes. No sponsor, logo, credits, or partner promotion changes.