### PR TITLE
feat: show one-shot cronjobs in gateway calendar view

### DIFF
--- a/src/screens/gateway/components/calendar-view.tsx
+++ b/src/screens/gateway/components/calendar-view.tsx
@@ -14,7 +14,7 @@ export type CalendarViewProps = {
 type CalendarMode = 'month' | 'week' | 'day'
 
 type ParsedCronSchedule = {
-  kind: 'daily' | 'weekly' | 'monthly'
+  kind: 'daily' | 'weekly' | 'monthly' | 'one-shot'
   hour: number
   minute: number
   weekdays: number[]
@@ -182,6 +182,18 @@ function parseSchedule(schedule: string, fallbackDate: Date): ParsedCronSchedule
     }
   }
 
+  // One-shot / once-only schedules (e.g. "once at 2026-07-21 08:00")
+  if (text.includes('once')) {
+    const dateFromTimestamp = new Date(fallbackDate)
+    return {
+      kind: 'one-shot',
+      hour: dateFromTimestamp.getHours(),
+      minute: dateFromTimestamp.getMinutes(),
+      weekdays: [],
+      monthDay: dateFromTimestamp.getDate(),
+    }
+  }
+
   return {
     kind: 'daily',
     hour: fallbackTime.hour,
@@ -242,8 +254,13 @@ export function CalendarView({ cronJobs, missionRuns, onSelectEvent }: CalendarV
       for (let day = new Date(rangeStart); day < rangeEnd; day = addDays(day, 1)) {
         let include = false
         if (parsed.kind === 'daily') include = true
-        if (parsed.kind === 'weekly') include = parsed.weekdays.includes(day.getDay())
-        if (parsed.kind === 'monthly') include = day.getDate() === parsed.monthDay
+        else if (parsed.kind === 'weekly') include = parsed.weekdays.includes(day.getDay())
+        else if (parsed.kind === 'monthly') include = day.getDate() === parsed.monthDay
+        else if (parsed.kind === 'one-shot') {
+          // One-shot: include only on the exact nextRunAt day
+          const runDate = startOfDay(fallbackDate)
+          include = isSameDay(day, runDate)
+        }
         if (!include) continue
 
         const eventDate = new Date(day)


### PR DESCRIPTION
One-shot cronjobs (e.g. 'once at 2026-07-21 08:00') were invisible in the calendar because parseSchedule() only handled daily/weekly/monthly schedules.

## Changes
- Add `'one-shot'` kind to `ParsedCronSchedule` type
- Detect one-shot schedules in `parseSchedule()` (text contains 'once')
- Include one-shot events in the calendar loop only on the exact `nextRunAt` date

## How to test
1. Create a one-shot cronjob via Hermes CLI: `hermes cron create --schedule "2026-07-21T08:00:00" --prompt "test"`
2. Open gateway calendar view, navigate to July 2026
3. The one-shot job should appear on July 21 at 08:00