### PR TITLE
fix: pin supported pnpm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "type": "module",
   "main": "electron/main.cjs",
+  "packageManager": "pnpm@11.17.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Pins Hermes Workspace to pnpm 11.17.0.

The previous package-manager pin referenced pnpm 11.13.0, a release whose `@pnpm/exe` distribution is broken. On a fresh launch this can prevent dependency installation and leave the Workspace development service unable to start. The new pin matches the supported local pnpm release.

## Validation

- `pnpm install --frozen-lockfile` completed successfully with pnpm 11.17.0
- `pnpm exec vite --version` completed successfully
- The running Workspace served HTTP 200 and connected to the Hermes API after gateway recovery.
