### PR TITLE
fix(mcp): fetch the server list from /api/mcp/servers

### DIFF
--- a/src/routes/api/mcp.ts
+++ b/src/routes/api/mcp.ts
@@ -22,6 +22,7 @@ import type { McpServerInput } from '../../types/mcp-input'
 import { parseMcpServerInput } from '../../server/mcp-input-validate'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 import { getProbe } from '../../server/mcp-tools-cache'
+import { fetchMcpList } from '../../server/mcp-upstream'
 
 const KNOWN_CATEGORIES = ['All', 'Connected', 'Failed', 'Disabled'] as const
 const REQUEST_TIMEOUT_MS = 30_000
@@ -123,9 +124,9 @@ export const Route = createFileRoute('/api/mcp')({
 
           let servers: ReturnType<typeof normalizeMcpList>
           if (capabilities.mcp) {
-            const response = await mcpFetch('/api/mcp', {
-              signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-            })
+            const response = await fetchMcpList((path) =>
+              mcpFetch(path, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) }),
+            )
             if (!response.ok) {
               return json(
                 {

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -245,7 +245,7 @@ describe('gateway-capabilities', () => {
           headers: { 'content-type': 'application/json' },
         })
       }
-      if (url === 'http://dashboard.test/api/mcp') {
+      if (url === 'http://dashboard.test/api/mcp/servers' || url === 'http://dashboard.test/api/mcp') {
         return new Response('not found', { status: 404 })
       }
       if (url === 'http://dashboard.test/api/config') {
@@ -259,7 +259,7 @@ describe('gateway-capabilities', () => {
       if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') {
         return new Response('', { status: 404 })
       }
-      if (url === 'http://gateway.test/api/mcp') {
+      if (url === 'http://gateway.test/api/mcp/servers' || url === 'http://gateway.test/api/mcp') {
         return new Response('', { status: 404 })
       }
       return new Response(JSON.stringify({ ok: true }), {
@@ -308,7 +308,8 @@ describe('gateway-capabilities', () => {
       }
       if (url === 'http://gateway.test/v1/chat/completions') return new Response('', { status: 405 })
       if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') return new Response('', { status: 404 })
-      if (url.endsWith('/api/mcp')) return new Response('', { status: 404 })
+      if (url.endsWith('/api/mcp/servers') || url.endsWith('/api/mcp'))
+        return new Response('', { status: 404 })
       return new Response(JSON.stringify({ ok: true }), {
         headers: { 'content-type': 'application/json' },
       })
@@ -318,6 +319,55 @@ describe('gateway-capabilities', () => {
     const caps = await mod.probeGateway({ force: true })
 
     expect(caps.conductor).toBe(true)
+  })
+
+  it('marks MCP available when the dashboard only serves /api/mcp/servers', async () => {
+    // Regression for #725: the probe used to request /api/mcp, which the
+    // gateway answers with 404, so the MCP screen reported "Not available"
+    // even though MCP was configured and working.
+    process.env.HERMES_API_URL = 'http://gateway.test'
+    process.env.CLAUDE_DASHBOARD_URL = 'http://dashboard.test'
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === 'http://dashboard.test/api/status') {
+        return new Response(JSON.stringify({ version: '0.19.0' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url === 'http://dashboard.test/') {
+        return new Response("<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>", {
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+      if (url === 'http://dashboard.test/api/mcp/servers') {
+        return new Response(
+          JSON.stringify({
+            servers: [{ name: 'filesystem', transport: 'stdio', enabled: true }],
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        )
+      }
+      // The old path stays absent, exactly as the real gateway behaves.
+      if (url.endsWith('/api/mcp')) {
+        return new Response(JSON.stringify({ detail: 'No such API endpoint: /api/mcp' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const mod = await loadMod()
+    const caps = await mod.probeGateway({ force: true })
+
+    expect(caps.mcp).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://dashboard.test/api/mcp/servers',
+      expect.anything(),
+    )
   })
 
   describe('isLocalhostDeployment', () => {

--- a/src/server/__tests__/mcp-upstream.test.ts
+++ b/src/server/__tests__/mcp-upstream.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { MCP_LIST_PATH, MCP_LIST_PATH_LEGACY, fetchMcpList } from '../mcp-upstream'
+
+const ok = (body: unknown = { servers: [] }) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('fetchMcpList', () => {
+  it('requests /api/mcp/servers first', async () => {
+    const fetcher = vi.fn(async () => ok())
+
+    const res = await fetchMcpList(fetcher)
+
+    expect(res.status).toBe(200)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledWith(MCP_LIST_PATH, undefined)
+  })
+
+  it('falls back to /api/mcp when the gateway 404s the new path', async () => {
+    const fetcher = vi.fn(async (path: string) =>
+      path === MCP_LIST_PATH ? new Response('not found', { status: 404 }) : ok(),
+    )
+
+    const res = await fetchMcpList(fetcher)
+
+    expect(res.status).toBe(200)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(fetcher).toHaveBeenNthCalledWith(1, MCP_LIST_PATH, undefined)
+    expect(fetcher).toHaveBeenNthCalledWith(2, MCP_LIST_PATH_LEGACY, undefined)
+  })
+
+  it('returns 404 when neither path exists', async () => {
+    const fetcher = vi.fn(async () => new Response('not found', { status: 404 }))
+
+    const res = await fetchMcpList(fetcher)
+
+    expect(res.status).toBe(404)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([401, 403, 500, 502])('does not retry on %i', async (status) => {
+    const fetcher = vi.fn(async () => new Response('', { status }))
+
+    const res = await fetchMcpList(fetcher)
+
+    // Only 404 means "wrong path" — masking anything else behind a second
+    // request would hide auth and upstream failures from the caller.
+    expect(res.status).toBe(status)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards init to both attempts', async () => {
+    const init: RequestInit = { method: 'GET', headers: { 'x-test': '1' } }
+    const fetcher = vi.fn(async (path: string) =>
+      path === MCP_LIST_PATH ? new Response('', { status: 404 }) : ok(),
+    )
+
+    await fetchMcpList(fetcher, init)
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, MCP_LIST_PATH, init)
+    expect(fetcher).toHaveBeenNthCalledWith(2, MCP_LIST_PATH_LEGACY, init)
+  })
+})

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -497,12 +497,15 @@ async function probeChatCompletions(): Promise<boolean> {
 /**
  * Strict MCP capability probe.
  *
- * Per plan §Open Questions #4: probing `dashboard.available || /api/mcp` is
- * insufficient. The probe must hit `GET /api/mcp` directly and verify both:
+ * Per plan §Open Questions #4: probing `dashboard.available || <list endpoint>`
+ * is insufficient. The probe must fetch the list endpoint directly and verify:
  *   1. 200 OK
  *   2. Body parses through normalizeMcpList (i.e. shape is recognizable)
- * If the dashboard is up but `/api/mcp` is absent (404) or returns a
+ * If the dashboard is up but the endpoint is absent (404) or returns a
  * malformed body, capability is `false`.
+ *
+ * The list lives at `/api/mcp/servers`; `/api/mcp` is tried as a fallback.
+ * See `./mcp-upstream`.
  */
 async function probeMcp(): Promise<boolean> {
   const { normalizeMcpList } = await import('./mcp-normalize')
@@ -519,19 +522,22 @@ async function probeMcp(): Promise<boolean> {
   // Use dashboardFetch so the probe goes through the same authenticated path
   // workspace routes use at runtime — otherwise an auth-protected dashboard
   // /api/mcp would falsely report capability=false (Codex MAJOR finding).
+  const { fetchMcpList } = await import('./mcp-upstream')
   try {
-    const res = await dashboardFetch('/api/mcp', {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
+    const res = await fetchMcpList((path) =>
+      dashboardFetch(path, { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) }),
+    )
     if (await validate(res)) return true
   } catch {
     // fall through to gateway path
   }
   try {
-    const res = await fetch(`${CLAUDE_API}/api/mcp`, {
-      headers: authHeaders(),
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
+    const res = await fetchMcpList((path) =>
+      fetch(`${CLAUDE_API}${path}`, {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      }),
+    )
     return await validate(res)
   } catch {
     return false

--- a/src/server/mcp-upstream.ts
+++ b/src/server/mcp-upstream.ts
@@ -1,0 +1,33 @@
+/**
+ * Upstream MCP endpoint resolution.
+ *
+ * The gateway exposes its MCP server list at `GET /api/mcp/servers`. The
+ * workspace used to request `GET /api/mcp`, which the gateway answers with
+ * `{"detail":"No such API endpoint: /api/mcp"}` — so the capability probe saw
+ * a 404 and the MCP screen reported "Not available on this backend" even
+ * though MCP was configured and working.
+ *
+ * `/api/mcp` is still tried as a fallback so gateways that do serve the list
+ * there keep working.
+ */
+
+/** Current gateway path for listing MCP servers. */
+export const MCP_LIST_PATH = '/api/mcp/servers'
+
+/** Legacy path, retained for gateways that still serve the list here. */
+export const MCP_LIST_PATH_LEGACY = '/api/mcp'
+
+type Fetcher = (path: string, init?: RequestInit) => Promise<Response>
+
+/**
+ * Fetch the upstream MCP server list, preferring {@link MCP_LIST_PATH}.
+ *
+ * Falls back to {@link MCP_LIST_PATH_LEGACY} only on 404 — any other status is
+ * returned as-is, so a 401 or 500 surfaces to the caller instead of being
+ * masked by a second request.
+ */
+export async function fetchMcpList(fetcher: Fetcher, init?: RequestInit): Promise<Response> {
+  const res = await fetcher(MCP_LIST_PATH, init)
+  if (res.status !== 404) return res
+  return fetcher(MCP_LIST_PATH_LEGACY, init)
+}


### PR DESCRIPTION
Fixes #725

## Problem

The workspace requests `GET /api/mcp` from the gateway, which answers:

```
{"detail":"No such API endpoint: /api/mcp"}
```

The capability probe reads that 404 as "no MCP support", so the MCP screen shows *"Not available on this backend. Connect to a Hermes Agent gateway to unlock MCP Servers"* — even when MCP is configured and working. As the reporter noted, sessions, skills, memory, config and jobs all load; only MCP fails.

The list is served at `/api/mcp/servers`.

## Two call sites, not one

- `src/server/gateway-capabilities.ts` — `probeMcp()` requested `/api/mcp` on both the dashboard and the gateway. This is what gates the screen.
- `src/routes/api/mcp.ts` — the GET handler fetched the list from the same wrong path.

Fixing only the probe would have unlocked the screen and then failed to load any servers, so both are changed.

## Fix

Both now go through `fetchMcpList()` in the new `src/server/mcp-upstream.ts`, which requests `/api/mcp/servers` and falls back to `/api/mcp` on **404 only** — so gateways still serving the list at the old path keep working, while a 401 or 5xx is returned as-is instead of being masked behind a second request.

The `POST /api/mcp` create path is a different endpoint and is deliberately untouched.

## Tests

`marks MCP available when the dashboard only serves /api/mcp/servers` reproduces the bug: it fails on the current code with `expected false to be true`, and passes with this change.

Three existing mocks in `gateway-capabilities.test.ts` needed updating. They 404 `/api/mcp` but have a catch-all returning `200 {ok:true}`, so the new request would have hit the catch-all and flipped those assertions from false to true. They now 404 both paths, preserving the original intent.

`src/server/__tests__/mcp-upstream.test.ts` covers path preference, the 404 fallback, both paths missing, no-retry on 401/403/500/502, and `init` forwarding.

## Verification

Full suite before this change: `13 failed | 105 passed (118 files)`, `38 failed | 704 passed (742 tests)`.
After: `13 failed | 106 passed (119 files)`, `38 failed | 713 passed (751 tests)`.

Same 38 pre-existing failures (e2e specs needing a browser, the mcp store tests, i18n); the +9 passing are the tests added here. No regressions.