### PR TITLE
fix: declare pnpm workspace packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   electron: true
   electron-winstaller: true


### PR DESCRIPTION
## What changed

- Declares the root package in `pnpm-workspace.yaml` with `packages: ['.']`.
- Keeps the existing `allowBuilds` approvals for Electron, esbuild, and related install scripts.

## Why

A fresh clone currently fails before dependencies can be installed:

```bash
git clone https://github.com/outsourc-e/hermes-workspace.git
cd hermes-workspace
pnpm install
```

pnpm exits with:

```text
ERROR packages field missing or empty
```

The workspace file exists, but it only contains `allowBuilds`. pnpm expects a non-empty `packages` field when `pnpm-workspace.yaml` is present.

## Verification

Validated in a clean clone:

```bash
pnpm install --frozen-lockfile
cp .env.example .env
printf '\nHERMES_API_URL=http://127.0.0.1:8642\nHERMES_DASHBOARD_URL=http://127.0.0.1:9119\n' >> .env
PORT=4300 pnpm dev
```

Result: install completes successfully and Vite starts at `http://localhost:4300/`.
