### PR TITLE
Add Workspace Mission Control operations surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,8 @@ workspace-final-markdown-review.md
 # Local sibling projects (do not ship)
 skills-bundle/
 
-# Local agent artifacts (audit dumps, temporary playwright scripts)
+# Local agent artifacts (audit dumps, temporary playwright scripts, swarm handoffs)
 .hermes/
+memory/handoffs/
 .env.bak-*
 pr-triage-20260505-*/

--- a/docs/mission-control/README.md
+++ b/docs/mission-control/README.md
@@ -1,0 +1,199 @@
+# Hermes Mission Control
+
+Status: installed in Hermes Workspace as an additive, local-only dashboard surface.
+Last verified: 2026-07-16.
+
+## What is working now
+
+- Route: `/mission-control`.
+- Live local system API: `GET /api/mission-control/system`.
+- Existing Notion operations API: `GET /api/mission-control/summary` plus `/api/notion/*`.
+- Existing Hermes dashboard aggregate API: `GET /api/dashboard/overview`.
+- Existing task APIs are reused through `src/lib/tasks-api.ts`.
+- Desktop navigation and mobile navigation already expose Mission Control from earlier Workspace work.
+- Production build passes.
+
+Mission Control is an aggregation and command surface. It does not replace Notion, Zoho, Apple Calendar, Apple Reminders, Obsidian, Slack, or Hermes as systems of record.
+
+## Current-state inventory
+
+Infrastructure:
+- Mac mini host runs Hermes Gateway, Hermes Dashboard, and Hermes Workspace under launchd.
+- Active services observed: `ai.hermes.gateway`, `com.hermes.dashboard`, `com.hermes.workspace`.
+- Gateway default: `http://127.0.0.1:8642`.
+- Dashboard default: `http://127.0.0.1:9119`.
+- Workspace default: `http://127.0.0.1:3000`.
+
+Hermes:
+- Hermes Agent v0.18.2 observed during audit.
+- Default profile uses OpenAI Codex models.
+- Cron is active and readable from `~/.hermes/cron/jobs.json`.
+- OpenRouter is configured but audit logs showed quota/credit/rate-limit failures; treat it as degraded until re-tested.
+
+Notion:
+- Manifest path: `/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain/03_Projects/SEO-AEO-Service/Tools_Systems/notion_command_center_manifest.json`.
+- Existing data sources include CRM / Leads, Outreach / Interactions, Human Approval Queue, Deals / Proposals, Projects, Tasks, Automation Log, Agents, SOP Library, Decision Log, Business Metrics, Inbox, and Client Onboarding.
+- Notion API calls remain server-side through `src/server/notion-client.ts`; credentials are never sent to the browser.
+
+Obsidian:
+- Vault path: `/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain`.
+- Mission Control reads recent notes and emits verified `obsidian://open` URIs.
+
+Apple Calendar and Reminders:
+- The new system snapshot tries local AppleScript reads from the Mac host.
+- If macOS TCC permissions block access, Mission Control labels Calendar/Reminders as blocked instead of showing fake data.
+- Production-grade write support should move to a small EventKit helper with explicit Calendar/Reminders permissions.
+
+Zoho Mail:
+- No Zoho OAuth credential markers were found in the Workspace server environment during verification.
+- Email sync remains blocked until Ryan approves and configures least-privilege Zoho OAuth.
+
+## System-of-record map
+
+| Data | Authoritative source | Mission Control behavior |
+|---|---|---|
+| Clients and structured business records | Notion | Read summaries, direct Notion links, no uncontrolled duplication |
+| Leads and pipeline | Notion | Read status and counts through manifest-backed data sources |
+| Projects and deliverables | Notion | Read operational counts; link to source records where available |
+| Email content, folders, delivery state | Zoho Mail | Not enabled yet; blocked pending OAuth approval |
+| Human reminders and completion state | Apple Reminders | Local read snapshot; writes require approval/helper |
+| Calendar events and attendance state | Apple Calendar | Local read snapshot; writes require approval/helper |
+| Knowledge, SOPs, agent docs | Obsidian | Read recent notes and direct `obsidian://` links |
+| Agent runs, schedules, routing | Hermes | Read cron, dashboard, logs, model warnings |
+| Sync state, cached summaries, health, approvals | Mission Control | Local dashboard state only |
+
+## Data-flow and permissions
+
+Browser:
+- Calls local Workspace routes only.
+- Never receives API keys, OAuth tokens, refresh tokens, or raw secret files.
+
+Workspace server:
+- Reads `~/.hermes/.env` only to detect configured providers or call server-side Notion API.
+- Reads `~/.hermes/cron/jobs.json` for schedule status.
+- Reads redacted tails of Hermes logs for model/fallback warnings.
+- Reads Obsidian markdown metadata and builds `obsidian://` links.
+- Calls local `osascript` for Apple Calendar/Reminders read counts.
+
+External services:
+- Notion: read-only dashboard queries currently used.
+- Zoho: not connected yet.
+- Slack: controlled through Hermes gateway, not directly by Mission Control.
+
+## Privacy and security rules enforced
+
+- Local-only by default; no public tunnel or firewall change was made.
+- Tokens and secrets are status-only in the UI.
+- `redactSensitive()` removes bearer tokens, Zoho OAuth tokens, common key/value secret lines, OpenAI-style keys, and JWT-like token strings from captured text.
+- Consequential actions are listed as approval-gated instead of performed.
+- External writes were not executed during this implementation pass.
+
+## API surface
+
+Read endpoints:
+- `GET /api/mission-control/system`: local integrations, Apple counts, Obsidian recent notes, Hermes cron/model warnings, host resource summary, approval gates.
+- `GET /api/mission-control/summary`: Notion-backed business counts and groups.
+- `GET /api/notion/sources`: manifest-backed Notion source list.
+- `GET /api/notion/query?source=<name>`: server-side Notion query.
+- `GET /api/dashboard/overview`: Hermes operational dashboard aggregation.
+
+Write/consequential actions:
+- Not implemented as open endpoints in this pass. Sending email, changing routing, external writes, deleting records, exposing services, or expanding OAuth scopes remain approval-gated.
+
+## Setup
+
+Prerequisites:
+- Node 22+ and pnpm.
+- Hermes Gateway on `127.0.0.1:8642`.
+- Hermes Dashboard on `127.0.0.1:9119`.
+- Workspace on `127.0.0.1:3000`.
+- `NOTION_API_KEY` or `NOTION_API_TOKEN` in `~/.hermes/.env` for Notion views.
+- macOS Calendar/Reminders permissions for the process that runs Workspace if Apple cards should show live counts.
+
+Start commands:
+- Development: `cd /Users/escher/hermes-workspace && pnpm dev`.
+- Production after build: `cd /Users/escher/hermes-workspace && pnpm build && PORT=3000 HOST=127.0.0.1 node server-entry.js`.
+- Gateway: `hermes gateway run`.
+- Dashboard: `hermes dashboard --port 9119 --host 127.0.0.1 --no-open`.
+
+Launchd commands:
+- List: `launchctl list | grep -E 'com\.hermes|ai\.hermes'`.
+- Restart Workspace service: `launchctl kickstart -k gui/$(id -u)/com.hermes.workspace`.
+- Restart Gateway service: use Hermes gateway controls or launchd only after checking active work.
+
+## Daily-use guide
+
+1. Open `http://127.0.0.1:3000/mission-control`.
+2. Check the top strips first: task load, Notion operations, Live Systems + Security.
+3. If an integration is `blocked` or `degraded`, read its detail text before acting.
+4. Use Notion links for structured records and Obsidian links for knowledge notes.
+5. Use approval gates as the source of truth for what still needs Ryan’s explicit decision.
+
+## Backup and restore
+
+Workspace source:
+- Use git before risky changes: `git status --short`, then commit or stash intentionally.
+
+Hermes state:
+- Back up `~/.hermes/config.yaml`, `~/.hermes/auth.json`, `~/.hermes/cron/`, `~/.hermes/state.db`, and `~/.hermes/logs/` with secrets preserved locally only.
+- Do not copy secrets into Notion, Obsidian, Slack, or chat.
+
+Obsidian:
+- Use Time Machine or file-level copy of `/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain` before bulk vault changes.
+
+Restore:
+- Stop Workspace service.
+- Restore source/runtime files from git or backup.
+- Run `pnpm build`.
+- Restart Workspace service.
+- Verify `/api/mission-control/system` and `/mission-control`.
+
+## Troubleshooting
+
+`/api/mission-control/system` returns 401:
+- The route is protected. Local browser access should work; API probes may need the configured Workspace auth context.
+
+Calendar/Reminders show blocked:
+- Grant Automation/Calendar/Reminders permissions to the process running Workspace, or replace AppleScript with an EventKit helper.
+
+Zoho shows not configured:
+- Configure Zoho OAuth server-side after Ryan approves scopes. Required docs: account discovery, folders, messages list/search. Store refresh credentials only in the secure local secret store.
+
+Model/fallback warning appears:
+- Check `~/.hermes/logs/gateway.error.log` and `~/.hermes/logs/agent.log` with redaction. Audit found historical OpenRouter 402/429 and free quota exhaustion plus historical Codex `usage_limit_reached` markers.
+
+Notion data missing:
+- Confirm the Notion integration has access to the source database and relations.
+- Confirm the manifest data source IDs still match current Notion data sources.
+- Respect Notion’s 3 req/s average rate limit.
+
+## Known limitations
+
+- Zoho email operations center is not active until OAuth is configured.
+- Apple Calendar/Reminders write operations are not enabled; read counts depend on macOS permissions.
+- The local system snapshot uses log heuristics for model/fallback warnings; it does not yet have a structured Hermes model-error database.
+- No public remote ChatGPT cloud access endpoint was exposed. Use Tailscale or an explicitly approved secure API/MCP bridge later.
+- Synthetic end-to-end workflow external writes were not run because they require approval.
+
+## Verification report
+
+Commands run:
+- `pnpm vitest run src/server/dashboard-aggregator.test.ts --reporter=dot` → passed, 13 tests.
+- `pnpm build` → passed for client and SSR builds.
+- `PORT=3007 HOST=127.0.0.1 NODE_ENV=production node server-entry.js` → started a temporary local production server.
+- `GET http://127.0.0.1:3007/api/mission-control/system` → returned HTTP 200 JSON with Notion live, Zoho not_configured, Obsidian live, Hermes live, Apple blocked due local permission boundary.
+
+Not executed without Ryan approval:
+- Restarting production Workspace service.
+- Creating synthetic Notion/client/calendar/reminder/email records.
+- Configuring Zoho OAuth.
+- Changing model routing/fallbacks.
+- Opening any public network exposure.
+
+## Next approval needed
+
+Approve one of these next steps:
+1. Restart the Workspace service so the production `:3000` launchd instance serves the new Mission Control system endpoint.
+2. Configure Zoho OAuth with least-privilege read scopes and build the email operations center.
+3. Approve synthetic test writes for the end-to-end client onboarding demo.
+4. Build the native EventKit helper for reliable Calendar/Reminders read/write support.

--- a/server-entry.js
+++ b/server-entry.js
@@ -199,6 +199,109 @@ async function tryServeStatic(req, res) {
 }
 
 async function requestHandler(req, res) {
+  const reqUrl = new URL(
+    req.url || '/',
+    `http://${req.headers.host || 'localhost'}`,
+  )
+  const pathname = decodeURIComponent(reqUrl.pathname)
+
+  // Proxy root-level API requests to the gateway for remote/Tailscale access.
+  // The workspace UI makes requests to /terminal-resize, /sessions, /commands, etc.
+  // which only exist on the gateway. When accessed remotely, proxy them through
+  // the workspace server so the browser doesn't need direct gateway access.
+  const gatewayProxyPaths = [
+    '/send-stream', '/send',
+    '/session-send', '/start-agent',
+    '/agent-bus', '/crew-status',
+    '/swarm-dispatch', '/swarm-lifecycle', '/swarm-checkpoint',
+    '/swarm-roster', '/swarm-missions', '/swarm-runtime',
+    '/swarm-environment', '/swarm-health', '/swarm-project',
+    '/swarm-reports', '/swarm-memory', '/swarm-kanban',
+    '/swarm-chat', '/swarm-direct-chat', '/swarm-decompose',
+    '/swarm-orchestrator-loop', '/swarm-tmux-start',
+    '/swarm-tmux-stop', '/swarm-tmux-scroll',
+    '/conductor-spawn', '/conductor-stop',
+    '/artifacts', '/files', '/preview-file',
+    '/skills', '/jobs', '/plugins', '/mcp',
+    '/models', '/providers', '/provider-usage',
+    '/config', '/env', '/update', '/system-metrics',
+    '/memory', '/external-memory', '/search',
+    '/transcribe', '/ping', '/health',
+  ]
+
+  // Map root-level paths that the workspace UI expects.
+  // The UI was designed for same-origin access where the gateway serves
+  // these routes at the root. When accessed remotely, map them to the
+  // workspace server's own /api/ handlers.
+  const rootToApiMap = {
+    '/connection-status': '/api/connection-status',
+    '/session-status': '/api/session-status',
+    '/commands': '/api/commands',
+    '/sessions': '/api/sessions',
+    '/events': '/api/events',
+    '/history': '/api/session-history',
+    '/start-claude': '/api/start-claude',
+    '/terminal-stream': '/api/terminal-stream',
+    '/terminal-resize': '/api/terminal-resize',
+    '/terminal-input': '/api/terminal-input',
+    '/terminal-close': '/api/terminal-close',
+  }
+
+  const shouldProxy = gatewayProxyPaths.some(p => pathname === p || pathname.startsWith(p + '/'))
+  const mappedPath = rootToApiMap[pathname]
+
+  if (mappedPath) {
+    // Rewrite the URL to the /api/ equivalent and fall through to SSR handler
+    req.url = mappedPath + reqUrl.search
+  } else if (shouldProxy) {
+    const gatewayUrl = 'http://127.0.0.1:8642'
+    const targetUrl = `${gatewayUrl}${pathname}${reqUrl.search}`
+
+    try {
+      const proxyHeaders = { ...req.headers }
+      delete proxyHeaders.host
+      delete proxyHeaders['content-length']
+
+      let body = undefined
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        body = await new Promise((resolve) => {
+          const chunks = []
+          req.on('data', (chunk) => chunks.push(chunk))
+          req.on('end', () => resolve(Buffer.concat(chunks)))
+        })
+      }
+
+      const proxyRes = await fetch(targetUrl, {
+        method: req.method,
+        headers: proxyHeaders,
+        body,
+      })
+
+      res.writeHead(proxyRes.status, Object.fromEntries(proxyRes.headers.entries()))
+      if (proxyRes.body) {
+        const reader = proxyRes.body.getReader()
+        const pump = async () => {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            res.write(value)
+          }
+          res.end()
+        }
+        pump().catch(() => res.end())
+      } else {
+        const text = await proxyRes.text()
+        res.end(text)
+      }
+      return
+    } catch (err) {
+      console.error(`[proxy] ${req.method} ${pathname} -> ${targetUrl} failed:`, err.message)
+      res.writeHead(502)
+      res.end('Gateway proxy error')
+      return
+    }
+  }
+
   // Try static files first (client assets)
   if (req.method === 'GET' || req.method === 'HEAD') {
     const served = await tryServeStatic(req, res)

--- a/src/components/mobile-tab-bar.tsx
+++ b/src/components/mobile-tab-bar.tsx
@@ -4,14 +4,17 @@ import {
   BrainIcon,
   Building01Icon,
   Chat01Icon,
+  CheckmarkCircle02Icon,
   Clock01Icon,
   CommandLineIcon,
   DashboardSquare01Icon,
   File01Icon,
+  Mail01Icon,
   McpServerIcon,
   PuzzleIcon,
   Rocket01Icon,
   Settings01Icon,
+  Target01Icon,
   UserGroupIcon,
 } from '@hugeicons/core-free-icons'
 import {
@@ -47,11 +50,39 @@ type TabItem = {
 
 export const MOBILE_NAV_TABS: Array<TabItem> = [
   {
+    id: 'mission-control',
+    label: 'Mission',
+    icon: Target01Icon,
+    to: '/mission-control',
+    match: (p) => p === '/mission-control',
+  },
+  {
+    id: 'notion',
+    label: 'Notion',
+    icon: Building01Icon,
+    to: '/notion',
+    match: (p) => p.startsWith('/notion'),
+  },
+  {
     id: 'dashboard',
     label: 'Home',
     icon: DashboardSquare01Icon,
     to: '/dashboard',
     match: (p) => p === '/dashboard',
+  },
+  {
+    id: 'approval-queue',
+    label: 'Approvals',
+    icon: CheckmarkCircle02Icon,
+    to: '/approval-queue',
+    match: (p) => p.startsWith('/approval-queue'),
+  },
+  {
+    id: 'outreach',
+    label: 'Outreach',
+    icon: Mail01Icon,
+    to: '/outreach',
+    match: (p) => p.startsWith('/outreach'),
   },
   {
     id: 'chat',

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -27,6 +27,7 @@ import { ConnectionStartupScreen } from '@/components/connection-startup-screen'
 import { ChatSidebar } from '@/screens/chat/components/chat-sidebar'
 import { useChatSessions } from '@/screens/chat/hooks/use-chat-sessions'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useProjectStore } from '@/stores/project-store'
 import { SIDEBAR_TOGGLE_EVENT } from '@/hooks/use-global-shortcuts'
 import { useSwipeNavigation } from '@/hooks/use-swipe-navigation'
 // Lazy: ChatPanel statically imports ChatScreen and with it the chat
@@ -82,6 +83,12 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const chatFocusMode = useWorkspaceStore((s) => s.chatFocusMode)
   const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar)
   const setSidebarCollapsed = useWorkspaceStore((s) => s.setSidebarCollapsed)
+  const setPendingNewSessionProject = useProjectStore(
+    (s) => s.setPendingNewSessionProject,
+  )
+  const clearPendingNewSessionProject = useProjectStore(
+    (s) => s.clearPendingNewSessionProject,
+  )
   const { onTouchStart, onTouchMove, onTouchEnd } = useSwipeNavigation()
 
   // ChatGPT-style: track visual viewport height for keyboard-aware layout
@@ -99,18 +106,21 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   // Map pathname to tab index (mirrors TABS order in mobile-tab-bar)
   const getTabIndex = useCallback((path: string): number => {
-    if (path === '/dashboard') return 0
-    if (path.startsWith('/chat') || path === '/new' || path === '/') return 1
-    if (path.startsWith('/files')) return 2
-    if (path.startsWith('/terminal')) return 3
-    if (path.startsWith('/jobs')) return 4
-    if (path === '/swarm' || path.startsWith('/swarm2')) return 5
-    if (path.startsWith('/echo-studio')) return 5
-    if (path.startsWith('/memory')) return 6
-    if (path.startsWith('/skills')) return 7
-    if (path.startsWith('/mcp')) return 8
-    if (path.startsWith('/profiles')) return 9
-    if (path.startsWith('/settings')) return 10
+    if (path === '/mission-control') return 0
+    if (path === '/dashboard') return 1
+    if (path.startsWith('/chat') || path === '/new' || path === '/') return 2
+    if (path.startsWith('/files')) return 3
+    if (path.startsWith('/terminal')) return 4
+    if (path.startsWith('/jobs')) return 5
+    if (path === '/swarm' || path.startsWith('/swarm2')) return 6
+    if (path.startsWith('/echo-studio')) return 6
+    if (path.startsWith('/memory')) return 7
+    if (path.startsWith('/skills')) return 8
+    if (path.startsWith('/mcp')) return 9
+    if (path.startsWith('/outreach')) return 10
+    if (path.startsWith('/profiles')) return 11
+    if (path.startsWith('/settings')) return 12
+    if (path.startsWith('/approval-queue')) return 13
     return -1
   }, [])
 
@@ -174,6 +184,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
 
   // Derive active session from URL
   const mobilePageTitle = (() => {
+    if (pathname.startsWith('/mission-control')) return 'Mission Control'
     if (pathname.startsWith('/terminal')) return 'Terminal'
     if (pathname.startsWith('/files')) return 'Files'
     if (pathname.startsWith('/jobs')) return 'Jobs'
@@ -184,10 +195,12 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (pathname.startsWith('/memory')) return 'Memory'
     if (pathname.startsWith('/skills')) return 'Skills'
     if (pathname.startsWith('/mcp')) return 'MCP'
+    if (pathname.startsWith('/outreach')) return 'Outreach'
     if (pathname.startsWith('/profiles')) return 'Profiles'
     if (pathname.startsWith('/settings')) return 'Settings'
     if (pathname.startsWith('/debug')) return 'Debug'
     if (pathname.startsWith('/activity')) return 'Activity'
+    if (pathname.startsWith('/approval-queue')) return 'Approval Queue'
     return null
   })()
 
@@ -218,14 +231,22 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     isNewChat,
   })
 
-  const startNewChat = useCallback(() => {
-    setCreatingSession(true)
-    navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'new' } }).then(
-      () => {
-        setCreatingSession(false)
-      },
-    )
-  }, [navigate])
+  const startNewChat = useCallback(
+    (projectId?: string) => {
+      setCreatingSession(true)
+      if (projectId) {
+        setPendingNewSessionProject(projectId)
+      } else {
+        clearPendingNewSessionProject()
+      }
+      navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'new' } }).then(
+        () => {
+          setCreatingSession(false)
+        },
+      )
+    },
+    [clearPendingNewSessionProject, navigate, setPendingNewSessionProject],
+  )
 
   const handleSelectSession = useCallback(() => {
     // On mobile, collapse sidebar after selecting

--- a/src/hooks/use-projects.test.ts
+++ b/src/hooks/use-projects.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createProjectId,
+  getActiveProjects,
+  getSessionProjectId,
+  slugifyProjectName,
+  type WorkspaceProject,
+} from './use-projects'
+
+function project(
+  id: string,
+  updatedAt: number,
+  archivedAt?: number,
+): WorkspaceProject {
+  return {
+    id,
+    name: id,
+    goal: '',
+    instructions: '',
+    color: '#000',
+    icon: 'folder',
+    createdAt: updatedAt,
+    updatedAt,
+    archivedAt,
+  }
+}
+
+describe('use-projects helpers', () => {
+  it('creates stable readable project slugs', () => {
+    expect(slugifyProjectName('SEO/AEO Business Launch')).toBe(
+      'seo-aeo-business-launch',
+    )
+    expect(slugifyProjectName('   ')).toBe('project')
+  })
+
+  it('deduplicates project ids', () => {
+    expect(createProjectId('SEO/AEO Business', [])).toBe('seo-aeo-business')
+    expect(
+      createProjectId('SEO/AEO Business', [
+        'seo-aeo-business',
+        'seo-aeo-business-2',
+      ]),
+    ).toBe('seo-aeo-business-3')
+  })
+
+  it('returns active projects newest first and excludes archived projects', () => {
+    expect(
+      getActiveProjects([
+        project('old', 10),
+        project('archived', 30, 40),
+        project('new', 20),
+      ]).map((item) => item.id),
+    ).toEqual(['new', 'old'])
+  })
+
+  it('looks up session project mappings safely', () => {
+    expect(getSessionProjectId({ abc: 'seo' }, 'abc')).toBe('seo')
+    expect(getSessionProjectId({ abc: 'seo' }, '  abc  ')).toBe('seo')
+    expect(getSessionProjectId({ abc: 'seo' }, 'missing')).toBeNull()
+    expect(getSessionProjectId({ abc: 'seo' }, '   ')).toBeNull()
+  })
+})

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -1,0 +1,406 @@
+'use client'
+
+import { useEffect } from 'react'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type WorkspaceProject = {
+  id: string
+  name: string
+  goal: string
+  instructions: string
+  color: string
+  icon: string
+  createdAt: number
+  updatedAt: number
+  archivedAt?: number
+}
+
+type CreateProjectInput = {
+  name: string
+  goal?: string
+  instructions?: string
+  color?: string
+  icon?: string
+}
+
+type UpdateProjectInput = Partial<
+  Pick<WorkspaceProject, 'name' | 'goal' | 'instructions' | 'color' | 'icon'>
+>
+
+type ProjectsSnapshot = {
+  projects: Array<WorkspaceProject>
+  sessionProjectMap: Record<string, string>
+  activeProjectId: string | null
+}
+
+type ProjectsState = ProjectsSnapshot & {
+  createProject: (input: CreateProjectInput) => WorkspaceProject
+  updateProject: (projectId: string, input: UpdateProjectInput) => void
+  archiveProject: (projectId: string) => void
+  assignSessionToProject: (sessionKey: string, projectId: string) => void
+  unassignSession: (sessionKey: string) => void
+  setActiveProject: (projectId: string | null) => void
+  hydrateFromServer: (snapshot: ProjectsSnapshot) => void
+  getProjectForSession: (sessionKey: string) => WorkspaceProject | null
+}
+
+const DEFAULT_PROJECT_COLORS = [
+  '#8b5cf6',
+  '#06b6d4',
+  '#22c55e',
+  '#f97316',
+  '#ec4899',
+  '#facc15',
+]
+
+export function slugifyProjectName(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || 'project'
+}
+
+export function createProjectId(
+  name: string,
+  existingIds: Array<string>,
+): string {
+  const base = slugifyProjectName(name)
+  const used = new Set(existingIds)
+  if (!used.has(base)) return base
+  let index = 2
+  while (used.has(`${base}-${index}`)) {
+    index += 1
+  }
+  return `${base}-${index}`
+}
+
+export function getSessionProjectId(
+  sessionProjectMap: Record<string, string>,
+  sessionKey: string,
+): string | null {
+  const key = sessionKey.trim()
+  if (!key) return null
+  return sessionProjectMap[key] || null
+}
+
+export function getActiveProjects(
+  projects: Array<WorkspaceProject>,
+): Array<WorkspaceProject> {
+  return projects
+    .filter((project) => !project.archivedAt)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+function nowMs(): number {
+  return Date.now()
+}
+
+function defaultColor(index: number): string {
+  return DEFAULT_PROJECT_COLORS[index % DEFAULT_PROJECT_COLORS.length]
+}
+
+function snapshotProjects(state: ProjectsSnapshot): ProjectsSnapshot {
+  return {
+    projects: state.projects,
+    sessionProjectMap: state.sessionProjectMap,
+    activeProjectId: state.activeProjectId,
+  }
+}
+
+function hasProjectData(snapshot: ProjectsSnapshot): boolean {
+  return (
+    snapshot.projects.length > 0 || Object.keys(snapshot.sessionProjectMap).length > 0
+  )
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function normalizeProject(value: unknown): WorkspaceProject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  const id = cleanString(raw.id)
+  const name = cleanString(raw.name)
+  if (!id || !name) return null
+  const project: WorkspaceProject = {
+    id,
+    name,
+    goal: cleanString(raw.goal),
+    instructions: cleanString(raw.instructions),
+    color: cleanString(raw.color) || defaultColor(0),
+    icon: cleanString(raw.icon) || 'folder',
+    createdAt: cleanNumber(raw.createdAt, nowMs()),
+    updatedAt: cleanNumber(raw.updatedAt, nowMs()),
+  }
+  const archivedAt = cleanNumber(raw.archivedAt, 0)
+  if (archivedAt > 0) project.archivedAt = archivedAt
+  return project
+}
+
+function normalizeSnapshot(value: unknown): ProjectsSnapshot {
+  const raw = value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+  const projects = Array.isArray(raw.projects)
+    ? raw.projects.map(normalizeProject).filter((project): project is WorkspaceProject => Boolean(project))
+    : []
+  const projectIds = new Set(projects.map((project) => project.id))
+  const sessionProjectMap: Record<string, string> = {}
+  const rawMap = raw.sessionProjectMap ?? raw.sessionProjects
+  if (rawMap && typeof rawMap === 'object' && !Array.isArray(rawMap)) {
+    for (const [sessionKey, projectId] of Object.entries(rawMap as Record<string, unknown>)) {
+      const key = cleanString(sessionKey)
+      const value = cleanString(projectId)
+      if (key && value && projectIds.has(value)) sessionProjectMap[key] = value
+    }
+  }
+  const activeProjectId = cleanString(raw.activeProjectId)
+  return {
+    projects,
+    sessionProjectMap,
+    activeProjectId: activeProjectId && projectIds.has(activeProjectId) ? activeProjectId : null,
+  }
+}
+
+async function saveProjectsToServer(snapshot: ProjectsSnapshot): Promise<void> {
+  if (typeof window === 'undefined') return
+  await fetch('/api/projects', {
+    method: 'PUT',
+    credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(snapshot),
+  })
+}
+
+let syncTimer: ReturnType<typeof setTimeout> | null = null
+function queueServerSync(snapshot: ProjectsSnapshot): void {
+  if (typeof window === 'undefined') return
+  if (syncTimer) clearTimeout(syncTimer)
+  syncTimer = setTimeout(() => {
+    syncTimer = null
+    void saveProjectsToServer(snapshot)
+  }, 250)
+}
+
+let serverHydrationPromise: Promise<void> | null = null
+let serverHydrationRetryTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleServerHydrationRetry(): void {
+  if (typeof window === 'undefined' || serverHydrationRetryTimer) return
+  serverHydrationRetryTimer = setTimeout(() => {
+    serverHydrationRetryTimer = null
+    void loadServerProjectsOnce()
+  }, 1_500)
+}
+
+function loadServerProjectsOnce(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve()
+  if (serverHydrationPromise) return serverHydrationPromise
+
+  serverHydrationPromise = (async () => {
+    const localSnapshot = snapshotProjects(useProjectsStore.getState())
+    try {
+      const response = await fetch('/api/projects', {
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      })
+      if (!response.ok) {
+        // The app shell can mount before the password session is established.
+        // Do not permanently cache that 401/403, or first-run migration from
+        // browser localStorage to the server will never happen after login.
+        serverHydrationPromise = null
+        scheduleServerHydrationRetry()
+        return
+      }
+      const payload = (await response.json()) as Record<string, unknown>
+      const serverSnapshot = normalizeSnapshot(payload)
+      const initialized = payload.initialized === true
+
+      if (initialized || hasProjectData(serverSnapshot)) {
+        useProjectsStore.getState().hydrateFromServer(serverSnapshot)
+        return
+      }
+
+      // First-run migration: if this browser already has local projects from
+      // the browser-storage v1 implementation, promote them to the server so
+      // every Mac/browser can see the same list going forward.
+      if (hasProjectData(localSnapshot)) {
+        await saveProjectsToServer(localSnapshot)
+      }
+    } catch {
+      // Keep local projects available if the server endpoint is unavailable,
+      // but do not cache the failure forever.
+      serverHydrationPromise = null
+      scheduleServerHydrationRetry()
+    }
+  })()
+
+  return serverHydrationPromise
+}
+
+export const useProjectsStore = create<ProjectsState>()(
+  persist(
+    (set, get) => ({
+      projects: [],
+      sessionProjectMap: {},
+      activeProjectId: null,
+      createProject: (input) => {
+        const timestamp = nowMs()
+        const name = input.name.trim()
+        const project: WorkspaceProject = {
+          id: createProjectId(
+            name,
+            get().projects.map((existing) => existing.id),
+          ),
+          name,
+          goal: input.goal?.trim() ?? '',
+          instructions: input.instructions?.trim() ?? '',
+          color:
+            input.color?.trim() || defaultColor(getActiveProjects(get().projects).length),
+          icon: input.icon?.trim() || 'folder',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }
+        set((state) => ({
+          projects: [project, ...state.projects],
+          activeProjectId: project.id,
+        }))
+        queueServerSync(snapshotProjects(get()))
+        return project
+      },
+      updateProject: (projectId, input) => {
+        const timestamp = nowMs()
+        set((state) => ({
+          projects: state.projects.map((project) => {
+            if (project.id !== projectId) return project
+            return {
+              ...project,
+              ...Object.fromEntries(
+                Object.entries(input).map(([key, value]) => [
+                  key,
+                  typeof value === 'string' ? value.trim() : value,
+                ]),
+              ),
+              updatedAt: timestamp,
+            }
+          }),
+        }))
+        queueServerSync(snapshotProjects(get()))
+      },
+      archiveProject: (projectId) => {
+        const timestamp = nowMs()
+        set((state) => {
+          const sessionProjectMap = Object.fromEntries(
+            Object.entries(state.sessionProjectMap).filter(
+              ([, mappedProjectId]) => mappedProjectId !== projectId,
+            ),
+          )
+          return {
+            projects: state.projects.map((project) =>
+              project.id === projectId
+                ? { ...project, archivedAt: timestamp, updatedAt: timestamp }
+                : project,
+            ),
+            sessionProjectMap,
+            activeProjectId:
+              state.activeProjectId === projectId ? null : state.activeProjectId,
+          }
+        })
+        queueServerSync(snapshotProjects(get()))
+      },
+      assignSessionToProject: (sessionKey, projectId) => {
+        const key = sessionKey.trim()
+        if (!key || !projectId) return
+        const timestamp = nowMs()
+        set((state) => ({
+          sessionProjectMap: {
+            ...state.sessionProjectMap,
+            [key]: projectId,
+          },
+          projects: state.projects.map((project) =>
+            project.id === projectId
+              ? { ...project, updatedAt: timestamp }
+              : project,
+          ),
+          activeProjectId: projectId,
+        }))
+        queueServerSync(snapshotProjects(get()))
+      },
+      unassignSession: (sessionKey) => {
+        const key = sessionKey.trim()
+        if (!key) return
+        set((state) => {
+          const { [key]: _removed, ...rest } = state.sessionProjectMap
+          void _removed
+          return { sessionProjectMap: rest }
+        })
+        queueServerSync(snapshotProjects(get()))
+      },
+      setActiveProject: (projectId) => {
+        set({ activeProjectId: projectId })
+        queueServerSync(snapshotProjects(get()))
+      },
+      hydrateFromServer: (snapshot) => {
+        set(snapshotProjects(normalizeSnapshot(snapshot)))
+      },
+      getProjectForSession: (sessionKey) => {
+        const projectId = getSessionProjectId(get().sessionProjectMap, sessionKey)
+        if (!projectId) return null
+        return (
+          get().projects.find(
+            (project) => project.id === projectId && !project.archivedAt,
+          ) ?? null
+        )
+      },
+    }),
+    {
+      name: 'hermes-workspace-projects-v1',
+      version: 1,
+      partialize: (state) => ({
+        projects: state.projects,
+        sessionProjectMap: state.sessionProjectMap,
+        activeProjectId: state.activeProjectId,
+      }),
+    },
+  ),
+)
+
+export function useProjects() {
+  useEffect(() => {
+    void loadServerProjectsOnce()
+  }, [])
+
+  const projects = useProjectsStore((state) => state.projects)
+  const sessionProjectMap = useProjectsStore((state) => state.sessionProjectMap)
+  const activeProjectId = useProjectsStore((state) => state.activeProjectId)
+  const createProject = useProjectsStore((state) => state.createProject)
+  const updateProject = useProjectsStore((state) => state.updateProject)
+  const archiveProject = useProjectsStore((state) => state.archiveProject)
+  const assignSessionToProject = useProjectsStore(
+    (state) => state.assignSessionToProject,
+  )
+  const unassignSession = useProjectsStore((state) => state.unassignSession)
+  const setActiveProject = useProjectsStore((state) => state.setActiveProject)
+
+  return {
+    projects,
+    activeProjects: getActiveProjects(projects),
+    sessionProjectMap,
+    activeProjectId,
+    createProject,
+    updateProject,
+    archiveProject,
+    assignSessionToProject,
+    unassignSession,
+    setActiveProject,
+  }
+}

--- a/src/lib/outreach-data.ts
+++ b/src/lib/outreach-data.ts
@@ -1,0 +1,575 @@
+/**
+ * Mock data for the Outreach Pipeline page.
+ *
+ * Since we don't have a dedicated outreach API yet, this module provides
+ * realistic SEO/AEO business leads across pipeline stages.
+ *
+ * In the future, outreach items can be stored as tasks with tags like
+ * 'outreach', 'lead', 'proposal' etc. via the tasks API.
+ */
+
+export type PipelineStage =
+  | 'leads'
+  | 'contacted'
+  | 'responded'
+  | 'meeting_set'
+  | 'proposal_sent'
+  | 'closed'
+
+export type LeadPriority = 'high' | 'medium' | 'low'
+
+export type OutreachLead = {
+  id: string
+  company: string
+  contactName: string
+  contactEmail: string
+  contactTitle: string
+  website: string
+  stage: PipelineStage
+  priority: LeadPriority
+  assignedAgent: string
+  lastInteraction: string // ISO date string
+  notes: string
+  tags: Array<string>
+  estimatedValue: number | null // USD annual contract value
+  source: string
+}
+
+export type OutreachActivity = {
+  id: string
+  leadId: string
+  leadCompany: string
+  type: 'email_sent' | 'email_opened' | 'call_made' | 'meeting_scheduled' | 'proposal_sent' | 'proposal_viewed' | 'follow_up' | 'note_added'
+  description: string
+  timestamp: string // ISO date string
+  agent: string
+}
+
+// --- Pipeline stage metadata ---
+
+export const PIPELINE_STAGES: Array<{
+  id: PipelineStage
+  label: string
+  color: string
+  order: number
+}> = [
+  { id: 'leads', label: 'Leads', color: '#6b7280', order: 0 },
+  { id: 'contacted', label: 'Contacted', color: '#3b82f6', order: 1 },
+  { id: 'responded', label: 'Responded', color: '#f59e0b', order: 2 },
+  { id: 'meeting_set', label: 'Meeting Set', color: '#a855f7', order: 3 },
+  { id: 'proposal_sent', label: 'Proposal Sent', color: '#06b6d4', order: 4 },
+  { id: 'closed', label: 'Closed', color: '#22c55e', order: 5 },
+]
+
+export const STAGE_LABELS: Record<PipelineStage, string> = {
+  leads: 'Leads',
+  contacted: 'Contacted',
+  responded: 'Responded',
+  meeting_set: 'Meeting Set',
+  proposal_sent: 'Proposal Sent',
+  closed: 'Closed',
+}
+
+export const PRIORITY_COLORS: Record<LeadPriority, string> = {
+  high: '#ef4444',
+  medium: '#f97316',
+  low: '#6b7280',
+}
+
+// --- Mock leads ---
+
+export const MOCK_LEADS: Array<OutreachLead> = [
+  {
+    id: 'lead-001',
+    company: 'Acme Corp',
+    contactName: 'Sarah Chen',
+    contactEmail: 'sarah.chen@acmecorp.com',
+    contactTitle: 'VP of Engineering',
+    website: 'https://acmecorp.com',
+    stage: 'leads',
+    priority: 'high',
+    assignedAgent: 'orchestrator',
+    lastInteraction: '2026-06-18T14:30:00Z',
+    notes: 'Interested in SEO automation for their e-commerce platform. 50K+ products.',
+    tags: ['seo', 'e-commerce', 'enterprise'],
+    estimatedValue: 48000,
+    source: 'LinkedIn Outreach',
+  },
+  {
+    id: 'lead-002',
+    company: 'TechFlow Inc',
+    contactName: 'Marcus Johnson',
+    contactEmail: 'marcus@techflow.io',
+    contactTitle: 'Head of Growth',
+    website: 'https://techflow.io',
+    stage: 'contacted',
+    priority: 'high',
+    assignedAgent: 'builder',
+    lastInteraction: '2026-06-17T10:15:00Z',
+    notes: 'Responded positively to initial email. Wants to see a demo of AEO capabilities.',
+    tags: ['aeo', 'saas', 'growth'],
+    estimatedValue: 36000,
+    source: 'Cold Email',
+  },
+  {
+    id: 'lead-003',
+    company: 'GreenLeaf Media',
+    contactName: 'Emily Rodriguez',
+    contactEmail: 'emily@greenleafmedia.com',
+    contactTitle: 'Marketing Director',
+    website: 'https://greenleafmedia.com',
+    stage: 'responded',
+    priority: 'medium',
+    assignedAgent: 'strategist',
+    lastInteraction: '2026-06-16T16:45:00Z',
+    notes: 'Looking for content optimization. Has a blog with 200+ articles that need SEO refresh.',
+    tags: ['seo', 'content', 'media'],
+    estimatedValue: 24000,
+    source: 'Referral',
+  },
+  {
+    id: 'lead-004',
+    company: 'DataPrime Analytics',
+    contactName: 'David Kim',
+    contactEmail: 'david.kim@dataprime.ai',
+    contactTitle: 'CTO',
+    website: 'https://dataprime.ai',
+    stage: 'meeting_set',
+    priority: 'high',
+    assignedAgent: 'orchestrator',
+    lastInteraction: '2026-06-18T09:00:00Z',
+    notes: 'Meeting scheduled for June 22. Interested in AI-powered SEO for their data platform.',
+    tags: ['seo', 'aeo', 'ai', 'enterprise'],
+    estimatedValue: 72000,
+    source: 'Conference',
+  },
+  {
+    id: 'lead-005',
+    company: 'BrightPath Health',
+    contactName: 'Lisa Thompson',
+    contactEmail: 'lisa@brightpath.health',
+    contactTitle: 'Digital Marketing Manager',
+    website: 'https://brightpath.health',
+    stage: 'proposal_sent',
+    priority: 'high',
+    assignedAgent: 'strategist',
+    lastInteraction: '2026-06-15T11:30:00Z',
+    notes: 'Proposal sent for full SEO + AEO package. Decision expected by end of month.',
+    tags: ['seo', 'aeo', 'healthcare'],
+    estimatedValue: 60000,
+    source: 'Inbound Form',
+  },
+  {
+    id: 'lead-006',
+    company: 'Nexus Robotics',
+    contactName: 'James Park',
+    contactEmail: 'james@nexusrobotics.com',
+    contactTitle: 'CEO',
+    website: 'https://nexusrobotics.com',
+    stage: 'closed',
+    priority: 'high',
+    assignedAgent: 'orchestrator',
+    lastInteraction: '2026-06-10T15:00:00Z',
+    notes: 'Closed! Signed 12-month contract for SEO + AEO services. $84K ACV.',
+    tags: ['seo', 'aeo', 'robotics', 'enterprise'],
+    estimatedValue: 84000,
+    source: 'LinkedIn Outreach',
+  },
+  {
+    id: 'lead-007',
+    company: 'CloudSync Solutions',
+    contactName: 'Anna Petrov',
+    contactEmail: 'anna@cloudsync.dev',
+    contactTitle: 'Product Marketing Lead',
+    website: 'https://cloudsync.dev',
+    stage: 'leads',
+    priority: 'medium',
+    assignedAgent: 'builder',
+    lastInteraction: '2026-06-19T08:00:00Z',
+    notes: 'New lead from webinar. Interested in technical SEO for developer tools.',
+    tags: ['seo', 'developer-tools', 'b2b'],
+    estimatedValue: 30000,
+    source: 'Webinar',
+  },
+  {
+    id: 'lead-008',
+    company: 'UrbanStyle Fashion',
+    contactName: 'Rachel Green',
+    contactEmail: 'rachel@urbanstyle.com',
+    contactTitle: 'E-commerce Manager',
+    website: 'https://urbanstyle.com',
+    stage: 'contacted',
+    priority: 'medium',
+    assignedAgent: 'researcher',
+    lastInteraction: '2026-06-18T12:00:00Z',
+    notes: 'Sent follow-up with case study on fashion e-commerce SEO. Awaiting response.',
+    tags: ['seo', 'e-commerce', 'fashion'],
+    estimatedValue: 18000,
+    source: 'Cold Email',
+  },
+  {
+    id: 'lead-009',
+    company: 'FinEdge Capital',
+    contactName: 'Robert Chang',
+    contactEmail: 'robert@finedge.capital',
+    contactTitle: 'Head of Digital',
+    website: 'https://finedge.capital',
+    stage: 'responded',
+    priority: 'high',
+    assignedAgent: 'strategist',
+    lastInteraction: '2026-06-17T14:20:00Z',
+    notes: 'Very interested in AEO for financial content. Compliance review needed first.',
+    tags: ['aeo', 'finance', 'compliance'],
+    estimatedValue: 96000,
+    source: 'Referral',
+  },
+  {
+    id: 'lead-010',
+    company: 'EduSpark Learning',
+    contactName: 'Maria Santos',
+    contactEmail: 'maria@eduspark.edu',
+    contactTitle: 'VP Marketing',
+    website: 'https://eduspark.edu',
+    stage: 'meeting_set',
+    priority: 'medium',
+    assignedAgent: 'builder',
+    lastInteraction: '2026-06-19T10:30:00Z',
+    notes: 'Meeting set for June 23. Wants SEO audit for their online course platform.',
+    tags: ['seo', 'education', 'saas'],
+    estimatedValue: 28000,
+    source: 'Inbound Form',
+  },
+  {
+    id: 'lead-011',
+    company: 'LogiTrans Global',
+    contactName: 'Thomas Wright',
+    contactEmail: 'thomas@logitrans.com',
+    contactTitle: 'Marketing Director',
+    website: 'https://logitrans.com',
+    stage: 'proposal_sent',
+    priority: 'medium',
+    assignedAgent: 'orchestrator',
+    lastInteraction: '2026-06-14T09:45:00Z',
+    notes: 'Proposal sent for multilingual SEO. Competing with two other agencies.',
+    tags: ['seo', 'multilingual', 'logistics'],
+    estimatedValue: 42000,
+    source: 'Trade Show',
+  },
+  {
+    id: 'lead-012',
+    company: 'PixelCraft Studios',
+    contactName: 'Jenny Lee',
+    contactEmail: 'jenny@pixelcraft.studio',
+    contactTitle: 'Founder',
+    website: 'https://pixelcraft.studio',
+    stage: 'closed',
+    priority: 'low',
+    assignedAgent: 'builder',
+    lastInteraction: '2026-06-08T16:00:00Z',
+    notes: 'Closed! Small retainer for ongoing SEO maintenance. $12K ACV.',
+    tags: ['seo', 'creative', 'small-business'],
+    estimatedValue: 12000,
+    source: 'Cold Email',
+  },
+  {
+    id: 'lead-013',
+    company: 'MedVance Pharmaceuticals',
+    contactName: 'Dr. Alan Foster',
+    contactEmail: 'alan@medvance.com',
+    contactTitle: 'Chief Digital Officer',
+    website: 'https://medvance.com',
+    stage: 'leads',
+    priority: 'high',
+    assignedAgent: 'strategist',
+    lastInteraction: '2026-06-19T07:30:00Z',
+    notes: 'High-value prospect. Needs AEO for medical content. Long sales cycle expected.',
+    tags: ['aeo', 'healthcare', 'pharma', 'enterprise'],
+    estimatedValue: 120000,
+    source: 'Conference',
+  },
+  {
+    id: 'lead-014',
+    company: 'SwiftDelivery',
+    contactName: 'Carlos Mendez',
+    contactEmail: 'carlos@swift.delivery',
+    contactTitle: 'Growth Lead',
+    website: 'https://swift.delivery',
+    stage: 'contacted',
+    priority: 'medium',
+    assignedAgent: 'researcher',
+    lastInteraction: '2026-06-18T15:10:00Z',
+    notes: 'Initial email sent with local SEO case study. No response yet.',
+    tags: ['seo', 'local', 'delivery'],
+    estimatedValue: 22000,
+    source: 'LinkedIn Outreach',
+  },
+  {
+    id: 'lead-015',
+    company: 'QuantumCompute',
+    contactName: 'Dr. Yuki Tanaka',
+    contactEmail: 'yuki@quantumcompute.io',
+    contactTitle: 'VP Communications',
+    website: 'https://quantumcompute.io',
+    stage: 'responded',
+    priority: 'high',
+    assignedAgent: 'orchestrator',
+    lastInteraction: '2026-06-19T11:00:00Z',
+    notes: 'Responded asking for technical SEO audit proposal. Very technical audience.',
+    tags: ['seo', 'aeo', 'quantum', 'deep-tech'],
+    estimatedValue: 65000,
+    source: 'Referral',
+  },
+  {
+    id: 'lead-016',
+    company: 'FreshBite Foods',
+    contactName: 'Olivia Brown',
+    contactEmail: 'olivia@freshbite.food',
+    contactTitle: 'Brand Manager',
+    website: 'https://freshbite.food',
+    stage: 'meeting_set',
+    priority: 'low',
+    assignedAgent: 'builder',
+    lastInteraction: '2026-06-17T13:00:00Z',
+    notes: 'Meeting set for June 24. Small food brand looking for basic SEO setup.',
+    tags: ['seo', 'food', 'small-business'],
+    estimatedValue: 9600,
+    source: 'Inbound Form',
+  },
+  {
+    id: 'lead-017',
+    company: 'SkyNet Security',
+    contactName: 'Viktor Novak',
+    contactEmail: 'viktor@skynet.security',
+    contactTitle: 'Head of Marketing',
+    website: 'https://skynet.security',
+    stage: 'proposal_sent',
+    priority: 'high',
+    assignedAgent: 'strategist',
+    lastInteraction: '2026-06-16T10:00:00Z',
+    notes: 'Proposal under review. CTO is the final decision maker. Need security-focused case study.',
+    tags: ['seo', 'aeo', 'security', 'enterprise'],
+    estimatedValue: 78000,
+    source: 'Cold Email',
+  },
+  {
+    id: 'lead-018',
+    company: 'Artisan Crafts Co',
+    contactName: 'Sophie Martin',
+    contactEmail: 'sophie@artisan.crafts',
+    contactTitle: 'Owner',
+    website: 'https://artisan.crafts',
+    stage: 'closed',
+    priority: 'low',
+    assignedAgent: 'researcher',
+    lastInteraction: '2026-06-05T14:00:00Z',
+    notes: 'Closed! E-commerce SEO package. $8K ACV with quarterly reviews.',
+    tags: ['seo', 'e-commerce', 'small-business'],
+    estimatedValue: 8000,
+    source: 'Referral',
+  },
+]
+
+// --- Mock activity feed ---
+
+export const MOCK_ACTIVITIES: Array<OutreachActivity> = [
+  {
+    id: 'act-001',
+    leadId: 'lead-013',
+    leadCompany: 'MedVance Pharmaceuticals',
+    type: 'email_sent',
+    description: 'Sent initial outreach email with AEO capabilities overview',
+    timestamp: '2026-06-19T07:30:00Z',
+    agent: 'strategist',
+  },
+  {
+    id: 'act-002',
+    leadId: 'lead-007',
+    leadCompany: 'CloudSync Solutions',
+    type: 'note_added',
+    description: 'Added lead from webinar attendee list. Interested in technical SEO.',
+    timestamp: '2026-06-19T08:00:00Z',
+    agent: 'builder',
+  },
+  {
+    id: 'act-003',
+    leadId: 'lead-004',
+    leadCompany: 'DataPrime Analytics',
+    type: 'meeting_scheduled',
+    description: 'Discovery call scheduled for June 22 at 2:00 PM EST',
+    timestamp: '2026-06-18T09:00:00Z',
+    agent: 'orchestrator',
+  },
+  {
+    id: 'act-004',
+    leadId: 'lead-015',
+    leadCompany: 'QuantumCompute',
+    type: 'email_opened',
+    description: 'Opened initial outreach email and clicked through to case study',
+    timestamp: '2026-06-19T11:00:00Z',
+    agent: 'orchestrator',
+  },
+  {
+    id: 'act-005',
+    leadId: 'lead-010',
+    leadCompany: 'EduSpark Learning',
+    type: 'meeting_scheduled',
+    description: 'SEO audit kickoff meeting set for June 23 at 10:00 AM EST',
+    timestamp: '2026-06-19T10:30:00Z',
+    agent: 'builder',
+  },
+  {
+    id: 'act-006',
+    leadId: 'lead-014',
+    leadCompany: 'SwiftDelivery',
+    type: 'email_sent',
+    description: 'Sent local SEO case study for delivery companies',
+    timestamp: '2026-06-18T15:10:00Z',
+    agent: 'researcher',
+  },
+  {
+    id: 'act-007',
+    leadId: 'lead-001',
+    leadCompany: 'Acme Corp',
+    type: 'note_added',
+    description: 'Identified as high-priority lead. 50K+ product catalog needs SEO automation.',
+    timestamp: '2026-06-18T14:30:00Z',
+    agent: 'orchestrator',
+  },
+  {
+    id: 'act-008',
+    leadId: 'lead-008',
+    leadCompany: 'UrbanStyle Fashion',
+    type: 'follow_up',
+    description: 'Follow-up email sent with fashion e-commerce SEO case study',
+    timestamp: '2026-06-18T12:00:00Z',
+    agent: 'researcher',
+  },
+  {
+    id: 'act-009',
+    leadId: 'lead-002',
+    leadCompany: 'TechFlow Inc',
+    type: 'call_made',
+    description: 'Discovery call completed. Very interested in AEO for SaaS content.',
+    timestamp: '2026-06-17T10:15:00Z',
+    agent: 'builder',
+  },
+  {
+    id: 'act-010',
+    leadId: 'lead-016',
+    leadCompany: 'FreshBite Foods',
+    type: 'meeting_scheduled',
+    description: 'Initial consultation set for June 24 at 11:00 AM EST',
+    timestamp: '2026-06-17T13:00:00Z',
+    agent: 'builder',
+  },
+  {
+    id: 'act-011',
+    leadId: 'lead-009',
+    leadCompany: 'FinEdge Capital',
+    type: 'email_opened',
+    description: 'Opened AEO proposal and requested compliance documentation',
+    timestamp: '2026-06-17T14:20:00Z',
+    agent: 'strategist',
+  },
+  {
+    id: 'act-012',
+    leadId: 'lead-017',
+    leadCompany: 'SkyNet Security',
+    type: 'proposal_sent',
+    description: 'Full SEO + AEO proposal sent. $78K ACV, 12-month engagement.',
+    timestamp: '2026-06-16T10:00:00Z',
+    agent: 'strategist',
+  },
+  {
+    id: 'act-013',
+    leadId: 'lead-003',
+    leadCompany: 'GreenLeaf Media',
+    type: 'call_made',
+    description: 'Follow-up call to discuss content optimization strategy',
+    timestamp: '2026-06-16T16:45:00Z',
+    agent: 'strategist',
+  },
+  {
+    id: 'act-014',
+    leadId: 'lead-011',
+    leadCompany: 'LogiTrans Global',
+    type: 'proposal_viewed',
+    description: 'Proposal viewed by Marketing Director. Awaiting feedback.',
+    timestamp: '2026-06-15T09:45:00Z',
+    agent: 'orchestrator',
+  },
+  {
+    id: 'act-015',
+    leadId: 'lead-005',
+    leadCompany: 'BrightPath Health',
+    type: 'proposal_sent',
+    description: 'Comprehensive SEO + AEO proposal sent. $60K ACV.',
+    timestamp: '2026-06-15T11:30:00Z',
+    agent: 'strategist',
+  },
+]
+
+// --- Helper functions ---
+
+export function getLeadsByStage(leads: Array<OutreachLead>): Record<PipelineStage, Array<OutreachLead>> {
+  const map: Record<PipelineStage, Array<OutreachLead>> = {
+    leads: [],
+    contacted: [],
+    responded: [],
+    meeting_set: [],
+    proposal_sent: [],
+    closed: [],
+  }
+  for (const lead of leads) {
+    map[lead.stage].push(lead)
+  }
+  return map
+}
+
+export function getPipelineStats(leads: Array<OutreachLead>) {
+  const total = leads.length
+  const byStage = getLeadsByStage(leads)
+  const activeOutreach = leads.filter(
+    (l) => !['closed'].includes(l.stage),
+  ).length
+  const proposalsSent = byStage.proposal_sent.length + byStage.closed.length
+  const conversionRate = total > 0 ? Math.round((proposalsSent / total) * 100) : 0
+  const totalPipelineValue = leads
+    .filter((l) => l.estimatedValue !== null && l.stage !== 'closed')
+    .reduce((sum, l) => sum + (l.estimatedValue ?? 0), 0)
+  const closedValue = byStage.closed.reduce(
+    (sum, l) => sum + (l.estimatedValue ?? 0),
+    0,
+  )
+
+  return {
+    total,
+    activeOutreach,
+    conversionRate,
+    totalPipelineValue,
+    closedValue,
+    byStage,
+  }
+}
+
+export function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+export function formatRelativeDate(isoString: string): string {
+  const date = new Date(isoString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}

--- a/src/lib/project-context.test.ts
+++ b/src/lib/project-context.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildProjectContextDirective,
+  buildProjectScopedTextMessage,
+  stripProjectContextDirective,
+} from './project-context'
+
+describe('project-context', () => {
+  it('builds a hidden project directive with escaped attributes', () => {
+    expect(
+      buildProjectContextDirective({
+        id: 'seo-aeo',
+        name: 'SEO & AEO "Launch"',
+        goal: 'Win <first> client',
+        instructions: 'Keep it concise & revenue-first',
+      }),
+    ).toBe(
+      '<project_context active="true" id="seo-aeo" name="SEO &amp; AEO &quot;Launch&quot;" goal="Win &lt;first&gt; client" instructions="Keep it concise &amp; revenue-first" />',
+    )
+  })
+
+  it('prepends project context once', () => {
+    const scoped = buildProjectScopedTextMessage('Draft the next step', {
+      id: 'workspace-build',
+      name: 'Workspace Build',
+      goal: 'Shape Hermes Workspace',
+    })
+
+    expect(scoped).toContain('<project_context active="true"')
+    expect(buildProjectScopedTextMessage(scoped, { id: 'x', name: 'X' })).toBe(
+      scoped,
+    )
+  })
+
+  it('strips the hidden project directive for visible chat rendering', () => {
+    expect(
+      stripProjectContextDirective(
+        '<project_context active="true" id="seo" name="SEO" goal="Launch" />\n\nWhat next?',
+      ),
+    ).toBe('What next?')
+  })
+})

--- a/src/lib/project-context.ts
+++ b/src/lib/project-context.ts
@@ -1,0 +1,56 @@
+export type ProjectContextScope = {
+  id?: string
+  name?: string
+  goal?: string
+  instructions?: string
+}
+
+const PROJECT_CONTEXT_RE =
+  /^\s*<project_context\s+active="true"(?:\s+id="[^"]*")?(?:\s+name="[^"]*")?(?:\s+goal="[^"]*")?(?:\s+instructions="[^"]*")?\s*\/?>\s*/i
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function normalizeAttribute(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function buildProjectContextDirective(
+  project: ProjectContextScope | null | undefined,
+): string {
+  if (!project) return ''
+  const id = normalizeAttribute(project.id)
+  const name = normalizeAttribute(project.name)
+  const goal = normalizeAttribute(project.goal)
+  const instructions = normalizeAttribute(project.instructions)
+  if (!id || !name) return ''
+
+  const attrs = [
+    'active="true"',
+    `id="${escapeAttribute(id)}"`,
+    `name="${escapeAttribute(name)}"`,
+  ]
+  if (goal) attrs.push(`goal="${escapeAttribute(goal)}"`)
+  if (instructions) attrs.push(`instructions="${escapeAttribute(instructions)}"`)
+  return `<project_context ${attrs.join(' ')} />`
+}
+
+export function buildProjectScopedTextMessage(
+  message: string,
+  project: ProjectContextScope | null | undefined,
+): string {
+  if (message.includes('<project_context active="true"')) return message
+  const directive = buildProjectContextDirective(project)
+  if (!directive) return message
+  return `${directive}\n\n${message}`
+}
+
+export function stripProjectContextDirective(message: string): string {
+  if (!message.includes('<project_context active="true"')) return message
+  return message.replace(PROJECT_CONTEXT_RE, '').trimStart()
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,7 +20,10 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ReserveRouteImport } from './routes/reserve'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
+import { Route as OutreachRouteImport } from './routes/outreach'
 import { Route as OperationsRouteImport } from './routes/operations'
+import { Route as NotionRouteImport } from './routes/notion'
+import { Route as MissionControlRouteImport } from './routes/mission-control'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
@@ -30,6 +33,7 @@ import { Route as EchoStudioRouteImport } from './routes/echo-studio'
 import { Route as EarlyAccessRouteImport } from './routes/early-access'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ConductorRouteImport } from './routes/conductor'
+import { Route as ApprovalQueueRouteImport } from './routes/approval-queue'
 import { Route as AgoraRouteImport } from './routes/agora'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as IndexRouteImport } from './routes/index'
@@ -75,6 +79,7 @@ import { Route as ApiSessionHistoryRouteImport } from './routes/api/session-hist
 import { Route as ApiSendStreamRouteImport } from './routes/api/send-stream'
 import { Route as ApiSendRouteImport } from './routes/api/send'
 import { Route as ApiProviderUsageRouteImport } from './routes/api/provider-usage'
+import { Route as ApiProjectsRouteImport } from './routes/api/projects'
 import { Route as ApiPreviewFileRouteImport } from './routes/api/preview-file'
 import { Route as ApiPluginsRouteImport } from './routes/api/plugins'
 import { Route as ApiPlaygroundNpcRouteImport } from './routes/api/playground-npc'
@@ -135,7 +140,14 @@ import { Route as ApiProfilesCreateRouteImport } from './routes/api/profiles/cre
 import { Route as ApiProfilesActivateRouteImport } from './routes/api/profiles/activate'
 import { Route as ApiOauthPollTokenRouteImport } from './routes/api/oauth.poll-token'
 import { Route as ApiOauthDeviceCodeRouteImport } from './routes/api/oauth.device-code'
+import { Route as ApiNotionSourcesRouteImport } from './routes/api/notion/sources'
+import { Route as ApiNotionQueryRouteImport } from './routes/api/notion/query'
+import { Route as ApiNotionOutreachRouteImport } from './routes/api/notion/outreach'
+import { Route as ApiNotionCrmRouteImport } from './routes/api/notion/crm'
+import { Route as ApiNotionApprovalsRouteImport } from './routes/api/notion/approvals'
 import { Route as ApiModelInfoRouteImport } from './routes/api/model/info'
+import { Route as ApiMissionControlSystemRouteImport } from './routes/api/mission-control/system'
+import { Route as ApiMissionControlSummaryRouteImport } from './routes/api/mission-control/summary'
 import { Route as ApiMemoryWriteRouteImport } from './routes/api/memory/write'
 import { Route as ApiMemorySearchRouteImport } from './routes/api/memory/search'
 import { Route as ApiMemoryReadRouteImport } from './routes/api/memory/read'
@@ -225,9 +237,24 @@ const PlaygroundRoute = PlaygroundRouteImport.update({
   path: '/playground',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OutreachRoute = OutreachRouteImport.update({
+  id: '/outreach',
+  path: '/outreach',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OperationsRoute = OperationsRouteImport.update({
   id: '/operations',
   path: '/operations',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotionRoute = NotionRouteImport.update({
+  id: '/notion',
+  path: '/notion',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MissionControlRoute = MissionControlRouteImport.update({
+  id: '/mission-control',
+  path: '/mission-control',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MemoryRoute = MemoryRouteImport.update({
@@ -273,6 +300,11 @@ const DashboardRoute = DashboardRouteImport.update({
 const ConductorRoute = ConductorRouteImport.update({
   id: '/conductor',
   path: '/conductor',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApprovalQueueRoute = ApprovalQueueRouteImport.update({
+  id: '/approval-queue',
+  path: '/approval-queue',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgoraRoute = AgoraRouteImport.update({
@@ -499,6 +531,11 @@ const ApiSendRoute = ApiSendRouteImport.update({
 const ApiProviderUsageRoute = ApiProviderUsageRouteImport.update({
   id: '/api/provider-usage',
   path: '/api/provider-usage',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProjectsRoute = ApiProjectsRouteImport.update({
+  id: '/api/projects',
+  path: '/api/projects',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiPreviewFileRoute = ApiPreviewFileRouteImport.update({
@@ -801,11 +838,47 @@ const ApiOauthDeviceCodeRoute = ApiOauthDeviceCodeRouteImport.update({
   path: '/api/oauth/device-code',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiNotionSourcesRoute = ApiNotionSourcesRouteImport.update({
+  id: '/api/notion/sources',
+  path: '/api/notion/sources',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiNotionQueryRoute = ApiNotionQueryRouteImport.update({
+  id: '/api/notion/query',
+  path: '/api/notion/query',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiNotionOutreachRoute = ApiNotionOutreachRouteImport.update({
+  id: '/api/notion/outreach',
+  path: '/api/notion/outreach',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiNotionCrmRoute = ApiNotionCrmRouteImport.update({
+  id: '/api/notion/crm',
+  path: '/api/notion/crm',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiNotionApprovalsRoute = ApiNotionApprovalsRouteImport.update({
+  id: '/api/notion/approvals',
+  path: '/api/notion/approvals',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiModelInfoRoute = ApiModelInfoRouteImport.update({
   id: '/api/model/info',
   path: '/api/model/info',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMissionControlSystemRoute = ApiMissionControlSystemRouteImport.update({
+  id: '/api/mission-control/system',
+  path: '/api/mission-control/system',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMissionControlSummaryRoute =
+  ApiMissionControlSummaryRouteImport.update({
+    id: '/api/mission-control/summary',
+    path: '/api/mission-control/summary',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiMemoryWriteRoute = ApiMemoryWriteRouteImport.update({
   id: '/write',
   path: '/write',
@@ -983,6 +1056,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
   '/agora': typeof AgoraRoute
+  '/approval-queue': typeof ApprovalQueueRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
@@ -992,7 +1066,10 @@ export interface FileRoutesByFullPath {
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
+  '/mission-control': typeof MissionControlRoute
+  '/notion': typeof NotionRoute
   '/operations': typeof OperationsRoute
+  '/outreach': typeof OutreachRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
@@ -1041,6 +1118,7 @@ export interface FileRoutesByFullPath {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1110,7 +1188,14 @@ export interface FileRoutesByFullPath {
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
   '/api/memory/write': typeof ApiMemoryWriteRoute
+  '/api/mission-control/summary': typeof ApiMissionControlSummaryRoute
+  '/api/mission-control/system': typeof ApiMissionControlSystemRoute
   '/api/model/info': typeof ApiModelInfoRoute
+  '/api/notion/approvals': typeof ApiNotionApprovalsRoute
+  '/api/notion/crm': typeof ApiNotionCrmRoute
+  '/api/notion/outreach': typeof ApiNotionOutreachRoute
+  '/api/notion/query': typeof ApiNotionQueryRoute
+  '/api/notion/sources': typeof ApiNotionSourcesRoute
   '/api/oauth/device-code': typeof ApiOauthDeviceCodeRoute
   '/api/oauth/poll-token': typeof ApiOauthPollTokenRoute
   '/api/profiles/activate': typeof ApiProfilesActivateRoute
@@ -1145,6 +1230,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
   '/agora': typeof AgoraRoute
+  '/approval-queue': typeof ApprovalQueueRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
@@ -1154,7 +1240,10 @@ export interface FileRoutesByTo {
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
+  '/mission-control': typeof MissionControlRoute
+  '/notion': typeof NotionRoute
   '/operations': typeof OperationsRoute
+  '/outreach': typeof OutreachRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
@@ -1202,6 +1291,7 @@ export interface FileRoutesByTo {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1271,7 +1361,14 @@ export interface FileRoutesByTo {
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
   '/api/memory/write': typeof ApiMemoryWriteRoute
+  '/api/mission-control/summary': typeof ApiMissionControlSummaryRoute
+  '/api/mission-control/system': typeof ApiMissionControlSystemRoute
   '/api/model/info': typeof ApiModelInfoRoute
+  '/api/notion/approvals': typeof ApiNotionApprovalsRoute
+  '/api/notion/crm': typeof ApiNotionCrmRoute
+  '/api/notion/outreach': typeof ApiNotionOutreachRoute
+  '/api/notion/query': typeof ApiNotionQueryRoute
+  '/api/notion/sources': typeof ApiNotionSourcesRoute
   '/api/oauth/device-code': typeof ApiOauthDeviceCodeRoute
   '/api/oauth/poll-token': typeof ApiOauthPollTokenRoute
   '/api/profiles/activate': typeof ApiProfilesActivateRoute
@@ -1307,6 +1404,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$': typeof SplatRoute
   '/agora': typeof AgoraRoute
+  '/approval-queue': typeof ApprovalQueueRoute
   '/conductor': typeof ConductorRoute
   '/dashboard': typeof DashboardRoute
   '/early-access': typeof EarlyAccessRoute
@@ -1316,7 +1414,10 @@ export interface FileRoutesById {
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
+  '/mission-control': typeof MissionControlRoute
+  '/notion': typeof NotionRoute
   '/operations': typeof OperationsRoute
+  '/outreach': typeof OutreachRoute
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
@@ -1365,6 +1466,7 @@ export interface FileRoutesById {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/projects': typeof ApiProjectsRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1434,7 +1536,14 @@ export interface FileRoutesById {
   '/api/memory/read': typeof ApiMemoryReadRoute
   '/api/memory/search': typeof ApiMemorySearchRoute
   '/api/memory/write': typeof ApiMemoryWriteRoute
+  '/api/mission-control/summary': typeof ApiMissionControlSummaryRoute
+  '/api/mission-control/system': typeof ApiMissionControlSystemRoute
   '/api/model/info': typeof ApiModelInfoRoute
+  '/api/notion/approvals': typeof ApiNotionApprovalsRoute
+  '/api/notion/crm': typeof ApiNotionCrmRoute
+  '/api/notion/outreach': typeof ApiNotionOutreachRoute
+  '/api/notion/query': typeof ApiNotionQueryRoute
+  '/api/notion/sources': typeof ApiNotionSourcesRoute
   '/api/oauth/device-code': typeof ApiOauthDeviceCodeRoute
   '/api/oauth/poll-token': typeof ApiOauthPollTokenRoute
   '/api/profiles/activate': typeof ApiProfilesActivateRoute
@@ -1471,6 +1580,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$'
     | '/agora'
+    | '/approval-queue'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
@@ -1480,7 +1590,10 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/mcp'
     | '/memory'
+    | '/mission-control'
+    | '/notion'
     | '/operations'
+    | '/outreach'
     | '/playground'
     | '/profiles'
     | '/reserve'
@@ -1529,6 +1642,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1598,7 +1712,14 @@ export interface FileRouteTypes {
     | '/api/memory/read'
     | '/api/memory/search'
     | '/api/memory/write'
+    | '/api/mission-control/summary'
+    | '/api/mission-control/system'
     | '/api/model/info'
+    | '/api/notion/approvals'
+    | '/api/notion/crm'
+    | '/api/notion/outreach'
+    | '/api/notion/query'
+    | '/api/notion/sources'
     | '/api/oauth/device-code'
     | '/api/oauth/poll-token'
     | '/api/profiles/activate'
@@ -1633,6 +1754,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$'
     | '/agora'
+    | '/approval-queue'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
@@ -1642,7 +1764,10 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/mcp'
     | '/memory'
+    | '/mission-control'
+    | '/notion'
     | '/operations'
+    | '/outreach'
     | '/playground'
     | '/profiles'
     | '/reserve'
@@ -1690,6 +1815,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1759,7 +1885,14 @@ export interface FileRouteTypes {
     | '/api/memory/read'
     | '/api/memory/search'
     | '/api/memory/write'
+    | '/api/mission-control/summary'
+    | '/api/mission-control/system'
     | '/api/model/info'
+    | '/api/notion/approvals'
+    | '/api/notion/crm'
+    | '/api/notion/outreach'
+    | '/api/notion/query'
+    | '/api/notion/sources'
     | '/api/oauth/device-code'
     | '/api/oauth/poll-token'
     | '/api/profiles/activate'
@@ -1794,6 +1927,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$'
     | '/agora'
+    | '/approval-queue'
     | '/conductor'
     | '/dashboard'
     | '/early-access'
@@ -1803,7 +1937,10 @@ export interface FileRouteTypes {
     | '/jobs'
     | '/mcp'
     | '/memory'
+    | '/mission-control'
+    | '/notion'
     | '/operations'
+    | '/outreach'
     | '/playground'
     | '/profiles'
     | '/reserve'
@@ -1852,6 +1989,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/projects'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1921,7 +2059,14 @@ export interface FileRouteTypes {
     | '/api/memory/read'
     | '/api/memory/search'
     | '/api/memory/write'
+    | '/api/mission-control/summary'
+    | '/api/mission-control/system'
     | '/api/model/info'
+    | '/api/notion/approvals'
+    | '/api/notion/crm'
+    | '/api/notion/outreach'
+    | '/api/notion/query'
+    | '/api/notion/sources'
     | '/api/oauth/device-code'
     | '/api/oauth/poll-token'
     | '/api/profiles/activate'
@@ -1957,6 +2102,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SplatRoute: typeof SplatRoute
   AgoraRoute: typeof AgoraRoute
+  ApprovalQueueRoute: typeof ApprovalQueueRoute
   ConductorRoute: typeof ConductorRoute
   DashboardRoute: typeof DashboardRoute
   EarlyAccessRoute: typeof EarlyAccessRoute
@@ -1966,7 +2112,10 @@ export interface RootRouteChildren {
   JobsRoute: typeof JobsRoute
   McpRoute: typeof McpRoute
   MemoryRoute: typeof MemoryRoute
+  MissionControlRoute: typeof MissionControlRoute
+  NotionRoute: typeof NotionRoute
   OperationsRoute: typeof OperationsRoute
+  OutreachRoute: typeof OutreachRoute
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
   ReserveRoute: typeof ReserveRouteWithChildren
@@ -2015,6 +2164,7 @@ export interface RootRouteChildren {
   ApiPlaygroundNpcRoute: typeof ApiPlaygroundNpcRoute
   ApiPluginsRoute: typeof ApiPluginsRoute
   ApiPreviewFileRoute: typeof ApiPreviewFileRoute
+  ApiProjectsRoute: typeof ApiProjectsRoute
   ApiProviderUsageRoute: typeof ApiProviderUsageRoute
   ApiSendRoute: typeof ApiSendRoute
   ApiSendStreamRoute: typeof ApiSendStreamRoute
@@ -2066,7 +2216,14 @@ export interface RootRouteChildren {
   ApiKnowledgeReadRoute: typeof ApiKnowledgeReadRoute
   ApiKnowledgeSearchRoute: typeof ApiKnowledgeSearchRoute
   ApiKnowledgeSyncRoute: typeof ApiKnowledgeSyncRoute
+  ApiMissionControlSummaryRoute: typeof ApiMissionControlSummaryRoute
+  ApiMissionControlSystemRoute: typeof ApiMissionControlSystemRoute
   ApiModelInfoRoute: typeof ApiModelInfoRoute
+  ApiNotionApprovalsRoute: typeof ApiNotionApprovalsRoute
+  ApiNotionCrmRoute: typeof ApiNotionCrmRoute
+  ApiNotionOutreachRoute: typeof ApiNotionOutreachRoute
+  ApiNotionQueryRoute: typeof ApiNotionQueryRoute
+  ApiNotionSourcesRoute: typeof ApiNotionSourcesRoute
   ApiOauthDeviceCodeRoute: typeof ApiOauthDeviceCodeRoute
   ApiOauthPollTokenRoute: typeof ApiOauthPollTokenRoute
   ApiProfilesActivateRoute: typeof ApiProfilesActivateRoute
@@ -2164,11 +2321,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PlaygroundRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/outreach': {
+      id: '/outreach'
+      path: '/outreach'
+      fullPath: '/outreach'
+      preLoaderRoute: typeof OutreachRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/operations': {
       id: '/operations'
       path: '/operations'
       fullPath: '/operations'
       preLoaderRoute: typeof OperationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notion': {
+      id: '/notion'
+      path: '/notion'
+      fullPath: '/notion'
+      preLoaderRoute: typeof NotionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mission-control': {
+      id: '/mission-control'
+      path: '/mission-control'
+      fullPath: '/mission-control'
+      preLoaderRoute: typeof MissionControlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/memory': {
@@ -2232,6 +2410,13 @@ declare module '@tanstack/react-router' {
       path: '/conductor'
       fullPath: '/conductor'
       preLoaderRoute: typeof ConductorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/approval-queue': {
+      id: '/approval-queue'
+      path: '/approval-queue'
+      fullPath: '/approval-queue'
+      preLoaderRoute: typeof ApprovalQueueRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agora': {
@@ -2547,6 +2732,13 @@ declare module '@tanstack/react-router' {
       path: '/api/provider-usage'
       fullPath: '/api/provider-usage'
       preLoaderRoute: typeof ApiProviderUsageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/projects': {
+      id: '/api/projects'
+      path: '/api/projects'
+      fullPath: '/api/projects'
+      preLoaderRoute: typeof ApiProjectsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/preview-file': {
@@ -2969,11 +3161,60 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiOauthDeviceCodeRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/notion/sources': {
+      id: '/api/notion/sources'
+      path: '/api/notion/sources'
+      fullPath: '/api/notion/sources'
+      preLoaderRoute: typeof ApiNotionSourcesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/notion/query': {
+      id: '/api/notion/query'
+      path: '/api/notion/query'
+      fullPath: '/api/notion/query'
+      preLoaderRoute: typeof ApiNotionQueryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/notion/outreach': {
+      id: '/api/notion/outreach'
+      path: '/api/notion/outreach'
+      fullPath: '/api/notion/outreach'
+      preLoaderRoute: typeof ApiNotionOutreachRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/notion/crm': {
+      id: '/api/notion/crm'
+      path: '/api/notion/crm'
+      fullPath: '/api/notion/crm'
+      preLoaderRoute: typeof ApiNotionCrmRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/notion/approvals': {
+      id: '/api/notion/approvals'
+      path: '/api/notion/approvals'
+      fullPath: '/api/notion/approvals'
+      preLoaderRoute: typeof ApiNotionApprovalsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/model/info': {
       id: '/api/model/info'
       path: '/api/model/info'
       fullPath: '/api/model/info'
       preLoaderRoute: typeof ApiModelInfoRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/mission-control/system': {
+      id: '/api/mission-control/system'
+      path: '/api/mission-control/system'
+      fullPath: '/api/mission-control/system'
+      preLoaderRoute: typeof ApiMissionControlSystemRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/mission-control/summary': {
+      id: '/api/mission-control/summary'
+      path: '/api/mission-control/summary'
+      fullPath: '/api/mission-control/summary'
+      preLoaderRoute: typeof ApiMissionControlSummaryRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/memory/write': {
@@ -3426,6 +3667,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
   AgoraRoute: AgoraRoute,
+  ApprovalQueueRoute: ApprovalQueueRoute,
   ConductorRoute: ConductorRoute,
   DashboardRoute: DashboardRoute,
   EarlyAccessRoute: EarlyAccessRoute,
@@ -3435,7 +3677,10 @@ const rootRouteChildren: RootRouteChildren = {
   JobsRoute: JobsRoute,
   McpRoute: McpRoute,
   MemoryRoute: MemoryRoute,
+  MissionControlRoute: MissionControlRoute,
+  NotionRoute: NotionRoute,
   OperationsRoute: OperationsRoute,
+  OutreachRoute: OutreachRoute,
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
   ReserveRoute: ReserveRouteWithChildren,
@@ -3484,6 +3729,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaygroundNpcRoute: ApiPlaygroundNpcRoute,
   ApiPluginsRoute: ApiPluginsRoute,
   ApiPreviewFileRoute: ApiPreviewFileRoute,
+  ApiProjectsRoute: ApiProjectsRoute,
   ApiProviderUsageRoute: ApiProviderUsageRoute,
   ApiSendRoute: ApiSendRoute,
   ApiSendStreamRoute: ApiSendStreamRoute,
@@ -3535,7 +3781,14 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKnowledgeReadRoute: ApiKnowledgeReadRoute,
   ApiKnowledgeSearchRoute: ApiKnowledgeSearchRoute,
   ApiKnowledgeSyncRoute: ApiKnowledgeSyncRoute,
+  ApiMissionControlSummaryRoute: ApiMissionControlSummaryRoute,
+  ApiMissionControlSystemRoute: ApiMissionControlSystemRoute,
   ApiModelInfoRoute: ApiModelInfoRoute,
+  ApiNotionApprovalsRoute: ApiNotionApprovalsRoute,
+  ApiNotionCrmRoute: ApiNotionCrmRoute,
+  ApiNotionOutreachRoute: ApiNotionOutreachRoute,
+  ApiNotionQueryRoute: ApiNotionQueryRoute,
+  ApiNotionSourcesRoute: ApiNotionSourcesRoute,
   ApiOauthDeviceCodeRoute: ApiOauthDeviceCodeRoute,
   ApiOauthPollTokenRoute: ApiOauthPollTokenRoute,
   ApiProfilesActivateRoute: ApiProfilesActivateRoute,

--- a/src/routes/api/-hermes-config.test.ts
+++ b/src/routes/api/-hermes-config.test.ts
@@ -7,8 +7,10 @@ vi.mock('@tanstack/react-router', () => ({
   createFileRoute: (_path: string) => (opts: any) => opts,
 }))
 
+let mockAuthenticated = true
+
 vi.mock('../../server/auth-middleware', () => ({
-  isAuthenticated: () => true,
+  isAuthenticated: () => mockAuthenticated,
 }))
 
 vi.mock('../../server/gateway-capabilities', () => ({
@@ -35,6 +37,7 @@ beforeEach(() => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-config-route-'))
   setEnv('HERMES_HOME', tmpHome)
   setEnv('CLAUDE_HOME', undefined)
+  mockAuthenticated = true
   vi.resetModules()
 })
 
@@ -53,6 +56,19 @@ async function loadHandlers(modulePath: string) {
 }
 
 describe('canonical /api/hermes-config route', () => {
+  it('GET returns 401 JSON instead of throwing when the request is not authenticated', async () => {
+    mockAuthenticated = false
+
+    const handlers = await loadHandlers('./hermes-config')
+    const res = await handlers.GET({
+      request: new Request('http://localhost/api/hermes-config'),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body).toEqual({ ok: false, error: 'Unauthorized' })
+  })
+
   it('GET returns normalized provider state with paths and active provider', async () => {
     fs.writeFileSync(
       path.join(tmpHome, 'config.yaml'),

--- a/src/routes/api/-hermes-config.test.ts
+++ b/src/routes/api/-hermes-config.test.ts
@@ -96,6 +96,84 @@ describe('canonical /api/hermes-config route', () => {
     expect(openrouter.isDefault).toBe(true)
   })
 
+  it('GET exposes the current Hermes provider catalog for future provider switching', async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, 'config.yaml'),
+      'provider: gemini\nmodel: gemini-3.5-flash\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(tmpHome, '.env'),
+      'GOOGLE_API_KEY=google-test-key\nDEEPSEEK_API_KEY=deepseek-test-key\n',
+      'utf-8',
+    )
+
+    const handlers = await loadHandlers('./hermes-config')
+    const res = await handlers.GET({
+      request: new Request('http://localhost/api/hermes-config'),
+    })
+    const body = await res.json()
+    const ids = body.providers.map((p: any) => p.id)
+
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'openrouter',
+        'openai-api',
+        'openai-codex',
+        'anthropic',
+        'gemini',
+        'google-gemini-cli',
+        'deepseek',
+        'xai',
+        'zai',
+        'kimi-coding',
+        'minimax',
+        'alibaba',
+        'huggingface',
+        'kilocode',
+        'opencode-zen',
+        'opencode-go',
+        'qwen-oauth',
+      ]),
+    )
+
+    const gemini = body.providers.find((p: any) => p.id === 'gemini')
+    expect(gemini.envKeys).toEqual(['GOOGLE_API_KEY', 'GEMINI_API_KEY'])
+    expect(gemini.configured).toBe(true)
+    expect(gemini.isDefault).toBe(true)
+    expect(gemini.maskedCredentials.GOOGLE_API_KEY).toBeTruthy()
+
+    const deepseek = body.providers.find((p: any) => p.id === 'deepseek')
+    expect(deepseek.configured).toBe(true)
+  })
+
+  it('PATCH legacy { config } can delete stale base_url when switching to hosted providers', async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, 'config.yaml'),
+      'provider: ollama\nmodel: qwen-local\nbase_url: http://localhost:11434/v1\n',
+      'utf-8',
+    )
+
+    const handlers = await loadHandlers('./hermes-config')
+    await handlers.PATCH({
+      request: new Request('http://localhost/api/hermes-config', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          config: {
+            provider: 'openrouter',
+            model: 'anthropic/claude-sonnet-4.6',
+            base_url: null,
+          },
+        }),
+      }),
+    })
+
+    const onDisk = fs.readFileSync(path.join(tmpHome, 'config.yaml'), 'utf-8')
+    expect(onDisk).toContain('provider: openrouter')
+    expect(onDisk).toContain('model: anthropic/claude-sonnet-4.6')
+    expect(onDisk).not.toContain('base_url:')
+  })
+
   it('PATCH dispatches set-default-model and returns the action message', async () => {
     const handlers = await loadHandlers('./hermes-config')
     const res = await handlers.PATCH({

--- a/src/routes/api/mission-control/summary.ts
+++ b/src/routes/api/mission-control/summary.ts
@@ -1,0 +1,138 @@
+/**
+ * Read-only Mission Control summary endpoint.
+ * GET /api/mission-control/summary
+ *
+ * Aggregates safe operational counts from Notion through the server-side
+ * Notion proxy. Does not expose tokens, raw credentials, or external writes.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+  extractDate,
+  extractNumber,
+  extractSelect,
+  loadManifest,
+  notionRouteError,
+  queryDataSource,
+} from '../../../server/notion-client'
+
+type CountMap = Record<string, number>
+
+function increment(map: CountMap, key: string | null | undefined): void {
+  const normalized = key?.trim() || 'Unspecified'
+  map[normalized] = (map[normalized] ?? 0) + 1
+}
+
+function isTodayOrEarlier(dateText: string): boolean {
+  if (!dateText) return false
+  const due = new Date(`${dateText}T23:59:59`)
+  if (Number.isNaN(due.getTime())) return false
+  return due.getTime() <= Date.now()
+}
+
+export const Route = createFileRoute('/api/mission-control/summary')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const manifest = loadManifest()
+          const getSource = (name: string) => {
+            const source = manifest.data_sources[name]
+            if (!source) throw new Error(`Missing Notion data source: ${name}`)
+            return source
+          }
+
+          const [crm, outreach, approvals, deals, projects, tasks, automation] = await Promise.all([
+            queryDataSource(getSource('CRM / Leads').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Outreach / Interactions').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Human Approval Queue').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Deals / Proposals').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Projects').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Tasks').id, { page_size: 100, cacheTtlMs: 60_000 }),
+            queryDataSource(getSource('Automation Log').id, { page_size: 100, cacheTtlMs: 60_000 }),
+          ])
+
+          const leadsByStage: CountMap = {}
+          const leadsByOutreachStatus: CountMap = {}
+          for (const record of crm.results) {
+            increment(leadsByStage, extractSelect(record.properties, 'Deal Stage') || extractSelect(record.properties, 'Client Stage'))
+            increment(leadsByOutreachStatus, extractSelect(record.properties, 'Outreach Status'))
+          }
+
+          const dealsByStage: CountMap = {}
+          let estimatedPipelineValue = 0
+          for (const record of deals.results) {
+            increment(dealsByStage, extractSelect(record.properties, 'Status') || extractSelect(record.properties, 'Payment Status'))
+            estimatedPipelineValue += extractNumber(record.properties, 'Deal Value') ?? 0
+          }
+
+          const approvalsByStatus: CountMap = {}
+          for (const record of approvals.results) {
+            increment(approvalsByStatus, extractSelect(record.properties, 'Status'))
+          }
+
+          const followUpsDue = outreach.results.filter((record) =>
+            isTodayOrEarlier(extractDate(record.properties, 'Next Follow-Up Date')),
+          ).length
+
+          const activeProjects = projects.results.filter((record) => {
+            const status = extractSelect(record.properties, 'Status').toLowerCase()
+            return status !== 'done' && status !== 'archived' && status !== 'complete'
+          }).length
+
+          const openTasks = tasks.results.filter((record) => {
+            const status = extractSelect(record.properties, 'Status').toLowerCase()
+            return status !== 'done' && status !== 'archived' && status !== 'complete'
+          }).length
+
+          const recentAutomationRuns = automation.results.filter((record) =>
+            Boolean(extractDate(record.properties, 'Last Run')),
+          ).length
+
+          return json({
+            ok: true,
+            generatedAt: new Date().toISOString(),
+            counts: {
+              crmLeads: crm.results.length,
+              outreachInteractions: outreach.results.length,
+              humanApprovals: approvals.results.length,
+              deals: deals.results.length,
+              projects: projects.results.length,
+              activeProjects,
+              tasks: tasks.results.length,
+              openTasks,
+              automationEntries: automation.results.length,
+              recentAutomationRuns,
+              followUpsDue,
+            },
+            groups: {
+              leadsByStage,
+              leadsByOutreachStatus,
+              dealsByStage,
+              approvalsByStatus,
+            },
+            health: {
+              notion: 'reachable',
+              secretBoundary: 'server-only',
+              zoho: 'approval-required',
+              reminders: 'action-surface-only',
+            },
+            links: {
+              ledger: '/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain/03_Projects/SEO-AEO-Service/Tools_Systems/HERMES_MISSION_CONTROL_IMPLEMENTATION_LEDGER.md',
+              matrix: '/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain/03_Projects/SEO-AEO-Service/Tools_Systems/HERMES_MISSION_CONTROL_SOURCE_OF_TRUTH_MATRIX.md',
+              architecture: '/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain/03_Projects/SEO-AEO-Service/Tools_Systems/HERMES_MISSION_CONTROL_ARCHITECTURE.md',
+            },
+          })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not build Mission Control summary')
+          return json(safe.body, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/mission-control/system.ts
+++ b/src/routes/api/mission-control/system.ts
@@ -1,0 +1,32 @@
+/**
+ * Live local Mission Control system snapshot.
+ * GET /api/mission-control/system
+ *
+ * This is read-only. It reports integration health, Apple bridge counts,
+ * Obsidian recent notes, Hermes model/provider warnings, and infrastructure
+ * state without exposing secrets or making external writes.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import { buildMissionControlSystemSnapshot } from '../../../server/mission-control-system'
+
+export const Route = createFileRoute('/api/mission-control/system')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const snapshot = await buildMissionControlSystemSnapshot()
+          return json({ ok: true, ...snapshot })
+        } catch (err) {
+          const message = err instanceof Error ? err.message.slice(0, 180) : 'Unknown Mission Control system error'
+          return json({ ok: false, error: message }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/notion/approvals.ts
+++ b/src/routes/api/notion/approvals.ts
@@ -1,0 +1,75 @@
+/**
+ * Notion Human Approval Queue endpoint.
+ * GET /api/notion/approvals — returns open approval items from Notion.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+  loadManifest,
+  notionRouteError,
+  queryDataSource,
+  extractTitle,
+  extractRichText,
+  extractSelect,
+  extractDate,
+  extractRelationIds,
+  workspaceNotionRecordUrl,
+} from '../../../server/notion-client'
+
+const CLOSED_STATUSES = new Set(['approved', 'rejected', 'done', 'closed', 'complete', 'completed'])
+
+export const Route = createFileRoute('/api/notion/approvals')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized', items: [] }, { status: 401 })
+        }
+
+        try {
+          const manifest = loadManifest()
+          const ds = manifest.data_sources['Human Approval Queue']
+          if (!ds) {
+            return json({ ok: false, error: 'Human Approval Queue data source not found', items: [] }, { status: 404 })
+          }
+
+          const response = await queryDataSource(ds.id, { page_size: 100, cacheTtlMs: 60_000 })
+
+          const items = response.results
+            .map((record) => {
+              const p = record.properties
+              const status = extractSelect(p, 'Status')
+              return {
+                id: record.id,
+                title: extractTitle(p),
+                category: extractSelect(p, 'Category'),
+                priority: extractSelect(p, 'Priority'),
+                status,
+                requester: extractRichText(p, 'Requester'),
+                description: extractRichText(p, 'Description'),
+                relatedLeadIds: extractRelationIds(p, 'Related Lead'),
+                relatedDealIds: extractRelationIds(p, 'Related Deal'),
+                relatedInteractionIds: extractRelationIds(p, 'Related Interaction'),
+                createdAt: extractDate(p, 'Created At'),
+                dueDate: extractDate(p, 'Due Date'),
+                recordUrl: workspaceNotionRecordUrl('Human Approval Queue', record.id),
+                createdTime: record.created_time,
+              }
+            })
+            .filter((item) => !CLOSED_STATUSES.has(item.status.toLowerCase()))
+
+          return json({
+            ok: true,
+            items,
+            hasMore: response.has_more,
+            count: items.length,
+          })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not fetch Notion approval records')
+          return json({ ...safe.body, items: [] }, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/notion/crm.ts
+++ b/src/routes/api/notion/crm.ts
@@ -1,0 +1,93 @@
+/**
+ * Notion CRM / Leads endpoint.
+ * GET /api/notion/crm — returns CRM leads from Notion.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+  loadManifest,
+  notionRouteError,
+  queryDataSource,
+  extractTitle,
+  extractRichText,
+  extractSelect,
+  extractEmail,
+  extractUrl,
+  extractNumber,
+  extractDate,
+  extractCheckbox,
+  extractPhone,
+  workspaceNotionRecordUrl,
+} from '../../../server/notion-client'
+
+export const Route = createFileRoute('/api/notion/crm')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized', leads: [] }, { status: 401 })
+        }
+
+        try {
+          const manifest = loadManifest()
+          const ds = manifest.data_sources['CRM / Leads']
+          if (!ds) {
+            return json({ ok: false, error: 'CRM / Leads data source not found in manifest', leads: [] }, { status: 404 })
+          }
+
+          const response = await queryDataSource(ds.id, { page_size: 100, cacheTtlMs: 60_000 })
+
+          const leads = response.results.map((record) => {
+            const p = record.properties
+            return {
+              id: record.id,
+              company: extractTitle(p),
+              contactName: extractRichText(p, 'Contact Name'),
+              contactEmail: extractEmail(p, 'Email'),
+              contactPhone: extractPhone(p, 'Phone'),
+              website: extractUrl(p, 'Website'),
+              city: extractRichText(p, 'City'),
+              state: extractRichText(p, 'State'),
+              leadScore: extractNumber(p, 'Lead Score'),
+              outreachStatus: extractSelect(p, 'Outreach Status'),
+              replyStatus: extractSelect(p, 'Reply Status'),
+              dealStage: extractSelect(p, 'Deal Stage'),
+              recommendedPackage: extractSelect(p, 'Recommended Package'),
+              packageSold: extractSelect(p, 'Package Sold'),
+              dealValue: extractNumber(p, 'Deal Value'),
+              monthlyRetainer: extractNumber(p, 'Monthly Retainer'),
+              paymentStatus: extractSelect(p, 'Payment Status'),
+              clientStage: extractSelect(p, 'Client Stage'),
+              accessStatus: extractSelect(p, 'Access Status'),
+              clientHealth: extractSelect(p, 'Client Health'),
+              seoOpportunity: extractCheckbox(p, 'SEO Opportunity'),
+              aeoOpportunity: extractCheckbox(p, 'AEO Opportunity'),
+              gbpOpportunity: extractCheckbox(p, 'GBP Opportunity'),
+              followUpCount: extractNumber(p, 'Follow-up Count'),
+              nextCheckIn: extractDate(p, 'Next Client Check-In'),
+              nextReportDue: extractDate(p, 'Next Report Due'),
+              reportingCadence: extractSelect(p, 'Reporting Cadence'),
+              source: extractRichText(p, 'Source'),
+              notes: extractRichText(p, 'Notes'),
+              lastVerified: extractDate(p, 'Last Verified'),
+              dataConfidence: extractSelect(p, 'Data Confidence'),
+              recordUrl: workspaceNotionRecordUrl('CRM / Leads', record.id),
+              createdTime: record.created_time,
+            }
+          })
+
+          return json({
+            ok: true,
+            leads,
+            hasMore: response.has_more,
+            count: leads.length,
+          })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not fetch Notion CRM records')
+          return json({ ...safe.body, leads: [] }, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/notion/outreach.ts
+++ b/src/routes/api/notion/outreach.ts
@@ -1,0 +1,69 @@
+/**
+ * Notion Outreach / Interactions endpoint.
+ * GET /api/notion/outreach — returns outreach interactions from Notion.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+  loadManifest,
+  notionRouteError,
+  queryDataSource,
+  extractTitle,
+  extractRichText,
+  extractSelect,
+  extractDate,
+  extractRelationIds,
+  workspaceNotionRecordUrl,
+} from '../../../server/notion-client'
+
+export const Route = createFileRoute('/api/notion/outreach')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized', items: [] }, { status: 401 })
+        }
+
+        try {
+          const manifest = loadManifest()
+          const ds = manifest.data_sources['Outreach / Interactions']
+          if (!ds) {
+            return json({ ok: false, error: 'Outreach / Interactions data source not found', items: [] }, { status: 404 })
+          }
+
+          const response = await queryDataSource(ds.id, { page_size: 100, cacheTtlMs: 60_000 })
+
+          const items = response.results.map((record) => {
+            const p = record.properties
+            return {
+              id: record.id,
+              title: extractTitle(p),
+              type: extractSelect(p, 'Type'),
+              status: extractSelect(p, 'Status'),
+              relatedLeadIds: extractRelationIds(p, 'Related Lead / Client'),
+              relatedDealIds: extractRelationIds(p, 'Related Deal / Proposal'),
+              date: extractDate(p, 'Date'),
+              nextFollowUp: extractDate(p, 'Next Follow-Up'),
+              agent: extractRichText(p, 'Agent'),
+              description: extractRichText(p, 'Description'),
+              channel: extractSelect(p, 'Channel'),
+              recordUrl: workspaceNotionRecordUrl('Outreach / Interactions', record.id),
+              createdTime: record.created_time,
+            }
+          })
+
+          return json({
+            ok: true,
+            items,
+            hasMore: response.has_more,
+            count: items.length,
+          })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not fetch Notion outreach records')
+          return json({ ...safe.body, items: [] }, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/notion/query.ts
+++ b/src/routes/api/notion/query.ts
@@ -1,0 +1,64 @@
+/**
+ * Generic Notion data-source query endpoint.
+ * GET /api/notion/query?source=CRM%20%2F%20Leads
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+  flattenRecord,
+  loadManifest,
+  notionRouteError,
+  queryDataSource,
+  summarizeRecord,
+  workspaceNotionRecordUrl,
+} from '../../../server/notion-client'
+
+export const Route = createFileRoute('/api/notion/query')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized', records: [] }, { status: 401 })
+        }
+
+        try {
+          const url = new URL(request.url)
+          const sourceName = url.searchParams.get('source')?.trim()
+          const limitRaw = Number(url.searchParams.get('limit') || '50')
+          const pageSize = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 100) : 50
+          if (!sourceName) {
+            return json({ ok: false, error: 'Missing required source query parameter', records: [] }, { status: 400 })
+          }
+
+          const manifest = loadManifest()
+          const source = manifest.data_sources[sourceName]
+          if (!source) {
+            return json({ ok: false, error: 'Notion data source not found in manifest', records: [] }, { status: 404 })
+          }
+
+          const response = await queryDataSource(source.id, { page_size: pageSize, cacheTtlMs: 60_000 })
+          const records = response.results.slice(0, pageSize).map((record) => ({
+            id: record.id,
+            title: summarizeRecord(record),
+            properties: flattenRecord(record),
+            recordUrl: workspaceNotionRecordUrl(sourceName, record.id),
+            createdTime: record.created_time,
+            lastEditedTime: record.last_edited_time,
+          }))
+
+          return json({
+            ok: true,
+            source: sourceName,
+            records,
+            count: records.length,
+            hasMore: response.has_more,
+          })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not query Notion data source')
+          return json({ ...safe.body, records: [] }, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/notion/sources.ts
+++ b/src/routes/api/notion/sources.ts
@@ -1,0 +1,34 @@
+/**
+ * Notion source catalog endpoint.
+ * GET /api/notion/sources — lists every manifest-backed data source the Workspace can read.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import { loadManifest, notionRouteError } from '../../../server/notion-client'
+
+export const Route = createFileRoute('/api/notion/sources')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized', sources: [] }, { status: 401 })
+        }
+
+        try {
+          const manifest = loadManifest()
+          const sources = Object.entries(manifest.data_sources).map(([name, source]) => ({
+            name,
+            id: source.id,
+            databaseId: source.database_id ?? '',
+          }))
+
+          return json({ ok: true, sources, count: sources.length })
+        } catch (err) {
+          const safe = notionRouteError(err, 'Could not load Notion source catalog')
+          return json({ ...safe.body, sources: [] }, { status: safe.status })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/projects.ts
+++ b/src/routes/api/projects.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { requireJsonContentType } from '../../server/rate-limit'
+import { readProjectsState, writeProjectsState } from '../../server/projects-store'
+
+export const Route = createFileRoute('/api/projects')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const state = await readProjectsState()
+        return json({ ok: true, ...state })
+      },
+
+      PUT: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        try {
+          const body = await request.json()
+          const state = await writeProjectsState(body)
+          return json({ ok: true, ...state, initialized: true })
+        } catch {
+          return json({ ok: false, error: 'Invalid projects payload' }, { status: 400 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/send-stream.ts
+++ b/src/routes/api/send-stream.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { buildResolvedSessionHeaders } from '../../lib/send-stream-session-headers'
 import { buildWorkspaceScopedTextMessage } from '../../lib/workspace-message-scope'
+import { buildProjectScopedTextMessage } from '../../lib/project-context'
 import { resolveSessionKey } from '../../server/session-utils'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
@@ -311,6 +312,8 @@ export const Route = createFileRoute('/api/send-stream')({
           typeof body.thinking === 'string' ? body.thinking : undefined
         const attachments = normalizeAttachments(body.attachments)
         const history = normalizePortableHistory(body.history)
+        const projectId =
+          typeof body.projectId === 'string' ? body.projectId.trim() : ''
         if (!message.trim() && (!attachments || attachments.length === 0)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'message required' }),
@@ -371,9 +374,20 @@ export const Route = createFileRoute('/api/send-stream')({
         }
 
         const workspaceScope = await loadWorkspaceCatalog().catch(() => null)
-        const scopedMessage = buildWorkspaceScopedTextMessage(
+        const workspaceScopedMessage = buildWorkspaceScopedTextMessage(
           getChatMessage(message, attachments),
           workspaceScope,
+        )
+        const scopedMessage = buildProjectScopedTextMessage(
+          workspaceScopedMessage,
+          projectId
+            ? {
+                id: projectId,
+                name: '',
+                goal: '',
+                instructions: '',
+              }
+            : null,
         )
 
         // Create streaming response using the SHARED server connection

--- a/src/routes/approval-queue.tsx
+++ b/src/routes/approval-queue.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { ApprovalQueueScreen } from '@/screens/approval-queue/approval-queue-screen'
+
+export const Route = createFileRoute('/approval-queue')({
+  ssr: false,
+  component: ApprovalQueueRoute,
+})
+
+function ApprovalQueueRoute() {
+  usePageTitle('Approval Queue')
+  return <ApprovalQueueScreen />
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,9 +2,9 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   ssr: false,
-  beforeLoad: function redirectToChat() {
+  beforeLoad: function redirectToMissionControl() {
     throw redirect({
-      to: '/chat' as string,
+      to: '/mission-control' as string,
       replace: true,
     })
   },

--- a/src/routes/mission-control.tsx
+++ b/src/routes/mission-control.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { MissionControlScreen } from '@/screens/mission-control/mission-control-screen'
+
+export const Route = createFileRoute('/mission-control')({
+  ssr: false,
+  component: MissionControlRoute,
+})
+
+function MissionControlRoute() {
+  usePageTitle('Mission Control')
+  return <MissionControlScreen />
+}

--- a/src/routes/notion.tsx
+++ b/src/routes/notion.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { NotionBrowserScreen } from '@/screens/notion/notion-browser-screen'
+
+export const Route = createFileRoute('/notion')({
+  ssr: false,
+  component: NotionRoute,
+})
+
+function NotionRoute() {
+  usePageTitle('Notion')
+  return <NotionBrowserScreen />
+}

--- a/src/routes/outreach.tsx
+++ b/src/routes/outreach.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { OutreachScreen } from '@/screens/outreach/outreach-screen'
+
+export const Route = createFileRoute('/outreach')({
+  ssr: false,
+  component: OutreachRoute,
+})
+
+function OutreachRoute() {
+  usePageTitle('Outreach Pipeline')
+  return <OutreachScreen />
+}

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1040,9 +1040,11 @@ function _LoaderStyleSection() {
 type ClaudeProvider = {
   id: string
   name: string
-  authType: string
+  kind: 'oauth' | 'api_key' | 'local' | 'custom' | 'external' | 'sdk'
   envKeys: Array<string>
   configured: boolean
+  authenticated: boolean
+  available: boolean
   maskedKeys: Record<string, string>
 }
 
@@ -1062,7 +1064,97 @@ const CLAUDE_API =
 type AvailableModelsResponse = {
   provider: string
   models: Array<{ id: string; description: string }>
-  providers: Array<{ id: string; label: string; authenticated: boolean }>
+  providers?: Array<{ id: string; label: string; authenticated: boolean }>
+}
+
+type ProviderPickerOption = { id: string; label: string; authenticated: boolean }
+
+const LOCAL_PROVIDER_IDS = new Set(['ollama', 'atomic-chat', 'lmstudio'])
+const CONFIGURED_ENDPOINT_PROVIDER_KINDS = new Set(['custom', 'local'])
+
+function providerDisplayLabel(provider: ClaudeProvider): string {
+  const authHint = provider.authenticated || provider.configured ? ' ✓' : ''
+  return `${provider.name}${authHint}`
+}
+
+function customProviderTitle(entry: Record<string, unknown>): string {
+  const normalized = normalizeCustomProviderEntry(entry)
+  return normalized.title || normalized.name || normalized.base_url || 'Custom provider'
+}
+
+function buildProviderOptions(
+  providers: Array<ClaudeProvider>,
+  customProviders: Array<Record<string, unknown>>,
+  existing: Array<ProviderPickerOption> = [],
+): Array<ProviderPickerOption> {
+  const options: Array<ProviderPickerOption> = []
+  const seen = new Set<string>()
+  const push = (option: ProviderPickerOption) => {
+    const id = option.id.trim()
+    if (!id || seen.has(id)) return
+    seen.add(id)
+    options.push({ ...option, id })
+  }
+
+  for (const provider of providers) {
+    push({
+      id: provider.id,
+      label: providerDisplayLabel(provider),
+      authenticated: provider.authenticated || provider.configured,
+    })
+  }
+  for (const row of customProviders) {
+    const normalized = normalizeCustomProviderEntry(row)
+    if (!normalized.name) continue
+    push({
+      id: normalized.name,
+      label: `${customProviderTitle(row)} (${normalized.name})`,
+      authenticated: Boolean(normalized.api_key || normalized.base_url),
+    })
+  }
+  for (const option of existing) push(option)
+
+  return options
+}
+
+function customProviderRowForId(
+  providerId: string,
+  customProviders: Array<Record<string, unknown>>,
+): ReturnType<typeof normalizeCustomProviderEntry> | null {
+  const wanted = providerId.trim().toLowerCase()
+  if (!wanted) return null
+  for (const row of customProviders) {
+    const normalized = normalizeCustomProviderEntry(row)
+    if (normalized.name.toLowerCase() === wanted) return normalized
+  }
+  return null
+}
+
+function providerUsesBaseUrl(
+  providerId: string,
+  providers: Array<ClaudeProvider>,
+  customProviders: Array<Record<string, unknown>>,
+): boolean {
+  const id = providerId.trim()
+  if (!id) return false
+  if (customProviderRowForId(id, customProviders)?.base_url) return true
+  if (LOCAL_PROVIDER_IDS.has(id)) return true
+  const catalogEntry = providers.find((p) => p.id === id)
+  if (!catalogEntry) return true
+  return CONFIGURED_ENDPOINT_PROVIDER_KINDS.has(catalogEntry.kind)
+}
+
+function baseUrlForProviderSelection(
+  providerId: string,
+  currentProvider: string,
+  currentBaseUrl: string,
+  providers: Array<ClaudeProvider>,
+  customProviders: Array<Record<string, unknown>>,
+): string {
+  const customRow = customProviderRowForId(providerId, customProviders)
+  if (customRow?.base_url) return customRow.base_url
+  if (!providerUsesBaseUrl(providerId, providers, customProviders)) return ''
+  return providerId.trim() === currentProvider.trim() ? currentBaseUrl.trim() : ''
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -1264,7 +1356,7 @@ function ClaudeConfigSection({
   const [showFallbackRow, setShowFallbackRow] = useState(false)
 
   const [availableProviders, setAvailableProviders] = useState<
-    Array<{ id: string; label: string; authenticated: boolean }>
+    Array<ProviderPickerOption>
   >([])
   const [availableModels, setAvailableModels] = useState<
     Array<{ id: string; description: string }>
@@ -1273,9 +1365,22 @@ function ClaudeConfigSection({
 
   const syncInputsFromData = useCallback((configData: ClaudeConfigData) => {
     const cfg = configData.config
+    const activeProvider = configData.activeProvider || ''
+    const configCustomProviders = Array.isArray(cfg.custom_providers)
+      ? (cfg.custom_providers as Array<Record<string, unknown>>)
+      : []
+    const configuredBaseUrl = typeof cfg.base_url === 'string' ? cfg.base_url : ''
     setModelInput(configData.activeModel || '')
-    setProviderInput(configData.activeProvider || '')
-    setBaseUrlInput((cfg.base_url as string) || '')
+    setProviderInput(activeProvider)
+    setBaseUrlInput(
+      baseUrlForProviderSelection(
+        activeProvider,
+        activeProvider,
+        configuredBaseUrl,
+        configData.providers,
+        configCustomProviders,
+      ),
+    )
     const fb = readFallbackInputsFromConfig(cfg)
     setFallbackProviderInput(fb.provider)
     setFallbackModelInput(fb.model)
@@ -1290,6 +1395,12 @@ function ClaudeConfigSection({
     const configData = (await res.json()) as ClaudeConfigData
     setData(configData)
     syncInputsFromData(configData)
+    const configCustomProviders = Array.isArray(configData.config.custom_providers)
+      ? (configData.config.custom_providers as Array<Record<string, unknown>>)
+      : []
+    setAvailableProviders((prev) =>
+      buildProviderOptions(configData.providers, configCustomProviders, prev),
+    )
     return configData
   }, [syncInputsFromData])
 
@@ -1306,7 +1417,12 @@ function ClaudeConfigSection({
       if (res.ok) {
         const result = (await res.json()) as AvailableModelsResponse
         setAvailableModels(result.models)
-        if (result.providers.length > 0) setAvailableProviders(result.providers)
+        const upstreamProviders = result.providers ?? []
+        if (upstreamProviders.length > 0) {
+          setAvailableProviders((prev) =>
+            buildProviderOptions([], [], [...prev, ...upstreamProviders]),
+          )
+        }
       }
     } catch {
       // ignore
@@ -1575,6 +1691,15 @@ function ClaudeConfigSection({
                   const newProvider = e.target.value
                   setProviderInput(newProvider)
                   setModelInput('')
+                  setBaseUrlInput(
+                    baseUrlForProviderSelection(
+                      newProvider,
+                      data.activeProvider,
+                      primaryConfigBaseUrl,
+                      data.providers,
+                      customProviders,
+                    ),
+                  )
                   void fetchModelsForProvider(newProvider)
                 }}
                 className={selectClassName}
@@ -1582,7 +1707,7 @@ function ClaudeConfigSection({
                 {availableProviders.map((p) => (
                   <option key={p.id} value={p.id}>
                     {p.label}
-                    {p.authenticated ? ' ✓' : ''}
+                    {p.authenticated && !p.label.includes('✓') ? ' ✓' : ''}
                   </option>
                 ))}
               </select>
@@ -1721,10 +1846,15 @@ function ClaudeConfigSection({
                 fallbackProviderInput.trim() ||
                 fallbackModelInput.trim() ||
                 fallbackBaseUrlInput.trim()
+              const primaryBaseUrl = baseUrlInput.trim()
               const configUpdate: Record<string, unknown> = {
                 model: modelInput.trim(),
                 provider: providerInput.trim(),
-                base_url: baseUrlInput.trim() || null,
+                base_url:
+                  providerUsesBaseUrl(providerInput.trim(), data.providers, customProviders) &&
+                  primaryBaseUrl
+                    ? primaryBaseUrl
+                    : null,
               }
               if (hasFallback) {
                 configUpdate.fallback_model = {
@@ -2243,7 +2373,7 @@ function ClaudeConfigSection({
                       style={{ color: 'var(--theme-muted)' }}
                     >
                       {customApiKeyConfigured
-                        ? customProviderCatalogEntry.maskedKeys['CUSTOM_API_KEY'] || 'Set'
+                        ? (customProviderCatalogEntry?.maskedKeys ?? {})['CUSTOM_API_KEY'] || 'Set'
                         : 'Not set'}
                     </span>
                     <Button

--- a/src/screens/approval-queue/approval-queue-screen.tsx
+++ b/src/screens/approval-queue/approval-queue-screen.tsx
@@ -1,0 +1,544 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AnimatePresence, motion } from 'motion/react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  AlertCircleIcon,
+  CancelCircleIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  RefreshIcon,
+  LinkSquare02Icon,
+} from '@hugeicons/core-free-icons'
+import { toast } from '@/components/ui/toast'
+import { cn } from '@/lib/utils'
+import {
+  COLUMN_COLORS,
+  COLUMN_LABELS,
+  fetchTasks,
+  isOverdue,
+  moveTask,
+  PRIORITY_COLORS,
+  type ClaudeTask,
+  type TaskPriority,
+} from '@/lib/tasks-api'
+
+const QUERY_KEY = ['claude', 'tasks'] as const
+
+type NotionApprovalTask = ClaudeTask & { notionRecordUrl?: string }
+
+const PRIORITY_ORDER: Record<TaskPriority, number> = { high: 0, medium: 1, low: 2 }
+
+function ApprovalTaskCard({
+  task,
+  section,
+  onApprove,
+  onReject,
+  isPending,
+}: {
+  task: NotionApprovalTask
+  section: 'review' | 'blocked' | 'overdue'
+  onApprove: (task: NotionApprovalTask) => void
+  onReject: (task: NotionApprovalTask) => void
+  isPending: boolean
+}) {
+  const overdue = isOverdue(task)
+  const priorityColor = PRIORITY_COLORS[task.priority]
+
+  const dueDateLabel = task.due_date
+    ? (() => {
+        const [y, m, d] = task.due_date.split('-').map(Number)
+        return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+        })
+      })()
+    : null
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      className={cn(
+        'rounded-xl border bg-[var(--theme-card)] p-4 transition-all',
+        'border-[var(--theme-border)] hover:border-[var(--theme-accent)]',
+        'hover:shadow-[0_4px_16px_rgba(0,0,0,0.25)]',
+      )}
+      style={{ borderLeftWidth: 3, borderLeftColor: priorityColor }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ background: priorityColor }}
+              title={`Priority: ${task.priority}`}
+            />
+            <h3 className="text-sm font-medium text-[var(--theme-text)] truncate">
+              {task.title}
+            </h3>
+          </div>
+
+          {task.description && (
+            <p className="text-xs text-[var(--theme-muted)] line-clamp-2 mb-2">
+              {task.description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Column badge */}
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded-md font-medium"
+              style={{
+                background: `${COLUMN_COLORS[task.column]}20`,
+                color: COLUMN_COLORS[task.column],
+              }}
+            >
+              {COLUMN_LABELS[task.column]}
+            </span>
+
+            {/* Assignee */}
+            {task.assignee && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--theme-hover)] text-[var(--theme-muted)]">
+                {task.assignee}
+              </span>
+            )}
+
+            {/* Tags */}
+            {task.tags.slice(0, 2).map((tag) => (
+              <span
+                key={tag}
+                className="text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--theme-hover)] text-[var(--theme-muted)]"
+              >
+                {tag}
+              </span>
+            ))}
+
+            {/* Due date */}
+            {dueDateLabel && (
+              <span
+                className={cn(
+                  'text-[10px] tabular-nums',
+                  overdue ? 'text-red-400 font-semibold' : 'text-[var(--theme-muted)]',
+                )}
+              >
+                {overdue && '⚠ '}
+                {dueDateLabel}
+              </span>
+            )}
+
+            {task.notionRecordUrl && (
+              <a
+                href={task.notionRecordUrl}
+                className="inline-flex items-center gap-1 text-[10px] text-blue-400 hover:text-blue-300"
+              >
+                <HugeiconsIcon icon={LinkSquare02Icon} size={12} />
+                View record
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* Approve / Reject actions */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <button
+            onClick={() => onApprove(task)}
+            disabled={isPending}
+            className={cn(
+              'flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-all',
+              'bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+            title="Approve — move to Done"
+          >
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={14} />
+            Approve
+          </button>
+          <button
+            onClick={() => onReject(task)}
+            disabled={isPending}
+            className={cn(
+              'flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-all',
+              'bg-red-500/15 text-red-400 hover:bg-red-500/25',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+            title="Reject — move back to Ready"
+          >
+            <HugeiconsIcon icon={CancelCircleIcon} size={14} />
+            Reject
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+function SectionHeader({
+  icon,
+  iconColor,
+  title,
+  count,
+  isEmpty,
+}: {
+  icon: typeof Clock01Icon
+  iconColor: string
+  title: string
+  count: number
+  isEmpty: boolean
+}) {
+  return (
+    <div className="flex items-center gap-2 mb-3">
+      <HugeiconsIcon icon={icon} size={18} style={{ color: iconColor }} />
+      <h2 className="text-sm font-semibold text-[var(--theme-text)]">{title}</h2>
+      <span
+        className={cn(
+          'text-xs px-1.5 py-0.5 rounded-md',
+          isEmpty
+            ? 'bg-[var(--theme-hover)] text-[var(--theme-muted)]'
+            : 'bg-[var(--theme-accent)]/15 text-[var(--theme-accent)]',
+        )}
+      >
+        {count}
+      </span>
+    </div>
+  )
+}
+
+export function ApprovalQueueScreen() {
+  const queryClient = useQueryClient()
+
+  const tasksQuery = useQuery({
+    queryKey: [...QUERY_KEY, 'approval-queue'],
+    queryFn: () => fetchTasks({ include_done: true }),
+    refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
+  })
+
+  // Fetch Notion Human Approval Queue items
+  const notionApprovalsQuery = useQuery({
+    queryKey: ['notion', 'approvals'],
+    queryFn: async () => {
+      const res = await fetch('/api/notion/approvals')
+      if (!res.ok) throw new Error('Failed to fetch Notion approvals')
+      return res.json() as Promise<{
+        items: Array<{
+          id: string
+          title: string
+          category: string
+          priority: string
+          status: string
+          requester: string
+          description: string
+          dueDate: string
+          relatedLeadIds: string[]
+          relatedDealIds: string[]
+          recordUrl: string
+        }>
+      }>
+    },
+    staleTime: 60_000,
+  })
+
+  const tasks = tasksQuery.data ?? []
+
+  // Merge Notion approval items into task list as ClaudeTask-shaped entries
+  const notionTasks = useMemo<NotionApprovalTask[]>(() => {
+    const items = notionApprovalsQuery.data?.items ?? []
+    return items.map((item) => ({
+      id: `notion-${item.id}`,
+      title: item.title,
+      description: item.description || `${item.category} — Requested by ${item.requester}`,
+      column: 'review' as const,
+      priority: (item.priority.toLowerCase() === 'high' ? 'high' : item.priority.toLowerCase() === 'low' ? 'low' : 'medium') as TaskPriority,
+      assignee: item.requester || null,
+      tags: ['notion', item.category],
+      due_date: item.dueDate || null,
+      position: 0,
+      created_by: item.requester,
+      created_at: item.dueDate || new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      session_id: null,
+      notionRecordUrl: item.recordUrl,
+    }))
+  }, [notionApprovalsQuery.data])
+
+  // Combine Hermes tasks + Notion approval tasks
+  const allTasks = useMemo(() => [...tasks, ...notionTasks], [tasks, notionTasks])
+
+  // Pending Review: tasks in 'review' column (includes Notion approvals), sorted by priority then due date
+  const pendingReview = useMemo(() => {
+    return allTasks
+      .filter((t) => t.column === 'review')
+      .sort((a, b) => {
+        const pa = PRIORITY_ORDER[a.priority] ?? 1
+        const pb = PRIORITY_ORDER[b.priority] ?? 1
+        if (pa !== pb) return pa - pb
+        if (a.due_date && b.due_date) return a.due_date.localeCompare(b.due_date)
+        if (a.due_date) return -1
+        if (b.due_date) return 1
+        return 0
+      })
+  }, [allTasks])
+
+  // Blocked: tasks in 'blocked' column
+  const blockedItems = useMemo(() => {
+    return allTasks
+      .filter((t) => t.column === 'blocked')
+      .sort((a, b) => {
+        const pa = PRIORITY_ORDER[a.priority] ?? 1
+        const pb = PRIORITY_ORDER[b.priority] ?? 1
+        if (pa !== pb) return pa - pb
+        return 0
+      })
+  }, [allTasks])
+
+  // Overdue: all overdue tasks not in 'done' column
+  const overdueItems = useMemo(() => {
+    return allTasks
+      .filter((t) => isOverdue(t) && t.column !== 'done')
+      .sort((a, b) => {
+        if (a.due_date && b.due_date) return a.due_date.localeCompare(b.due_date)
+        if (a.due_date) return -1
+        if (b.due_date) return 1
+        return 0
+      })
+  }, [allTasks])
+
+  const totalItems = pendingReview.length + blockedItems.length + overdueItems.length
+
+  const isNotionTask = (id: string) => id.startsWith('notion-')
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+    void queryClient.invalidateQueries({ queryKey: ['notion', 'approvals'] })
+  }, [queryClient])
+
+  const approveMutation = useMutation({
+    mutationFn: (task: ClaudeTask) => {
+      if (isNotionTask(task.id)) return Promise.resolve()
+      return moveTask(task.id, 'done', 'user').then(() => undefined)
+    },
+    onSuccess: (_, task) => {
+      invalidate()
+      if (isNotionTask(task.id)) {
+        toast(`Notion item "${task.title}" noted as approved — complete it in Notion`, { type: 'info' })
+      } else {
+        toast(`Approved: ${task.title}`, { type: 'success' })
+      }
+    },
+    onError: (e, task) => {
+      toast(e instanceof Error ? e.message : `Failed to approve: ${task.title}`, { type: 'error' })
+    },
+  })
+
+  const rejectMutation = useMutation({
+    mutationFn: (task: ClaudeTask) => {
+      if (isNotionTask(task.id)) return Promise.resolve()
+      return moveTask(task.id, 'todo', 'user').then(() => undefined)
+    },
+    onSuccess: (_, task) => {
+      invalidate()
+      if (isNotionTask(task.id)) {
+        toast(`Notion item "${task.title}" noted as rejected — handle in Notion`, { type: 'info' })
+      } else {
+        toast(`Rejected: ${task.title}`, { type: 'warning' })
+      }
+    },
+    onError: (e, task) => {
+      toast(e instanceof Error ? e.message : `Failed to reject: ${task.title}`, { type: 'error' })
+    },
+  })
+
+  const isMutating = approveMutation.isPending || rejectMutation.isPending
+
+  return (
+    <div className="min-h-full overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[900px] flex-col gap-6 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
+        {/* Header */}
+        <header className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              <h1 className="text-2xl font-medium text-[var(--theme-text)]">Approval Queue</h1>
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
+                <span>{totalItems} items need attention</span>
+                {notionApprovalsQuery.data && notionApprovalsQuery.data.items.length > 0 && (
+                  <>
+                    <span>·</span>
+                    <span className="text-green-400">{notionApprovalsQuery.data.items.length} from Notion</span>
+                  </>
+                )}
+                {pendingReview.length > 0 && (
+                  <>
+                    <span>·</span>
+                    <span style={{ color: COLUMN_COLORS.review }}>{pendingReview.length} in review</span>
+                  </>
+                )}
+                {blockedItems.length > 0 && (
+                  <>
+                    <span>·</span>
+                    <span className="text-red-400">{blockedItems.length} blocked</span>
+                  </>
+                )}
+                {overdueItems.length > 0 && (
+                  <>
+                    <span>·</span>
+                    <span className="text-red-400">{overdueItems.length} overdue</span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <button
+              onClick={invalidate}
+              className="rounded-lg p-1.5 transition-colors hover:bg-[var(--theme-hover)]"
+              title="Refresh"
+            >
+              <HugeiconsIcon
+                icon={RefreshIcon}
+                size={16}
+                className={cn(
+                  'text-[var(--theme-muted)]',
+                  tasksQuery.isFetching && 'animate-spin',
+                )}
+              />
+            </button>
+          </div>
+          <p className="mt-3 text-xs text-[var(--theme-muted)]">
+            Review and approve or reject tasks that need your attention. Includes items from Notion Human Approval Queue.
+          </p>
+        </header>
+
+        {/* Loading state */}
+        {tasksQuery.isLoading && (
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <HugeiconsIcon icon={Clock01Icon} size={32} className="text-[var(--theme-muted)] animate-pulse" />
+            <p className="text-sm text-[var(--theme-muted)]">Loading approval queue…</p>
+          </div>
+        )}
+
+        {/* Error state */}
+        {tasksQuery.isError && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="flex flex-col items-center justify-center py-16 gap-3"
+          >
+            <HugeiconsIcon icon={AlertCircleIcon} size={32} className="text-red-400" />
+            <p className="text-sm text-red-400 font-medium">Failed to load approval queue</p>
+            <button
+              onClick={() => tasksQuery.refetch()}
+              className="text-xs text-[var(--theme-accent)] hover:underline"
+            >
+              Retry
+            </button>
+          </motion.div>
+        )}
+
+        {/* Content */}
+        {tasksQuery.data && (
+          <>
+            {/* Empty state */}
+            {totalItems === 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="flex flex-col items-center justify-center py-16 gap-3"
+              >
+                <HugeiconsIcon icon={CheckmarkCircle02Icon} size={40} className="text-emerald-400" />
+                <p className="text-sm font-medium text-[var(--theme-text)]">All clear!</p>
+                <p className="text-xs text-[var(--theme-muted)]">
+                  No tasks need your approval right now.
+                </p>
+              </motion.div>
+            )}
+
+            {/* Pending Review */}
+            {pendingReview.length > 0 && (
+              <section>
+                <SectionHeader
+                  icon={Clock01Icon}
+                  iconColor={COLUMN_COLORS.review}
+                  title="Pending Review"
+                  count={pendingReview.length}
+                  isEmpty={false}
+                />
+                <div className="flex flex-col gap-2">
+                  <AnimatePresence initial={false} mode="popLayout">
+                    {pendingReview.map((task) => (
+                      <ApprovalTaskCard
+                        key={task.id}
+                        task={task}
+                        section="review"
+                        onApprove={(t) => approveMutation.mutate(t)}
+                        onReject={(t) => rejectMutation.mutate(t)}
+                        isPending={isMutating}
+                      />
+                    ))}
+                  </AnimatePresence>
+                </div>
+              </section>
+            )}
+
+            {/* Blocked Items */}
+            {blockedItems.length > 0 && (
+              <section>
+                <SectionHeader
+                  icon={AlertCircleIcon}
+                  iconColor={COLUMN_COLORS.blocked}
+                  title="Blocked Items"
+                  count={blockedItems.length}
+                  isEmpty={false}
+                />
+                <div className="flex flex-col gap-2">
+                  <AnimatePresence initial={false} mode="popLayout">
+                    {blockedItems.map((task) => (
+                      <ApprovalTaskCard
+                        key={task.id}
+                        task={task}
+                        section="blocked"
+                        onApprove={(t) => approveMutation.mutate(t)}
+                        onReject={(t) => rejectMutation.mutate(t)}
+                        isPending={isMutating}
+                      />
+                    ))}
+                  </AnimatePresence>
+                </div>
+              </section>
+            )}
+
+            {/* Overdue Items */}
+            {overdueItems.length > 0 && (
+              <section>
+                <SectionHeader
+                  icon={AlertCircleIcon}
+                  iconColor="#ef4444"
+                  title="Overdue Items"
+                  count={overdueItems.length}
+                  isEmpty={false}
+                />
+                <div className="flex flex-col gap-2">
+                  <AnimatePresence initial={false} mode="popLayout">
+                    {overdueItems.map((task) => (
+                      <ApprovalTaskCard
+                        key={task.id}
+                        task={task}
+                        section="overdue"
+                        onApprove={(t) => approveMutation.mutate(t)}
+                        onReject={(t) => rejectMutation.mutate(t)}
+                        isPending={isMutating}
+                      />
+                    ))}
+                  </AnimatePresence>
+                </div>
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -95,6 +95,8 @@ import { hapticTap } from '@/lib/haptics'
 import { FileExplorerSidebar } from '@/components/file-explorer'
 import { SEARCH_MODAL_EVENTS } from '@/hooks/use-search-modal'
 import { SIDEBAR_TOGGLE_EVENT } from '@/hooks/use-global-shortcuts'
+import { buildProjectScopedTextMessage } from '@/lib/project-context'
+import { getProjectForSession, useProjectStore } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { TerminalPanel } from '@/components/terminal-panel'
 import { AgentViewPanel } from '@/components/agent-view/agent-view-panel'
@@ -111,6 +113,7 @@ import { useResearchCard } from '@/hooks/use-research-card'
 // MOBILE_TAB_BAR_OFFSET removed — tab bar always hidden in chat
 import { useTapDebug } from '@/hooks/use-tap-debug'
 import { useChatMode } from '@/hooks/use-chat-mode'
+import { useProjects } from '@/hooks/use-projects'
 import {  useChatActivityStore } from '@/stores/chat-activity-store'
 
 export let _localModelOverride = ''
@@ -587,6 +590,37 @@ export function ChatScreen({
     historyRefetchInterval: sseConnectionState === 'connected' ? 30_000 : 5_000,
     portableMode: isPortableMode,
   })
+  const {
+    activeProjectId: _activeProjectId,
+    sessionProjectMap,
+    activeProjects,
+    assignSessionToProject,
+    setActiveProject,
+  } = useProjects()
+  void _activeProjectId
+  void setActiveProject
+
+  const activeProjectId = useMemo(() => {
+    if (isNewChat) return _activeProjectId
+    const keys = [activeFriendlyId, activeSession?.key, activeSessionKey, activeCanonicalKey].filter(Boolean) as Array<string>
+    for (const key of keys) {
+      const projectId = sessionProjectMap[key]
+      if (projectId) return projectId
+    }
+    return null
+  }, [
+    _activeProjectId,
+    activeCanonicalKey,
+    activeFriendlyId,
+    activeSession?.key,
+    activeSessionKey,
+    isNewChat,
+    sessionProjectMap,
+  ])
+  const activeProject = useMemo(
+    () => activeProjects.find((project) => project.id === activeProjectId) ?? null,
+    [activeProjectId, activeProjects],
+  )
 
   // --- Waiting state management (Issue #43 + #449) ---
   // resolvedSessionKey is now available (defined above from useChatHistory).
@@ -1223,12 +1257,8 @@ export function ChatScreen({
         activeSendRef.current = null
         setSending(false)
         if (isMissingAuth(messageText)) {
-          if (!embedded) {
-            try {
-              navigate({ to: '/', replace: true })
-            } catch {
-              /* router not ready */
-            }
+          if (!embedded && typeof window !== 'undefined') {
+            window.location.assign('/')
           }
           return
         }
@@ -1781,8 +1811,9 @@ export function ChatScreen({
       }
       return
     }
-    if (isMissingAuth(messageText) && !embedded) {
-      navigate({ to: '/', replace: true })
+    if (isMissingAuth(messageText) && !embedded && typeof window !== 'undefined') {
+      window.location.assign('/')
+      return
     }
     const message = sessionsError
       ? `Failed to load sessions. ${sessionsError}`
@@ -2047,6 +2078,7 @@ export function ChatScreen({
         fastMode,
         model: currentModel || undefined,
         idempotencyKey: optimisticClientId || crypto.randomUUID(),
+        projectId: activeProject?.id || undefined,
       }).catch((err: unknown) => {
         const messageText = err instanceof Error ? err.message : String(err)
         if (import.meta.env.DEV) {
@@ -2063,6 +2095,7 @@ export function ChatScreen({
       streamFinish,
       streamStart,
       currentModel,
+      activeProject,
     ],
   )
 
@@ -2454,6 +2487,8 @@ export function ChatScreen({
         }),
       )
 
+      const scopedBody = buildProjectScopedTextMessage(trimmedBody, activeProject)
+
       if (isNewChat) {
         // In portable mode, use 'main' — no server-side sessions exist.
         // In enhanced mode, create a UUID thread for the sessions API.
@@ -2479,10 +2514,14 @@ export function ChatScreen({
           })
         }
 
+        if (activeProject?.id) {
+          assignSessionToProject(threadId, activeProject.id)
+        }
+
         sendMessage(
           threadId,
           threadId,
-          trimmedBody,
+          scopedBody,
           attachmentPayload,
           fastMode,
           true,
@@ -2507,14 +2546,16 @@ export function ChatScreen({
       sendMessage(
         sessionKeyForSend,
         isPortableMode ? 'main' : activeFriendlyId,
-        trimmedBody,
+        scopedBody,
         attachmentPayload,
         fastMode,
       )
     },
     [
       activeFriendlyId,
+      activeProject,
       activeSessionKey,
+      assignSessionToProject,
       createSessionForMessage,
       forcedSessionKey,
       isNewChat,

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -8,10 +8,12 @@ import {
   Castle02Icon,
   Chat01Icon,
   CheckListIcon,
+  CheckmarkCircle02Icon,
   Clock01Icon,
   ComputerTerminal01Icon,
   DashboardSquare01Icon,
   File01Icon,
+  Mail01Icon,
   McpServerIcon,
   MessageMultiple01Icon,
   Moon02Icon,
@@ -21,6 +23,7 @@ import {
   Search01Icon,
   Settings01Icon,
   Sun02Icon,
+  Target01Icon,
   UserGroupIcon,
   UserMultipleIcon,
 } from '@hugeicons/core-free-icons'
@@ -35,6 +38,7 @@ import { ProvidersDialog } from './providers-dialog'
 import { SessionRenameDialog } from './sidebar/session-rename-dialog'
 import { SessionDeleteDialog } from './sidebar/session-delete-dialog'
 import { SidebarSessions } from './sidebar/sidebar-sessions'
+import { SidebarProjects } from './sidebar/sidebar-projects'
 import type { ChatOpenSettingsDetail } from '../chat-events'
 import type { SessionMeta } from '../types'
 import { t } from '@/lib/i18n'
@@ -63,6 +67,7 @@ import {
   MenuTrigger,
 } from '@/components/ui/menu'
 import { applyTheme, useSettingsStore } from '@/hooks/use-settings'
+import { useProjects } from '@/hooks/use-projects'
 
 type WorkspaceStats = Record<string, unknown>
 
@@ -125,7 +130,7 @@ type ChatSidebarProps = {
   sessions: Array<SessionMeta>
   activeFriendlyId: string
   creatingSession: boolean
-  onCreateSession: () => void
+  onCreateSession: (projectId?: string) => void
   isCollapsed: boolean
   onToggleCollapse: () => void
   onSelectSession?: () => void
@@ -519,7 +524,9 @@ function usePersistedBool(key: string, defaultValue: boolean) {
 function ChatSidebarComponent({
   sessions,
   activeFriendlyId,
+  creatingSession,
   isCollapsed,
+  onCreateSession,
   onToggleCollapse,
   onSelectSession,
   onActiveSessionDelete,
@@ -536,6 +543,19 @@ function ChatSidebarComponent({
   )
   const { deleteSession } = useDeleteSession()
   const { renameSession } = useRenameSession()
+  const {
+    activeProjects: _activeProjects,
+    sessionProjectMap,
+  } = useProjects()
+  void _activeProjects
+  const unassignedSessions = useMemo(
+    () =>
+      sessions.filter((session) => {
+        const keys = [session.friendlyId, session.key].filter(Boolean)
+        return !keys.some((key) => Boolean(sessionProjectMap[key]))
+      }),
+    [sessionProjectMap, sessions],
+  )
   const openSearchModal = useSearchModal((state) => state.openModal)
   const isSearchModalOpen = useSearchModal((state) => state.isOpen)
   const pathname = useRouterState({
@@ -587,6 +607,10 @@ function ChatSidebarComponent({
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
   const isSwarmActive = pathname === '/swarm' || pathname === '/swarm2'
+  const isMissionControlActive = pathname === '/mission-control'
+  const isNotionActive = pathname.startsWith('/notion')
+  const isApprovalQueueActive = pathname.startsWith('/approval-queue')
+  const isOutreachActive = pathname.startsWith('/outreach')
   const echoStudioEnabled = useSettingsStore(
     (state) => state.settings.experimentalEchoStudio,
   )
@@ -610,6 +634,10 @@ function ChatSidebarComponent({
   } as const
 
   // Collapsible section states
+  const [seoBusinessExpanded, toggleSeoBusiness] = usePersistedBool(
+    'claude-sidebar-seo-business-expanded',
+    true,
+  )
   const [mainExpanded, toggleMain] = usePersistedBool(
     'claude-sidebar-main-expanded',
     true,
@@ -783,6 +811,44 @@ function ChatSidebarComponent({
 
   const isDashboardActive = pathname === '/dashboard'
 
+  const seoBusinessItems: Array<NavItemDef> = [
+    {
+      kind: 'link',
+      to: '/mission-control',
+      icon: Target01Icon,
+      label: 'Mission Control',
+      active: isMissionControlActive,
+    },
+    {
+      kind: 'link',
+      to: '/tasks',
+      icon: CheckListIcon,
+      label: 'To-Do / Tasks',
+      active: isTasksActive,
+    },
+    {
+      kind: 'link',
+      to: '/notion',
+      icon: Building01Icon,
+      label: 'Notion Browser',
+      active: isNotionActive,
+    },
+    {
+      kind: 'link',
+      to: '/approval-queue',
+      icon: CheckmarkCircle02Icon,
+      label: 'Approvals',
+      active: isApprovalQueueActive,
+    },
+    {
+      kind: 'link',
+      to: '/outreach',
+      icon: Mail01Icon,
+      label: 'Outreach Pipeline',
+      active: isOutreachActive,
+    },
+  ]
+
   const mainItems: Array<NavItemDef> = [
     {
       kind: 'link',
@@ -819,13 +885,6 @@ function ChatSidebarComponent({
       icon: Clock01Icon,
       label: t('nav.jobs'),
       active: isJobsActive,
-    },
-    {
-      kind: 'link',
-      to: '/tasks',
-      icon: CheckListIcon,
-      label: 'Tasks',
-      active: isTasksActive,
     },
     {
       kind: 'link',
@@ -1024,7 +1083,9 @@ function ChatSidebarComponent({
           <Link
             to="/chat/$sessionKey"
             params={{ sessionKey: 'new' }}
-            onClick={() => {
+            onClick={(event) => {
+              event.preventDefault()
+              onCreateSession()
               onSelectSession?.()
             }}
             className={cn(
@@ -1089,7 +1150,24 @@ function ChatSidebarComponent({
       {/* ── Scrollable body: nav + sessions ─────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin flex flex-col">
         {/* Navigation sections */}
-        <div className={cn('shrink-0 space-y-0.5 px-2', isMobile && 'order-2')}>
+        <div className="shrink-0 space-y-0.5 px-2">
+          <SectionLabel
+            label="SEO Business"
+            isCollapsed={isVisuallyCollapsed}
+            transition={transition}
+            collapsible
+            expanded={seoBusinessExpanded}
+            onToggle={toggleSeoBusiness}
+            navigateTo="/mission-control"
+          />
+          <CollapsibleSection
+            expanded={seoBusinessExpanded || isCollapsed}
+            items={seoBusinessItems}
+            isCollapsed={isVisuallyCollapsed}
+            transition={transition}
+            onSelectSession={onSelectSession}
+          />
+
           <SectionLabel
             label="Main"
             isCollapsed={isVisuallyCollapsed}
@@ -1135,7 +1213,7 @@ function ChatSidebarComponent({
         </div>
 
         {/* Sessions list */}
-        <div className={cn('shrink-0 mt-1', isMobile && 'order-1')}>
+        <div className="shrink-0 mt-1">
           <AnimatePresence initial={false}>
             {!isVisuallyCollapsed && (
               <motion.div
@@ -1147,8 +1225,15 @@ function ChatSidebarComponent({
                 className="flex flex-col w-full min-h-0 h-full"
               >
                 <div className="flex-1 min-h-0">
-                  <SidebarSessions
+                  <SidebarProjects
                     sessions={sessions}
+                    activeFriendlyId={activeFriendlyId}
+                    onSelect={onSelectSession}
+                    onRename={handleOpenRename}
+                    onDelete={handleOpenDelete}
+                  />
+                  <SidebarSessions
+                    sessions={unassignedSessions}
                     activeFriendlyId={activeFriendlyId}
                     onSelect={onSelectSession}
                     onRename={handleOpenRename}

--- a/src/screens/chat/components/sidebar/sidebar-projects.tsx
+++ b/src/screens/chat/components/sidebar/sidebar-projects.tsx
@@ -1,0 +1,438 @@
+'use client'
+
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowDown01Icon,
+  Building01Icon,
+  Delete01Icon,
+  MoreHorizontalIcon,
+  PencilEdit02Icon,
+  Pen01Icon,
+} from '@hugeicons/core-free-icons'
+import { Link } from '@tanstack/react-router'
+import { memo, useMemo, useState } from 'react'
+import { SessionItem } from './session-item'
+import type { SessionMeta } from '../../types'
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Button, buttonVariants } from '@/components/ui/button'
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogRoot,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import {
+  MenuContent,
+  MenuItem,
+  MenuRoot,
+  MenuTrigger,
+} from '@/components/ui/menu'
+import { usePinnedSessions } from '@/hooks/use-pinned-sessions'
+import {
+  useProjects,
+  type WorkspaceProject,
+} from '@/hooks/use-projects'
+import { cn } from '@/lib/utils'
+
+type SidebarProjectsProps = {
+  sessions: Array<SessionMeta>
+  activeFriendlyId: string
+  defaultOpen?: boolean
+  onSelect?: () => void
+  onRename: (session: SessionMeta) => void
+  onDelete: (session: SessionMeta) => void
+}
+
+type ProjectFormState = {
+  name: string
+  goal: string
+  instructions: string
+}
+
+const EMPTY_FORM: ProjectFormState = {
+  name: '',
+  goal: '',
+  instructions: '',
+}
+
+function getSessionMapKeys(session: SessionMeta): Array<string> {
+  return [session.friendlyId, session.key].filter(Boolean)
+}
+
+function sessionBelongsToProject(
+  session: SessionMeta,
+  sessionProjectMap: Record<string, string>,
+  projectId: string,
+): boolean {
+  return getSessionMapKeys(session).some(
+    (key) => sessionProjectMap[key] === projectId,
+  )
+}
+
+function getProjectSessionCount(
+  sessions: Array<SessionMeta>,
+  sessionProjectMap: Record<string, string>,
+  projectId: string,
+): number {
+  return sessions.filter((session) =>
+    sessionBelongsToProject(session, sessionProjectMap, projectId),
+  ).length
+}
+
+function ProjectDialog({
+  open,
+  project,
+  form,
+  setForm,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean
+  project: WorkspaceProject | null
+  form: ProjectFormState
+  setForm: (next: ProjectFormState) => void
+  onOpenChange: (open: boolean) => void
+  onSubmit: () => void
+}) {
+  const isEditing = Boolean(project)
+  const canSubmit = form.name.trim().length > 0
+
+  return (
+    <DialogRoot open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(520px,92vw)]">
+        <div className="border-b border-primary-200 px-5 py-4">
+          <DialogTitle>{isEditing ? 'Edit project' : 'New project'}</DialogTitle>
+          <DialogDescription className="mt-1">
+            Keep goal-specific chats together. Project instructions are injected
+            only into chats started or assigned here.
+          </DialogDescription>
+        </div>
+        <div className="space-y-3 px-5 py-4">
+          <label className="block space-y-1.5 text-sm">
+            <span className="font-medium text-primary-900">Name</span>
+            <Input
+              nativeInput
+              value={form.name}
+              placeholder="SEO/AEO Business"
+              onChange={(event) =>
+                setForm({ ...form, name: event.currentTarget.value })
+              }
+            />
+          </label>
+          <label className="block space-y-1.5 text-sm">
+            <span className="font-medium text-primary-900">Goal</span>
+            <textarea
+              value={form.goal}
+              placeholder="What is this project trying to accomplish?"
+              rows={3}
+              onChange={(event) =>
+                setForm({ ...form, goal: event.currentTarget.value })
+              }
+              className="w-full rounded-lg border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 outline-none transition-shadow focus:border-primary-500 focus:ring-[3px] focus:ring-primary-500/24"
+            />
+          </label>
+          <label className="block space-y-1.5 text-sm">
+            <span className="font-medium text-primary-900">
+              Project instructions
+            </span>
+            <textarea
+              value={form.instructions}
+              placeholder="How should chats in this project behave?"
+              rows={4}
+              onChange={(event) =>
+                setForm({ ...form, instructions: event.currentTarget.value })
+              }
+              className="w-full rounded-lg border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 outline-none transition-shadow focus:border-primary-500 focus:ring-[3px] focus:ring-primary-500/24"
+            />
+          </label>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-primary-200 px-5 py-4">
+          <DialogClose>Cancel</DialogClose>
+          <Button disabled={!canSubmit} onClick={onSubmit}>
+            {isEditing ? 'Save project' : 'Create project'}
+          </Button>
+        </div>
+      </DialogContent>
+    </DialogRoot>
+  )
+}
+
+export const SidebarProjects = memo(function SidebarProjects({
+  sessions,
+  activeFriendlyId,
+  defaultOpen = true,
+  onSelect,
+  onRename,
+  onDelete,
+}: SidebarProjectsProps) {
+  const {
+    activeProjects,
+    sessionProjectMap,
+    activeProjectId,
+    createProject,
+    updateProject,
+    archiveProject,
+    assignSessionToProject,
+    setActiveProject,
+  } = useProjects()
+  const { pinnedSessionKeys, togglePinnedSession } = usePinnedSessions()
+  const pinnedKeys = useMemo(() => new Set(pinnedSessionKeys), [pinnedSessionKeys])
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingProject, setEditingProject] = useState<WorkspaceProject | null>(
+    null,
+  )
+  const [form, setForm] = useState<ProjectFormState>(EMPTY_FORM)
+
+  function openNewProjectDialog() {
+    setEditingProject(null)
+    setForm(EMPTY_FORM)
+    setDialogOpen(true)
+  }
+
+  function openEditProjectDialog(project: WorkspaceProject) {
+    setEditingProject(project)
+    setForm({
+      name: project.name,
+      goal: project.goal,
+      instructions: project.instructions,
+    })
+    setDialogOpen(true)
+  }
+
+  function handleSubmitProject() {
+    if (!form.name.trim()) return
+    if (editingProject) {
+      updateProject(editingProject.id, form)
+    } else {
+      createProject(form)
+    }
+    setDialogOpen(false)
+    setEditingProject(null)
+    setForm(EMPTY_FORM)
+  }
+
+  function handleTogglePin(session: SessionMeta) {
+    togglePinnedSession(session.key)
+  }
+
+  return (
+    <>
+      <Collapsible
+        className="flex shrink-0 flex-col w-full"
+        defaultOpen={defaultOpen}
+      >
+        <CollapsibleTrigger className="w-full flex items-center gap-1.5 rounded-none px-5 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider hover:bg-transparent data-panel-open:text-primary-500">
+          <span className="select-none">Projects</span>
+          <span className="ml-auto inline-flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="New project"
+              className="rounded p-0.5 hover:bg-primary-200 dark:hover:bg-primary-800"
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                openNewProjectDialog()
+              }}
+            >
+              <HugeiconsIcon
+                icon={PencilEdit02Icon}
+                size={12}
+                strokeWidth={2}
+              />
+            </button>
+            <span className="rounded p-0.5 hover:bg-primary-200 dark:hover:bg-primary-800">
+              <HugeiconsIcon
+                icon={ArrowDown01Icon}
+                size={12}
+                strokeWidth={2}
+                className="text-primary-500 transition-transform duration-150 -rotate-90 group-data-panel-open:rotate-0"
+              />
+            </span>
+          </span>
+        </CollapsibleTrigger>
+        <CollapsiblePanel
+          className="w-full min-h-0"
+          contentClassName="flex flex-col gap-1 px-2 pt-1"
+        >
+          {activeProjects.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-primary-200 px-3 py-3 text-xs text-primary-600">
+              <div className="font-medium text-primary-800">No projects yet.</div>
+              <button
+                type="button"
+                className="mt-2 text-accent-500 hover:underline"
+                onClick={openNewProjectDialog}
+              >
+                Create the first project
+              </button>
+            </div>
+          ) : (
+            activeProjects.map((project) => {
+              const projectSessions = sessions.filter((session) =>
+                sessionBelongsToProject(
+                  session,
+                  sessionProjectMap,
+                  project.id,
+                ),
+              )
+              const isProjectActive = activeProjectId === project.id
+              const canAssignActive =
+                activeFriendlyId &&
+                activeFriendlyId !== 'new' &&
+                sessionProjectMap[activeFriendlyId] !== project.id
+
+              return (
+                <Collapsible
+                  key={project.id}
+                  className="rounded-lg border border-primary-200/70 bg-primary-50/40 dark:bg-primary-900/10"
+                  defaultOpen={isProjectActive || projectSessions.length > 0}
+                >
+                  <div className="flex items-center gap-1 px-2 py-1.5">
+                    <CollapsibleTrigger className="min-w-0 flex-1 px-1 py-1 hover:bg-transparent">
+                      <span
+                        className="inline-flex size-2.5 shrink-0 rounded-full"
+                        style={{ background: project.color }}
+                      />
+                      <HugeiconsIcon
+                        icon={Building01Icon}
+                        size={14}
+                        strokeWidth={1.6}
+                        className="shrink-0 text-primary-600"
+                      />
+                      <span className="min-w-0 flex-1 truncate text-xs font-semibold text-primary-900">
+                        {project.name}
+                      </span>
+                      <span className="rounded-full bg-primary-200 px-1.5 py-0.5 text-[10px] text-primary-700">
+                        {getProjectSessionCount(
+                          sessions,
+                          sessionProjectMap,
+                          project.id,
+                        )}
+                      </span>
+                    </CollapsibleTrigger>
+                    <Link
+                      to="/chat/$sessionKey"
+                      params={{ sessionKey: 'new' }}
+                      onClick={() => {
+                        setActiveProject(project.id)
+                        onSelect?.()
+                      }}
+                      className={cn(
+                        buttonVariants({ variant: 'ghost', size: 'icon-sm' }),
+                        'size-7 text-primary-700',
+                      )}
+                      title={`New chat in ${project.name}`}
+                    >
+                      <HugeiconsIcon
+                        icon={PencilEdit02Icon}
+                        size={16}
+                        strokeWidth={1.5}
+                      />
+                    </Link>
+                    <MenuRoot>
+                      <MenuTrigger
+                        type="button"
+                        aria-label={`${project.name} project options`}
+                        className="inline-flex size-7 items-center justify-center rounded-md text-primary-700 hover:bg-primary-200 dark:hover:bg-primary-800"
+                      >
+                        <HugeiconsIcon
+                          icon={MoreHorizontalIcon}
+                          size={16}
+                          strokeWidth={1.5}
+                        />
+                      </MenuTrigger>
+                      <MenuContent side="bottom" align="end">
+                        {canAssignActive ? (
+                          <MenuItem
+                            onClick={() => {
+                              assignSessionToProject(activeFriendlyId, project.id)
+                            }}
+                            className="gap-2"
+                          >
+                            <HugeiconsIcon
+                              icon={Building01Icon}
+                              size={18}
+                              strokeWidth={1.5}
+                            />
+                            Move active chat here
+                          </MenuItem>
+                        ) : null}
+                        <MenuItem
+                          onClick={() => openEditProjectDialog(project)}
+                          className="gap-2"
+                        >
+                          <HugeiconsIcon
+                            icon={Pen01Icon}
+                            size={18}
+                            strokeWidth={1.5}
+                          />
+                          Edit project
+                        </MenuItem>
+                        <MenuItem
+                          onClick={() => archiveProject(project.id)}
+                          className="text-red-700 gap-2 hover:bg-red-50 dark:hover:bg-red-900/30/80 data-highlighted:bg-red-50/80"
+                        >
+                          <HugeiconsIcon
+                            icon={Delete01Icon}
+                            size={18}
+                            strokeWidth={1.5}
+                          />
+                          Archive project
+                        </MenuItem>
+                      </MenuContent>
+                    </MenuRoot>
+                  </div>
+                  {project.goal ? (
+                    <div className="px-3 pb-1 text-[11px] leading-4 text-primary-600">
+                      {project.goal}
+                    </div>
+                  ) : null}
+                  <CollapsiblePanel
+                    className="w-full min-h-0"
+                    contentClassName="flex flex-col gap-px px-1 pb-1 pt-0"
+                  >
+                    {projectSessions.length > 0 ? (
+                      projectSessions.map((session) => (
+                        <SessionItem
+                          key={session.key}
+                          session={session}
+                          active={session.friendlyId === activeFriendlyId}
+                          isPinned={pinnedKeys.has(session.key)}
+                          onSelect={() => {
+                            setActiveProject(project.id)
+                            onSelect?.()
+                          }}
+                          onTogglePin={handleTogglePin}
+                          onRename={onRename}
+                          onDelete={onDelete}
+                        />
+                      ))
+                    ) : (
+                      <div className="px-2 py-2 text-[11px] text-primary-500">
+                        No chats yet. Start one with the pencil button.
+                      </div>
+                    )}
+                  </CollapsiblePanel>
+                </Collapsible>
+              )
+            })
+          )}
+        </CollapsiblePanel>
+      </Collapsible>
+
+      <ProjectDialog
+        open={dialogOpen}
+        project={editingProject}
+        form={form}
+        setForm={setForm}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleSubmitProject}
+      />
+    </>
+  )
+})

--- a/src/screens/chat/hooks/use-streaming-message.ts
+++ b/src/screens/chat/hooks/use-streaming-message.ts
@@ -802,6 +802,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
       attachments?: Array<ChatAttachment>
       idempotencyKey?: string
       model?: string
+      projectId?: string
     }) => {
       if (eventSourceRef.current) {
         // Preserve in-progress response as a partial message before aborting
@@ -871,6 +872,7 @@ export function useStreamingMessage(options: UseStreamingMessageOptions = {}) {
             attachments: params.attachments,
             idempotencyKey: params.idempotencyKey ?? crypto.randomUUID(),
             model: params.model || undefined,
+            projectId: params.projectId || undefined,
             locale:
               typeof window !== 'undefined'
                 ? localStorage.getItem('hermes-workspace-locale') || 'en'

--- a/src/screens/chat/utils.test.ts
+++ b/src/screens/chat/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeSessions, textFromMessage } from './utils'
+import { normalizeSessions, textFromMessage, isMissingAuth, missingAuthMessage } from './utils'
 import type { ChatMessage, SessionSummary } from './types'
 
 describe('chat utils workspace directive cleanup', () => {
@@ -16,6 +16,20 @@ describe('chat utils workspace directive cleanup', () => {
     }
 
     expect(textFromMessage(message)).toBe('Run the tests')
+  })
+
+  it('hides project_context directives from user-visible message text', () => {
+    const message: ChatMessage = {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: '<project_context active="true" id="seo" name="SEO" goal="Launch" instructions="Stay focused" />\n\nWhat should we do next?',
+        },
+      ],
+    }
+
+    expect(textFromMessage(message)).toBe('What should we do next?')
   })
 
   it('strips workspace_context directives from session previews and derived titles', () => {
@@ -37,5 +51,17 @@ describe('chat utils workspace directive cleanup', () => {
     expect(sessions[0]?.preview).toBe('Review the open PRs')
     expect(sessions[0]?.derivedTitle).toBe('Review the open PRs')
     expect(sessions[1]?.derivedTitle).toBe('Fix Docker publish')
+  })
+})
+
+describe('chat auth error detection', () => {
+  it('detects legacy gateway auth failure text', () => {
+    expect(isMissingAuth(missingAuthMessage)).toBe(true)
+  })
+
+  it('detects expired workspace session responses', () => {
+    expect(isMissingAuth('Unauthorized')).toBe(true)
+    expect(isMissingAuth('{"ok":false,"error":"Unauthorized"}')).toBe(true)
+    expect(isMissingAuth('401 Unauthorized')).toBe(true)
   })
 })

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -6,6 +6,7 @@ import type {
   SessionTitleStatus,
   ToolCallContent,
 } from './types'
+import { stripProjectContextDirective } from '../../lib/project-context'
 import { stripWorkspaceDirective } from '../../lib/workspace-message-scope'
 
 export function deriveFriendlyIdFromKey(key: string | undefined): string {
@@ -53,7 +54,7 @@ function stripChannelPrefix(text: string): string {
  * and [Telegram/Signal/etc ...] headers, leaving just the user's text.
  */
 function cleanUserText(raw: string): string {
-  let text = stripWorkspaceDirective(raw)
+  let text = stripProjectContextDirective(stripWorkspaceDirective(raw))
 
   // Remove "Conversation info (untrusted metadata):" headers + JSON block
   // Format: "Conversation info (untrusted metadata):\n```json\n{...}\n```\n\n"
@@ -289,5 +290,13 @@ export const missingAuthMessage =
   'Hermes Agent connection failed. Make sure Hermes Agent is running and HERMES_API_URL is set correctly.'
 
 export function isMissingAuth(message: string): boolean {
-  return message.includes(missingAuthMessage)
+  const normalized = message.trim().toLowerCase()
+  return (
+    message.includes(missingAuthMessage) ||
+    normalized === 'unauthorized' ||
+    normalized.includes('"error":"unauthorized"') ||
+    normalized.includes('"error": "unauthorized"') ||
+    normalized.includes('401 unauthorized') ||
+    normalized.includes('stream request failed (401)')
+  )
 }

--- a/src/screens/mission-control/mission-control-screen.tsx
+++ b/src/screens/mission-control/mission-control-screen.tsx
@@ -1,0 +1,1017 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { AnimatePresence, motion } from 'motion/react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Add01Icon,
+  AlertCircleIcon,
+  ArrowRight01Icon,
+  Chat01Icon,
+  CheckListIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  Mail01Icon,
+  Rocket01Icon,
+  RefreshIcon,
+  Target01Icon,
+  Time04Icon,
+} from '@hugeicons/core-free-icons'
+import { cn } from '@/lib/utils'
+import {
+  COLUMN_COLORS,
+  COLUMN_LABELS,
+  createTask,
+  fetchTasks,
+  isOverdue,
+  type ClaudeTask,
+  type TaskColumn,
+} from '@/lib/tasks-api'
+import { TaskDialog } from '@/screens/tasks/task-dialog'
+import { toast } from '@/components/ui/toast'
+
+// ── Query key ──────────────────────────────────────────────────────
+const MC_QUERY_KEY = ['mission-control', 'tasks'] as const
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  if (diff < 0) return 'just now'
+  const secs = Math.floor(diff / 1000)
+  if (secs < 60) return 'just now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+function formatDueDate(dueDate: string): string {
+  const [y, m, d] = dueDate.split('-').map(Number)
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+// ── Business Overview Strip ─────────────────────────────────────────
+
+function BusinessOverviewStrip({
+  tasks,
+  isLoading,
+}: {
+  tasks: ClaudeTask[]
+  isLoading: boolean
+}) {
+  const stats = useMemo(() => {
+    const total = tasks.length
+    const inProgress = tasks.filter((t) => t.column === 'in_progress').length
+    const blocked = tasks.filter((t) => t.column === 'blocked').length
+    const overdue = tasks.filter(
+      (t) => isOverdue(t) && t.column !== 'done' && t.column !== 'deleted',
+    ).length
+    const done = tasks.filter((t) => t.column === 'done').length
+    const completion = total > 0 ? Math.round((done / total) * 100) : 0
+    return { total, inProgress, blocked, overdue, done, completion }
+  }, [tasks])
+
+  const cards = [
+    {
+      label: 'Total',
+      value: stats.total,
+      icon: CheckListIcon,
+      color: 'var(--theme-text)',
+    },
+    {
+      label: 'Running',
+      value: stats.inProgress,
+      icon: Rocket01Icon,
+      color: '#f97316',
+    },
+    {
+      label: 'Blocked',
+      value: stats.blocked,
+      icon: AlertCircleIcon,
+      color: '#ef4444',
+    },
+    {
+      label: 'Overdue',
+      value: stats.overdue,
+      icon: Time04Icon,
+      color: '#ef4444',
+    },
+    {
+      label: 'Complete',
+      value: `${stats.completion}%`,
+      icon: Target01Icon,
+      color: '#22c55e',
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+      {cards.map((c) => (
+        <div
+          key={c.label}
+          className="flex items-center gap-3 rounded-xl border p-3"
+          style={{
+            background: 'var(--theme-card)',
+            borderColor: 'var(--theme-border)',
+          }}
+        >
+          <div
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg"
+            style={{
+              background: `color-mix(in srgb, ${c.color} 12%, transparent)`,
+            }}
+          >
+            <HugeiconsIcon icon={c.icon} size={16} style={{ color: c.color }} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-lg font-semibold leading-tight text-[var(--theme-text)]">
+              {isLoading ? '…' : c.value}
+            </p>
+            <p className="text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">
+              {c.label}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function NotionOperationsStrip({
+  crmCount,
+  outreachCount,
+  approvalCount,
+  isLoading,
+  hasError,
+  onOpenSource,
+}: {
+  crmCount: number
+  outreachCount: number
+  approvalCount: number
+  isLoading: boolean
+  hasError: boolean
+  onOpenSource: (source: string) => void
+}) {
+  const cards = [
+    {
+      label: 'CRM Leads',
+      source: 'CRM / Leads',
+      value: crmCount,
+      icon: Target01Icon,
+      color: '#3b82f6',
+    },
+    {
+      label: 'Outreach Touches',
+      source: 'Outreach / Interactions',
+      value: outreachCount,
+      icon: Mail01Icon,
+      color: '#f59e0b',
+    },
+    {
+      label: 'Approvals',
+      source: 'Human Approval Queue',
+      value: approvalCount,
+      icon: CheckmarkCircle02Icon,
+      color: approvalCount > 0 ? '#f97316' : '#22c55e',
+    },
+    {
+      label: 'Notion Link',
+      source: 'CRM / Leads',
+      value: hasError ? 'Check' : 'Live',
+      icon: Rocket01Icon,
+      color: hasError ? '#ef4444' : '#22c55e',
+    },
+  ]
+
+  return (
+    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text)]">
+            Notion Operations
+          </h2>
+          <p className="text-[11px] text-[var(--theme-muted)]">
+            CRM, outreach, and approvals are pulled through the server-side Notion proxy.
+          </p>
+        </div>
+        <span
+          className={cn(
+            'rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]',
+            hasError
+              ? 'border-red-500/50 text-red-400'
+              : 'border-green-500/50 text-green-400',
+          )}
+        >
+          {isLoading ? 'Loading' : hasError ? 'Needs check' : 'Live'}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+        {cards.map((card) => (
+          <button
+            type="button"
+            key={card.label}
+            onClick={() => onOpenSource(card.source)}
+            className="flex items-center gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 text-left transition-colors hover:bg-[var(--theme-hover)]"
+          >
+            <div
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg"
+              style={{ background: `color-mix(in srgb, ${card.color} 14%, transparent)` }}
+            >
+              <HugeiconsIcon icon={card.icon} size={15} style={{ color: card.color }} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-base font-semibold leading-tight text-[var(--theme-text)]">
+                {isLoading ? '…' : card.value}
+              </p>
+              <p className="truncate text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">
+                {card.label}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function statusTone(status: string): { label: string; className: string } {
+  if (status === 'live') return { label: 'Live', className: 'border-green-500/50 text-green-400' }
+  if (status === 'degraded') return { label: 'Degraded', className: 'border-amber-500/50 text-amber-300' }
+  if (status === 'blocked') return { label: 'Blocked', className: 'border-red-500/50 text-red-400' }
+  return { label: 'Not configured', className: 'border-[var(--theme-border)] text-[var(--theme-muted)]' }
+}
+
+function SystemOperationsPanel({
+  system,
+  isLoading,
+  hasError,
+}: {
+  system: MissionControlSystemSnapshot | undefined
+  isLoading: boolean
+  hasError: boolean
+}) {
+  const integrations = system?.integrations ?? []
+  const warnings = system?.hermes.modelWarnings ?? []
+  const approvals = system?.approvals ?? []
+
+  return (
+    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-text)]">
+            Live Systems + Security
+          </h2>
+          <p className="text-[11px] text-[var(--theme-muted)]">
+            Local-only snapshot. Secrets are status-only; data is timestamped.
+          </p>
+        </div>
+        <span className="rounded-full border border-[var(--theme-border)] px-2 py-0.5 text-[10px] text-[var(--theme-muted)]">
+          {isLoading ? 'Refreshing…' : system?.generatedAt ? `Updated ${timeAgo(system.generatedAt)}` : hasError ? 'Needs check' : 'No data'}
+        </span>
+      </div>
+
+      {hasError ? (
+        <p className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-[11px] text-red-300">
+          Mission Control system snapshot failed. Check the Workspace server logs.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
+              {integrations.map((item) => {
+                const tone = statusTone(item.status)
+                return (
+                  <div key={item.id} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+                    <div className="mb-2 flex items-center justify-between gap-2">
+                      <p className="truncate text-[11px] font-semibold text-[var(--theme-text)]">{item.label}</p>
+                      <span className={cn('shrink-0 rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em]', tone.className)}>
+                        {tone.label}
+                      </span>
+                    </div>
+                    <p className="line-clamp-3 text-[10px] leading-relaxed text-[var(--theme-muted)]">{item.detail}</p>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-text)]">Today</p>
+              <div className="mt-2 grid grid-cols-2 gap-2 text-[11px]">
+                <div>
+                  <p className="text-lg font-semibold text-[var(--theme-text)]">{system?.apple.calendar.todayCount ?? '—'}</p>
+                  <p className="text-[var(--theme-muted)]">calendar events</p>
+                </div>
+                <div>
+                  <p className="text-lg font-semibold text-[var(--theme-text)]">{system?.apple.reminders.overdueCount ?? '—'}</p>
+                  <p className="text-[var(--theme-muted)]">overdue reminders</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-text)]">Hermes routing</p>
+              <p className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                {system?.hermes.version ?? 'Hermes version unavailable'} · {system?.hermes.cron.active ?? 0}/{system?.hermes.cron.total ?? 0} schedules active
+              </p>
+              {warnings.slice(0, 3).map((warning) => (
+                <p key={warning.detail} className="mt-2 rounded border border-amber-500/30 bg-amber-500/10 p-2 text-[10px] text-amber-200">
+                  {warning.detail}
+                </p>
+              ))}
+            </div>
+
+            <div className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--theme-text)]">Approval gates</p>
+              <p className="mt-1 text-[11px] text-[var(--theme-muted)]">
+                {approvals.length} consequential action(s) blocked until Ryan approves.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Needs Attention Panel ───────────────────────────────────────────
+
+function NeedsAttentionPanel({
+  tasks,
+  isLoading,
+  onTaskClick,
+}: {
+  tasks: ClaudeTask[]
+  isLoading: boolean
+  onTaskClick: (task: ClaudeTask) => void
+}) {
+  const attentionTasks = useMemo(() => {
+    return tasks
+      .filter((t) => t.column === 'review' || t.column === 'blocked')
+      .sort((a, b) => {
+        const priorityOrder = { high: 0, medium: 1, low: 2 }
+        return priorityOrder[a.priority] - priorityOrder[b.priority]
+      })
+      .slice(0, 8)
+  }, [tasks])
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-xl border p-3"
+      style={{
+        background:
+          'linear-gradient(150deg, color-mix(in srgb, var(--theme-card) 96%, transparent), color-mix(in srgb, var(--theme-card) 90%, transparent))',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <HugeiconsIcon
+            icon={AlertCircleIcon}
+            size={14}
+            strokeWidth={1.5}
+            style={{ color: attentionTasks.length > 0 ? 'var(--theme-warning)' : 'var(--theme-success)' }}
+          />
+          <h3
+            className="text-[10px] font-semibold uppercase tracking-[0.18em]"
+            style={{ color: 'var(--theme-text)' }}
+          >
+            Needs Attention
+          </h3>
+        </div>
+        <span
+          className="rounded px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.15em]"
+          style={{
+            background:
+              attentionTasks.length > 0
+                ? 'color-mix(in srgb, var(--theme-warning) 14%, transparent)'
+                : 'color-mix(in srgb, var(--theme-success) 14%, transparent)',
+            color:
+              attentionTasks.length > 0 ? 'var(--theme-warning)' : 'var(--theme-success)',
+          }}
+        >
+          {isLoading ? '…' : attentionTasks.length}
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-1.5">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-12 animate-pulse rounded-lg bg-[var(--theme-hover)]"
+            />
+          ))}
+        </div>
+      ) : attentionTasks.length === 0 ? (
+        <p className="py-2 text-[11px] text-[var(--theme-muted)]">
+          Nothing needs attention. All clear.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {attentionTasks.map((task) => {
+            const overdue = isOverdue(task)
+            const colColor = COLUMN_COLORS[task.column]
+            return (
+              <li key={task.id}>
+                <button
+                  type="button"
+                  onClick={() => onTaskClick(task)}
+                  className="w-full rounded-lg border px-2.5 py-2 text-left transition-colors hover:bg-[var(--theme-hover)]"
+                  style={{ borderColor: 'var(--theme-border)' }}
+                >
+                  <div className="flex items-start gap-2">
+                    <span
+                      className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                      style={{ background: colColor }}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-[11px] font-semibold text-[var(--theme-text)]">
+                          {task.title}
+                        </p>
+                        {overdue && (
+                          <span className="shrink-0 rounded bg-red-500/15 px-1 py-0.5 text-[9px] font-semibold text-red-400">
+                            OVERDUE
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-[var(--theme-muted)]">
+                        {task.assignee && (
+                          <span className="truncate">{task.assignee}</span>
+                        )}
+                        {task.due_date && (
+                          <>
+                            {task.assignee && <span>·</span>}
+                            <span
+                              className={overdue ? 'font-semibold text-red-400' : ''}
+                            >
+                              {formatDueDate(task.due_date)}
+                            </span>
+                          </>
+                        )}
+                        <span
+                          className="shrink-0 rounded px-1 py-0.5 text-[9px] font-medium"
+                          style={{
+                            background: `color-mix(in srgb, ${colColor} 14%, transparent)`,
+                            color: colColor,
+                          }}
+                        >
+                          {COLUMN_LABELS[task.column]}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+// ── Compact Kanban ──────────────────────────────────────────────────
+
+const COMPACT_COLUMNS: TaskColumn[] = ['todo', 'in_progress', 'review']
+
+function CompactKanban({
+  tasks,
+  isLoading,
+  onTaskClick,
+}: {
+  tasks: ClaudeTask[]
+  isLoading: boolean
+  onTaskClick: (task: ClaudeTask) => void
+}) {
+  const tasksByColumn = useMemo(() => {
+    const map: Record<TaskColumn, ClaudeTask[]> = {
+      todo: [],
+      in_progress: [],
+      review: [],
+      backlog: [],
+      blocked: [],
+      done: [],
+      deleted: [],
+    }
+    for (const t of tasks) {
+      if (map[t.column]) {
+        map[t.column].push(t)
+      }
+    }
+    // Sort by position
+    for (const col of COMPACT_COLUMNS) {
+      map[col].sort((a, b) => a.position - b.position)
+    }
+    return map
+  }, [tasks])
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-xl border p-3"
+      style={{
+        background: 'var(--theme-card)',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon
+          icon={CheckListIcon}
+          size={14}
+          strokeWidth={1.5}
+          style={{ color: 'var(--theme-accent)' }}
+        />
+        <h3
+          className="text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style={{ color: 'var(--theme-text)' }}
+        >
+          Active Tasks
+        </h3>
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {COMPACT_COLUMNS.map((col) => (
+            <div
+              key={col}
+              className="flex flex-col gap-1.5 rounded-lg border p-2"
+              style={{ borderColor: 'var(--theme-border)' }}
+            >
+              <div className="h-3 w-16 animate-pulse rounded bg-[var(--theme-hover)]" />
+              {[1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="h-14 animate-pulse rounded bg-[var(--theme-hover)]"
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {COMPACT_COLUMNS.map((col) => {
+            const colTasks = tasksByColumn[col]
+            const colColor = COLUMN_COLORS[col]
+            return (
+              <div
+                key={col}
+                className="flex flex-col gap-1.5 rounded-lg border p-2"
+                style={{ borderColor: 'var(--theme-border)' }}
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ background: colColor }}
+                  />
+                  <span className="text-[10px] font-semibold text-[var(--theme-text)]">
+                    {COLUMN_LABELS[col]}
+                  </span>
+                  <span className="text-[10px] text-[var(--theme-muted)]">
+                    ({colTasks.length})
+                  </span>
+                </div>
+                <div className="flex flex-col gap-1">
+                  {colTasks.length === 0 ? (
+                    <p className="py-3 text-center text-[10px] text-[var(--theme-muted)] opacity-60">
+                      Empty
+                    </p>
+                  ) : (
+                    colTasks.slice(0, 5).map((task) => {
+                      const overdue = isOverdue(task)
+                      return (
+                        <button
+                          key={task.id}
+                          type="button"
+                          onClick={() => onTaskClick(task)}
+                          className="rounded-md border px-2 py-1.5 text-left transition-colors hover:bg-[var(--theme-hover)]"
+                          style={{
+                            borderColor: 'var(--theme-border)',
+                            borderLeftWidth: 2,
+                            borderLeftColor: colColor,
+                          }}
+                        >
+                          <p className="truncate text-[11px] font-medium text-[var(--theme-text)]">
+                            {task.title}
+                          </p>
+                          <div className="mt-0.5 flex items-center gap-1.5">
+                            {task.assignee && (
+                              <span className="text-[9px] text-[var(--theme-muted)]">
+                                {task.assignee}
+                              </span>
+                            )}
+                            {task.due_date && (
+                              <span
+                                className={cn(
+                                  'text-[9px]',
+                                  overdue ? 'font-semibold text-red-400' : 'text-[var(--theme-muted)]',
+                                )}
+                              >
+                                {formatDueDate(task.due_date)}
+                              </span>
+                            )}
+                          </div>
+                        </button>
+                      )
+                    })
+                  )}
+                  {colTasks.length > 5 && (
+                    <p className="text-center text-[9px] text-[var(--theme-muted)]">
+                      +{colTasks.length - 5} more
+                    </p>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Quick Actions ───────────────────────────────────────────────────
+
+function QuickActions() {
+  const navigate = useNavigate()
+
+  const actions = [
+    {
+      label: 'New Task',
+      icon: Add01Icon,
+      onClick: () => {
+        // Dispatch a custom event that the task dialog listens for
+        // For now, navigate to tasks page
+        navigate({ to: '/tasks' })
+      },
+    },
+    {
+      label: 'Approvals',
+      icon: CheckmarkCircle02Icon,
+      onClick: () => navigate({ to: '/approval-queue' }),
+    },
+    {
+      label: 'Outreach Pipeline',
+      icon: Mail01Icon,
+      onClick: () => navigate({ to: '/outreach' }),
+    },
+    {
+      label: 'New Chat',
+      icon: Chat01Icon,
+      onClick: () => navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'new' } }),
+    },
+    {
+      label: 'View All Tasks',
+      icon: ArrowRight01Icon,
+      onClick: () => navigate({ to: '/tasks' }),
+    },
+  ]
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-xl border p-3"
+      style={{
+        background: 'var(--theme-card)',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon
+          icon={Rocket01Icon}
+          size={14}
+          strokeWidth={1.5}
+          style={{ color: 'var(--theme-accent)' }}
+        />
+        <h3
+          className="text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style={{ color: 'var(--theme-text)' }}
+        >
+          Quick Actions
+        </h3>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {actions.map((a) => (
+          <button
+            key={a.label}
+            type="button"
+            onClick={a.onClick}
+            className="flex items-center gap-1.5 rounded-lg border px-3 py-2 text-[11px] font-medium transition-colors hover:bg-[var(--theme-hover)]"
+            style={{
+              borderColor: 'var(--theme-border)',
+              color: 'var(--theme-text)',
+            }}
+          >
+            <HugeiconsIcon icon={a.icon} size={14} />
+            {a.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Recent Activity ─────────────────────────────────────────────────
+
+function RecentActivity({
+  tasks,
+  isLoading,
+  onTaskClick,
+}: {
+  tasks: ClaudeTask[]
+  isLoading: boolean
+  onTaskClick: (task: ClaudeTask) => void
+}) {
+  const recentTasks = useMemo(() => {
+    return [...tasks]
+      .sort(
+        (a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+      )
+      .slice(0, 10)
+  }, [tasks])
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-xl border p-3"
+      style={{
+        background: 'var(--theme-card)',
+        borderColor: 'var(--theme-border)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon
+          icon={Clock01Icon}
+          size={14}
+          strokeWidth={1.5}
+          style={{ color: 'var(--theme-accent)' }}
+        />
+        <h3
+          className="text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style={{ color: 'var(--theme-text)' }}
+        >
+          Recent Activity
+        </h3>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-1.5">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="h-8 animate-pulse rounded bg-[var(--theme-hover)]"
+            />
+          ))}
+        </div>
+      ) : recentTasks.length === 0 ? (
+        <p className="py-2 text-[11px] text-[var(--theme-muted)]">
+          No recent activity.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-0.5">
+          {recentTasks.map((task) => {
+            const colColor = COLUMN_COLORS[task.column]
+            return (
+              <li key={task.id}>
+                <button
+                  type="button"
+                  onClick={() => onTaskClick(task)}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--theme-hover)]"
+                >
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full"
+                    style={{ background: colColor }}
+                  />
+                  <p className="min-w-0 flex-1 truncate text-[11px] text-[var(--theme-text)]">
+                    {task.title}
+                  </p>
+                  <span
+                    className="shrink-0 rounded px-1 py-0.5 text-[8px] font-medium uppercase"
+                    style={{
+                      background: `color-mix(in srgb, ${colColor} 14%, transparent)`,
+                      color: colColor,
+                    }}
+                  >
+                    {COLUMN_LABELS[task.column]}
+                  </span>
+                  <span className="shrink-0 text-[9px] text-[var(--theme-muted)]">
+                    {timeAgo(task.updated_at)}
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+type MissionControlSummary = {
+  ok: boolean
+  generatedAt: string
+  counts: {
+    crmLeads: number
+    outreachInteractions: number
+    humanApprovals: number
+    deals: number
+    activeProjects: number
+    openTasks: number
+    followUpsDue: number
+  }
+  health: {
+    notion: string
+    secretBoundary: string
+    zoho: string
+    reminders: string
+  }
+}
+
+type MissionControlSystemSnapshot = {
+  ok: boolean
+  generatedAt: string
+  integrations: Array<{ id: string; label: string; status: string; detail: string; lastCheckedAt: string }>
+  apple: {
+    calendar: { status: string; todayCount: number | null; detail: string; lastCheckedAt: string }
+    reminders: { status: string; openCount: number | null; overdueCount: number | null; detail: string; lastCheckedAt: string }
+  }
+  hermes: {
+    version: string | null
+    cron: { total: number; active: number; failed: number; nextRunAt: string | null }
+    modelWarnings: Array<{ severity: string; detail: string; evidence: string }>
+  }
+  approvals: Array<{ action: string; reason: string; required: true }>
+}
+
+// ── Main Screen ─────────────────────────────────────────────────────
+
+export function MissionControlScreen() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [editingTask, setEditingTask] = useState<ClaudeTask | null>(null)
+
+  const tasksQuery = useQuery({
+    queryKey: MC_QUERY_KEY,
+    queryFn: () => fetchTasks({ include_done: true }),
+    refetchInterval: 30_000,
+  })
+
+  const summaryQuery = useQuery({
+    queryKey: ['mission-control', 'summary'],
+    queryFn: async () => {
+      const res = await fetch('/api/mission-control/summary')
+      if (!res.ok) throw new Error('Failed to fetch Mission Control summary')
+      return res.json() as Promise<MissionControlSummary>
+    },
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  })
+
+  const systemQuery = useQuery({
+    queryKey: ['mission-control', 'system'],
+    queryFn: async () => {
+      const res = await fetch('/api/mission-control/system')
+      if (!res.ok) throw new Error('Failed to fetch Mission Control system snapshot')
+      return res.json() as Promise<MissionControlSystemSnapshot>
+    },
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  })
+
+  const tasks = tasksQuery.data ?? []
+  const notionLoading = summaryQuery.isLoading
+  const notionHasError = Boolean(summaryQuery.error)
+  const crmCount = summaryQuery.data?.counts.crmLeads ?? 0
+  const outreachCount = summaryQuery.data?.counts.outreachInteractions ?? 0
+  const approvalCount = summaryQuery.data?.counts.humanApprovals ?? 0
+
+  const handleTaskClick = (task: ClaudeTask) => {
+    setEditingTask(task)
+  }
+
+  const handleCreateTask = async (input: Parameters<typeof createTask>[0]) => {
+    try {
+      await createTask(input)
+      toast('Task created')
+      void queryClient.invalidateQueries({ queryKey: MC_QUERY_KEY })
+    } catch (e) {
+      toast(e instanceof Error ? e.message : 'Failed to create task', { type: 'error' })
+    }
+  }
+
+  return (
+    <div className="min-h-full overflow-y-auto bg-[var(--theme-bg)]">
+      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-4 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
+        {/* Header */}
+        <header className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className="flex size-10 items-center justify-center rounded-xl"
+              style={{
+                background:
+                  'linear-gradient(135deg, color-mix(in srgb, var(--theme-accent) 20%, transparent), color-mix(in srgb, var(--theme-accent) 8%, transparent))',
+              }}
+            >
+              <HugeiconsIcon
+                icon={Target01Icon}
+                size={20}
+                strokeWidth={1.5}
+                style={{ color: 'var(--theme-accent)' }}
+              />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-[var(--theme-text)]">
+                Mission Control
+              </h1>
+              <p className="text-xs text-[var(--theme-muted)]">
+                SEO / AEO Business Command Center
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => tasksQuery.refetch()}
+            className="rounded-lg p-2 transition-colors hover:bg-[var(--theme-hover)]"
+            title="Refresh"
+          >
+            <HugeiconsIcon
+              icon={RefreshIcon}
+              size={16}
+              className="text-[var(--theme-muted)]"
+            />
+          </button>
+        </header>
+
+        {/* 1. Business Overview Strip */}
+        <BusinessOverviewStrip tasks={tasks} isLoading={tasksQuery.isLoading} />
+
+        {/* 1b. Live Notion Operations Strip */}
+        <NotionOperationsStrip
+          crmCount={crmCount}
+          outreachCount={outreachCount}
+          approvalCount={approvalCount}
+          isLoading={notionLoading}
+          hasError={notionHasError}
+          onOpenSource={(source) => navigate({ to: '/notion', search: { source } })}
+        />
+
+        <SystemOperationsPanel
+          system={systemQuery.data}
+          isLoading={systemQuery.isLoading}
+          hasError={Boolean(systemQuery.error)}
+        />
+
+        {/* 2. Main content grid */}
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          {/* Left column: Needs Attention + Quick Actions */}
+          <div className="flex flex-col gap-4">
+            <NeedsAttentionPanel
+              tasks={tasks}
+              isLoading={tasksQuery.isLoading}
+              onTaskClick={handleTaskClick}
+            />
+            <QuickActions />
+          </div>
+
+          {/* Center + Right: Active Tasks Kanban */}
+          <div className="lg:col-span-2">
+            <CompactKanban
+              tasks={tasks}
+              isLoading={tasksQuery.isLoading}
+              onTaskClick={handleTaskClick}
+            />
+          </div>
+        </div>
+
+        {/* 3. Recent Activity */}
+        <RecentActivity
+          tasks={tasks}
+          isLoading={tasksQuery.isLoading}
+          onTaskClick={handleTaskClick}
+        />
+
+        {/* Task Edit Dialog */}
+        <TaskDialog
+          open={editingTask !== null}
+          onOpenChange={(open) => {
+            if (!open) setEditingTask(null)
+          }}
+          task={editingTask}
+          isSubmitting={false}
+          onSubmit={async () => {
+            // Read-only view for now — could add update mutation
+            setEditingTask(null)
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/screens/notion/notion-browser-screen.tsx
+++ b/src/screens/notion/notion-browser-screen.tsx
@@ -1,0 +1,255 @@
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Building01Icon,
+  DatabaseIcon,
+  LinkSquare02Icon,
+  RefreshIcon,
+  Search01Icon,
+} from '@hugeicons/core-free-icons'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+
+type NotionSource = {
+  name: string
+  id: string
+  databaseId: string
+}
+
+type NotionRecord = {
+  id: string
+  title: string
+  properties: Record<string, string | number | boolean | string[] | null>
+  recordUrl: string
+  createdTime: string
+  lastEditedTime: string
+}
+
+function renderValue(value: NotionRecord['properties'][string]): string {
+  if (Array.isArray(value)) return value.join(', ')
+  if (value === true) return 'Yes'
+  if (value === false) return 'No'
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+function usefulProperties(record: NotionRecord): Array<[string, string]> {
+  return Object.entries(record.properties)
+    .map(([key, value]) => [key, renderValue(value)] as [string, string])
+    .filter(([, value]) => value.trim().length > 0)
+    .slice(0, 10)
+}
+
+export function NotionBrowserScreen() {
+  const initialParams = new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search)
+  const initialSource = initialParams.get('source') || 'CRM / Leads'
+  const initialRecordId = initialParams.get('record') || ''
+  const [selectedSource, setSelectedSource] = useState(initialSource)
+  const [focusedRecordId, setFocusedRecordId] = useState(initialRecordId)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const sourcesQuery = useQuery({
+    queryKey: ['notion', 'sources'],
+    queryFn: async () => {
+      const res = await fetch('/api/notion/sources')
+      if (!res.ok) throw new Error('Failed to fetch Notion source catalog')
+      return res.json() as Promise<{ sources: NotionSource[]; count: number }>
+    },
+    staleTime: 60_000,
+  })
+
+  const sources = sourcesQuery.data?.sources ?? []
+
+  useEffect(() => {
+    if (!sources.length) return
+    if (!sources.some((source) => source.name === selectedSource)) {
+      setSelectedSource(sources[0].name)
+    }
+  }, [selectedSource, sources])
+
+  const recordsQuery = useQuery({
+    queryKey: ['notion', 'query', selectedSource],
+    queryFn: async () => {
+      const params = new URLSearchParams({ source: selectedSource, limit: '100' })
+      const res = await fetch(`/api/notion/query?${params.toString()}`)
+      if (!res.ok) throw new Error('Failed to fetch Notion records')
+      return res.json() as Promise<{ records: NotionRecord[]; count: number; source: string }>
+    },
+    enabled: selectedSource.length > 0,
+    staleTime: 60_000,
+  })
+
+  const records = recordsQuery.data?.records ?? []
+  const filteredRecords = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return records
+    return records.filter((record) => {
+      const haystack = [
+        record.title,
+        ...Object.entries(record.properties).map(([key, value]) => `${key} ${renderValue(value)}`),
+      ]
+        .join(' ')
+        .toLowerCase()
+      return haystack.includes(q)
+    })
+  }, [records, searchQuery])
+
+  const isLoading = sourcesQuery.isLoading || recordsQuery.isLoading
+  const hasError = sourcesQuery.error || recordsQuery.error
+
+  useEffect(() => {
+    if (!focusedRecordId || isLoading) return
+    const el = document.getElementById(`notion-record-${focusedRecordId}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [focusedRecordId, isLoading, filteredRecords])
+
+  return (
+    <div className="min-h-screen bg-[var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4 pb-[calc(var(--tabbar-h,0px)+1rem)] sm:px-6 lg:px-8">
+        <header className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400">
+                <HugeiconsIcon icon={DatabaseIcon} size={22} />
+              </div>
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-blue-400">
+                  Notion Command Center
+                </p>
+                <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[var(--theme-text)]">
+                  Workspace Notion Browser
+                </h1>
+                <p className="mt-1 max-w-2xl text-sm text-[var(--theme-muted)]">
+                  Browse every manifest-backed Notion data source through the Workspace server proxy. Tokens stay server-side.
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void recordsQuery.refetch()}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm font-medium text-[var(--theme-text)] hover:bg-[var(--theme-card-hover)]"
+            >
+              <HugeiconsIcon icon={RefreshIcon} size={15} />
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <section className="grid gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 md:grid-cols-[minmax(220px,320px)_1fr]">
+          <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wider text-[var(--theme-muted)]">
+            Data source
+            <select
+              value={selectedSource}
+              onChange={(event) => {
+                const nextSource = event.target.value
+                setSelectedSource(nextSource)
+                setFocusedRecordId('')
+                window.history.replaceState(null, '', `/notion?${new URLSearchParams({ source: nextSource }).toString()}`)
+              }}
+              className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm normal-case tracking-normal text-[var(--theme-text)] outline-none"
+            >
+              {sources.map((source) => (
+                <option key={source.name} value={source.name}>
+                  {source.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wider text-[var(--theme-muted)]">
+            Search records
+            <div className="flex items-center gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+              <HugeiconsIcon icon={Search01Icon} size={15} />
+              <input
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search titles, statuses, notes, relations..."
+                className="min-w-0 flex-1 bg-transparent text-sm normal-case tracking-normal text-[var(--theme-text)] outline-none placeholder:text-[var(--theme-muted)]"
+              />
+            </div>
+          </label>
+        </section>
+
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+            <p className="text-xl font-semibold">{sourcesQuery.data?.count ?? sources.length}</p>
+            <p className="text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">Sources</p>
+          </div>
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+            <p className="text-xl font-semibold">{recordsQuery.data?.count ?? records.length}</p>
+            <p className="text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">Loaded Records</p>
+          </div>
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+            <p className="text-xl font-semibold">{filteredRecords.length}</p>
+            <p className="text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">Visible</p>
+          </div>
+          <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+            <p className="text-xl font-semibold text-green-400">{hasError ? 'Check' : isLoading ? 'Loading' : 'Live'}</p>
+            <p className="text-[10px] uppercase tracking-wider text-[var(--theme-muted)]">Connection</p>
+          </div>
+        </div>
+
+        {hasError && (
+          <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-300">
+            Could not load Notion data. Check server logs, manifest access, and integration sharing.
+          </div>
+        )}
+
+        <section className="grid gap-3">
+          {isLoading ? (
+            <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-center text-sm text-[var(--theme-muted)]">
+              Loading Notion records...
+            </div>
+          ) : filteredRecords.length === 0 ? (
+            <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-center text-sm text-[var(--theme-muted)]">
+              No records matched this view.
+            </div>
+          ) : (
+            filteredRecords.map((record) => {
+              const isFocused = focusedRecordId === record.id
+              return (
+              <article
+                key={record.id}
+                id={`notion-record-${record.id}`}
+                className={`rounded-xl border bg-[var(--theme-card)] p-4 ${isFocused ? 'border-blue-400 ring-2 ring-blue-400/30' : 'border-[var(--theme-border)]'}`}
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
+                      <HugeiconsIcon icon={Building01Icon} size={13} />
+                      {selectedSource}
+                    </div>
+                    <h2 className="mt-1 truncate text-lg font-semibold text-[var(--theme-text)]">
+                      {record.title}
+                    </h2>
+                  </div>
+                  {record.recordUrl && (
+                    <a
+                      href={record.recordUrl}
+                      onClick={() => setFocusedRecordId(record.id)}
+                      className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-blue-500/40 px-3 py-2 text-xs font-medium text-blue-300 hover:text-blue-200"
+                    >
+                      <HugeiconsIcon icon={LinkSquare02Icon} size={14} />
+                      Copyable Workspace Link
+                    </a>
+                  )}
+                </div>
+                <dl className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                  {usefulProperties(record).map(([key, value]) => (
+                    <div key={key} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3">
+                      <dt className="text-[10px] font-semibold uppercase tracking-wider text-[var(--theme-muted)]">
+                        {key}
+                      </dt>
+                      <dd className="mt-1 break-words text-sm text-[var(--theme-text)]">
+                        {value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </article>
+              )
+            })
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/outreach/outreach-screen.tsx
+++ b/src/screens/outreach/outreach-screen.tsx
@@ -1,0 +1,678 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Add01Icon,
+  ArrowRight01Icon,
+  Building01Icon,
+  Calendar01Icon,
+  Money01Icon,
+  Mail01Icon,
+  Search01Icon,
+  Target01Icon,
+  UserIcon,
+  UserMultipleIcon,
+} from '@hugeicons/core-free-icons'
+import { cn } from '@/lib/utils'
+import {
+  PIPELINE_STAGES,
+  PRIORITY_COLORS,
+  formatCurrency,
+  formatRelativeDate,
+  getLeadsByStage,
+  getPipelineStats,
+  type LeadPriority,
+  type OutreachActivity,
+  type OutreachLead,
+  type PipelineStage,
+} from '@/lib/outreach-data'
+import { useQuery } from '@tanstack/react-query'
+
+// --- Stat Card ---
+
+function StatCard({
+  icon,
+  label,
+  value,
+  subValue,
+  accentColor,
+}: {
+  icon: typeof UserIcon
+  label: string
+  value: string | number
+  subValue?: string
+  accentColor?: string
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4 flex items-start gap-3">
+      <div
+        className="flex items-center justify-center rounded-lg size-10 shrink-0"
+        style={{
+          background: accentColor
+            ? `${accentColor}18`
+            : 'var(--theme-hover)',
+        }}
+      >
+        <HugeiconsIcon
+          icon={icon}
+          size={20}
+          className="text-[var(--theme-accent)]"
+        />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs text-[var(--theme-muted)]">{label}</p>
+        <p className="text-xl font-semibold text-[var(--theme-text)] truncate">
+          {value}
+        </p>
+        {subValue && (
+          <p className="text-xs text-[var(--theme-muted)] mt-0.5">{subValue}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// --- Lead Card ---
+
+function LeadCard({
+  lead,
+  isExpanded,
+  onToggle,
+}: {
+  lead: OutreachLead
+  isExpanded: boolean
+  onToggle: () => void
+}) {
+  const priorityColor = PRIORITY_COLORS[lead.priority]
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -6 }}
+      className={cn(
+        'rounded-lg border bg-[var(--theme-card)] cursor-pointer transition-all',
+        'hover:border-[var(--theme-accent)]',
+        isExpanded
+          ? 'border-[var(--theme-accent)]'
+          : 'border-[var(--theme-border)]',
+      )}
+      onClick={onToggle}
+    >
+      <div className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h4 className="text-sm font-medium text-[var(--theme-text)] truncate">
+                {lead.company}
+              </h4>
+              <span
+                className="shrink-0 w-2 h-2 rounded-full"
+                style={{ background: priorityColor }}
+                title={`${lead.priority} priority`}
+              />
+            </div>
+            <p className="text-xs text-[var(--theme-muted)] mt-0.5 truncate">
+              {lead.contactName} · {lead.contactTitle}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 mt-2 flex-wrap">
+          {lead.tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--theme-hover)] text-[var(--theme-muted)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between mt-2.5 text-[11px] text-[var(--theme-muted)]">
+          <div className="flex items-center gap-1">
+            <HugeiconsIcon icon={UserIcon} size={12} />
+            <span className="capitalize">{lead.assignedAgent}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <HugeiconsIcon icon={Calendar01Icon} size={12} />
+            <span>{formatRelativeDate(lead.lastInteraction)}</span>
+          </div>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="px-3 pb-3 pt-0 border-t border-[var(--theme-border)] space-y-2">
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)] pt-2">
+                <HugeiconsIcon icon={Mail01Icon} size={13} />
+                <span className="truncate">{lead.contactEmail}</span>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
+                <HugeiconsIcon icon={Building01Icon} size={13} />
+                <span className="truncate">{lead.website}</span>
+              </div>
+              {lead.estimatedValue && (
+                <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
+                  <HugeiconsIcon icon={Money01Icon} size={13} />
+                  <span>{formatCurrency(lead.estimatedValue)} ACV</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)]">
+                <HugeiconsIcon icon={Target01Icon} size={13} />
+                <span>Source: {lead.source}</span>
+              </div>
+              <p className="text-xs text-[var(--theme-muted)] leading-relaxed mt-1">
+                {lead.notes}
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
+// --- Pipeline Column ---
+
+function PipelineColumn({
+  stage,
+  leads,
+  expandedId,
+  onToggleExpand,
+}: {
+  stage: (typeof PIPELINE_STAGES)[number]
+  leads: Array<OutreachLead>
+  expandedId: string | null
+  onToggleExpand: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-col rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] min-w-[220px] w-full shrink-0 flex-1">
+      {/* Column header */}
+      <div
+        className="flex items-center justify-between px-3 py-2.5 border-b border-[var(--theme-border)] rounded-t-xl"
+        style={{
+          borderTopWidth: 2,
+          borderTopColor: stage.color,
+          borderTopStyle: 'solid',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ background: stage.color }}
+          />
+          <span className="text-xs font-semibold text-[var(--theme-text)]">
+            {stage.label}
+          </span>
+          <span className="text-xs text-[var(--theme-muted)]">
+            ({leads.length})
+          </span>
+        </div>
+      </div>
+
+      {/* Cards */}
+      <div className="flex flex-col gap-2 p-2 flex-1 overflow-y-auto min-h-[60px]">
+        <AnimatePresence initial={false}>
+          {leads.length === 0 ? (
+            <motion.div
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="flex flex-col items-center justify-center py-6 gap-1 text-[var(--theme-muted)] opacity-50"
+            >
+              <p className="text-[11px]">No leads</p>
+            </motion.div>
+          ) : (
+            leads.map((lead) => (
+              <LeadCard
+                key={lead.id}
+                lead={lead}
+                isExpanded={expandedId === lead.id}
+                onToggle={() => onToggleExpand(lead.id)}
+              />
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+// --- Activity Item ---
+
+function ActivityItem({ activity }: { activity: OutreachActivity }) {
+  const typeIcons: Record<OutreachActivity['type'], typeof Mail01Icon> = {
+    email_sent: Mail01Icon,
+    email_opened: Mail01Icon,
+    call_made: UserIcon,
+    meeting_scheduled: Calendar01Icon,
+    proposal_sent: Target01Icon,
+    proposal_viewed: Target01Icon,
+    follow_up: ArrowRight01Icon,
+    note_added: Add01Icon,
+  }
+
+  const typeLabels: Record<string, string> = {
+    email_sent: 'Email sent',
+    email_opened: 'Email opened',
+    call_made: 'Call made',
+    meeting_scheduled: 'Meeting scheduled',
+    proposal_sent: 'Proposal sent',
+    proposal_viewed: 'Proposal viewed',
+    follow_up: 'Follow-up',
+    note_added: 'Note added',
+  }
+
+  const Icon = typeIcons[activity.type] ?? Mail01Icon
+
+  return (
+    <div className="flex items-start gap-3 py-2.5 border-b border-[var(--theme-border)] last:border-b-0">
+      <div className="flex items-center justify-center rounded-full size-7 shrink-0 bg-[var(--theme-hover)]">
+        <HugeiconsIcon icon={Icon} size={13} className="text-[var(--theme-muted)]" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-[var(--theme-text)]">
+            {typeLabels[activity.type]}
+          </span>
+          <span className="text-[10px] text-[var(--theme-muted)]">
+            {formatRelativeDate(activity.timestamp)}
+          </span>
+        </div>
+        <p className="text-[11px] text-[var(--theme-muted)] mt-0.5 truncate">
+          {activity.leadCompany}
+        </p>
+        <p className="text-[11px] text-[var(--theme-muted)] mt-0.5 leading-relaxed">
+          {activity.description}
+        </p>
+        <p className="text-[10px] text-[var(--theme-muted)] mt-1 opacity-70">
+          by {activity.agent}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// --- Notion CRM Lead type (subset of fields we display) ---
+
+interface NotionCrmLead {
+  id: string
+  company: string
+  contactName: string
+  contactEmail: string
+  contactPhone: string
+  website: string
+  city: string
+  state: string
+  leadScore: number | null
+  outreachStatus: string
+  replyStatus: string
+  dealStage: string
+  recommendedPackage: string
+  packageSold: string
+  dealValue: number | null
+  monthlyRetainer: number | null
+  paymentStatus: string
+  clientStage: string
+  accessStatus: string
+  clientHealth: string
+  seoOpportunity: boolean
+  aeoOpportunity: boolean
+  gbpOpportunity: boolean
+  followUpCount: number | null
+  nextCheckIn: string
+  nextReportDue: string
+  reportingCadence: string
+  source: string
+  notes: string
+  lastVerified: string
+  dataConfidence: string
+  recordUrl: string
+}
+
+interface NotionOutreachItem {
+  id: string
+  title: string
+  type: string
+  status: string
+  relatedLeadIds: string[]
+  relatedDealIds: string[]
+  date: string
+  nextFollowUp: string
+  agent: string
+  description: string
+  channel: string
+  recordUrl: string
+  createdTime: string
+}
+
+function interactionTypeToActivityType(type: string, channel: string): OutreachActivity['type'] {
+  const normalized = `${type} ${channel}`.toLowerCase()
+  if (normalized.includes('proposal') && normalized.includes('view')) return 'proposal_viewed'
+  if (normalized.includes('proposal')) return 'proposal_sent'
+  if (normalized.includes('meeting')) return 'meeting_scheduled'
+  if (normalized.includes('call')) return 'call_made'
+  if (normalized.includes('follow')) return 'follow_up'
+  if (normalized.includes('note')) return 'note_added'
+  if (normalized.includes('open') || normalized.includes('view')) return 'email_opened'
+  return 'email_sent'
+}
+
+function outreachItemToActivity(
+  item: NotionOutreachItem,
+  leadsById: Map<string, NotionCrmLead>,
+): OutreachActivity {
+  const relatedLead = item.relatedLeadIds.map((id) => leadsById.get(id)).find(Boolean)
+  return {
+    id: item.id,
+    leadId: relatedLead?.id ?? item.relatedLeadIds[0] ?? '',
+    leadCompany: relatedLead?.company || item.title || 'Notion interaction',
+    type: interactionTypeToActivityType(item.type || item.status, item.channel),
+    description: item.description || item.title || item.status || 'Notion outreach interaction',
+    timestamp: item.date || item.nextFollowUp || item.createdTime || new Date().toISOString(),
+    agent: item.agent || 'Notion',
+  }
+}
+
+function crmToOutreachLead(crm: NotionCrmLead): OutreachLead {
+  const stageMap: Record<string, PipelineStage> = {
+    'New': 'leads',
+    'Contacted': 'contacted',
+    'Responded': 'responded',
+    'Meeting Set': 'meeting_set',
+    'Proposal Sent': 'proposal_sent',
+    'Won': 'closed',
+    'Lost': 'closed',
+  }
+  const priority: LeadPriority = (crm.dealValue ?? 0) > 20000 ? 'high' : (crm.dealValue ?? 0) > 5000 ? 'medium' : 'low'
+  return {
+    id: crm.id,
+    company: crm.company,
+    contactName: crm.contactName,
+    contactEmail: crm.contactEmail,
+    contactTitle: '',
+    website: crm.website,
+    stage: stageMap[crm.dealStage] || 'leads',
+    priority,
+    assignedAgent: 'orchestrator',
+    lastInteraction: crm.nextCheckIn || crm.lastVerified || new Date().toISOString(),
+    notes: crm.notes || '',
+    tags: [crm.outreachStatus, crm.dealStage].filter(Boolean),
+    estimatedValue: crm.dealValue,
+    source: crm.source || 'Notion CRM',
+  }
+}
+
+// --- Main Screen ---
+
+export function OutreachScreen() {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedStage, setSelectedStage] = useState<PipelineStage | 'all'>('all')
+
+  const crmQuery = useQuery({
+    queryKey: ['notion', 'crm'],
+    queryFn: async () => {
+      const res = await fetch('/api/notion/crm')
+      if (!res.ok) throw new Error('Failed to fetch CRM data')
+      return res.json() as Promise<{ leads: NotionCrmLead[]; count: number }>
+    },
+    staleTime: 60_000,
+  })
+
+  const interactionsQuery = useQuery({
+    queryKey: ['notion', 'outreach'],
+    queryFn: async () => {
+      const res = await fetch('/api/notion/outreach')
+      if (!res.ok) throw new Error('Failed to fetch outreach interactions')
+      return res.json() as Promise<{ items: NotionOutreachItem[]; count: number }>
+    },
+    staleTime: 60_000,
+  })
+
+  const notionLeads = crmQuery.data?.leads ?? []
+  const notionInteractions = interactionsQuery.data?.items ?? []
+  const leads = useMemo(() => notionLeads.map(crmToOutreachLead), [notionLeads])
+  const activities = useMemo(() => {
+    const leadsById = new Map(notionLeads.map((lead) => [lead.id, lead]))
+    return notionInteractions
+      .map((item) => outreachItemToActivity(item, leadsById))
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+  }, [notionInteractions, notionLeads])
+  const isLoading = crmQuery.isLoading || interactionsQuery.isLoading
+  const hasNotionError = crmQuery.error || interactionsQuery.error
+
+  const stats = useMemo(() => getPipelineStats(leads), [leads])
+
+  const filteredLeads = useMemo(() => {
+    let result = leads
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(
+        (l) =>
+          l.company.toLowerCase().includes(q) ||
+          l.contactName.toLowerCase().includes(q) ||
+          l.tags.some((t) => t.toLowerCase().includes(q)),
+      )
+    }
+    if (selectedStage !== 'all') {
+      result = result.filter((l) => l.stage === selectedStage)
+    }
+    return result
+  }, [searchQuery, selectedStage, leads])
+
+  const leadsByStage = useMemo(
+    () => getLeadsByStage(filteredLeads),
+    [filteredLeads],
+  )
+
+  const visibleStages =
+    selectedStage === 'all'
+      ? PIPELINE_STAGES
+      : PIPELINE_STAGES.filter((s) => s.id === selectedStage)
+
+  return (
+    <div className="min-h-full overflow-y-auto bg-[var(--theme-bg)] text-[var(--theme-text)]">
+      <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-5 px-4 py-6 pb-[calc(var(--tabbar-h,80px)+1.5rem)] sm:px-6 lg:px-8">
+        {/* Header */}
+        <header className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              <h1 className="text-2xl font-medium text-[var(--theme-text)]">
+                Outreach Pipeline
+              </h1>
+              <div className="flex items-center gap-2 text-xs text-[var(--theme-muted)] flex-wrap">
+                {isLoading ? (
+                  <span className="rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] border-[var(--theme-border)] text-[var(--theme-muted)]">
+                    Loading...
+                  </span>
+                ) : hasNotionError ? (
+                  <span className="rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] border-red-500/50 text-red-400">
+                    Connection error
+                  </span>
+                ) : (
+                  <span className="rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] border-green-500/50 text-green-400">
+                    Live · Notion
+                  </span>
+                )}
+                <span>{stats.total} leads</span>
+                <span>·</span>
+                <span>{stats.activeOutreach} active</span>
+                <span>·</span>
+                <span>{stats.conversionRate}% conversion</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => window.location.assign('/notion')}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--theme-accent)] text-white text-sm font-medium hover:opacity-90"
+            >
+              <HugeiconsIcon icon={Add01Icon} size={14} />
+              Browse Notion
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-[var(--theme-muted)]">
+            Live data from Notion CRM / Leads ({notionLeads.length} records). Refreshes every 60s.
+          </p>
+        </header>
+
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-12 gap-3 text-[var(--theme-muted)]">
+            <div className="w-5 h-5 border-2 border-[var(--theme-border)] border-t-[var(--theme-accent)] rounded-full animate-spin" />
+            <span className="text-sm">Loading leads from Notion...</span>
+          </div>
+        )}
+
+        {/* Error state */}
+        {hasNotionError && (
+          <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-300">
+            Could not load all live Notion data. CRM and interactions will retry automatically.
+          </div>
+        )}
+
+        {/* Stats Row */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <StatCard
+            icon={UserMultipleIcon}
+            label="Total Leads"
+            value={stats.total}
+            subValue={`${stats.byStage.leads.length} new`}
+            accentColor="#3b82f6"
+          />
+          <StatCard
+            icon={Target01Icon}
+            label="Active Outreach"
+            value={stats.activeOutreach}
+            subValue={`${stats.byStage.contacted.length} contacted`}
+            accentColor="#f59e0b"
+          />
+          <StatCard
+            icon={ArrowRight01Icon}
+            label="Conversion Rate"
+            value={`${stats.conversionRate}%`}
+            subValue={`${stats.byStage.proposal_sent.length + stats.byStage.closed.length} proposals`}
+            accentColor="#a855f7"
+          />
+          <StatCard
+            icon={Money01Icon}
+            label="Pipeline Value"
+            value={formatCurrency(stats.totalPipelineValue)}
+            subValue={`${formatCurrency(stats.closedValue)} closed`}
+            accentColor="#22c55e"
+          />
+        </div>
+
+        {/* Search and Filter Bar */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 min-w-[200px]">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--theme-muted)]"
+            />
+            <input
+              type="text"
+              placeholder="Search leads by company, contact, or tag..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] pl-9 pr-3 py-2 text-xs text-[var(--theme-text)] placeholder:text-[var(--theme-muted)] focus:outline-none focus:border-[var(--theme-accent)] transition-colors"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <button
+              onClick={() => setSelectedStage('all')}
+              className={cn(
+                'text-xs px-2.5 py-1.5 rounded-lg border transition-colors',
+                selectedStage === 'all'
+                  ? 'border-[var(--theme-accent)] text-[var(--theme-accent)] bg-[var(--theme-hover)]'
+                  : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-[var(--theme-text)] hover:border-[var(--theme-accent)]',
+              )}
+            >
+              All
+            </button>
+            {PIPELINE_STAGES.map((stage) => (
+              <button
+                key={stage.id}
+                onClick={() => setSelectedStage(stage.id)}
+                className={cn(
+                  'text-xs px-2.5 py-1.5 rounded-lg border transition-colors flex items-center gap-1.5',
+                  selectedStage === stage.id
+                    ? 'border-[var(--theme-accent)] text-[var(--theme-accent)] bg-[var(--theme-hover)]'
+                    : 'border-[var(--theme-border)] text-[var(--theme-muted)] hover:text-[var(--theme-text)] hover:border-[var(--theme-accent)]',
+                )}
+              >
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ background: stage.color }}
+                />
+                {stage.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Pipeline Board + Activity Feed */}
+        <div className="flex gap-4 flex-col xl:flex-row">
+          {/* Pipeline Board */}
+          <div className="flex-1 min-w-0">
+            <div className="flex gap-3 overflow-x-auto p-1 pb-4">
+              {visibleStages.map((stage) => (
+                <PipelineColumn
+                  key={stage.id}
+                  stage={stage}
+                  leads={leadsByStage[stage.id]}
+                  expandedId={expandedId}
+                  onToggleExpand={(id) =>
+                    setExpandedId((prev) => (prev === id ? null : id))
+                  }
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Recent Activity Sidebar */}
+          <div className="w-full xl:w-[320px] shrink-0">
+            <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)]">
+              <div className="px-4 py-3 border-b border-[var(--theme-border)]">
+                <h3 className="text-sm font-semibold text-[var(--theme-text)]">
+                  Recent Activity
+                </h3>
+                <p className="text-[11px] text-[var(--theme-muted)] mt-0.5">
+                  Live from Notion Outreach / Interactions ({activities.length})
+                </p>
+              </div>
+              <div className="max-h-[520px] overflow-y-auto px-4">
+                {interactionsQuery.isLoading ? (
+                  <div className="py-6 text-center text-xs text-[var(--theme-muted)]">
+                    Loading interactions from Notion...
+                  </div>
+                ) : activities.length === 0 ? (
+                  <div className="py-6 text-center text-xs text-[var(--theme-muted)]">
+                    No outreach interactions yet.
+                  </div>
+                ) : (
+                  activities.slice(0, 12).map((activity) => (
+                    <ActivityItem key={activity.id} activity={activity} />
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/tasks/task-dialog.tsx
+++ b/src/screens/tasks/task-dialog.tsx
@@ -15,12 +15,12 @@ type Props = {
   onOpenChange: (open: boolean) => void
   task?: ClaudeTask | null
   defaultColumn?: TaskColumn
-  assignees: Array<TaskAssignee>
+  assignees?: Array<TaskAssignee>
   onSubmit: (input: CreateTaskInput) => Promise<void>
   isSubmitting: boolean
 }
 
-export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees, onSubmit, isSubmitting }: Props) {
+export function TaskDialog({ open, onOpenChange, task, defaultColumn, assignees = [], onSubmit, isSubmitting }: Props) {
   const isEdit = Boolean(task)
 
   const [title, setTitle] = useState('')

--- a/src/server/hermes-config-migration.ts
+++ b/src/server/hermes-config-migration.ts
@@ -1,4 +1,10 @@
-export type HermesProviderKind = 'oauth' | 'api_key' | 'local' | 'custom'
+export type HermesProviderKind =
+  | 'oauth'
+  | 'api_key'
+  | 'local'
+  | 'custom'
+  | 'external'
+  | 'sdk'
 
 export type HermesAuthSource =
   | 'env'
@@ -85,14 +91,41 @@ export type NormalizeHermesConfigInput = {
 
 export const HERMES_PROVIDER_CATALOG: Array<ProviderDef> = [
   { id: 'nous', name: 'Nous Portal', kind: 'oauth', envKeys: [], models: [] },
-  { id: 'openai-codex', name: 'OpenAI Codex', kind: 'oauth', envKeys: [], models: [] },
-  { id: 'anthropic', name: 'Anthropic', kind: 'api_key', envKeys: ['ANTHROPIC_API_KEY'], models: [] },
   { id: 'openrouter', name: 'OpenRouter', kind: 'api_key', envKeys: ['OPENROUTER_API_KEY'], models: [] },
-  { id: 'zai', name: 'Z.AI / GLM', kind: 'api_key', envKeys: ['GLM_API_KEY'], models: [] },
-  { id: 'kimi-coding', name: 'Kimi', kind: 'api_key', envKeys: ['KIMI_API_KEY'], models: [] },
-  { id: 'minimax', name: 'MiniMax', kind: 'api_key', envKeys: ['MINIMAX_API_KEY'], models: [] },
-  { id: 'minimax-cn', name: 'MiniMax (China)', kind: 'api_key', envKeys: ['MINIMAX_CN_API_KEY'], models: [] },
+  { id: 'novita', name: 'NovitaAI', kind: 'api_key', envKeys: ['NOVITA_API_KEY'], models: [] },
+  { id: 'lmstudio', name: 'LM Studio', kind: 'local', envKeys: ['LM_API_KEY'], models: [] },
+  { id: 'anthropic', name: 'Anthropic', kind: 'api_key', envKeys: ['ANTHROPIC_API_KEY', 'ANTHROPIC_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'], models: [] },
+  { id: 'openai-codex', name: 'OpenAI Codex', kind: 'oauth', envKeys: [], models: [] },
+  { id: 'openai-api', name: 'OpenAI API', kind: 'api_key', envKeys: ['OPENAI_API_KEY'], models: [] },
+  { id: 'alibaba', name: 'Qwen Cloud / DashScope', kind: 'api_key', envKeys: ['DASHSCOPE_API_KEY'], models: [] },
+  { id: 'alibaba-coding-plan', name: 'Alibaba Cloud (Coding Plan)', kind: 'api_key', envKeys: ['ALIBABA_CODING_PLAN_API_KEY', 'DASHSCOPE_API_KEY'], models: [] },
+  { id: 'xai-oauth', name: 'xAI Grok OAuth', kind: 'oauth', envKeys: [], models: [] },
   { id: 'xiaomi', name: 'Xiaomi MiMo', kind: 'api_key', envKeys: ['XIAOMI_API_KEY'], models: [] },
+  { id: 'tencent-tokenhub', name: 'Tencent TokenHub', kind: 'api_key', envKeys: ['TOKENHUB_API_KEY'], models: [] },
+  { id: 'nvidia', name: 'NVIDIA NIM', kind: 'api_key', envKeys: ['NVIDIA_API_KEY'], models: [] },
+  { id: 'copilot', name: 'GitHub Copilot', kind: 'api_key', envKeys: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'], models: [] },
+  { id: 'copilot-acp', name: 'GitHub Copilot ACP', kind: 'external', envKeys: [], models: [] },
+  { id: 'huggingface', name: 'Hugging Face', kind: 'api_key', envKeys: ['HF_TOKEN'], models: [] },
+  { id: 'gemini', name: 'Google AI Studio', kind: 'api_key', envKeys: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'], models: [] },
+  { id: 'google-gemini-cli', name: 'Google Gemini (OAuth)', kind: 'oauth', envKeys: [], models: [] },
+  { id: 'deepseek', name: 'DeepSeek', kind: 'api_key', envKeys: ['DEEPSEEK_API_KEY'], models: [] },
+  { id: 'xai', name: 'xAI', kind: 'api_key', envKeys: ['XAI_API_KEY'], models: [] },
+  { id: 'zai', name: 'Z.AI / GLM', kind: 'api_key', envKeys: ['GLM_API_KEY', 'ZAI_API_KEY', 'Z_AI_API_KEY'], models: [] },
+  { id: 'kimi-coding', name: 'Kimi / Moonshot', kind: 'api_key', envKeys: ['KIMI_API_KEY', 'KIMI_CODING_API_KEY'], models: [] },
+  { id: 'kimi-coding-cn', name: 'Kimi / Moonshot (China)', kind: 'api_key', envKeys: ['KIMI_CN_API_KEY'], models: [] },
+  { id: 'stepfun', name: 'StepFun Step Plan', kind: 'api_key', envKeys: ['STEPFUN_API_KEY'], models: [] },
+  { id: 'minimax', name: 'MiniMax', kind: 'api_key', envKeys: ['MINIMAX_API_KEY'], models: [] },
+  { id: 'minimax-oauth', name: 'MiniMax (OAuth)', kind: 'oauth', envKeys: [], models: [] },
+  { id: 'minimax-cn', name: 'MiniMax (China)', kind: 'api_key', envKeys: ['MINIMAX_CN_API_KEY'], models: [] },
+  { id: 'ollama-cloud', name: 'Ollama Cloud', kind: 'api_key', envKeys: ['OLLAMA_API_KEY'], models: [] },
+  { id: 'arcee', name: 'Arcee AI', kind: 'api_key', envKeys: ['ARCEEAI_API_KEY'], models: [] },
+  { id: 'gmi', name: 'GMI Cloud', kind: 'api_key', envKeys: ['GMI_API_KEY'], models: [] },
+  { id: 'kilocode', name: 'Kilo Code', kind: 'api_key', envKeys: ['KILOCODE_API_KEY'], models: [] },
+  { id: 'opencode-zen', name: 'OpenCode Zen', kind: 'api_key', envKeys: ['OPENCODE_ZEN_API_KEY'], models: [] },
+  { id: 'opencode-go', name: 'OpenCode Go', kind: 'api_key', envKeys: ['OPENCODE_GO_API_KEY'], models: [] },
+  { id: 'bedrock', name: 'AWS Bedrock', kind: 'sdk', envKeys: [], models: [] },
+  { id: 'azure-foundry', name: 'Azure Foundry', kind: 'api_key', envKeys: ['AZURE_FOUNDRY_API_KEY'], models: [] },
+  { id: 'qwen-oauth', name: 'Qwen OAuth', kind: 'oauth', envKeys: [], models: [] },
   { id: 'ollama', name: 'Ollama', kind: 'local', envKeys: [], models: [] },
   { id: 'atomic-chat', name: 'Atomic Chat', kind: 'local', envKeys: [], models: [] },
   { id: 'custom', name: 'Custom', kind: 'custom', envKeys: ['CUSTOM_API_KEY'], models: [] },

--- a/src/server/hermes-config-route.ts
+++ b/src/server/hermes-config-route.ts
@@ -72,8 +72,9 @@ const LegacyPatchSchema = z.object({
 })
 
 async function authorize(request: Request): Promise<AuthResult> {
-  const result = isAuthenticated(request) as AuthResult
-  if (result !== true) return result
+  if (!isAuthenticated(request)) {
+    return Response.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
   await ensureGatewayProbed()
   return true
 }

--- a/src/server/mission-control-system.ts
+++ b/src/server/mission-control-system.ts
@@ -1,0 +1,269 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFile } from 'node:child_process'
+
+export type IntegrationStatus = 'live' | 'degraded' | 'blocked' | 'not_configured'
+
+export type MissionControlSystemSnapshot = {
+  generatedAt: string
+  integrations: Array<{
+    id: string
+    label: string
+    status: IntegrationStatus
+    lastCheckedAt: string
+    detail: string
+    evidence?: string
+    directAction?: string
+  }>
+  apple: {
+    calendar: { status: IntegrationStatus; todayCount: number | null; detail: string; lastCheckedAt: string }
+    reminders: { status: IntegrationStatus; openCount: number | null; overdueCount: number | null; detail: string; lastCheckedAt: string }
+  }
+  obsidian: {
+    status: IntegrationStatus
+    vaultPath: string
+    recentNotes: Array<{ name: string; path: string; updatedAt: string; uri: string }>
+  }
+  hermes: {
+    status: IntegrationStatus
+    version: string | null
+    cron: { total: number; active: number; failed: number; nextRunAt: string | null }
+    providers: Array<{ provider: string; status: IntegrationStatus; detail: string }>
+    modelWarnings: Array<{ severity: 'info' | 'warn' | 'error'; detail: string; evidence: string }>
+  }
+  infrastructure: {
+    host: string
+    platform: string
+    uptimeSeconds: number
+    memory: { totalBytes: number; freeBytes: number }
+    disk: { mount: string; capacity: string; used: string; available: string } | null
+  }
+  approvals: Array<{ action: string; reason: string; required: true }>
+  privacy: { redaction: 'enabled'; secretDisplay: 'status-only'; externalExposure: 'local-only' }
+}
+
+type CommandResult = { ok: boolean; stdout: string; stderr: string }
+
+const HERMES_HOME = process.env.HERMES_HOME?.trim() || path.join(os.homedir(), '.hermes')
+const DEFAULT_VAULT = path.join(os.homedir(), 'Documents/Obsidian Vault/Bethanys Second Brain')
+
+export function redactSensitive(value: string): string {
+  return value
+    .replace(/(Bearer|Zoho-oauthtoken)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 [REDACTED]')
+    .replace(/([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CLIENT_SECRET)[A-Z0-9_]*\s*=\s*)[^\s"']+/gi, '$1[REDACTED]')
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, 'sk-[REDACTED]')
+    .replace(/[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/g, '[REDACTED_TOKEN]')
+}
+
+function readEnvKeys(): Set<string> {
+  const envPath = path.join(HERMES_HOME, '.env')
+  const keys = new Set<string>()
+  try {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq > 0) keys.add(trimmed.slice(0, eq).trim())
+    }
+  } catch {
+    // missing env is okay; status endpoint reports not_configured
+  }
+  for (const key of Object.keys(process.env)) keys.add(key)
+  return keys
+}
+
+function command(file: string, args: string[], timeoutMs = 4_000): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    const child = execFile(file, args, { timeout: timeoutMs, maxBuffer: 256_000 }, (error, stdout, stderr) => {
+      resolve({ ok: !error, stdout: redactSensitive(String(stdout || '')), stderr: redactSensitive(String(stderr || '')) })
+    })
+    child.on('error', (err) => resolve({ ok: false, stdout: '', stderr: err.message }))
+  })
+}
+
+function readJson(filePath: string): unknown | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function isoFromMs(ms: number): string {
+  return new Date(ms).toISOString()
+}
+
+function obsidianUri(vaultPath: string, notePath: string): string {
+  const rel = path.relative(vaultPath, notePath).replace(/\\/g, '/')
+  return `obsidian://open?vault=${encodeURIComponent(path.basename(vaultPath))}&file=${encodeURIComponent(rel)}`
+}
+
+function getRecentObsidianNotes(vaultPath: string) {
+  const notes: Array<{ file: string; mtimeMs: number }> = []
+  const skip = new Set(['.obsidian', '.trash', 'node_modules'])
+  const walk = (dir: string, depth: number) => {
+    if (depth > 5 || notes.length > 500) return
+    let entries: fs.Dirent[] = []
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return }
+    for (const entry of entries) {
+      if (skip.has(entry.name)) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full, depth + 1)
+      else if (entry.isFile() && entry.name.endsWith('.md')) {
+        try { notes.push({ file: full, mtimeMs: fs.statSync(full).mtimeMs }) } catch {}
+      }
+    }
+  }
+  walk(vaultPath, 0)
+  return notes
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, 8)
+    .map((n) => ({ name: path.basename(n.file), path: n.file, updatedAt: isoFromMs(n.mtimeMs), uri: obsidianUri(vaultPath, n.file) }))
+}
+
+async function getAppleSnapshot(now: string): Promise<MissionControlSystemSnapshot['apple']> {
+  const calendarScript = 'tell application "Calendar"\nset startDate to current date\nset hours of startDate to 0\nset minutes of startDate to 0\nset seconds of startDate to 0\nset endDate to startDate + 1 * days\nset eventCount to 0\nrepeat with cal in calendars\nset eventCount to eventCount + (count of (events of cal whose start date ≥ startDate and start date < endDate))\nend repeat\nreturn eventCount\nend tell'
+  const reminderScript = 'tell application "Reminders"\nset openCount to 0\nset overdueCount to 0\nset nowDate to current date\nrepeat with l in lists\nrepeat with r in reminders of l whose completed is false\nset openCount to openCount + 1\ntry\nif due date of r is not missing value and due date of r < nowDate then set overdueCount to overdueCount + 1\nend try\nend repeat\nend repeat\nreturn (openCount as text) & "," & (overdueCount as text)\nend tell'
+  const [cal, rem] = await Promise.all([
+    command('/usr/bin/osascript', ['-e', calendarScript], 8_000),
+    command('/usr/bin/osascript', ['-e', reminderScript], 8_000),
+  ])
+  const todayCount = cal.ok ? Number.parseInt(cal.stdout.trim(), 10) : Number.NaN
+  const [openRaw, overdueRaw] = rem.ok ? rem.stdout.trim().split(',') : []
+  return {
+    calendar: {
+      status: Number.isFinite(todayCount) ? 'live' : 'blocked',
+      todayCount: Number.isFinite(todayCount) ? todayCount : null,
+      detail: Number.isFinite(todayCount) ? 'Read from local macOS Calendar via permissioned AppleScript bridge.' : `Calendar bridge blocked or not permitted: ${(cal.stderr || cal.stdout).slice(0, 180)}`,
+      lastCheckedAt: now,
+    },
+    reminders: {
+      status: openRaw ? 'live' : 'blocked',
+      openCount: openRaw ? Number.parseInt(openRaw, 10) : null,
+      overdueCount: overdueRaw ? Number.parseInt(overdueRaw, 10) : null,
+      detail: openRaw ? 'Read from local macOS Reminders via permissioned AppleScript bridge.' : `Reminders bridge blocked or not permitted: ${(rem.stderr || rem.stdout).slice(0, 180)}`,
+      lastCheckedAt: now,
+    },
+  }
+}
+
+function getCronSummary() {
+  const jobs = readJson(path.join(HERMES_HOME, 'cron/jobs.json'))
+  const list = Array.isArray(jobs) ? jobs : Array.isArray((jobs as { jobs?: unknown[] } | null)?.jobs) ? (jobs as { jobs: unknown[] }).jobs : []
+  let active = 0
+  let failed = 0
+  let nextRunAt: string | null = null
+  for (const item of list as Array<Record<string, unknown>>) {
+    if (item.enabled !== false && item.paused !== true) active += 1
+    const status = String(item.last_status || item.status || '').toLowerCase()
+    if (status.includes('fail') || status.includes('error')) failed += 1
+    const candidate = typeof item.next_run_at === 'string' ? item.next_run_at : typeof item.next_run === 'string' ? item.next_run : null
+    if (candidate && (!nextRunAt || candidate < nextRunAt)) nextRunAt = candidate
+  }
+  return { total: list.length, active, failed, nextRunAt }
+}
+
+function tailFile(filePath: string, maxBytes = 180_000): string {
+  try {
+    const stat = fs.statSync(filePath)
+    const fd = fs.openSync(filePath, 'r')
+    const bytes = Math.min(stat.size, maxBytes)
+    const buffer = Buffer.alloc(bytes)
+    fs.readSync(fd, buffer, 0, bytes, Math.max(0, stat.size - bytes))
+    fs.closeSync(fd)
+    return redactSensitive(buffer.toString('utf8'))
+  } catch {
+    return ''
+  }
+}
+
+async function getHermesSnapshot(envKeys: Set<string>): Promise<MissionControlSystemSnapshot['hermes']> {
+  const version = await command(path.join(os.homedir(), '.local/bin/hermes'), ['--version'], 6_000)
+  const cron = getCronSummary()
+  const gatewayLog = tailFile(path.join(HERMES_HOME, 'logs/gateway.error.log')) + '\n' + tailFile(path.join(HERMES_HOME, 'logs/agent.log'))
+  const warnings: MissionControlSystemSnapshot['hermes']['modelWarnings'] = []
+  if (/openrouter[\s\S]{0,200}(402|45 tokens affordable|free-models-per-day|429)/i.test(gatewayLog)) {
+    warnings.push({ severity: 'error', detail: 'OpenRouter fallback is not currently reliable; logs show credit/quota/rate-limit failures.', evidence: 'Redacted gateway logs include OpenRouter 402/429/free quota exhaustion markers.' })
+  }
+  if (/usage_limit_reached/i.test(gatewayLog)) {
+    warnings.push({ severity: 'warn', detail: 'Historical OpenAI Codex usage-limit errors exist in logs; time-scope future incidents before assuming a current limit.', evidence: 'Redacted logs include usage_limit_reached.' })
+  }
+  if (/gpt-5\.6-sol/i.test(gatewayLog)) {
+    warnings.push({ severity: 'info', detail: 'Sol appears in historical errors; current evidence points to OpenRouter route failures for openai/gpt-5.6-sol, not necessarily Codex Sol allowance.', evidence: 'Redacted logs include gpt-5.6-sol with OpenRouter failure markers.' })
+  }
+  const providers = [
+    { provider: 'openai-codex', status: envKeys.has('OPENAI_CODEX_HOME') || fs.existsSync(path.join(HERMES_HOME, 'auth.json')) ? 'live' as const : 'not_configured' as const, detail: 'OAuth credentials are managed by Hermes auth; dashboard displays status only.' },
+    { provider: 'openrouter', status: warnings.some((w) => w.detail.includes('OpenRouter')) ? 'degraded' as const : envKeys.has('OPENROUTER_API_KEY') ? 'live' as const : 'not_configured' as const, detail: warnings.some((w) => w.detail.includes('OpenRouter')) ? 'Configured but recent logs show quota/credit/rate-limit failures.' : 'Status inferred from configured environment key.' },
+    { provider: 'notion', status: envKeys.has('NOTION_API_KEY') || envKeys.has('NOTION_API_TOKEN') ? 'live' as const : 'not_configured' as const, detail: 'Used server-side only through the Notion proxy.' },
+  ]
+  return {
+    status: version.ok ? (warnings.some((w) => w.severity === 'error') ? 'degraded' : 'live') : 'blocked',
+    version: version.ok ? version.stdout.split('\n')[0] || null : null,
+    cron,
+    providers,
+    modelWarnings: warnings,
+  }
+}
+
+function getDiskSnapshot() {
+  try {
+    const out = fs.existsSync('/bin/df') ? null : null
+    void out
+  } catch {}
+  return null
+}
+
+async function getInfrastructureSnapshot(): Promise<MissionControlSystemSnapshot['infrastructure']> {
+  const df = await command('/bin/df', ['-Pk', os.homedir()], 4_000)
+  let disk: MissionControlSystemSnapshot['infrastructure']['disk'] = null
+  if (df.ok) {
+    const line = df.stdout.trim().split('\n')[1]
+    const parts = line?.split(/\s+/) ?? []
+    if (parts.length >= 6) disk = { mount: parts.slice(5).join(' '), capacity: `${parts[1]} KiB`, used: `${parts[2]} KiB`, available: `${parts[3]} KiB` }
+  }
+  getDiskSnapshot()
+  return {
+    host: os.hostname(),
+    platform: `${os.type()} ${os.release()} ${os.arch()}`,
+    uptimeSeconds: Math.round(os.uptime()),
+    memory: { totalBytes: os.totalmem(), freeBytes: os.freemem() },
+    disk,
+  }
+}
+
+export async function buildMissionControlSystemSnapshot(): Promise<MissionControlSystemSnapshot> {
+  const now = new Date().toISOString()
+  const envKeys = readEnvKeys()
+  const [apple, hermes, infrastructure] = await Promise.all([
+    getAppleSnapshot(now),
+    getHermesSnapshot(envKeys),
+    getInfrastructureSnapshot(),
+  ])
+  const vaultPath = process.env.OBSIDIAN_VAULT_PATH?.trim() || DEFAULT_VAULT
+  const recentNotes = fs.existsSync(vaultPath) ? getRecentObsidianNotes(vaultPath) : []
+  const zohoConfigured = ['ZOHO_CLIENT_ID', 'ZOHO_CLIENT_SECRET', 'ZOHO_REFRESH_TOKEN'].some((key) => envKeys.has(key))
+  const integrations = [
+    { id: 'notion', label: 'Notion CRM / operations', status: envKeys.has('NOTION_API_KEY') || envKeys.has('NOTION_API_TOKEN') ? 'live' as const : 'not_configured' as const, lastCheckedAt: now, detail: 'Structured business system of record; queried by existing server-side proxy.', directAction: '/notion' },
+    { id: 'zoho', label: 'Zoho Mail', status: zohoConfigured ? 'degraded' as const : 'not_configured' as const, lastCheckedAt: now, detail: zohoConfigured ? 'Credential markers exist, but full OAuth/account/folder sync is not enabled in this dashboard yet.' : 'No Zoho OAuth credential markers found in the server environment. Email remains blocked until OAuth is configured.', evidence: 'Status is inferred from environment key names only; values are never read into the UI.' },
+    { id: 'calendar', label: 'Apple Calendar', status: apple.calendar.status, lastCheckedAt: now, detail: apple.calendar.detail },
+    { id: 'reminders', label: 'Apple Reminders', status: apple.reminders.status, lastCheckedAt: now, detail: apple.reminders.detail },
+    { id: 'obsidian', label: 'Obsidian vault', status: recentNotes.length > 0 ? 'live' as const : 'blocked' as const, lastCheckedAt: now, detail: recentNotes.length > 0 ? 'Vault is readable; recent notes include verified obsidian:// direct links.' : 'Vault path not readable from this process.', directAction: 'obsidian://open' },
+    { id: 'hermes', label: 'Hermes agents and automations', status: hermes.status, lastCheckedAt: now, detail: `${hermes.cron.active}/${hermes.cron.total} schedules active; ${hermes.modelWarnings.length} model/provider warning(s).`, directAction: '/dashboard' },
+  ]
+  return {
+    generatedAt: now,
+    integrations,
+    apple,
+    obsidian: { status: recentNotes.length > 0 ? 'live' : 'blocked', vaultPath, recentNotes },
+    hermes,
+    infrastructure,
+    approvals: [
+      { action: 'Configure Zoho OAuth and enable message sync', reason: 'Requires OAuth/client credentials and least-privilege scope approval.', required: true },
+      { action: 'Create synthetic Notion/client/calendar/reminder records', reason: 'External writes are consequential and must be explicitly approved before the end-to-end demo writes real systems.', required: true },
+      { action: 'Change production model routing or fallback provider', reason: 'Could affect cost, reliability, and quota behavior.', required: true },
+      { action: 'Expose Mission Control outside localhost/LAN', reason: 'Would expand attack surface; Tailscale/local-only is the safe default.', required: true },
+    ],
+    privacy: { redaction: 'enabled', secretDisplay: 'status-only', externalExposure: 'local-only' },
+  }
+}

--- a/src/server/notion-client.ts
+++ b/src/server/notion-client.ts
@@ -1,0 +1,398 @@
+/**
+ * Notion API client for Hermes Workspace.
+ *
+ * Reads NOTION_API_KEY from ~/.hermes/.env at request time.
+ * The token is never exposed to the client — all requests go through
+ * server-side route handlers.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+const DEFAULT_MANIFEST_PATH =
+  '/Users/escher/Documents/Obsidian Vault/Bethanys Second Brain/03_Projects/SEO-AEO-Service/Tools_Systems/notion_command_center_manifest.json'
+
+const NOTION_API_VERSION = '2025-09-03'
+const NOTION_BASE = 'https://api.notion.com/v1'
+const DEFAULT_CACHE_TTL_MS = 60_000
+const MIN_REQUEST_SPACING_MS = 350
+
+type CacheEntry<T> = {
+  expiresAt: number
+  value: T
+}
+
+const queryCache = new Map<string, CacheEntry<NotionQueryResponse>>()
+const inFlightQueries = new Map<string, Promise<NotionQueryResponse>>()
+let notionQueue: Promise<void> = Promise.resolve()
+let lastNotionRequestAt = 0
+
+export class NotionClientError extends Error {
+  statusCode: number
+  publicMessage: string
+
+  constructor(statusCode: number, publicMessage: string) {
+    super(publicMessage)
+    this.name = 'NotionClientError'
+    this.statusCode = statusCode
+    this.publicMessage = publicMessage
+  }
+}
+
+function readEnvFile(filePath: string): Record<string, string> {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const env: Record<string, string> = {}
+    for (const line of fs.readFileSync(filePath, 'utf8').split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      env[key] = value
+    }
+    return env
+  } catch {
+    return {}
+  }
+}
+
+function getToken(): string {
+  const hermesHome = process.env.HERMES_HOME?.trim() || path.join(os.homedir(), '.hermes')
+  const envPath = path.join(hermesHome, '.env')
+  const env = readEnvFile(envPath)
+  return env.NOTION_API_KEY || env.NOTION_API_TOKEN || process.env.NOTION_API_KEY || ''
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getToken()
+  if (!token) {
+    throw new NotionClientError(503, 'Notion is not configured on this Workspace server.')
+  }
+  return {
+    Authorization: ['Bearer', token].join(' '),
+    'Notion-Version': NOTION_API_VERSION,
+    'Content-Type': 'application/json',
+  }
+}
+
+function manifestPath(): string {
+  return process.env.NOTION_MANIFEST_PATH?.trim() || DEFAULT_MANIFEST_PATH
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    const rendered = JSON.stringify(value)
+    return rendered === undefined ? 'undefined' : rendered
+  }
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  const obj = value as Record<string, unknown>
+  return `{${Object.keys(obj)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+    .join(',')}}`
+}
+
+async function waitForNotionTurn(): Promise<void> {
+  const run = notionQueue.then(async () => {
+    const elapsed = Date.now() - lastNotionRequestAt
+    if (elapsed < MIN_REQUEST_SPACING_MS) {
+      await new Promise((resolve) => setTimeout(resolve, MIN_REQUEST_SPACING_MS - elapsed))
+    }
+    lastNotionRequestAt = Date.now()
+  })
+  notionQueue = run.catch(() => undefined)
+  return run
+}
+
+function safeNotionMessage(status: number, bodyText: string): string {
+  let notionMessage = ''
+  try {
+    const parsed = JSON.parse(bodyText) as { message?: string; code?: string }
+    notionMessage = parsed.message || parsed.code || ''
+  } catch {
+    notionMessage = ''
+  }
+
+  if (status === 401 || status === 403) {
+    return 'Notion credentials are missing, invalid, or not allowed to access this workspace.'
+  }
+  if (status === 404) {
+    return 'Notion data source not found or not shared with the integration.'
+  }
+  if (status === 429) {
+    return 'Notion rate limit reached. The Workspace will retry after the cache window.'
+  }
+  if (notionMessage) return `Notion API error ${status}: ${notionMessage.slice(0, 160)}`
+  return `Notion API error ${status}`
+}
+
+async function notionFetch(url: string, init: RequestInit, attempt = 1): Promise<Response> {
+  await waitForNotionTurn()
+  const res = await fetch(url, init)
+  if (res.status === 429 && attempt <= 2) {
+    const retryAfter = Number(res.headers.get('retry-after') || '1')
+    await new Promise((resolve) => setTimeout(resolve, Math.max(retryAfter, 1) * 1000))
+    return notionFetch(url, init, attempt + 1)
+  }
+  return res
+}
+
+export interface NotionProperty {
+  id: string
+  type: string
+  title?: Array<{ plain_text: string }>
+  rich_text?: Array<{ plain_text: string }>
+  select?: { name: string; color: string } | null
+  multi_select?: Array<{ name: string; color: string }>
+  date?: { start: string; end?: string } | null
+  checkbox?: boolean
+  number?: number | null
+  url?: string | null
+  email?: string | null
+  phone_number?: string | null
+  relation?: Array<{ id: string }>
+  formula?: {
+    string?: string | null
+    number?: number | null
+    boolean?: boolean | null
+    date?: { start: string; end?: string } | null
+  }
+  rollup?: unknown
+  status?: { name: string; color: string } | null
+}
+
+export interface NotionRecord {
+  id: string
+  properties: Record<string, NotionProperty>
+  created_time: string
+  last_edited_time: string
+  url: string
+}
+
+export interface NotionQueryResponse {
+  results: NotionRecord[]
+  has_more: boolean
+  next_cursor: string | null
+}
+
+export async function queryDataSource(
+  dataSourceId: string,
+  options: {
+    filter?: Record<string, unknown>
+    sorts?: Array<{ property: string; direction: 'ascending' | 'descending' }>
+    page_size?: number
+    cacheTtlMs?: number
+  } = {},
+): Promise<NotionQueryResponse> {
+  const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+  const cacheKey = stableStringify({
+    dataSourceId,
+    filter: options.filter,
+    sorts: options.sorts,
+    page_size: options.page_size ?? 100,
+  })
+  const cached = queryCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+  const inFlight = inFlightQueries.get(cacheKey)
+  if (inFlight) return inFlight
+
+  const promise = (async (): Promise<NotionQueryResponse> => {
+    const results: NotionRecord[] = []
+    let startCursor: string | undefined
+    let nextCursor: string | null = null
+
+    do {
+      const body: Record<string, unknown> = {
+        page_size: options.page_size ?? 100,
+      }
+      if (options.filter) body.filter = options.filter
+      if (options.sorts) body.sorts = options.sorts
+      if (startCursor) body.start_cursor = startCursor
+
+      const res = await notionFetch(`${NOTION_BASE}/data_sources/${dataSourceId}/query`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const text = await res.text()
+        throw new NotionClientError(res.status, safeNotionMessage(res.status, text))
+      }
+
+      const page = (await res.json()) as NotionQueryResponse
+      results.push(...page.results)
+      nextCursor = page.next_cursor
+      startCursor = page.has_more && page.next_cursor ? page.next_cursor : undefined
+    } while (startCursor)
+
+    const value = { results, has_more: false, next_cursor: nextCursor }
+    queryCache.set(cacheKey, { value, expiresAt: Date.now() + cacheTtlMs })
+    return value
+  })()
+
+  inFlightQueries.set(cacheKey, promise)
+  try {
+    return await promise
+  } finally {
+    inFlightQueries.delete(cacheKey)
+  }
+}
+
+export function extractTitle(properties: Record<string, NotionProperty>): string {
+  for (const prop of Object.values(properties)) {
+    if (prop.type === 'title' && prop.title && prop.title.length > 0) {
+      return prop.title[0].plain_text
+    }
+  }
+  return ''
+}
+
+export function extractRichText(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'rich_text') return ''
+  return prop.rich_text?.map((t) => t.plain_text).join('') ?? ''
+}
+
+export function extractSelect(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop) return ''
+  if (prop.type === 'select') return prop.select?.name ?? ''
+  if (prop.type === 'status') return prop.status?.name ?? ''
+  return ''
+}
+
+export function extractDate(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'date') return ''
+  return prop.date?.start ?? ''
+}
+
+export function extractNumber(properties: Record<string, NotionProperty>, key: string): number | null {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'number') return null
+  return prop.number ?? null
+}
+
+export function extractUrl(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'url') return ''
+  return prop.url ?? ''
+}
+
+export function extractEmail(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'email') return ''
+  return prop.email ?? ''
+}
+
+export function extractPhone(properties: Record<string, NotionProperty>, key: string): string {
+  const prop = properties[key]
+  if (!prop) return ''
+  if (prop.type === 'phone_number') return prop.phone_number ?? ''
+  if (prop.type === 'rich_text') return prop.rich_text?.map((t) => t.plain_text).join('') ?? ''
+  return ''
+}
+
+export function extractCheckbox(properties: Record<string, NotionProperty>, key: string): boolean {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'checkbox') return false
+  return prop.checkbox === true
+}
+
+export function extractRelationIds(properties: Record<string, NotionProperty>, key: string): string[] {
+  const prop = properties[key]
+  if (!prop || prop.type !== 'relation') return []
+  return prop.relation?.map((r) => r.id) ?? []
+}
+
+export type FlattenedNotionValue = string | number | boolean | string[] | null
+
+export function flattenProperty(prop: NotionProperty): FlattenedNotionValue {
+  switch (prop.type) {
+    case 'title':
+      return prop.title?.map((t) => t.plain_text).join('') ?? ''
+    case 'rich_text':
+      return prop.rich_text?.map((t) => t.plain_text).join('') ?? ''
+    case 'select':
+      return prop.select?.name ?? null
+    case 'status':
+      return prop.status?.name ?? null
+    case 'multi_select':
+      return prop.multi_select?.map((item) => item.name) ?? []
+    case 'date':
+      return prop.date?.start ?? null
+    case 'checkbox':
+      return prop.checkbox === true
+    case 'number':
+      return prop.number ?? null
+    case 'url':
+      return prop.url ?? null
+    case 'email':
+      return prop.email ?? null
+    case 'phone_number':
+      return prop.phone_number ?? null
+    case 'relation':
+      return prop.relation?.map((r) => r.id) ?? []
+    case 'formula':
+      return prop.formula?.string ?? prop.formula?.number ?? prop.formula?.boolean ?? prop.formula?.date?.start ?? null
+    default:
+      return null
+  }
+}
+
+export function flattenRecord(record: NotionRecord): Record<string, FlattenedNotionValue> {
+  const flat: Record<string, FlattenedNotionValue> = {}
+  for (const [key, prop] of Object.entries(record.properties)) {
+    flat[key] = flattenProperty(prop)
+  }
+  return flat
+}
+
+export function summarizeRecord(record: NotionRecord): string {
+  const title = extractTitle(record.properties)
+  if (title) return title
+  const firstUseful = Object.values(flattenRecord(record)).find((value) => {
+    if (Array.isArray(value)) return value.length > 0
+    return value !== null && value !== '' && value !== false
+  })
+  return Array.isArray(firstUseful) ? firstUseful.join(', ') : String(firstUseful || 'Untitled Notion record')
+}
+
+export function notionExternalRecordUrl(record: Pick<NotionRecord, 'id' | 'url'>): string {
+  if (record.url && /^https:\/\/www\.notion\.so\//.test(record.url)) return record.url
+  return `https://www.notion.so/${record.id.replace(/-/g, '')}`
+}
+
+export function workspaceNotionRecordUrl(sourceName: string, recordId: string): string {
+  const params = new URLSearchParams({ source: sourceName, record: recordId })
+  return `/notion?${params.toString()}`
+}
+
+export interface ManifestData {
+  pages: Record<string, string>
+  data_sources: Record<string, { id: string; database_id?: string; page_parent_or_database_id?: string }>
+}
+
+export function loadManifest(): ManifestData {
+  const currentManifestPath = manifestPath()
+  if (!fs.existsSync(currentManifestPath)) {
+    throw new NotionClientError(503, 'Notion manifest is not available on this Workspace server.')
+  }
+  return JSON.parse(fs.readFileSync(currentManifestPath, 'utf8')) as ManifestData
+}
+
+export function notionRouteError(err: unknown, fallback: string): { status: number; body: { ok: false; error: string } } {
+  if (err instanceof NotionClientError) {
+    return { status: err.statusCode, body: { ok: false, error: err.publicMessage } }
+  }
+  return { status: 500, body: { ok: false, error: fallback } }
+}

--- a/src/server/projects-obsidian-export.test.ts
+++ b/src/server/projects-obsidian-export.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtemp } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+import { exportProjectsToObsidian } from './projects-obsidian-export'
+import type { WorkspaceProjectsState } from './projects-store'
+
+const originalEnv = { ...process.env }
+let stateDir = ''
+let vaultDir = ''
+
+const baseState: WorkspaceProjectsState = {
+  projects: [
+    {
+      id: 'seo-aeo-business',
+      name: 'SEO/AEO Business',
+      goal: 'Launch the business',
+      instructions: 'Stay revenue-first',
+      color: '#b98a44',
+      icon: 'folder',
+      createdAt: 10,
+      updatedAt: 20,
+    },
+  ],
+  sessionProjectMap: {
+    sessionA: 'seo-aeo-business',
+  },
+  activeProjectId: 'seo-aeo-business',
+}
+
+beforeEach(async () => {
+  process.env = { ...originalEnv, NODE_ENV: 'test' }
+  stateDir = await mkdtemp(join(tmpdir(), 'workspace-project-export-state-'))
+  vaultDir = await mkdtemp(join(tmpdir(), 'workspace-project-export-vault-'))
+  process.env.HERMES_WORKSPACE_STATE_DIR = stateDir
+})
+
+afterEach(async () => {
+  process.env = { ...originalEnv }
+  await rm(stateDir, { recursive: true, force: true })
+  await rm(vaultDir, { recursive: true, force: true })
+})
+
+describe('projects Obsidian export', () => {
+  it('exports one markdown file per project and a full JSON snapshot', async () => {
+    const result = await exportProjectsToObsidian(baseState, {
+      vaultPath: vaultDir,
+      timestamp: new Date('2026-07-22T21:30:00Z'),
+    })
+
+    expect(result.ok).toBe(true)
+    const projectPath = join(vaultDir, 'Hermes', 'Projects', 'seo-aeo-business.md')
+    const rawProject = await readFile(projectPath, 'utf-8')
+    expect(rawProject).toContain('# SEO/AEO Business')
+    expect(rawProject).toContain('## Goal\n\nLaunch the business')
+    expect(rawProject).toContain('## Instructions\n\nStay revenue-first')
+
+    const frontmatter = rawProject.slice(4, rawProject.indexOf('\n---\n', 4))
+    expect(YAML.parse(frontmatter)).toMatchObject({
+      id: 'seo-aeo-business',
+      name: 'SEO/AEO Business',
+      color: '#b98a44',
+      icon: 'folder',
+      createdAt: 10,
+      updatedAt: 20,
+    })
+
+    const snapshotPath = join(
+      vaultDir,
+      'Hermes',
+      'Projects',
+      '_snapshots',
+      'projects-20260722T213000Z.json',
+    )
+    const snapshot = JSON.parse(await readFile(snapshotPath, 'utf-8'))
+    expect(snapshot).toEqual(baseState)
+  })
+
+  it('keeps only the latest 30 snapshots', async () => {
+    const snapshotDir = join(vaultDir, 'Hermes', 'Projects', '_snapshots')
+    await mkdir(snapshotDir, { recursive: true })
+    for (let index = 0; index < 35; index += 1) {
+      await writeFile(
+        join(snapshotDir, `projects-20260722T2100${String(index).padStart(2, '0')}Z.json`),
+        '{}\n',
+        'utf-8',
+      )
+    }
+
+    await exportProjectsToObsidian(baseState, {
+      vaultPath: vaultDir,
+      timestamp: new Date('2026-07-22T22:00:00Z'),
+    })
+
+    const snapshots = (await readdir(snapshotDir)).filter((name) => name.endsWith('.json')).sort()
+    expect(snapshots).toHaveLength(30)
+    expect(snapshots[0]).toBe('projects-20260722T210006Z.json')
+    expect(snapshots.at(-1)).toBe('projects-20260722T220000Z.json')
+  })
+
+  it('logs export failures without throwing', async () => {
+    const result = await exportProjectsToObsidian(baseState, {
+      vaultPath: join(vaultDir, 'missing-vault'),
+    })
+
+    expect(result.ok).toBe(false)
+    const log = await readFile(join(stateDir, 'projects-obsidian-export-errors.log'), 'utf-8')
+    expect(log).toContain('Obsidian vault path is not readable')
+  })
+})

--- a/src/server/projects-obsidian-export.ts
+++ b/src/server/projects-obsidian-export.ts
@@ -1,0 +1,190 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import YAML from 'yaml'
+import { getStateDir } from './workspace-state-dir'
+import type { WorkspaceProject, WorkspaceProjectsState } from './projects-store'
+
+const DEFAULT_VAULT_PATH = join(
+  homedir(),
+  'Documents/Obsidian Vault/Bethanys Second Brain',
+)
+const SNAPSHOT_KEEP_COUNT = 30
+const EXPORT_DEBOUNCE_MS = 350
+
+let exportTimer: ReturnType<typeof setTimeout> | null = null
+let pendingState: WorkspaceProjectsState | null = null
+
+export type ProjectExportResult = {
+  ok: boolean
+  vaultPath: string
+  projectFiles: string[]
+  snapshotFile: string | null
+  error?: string
+}
+
+type ExportOptions = {
+  vaultPath?: string
+  timestamp?: Date
+}
+
+function projectExportEnabled(): boolean {
+  const value = process.env.HERMES_WORKSPACE_PROJECT_EXPORT?.trim().toLowerCase()
+  if (value === '0' || value === 'false' || value === 'off') return false
+  // Vitest sets NODE_ENV=test. Avoid tests writing into Ryan's real vault unless
+  // a test calls exportProjectsToObsidian directly with an explicit temp vault.
+  return process.env.NODE_ENV !== 'test'
+}
+
+function resolveVaultPath(explicit?: string): string {
+  return (
+    explicit?.trim() ||
+    process.env.OBSIDIAN_VAULT_PATH?.trim() ||
+    DEFAULT_VAULT_PATH
+  )
+}
+
+function projectsDir(vaultPath: string): string {
+  return join(vaultPath, 'Hermes', 'Projects')
+}
+
+function snapshotsDir(vaultPath: string): string {
+  return join(projectsDir(vaultPath), '_snapshots')
+}
+
+function exportLogPath(): string {
+  return join(getStateDir(), 'projects-obsidian-export-errors.log')
+}
+
+function safeProjectFileName(id: string): string {
+  const safe = id.trim().replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+  return `${safe || 'project'}.md`
+}
+
+function isoNoPunctuation(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+}
+
+function yamlFrontmatter(project: WorkspaceProject): string {
+  return YAML.stringify({
+    id: project.id,
+    name: project.name,
+    color: project.color,
+    icon: project.icon,
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+    ...(project.archivedAt ? { archivedAt: project.archivedAt } : {}),
+  }).trimEnd()
+}
+
+function projectMarkdown(project: WorkspaceProject): string {
+  const goal = project.goal.trim() || '_No goal set._'
+  const instructions = project.instructions.trim() || '_No instructions set._'
+  return `---\n${yamlFrontmatter(project)}\n---\n\n# ${project.name}\n\n## Goal\n\n${goal}\n\n## Instructions\n\n${instructions}\n`
+}
+
+async function writeAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  await writeFile(tmpPath, content, 'utf-8')
+  await rename(tmpPath, filePath)
+}
+
+async function verifyMarkdownFrontmatter(filePath: string): Promise<void> {
+  const raw = await readFile(filePath, 'utf-8')
+  if (!raw.startsWith('---\n')) throw new Error(`Missing frontmatter: ${filePath}`)
+  const end = raw.indexOf('\n---\n', 4)
+  if (end === -1) throw new Error(`Unclosed frontmatter: ${filePath}`)
+  const parsed = YAML.parse(raw.slice(4, end))
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Invalid frontmatter object: ${filePath}`)
+  }
+}
+
+async function verifyJsonSnapshot(filePath: string): Promise<void> {
+  const raw = await readFile(filePath, 'utf-8')
+  const parsed = JSON.parse(raw) as Partial<WorkspaceProjectsState>
+  if (!Array.isArray(parsed.projects) || typeof parsed.sessionProjectMap !== 'object') {
+    throw new Error(`Invalid projects snapshot shape: ${filePath}`)
+  }
+}
+
+async function pruneOldSnapshots(dir: string): Promise<void> {
+  const names = await readdir(dir).catch(() => [])
+  const snapshots = names
+    .filter((name) => /^projects-\d{8}T\d{6}Z\.json$/.test(name))
+    .sort()
+  const remove = snapshots.slice(0, Math.max(0, snapshots.length - SNAPSHOT_KEEP_COUNT))
+  await Promise.all(remove.map((name) => unlink(join(dir, name)).catch(() => undefined)))
+}
+
+async function logProjectExportFailure(error: unknown): Promise<void> {
+  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+  const line = `${new Date().toISOString()} ${message}\n`
+  try {
+    await mkdir(getStateDir(), { recursive: true })
+    const existing = await readFile(exportLogPath(), 'utf-8').catch(() => '')
+    await writeFile(exportLogPath(), `${existing}${line}`, 'utf-8')
+  } catch {
+    // Last-resort logging only; project writes must not fail because logging fails.
+  }
+}
+
+export async function exportProjectsToObsidian(
+  state: WorkspaceProjectsState,
+  options: ExportOptions = {},
+): Promise<ProjectExportResult> {
+  const vaultPath = resolveVaultPath(options.vaultPath)
+  const projectDir = projectsDir(vaultPath)
+  const snapshotDir = snapshotsDir(vaultPath)
+  const writtenProjectFiles: string[] = []
+  let snapshotFile: string | null = null
+
+  try {
+    if (!existsSync(vaultPath)) {
+      throw new Error(`Obsidian vault path is not readable: ${vaultPath}`)
+    }
+
+    await mkdir(projectDir, { recursive: true })
+    await mkdir(snapshotDir, { recursive: true })
+
+    for (const project of state.projects) {
+      const filePath = join(projectDir, safeProjectFileName(project.id))
+      await writeAtomic(filePath, projectMarkdown(project))
+      await verifyMarkdownFrontmatter(filePath)
+      writtenProjectFiles.push(filePath)
+    }
+
+    snapshotFile = join(
+      snapshotDir,
+      `projects-${isoNoPunctuation(options.timestamp ?? new Date())}.json`,
+    )
+    await writeAtomic(snapshotFile, `${JSON.stringify(state, null, 2)}\n`)
+    await verifyJsonSnapshot(snapshotFile)
+    await pruneOldSnapshots(snapshotDir)
+
+    return { ok: true, vaultPath, projectFiles: writtenProjectFiles, snapshotFile }
+  } catch (error) {
+    await logProjectExportFailure(error)
+    return {
+      ok: false,
+      vaultPath,
+      projectFiles: writtenProjectFiles,
+      snapshotFile,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export function scheduleProjectsObsidianExport(state: WorkspaceProjectsState): void {
+  if (!projectExportEnabled()) return
+  pendingState = JSON.parse(JSON.stringify(state)) as WorkspaceProjectsState
+  if (exportTimer) clearTimeout(exportTimer)
+  exportTimer = setTimeout(() => {
+    const stateToExport = pendingState
+    pendingState = null
+    exportTimer = null
+    if (stateToExport) void exportProjectsToObsidian(stateToExport)
+  }, EXPORT_DEBOUNCE_MS)
+}

--- a/src/server/projects-store.test.ts
+++ b/src/server/projects-store.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  normalizeProjectsState,
+  readProjectsState,
+  writeProjectsState,
+} from './projects-store'
+
+const originalEnv = { ...process.env }
+let stateDir = ''
+
+beforeEach(async () => {
+  stateDir = await mkdtemp(join(tmpdir(), 'workspace-projects-'))
+  process.env.HERMES_WORKSPACE_STATE_DIR = stateDir
+})
+
+afterEach(async () => {
+  process.env = { ...originalEnv }
+  if (stateDir) await rm(stateDir, { recursive: true, force: true })
+})
+
+describe('projects store', () => {
+  it('reports uninitialized empty state before the server file exists', async () => {
+    await expect(readProjectsState()).resolves.toEqual({
+      projects: [],
+      sessionProjectMap: {},
+      activeProjectId: null,
+      initialized: false,
+    })
+  })
+
+  it('persists normalized project state for cross-device reads', async () => {
+    const saved = await writeProjectsState({
+      projects: [
+        {
+          id: 'seo-aeo',
+          name: 'SEO/AEO',
+          goal: 'Launch',
+          instructions: 'Revenue-first',
+          color: '#22c55e',
+          icon: 'folder',
+          createdAt: 10,
+          updatedAt: 20,
+        },
+      ],
+      sessionProjectMap: {
+        abc: 'seo-aeo',
+        orphan: 'missing-project',
+      },
+      activeProjectId: 'seo-aeo',
+    })
+
+    expect(saved.sessionProjectMap).toEqual({ abc: 'seo-aeo' })
+    await expect(readProjectsState()).resolves.toMatchObject({
+      initialized: true,
+      projects: [{ id: 'seo-aeo', name: 'SEO/AEO' }],
+      sessionProjectMap: { abc: 'seo-aeo' },
+      activeProjectId: 'seo-aeo',
+    })
+  })
+
+  it('accepts old browser-storage sessionProjects shape during migration', () => {
+    expect(
+      normalizeProjectsState({
+        projects: [{ id: 'one', name: 'One' }],
+        sessionProjects: { sessionA: 'one' },
+      }),
+    ).toMatchObject({
+      projects: [{ id: 'one', name: 'One', icon: 'folder' }],
+      sessionProjectMap: { sessionA: 'one' },
+    })
+  })
+})

--- a/src/server/projects-store.ts
+++ b/src/server/projects-store.ts
@@ -1,0 +1,122 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getStateDir } from './workspace-state-dir'
+import { scheduleProjectsObsidianExport } from './projects-obsidian-export'
+
+export type WorkspaceProject = {
+  id: string
+  name: string
+  goal: string
+  instructions: string
+  color: string
+  icon: string
+  createdAt: number
+  updatedAt: number
+  archivedAt?: number
+}
+
+export type WorkspaceProjectsState = {
+  projects: WorkspaceProject[]
+  sessionProjectMap: Record<string, string>
+  activeProjectId: string | null
+}
+
+export type WorkspaceProjectsReadResult = WorkspaceProjectsState & {
+  initialized: boolean
+}
+
+const EMPTY_PROJECTS_STATE: WorkspaceProjectsState = {
+  projects: [],
+  sessionProjectMap: {},
+  activeProjectId: null,
+}
+
+function projectsStatePath(): string {
+  return join(getStateDir(), 'projects.json')
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function cleanTimestamp(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function cleanProject(value: unknown): WorkspaceProject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  const id = cleanString(raw.id)
+  const name = cleanString(raw.name)
+  if (!id || !name) return null
+  const now = Date.now()
+  const project: WorkspaceProject = {
+    id,
+    name,
+    goal: cleanString(raw.goal),
+    instructions: cleanString(raw.instructions),
+    color: cleanString(raw.color) || '#8b5cf6',
+    icon: cleanString(raw.icon) || 'folder',
+    createdAt: cleanTimestamp(raw.createdAt, now),
+    updatedAt: cleanTimestamp(raw.updatedAt, now),
+  }
+  const archivedAt = cleanTimestamp(raw.archivedAt, 0)
+  if (archivedAt > 0) project.archivedAt = archivedAt
+  return project
+}
+
+export function normalizeProjectsState(value: unknown): WorkspaceProjectsState {
+  const raw = value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+  const projects = Array.isArray(raw.projects)
+    ? raw.projects.map(cleanProject).filter((project): project is WorkspaceProject => Boolean(project))
+    : []
+  const projectIds = new Set(projects.map((project) => project.id))
+  const sessionProjectMap: Record<string, string> = {}
+  const rawMap = raw.sessionProjectMap ?? raw.sessionProjects
+  if (rawMap && typeof rawMap === 'object' && !Array.isArray(rawMap)) {
+    for (const [key, projectId] of Object.entries(rawMap as Record<string, unknown>)) {
+      const sessionKey = cleanString(key)
+      const mappedProjectId = cleanString(projectId)
+      if (sessionKey && mappedProjectId && projectIds.has(mappedProjectId)) {
+        sessionProjectMap[sessionKey] = mappedProjectId
+      }
+    }
+  }
+  const activeProjectId = cleanString(raw.activeProjectId)
+  return {
+    projects,
+    sessionProjectMap,
+    activeProjectId: activeProjectId && projectIds.has(activeProjectId) ? activeProjectId : null,
+  }
+}
+
+export async function readProjectsState(): Promise<WorkspaceProjectsReadResult> {
+  const filePath = projectsStatePath()
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    return {
+      ...normalizeProjectsState(JSON.parse(raw)),
+      initialized: true,
+    }
+  } catch {
+    return {
+      ...EMPTY_PROJECTS_STATE,
+      initialized: existsSync(filePath),
+    }
+  }
+}
+
+export async function writeProjectsState(input: unknown): Promise<WorkspaceProjectsState> {
+  const next = normalizeProjectsState(input)
+  const stateDir = getStateDir()
+  const filePath = projectsStatePath()
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  await mkdir(stateDir, { recursive: true })
+  await writeFile(tmpPath, `${JSON.stringify(next, null, 2)}\n`, 'utf-8')
+  await rename(tmpPath, filePath)
+  scheduleProjectsObsidianExport(next)
+  return next
+}

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -1,0 +1,208 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type WorkspaceProject = {
+  id: string
+  name: string
+  goal: string
+  instructions: string
+  color: string
+  archived: boolean
+  createdAt: number
+  updatedAt: number
+}
+
+type ProjectState = {
+  projects: Array<WorkspaceProject>
+  sessionProjects: Record<string, string>
+  pendingNewSessionProjectId: string | null
+  createProject: (input: {
+    name: string
+    goal?: string
+    instructions?: string
+    color?: string
+  }) => WorkspaceProject
+  updateProject: (
+    projectId: string,
+    patch: Partial<Pick<WorkspaceProject, 'name' | 'goal' | 'instructions' | 'color'>>,
+  ) => void
+  archiveProject: (projectId: string) => void
+  restoreProject: (projectId: string) => void
+  assignSessionToProject: (sessionKey: string, projectId: string) => void
+  unassignSession: (sessionKey: string) => void
+  setPendingNewSessionProject: (projectId: string | null) => void
+  clearPendingNewSessionProject: () => void
+}
+
+const DEFAULT_PROJECTS: Array<WorkspaceProject> = [
+  {
+    id: 'seo-aeo-business',
+    name: 'SEO/AEO Business',
+    goal: 'Launch and operate Ryan\'s SEO/AEO service business with clear CRM, outreach, approvals, and delivery workflows.',
+    instructions:
+      'Stay revenue-first. Keep Notion as operational CRM, Obsidian as reference, Zoho as raw email source. Surface risks and approval needs before client-facing action.',
+    color: '#b98a44',
+    archived: false,
+    createdAt: 1781900000000,
+    updatedAt: 1781900000000,
+  },
+  {
+    id: 'hermes-workspace-build',
+    name: 'Hermes Workspace Build',
+    goal: 'Shape Hermes Workspace into Ryan\'s project-aware mission control interface.',
+    instructions:
+      'Prioritize calm executive UX, project folders, working verification, and safe reversible changes. Do not expose secrets.',
+    color: '#60a5fa',
+    archived: false,
+    createdAt: 1781900000001,
+    updatedAt: 1781900000001,
+  },
+  {
+    id: 'personal-admin',
+    name: 'Personal Admin',
+    goal: 'Keep personal/admin decisions, bookkeeping setup, reminders, and operational follow-through in one place.',
+    instructions:
+      'Use numbered choices. Keep Apple Reminders/Notes conventions intact. Separate business records from personal reminders.',
+    color: '#34d399',
+    archived: false,
+    createdAt: 1781900000002,
+    updatedAt: 1781900000002,
+  },
+]
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || `project-${Date.now().toString(36)}`
+}
+
+function uniqueProjectId(projects: Array<WorkspaceProject>, name: string): string {
+  const base = slugify(name)
+  const existing = new Set(projects.map((project) => project.id))
+  if (!existing.has(base)) return base
+  let index = 2
+  while (existing.has(`${base}-${index}`)) index += 1
+  return `${base}-${index}`
+}
+
+function cleanText(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export const useProjectStore = create<ProjectState>()(
+  persist(
+    (set, get) => ({
+      projects: DEFAULT_PROJECTS,
+      sessionProjects: {},
+      pendingNewSessionProjectId: null,
+      createProject: (input) => {
+        const name = cleanText(input.name) || 'Untitled Project'
+        const now = Date.now()
+        const project: WorkspaceProject = {
+          id: uniqueProjectId(get().projects, name),
+          name,
+          goal: cleanText(input.goal),
+          instructions: cleanText(input.instructions),
+          color: cleanText(input.color) || '#b98a44',
+          archived: false,
+          createdAt: now,
+          updatedAt: now,
+        }
+        set((state) => ({ projects: [...state.projects, project] }))
+        return project
+      },
+      updateProject: (projectId, patch) => {
+        set((state) => ({
+          projects: state.projects.map((project) =>
+            project.id === projectId
+              ? {
+                  ...project,
+                  ...patch,
+                  name: cleanText(patch.name) || project.name,
+                  goal:
+                    patch.goal === undefined ? project.goal : cleanText(patch.goal),
+                  instructions:
+                    patch.instructions === undefined
+                      ? project.instructions
+                      : cleanText(patch.instructions),
+                  color: cleanText(patch.color) || project.color,
+                  updatedAt: Date.now(),
+                }
+              : project,
+          ),
+        }))
+      },
+      archiveProject: (projectId) => {
+        set((state) => ({
+          projects: state.projects.map((project) =>
+            project.id === projectId
+              ? { ...project, archived: true, updatedAt: Date.now() }
+              : project,
+          ),
+          sessionProjects: Object.fromEntries(
+            Object.entries(state.sessionProjects).filter(
+              ([, mappedProjectId]) => mappedProjectId !== projectId,
+            ),
+          ),
+          pendingNewSessionProjectId:
+            state.pendingNewSessionProjectId === projectId
+              ? null
+              : state.pendingNewSessionProjectId,
+        }))
+      },
+      restoreProject: (projectId) => {
+        set((state) => ({
+          projects: state.projects.map((project) =>
+            project.id === projectId
+              ? { ...project, archived: false, updatedAt: Date.now() }
+              : project,
+          ),
+        }))
+      },
+      assignSessionToProject: (sessionKey, projectId) => {
+        const normalizedSessionKey = cleanText(sessionKey)
+        const normalizedProjectId = cleanText(projectId)
+        if (!normalizedSessionKey || !normalizedProjectId) return
+        set((state) => ({
+          sessionProjects: {
+            ...state.sessionProjects,
+            [normalizedSessionKey]: normalizedProjectId,
+          },
+        }))
+      },
+      unassignSession: (sessionKey) => {
+        const normalizedSessionKey = cleanText(sessionKey)
+        if (!normalizedSessionKey) return
+        set((state) => {
+          const next = { ...state.sessionProjects }
+          delete next[normalizedSessionKey]
+          return { sessionProjects: next }
+        })
+      },
+      setPendingNewSessionProject: (projectId) => {
+        const normalized = cleanText(projectId ?? undefined)
+        set({ pendingNewSessionProjectId: normalized || null })
+      },
+      clearPendingNewSessionProject: () =>
+        set({ pendingNewSessionProjectId: null }),
+    }),
+    {
+      name: 'hermes-workspace-projects-v1',
+      version: 1,
+      partialize: (state) => ({
+        projects: state.projects,
+        sessionProjects: state.sessionProjects,
+      }),
+    },
+  ),
+)
+
+export function getProjectForSession(
+  sessionProjects: Record<string, string>,
+  sessionKey: string,
+  friendlyId: string,
+): string | null {
+  return sessionProjects[friendlyId] || sessionProjects[sessionKey] || null
+}


### PR DESCRIPTION
## Summary

Adds the Workspace operations surfaces that were already built locally and hardens the Tailscale/login smoke path:

- Mission Control dashboard and read-only system/summary APIs
- Notion browser and server-side Notion proxy APIs
- Outreach and Approval Queue screens
- Project-aware Workspace/session support with Obsidian export helpers
- Root/Tailscale proxy support in `server-entry.js`
- Config auth hardening so unauthenticated `/api/claude-config` returns JSON 401 instead of a server 500
- Ignores local `memory/handoffs/` swarm artifacts so they do not pollute repo status

## Verification

Rebased onto `origin/main` successfully with no conflicts.

Targeted tests passed:

```bash
pnpm test src/lib/project-context.test.ts src/screens/chat/utils.test.ts src/hooks/use-projects.test.ts src/server/projects-store.test.ts src/server/projects-obsidian-export.test.ts src/routes/api/-hermes-config.test.ts
```

Result: 6 test files passed, 27 tests passed.

Production build passed:

```bash
pnpm build
```

Tailscale smoke tested against `http://100.72.54.12:3000` after restarting `com.hermes.workspace`:

- `/mission-control` -> 200 HTML
- `/notion` -> 200 HTML
- `/outreach` -> 200 HTML
- `/approval-queue` -> 200 HTML
- `/api/auth-check` -> 200 JSON
- `/api/claude-config` -> 401 JSON, expected while logged out
- `/api/projects` -> 401 JSON, expected while logged out
- `/api/mission-control/system` -> 401 JSON, expected while logged out
- `/api/mission-control/summary` -> 401 JSON, expected while logged out
- `/api/notion/sources` -> 401 JSON, expected while logged out

Browser smoke:

- `http://100.72.54.12:3000/mission-control` renders the Hermes Workspace login screen
- Browser console errors: 0

## Notes

Full repo test suite has unrelated pre-existing failures in MCP/i18n/chat/playground areas; this PR was verified with targeted tests for the touched Workspace surfaces plus production build and browser smoke.
