### PR TITLE
feat: add subscription orchestration and runtime Runs control

### DIFF
--- a/SUBSCRIPTION_ORCHESTRATION.md
+++ b/SUBSCRIPTION_ORCHESTRATION.md
@@ -1,0 +1,142 @@
+# Subscription-only orchestration
+
+Hermes Workspace exposes subscription-backed orchestration controls under **Settings → Orchestration**. The feature deliberately keeps API-billed transports hidden unless the user explicitly enables them.
+
+## Routes and precedence
+
+Model selection uses canonical references such as:
+
+- `claude-cwm4tx/sonnet`
+- `claude-gp/opus`
+- `openai-codex/gpt-5.6-sol`
+
+The effective child route follows this order:
+
+1. Explicit `model` on a delegation task
+2. Named `worker` preset
+3. Session override
+4. Global default child
+5. Existing safe Hermes default
+
+Changing a model in a chat writes a browser-local session override. `ChatScreen` reads that exact canonical route and sends it as the request `model`; it does not rewrite the global Hermes model. A new chat keeps the override under `new` until Hermes resolves the real session key, then migrates it to that session. Global defaults are changed only from Orchestration settings.
+
+## Configure any OAuth route in any role
+
+All role selectors consume one canonical OAuth subscription registry. A route identifies both the authenticated account/transport and the model, so the two Claude Max accounts remain deterministic rather than being collapsed into one `claude` provider.
+
+The shared registry is available in:
+
+- **Chat → Chat controls → Model** for the current conversation
+- **Settings → Orchestration → Orchestrator model**
+- **Settings → Orchestration → Default child model**
+- **Settings → Orchestration → Fallback chain**
+- **Settings → Orchestration → Named workers**
+- **Settings → Orchestration → Swarm role assignments** for every existing semantic role
+- **Swarm → Add Swarm → Model** for newly created roles
+
+To change an existing Swarm role, open **Settings → Orchestration**, choose a canonical route beside the role, and click **Apply role assignments**. The saved route is synchronized into that worker profile before its next start or dispatch-created session. A worker that is already running must be restarted to load the new profile model. The worker-card settings panel displays the effective runtime model but does not offer a misleading local-only model override. Legacy free-text assignments remain visible until replaced; an unresolved legacy or default `Worker` label leaves the existing profile model untouched instead of blocking startup. New assignments are validated against the canonical OAuth registry.
+
+Runtime ownership is explicit:
+
+- **Orchestrator model** synchronizes to Hermes top-level `model.provider` and `model.default`.
+- **Default child model** synchronizes to `delegation.provider` and `delegation.model`.
+- **Swarm Router decomposition** uses `orchestratorModelRef`, then the default child route when no parent override exists. Request overrides must match a selectable canonical OAuth route.
+- **Swarm workers** resolve their canonical roster route into the worker profile before a new live session starts.
+
+Swarm worker execution requires `tmux`. On Windows, use the native ConPTY port: `winget install --id arndawg.tmux-windows`. Workspace creates an interactive Git Bash pane and sends the Hermes command into it; it does not use WSL or duplicate OAuth credentials. On macOS use `brew install tmux`; on Debian/Ubuntu use `sudo apt install tmux`.
+
+The canonical OAuth assignment is synchronized into each generated worker profile before the tmux-backed Hermes process starts. tmux is only the persistent process/pane transport; it does not authenticate providers or store OAuth material. Native Windows tmux does not support Workspace's Unix-style `new-session -c` usage, so the Windows launch plan changes directory inside the pane instead. Unix wrapper files under `~/.local/bin` are not required on Windows; profiles bootstrap from the active `HERMES_HOME`.
+
+Changing a route assigned to an already-running worker requires stopping and starting that worker. The next launch reads the synchronized profile; an active Hermes TUI does not hot-swap its model transport.
+
+The normal route states are:
+
+- `available`: selectable
+- `quota_limited`: visible with a warning but disabled until quota becomes available
+- `auth_expired` or `unavailable`: visible but disabled
+- unvalidated CLI transports: reported in transport status but do not publish selectable model routes
+
+OpenAI Codex and Nous models are discovered with the Python interpreter from the managed Hermes installation, not an unrelated system Python. This keeps the dashboard catalog aligned with the models the installed Hermes runtime can actually resolve.
+
+The live catalog endpoint is `GET /api/orchestration-catalog`. Existing Swarm role updates use `PATCH /api/swarm-roster` with `{ "id": "<worker>", "modelRef": "<canonical-route>" }`; the endpoint rejects unknown, disabled, or API-billed routes.
+
+## Defaults
+
+- Active child agents globally: 3
+- Active jobs per subscription account: 1
+- Delegation depth: 2
+- Total live agents: 8
+- Child memory: shared read/write
+- Child writes: parent review queue
+- Context transfer: full conversation
+- Context overflow: compact to a valid recent conversation boundary and notify
+- Interactive quota exhaustion: display the limited route and offer alternatives
+- Unattended quota exhaustion: configured subscription fallback chain
+- API-billed models: hidden and disabled
+- Auxiliary paid fallback: disabled while the API-billing gate is closed
+
+Pending child memory writes can be reviewed through the existing Hermes memory pending/approve/reject workflow.
+
+## Why one job per subscription account
+
+Vendors do not publish numeric concurrent-CLI process limits. The default queues work per account to avoid accidental subscription-window bursts while still allowing separate authenticated accounts to run concurrently.
+
+- Claude Max usage is shared across Claude surfaces and has five-hour and weekly windows.
+- Codex local and cloud activity share rolling usage windows and may have weekly limits.
+- Gemini Ultra publishes daily request capacity, but not a numeric per-minute concurrency cap; one prompt can consume multiple requests.
+- Nous Portal does not publish numeric concurrency or reset limits.
+- Copilot documents temporary fair-use limits but not a numeric concurrency cap.
+
+The per-account setting is configurable, but increases should be based on ordinary observed work rather than synthetic burst tests.
+
+Official references:
+
+- Claude Max: https://support.claude.com/en/articles/11049741-what-is-the-max-plan
+- Claude Code subscription use: https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan
+- OpenAI Codex pricing and limits: https://developers.openai.com/codex/pricing/
+- Gemini CLI quota: https://geminicli.com/docs/resources/quota-and-pricing
+- Nous Portal: https://hermes-agent.nousresearch.com/docs/integrations/nous-portal
+- GitHub Copilot limits: https://docs.github.com/en/copilot/concepts/usage-limits
+
+## Quota behavior
+
+Quota-limited models stay visible with warnings and a reset timestamp when the provider exposes one. The user can choose:
+
+- Configured subscription fallback
+- Stop and notify
+- Wait until a known reset time
+
+A wait policy does not busy-poll. If no reset time is known, Hermes cannot safely schedule a wait and must notify instead.
+
+Explicitly selected routes are not silently replaced. Automatic fallback is for configured unattended work.
+
+## Security and billing boundaries
+
+- Claude Max uses the local first-party Claude CLI relay. Hermes' native Anthropic API/Extra Usage route is not used.
+- OpenAI Codex uses ChatGPT OAuth, not `OPENAI_API_KEY`.
+- Nous Portal routes use Nous OAuth. Their individual entitlement and bundled usage may vary by subscription, so the dashboard retains the `subscription_unknown` warning rather than representing them as API-key routes.
+- Gemini, when enabled, must use Gemini CLI Google OAuth rather than API keys or Vertex billing.
+- Additional Usage, Anthropic Extra Usage, and API-key fallbacks remain disabled unless deliberately enabled outside the default policy.
+- Account tokens and OAuth files are never copied into Workspace policy files.
+- Policy changes, Swarm roster changes, Swarm decomposition, and Swarm dispatch require the local-or-auth request boundary. Enabling API-billed routes additionally requires the explicit billing confirmation field.
+- An explicitly configured gateway token takes precedence over localhost-only discovery of the co-located Hermes `API_SERVER_KEY`.
+
+## Policy storage
+
+- Global policy: `%HERMES_HOME%/workspace/orchestration-policy.json`
+- Session overrides: `%HERMES_HOME%/workspace/orchestration-sessions.json`
+- Runtime translation: selected global fields are synchronized into `%HERMES_HOME%/config.yaml`
+
+The JSON policy stores route names and behavior only, never credentials.
+
+## Verification
+
+From the Workspace repository:
+
+```bash
+npx vitest run src/server/subscription-model-catalog.test.ts src/server/swarm-model-resolver.test.ts src/server/swarm-roster.test.ts src/server/swarm-decompose-model.test.ts src/server/orchestration-hermes-sync.test.ts src/server/__tests__/gateway-capabilities.test.ts src/routes/api/-orchestration-policy.test.ts src/routes/api/-swarm-dispatch-auth.test.ts src/routes/api/-swarm-dispatch.test.ts src/screens/swarm2/swarm2-screen.test.ts src/screens/swarm2/operational-worker-card-model.test.ts src/components/settings-dialog/settings-dialog-orchestration.test.ts src/routes/api/__tests__/-models.test.ts src/screens/chat/components/chat-composer-model-switch.test.ts
+npm run build
+node .hermes/verify-oauth-role-ui-readonly.mjs
+```
+
+The browser check is read-only. It verifies that account-specific Claude routes and OpenAI Codex appear in the Chat picker, every Orchestration role selector, every existing Swarm role selector, and the new Swarm-role picker.

--- a/deployment/windows/hermes-stack/README.md
+++ b/deployment/windows/hermes-stack/README.md
@@ -1,0 +1,54 @@
+# Hermes Workspace Windows stack
+
+This directory is the version-controlled source of truth for the local Windows
+runtime currently deployed under `%LOCALAPPDATA%\hermes`.
+
+## Contents
+
+- `stack-supervisor/` — single-instance supervisor, Scheduled Task installer,
+  launcher, and lifecycle tests.
+- `antigravity-relay/` — loopback OpenAI-compatible Antigravity OAuth relay and
+  tests.
+- `deploy.ps1` — copies the four runtime files into `%LOCALAPPDATA%\hermes`
+  without deleting logs, caches, model inventory, status, or other runtime
+  state, then runs the idempotent Scheduled Task installer.
+
+Generated runtime state is intentionally not versioned. In particular, do not
+copy OAuth settings, model caches, logs, status files, lock files, or provider
+output into this directory.
+
+The installer resolves only explicit validated executable candidates. The
+current Windows deployment requires Python 3.12 (including `pythonw.exe` and
+`psutil`), Node/npm, the managed Hermes executable, and
+`%LOCALAPPDATA%\agy\bin\agy.exe`; it does not fall back to `PATH` discovery.
+The relay `/health` endpoint reports local relay readiness without consuming an
+Antigravity job slot. Provider inventory and its persisted non-secret cache are
+owned by `/v1/models`.
+
+## Verify
+
+From this directory:
+
+```powershell
+python -m unittest discover -s antigravity-relay\tests -p test_relay.py -v
+python -m unittest discover -s stack-supervisor\tests -p test_supervisor.py -v
+python -m py_compile antigravity-relay\relay.py stack-supervisor\supervisor.py
+```
+
+## Deploy
+
+Preview the copy targets:
+
+```powershell
+.\deploy.ps1 -WhatIf
+```
+
+Deploy and register/start `Hermes_Workspace_Stack`:
+
+```powershell
+.\deploy.ps1
+```
+
+Use `-SkipInstall` only when updating files without re-registering the task.
+The running supervisor must still be restarted before Python source changes are
+loaded into memory.

--- a/deployment/windows/hermes-stack/antigravity-relay/.gitignore
+++ b/deployment/windows/hermes-stack/antigravity-relay/.gitignore
@@ -1,0 +1,4 @@
+models-cache.json
+models-cache.tmp
+*.tmp
+__pycache__/

--- a/deployment/windows/hermes-stack/antigravity-relay/relay.py
+++ b/deployment/windows/hermes-stack/antigravity-relay/relay.py
@@ -1,0 +1,817 @@
+"""Loopback OpenAI-compatible relay backed by Antigravity CLI OAuth."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import urlparse
+
+ACTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "kind": {"type": "string", "enum": ["message", "tool_calls"]},
+        "content": {"type": "string"},
+        "calls": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "arguments": {"type": "object"},
+                },
+                "required": ["id", "name", "arguments"],
+            },
+        },
+    },
+    "required": ["kind"],
+}
+
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_CONCURRENT_HTTP_REQUESTS = 16
+MAX_CONCURRENT_AGY_JOBS = 1
+REQUEST_SOCKET_TIMEOUT = 30
+AGY_JOB_SLOTS = threading.BoundedSemaphore(MAX_CONCURRENT_AGY_JOBS)
+_LOCAL_APP_DATA = pathlib.Path(
+    os.environ.get("LOCALAPPDATA", pathlib.Path.home() / "AppData/Local")
+)
+MODEL_CACHE_FILE = pathlib.Path(
+    os.environ.get(
+        "ANTIGRAVITY_MODEL_CACHE_FILE",
+        _LOCAL_APP_DATA / "hermes/antigravity-relay/models-cache.json",
+    )
+)
+_MODEL_CACHE: tuple[float, list[dict[str, str]]] = (0.0, [])
+_MODEL_CACHE_LOCK = threading.Lock()
+_AGY_EXECUTABLE: str | None = None
+_AGY_EXECUTABLE_LOCK = threading.Lock()
+
+# Compatibility aliases for callers of the first bounded relay revision.
+MAX_CONCURRENT_REQUESTS = MAX_CONCURRENT_AGY_JOBS
+REQUEST_SLOTS = AGY_JOB_SLOTS
+
+PUBLIC_NOT_FOUND = "Not found"
+PUBLIC_PROTOCOL_REJECTED = "Request rejected"
+PUBLIC_REQUEST_REJECTED = "Request origin or content type rejected"
+PUBLIC_CONTENT_LENGTH_REQUIRED = "Content-Length is required"
+PUBLIC_INVALID_BODY = "Invalid request body"
+PUBLIC_BODY_TOO_LARGE = "Request body is too large"
+PUBLIC_INVALID_MODEL = "Invalid request or model"
+PUBLIC_HTTP_BUSY = "Relay request capacity exceeded"
+PUBLIC_AGY_BUSY = "Relay job capacity exceeded"
+PUBLIC_INVENTORY_UNAVAILABLE = "Model inventory unavailable"
+PUBLIC_PROVIDER_FAILURE = "Antigravity request failed"
+
+INTERNAL_CONFIGURATION_FAILURE = "configuration_error"
+INTERNAL_PROVIDER_FAILURE = "provider_execution_failed"
+INTERNAL_INVENTORY_FAILURE = "inventory_unavailable"
+
+_CONTENT_LENGTH_PATTERN = re.compile(r"[0-9]+", re.ASCII)
+_MODEL_ID_PATTERN = re.compile(r"gemini-[a-z0-9][a-z0-9._-]{0,127}", re.ASCII)
+_LOG_CATEGORIES = frozenset(
+    {
+        "agy_capacity",
+        "body_invalid",
+        "body_too_large",
+        "http_error",
+        "http_message",
+        "http_response",
+        "inventory_unavailable",
+        "model_invalid",
+        "provider_failure",
+        "request_capacity",
+        "request_rejected",
+        "server_started",
+        "server_stopped",
+        "startup_failed",
+        "unexpected_failure",
+    }
+)
+
+
+class RelayConfigurationError(RuntimeError):
+    pass
+
+
+class InvalidRequestBodyError(ValueError):
+    pass
+
+
+class RequestBodySizeError(InvalidRequestBodyError):
+    pass
+
+
+class MissingContentLengthError(RequestBodySizeError):
+    pass
+
+
+class RequestBodyTooLargeError(RequestBodySizeError):
+    pass
+
+
+class AgyCapacityError(RuntimeError):
+    pass
+
+
+class ProviderExecutionError(RuntimeError):
+    pass
+
+
+class ModelInventoryError(RuntimeError):
+    pass
+
+
+def log_event(category: str, *, status: int | None = None) -> None:
+    """Write only fixed, low-cardinality local diagnostic categories."""
+    safe_category = category if category in _LOG_CATEGORIES else "unexpected_failure"
+    suffix = f" status={int(status)}" if isinstance(status, int) else ""
+    print(f"relay event={safe_category}{suffix}", file=sys.stderr, flush=True)
+
+
+def _localhost_addresses() -> list[str]:
+    try:
+        results = socket.getaddrinfo(
+            "localhost",
+            0,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+    except OSError:
+        raise ValueError("loopback_host_invalid") from None
+    addresses = list(dict.fromkeys(result[4][0] for result in results if result[4]))
+    if not addresses:
+        raise ValueError("loopback_host_invalid")
+    try:
+        if any(not ipaddress.ip_address(address).is_loopback for address in addresses):
+            raise ValueError("loopback_host_invalid")
+    except ValueError:
+        raise ValueError("loopback_host_invalid") from None
+    return addresses
+
+
+def validate_loopback_host(host: str) -> str:
+    normalized = host.strip().lower()
+    if normalized in {"127.0.0.1", "::1"}:
+        return normalized
+    if normalized != "localhost":
+        raise ValueError("loopback_host_invalid")
+    _localhost_addresses()
+    return normalized
+
+
+def parse_content_length(value: str | None) -> int:
+    if value is None or value == "":
+        raise MissingContentLengthError("content_length_missing")
+    if not isinstance(value, str) or _CONTENT_LENGTH_PATTERN.fullmatch(value) is None:
+        raise InvalidRequestBodyError("content_length_invalid")
+    canonical = value.lstrip("0") or "0"
+    maximum = str(MAX_REQUEST_BYTES)
+    if len(canonical) > len(maximum) or (
+        len(canonical) == len(maximum) and canonical > maximum
+    ):
+        raise RequestBodyTooLargeError("body_too_large")
+    size = int(canonical)
+    if size == 0:
+        raise InvalidRequestBodyError("content_length_invalid")
+    return size
+
+
+def read_json_body(headers: Any, stream: Any) -> dict[str, Any]:
+    transfer_encodings = headers.get_all("Transfer-Encoding", []) or []
+    if transfer_encodings:
+        raise InvalidRequestBodyError("transfer_encoding_rejected")
+    length_values = headers.get_all("Content-Length", []) or []
+    if not length_values:
+        raise MissingContentLengthError("content_length_missing")
+    if len(length_values) != 1:
+        raise InvalidRequestBodyError("content_length_invalid")
+    size = parse_content_length(length_values[0])
+    try:
+        raw = stream.read(size)
+    except OSError:
+        raise InvalidRequestBodyError("body_read_failed") from None
+    if not isinstance(raw, bytes) or len(raw) != size:
+        raise InvalidRequestBodyError("body_length_mismatch")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise InvalidRequestBodyError("body_json_invalid") from None
+    if not isinstance(payload, dict):
+        raise InvalidRequestBodyError("body_json_invalid")
+    return payload
+
+
+def validate_host_header(value: str | None) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("host_rejected")
+    try:
+        parsed = urlparse(f"//{value.strip()}")
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError:
+        raise ValueError("host_rejected") from None
+    if not hostname or parsed.username is not None or parsed.password is not None:
+        raise ValueError("host_rejected")
+    try:
+        validate_loopback_host(hostname)
+    except ValueError:
+        raise ValueError("host_rejected") from None
+
+
+def validate_http_request(content_type: str | None, origin: str | None) -> None:
+    media_type = (content_type or "").split(";", 1)[0].strip().lower()
+    if media_type != "application/json":
+        raise ValueError("content_type_rejected")
+    if origin:
+        hostname = (urlparse(origin).hostname or "").lower()
+        try:
+            validate_loopback_host(hostname)
+        except ValueError:
+            raise ValueError("origin_rejected") from None
+
+
+def resolve_agy_executable() -> str:
+    global _AGY_EXECUTABLE
+    if _AGY_EXECUTABLE is not None:
+        return _AGY_EXECUTABLE
+    with _AGY_EXECUTABLE_LOCK:
+        if _AGY_EXECUTABLE is not None:
+            return _AGY_EXECUTABLE
+        located = os.environ.get("ANTIGRAVITY_AGY_BIN", "").strip()
+        if not located:
+            raise RelayConfigurationError(INTERNAL_CONFIGURATION_FAILURE)
+        candidate = pathlib.Path(located)
+        if not candidate.is_absolute():
+            raise RelayConfigurationError(INTERNAL_CONFIGURATION_FAILURE)
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            raise RelayConfigurationError(INTERNAL_CONFIGURATION_FAILURE) from None
+        if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            raise RelayConfigurationError(INTERNAL_CONFIGURATION_FAILURE)
+        _AGY_EXECUTABLE = str(resolved)
+        return _AGY_EXECUTABLE
+
+
+def parse_models(raw: str) -> list[dict[str, str]]:
+    models: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for line in raw.splitlines():
+        if "\t" not in line:
+            continue
+        model_id, label = (part.strip() for part in line.split("\t", 1))
+        if _MODEL_ID_PATTERN.fullmatch(model_id) is None or model_id in seen:
+            continue
+        seen.add(model_id)
+        models.append({"id": model_id, "label": label})
+    return models
+
+
+def _load_persisted_models() -> list[dict[str, str]]:
+    try:
+        payload = json.loads(MODEL_CACHE_FILE.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    models: list[dict[str, str]] = []
+    for row in payload:
+        if not isinstance(row, dict):
+            continue
+        model_id = row.get("id")
+        label = row.get("label")
+        if (
+            isinstance(model_id, str)
+            and _MODEL_ID_PATTERN.fullmatch(model_id) is not None
+            and isinstance(label, str)
+        ):
+            models.append({"id": model_id, "label": label})
+    return models
+
+
+def _persist_models(models: list[dict[str, str]]) -> None:
+    if not models:
+        return
+    temporary = MODEL_CACHE_FILE.with_suffix(".tmp")
+    try:
+        MODEL_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_text(json.dumps(models, ensure_ascii=False), encoding="utf-8")
+        temporary.replace(MODEL_CACHE_FILE)
+    except OSError:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _run_agy_process(
+    args: list[str],
+    *,
+    runner: Any,
+    timeout: int,
+) -> Any:
+    if not AGY_JOB_SLOTS.acquire(blocking=False):
+        raise AgyCapacityError("agy_capacity")
+    try:
+        try:
+            return runner(
+                args,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                timeout=timeout,
+                shell=False,
+            )
+        except Exception:
+            raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE) from None
+    finally:
+        AGY_JOB_SLOTS.release()
+
+
+def _last_known_models(now: float) -> list[dict[str, str]]:
+    global _MODEL_CACHE
+    with _MODEL_CACHE_LOCK:
+        cached = list(_MODEL_CACHE[1])
+    if cached:
+        return cached
+    persisted = _load_persisted_models()
+    if persisted:
+        with _MODEL_CACHE_LOCK:
+            _MODEL_CACHE = (now, persisted)
+        return list(persisted)
+    return []
+
+
+def list_models(*, runner=subprocess.run, ttl: int = 3600) -> list[dict[str, str]]:
+    global _MODEL_CACHE
+    now = time.monotonic()
+    with _MODEL_CACHE_LOCK:
+        cached_at, cached_models = _MODEL_CACHE
+        if cached_models and now - cached_at < ttl:
+            return list(cached_models)
+    try:
+        completed = _run_agy_process(
+            [resolve_agy_executable(), "models"],
+            runner=runner,
+            timeout=30,
+        )
+        if getattr(completed, "returncode", 1) != 0:
+            raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE)
+        stdout = getattr(completed, "stdout", "")
+        models = parse_models(stdout if isinstance(stdout, str) else "")
+    except AgyCapacityError:
+        fallback = _last_known_models(now)
+        if fallback:
+            return fallback
+        raise
+    except (ProviderExecutionError, TypeError):
+        fallback = _last_known_models(now)
+        if fallback:
+            return fallback
+        raise ModelInventoryError(INTERNAL_INVENTORY_FAILURE) from None
+    if not models:
+        fallback = _last_known_models(now)
+        if fallback:
+            return fallback
+        raise ModelInventoryError(INTERNAL_INVENTORY_FAILURE)
+    with _MODEL_CACHE_LOCK:
+        _MODEL_CACHE = (now, models)
+    _persist_models(models)
+    return list(models)
+
+
+def resolve_model(
+    route_ref: str,
+    *,
+    available_models: list[dict[str, str]] | None = None,
+) -> str:
+    raw = route_ref.strip()
+    prefix = "google-antigravity/"
+    model = raw[len(prefix) :] if raw.startswith(prefix) else raw
+    if _MODEL_ID_PATTERN.fullmatch(model) is None:
+        raise ValueError("model_invalid")
+    inventory = list_models() if available_models is None else available_models
+    if model not in {entry.get("id") for entry in inventory if isinstance(entry, dict)}:
+        raise ValueError("model_undiscovered")
+    return model
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                parts.append(str(part))
+            elif part.get("type") in {"text", "input_text"}:
+                parts.append(str(part.get("text", "")))
+            elif part.get("type") in {"image_url", "input_image"}:
+                parts.append(f"[image: {part.get('image_url') or part.get('url') or '[image]'}]")
+        return "\n".join(parts)
+    return json.dumps(content, ensure_ascii=False)
+
+
+def build_prompt(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> str:
+    transcript: list[str] = []
+    for message in messages:
+        entry: dict[str, Any] = {"content": _content_text(message.get("content", ""))}
+        if message.get("name"):
+            entry["name"] = message["name"]
+        if message.get("tool_call_id"):
+            entry["tool_call_id"] = message["tool_call_id"]
+        if message.get("tool_calls"):
+            entry["tool_calls"] = message["tool_calls"]
+        transcript.append(
+            f"{str(message.get('role', 'unknown')).upper()}: "
+            f"{json.dumps(entry, ensure_ascii=False)}"
+        )
+    tool_specs = [tool.get("function", tool) for tool in tools]
+    return (
+        "You are the reasoning model inside Hermes Agent. Hermes owns tool execution. "
+        "Do not claim to have run a tool yourself. Choose exactly one response shape.\n\n"
+        f"RESPONSE SCHEMA:\n{json.dumps(ACTION_SCHEMA, ensure_ascii=False)}\n\n"
+        f"AVAILABLE HERMES TOOLS:\n{json.dumps(tool_specs, ensure_ascii=False)}\n\n"
+        "CONVERSATION:\n" + "\n".join(transcript)
+    )
+
+
+def run_agy(
+    prompt: str,
+    model_id: str,
+    *,
+    available_models: list[dict[str, str]] | None = None,
+    runner=subprocess.run,
+    timeout: int = 360,
+) -> dict[str, Any]:
+    model = resolve_model(model_id, available_models=available_models)
+    args = [
+        resolve_agy_executable(),
+        "-p",
+        prompt,
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        "--json-schema",
+        json.dumps(ACTION_SCHEMA, separators=(",", ":")),
+        "--disable-slash-commands",
+        "--print-timeout",
+        "5m",
+    ]
+    completed = _run_agy_process(args, runner=runner, timeout=timeout)
+    if getattr(completed, "returncode", 1) != 0:
+        raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE)
+    stdout = getattr(completed, "stdout", "")
+    if not isinstance(stdout, str):
+        raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE) from None
+    if isinstance(payload, dict) and isinstance(payload.get("structured_output"), dict):
+        return payload
+    if isinstance(payload, dict) and payload.get("kind"):
+        return {"structured_output": payload}
+    if isinstance(payload, dict) and isinstance(payload.get("result"), dict):
+        return {"structured_output": payload["result"]}
+    raise ProviderExecutionError(INTERNAL_PROVIDER_FAILURE)
+
+
+def antigravity_result_to_choice(payload: dict[str, Any]) -> dict[str, Any]:
+    output = payload.get("structured_output")
+    if not isinstance(output, dict):
+        output = {"kind": "message", "content": str(payload.get("result", ""))}
+    if output.get("kind") == "tool_calls":
+        calls = []
+        for index, call in enumerate(output.get("calls") or []):
+            if not isinstance(call, dict) or not call.get("name"):
+                continue
+            arguments = call.get("arguments", {})
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            calls.append(
+                {
+                    "id": str(call.get("id") or f"call_{index + 1}"),
+                    "type": "function",
+                    "function": {"name": str(call["name"]), "arguments": arguments},
+                }
+            )
+        return {"role": "assistant", "content": None, "tool_calls": calls}
+    return {"role": "assistant", "content": str(output.get("content", ""))}
+
+
+class BoundedThreadingHTTPServer(ThreadingHTTPServer):
+    """Threaded HTTP server with admission before a handler thread is created."""
+
+    daemon_threads = True
+    request_queue_size = MAX_CONCURRENT_HTTP_REQUESTS
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
+        bind_and_activate: bool = True,
+        *,
+        max_concurrent_requests: int = MAX_CONCURRENT_HTTP_REQUESTS,
+    ) -> None:
+        host, port = server_address
+        normalized_host = str(host).strip().lower()
+        if normalized_host == "localhost":
+            addresses = _localhost_addresses()
+            bind_host = next(
+                (address for address in addresses if ":" not in address),
+                addresses[0],
+            )
+        else:
+            bind_host = validate_loopback_host(normalized_host)
+        self.address_family = socket.AF_INET6 if ":" in bind_host else socket.AF_INET
+        if max_concurrent_requests < 1:
+            raise ValueError("request_capacity_invalid")
+        self._request_slots = threading.BoundedSemaphore(max_concurrent_requests)
+        super().__init__((bind_host, port), request_handler_class, bind_and_activate)
+
+    def get_request(self) -> tuple[Any, Any]:
+        request, client_address = super().get_request()
+        request.settimeout(REQUEST_SOCKET_TIMEOUT)
+        return request, client_address
+
+    def process_request(self, request: Any, client_address: Any) -> None:
+        if not self._request_slots.acquire(blocking=False):
+            self._reject_saturated_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            self._request_slots.release()
+            raise
+
+    def process_request_thread(self, request: Any, client_address: Any) -> None:
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self._request_slots.release()
+
+    def _reject_saturated_request(self, request: Any) -> None:
+        payload = json.dumps(
+            {"error": {"message": PUBLIC_HTTP_BUSY}},
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        response = (
+            b"HTTP/1.1 503 Service Unavailable\r\n"
+            b"Content-Type: application/json; charset=utf-8\r\n"
+            + f"Content-Length: {len(payload)}\r\n".encode("ascii")
+            + b"Connection: close\r\nRetry-After: 1\r\n\r\n"
+            + payload
+        )
+        try:
+            request.sendall(response)
+        except OSError:
+            pass
+        finally:
+            self.shutdown_request(request)
+        log_event("request_capacity", status=503)
+
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        log_event("http_error")
+
+
+class RelayHandler(BaseHTTPRequestHandler):
+    server_version = "HermesAntigravityRelay"
+    sys_version = ""
+    protocol_version = "HTTP/1.1"
+
+    def version_string(self) -> str:
+        return self.server_version
+
+    def log_request(self, code: int | str = "-", size: int | str = "-") -> None:
+        status = int(code) if isinstance(code, int) else None
+        log_event("http_response", status=status)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        log_event("http_message")
+
+    def log_error(self, format: str, *args: Any) -> None:
+        log_event("http_error")
+
+    def send_error(
+        self,
+        code: int,
+        message: str | None = None,
+        explain: str | None = None,
+    ) -> None:
+        self._json(int(code), {"error": {"message": PUBLIC_PROTOCOL_REJECTED}})
+
+    def _json(self, status: int, payload: Any) -> None:
+        encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        if status >= 400:
+            self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store")
+        if status >= 400:
+            self.send_header("Connection", "close")
+        self.end_headers()
+        if getattr(self, "command", None) != "HEAD":
+            self.wfile.write(encoded)
+
+    def _error(self, status: int, message: str) -> None:
+        self._json(status, {"error": {"message": message}})
+
+    def _host_allowed(self) -> bool:
+        try:
+            validate_host_header(self.headers.get("Host"))
+            return True
+        except ValueError:
+            log_event("request_rejected", status=403)
+            self._error(403, PUBLIC_REQUEST_REJECTED)
+            return False
+
+    def do_GET(self) -> None:
+        if not self._host_allowed():
+            return
+        if self.path not in {"/health", "/v1/models"}:
+            self._error(404, PUBLIC_NOT_FOUND)
+            return
+        if self.path == "/health":
+            models = _last_known_models(time.monotonic())
+            self._json(
+                200,
+                {
+                    "status": "ok",
+                    "provider": "google-antigravity",
+                    "authenticated": bool(models),
+                    "model_count": len(models),
+                },
+            )
+            return
+        try:
+            models = list_models()
+        except AgyCapacityError:
+            log_event("agy_capacity", status=429)
+            self._error(429, PUBLIC_AGY_BUSY)
+            return
+        except Exception:
+            log_event("inventory_unavailable", status=503)
+            self._error(503, PUBLIC_INVENTORY_UNAVAILABLE)
+            return
+        self._json(
+            200,
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": f"google-antigravity/{model['id']}",
+                        "object": "model",
+                        "owned_by": "antigravity-oauth",
+                        "label": model["label"],
+                    }
+                    for model in models
+                ],
+            },
+        )
+
+    def do_POST(self) -> None:
+        if not self._host_allowed():
+            return
+        if self.path != "/v1/chat/completions":
+            self._error(404, PUBLIC_NOT_FOUND)
+            return
+        try:
+            validate_http_request(
+                self.headers.get("Content-Type"), self.headers.get("Origin")
+            )
+        except ValueError:
+            log_event("request_rejected", status=403)
+            self._error(403, PUBLIC_REQUEST_REJECTED)
+            return
+        try:
+            body = read_json_body(self.headers, self.rfile)
+        except RequestBodyTooLargeError:
+            log_event("body_too_large", status=413)
+            self._error(413, PUBLIC_BODY_TOO_LARGE)
+            return
+        except MissingContentLengthError:
+            log_event("body_invalid", status=411)
+            self._error(411, PUBLIC_CONTENT_LENGTH_REQUIRED)
+            return
+        except InvalidRequestBodyError:
+            log_event("body_invalid", status=400)
+            self._error(400, PUBLIC_INVALID_BODY)
+            return
+        try:
+            inventory = list_models()
+        except AgyCapacityError:
+            log_event("agy_capacity", status=429)
+            self._error(429, PUBLIC_AGY_BUSY)
+            return
+        except Exception:
+            log_event("inventory_unavailable", status=503)
+            self._error(503, PUBLIC_INVENTORY_UNAVAILABLE)
+            return
+        try:
+            model = resolve_model(
+                str(body.get("model", "")), available_models=inventory
+            )
+            messages = body.get("messages") or []
+            tools = body.get("tools") or []
+            if not isinstance(messages, list) or not all(
+                isinstance(message, dict) for message in messages
+            ):
+                raise ValueError("messages_invalid")
+            if not isinstance(tools, list) or not all(
+                isinstance(tool, dict) for tool in tools
+            ):
+                raise ValueError("tools_invalid")
+            prompt = build_prompt(messages, tools)
+        except (TypeError, ValueError):
+            log_event("model_invalid", status=400)
+            self._error(400, PUBLIC_INVALID_MODEL)
+            return
+        try:
+            payload = run_agy(
+                prompt,
+                model,
+                available_models=inventory,
+            )
+            message = antigravity_result_to_choice(payload)
+        except AgyCapacityError:
+            log_event("agy_capacity", status=429)
+            self._error(429, PUBLIC_AGY_BUSY)
+            return
+        except ProviderExecutionError:
+            log_event("provider_failure", status=502)
+            self._error(502, PUBLIC_PROVIDER_FAILURE)
+            return
+        except Exception:
+            log_event("unexpected_failure", status=500)
+            self._error(500, PUBLIC_PROVIDER_FAILURE)
+            return
+        self._json(
+            200,
+            {
+                "id": f"chatcmpl-{uuid.uuid4().hex}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": (
+                            "tool_calls" if message.get("tool_calls") else "stop"
+                        ),
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            },
+        )
+
+
+def main() -> None:
+    try:
+        resolve_agy_executable()
+        host = os.environ.get("ANTIGRAVITY_RELAY_HOST", "127.0.0.1")
+        port = int(os.environ.get("ANTIGRAVITY_RELAY_PORT", "8651"))
+        if not 1 <= port <= 65535:
+            raise ValueError("port_invalid")
+        server = BoundedThreadingHTTPServer((host, port), RelayHandler)
+    except (OSError, RelayConfigurationError, ValueError):
+        log_event("startup_failed")
+        raise SystemExit(1) from None
+    log_event("server_started")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    except Exception:
+        log_event("unexpected_failure")
+        raise SystemExit(1) from None
+    finally:
+        try:
+            server.server_close()
+        except OSError:
+            pass
+        log_event("server_stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/windows/hermes-stack/antigravity-relay/tests/test_relay.py
+++ b/deployment/windows/hermes-stack/antigravity-relay/tests/test_relay.py
@@ -1,0 +1,690 @@
+import contextlib
+import http.client
+import io
+import importlib.util
+import json
+import os
+import pathlib
+import socket
+import tempfile
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("antigravity_relay", ROOT / "relay.py")
+relay = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(relay)
+
+
+class FakeHeaders:
+    def __init__(self, values):
+        self._values = {
+            name.lower(): value if isinstance(value, list) else [value]
+            for name, value in values.items()
+        }
+
+    def get(self, name, default=None):
+        values = self._values.get(name.lower())
+        if not values and name.lower() == "host":
+            return "127.0.0.1:8651"
+        return values[0] if values else default
+
+    def get_all(self, name, default=None):
+        values = self._values.get(name.lower())
+        return list(values) if values else default
+
+
+class AntigravityRelayTests(unittest.TestCase):
+    def setUp(self):
+        self._agy_directory = tempfile.TemporaryDirectory()
+        executable = pathlib.Path(self._agy_directory.name) / "agy.exe"
+        executable.write_text("fixture", encoding="utf-8")
+        executable.chmod(0o755)
+        self._agy_environment = mock.patch.dict(
+            os.environ,
+            {"ANTIGRAVITY_AGY_BIN": str(executable)},
+        )
+        self._agy_environment.start()
+        relay._AGY_EXECUTABLE = None
+
+    def tearDown(self):
+        relay._AGY_EXECUTABLE = None
+        self._agy_environment.stop()
+        self._agy_directory.cleanup()
+
+    def test_default_model_cache_is_outside_versioned_source_tree(self):
+        self.assertNotEqual(relay.MODEL_CACHE_FILE.parent, ROOT)
+        self.assertIn("antigravity-relay", relay.MODEL_CACHE_FILE.parts)
+
+    def test_parse_models_keeps_only_concrete_gemini_routes(self):
+        raw = "\n".join(
+            [
+                "Fetching available models...",
+                "gemini-3.6-flash-high\tGemini 3.6 Flash (High)",
+                "gemini-3.1-pro-low\tGemini 3.1 Pro (Low)",
+                "claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)",
+                "gpt-oss-120b-medium\tGPT-OSS 120B (Medium)",
+            ]
+        )
+        self.assertEqual(
+            relay.parse_models(raw),
+            [
+                {"id": "gemini-3.6-flash-high", "label": "Gemini 3.6 Flash (High)"},
+                {"id": "gemini-3.1-pro-low", "label": "Gemini 3.1 Pro (Low)"},
+            ],
+        )
+
+    def test_list_models_falls_back_to_persisted_non_secret_inventory(self):
+        original_path = relay.MODEL_CACHE_FILE
+        original_cache = relay._MODEL_CACHE
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                relay.MODEL_CACHE_FILE = pathlib.Path(directory) / "models.json"
+                relay._MODEL_CACHE = (0.0, [])
+                success = lambda *_args, **_kwargs: SimpleNamespace(
+                    returncode=0,
+                    stdout="gemini-3.6-flash-high\tGemini 3.6 Flash (High)\n",
+                    stderr="",
+                )
+                expected = relay.list_models(runner=success, ttl=0)
+                relay._MODEL_CACHE = (0.0, [])
+                failure = lambda *_args, **_kwargs: SimpleNamespace(
+                    returncode=1,
+                    stdout="",
+                    stderr="temporarily unavailable",
+                )
+                self.assertEqual(relay.list_models(runner=failure, ttl=0), expected)
+        finally:
+            relay.MODEL_CACHE_FILE = original_path
+            relay._MODEL_CACHE = original_cache
+
+    def test_list_models_uses_stale_cache_when_provider_slot_is_busy(self):
+        original_cache = relay._MODEL_CACHE
+        stale = [
+            {
+                "id": "gemini-3.6-flash-high",
+                "label": "Gemini 3.6 Flash (High)",
+            }
+        ]
+        acquired = relay.AGY_JOB_SLOTS.acquire(blocking=False)
+        self.assertTrue(acquired)
+        try:
+            relay._MODEL_CACHE = (0.0, stale)
+            with mock.patch.object(
+                relay, "resolve_agy_executable", return_value=r"C:\agy.exe"
+            ):
+                self.assertEqual(relay.list_models(ttl=0), stale)
+        finally:
+            relay._MODEL_CACHE = original_cache
+            relay.AGY_JOB_SLOTS.release()
+
+    def test_health_does_not_require_provider_inventory_or_job_capacity(self):
+        handler = relay.RelayHandler.__new__(relay.RelayHandler)
+        handler.path = "/health"
+        handler.headers = FakeHeaders({"Host": "127.0.0.1:8651"})
+        responses = []
+        handler._json = lambda status, payload: responses.append((status, payload))
+
+        with mock.patch.object(
+            relay,
+            "list_models",
+            side_effect=AssertionError("health must not run provider inventory"),
+        ), mock.patch.object(relay, "_last_known_models", return_value=[]):
+            handler.do_GET()
+
+        self.assertEqual(responses[0][0], 200)
+        self.assertEqual(responses[0][1]["status"], "ok")
+        self.assertEqual(responses[0][1]["model_count"], 0)
+
+    def test_get_rejects_non_loopback_host_before_health_processing(self):
+        handler = relay.RelayHandler.__new__(relay.RelayHandler)
+        handler.path = "/health"
+        handler.headers = FakeHeaders({"Host": "attacker.example:8651"})
+        responses = []
+        handler._json = lambda status, payload: responses.append((status, payload))
+
+        with mock.patch.object(
+            relay,
+            "_last_known_models",
+            side_effect=AssertionError("rejected host must not reach health processing"),
+        ):
+            handler.do_GET()
+
+        self.assertEqual(
+            responses,
+            [(403, {"error": {"message": relay.PUBLIC_REQUEST_REJECTED}})],
+        )
+
+    def test_validate_loopback_host_rejects_non_loopback_bindings(self):
+        for host in ("127.0.0.1", "::1"):
+            self.assertEqual(relay.validate_loopback_host(host), host)
+        for host in (
+            "0.0.0.0",
+            "127.0.0.2",
+            "192.168.1.10",
+            "example.com",
+            "[::1]",
+            "localhost.",
+        ):
+            with self.assertRaises(ValueError):
+                relay.validate_loopback_host(host)
+
+    def test_localhost_is_allowed_only_when_every_resolution_is_loopback(self):
+        loopback_results = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0)),
+        ]
+        with mock.patch.object(relay.socket, "getaddrinfo", return_value=loopback_results):
+            self.assertEqual(relay.validate_loopback_host("LOCALHOST"), "localhost")
+
+        unsafe_results = loopback_results + [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.9", 0))
+        ]
+        with mock.patch.object(relay.socket, "getaddrinfo", return_value=unsafe_results):
+            with self.assertRaises(ValueError):
+                relay.validate_loopback_host("localhost")
+        with mock.patch.object(relay.socket, "getaddrinfo", return_value=[]):
+            with self.assertRaises(ValueError):
+                relay.validate_loopback_host("localhost")
+
+    def test_parse_content_length_rejects_missing_invalid_and_oversized_bodies(self):
+        self.assertEqual(relay.parse_content_length("128"), 128)
+        for value in (
+            None,
+            "",
+            "0",
+            "abc",
+            "-1",
+            "+1",
+            " 1",
+            "1 ",
+            "1.0",
+            "1, 1",
+            "١",
+            "9" * 5000,
+            str(relay.MAX_REQUEST_BYTES + 1),
+        ):
+            with self.assertRaises(ValueError):
+                relay.parse_content_length(value)
+
+    def test_oversized_body_is_rejected_before_the_stream_is_read(self):
+        class UnreadableBody:
+            read_called = False
+
+            def read(self, _size):
+                self.read_called = True
+                raise AssertionError("oversized request body must not be allocated")
+
+        stream = UnreadableBody()
+        headers = FakeHeaders(
+            {"Content-Length": str(relay.MAX_REQUEST_BYTES + 1)}
+        )
+        with self.assertRaises(relay.RequestBodyTooLargeError):
+            relay.read_json_body(headers, stream)
+        self.assertFalse(stream.read_called)
+
+    def test_body_reader_rejects_missing_duplicate_and_short_content_length(self):
+        cases = (
+            (FakeHeaders({}), b"{}"),
+            (FakeHeaders({"Content-Length": ["2", "2"]}), b"{}"),
+            (FakeHeaders({"Content-Length": "3"}), b"{}"),
+            (
+                FakeHeaders(
+                    {"Content-Length": "2", "Transfer-Encoding": "chunked"}
+                ),
+                b"{}",
+            ),
+        )
+        for headers, body in cases:
+            with self.subTest(headers=headers._values):
+                with self.assertRaises(relay.InvalidRequestBodyError):
+                    relay.read_json_body(headers, io.BytesIO(body))
+
+    def test_validate_http_request_blocks_cross_site_and_non_json_posts(self):
+        relay.validate_http_request("application/json; charset=utf-8", None)
+        relay.validate_http_request("application/json", "http://127.0.0.1:3000")
+        for content_type, origin in (
+            ("text/plain", None),
+            ("application/json", "https://example.com"),
+        ):
+            with self.assertRaises(ValueError):
+                relay.validate_http_request(content_type, origin)
+
+    def test_validate_host_header_allows_only_loopback_hosts(self):
+        for value in ("127.0.0.1:8651", "localhost:8651", "[::1]:8651"):
+            relay.validate_host_header(value)
+        for value in (None, "", "example.com:8651", "127.0.0.2:8651", "malformed@@"):
+            with self.assertRaises(ValueError):
+                relay.validate_host_header(value)
+
+    def test_http_admission_returns_503_without_spawning_when_saturated(self):
+        class FakeRequest:
+            def __init__(self):
+                self.sent = bytearray()
+
+            def sendall(self, data):
+                self.sent.extend(data)
+
+        server = relay.BoundedThreadingHTTPServer.__new__(
+            relay.BoundedThreadingHTTPServer
+        )
+        server._request_slots = threading.BoundedSemaphore(1)
+        self.assertTrue(server._request_slots.acquire(blocking=False))
+        closed = []
+        server.shutdown_request = lambda request: closed.append(request)
+        request = FakeRequest()
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            server.process_request(request, ("127.0.0.1", 12345))
+
+        response = bytes(request.sent)
+        self.assertIn(b"HTTP/1.1 503 Service Unavailable", response)
+        self.assertIn(relay.PUBLIC_HTTP_BUSY.encode("utf-8"), response)
+        self.assertEqual(closed, [request])
+
+    def test_bounded_server_enforces_and_releases_http_capacity_end_to_end(self):
+        entered = threading.Event()
+        release = threading.Event()
+
+        class BlockingHandler(relay.BaseHTTPRequestHandler):
+            def do_GET(self):
+                entered.set()
+                release.wait(timeout=3)
+                payload = b"ok"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, _format, *_args):
+                pass
+
+        server = relay.BoundedThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            BlockingHandler,
+            max_concurrent_requests=1,
+        )
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        first_status = []
+
+        def first_request():
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_port, timeout=3
+            )
+            try:
+                connection.request("GET", "/", headers={"Connection": "close"})
+                response = connection.getresponse()
+                first_status.append((response.status, response.read()))
+            finally:
+                connection.close()
+
+        first_thread = threading.Thread(target=first_request, daemon=True)
+        logs = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(logs):
+                server_thread.start()
+                first_thread.start()
+                self.assertTrue(entered.wait(timeout=2))
+
+                second = http.client.HTTPConnection(
+                    "127.0.0.1", server.server_port, timeout=3
+                )
+                try:
+                    second.request("GET", "/", headers={"Connection": "close"})
+                    saturated = second.getresponse()
+                    saturated_body = json.loads(saturated.read())
+                finally:
+                    second.close()
+                self.assertEqual(saturated.status, 503)
+                self.assertEqual(
+                    saturated_body,
+                    {"error": {"message": relay.PUBLIC_HTTP_BUSY}},
+                )
+
+                release.set()
+                first_thread.join(timeout=3)
+                self.assertFalse(first_thread.is_alive())
+                self.assertEqual(first_status, [(200, b"ok")])
+
+                deadline = time.monotonic() + 2
+                while not server._request_slots.acquire(blocking=False):
+                    if time.monotonic() >= deadline:
+                        self.fail("HTTP request slot was not released")
+                    time.sleep(0.01)
+                server._request_slots.release()
+        finally:
+            release.set()
+            server.shutdown()
+            server.server_close()
+            first_thread.join(timeout=3)
+            server_thread.join(timeout=3)
+
+    def test_agy_job_slots_are_separate_and_reject_without_running(self):
+        original_slots = relay.AGY_JOB_SLOTS
+        relay.AGY_JOB_SLOTS = threading.BoundedSemaphore(1)
+        self.assertTrue(relay.AGY_JOB_SLOTS.acquire(blocking=False))
+        runner_called = False
+
+        def runner(*_args, **_kwargs):
+            nonlocal runner_called
+            runner_called = True
+            raise AssertionError("saturated admission must not launch agy")
+
+        try:
+            with self.assertRaises(relay.AgyCapacityError):
+                relay.run_agy(
+                    "hello",
+                    "gemini-3.6-flash-high",
+                    available_models=[
+                        {
+                            "id": "gemini-3.6-flash-high",
+                            "label": "Gemini 3.6 Flash (High)",
+                        }
+                    ],
+                    runner=runner,
+                )
+            self.assertFalse(runner_called)
+        finally:
+            relay.AGY_JOB_SLOTS.release()
+            relay.AGY_JOB_SLOTS = original_slots
+
+    def test_post_returns_429_when_agy_job_admission_is_saturated(self):
+        request_body = json.dumps(
+            {
+                "model": "google-antigravity/gemini-3.6-flash-high",
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+        ).encode("utf-8")
+        handler = relay.RelayHandler.__new__(relay.RelayHandler)
+        handler.path = "/v1/chat/completions"
+        handler.headers = FakeHeaders(
+            {
+                "Content-Type": "application/json",
+                "Content-Length": str(len(request_body)),
+            }
+        )
+        handler.rfile = io.BytesIO(request_body)
+        responses = []
+        handler._json = lambda status, payload: responses.append((status, payload))
+        inventory = [
+            {
+                "id": "gemini-3.6-flash-high",
+                "label": "Gemini 3.6 Flash (High)",
+            }
+        ]
+        with contextlib.redirect_stderr(io.StringIO()), mock.patch.object(
+            relay, "list_models", return_value=inventory
+        ), mock.patch.object(relay, "run_agy", side_effect=relay.AgyCapacityError):
+            handler.do_POST()
+        self.assertEqual(
+            responses,
+            [(429, {"error": {"message": relay.PUBLIC_AGY_BUSY}})],
+        )
+
+    def test_resolve_model_accepts_only_discovered_canonical_routes(self):
+        inventory = [{"id": "gemini-3.6-flash-high", "label": "Gemini 3.6 Flash (High)"}]
+        self.assertEqual(
+            relay.resolve_model(
+                "google-antigravity/gemini-3.6-flash-high",
+                available_models=inventory,
+            ),
+            "gemini-3.6-flash-high",
+        )
+        for route in (
+            "google-antigravity/claude-opus-4-6-thinking",
+            "google-antigravity/gemini-undiscovered",
+        ):
+            with self.assertRaises(ValueError):
+                relay.resolve_model(route, available_models=inventory)
+
+    def test_resolve_model_uses_discovered_inventory_when_not_explicit(self):
+        inventory = [
+            {
+                "id": "gemini-3.6-flash-high",
+                "label": "Gemini 3.6 Flash (High)",
+            }
+        ]
+        with mock.patch.object(relay, "list_models", return_value=inventory):
+            self.assertEqual(
+                relay.resolve_model("gemini-3.6-flash-high"),
+                "gemini-3.6-flash-high",
+            )
+            with self.assertRaises(ValueError):
+                relay.resolve_model("gemini-undiscovered")
+
+        runner_called = False
+
+        def runner(*_args, **_kwargs):
+            nonlocal runner_called
+            runner_called = True
+            raise AssertionError("undiscovered models must be rejected before execution")
+
+        with self.assertRaises(ValueError):
+            relay.run_agy(
+                "hello",
+                "gemini-undiscovered",
+                available_models=inventory,
+                runner=runner,
+            )
+        self.assertFalse(runner_called)
+
+    def test_agy_executable_is_validated_absolute_and_pinned(self):
+        captured = {}
+
+        def runner(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {"structured_output": {"kind": "message", "content": "ready"}}
+                ),
+                stderr="",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            executable = pathlib.Path(directory) / (
+                "agy.exe" if os.name == "nt" else "agy"
+            )
+            executable.write_bytes(b"test executable")
+            executable.chmod(executable.stat().st_mode | 0o111)
+            with mock.patch.object(
+                relay, "_AGY_EXECUTABLE", None, create=True
+            ), mock.patch.dict(
+                os.environ,
+                {"ANTIGRAVITY_AGY_BIN": str(executable)},
+            ):
+                pinned = relay.resolve_agy_executable()
+                self.assertTrue(pathlib.Path(pinned).is_absolute())
+                self.assertEqual(pathlib.Path(pinned), executable.resolve())
+                relay.run_agy(
+                    "hello",
+                    "gemini-3.6-flash-high",
+                    available_models=[
+                        {
+                            "id": "gemini-3.6-flash-high",
+                            "label": "Gemini 3.6 Flash (High)",
+                        }
+                    ],
+                    runner=runner,
+                )
+                self.assertEqual(relay.resolve_agy_executable(), pinned)
+
+        self.assertEqual(captured["args"][0], pinned)
+        self.assertIs(captured["kwargs"]["shell"], False)
+
+    def test_missing_explicit_agy_path_is_rejected_even_if_path_has_a_candidate(self):
+        with mock.patch.object(
+            relay, "_AGY_EXECUTABLE", None, create=True
+        ), mock.patch.dict(
+            os.environ, {}, clear=True
+        ):
+            with self.assertRaises(relay.RelayConfigurationError):
+                relay.resolve_agy_executable()
+
+    def test_run_agy_uses_authenticated_antigravity_cli_and_json_schema(self):
+        captured = {}
+
+        def runner(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "structured_output": {
+                            "kind": "message",
+                            "content": "ready",
+                        }
+                    }
+                ),
+                stderr="",
+            )
+
+        result = relay.run_agy(
+            "hello",
+            "google-antigravity/gemini-3.1-pro-high",
+            available_models=[
+                {
+                    "id": "gemini-3.1-pro-high",
+                    "label": "Gemini 3.1 Pro (High)",
+                }
+            ],
+            runner=runner,
+        )
+        self.assertEqual(result["structured_output"]["content"], "ready")
+        args = captured["args"]
+        self.assertEqual(args[0], relay.resolve_agy_executable())
+        self.assertIn("--model", args)
+        self.assertIn("gemini-3.1-pro-high", args)
+        self.assertIn("--output-format", args)
+        self.assertIn("json", args)
+        self.assertIn("--json-schema", args)
+        self.assertIn("--disable-slash-commands", args)
+        self.assertEqual(args[1:3], ["-p", "hello"])
+        self.assertNotIn("input", captured["kwargs"])
+        self.assertIs(captured["kwargs"]["shell"], False)
+
+    def test_provider_failure_and_get_error_are_redacted(self):
+        secret_parts = (
+            "PROMPT-SECRET",
+            "token-abc123",
+            "account=user@example.com",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "C:\\private\\provider.log",
+        )
+        diagnostic = " | ".join(secret_parts)
+
+        def failure_runner(*_args, **_kwargs):
+            return SimpleNamespace(
+                returncode=1,
+                stdout=f"stdout {diagnostic}",
+                stderr=f"stderr {diagnostic}",
+            )
+
+        with self.assertRaises(relay.ProviderExecutionError) as caught:
+            relay.run_agy(
+                "PROMPT-SECRET",
+                "gemini-3.6-flash-high",
+                available_models=[
+                    {
+                        "id": "gemini-3.6-flash-high",
+                        "label": "Gemini 3.6 Flash (High)",
+                    }
+                ],
+                runner=failure_runner,
+            )
+        self.assertEqual(str(caught.exception), relay.INTERNAL_PROVIDER_FAILURE)
+
+        handler = relay.RelayHandler.__new__(relay.RelayHandler)
+        handler.path = "/v1/models"
+        handler.headers = FakeHeaders({})
+        responses = []
+        handler._json = lambda status, payload: responses.append((status, payload))
+        logs = io.StringIO()
+        with contextlib.redirect_stdout(logs), contextlib.redirect_stderr(logs), mock.patch.object(
+            relay, "list_models", side_effect=RuntimeError(diagnostic)
+        ):
+            handler.do_GET()
+            handler.log_message("provider=%s", diagnostic)
+
+        public_and_logs = json.dumps(responses) + logs.getvalue()
+        for secret in secret_parts:
+            self.assertNotIn(secret, str(caught.exception))
+            self.assertNotIn(secret, public_and_logs)
+        self.assertEqual(
+            responses,
+            [(503, {"error": {"message": relay.PUBLIC_INVENTORY_UNAVAILABLE}})],
+        )
+        self.assertIn("inventory_unavailable", logs.getvalue())
+
+        request_body = json.dumps(
+            {
+                "model": "google-antigravity/gemini-3.6-flash-high",
+                "messages": [{"role": "user", "content": "PROMPT-SECRET"}],
+            }
+        ).encode("utf-8")
+        post_handler = relay.RelayHandler.__new__(relay.RelayHandler)
+        post_handler.path = "/v1/chat/completions"
+        post_handler.headers = FakeHeaders(
+            {
+                "Content-Type": "application/json",
+                "Content-Length": str(len(request_body)),
+            }
+        )
+        post_handler.rfile = io.BytesIO(request_body)
+        post_responses = []
+        post_handler._json = lambda status, payload: post_responses.append(
+            (status, payload)
+        )
+        inventory = [
+            {
+                "id": "gemini-3.6-flash-high",
+                "label": "Gemini 3.6 Flash (High)",
+            }
+        ]
+        post_logs = io.StringIO()
+        with contextlib.redirect_stdout(post_logs), contextlib.redirect_stderr(
+            post_logs
+        ), mock.patch.object(
+            relay, "list_models", return_value=inventory
+        ), mock.patch.object(
+            relay,
+            "run_agy",
+            side_effect=relay.ProviderExecutionError(diagnostic),
+        ):
+            post_handler.do_POST()
+        post_public_and_logs = json.dumps(post_responses) + post_logs.getvalue()
+        for secret in secret_parts:
+            self.assertNotIn(secret, post_public_and_logs)
+        self.assertEqual(
+            post_responses,
+            [(502, {"error": {"message": relay.PUBLIC_PROVIDER_FAILURE}})],
+        )
+
+    def test_result_converts_to_openai_message_and_tool_calls(self):
+        message = relay.antigravity_result_to_choice(
+            {"structured_output": {"kind": "message", "content": "done"}}
+        )
+        self.assertEqual(message, {"role": "assistant", "content": "done"})
+
+        tools = relay.antigravity_result_to_choice(
+            {
+                "structured_output": {
+                    "kind": "tool_calls",
+                    "calls": [
+                        {"id": "call_1", "name": "read_file", "arguments": {"path": "x"}}
+                    ],
+                }
+            }
+        )
+        self.assertEqual(tools["tool_calls"][0]["function"]["name"], "read_file")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deployment/windows/hermes-stack/deploy.ps1
+++ b/deployment/windows/hermes-stack/deploy.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [switch]$SkipInstall
+)
+
+$ErrorActionPreference = 'Stop'
+$sourceRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$runtimeRoot = Join-Path $env:LOCALAPPDATA 'hermes'
+
+$runtimeFiles = @(
+  'stack-supervisor\supervisor.py',
+  'stack-supervisor\install.ps1',
+  'stack-supervisor\launch-workspace.ps1',
+  'antigravity-relay\relay.py'
+)
+
+foreach ($relativePath in $runtimeFiles) {
+  $source = Join-Path $sourceRoot $relativePath
+  if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+    throw "Versioned runtime source is missing: $source"
+  }
+
+  $destination = Join-Path $runtimeRoot $relativePath
+  $destinationDirectory = Split-Path -Parent $destination
+  if ($PSCmdlet.ShouldProcess($destination, "Deploy $source")) {
+    New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+    Copy-Item -LiteralPath $source -Destination $destination -Force
+  }
+}
+
+if (-not $SkipInstall -and -not $WhatIfPreference) {
+  $installer = Join-Path $runtimeRoot 'stack-supervisor\install.ps1'
+  & $installer
+}
+
+Write-Output "Hermes stack runtime deployed to $runtimeRoot"

--- a/deployment/windows/hermes-stack/stack-supervisor/install.ps1
+++ b/deployment/windows/hermes-stack/stack-supervisor/install.ps1
@@ -1,0 +1,147 @@
+$ErrorActionPreference = 'Stop'
+$taskName = 'Hermes_Workspace_Stack'
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Resolve-PinnedExecutable {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Candidates
+  )
+  foreach ($candidate in $Candidates) {
+    if ([string]::IsNullOrWhiteSpace([string]$candidate)) {
+      continue
+    }
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      $resolved = (Resolve-Path -LiteralPath $candidate).ProviderPath
+      if (-not [IO.Path]::IsPathRooted($resolved)) {
+        throw "$Name resolved to a non-absolute path: $resolved"
+      }
+      return $resolved
+    }
+  }
+  throw "$Name executable was not found in any validated candidate path."
+}
+
+function Assert-PinnedExecutable {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string[]]$Arguments
+  )
+  if ($Name -eq 'pythonw') {
+    $quotedArguments = @(
+      $Arguments | ForEach-Object {
+        '"' + $_.Replace('"', '\"') + '"'
+      }
+    ) -join ' '
+    $process = Start-Process `
+      -FilePath $Path `
+      -ArgumentList $quotedArguments `
+      -WindowStyle Hidden `
+      -Wait `
+      -PassThru
+    $exitCode = $process.ExitCode
+  } else {
+    & $Path @Arguments *> $null
+    $exitCode = $LASTEXITCODE
+  }
+  if ($exitCode -ne 0) {
+    throw "$Name validation failed for $Path with exit code $exitCode."
+  }
+}
+
+function Quote-TaskArgument {
+  param([Parameter(Mandatory = $true)][string]$Value)
+  if ($Value.Contains('"')) {
+    throw "Scheduled-task arguments cannot contain a double quote: $Value"
+  }
+  return '"' + $Value + '"'
+}
+
+$programFiles = $env:ProgramFiles
+$localPrograms = Join-Path $env:LOCALAPPDATA 'Programs'
+$hermesHome = Join-Path $env:LOCALAPPDATA 'hermes'
+
+$python = Resolve-PinnedExecutable 'python' @(
+  (Join-Path $programFiles 'Python312\python.exe'),
+  (Join-Path $localPrograms 'Python\Python312\python.exe')
+)
+$pythonw = Resolve-PinnedExecutable 'pythonw' @(
+  (Join-Path (Split-Path -Parent $python) 'pythonw.exe'),
+  (Join-Path $programFiles 'Python312\pythonw.exe'),
+  (Join-Path $localPrograms 'Python\Python312\pythonw.exe')
+)
+$hermes = Resolve-PinnedExecutable 'hermes' @(
+  (Join-Path $hermesHome 'hermes-agent\venv\Scripts\hermes.exe')
+)
+$node = Resolve-PinnedExecutable 'node' @(
+  (Join-Path $programFiles 'nodejs\node.exe'),
+  (Join-Path $localPrograms 'nodejs\node.exe')
+)
+$npm = Resolve-PinnedExecutable 'npm' @(
+  (Join-Path $programFiles 'nodejs\npm.cmd'),
+  (Join-Path $localPrograms 'nodejs\npm.cmd')
+)
+$agy = Resolve-PinnedExecutable 'agy' @(
+  (Join-Path $env:LOCALAPPDATA 'agy\bin\agy.exe')
+)
+
+Assert-PinnedExecutable 'python' $python @('--version')
+Assert-PinnedExecutable 'pythonw' $pythonw @('-c', 'import sys; raise SystemExit(0)')
+Assert-PinnedExecutable 'python-psutil' $python @('-c', 'import psutil')
+Assert-PinnedExecutable 'hermes' $hermes @('--version')
+Assert-PinnedExecutable 'node' $node @('--version')
+Assert-PinnedExecutable 'npm' $npm @('--version')
+Assert-PinnedExecutable 'agy' $agy @('--version')
+
+$supervisorPath = Join-Path $root 'supervisor.py'
+$supervisorArguments = @(
+  (Quote-TaskArgument $supervisorPath),
+  '--python-exe', (Quote-TaskArgument $python),
+  '--pythonw-exe', (Quote-TaskArgument $pythonw),
+  '--hermes-exe', (Quote-TaskArgument $hermes),
+  '--node-exe', (Quote-TaskArgument $node),
+  '--npm-exe', (Quote-TaskArgument $npm),
+  '--agy-exe', (Quote-TaskArgument $agy)
+) -join ' '
+
+$action = New-ScheduledTaskAction `
+  -Execute $pythonw `
+  -Argument $supervisorArguments `
+  -WorkingDirectory $root
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -StartWhenAvailable `
+  -MultipleInstances IgnoreNew `
+  -RestartCount 999 `
+  -RestartInterval (New-TimeSpan -Minutes 1) `
+  -ExecutionTimeLimit ([TimeSpan]::Zero)
+Register-ScheduledTask `
+  -TaskName $taskName `
+  -Action $action `
+  -Trigger $trigger `
+  -Settings $settings `
+  -Description 'Single-instance supervisor for Hermes gateway, Claude Max relay, Antigravity relay, dashboard, and Workspace.' `
+  -Force | Out-Null
+
+$desktopPath = [Environment]::GetFolderPath('DesktopDirectory')
+$shortcutPath = Join-Path $desktopPath 'Hermes Workspace.lnk'
+$shell = New-Object -ComObject WScript.Shell
+$shortcut = $shell.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+$shortcut.Arguments = ('-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "{0}"' -f (Join-Path $root 'launch-workspace.ps1'))
+$shortcut.WorkingDirectory = $root
+$shortcut.Description = 'Start or recover Hermes Workspace, then open Operations'
+$shortcut.Save()
+
+# Start only when registration did not leave the task running. IgnoreNew remains
+# the second line of defense, but avoiding a redundant start also keeps
+# LastTaskResult from being polluted with ERROR_REQUEST_REFUSED.
+$registeredTask = Get-ScheduledTask -TaskName $taskName -ErrorAction Stop
+if ($registeredTask.State -ne 'Running') {
+  Start-ScheduledTask -TaskName $taskName -ErrorAction Stop
+}
+Write-Output "Installed and started $taskName"
+Write-Output "Launcher: $shortcutPath"

--- a/deployment/windows/hermes-stack/stack-supervisor/launch-workspace.ps1
+++ b/deployment/windows/hermes-stack/stack-supervisor/launch-workspace.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+param(
+  [ValidateRange(0, 600)]
+  [int]$TimeoutSeconds = 45,
+
+  [ValidateRange(1, 10000)]
+  [int]$PollMilliseconds = 750,
+
+  [switch]$NoFailureDialog
+)
+
+$ErrorActionPreference = 'Stop'
+$taskName = 'Hermes_Workspace_Stack'
+$url = 'http://127.0.0.1:3000/operations'
+$expectedContent = 'Hermes Workspace'
+
+try {
+  try {
+    $task = Get-ScheduledTask -TaskName $taskName -ErrorAction Stop
+  } catch {
+    throw "Required scheduled task '$taskName' was not found. Run install.ps1 first. $($_.Exception.Message)"
+  }
+
+  if ($task.State -ne 'Running') {
+    try {
+      Start-ScheduledTask -TaskName $taskName -ErrorAction Stop
+    } catch {
+      throw "Scheduled task '$taskName' could not be started. $($_.Exception.Message)"
+    }
+  }
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $ready = $false
+  do {
+    try {
+      $response = Invoke-WebRequest -UseBasicParsing -Uri $url -TimeoutSec 2 -ErrorAction Stop
+      if (
+        $response.StatusCode -eq 200 -and
+        ([string]$response.Content).Contains($expectedContent)
+      ) {
+        $ready = $true
+        break
+      }
+    } catch {
+      # The scheduled supervisor may still be starting Workspace.
+    }
+    Start-Sleep -Milliseconds $PollMilliseconds
+  } while ((Get-Date) -lt $deadline)
+
+  if (-not $ready) {
+    $taskState = 'unknown'
+    $lastTaskResult = 'unknown'
+    try {
+      $taskState = (Get-ScheduledTask -TaskName $taskName -ErrorAction Stop).State
+      $lastTaskResult = (Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction Stop).LastTaskResult
+    } catch {
+      # Preserve the health timeout as the primary failure.
+    }
+    throw "Hermes Workspace did not become healthy within $TimeoutSeconds seconds (task state: $taskState; last result: $lastTaskResult)."
+  }
+
+  Start-Process -FilePath $url -ErrorAction Stop
+} catch {
+  $message = "Hermes Workspace launcher failed: $($_.Exception.Message)"
+  [Console]::Error.WriteLine($message)
+  if (-not $NoFailureDialog) {
+    try {
+      $shell = New-Object -ComObject WScript.Shell
+      [void]$shell.Popup($message, 0, 'Hermes Workspace', 0x10)
+    } catch {
+      # The nonzero exit and stderr message still surface failure to callers.
+    }
+  }
+  exit 1
+}

--- a/deployment/windows/hermes-stack/stack-supervisor/supervisor.py
+++ b/deployment/windows/hermes-stack/stack-supervisor/supervisor.py
@@ -1,0 +1,777 @@
+"""Single-instance health supervisor for the local Hermes Workspace stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import msvcrt
+import os
+import pathlib
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import psutil
+
+HOME = pathlib.Path.home()
+HERMES_HOME = pathlib.Path(os.environ.get("LOCALAPPDATA", HOME / "AppData/Local")) / "hermes"
+WORKSPACE = HOME / "hermes-workspace"
+LOG_DIR = HERMES_HOME / "logs" / "workspace-stack"
+STATUS_FILE = HERMES_HOME / "stack-status.json"
+LOCK_FILE = HERMES_HOME / "stack-supervisor.lock"
+STARTUP_GRACE_SECONDS = 30.0
+BACKOFF_BASE_SECONDS = 5.0
+BACKOFF_MAX_SECONDS = 300.0
+HEALTH_FAILURE_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class RuntimeExecutables:
+    python: str
+    pythonw: str
+    hermes: str
+    node: str
+    npm: str
+    agy: str
+
+
+@dataclass
+class RetryState:
+    started_at: Optional[float] = None
+    failures: int = 0
+    health_failures: int = 0
+    retry_at: float = 0.0
+    last_exit_code: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ServiceResult:
+    state: str
+    healthy: bool
+    owned: bool
+    pid: Optional[int] = None
+    last_exit_code: Optional[int] = None
+    error: Optional[str] = None
+
+
+class ServiceSpec:
+    def __init__(
+        self,
+        name: str,
+        port: int,
+        health_url: str,
+        command: list[str],
+        cwd: pathlib.Path,
+        env: Optional[dict[str, str]] = None,
+        expected_status: int = 200,
+        expected_content: Optional[str] = None,
+        expected_json: Optional[dict[str, object]] = None,
+    ) -> None:
+        self.name = name
+        self.port = port
+        self.health_url = health_url
+        self.command = command
+        self.cwd = cwd
+        self.env = env or {}
+        self.expected_status = expected_status
+        self.expected_content = expected_content
+        self.expected_json = expected_json
+
+
+def resolve_executable(
+    name: str,
+    candidates: list[pathlib.Path | str],
+) -> str:
+    """Return the first existing absolute executable path or fail closed."""
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = pathlib.Path(candidate).expanduser()
+        if not path.is_absolute() or not path.is_file():
+            continue
+        return str(path.resolve(strict=True))
+    rendered = ", ".join(str(candidate) for candidate in candidates if candidate)
+    raise FileNotFoundError(f"{name} executable was not found in: {rendered}")
+
+
+def resolve_runtime_executables() -> RuntimeExecutables:
+    """Resolve immutable absolute paths once, before the monitor loop starts."""
+    current_python = pathlib.Path(sys.executable).resolve()
+    current_python_dir = current_python.parent
+    program_files = pathlib.Path(os.environ.get("ProgramFiles", "C:/Program Files"))
+    local_programs = pathlib.Path(
+        os.environ.get("LOCALAPPDATA", str(HOME / "AppData/Local"))
+    ) / "Programs"
+    return RuntimeExecutables(
+        python=resolve_executable(
+            "python",
+            [
+                current_python_dir / "python.exe",
+                program_files / "Python312/python.exe",
+                local_programs / "Python/Python312/python.exe",
+            ],
+        ),
+        pythonw=resolve_executable(
+            "pythonw",
+            [
+                current_python_dir / "pythonw.exe",
+                program_files / "Python312/pythonw.exe",
+                local_programs / "Python/Python312/pythonw.exe",
+            ],
+        ),
+        hermes=resolve_executable(
+            "hermes",
+            [HERMES_HOME / "hermes-agent/venv/Scripts/hermes.exe"],
+        ),
+        node=resolve_executable(
+            "node",
+            [
+                program_files / "nodejs/node.exe",
+                local_programs / "nodejs/node.exe",
+            ],
+        ),
+        npm=resolve_executable(
+            "npm",
+            [
+                program_files / "nodejs/npm.cmd",
+                local_programs / "nodejs/npm.cmd",
+            ],
+        ),
+        agy=resolve_executable(
+            "agy",
+            [HERMES_HOME.parent / "agy/bin/agy.exe"],
+        ),
+    )
+
+
+def validate_runtime_executables(executables: RuntimeExecutables) -> RuntimeExecutables:
+    return RuntimeExecutables(
+        **{
+            name: resolve_executable(name, [getattr(executables, name)])
+            for name in ("python", "pythonw", "hermes", "node", "npm", "agy")
+        }
+    )
+
+
+def _pinned_path(executables: RuntimeExecutables) -> str:
+    directories: list[str] = []
+    for executable in (
+        executables.python,
+        executables.pythonw,
+        executables.hermes,
+        executables.node,
+        executables.npm,
+        executables.agy,
+    ):
+        directory = str(pathlib.Path(executable).parent)
+        if directory not in directories:
+            directories.append(directory)
+    existing = os.environ.get("PATH")
+    if existing:
+        directories.append(existing)
+    return os.pathsep.join(directories)
+
+
+def build_service_specs(
+    executables: Optional[RuntimeExecutables] = None,
+) -> list[ServiceSpec]:
+    executables = validate_runtime_executables(
+        executables or resolve_runtime_executables()
+    )
+    common_env = {
+        "HERMES_API_URL": "http://127.0.0.1:8642",
+        "HERMES_DASHBOARD_URL": "http://127.0.0.1:9119",
+        "CLAUDE_RELAY_BASE_URL": "http://127.0.0.1:8650",
+        "ANTIGRAVITY_RELAY_BASE_URL": "http://127.0.0.1:8651",
+        "ANTIGRAVITY_AGY_BIN": executables.agy,
+        "PATH": _pinned_path(executables),
+    }
+    return [
+        ServiceSpec(
+            "hermes-gateway",
+            8642,
+            "http://127.0.0.1:8642/health",
+            [
+                executables.hermes,
+                "gateway",
+                "run",
+                "--replace",
+                "--external-supervisor",
+            ],
+            HOME,
+            {
+                **common_env,
+                "API_SERVER_HOST": "127.0.0.1",
+            },
+            expected_json={"status": "ok"},
+        ),
+        ServiceSpec(
+            "claude-max-relay",
+            8650,
+            "http://127.0.0.1:8650/health",
+            [executables.python, "-u", str(HERMES_HOME / "claude-max-relay/relay.py")],
+            HERMES_HOME / "claude-max-relay",
+            {
+                **common_env,
+                "CLAUDE_RELAY_HOST": "127.0.0.1",
+            },
+            expected_json={"status": "ok"},
+        ),
+        ServiceSpec(
+            "antigravity-relay",
+            8651,
+            "http://127.0.0.1:8651/health",
+            [executables.python, "-u", str(HERMES_HOME / "antigravity-relay/relay.py")],
+            HERMES_HOME / "antigravity-relay",
+            {
+                **common_env,
+                "ANTIGRAVITY_RELAY_HOST": "127.0.0.1",
+            },
+            expected_json={"status": "ok"},
+        ),
+        ServiceSpec(
+            "hermes-dashboard",
+            9119,
+            "http://127.0.0.1:9119/",
+            [
+                executables.hermes,
+                "dashboard",
+                "--port",
+                "9119",
+                "--host",
+                "127.0.0.1",
+                "--no-open",
+            ],
+            HOME,
+            common_env,
+            expected_content="<title>Hermes Agent - Dashboard</title>",
+        ),
+        ServiceSpec(
+            "hermes-workspace",
+            3000,
+            "http://127.0.0.1:3000/operations",
+            [executables.node, str(WORKSPACE / "server-entry.js")],
+            WORKSPACE,
+            {
+                **common_env,
+                "NODE_ENV": "production",
+                "PORT": "3000",
+                "HOST": "127.0.0.1",
+            },
+            expected_content="Hermes Workspace",
+        ),
+    ]
+
+
+def health_check(spec: ServiceSpec, timeout: float = 3.0) -> bool:
+    try:
+        request = urllib.request.Request(
+            spec.health_url,
+            headers={"User-Agent": "HermesStackSupervisor/1.0"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if response.status != spec.expected_status:
+                return False
+            body = response.read(1024 * 1024)
+            text = body.decode("utf-8", errors="replace")
+            if spec.expected_content is not None and spec.expected_content not in text:
+                return False
+            if spec.expected_json is not None:
+                payload = json.loads(text)
+                if not isinstance(payload, dict):
+                    return False
+                if any(payload.get(key) != value for key, value in spec.expected_json.items()):
+                    return False
+            return True
+    except Exception:
+        return False
+
+
+def port_listening(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def listener_owner_pids(port: int) -> set[int]:
+    """Return listener PIDs or fail explicitly when ownership is unknowable."""
+    try:
+        owners = set()
+        for connection in psutil.net_connections(kind="tcp"):
+            if connection.status != psutil.CONN_LISTEN or not connection.laddr:
+                continue
+            if connection.laddr.port == port and connection.pid is not None:
+                owners.add(int(connection.pid))
+        return owners
+    except Exception:
+        raise RuntimeError("listener ownership unavailable") from None
+
+
+def owned_process_pids(process: object) -> set[int]:
+    pid = getattr(process, "pid", None)
+    if not isinstance(pid, int) or pid <= 0:
+        return set()
+    pids = {pid}
+    try:
+        pids.update(child.pid for child in psutil.Process(pid).children(recursive=True))
+    except Exception:
+        pass
+    return pids
+
+
+def process_owns_listener(spec: ServiceSpec, process: object) -> bool:
+    return bool(listener_owner_pids(spec.port) & owned_process_pids(process))
+
+
+def terminate_process(process: object, timeout: float = 5.0) -> None:
+    """Ask an owned child to exit, then force it only if it does not stop."""
+    poll = getattr(process, "poll")
+    if poll() is not None:
+        return
+    send_signal = getattr(process, "send_signal", None)
+    if (
+        os.name == "nt"
+        and callable(send_signal)
+        and hasattr(signal, "CTRL_BREAK_EVENT")
+    ):
+        try:
+            send_signal(signal.CTRL_BREAK_EVENT)
+            process.wait(timeout=timeout)
+            return
+        except (OSError, ValueError, subprocess.TimeoutExpired, TimeoutError):
+            if poll() is not None:
+                return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=timeout)
+    except (subprocess.TimeoutExpired, TimeoutError):
+        if poll() is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                return
+            process.wait(timeout=timeout)
+
+
+def _rotate_log(path: pathlib.Path, limit: int = 5 * 1024 * 1024) -> None:
+    if not path.exists() or path.stat().st_size < limit:
+        return
+    for index in range(3, 0, -1):
+        previous = path.with_suffix(f".log.{index}")
+        following = path.with_suffix(f".log.{index + 1}")
+        if previous.exists():
+            if index == 3:
+                previous.unlink(missing_ok=True)
+            else:
+                previous.replace(following)
+    path.replace(path.with_suffix(".log.1"))
+
+
+def spawn_service(spec: ServiceSpec) -> subprocess.Popen[bytes]:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_path = LOG_DIR / f"{spec.name}.log"
+    _rotate_log(log_path)
+    env = os.environ.copy()
+    env.update(spec.env)
+    creation_flags = (
+        getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    )
+    with open(log_path, "ab", buffering=0) as output:
+        return subprocess.Popen(
+            spec.command,
+            cwd=spec.cwd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            creationflags=creation_flags,
+        )
+
+
+def _record_failure(
+    retry: RetryState,
+    now: float,
+    backoff_base: float,
+    backoff_max: float,
+    exit_code: Optional[int] = None,
+) -> None:
+    retry.started_at = None
+    retry.failures += 1
+    retry.health_failures = 0
+    retry.last_exit_code = exit_code
+    cap = max(0.0, backoff_max)
+    delay = min(cap, max(0.0, backoff_base))
+    remaining_doublings = retry.failures - 1
+    while delay > 0.0 and delay < cap and remaining_doublings > 0:
+        delay = min(cap, delay * 2.0)
+        remaining_doublings -= 1
+    retry.retry_at = now + delay
+
+
+def _reset_retry(retry: RetryState) -> None:
+    retry.started_at = None
+    retry.failures = 0
+    retry.health_failures = 0
+    retry.retry_at = 0.0
+    retry.last_exit_code = None
+
+
+def ensure_service(
+    spec: ServiceSpec,
+    owned: Optional[dict[str, object]] = None,
+    retries: Optional[dict[str, RetryState]] = None,
+    *,
+    health_check: Callable[[ServiceSpec], bool] = health_check,
+    spawn: Callable[[ServiceSpec], object] = spawn_service,
+    port_check: Callable[[int], bool] = port_listening,
+    owns_listener: Callable[[ServiceSpec, object], bool] = process_owns_listener,
+    terminate: Callable[[object], None] = terminate_process,
+    now: Optional[float] = None,
+    startup_grace: float = STARTUP_GRACE_SECONDS,
+    backoff_base: float = BACKOFF_BASE_SECONDS,
+    backoff_max: float = BACKOFF_MAX_SECONDS,
+) -> ServiceResult:
+    owned = owned if owned is not None else {}
+    retries = retries if retries is not None else {}
+    current_time = time.monotonic() if now is None else now
+    retry = retries.setdefault(spec.name, RetryState())
+    process = owned.get(spec.name)
+    observed_exit_code: Optional[int] = None
+
+    if process is not None:
+        observed_exit_code = process.poll()
+        if observed_exit_code is not None:
+            del owned[spec.name]
+            process = None
+            _record_failure(
+                retry,
+                current_time,
+                backoff_base,
+                backoff_max,
+                observed_exit_code,
+            )
+
+    if health_check(spec):
+        pid = getattr(process, "pid", None) if process is not None else None
+        _reset_retry(retry)
+        return ServiceResult("healthy", True, process is not None, pid, observed_exit_code)
+
+    listening = port_check(spec.port)
+    if listening:
+        if process is not None and owns_listener(spec, process):
+            if (
+                retry.started_at is not None
+                and current_time - retry.started_at < startup_grace
+            ):
+                return ServiceResult("starting", False, True, process.pid)
+            retry.health_failures += 1
+            if retry.health_failures < HEALTH_FAILURE_THRESHOLD:
+                return ServiceResult(
+                    "degraded_owned_listener",
+                    False,
+                    True,
+                    process.pid,
+                )
+            terminate(process)
+            owned.pop(spec.name, None)
+            _record_failure(retry, current_time, backoff_base, backoff_max)
+            return ServiceResult("restart_pending", False, False)
+        return ServiceResult(
+            "degraded_unowned_listener",
+            False,
+            False,
+            last_exit_code=observed_exit_code,
+        )
+
+    if process is not None:
+        if (
+            retry.started_at is not None
+            and current_time - retry.started_at < startup_grace
+        ):
+            return ServiceResult("starting", False, True, process.pid)
+        terminate(process)
+        owned.pop(spec.name, None)
+        _record_failure(retry, current_time, backoff_base, backoff_max)
+        return ServiceResult("restart_pending", False, False)
+
+    if current_time < retry.retry_at:
+        return ServiceResult(
+            "backoff",
+            False,
+            False,
+            last_exit_code=observed_exit_code or retry.last_exit_code,
+        )
+
+    try:
+        process = spawn(spec)
+        pid = getattr(process, "pid", None)
+        poll = getattr(process, "poll", None)
+        if not isinstance(pid, int) or pid <= 0 or not callable(poll):
+            raise TypeError("spawn did not return a Popen-compatible process")
+        immediate_exit = poll()
+        if immediate_exit is not None:
+            _record_failure(
+                retry,
+                current_time,
+                backoff_base,
+                backoff_max,
+                immediate_exit,
+            )
+            return ServiceResult(
+                "spawn_exited",
+                False,
+                False,
+                last_exit_code=immediate_exit,
+            )
+        owned[spec.name] = process
+        retry.started_at = current_time
+        return ServiceResult("started", False, True, pid)
+    except Exception as exc:
+        _record_failure(retry, current_time, backoff_base, backoff_max)
+        return ServiceResult("spawn_error", False, False, error=str(exc))
+
+
+def supervise_once(
+    specs: list[ServiceSpec],
+    owned: dict[str, object],
+    retries: dict[str, RetryState],
+    *,
+    health_check: Callable[[ServiceSpec], bool] = health_check,
+    spawn: Callable[[ServiceSpec], object] = spawn_service,
+    port_check: Callable[[int], bool] = port_listening,
+    owns_listener: Callable[[ServiceSpec, object], bool] = process_owns_listener,
+    terminate: Callable[[object], None] = terminate_process,
+    now: Optional[float] = None,
+    startup_grace: float = STARTUP_GRACE_SECONDS,
+    backoff_base: float = BACKOFF_BASE_SECONDS,
+    backoff_max: float = BACKOFF_MAX_SECONDS,
+) -> dict[str, dict[str, object]]:
+    statuses: dict[str, dict[str, object]] = {}
+    for spec in specs:
+        try:
+            result = ensure_service(
+                spec,
+                owned,
+                retries,
+                health_check=health_check,
+                spawn=spawn,
+                port_check=port_check,
+                owns_listener=owns_listener,
+                terminate=terminate,
+                now=now,
+                startup_grace=startup_grace,
+                backoff_base=backoff_base,
+                backoff_max=backoff_max,
+            )
+        except Exception as exc:
+            process = owned.get(spec.name)
+            pid = getattr(process, "pid", None) if process is not None else None
+            result = ServiceResult(
+                "error",
+                False,
+                process is not None,
+                pid,
+                error=str(exc),
+            )
+        status: dict[str, object] = {
+            "port": spec.port,
+            "health_url": spec.health_url,
+            "state": result.state,
+            "healthy": result.healthy,
+            "owned": result.owned,
+            "pid": result.pid,
+        }
+        if result.last_exit_code is not None:
+            status["last_exit_code"] = result.last_exit_code
+        if result.error:
+            status["error"] = result.error
+        statuses[spec.name] = status
+    return statuses
+
+
+def _write_status(
+    statuses: dict[str, dict[str, object]],
+    *,
+    status_file: pathlib.Path = STATUS_FILE,
+) -> None:
+    status_file.parent.mkdir(parents=True, exist_ok=True)
+    document = {
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "services": statuses,
+    }
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=f".{status_file.name}.",
+        suffix=".tmp",
+        dir=status_file.parent,
+    )
+    temp_path = pathlib.Path(temp_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as output:
+            json.dump(document, output, indent=2)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temp_path, status_file)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _report_monitor_error(context: str, error: Exception) -> None:
+    try:
+        if sys.stderr is not None:
+            print(f"Hermes stack supervisor {context}: {error}", file=sys.stderr)
+    except Exception:
+        pass
+
+
+def monitor_loop(
+    specs: list[ServiceSpec],
+    owned: dict[str, object],
+    retries: dict[str, RetryState],
+    *,
+    interval: float = 15.0,
+    max_cycles: Optional[int] = None,
+    writer: Callable[[dict[str, dict[str, object]]], None] = _write_status,
+    sleeper: Callable[[float], None] = time.sleep,
+    now: Callable[[], float] = time.monotonic,
+    health_check: Callable[[ServiceSpec], bool] = health_check,
+    spawn: Callable[[ServiceSpec], object] = spawn_service,
+    port_check: Callable[[int], bool] = port_listening,
+    owns_listener: Callable[[ServiceSpec, object], bool] = process_owns_listener,
+    terminate: Callable[[object], None] = terminate_process,
+    startup_grace: float = STARTUP_GRACE_SECONDS,
+    backoff_base: float = BACKOFF_BASE_SECONDS,
+    backoff_max: float = BACKOFF_MAX_SECONDS,
+) -> None:
+    cycles = 0
+    while max_cycles is None or cycles < max_cycles:
+        try:
+            statuses = supervise_once(
+                specs,
+                owned,
+                retries,
+                health_check=health_check,
+                spawn=spawn,
+                port_check=port_check,
+                owns_listener=owns_listener,
+                terminate=terminate,
+                now=now(),
+                startup_grace=startup_grace,
+                backoff_base=backoff_base,
+                backoff_max=backoff_max,
+            )
+        except Exception as exc:
+            _report_monitor_error("cycle failed", exc)
+            statuses = {}
+        try:
+            writer(statuses)
+        except Exception as exc:
+            _report_monitor_error("status write failed", exc)
+        cycles += 1
+        if max_cycles is not None and cycles >= max_cycles:
+            break
+        try:
+            sleeper(interval)
+        except Exception as exc:
+            _report_monitor_error("sleep failed", exc)
+
+
+def shutdown_owned_services(
+    owned: dict[str, object],
+    *,
+    terminate: Callable[[object], None] = terminate_process,
+) -> None:
+    for name, process in list(owned.items()):
+        try:
+            if process.poll() is None:
+                terminate(process)
+        except Exception as exc:
+            _report_monitor_error(f"cleanup failed for {name}", exc)
+        finally:
+            owned.pop(name, None)
+
+
+def acquire_single_instance():
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(LOCK_FILE, "a+b")
+    handle.seek(0)
+    try:
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+    except OSError:
+        handle.close()
+        return None
+    return handle
+
+
+def run_supervisor(
+    interval: int = 15,
+    executables: Optional[RuntimeExecutables] = None,
+) -> int:
+    lock = acquire_single_instance()
+    if lock is None:
+        return 0
+    owned: dict[str, object] = {}
+    retries: dict[str, RetryState] = {}
+    try:
+        specs = build_service_specs(executables)
+        monitor_loop(specs, owned, retries, interval=interval)
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        shutdown_owned_services(owned)
+        lock.close()
+    return 0
+
+
+def parse_cli(argv: Optional[list[str]] = None) -> tuple[int, RuntimeExecutables]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interval", type=int, default=15)
+    parser.add_argument("--python-exe")
+    parser.add_argument("--pythonw-exe")
+    parser.add_argument("--hermes-exe")
+    parser.add_argument("--node-exe")
+    parser.add_argument("--npm-exe")
+    parser.add_argument("--agy-exe")
+    arguments = parser.parse_args(argv)
+    if arguments.interval < 1:
+        parser.error("--interval must be at least 1 second")
+
+    overrides = {
+        "python": arguments.python_exe,
+        "pythonw": arguments.pythonw_exe,
+        "hermes": arguments.hermes_exe,
+        "node": arguments.node_exe,
+        "npm": arguments.npm_exe,
+        "agy": arguments.agy_exe,
+    }
+    supplied = [value is not None for value in overrides.values()]
+    if any(supplied) and not all(supplied):
+        parser.error("all six executable overrides must be supplied together")
+    executables = (
+        validate_runtime_executables(RuntimeExecutables(**overrides))
+        if all(supplied)
+        else resolve_runtime_executables()
+    )
+    return arguments.interval, executables
+
+
+def main() -> None:
+    interval, executables = parse_cli()
+    raise SystemExit(run_supervisor(interval, executables))
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/windows/hermes-stack/stack-supervisor/tests/test_supervisor.py
+++ b/deployment/windows/hermes-stack/stack-supervisor/tests/test_supervisor.py
@@ -1,0 +1,802 @@
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+POWERSHELL = pathlib.Path(os.environ.get("WINDIR", r"C:\Windows")) / (
+    r"System32\WindowsPowerShell\v1.0\powershell.exe"
+)
+SPEC = importlib.util.spec_from_file_location("stack_supervisor", ROOT / "supervisor.py")
+supervisor = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = supervisor
+SPEC.loader.exec_module(supervisor)
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        responses = {
+            "/good": (200, "application/json", json.dumps({"status": "ok"})),
+            "/wrong-status": (204, "application/json", json.dumps({"status": "ok"})),
+            "/wrong-json": (200, "application/json", json.dumps({"status": "starting"})),
+            "/good-html": (
+                200,
+                "text/html",
+                "<title>Operations — Hermes Workspace</title>",
+            ),
+            "/wrong-html": (200, "text/html", "<title>Unrelated service</title>"),
+        }
+        status, content_type, body = responses[self.path]
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+@contextlib.contextmanager
+def health_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def powershell_quote(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def run_powershell(source, timeout=30):
+    return subprocess.run(
+        [
+            str(POWERSHELL),
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            source,
+        ],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def make_executables(directory: pathlib.Path):
+    names = {
+        "python": "python.exe",
+        "pythonw": "pythonw.exe",
+        "hermes": "hermes.exe",
+        "node": "node.exe",
+        "npm": "npm.cmd",
+        "agy": "agy.exe",
+    }
+    paths = {}
+    for key, name in names.items():
+        path = directory / name
+        path.touch()
+        paths[key] = str(path.resolve())
+    return supervisor.RuntimeExecutables(**paths)
+
+
+def make_spec(name="test"):
+    return supervisor.ServiceSpec(
+        name,
+        9999,
+        "http://127.0.0.1:9999/health",
+        [r"C:\absolute\test.exe"],
+        ROOT,
+        expected_json={"status": "ok"},
+    )
+
+
+class FakeProcess:
+    def __init__(self, pid, returncode=None):
+        self.pid = pid
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            raise TimeoutError(f"still running after {timeout}")
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+class GracefulProcess(FakeProcess):
+    def __init__(self, pid):
+        super().__init__(pid)
+        self.signals = []
+
+    def send_signal(self, sent_signal):
+        self.signals.append(sent_signal)
+        self.returncode = 0
+
+
+class StackSupervisorTests(unittest.TestCase):
+    def test_resolve_executable_returns_a_validated_absolute_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            executable = pathlib.Path(temp_dir) / "tool.exe"
+            executable.touch()
+            resolved = supervisor.resolve_executable("tool", [executable])
+            self.assertEqual(resolved, str(executable.resolve()))
+
+    def test_resolve_executable_rejects_missing_candidates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = pathlib.Path(temp_dir) / "missing.exe"
+            with self.assertRaisesRegex(FileNotFoundError, "tool"):
+                supervisor.resolve_executable("tool", [missing])
+
+    def test_listener_inspection_failure_is_not_silently_treated_as_unowned(self):
+        class FailingPsutil:
+            CONN_LISTEN = "LISTEN"
+
+            @staticmethod
+            def net_connections(kind):
+                raise RuntimeError(f"inspection failed for {kind}")
+
+        with patch.object(supervisor, "psutil", FailingPsutil, create=True):
+            with self.assertRaisesRegex(RuntimeError, "listener ownership unavailable"):
+                supervisor.listener_owner_pids(9999)
+
+    def test_specs_pin_absolute_commands_and_force_loopback_bindings(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            executables = make_executables(pathlib.Path(temp_dir))
+            specs = supervisor.build_service_specs(executables)
+
+        self.assertEqual(
+            [spec.name for spec in specs],
+            [
+                "hermes-gateway",
+                "claude-max-relay",
+                "antigravity-relay",
+                "hermes-dashboard",
+                "hermes-workspace",
+            ],
+        )
+        self.assertEqual([spec.port for spec in specs], [8642, 8650, 8651, 9119, 3000])
+        self.assertTrue(all(pathlib.Path(spec.command[0]).is_absolute() for spec in specs))
+        self.assertEqual(specs[0].env["API_SERVER_HOST"], "127.0.0.1")
+        self.assertEqual(specs[1].env["CLAUDE_RELAY_HOST"], "127.0.0.1")
+        self.assertEqual(specs[2].env["ANTIGRAVITY_RELAY_HOST"], "127.0.0.1")
+        self.assertEqual(specs[2].env["ANTIGRAVITY_AGY_BIN"], executables.agy)
+        self.assertIn("--host", specs[3].command)
+        self.assertEqual(specs[3].command[specs[3].command.index("--host") + 1], "127.0.0.1")
+        self.assertEqual(specs[4].env["HOST"], "127.0.0.1")
+        self.assertTrue(all("127.0.0.1" in spec.health_url for spec in specs))
+        self.assertEqual(
+            specs[0].command[1:],
+            ["gateway", "run", "--replace", "--external-supervisor"],
+        )
+        self.assertEqual(specs[4].expected_content, "Hermes Workspace")
+
+    def test_health_check_accepts_only_the_expected_status_and_json_content(self):
+        with health_server() as base_url:
+            good = supervisor.ServiceSpec(
+                "good",
+                1,
+                f"{base_url}/good",
+                ["unused"],
+                ROOT,
+                expected_json={"status": "ok"},
+            )
+            wrong_status = supervisor.ServiceSpec(
+                "wrong-status",
+                1,
+                f"{base_url}/wrong-status",
+                ["unused"],
+                ROOT,
+                expected_json={"status": "ok"},
+            )
+            wrong_json = supervisor.ServiceSpec(
+                "wrong-json",
+                1,
+                f"{base_url}/wrong-json",
+                ["unused"],
+                ROOT,
+                expected_json={"status": "ok"},
+            )
+
+            self.assertTrue(supervisor.health_check(good))
+            self.assertFalse(supervisor.health_check(wrong_status))
+            self.assertFalse(supervisor.health_check(wrong_json))
+
+    def test_health_check_requires_the_expected_html_marker(self):
+        with health_server() as base_url:
+            good = supervisor.ServiceSpec(
+                "good-html",
+                1,
+                f"{base_url}/good-html",
+                ["unused"],
+                ROOT,
+                expected_content="Hermes Workspace",
+            )
+            wrong = supervisor.ServiceSpec(
+                "wrong-html",
+                1,
+                f"{base_url}/wrong-html",
+                ["unused"],
+                ROOT,
+                expected_content="Hermes Workspace",
+            )
+
+            self.assertTrue(supervisor.health_check(good))
+            self.assertFalse(supervisor.health_check(wrong))
+
+    def test_workspace_environment_preserves_oauth_relay_routes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = supervisor.build_service_specs(
+                make_executables(pathlib.Path(temp_dir))
+            )[-1]
+        self.assertEqual(workspace.env["PORT"], "3000")
+        self.assertEqual(workspace.env["CLAUDE_RELAY_BASE_URL"], "http://127.0.0.1:8650")
+        self.assertEqual(
+            workspace.env["ANTIGRAVITY_RELAY_BASE_URL"],
+            "http://127.0.0.1:8651",
+        )
+
+    def test_cli_validates_all_six_pinned_executable_overrides(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            executables = make_executables(pathlib.Path(temp_dir))
+            interval, parsed = supervisor.parse_cli(
+                [
+                    "--interval",
+                    "7",
+                    "--python-exe",
+                    executables.python,
+                    "--pythonw-exe",
+                    executables.pythonw,
+                    "--hermes-exe",
+                    executables.hermes,
+                    "--node-exe",
+                    executables.node,
+                    "--npm-exe",
+                    executables.npm,
+                    "--agy-exe",
+                    executables.agy,
+                ]
+            )
+
+        self.assertEqual(interval, 7)
+        self.assertEqual(parsed, executables)
+
+
+class ServiceLifecycleTests(unittest.TestCase):
+    def test_windows_process_group_gets_graceful_break_before_termination(self):
+        process = GracefulProcess(909)
+
+        supervisor.terminate_process(process)
+
+        self.assertEqual(process.signals, [signal.CTRL_BREAK_EVENT])
+        self.assertFalse(process.terminated)
+        self.assertFalse(process.killed)
+
+    def test_unhealthy_unowned_listener_is_reported_degraded_and_never_replaced(self):
+        spawned = []
+        owned = {}
+        retries = {}
+
+        result = supervisor.ensure_service(
+            make_spec(),
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: True,
+            owns_listener=lambda _spec, _process: False,
+            spawn=lambda spec: spawned.append(spec),
+            now=100.0,
+        )
+
+        self.assertEqual(result.state, "degraded_unowned_listener")
+        self.assertFalse(result.healthy)
+        self.assertFalse(result.owned)
+        self.assertEqual(spawned, [])
+        self.assertEqual(owned, {})
+
+    def test_single_failed_probe_does_not_restart_owned_listener(self):
+        spec = make_spec()
+        process = FakeProcess(100)
+        owned = {spec.name: process}
+        retries = {spec.name: supervisor.RetryState()}
+
+        result = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: True,
+            owns_listener=lambda _spec, current: current is process,
+            terminate=supervisor.terminate_process,
+            now=100.0,
+        )
+
+        self.assertEqual(result.state, "degraded_owned_listener")
+        self.assertTrue(result.owned)
+        self.assertFalse(process.terminated)
+        self.assertIs(owned[spec.name], process)
+
+    def test_hung_owned_listener_is_terminated_then_restarted_after_backoff(self):
+        spec = make_spec()
+        hung = FakeProcess(101)
+        replacement = FakeProcess(202)
+        owned = {spec.name: hung}
+        retries = {
+            spec.name: supervisor.RetryState(started_at=0.0),
+        }
+        spawned = []
+
+        for current_time in (20.0, 21.0):
+            degraded = supervisor.ensure_service(
+                spec,
+                owned,
+                retries,
+                health_check=lambda _spec: False,
+                port_check=lambda _port: True,
+                owns_listener=lambda _spec, process: process is hung,
+                spawn=lambda _spec: replacement,
+                terminate=supervisor.terminate_process,
+                now=current_time,
+                startup_grace=10.0,
+                backoff_base=5.0,
+            )
+            self.assertEqual(degraded.state, "degraded_owned_listener")
+            self.assertFalse(hung.terminated)
+
+        stopped = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: True,
+            owns_listener=lambda _spec, process: process is hung,
+            spawn=lambda _spec: replacement,
+            terminate=supervisor.terminate_process,
+            now=22.0,
+            startup_grace=10.0,
+            backoff_base=5.0,
+        )
+
+        self.assertEqual(stopped.state, "restart_pending")
+        self.assertTrue(hung.terminated)
+        self.assertNotIn(spec.name, owned)
+        self.assertEqual(retries[spec.name].retry_at, 27.0)
+
+        restarted = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            owns_listener=lambda _spec, _process: False,
+            spawn=lambda current: (spawned.append(current), replacement)[1],
+            now=27.0,
+            startup_grace=10.0,
+            backoff_base=5.0,
+        )
+
+        self.assertEqual(restarted.state, "started")
+        self.assertEqual(restarted.pid, 202)
+        self.assertIs(owned[spec.name], replacement)
+        self.assertEqual(spawned, [spec])
+
+    def test_slow_start_stays_in_grace_and_cannot_spawn_a_duplicate(self):
+        spec = make_spec()
+        slow = FakeProcess(303)
+        spawned = []
+        owned = {}
+        retries = {}
+
+        first = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            spawn=lambda current: (spawned.append(current), slow)[1],
+            now=10.0,
+            startup_grace=30.0,
+        )
+        second = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            spawn=lambda current: (spawned.append(current), FakeProcess(404))[1],
+            now=25.0,
+            startup_grace=30.0,
+        )
+
+        self.assertEqual(first.state, "started")
+        self.assertEqual(second.state, "starting")
+        self.assertEqual(second.pid, 303)
+        self.assertEqual(spawned, [spec])
+        self.assertIs(owned[spec.name], slow)
+
+    def test_exited_popen_is_removed_and_backoff_blocks_an_immediate_respawn(self):
+        spec = make_spec()
+        exited = FakeProcess(505, returncode=17)
+        owned = {spec.name: exited}
+        retries = {spec.name: supervisor.RetryState(started_at=40.0)}
+        spawned = []
+
+        result = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            spawn=lambda current: spawned.append(current),
+            now=41.0,
+            backoff_base=5.0,
+        )
+
+        self.assertEqual(result.state, "backoff")
+        self.assertEqual(result.last_exit_code, 17)
+        self.assertNotIn(spec.name, owned)
+        self.assertEqual(spawned, [])
+        self.assertEqual(retries[spec.name].retry_at, 46.0)
+
+    def test_healthy_unowned_process_is_preserved(self):
+        spec = make_spec()
+        spawned = []
+        owned = {}
+        retries = {spec.name: supervisor.RetryState(failures=3, retry_at=500.0)}
+
+        result = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: True,
+            port_check=lambda _port: True,
+            spawn=lambda current: spawned.append(current),
+            now=100.0,
+        )
+
+        self.assertEqual(result.state, "healthy")
+        self.assertTrue(result.healthy)
+        self.assertFalse(result.owned)
+        self.assertEqual(spawned, [])
+        self.assertEqual(retries[spec.name].failures, 0)
+        self.assertEqual(retries[spec.name].retry_at, 0.0)
+
+    def test_backoff_remains_capped_after_many_consecutive_failures(self):
+        spec = make_spec()
+        exited = FakeProcess(1001, returncode=1)
+        owned = {spec.name: exited}
+        retries = {
+            spec.name: supervisor.RetryState(
+                started_at=9.0,
+                failures=5000,
+            )
+        }
+
+        result = supervisor.ensure_service(
+            spec,
+            owned,
+            retries,
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            now=10.0,
+            backoff_base=5.0,
+            backoff_max=300.0,
+        )
+
+        self.assertEqual(result.state, "backoff")
+        self.assertEqual(retries[spec.name].retry_at, 310.0)
+
+
+class MonitorAndStatusTests(unittest.TestCase):
+    def test_spawn_exception_is_isolated_and_later_services_are_still_started(self):
+        first = make_spec("first")
+        second = make_spec("second")
+        replacement = FakeProcess(606)
+        spawn_attempts = []
+
+        def spawn(spec):
+            spawn_attempts.append(spec.name)
+            if spec is first:
+                raise OSError("cannot spawn first")
+            return replacement
+
+        owned = {}
+        statuses = supervisor.supervise_once(
+            [first, second],
+            owned,
+            {},
+            health_check=lambda _spec: False,
+            port_check=lambda _port: False,
+            spawn=spawn,
+            now=10.0,
+        )
+
+        self.assertEqual(spawn_attempts, ["first", "second"])
+        self.assertEqual(statuses["first"]["state"], "spawn_error")
+        self.assertIn("cannot spawn first", statuses["first"]["error"])
+        self.assertEqual(statuses["second"]["state"], "started")
+        self.assertEqual(statuses["second"]["pid"], 606)
+        self.assertIs(owned["second"], replacement)
+
+    def test_per_service_health_exception_does_not_abort_the_cycle(self):
+        first = make_spec("first")
+        second = make_spec("second")
+
+        def check(spec):
+            if spec is first:
+                raise RuntimeError("broken health probe")
+            return True
+
+        statuses = supervisor.supervise_once(
+            [first, second],
+            {},
+            {},
+            health_check=check,
+            port_check=lambda _port: False,
+            now=10.0,
+        )
+
+        self.assertEqual(statuses["first"]["state"], "error")
+        self.assertIn("broken health probe", statuses["first"]["error"])
+        self.assertEqual(statuses["second"]["state"], "healthy")
+
+    def test_status_write_exception_does_not_stop_later_monitor_cycles(self):
+        writes = []
+
+        def writer(statuses):
+            writes.append(statuses)
+            if len(writes) == 1:
+                raise OSError("disk temporarily unavailable")
+
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors):
+            supervisor.monitor_loop(
+                [make_spec()],
+                {},
+                {},
+                interval=0,
+                max_cycles=2,
+                writer=writer,
+                sleeper=lambda _seconds: None,
+                health_check=lambda _spec: True,
+                port_check=lambda _port: True,
+                now=lambda: 10.0,
+            )
+
+        self.assertEqual(len(writes), 2)
+        self.assertEqual(writes[1]["test"]["state"], "healthy")
+        self.assertIn("status write failed", errors.getvalue())
+
+    def test_status_file_is_published_by_atomic_replace(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            status_file = pathlib.Path(temp_dir) / "status.json"
+            status_file.write_text('{"generation":"old"}', encoding="utf-8")
+            real_replace = os.replace
+            observed = {}
+
+            def observe_replace(source, target):
+                observed["old"] = status_file.read_text(encoding="utf-8")
+                observed["new"] = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+                real_replace(source, target)
+
+            with patch.object(supervisor.os, "replace", side_effect=observe_replace):
+                supervisor._write_status(
+                    {"test": {"state": "healthy"}},
+                    status_file=status_file,
+                )
+
+            self.assertEqual(observed["old"], '{"generation":"old"}')
+            self.assertEqual(observed["new"]["services"]["test"]["state"], "healthy")
+            published = json.loads(status_file.read_text(encoding="utf-8"))
+            self.assertEqual(published["services"]["test"]["state"], "healthy")
+
+    def test_failed_atomic_replace_preserves_old_status_and_removes_temp_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = pathlib.Path(temp_dir)
+            status_file = directory / "status.json"
+            status_file.write_text('{"generation":"old"}', encoding="utf-8")
+
+            with patch.object(supervisor.os, "replace", side_effect=OSError("locked")):
+                with self.assertRaisesRegex(OSError, "locked"):
+                    supervisor._write_status(
+                        {"test": {"state": "healthy"}},
+                        status_file=status_file,
+                    )
+
+            self.assertEqual(
+                status_file.read_text(encoding="utf-8"),
+                '{"generation":"old"}',
+            )
+            self.assertEqual([path.name for path in directory.iterdir()], ["status.json"])
+
+    def test_shutdown_terminates_only_tracked_owned_children(self):
+        owned_process = FakeProcess(707)
+        healthy_unowned_process = FakeProcess(808)
+        owned = {"owned": owned_process}
+
+        supervisor.shutdown_owned_services(owned)
+
+        self.assertTrue(owned_process.terminated)
+        self.assertFalse(healthy_unowned_process.terminated)
+        self.assertEqual(owned, {})
+
+
+class PowerShellScriptTests(unittest.TestCase):
+    def test_launcher_surfaces_a_missing_scheduled_task_and_never_opens_browser(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            browser_marker = pathlib.Path(temp_dir) / "browser.txt"
+            source = f"""
+function Get-ScheduledTask {{ throw 'task lookup failed' }}
+function Start-Process {{ param($FilePath) Set-Content -LiteralPath {powershell_quote(browser_marker)} -Value $FilePath }}
+. {powershell_quote(ROOT / 'launch-workspace.ps1')} -TimeoutSeconds 0 -PollMilliseconds 1 -NoFailureDialog
+"""
+            result = run_powershell(source)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Required scheduled task 'Hermes_Workspace_Stack' was not found",
+                result.stdout + result.stderr,
+            )
+            self.assertFalse(browser_marker.exists())
+
+    def test_launcher_rejects_wrong_health_content_and_never_opens_browser(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            browser_marker = pathlib.Path(temp_dir) / "browser.txt"
+            source = f"""
+$script:dateCalls = 0
+function Get-Date {{
+  $script:dateCalls += 1
+  if ($script:dateCalls -eq 1) {{ return [datetime]'2026-01-01T00:00:00' }}
+  return [datetime]'2026-01-01T00:01:00'
+}}
+function Get-ScheduledTask {{ [pscustomobject]@{{ State = 'Running' }} }}
+function Get-ScheduledTaskInfo {{ [pscustomobject]@{{ LastTaskResult = 0 }} }}
+function Invoke-WebRequest {{ [pscustomobject]@{{ StatusCode = 200; Content = '<title>Wrong service</title>' }} }}
+function Start-Sleep {{ param($Milliseconds) }}
+function Start-Process {{ param($FilePath) Set-Content -LiteralPath {powershell_quote(browser_marker)} -Value $FilePath }}
+. {powershell_quote(ROOT / 'launch-workspace.ps1')} -TimeoutSeconds 0 -PollMilliseconds 1 -NoFailureDialog
+"""
+            result = run_powershell(source)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Hermes Workspace launcher failed", result.stdout + result.stderr)
+            self.assertIn("did not become healthy", result.stdout + result.stderr)
+            self.assertFalse(browser_marker.exists())
+
+    def test_launcher_opens_operations_only_after_expected_health_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            browser_marker = pathlib.Path(temp_dir) / "browser.txt"
+            source = f"""
+function Get-ScheduledTask {{ [pscustomobject]@{{ State = 'Running' }} }}
+function Invoke-WebRequest {{ [pscustomobject]@{{ StatusCode = 200; Content = '<title>Operations — Hermes Workspace</title>' }} }}
+function Start-Process {{ param($FilePath) Set-Content -LiteralPath {powershell_quote(browser_marker)} -Value $FilePath }}
+. {powershell_quote(ROOT / 'launch-workspace.ps1')} -TimeoutSeconds 1 -PollMilliseconds 1 -NoFailureDialog
+"""
+            result = run_powershell(source)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                browser_marker.read_text(encoding="utf-8-sig").strip(),
+                "http://127.0.0.1:3000/operations",
+            )
+
+    def test_installer_waits_for_pythonw_validation_process(self):
+        source = (ROOT / "install.ps1").read_text(encoding="utf-8")
+        self.assertIn("Start-Process", source)
+        self.assertIn("-Wait", source)
+        self.assertIn(".ExitCode", source)
+
+    def test_installer_validates_required_psutil_dependency(self):
+        source = (ROOT / "install.ps1").read_text(encoding="utf-8")
+        self.assertIn("import psutil", source)
+
+    def test_installer_does_not_resolve_executables_from_path(self):
+        source = (ROOT / "install.ps1").read_text(encoding="utf-8")
+        self.assertNotIn("Get-ApplicationPath", source)
+        self.assertNotIn("Get-Command", source)
+
+    def test_deploy_wrapper_does_not_read_stale_native_exit_code(self):
+        source = (ROOT.parent / "deploy.ps1").read_text(encoding="utf-8")
+        self.assertNotIn("$LASTEXITCODE", source)
+
+    def test_installer_is_repeatable_pins_all_executables_and_ignores_duplicates(self):
+        source = f"""
+class FakeShortcut {{
+  [string]$TargetPath
+  [string]$Arguments
+  [string]$WorkingDirectory
+  [string]$Description
+  [void] Save() {{}}
+}}
+class FakeShell {{
+  [object] CreateShortcut([string]$Path) {{ return [FakeShortcut]::new() }}
+}}
+$script:registerCount = 0
+$script:startCount = 0
+$script:taskState = 'Ready'
+$script:lastAction = $null
+$script:lastSettings = $null
+function New-ScheduledTaskAction {{
+  param($Execute, $Argument, $WorkingDirectory)
+  $script:lastAction = [pscustomobject]@{{ Execute = $Execute; Argument = $Argument; WorkingDirectory = $WorkingDirectory }}
+  return $script:lastAction
+}}
+function New-ScheduledTaskTrigger {{ param([switch]$AtLogOn, $User) return [pscustomobject]@{{ User = $User }} }}
+function New-ScheduledTaskSettingsSet {{
+  param(
+    [switch]$AllowStartIfOnBatteries,
+    [switch]$DontStopIfGoingOnBatteries,
+    [switch]$StartWhenAvailable,
+    $MultipleInstances,
+    $RestartCount,
+    $RestartInterval,
+    $ExecutionTimeLimit
+  )
+  $script:lastSettings = [pscustomobject]@{{ MultipleInstances = $MultipleInstances; RestartCount = $RestartCount }}
+  return $script:lastSettings
+}}
+function Register-ScheduledTask {{
+  param($TaskName, $Action, $Trigger, $Settings, $Description, [switch]$Force)
+  if (-not $Force) {{ throw 'installer must register idempotently with -Force' }}
+  $script:registerCount += 1
+  return [pscustomobject]@{{ TaskName = $TaskName }}
+}}
+function Get-ScheduledTask {{ param($TaskName) [pscustomobject]@{{ State = $script:taskState }} }}
+function Start-ScheduledTask {{
+  param($TaskName)
+  $script:startCount += 1
+  $script:taskState = 'Running'
+}}
+function New-Object {{ param($ComObject) return [FakeShell]::new() }}
+. {powershell_quote(ROOT / 'install.ps1')}
+. {powershell_quote(ROOT / 'install.ps1')}
+if ($script:registerCount -ne 2) {{ throw "expected two safe registrations, got $script:registerCount" }}
+if ($script:startCount -ne 1) {{ throw "expected one nonredundant task start, got $script:startCount" }}
+if ($script:lastSettings.MultipleInstances -ne 'IgnoreNew') {{ throw 'task must ignore duplicate instances' }}
+if (-not [IO.Path]::IsPathRooted($script:lastAction.Execute)) {{ throw 'pythonw action is not absolute' }}
+foreach ($flag in @('--python-exe','--pythonw-exe','--hermes-exe','--node-exe','--npm-exe','--agy-exe')) {{
+  if ($script:lastAction.Argument -notlike "*$flag*") {{ throw "missing pinned argument $flag" }}
+}}
+'INSTALL_TEST_OK'
+"""
+        result = run_powershell(source, timeout=60)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("INSTALL_TEST_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server-entry.js
+++ b/server-entry.js
@@ -44,6 +44,10 @@ const port = parseInt(process.env.PORT || '3000', 10)
 // on a LAN / Tailscale / public surface must opt in explicitly with
 // HOST=0.0.0.0 *and* set CLAUDE_PASSWORD (enforced below). See #122.
 const host = process.env.HOST || '127.0.0.1'
+// Publish the effective bind for server-side request guards. The default was
+// previously implicit, so route code could not distinguish a loopback-only
+// deployment from an unknown/fail-open peer.
+process.env.HOST = host
 
 function isNonLoopbackHost(h) {
   if (!h) return false

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -79,6 +79,13 @@ export const MOBILE_HAMBURGER_NAV_ITEMS = [
     match: (p: string) => p.startsWith('/operations'),
   },
   {
+    id: 'runs',
+    label: 'Runs',
+    icon: Clock01Icon,
+    to: '/runs',
+    match: (p: string) => p.startsWith('/runs'),
+  },
+  {
     id: 'swarm',
     label: 'Swarm',
     icon: UserGroupIcon,

--- a/src/components/settings-dialog/settings-dialog-orchestration.test.ts
+++ b/src/components/settings-dialog/settings-dialog-orchestration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OAUTH_ROLE_ASSIGNMENT_SURFACES,
+  modelLabel,
+} from '../settings/orchestration-settings'
+import { SETTINGS_DIALOG_SECTIONS } from './settings-dialog'
+
+describe('SettingsDialog orchestration navigation', () => {
+  it('exposes subscription orchestration in the primary settings dialog', () => {
+    expect(SETTINGS_DIALOG_SECTIONS).toContainEqual(
+      expect.objectContaining({ id: 'orchestration', label: 'Orchestration' }),
+    )
+  })
+
+  it('covers every configurable agent role with the canonical OAuth registry', () => {
+    expect(OAUTH_ROLE_ASSIGNMENT_SURFACES).toEqual([
+      'current-chat',
+      'orchestrator',
+      'default-subagent',
+      'named-worker',
+      'fallback',
+      'swarm-role',
+    ])
+  })
+
+  it('renders human Claude Max account and Antigravity Gemini labels instead of raw route IDs', () => {
+    expect(
+      modelLabel({
+        id: 'claude-cwm4tx/sonnet',
+        provider: 'claude-max-relay',
+        account: 'cwm4tx',
+        model: 'sonnet',
+        transport: 'claude-cli-oauth',
+        billingClass: 'subscription_included',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+      }),
+    ).toBe('Claude Max CWM · Sonnet')
+    expect(
+      modelLabel({
+        id: 'claude-gp/claude-opus-5',
+        provider: 'claude-max-relay',
+        account: 'gp',
+        model: 'claude-opus-5',
+        transport: 'claude-cli-oauth',
+        billingClass: 'subscription_included',
+        status: 'quota_limited',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+      }),
+    ).toBe('Claude Max GP · Claude Opus 5 · quota limited')
+    expect(
+      modelLabel({
+        id: 'google-antigravity/gemini-3.6-flash-high',
+        provider: 'google-antigravity',
+        account: 'google-antigravity',
+        model: 'gemini-3.6-flash-high',
+        transport: 'google-antigravity-oauth',
+        billingClass: 'subscription_included',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+      }),
+    ).toBe('Antigravity · Gemini 3.6 Flash (High)')
+  })
+})

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -49,6 +49,7 @@ import { applyAccentColor } from '@/lib/accent-colors'
 import { getUnavailableReason } from '@/lib/feature-gates'
 import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import { ProviderLogo } from '@/components/provider-logo'
+import { OrchestrationSettings } from '@/components/settings/orchestration-settings'
 import {
   DialogClose,
   DialogContent,
@@ -65,6 +66,7 @@ import { LOCALE_LABELS,  getLocale, setLocale } from '@/lib/i18n'
 
 type SectionId =
   | 'claude'
+  | 'orchestration'
   | 'agent'
   | 'voice'
   | 'display'
@@ -73,8 +75,13 @@ type SectionId =
   | 'notifications'
   | 'language'
 
-const SECTIONS: Array<{ id: SectionId; label: string; icon: any }> = [
+export const SETTINGS_DIALOG_SECTIONS: Array<{
+  id: SectionId
+  label: string
+  icon: any
+}> = [
   { id: 'claude', label: 'Model & Provider', icon: CloudIcon },
+  { id: 'orchestration', label: 'Orchestration', icon: MessageMultiple01Icon },
   { id: 'agent', label: 'Agent', icon: Settings02Icon },
   { id: 'voice', label: 'Voice', icon: VolumeHighIcon },
   { id: 'display', label: 'Display', icon: PaintBoardIcon },
@@ -2475,6 +2482,7 @@ function LanguageContent() {
 
 const CONTENT_MAP: Record<SectionId, () => React.JSX.Element> = {
   claude: HermesContent,
+  orchestration: OrchestrationSettings,
   agent: AgentBehaviorContent,
   voice: VoiceContent,
   display: DisplayContent,
@@ -2551,7 +2559,7 @@ export function SettingsDialog({
                 )}
               >
                 <nav className="space-y-1">
-                  {SECTIONS.map((s) => (
+                  {SETTINGS_DIALOG_SECTIONS.map((s) => (
                     <button
                       key={s.id}
                       type="button"

--- a/src/components/settings/orchestration-settings.tsx
+++ b/src/components/settings/orchestration-settings.tsx
@@ -1,0 +1,935 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+
+interface ModelEntry {
+  id: string
+  provider: string
+  account: string
+  model: string
+  transport: string
+  billingClass: string
+  status: string
+  selectable: boolean
+  warning: string
+  resetAt: string | null
+}
+
+interface TransportEntry {
+  id: string
+  label: string
+  authenticated: boolean
+  status: string
+  warning?: string
+}
+
+interface NamedWorker {
+  id: string
+  name: string
+  modelRef: string
+  role: 'leaf' | 'orchestrator'
+  description: string
+}
+
+interface SwarmWorker {
+  id: string
+  name: string
+  role: string
+  model: string
+}
+
+export const OAUTH_ROLE_ASSIGNMENT_SURFACES = [
+  'current-chat',
+  'orchestrator',
+  'default-subagent',
+  'named-worker',
+  'fallback',
+  'swarm-role',
+] as const
+
+interface Policy {
+  orchestratorModelRef: string
+  defaultSubagentModelRef: string
+  routingMode: 'explicit' | 'automatic' | 'hybrid'
+  limits: {
+    preset: 'conservative' | 'balanced' | 'high_parallelism' | 'custom'
+    maxConcurrentChildren: number
+    maxConcurrentPerAccount: number
+    maxSpawnDepth: number
+    maxTotalAgents: number
+  }
+  quota: {
+    interactive:
+      | 'offer_alternative'
+      | 'subscription_fallback'
+      | 'stop_notify'
+      | 'wait_reset'
+    unattended: 'subscription_fallback' | 'stop_notify' | 'wait_reset'
+    fallbackModelRefs: Array<string>
+  }
+  billing: { allowApiBilledModels: boolean; showNousModels: boolean }
+  memory: {
+    childAccess: 'shared_read_write' | 'shared_read_only' | 'context_only'
+    childWriteReview: 'parent_queue' | 'normal_policy' | 'automatic'
+  }
+  context: {
+    preferred: 'full' | 'summary_recent' | 'focused' | 'explicit_only'
+    overflow:
+      | 'auto_compact_notify'
+      | 'ask'
+      | 'larger_model'
+      | 'recent_window'
+      | 'cancel'
+    recentMessages: number
+    maxInputPercent: number
+  }
+  namedWorkers: Array<NamedWorker>
+}
+
+const selectClass =
+  'w-full rounded-xl border border-primary-200 bg-primary-50 px-3 py-2 text-sm text-primary-900 outline-none'
+const cardClass = 'rounded-xl border border-primary-200 bg-primary-100/40 p-4'
+
+function titleCase(value: string): string {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function claudeModelLabel(model: string): string {
+  const match = model.match(
+    /^(claude-)?(opus|sonnet|haiku|fable)(?:-(\d+(?:-\d+)*))?$/i,
+  )
+  if (!match) return titleCase(model)
+  const family = titleCase(match[2])
+  const version = match.at(3)?.replaceAll('-', '.') || ''
+  return `${match[1] ? 'Claude ' : ''}${family}${version ? ` ${version}` : ''}`
+}
+
+function geminiModelLabel(model: string): string {
+  const match = model.match(
+    /^gemini-(\d+(?:\.\d+)+)-(.+?)(?:-(high|medium|low))?$/i,
+  )
+  if (!match) return titleCase(model)
+  const effort = match[3] ? ` (${titleCase(match[3])})` : ''
+  return `Gemini ${match[1]} ${titleCase(match[2])}${effort}`
+}
+
+export function modelLabel(model: ModelEntry): string {
+  const status =
+    model.status === 'available'
+      ? ''
+      : ` · ${model.status.replaceAll('_', ' ')}`
+  if (model.provider === 'claude-max-relay') {
+    const account =
+      model.account.toLowerCase() === 'cwm4tx'
+        ? 'CWM'
+        : model.account.toLowerCase() === 'gp'
+          ? 'GP'
+          : model.account.toUpperCase()
+    return `Claude Max ${account} · ${claudeModelLabel(model.model)}${status}`
+  }
+  if (model.provider === 'google-antigravity') {
+    return `Antigravity · ${geminiModelLabel(model.model)}${status}`
+  }
+  return `${model.id}${status}`
+}
+
+function ModelSelect({
+  value,
+  onChange,
+  models,
+  inheritLabel,
+}: {
+  value: string
+  onChange: (value: string) => void
+  models: Array<ModelEntry>
+  inheritLabel: string
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className={selectClass}
+    >
+      <option value="">{inheritLabel}</option>
+      {value && !models.some((model) => model.id === value) ? (
+        <option value={value}>{value} · current legacy assignment</option>
+      ) : null}
+      {models.map((model) => (
+        <option key={model.id} value={model.id} disabled={!model.selectable}>
+          {modelLabel(model)}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium text-primary-900">{label}</span>
+      {hint ? (
+        <span className="block text-xs text-primary-600">{hint}</span>
+      ) : null}
+      {children}
+    </label>
+  )
+}
+
+export function OrchestrationSettings() {
+  const [scope, setScope] = useState<'global' | 'session'>('global')
+  const [sessionKey, setSessionKey] = useState('')
+  const [policy, setPolicy] = useState<Policy | null>(null)
+  const [models, setModels] = useState<Array<ModelEntry>>([])
+  const [transports, setTransports] = useState<Array<TransportEntry>>([])
+  const [swarmWorkers, setSwarmWorkers] = useState<Array<SwarmWorker>>([])
+  const [dirtySwarmWorkers, setDirtySwarmWorkers] = useState<Set<string>>(
+    new Set(),
+  )
+  const [message, setMessage] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [confirmApiBilling, setConfirmApiBilling] = useState(false)
+
+  const selectedWarnings = useMemo(() => {
+    const refs = new Set([
+      policy?.orchestratorModelRef,
+      policy?.defaultSubagentModelRef,
+      ...(policy?.quota.fallbackModelRefs || []),
+    ])
+    return models.filter(
+      (model) => refs.has(model.id) && model.status !== 'available',
+    )
+  }, [models, policy])
+
+  async function loadPolicy(nextScope = scope, nextSessionKey = sessionKey) {
+    const query =
+      nextScope === 'session' && nextSessionKey.trim()
+        ? `?sessionKey=${encodeURIComponent(nextSessionKey.trim())}`
+        : ''
+    const response = await fetch(`/api/orchestration-policy${query}`)
+    if (!response.ok)
+      throw new Error(`Policy request failed (${response.status})`)
+    const payload = (await response.json()) as {
+      global: Policy
+      effective: Policy
+    }
+    setPolicy(nextScope === 'session' ? payload.effective : payload.global)
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    void Promise.all([
+      fetch('/api/orchestration-policy').then((response) => response.json()),
+      fetch('/api/orchestration-catalog').then((response) => response.json()),
+      fetch('/api/swarm-roster').then((response) => response.json()),
+    ])
+      .then(([policyPayload, catalogPayload, rosterPayload]) => {
+        if (cancelled) return
+        setPolicy(policyPayload.global)
+        setModels(
+          Array.isArray(catalogPayload.models) ? catalogPayload.models : [],
+        )
+        setTransports(
+          Array.isArray(catalogPayload.transports)
+            ? catalogPayload.transports
+            : [],
+        )
+        setSwarmWorkers(
+          Array.isArray(rosterPayload.roster?.workers)
+            ? rosterPayload.roster.workers
+            : [],
+        )
+      })
+      .catch((error) => {
+        if (!cancelled)
+          setMessage(error instanceof Error ? error.message : String(error))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function changeScope(nextScope: 'global' | 'session') {
+    setScope(nextScope)
+    setMessage('')
+    if (nextScope === 'global' || sessionKey.trim()) {
+      try {
+        await loadPolicy(nextScope, sessionKey)
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : String(error))
+      }
+    }
+  }
+
+  async function save() {
+    if (!policy) return
+    if (scope === 'session' && !sessionKey.trim()) {
+      setMessage('Enter a session key before saving a session override.')
+      return
+    }
+    setBusy(true)
+    setMessage('')
+    try {
+      const response = await fetch('/api/orchestration-policy', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          scope,
+          sessionKey: scope === 'session' ? sessionKey.trim() : undefined,
+          patch: policy,
+          confirmApiBilling,
+        }),
+      })
+      const payload = await response.json()
+      if (!response.ok)
+        throw new Error(payload.error || `Save failed (${response.status})`)
+      setPolicy(payload.policy)
+      setMessage(
+        scope === 'global'
+          ? 'Global orchestration defaults saved.'
+          : 'Session orchestration override saved.',
+      )
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function update<TKey extends keyof Policy>(key: TKey, value: Policy[TKey]) {
+    setPolicy((current) => (current ? { ...current, [key]: value } : current))
+  }
+
+  function updateSwarmWorkerModel(id: string, model: string) {
+    setSwarmWorkers((current) =>
+      current.map((worker) =>
+        worker.id === id ? { ...worker, model } : worker,
+      ),
+    )
+    setDirtySwarmWorkers((current) => new Set(current).add(id))
+  }
+
+  async function saveSwarmAssignments() {
+    if (dirtySwarmWorkers.size === 0) return
+    setBusy(true)
+    setMessage('')
+    try {
+      for (const worker of swarmWorkers.filter((entry) =>
+        dirtySwarmWorkers.has(entry.id),
+      )) {
+        const response = await fetch('/api/swarm-roster', {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: worker.id, modelRef: worker.model }),
+        })
+        const payload = await response.json()
+        if (!response.ok)
+          throw new Error(
+            payload.error || `Failed to update ${worker.name || worker.id}`,
+          )
+      }
+      setDirtySwarmWorkers(new Set())
+      setMessage(
+        'Swarm OAuth role assignments saved. They apply on each worker’s next start.',
+      )
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!policy)
+    return (
+      <p className="text-sm text-primary-600">
+        Loading orchestration settings…
+      </p>
+    )
+
+  return (
+    <div className="space-y-4">
+      <div className={cardClass}>
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field
+            label="Configuration scope"
+            hint="Global defaults initialize new sessions; session overrides do not rewrite other sessions."
+          >
+            <select
+              value={scope}
+              onChange={(event) =>
+                void changeScope(event.target.value as 'global' | 'session')
+              }
+              className={selectClass}
+            >
+              <option value="global">Global defaults</option>
+              <option value="session">Per-session override</option>
+            </select>
+          </Field>
+          {scope === 'session' ? (
+            <Field label="Session key">
+              <div className="flex gap-2">
+                <Input
+                  value={sessionKey}
+                  onChange={(event) => setSessionKey(event.target.value)}
+                  placeholder="main or session id"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void loadPolicy('session', sessionKey)}
+                >
+                  Load
+                </Button>
+              </div>
+            </Field>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={cardClass}>
+        <h3 className="mb-3 text-sm font-semibold text-primary-900">
+          Models and routing
+        </h3>
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field
+            label="Orchestrator"
+            hint="Any authenticated subscription route; blank inherits the current Hermes default."
+          >
+            <ModelSelect
+              value={policy.orchestratorModelRef}
+              onChange={(value) => update('orchestratorModelRef', value)}
+              models={models}
+              inheritLabel="Use Hermes default"
+            />
+          </Field>
+          <Field
+            label="Default subagent"
+            hint="Can be overridden by a named worker or explicit delegation model."
+          >
+            <ModelSelect
+              value={policy.defaultSubagentModelRef}
+              onChange={(value) => update('defaultSubagentModelRef', value)}
+              models={models}
+              inheritLabel="Inherit orchestrator"
+            />
+          </Field>
+          <Field label="Routing mode">
+            <select
+              value={policy.routingMode}
+              onChange={(event) =>
+                update(
+                  'routingMode',
+                  event.target.value as Policy['routingMode'],
+                )
+              }
+              className={selectClass}
+            >
+              <option value="explicit">Explicit</option>
+              <option value="automatic">Automatic</option>
+              <option value="hybrid">Hybrid</option>
+            </select>
+          </Field>
+          <Field label="Interactive limit behavior">
+            <select
+              value={policy.quota.interactive}
+              onChange={(event) =>
+                update('quota', {
+                  ...policy.quota,
+                  interactive: event.target
+                    .value as Policy['quota']['interactive'],
+                })
+              }
+              className={selectClass}
+            >
+              <option value="offer_alternative">
+                Notify and offer alternatives
+              </option>
+              <option value="subscription_fallback">
+                Use configured subscription fallback
+              </option>
+              <option value="stop_notify">Stop and notify</option>
+              <option value="wait_reset">Wait for known reset</option>
+            </select>
+          </Field>
+          <Field label="Unattended limit behavior">
+            <select
+              value={policy.quota.unattended}
+              onChange={(event) =>
+                update('quota', {
+                  ...policy.quota,
+                  unattended: event.target
+                    .value as Policy['quota']['unattended'],
+                })
+              }
+              className={selectClass}
+            >
+              <option value="subscription_fallback">
+                Use configured subscription fallback
+              </option>
+              <option value="stop_notify">Stop and notify</option>
+              <option value="wait_reset">Wait for known reset</option>
+            </select>
+          </Field>
+          <Field label="Subscription fallback">
+            <ModelSelect
+              value={policy.quota.fallbackModelRefs[0] || ''}
+              onChange={(value) =>
+                update('quota', {
+                  ...policy.quota,
+                  fallbackModelRefs: value ? [value] : [],
+                })
+              }
+              models={models.filter(
+                (model) => model.billingClass !== 'api_billed',
+              )}
+              inheritLabel="No configured fallback"
+            />
+          </Field>
+        </div>
+        {selectedWarnings.map((model) => (
+          <div
+            key={model.id}
+            className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200"
+          >
+            <strong>{model.id}</strong>:{' '}
+            {model.warning || model.status.replaceAll('_', ' ')}
+            {model.resetAt
+              ? ` Reset: ${new Date(model.resetAt).toLocaleString()}`
+              : ''}
+          </div>
+        ))}
+      </div>
+
+      <div className={cardClass}>
+        <h3 className="mb-3 text-sm font-semibold text-primary-900">
+          Delegation limits
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <Field label="Preset">
+            <select
+              value={policy.limits.preset}
+              onChange={(event) =>
+                update('limits', {
+                  ...policy.limits,
+                  preset: event.target.value as Policy['limits']['preset'],
+                })
+              }
+              className={selectClass}
+            >
+              <option value="conservative">Conservative</option>
+              <option value="balanced">Balanced</option>
+              <option value="high_parallelism">High parallelism</option>
+              <option value="custom">Custom</option>
+            </select>
+          </Field>
+          {(
+            [
+              ['maxConcurrentChildren', 'Concurrent children'],
+              ['maxConcurrentPerAccount', 'Per account'],
+              ['maxSpawnDepth', 'Spawn depth'],
+              ['maxTotalAgents', 'Total agents'],
+            ] as const
+          ).map(([key, label]) => (
+            <Field key={key} label={label}>
+              <Input
+                type="number"
+                min={1}
+                value={policy.limits[key]}
+                onChange={(event) =>
+                  update('limits', {
+                    ...policy.limits,
+                    preset: 'custom',
+                    [key]: Number(event.target.value),
+                  })
+                }
+              />
+            </Field>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-primary-600">
+          Balanced starts at three children globally, one active request per
+          OAuth account, depth two, and eight total agents. Excess work is
+          queued rather than burst.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className={cardClass}>
+          <h3 className="mb-3 text-sm font-semibold text-primary-900">
+            Memory
+          </h3>
+          <div className="space-y-3">
+            <Field label="Child memory access">
+              <select
+                value={policy.memory.childAccess}
+                onChange={(event) =>
+                  update('memory', {
+                    ...policy.memory,
+                    childAccess: event.target
+                      .value as Policy['memory']['childAccess'],
+                  })
+                }
+                className={selectClass}
+              >
+                <option value="shared_read_write">Shared read/write</option>
+                <option value="shared_read_only">Shared read-only</option>
+                <option value="context_only">Explicit context only</option>
+              </select>
+            </Field>
+            <Field label="Child write review">
+              <select
+                value={policy.memory.childWriteReview}
+                onChange={(event) =>
+                  update('memory', {
+                    ...policy.memory,
+                    childWriteReview: event.target
+                      .value as Policy['memory']['childWriteReview'],
+                  })
+                }
+                className={selectClass}
+              >
+                <option value="parent_queue">Parent review queue</option>
+                <option value="normal_policy">Normal Hermes policy</option>
+                <option value="automatic">Automatic</option>
+              </select>
+            </Field>
+          </div>
+        </div>
+        <div className={cardClass}>
+          <h3 className="mb-3 text-sm font-semibold text-primary-900">
+            Conversation context
+          </h3>
+          <div className="space-y-3">
+            <Field label="Preferred handoff">
+              <select
+                value={policy.context.preferred}
+                onChange={(event) =>
+                  update('context', {
+                    ...policy.context,
+                    preferred: event.target
+                      .value as Policy['context']['preferred'],
+                  })
+                }
+                className={selectClass}
+              >
+                <option value="full">Full conversation</option>
+                <option value="summary_recent">Summary + recent turns</option>
+                <option value="focused">Focused context</option>
+                <option value="explicit_only">Explicit context only</option>
+              </select>
+            </Field>
+            <Field label="If context does not fit">
+              <select
+                value={policy.context.overflow}
+                onChange={(event) =>
+                  update('context', {
+                    ...policy.context,
+                    overflow: event.target
+                      .value as Policy['context']['overflow'],
+                  })
+                }
+                className={selectClass}
+              >
+                <option value="auto_compact_notify">
+                  Auto-compact and notify
+                </option>
+                <option value="ask">Ask before compacting</option>
+                <option value="larger_model">Offer larger-context model</option>
+                <option value="recent_window">Use recent window</option>
+                <option value="cancel">Cancel delegation</option>
+              </select>
+            </Field>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Recent messages">
+                <Input
+                  type="number"
+                  min={1}
+                  value={policy.context.recentMessages}
+                  onChange={(event) =>
+                    update('context', {
+                      ...policy.context,
+                      recentMessages: Number(event.target.value),
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Max input %">
+                <Input
+                  type="number"
+                  min={30}
+                  max={90}
+                  value={policy.context.maxInputPercent}
+                  onChange={(event) =>
+                    update('context', {
+                      ...policy.context,
+                      maxInputPercent: Number(event.target.value),
+                    })
+                  }
+                />
+              </Field>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={cardClass}>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-primary-900">
+              Named workers
+            </h3>
+            <p className="text-xs text-primary-600">
+              Optional reusable presets; raw model selection remains available.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              update('namedWorkers', [
+                ...policy.namedWorkers,
+                {
+                  id: `worker-${Date.now()}`,
+                  name: 'New worker',
+                  modelRef: policy.defaultSubagentModelRef,
+                  role: 'leaf',
+                  description: '',
+                },
+              ])
+            }
+          >
+            Add worker
+          </Button>
+        </div>
+        <div className="space-y-3">
+          {policy.namedWorkers.length === 0 ? (
+            <p className="text-xs text-primary-600">
+              No named workers configured.
+            </p>
+          ) : null}
+          {policy.namedWorkers.map((worker, index) => (
+            <div
+              key={worker.id}
+              className="grid gap-2 rounded-lg border border-primary-200 p-3 md:grid-cols-[1fr_1.5fr_0.7fr_auto]"
+            >
+              <Input
+                value={worker.name}
+                aria-label="Worker name"
+                onChange={(event) =>
+                  update(
+                    'namedWorkers',
+                    policy.namedWorkers.map((item, itemIndex) =>
+                      itemIndex === index
+                        ? { ...item, name: event.target.value }
+                        : item,
+                    ),
+                  )
+                }
+              />
+              <ModelSelect
+                value={worker.modelRef}
+                onChange={(value) =>
+                  update(
+                    'namedWorkers',
+                    policy.namedWorkers.map((item, itemIndex) =>
+                      itemIndex === index ? { ...item, modelRef: value } : item,
+                    ),
+                  )
+                }
+                models={models}
+                inheritLabel="Use default subagent"
+              />
+              <select
+                value={worker.role}
+                onChange={(event) =>
+                  update(
+                    'namedWorkers',
+                    policy.namedWorkers.map((item, itemIndex) =>
+                      itemIndex === index
+                        ? {
+                            ...item,
+                            role: event.target.value as NamedWorker['role'],
+                          }
+                        : item,
+                    ),
+                  )
+                }
+                className={selectClass}
+              >
+                <option value="leaf">Leaf</option>
+                <option value="orchestrator">Orchestrator</option>
+              </select>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() =>
+                  update(
+                    'namedWorkers',
+                    policy.namedWorkers.filter(
+                      (_, itemIndex) => itemIndex !== index,
+                    ),
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={cardClass}>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold text-primary-900">
+              Swarm role assignments
+            </h3>
+            <p className="text-xs text-primary-600">
+              Assign any validated OAuth subscription route to any existing
+              semantic Swarm role. Restart an active worker after changing its
+              route; running TUI sessions do not hot-swap models.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy || dirtySwarmWorkers.size === 0}
+            onClick={() => void saveSwarmAssignments()}
+          >
+            Apply role assignments
+          </Button>
+        </div>
+        <div className="space-y-2">
+          {swarmWorkers.map((worker) => (
+            <div
+              key={worker.id}
+              className="grid gap-2 rounded-lg border border-primary-200 p-3 md:grid-cols-[1fr_1.7fr] md:items-center"
+            >
+              <div>
+                <div className="text-sm font-medium text-primary-900">
+                  {worker.name || worker.id}
+                </div>
+                <div className="text-xs text-primary-600">
+                  {worker.role} · {worker.id}
+                </div>
+              </div>
+              <ModelSelect
+                value={worker.model}
+                onChange={(value) => updateSwarmWorkerModel(worker.id, value)}
+                models={models}
+                inheritLabel="Keep current profile model"
+              />
+            </div>
+          ))}
+          {swarmWorkers.length === 0 ? (
+            <p className="text-xs text-primary-600">
+              No Swarm roles were discovered.
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={cardClass}>
+        <h3 className="mb-2 text-sm font-semibold text-primary-900">
+          Authenticated transports
+        </h3>
+        <div className="grid gap-2 md:grid-cols-2">
+          {transports.map((transport) => (
+            <div
+              key={transport.id}
+              className="rounded-lg border border-primary-200 px-3 py-2 text-xs"
+            >
+              <div className="flex justify-between gap-2">
+                <strong>{transport.label}</strong>
+                <span>{transport.status.replaceAll('_', ' ')}</span>
+              </div>
+              {transport.warning ? (
+                <p className="mt-1 text-primary-600">{transport.warning}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <details className={cardClass}>
+        <summary className="cursor-pointer text-sm font-semibold text-primary-900">
+          Hidden model providers
+        </summary>
+        <div className="mt-3 flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm text-primary-900">Show Nous models</p>
+            <p className="text-xs text-primary-600">
+              Nous remains configured but is hidden from model selectors by
+              default.
+            </p>
+          </div>
+          <Switch
+            checked={policy.billing.showNousModels}
+            onCheckedChange={(checked) =>
+              update('billing', {
+                ...policy.billing,
+                showNousModels: checked,
+              })
+            }
+          />
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm text-primary-900">Show API-billed models</p>
+            <p className="text-xs text-primary-600">
+              API providers remain configured but hidden by default. Unhiding
+              allows explicit selection and may incur per-token charges.
+            </p>
+          </div>
+          <Switch
+            checked={policy.billing.allowApiBilledModels}
+            onCheckedChange={(checked) => {
+              update('billing', {
+                ...policy.billing,
+                allowApiBilledModels: checked,
+              })
+              setConfirmApiBilling(false)
+            }}
+          />
+        </div>
+        {policy.billing.allowApiBilledModels ? (
+          <label className="mt-3 flex items-center gap-2 text-xs text-amber-700">
+            <input
+              type="checkbox"
+              checked={confirmApiBilling}
+              onChange={(event) => setConfirmApiBilling(event.target.checked)}
+            />
+            I explicitly understand this may incur API charges.
+          </label>
+        ) : null}
+      </details>
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-primary-600" role="status">
+          {message}
+        </p>
+        <Button
+          type="button"
+          disabled={
+            busy || (policy.billing.allowApiBilledModels && !confirmApiBilling)
+          }
+          onClick={() => void save()}
+        >
+          {busy ? 'Saving…' : 'Save orchestration settings'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/settings-sidebar.tsx
+++ b/src/components/settings/settings-sidebar.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 export type SettingsNavId =
   | 'connection'
   | 'claude'
+  | 'orchestration'
   | 'agent'
   | 'voice'
   | 'display'
@@ -17,6 +18,7 @@ type NavItem = { id: SettingsNavId; label: string }
 export const SETTINGS_NAV_ITEMS: Array<NavItem> = [
   { id: 'connection', label: 'Connection' },
   { id: 'claude', label: 'Model & Provider' },
+  { id: 'orchestration', label: 'Orchestration' },
   { id: 'agent', label: 'Agent Behavior' },
   { id: 'voice', label: 'Voice' },
   { id: 'display', label: 'Display' },

--- a/src/components/workspace-shell.test.ts
+++ b/src/components/workspace-shell.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { MOBILE_HAMBURGER_NAV_ITEMS } from './mobile-hamburger-menu'
 import { MOBILE_NAV_TABS } from './mobile-tab-bar'
-import { DESKTOP_SIDEBAR_BACKDROP_CLASS } from './workspace-shell'
+import { DESKTOP_SIDEBAR_BACKDROP_CLASS, isEmbeddedWorkspaceSurface } from './workspace-shell'
 
 describe('workspace shell sidebar backdrop', () => {
+  it('tolerates routes without search state when detecting embedded surfaces', () => {
+    expect(isEmbeddedWorkspaceSurface(undefined)).toBe(false)
+    expect(isEmbeddedWorkspaceSurface({ embed: '1' })).toBe(true)
+  })
+
   it('only spans the desktop sidebar width, not the full viewport', () => {
     expect(DESKTOP_SIDEBAR_BACKDROP_CLASS).toContain('w-[300px]')
     expect(DESKTOP_SIDEBAR_BACKDROP_CLASS).not.toContain('inset-0')

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -59,6 +59,12 @@ const TerminalWorkspace = lazy(() =>
 export const DESKTOP_SIDEBAR_BACKDROP_CLASS =
   'fixed left-0 bottom-0 top-[var(--titlebar-h,0px)] w-[300px] z-10 bg-black/10 backdrop-blur-[1px]'
 
+export function isEmbeddedWorkspaceSurface(search: unknown): boolean {
+  if (!search || typeof search !== 'object') return false
+  const value = search as Record<string, unknown>
+  return value.embed === '1' || value.embed === 'true' || value.mode === 'embed'
+}
+
 type WorkspaceShellProps = {
   children?: React.ReactNode
 }
@@ -179,6 +185,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     if (pathname.startsWith('/jobs')) return 'Jobs'
     if (pathname.startsWith('/conductor')) return 'Conductor'
     if (pathname.startsWith('/operations')) return 'Operations'
+    if (pathname.startsWith('/runs')) return 'Runs'
     if (pathname.startsWith('/swarm2') || pathname === '/swarm') return 'Swarm'
     if (pathname.startsWith('/echo-studio')) return 'Echo Studio'
     if (pathname.startsWith('/memory')) return 'Memory'
@@ -197,8 +204,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
   const isOnTerminalRoute = pathname.startsWith('/terminal')
   const isOnPlaygroundRoute = pathname === '/playground' || pathname.startsWith('/playground/')
   const isOnHermesWorldLandingRoute = pathname === '/hermes-world' || pathname.startsWith('/hermes-world/') || pathname === '/world' || pathname.startsWith('/world/')
-  const isEmbeddedSurface =
-    search?.embed === '1' || search?.embed === 'true' || search?.mode === 'embed'
+  const isEmbeddedSurface = isEmbeddedWorkspaceSurface(search)
   const isChromeFreeSurface = isEmbeddedSurface || isOnHermesWorldLandingRoute
   const hideChatSidebar = isOnChatRoute && chatFocusMode
   const showDesktopSidebarBackdrop =

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -75,6 +75,7 @@ import { Route as ApiSessionHistoryRouteImport } from './routes/api/session-hist
 import { Route as ApiSendStreamRouteImport } from './routes/api/send-stream'
 import { Route as ApiSendRouteImport } from './routes/api/send'
 import { Route as ApiProviderUsageRouteImport } from './routes/api/provider-usage'
+import { Route as ApiProviderRuntimesRouteImport } from './routes/api/provider-runtimes'
 import { Route as ApiPreviewFileRouteImport } from './routes/api/preview-file'
 import { Route as ApiPluginsRouteImport } from './routes/api/plugins'
 import { Route as ApiPlaygroundNpcRouteImport } from './routes/api/playground-npc'
@@ -501,6 +502,11 @@ const ApiSendRoute = ApiSendRouteImport.update({
 const ApiProviderUsageRoute = ApiProviderUsageRouteImport.update({
   id: '/api/provider-usage',
   path: '/api/provider-usage',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProviderRuntimesRoute = ApiProviderRuntimesRouteImport.update({
+  id: '/api/provider-runtimes',
+  path: '/api/provider-runtimes',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiPreviewFileRoute = ApiPreviewFileRouteImport.update({
@@ -1055,6 +1061,7 @@ export interface FileRoutesByFullPath {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1218,6 +1225,7 @@ export interface FileRoutesByTo {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1383,6 +1391,7 @@ export interface FileRoutesById {
   '/api/playground-npc': typeof ApiPlaygroundNpcRoute
   '/api/plugins': typeof ApiPluginsRoute
   '/api/preview-file': typeof ApiPreviewFileRoute
+  '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
@@ -1549,6 +1558,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/provider-runtimes'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1712,6 +1722,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/provider-runtimes'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -1876,6 +1887,7 @@ export interface FileRouteTypes {
     | '/api/playground-npc'
     | '/api/plugins'
     | '/api/preview-file'
+    | '/api/provider-runtimes'
     | '/api/provider-usage'
     | '/api/send'
     | '/api/send-stream'
@@ -2041,6 +2053,7 @@ export interface RootRouteChildren {
   ApiPlaygroundNpcRoute: typeof ApiPlaygroundNpcRoute
   ApiPluginsRoute: typeof ApiPluginsRoute
   ApiPreviewFileRoute: typeof ApiPreviewFileRoute
+  ApiProviderRuntimesRoute: typeof ApiProviderRuntimesRoute
   ApiProviderUsageRoute: typeof ApiProviderUsageRoute
   ApiSendRoute: typeof ApiSendRoute
   ApiSendStreamRoute: typeof ApiSendStreamRoute
@@ -2573,6 +2586,13 @@ declare module '@tanstack/react-router' {
       path: '/api/provider-usage'
       fullPath: '/api/provider-usage'
       preLoaderRoute: typeof ApiProviderUsageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/provider-runtimes': {
+      id: '/api/provider-runtimes'
+      path: '/api/provider-runtimes'
+      fullPath: '/api/provider-runtimes'
+      preLoaderRoute: typeof ApiProviderRuntimesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/preview-file': {
@@ -3526,6 +3546,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaygroundNpcRoute: ApiPlaygroundNpcRoute,
   ApiPluginsRoute: ApiPluginsRoute,
   ApiPreviewFileRoute: ApiPreviewFileRoute,
+  ApiProviderRuntimesRoute: ApiProviderRuntimesRoute,
   ApiProviderUsageRoute: ApiProviderUsageRoute,
   ApiSendRoute: ApiSendRoute,
   ApiSendStreamRoute: ApiSendStreamRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -81,6 +81,8 @@ import { Route as ApiPlaygroundNpcRouteImport } from './routes/api/playground-np
 import { Route as ApiPlaygroundAdminRouteImport } from './routes/api/playground-admin'
 import { Route as ApiPingRouteImport } from './routes/api/ping'
 import { Route as ApiPathsRouteImport } from './routes/api/paths'
+import { Route as ApiOrchestrationPolicyRouteImport } from './routes/api/orchestration-policy'
+import { Route as ApiOrchestrationCatalogRouteImport } from './routes/api/orchestration-catalog'
 import { Route as ApiModelsRouteImport } from './routes/api/models'
 import { Route as ApiMemoryRouteImport } from './routes/api/memory'
 import { Route as ApiMediaRouteImport } from './routes/api/media'
@@ -529,6 +531,16 @@ const ApiPingRoute = ApiPingRouteImport.update({
 const ApiPathsRoute = ApiPathsRouteImport.update({
   id: '/api/paths',
   path: '/api/paths',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiOrchestrationPolicyRoute = ApiOrchestrationPolicyRouteImport.update({
+  id: '/api/orchestration-policy',
+  path: '/api/orchestration-policy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiOrchestrationCatalogRoute = ApiOrchestrationCatalogRouteImport.update({
+  id: '/api/orchestration-catalog',
+  path: '/api/orchestration-catalog',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiModelsRoute = ApiModelsRouteImport.update({
@@ -1035,6 +1047,8 @@ export interface FileRoutesByFullPath {
   '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
+  '/api/orchestration-catalog': typeof ApiOrchestrationCatalogRoute
+  '/api/orchestration-policy': typeof ApiOrchestrationPolicyRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
   '/api/playground-admin': typeof ApiPlaygroundAdminRoute
@@ -1196,6 +1210,8 @@ export interface FileRoutesByTo {
   '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
+  '/api/orchestration-catalog': typeof ApiOrchestrationCatalogRoute
+  '/api/orchestration-policy': typeof ApiOrchestrationPolicyRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
   '/api/playground-admin': typeof ApiPlaygroundAdminRoute
@@ -1359,6 +1375,8 @@ export interface FileRoutesById {
   '/api/media': typeof ApiMediaRoute
   '/api/memory': typeof ApiMemoryRouteWithChildren
   '/api/models': typeof ApiModelsRoute
+  '/api/orchestration-catalog': typeof ApiOrchestrationCatalogRoute
+  '/api/orchestration-policy': typeof ApiOrchestrationPolicyRoute
   '/api/paths': typeof ApiPathsRoute
   '/api/ping': typeof ApiPingRoute
   '/api/playground-admin': typeof ApiPlaygroundAdminRoute
@@ -1523,6 +1541,8 @@ export interface FileRouteTypes {
     | '/api/media'
     | '/api/memory'
     | '/api/models'
+    | '/api/orchestration-catalog'
+    | '/api/orchestration-policy'
     | '/api/paths'
     | '/api/ping'
     | '/api/playground-admin'
@@ -1684,6 +1704,8 @@ export interface FileRouteTypes {
     | '/api/media'
     | '/api/memory'
     | '/api/models'
+    | '/api/orchestration-catalog'
+    | '/api/orchestration-policy'
     | '/api/paths'
     | '/api/ping'
     | '/api/playground-admin'
@@ -1846,6 +1868,8 @@ export interface FileRouteTypes {
     | '/api/media'
     | '/api/memory'
     | '/api/models'
+    | '/api/orchestration-catalog'
+    | '/api/orchestration-policy'
     | '/api/paths'
     | '/api/ping'
     | '/api/playground-admin'
@@ -2009,6 +2033,8 @@ export interface RootRouteChildren {
   ApiMediaRoute: typeof ApiMediaRoute
   ApiMemoryRoute: typeof ApiMemoryRouteWithChildren
   ApiModelsRoute: typeof ApiModelsRoute
+  ApiOrchestrationCatalogRoute: typeof ApiOrchestrationCatalogRoute
+  ApiOrchestrationPolicyRoute: typeof ApiOrchestrationPolicyRoute
   ApiPathsRoute: typeof ApiPathsRoute
   ApiPingRoute: typeof ApiPingRoute
   ApiPlaygroundAdminRoute: typeof ApiPlaygroundAdminRoute
@@ -2589,6 +2615,20 @@ declare module '@tanstack/react-router' {
       path: '/api/paths'
       fullPath: '/api/paths'
       preLoaderRoute: typeof ApiPathsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/orchestration-policy': {
+      id: '/api/orchestration-policy'
+      path: '/api/orchestration-policy'
+      fullPath: '/api/orchestration-policy'
+      preLoaderRoute: typeof ApiOrchestrationPolicyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/orchestration-catalog': {
+      id: '/api/orchestration-catalog'
+      path: '/api/orchestration-catalog'
+      fullPath: '/api/orchestration-catalog'
+      preLoaderRoute: typeof ApiOrchestrationCatalogRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/models': {
@@ -3478,6 +3518,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiMediaRoute: ApiMediaRoute,
   ApiMemoryRoute: ApiMemoryRouteWithChildren,
   ApiModelsRoute: ApiModelsRoute,
+  ApiOrchestrationCatalogRoute: ApiOrchestrationCatalogRoute,
+  ApiOrchestrationPolicyRoute: ApiOrchestrationPolicyRoute,
   ApiPathsRoute: ApiPathsRoute,
   ApiPingRoute: ApiPingRoute,
   ApiPlaygroundAdminRoute: ApiPlaygroundAdminRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as Swarm2RouteImport } from './routes/swarm2'
 import { Route as SwarmRouteImport } from './routes/swarm'
 import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RunsRouteImport } from './routes/runs'
 import { Route as ReserveRouteImport } from './routes/reserve'
 import { Route as ProfilesRouteImport } from './routes/profiles'
 import { Route as PlaygroundRouteImport } from './routes/playground'
@@ -74,6 +75,7 @@ import { Route as ApiSessionSendRouteImport } from './routes/api/session-send'
 import { Route as ApiSessionHistoryRouteImport } from './routes/api/session-history'
 import { Route as ApiSendStreamRouteImport } from './routes/api/send-stream'
 import { Route as ApiSendRouteImport } from './routes/api/send'
+import { Route as ApiRuntimeRunsRouteImport } from './routes/api/runtime-runs'
 import { Route as ApiProviderUsageRouteImport } from './routes/api/provider-usage'
 import { Route as ApiProviderRuntimesRouteImport } from './routes/api/provider-runtimes'
 import { Route as ApiPreviewFileRouteImport } from './routes/api/preview-file'
@@ -211,6 +213,11 @@ const SkillsRoute = SkillsRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RunsRoute = RunsRouteImport.update({
+  id: '/runs',
+  path: '/runs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ReserveRoute = ReserveRouteImport.update({
@@ -497,6 +504,11 @@ const ApiSendStreamRoute = ApiSendStreamRouteImport.update({
 const ApiSendRoute = ApiSendRouteImport.update({
   id: '/api/send',
   path: '/api/send',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRuntimeRunsRoute = ApiRuntimeRunsRouteImport.update({
+  id: '/api/runtime-runs',
+  path: '/api/runtime-runs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiProviderUsageRoute = ApiProviderUsageRouteImport.update({
@@ -1014,6 +1026,7 @@ export interface FileRoutesByFullPath {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/runs': typeof RunsRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1063,6 +1076,7 @@ export interface FileRoutesByFullPath {
   '/api/preview-file': typeof ApiPreviewFileRoute
   '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
+  '/api/runtime-runs': typeof ApiRuntimeRunsRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-history': typeof ApiSessionHistoryRoute
@@ -1179,6 +1193,7 @@ export interface FileRoutesByTo {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/runs': typeof RunsRoute
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
   '/swarm2': typeof Swarm2Route
@@ -1227,6 +1242,7 @@ export interface FileRoutesByTo {
   '/api/preview-file': typeof ApiPreviewFileRoute
   '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
+  '/api/runtime-runs': typeof ApiRuntimeRunsRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-history': typeof ApiSessionHistoryRoute
@@ -1344,6 +1360,7 @@ export interface FileRoutesById {
   '/playground': typeof PlaygroundRoute
   '/profiles': typeof ProfilesRoute
   '/reserve': typeof ReserveRouteWithChildren
+  '/runs': typeof RunsRoute
   '/settings': typeof SettingsRouteWithChildren
   '/skills': typeof SkillsRoute
   '/swarm': typeof SwarmRoute
@@ -1393,6 +1410,7 @@ export interface FileRoutesById {
   '/api/preview-file': typeof ApiPreviewFileRoute
   '/api/provider-runtimes': typeof ApiProviderRuntimesRoute
   '/api/provider-usage': typeof ApiProviderUsageRoute
+  '/api/runtime-runs': typeof ApiRuntimeRunsRoute
   '/api/send': typeof ApiSendRoute
   '/api/send-stream': typeof ApiSendStreamRoute
   '/api/session-history': typeof ApiSessionHistoryRoute
@@ -1511,6 +1529,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/runs'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1560,6 +1579,7 @@ export interface FileRouteTypes {
     | '/api/preview-file'
     | '/api/provider-runtimes'
     | '/api/provider-usage'
+    | '/api/runtime-runs'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-history'
@@ -1676,6 +1696,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/runs'
     | '/skills'
     | '/swarm'
     | '/swarm2'
@@ -1724,6 +1745,7 @@ export interface FileRouteTypes {
     | '/api/preview-file'
     | '/api/provider-runtimes'
     | '/api/provider-usage'
+    | '/api/runtime-runs'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-history'
@@ -1840,6 +1862,7 @@ export interface FileRouteTypes {
     | '/playground'
     | '/profiles'
     | '/reserve'
+    | '/runs'
     | '/settings'
     | '/skills'
     | '/swarm'
@@ -1889,6 +1912,7 @@ export interface FileRouteTypes {
     | '/api/preview-file'
     | '/api/provider-runtimes'
     | '/api/provider-usage'
+    | '/api/runtime-runs'
     | '/api/send'
     | '/api/send-stream'
     | '/api/session-history'
@@ -2006,6 +2030,7 @@ export interface RootRouteChildren {
   PlaygroundRoute: typeof PlaygroundRoute
   ProfilesRoute: typeof ProfilesRoute
   ReserveRoute: typeof ReserveRouteWithChildren
+  RunsRoute: typeof RunsRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SkillsRoute: typeof SkillsRoute
   SwarmRoute: typeof SwarmRoute
@@ -2055,6 +2080,7 @@ export interface RootRouteChildren {
   ApiPreviewFileRoute: typeof ApiPreviewFileRoute
   ApiProviderRuntimesRoute: typeof ApiProviderRuntimesRoute
   ApiProviderUsageRoute: typeof ApiProviderUsageRoute
+  ApiRuntimeRunsRoute: typeof ApiRuntimeRunsRoute
   ApiSendRoute: typeof ApiSendRoute
   ApiSendStreamRoute: typeof ApiSendStreamRoute
   ApiSessionHistoryRoute: typeof ApiSessionHistoryRoute
@@ -2180,6 +2206,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/runs': {
+      id: '/runs'
+      path: '/runs'
+      fullPath: '/runs'
+      preLoaderRoute: typeof RunsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reserve': {
@@ -2579,6 +2612,13 @@ declare module '@tanstack/react-router' {
       path: '/api/send'
       fullPath: '/api/send'
       preLoaderRoute: typeof ApiSendRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/runtime-runs': {
+      id: '/api/runtime-runs'
+      path: '/api/runtime-runs'
+      fullPath: '/api/runtime-runs'
+      preLoaderRoute: typeof ApiRuntimeRunsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/provider-usage': {
@@ -3499,6 +3539,7 @@ const rootRouteChildren: RootRouteChildren = {
   PlaygroundRoute: PlaygroundRoute,
   ProfilesRoute: ProfilesRoute,
   ReserveRoute: ReserveRouteWithChildren,
+  RunsRoute: RunsRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SkillsRoute: SkillsRoute,
   SwarmRoute: SwarmRoute,
@@ -3548,6 +3589,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPreviewFileRoute: ApiPreviewFileRoute,
   ApiProviderRuntimesRoute: ApiProviderRuntimesRoute,
   ApiProviderUsageRoute: ApiProviderUsageRoute,
+  ApiRuntimeRunsRoute: ApiRuntimeRunsRoute,
   ApiSendRoute: ApiSendRoute,
   ApiSendStreamRoute: ApiSendStreamRoute,
   ApiSessionHistoryRoute: ApiSessionHistoryRoute,

--- a/src/routes/-runs-route.test.ts
+++ b/src/routes/-runs-route.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const read = (path: string) => readFileSync(path, 'utf8')
+
+describe('Runs top-level route and navigation', () => {
+  it('defines a client-only /runs route with a Runs page title and safe search validation', () => {
+    const source = read('src/routes/runs.tsx')
+    expect(source).toContain("createFileRoute('/runs')")
+    expect(source).toContain('ssr: false')
+    expect(source).toContain("usePageTitle('Runs')")
+    expect(source).toContain('validateSearch')
+    expect(source).toContain('Loading runs...')
+  })
+
+  it('adds Runs immediately after Operations in desktop and mobile drawer navigation', () => {
+    const desktop = read('src/screens/chat/components/chat-sidebar.tsx')
+    const mobile = read('src/components/mobile-hamburger-menu.tsx')
+    expect(desktop.indexOf("to: '/runs'")).toBeGreaterThan(desktop.indexOf("to: '/operations'"))
+    expect(desktop.indexOf("to: '/runs'")).toBeLessThan(desktop.indexOf("to: '/swarm'"))
+    expect(mobile.indexOf("to: '/runs'")).toBeGreaterThan(mobile.indexOf("to: '/operations'"))
+    expect(mobile.indexOf("to: '/runs'")).toBeLessThan(mobile.indexOf("to: '/swarm'"))
+  })
+
+  it('keeps Runs out of the overcrowded mobile pill tab bar', () => {
+    const source = read('src/components/mobile-tab-bar.tsx')
+    expect(source).not.toContain("id: 'runs'")
+    expect(source).not.toContain("to: '/runs'")
+  })
+
+  it('recognizes Runs in the workspace shell mobile title and route ordering', () => {
+    const source = read('src/components/workspace-shell.tsx')
+    expect(source).toContain("pathname.startsWith('/runs')")
+    expect(source).toContain("return 'Runs'")
+  })
+})

--- a/src/routes/api/-hermes-config.test.ts
+++ b/src/routes/api/-hermes-config.test.ts
@@ -3,6 +3,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const gatewayState = vi.hoisted(() => ({ config: true, local: true }))
+
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: (_path: string) => (opts: any) => opts,
 }))
@@ -13,7 +15,8 @@ vi.mock('../../server/auth-middleware', () => ({
 
 vi.mock('../../server/gateway-capabilities', () => ({
   ensureGatewayProbed: vi.fn(),
-  getCapabilities: () => ({ config: true }),
+  getCapabilities: () => ({ config: gatewayState.config }),
+  isLocalhostDeployment: () => gatewayState.local,
 }))
 
 vi.mock('../../server/local-provider-discovery', () => ({
@@ -32,6 +35,8 @@ function setEnv(key: string, value: string | undefined) {
 }
 
 beforeEach(() => {
+  gatewayState.config = true
+  gatewayState.local = true
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-config-route-'))
   setEnv('HERMES_HOME', tmpHome)
   setEnv('CLAUDE_HOME', undefined)
@@ -87,8 +92,8 @@ describe('canonical /api/hermes-config route', () => {
         method: 'PATCH',
         body: JSON.stringify({
           action: 'set-default-model',
-          providerId: 'openrouter',
-          modelId: 'auto',
+          providerId: 'openai-codex',
+          modelId: 'gpt-5.6-sol',
         }),
       }),
     })
@@ -97,7 +102,138 @@ describe('canonical /api/hermes-config route', () => {
     expect(body).toMatchObject({ ok: true, message: 'Default model updated.' })
     expect(
       fs.readFileSync(path.join(tmpHome, 'config.yaml'), 'utf-8'),
-    ).toMatch(/provider: openrouter/)
+    ).toMatch(/provider: openai-codex/)
+  })
+
+  it('PATCH rejects OpenRouter action writes without touching config', async () => {
+    const handlers = await loadHandlers('./hermes-config')
+    for (const payload of [
+      {
+        action: 'set-default-model',
+        providerId: 'OpenRouter',
+        modelId: 'anthropic/claude-opus',
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway',
+          baseUrl: 'https://openrouter.ai/api/v1',
+        },
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway-fqdn',
+          baseUrl: 'https://openrouter.ai./api/v1',
+        },
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway-schemeless',
+          baseUrl: 'openrouter.ai/api/v1',
+        },
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway-missing-slashes',
+          baseUrl: 'https:openrouter.ai/api/v1',
+        },
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway-one-slash',
+          baseUrl: 'https:/openrouter.ai/api/v1',
+        },
+      },
+      {
+        action: 'set-custom-provider',
+        provider: {
+          name: 'gateway-backslash',
+          baseUrl: 'https:\\openrouter.ai/api/v1',
+        },
+      },
+    ]) {
+      const res = await handlers.PATCH({
+        request: new Request('http://localhost/api/hermes-config', {
+          method: 'PATCH',
+          body: JSON.stringify(payload),
+        }),
+      })
+      expect(res.status).toBe(400)
+    }
+    expect(fs.existsSync(path.join(tmpHome, 'config.yaml'))).toBe(false)
+  })
+
+  it('PATCH rejects OpenRouter assignments in the legacy config body', async () => {
+    const handlers = await loadHandlers('./claude-config')
+    const res = await handlers.PATCH({
+      request: new Request('http://localhost/api/claude-config', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          config: {
+            provider: 'openrouter',
+            model: 'openrouter/anthropic/claude-opus',
+          },
+        }),
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(fs.existsSync(path.join(tmpHome, 'config.yaml'))).toBe(false)
+  })
+
+  it('PATCH rejects a schemeless OpenRouter URL in the legacy config body', async () => {
+    const handlers = await loadHandlers('./claude-config')
+    const res = await handlers.PATCH({
+      request: new Request('http://localhost/api/claude-config', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          config: {
+            custom_providers: [
+              { name: 'gateway', base_url: 'api.openrouter.ai/v1' },
+            ],
+          },
+        }),
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(fs.existsSync(path.join(tmpHome, 'config.yaml'))).toBe(false)
+  })
+
+  it('PATCH allows benign OpenRouter text outside routing fields', async () => {
+    const handlers = await loadHandlers('./claude-config')
+    const res = await handlers.PATCH({
+      request: new Request('http://localhost/api/claude-config', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          config: {
+            agent: {
+              system_prompt: 'openrouter/example must not be used as a fallback.',
+            },
+          },
+        }),
+      }),
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('PATCH rejects prototype-polluting legacy config keys', async () => {
+    const handlers = await loadHandlers('./claude-config')
+    const res = await handlers.PATCH({
+      request: new Request('http://localhost/api/claude-config', {
+        method: 'PATCH',
+        body: '{"config":{"memory":{"__proto__":{"confirmApiBilling":true}}}}',
+      }),
+    })
+
+    expect(res.status).toBe(400)
+    expect(({} as { confirmApiBilling?: boolean }).confirmApiBilling).toBeUndefined()
+    expect(fs.existsSync(path.join(tmpHome, 'config.yaml'))).toBe(false)
   })
 
   it('PATCH legacy { config } body deep-merges and preserves siblings', async () => {
@@ -132,10 +268,8 @@ describe('canonical /api/hermes-config route', () => {
   })
 
   it('PATCH returns 503 when the gateway capability is unavailable', async () => {
-    vi.doMock('../../server/gateway-capabilities', () => ({
-      ensureGatewayProbed: vi.fn(),
-      getCapabilities: () => ({ config: false }),
-    }))
+    gatewayState.config = false
+    gatewayState.local = false
     const handlers = await loadHandlers('./hermes-config')
     const res = await handlers.PATCH({
       request: new Request('http://localhost/api/hermes-config', {
@@ -144,7 +278,26 @@ describe('canonical /api/hermes-config route', () => {
       }),
     })
     expect(res.status).toBe(503)
-    vi.doUnmock('../../server/gateway-capabilities')
+  })
+
+  it('GET uses the local Hermes config when the loopback gateway lacks config endpoints', async () => {
+    gatewayState.config = false
+    gatewayState.local = true
+    fs.writeFileSync(
+      path.join(tmpHome, 'config.yaml'),
+      'provider: custom\nmodel: claude-cwm4tx/sonnet\n',
+      'utf-8',
+    )
+
+    const handlers = await loadHandlers('./hermes-config')
+    const res = await handlers.GET({
+      request: new Request('http://localhost/api/hermes-config'),
+    })
+    const body = await res.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.activeProvider).toBe('custom')
+    expect(body.activeModel).toBe('claude-cwm4tx/sonnet')
   })
 })
 

--- a/src/routes/api/-orchestration-catalog.test.ts
+++ b/src/routes/api/-orchestration-catalog.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: (_path: string) => (opts: any) => opts,
+}))
+
+const requireLocalOrAuth = vi.fn(() => true)
+vi.mock('../../server/auth-middleware', () => ({
+  isAuthenticated: () => true,
+  requireLocalOrAuth,
+}))
+
+const loadSubscriptionCatalog = vi.fn()
+vi.mock('../../server/subscription-model-catalog', () => ({
+  loadSubscriptionCatalog: () => loadSubscriptionCatalog(),
+}))
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.resetModules()
+  loadSubscriptionCatalog.mockReset()
+  requireLocalOrAuth.mockReset()
+  requireLocalOrAuth.mockReturnValue(true)
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('GET /api/orchestration-catalog', () => {
+  it('rejects requests outside the local-or-auth boundary before loading the catalog', async () => {
+    requireLocalOrAuth.mockReturnValue(false)
+    const { Route } = await import('./orchestration-catalog')
+    const res = await Route.server.handlers.GET({
+      request: new Request('http://workspace.example/api/orchestration-catalog'),
+    })
+
+    expect(requireLocalOrAuth).toHaveBeenCalledOnce()
+    expect(loadSubscriptionCatalog).not.toHaveBeenCalled()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the catalog on success', async () => {
+    loadSubscriptionCatalog.mockResolvedValue({ routes: [] })
+    const { Route } = await import('./orchestration-catalog')
+    const res = await Route.server.handlers.GET({
+      request: new Request('http://localhost/api/orchestration-catalog'),
+    })
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true, routes: [] })
+  })
+
+  it('returns a fixed generic error and never leaks the caught exception message', async () => {
+    const sensitive = 'SECRET_TOKEN=abc123 at /Users/cwm4t/.hermes/config.yaml'
+    loadSubscriptionCatalog.mockRejectedValue(new Error(sensitive))
+    const { Route } = await import('./orchestration-catalog')
+    const res = await Route.server.handlers.GET({
+      request: new Request('http://localhost/api/orchestration-catalog'),
+    })
+    const rawBody = await res.text()
+    const body = JSON.parse(rawBody)
+
+    expect(res.status).toBe(500)
+    expect(body).toEqual({ ok: false, error: 'Failed to load orchestration catalog.' })
+    expect(rawBody).not.toContain(sensitive)
+    expect(rawBody).not.toContain('SECRET_TOKEN')
+    expect(rawBody).not.toContain('/Users/cwm4t')
+  })
+
+  it('logs the real error server-side for diagnostics', async () => {
+    const sensitive = new Error('boom: sensitive diagnostic detail')
+    loadSubscriptionCatalog.mockRejectedValue(sensitive)
+    const { Route } = await import('./orchestration-catalog')
+    await Route.server.handlers.GET({
+      request: new Request('http://localhost/api/orchestration-catalog'),
+    })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[orchestration-catalog] failed to load catalog:',
+      sensitive,
+    )
+  })
+
+  it('handles non-Error throw values without leaking their content to the client', async () => {
+    loadSubscriptionCatalog.mockRejectedValue('raw string throw with secret=xyz')
+    const { Route } = await import('./orchestration-catalog')
+    const res = await Route.server.handlers.GET({
+      request: new Request('http://localhost/api/orchestration-catalog'),
+    })
+    const rawBody = await res.text()
+
+    expect(res.status).toBe(500)
+    expect(rawBody).not.toContain('secret=xyz')
+    expect(JSON.parse(rawBody)).toEqual({ ok: false, error: 'Failed to load orchestration catalog.' })
+  })
+})

--- a/src/routes/api/-orchestration-policy.test.ts
+++ b/src/routes/api/-orchestration-policy.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn(() => true),
+  requireLocalOrAuth: vi.fn(() => true),
+}))
+const catalogMocks = vi.hoisted(() => ({
+  loadSubscriptionCatalog: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: (_path: string) => (options: unknown) => options,
+}))
+vi.mock('../../server/auth-middleware', () => authMocks)
+vi.mock('../../server/subscription-model-catalog', () => catalogMocks)
+
+let stateDir = ''
+const previousStateDir = process.env.HERMES_WORKSPACE_STATE_DIR
+const previousHermesHome = process.env.HERMES_HOME
+
+const catalog = {
+  generatedAt: '2026-08-10T00:00:00.000Z',
+  subscriptionOnly: true,
+  transports: [],
+  visibility: { showNousModels: false, showApiBilledModels: false },
+  models: [
+    {
+      id: 'openai-codex/gpt-5.6-sol',
+      provider: 'openai-codex',
+      account: 'openai-codex',
+      model: 'gpt-5.6-sol',
+      transport: 'openai-codex-oauth',
+      billingClass: 'subscription_included',
+      status: 'available',
+      selectable: true,
+      warning: '',
+      resetAt: null,
+    },
+  ],
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'workspace-orchestration-route-'))
+  process.env.HERMES_WORKSPACE_STATE_DIR = stateDir
+  process.env.HERMES_HOME = join(stateDir, 'hermes-home')
+  vi.resetModules()
+  authMocks.isAuthenticated.mockReturnValue(true)
+  authMocks.requireLocalOrAuth.mockReturnValue(true)
+  catalogMocks.loadSubscriptionCatalog.mockResolvedValue(catalog)
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  if (previousStateDir === undefined)
+    delete process.env.HERMES_WORKSPACE_STATE_DIR
+  else process.env.HERMES_WORKSPACE_STATE_DIR = previousStateDir
+  if (previousHermesHome === undefined) delete process.env.HERMES_HOME
+  else process.env.HERMES_HOME = previousHermesHome
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+async function handlers() {
+  const module = await import('./orchestration-policy')
+  return (module as any).Route.server.handlers
+}
+
+describe('/api/orchestration-policy', () => {
+  it('rejects policy mutations denied by the local-or-auth boundary', async () => {
+    authMocks.requireLocalOrAuth.mockReturnValue(false)
+    const route = await handlers()
+    const response = await route.PATCH({
+      request: new Request(
+        'http://workspace.example/api/orchestration-policy',
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            scope: 'global',
+            patch: { billing: { allowApiBilledModels: true } },
+            confirmApiBilling: true,
+          }),
+        },
+      ),
+    })
+
+    expect(authMocks.requireLocalOrAuth).toHaveBeenCalledOnce()
+    expect(response.status).toBe(401)
+  })
+
+  it('returns global defaults and effective session policy', async () => {
+    const route = await handlers()
+    const response = await route.GET({
+      request: new Request(
+        'http://localhost/api/orchestration-policy?sessionKey=s1',
+      ),
+    })
+    const body = await response.json()
+
+    expect(body.ok).toBe(true)
+    expect(body.global.memory.childWriteReview).toBe('parent_queue')
+    expect(body.effective.context.overflow).toBe('auto_compact_notify')
+  })
+
+  it('saves global and per-session policies', async () => {
+    const route = await handlers()
+    const globalResponse = await route.PATCH({
+      request: new Request('http://localhost/api/orchestration-policy', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          scope: 'global',
+          patch: { defaultSubagentModelRef: 'openai-codex/gpt-5.6-sol' },
+        }),
+      }),
+    })
+    expect(globalResponse.status).toBe(200)
+
+    const sessionResponse = await route.PATCH({
+      request: new Request('http://localhost/api/orchestration-policy', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          scope: 'session',
+          sessionKey: 's1',
+          patch: { routingMode: 'automatic' },
+        }),
+      }),
+    })
+    const body = await sessionResponse.json()
+    expect(body.policy.defaultSubagentModelRef).toBe('openai-codex/gpt-5.6-sol')
+    expect(body.policy.routingMode).toBe('automatic')
+  })
+
+  it('requires explicit API-billing confirmation', async () => {
+    const route = await handlers()
+    const response = await route.PATCH({
+      request: new Request('http://localhost/api/orchestration-policy', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          scope: 'global',
+          patch: { billing: { allowApiBilledModels: true } },
+        }),
+      }),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects unknown and case-varied OpenRouter model assignments without mutating policy', async () => {
+    const route = await handlers()
+    for (const modelRef of [
+      'unknown/model',
+      'OpenRouter/anthropic/claude-opus-5',
+    ]) {
+      const response = await route.PATCH({
+        request: new Request('http://localhost/api/orchestration-policy', {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            scope: 'global',
+            patch: { orchestratorModelRef: modelRef },
+          }),
+        }),
+      })
+      expect(response.status).toBe(400)
+    }
+
+    const response = await route.GET({
+      request: new Request('http://localhost/api/orchestration-policy'),
+    })
+    expect((await response.json()).global.orchestratorModelRef).toBe('')
+  })
+})

--- a/src/routes/api/-provider-runtimes.test.ts
+++ b/src/routes/api/-provider-runtimes.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', () => ({ createFileRoute: (_path: string) => (options: any) => options }))
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(() => true),
+  list: vi.fn(() => []),
+  mutate: vi.fn(async () => ({ ok: true })),
+  refresh: vi.fn(async () => []),
+  catalog: vi.fn(async () => ({ subscriptionOnly: true, models: [{ id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', billingClass: 'subscription_included', selectable: true }] })),
+}))
+vi.mock('../../server/auth-middleware', () => ({ requireLocalOrAuth: mocks.auth, requireProviderRuntimeMutationAuth: mocks.auth }))
+vi.mock('../../server/provider-runtime-service', () => ({ getProviderRuntimeService: () => ({ list: mocks.list, refresh: mocks.refresh, mutate: mocks.mutate }) }))
+vi.mock('../../server/subscription-model-catalog', () => ({ loadSubscriptionCatalog: mocks.catalog }))
+
+describe('/api/provider-runtimes', () => {
+  beforeEach(() => { vi.clearAllMocks(); mocks.auth.mockReturnValue(true) })
+
+  it.each(['resume', 'fork', 'steer', 'interrupt', 'archive', 'create', 'background', 'stop', 'attach', 'link_kanban'])(
+    'denies %s before parsing or side effects', async (action) => {
+      mocks.auth.mockReturnValue(false)
+      const json = vi.fn(async () => ({ action }))
+      const { Route } = await import('./provider-runtimes')
+      const response = await Route.server.handlers.POST({ request: { json } as unknown as Request })
+      expect(response.status).toBe(401)
+      expect(json).not.toHaveBeenCalled()
+      expect(mocks.catalog).not.toHaveBeenCalled()
+      expect(mocks.mutate).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects non-subscription routeRefs before lifecycle side effects', async () => {
+    const { Route } = await import('./provider-runtimes')
+    const response = await Route.server.handlers.POST({ request: new Request('http://localhost/api/provider-runtimes', { method: 'POST', body: JSON.stringify({ runtimeId: 'codex:t1', action: 'steer', routeRef: 'openai-api/paid', text: 'hello' }) }) })
+    expect(response.status).toBe(400)
+    expect(mocks.mutate).not.toHaveBeenCalled()
+  })
+
+  it('returns inventory with deferred messaging and runtime ownership choices', async () => {
+    const { Route } = await import('./provider-runtimes')
+    const response = await Route.server.handlers.GET({ request: new Request('http://localhost/api/provider-runtimes') })
+    const body = await response.json()
+    expect(body.directProviderMessaging).toMatchObject({ enabled: false, state: 'deferred' })
+    expect(body.codexRuntimeChoices).toHaveLength(2)
+  })
+
+  it('links Kanban metadata without requiring a provider route lookup', async () => {
+    const { Route } = await import('./provider-runtimes')
+    const response = await Route.server.handlers.POST({ request: new Request('http://localhost/api/provider-runtimes', { method: 'POST', body: JSON.stringify({ runtimeId: 'codex:t1', action: 'link_kanban', kanbanTaskId: 'task-1' }) }) })
+    expect(response.status).toBe(200)
+    expect(mocks.mutate).toHaveBeenCalledWith({ runtimeId: 'codex:t1', action: 'link_kanban', kanbanTaskId: 'task-1' })
+    expect(mocks.catalog).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/api/-provider-runtimes.test.ts
+++ b/src/routes/api/-provider-runtimes.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   list: vi.fn(() => []),
   mutate: vi.fn(async () => ({ ok: true })),
   refresh: vi.fn(async () => []),
-  catalog: vi.fn(async () => ({ subscriptionOnly: true, models: [{ id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', billingClass: 'subscription_included', selectable: true }] })),
+  catalog: vi.fn(async () => ({ subscriptionOnly: true, models: [{ id: 'openai-codex/gpt-5.6-sol', model: 'gpt-5.6-sol', account: 'openai-codex', billingClass: 'subscription_included', selectable: true }] })),
 }))
 vi.mock('../../server/auth-middleware', () => ({ requireLocalOrAuth: mocks.auth, requireProviderRuntimeMutationAuth: mocks.auth }))
 vi.mock('../../server/provider-runtime-service', () => ({ getProviderRuntimeService: () => ({ list: mocks.list, refresh: mocks.refresh, mutate: mocks.mutate }) }))
@@ -33,6 +33,14 @@ describe('/api/provider-runtimes', () => {
     const response = await Route.server.handlers.POST({ request: new Request('http://localhost/api/provider-runtimes', { method: 'POST', body: JSON.stringify({ runtimeId: 'codex:t1', action: 'steer', routeRef: 'openai-api/paid', text: 'hello' }) }) })
     expect(response.status).toBe(400)
     expect(mocks.mutate).not.toHaveBeenCalled()
+  })
+
+  it('binds the catalog provider model into lifecycle execution', async () => {
+    const { Route } = await import('./provider-runtimes')
+    const requestBody = { runtimeId: 'codex:t1', action: 'archive', routeRef: 'openai-codex/gpt-5.6-sol' }
+    const response = await Route.server.handlers.POST({ request: new Request('http://localhost/api/provider-runtimes', { method: 'POST', body: JSON.stringify(requestBody) }) })
+    expect(response.status).toBe(200)
+    expect(mocks.mutate).toHaveBeenCalledWith({ ...requestBody, providerModel: 'gpt-5.6-sol' })
   })
 
   it('returns inventory with deferred messaging and runtime ownership choices', async () => {

--- a/src/routes/api/-provider-runtimes.test.ts
+++ b/src/routes/api/-provider-runtimes.test.ts
@@ -5,11 +5,13 @@ const mocks = vi.hoisted(() => ({
   auth: vi.fn(() => true),
   list: vi.fn(() => []),
   mutate: vi.fn(async () => ({ ok: true })),
-  refresh: vi.fn(async () => []),
-  catalog: vi.fn(async () => ({ subscriptionOnly: true, models: [{ id: 'openai-codex/gpt-5.6-sol', model: 'gpt-5.6-sol', account: 'openai-codex', billingClass: 'subscription_included', selectable: true }] })),
+  refresh: vi.fn(async () => [{ source: 'codex', ok: true, count: 1 }]),
+  writeRoutes: vi.fn(),
+  catalog: vi.fn(async () => ({ subscriptionOnly: true, models: [{ id: 'openai-codex/gpt-5.6-sol', model: 'gpt-5.6-sol', account: 'openai-codex', status: 'available', billingClass: 'subscription_included', selectable: true }] })),
 }))
 vi.mock('../../server/auth-middleware', () => ({ requireLocalOrAuth: mocks.auth, requireProviderRuntimeMutationAuth: mocks.auth }))
 vi.mock('../../server/provider-runtime-service', () => ({ getProviderRuntimeService: () => ({ list: mocks.list, refresh: mocks.refresh, mutate: mocks.mutate }) }))
+vi.mock('../../server/runtime-route-cache', () => ({ writeRuntimeRouteSnapshot: mocks.writeRoutes }))
 vi.mock('../../server/subscription-model-catalog', () => ({ loadSubscriptionCatalog: mocks.catalog }))
 
 describe('/api/provider-runtimes', () => {
@@ -28,9 +30,49 @@ describe('/api/provider-runtimes', () => {
     },
   )
 
+  it('refreshes providers and snapshots current subscription routes only after explicit action', async () => {
+    const { Route } = await import('./provider-runtimes')
+    const post = (Route as unknown as {
+      server: { handlers: { POST: (input: { request: Request }) => Promise<Response> } }
+    }).server.handlers.POST
+    const response = await post({
+      request: new Request('http://localhost/api/provider-runtimes', {
+        method: 'POST', body: JSON.stringify({ action: 'refresh' }),
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(mocks.refresh).toHaveBeenCalledTimes(1)
+    expect(mocks.catalog).toHaveBeenCalledTimes(1)
+    expect(mocks.writeRoutes).toHaveBeenCalledWith([
+      { id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available' },
+    ])
+    await expect(response.json()).resolves.toMatchObject({
+      availableRoutes: [{ id: 'openai-codex/gpt-5.6-sol', status: 'available' }],
+    })
+  })
+
   it('rejects non-subscription routeRefs before lifecycle side effects', async () => {
     const { Route } = await import('./provider-runtimes')
     const response = await Route.server.handlers.POST({ request: new Request('http://localhost/api/provider-runtimes', { method: 'POST', body: JSON.stringify({ runtimeId: 'codex:t1', action: 'steer', routeRef: 'openai-api/paid', text: 'hello' }) }) })
+    expect(response.status).toBe(400)
+    expect(mocks.mutate).not.toHaveBeenCalled()
+  })
+
+  it('rejects unavailable subscription routeRefs before lifecycle side effects', async () => {
+    mocks.catalog.mockResolvedValueOnce({
+      subscriptionOnly: true,
+      models: [{
+        id: 'openai-codex/gpt-5.6-sol', model: 'gpt-5.6-sol', account: 'openai-codex',
+        status: 'quota_limited', billingClass: 'subscription_included', selectable: true,
+      }],
+    })
+    const { Route } = await import('./provider-runtimes')
+    const post = (Route as unknown as {
+      server: { handlers: { POST: (input: { request: Request }) => Promise<Response> } }
+    }).server.handlers.POST
+    const response = await post({ request: new Request('http://localhost/api/provider-runtimes', {
+      method: 'POST', body: JSON.stringify({ runtimeId: 'codex:t1', action: 'archive', routeRef: 'openai-codex/gpt-5.6-sol' }),
+    }) })
     expect(response.status).toBe(400)
     expect(mocks.mutate).not.toHaveBeenCalled()
   })

--- a/src/routes/api/-runtime-runs.test.ts
+++ b/src/routes/api/-runtime-runs.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {  capabilityMatrix } from '../../server/provider-runtime-control-plane'
+import type {ProviderRuntimeRecord} from '../../server/provider-runtime-control-plane';
+
+vi.mock('@tanstack/react-router', () => ({ createFileRoute: (_path: string) => (options: any) => options }))
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(() => true),
+  list: vi.fn<() => Array<ProviderRuntimeRecord>>(() => []),
+  refresh: vi.fn(async () => []),
+  routes: vi.fn(() => [
+    { id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available' },
+  ]),
+  catalog: vi.fn(async () => ({
+    subscriptionOnly: true,
+    models: [
+      { id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available', selectable: true, billingClass: 'subscription_included' },
+      { id: 'openai-api/paid', account: 'openai-api', model: 'paid', status: 'available', selectable: true, billingClass: 'api_billed' },
+    ],
+  })),
+}))
+
+vi.mock('../../server/auth-middleware', () => ({ requireProviderRuntimeMutationAuth: mocks.auth }))
+vi.mock('../../server/provider-runtime-service', () => ({
+  getProviderRuntimeService: () => ({ list: mocks.list, refresh: mocks.refresh }),
+}))
+vi.mock('../../server/runtime-route-cache', () => ({ readRuntimeRouteSnapshot: mocks.routes }))
+vi.mock('../../server/subscription-model-catalog', () => ({ loadSubscriptionCatalog: mocks.catalog }))
+
+describe('/api/runtime-runs', () => {
+  const getHandler = async () => {
+    const { Route } = await import('./runtime-runs')
+    return (Route as unknown as { server: { handlers: { GET: (input: { request: Request }) => Promise<Response> } } }).server.handlers.GET
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.auth.mockReturnValue(true)
+    mocks.list.mockReturnValue([])
+  })
+
+  it('denies inventory before touching the registry or any provider process seam', async () => {
+    mocks.auth.mockReturnValue(false)
+    const response = await (await getHandler())({ request: new Request('http://localhost/api/runtime-runs') })
+    expect(response.status).toBe(401)
+    expect(mocks.list).not.toHaveBeenCalled()
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    expect(mocks.catalog).not.toHaveBeenCalled()
+  })
+
+  it('returns a bounded provider-neutral page and summary without refreshing providers', async () => {
+    mocks.list.mockReturnValue([
+      {
+        runtimeId: 'codex:t1', kind: 'codex_thread', routeRef: 'openai-codex/gpt-5.6-sol', accountAlias: 'openai-codex',
+        externalId: 't1', model: 'gpt-5.6-sol', cwd: 'C:/repo', worktree: 'C:/repo', hostKind: 'stdio', hostStatus: 'idle',
+        capabilities: capabilityMatrix('codex_thread'), lease: null, parentRuntimeId: null, kanbanTaskId: null, createdAt: 1, updatedAt: 2,
+      },
+    ])
+    const response = await (await getHandler())({ request: new Request('http://localhost/api/runtime-runs?provider=codex&account=openai-codex&project=repo&kanban=unlinked&page=1&size=25') })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({
+      ok: true,
+      runs: [{ id: 'codex:t1', source: 'provider-runtime', provider: 'codex' }],
+      summary: { total: 1, idleResumable: 1 },
+      availableRoutes: [{ id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available' }],
+      page: { number: 1, size: 25, total: 1, pages: 1, hasNext: false, hasPrevious: false },
+    })
+    expect(typeof body.generatedAt).toBe('number')
+    expect(body.filters).toMatchObject({ account: ['openai-codex'], project: ['repo'], linked: 'unlinked' })
+    expect(mocks.list).toHaveBeenCalledTimes(1)
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    expect(mocks.catalog).not.toHaveBeenCalled()
+    expect(mocks.routes).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a bounded selected run outside the current filters and page', async () => {
+    mocks.list.mockReturnValue([
+      {
+        runtimeId: 'codex:selected', kind: 'codex_thread', routeRef: null, accountAlias: 'openai-codex',
+        externalId: 'selected', model: null, cwd: 'C:/selected', worktree: 'C:/selected', hostKind: 'stdio', hostStatus: 'idle',
+        capabilities: capabilityMatrix('codex_thread'), lease: null, parentRuntimeId: null, kanbanTaskId: null, createdAt: 1, updatedAt: 2,
+      },
+    ])
+    const response = await (await getHandler())({
+      request: new Request('http://localhost/api/runtime-runs?provider=claude&run=codex%3Aselected&page=9&size=25'),
+    })
+    const body = await response.json()
+    expect(body.runs).toEqual([])
+    expect(body.selectedRun).toMatchObject({ id: 'codex:selected', nativeId: 'selected' })
+  })
+
+  it('applies bounded project filters longer than 32 characters instead of silently widening results', async () => {
+    const longProject = 'project-with-a-deliberately-long-name-12345'
+    mocks.list.mockReturnValue([
+      {
+        runtimeId: 'codex:long', kind: 'codex_thread', routeRef: 'openai-codex/gpt-5.6-sol', accountAlias: 'openai-codex',
+        externalId: 'long', model: 'gpt-5.6-sol', cwd: `C:/${longProject}`, worktree: `C:/${longProject}`, hostKind: 'stdio', hostStatus: 'idle',
+        capabilities: capabilityMatrix('codex_thread'), lease: null, parentRuntimeId: null, kanbanTaskId: null, createdAt: 1, updatedAt: 2,
+      },
+      {
+        runtimeId: 'codex:other', kind: 'codex_thread', routeRef: 'openai-codex/gpt-5.6-sol', accountAlias: 'openai-codex',
+        externalId: 'other', model: 'gpt-5.6-sol', cwd: 'C:/other', worktree: 'C:/other', hostKind: 'stdio', hostStatus: 'idle',
+        capabilities: capabilityMatrix('codex_thread'), lease: null, parentRuntimeId: null, kanbanTaskId: null, createdAt: 1, updatedAt: 2,
+      },
+    ])
+    const response = await (await getHandler())({ request: new Request(`http://localhost/api/runtime-runs?project=${longProject}`) })
+    const body = await response.json()
+    expect(body.page.total).toBe(1)
+    expect(body.runs).toEqual([expect.objectContaining({ id: 'codex:long', project: longProject })])
+  })
+
+  it('returns a bounded typed error for registry corruption without leaking the raw error', async () => {
+    mocks.list.mockImplementation(() => { throw new Error('Provider runtime registry is corrupt at C:/secret/path') })
+    const response = await (await getHandler())({ request: new Request('http://localhost/api/runtime-runs') })
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ ok: false, error: 'Provider runtime inventory is unavailable' })
+    expect(JSON.stringify(body)).not.toContain('C:/secret/path')
+    expect(mocks.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/api/-swarm-dispatch-auth.test.ts
+++ b/src/routes/api/-swarm-dispatch-auth.test.ts
@@ -4,11 +4,16 @@ const authMocks = vi.hoisted(() => ({
   isAuthenticated: vi.fn(() => true),
   requireLocalOrAuth: vi.fn(() => false),
 }))
+const lifecycleMocks = vi.hoisted(() => ({
+  startWorkerProcess: vi.fn(),
+  sendToWorker: vi.fn(),
+}))
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: (_path: string) => (options: unknown) => options,
 }))
 vi.mock('../../server/auth-middleware', () => authMocks)
+vi.mock('../../server/swarm-lifecycle', () => lifecycleMocks)
 
 async function handlers() {
   const module = await import('./swarm-dispatch')
@@ -27,6 +32,8 @@ describe('/api/swarm-dispatch authorization', () => {
     })
 
     expect(authMocks.requireLocalOrAuth).toHaveBeenCalledOnce()
+    expect(lifecycleMocks.startWorkerProcess).not.toHaveBeenCalled()
+    expect(lifecycleMocks.sendToWorker).not.toHaveBeenCalled()
     expect(response.status).toBe(401)
   })
 })

--- a/src/routes/api/-swarm-dispatch-auth.test.ts
+++ b/src/routes/api/-swarm-dispatch-auth.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  isAuthenticated: vi.fn(() => true),
+  requireLocalOrAuth: vi.fn(() => false),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: (_path: string) => (options: unknown) => options,
+}))
+vi.mock('../../server/auth-middleware', () => authMocks)
+
+async function handlers() {
+  const module = await import('./swarm-dispatch')
+  return (module as any).Route.server.handlers
+}
+
+describe('/api/swarm-dispatch authorization', () => {
+  it('rejects dispatch when the local-or-auth boundary denies the request', async () => {
+    const route = await handlers()
+    const response = await route.POST({
+      request: new Request('http://workspace.example/api/swarm-dispatch', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ workerIds: ['swarm1'], prompt: 'must not run' }),
+      }),
+    })
+
+    expect(authMocks.requireLocalOrAuth).toHaveBeenCalledOnce()
+    expect(response.status).toBe(401)
+  })
+})

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -197,16 +197,14 @@ describe('buildHermesTmuxLaunchCommand', () => {
 })
 
 describe('buildHermesChatQueryArgs', () => {
-  it('passes the prompt immediately after -q so flags are not parsed as the query', () => {
+  it('keeps prompts out of process arguments', () => {
     const prompt = 'STATE: DONE\nRESULT: ok'
-    const args = buildHermesChatQueryArgs(prompt)
+    const args = buildHermesChatQueryArgs()
 
-    expect(args.slice(0, 3)).toEqual(['chat', '-q', prompt])
     expect(args).toContain('-Q')
     expect(args).toContain('--source')
-    expect(args[1]).toBe('-q')
-    expect(args[2]).toBe(prompt)
-    expect(args[3]).toBe('-Q')
+    expect(args).not.toContain('-q')
+    expect(args).not.toContain(prompt)
   })
 })
 

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   dispatchBlockReason,
   runtimeCheckpointSignature,
   runtimeSnapshotIsFresh,
+  runBestEffortDispatchBookkeeping,
   syncWorkerProfileModel,
 } from './swarm-dispatch'
 
@@ -183,6 +184,30 @@ describe('buildHermesTmuxLaunchCommand', () => {
     expect(source).not.toContain('new Promise(async')
     expect(source).toContain('unexpected dispatch failure')
   })
+
+  it('records mission dispatch only after process delivery succeeds', () => {
+    const source = readFileSync(new URL('./swarm-dispatch.ts', import.meta.url), 'utf8')
+    expect(source.indexOf('const bookkeepingFailures = liveResult.ok ? recordAcceptedDispatch() : []')).toBeGreaterThan(source.indexOf('await sendPromptToLiveSession(workerId, prompt)'))
+  })
+
+  it.each(['runtime', 'mission', 'memory'] as const)(
+    'preserves successful delivery when %s bookkeeping fails',
+    (failedWriter) => {
+      const calls: string[] = []
+      const failures = runBestEffortDispatchBookkeeping(
+        (['runtime', 'mission', 'memory'] as const).map((label) => ({
+          label,
+          run: () => {
+            calls.push(label)
+            if (label === failedWriter) throw new Error(`${label} unavailable`)
+          },
+        })),
+      )
+
+      expect(calls).toEqual(['runtime', 'mission', 'memory'])
+      expect(failures).toEqual([{ label: failedWriter, error: `${failedWriter} unavailable` }])
+    },
+  )
 
   it('publishes runtime checkpoint updates with an atomic rename', () => {
     const source = readFileSync(

--- a/src/routes/api/-swarm-dispatch.test.ts
+++ b/src/routes/api/-swarm-dispatch.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   buildHermesChatQueryArgs,
@@ -7,6 +8,7 @@ import {
   dispatchBlockReason,
   runtimeCheckpointSignature,
   runtimeSnapshotIsFresh,
+  syncWorkerProfileModel,
 } from './swarm-dispatch'
 
 describe('checkpointFromRuntimeSnapshot', () => {
@@ -26,7 +28,9 @@ describe('checkpointFromRuntimeSnapshot', () => {
     expect(checkpoint).not.toBeNull()
     expect(checkpoint?.stateLabel).toBe('DONE')
     expect(checkpoint?.checkpointStatus).toBe('done')
-    expect(checkpoint?.result).toBe('Structured checkpoint returned to RouterChat')
+    expect(checkpoint?.result).toBe(
+      'Structured checkpoint returned to RouterChat',
+    )
     expect(checkpoint?.nextAction).toBe('Verify in UI flow')
     expect(checkpoint?.raw).toContain('STATE: DONE')
   })
@@ -50,9 +54,30 @@ describe('checkpointFromRuntimeSnapshot', () => {
 
 describe('dispatchBlockReason', () => {
   it('turns failed or timed-out dispatch results into mission blocker text', () => {
-    expect(dispatchBlockReason({ ok: false, error: 'Command failed: worker exited', output: '', checkpointStatus: undefined })).toBe('Command failed: worker exited')
-    expect(dispatchBlockReason({ ok: true, error: null, output: 'Delivered', checkpointStatus: 'timeout' })).toBe('No fresh checkpoint before poll timeout.')
-    expect(dispatchBlockReason({ ok: true, error: null, output: 'Checkpoint DONE', checkpointStatus: 'checkpointed' })).toBeNull()
+    expect(
+      dispatchBlockReason({
+        ok: false,
+        error: 'Command failed: worker exited',
+        output: '',
+        checkpointStatus: undefined,
+      }),
+    ).toBe('Command failed: worker exited')
+    expect(
+      dispatchBlockReason({
+        ok: true,
+        error: null,
+        output: 'Delivered',
+        checkpointStatus: 'timeout',
+      }),
+    ).toBe('No fresh checkpoint before poll timeout.')
+    expect(
+      dispatchBlockReason({
+        ok: true,
+        error: null,
+        output: 'Checkpoint DONE',
+        checkpointStatus: 'checkpointed',
+      }),
+    ).toBeNull()
   })
 })
 
@@ -71,7 +96,13 @@ describe('runtimeSnapshotIsFresh', () => {
     }
     const dispatchedAt = 1_746_000_000_000
 
-    expect(runtimeSnapshotIsFresh(baseline, runtimeCheckpointSignature(baseline), dispatchedAt)).toBe(false)
+    expect(
+      runtimeSnapshotIsFresh(
+        baseline,
+        runtimeCheckpointSignature(baseline),
+        dispatchedAt,
+      ),
+    ).toBe(false)
 
     const updated = {
       ...baseline,
@@ -82,7 +113,13 @@ describe('runtimeSnapshotIsFresh', () => {
       lastOutputAt: 1_746_000_001_000,
     }
 
-    expect(runtimeSnapshotIsFresh(updated, runtimeCheckpointSignature(baseline), dispatchedAt)).toBe(true)
+    expect(
+      runtimeSnapshotIsFresh(
+        updated,
+        runtimeCheckpointSignature(baseline),
+        dispatchedAt,
+      ),
+    ).toBe(true)
   })
 })
 
@@ -105,17 +142,57 @@ describe('checkpoint filtering', () => {
 })
 
 describe('buildHermesTmuxLaunchCommand', () => {
+  it('leaves the existing profile model untouched for the default Worker label', () => {
+    expect(
+      syncWorkerProfileModel('new-worker', 'unused-profile', {
+        id: 'new-worker',
+        model: 'Worker',
+      } as never),
+    ).toEqual({ ok: true, skipped: true })
+  })
+
+  it('synchronizes the roster route into the worker profile before starting a live session', () => {
+    const source = readFileSync(
+      new URL('./swarm-dispatch.ts', import.meta.url),
+      'utf8',
+    )
+    expect(source).toContain('syncWorkerProfileModel(workerId, profilePath)')
+  })
+
   it('keeps the tmux shell alive so startup failures leave readable output', () => {
     const command = buildHermesTmuxLaunchCommand({
       profilePath: '/tmp/hermes profiles/swarm1',
+      cwd: '/tmp/workspace',
       hermesBin: '/opt/homebrew/bin/hermes',
-      ghToken: 'ghp_te...3456',
+      platform: 'linux',
     })
 
     expect(command).toContain("HERMES_HOME='/tmp/hermes profiles/swarm1'")
     expect(command).toContain("'/opt/homebrew/bin/hermes' chat --tui")
     expect(command).toContain('[Hermes worker exited with status %s]')
     expect(command).not.toContain('exec ')
+    expect(command).not.toContain('GH_TOKEN=')
+    expect(command).not.toContain('GITHUB_TOKEN=')
+  })
+
+  it('settles unexpected async dispatch failures instead of using an async Promise executor', () => {
+    const source = readFileSync(
+      new URL('./swarm-dispatch.ts', import.meta.url),
+      'utf8',
+    )
+    expect(source).not.toContain('new Promise(async')
+    expect(source).toContain('unexpected dispatch failure')
+  })
+
+  it('publishes runtime checkpoint updates with an atomic rename', () => {
+    const source = readFileSync(
+      new URL('./swarm-dispatch.ts', import.meta.url),
+      'utf8',
+    )
+    expect(source).toContain('renameSync(runtimeTempPath, runtimePath)')
+    expect(source).not.toContain(
+      "writeFileSync(runtimePath, JSON.stringify(next, null, 2) + '\\n')",
+    )
   })
 })
 
@@ -165,8 +242,12 @@ describe('buildWorkerPrompt', () => {
 
     expect(prompt).toContain('Worker: Builder — Primary Builder')
     expect(prompt).toContain('Machine ID: swarm5')
-    expect(prompt).toContain('Mission: Ship focused product slices with tests and clean diffs.')
-    expect(prompt).toContain('Capabilities: code-editing, ui-implementation, build-verification')
+    expect(prompt).toContain(
+      'Mission: Ship focused product slices with tests and clean diffs.',
+    )
+    expect(prompt).toContain(
+      'Capabilities: code-editing, ui-implementation, build-verification',
+    )
     expect(prompt).toContain('Skills: swarm-ui-worker, swarm-worker-core')
   })
 

--- a/src/routes/api/-swarm-tmux-start.test.ts
+++ b/src/routes/api/-swarm-tmux-start.test.ts
@@ -12,8 +12,10 @@ describe('/api/swarm-tmux-start Windows compatibility', () => {
     expect(source).not.toContain('No wrapper for')
   })
 
-  it('starts an interactive pane and sends the Hermes launch command into it', () => {
-    expect(source).toContain('buildTmuxNewSessionArgs')
-    expect(source).toContain('buildTmuxSendKeysArgs')
+  it('delegates process ownership instead of constructing tmux sessions in the route', () => {
+    expect(source).toContain('startWorkerProcess(workerId)')
+    expect(source).toContain('getWorkerProcessHost().status(workerId)')
+    expect(source).not.toContain('buildTmuxNewSessionArgs')
+    expect(source).not.toContain('buildTmuxSendKeysArgs')
   })
 })

--- a/src/routes/api/-swarm-tmux-start.test.ts
+++ b/src/routes/api/-swarm-tmux-start.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('/api/swarm-tmux-start Windows compatibility', () => {
+  const source = readFileSync(
+    new URL('./swarm-tmux-start.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('creates worker profiles instead of requiring Unix wrapper files', () => {
+    expect(source).toContain('ensureSwarmProfileConfig(profilePath)')
+    expect(source).not.toContain('No wrapper for')
+  })
+
+  it('starts an interactive pane and sends the Hermes launch command into it', () => {
+    expect(source).toContain('buildTmuxNewSessionArgs')
+    expect(source).toContain('buildTmuxSendKeysArgs')
+  })
+})

--- a/src/routes/api/__tests__/-models.test.ts
+++ b/src/routes/api/__tests__/-models.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import path from 'node:path'
 
-const { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } = vi.hoisted(() => ({
+const { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, readdirSync, gatewayCapabilities, requireLocalOrAuth, loadSubscriptionCatalog } = vi.hoisted(() => ({
   existsSync: vi.fn().mockReturnValue(false),
   readFileSync: vi.fn().mockReturnValue(''),
   writeFileSync: vi.fn().mockImplementation(() => {}),
   mkdirSync: vi.fn().mockImplementation(() => {}),
   statSync: vi.fn().mockReturnValue({ isFile: () => false, mtimeMs: 0 }),
   readdirSync: vi.fn().mockReturnValue([]),
+  gatewayCapabilities: { models: false },
+  requireLocalOrAuth: vi.fn(() => true),
+  loadSubscriptionCatalog: vi.fn(),
 }))
 
 vi.mock('node:fs', () => ({
@@ -34,6 +37,7 @@ vi.mock('@tanstack/react-start', () => ({
 
 vi.mock('../../../server/auth-middleware', () => ({
   isAuthenticated: () => true,
+  requireLocalOrAuth,
 }))
 
 vi.mock('../../../server/gateway-capabilities', () => ({
@@ -43,7 +47,7 @@ vi.mock('../../../server/gateway-capabilities', () => ({
 
 vi.mock('../../../server/claude-api', () => ({
   ensureGatewayProbed: vi.fn(),
-  getGatewayCapabilities: () => ({ models: false }),
+  getGatewayCapabilities: () => gatewayCapabilities,
 }))
 
 vi.mock('../../../server/local-provider-discovery', () => ({
@@ -52,13 +56,62 @@ vi.mock('../../../server/local-provider-discovery', () => ({
   ensureProviderInConfig: () => false,
 }))
 
+vi.mock('../../../server/subscription-model-catalog', () => ({
+  loadSubscriptionCatalog,
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
+  gatewayCapabilities.models = false
+  requireLocalOrAuth.mockReturnValue(true)
+  loadSubscriptionCatalog.mockResolvedValue({
+    generatedAt: new Date(0).toISOString(),
+    subscriptionOnly: true,
+    models: [],
+    transports: [],
+  })
+  vi.unstubAllGlobals()
   delete process.env.HERMES_HOME
   delete process.env.CLAUDE_HOME
 })
 
 describe('models route', () => {
+  it('rejects requests outside the local-or-auth boundary before probing providers', async () => {
+    requireLocalOrAuth.mockReturnValue(false)
+    const get = await getHandler()
+    const res = await get({
+      request: new Request('http://workspace.example/api/models'),
+    })
+
+    expect(requireLocalOrAuth).toHaveBeenCalledOnce()
+    expect(res.status).toBe(401)
+  })
+
+  it('enriches duplicate model entries with later subscription status metadata', async () => {
+    const { mergeModelEntries, subscriptionModelToEntry } = await import('../models')
+
+    expect(
+      mergeModelEntries(
+        [{ id: 'claude-gp/sonnet', name: 'claude-gp/sonnet' }],
+        [
+          subscriptionModelToEntry({
+            id: 'claude-gp/sonnet',
+            name: 'claude-gp/sonnet',
+            provider: 'claude-gp',
+            status: 'quota_limited',
+            warning: 'Monthly allocation exhausted',
+          }),
+        ],
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: 'claude-gp/sonnet',
+        availability: 'quota_limited',
+        warning: 'Monthly allocation exhausted',
+      }),
+    ])
+  })
+
   async function importModels() {
     vi.resetModules()
     const mod = await import('../models')
@@ -82,6 +135,34 @@ describe('models route', () => {
     expect(json.data).toEqual([])
   })
 
+  it('redacts arbitrary provider errors from the client response', async () => {
+    const rawError = 'provider diagnostic secret-model-token'
+    loadSubscriptionCatalog.mockRejectedValueOnce(new Error(rawError))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const get = await getHandler()
+    const res = await get({
+      request: new Request('http://localhost/api/models'),
+    })
+
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ ok: false, error: 'Model catalog unavailable.' })
+    expect(JSON.stringify(body)).not.toContain(rawError)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[models] request failed',
+      expect.any(Error),
+    )
+  })
+
+  it('keeps catalogs available when gateway model discovery rejects authentication', async () => {
+    gatewayCapabilities.models = true
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 401 })))
+    const get = await getHandler()
+    const res = await get({ request: new Request('http://localhost/api/models') })
+    expect(res.status).toBe(200)
+    expect((await res.json()).ok).toBe(true)
+  })
+
   it('reads default model from CLAUDE_HOME config using YAML.parse', async () => {
     const envHome = '/mock/profiles/jarvis'
     process.env.CLAUDE_HOME = envHome
@@ -89,11 +170,11 @@ describe('models route', () => {
     const configYaml = 'model: jarvis-model\nprovider: nous\n'
     const modelsJson = '[{"model":"x","provider":"y"}]'
     existsSync.mockImplementation((p: string) => {
-      return p === `${envHome}/models.json` || p === `${envHome}/config.yaml`
+      return p === path.join(envHome, 'models.json') || p === path.join(envHome, 'config.yaml')
     })
     readFileSync.mockImplementation((p: string) => {
-      if (p === `${envHome}/config.yaml`) return configYaml
-      if (p === `${envHome}/models.json`) return modelsJson
+      if (p === path.join(envHome, 'config.yaml')) return configYaml
+      if (p === path.join(envHome, 'models.json')) return modelsJson
       return ''
     })
 
@@ -112,9 +193,9 @@ describe('models route', () => {
     process.env.CLAUDE_HOME = envHome
 
     const configYaml = 'model:\n  default: nest-model\n  provider: anthropic\n'
-    existsSync.mockImplementation((p: string) => p === `${envHome}/config.yaml`)
+    existsSync.mockImplementation((p: string) => p === path.join(envHome, 'config.yaml'))
     readFileSync.mockImplementation((p: string) => {
-      if (p === `${envHome}/config.yaml`) return configYaml
+      if (p === path.join(envHome, 'config.yaml')) return configYaml
       return ''
     })
 

--- a/src/routes/api/crew-status.ts
+++ b/src/routes/api/crew-status.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import * as yaml from 'yaml'
 import { BEARER_TOKEN, CLAUDE_API, ensureGatewayProbed } from '../../server/gateway-capabilities'
 import { getClaudeRoot, getProfileClaudeHome, getWorkspaceClaudeHome } from '../../server/claude-paths'
+import { resolveManagedPythonBin } from '../../server/managed-python'
 import { formatSwarmWorkerLabel, rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
 
 type CrewDefinition = {
@@ -163,7 +164,7 @@ if last_row is not None:
 conn.close()
 print(json.dumps(out))
 `
-    const raw = execFileSync('python3', ['-c', script, dbPath], {
+    const raw = execFileSync(resolveManagedPythonBin(), ['-c', script, dbPath], {
       encoding: 'utf-8',
       timeout: 3_000,
     })

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import YAML from 'yaml'
 import { json } from '@tanstack/react-start'
 import { createFileRoute } from '@tanstack/react-router'
-import { isAuthenticated } from '../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
 import {
   ensureGatewayProbed,
   getGatewayCapabilities,
@@ -15,6 +15,7 @@ import {
   ensureProviderInConfig,
   getDiscoveredModels,
 } from '../../server/local-provider-discovery'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
 
 const CLAUDE_HOME = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME ?? path.join(os.homedir(), '.hermes')
 const MODELS_PATH = path.join(CLAUDE_HOME, 'models.json')
@@ -27,6 +28,12 @@ type ModelEntry = {
   [key: string]: unknown
 }
 
+type NormalizedModelEntry = ModelEntry & {
+  id: string
+  name: string
+  provider: string
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === 'object' && !Array.isArray(value))
     return value as Record<string, unknown>
@@ -37,14 +44,14 @@ function readString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function normalizeModel(entry: unknown): ModelEntry | null {
+function normalizeModel(entry: unknown): NormalizedModelEntry | null {
   if (typeof entry === 'string') {
     const id = entry.trim()
     if (!id) return null
     return {
       id,
       name: id,
-      provider: id.includes('/') ? id.split('/')[0] : 'unknown',
+      provider: id.includes('/') ? (id.split('/')[0] ?? 'unknown') : 'unknown',
     }
   }
   const record = asRecord(entry)
@@ -62,24 +69,45 @@ function normalizeModel(entry: unknown): ModelEntry | null {
     provider:
       readString(record.provider) ||
       readString(record.owned_by) ||
-      (id.includes('/') ? id.split('/')[0] : 'unknown'),
+      (id.includes('/') ? (id.split('/')[0] ?? 'unknown') : 'unknown'),
   }
 }
 
 export function mergeModelEntries(...sources: Array<Array<ModelEntry>>): Array<ModelEntry> {
   const merged: Array<ModelEntry> = []
-  const seen = new Set<string>()
+  const indexById = new Map<string, number>()
 
   for (const source of sources) {
     for (const model of source) {
       const normalized = normalizeModel(model)
-      if (!normalized || seen.has(normalized.id)) continue
+      if (!normalized) continue
+      const existingIndex = indexById.get(normalized.id)
+      if (existingIndex !== undefined) {
+        // Keep the first configured entry authoritative for identity and display
+        // fields while allowing later live sources to fill metadata that the
+        // configured entry did not provide (availability, quota, warnings).
+        merged[existingIndex] = { ...normalized, ...merged[existingIndex] }
+        continue
+      }
+      indexById.set(normalized.id, merged.length)
       merged.push(normalized)
-      seen.add(normalized.id)
     }
   }
 
   return merged
+}
+
+export function subscriptionModelToEntry(
+  model: unknown,
+): ModelEntry {
+  const record = asRecord(model)
+  const id = readString(record.id)
+  return {
+    ...record,
+    id,
+    name: readString(record.name) || id,
+    availability: readString(record.status),
+  }
 }
 
 /**
@@ -288,7 +316,7 @@ async function fetchConfiguredLiveModels(): Promise<Array<ModelEntry>> {
             : []
         models = rawModels
           .map(normalizeModel)
-          .filter((entry): entry is ModelEntry => entry !== null)
+          .filter((entry): entry is NormalizedModelEntry => entry !== null)
           .map((entry) => ({
             ...entry,
             provider: readString(entry.provider) || endpoint.provider,
@@ -402,14 +430,14 @@ async function fetchClaudeModels(): Promise<Array<ModelEntry>> {
       : []
   return rawModels
     .map(normalizeModel)
-    .filter((e): e is ModelEntry => e !== null)
+    .filter((e): e is NormalizedModelEntry => e !== null)
 }
 
 export const Route = createFileRoute('/api/models')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         await ensureGatewayProbed()
@@ -444,9 +472,15 @@ export const Route = createFileRoute('/api/models')({
           // Operations picker only showed the local Workspace subset and drifted
           // from the CLI/backend model universe.
           if (getGatewayCapabilities().models) {
-            const hermesModels = await fetchClaudeModels()
-            models = mergeModelEntries(models, hermesModels)
-            source = source === 'models.json' ? 'models.json+hermes-agent' : 'hermes-agent'
+            try {
+              const hermesModels = await fetchClaudeModels()
+              models = mergeModelEntries(models, hermesModels)
+              source = source === 'models.json' ? 'models.json+hermes-agent' : 'hermes-agent'
+            } catch {
+              // A stale/missing gateway bearer token must not hide the local
+              // subscription catalog. Continue with configured and OAuth
+              // sources instead of failing the entire picker.
+            }
           }
 
           // Merge live OpenAI-compatible catalogs from base_url entries that
@@ -459,12 +493,33 @@ export const Route = createFileRoute('/api/models')({
             source = `${source}+live-proxy`
           }
 
+          // Merge every model exposed by an authenticated subscription
+          // transport. The catalog applies the API-billing visibility policy
+          // before entries reach any dashboard picker.
+          const subscriptionCatalog = await loadSubscriptionCatalog()
+          if (subscriptionCatalog.models.length > 0) {
+            models = mergeModelEntries(
+              models,
+              subscriptionCatalog.models.map(subscriptionModelToEntry),
+            )
+            source = `${source}+subscription-oauth`
+          }
+
           // Merge auto-discovered local models (Ollama, Atomic Chat, etc.)
           await ensureDiscovery()
           const localModels = getDiscoveredModels()
           models = mergeModelEntries(models, localModels)
           for (const m of localModels) {
             ensureProviderInConfig(m.provider)
+          }
+
+          // Merges append new entries. Re-assert the configured default at the
+          // front after every catalog source has been considered.
+          if (defaultModel) {
+            const enrichedDefault =
+              models.find((model) => model.id === defaultModel.id) ?? defaultModel
+            models = models.filter((model) => model.id !== defaultModel.id)
+            models.unshift({ ...defaultModel, ...enrichedDefault })
           }
 
           const configuredProviders = Array.from(
@@ -489,10 +544,11 @@ export const Route = createFileRoute('/api/models')({
             ...streamTimeouts,
           })
         } catch (err) {
+          console.error('[models] request failed', err)
           return json(
             {
               ok: false,
-              error: err instanceof Error ? err.message : String(err),
+              error: 'Model catalog unavailable.',
             },
             { status: 503 },
           )

--- a/src/routes/api/orchestration-catalog.ts
+++ b/src/routes/api/orchestration-catalog.ts
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
+
+async function getCatalog({ request }: { request: Request }): Promise<Response> {
+  if (!requireLocalOrAuth(request)) {
+    return Response.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    return Response.json({ ok: true, ...(await loadSubscriptionCatalog()) })
+  } catch (error) {
+    console.error('[orchestration-catalog] failed to load catalog:', error)
+    return Response.json({ ok: false, error: 'Failed to load orchestration catalog.' }, { status: 500 })
+  }
+}
+
+export const Route = createFileRoute('/api/orchestration-catalog')({
+  server: { handlers: { GET: getCatalog } },
+})

--- a/src/routes/api/orchestration-policy.ts
+++ b/src/routes/api/orchestration-policy.ts
@@ -1,0 +1,132 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  clearSessionOrchestrationPolicy,
+  getOrchestrationPolicy,
+  getSessionOrchestrationPolicy,
+  saveSessionOrchestrationPolicy,
+} from '../../server/orchestration-policy'
+import {
+  applyGlobalOrchestrationPolicyTransaction,
+  serializeOrchestrationWrite,
+} from '../../server/orchestration-hermes-sync'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
+
+const PatchBody = z.object({
+  scope: z.enum(['global', 'session']),
+  sessionKey: z.string().trim().min(1).optional(),
+  patch: z.record(z.string(), z.unknown()),
+  confirmApiBilling: z.boolean().optional(),
+})
+
+function authorize(request: Request): Response | true {
+  if (requireLocalOrAuth(request)) return true
+  return Response.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+}
+
+async function getPolicy({ request }: { request: Request }): Promise<Response> {
+  const auth = await authorize(request)
+  if (auth !== true) return auth
+  const sessionKey =
+    new URL(request.url).searchParams.get('sessionKey')?.trim() || ''
+  const global = getOrchestrationPolicy()
+  return Response.json({
+    ok: true,
+    global,
+    effective: sessionKey ? getSessionOrchestrationPolicy(sessionKey) : global,
+    sessionKey: sessionKey || null,
+  })
+}
+
+async function patchPolicy({
+  request,
+}: {
+  request: Request
+}): Promise<Response> {
+  const auth = await authorize(request)
+  if (auth !== true) return auth
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+  }
+  const parsed = PatchBody.safeParse(body)
+  if (!parsed.success) {
+    return Response.json(
+      {
+        ok: false,
+        error: 'Invalid orchestration policy patch',
+        issues: parsed.error.issues,
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const catalog = await loadSubscriptionCatalog()
+    const isSession = parsed.data.scope === 'session'
+    if (isSession) {
+      const policy = await serializeOrchestrationWrite(() =>
+        saveSessionOrchestrationPolicy(
+          parsed.data.sessionKey || '',
+          parsed.data.patch,
+          { catalog },
+        ),
+      )
+      return Response.json({ ok: true, policy })
+    }
+
+    const policy = await applyGlobalOrchestrationPolicyTransaction(
+      parsed.data.patch,
+      {
+        catalog,
+        confirmApiBilling: parsed.data.confirmApiBilling,
+      },
+    )
+    return Response.json({ ok: true, policy })
+  } catch {
+    return Response.json(
+      {
+        ok: false,
+        error: 'Unable to apply orchestration policy',
+      },
+      { status: 400 },
+    )
+  }
+}
+
+async function deletePolicy({
+  request,
+}: {
+  request: Request
+}): Promise<Response> {
+  const auth = await authorize(request)
+  if (auth !== true) return auth
+  const sessionKey =
+    new URL(request.url).searchParams.get('sessionKey')?.trim() || ''
+  if (!sessionKey) {
+    return Response.json(
+      { ok: false, error: 'sessionKey is required' },
+      { status: 400 },
+    )
+  }
+  await serializeOrchestrationWrite(() =>
+    clearSessionOrchestrationPolicy(sessionKey),
+  )
+  return Response.json({ ok: true, policy: getOrchestrationPolicy() })
+}
+
+export const Route = createFileRoute('/api/orchestration-policy')({
+  server: {
+    handlers: {
+      GET: getPolicy,
+      PATCH: patchPolicy,
+      POST: patchPolicy,
+      DELETE: deletePolicy,
+    },
+  },
+})

--- a/src/routes/api/profiles/-mutation-auth.test.ts
+++ b/src/routes/api/profiles/-mutation-auth.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const mutationRoutes = [
+  'activate.ts',
+  'create.ts',
+  'delete.ts',
+  'rename.ts',
+  'toggle-skill.ts',
+  'update.ts',
+]
+
+describe('profile mutation authorization boundary', () => {
+  for (const route of mutationRoutes) {
+    it(`${route} requires a local request or authenticated session`, () => {
+      const source = readFileSync(join(here, route), 'utf8')
+      expect(source).toContain('requireLocalOrAuth(request)')
+      expect(source).not.toContain('if (!isAuthenticated(request))')
+    })
+  }
+})

--- a/src/routes/api/profiles/-operations-model-selection.test.ts
+++ b/src/routes/api/profiles/-operations-model-selection.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireLocalOrAuth: vi.fn(() => true),
+  createProfile: vi.fn(() => ({ config: {} })),
+  readProfile: vi.fn(() => ({ config: {} })),
+  updateProfileConfig: vi.fn(
+    (_name: string, patch: Record<string, unknown>) => ({
+      config: patch,
+    }),
+  ),
+  loadSubscriptionCatalog: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: (_path: string) => (options: unknown) => options,
+}))
+vi.mock('../../../server/auth-middleware', () => ({
+  isAuthenticated: vi.fn(() => true),
+  requireLocalOrAuth: mocks.requireLocalOrAuth,
+}))
+vi.mock('../../../server/profiles-browser', () => ({
+  createProfile: mocks.createProfile,
+  readProfile: mocks.readProfile,
+  updateProfileConfig: mocks.updateProfileConfig,
+}))
+vi.mock('../../../server/subscription-model-catalog', async () => {
+  const actual = await vi.importActual(
+    '../../../server/subscription-model-catalog',
+  )
+  return { ...actual, loadSubscriptionCatalog: mocks.loadSubscriptionCatalog }
+})
+
+function catalog() {
+  return {
+    generatedAt: new Date(0).toISOString(),
+    subscriptionOnly: true,
+    transports: [],
+    models: [
+      {
+        id: 'openai-codex/gpt-5.6-sol',
+        provider: 'openai-codex',
+        account: 'openai-codex',
+        model: 'gpt-5.6-sol',
+        transport: 'openai-codex-oauth',
+        billingClass: 'subscription_included',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+        capabilities: {
+          contextWindow: 1_050_000,
+          maxInputTokens: 922_000,
+          maxOutputTokens: 128_000,
+          supportsReasoning: true,
+          supportsTools: true,
+          supportsVision: true,
+          supportsOutputTokenLimit: false,
+          reasoningEfforts: ['provider_default', 'low', 'high'],
+          metadataSource: 'models.dev',
+        },
+      },
+      {
+        id: 'nous/google/gemini-3.1-pro-preview',
+        provider: 'nous',
+        account: 'nous',
+        model: 'google/gemini-3.1-pro-preview',
+        transport: 'nous-oauth',
+        billingClass: 'subscription_unknown',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+        capabilities: {
+          contextWindow: 1_048_576,
+          maxInputTokens: null,
+          maxOutputTokens: 65_536,
+          supportsReasoning: true,
+          supportsTools: true,
+          supportsVision: true,
+          supportsOutputTokenLimit: true,
+          reasoningEfforts: ['provider_default', 'low', 'high'],
+          metadataSource: 'models.dev',
+        },
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.requireLocalOrAuth.mockReturnValue(true)
+  mocks.loadSubscriptionCatalog.mockResolvedValue(catalog())
+  mocks.readProfile.mockReturnValue({ config: {} })
+})
+
+async function createHandler() {
+  const module = await import('./create')
+  return (module as any).Route.server.handlers.POST
+}
+
+async function updateHandler() {
+  const module = await import('./update')
+  return (module as any).Route.server.handlers.POST
+}
+
+describe('Operations profile model mutations', () => {
+  it('denies profile creation before loading catalogs or touching disk', async () => {
+    mocks.requireLocalOrAuth.mockReturnValue(false)
+    const response = await (
+      await createHandler()
+    )({
+      request: new Request('http://workspace.example/api/profiles/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'worker' }),
+      }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(mocks.loadSubscriptionCatalog).not.toHaveBeenCalled()
+    expect(mocks.createProfile).not.toHaveBeenCalled()
+  })
+
+  it('creates a profile with an executable canonical model selection', async () => {
+    const response = await (
+      await createHandler()
+    )({
+      request: new Request('http://localhost/api/profiles/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'worker',
+          modelSelection: {
+            routeRef: 'nous/google/gemini-3.1-pro-preview',
+            reasoningEffort: 'high',
+            maxOutputTokens: 32768,
+          },
+        }),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.createProfile).toHaveBeenCalledWith('worker', {
+      cloneFrom: undefined,
+    })
+    expect(mocks.updateProfileConfig).toHaveBeenCalledWith(
+      'worker',
+      expect.objectContaining({
+        model: {
+          provider: 'nous',
+          default: 'google/gemini-3.1-pro-preview',
+          max_tokens: 32768,
+        },
+        agent: { reasoning_effort: 'high' },
+        workspace: { route_ref: 'nous/google/gemini-3.1-pro-preview' },
+      }),
+    )
+  })
+
+  it('updates only allowlisted profile fields with canonical selection', async () => {
+    const response = await (
+      await updateHandler()
+    )({
+      request: new Request('http://localhost/api/profiles/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'worker',
+          patch: { system_prompt: 'Safe prompt', arbitrary: 'blocked' },
+          modelSelection: {
+            routeRef: 'openai-codex/gpt-5.6-sol',
+            reasoningEffort: 'low',
+          },
+        }),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateProfileConfig).toHaveBeenCalledWith('worker', {
+      system_prompt: 'Safe prompt',
+      model: { provider: 'openai-codex', default: 'gpt-5.6-sol' },
+      agent: { reasoning_effort: 'low' },
+      workspace: { route_ref: 'openai-codex/gpt-5.6-sol' },
+    })
+  })
+})

--- a/src/routes/api/profiles/-operations-model-selection.test.ts
+++ b/src/routes/api/profiles/-operations-model-selection.test.ts
@@ -179,9 +179,9 @@ describe('Operations profile model mutations', () => {
     expect(response.status).toBe(200)
     expect(mocks.updateProfileConfig).toHaveBeenCalledWith('worker', {
       system_prompt: 'Safe prompt',
-      model: { provider: 'openai-codex', default: 'gpt-5.6-sol' },
+      model: { provider: 'openai-codex', default: 'gpt-5.6-sol', openai_runtime: 'hermes_default' },
       agent: { reasoning_effort: 'low' },
-      workspace: { route_ref: 'openai-codex/gpt-5.6-sol' },
+      workspace: { route_ref: 'openai-codex/gpt-5.6-sol', codex_runtime: 'hermes_default' },
     })
   })
 })

--- a/src/routes/api/profiles/activate.ts
+++ b/src/routes/api/profiles/activate.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
 import { setActiveProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/api/profiles/activate')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         const csrfCheck = requireJsonContentType(request)

--- a/src/routes/api/profiles/create.ts
+++ b/src/routes/api/profiles/create.ts
@@ -1,14 +1,24 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
-import { createProfile } from '../../../server/profiles-browser'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+
+  operationsModelSelectionPatch
+} from '../../../server/operations-agent-config'
+import {
+  createProfile,
+  readProfile,
+  updateProfileConfig,
+} from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
+import { loadSubscriptionCatalog } from '../../../server/subscription-model-catalog'
+import type {OperationsModelSelection} from '../../../server/operations-agent-config';
 
 export const Route = createFileRoute('/api/profiles/create')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         const csrfCheck = requireJsonContentType(request)
@@ -18,16 +28,27 @@ export const Route = createFileRoute('/api/profiles/create')({
             name?: string
             cloneFrom?: string
             model?: string
-            provider?: string
+            modelSelection?: OperationsModelSelection
           }
-          return json({
-            ok: true,
-            profile: createProfile(body.name || '', {
-              cloneFrom: body.cloneFrom,
-              model: body.model,
-              provider: body.provider,
-            }),
-          })
+          const selection =
+            body.modelSelection ??
+            (body.model?.trim() ? { routeRef: body.model.trim() } : undefined)
+          let modelPatch: Record<string, unknown> = {}
+          if (selection) {
+            const baseConfig = readProfile(body.cloneFrom || 'default').config
+            modelPatch = operationsModelSelectionPatch(
+              selection,
+              baseConfig,
+              await loadSubscriptionCatalog(),
+            )
+          }
+
+          createProfile(body.name || '', { cloneFrom: body.cloneFrom })
+          const profile =
+            Object.keys(modelPatch).length > 0
+              ? updateProfileConfig(body.name || '', modelPatch)
+              : readProfile(body.name || '')
+          return json({ ok: true, profile })
         } catch (error) {
           return json(
             {
@@ -36,7 +57,7 @@ export const Route = createFileRoute('/api/profiles/create')({
                   ? error.message
                   : 'Failed to create profile',
             },
-            { status: 500 },
+            { status: 400 },
           )
         }
       },

--- a/src/routes/api/profiles/delete.ts
+++ b/src/routes/api/profiles/delete.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
 import { deleteProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/api/profiles/delete')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         const csrfCheck = requireJsonContentType(request)

--- a/src/routes/api/profiles/rename.ts
+++ b/src/routes/api/profiles/rename.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
 import { renameProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/api/profiles/rename')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         const csrfCheck = requireJsonContentType(request)

--- a/src/routes/api/profiles/toggle-skill.ts
+++ b/src/routes/api/profiles/toggle-skill.ts
@@ -11,7 +11,7 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
 import {
   dashboardFetch,
   ensureGatewayProbed,
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/api/profiles/toggle-skill')({
   server: {
     handlers: {
       PUT: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         const capabilities = await ensureGatewayProbed()

--- a/src/routes/api/profiles/update.ts
+++ b/src/routes/api/profiles/update.ts
@@ -1,14 +1,35 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
-import { updateProfileConfig } from '../../../server/profiles-browser'
+import { requireLocalOrAuth } from '../../../server/auth-middleware'
+import {
+
+  operationsModelSelectionPatch
+} from '../../../server/operations-agent-config'
+import {
+  readProfile,
+  updateProfileConfig,
+} from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
+import { loadSubscriptionCatalog } from '../../../server/subscription-model-catalog'
+import type {OperationsModelSelection} from '../../../server/operations-agent-config';
+
+function allowlistedProfilePatch(
+  patch: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!patch) return {}
+  const safe: Record<string, unknown> = {}
+  for (const key of ['system_prompt', 'description'] as const) {
+    const value = patch[key]
+    if (typeof value === 'string' || value === null) safe[key] = value
+  }
+  return safe
+}
 
 export const Route = createFileRoute('/api/profiles/update')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         const csrfCheck = requireJsonContentType(request)
@@ -17,11 +38,31 @@ export const Route = createFileRoute('/api/profiles/update')({
           const body = (await request.json()) as {
             name?: string
             patch?: Record<string, unknown>
+            modelSelection?: OperationsModelSelection
           }
-          if (!body.patch || typeof body.patch !== 'object') {
-            return json({ error: 'patch is required' }, { status: 400 })
+          const name = body.name || ''
+          const current = readProfile(name)
+          const legacyRouteRef =
+            typeof body.patch?.model === 'string' ? body.patch.model.trim() : ''
+          const selection =
+            body.modelSelection ??
+            (legacyRouteRef ? { routeRef: legacyRouteRef } : undefined)
+          const safePatch = allowlistedProfilePatch(body.patch)
+          const modelPatch = selection
+            ? operationsModelSelectionPatch(
+                selection,
+                current.config,
+                await loadSubscriptionCatalog(),
+              )
+            : {}
+          const patch = { ...safePatch, ...modelPatch }
+          if (Object.keys(patch).length === 0) {
+            return json(
+              { error: 'No supported profile changes supplied' },
+              { status: 400 },
+            )
           }
-          const profile = updateProfileConfig(body.name || '', body.patch)
+          const profile = updateProfileConfig(name, patch)
           return json({ ok: true, profile })
         } catch (error) {
           return json(
@@ -31,7 +72,7 @@ export const Route = createFileRoute('/api/profiles/update')({
                   ? error.message
                   : 'Failed to update profile',
             },
-            { status: 500 },
+            { status: 400 },
           )
         }
       },

--- a/src/routes/api/provider-runtimes.ts
+++ b/src/routes/api/provider-runtimes.ts
@@ -76,7 +76,7 @@ export const Route = createFileRoute('/api/provider-runtimes')({
         if (runtimeId.startsWith('codex:') && route.account !== 'openai-codex') {
           return Response.json({ ok: false, error: 'Codex runtime requires an OpenAI Codex subscription route' }, { status: 400 })
         }
-        const result = await getProviderRuntimeService().mutate(raw)
+        const result = await getProviderRuntimeService().mutate({ ...raw, providerModel: route.model })
         if (!result || typeof result !== 'object' || (result as { ok?: unknown }).ok !== true) {
           return Response.json({ ok: false, result }, { status: 409 })
         }

--- a/src/routes/api/provider-runtimes.ts
+++ b/src/routes/api/provider-runtimes.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { requireProviderRuntimeMutationAuth } from '../../server/auth-middleware'
 import { getProviderRuntimeService } from '../../server/provider-runtime-service'
+import { writeRuntimeRouteSnapshot } from '../../server/runtime-route-cache'
 import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
 
 const MAX_TEXT = 32_000
@@ -42,7 +43,12 @@ export const Route = createFileRoute('/api/provider-runtimes')({
         if (!body || typeof body !== 'object') return Response.json({ ok: false, error: 'Invalid request' }, { status: 400 })
         if ((body as Record<string, unknown>).action === 'refresh') {
           const refresh = await getProviderRuntimeService().refresh()
-          return inventoryResponse(refresh)
+          const catalog = await loadSubscriptionCatalog()
+          const availableRoutes = catalog.models
+            .filter((entry) => entry.selectable && entry.billingClass === 'subscription_included')
+            .map((entry) => ({ id: entry.id, account: entry.account, model: entry.model, status: entry.status }))
+          writeRuntimeRouteSnapshot(availableRoutes)
+          return inventoryResponse(refresh, availableRoutes)
         }
         if ((body as Record<string, unknown>).action === 'recover-lease') {
           const runtimeId = (body as Record<string, unknown>).runtimeId
@@ -52,7 +58,7 @@ export const Route = createFileRoute('/api/provider-runtimes')({
         }
         if ((body as Record<string, unknown>).action === 'link_kanban') {
           const result = await getProviderRuntimeService().mutate(body as Record<string, unknown>)
-          const ok = Boolean((result as { ok?: unknown })?.ok)
+          const ok = Boolean((result as { ok?: unknown }).ok)
           return Response.json({ ok, result }, { status: ok ? 200 : 409 })
         }
         const raw = body as Record<string, unknown>
@@ -65,7 +71,7 @@ export const Route = createFileRoute('/api/provider-runtimes')({
         }
         const catalog = await loadSubscriptionCatalog()
         const route = catalog.models.find((entry) => entry.id === routeRef)
-        if (!catalog.subscriptionOnly || !route?.selectable || route.billingClass !== 'subscription_included') {
+        if (!catalog.subscriptionOnly || !route?.selectable || route.status !== 'available' || route.billingClass !== 'subscription_included') {
           return Response.json({ ok: false, error: 'routeRef is not an assignable subscription-included route' }, { status: 400 })
         }
         const accountAlias = typeof raw.accountAlias === 'string' ? raw.accountAlias : ''

--- a/src/routes/api/provider-runtimes.ts
+++ b/src/routes/api/provider-runtimes.ts
@@ -1,0 +1,87 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { requireProviderRuntimeMutationAuth } from '../../server/auth-middleware'
+import { getProviderRuntimeService } from '../../server/provider-runtime-service'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
+
+const MAX_TEXT = 32_000
+
+function inventoryResponse(refresh: unknown = null, availableRoutes: Array<unknown> = []): Response {
+  return Response.json({
+    ok: true,
+    runtimes: getProviderRuntimeService().list(),
+    refresh,
+    availableRoutes,
+    kanbanAuthority: 'Kanban task state remains authoritative; runtime linkage is metadata only.',
+    restartSemantics: 'Resume preserves provider identity when supported; create/fork produces a new runtime identity.',
+    directProviderMessaging: { enabled: false, state: 'deferred', explanation: 'Deferred until provider-native live stability is proven.' },
+    codexRuntimeChoices: [
+      { value: 'hermes_default', label: 'Hermes default', explanation: 'Hermes owns tools and the worker lifecycle.' },
+      { value: 'codex_app_server', label: 'Codex app server', explanation: 'Codex owns its provider-native thread and tool loop through local stdio.' },
+    ],
+  })
+}
+
+export const Route = createFileRoute('/api/provider-runtimes')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!requireProviderRuntimeMutationAuth(request)) return Response.json({ ok: false, error: 'Provider runtime inventory requires dashboard authentication' }, { status: 401 })
+        const catalog = await loadSubscriptionCatalog()
+        const availableRoutes = catalog.models
+          .filter((entry) => entry.selectable && entry.billingClass === 'subscription_included')
+          .map((entry) => ({ id: entry.id, account: entry.account, model: entry.model, status: entry.status }))
+        return inventoryResponse(null, availableRoutes)
+      },
+      POST: async ({ request }) => {
+        // Deliberately first: denial must happen before body parsing, catalog
+        // lookup, lease acquisition, CLI launch, or provider invocation.
+        if (!requireProviderRuntimeMutationAuth(request)) return Response.json({ ok: false, error: 'Provider runtime mutations require dashboard authentication' }, { status: 401 })
+        let body: unknown
+        try { body = await request.json() } catch { return Response.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 }) }
+        if (!body || typeof body !== 'object') return Response.json({ ok: false, error: 'Invalid request' }, { status: 400 })
+        if ((body as Record<string, unknown>).action === 'refresh') {
+          const refresh = await getProviderRuntimeService().refresh()
+          return inventoryResponse(refresh)
+        }
+        if ((body as Record<string, unknown>).action === 'recover-lease') {
+          const runtimeId = (body as Record<string, unknown>).runtimeId
+          if (typeof runtimeId !== 'string' || !runtimeId) return Response.json({ ok: false, error: 'runtimeId required' }, { status: 400 })
+          const result = getProviderRuntimeService().recoverLease(runtimeId)
+          return Response.json(result, { status: result.ok ? 200 : 409 })
+        }
+        if ((body as Record<string, unknown>).action === 'link_kanban') {
+          const result = await getProviderRuntimeService().mutate(body as Record<string, unknown>)
+          const ok = Boolean((result as { ok?: unknown })?.ok)
+          return Response.json({ ok, result }, { status: ok ? 200 : 409 })
+        }
+        const raw = body as Record<string, unknown>
+        const action = typeof raw.action === 'string' ? raw.action : ''
+        const runtimeId = typeof raw.runtimeId === 'string' ? raw.runtimeId : ''
+        const routeRef = typeof raw.routeRef === 'string' ? raw.routeRef.trim() : ''
+        const text = typeof raw.text === 'string' ? raw.text : (typeof raw.prompt === 'string' ? raw.prompt : '')
+        if (!action || action.length > 32 || runtimeId.length > 300 || text.length > MAX_TEXT || !routeRef) {
+          return Response.json({ ok: false, error: 'Invalid or oversized lifecycle request' }, { status: 400 })
+        }
+        const catalog = await loadSubscriptionCatalog()
+        const route = catalog.models.find((entry) => entry.id === routeRef)
+        if (!catalog.subscriptionOnly || !route?.selectable || route.billingClass !== 'subscription_included') {
+          return Response.json({ ok: false, error: 'routeRef is not an assignable subscription-included route' }, { status: 400 })
+        }
+        const accountAlias = typeof raw.accountAlias === 'string' ? raw.accountAlias : ''
+        const isClaudeAction = runtimeId.startsWith('claude:') || action === 'create' || action === 'background'
+        if (isClaudeAction && route.account !== accountAlias) {
+          return Response.json({ ok: false, error: 'Claude account and routeRef do not match' }, { status: 400 })
+        }
+        if (runtimeId.startsWith('codex:') && route.account !== 'openai-codex') {
+          return Response.json({ ok: false, error: 'Codex runtime requires an OpenAI Codex subscription route' }, { status: 400 })
+        }
+        const result = await getProviderRuntimeService().mutate(raw)
+        if (!result || typeof result !== 'object' || (result as { ok?: unknown }).ok !== true) {
+          return Response.json({ ok: false, result }, { status: 409 })
+        }
+        return Response.json({ ok: true, result })
+      },
+    },
+  },
+})

--- a/src/routes/api/runtime-runs.ts
+++ b/src/routes/api/runtime-runs.ts
@@ -1,0 +1,124 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { requireProviderRuntimeMutationAuth } from '../../server/auth-middleware'
+import { getProviderRuntimeService } from '../../server/provider-runtime-service'
+import { readRuntimeRouteSnapshot } from '../../server/runtime-route-cache'
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MAX_PROJECTED_RUNS,
+  RUNTIME_RUN_SORT_KEYS,
+  filterRuntimeRuns,
+  paginateRuntimeRuns,
+  projectRuntimeRuns,
+  sortRuntimeRuns,
+  summarizeRuntimeRuns
+} from '../../server/runtime-run-projection'
+import type {RuntimeRunFilters, RuntimeRunLinkFilter, RuntimeRunSortDirection, RuntimeRunSortKey} from '../../server/runtime-run-projection';
+
+// Read-only inventory: this route never refreshes providers, never launches a
+// CLI, and never touches a lease. Refresh stays on the authenticated POST of
+// /api/provider-runtimes so a page load cannot fan out into provider processes.
+const UNAVAILABLE = 'Provider runtime inventory is unavailable'
+const MAX_FILTER_VALUES = 12
+const MAX_FILTER_VALUE_LENGTH = 200
+const MAX_QUERY_LENGTH = 200
+
+function multi(params: URLSearchParams, name: string): Array<string> | undefined {
+  const values = params.getAll(name)
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((value) => value.length <= MAX_FILTER_VALUE_LENGTH)
+    .slice(0, MAX_FILTER_VALUES)
+  return values.length ? values : undefined
+}
+
+function linkFilter(value: string | null): RuntimeRunLinkFilter {
+  return value === 'linked' || value === 'unlinked' ? value : 'all'
+}
+
+function sortKey(value: string | null): RuntimeRunSortKey {
+  return RUNTIME_RUN_SORT_KEYS.includes(value as RuntimeRunSortKey) ? (value as RuntimeRunSortKey) : 'updated'
+}
+
+function integer(value: string | null, min: number, max: number, fallback: number): number {
+  const numeric = Number(value)
+  if (!value || !Number.isFinite(numeric)) return fallback
+  return Math.min(max, Math.max(min, Math.trunc(numeric)))
+}
+
+function runId(value: string | null): string | undefined {
+  if (!value) return undefined
+  const normalized = value.trim()
+  return normalized && normalized.length <= 300 ? normalized : undefined
+}
+
+function timestamp(value: string | null): number | undefined {
+  if (!value || value.length > 40) return undefined
+  const numeric = Number(value)
+  if (Number.isFinite(numeric) && numeric >= 0) return numeric
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export const Route = createFileRoute('/api/runtime-runs')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        // Deliberately first: denial must happen before the registry is read.
+        if (!requireProviderRuntimeMutationAuth(request)) {
+          return Response.json({ ok: false, error: 'Provider runtime inventory requires dashboard authentication' }, { status: 401 })
+        }
+        const params = new URL(request.url).searchParams
+        const filters: RuntimeRunFilters = {
+          provider: multi(params, 'provider'),
+          account: multi(params, 'account'),
+          state: multi(params, 'state'),
+          ownership: multi(params, 'ownership'),
+          project: multi(params, 'project'),
+          linked: linkFilter(params.get('kanban') ?? params.get('linked')),
+          kanbanTaskId: params.get('task')?.slice(0, 200),
+          updatedFrom: timestamp(params.get('from')),
+          updatedTo: timestamp(params.get('to')),
+          query: params.get('q')?.slice(0, MAX_QUERY_LENGTH) ?? params.get('query')?.slice(0, MAX_QUERY_LENGTH) ?? undefined,
+        }
+        const direction: RuntimeRunSortDirection = params.get('direction') === 'asc' ? 'asc' : 'desc'
+        const requestedPage = integer(params.get('page'), 1, 10_000, 1)
+        const requestedSize = integer(params.get('size'), 1, MAX_PAGE_SIZE, DEFAULT_PAGE_SIZE)
+        const requestedRunId = runId(params.get('run'))
+        try {
+          const generatedAt = Date.now()
+          const records = getProviderRuntimeService().list()
+          const availableRoutes = readRuntimeRouteSnapshot()
+          const projected = projectRuntimeRuns(records, generatedAt, MAX_PROJECTED_RUNS)
+          const selectedRun = requestedRunId ? projected.find((run) => run.id === requestedRunId) ?? null : null
+          const matched = sortRuntimeRuns(filterRuntimeRuns(projected, filters), sortKey(params.get('sort')), direction)
+          const page = paginateRuntimeRuns(matched, requestedPage, requestedSize)
+          return Response.json({
+            ok: true,
+            generatedAt,
+            runs: page.items,
+            selectedRun,
+            availableRoutes,
+            summary: summarizeRuntimeRuns(matched, generatedAt),
+            page: {
+              number: page.page,
+              size: page.pageSize,
+              total: page.total,
+              pages: page.pages,
+              hasNext: page.hasNext,
+              hasPrevious: page.hasPrevious,
+            },
+            inventory: { projected: projected.length, matched: matched.length, truncated: Array.isArray(records) && records.length > projected.length },
+            filters: { ...filters, sort: sortKey(params.get('sort')), direction },
+            refreshed: false,
+          })
+        } catch {
+          // Registry corruption paths carry filesystem detail; return a fixed message.
+          return Response.json({ ok: false, error: UNAVAILABLE }, { status: 500 })
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/swarm-decompose.ts
+++ b/src/routes/api/swarm-decompose.ts
@@ -1,8 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../server/auth-middleware'
-import { ensureGatewayProbed, getResolvedUrls } from '../../server/gateway-capabilities'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  ensureGatewayProbed,
+  getResolvedUrls,
+} from '../../server/gateway-capabilities'
 import { getBearerToken } from '../../server/openai-compat-api'
+import { getOrchestrationPolicy } from '../../server/orchestration-policy'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
+import { selectSwarmOrchestratorRoute } from '../../server/swarm-decompose-model'
 
 type DecomposeRequest = {
   prompt?: unknown
@@ -40,7 +46,11 @@ Rules:
 - Keep rationale short (one sentence).
 `
 
-async function callOrchestrator(prompt: string, workers: WorkerHint[], model: string): Promise<{ assignments: RouteAssignment[]; unassigned: string[] }>{
+async function callOrchestrator(
+  prompt: string,
+  workers: Array<WorkerHint>,
+  model: string,
+): Promise<{ assignments: Array<RouteAssignment>; unassigned: Array<string> }> {
   const rosterText = workers
     .map((worker) => {
       const parts = [
@@ -49,9 +59,13 @@ async function callOrchestrator(prompt: string, workers: WorkerHint[], model: st
         worker.specialty ? `specialty=${worker.specialty}` : '',
         worker.mission ? `mission=${worker.mission}` : '',
         worker.skills?.length ? `skills=${worker.skills.join(',')}` : '',
-        worker.capabilities?.length ? `capabilities=${worker.capabilities.join(',')}` : '',
+        worker.capabilities?.length
+          ? `capabilities=${worker.capabilities.join(',')}`
+          : '',
         worker.notes ? `notes=${worker.notes}` : '',
-      ].filter(Boolean).join('; ')
+      ]
+        .filter(Boolean)
+        .join('; ')
       return `- ${worker.id}${parts ? ` — ${parts}` : ''}`
     })
     .join('\n')
@@ -83,7 +97,9 @@ async function callOrchestrator(prompt: string, workers: WorkerHint[], model: st
     const text = await res.text().catch(() => '')
     throw new Error(`Orchestrator HTTP ${res.status}: ${text.slice(0, 240)}`)
   }
-  const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> }
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>
+  }
   const raw = data.choices?.[0]?.message?.content?.trim() ?? ''
   if (!raw) throw new Error('Orchestrator returned empty content')
 
@@ -91,50 +107,73 @@ async function callOrchestrator(prompt: string, workers: WorkerHint[], model: st
   const start = raw.indexOf('{')
   const end = raw.lastIndexOf('}')
   if (start === -1 || end === -1 || end <= start) {
-    throw new Error(`Orchestrator did not return JSON. Snippet: ${raw.slice(0, 240)}`)
+    throw new Error(
+      `Orchestrator did not return JSON. Snippet: ${raw.slice(0, 240)}`,
+    )
   }
   const slice = raw.slice(start, end + 1)
   let parsed: unknown
   try {
     parsed = JSON.parse(slice)
   } catch (error) {
-    throw new Error(`Orchestrator returned invalid JSON: ${(error as Error).message}`)
+    throw new Error(
+      `Orchestrator returned invalid JSON: ${(error as Error).message}`,
+    )
   }
 
   const obj = parsed as { assignments?: unknown; unassigned?: unknown }
   const assignmentsRaw = Array.isArray(obj.assignments) ? obj.assignments : []
   const validIds = new Set(workers.map((worker) => worker.id))
-  const assignments: RouteAssignment[] = []
+  const assignments: Array<RouteAssignment> = []
   for (const entry of assignmentsRaw) {
     if (!entry || typeof entry !== 'object') continue
     const item = entry as Record<string, unknown>
-    const workerId = typeof item.workerId === 'string' ? item.workerId.trim() : ''
+    const workerId =
+      typeof item.workerId === 'string' ? item.workerId.trim() : ''
     const task = typeof item.task === 'string' ? item.task.trim() : ''
-    const rationale = typeof item.rationale === 'string' ? item.rationale.trim() : ''
+    const rationale =
+      typeof item.rationale === 'string' ? item.rationale.trim() : ''
     if (!workerId || !task) continue
     if (!validIds.has(workerId)) continue
     assignments.push({ workerId, task, rationale })
   }
   const unassignedRaw = Array.isArray(obj.unassigned) ? obj.unassigned : []
-  const unassigned: string[] = []
+  const unassigned: Array<string> = []
   for (const entry of unassignedRaw) {
     if (typeof entry === 'string' && entry.trim()) unassigned.push(entry.trim())
   }
   return { assignments, unassigned }
 }
 
-
 function scoreWorker(prompt: string, worker: WorkerHint): number {
-  const text = [worker.id, worker.role, worker.model, worker.specialty, worker.mission, ...(worker.skills ?? []), ...(worker.capabilities ?? []), worker.notes]
+  const text = [
+    worker.id,
+    worker.role,
+    worker.model,
+    worker.specialty,
+    worker.mission,
+    ...(worker.skills ?? []),
+    ...(worker.capabilities ?? []),
+    worker.notes,
+  ]
     .filter(Boolean)
     .join(' ')
     .toLowerCase()
   const lower = prompt.toLowerCase()
   let score = 0
   const pairs: Array<[RegExp, Array<string>]> = [
-    [/research|investigate|options|tradeoff|source|synth/i, ['research', 'analysis']],
-    [/build|implement|code|patch|ui|frontend|backend|api|fix/i, ['builder', 'implementation', 'ui', 'backend', 'runtime']],
-    [/review|test|verify|quality|regression|gate/i, ['reviewer', 'review', 'pr', 'issues']],
+    [
+      /research|investigate|options|tradeoff|source|synth/i,
+      ['research', 'analysis'],
+    ],
+    [
+      /build|implement|code|patch|ui|frontend|backend|api|fix/i,
+      ['builder', 'implementation', 'ui', 'backend', 'runtime'],
+    ],
+    [
+      /review|test|verify|quality|regression|gate/i,
+      ['reviewer', 'review', 'pr', 'issues'],
+    ],
     [/pr|issue|github|repro/i, ['pr', 'issues', 'github']],
     [/ops|health|runtime|tmux|gateway/i, ['ops', 'runtime', 'backend']],
     [/docs|handoff|spec|readme/i, ['docs', 'scribe']],
@@ -147,12 +186,19 @@ function scoreWorker(prompt: string, worker: WorkerHint): number {
   return score
 }
 
-function heuristicAssignments(prompt: string, workers: WorkerHint[]): { assignments: RouteAssignment[]; unassigned: string[] } {
+function heuristicAssignments(
+  prompt: string,
+  workers: Array<WorkerHint>,
+): { assignments: Array<RouteAssignment>; unassigned: Array<string> } {
   const ranked = [...workers]
     .map((worker) => ({ worker, score: scoreWorker(prompt, worker) }))
     .sort((a, b) => b.score - a.score || a.worker.id.localeCompare(b.worker.id))
-  const selected = ranked.filter((row) => row.score > 0).slice(0, Math.min(3, workers.length))
-  const fallback = selected.length ? selected : ranked.slice(0, Math.min(2, workers.length))
+  const selected = ranked
+    .filter((row) => row.score > 0)
+    .slice(0, Math.min(3, workers.length))
+  const fallback = selected.length
+    ? selected
+    : ranked.slice(0, Math.min(2, workers.length))
   const assignments = fallback.map(({ worker }) => ({
     workerId: worker.id,
     task: `Handle your lane for this Swarm2 mission and return only the required proof checkpoint. Mission: ${prompt}`,
@@ -160,7 +206,11 @@ function heuristicAssignments(prompt: string, workers: WorkerHint[]): { assignme
   }))
   return {
     assignments,
-    unassigned: selected.length ? [] : ['Model decomposition failed or produced no confident matches; used deterministic roster fallback.'],
+    unassigned: selected.length
+      ? []
+      : [
+          'Model decomposition failed or produced no confident matches; used deterministic roster fallback.',
+        ],
   }
 }
 
@@ -168,19 +218,24 @@ export const Route = createFileRoute('/api/swarm-decompose')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         await ensureGatewayProbed()
         let body: DecomposeRequest
-        try { body = await request.json() as DecomposeRequest } catch { return json({ error: 'Invalid JSON body' }, { status: 400 }) }
+        try {
+          body = (await request.json()) as DecomposeRequest
+        } catch {
+          return json({ error: 'Invalid JSON body' }, { status: 400 })
+        }
 
         const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
         if (!prompt) return json({ error: 'prompt required' }, { status: 400 })
-        if (prompt.length > 16_000) return json({ error: 'prompt too long' }, { status: 400 })
+        if (prompt.length > 16_000)
+          return json({ error: 'prompt too long' }, { status: 400 })
 
         const workersRaw = Array.isArray(body.workers) ? body.workers : []
-        const workers: WorkerHint[] = []
+        const workers: Array<WorkerHint> = []
         for (const entry of workersRaw) {
           if (!entry || typeof entry !== 'object') continue
           const obj = entry as Record<string, unknown>
@@ -190,16 +245,46 @@ export const Route = createFileRoute('/api/swarm-decompose')({
             id,
             role: typeof obj.role === 'string' ? obj.role : undefined,
             model: typeof obj.model === 'string' ? obj.model : undefined,
-            specialty: typeof obj.specialty === 'string' ? obj.specialty : undefined,
+            specialty:
+              typeof obj.specialty === 'string' ? obj.specialty : undefined,
             mission: typeof obj.mission === 'string' ? obj.mission : undefined,
-            skills: Array.isArray(obj.skills) ? obj.skills.filter((value): value is string => typeof value === 'string') : undefined,
-            capabilities: Array.isArray(obj.capabilities) ? obj.capabilities.filter((value): value is string => typeof value === 'string') : undefined,
+            skills: Array.isArray(obj.skills)
+              ? obj.skills.filter(
+                  (value): value is string => typeof value === 'string',
+                )
+              : undefined,
+            capabilities: Array.isArray(obj.capabilities)
+              ? obj.capabilities.filter(
+                  (value): value is string => typeof value === 'string',
+                )
+              : undefined,
             notes: typeof obj.notes === 'string' ? obj.notes : undefined,
           })
         }
-        if (workers.length === 0) return json({ error: 'workers[] required' }, { status: 400 })
+        if (workers.length === 0)
+          return json({ error: 'workers[] required' }, { status: 400 })
 
-        const requestedModel = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : (process.env.CLAUDE_DEFAULT_MODEL ?? 'claude-opus-4-7')
+        let requestedModel: string
+        try {
+          const policy = getOrchestrationPolicy()
+          const catalog = await loadSubscriptionCatalog()
+          requestedModel = selectSwarmOrchestratorRoute({
+            requestedModel: typeof body.model === 'string' ? body.model : '',
+            orchestratorModelRef: policy.orchestratorModelRef,
+            fallbackModelRef: policy.defaultSubagentModelRef,
+            routes: catalog.models,
+          })
+        } catch (error) {
+          return json(
+            {
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'No selectable OAuth subscription route is configured',
+            },
+            { status: 400 },
+          )
+        }
 
         try {
           const result = await callOrchestrator(prompt, workers, requestedModel)
@@ -214,7 +299,8 @@ export const Route = createFileRoute('/api/swarm-decompose')({
           return json({
             ok: true,
             fallback: true,
-            warning: error instanceof Error ? error.message : 'decompose failed',
+            warning:
+              error instanceof Error ? error.message : 'decompose failed',
             decomposedAt: Date.now(),
             model: requestedModel,
             ...fallback,

--- a/src/routes/api/swarm-direct-chat.ts
+++ b/src/routes/api/swarm-direct-chat.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { readWorkerMessages, type SwarmChatMessage } from '../../server/swarm-chat-reader'
 import { rosterByWorkerId } from '../../server/swarm-roster'
+import { getWorkerProcessHost } from '../../server/worker-process-host'
 
 type DirectChatRequest = {
   workerId?: unknown
@@ -158,25 +159,8 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
 }
 
 async function sendPromptToLiveSession(workerId: string, prompt: string): Promise<{ ok: true; delivery: 'tmux' } | { ok: false; error: string }> {
-  const ensured = await ensureLiveTmuxSession(workerId)
-  if (!ensured.ok) return { ok: false, error: ensured.error }
-  const { tmuxBin, sessionName } = ensured
-  const bufferName = `swarm-direct-chat-${workerId}`
-  const normalizedPrompt = prompt.replace(/\r\n/g, '\n')
-
-  const loaded = await execFileAsync(tmuxBin, ['load-buffer', '-b', bufferName, '-'], 8_000, normalizedPrompt)
-  if (!loaded.ok) return { ok: false, error: loaded.error }
-
-  const cleared = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-u'])
-  if (!cleared.ok) return { ok: false, error: cleared.error }
-
-  const pasted = await execFileAsync(tmuxBin, ['paste-buffer', '-d', '-b', bufferName, '-t', sessionName])
-  if (!pasted.ok) return { ok: false, error: pasted.error }
-
-  await sleep(120)
-  const entered = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'Enter'])
-  if (!entered.ok) return { ok: false, error: entered.error }
-
+  const sent = await getWorkerProcessHost().send(workerId, prompt)
+  if (!sent.ok) return { ok: false, error: sent.error ?? 'Worker host rejected the prompt' }
   return { ok: true, delivery: 'tmux' }
 }
 

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -106,6 +106,20 @@ const MAX_OUTPUT_CHARS = 200_000
 const DEFAULT_TIMEOUT_S = 240
 const MAX_TIMEOUT_S = 600
 
+export type DispatchBookkeepingFailure = { label: string; error: string }
+
+export function runBestEffortDispatchBookkeeping(
+  operations: Array<{ label: string; run: () => void }>,
+): DispatchBookkeepingFailure[] {
+  const failures: DispatchBookkeepingFailure[] = []
+  for (const operation of operations) {
+    try { operation.run() } catch (error) {
+      failures.push({ label: operation.label, error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+  return failures
+}
+
 function getProfilesDir(): string {
   const base = process.env.HERMES_HOME ?? process.env.CLAUDE_HOME
   if (base) {
@@ -973,41 +987,64 @@ function runWorker(
       const baselineRuntimeSignature = runtimeCheckpointSignature(
         runtimeBeforeDispatch,
       )
-      markDispatchStarted(
-        workerId,
-        assignment.task,
-        options?.missionId ?? null,
-        assignment.assignmentId ?? null,
-        options?.notifySessionKey ?? 'main',
-      )
-      if (options?.missionId) {
-        markMissionAssignmentDispatched({
-          missionId: options.missionId,
-          workerId,
-          task: assignment.task,
-          source: 'swarm-dispatch',
-          author: 'aurora',
-        })
-      }
-      appendSwarmMemoryEvent({
-        workerId,
-        missionId: options?.missionId ?? null,
-        assignmentId: assignment.assignmentId ?? null,
-        type: 'dispatch',
-        summary: `Dispatched task: ${assignment.task.slice(0, 240)}`,
-        event: {
-          task: assignment.task,
-          rationale: assignment.rationale ?? null,
-          direct: assignment.direct ?? false,
-          deliveryTarget: 'tmux',
-        },
-      })
+      const recordAcceptedDispatch = (): DispatchBookkeepingFailure[] =>
+        runBestEffortDispatchBookkeeping([
+          {
+            label: 'runtime',
+            run: () => markDispatchStarted(
+              workerId,
+              assignment.task,
+              options?.missionId ?? null,
+              assignment.assignmentId ?? null,
+              options?.notifySessionKey ?? 'main',
+            ),
+          },
+          ...(options?.missionId ? [{
+            label: 'mission',
+            run: () => markMissionAssignmentDispatched({
+              missionId: options.missionId!,
+              workerId,
+              task: assignment.task,
+              source: 'swarm-dispatch',
+              author: 'aurora',
+            }),
+          }] : []),
+          {
+            label: 'memory',
+            run: () => appendSwarmMemoryEvent({
+              workerId,
+              missionId: options?.missionId ?? null,
+              assignmentId: assignment.assignmentId ?? null,
+              type: 'dispatch',
+              summary: `Dispatched task: ${assignment.task.slice(0, 240)}`,
+              event: {
+                task: assignment.task,
+                rationale: assignment.rationale ?? null,
+                direct: assignment.direct ?? false,
+                deliveryTarget: 'worker-process-host',
+              },
+            }),
+          },
+        ])
       const wrapperPath = getWrapperPath(workerId)
 
       // Prefer the persistent live agent session when available/startable.
       const liveResult = await sendPromptToLiveSession(workerId, prompt)
       if (liveResult) {
-        markDispatchResult(workerId, liveResult)
+        const bookkeepingFailures = liveResult.ok ? recordAcceptedDispatch() : []
+        bookkeepingFailures.push(...runBestEffortDispatchBookkeeping([{
+          label: 'runtime-result',
+          run: () => markDispatchResult(workerId, liveResult),
+        }]))
+        if (bookkeepingFailures.length > 0) {
+          console.error('[swarm-dispatch] post-delivery bookkeeping failed', {
+            workerId,
+            failures: bookkeepingFailures,
+          })
+          if (liveResult.ok) {
+            liveResult.output = `${liveResult.output}\nDelivered; bookkeeping incomplete (${bookkeepingFailures.map(({ label }) => label).join(', ')}).`
+          }
+        }
         if (options?.waitForCheckpoint && liveResult.ok) {
           const checkpoint = await waitForFreshCheckpoint(
             workerId,

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -1,35 +1,49 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { isAuthenticated } from '../../server/auth-middleware'
-import { newestCheckpointFromMessages, parseSwarmCheckpoint, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  newestCheckpointFromMessages,
+  parseSwarmCheckpoint,
+  type ParsedSwarmCheckpoint,
+} from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
-import { createOrUpdateMission, getSwarmMission, markMissionAssignmentDispatched, recordMissionAssignmentBlocked, recordMissionCheckpoint } from '../../server/swarm-missions'
-import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
-import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
+import {
+  createOrUpdateMission,
+  getSwarmMission,
+  markMissionAssignmentDispatched,
+  recordMissionAssignmentBlocked,
+  recordMissionCheckpoint,
+} from '../../server/swarm-missions'
+import {
+  appendSwarmMemoryEvent,
+  buildSwarmStartupSnapshot,
+} from '../../server/swarm-memory'
+import { rosterByWorkerId } from '../../server/swarm-roster'
+import type { SwarmRosterWorker } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
-import { ensureSwarmProfileConfig } from '../../server/swarm-profile-config'
-
-const HERMES_BIN_CANDIDATES = [
-  process.env.HERMES_CLI_BIN,
-  join(homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
-  join(homedir(), '.local', 'bin', 'hermes'),
-  'hermes',
-].filter((value): value is string => Boolean(value))
-
-function resolveHermesBin(): string {
-  for (const candidate of HERMES_BIN_CANDIDATES) {
-    if (candidate.includes('/')) {
-      if (existsSync(candidate)) return candidate
-      continue
-    }
-    return candidate
-  }
-  return 'hermes'
-}
+import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
+import {
+  ensureSwarmProfileConfig,
+  syncSwarmProfileModel,
+} from '../../server/swarm-profile-config'
+import {
+  buildSwarmTmuxLaunchCommand,
+  buildTmuxBufferLoad,
+  buildTmuxNewSessionArgs,
+  buildTmuxSendKeysArgs,
+  resolveSwarmHermesBin as resolveHermesBin,
+  resolveSwarmTmuxBin as resolveTmuxBin,
+} from '../../server/swarm-tmux-launch'
 
 type AssignmentRequest = {
   workerId: string
@@ -68,7 +82,13 @@ type WorkerResult = {
 }
 
 type RuntimeCheckpointSnapshot = {
-  checkpointStatus: 'none' | 'in_progress' | 'done' | 'blocked' | 'handoff' | 'needs_input'
+  checkpointStatus:
+    | 'none'
+    | 'in_progress'
+    | 'done'
+    | 'blocked'
+    | 'handoff'
+    | 'needs_input'
   state: string | null
   lastSummary: string | null
   lastResult: string | null
@@ -106,45 +126,20 @@ function getProfilePath(workerId: string): string {
   return join(getProfilesDir(), workerId)
 }
 
-function validateWorkerId(workerId: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(workerId)
+export function syncWorkerProfileModel(
+  workerId: string,
+  profilePath: string,
+  rosterWorker?: Pick<SwarmRosterWorker, 'model'>,
+): { ok: true; skipped?: true } | { ok: false; error: string } {
+  const worker = rosterWorker ?? rosterByWorkerId([workerId]).get(workerId)
+  const resolved = resolveSwarmModelLabel(worker?.model ?? null)
+  if (!resolved) return { ok: true, skipped: true }
+  const synced = syncSwarmProfileModel(profilePath, resolved)
+  return synced.ok ? { ok: true } : { ok: false, error: synced.error }
 }
 
-const TMUX_BIN_CANDIDATES = [
-  process.env.TMUX_BIN,
-  '/opt/homebrew/bin/tmux',
-  '/usr/local/bin/tmux',
-  '/usr/bin/tmux',
-  join(homedir(), '.local', 'bin', 'tmux'),
-  'tmux',
-].filter((value): value is string => Boolean(value))
-
-function resolveTmuxBin(): string | null {
-  // Allow operators on non-standard installs (Docker, NixOS, custom
-  // package layouts) to point Swarm at the right tmux binary without
-  // patching this list. See #244.
-  const override = process.env.HERMES_TMUX_BIN || process.env.CLAUDE_TMUX_BIN
-  if (override) {
-    if (existsSync(override)) return override
-    // If the override looks like a bare command (no slashes), trust it
-    // and let execFile resolve it via PATH.
-    if (!override.includes('/')) return override
-  }
-  for (const candidate of TMUX_BIN_CANDIDATES) {
-    if (candidate.includes('/')) {
-      if (
-        candidate === process.env.TMUX_BIN ||
-        candidate === '/opt/homebrew/bin/tmux' ||
-        candidate === '/usr/local/bin/tmux' ||
-        existsSync(candidate)
-      ) {
-        return candidate
-      }
-      continue
-    }
-    return candidate
-  }
-  return null
+function validateWorkerId(workerId: string): boolean {
+  return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(workerId)
 }
 
 function tmuxHasSession(tmuxBin: string, name: string): Promise<boolean> {
@@ -160,19 +155,29 @@ function execFileAsync(
   args: Array<string>,
   timeout = 8_000,
   input?: string,
-): Promise<{ ok: true; stdout: string; stderr: string } | { ok: false; error: string }> {
+): Promise<
+  { ok: true; stdout: string; stderr: string } | { ok: false; error: string }
+> {
   return new Promise((resolve) => {
-    const child = execFile(cmd, args, { timeout, maxBuffer: MAX_OUTPUT_CHARS }, (error, stdout, stderr) => {
-      if (error) {
-        resolve({ ok: false, error: stderr?.toString().trim() || error.message })
-        return
-      }
-      resolve({
-        ok: true,
-        stdout: (stdout || '').toString(),
-        stderr: (stderr || '').toString(),
-      })
-    })
+    const child = execFile(
+      cmd,
+      args,
+      { timeout, maxBuffer: MAX_OUTPUT_CHARS },
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve({
+            ok: false,
+            error: stderr?.toString().trim() || error.message,
+          })
+          return
+        }
+        resolve({
+          ok: true,
+          stdout: (stdout || '').toString(),
+          stderr: (stderr || '').toString(),
+        })
+      },
+    )
     if (input !== undefined) {
       child.stdin?.end(input)
     }
@@ -193,27 +198,16 @@ function resolveGithubToken(): string | null {
   return null
 }
 
-function shellEscapeSingle(value: string): string {
-  return value.replace(/'/g, `'\\''`)
-}
-
 export function buildHermesTmuxLaunchCommand(input: {
   profilePath: string
+  cwd: string
   hermesBin: string
-  ghToken?: string | null
+  platform?: NodeJS.Platform
 }): string {
-  const launchPrefix = [
-    `HERMES_HOME='${shellEscapeSingle(input.profilePath)}'`,
-    `HERMES_CLI_BIN='${shellEscapeSingle(input.hermesBin)}'`,
-    input.ghToken ? `GH_TOKEN='${shellEscapeSingle(input.ghToken)}'` : '',
-    input.ghToken ? `GITHUB_TOKEN='${shellEscapeSingle(input.ghToken)}'` : '',
-  ].filter(Boolean).join(' ')
-  const hermesBin = shellEscapeSingle(input.hermesBin)
-
-  // Do not exec the Hermes process. Keeping the parent shell alive means a
-  // failed worker startup leaves a readable tmux pane instead of destroying the
-  // session and turning the real error into "can't find pane".
-  return `${launchPrefix} '${hermesBin}' chat --tui; status=$?; printf '\n[Hermes worker exited with status %s]\n' "$status"`
+  return buildSwarmTmuxLaunchCommand({
+    ...input,
+    keepShellAlive: true,
+  })
 }
 
 function parseAssignments(value: unknown): Array<AssignmentRequest> {
@@ -224,12 +218,26 @@ function parseAssignments(value: unknown): Array<AssignmentRequest> {
     const obj = entry as Record<string, unknown>
     const workerId = typeof obj.workerId === 'string' ? obj.workerId.trim() : ''
     const task = typeof obj.task === 'string' ? obj.task.trim() : ''
-    const rationale = typeof obj.rationale === 'string' ? obj.rationale.trim() : undefined
-    const dependsOn = Array.isArray(obj.dependsOn) ? obj.dependsOn.filter((value): value is string => typeof value === 'string' && value.trim().length > 0) : undefined
-    const reviewRequired = typeof obj.reviewRequired === 'boolean' ? obj.reviewRequired : undefined
+    const rationale =
+      typeof obj.rationale === 'string' ? obj.rationale.trim() : undefined
+    const dependsOn = Array.isArray(obj.dependsOn)
+      ? obj.dependsOn.filter(
+          (value): value is string =>
+            typeof value === 'string' && value.trim().length > 0,
+        )
+      : undefined
+    const reviewRequired =
+      typeof obj.reviewRequired === 'boolean' ? obj.reviewRequired : undefined
     const direct = typeof obj.direct === 'boolean' ? obj.direct : undefined
     if (!workerId || !task || !validateWorkerId(workerId)) continue
-    assignments.push({ workerId, task, rationale, dependsOn, reviewRequired, direct })
+    assignments.push({
+      workerId,
+      task,
+      rationale,
+      dependsOn,
+      reviewRequired,
+      direct,
+    })
   }
   return assignments
 }
@@ -238,13 +246,19 @@ function readRuntimeJson(profilePath: string): Record<string, unknown> {
   const runtimePath = join(profilePath, 'runtime.json')
   if (!existsSync(runtimePath)) return {}
   try {
-    return JSON.parse(readFileSync(runtimePath, 'utf8')) as Record<string, unknown>
+    return JSON.parse(readFileSync(runtimePath, 'utf8')) as Record<
+      string,
+      unknown
+    >
   } catch {
     return {}
   }
 }
 
-function writeRuntimePatch(workerId: string, patch: Record<string, unknown>): void {
+function writeRuntimePatch(
+  workerId: string,
+  patch: Record<string, unknown>,
+): void {
   const profilePath = getProfilePath(workerId)
   mkdirSync(profilePath, { recursive: true })
   const runtimePath = join(profilePath, 'runtime.json')
@@ -254,7 +268,9 @@ function writeRuntimePatch(workerId: string, patch: Record<string, unknown>): vo
     workerId,
     ...patch,
   }
-  writeFileSync(runtimePath, JSON.stringify(next, null, 2) + '\n')
+  const runtimeTempPath = `${runtimePath}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(runtimeTempPath, JSON.stringify(next, null, 2) + '\n')
+  renameSync(runtimeTempPath, runtimePath)
 }
 
 function cleanRuntimeText(value: unknown): string | null {
@@ -267,13 +283,21 @@ function cleanRuntimeNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
-function cleanRuntimeCheckpointStatus(value: unknown): RuntimeCheckpointSnapshot['checkpointStatus'] {
-  return value === 'in_progress' || value === 'done' || value === 'blocked' || value === 'handoff' || value === 'needs_input'
+function cleanRuntimeCheckpointStatus(
+  value: unknown,
+): RuntimeCheckpointSnapshot['checkpointStatus'] {
+  return value === 'in_progress' ||
+    value === 'done' ||
+    value === 'blocked' ||
+    value === 'handoff' ||
+    value === 'needs_input'
     ? value
     : 'none'
 }
 
-export function readRuntimeCheckpointSnapshot(profilePath: string): RuntimeCheckpointSnapshot {
+export function readRuntimeCheckpointSnapshot(
+  profilePath: string,
+): RuntimeCheckpointSnapshot {
   const raw = readRuntimeJson(profilePath)
   return {
     checkpointStatus: cleanRuntimeCheckpointStatus(raw.checkpointStatus),
@@ -288,7 +312,9 @@ export function readRuntimeCheckpointSnapshot(profilePath: string): RuntimeCheck
   }
 }
 
-export function runtimeCheckpointSignature(snapshot: RuntimeCheckpointSnapshot): string {
+export function runtimeCheckpointSignature(
+  snapshot: RuntimeCheckpointSnapshot,
+): string {
   return JSON.stringify(snapshot)
 }
 
@@ -298,7 +324,9 @@ function isoToMs(value: string | null): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function stateLabelForRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): ParsedSwarmCheckpoint['stateLabel'] | null {
+function stateLabelForRuntimeSnapshot(
+  snapshot: RuntimeCheckpointSnapshot,
+): ParsedSwarmCheckpoint['stateLabel'] | null {
   switch (snapshot.checkpointStatus) {
     case 'done':
       return 'DONE'
@@ -316,12 +344,21 @@ function stateLabelForRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): Pars
   const state = snapshot.state?.toLowerCase()
   if (state === 'blocked') return 'BLOCKED'
   if (state === 'waiting') return 'NEEDS_INPUT'
-  if (state === 'executing' || state === 'thinking' || state === 'writing' || state === 'reviewing' || state === 'syncing') return 'IN_PROGRESS'
+  if (
+    state === 'executing' ||
+    state === 'thinking' ||
+    state === 'writing' ||
+    state === 'reviewing' ||
+    state === 'syncing'
+  )
+    return 'IN_PROGRESS'
   if (state === 'idle') return 'DONE'
   return null
 }
 
-function runtimeSnapshotHasMeaningfulCheckpoint(snapshot: RuntimeCheckpointSnapshot): boolean {
+function runtimeSnapshotHasMeaningfulCheckpoint(
+  snapshot: RuntimeCheckpointSnapshot,
+): boolean {
   return Boolean(
     snapshot.checkpointRaw ||
     snapshot.lastSummary ||
@@ -331,7 +368,11 @@ function runtimeSnapshotHasMeaningfulCheckpoint(snapshot: RuntimeCheckpointSnaps
   )
 }
 
-export function runtimeSnapshotIsFresh(snapshot: RuntimeCheckpointSnapshot, baselineSignature: string, dispatchedAt: number): boolean {
+export function runtimeSnapshotIsFresh(
+  snapshot: RuntimeCheckpointSnapshot,
+  baselineSignature: string,
+  dispatchedAt: number,
+): boolean {
   const changed = runtimeCheckpointSignature(snapshot) !== baselineSignature
   if (!changed) return false
   const outputAt = snapshot.lastOutputAt
@@ -353,13 +394,18 @@ function formatRuntimeCheckpointRaw(checkpoint: ParsedSwarmCheckpoint): string {
   ].join('\n')
 }
 
-export function checkpointFromRuntimeSnapshot(snapshot: RuntimeCheckpointSnapshot): ParsedSwarmCheckpoint | null {
+export function checkpointFromRuntimeSnapshot(
+  snapshot: RuntimeCheckpointSnapshot,
+): ParsedSwarmCheckpoint | null {
   if (snapshot.checkpointRaw) {
-    const parsed = newestCheckpointFromMessages([{ role: 'assistant', content: snapshot.checkpointRaw }])
+    const parsed = newestCheckpointFromMessages([
+      { role: 'assistant', content: snapshot.checkpointRaw },
+    ])
     if (parsed) return parsed
   }
   const stateLabel = stateLabelForRuntimeSnapshot(snapshot)
-  if (!stateLabel || !runtimeSnapshotHasMeaningfulCheckpoint(snapshot)) return null
+  if (!stateLabel || !runtimeSnapshotHasMeaningfulCheckpoint(snapshot))
+    return null
   const result = snapshot.lastResult ?? snapshot.lastSummary
   const blocker = snapshot.blockedReason
   const checkpoint: ParsedSwarmCheckpoint = {
@@ -408,9 +454,14 @@ export function buildWorkerPrompt(input: {
   const displayName = roster?.name?.trim() || input.workerId
   const role = roster?.role || 'Worker'
   const humanLabel = `${displayName} — ${role}`
-  const skills = roster?.skills?.length ? roster.skills.join(', ') : 'swarm-worker-core'
-  const capabilities = roster?.capabilities?.length ? roster.capabilities.join(', ') : 'not declared'
-  const mission = roster?.mission || 'Execute assigned swarm tasks and checkpoint progress.'
+  const skills = roster?.skills?.length
+    ? roster.skills.join(', ')
+    : 'swarm-worker-core'
+  const capabilities = roster?.capabilities?.length
+    ? roster.capabilities.join(', ')
+    : 'not declared'
+  const mission =
+    roster?.mission || 'Execute assigned swarm tasks and checkpoint progress.'
   const specialty = roster?.specialty || 'General execution'
 
   let snapshotSection = ''
@@ -468,7 +519,13 @@ export function buildWorkerPrompt(input: {
   return lines.filter(Boolean).join('\n')
 }
 
-function markDispatchStarted(workerId: string, task: string, missionId?: string | null, assignmentId?: string | null, notifySessionKey?: string | null): void {
+function markDispatchStarted(
+  workerId: string,
+  task: string,
+  missionId?: string | null,
+  assignmentId?: string | null,
+  notifySessionKey?: string | null,
+): void {
   const controlMessage = `Dispatched task: ${task.slice(0, 180)}`
   writeRuntimePatch(workerId, {
     state: 'executing',
@@ -485,7 +542,8 @@ function markDispatchStarted(workerId: string, task: string, missionId?: string 
     lastCheckIn: new Date().toISOString(),
     lastSummary: controlMessage,
     lastControlMessage: controlMessage,
-    nextAction: 'Worker should execute and return the required checkpoint format.',
+    nextAction:
+      'Worker should execute and return the required checkpoint format.',
     notifySessionKey: notifySessionKey ?? 'main',
   })
 }
@@ -494,7 +552,9 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
   writeRuntimePatch(workerId, {
     lastDispatchAt: Date.now(),
     lastDispatchMode: result.delivery ?? 'none',
-    lastDispatchResult: result.ok ? result.output.slice(0, 500) : (result.error ?? 'dispatch failed').slice(0, 500),
+    lastDispatchResult: result.ok
+      ? result.output.slice(0, 500)
+      : (result.error ?? 'dispatch failed').slice(0, 500),
     state: result.ok ? 'executing' : 'blocked',
     checkpointStatus: result.ok ? 'in_progress' : 'blocked',
     blockedReason: result.ok ? null : result.error,
@@ -502,13 +562,26 @@ function markDispatchResult(workerId: string, result: WorkerResult): void {
   })
 }
 
-export function dispatchBlockReason(result: Pick<WorkerResult, 'ok' | 'error' | 'output' | 'checkpointStatus'>): string | null {
-  if (!result.ok) return result.error?.trim() || result.output?.trim() || 'Dispatch failed before a worker checkpoint was recorded.'
-  if (result.checkpointStatus === 'timeout') return 'No fresh checkpoint before poll timeout.'
+export function dispatchBlockReason(
+  result: Pick<WorkerResult, 'ok' | 'error' | 'output' | 'checkpointStatus'>,
+): string | null {
+  if (!result.ok)
+    return (
+      result.error?.trim() ||
+      result.output?.trim() ||
+      'Dispatch failed before a worker checkpoint was recorded.'
+    )
+  if (result.checkpointStatus === 'timeout')
+    return 'No fresh checkpoint before poll timeout.'
   return null
 }
 
-function recordDispatchBlock(workerId: string, assignment: AssignmentRequest, result: WorkerResult, options?: { missionId?: string | null }): void {
+function recordDispatchBlock(
+  workerId: string,
+  assignment: AssignmentRequest,
+  result: WorkerResult,
+  options?: { missionId?: string | null },
+): void {
   const reason = dispatchBlockReason(result)
   if (!reason) return
   recordMissionAssignmentBlocked({
@@ -529,7 +602,11 @@ function recordDispatchBlock(workerId: string, assignment: AssignmentRequest, re
   })
 }
 
-function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoint, notifySessionKey?: string | null): void {
+function markCheckpointResult(
+  workerId: string,
+  checkpoint: ParsedSwarmCheckpoint,
+  notifySessionKey?: string | null,
+): void {
   // When the checkpoint reaches any terminal status (anything other than
   // 'in_progress' — i.e. done/blocked/needs_input/handoff) the worker is no
   // longer running this task, so clear currentTask the same way conductor-stop
@@ -549,7 +626,11 @@ function markCheckpointResult(workerId: string, checkpoint: ParsedSwarmCheckpoin
     lastRealResult: checkpoint.result,
     lastControlMessage: null,
     nextAction: checkpoint.nextAction,
-    blockedReason: checkpoint.stateLabel === 'BLOCKED' || checkpoint.stateLabel === 'NEEDS_INPUT' ? checkpoint.blocker : null,
+    blockedReason:
+      checkpoint.stateLabel === 'BLOCKED' ||
+      checkpoint.stateLabel === 'NEEDS_INPUT'
+        ? checkpoint.blocker
+        : null,
     needsHuman: checkpoint.stateLabel === 'NEEDS_INPUT',
     checkpointRaw: checkpoint.raw,
     checkpointFilesChanged: checkpoint.filesChanged,
@@ -569,9 +650,16 @@ async function waitForFreshCheckpoint(
   const profilePath = getProfilePath(workerId)
   while (Date.now() - started < timeoutMs) {
     const runtimeSnapshot = readRuntimeCheckpointSnapshot(profilePath)
-    if (runtimeSnapshotIsFresh(runtimeSnapshot, baselineRuntimeSignature, dispatchedAt)) {
+    if (
+      runtimeSnapshotIsFresh(
+        runtimeSnapshot,
+        baselineRuntimeSignature,
+        dispatchedAt,
+      )
+    ) {
       const runtimeCheckpoint = checkpointFromRuntimeSnapshot(runtimeSnapshot)
-      if (runtimeCheckpoint && runtimeCheckpoint.raw !== previousRaw) return runtimeCheckpoint
+      if (runtimeCheckpoint && runtimeCheckpoint.raw !== previousRaw)
+        return runtimeCheckpoint
     }
 
     const chat = readWorkerMessages(profilePath, 50)
@@ -601,8 +689,15 @@ function resolveWorkerCwd(workerId: string): string {
   return homedir()
 }
 
-async function captureTmuxPane(tmuxBin: string, sessionName: string): Promise<string> {
-  const captured = await execFileAsync(tmuxBin, ['capture-pane', '-p', '-t', sessionName, '-S', '-200'], 8_000)
+async function captureTmuxPane(
+  tmuxBin: string,
+  sessionName: string,
+): Promise<string> {
+  const captured = await execFileAsync(
+    tmuxBin,
+    ['capture-pane', '-p', '-t', sessionName, '-S', '-200'],
+    8_000,
+  )
   return captured.ok ? captured.stdout.trim() : ''
 }
 
@@ -612,7 +707,12 @@ function redactStartupOutput(output: string): string {
     .replace(/(gh[pousr]_[A-Za-z0-9_]{12,})/g, '[REDACTED]')
 }
 
-async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmuxBin: string; sessionName: string } | { ok: false; error: string }> {
+async function ensureLiveTmuxSession(
+  workerId: string,
+): Promise<
+  | { ok: true; tmuxBin: string; sessionName: string }
+  | { ok: false; error: string }
+> {
   const tmuxBin = resolveTmuxBin()
   if (!tmuxBin) return { ok: false, error: 'tmux not installed' }
 
@@ -623,27 +723,28 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
 
   const profilePath = getProfilePath(workerId)
   ensureSwarmProfileConfig(profilePath)
+  const modelSync = syncWorkerProfileModel(workerId, profilePath)
+  if (!modelSync.ok) return modelSync
   const cwd = resolveWorkerCwd(workerId)
   const hermesBin = resolveHermesBin()
   const launchCommand = buildHermesTmuxLaunchCommand({
     profilePath,
+    cwd,
     hermesBin,
-    ghToken: resolveGithubToken(),
   })
 
-  const started = await execFileAsync(tmuxBin, [
-    'new-session',
-    '-d',
-    '-s',
-    sessionName,
-    '-c',
-    cwd,
-  ])
+  const started = await execFileAsync(
+    tmuxBin,
+    buildTmuxNewSessionArgs({ sessionName, cwd }),
+  )
   if (!started.ok) {
     return { ok: false, error: started.error }
   }
 
-  const launched = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, launchCommand, 'C-m'])
+  const launched = await execFileAsync(
+    tmuxBin,
+    buildTmuxSendKeysArgs(sessionName, launchCommand),
+  )
   if (!launched.ok) {
     return { ok: false, error: launched.error }
   }
@@ -653,7 +754,10 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
   // surface the real startup failure instead of a later tmux "can't find pane".
   await sleep(1200)
   if (!(await tmuxHasSession(tmuxBin, sessionName))) {
-    return { ok: false, error: `Hermes worker tmux session ${sessionName} exited during startup` }
+    return {
+      ok: false,
+      error: `Hermes worker tmux session ${sessionName} exited during startup`,
+    }
   }
 
   const startupOutput = await captureTmuxPane(tmuxBin, sessionName)
@@ -665,8 +769,12 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
     const logsDir = join(profilePath, 'logs')
     mkdirSync(logsDir, { recursive: true })
     const startupLogPath = join(logsDir, 'swarm-dispatch-startup.log')
-    writeFileSync(startupLogPath, `${new Date().toISOString()} ${sanitizedOutput}
-`, { flag: 'a' })
+    writeFileSync(
+      startupLogPath,
+      `${new Date().toISOString()} ${sanitizedOutput}
+`,
+      { flag: 'a' },
+    )
     return {
       ok: false,
       error: `Hermes worker failed to start in tmux session ${sessionName}. Startup output saved to ${startupLogPath}: ${sanitizedOutput}`,
@@ -676,7 +784,10 @@ async function ensureLiveTmuxSession(workerId: string): Promise<{ ok: true; tmux
   return { ok: true, tmuxBin, sessionName }
 }
 
-async function sendPromptToLiveSession(workerId: string, prompt: string): Promise<WorkerResult | null> {
+async function sendPromptToLiveSession(
+  workerId: string,
+  prompt: string,
+): Promise<WorkerResult | null> {
   const startedAt = Date.now()
   const ensured = await ensureLiveTmuxSession(workerId)
   if (!ensured.ok) return null
@@ -688,12 +799,17 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // reliable for live TUI delivery because it preserves multiline content and
   // avoids key translation/terminal timing issues. Enter submits the composed
   // prompt after paste.
-  const loaded = await execFileAsync(tmuxBin, [
-    'load-buffer',
-    '-b',
-    `swarm-dispatch-${workerId}`,
-    '-',
-  ], 8_000, normalizedPrompt)
+  const bufferName = `swarm-dispatch-${workerId}`
+  const bufferLoad = buildTmuxBufferLoad({
+    bufferName,
+    content: normalizedPrompt,
+  })
+  const loaded = await execFileAsync(
+    tmuxBin,
+    bufferLoad.args,
+    8_000,
+    bufferLoad.stdin,
+  )
   if (!loaded.ok) {
     return {
       workerId,
@@ -709,7 +825,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // Ensure we are sending a fresh prompt, not appending onto a partially typed
   // line left in the agent TUI. Ctrl-U clears readline-style input in the
   // current prompt without disrupting the session.
-  const cleared = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-u'])
+  const cleared = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-u',
+  ])
   if (!cleared.ok) {
     return {
       workerId,
@@ -726,7 +847,7 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
     'paste-buffer',
     '-d',
     '-b',
-    `swarm-dispatch-${workerId}`,
+    bufferName,
     '-t',
     sessionName,
   ])
@@ -747,7 +868,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   // to accept Enter; sending a confirmation Enter shortly after the first one
   // prevents the user-visible failure mode where the task sits at the prompt.
   await sleep(2000)
-  const enter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
+  const enter = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-m',
+  ])
   if (!enter.ok) {
     return {
       workerId,
@@ -760,7 +886,12 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
     }
   }
   await sleep(1000)
-  const confirmEnter = await execFileAsync(tmuxBin, ['send-keys', '-t', sessionName, 'C-m'])
+  const confirmEnter = await execFileAsync(tmuxBin, [
+    'send-keys',
+    '-t',
+    sessionName,
+    'C-m',
+  ])
   if (!confirmEnter.ok) {
     return {
       workerId,
@@ -789,211 +920,128 @@ export function buildHermesChatQueryArgs(prompt: string): string[] {
   // Keeping the prompt adjacent to -q prevents argparse from interpreting
   // following flags (for example -Q) as a missing query and failing with:
   // "argument -q/--query: expected one argument".
-  return ['chat', '-q', prompt, '-Q', '--yolo', '--ignore-rules', '--source', 'swarm-dispatch']
+  return [
+    'chat',
+    '-q',
+    prompt,
+    '-Q',
+    '--yolo',
+    '--ignore-rules',
+    '--source',
+    'swarm-dispatch',
+  ]
 }
 
-function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: SwarmRosterWorker | undefined, options?: { waitForCheckpoint?: boolean; checkpointPollMs?: number; missionId?: string | null; notifySessionKey?: string | null }): Promise<WorkerResult> {
-  return new Promise(async (resolve) => {
-    const workerId = assignment.workerId
-    const prompt = buildWorkerPrompt({
-      workerId,
-      task: assignment.task,
-      rationale: assignment.rationale,
-      roster,
-      direct: assignment.direct,
-      missionId: options?.missionId ?? null,
-      taskTitle: assignment.task.slice(0, 120),
-    })
-    const profilePath = getProfilePath(workerId)
-    const runtimeBeforeDispatch = readRuntimeCheckpointSnapshot(profilePath)
-    const previousRaw = runtimeBeforeDispatch.checkpointRaw
-    const baselineRuntimeSignature = runtimeCheckpointSignature(runtimeBeforeDispatch)
-    markDispatchStarted(workerId, assignment.task, options?.missionId ?? null, assignment.assignmentId ?? null, options?.notifySessionKey ?? 'main')
-    if (options?.missionId) {
-      markMissionAssignmentDispatched({
-        missionId: options.missionId,
+function runWorker(
+  assignment: AssignmentRequest,
+  timeoutMs: number,
+  roster: SwarmRosterWorker | undefined,
+  options?: {
+    waitForCheckpoint?: boolean
+    checkpointPollMs?: number
+    missionId?: string | null
+    notifySessionKey?: string | null
+  },
+): Promise<WorkerResult> {
+  const workerId = assignment.workerId
+  const startedAt = Date.now()
+  return new Promise((resolve) => {
+    void (async () => {
+      const prompt = buildWorkerPrompt({
         workerId,
         task: assignment.task,
-        source: 'swarm-dispatch',
-        author: 'aurora',
+        rationale: assignment.rationale,
+        roster,
+        direct: assignment.direct,
+        missionId: options?.missionId ?? null,
+        taskTitle: assignment.task.slice(0, 120),
       })
-    }
-    appendSwarmMemoryEvent({
-      workerId,
-      missionId: options?.missionId ?? null,
-      assignmentId: assignment.assignmentId ?? null,
-      type: 'dispatch',
-      summary: `Dispatched task: ${assignment.task.slice(0, 240)}`,
-      event: {
-        task: assignment.task,
-        rationale: assignment.rationale ?? null,
-        direct: assignment.direct ?? false,
-        deliveryTarget: 'tmux',
-      },
-    })
-    const startedAt = Date.now()
-    const wrapperPath = getWrapperPath(workerId)
-
-    // Prefer the persistent live agent session when available/startable.
-    const liveResult = await sendPromptToLiveSession(workerId, prompt)
-    if (liveResult) {
-      markDispatchResult(workerId, liveResult)
-      if (options?.waitForCheckpoint && liveResult.ok) {
-        const checkpoint = await waitForFreshCheckpoint(
-          workerId,
-          previousRaw,
-          baselineRuntimeSignature,
-          startedAt,
-          options.checkpointPollMs ?? 90_000,
-        )
-        if (checkpoint) {
-          markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
-          const updatedMission = recordMissionCheckpoint({
-            missionId: options?.missionId,
-            assignmentId: assignment.assignmentId ?? null,
-            workerId,
-            checkpoint,
-            source: 'swarm-dispatch',
-          })
-          if (updatedMission?._completed) {
-            try {
-              for (const wId of new Set(updatedMission.assignments.map((a) => a.workerId))) {
-                appendSwarmMemoryEvent({
-                  workerId: wId,
-                  missionId: updatedMission.id,
-                  type: 'complete',
-                  title: updatedMission.title,
-                  summary: `Mission complete: ${updatedMission.title}`,
-                })
-              }
-            } catch { /* memory write best-effort */ }
-          }
-          appendSwarmMemoryEvent({
-            workerId,
-            missionId: options?.missionId ?? null,
-            assignmentId: assignment.assignmentId ?? null,
-            type: 'checkpoint',
-            summary: checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
-            checkpoint,
-            event: {
-              stateLabel: checkpoint.stateLabel,
-              filesChanged: checkpoint.filesChanged,
-              commandsRun: checkpoint.commandsRun,
-              blocker: checkpoint.blocker,
-              nextAction: checkpoint.nextAction,
-            },
-          })
-          publishSwarmCheckpointNotification({
-            workerId,
-            missionId: options?.missionId ?? null,
-            assignmentId: assignment.assignmentId ?? null,
-            checkpoint,
-            notifySessionKey: options?.notifySessionKey ?? 'main',
-          })
-          liveResult.checkpoint = checkpoint
-          liveResult.checkpointStatus = 'checkpointed'
-          liveResult.output = `${liveResult.output}\nCheckpoint ${checkpoint.stateLabel}: ${checkpoint.result ?? 'no result'}`
-        } else {
-          liveResult.checkpoint = null
-          liveResult.checkpointStatus = 'timeout'
-          liveResult.output = `${liveResult.output}\nNo fresh checkpoint before poll timeout.`
-        }
-      } else {
-        liveResult.checkpointStatus = 'not-requested'
-      }
-      recordDispatchBlock(workerId, assignment, liveResult, options)
-      resolve(liveResult)
-      return
-    }
-
-    if (!existsSync(profilePath)) {
-      const result: WorkerResult = {
+      const profilePath = getProfilePath(workerId)
+      const runtimeBeforeDispatch = readRuntimeCheckpointSnapshot(profilePath)
+      const previousRaw = runtimeBeforeDispatch.checkpointRaw
+      const baselineRuntimeSignature = runtimeCheckpointSignature(
+        runtimeBeforeDispatch,
+      )
+      markDispatchStarted(
         workerId,
-        ok: false,
-        output: '',
-        error: `Profile not found at ${profilePath}`,
-        durationMs: Date.now() - startedAt,
-        exitCode: null,
-        delivery: 'oneshot',
-      }
-      markDispatchResult(workerId, result)
-      recordDispatchBlock(workerId, assignment, result, options)
-      resolve(result)
-      return
-    }
-
-    const useWrapper = existsSync(wrapperPath)
-    const cmd = useWrapper ? wrapperPath : resolveHermesBin()
-    const args = buildHermesChatQueryArgs(prompt)
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      HERMES_HOME: profilePath,
-    }
-    const ghToken = resolveGithubToken()
-    if (ghToken) {
-      env.GH_TOKEN = ghToken
-      env.GITHUB_TOKEN = ghToken
-    }
-
-    const proc = execFile(
-      cmd,
-      args,
-      {
-        env,
-        cwd: homedir(),
-        timeout: timeoutMs,
-        maxBuffer: MAX_OUTPUT_CHARS,
-        killSignal: 'SIGTERM',
-      },
-      (error, stdout, stderr) => {
-        const durationMs = Date.now() - startedAt
-        const stdoutStr = (stdout || '').toString()
-        const stderrStr = (stderr || '').toString()
-        const out = stdoutStr.length > MAX_OUTPUT_CHARS ? stdoutStr.slice(-MAX_OUTPUT_CHARS) : stdoutStr
-
-        if (error) {
-          const code = (error as { code?: number | null }).code ?? null
-          const result: WorkerResult = {
-            workerId,
-            ok: false,
-            output: out,
-            error: stderrStr.trim() || error.message,
-            durationMs,
-            exitCode: typeof code === 'number' ? code : null,
-            delivery: 'oneshot',
-          }
-          markDispatchResult(workerId, result)
-          recordDispatchBlock(workerId, assignment, result, options)
-          resolve(result)
-          return
-        }
-
-        const result: WorkerResult = {
+        assignment.task,
+        options?.missionId ?? null,
+        assignment.assignmentId ?? null,
+        options?.notifySessionKey ?? 'main',
+      )
+      if (options?.missionId) {
+        markMissionAssignmentDispatched({
+          missionId: options.missionId,
           workerId,
-          ok: true,
-          output: out,
-          error: stderrStr.trim() || null,
-          durationMs,
-          exitCode: 0,
-          delivery: 'oneshot',
-        }
-        if (options?.waitForCheckpoint) {
-          const checkpoint = parseSwarmCheckpoint(out)
+          task: assignment.task,
+          source: 'swarm-dispatch',
+          author: 'aurora',
+        })
+      }
+      appendSwarmMemoryEvent({
+        workerId,
+        missionId: options?.missionId ?? null,
+        assignmentId: assignment.assignmentId ?? null,
+        type: 'dispatch',
+        summary: `Dispatched task: ${assignment.task.slice(0, 240)}`,
+        event: {
+          task: assignment.task,
+          rationale: assignment.rationale ?? null,
+          direct: assignment.direct ?? false,
+          deliveryTarget: 'tmux',
+        },
+      })
+      const wrapperPath = getWrapperPath(workerId)
+
+      // Prefer the persistent live agent session when available/startable.
+      const liveResult = await sendPromptToLiveSession(workerId, prompt)
+      if (liveResult) {
+        markDispatchResult(workerId, liveResult)
+        if (options?.waitForCheckpoint && liveResult.ok) {
+          const checkpoint = await waitForFreshCheckpoint(
+            workerId,
+            previousRaw,
+            baselineRuntimeSignature,
+            startedAt,
+            options.checkpointPollMs ?? 90_000,
+          )
           if (checkpoint) {
-            markCheckpointResult(workerId, checkpoint, options?.notifySessionKey ?? 'main')
-            recordMissionCheckpoint({
+            markCheckpointResult(
+              workerId,
+              checkpoint,
+              options?.notifySessionKey ?? 'main',
+            )
+            const updatedMission = recordMissionCheckpoint({
               missionId: options?.missionId,
               assignmentId: assignment.assignmentId ?? null,
               workerId,
               checkpoint,
               source: 'swarm-dispatch',
             })
+            if (updatedMission?._completed) {
+              try {
+                for (const wId of new Set(
+                  updatedMission.assignments.map((a) => a.workerId),
+                )) {
+                  appendSwarmMemoryEvent({
+                    workerId: wId,
+                    missionId: updatedMission.id,
+                    type: 'complete',
+                    title: updatedMission.title,
+                    summary: `Mission complete: ${updatedMission.title}`,
+                  })
+                }
+              } catch {
+                /* memory write best-effort */
+              }
+            }
             appendSwarmMemoryEvent({
               workerId,
               missionId: options?.missionId ?? null,
               assignmentId: assignment.assignmentId ?? null,
               type: 'checkpoint',
-              summary: checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
+              summary:
+                checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
               checkpoint,
               event: {
                 stateLabel: checkpoint.stateLabel,
@@ -1010,33 +1058,183 @@ function runWorker(assignment: AssignmentRequest, timeoutMs: number, roster: Swa
               checkpoint,
               notifySessionKey: options?.notifySessionKey ?? 'main',
             })
-            result.checkpoint = checkpoint
-            result.checkpointStatus = 'checkpointed'
+            liveResult.checkpoint = checkpoint
+            liveResult.checkpointStatus = 'checkpointed'
+            liveResult.output = `${liveResult.output}\nCheckpoint ${checkpoint.stateLabel}: ${checkpoint.result ?? 'no result'}`
           } else {
-            result.checkpoint = null
-            result.checkpointStatus = 'timeout'
+            liveResult.checkpoint = null
+            liveResult.checkpointStatus = 'timeout'
+            liveResult.output = `${liveResult.output}\nNo fresh checkpoint before poll timeout.`
           }
         } else {
-          result.checkpointStatus = 'not-requested'
+          liveResult.checkpointStatus = 'not-requested'
+        }
+        recordDispatchBlock(workerId, assignment, liveResult, options)
+        resolve(liveResult)
+        return
+      }
+
+      if (!existsSync(profilePath)) {
+        const result: WorkerResult = {
+          workerId,
+          ok: false,
+          output: '',
+          error: `Profile not found at ${profilePath}`,
+          durationMs: Date.now() - startedAt,
+          exitCode: null,
+          delivery: 'oneshot',
         }
         markDispatchResult(workerId, result)
         recordDispatchBlock(workerId, assignment, result, options)
         resolve(result)
-      },
-    )
+        return
+      }
 
-    proc.on('error', (error) => {
+      const useWrapper = existsSync(wrapperPath)
+      const cmd = useWrapper ? wrapperPath : resolveHermesBin()
+      const args = buildHermesChatQueryArgs(prompt)
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        HERMES_HOME: profilePath,
+      }
+      const ghToken = resolveGithubToken()
+      if (ghToken) {
+        env.GH_TOKEN = ghToken
+        env.GITHUB_TOKEN = ghToken
+      }
+
+      const proc = execFile(
+        cmd,
+        args,
+        {
+          env,
+          cwd: homedir(),
+          timeout: timeoutMs,
+          maxBuffer: MAX_OUTPUT_CHARS,
+          killSignal: 'SIGTERM',
+        },
+        (error, stdout, stderr) => {
+          const durationMs = Date.now() - startedAt
+          const stdoutStr = (stdout || '').toString()
+          const stderrStr = (stderr || '').toString()
+          const out =
+            stdoutStr.length > MAX_OUTPUT_CHARS
+              ? stdoutStr.slice(-MAX_OUTPUT_CHARS)
+              : stdoutStr
+
+          if (error) {
+            const code = (error as { code?: number | null }).code ?? null
+            const result: WorkerResult = {
+              workerId,
+              ok: false,
+              output: out,
+              error: stderrStr.trim() || error.message,
+              durationMs,
+              exitCode: typeof code === 'number' ? code : null,
+              delivery: 'oneshot',
+            }
+            markDispatchResult(workerId, result)
+            recordDispatchBlock(workerId, assignment, result, options)
+            resolve(result)
+            return
+          }
+
+          const result: WorkerResult = {
+            workerId,
+            ok: true,
+            output: out,
+            error: stderrStr.trim() || null,
+            durationMs,
+            exitCode: 0,
+            delivery: 'oneshot',
+          }
+          if (options?.waitForCheckpoint) {
+            const checkpoint = parseSwarmCheckpoint(out)
+            if (checkpoint) {
+              markCheckpointResult(
+                workerId,
+                checkpoint,
+                options?.notifySessionKey ?? 'main',
+              )
+              recordMissionCheckpoint({
+                missionId: options?.missionId,
+                assignmentId: assignment.assignmentId ?? null,
+                workerId,
+                checkpoint,
+                source: 'swarm-dispatch',
+              })
+              appendSwarmMemoryEvent({
+                workerId,
+                missionId: options?.missionId ?? null,
+                assignmentId: assignment.assignmentId ?? null,
+                type: 'checkpoint',
+                summary:
+                  checkpoint.result ?? `Checkpoint ${checkpoint.stateLabel}`,
+                checkpoint,
+                event: {
+                  stateLabel: checkpoint.stateLabel,
+                  filesChanged: checkpoint.filesChanged,
+                  commandsRun: checkpoint.commandsRun,
+                  blocker: checkpoint.blocker,
+                  nextAction: checkpoint.nextAction,
+                },
+              })
+              publishSwarmCheckpointNotification({
+                workerId,
+                missionId: options?.missionId ?? null,
+                assignmentId: assignment.assignmentId ?? null,
+                checkpoint,
+                notifySessionKey: options?.notifySessionKey ?? 'main',
+              })
+              result.checkpoint = checkpoint
+              result.checkpointStatus = 'checkpointed'
+            } else {
+              result.checkpoint = null
+              result.checkpointStatus = 'timeout'
+            }
+          } else {
+            result.checkpointStatus = 'not-requested'
+          }
+          markDispatchResult(workerId, result)
+          recordDispatchBlock(workerId, assignment, result, options)
+          resolve(result)
+        },
+      )
+
+      proc.on('error', (error) => {
+        const result: WorkerResult = {
+          workerId,
+          ok: false,
+          output: '',
+          error: error.message,
+          durationMs: Date.now() - startedAt,
+          exitCode: null,
+          delivery: 'oneshot',
+        }
+        markDispatchResult(workerId, result)
+        recordDispatchBlock(workerId, assignment, result, options)
+        resolve(result)
+      })
+    })().catch((error: unknown) => {
+      console.error('[swarm-dispatch] unexpected dispatch failure', error)
       const result: WorkerResult = {
         workerId,
         ok: false,
         output: '',
-        error: error.message,
+        error: 'Unexpected dispatch failure',
         durationMs: Date.now() - startedAt,
         exitCode: null,
         delivery: 'oneshot',
       }
-      markDispatchResult(workerId, result)
-      recordDispatchBlock(workerId, assignment, result, options)
+      try {
+        markDispatchResult(workerId, result)
+        recordDispatchBlock(workerId, assignment, result, options)
+      } catch (recordError) {
+        console.error(
+          '[swarm-dispatch] failed to record unexpected dispatch failure',
+          recordError,
+        )
+      }
       resolve(result)
     })
   })
@@ -1079,23 +1277,47 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
   if (assignments.some((assignment) => assignment.task.length === 0)) {
     throw new SwarmDispatchError('assignment task required')
   }
-  if (assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)) {
-    throw new SwarmDispatchError(`assignment task exceeds ${MAX_PROMPT_CHARS} characters`)
+  if (
+    assignments.some((assignment) => assignment.task.length > MAX_PROMPT_CHARS)
+  ) {
+    throw new SwarmDispatchError(
+      `assignment task exceeds ${MAX_PROMPT_CHARS} characters`,
+    )
   }
 
-  const timeoutRaw = typeof body.timeoutSeconds === 'number' ? body.timeoutSeconds : DEFAULT_TIMEOUT_S
-  const timeoutSeconds = Math.max(10, Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)))
+  const timeoutRaw =
+    typeof body.timeoutSeconds === 'number'
+      ? body.timeoutSeconds
+      : DEFAULT_TIMEOUT_S
+  const timeoutSeconds = Math.max(
+    10,
+    Math.min(MAX_TIMEOUT_S, Math.floor(timeoutRaw)),
+  )
   const timeoutMs = timeoutSeconds * 1000
-  const waitForCheckpoint = !(body.waitForCheckpoint === false && body.allowAsync === true)
-  const pollRaw = typeof body.checkpointPollSeconds === 'number' ? body.checkpointPollSeconds : 90
+  const waitForCheckpoint = !(
+    body.waitForCheckpoint === false && body.allowAsync === true
+  )
+  const pollRaw =
+    typeof body.checkpointPollSeconds === 'number'
+      ? body.checkpointPollSeconds
+      : 90
   const checkpointPollSeconds = Math.max(5, Math.min(300, Math.floor(pollRaw)))
-  const notifySessionKey = typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim() ? body.notifySessionKey.trim() : 'main'
+  const notifySessionKey =
+    typeof body.notifySessionKey === 'string' && body.notifySessionKey.trim()
+      ? body.notifySessionKey.trim()
+      : 'main'
 
-  const requestedMissionId = typeof body.missionId === 'string' ? body.missionId.trim() : ''
-  const hasExplicitMissionTitle = typeof body.missionTitle === 'string' && body.missionTitle.trim()
+  const requestedMissionId =
+    typeof body.missionId === 'string' ? body.missionId.trim() : ''
+  const hasExplicitMissionTitle =
+    typeof body.missionTitle === 'string' && body.missionTitle.trim()
   const missionTitle = hasExplicitMissionTitle
     ? (body.missionTitle as string).trim()
-    : requestedMissionId ? '' : assignments.length === 1 ? assignments[0].task.slice(0, 120) : `${assignments.length} assigned tasks`
+    : requestedMissionId
+      ? ''
+      : assignments.length === 1
+        ? assignments[0].task.slice(0, 120)
+        : `${assignments.length} assigned tasks`
   const mission = createOrUpdateMission({
     missionId: requestedMissionId || null,
     title: missionTitle,
@@ -1116,20 +1338,33 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
     }
   }
 
-  const assignmentIdByKey = new Map(mission.assignments.map((item) => [`${item.workerId}\n${item.task}`, item.id]))
+  const assignmentIdByKey = new Map(
+    mission.assignments.map((item) => [
+      `${item.workerId}\n${item.task}`,
+      item.id,
+    ]),
+  )
   assignments = assignments.map((assignment) => ({
     ...assignment,
-    assignmentId: assignmentIdByKey.get(`${assignment.workerId}\n${assignment.task}`),
+    assignmentId: assignmentIdByKey.get(
+      `${assignment.workerId}\n${assignment.task}`,
+    ),
   }))
 
   const dispatchedAt = Date.now()
-  const roster = rosterByWorkerId(assignments.map((assignment) => assignment.workerId))
-  const results = await Promise.all(assignments.map((assignment) => runWorker(
-    assignment,
-    timeoutMs,
-    roster.get(assignment.workerId),
-    { waitForCheckpoint, checkpointPollMs: checkpointPollSeconds * 1000, missionId: mission.id, notifySessionKey },
-  )))
+  const roster = rosterByWorkerId(
+    assignments.map((assignment) => assignment.workerId),
+  )
+  const results = await Promise.all(
+    assignments.map((assignment) =>
+      runWorker(assignment, timeoutMs, roster.get(assignment.workerId), {
+        waitForCheckpoint,
+        checkpointPollMs: checkpointPollSeconds * 1000,
+        missionId: mission.id,
+        notifySessionKey,
+      }),
+    ),
+  )
 
   const latestMission = getSwarmMission(mission.id) ?? mission
 
@@ -1138,7 +1373,10 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
     completedAt: Date.now(),
     missionId: mission.id,
     mission: latestMission,
-    prompt: assignments.length === 1 ? assignments[0].task : `${assignments.length} assigned tasks`,
+    prompt:
+      assignments.length === 1
+        ? assignments[0].task
+        : `${assignments.length} assigned tasks`,
     assignments,
     timeoutSeconds,
     waitForCheckpoint,
@@ -1152,7 +1390,7 @@ export const Route = createFileRoute('/api/swarm-dispatch')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
 
@@ -1169,7 +1407,10 @@ export const Route = createFileRoute('/api/swarm-dispatch')({
           if (error instanceof SwarmDispatchError) {
             return json({ error: error.message }, { status: error.status })
           }
-          return json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 })
+          return json(
+            { error: error instanceof Error ? error.message : String(error) },
+            { status: 500 },
+          )
         }
       },
     },

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -32,6 +32,8 @@ import { rosterByWorkerId } from '../../server/swarm-roster'
 import type { SwarmRosterWorker } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
+import { sendToWorker, startWorkerProcess } from '../../server/swarm-lifecycle'
+import { buildSafeChildEnv } from '../../server/worker-process-host'
 import {
   ensureSwarmProfileConfig,
   syncSwarmProfileModel,
@@ -789,6 +791,19 @@ async function sendPromptToLiveSession(
   prompt: string,
 ): Promise<WorkerResult | null> {
   const startedAt = Date.now()
+  let sent = await sendToWorker(workerId, prompt)
+  if (!sent.ok) {
+    const started = await startWorkerProcess(workerId)
+    if (!started.ok) {
+      return { workerId, ok: false, output: '', error: started.error ?? sent.error ?? 'Owned worker host failed to start', durationMs: Date.now() - startedAt, exitCode: null, delivery: 'tmux' }
+    }
+    await sleep(1_500)
+    sent = await sendToWorker(workerId, prompt)
+  }
+  return { workerId, ok: sent.ok, output: sent.ok ? 'Delivered through the durable worker process host' : '', error: sent.error ?? null, durationMs: Date.now() - startedAt, exitCode: sent.ok ? 0 : null, delivery: 'tmux' }
+
+  /* Legacy tmux transport retained temporarily for fixture compatibility; it
+     is unreachable because the durable process host is the sole authority. */
   const ensured = await ensureLiveTmuxSession(workerId)
   if (!ensured.ok) return null
 
@@ -915,15 +930,11 @@ async function sendPromptToLiveSession(
   }
 }
 
-export function buildHermesChatQueryArgs(prompt: string): string[] {
-  // `hermes chat -q` requires the query as the *immediate* next argv item.
-  // Keeping the prompt adjacent to -q prevents argparse from interpreting
-  // following flags (for example -Q) as a missing query and failing with:
-  // "argument -q/--query: expected one argument".
+export function buildHermesChatQueryArgs(): string[] {
+  // Legacy one-shot construction intentionally contains no prompt. Active
+  // dispatch is stdin/tmux-buffer based through WorkerProcessHost.
   return [
     'chat',
-    '-q',
-    prompt,
     '-Q',
     '--yolo',
     '--ignore-rules',
@@ -1074,6 +1085,16 @@ function runWorker(
         return
       }
 
+      const unavailable: WorkerResult = {
+        workerId, ok: false, output: '',
+        error: 'Persistent worker host is unavailable; one-shot argv dispatch is disabled',
+        durationMs: Date.now() - startedAt, exitCode: null, delivery: 'oneshot',
+      }
+      markDispatchResult(workerId, unavailable)
+      recordDispatchBlock(workerId, assignment, unavailable, options)
+      resolve(unavailable)
+      return
+
       if (!existsSync(profilePath)) {
         const result: WorkerResult = {
           workerId,
@@ -1092,11 +1113,8 @@ function runWorker(
 
       const useWrapper = existsSync(wrapperPath)
       const cmd = useWrapper ? wrapperPath : resolveHermesBin()
-      const args = buildHermesChatQueryArgs(prompt)
-      const env: NodeJS.ProcessEnv = {
-        ...process.env,
-        HERMES_HOME: profilePath,
-      }
+      const args = buildHermesChatQueryArgs()
+      const env: NodeJS.ProcessEnv = buildSafeChildEnv(process.env, { HERMES_HOME: profilePath })
       const ghToken = resolveGithubToken()
       if (ghToken) {
         env.GH_TOKEN = ghToken

--- a/src/routes/api/swarm-roster.ts
+++ b/src/routes/api/swarm-roster.ts
@@ -1,14 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../server/auth-middleware'
-import { SWARM_ROSTER_PATH, readSwarmRoster, upsertSwarmRosterWorker } from '../../server/swarm-roster'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import {
+  SWARM_ROSTER_PATH,
+  readSwarmRoster,
+  updateSwarmRosterWorkerModel,
+  upsertSwarmRosterWorker,
+} from '../../server/swarm-roster'
 import { listSwarmWorkerIds } from '../../server/swarm-foundation'
+import { loadSubscriptionCatalog } from '../../server/subscription-model-catalog'
 
 export const Route = createFileRoute('/api/swarm-roster')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         const ids = listSwarmWorkerIds()
@@ -20,24 +26,96 @@ export const Route = createFileRoute('/api/swarm-roster')({
         })
       },
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         let body: unknown
         try {
           body = await request.json()
         } catch {
-          return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 })
+          return json(
+            { ok: false, error: 'Invalid JSON body' },
+            { status: 400 },
+          )
         }
         try {
           const ids = listSwarmWorkerIds()
           const roster = upsertSwarmRosterWorker(body as never, ids)
-          return json({ ok: true, path: SWARM_ROSTER_PATH, roster, savedAt: Date.now() })
-        } catch (error) {
           return json({
-            ok: false,
-            error: error instanceof Error ? error.message : 'Failed to save swarm roster entry',
-          }, { status: 400 })
+            ok: true,
+            path: SWARM_ROSTER_PATH,
+            roster,
+            savedAt: Date.now(),
+          })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to save swarm roster entry',
+            },
+            { status: 400 },
+          )
+        }
+      },
+      PATCH: async ({ request }) => {
+        if (!requireLocalOrAuth(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        let body: { id?: unknown; modelRef?: unknown }
+        try {
+          body = (await request.json()) as { id?: unknown; modelRef?: unknown }
+        } catch {
+          return json(
+            { ok: false, error: 'Invalid JSON body' },
+            { status: 400 },
+          )
+        }
+        const id = typeof body.id === 'string' ? body.id.trim() : ''
+        const modelRef =
+          typeof body.modelRef === 'string' ? body.modelRef.trim() : ''
+        if (!id || !modelRef) {
+          return json(
+            { ok: false, error: 'id and modelRef are required' },
+            { status: 400 },
+          )
+        }
+        try {
+          const catalog = await loadSubscriptionCatalog()
+          const route = catalog.models.find((model) => model.id === modelRef)
+          if (!route || !route.selectable) {
+            return json(
+              {
+                ok: false,
+                error: 'Model route is not an assignable OAuth subscription',
+              },
+              { status: 400 },
+            )
+          }
+          const roster = updateSwarmRosterWorkerModel(
+            id,
+            modelRef,
+            listSwarmWorkerIds(),
+          )
+          return json({
+            ok: true,
+            path: SWARM_ROSTER_PATH,
+            roster,
+            savedAt: Date.now(),
+          })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to update swarm model assignment',
+            },
+            { status: 400 },
+          )
         }
       },
     },

--- a/src/routes/api/swarm-tmux-start.ts
+++ b/src/routes/api/swarm-tmux-start.ts
@@ -1,13 +1,23 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { isAuthenticated } from '../../server/auth-middleware'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { requireLocalOrAuth } from '../../server/auth-middleware'
 import { rosterByWorkerId } from '../../server/swarm-roster'
 import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
-import { syncSwarmProfileModel } from '../../server/swarm-profile-config'
+import {
+  ensureSwarmProfileConfig,
+  syncSwarmProfileModel,
+} from '../../server/swarm-profile-config'
+import {
+  buildSwarmTmuxLaunchCommand,
+  buildTmuxNewSessionArgs,
+  buildTmuxSendKeysArgs,
+  resolveSwarmHermesBin as resolveHermesBin,
+  resolveSwarmTmuxBin as resolveTmuxBin,
+} from '../../server/swarm-tmux-launch'
 
 // Inlined to avoid SSR module-resolution races against freshly-written
 // helpers; mirrors `src/server/claude-paths.ts` getProfilesDir().
@@ -38,36 +48,6 @@ type StartRequest = {
   workerId?: unknown
 }
 
-const TMUX_BIN_CANDIDATES = [
-  process.env.TMUX_BIN,
-  '/opt/homebrew/bin/tmux',
-  '/usr/local/bin/tmux',
-  join(homedir(), '.local', 'bin', 'tmux'),
-  'tmux',
-].filter((value): value is string => Boolean(value))
-
-function resolveTmuxBin(): string | null {
-  for (const candidate of TMUX_BIN_CANDIDATES) {
-    if (candidate.includes('/')) {
-      // On this launchd-started Workspace, existsSync can incorrectly miss
-      // Homebrew binaries and then execFile('tmux') fails with ENOENT because
-      // PATH has been reshaped by pnpm. Prefer the stable absolute Homebrew
-      // paths; execFile will surface a clear error if they truly do not exist.
-      if (
-        candidate === process.env.TMUX_BIN ||
-        candidate === '/opt/homebrew/bin/tmux' ||
-        candidate === '/usr/local/bin/tmux' ||
-        existsSync(candidate)
-      ) {
-        return candidate
-      }
-      continue
-    }
-    return candidate
-  }
-  return null
-}
-
 function tmuxHasSession(tmuxBin: string, name: string): Promise<boolean> {
   return new Promise((resolve) => {
     execFile(tmuxBin, ['has-session', '-t', name], (error) => {
@@ -80,57 +60,43 @@ function validateWorkerId(value: string): boolean {
   return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(value)
 }
 
-const HERMES_BIN_CANDIDATES = [
-  process.env.HERMES_CLI_BIN,
-  join(homedir(), '.hermes', 'hermes-agent', 'venv', 'bin', 'hermes'),
-  join(homedir(), '.local', 'bin', 'hermes'),
-  'hermes',
-].filter((value): value is string => Boolean(value))
-
-function resolveHermesBin(): string {
-  for (const candidate of HERMES_BIN_CANDIDATES) {
-    if (candidate.includes('/')) {
-      if (existsSync(candidate)) return candidate
-      continue
-    }
-    return candidate
-  }
-  return 'hermes'
-}
-
 function startSession(
   tmuxBin: string,
   sessionName: string,
   profilePath: string,
   cwd: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  return new Promise((resolve) => {
-    const child = execFile(
-      tmuxBin,
-      [
-        'new-session',
-        '-d',
-        '-s',
-        sessionName,
-        '-c',
-        cwd,
-        `HERMES_HOME='${profilePath.replace(/'/g, `'\\''`)}' HERMES_CLI_BIN='${resolveHermesBin().replace(/'/g, `'\\''`)}' exec '${resolveHermesBin().replace(/'/g, `'\\''`)}' chat --tui`,
-      ],
-      { timeout: 8_000 },
-      (error, _stdout, stderr) => {
-        if (error) {
-          resolve({
-            ok: false,
-            error: stderr?.toString().trim() || error.message,
-          })
-          return
-        }
-        resolve({ ok: true })
-      },
-    )
-    child.on('error', (error) => {
-      resolve({ ok: false, error: error.message })
+  const run = (args: Array<string>) =>
+    new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      const child = execFile(
+        tmuxBin,
+        args,
+        { timeout: 8_000 },
+        (error, _stdout, stderr) => {
+          if (error) {
+            resolve({
+              ok: false,
+              error: stderr.toString().trim() || error.message,
+            })
+            return
+          }
+          resolve({ ok: true })
+        },
+      )
+      child.on('error', (error) => {
+        resolve({ ok: false, error: error.message })
+      })
     })
+
+  return run(buildTmuxNewSessionArgs({ sessionName, cwd })).then((started) => {
+    if (!started.ok) return started
+    const launchCommand = buildSwarmTmuxLaunchCommand({
+      profilePath,
+      cwd,
+      hermesBin: resolveHermesBin(),
+      keepShellAlive: true,
+    })
+    return run(buildTmuxSendKeysArgs(sessionName, launchCommand))
   })
 }
 
@@ -154,7 +120,7 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
+        if (!requireLocalOrAuth(request)) {
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
 
@@ -176,17 +142,14 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
 
         const profilesDir = getProfilesDir()
         const profilePath = join(profilesDir, workerId)
-        // Skip the existsSync gate; tmux new-session will fail loudly if the
-        // path is bogus, and the sandbox quirks on this host make existsSync
-        // unreliable for parent dirs even when leaf paths work.
-        // We still verify the wrapper exists as a sanity check.
-        const worker = rosterByWorkerId([workerId]).get(workerId)
-        const wrapperName = worker?.wrapper?.trim() || workerId
-        const wrapper = join(homedir(), '.local', 'bin', wrapperName)
-        if (!existsSync(wrapper)) {
+        const profileBootstrap = ensureSwarmProfileConfig(profilePath)
+        if (!profileBootstrap.ok) {
           return json(
-            { error: `No wrapper for ${workerId} at ${wrapper}` },
-            { status: 404 },
+            {
+              error:
+                profileBootstrap.error ?? 'Worker profile bootstrap failed',
+            },
+            { status: 500 },
           )
         }
 
@@ -204,7 +167,7 @@ export const Route = createFileRoute('/api/swarm-tmux-start')({
         // pass `--model`, so this is the only way the roster value is
         // honored. Best-effort: unrecognised labels (typos, custom
         // models) are left as-is so a worker never gets wedged. See #236.
-        let modelSync: {
+        const modelSync: {
           attempted: boolean
           changed: boolean
           target?: string

--- a/src/routes/api/swarm-tmux-start.ts
+++ b/src/routes/api/swarm-tmux-start.ts
@@ -1,235 +1,44 @@
-import { execFile } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
+
 import { requireLocalOrAuth } from '../../server/auth-middleware'
-import { rosterByWorkerId } from '../../server/swarm-roster'
+import { getProfilesDir } from '../../server/claude-paths'
+import { getWorkerProcessHost } from '../../server/worker-process-host'
+import { startWorkerProcess } from '../../server/swarm-lifecycle'
 import { resolveSwarmModelLabel } from '../../server/swarm-model-resolver'
-import {
-  ensureSwarmProfileConfig,
-  syncSwarmProfileModel,
-} from '../../server/swarm-profile-config'
-import {
-  buildSwarmTmuxLaunchCommand,
-  buildTmuxNewSessionArgs,
-  buildTmuxSendKeysArgs,
-  resolveSwarmHermesBin as resolveHermesBin,
-  resolveSwarmTmuxBin as resolveTmuxBin,
-} from '../../server/swarm-tmux-launch'
+import { ensureSwarmProfileConfig, syncSwarmProfileModel } from '../../server/swarm-profile-config'
+import { rosterByWorkerId } from '../../server/swarm-roster'
 
-// Inlined to avoid SSR module-resolution races against freshly-written
-// helpers; mirrors `src/server/claude-paths.ts` getProfilesDir().
-function getProfilesDir(): string {
-  const envHome = process.env.HERMES_HOME || process.env.CLAUDE_HOME
-  if (envHome) {
-    const parts = envHome.split('/').filter(Boolean)
-    if (parts.length >= 2 && parts.at(-2) === 'profiles') {
-      return envHome.split('/').slice(0, -1).join('/')
-    }
-    return join(envHome, 'profiles')
-  }
-  return join(homedir(), '.hermes', 'profiles')
-}
+type StartRequest = { workerId?: unknown }
+function validWorkerId(value: string): boolean { return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(value) }
 
-/**
- * POST /api/swarm-tmux-start
- * Body: { workerId: "swarm1" }
- *
- * Idempotently ensures a long-lived tmux session exists for a worker.
- * The session runs the worker's `hermes` TUI inside its profile + cwd, so
- * dispatch traffic + the swarm2 Runtime pane both see the same live agent.
- *
- * Returns: { workerId, sessionName, alreadyRunning, started }
- */
-
-type StartRequest = {
-  workerId?: unknown
-}
-
-function tmuxHasSession(tmuxBin: string, name: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    execFile(tmuxBin, ['has-session', '-t', name], (error) => {
-      resolve(!error)
-    })
-  })
-}
-
-function validateWorkerId(value: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(value)
-}
-
-function startSession(
-  tmuxBin: string,
-  sessionName: string,
-  profilePath: string,
-  cwd: string,
-): Promise<{ ok: boolean; error?: string }> {
-  const run = (args: Array<string>) =>
-    new Promise<{ ok: boolean; error?: string }>((resolve) => {
-      const child = execFile(
-        tmuxBin,
-        args,
-        { timeout: 8_000 },
-        (error, _stdout, stderr) => {
-          if (error) {
-            resolve({
-              ok: false,
-              error: stderr.toString().trim() || error.message,
-            })
-            return
-          }
-          resolve({ ok: true })
-        },
-      )
-      child.on('error', (error) => {
-        resolve({ ok: false, error: error.message })
-      })
-    })
-
-  return run(buildTmuxNewSessionArgs({ sessionName, cwd })).then((started) => {
-    if (!started.ok) return started
-    const launchCommand = buildSwarmTmuxLaunchCommand({
-      profilePath,
-      cwd,
-      hermesBin: resolveHermesBin(),
-      keepShellAlive: true,
-    })
-    return run(buildTmuxSendKeysArgs(sessionName, launchCommand))
-  })
-}
-
-function resolveWorkerCwd(workerId: string): string {
-  const worker = rosterByWorkerId([workerId]).get(workerId)
-  const wrapperName = worker?.wrapper?.trim() || workerId
-  const wrapperPath = join(homedir(), '.local', 'bin', wrapperName)
-  if (existsSync(wrapperPath)) {
-    try {
-      const text = readFileSync(wrapperPath, 'utf8')
-      const m = text.match(/cd\s+'([^']+)'/)
-      if (m && m[1] && existsSync(m[1])) return m[1]
-    } catch {
-      /* noop */
-    }
-  }
-  return homedir()
-}
-
+/** Compatibility endpoint; all process ownership is delegated to WorkerProcessHost. */
 export const Route = createFileRoute('/api/swarm-tmux-start')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!requireLocalOrAuth(request)) {
-          return json({ error: 'Unauthorized' }, { status: 401 })
-        }
-
+        if (!requireLocalOrAuth(request)) return json({ error: 'Unauthorized' }, { status: 401 })
         let body: StartRequest
-        try {
-          body = (await request.json()) as StartRequest
-        } catch {
-          return json({ error: 'Invalid JSON body' }, { status: 400 })
+        try { body = await request.json() as StartRequest } catch { return json({ error: 'Invalid JSON body' }, { status: 400 }) }
+        const workerId = typeof body.workerId === 'string' ? body.workerId.trim() : ''
+        if (!validWorkerId(workerId)) return json({ error: 'workerId required (alnum, _, -; ≤64 chars)' }, { status: 400 })
+
+        const profilePath = join(getProfilesDir(), workerId)
+        const bootstrap = ensureSwarmProfileConfig(profilePath)
+        if (!bootstrap.ok) return json({ error: bootstrap.error ?? 'Worker profile bootstrap failed' }, { status: 500 })
+        const resolved = resolveSwarmModelLabel(rosterByWorkerId([workerId]).get(workerId)?.model ?? null)
+        if (resolved) {
+          const synced = syncSwarmProfileModel(profilePath, resolved)
+          if (!synced.ok) return json({ error: synced.error ?? 'Worker model synchronization failed' }, { status: 500 })
         }
 
-        const workerId =
-          typeof body.workerId === 'string' ? body.workerId.trim() : ''
-        if (!workerId || !validateWorkerId(workerId)) {
-          return json(
-            { error: 'workerId required (alnum, _, -; ≤64 chars)' },
-            { status: 400 },
-          )
-        }
-
-        const profilesDir = getProfilesDir()
-        const profilePath = join(profilesDir, workerId)
-        const profileBootstrap = ensureSwarmProfileConfig(profilePath)
-        if (!profileBootstrap.ok) {
-          return json(
-            {
-              error:
-                profileBootstrap.error ?? 'Worker profile bootstrap failed',
-            },
-            { status: 500 },
-          )
-        }
-
-        const tmuxBin = resolveTmuxBin()
-        if (!tmuxBin) {
-          return json(
-            { error: 'tmux not installed on this host' },
-            { status: 503 },
-          )
-        }
-
-        // Sync the worker's profile config.yaml model section to the
-        // roster's `model:` label before we (re)attach tmux. Hermes Agent
-        // reads config.yaml on every invocation, and the wrapper does not
-        // pass `--model`, so this is the only way the roster value is
-        // honored. Best-effort: unrecognised labels (typos, custom
-        // models) are left as-is so a worker never gets wedged. See #236.
-        const modelSync: {
-          attempted: boolean
-          changed: boolean
-          target?: string
-          previous?: string
-          error?: string
-        } = { attempted: false, changed: false }
-        try {
-          const roster = rosterByWorkerId([workerId]).get(workerId)
-          const resolved = resolveSwarmModelLabel(roster?.model ?? null)
-          if (resolved) {
-            modelSync.attempted = true
-            const result = syncSwarmProfileModel(profilePath, resolved)
-            if (result.ok) {
-              modelSync.changed = result.changed
-              modelSync.target = `${resolved.provider}/${resolved.default}`
-              if (result.previous) {
-                modelSync.previous = `${result.previous.provider}/${result.previous.default}`
-              }
-            } else {
-              modelSync.error = result.error
-            }
-          }
-        } catch (err) {
-          modelSync.error = err instanceof Error ? err.message : String(err)
-        }
-
-        const sessionName = `swarm-${workerId}`
-        const alreadyRunning = await tmuxHasSession(tmuxBin, sessionName)
-        if (alreadyRunning) {
-          return json({
-            workerId,
-            sessionName,
-            alreadyRunning: true,
-            started: false,
-            tmuxBin,
-            modelSync,
-          })
-        }
-
-        const cwd = resolveWorkerCwd(workerId)
-        const result = await startSession(
-          tmuxBin,
-          sessionName,
-          profilePath,
-          cwd,
-        )
-        if (!result.ok) {
-          return json(
-            { error: result.error ?? 'tmux new-session failed' },
-            { status: 500 },
-          )
-        }
-
-        return json({
-          workerId,
-          sessionName,
-          alreadyRunning: false,
-          started: true,
-          tmuxBin,
-          cwd,
-          modelSync,
-        })
+        const before = await getWorkerProcessHost().status(workerId)
+        if (before.status === 'running') return json({ workerId, sessionName: before.sessionName, hostKind: before.hostKind, alreadyRunning: true, started: false })
+        const started = await startWorkerProcess(workerId)
+        if (!started.ok) return json({ error: started.error ?? 'Durable worker host failed to start' }, { status: 500 })
+        const status = await getWorkerProcessHost().status(workerId)
+        return json({ workerId, sessionName: status.sessionName, hostKind: status.hostKind, alreadyRunning: false, started: true })
       },
     },
   },

--- a/src/routes/api/swarm-tmux-stop.ts
+++ b/src/routes/api/swarm-tmux-stop.ts
@@ -1,148 +1,39 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { execFile } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-import { isAuthenticated } from '../../server/auth-middleware'
-import {
-  getSwarmProfilePath,
-  patchSwarmRuntimeFile,
-} from '../../server/swarm-foundation'
 
-/**
- * POST /api/swarm-tmux-stop
- * Body: { workerId: "swarm1" }
- *
- * Kills the tmux session backing a worker, if any. No-op if not running.
- */
+import { requireLocalOrAuth } from '../../server/auth-middleware'
+import { getSwarmProfilePath, patchSwarmRuntimeFile } from '../../server/swarm-foundation'
+import { getWorkerProcessHost } from '../../server/worker-process-host'
 
-type StopRequest = {
-  workerId?: unknown
-}
+type StopRequest = { workerId?: unknown }
+function validWorkerId(value: string): boolean { return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(value) }
 
-const TMUX_BIN_CANDIDATES = [
-  join(homedir(), '.local', 'bin', 'tmux'),
-  '/opt/homebrew/bin/tmux',
-  '/usr/local/bin/tmux',
-  'tmux',
-]
-
-function resolveTmuxBin(): string | null {
-  for (const candidate of TMUX_BIN_CANDIDATES) {
-    if (candidate.includes('/')) {
-      if (existsSync(candidate)) return candidate
-    } else {
-      return candidate
-    }
-  }
-  return null
-}
-
-function tmuxHasSession(tmuxBin: string, name: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    execFile(tmuxBin, ['has-session', '-t', name], (error) => {
-      resolve(!error)
-    })
-  })
-}
-
-function killSession(
-  tmuxBin: string,
-  sessionName: string,
-): Promise<{ ok: boolean; error?: string }> {
-  return new Promise((resolve) => {
-    execFile(
-      tmuxBin,
-      ['kill-session', '-t', sessionName],
-      { timeout: 5_000 },
-      (error, _stdout, stderr) => {
-        if (error) {
-          resolve({
-            ok: false,
-            error: stderr?.toString().trim() || error.message,
-          })
-          return
-        }
-        resolve({ ok: true })
-      },
-    )
-  })
-}
-
-function validateWorkerId(value: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(value)
-}
-
+/** Compatibility endpoint; all process termination is delegated to WorkerProcessHost. */
 export const Route = createFileRoute('/api/swarm-tmux-stop')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        if (!isAuthenticated(request)) {
-          return json({ error: 'Unauthorized' }, { status: 401 })
-        }
-
+        if (!requireLocalOrAuth(request)) return json({ error: 'Unauthorized' }, { status: 401 })
         let body: StopRequest
-        try {
-          body = (await request.json()) as StopRequest
-        } catch {
-          return json({ error: 'Invalid JSON body' }, { status: 400 })
-        }
+        try { body = await request.json() as StopRequest } catch { return json({ error: 'Invalid JSON body' }, { status: 400 }) }
+        const workerId = typeof body.workerId === 'string' ? body.workerId.trim() : ''
+        if (!validWorkerId(workerId)) return json({ error: 'workerId required' }, { status: 400 })
 
-        const workerId =
-          typeof body.workerId === 'string' ? body.workerId.trim() : ''
-        if (!workerId || !validateWorkerId(workerId)) {
-          return json({ error: 'workerId required' }, { status: 400 })
+        const before = await getWorkerProcessHost().status(workerId)
+        if (before.status === 'stopped' || before.status === 'unknown' && !before.pid && !before.sessionName) {
+          return json({ workerId, sessionName: before.sessionName, wasRunning: false, killed: false })
         }
+        const result = await getWorkerProcessHost().stop(workerId)
+        if (!result.ok) return json({ error: result.error ?? 'worker process stop failed' }, { status: 500 })
 
-        const tmuxBin = resolveTmuxBin()
-        if (!tmuxBin) {
-          return json(
-            { error: 'tmux not installed on this host' },
-            { status: 503 },
-          )
-        }
-
-        const sessionName = `swarm-${workerId}`
-        const exists = await tmuxHasSession(tmuxBin, sessionName)
-        if (!exists) {
-          return json({
-            workerId,
-            sessionName,
-            wasRunning: false,
-            killed: false,
-          })
-        }
-
-        const result = await killSession(tmuxBin, sessionName)
-        if (!result.ok) {
-          return json(
-            { error: result.error ?? 'tmux kill-session failed' },
-            { status: 500 },
-          )
-        }
-
-        // Reconcile runtime.json so the Swarm UI doesn't show a 'stuck'
-        // worker (tmux gone, lifecycle still says running/blocked). Best
-        // effort — the kill already succeeded, so a write failure here
-        // should NOT fail the stop request. Reported in #235.
-        const profilePath = getSwarmProfilePath(workerId)
-        const stoppedAt = Date.now()
-        const patchResult = patchSwarmRuntimeFile(profilePath, workerId, {
-          state: 'idle',
-          phase: 'stopped',
-          currentTask: null,
-          activeTool: null,
-          needsHuman: false,
-          blockedReason: null,
-          checkpointStatus: 'none',
-          lastDispatchResult: 'Stopped via UI',
-          lastOutputAt: stoppedAt,
+        const patchResult = patchSwarmRuntimeFile(getSwarmProfilePath(workerId), workerId, {
+          state: 'idle', phase: 'stopped', currentTask: null, activeTool: null,
+          needsHuman: false, blockedReason: null, checkpointStatus: 'none',
+          lastDispatchResult: 'Stopped via UI', lastOutputAt: Date.now(),
         })
-
         return json({
           workerId,
-          sessionName,
+          sessionName: result.record?.sessionName ?? null,
           wasRunning: true,
           killed: true,
           runtimePatched: patchResult.ok,

--- a/src/routes/runs.tsx
+++ b/src/routes/runs.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+import { usePageTitle } from '@/hooks/use-page-title'
+import { RunsScreen } from '@/screens/runs/runs-screen'
+
+const boundedText = (max: number) => z.string().max(max).optional()
+
+const runsSearchSchema = z.object({
+  q: boundedText(200),
+  view: z.enum(['active', 'recent', 'attention', 'archived']).catch('recent').optional(),
+  provider: boundedText(120),
+  account: boundedText(200),
+  state: boundedText(120),
+  ownership: boundedText(120),
+  project: boundedText(200),
+  kanban: z.enum(['all', 'linked', 'unlinked']).catch('all').optional(),
+  task: boundedText(200),
+  window: z.enum(['1h', '24h', '7d', '30d', 'all']).catch('all').optional(),
+  from: boundedText(40),
+  to: boundedText(40),
+  sort: z.enum(['updated', 'created', 'staleness', 'title', 'project', 'provider', 'state']).catch('updated').optional(),
+  direction: z.enum(['asc', 'desc']).catch('desc').optional(),
+  page: z.coerce.number().int().min(1).max(10_000).catch(1).optional(),
+  size: z.union([z.literal(25), z.literal(50), z.literal(100)]).catch(25).optional(),
+  run: boundedText(300),
+})
+
+export type RunsSearch = z.infer<typeof runsSearchSchema>
+
+export const Route = createFileRoute('/runs')({
+  ssr: false,
+  validateSearch: runsSearchSchema,
+  component: function RunsRoute() {
+    usePageTitle('Runs')
+    return <RunsScreen />
+  },
+  errorComponent: function RunsError({ error }) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-primary-50 p-6 text-center">
+        <h2 className="mb-3 text-xl font-semibold text-primary-900">Failed to Load Runs</h2>
+        <p className="mb-4 max-w-md text-sm text-primary-600">
+          {error instanceof Error ? error.message : 'An unexpected error occurred'}
+        </p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-lg bg-accent-500 px-4 py-2 text-white transition-colors hover:bg-accent-600"
+        >
+          Reload Page
+        </button>
+      </div>
+    )
+  },
+  pendingComponent: function RunsPending() {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center">
+          <div className="mb-3 inline-block h-8 w-8 animate-spin rounded-full border-4 border-accent-500 border-r-transparent" />
+          <p className="text-sm text-primary-500">Loading runs...</p>
+        </div>
+      </div>
+    )
+  },
+})

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -40,6 +40,7 @@ import {
   useChatSettingsStore,
 } from '@/hooks/use-chat-settings'
 import { UserAvatar } from '@/components/avatars'
+import { OrchestrationSettings } from '@/components/settings/orchestration-settings'
 import { Input } from '@/components/ui/input'
 import { LogoLoader } from '@/components/logo-loader'
 import { BrailleSpinner } from '@/components/ui/braille-spinner'
@@ -353,6 +354,15 @@ function SettingsRoute() {
           {/* ── Hermes Agent ──────────────────────────────────── */}
           {activeSection === 'claude' && (
             <ClaudeConfigSection activeView="claude" />
+          )}
+          {activeSection === 'orchestration' && (
+            <SettingsSection
+              title="Multi-model orchestration"
+              description="Choose subscription-backed orchestrators and subagents, context and memory policy, recursion limits, fallbacks, and optional worker presets."
+              icon={MessageMultiple01Icon}
+            >
+              <OrchestrationSettings />
+            </SettingsSection>
           )}
           {activeSection === 'agent' && (
             <ClaudeConfigSection activeView="agent" />

--- a/src/screens/agents/-operations-runtime-layout.test.ts
+++ b/src/screens/agents/-operations-runtime-layout.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Operations runtime information hierarchy', () => {
+  it('keeps the persistent agent roster above the bounded runtime-health summary', () => {
+    const source = readFileSync('src/screens/agents/operations-screen.tsx', 'utf8')
+    const bus = source.indexOf('<AgentBusPanel />')
+    const roster = source.indexOf('agents.map((agent, index)')
+    const health = source.indexOf('<RuntimeHealthCard />')
+    const activity = source.indexOf('Recent Activity')
+    expect(bus).toBeGreaterThan(-1)
+    expect(roster).toBeGreaterThan(bus)
+    expect(health).toBeGreaterThan(roster)
+    expect(activity).toBeGreaterThan(health)
+    expect(source).not.toContain('<ProviderRuntimePanel />')
+  })
+})

--- a/src/screens/agents/components/operations-agent-detail.tsx
+++ b/src/screens/agents/components/operations-agent-detail.tsx
@@ -1,156 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 import {
-  ArrowDown01Icon,
   Cancel01Icon,
   Delete02Icon,
   Settings01Icon,
 } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Button } from '@/components/ui/button'
-import {
-  fetchModels,
-  type GatewayModelCatalogEntry,
-} from '@/lib/gateway-api'
-import { cn } from '@/lib/utils'
+import { OperationsModelConfig } from './operations-model-config'
 import type { OperationsAgent } from '../hooks/use-operations'
-
-type AvailableModel = {
-  id: string
-  provider: string
-  name: string
-}
-
-function normalizeModel(model: GatewayModelCatalogEntry): AvailableModel | null {
-  if (typeof model === 'string') {
-    return {
-      id: model,
-      provider: model.includes('/') ? (model.split('/')[0] ?? 'model') : 'model',
-      name: model.split('/').pop() ?? model,
-    }
-  }
-
-  const id = model.id ?? model.alias ?? model.model ?? ''
-  if (!id) return null
-
-  return {
-    id,
-    provider: model.provider ?? id.split('/')[0] ?? 'model',
-    name:
-      model.label ?? model.displayName ?? model.name ?? id.split('/').pop() ?? id,
-  }
-}
-
-function ModelSelector({
-  value,
-  onChange,
-  models,
-}: {
-  value: string
-  onChange: (nextValue: string) => void
-  models: AvailableModel[]
-}) {
-  const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    if (!open) return
-
-    function handlePointerDown(event: MouseEvent) {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handlePointerDown)
-    return () => document.removeEventListener('mousedown', handlePointerDown)
-  }, [open])
-
-  const selected = (() => {
-    if (!value) return null
-    // If value includes provider prefix (e.g. 'anthropic/claude-sonnet-4-6'),
-    // match provider+id together to avoid OpenRouter stealing the match
-    const slashIndex = value.indexOf('/')
-    if (slashIndex > 0) {
-      const valueProvider = value.slice(0, slashIndex)
-      const valueModelId = value.slice(slashIndex + 1)
-      // First try exact provider+id match
-      const exactMatch = models.find(
-        (m) => m.provider === valueProvider && (m.id === value || m.id === valueModelId),
-      )
-      if (exactMatch) return exactMatch
-    }
-    // Fallback to plain id match
-    const idMatch = models.find((m) => m.id === value)
-    if (idMatch) return idMatch
-    return {
-      id: value,
-      provider: slashIndex > 0 ? value.slice(0, slashIndex) : 'model',
-      name: value.split('/').pop() ?? value,
-    }
-  })()
-
-  return (
-    <div className="relative" ref={containerRef}>
-      <button
-        type="button"
-        onClick={() => setOpen((current) => !current)}
-        className="inline-flex min-h-[3rem] w-full items-center justify-between gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-left text-sm text-[var(--theme-text)] shadow-[0_8px_24px_color-mix(in_srgb,var(--theme-shadow)_18%,transparent)]"
-      >
-        <span className="truncate">
-          {selected ? `${selected.provider} / ${selected.name}` : 'Default (auto)'}
-        </span>
-        <HugeiconsIcon
-          icon={ArrowDown01Icon}
-          size={16}
-          strokeWidth={1.8}
-          className={cn(
-            'text-[var(--theme-muted)] transition-transform',
-            open && 'rotate-180',
-          )}
-        />
-      </button>
-
-      {open ? (
-        <div className="absolute left-0 top-[calc(100%+0.5rem)] z-[80] w-full overflow-hidden rounded-2xl border border-[var(--theme-border2)] bg-[var(--theme-card)] shadow-[0_24px_80px_var(--theme-shadow)]">
-          <div className="max-h-80 overflow-y-auto p-2">
-            <button
-              type="button"
-              onClick={() => {
-                onChange('')
-                setOpen(false)
-              }}
-              className={cn(
-                'flex w-full rounded-xl px-3 py-2.5 text-left text-sm',
-                !value ? 'bg-[var(--theme-accent-soft)]' : 'hover:bg-[var(--theme-bg)]',
-              )}
-            >
-              Default (auto)
-            </button>
-            {models.map((model) => (
-              <button
-                key={model.id}
-                type="button"
-                onClick={() => {
-                  onChange(model.id)
-                  setOpen(false)
-                }}
-                className={cn(
-                  'mt-1 flex w-full rounded-xl px-3 py-2.5 text-left text-sm',
-                  value === model.id
-                    ? 'bg-[var(--theme-accent-soft)]'
-                    : 'hover:bg-[var(--theme-bg)]',
-                )}
-              >
-                {model.provider} / {model.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  )
-}
+import { Button } from '@/components/ui/button'
 
 export function OperationsAgentDetail({
   open,
@@ -168,6 +25,8 @@ export function OperationsAgentDetail({
     agentId: string
     name: string
     model: string
+    reasoningEffort?: string
+    maxOutputTokens?: number
     emoji: string
     systemPrompt: string
   }) => Promise<unknown>
@@ -178,6 +37,8 @@ export function OperationsAgentDetail({
   const [name, setName] = useState('')
   const [emoji, setEmoji] = useState('🤖')
   const [model, setModel] = useState('')
+  const [reasoningEffort, setReasoningEffort] = useState<string>()
+  const [maxOutputTokens, setMaxOutputTokens] = useState<number>()
   const [systemPrompt, setSystemPrompt] = useState('')
 
   useEffect(() => {
@@ -185,22 +46,10 @@ export function OperationsAgentDetail({
     setName(agent.name)
     setEmoji(agent.meta.emoji)
     setModel(agent.model || '')
+    setReasoningEffort(agent.reasoningEffort)
+    setMaxOutputTokens(agent.maxOutputTokens)
     setSystemPrompt(agent.meta.systemPrompt)
   }, [agent, open])
-
-  const modelsQuery = useQuery({
-    queryKey: ['operations', 'models'],
-    queryFn: fetchModels,
-    enabled: open,
-  })
-
-  const models = useMemo(
-    () =>
-      (modelsQuery.data?.models ?? [])
-        .map(normalizeModel)
-        .filter((entry): entry is AvailableModel => Boolean(entry)),
-    [modelsQuery.data?.models],
-  )
 
   if (!open || !agent) return null
 
@@ -210,13 +59,17 @@ export function OperationsAgentDetail({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-3xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-6"
+        className="max-h-[92vh] w-full max-w-3xl overflow-y-auto rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)] sm:p-6"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-4">
           <div className="flex items-start gap-3">
             <div className="flex size-11 items-center justify-center rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-accent)]">
-              <HugeiconsIcon icon={Settings01Icon} size={20} strokeWidth={1.8} />
+              <HugeiconsIcon
+                icon={Settings01Icon}
+                size={20}
+                strokeWidth={1.8}
+              />
             </div>
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-muted)]">
@@ -226,14 +79,15 @@ export function OperationsAgentDetail({
                 {agent.name}
               </h2>
               <p className="mt-2 text-sm text-[var(--theme-muted-2)]">
-                Update this agent without leaving the roster.
+                Model changes apply to the next agent session or process
+                restart.
               </p>
             </div>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="inline-flex size-10 items-center justify-center rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] text-lg text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-accent)] hover:text-[var(--theme-accent-strong)]"
+            className="inline-flex size-10 items-center justify-center rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)] hover:text-[var(--theme-accent-strong)]"
             aria-label="Close agent settings"
           >
             <HugeiconsIcon icon={Cancel01Icon} size={18} strokeWidth={1.8} />
@@ -242,16 +96,19 @@ export function OperationsAgentDetail({
 
         <div className="mt-6 grid gap-4 md:grid-cols-[1.2fr_0.6fr]">
           <label className="space-y-2">
-            <span className="text-sm font-medium text-[var(--theme-text)]">Name</span>
+            <span className="text-sm font-medium text-[var(--theme-text)]">
+              Name
+            </span>
             <input
               value={name}
               onChange={(event) => setName(event.target.value)}
               className="w-full rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-sm text-[var(--theme-text)] outline-none focus:border-[var(--theme-accent)]"
             />
           </label>
-
           <label className="space-y-2">
-            <span className="text-sm font-medium text-[var(--theme-text)]">Emoji</span>
+            <span className="text-sm font-medium text-[var(--theme-text)]">
+              Emoji
+            </span>
             <input
               value={emoji}
               onChange={(event) => setEmoji(event.target.value)}
@@ -260,10 +117,16 @@ export function OperationsAgentDetail({
           </label>
         </div>
 
-        <label className="mt-4 block space-y-2">
-          <span className="text-sm font-medium text-[var(--theme-text)]">Model</span>
-          <ModelSelector value={model} onChange={setModel} models={models} />
-        </label>
+        <div className="mt-4">
+          <OperationsModelConfig
+            routeRef={model}
+            reasoningEffort={reasoningEffort}
+            maxOutputTokens={maxOutputTokens}
+            onRouteChange={setModel}
+            onReasoningEffortChange={setReasoningEffort}
+            onMaxOutputTokensChange={setMaxOutputTokens}
+          />
+        </div>
 
         <label className="mt-4 block space-y-2">
           <span className="text-sm font-medium text-[var(--theme-text)]">
@@ -287,12 +150,7 @@ export function OperationsAgentDetail({
             {isDeleting ? 'Deleting…' : 'Delete agent'}
           </Button>
           <div className="flex justify-end gap-3">
-            <Button
-              variant="secondary"
-              className="border border-[var(--theme-border)] bg-[var(--theme-bg)] text-[var(--theme-text)] hover:bg-[var(--theme-card2)]"
-              onClick={onClose}
-              disabled={isDeleting}
-            >
+            <Button variant="secondary" onClick={onClose} disabled={isDeleting}>
               Cancel
             </Button>
             <Button
@@ -302,11 +160,13 @@ export function OperationsAgentDetail({
                   agentId: agent.id,
                   name,
                   model,
+                  reasoningEffort,
+                  maxOutputTokens,
                   emoji,
                   systemPrompt,
                 })
               }
-              disabled={isSaving || isDeleting}
+              disabled={isSaving || isDeleting || !model.trim()}
             >
               {isSaving ? 'Saving…' : 'Save'}
             </Button>

--- a/src/screens/agents/components/operations-agent-detail.tsx
+++ b/src/screens/agents/components/operations-agent-detail.tsx
@@ -27,6 +27,7 @@ export function OperationsAgentDetail({
     model: string
     reasoningEffort?: string
     maxOutputTokens?: number
+    codexRuntime?: 'hermes_default' | 'codex_app_server'
     emoji: string
     systemPrompt: string
   }) => Promise<unknown>
@@ -39,6 +40,7 @@ export function OperationsAgentDetail({
   const [model, setModel] = useState('')
   const [reasoningEffort, setReasoningEffort] = useState<string>()
   const [maxOutputTokens, setMaxOutputTokens] = useState<number>()
+  const [codexRuntime, setCodexRuntime] = useState<'hermes_default' | 'codex_app_server'>('hermes_default')
   const [systemPrompt, setSystemPrompt] = useState('')
 
   useEffect(() => {
@@ -48,6 +50,7 @@ export function OperationsAgentDetail({
     setModel(agent.model || '')
     setReasoningEffort(agent.reasoningEffort)
     setMaxOutputTokens(agent.maxOutputTokens)
+    setCodexRuntime(agent.codexRuntime ?? 'hermes_default')
     setSystemPrompt(agent.meta.systemPrompt)
   }, [agent, open])
 
@@ -122,9 +125,11 @@ export function OperationsAgentDetail({
             routeRef={model}
             reasoningEffort={reasoningEffort}
             maxOutputTokens={maxOutputTokens}
+            codexRuntime={codexRuntime}
             onRouteChange={setModel}
             onReasoningEffortChange={setReasoningEffort}
             onMaxOutputTokensChange={setMaxOutputTokens}
+            onCodexRuntimeChange={setCodexRuntime}
           />
         </div>
 
@@ -162,6 +167,7 @@ export function OperationsAgentDetail({
                   model,
                   reasoningEffort,
                   maxOutputTokens,
+                  codexRuntime,
                   emoji,
                   systemPrompt,
                 })

--- a/src/screens/agents/components/operations-model-config.test.ts
+++ b/src/screens/agents/components/operations-model-config.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildOutputCapOptions,
+  groupOperationsCatalogModels,
+  operationsModelDisplayName,
+  operationsModelLifecycle,
+} from './operations-model-config'
+
+const models = [
+  {
+    id: 'claude-cwm4tx/opus-5',
+    provider: 'claude-max-relay',
+    account: 'cwm4tx',
+    model: 'opus-5',
+    transport: 'claude-cli-oauth',
+    billingClass: 'subscription_included',
+    status: 'available',
+    selectable: true,
+    warning: '',
+    resetAt: null,
+  },
+  {
+    id: 'nous/google/gemini-3.1-pro-preview',
+    provider: 'nous',
+    account: 'nous',
+    model: 'google/gemini-3.1-pro-preview',
+    transport: 'nous-oauth',
+    billingClass: 'subscription_unknown',
+    status: 'available',
+    selectable: true,
+    warning: 'Entitlement varies',
+    resetAt: null,
+  },
+  {
+    id: 'openai-codex/gpt-5.6-sol',
+    provider: 'openai-codex',
+    account: 'openai-codex',
+    model: 'gpt-5.6-sol',
+    transport: 'openai-codex-oauth',
+    billingClass: 'subscription_included',
+    status: 'available',
+    selectable: true,
+    warning: '',
+    resetAt: null,
+  },
+  {
+    id: 'google-antigravity/gemini-3.1-pro',
+    provider: 'google-antigravity',
+    account: 'google-antigravity',
+    model: 'gemini-3.1-pro',
+    transport: 'google-antigravity-oauth',
+    billingClass: 'subscription_included',
+    status: 'available',
+    selectable: true,
+    warning: '',
+    resetAt: null,
+  },
+  {
+    id: 'blocked/model',
+    provider: 'blocked',
+    account: 'blocked',
+    model: 'model',
+    transport: 'blocked',
+    billingClass: 'api_billed',
+    status: 'unavailable',
+    selectable: false,
+    warning: '',
+    resetAt: null,
+  },
+] as const
+
+describe('Operations model catalog grouping', () => {
+  it('groups selectable routes by account-aware transport and searches all labels', () => {
+    expect(groupOperationsCatalogModels(models as any, 'gemini', '')).toEqual([
+      { label: 'Antigravity — Gemini', models: [models[3]] },
+    ])
+    expect(groupOperationsCatalogModels(models as any, '', '')[0]?.label).toBe(
+      'Claude Max — CWM',
+    )
+    expect(operationsModelDisplayName(models[3] as any)).toBe(
+      'Antigravity — Gemini 3.1 Pro',
+    )
+    expect(operationsModelDisplayName(models[2] as any)).toBe(
+      'OpenAI Codex — GPT 5.6 Sol',
+    )
+  })
+
+  it('always shows Codex while hiding Nous and API models until explicitly unhidden', () => {
+    const defaultIds = groupOperationsCatalogModels(models as any, '', '')
+      .flatMap((group) => group.models.map((model) => model.id))
+    expect(defaultIds).toContain('openai-codex/gpt-5.6-sol')
+    expect(defaultIds).not.toContain('nous/google/gemini-3.1-pro-preview')
+    expect(defaultIds).not.toContain('blocked/model')
+
+    const visibleIds = groupOperationsCatalogModels(
+      models as any,
+      '',
+      '',
+      false,
+      { showNous: true, showApi: true },
+    ).flatMap((group) => group.models.map((model) => model.id))
+    expect(visibleIds).toContain('nous/google/gemini-3.1-pro-preview')
+    expect(visibleIds).not.toContain('blocked/model')
+  })
+
+  it('preserves a selected unknown legacy route without exposing blocked catalog routes', () => {
+    const grouped = groupOperationsCatalogModels(
+      models as any,
+      '',
+      'legacy/model',
+    )
+    expect(
+      grouped.flatMap((group) => group.models).map((model) => model.id),
+    ).toEqual([
+      'legacy/model',
+      'claude-cwm4tx/opus-5',
+      'openai-codex/gpt-5.6-sol',
+      'google-antigravity/gemini-3.1-pro',
+    ])
+  })
+
+  it('preserves a selected catalog route that becomes unavailable', () => {
+    const expired = {
+      ...models[0],
+      status: 'auth_expired',
+      selectable: false,
+      warning: 'Claude OAuth expired',
+    }
+    const grouped = groupOperationsCatalogModels(
+      [expired, models[1]] as any,
+      'gemini',
+      expired.id,
+    )
+
+    expect(grouped.flatMap((group) => group.models)).toContainEqual(expired)
+  })
+
+  it('prioritizes latest aliases and hides previous Claude snapshots by default', () => {
+    const claudeModels = [
+      { ...models[0], id: 'claude-cwm4tx/fable', model: 'fable' },
+      {
+        ...models[0],
+        id: 'claude-cwm4tx/claude-fable-5',
+        model: 'claude-fable-5',
+      },
+      {
+        ...models[0],
+        id: 'claude-cwm4tx/claude-opus-4-8',
+        model: 'claude-opus-4-8',
+      },
+    ]
+
+    expect(operationsModelLifecycle(claudeModels[0] as any)).toBe(
+      'latest_alias',
+    )
+    expect(operationsModelLifecycle(claudeModels[1] as any)).toBe(
+      'current_pinned',
+    )
+    expect(operationsModelLifecycle(claudeModels[2] as any)).toBe(
+      'previous_pinned',
+    )
+    expect(
+      operationsModelLifecycle({
+        ...models[1],
+        id: 'nous/anthropic/claude-opus-4.8',
+        model: 'anthropic/claude-opus-4.8',
+      } as any),
+    ).toBe('previous_pinned')
+    expect(
+      groupOperationsCatalogModels(claudeModels as any, '', '').flatMap(
+        (group) => group.models.map((model) => model.id),
+      ),
+    ).toEqual(['claude-cwm4tx/fable', 'claude-cwm4tx/claude-fable-5'])
+    expect(
+      groupOperationsCatalogModels(
+        claudeModels as any,
+        '',
+        'claude-cwm4tx/claude-opus-4-8',
+      ).flatMap((group) => group.models.map((model) => model.id)),
+    ).toContain('claude-cwm4tx/claude-opus-4-8')
+    expect(
+      groupOperationsCatalogModels(claudeModels as any, '', '', true).flatMap(
+        (group) => group.models.map((model) => model.id),
+      ),
+    ).toContain('claude-cwm4tx/claude-opus-4-8')
+  })
+
+  it('builds configured output caps from each model hard maximum', () => {
+    expect(buildOutputCapOptions(65_536)).toEqual([
+      4096, 8192, 16_384, 32_768, 65_536,
+    ])
+    expect(buildOutputCapOptions(256_000)).toEqual([
+      4096, 8192, 16_384, 32_768, 65_536, 128_000, 256_000,
+    ])
+    expect(buildOutputCapOptions(8192, 6000)).toEqual([4096, 6000, 8192])
+  })
+})

--- a/src/screens/agents/components/operations-model-config.tsx
+++ b/src/screens/agents/components/operations-model-config.tsx
@@ -254,16 +254,20 @@ export function OperationsModelConfig({
   routeRef,
   reasoningEffort,
   maxOutputTokens,
+  codexRuntime = 'hermes_default',
   onRouteChange,
   onReasoningEffortChange,
   onMaxOutputTokensChange,
+  onCodexRuntimeChange,
 }: {
   routeRef: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime?: 'hermes_default' | 'codex_app_server'
   onRouteChange: (value: string) => void
   onReasoningEffortChange: (value: string | undefined) => void
   onMaxOutputTokensChange: (value: number | undefined) => void
+  onCodexRuntimeChange?: (value: 'hermes_default' | 'codex_app_server') => void
 }) {
   const [search, setSearch] = useState('')
   const [showPreviousVersions, setShowPreviousVersions] = useState(false)
@@ -345,6 +349,23 @@ export function OperationsModelConfig({
           ))}
         </select>
       </label>
+
+      {selected?.provider === 'openai-codex' ? (
+        <label className="block space-y-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3">
+          <span className="text-sm font-medium text-[var(--theme-text)]">Codex runtime</span>
+          <select
+            value={codexRuntime}
+            onChange={(event) => onCodexRuntimeChange?.(event.target.value as 'hermes_default' | 'codex_app_server')}
+            className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-sm text-[var(--theme-text)]"
+          >
+            <option value="hermes_default">Hermes default — Hermes owns tools and the agent loop</option>
+            <option value="codex_app_server">Codex app-server — native threads, approvals, steering, and interrupts</option>
+          </select>
+          <p className="text-xs text-[var(--theme-muted-2)]">
+            Applies on the next session or worker restart; this does not hot-swap a running process.
+          </p>
+        </label>
+      ) : null}
 
       {catalog.isLoading ? (
         <p className="text-xs text-[var(--theme-muted)]">

--- a/src/screens/agents/components/operations-model-config.tsx
+++ b/src/screens/agents/components/operations-model-config.tsx
@@ -1,0 +1,463 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+export type OperationsCatalogCapabilities = {
+  contextWindow: number | null
+  maxInputTokens: number | null
+  maxOutputTokens: number | null
+  supportsReasoning: boolean
+  supportsTools: boolean
+  supportsVision: boolean
+  supportsOutputTokenLimit: boolean
+  reasoningEfforts: Array<string>
+  metadataSource: string
+}
+
+export type OperationsCatalogModel = {
+  id: string
+  provider: string
+  account: string
+  model: string
+  transport: string
+  billingClass: 'subscription_included' | 'subscription_unknown' | 'api_billed'
+  status: string
+  selectable: boolean
+  warning: string
+  resetAt: string | null
+  capabilities?: OperationsCatalogCapabilities
+}
+
+type ModelGroup = { label: string; models: Array<OperationsCatalogModel> }
+
+export type OperationsCatalogVisibility = {
+  showNous: boolean
+  showApi: boolean
+}
+
+export type OperationsModelLifecycle =
+  | 'latest_alias'
+  | 'current_pinned'
+  | 'previous_pinned'
+
+export function operationsModelLifecycle(
+  model: OperationsCatalogModel,
+): OperationsModelLifecycle {
+  const canonicalModel = (model.model.split('/').at(-1) ?? model.model).replace(
+    /\.(?=\d)/g,
+    '-',
+  )
+  if (
+    model.provider === 'claude-max-relay' &&
+    /^(?:fable|opus|sonnet|haiku)$/.test(canonicalModel)
+  ) {
+    return 'latest_alias'
+  }
+  if (/^claude-(?:fable|opus|sonnet)-5$/.test(canonicalModel)) {
+    return 'current_pinned'
+  }
+  return /^claude-(?:fable|opus|sonnet|haiku)-\d/.test(canonicalModel)
+    ? 'previous_pinned'
+    : 'current_pinned'
+}
+
+export function buildOutputCapOptions(
+  hardMaximum: number | null | undefined,
+  configured?: number,
+): Array<number> {
+  if (!hardMaximum) return configured ? [configured] : []
+  return Array.from(
+    new Set(
+      [4096, 8192, 16_384, 32_768, 65_536, 128_000, hardMaximum, configured]
+        .filter((value): value is number => Boolean(value))
+        .filter((value) => value <= hardMaximum),
+    ),
+  ).sort((a, b) => a - b)
+}
+
+function groupLabel(model: OperationsCatalogModel): string {
+  if (model.provider === 'claude-max-relay') {
+    if (model.account === 'cwm4tx') return 'Claude Max — CWM'
+    if (model.account === 'gp') return 'Claude Max — GP'
+    return `Claude Max — ${model.account}`
+  }
+  if (model.provider === 'openai-codex') return 'OpenAI Codex OAuth'
+  if (model.provider === 'google-antigravity') return 'Antigravity — Gemini'
+  if (model.provider === 'nous') return 'Nous — hidden provider'
+  if (model.provider === 'legacy') return 'Legacy / unavailable'
+  return `${model.provider} · ${model.account}`
+}
+
+function prettyModelName(model: string): string {
+  return model
+    .replace(/[_-]+/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) =>
+      part.toLowerCase() === 'gpt'
+        ? 'GPT'
+        : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join(' ')
+}
+
+export function operationsModelDisplayName(
+  model: OperationsCatalogModel,
+): string {
+  const name = prettyModelName(model.model.split('/').at(-1) ?? model.model)
+  if (model.provider === 'google-antigravity') return `Antigravity — ${name}`
+  if (model.provider === 'openai-codex') return `OpenAI Codex — ${name}`
+  if (model.provider === 'claude-max-relay') {
+    const account =
+      model.account === 'cwm4tx'
+        ? 'CWM'
+        : model.account === 'gp'
+          ? 'GP'
+          : model.account
+    return `Claude Max — ${account} — ${name}`
+  }
+  return name
+}
+
+export function groupOperationsCatalogModels(
+  input: Array<OperationsCatalogModel>,
+  search: string,
+  selectedRoute: string,
+  showPreviousVersions = false,
+  visibility: OperationsCatalogVisibility = {
+    showNous: false,
+    showApi: false,
+  },
+): Array<ModelGroup> {
+  const selectedKnown = input.some((model) => model.id === selectedRoute)
+  const legacy: Array<OperationsCatalogModel> =
+    selectedRoute && !selectedKnown
+      ? [
+          {
+            id: selectedRoute,
+            provider: 'legacy',
+            account: 'legacy',
+            model: selectedRoute,
+            transport: 'unknown',
+            billingClass: 'subscription_unknown',
+            status: 'unavailable',
+            selectable: false,
+            warning:
+              'Legacy route is preserved until you deliberately select a replacement.',
+            resetAt: null,
+          },
+        ]
+      : []
+  const query = search.trim().toLowerCase()
+  const visible = [
+    ...legacy,
+    ...input.filter(
+      (model) =>
+        (model.id === selectedRoute ||
+          (model.selectable &&
+            (model.provider !== 'nous' || visibility.showNous) &&
+            (model.billingClass !== 'api_billed' || visibility.showApi))) &&
+        (showPreviousVersions ||
+          model.id === selectedRoute ||
+          operationsModelLifecycle(model) !== 'previous_pinned'),
+    ),
+  ].filter(
+    (model) =>
+      model.id === selectedRoute ||
+      !query ||
+      [
+        model.id,
+        model.provider,
+        model.account,
+        model.model,
+        model.transport,
+        operationsModelDisplayName(model),
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(query),
+  )
+  const groups = new Map<string, Array<OperationsCatalogModel>>()
+  for (const model of visible) {
+    const label = groupLabel(model)
+    const rows = groups.get(label) ?? []
+    rows.push(model)
+    groups.set(label, rows)
+  }
+  const lifecycleRank: Record<OperationsModelLifecycle, number> = {
+    latest_alias: 0,
+    current_pinned: 1,
+    previous_pinned: 2,
+  }
+  for (const rows of groups.values()) {
+    rows.sort(
+      (a, b) =>
+        lifecycleRank[operationsModelLifecycle(a)] -
+          lifecycleRank[operationsModelLifecycle(b)] ||
+        a.model.localeCompare(b.model),
+    )
+  }
+  return Array.from(groups, ([label, models]) => ({ label, models }))
+}
+
+async function fetchOperationsCatalog(): Promise<{
+  models: Array<OperationsCatalogModel>
+  visibility: OperationsCatalogVisibility
+}> {
+  const response = await fetch('/api/orchestration-catalog')
+  const body = (await response.json().catch(() => ({}))) as {
+    ok?: boolean
+    error?: string
+    models?: Array<OperationsCatalogModel>
+    visibility?: {
+      showNousModels?: boolean
+      showApiBilledModels?: boolean
+    }
+  }
+  if (!response.ok || body.ok === false) {
+    throw new Error(body.error || `Catalog request failed (${response.status})`)
+  }
+  return {
+    models: Array.isArray(body.models) ? body.models : [],
+    visibility: {
+      showNous: body.visibility?.showNousModels === true,
+      showApi: body.visibility?.showApiBilledModels === true,
+    },
+  }
+}
+
+function tokens(value: number | null | undefined): string {
+  return value
+    ? new Intl.NumberFormat().format(value)
+    : 'Not separately published'
+}
+
+function effortLabel(value: string): string {
+  if (value === 'provider_default') return 'Provider default'
+  if (value === 'xhigh') return 'XHigh'
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function routeLabel(model: OperationsCatalogModel): string {
+  const lifecycle = operationsModelLifecycle(model)
+  const suffix =
+    lifecycle === 'latest_alias'
+      ? 'Latest alias'
+      : lifecycle === 'previous_pinned'
+        ? 'Previous · pinned'
+        : model.provider === 'claude-max-relay'
+          ? 'Current · pinned'
+          : 'Pinned route'
+  return `${operationsModelDisplayName(model)} · ${suffix} · ${model.status}`
+}
+
+export function OperationsModelConfig({
+  routeRef,
+  reasoningEffort,
+  maxOutputTokens,
+  onRouteChange,
+  onReasoningEffortChange,
+  onMaxOutputTokensChange,
+}: {
+  routeRef: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
+  onRouteChange: (value: string) => void
+  onReasoningEffortChange: (value: string | undefined) => void
+  onMaxOutputTokensChange: (value: number | undefined) => void
+}) {
+  const [search, setSearch] = useState('')
+  const [showPreviousVersions, setShowPreviousVersions] = useState(false)
+  const catalog = useQuery({
+    queryKey: ['operations', 'orchestration-catalog'],
+    queryFn: fetchOperationsCatalog,
+  })
+  const models = catalog.data?.models ?? []
+  const groups = useMemo(
+    () =>
+      groupOperationsCatalogModels(
+        models,
+        search,
+        routeRef,
+        showPreviousVersions,
+        catalog.data?.visibility,
+      ),
+    [catalog.data?.visibility, models, routeRef, search, showPreviousVersions],
+  )
+  const selected = models.find((model) => model.id === routeRef)
+  const capabilities = selected?.capabilities
+  const outputOptions = buildOutputCapOptions(
+    capabilities?.maxOutputTokens,
+    maxOutputTokens,
+  )
+  const hasPreviousVersions = models.some(
+    (model) => operationsModelLifecycle(model) === 'previous_pinned',
+  )
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+      <label className="block space-y-2">
+        <span className="text-sm font-medium text-[var(--theme-text)]">
+          Search subscription models
+        </span>
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Provider, account, family, or version…"
+          className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none focus:border-[var(--theme-accent)]"
+        />
+      </label>
+      {hasPreviousVersions ? (
+        <label className="flex items-center gap-2 text-xs text-[var(--theme-muted-2)]">
+          <input
+            type="checkbox"
+            checked={showPreviousVersions}
+            onChange={(event) => setShowPreviousVersions(event.target.checked)}
+          />
+          Show previous pinned Claude versions
+        </label>
+      ) : null}
+      <label className="block space-y-2">
+        <span className="text-sm font-medium text-[var(--theme-text)]">
+          Model route
+        </span>
+        <select
+          value={routeRef}
+          onChange={(event) => {
+            onRouteChange(event.target.value)
+            onReasoningEffortChange(undefined)
+            onMaxOutputTokensChange(undefined)
+          }}
+          className="min-h-12 w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-text)] outline-none focus:border-[var(--theme-accent)]"
+        >
+          <option value="">Select a validated subscription route…</option>
+          {groups.map((group) => (
+            <optgroup key={group.label} label={group.label}>
+              {group.models.map((model) => (
+                <option
+                  key={model.id}
+                  value={model.id}
+                  disabled={!model.selectable}
+                >
+                  {routeLabel(model)}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </label>
+
+      {catalog.isLoading ? (
+        <p className="text-xs text-[var(--theme-muted)]">
+          Loading live OAuth catalog…
+        </p>
+      ) : null}
+      {catalog.error ? (
+        <p className="text-xs text-red-600">{catalog.error.message}</p>
+      ) : null}
+      {selected?.warning ? (
+        <p className="text-xs text-amber-600">{selected.warning}</p>
+      ) : null}
+      {routeRef && !selected ? (
+        <p className="text-xs text-amber-600">
+          This legacy route is unavailable. It will be preserved unless you
+          select a replacement.
+        </p>
+      ) : null}
+
+      {selected ? (
+        <div className="space-y-3 border-t border-[var(--theme-border)] pt-3">
+          <div className="grid gap-2 text-xs text-[var(--theme-muted-2)] sm:grid-cols-3">
+            <div>
+              <span className="block text-[var(--theme-muted)]">
+                Maximum prompt input
+              </span>
+              {tokens(capabilities?.maxInputTokens)}
+            </div>
+            <div>
+              <span className="block text-[var(--theme-muted)]">
+                Total context window
+              </span>
+              {tokens(capabilities?.contextWindow)}
+            </div>
+            <div>
+              <span className="block text-[var(--theme-muted)]">
+                Model metadata hard max output
+              </span>
+              {tokens(capabilities?.maxOutputTokens)}
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-2">
+              <span className="text-xs font-medium text-[var(--theme-text)]">
+                Reasoning / thinking effort
+              </span>
+              <select
+                value={reasoningEffort || 'provider_default'}
+                onChange={(event) =>
+                  onReasoningEffortChange(
+                    event.target.value === 'provider_default'
+                      ? undefined
+                      : event.target.value,
+                  )
+                }
+                disabled={!capabilities?.supportsReasoning}
+                className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-text)] disabled:opacity-50"
+              >
+                {(capabilities?.reasoningEfforts ?? ['provider_default']).map(
+                  (value) => (
+                    <option key={value} value={value}>
+                      {effortLabel(value)}
+                    </option>
+                  ),
+                )}
+              </select>
+            </label>
+            <label className="space-y-2">
+              <span className="text-xs font-medium text-[var(--theme-text)]">
+                Optional agent output cap
+              </span>
+              <select
+                value={maxOutputTokens ? String(maxOutputTokens) : ''}
+                onChange={(event) =>
+                  onMaxOutputTokensChange(
+                    event.target.value ? Number(event.target.value) : undefined,
+                  )
+                }
+                disabled={
+                  !capabilities?.maxOutputTokens ||
+                  !capabilities.supportsOutputTokenLimit
+                }
+                className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm text-[var(--theme-text)] disabled:opacity-50"
+              >
+                <option value="">
+                  {capabilities?.supportsOutputTokenLimit
+                    ? 'Use provider/model default (recommended)'
+                    : 'Transport does not expose an output-token cap'}
+                </option>
+                {outputOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {value === capabilities?.maxOutputTokens
+                      ? `Hard maximum — ${tokens(value)}`
+                      : `Cap at ${tokens(value)}`}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <p className="text-xs text-[var(--theme-muted)]">
+            The hard maximum is provider-published metadata for this selected
+            model, not a recommended response size. Leave the optional cap at
+            its default unless this agent needs a smaller bounded response.
+          </p>
+          <p className="text-xs text-[var(--theme-muted)]">
+            Transport: {selected.transport} · Billing:{' '}
+            {selected.billingClass.replaceAll('_', ' ')}
+            {capabilities
+              ? ` · Metadata: ${capabilities.metadataSource}`
+              : ' · Limits not published'}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/screens/agents/components/operations-new-agent-modal.tsx
+++ b/src/screens/agents/components/operations-new-agent-modal.tsx
@@ -49,6 +49,7 @@ export function OperationsNewAgentModal({
     model: string
     reasoningEffort?: string
     maxOutputTokens?: number
+    codexRuntime?: 'hermes_default' | 'codex_app_server'
     systemPrompt: string
     description?: string
   }) => Promise<unknown>
@@ -60,6 +61,7 @@ export function OperationsNewAgentModal({
   const [model, setModel] = useState(defaultModel)
   const [reasoningEffort, setReasoningEffort] = useState<string>()
   const [maxOutputTokens, setMaxOutputTokens] = useState<number>()
+  const [codexRuntime, setCodexRuntime] = useState<'hermes_default' | 'codex_app_server'>('hermes_default')
   const [description, setDescription] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('')
 
@@ -71,6 +73,7 @@ export function OperationsNewAgentModal({
     setModel(defaultModel)
     setReasoningEffort(undefined)
     setMaxOutputTokens(undefined)
+    setCodexRuntime('hermes_default')
     setDescription('')
     setSystemPrompt('')
   }, [defaultModel, open])
@@ -178,9 +181,11 @@ export function OperationsNewAgentModal({
             routeRef={model}
             reasoningEffort={reasoningEffort}
             maxOutputTokens={maxOutputTokens}
+            codexRuntime={codexRuntime}
             onRouteChange={setModel}
             onReasoningEffortChange={setReasoningEffort}
             onMaxOutputTokensChange={setMaxOutputTokens}
+            onCodexRuntimeChange={setCodexRuntime}
           />
         </div>
 
@@ -225,6 +230,7 @@ export function OperationsNewAgentModal({
                 model,
                 reasoningEffort,
                 maxOutputTokens,
+                codexRuntime,
                 systemPrompt,
                 description,
               }).then(() => onClose())

--- a/src/screens/agents/components/operations-new-agent-modal.tsx
+++ b/src/screens/agents/components/operations-new-agent-modal.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { ArrowDown01Icon, Cancel01Icon, PlusSignIcon } from '@hugeicons/core-free-icons'
+import { useEffect, useState } from 'react'
+import { Cancel01Icon, PlusSignIcon } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Button } from '@/components/ui/button'
-import { fetchModels, type GatewayModelCatalogEntry } from '@/lib/gateway-api'
-import { cn } from '@/lib/utils'
 import { AGENT_PRESETS } from '../agent-presets'
+import { OperationsModelConfig } from './operations-model-config'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 type PresetOption = {
   id: string
@@ -15,7 +14,7 @@ type PresetOption = {
   systemPrompt: string
 }
 
-const PRESET_OPTIONS: PresetOption[] = [
+const PRESET_OPTIONS: Array<PresetOption> = [
   {
     id: 'blank',
     name: 'Blank',
@@ -34,102 +33,6 @@ const PRESET_OPTIONS: PresetOption[] = [
     })),
 ]
 
-type AvailableModel = {
-  id: string
-  provider: string
-  name: string
-}
-
-function normalizeModel(model: GatewayModelCatalogEntry): AvailableModel | null {
-  if (typeof model === 'string') {
-    return {
-      id: model,
-      provider: model.includes('/') ? (model.split('/')[0] ?? 'model') : 'model',
-      name: model.split('/').pop() ?? model,
-    }
-  }
-
-  const id = model.id ?? model.alias ?? model.model ?? ''
-  if (!id) return null
-
-  return {
-    id,
-    provider: model.provider ?? id.split('/')[0] ?? 'model',
-    name: model.label ?? model.displayName ?? model.name ?? id.split('/').pop() ?? id,
-  }
-}
-
-function ModelSelector({
-  value,
-  onChange,
-  models,
-}: {
-  value: string
-  onChange: (nextValue: string) => void
-  models: AvailableModel[]
-}) {
-  const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    if (!open) return
-    function handlePointerDown(event: MouseEvent) {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handlePointerDown)
-    return () => document.removeEventListener('mousedown', handlePointerDown)
-  }, [open])
-
-  const selected = models.find((model) => model.id === value)
-
-  return (
-    <div className="relative" ref={containerRef}>
-      <button
-        type="button"
-        onClick={() => setOpen((current) => !current)}
-        className="inline-flex min-h-[3rem] w-full items-center justify-between gap-3 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-4 py-3 text-left text-sm text-[var(--theme-text)] shadow-[0_8px_24px_color-mix(in_srgb,var(--theme-shadow)_18%,transparent)]"
-      >
-        <span className="truncate">
-          {selected ? `${selected.provider} / ${selected.name}` : 'Default (auto)'}
-        </span>
-        <HugeiconsIcon
-          icon={ArrowDown01Icon}
-          size={16}
-          strokeWidth={1.8}
-          className={cn('text-[var(--theme-muted)] transition-transform', open && 'rotate-180')}
-        />
-      </button>
-
-      {open ? (
-        <div className="absolute left-0 top-[calc(100%+0.5rem)] z-[80] w-full overflow-hidden rounded-2xl border border-[var(--theme-border2)] bg-[var(--theme-card)] shadow-[0_24px_80px_var(--theme-shadow)]">
-          <div className="max-h-80 overflow-y-auto p-2">
-            {models.map((model) => (
-              <button
-                key={model.id}
-                type="button"
-                onClick={() => {
-                  onChange(model.id)
-                  setOpen(false)
-                }}
-                className={cn(
-                  'flex w-full rounded-xl px-3 py-2.5 text-left text-sm',
-                  value === model.id
-                    ? 'bg-[var(--theme-accent-soft)]'
-                    : 'hover:bg-[var(--theme-bg)]',
-                )}
-              >
-                {model.provider} / {model.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
 export function OperationsNewAgentModal({
   open,
   defaultModel,
@@ -144,6 +47,8 @@ export function OperationsNewAgentModal({
     name: string
     emoji: string
     model: string
+    reasoningEffort?: string
+    maxOutputTokens?: number
     systemPrompt: string
     description?: string
   }) => Promise<unknown>
@@ -153,6 +58,8 @@ export function OperationsNewAgentModal({
   const [name, setName] = useState('')
   const [emoji, setEmoji] = useState('🤖')
   const [model, setModel] = useState(defaultModel)
+  const [reasoningEffort, setReasoningEffort] = useState<string>()
+  const [maxOutputTokens, setMaxOutputTokens] = useState<number>()
   const [description, setDescription] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('')
 
@@ -162,6 +69,8 @@ export function OperationsNewAgentModal({
     setName('')
     setEmoji('🤖')
     setModel(defaultModel)
+    setReasoningEffort(undefined)
+    setMaxOutputTokens(undefined)
     setDescription('')
     setSystemPrompt('')
   }, [defaultModel, open])
@@ -175,20 +84,6 @@ export function OperationsNewAgentModal({
     setDescription(preset.description)
     setSystemPrompt(preset.systemPrompt)
   }
-
-  const modelsQuery = useQuery({
-    queryKey: ['operations', 'models'],
-    queryFn: fetchModels,
-    enabled: open,
-  })
-
-  const models = useMemo(
-    () =>
-      (modelsQuery.data?.models ?? [])
-        .map(normalizeModel)
-        .filter((entry): entry is AvailableModel => Boolean(entry)),
-    [modelsQuery.data?.models],
-  )
 
   if (!open) return null
 
@@ -247,14 +142,16 @@ export function OperationsNewAgentModal({
             ))}
           </div>
           <p className="text-xs text-[var(--theme-muted)]">
-            Templates fill in emoji, description, and system prompt. You can edit
-            everything before creating.
+            Templates fill in emoji, description, and system prompt. You can
+            edit everything before creating.
           </p>
         </div>
 
         <div className="mt-4 grid gap-4 md:grid-cols-[1.2fr_0.6fr]">
           <label className="space-y-2">
-            <span className="text-sm font-medium text-[var(--theme-text)]">Name</span>
+            <span className="text-sm font-medium text-[var(--theme-text)]">
+              Name
+            </span>
             <input
               value={name}
               onChange={(event) => setName(event.target.value)}
@@ -264,7 +161,9 @@ export function OperationsNewAgentModal({
           </label>
 
           <label className="space-y-2">
-            <span className="text-sm font-medium text-[var(--theme-text)]">Emoji</span>
+            <span className="text-sm font-medium text-[var(--theme-text)]">
+              Emoji
+            </span>
             <input
               value={emoji}
               onChange={(event) => setEmoji(event.target.value)}
@@ -274,13 +173,21 @@ export function OperationsNewAgentModal({
           </label>
         </div>
 
-        <label className="mt-4 block space-y-2">
-          <span className="text-sm font-medium text-[var(--theme-text)]">Model</span>
-          <ModelSelector value={model} onChange={setModel} models={models} />
-        </label>
+        <div className="mt-4">
+          <OperationsModelConfig
+            routeRef={model}
+            reasoningEffort={reasoningEffort}
+            maxOutputTokens={maxOutputTokens}
+            onRouteChange={setModel}
+            onReasoningEffortChange={setReasoningEffort}
+            onMaxOutputTokensChange={setMaxOutputTokens}
+          />
+        </div>
 
         <label className="mt-4 block space-y-2">
-          <span className="text-sm font-medium text-[var(--theme-text)]">Description</span>
+          <span className="text-sm font-medium text-[var(--theme-text)]">
+            Description
+          </span>
           <input
             value={description}
             onChange={(event) => setDescription(event.target.value)}
@@ -316,11 +223,13 @@ export function OperationsNewAgentModal({
                 name,
                 emoji,
                 model,
+                reasoningEffort,
+                maxOutputTokens,
                 systemPrompt,
                 description,
               }).then(() => onClose())
             }
-            disabled={isSaving || !name.trim()}
+            disabled={isSaving || !name.trim() || !model.trim()}
           >
             {isSaving ? 'Creating…' : 'Create Agent'}
           </Button>

--- a/src/screens/agents/components/provider-runtime-panel.tsx
+++ b/src/screens/agents/components/provider-runtime-panel.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+type RuntimeRecord = {
+  runtimeId: string
+  kind: 'claude_session' | 'codex_thread' | 'hermes_profile'
+  routeRef: string | null
+  accountAlias: string
+  externalId: string
+  cwd: string | null
+  worktree: string | null
+  hostStatus: string
+  kanbanTaskId: string | null
+  capabilities: Record<string, { state: string; explanation: string }>
+}
+
+type RuntimeRoute = { id: string; account: string; model: string; status: string }
+type Inventory = {
+  runtimes: Array<RuntimeRecord>
+  availableRoutes: Array<RuntimeRoute>
+  refresh: Array<{ source: string; ok: boolean; count: number; error?: string }>
+  directProviderMessaging: { enabled: false; state: string; explanation: string }
+}
+
+function runtimeAccount(runtime: RuntimeRecord): string {
+  return runtime.kind === 'codex_thread' ? 'openai-codex' : runtime.accountAlias
+}
+
+export function ProviderRuntimePanel() {
+  const [inventory, setInventory] = useState<Inventory | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [routeByRuntime, setRouteByRuntime] = useState<Record<string, string>>({})
+  const [textByRuntime, setTextByRuntime] = useState<Record<string, string>>({})
+  const [turnByRuntime, setTurnByRuntime] = useState<Record<string, string>>({})
+  const [kanbanByRuntime, setKanbanByRuntime] = useState<Record<string, string>>({})
+  const [busy, setBusy] = useState<string | null>(null)
+  const [create, setCreate] = useState(() => ({ accountAlias: 'cwm4tx', routeRef: '', worktree: '', prompt: '', requestId: crypto.randomUUID() }))
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/provider-runtimes')
+      const body = await response.json() as Inventory & { error?: string }
+      if (!response.ok) throw new Error(body.error || 'Runtime inventory failed')
+      setInventory(body)
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Runtime inventory failed')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  async function refreshFromProviders() {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/provider-runtimes', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'refresh' }) })
+      const body = await response.json() as { error?: string }
+      if (!response.ok) throw new Error(body.error || 'Provider refresh failed')
+      await refresh()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Provider refresh failed')
+      setLoading(false)
+    }
+  }
+
+  const routesByAccount = useMemo(() => {
+    const grouped: Record<string, Array<RuntimeRoute>> = {}
+    for (const route of inventory?.availableRoutes ?? []) (grouped[route.account] ||= []).push(route)
+    return grouped
+  }, [inventory])
+
+  async function mutate(body: Record<string, unknown>, key: string): Promise<boolean> {
+    setBusy(key)
+    setError(null)
+    try {
+      const response = await fetch('/api/provider-runtimes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const result = await response.json() as { error?: string; result?: { error?: string } }
+      if (!response.ok) throw new Error(result.error || result.result?.error || 'Runtime action was rejected')
+      await refresh()
+      return true
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Runtime action failed')
+      return false
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function createClaude(background: boolean) {
+    const ok = await mutate({
+      action: background ? 'background' : 'create',
+      accountAlias: create.accountAlias,
+      routeRef: create.routeRef,
+      cwd: create.worktree,
+      worktree: create.worktree,
+      prompt: create.prompt,
+      requestId: create.requestId,
+    }, background ? 'create-background' : 'create')
+    if (ok) setCreate((value) => ({ ...value, prompt: '', requestId: crypto.randomUUID() }))
+  }
+
+  return (
+    <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--theme-text)]">Provider-native runtimes</h2>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+            Claude UUID sessions and Codex app-server threads. Kanban remains authoritative; direct provider messaging is disabled.
+          </p>
+        </div>
+        <Button variant="secondary" disabled={loading} onClick={() => void refreshFromProviders()}>
+          {loading ? 'Refreshing…' : 'Refresh inventory'}
+        </Button>
+      </div>
+
+      {error ? <p className="mt-3 rounded-xl bg-[var(--theme-danger-soft)] px-3 py-2 text-sm text-[var(--theme-danger)]">{error}</p> : null}
+
+      <div className="mt-4 grid gap-2 rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-3 md:grid-cols-4">
+        <select className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" value={create.accountAlias} onChange={(event) => setCreate((value) => ({ ...value, accountAlias: event.target.value, routeRef: '' }))}>
+          <option value="cwm4tx">Claude Max CWM</option>
+          <option value="gp">Claude Max GP</option>
+        </select>
+        <select className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" value={create.routeRef} onChange={(event) => setCreate((value) => ({ ...value, routeRef: event.target.value }))}>
+          <option value="">Select subscription route</option>
+          {(routesByAccount[create.accountAlias] ?? []).map((route) => <option key={route.id} value={route.id}>{route.id}</option>)}
+        </select>
+        <input className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" placeholder="Isolated worktree path" value={create.worktree} onChange={(event) => setCreate((value) => ({ ...value, worktree: event.target.value }))} />
+        <input className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" placeholder="Initial prompt (stdin only)" value={create.prompt} onChange={(event) => setCreate((value) => ({ ...value, prompt: event.target.value }))} />
+        <div className="flex gap-2 md:col-span-4">
+          <Button disabled={busy !== null || !create.routeRef || !create.worktree || !create.prompt} onClick={() => void createClaude(false)}>Create Claude UUID</Button>
+          <Button variant="secondary" disabled title="Disabled until durable background writer ownership is implemented">Create background (unavailable)</Button>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {(inventory?.runtimes ?? []).map((runtime) => {
+          const account = runtimeAccount(runtime)
+          const routes = routesByAccount[account] ?? []
+          const routeRef = routeByRuntime[runtime.runtimeId] || runtime.routeRef || ''
+          const text = textByRuntime[runtime.runtimeId] || ''
+          const turnId = turnByRuntime[runtime.runtimeId] || ''
+          const kanbanTaskId = kanbanByRuntime[runtime.runtimeId] ?? runtime.kanbanTaskId ?? ''
+          const allows = (operation: string) => ['supported', 'degraded', 'experimental'].includes(runtime.capabilities[operation]?.state ?? '')
+          const common = { runtimeId: runtime.runtimeId, accountAlias: runtime.accountAlias, routeRef, cwd: runtime.cwd, worktree: runtime.worktree }
+          return (
+            <article key={runtime.runtimeId} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium text-[var(--theme-text)]">{runtime.kind} · {runtime.externalId.slice(0, 12)}</p>
+                  <p className="text-xs text-[var(--theme-muted)]">{runtime.accountAlias} · {runtime.hostStatus} · {runtime.worktree || 'no worktree'} · Kanban {runtime.kanbanTaskId || 'unlinked'}</p>
+                </div>
+                <span className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-xs">one writer</span>
+              </div>
+              <div className="mt-3 grid gap-2 md:grid-cols-3">
+                <select className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" value={routeRef} onChange={(event) => setRouteByRuntime((value) => ({ ...value, [runtime.runtimeId]: event.target.value }))}>
+                  <option value="">Select subscription route</option>
+                  {routes.map((route) => <option key={route.id} value={route.id}>{route.id}</option>)}
+                </select>
+                <input className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" placeholder="Follow-up / steering text" value={text} onChange={(event) => setTextByRuntime((value) => ({ ...value, [runtime.runtimeId]: event.target.value }))} />
+                {runtime.kind === 'codex_thread' ? <input className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" placeholder="Active turn ID" value={turnId} onChange={(event) => setTurnByRuntime((value) => ({ ...value, [runtime.runtimeId]: event.target.value }))} /> : <div />}
+                <input className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" placeholder="Kanban task ID" value={kanbanTaskId} onChange={(event) => setKanbanByRuntime((value) => ({ ...value, [runtime.runtimeId]: event.target.value }))} />
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {runtime.kind === 'claude_session' ? <>
+                  <Button disabled={busy !== null || !routeRef || !text} onClick={() => void mutate({ ...common, action: 'resume', prompt: text }, `${runtime.runtimeId}:resume`)}>Resume</Button>
+                  <Button variant="secondary" disabled={busy !== null || !routeRef || !text || !allows('fork')} title={runtime.capabilities.fork?.explanation} onClick={() => void mutate({ ...common, action: 'fork', prompt: text }, `${runtime.runtimeId}:fork`)}>Fork</Button>
+                  <Button variant="secondary" disabled={busy !== null || !routeRef || !allows('attach')} title={runtime.capabilities.attach?.explanation} onClick={() => void mutate({ ...common, action: 'attach' }, `${runtime.runtimeId}:attach`)}>Attach metadata</Button>
+                </> : <>
+                  <Button disabled={busy !== null || !routeRef || !allows('resume')} onClick={() => void mutate({ ...common, action: 'resume' }, `${runtime.runtimeId}:resume`)}>Resume</Button>
+                  <Button variant="secondary" disabled={busy !== null || !routeRef || !allows('fork')} onClick={() => void mutate({ ...common, action: 'fork' }, `${runtime.runtimeId}:fork`)}>Fork</Button>
+                  <Button disabled={busy !== null || !routeRef || !text || !turnId || !allows('steer')} title={runtime.capabilities.steer?.explanation} onClick={() => void mutate({ ...common, action: 'steer', text, turnId }, `${runtime.runtimeId}:steer`)}>Steer</Button>
+                  <Button variant="secondary" disabled={busy !== null || !routeRef || !turnId || !allows('interrupt')} title={runtime.capabilities.interrupt?.explanation} onClick={() => void mutate({ ...common, action: 'interrupt', turnId }, `${runtime.runtimeId}:interrupt`)}>Interrupt</Button>
+                  <Button variant="secondary" disabled={busy !== null || !routeRef || !allows('archive')} title={runtime.capabilities.archive?.explanation} onClick={() => { if (window.confirm('Archive this Codex thread?')) void mutate({ ...common, action: 'archive' }, `${runtime.runtimeId}:archive`) }}>Archive</Button>
+                </>}
+                <Button variant="secondary" disabled={busy !== null} onClick={() => void mutate({ runtimeId: runtime.runtimeId, action: 'link_kanban', kanbanTaskId }, `${runtime.runtimeId}:link`)}>Link Kanban</Button>
+              </div>
+            </article>
+          )
+        })}
+        {!loading && (inventory?.runtimes.length ?? 0) === 0 ? <p className="rounded-2xl border border-dashed border-[var(--theme-border)] p-5 text-sm text-[var(--theme-muted)]">No provider-native sessions discovered.</p> : null}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/agents/components/provider-runtime-panel.tsx
+++ b/src/screens/agents/components/provider-runtime-panel.tsx
@@ -8,6 +8,7 @@ type RuntimeRecord = {
   routeRef: string | null
   accountAlias: string
   externalId: string
+  model?: string | null
   cwd: string | null
   worktree: string | null
   hostStatus: string
@@ -157,9 +158,9 @@ export function ProviderRuntimePanel() {
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>
                   <p className="font-medium text-[var(--theme-text)]">{runtime.kind} · {runtime.externalId.slice(0, 12)}</p>
-                  <p className="text-xs text-[var(--theme-muted)]">{runtime.accountAlias} · {runtime.hostStatus} · {runtime.worktree || 'no worktree'} · Kanban {runtime.kanbanTaskId || 'unlinked'}</p>
+                  <p className="text-xs text-[var(--theme-muted)]">{runtime.accountAlias} · {runtime.model || runtime.routeRef || 'model unknown'} · {runtime.hostStatus} · {runtime.worktree || 'no worktree'} · Kanban {runtime.kanbanTaskId || 'unlinked'}</p>
                 </div>
-                <span className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-xs">one writer</span>
+                <span className="rounded-full border border-[var(--theme-border)] px-2 py-1 text-xs" title="Writer leases are acquired and checked atomically for each mutation">writer lease: enforced</span>
               </div>
               <div className="mt-3 grid gap-2 md:grid-cols-3">
                 <select className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-3 py-2 text-sm" value={routeRef} onChange={(event) => setRouteByRuntime((value) => ({ ...value, [runtime.runtimeId]: event.target.value }))}>

--- a/src/screens/agents/components/runtime-health-card.test.tsx
+++ b/src/screens/agents/components/runtime-health-card.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RuntimeHealthCard } from './runtime-health-card'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) =>
+    React.createElement('a', { href: to, ...props }, children),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, render, ...props }: {
+    children: React.ReactNode
+    render?: React.ReactElement
+    [key: string]: unknown
+  }) => render
+    ? React.cloneElement(render, props as React.HTMLAttributes<HTMLElement>, children)
+    : React.createElement('button', props, children),
+}))
+
+async function renderCard() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await React.act(async () => { root.render(<RuntimeHealthCard />) })
+  await React.act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)) })
+  return { container, unmount: async () => { await React.act(async () => root.unmount()); container.remove() } }
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => new Response(JSON.stringify({
+    ok: true,
+    runs: [],
+    summary: {
+      total: 20, active: 3, idle: 15, stopped: 1, attention: 1,
+      idleResumable: 16, linkedKanban: 18, unlinkedKanban: 2,
+      owned: 1, recoverable: 1, unknownOwnership: 1, stale: 4,
+      byProvider: { codex: 18, claude: 1, hermes: 1 },
+      byState: { active: 3, idle: 15, stopped: 1, attention: 1 },
+    },
+    page: { number: 1, size: 1, total: 20, pages: 20, hasNext: true, hasPrevious: false },
+    generatedAt: 1_000,
+  }), { status: 200 }))
+  global.fetch = fetchMock as typeof fetch
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('RuntimeHealthCard', () => {
+  it('renders bounded runtime health and never invokes provider refresh on Operations load', async () => {
+    const { container, unmount } = await renderCard()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/runtime-runs')
+    expect(fetchMock.mock.calls[0][1]?.method).not.toBe('POST')
+    expect(container.textContent).toContain('Runtime health')
+    expect(container.textContent).toContain('3 active')
+    expect(container.textContent).toContain('16 resumable')
+    expect(container.textContent).toContain('1 need attention')
+    expect(container.textContent).toContain('2 unlinked')
+    expect(container.textContent).toContain('1 recoverable')
+    expect(container.textContent).toContain('1 ownership unknown')
+    expect(container.querySelector('a[href="/runs"]')?.textContent).toContain('Open Runs')
+    await unmount()
+  })
+
+  it('shows a truthful unavailable state without inventing healthy counts', async () => {
+    fetchMock.mockImplementationOnce(async () => new Response(JSON.stringify({ ok: false, error: 'Unavailable' }), { status: 500 }))
+    const { container, unmount } = await renderCard()
+    expect(container.textContent).toContain('Runtime health unavailable')
+    expect(container.textContent).not.toContain('0 ownership conflicts')
+    await unmount()
+  })
+})

--- a/src/screens/agents/components/runtime-health-card.tsx
+++ b/src/screens/agents/components/runtime-health-card.tsx
@@ -1,0 +1,107 @@
+import { Link } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+type RuntimeHealthSummary = {
+  total: number
+  active: number
+  idleResumable: number
+  attention: number
+  unlinkedKanban: number
+  recoverable: number
+  unknownOwnership: number
+  stale: number
+}
+
+type RuntimeHealthResponse = {
+  ok?: boolean
+  summary?: RuntimeHealthSummary
+  generatedAt?: number
+  error?: string
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+export function RuntimeHealthCard() {
+  const [summary, setSummary] = useState<RuntimeHealthSummary | null>(null)
+  const [generatedAt, setGeneratedAt] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [unavailable, setUnavailable] = useState(false)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const load = async () => {
+      try {
+        const response = await fetch('/api/runtime-runs?size=1', {
+          cache: 'no-store',
+          signal: controller.signal,
+        })
+        const body = await response.json() as RuntimeHealthResponse
+        if (!response.ok || body.ok !== true || !body.summary) throw new Error('unavailable')
+        setSummary(body.summary)
+        setGeneratedAt(typeof body.generatedAt === 'number' ? body.generatedAt : null)
+        setUnavailable(false)
+      } catch (error) {
+        if (controller.signal.aborted) return
+        setUnavailable(true)
+        setSummary(null)
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+    void load()
+    return () => controller.abort()
+  }, [])
+
+  return (
+    <section
+      aria-labelledby="runtime-health-title"
+      className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--theme-accent)]">Execution readiness</p>
+          <h2 id="runtime-health-title" className="mt-1 text-lg font-semibold text-[var(--theme-text)]">Runtime health</h2>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+            Provider-backed execution summary. Inventory discovery runs only when explicitly requested from Runs.
+          </p>
+        </div>
+        <Button render={<Link to="/runs" />}>Open Runs</Button>
+      </div>
+
+      {loading ? (
+        <p className="mt-4 text-sm text-[var(--theme-muted)]">Loading runtime health…</p>
+      ) : unavailable || !summary ? (
+        <div className="mt-4 rounded-2xl border border-[var(--theme-danger)]/30 bg-[var(--theme-danger-soft)] p-4">
+          <p className="font-medium text-[var(--theme-danger)]">Runtime health unavailable</p>
+          <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Open Runs for inventory diagnostics. No provider refresh was attempted.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-6" aria-label="Runtime health counts">
+            {[
+              { value: summary.active, label: countLabel(summary.active, 'active') },
+              { value: summary.idleResumable, label: countLabel(summary.idleResumable, 'resumable') },
+              { value: summary.attention, label: `${summary.attention} need attention` },
+              { value: summary.unlinkedKanban, label: countLabel(summary.unlinkedKanban, 'unlinked') },
+              { value: summary.recoverable, label: countLabel(summary.recoverable, 'recoverable') },
+              { value: summary.unknownOwnership, label: `${summary.unknownOwnership} ownership unknown` },
+            ].map((item) => (
+              <div key={item.label} className="rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3">
+                <p className="text-lg font-semibold text-[var(--theme-text)]">{item.value}</p>
+                <p className="text-xs text-[var(--theme-muted)]">{item.label}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-[var(--theme-muted)]">
+            <span>{summary.total} total · {summary.stale} stale</span>
+            <span>{generatedAt ? `Inventory read ${new Date(generatedAt).toLocaleString()}` : 'Inventory timestamp unavailable'}</span>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/screens/agents/hooks/use-operations.ts
+++ b/src/screens/agents/hooks/use-operations.ts
@@ -23,6 +23,7 @@ type ClaudeProfileSummary = {
   routeRef?: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime?: 'hermes_default' | 'codex_app_server'
   description?: string
   systemPrompt?: string
   skillCount: number
@@ -37,6 +38,7 @@ export type GatewayConfigAgent = {
   model: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime?: 'hermes_default' | 'codex_app_server'
   workspace?: string
   agentDir?: string
   description?: string
@@ -224,6 +226,7 @@ function normalizeAgentList(input: unknown): Array<GatewayConfigAgent> {
         typeof row.maxOutputTokens === 'number'
           ? row.maxOutputTokens
           : undefined,
+      codexRuntime: row.codexRuntime === 'codex_app_server' ? 'codex_app_server' : 'hermes_default',
       workspace: readString(row.workspace) || undefined,
       agentDir: readString(row.agentDir) || undefined,
       description: readString(row.description) || undefined,
@@ -267,6 +270,7 @@ async function fetchOperationsConfig(): Promise<ConfigPayload> {
     model: profile.routeRef || profile.model || '',
     reasoningEffort: profile.reasoningEffort,
     maxOutputTokens: profile.maxOutputTokens,
+    codexRuntime: profile.codexRuntime ?? 'hermes_default',
     workspace: profile.path,
     agentDir: profile.path,
     description: profile.description || '',
@@ -290,6 +294,7 @@ async function createClaudeProfile(input: {
     routeRef: string
     reasoningEffort?: string
     maxOutputTokens?: number
+    codexRuntime?: 'hermes_default' | 'codex_app_server'
   }
   cloneFrom?: string
 }) {
@@ -316,6 +321,7 @@ async function updateClaudeProfile(
     routeRef: string
     reasoningEffort?: string
     maxOutputTokens?: number
+    codexRuntime?: 'hermes_default' | 'codex_app_server'
   },
 ) {
   const response = await fetch('/api/profiles/update', {
@@ -690,6 +696,7 @@ export function useOperations() {
       model: string
       reasoningEffort?: string
       maxOutputTokens?: number
+      codexRuntime?: 'hermes_default' | 'codex_app_server'
       emoji: string
       systemPrompt: string
       description?: string
@@ -713,6 +720,7 @@ export function useOperations() {
               routeRef: input.model.trim(),
               reasoningEffort: input.reasoningEffort,
               maxOutputTokens: input.maxOutputTokens,
+              codexRuntime: input.codexRuntime,
             }
           : undefined,
       })
@@ -754,6 +762,7 @@ export function useOperations() {
       model: string
       reasoningEffort?: string
       maxOutputTokens?: number
+      codexRuntime?: 'hermes_default' | 'codex_app_server'
       emoji: string
       systemPrompt: string
     }) => {
@@ -768,6 +777,7 @@ export function useOperations() {
               routeRef: input.model.trim(),
               reasoningEffort: input.reasoningEffort,
               maxOutputTokens: input.maxOutputTokens,
+              codexRuntime: input.codexRuntime,
             }
           : undefined,
       )

--- a/src/screens/agents/hooks/use-operations.ts
+++ b/src/screens/agents/hooks/use-operations.ts
@@ -1,10 +1,14 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { CronJob } from '@/components/cron-manager/cron-types'
+import type { GatewaySession } from '@/lib/gateway-api'
 import { toast } from '@/components/ui/toast'
 import { fetchCronJobs } from '@/lib/cron-api'
-import { fetchSessions, type GatewaySession } from '@/lib/gateway-api'
-import { formatModelName, formatRelativeTime } from '@/screens/dashboard/lib/formatters'
+import { fetchSessions } from '@/lib/gateway-api'
+import {
+  formatModelName,
+  formatRelativeTime,
+} from '@/screens/dashboard/lib/formatters'
 
 // Claude-Workspace adapter: Operations is backed by Hermes profiles
 // (each profile = one persistent agent). Profiles live at ~/.hermes/profiles/<name>/
@@ -16,6 +20,9 @@ type ClaudeProfileSummary = {
   exists: boolean
   model?: string
   provider?: string
+  routeRef?: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
   description?: string
   systemPrompt?: string
   skillCount: number
@@ -28,6 +35,8 @@ export type GatewayConfigAgent = {
   id: string
   name: string
   model: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
   workspace?: string
   agentDir?: string
   description?: string
@@ -63,15 +72,15 @@ export type OperationsAgent = GatewayConfigAgent & {
   shortModel: string
   status: OperationsAgentStatus
   sessionKey: string
-  sessions: GatewaySession[]
+  sessions: Array<GatewaySession>
   latestSession: GatewaySession | null
-  jobs: CronJob[]
+  jobs: Array<CronJob>
   nextRunAt: number | null
   lastActivityAt: number | null
   activityLabel: string
   progressValue: number
   progressStatus: 'running' | 'queued' | 'failed' | 'complete' | 'thinking'
-  recentOutputs: OperationsOutputItem[]
+  recentOutputs: Array<OperationsOutputItem>
   /**
    * True when the agent's profile has no model configured (blank model in
    * config.yaml). Dispatching into an unconfigured agent hangs because
@@ -87,7 +96,7 @@ type ConfigPayload = {
   payload?: {
     parsed?: {
       agents?: {
-        list?: unknown[]
+        list?: Array<unknown>
       }
       defaultModel?: string
       [key: string]: unknown
@@ -97,7 +106,7 @@ type ConfigPayload = {
   }
   parsed?: {
     agents?: {
-      list?: unknown[]
+      list?: Array<unknown>
     }
     defaultModel?: string
     [key: string]: unknown
@@ -129,7 +138,9 @@ function hashString(value: string): number {
 }
 
 function createFallbackColor(agentId: string): string {
-  return COLOR_PALETTE[hashString(agentId) % COLOR_PALETTE.length]?.body ?? '#3b82f6'
+  return (
+    COLOR_PALETTE[hashString(agentId) % COLOR_PALETTE.length]?.body ?? '#3b82f6'
+  )
 }
 
 function createFallbackEmoji(agentId: string): string {
@@ -190,10 +201,10 @@ function truncate(text: string, maxLength = 120): string {
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
 }
 
-function normalizeAgentList(input: unknown): GatewayConfigAgent[] {
+function normalizeAgentList(input: unknown): Array<GatewayConfigAgent> {
   if (!Array.isArray(input)) return []
 
-  const agents: GatewayConfigAgent[] = []
+  const agents: Array<GatewayConfigAgent> = []
 
   for (const entry of input) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
@@ -208,6 +219,11 @@ function normalizeAgentList(input: unknown): GatewayConfigAgent[] {
       id,
       name: readString(row.name) || id,
       model: readString(row.model),
+      reasoningEffort: readString(row.reasoningEffort) || undefined,
+      maxOutputTokens:
+        typeof row.maxOutputTokens === 'number'
+          ? row.maxOutputTokens
+          : undefined,
       workspace: readString(row.workspace) || undefined,
       agentDir: readString(row.agentDir) || undefined,
       description: readString(row.description) || undefined,
@@ -225,14 +241,14 @@ function parseConfigPayload(payload: ConfigPayload): ConfigPayload {
   return payload
 }
 
-async function fetchClaudeProfiles(): Promise<ClaudeProfileSummary[]> {
+async function fetchClaudeProfiles(): Promise<Array<ClaudeProfileSummary>> {
   const response = await fetch('/api/profiles/list')
   const contentType = response.headers.get('content-type') || ''
   if (!contentType.includes('json')) {
     throw new Error('/api/profiles/list returned non-JSON')
   }
   const payload = (await response.json().catch(() => ({}))) as {
-    profiles?: ClaudeProfileSummary[]
+    profiles?: Array<ClaudeProfileSummary>
     error?: string
   }
   if (!response.ok || payload.error) {
@@ -248,14 +264,17 @@ async function fetchOperationsConfig(): Promise<ConfigPayload> {
   const list = profiles.map((profile) => ({
     id: profile.name,
     name: profile.name === 'default' ? 'Workspace' : profile.name,
-    model: profile.model || '',
+    model: profile.routeRef || profile.model || '',
+    reasoningEffort: profile.reasoningEffort,
+    maxOutputTokens: profile.maxOutputTokens,
     workspace: profile.path,
     agentDir: profile.path,
     description: profile.description || '',
     systemPrompt: profile.systemPrompt || '',
   }))
   // Default-profile model becomes the operations defaultModel suggestion
-  const defaultModel = profiles.find((p) => p.name === 'default')?.model || ''
+  const defaultProfile = profiles.find((p) => p.name === 'default')
+  const defaultModel = defaultProfile?.routeRef || defaultProfile?.model || ''
   return {
     ok: true,
     parsed: {
@@ -267,8 +286,11 @@ async function fetchOperationsConfig(): Promise<ConfigPayload> {
 
 async function createClaudeProfile(input: {
   name: string
-  model?: string
-  provider?: string
+  modelSelection?: {
+    routeRef: string
+    reasoningEffort?: string
+    maxOutputTokens?: number
+  }
   cloneFrom?: string
 }) {
   const response = await fetch('/api/profiles/create', {
@@ -281,22 +303,34 @@ async function createClaudeProfile(input: {
     error?: string
   }
   if (!response.ok || payload.ok === false) {
-    throw new Error(payload.error || `Failed to create profile (${response.status})`)
+    throw new Error(
+      payload.error || `Failed to create profile (${response.status})`,
+    )
   }
 }
 
-async function updateClaudeProfile(name: string, patch: Record<string, unknown>) {
+async function updateClaudeProfile(
+  name: string,
+  patch: Record<string, unknown>,
+  modelSelection?: {
+    routeRef: string
+    reasoningEffort?: string
+    maxOutputTokens?: number
+  },
+) {
   const response = await fetch('/api/profiles/update', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ name, patch }),
+    body: JSON.stringify({ name, patch, modelSelection }),
   })
   const payload = (await response.json().catch(() => ({}))) as {
     ok?: boolean
     error?: string
   }
   if (!response.ok || payload.ok === false) {
-    throw new Error(payload.error || `Failed to update profile (${response.status})`)
+    throw new Error(
+      payload.error || `Failed to update profile (${response.status})`,
+    )
   }
 }
 
@@ -311,7 +345,9 @@ async function deleteClaudeProfile(name: string) {
     error?: string
   }
   if (!response.ok || payload.ok === false) {
-    throw new Error(payload.error || `Failed to delete profile (${response.status})`)
+    throw new Error(
+      payload.error || `Failed to delete profile (${response.status})`,
+    )
   }
 }
 
@@ -408,13 +444,14 @@ function persistSettings(settings: OperationsSettings) {
   window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
 }
 
-
-
-function getAgentJobs(agentId: string, jobs: CronJob[]): CronJob[] {
-  return jobs.filter((job) => job.name?.startsWith(`ops:${agentId}:`))
+function getAgentJobs(agentId: string, jobs: Array<CronJob>): Array<CronJob> {
+  return jobs.filter((job) => job.name.startsWith(`ops:${agentId}:`))
 }
 
-function getAgentSessions(agentId: string, sessions: GatewaySession[]): GatewaySession[] {
+function getAgentSessions(
+  agentId: string,
+  sessions: Array<GatewaySession>,
+): Array<GatewaySession> {
   return [...sessions]
     .filter((session) => {
       const label = readString(session.label)
@@ -428,7 +465,9 @@ function getAgentSessions(agentId: string, sessions: GatewaySession[]): GatewayS
     })
 }
 
-function getAgentStatus(latestSession: GatewaySession | null): OperationsAgentStatus {
+function getAgentStatus(
+  latestSession: GatewaySession | null,
+): OperationsAgentStatus {
   if (!latestSession) return 'idle'
 
   const status = readString(latestSession.status).toLowerCase()
@@ -486,7 +525,10 @@ function slugifyJobLabel(value: string): string {
   return normalizeAgentId(value) || 'scheduled-run'
 }
 
-function buildCronOutput(job: CronJob, agentId: string): OperationsOutputItem | null {
+function buildCronOutput(
+  job: CronJob,
+  agentId: string,
+): OperationsOutputItem | null {
   const startedAt = readTimestamp(job.lastRun?.startedAt)
   const summary = truncate(
     readString(job.lastRun?.deliverySummary) ||
@@ -509,7 +551,8 @@ function buildSessionOutput(
   session: GatewaySession,
   agentId: string,
 ): OperationsOutputItem | null {
-  const timestamp = readTimestamp(session.updatedAt) ?? readTimestamp(session.createdAt)
+  const timestamp =
+    readTimestamp(session.updatedAt) ?? readTimestamp(session.createdAt)
   const summary = truncate(extractSessionText(session))
   if (!timestamp || !summary) return null
 
@@ -529,7 +572,9 @@ export function getOperationsSessionKey(agentId: string): string {
 export function useOperations() {
   const queryClient = useQueryClient()
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
-  const [settings, setSettings] = useState<OperationsSettings>(() => loadSettings())
+  const [settings, setSettings] = useState<OperationsSettings>(() =>
+    loadSettings(),
+  )
   const [metaVersion, setMetaVersion] = useState(0)
 
   const configQuery = useQuery({
@@ -557,7 +602,12 @@ export function useOperations() {
     const parsed = configQuery.data?.parsed
     const allAgents = normalizeAgentList(parsed?.agents?.list)
     // Filter out system/internal agents — only show operations agents
-    const HIDDEN_AGENTS = new Set(['main', 'pc1-coder', 'pc1-planner', 'pc1-critic'])
+    const HIDDEN_AGENTS = new Set([
+      'main',
+      'pc1-coder',
+      'pc1-planner',
+      'pc1-critic',
+    ])
     const configAgents = allAgents.filter((a) => !HIDDEN_AGENTS.has(a.id))
     const sessions = sessionsQuery.data ?? []
     const cronJobs = cronJobsQuery.data ?? []
@@ -568,23 +618,30 @@ export function useOperations() {
         systemPrompt: agent.systemPrompt,
       })
       const agentSessions = getAgentSessions(agent.id, sessions)
-      const latestSession = agentSessions[0] ?? null
+      const latestSession: GatewaySession | null =
+        agentSessions.length > 0 ? agentSessions[0] : null
       const jobs = getAgentJobs(agent.id, cronJobs)
-      const nextRunAt = jobs
-        .filter((job) => job.enabled)
-        .map((job) => readTimestamp(job.nextRunAt))
-        .filter((value): value is number => value !== null)
-        .sort((left, right) => left - right)[0] ?? null
-      const lastActivityAt =
-        readTimestamp(latestSession?.updatedAt) ??
+      const nextRunAt =
+        jobs
+          .filter((job) => job.enabled)
+          .map((job) => readTimestamp(job.nextRunAt))
+          .filter((value): value is number => value !== null)
+          .sort((left, right) => left - right)[0] ?? null
+      const sessionActivityAt = latestSession
+        ? readTimestamp(latestSession.updatedAt)
+        : null
+      const jobActivityAt =
         jobs
           .map((job) => readTimestamp(job.lastRun?.startedAt))
           .filter((value): value is number => value !== null)
-          .sort((left, right) => right - left)[0] ??
-        null
+          .sort((left, right) => right - left)[0] ?? null
+      const lastActivityAt =
+        sessionActivityAt === null ? jobActivityAt : sessionActivityAt
       const status = getAgentStatus(latestSession)
       const recentOutputs = [
-        ...agentSessions.map((session) => buildSessionOutput(session, agent.id)),
+        ...agentSessions.map((session) =>
+          buildSessionOutput(session, agent.id),
+        ),
         ...jobs.map((job) => buildCronOutput(job, agent.id)),
       ]
         .filter((item): item is OperationsOutputItem => Boolean(item))
@@ -615,14 +672,10 @@ export function useOperations() {
         needsSetup,
       } satisfies OperationsAgent
     })
-  }, [
-    configQuery.data,
-    sessionsQuery.data,
-    cronJobsQuery.data,
-    metaVersion,
-  ])
+  }, [configQuery.data, sessionsQuery.data, cronJobsQuery.data, metaVersion])
 
-  const selectedAgent = agents.find((agent) => agent.id === selectedAgentId) ?? null
+  const selectedAgent =
+    agents.find((agent) => agent.id === selectedAgentId) ?? null
 
   const recentActivity = useMemo(() => {
     return agents
@@ -635,6 +688,8 @@ export function useOperations() {
     mutationFn: async (input: {
       name: string
       model: string
+      reasoningEffort?: string
+      maxOutputTokens?: number
       emoji: string
       systemPrompt: string
       description?: string
@@ -644,14 +699,22 @@ export function useOperations() {
       if (id === 'default') {
         throw new Error('"default" is reserved — pick another name')
       }
-      const currentAgents = normalizeAgentList(configQuery.data?.parsed?.agents?.list)
+      const currentAgents = normalizeAgentList(
+        configQuery.data?.parsed?.agents?.list,
+      )
       if (currentAgents.some((agent) => agent.id === id)) {
         throw new Error('A profile with this name already exists')
       }
 
       await createClaudeProfile({
         name: id,
-        model: input.model.trim() || undefined,
+        modelSelection: input.model.trim()
+          ? {
+              routeRef: input.model.trim(),
+              reasoningEffort: input.reasoningEffort,
+              maxOutputTokens: input.maxOutputTokens,
+            }
+          : undefined,
       })
       // Persist system prompt + description into the profile config so they
       // survive across browsers; localStorage meta keeps emoji/color preferences.
@@ -672,7 +735,9 @@ export function useOperations() {
       setSelectedAgentId(id)
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['operations', 'config'] })
+      await queryClient.invalidateQueries({
+        queryKey: ['operations', 'config'],
+      })
       toast('Agent created', { type: 'success' })
     },
     onError: (error) => {
@@ -687,17 +752,25 @@ export function useOperations() {
       agentId: string
       name: string
       model: string
+      reasoningEffort?: string
+      maxOutputTokens?: number
       emoji: string
       systemPrompt: string
     }) => {
-      // Persist model + system prompt to the profile's config.yaml so they
-      // survive across machines / clients.
-      const patch: Record<string, unknown> = {}
-      if (input.model.trim()) patch.model = input.model.trim()
-      if (input.systemPrompt.trim()) patch.system_prompt = input.systemPrompt.trim()
-      if (Object.keys(patch).length > 0) {
-        await updateClaudeProfile(input.agentId, patch)
+      const patch: Record<string, unknown> = {
+        system_prompt: input.systemPrompt.trim() || null,
       }
+      await updateClaudeProfile(
+        input.agentId,
+        patch,
+        input.model.trim()
+          ? {
+              routeRef: input.model.trim(),
+              reasoningEffort: input.reasoningEffort,
+              maxOutputTokens: input.maxOutputTokens,
+            }
+          : undefined,
+      )
       const currentMeta = loadAgentMeta(input.agentId)
       persistAgentMeta(input.agentId, {
         ...currentMeta,
@@ -707,7 +780,9 @@ export function useOperations() {
       setMetaVersion((value) => value + 1)
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['operations', 'config'] })
+      await queryClient.invalidateQueries({
+        queryKey: ['operations', 'config'],
+      })
       toast('Agent settings saved', { type: 'success' })
     },
     onError: (error) => {
@@ -728,8 +803,12 @@ export function useOperations() {
       setSelectedAgentId((current) => (current === agentId ? null : current))
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['operations', 'config'] })
-      await queryClient.invalidateQueries({ queryKey: ['operations', 'sessions'] })
+      await queryClient.invalidateQueries({
+        queryKey: ['operations', 'config'],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ['operations', 'sessions'],
+      })
       toast('Agent deleted', { type: 'success' })
     },
     onError: (error) => {
@@ -739,7 +818,10 @@ export function useOperations() {
     },
   })
 
-  function saveAgentMeta(agentId: string, partial: Partial<OperationsAgentMeta>) {
+  function saveAgentMeta(
+    agentId: string,
+    partial: Partial<OperationsAgentMeta>,
+  ) {
     const nextMeta = { ...loadAgentMeta(agentId), ...partial }
     persistAgentMeta(agentId, nextMeta)
     setMetaVersion((value) => value + 1)
@@ -763,7 +845,8 @@ export function useOperations() {
     settings,
     saveSettings,
     defaultModel:
-      readString(configQuery.data?.parsed?.defaultModel) || settings.defaultModel,
+      readString(configQuery.data?.parsed?.defaultModel) ||
+      settings.defaultModel,
     createAgent: createAgentMutation.mutateAsync,
     isCreatingAgent: createAgentMutation.isPending,
     saveAgent: saveAgentMutation.mutateAsync,

--- a/src/screens/agents/operations-screen.tsx
+++ b/src/screens/agents/operations-screen.tsx
@@ -17,7 +17,7 @@ import { OperationsNewAgentModal } from './components/operations-new-agent-modal
 import { OperationsSettingsModal } from './components/operations-settings-modal'
 import { FullOutputsView } from './components/full-outputs-view'
 import { AgentBusPanel } from './components/agent-bus-panel'
-import { ProviderRuntimePanel } from './components/provider-runtime-panel'
+import { RuntimeHealthCard } from './components/runtime-health-card'
 import { useOperations } from './hooks/use-operations'
 
 export const THEME_STYLE: CSSProperties = {
@@ -169,14 +169,6 @@ export function OperationsScreen() {
               <AgentBusPanel />
             </motion.div>
 
-            <motion.div
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.08, duration: 0.25 }}
-            >
-              <ProviderRuntimePanel />
-            </motion.div>
-
             <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {agents.map((agent, index) => (
                 <motion.div
@@ -208,6 +200,14 @@ export function OperationsScreen() {
                 <span className="mt-3 text-sm text-[var(--theme-muted)]">Add Agent</span>
               </motion.button>
             </section>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.08, duration: 0.25 }}
+            >
+              <RuntimeHealthCard />
+            </motion.div>
 
             <section className="rounded-3xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-5 shadow-[0_24px_80px_var(--theme-shadow)]">
               <div className="flex items-center justify-between gap-3">

--- a/src/screens/agents/operations-screen.tsx
+++ b/src/screens/agents/operations-screen.tsx
@@ -17,6 +17,7 @@ import { OperationsNewAgentModal } from './components/operations-new-agent-modal
 import { OperationsSettingsModal } from './components/operations-settings-modal'
 import { FullOutputsView } from './components/full-outputs-view'
 import { AgentBusPanel } from './components/agent-bus-panel'
+import { ProviderRuntimePanel } from './components/provider-runtime-panel'
 import { useOperations } from './hooks/use-operations'
 
 export const THEME_STYLE: CSSProperties = {
@@ -166,6 +167,14 @@ export function OperationsScreen() {
               transition={{ delay: 0.05, duration: 0.25 }}
             >
               <AgentBusPanel />
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.08, duration: 0.25 }}
+            >
+              <ProviderRuntimePanel />
             </motion.div>
 
             <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -38,6 +38,10 @@ import { ChatHeader } from './components/chat-header'
 import { ChatMessageList } from './components/chat-message-list'
 import { ChatEmptyState } from './components/chat-empty-state'
 import { ChatComposer } from './components/chat-composer'
+import {
+  ROLE_MODEL_CATALOG_ENDPOINT,
+  resolveChatRequestModel,
+} from './components/chat-composer-model-switch'
 import { ConnectionStatusMessage } from './components/connection-status-message'
 import {
   clearPendingSendForSession,
@@ -989,7 +993,7 @@ export function ChatScreen({
   const modelsQuery = useQuery({
     queryKey: ['models'],
     queryFn: async () => {
-      const res = await fetch('/api/models')
+      const res = await fetch(ROLE_MODEL_CATALOG_ENDPOINT)
       if (!res.ok) return { models: [] }
       const data = await res.json()
       return data
@@ -1057,8 +1061,25 @@ export function ChatScreen({
     return models.map((m: any) => m.id).filter((id: string) => id)
   }, [modelsQuery.data])
 
+  const modelSessionKey = isNewChat
+    ? 'new'
+    : forcedSessionKey ||
+      resolvedSessionKey ||
+      activeCanonicalKey ||
+      activeSessionKey ||
+      activeFriendlyId ||
+      'main'
+  const persistedSessionModel = useSessionModelStore(
+    (state) => state.models[modelSessionKey],
+  )
+  const setPersistedSessionModel = useSessionModelStore((state) => state.setModel)
+  const clearPersistedSessionModel = useSessionModelStore((state) => state.clearModel)
   const gatewayModel = currentModelQuery.data || ''
-  const currentModel = _localModelOverride || gatewayModel
+  const currentModel = resolveChatRequestModel({
+    localOverride: _localModelOverride,
+    sessionRoute: persistedSessionModel,
+    gatewayModel,
+  })
 
   // Ref so sendMessage can always read latest thinkingLevel without being in deps
   const thinkingLevelRef = useRef<ThinkingLevel>(thinkingLevel)
@@ -1138,6 +1159,10 @@ export function ChatScreen({
         sessionKey: string
         friendlyId: string
       }) => {
+        if (isNewChat && persistedSessionModel) {
+          setPersistedSessionModel(sessionKey, persistedSessionModel)
+          clearPersistedSessionModel(modelSessionKey)
+        }
         const activeSend = activeSendRef.current
         if (activeSend) {
           activeSendRef.current = {
@@ -1154,7 +1179,15 @@ export function ChatScreen({
         }
         onSessionResolved?.({ sessionKey, friendlyId })
       },
-      [activeFriendlyId, onSessionResolved],
+      [
+        activeFriendlyId,
+        clearPersistedSessionModel,
+        isNewChat,
+        modelSessionKey,
+        onSessionResolved,
+        persistedSessionModel,
+        setPersistedSessionModel,
+      ],
     ),
     onStarted: useCallback(
       ({ runId }: { runId: string | null }) => {
@@ -2903,14 +2936,7 @@ export function ChatScreen({
               onAbort={handleAbortStreaming}
               isLoading={sending || waitingForResponse}
               disabled={sending || hideUi}
-              sessionKey={
-                isNewChat
-                  ? undefined
-                  : forcedSessionKey ||
-                    resolvedSessionKey ||
-                    activeCanonicalKey ||
-                    activeSessionKey
-              }
+              sessionKey={modelSessionKey}
               wrapperRef={composerRef}
               composerRef={composerHandleRef}
               embedded={embedded}

--- a/src/screens/chat/components/chat-composer-model-switch.test.ts
+++ b/src/screens/chat/components/chat-composer-model-switch.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import {
   MODEL_SWITCH_BLOCKED_TOAST,
+  ROLE_MODEL_CATALOG_ENDPOINT,
+  getModelAvailabilityBadge,
   getZeroForkModelInfoFlags,
+  resolveChatRequestModel,
   shouldBlockZeroForkModelSwitch,
 } from './chat-composer-model-switch'
 
 describe('zero-fork model switch guard', () => {
+  it('uses the persisted session route for runtime requests before the gateway default', () => {
+    expect(
+      resolveChatRequestModel({
+        localOverride: '',
+        sessionRoute: 'claude-gp/sonnet',
+        gatewayModel: 'claude-cwm4tx/sonnet',
+      }),
+    ).toBe('claude-gp/sonnet')
+
+    expect(
+      resolveChatRequestModel({
+        localOverride: 'local/qwen',
+        sessionRoute: 'claude-gp/sonnet',
+        gatewayModel: 'claude-cwm4tx/sonnet',
+      }),
+    ).toBe('local/qwen')
+  })
+
+  it('uses the subscription-only role catalog for the chat picker', () => {
+    expect(ROLE_MODEL_CATALOG_ENDPOINT).toBe('/api/orchestration-catalog')
+  })
+
   it('blocks picker swaps only for zero-fork vanilla agents', () => {
     expect(
       shouldBlockZeroForkModelSwitch('zero-fork', {
@@ -49,5 +74,10 @@ describe('zero-fork model switch guard', () => {
     expect(MODEL_SWITCH_BLOCKED_TOAST).toBe(
       'Model switching requires the enhanced runtime. Set a default via `claude config set model <id>` — the displayed model reflects your config.',
     )
+  })
+
+  it('keeps quota-limited subscription routes visible with a warning badge', () => {
+    expect(getModelAvailabilityBadge('quota_limited')).toBe('quota limited')
+    expect(getModelAvailabilityBadge('available')).toBe('')
   })
 })

--- a/src/screens/chat/components/chat-composer-model-switch.ts
+++ b/src/screens/chat/components/chat-composer-model-switch.ts
@@ -1,9 +1,30 @@
 export const MODEL_SWITCH_BLOCKED_TOAST =
   'Model switching requires the enhanced runtime. Set a default via `claude config set model <id>` — the displayed model reflects your config.'
 
+export const ROLE_MODEL_CATALOG_ENDPOINT = '/api/orchestration-catalog'
+
 export type ZeroForkModelInfoFlags = {
   vanillaAgent: boolean
   supportsRuntimeSwitching: boolean
+}
+
+export function resolveChatRequestModel(input: {
+  localOverride?: string | null
+  sessionRoute?: string | null
+  gatewayModel?: string | null
+}): string {
+  return (
+    input.localOverride?.trim() ||
+    input.sessionRoute?.trim() ||
+    input.gatewayModel?.trim() ||
+    ''
+  )
+}
+
+export function getModelAvailabilityBadge(
+  availability: string | null | undefined,
+): string {
+  return availability === 'quota_limited' ? 'quota limited' : ''
 }
 
 function readBoolean(value: unknown): boolean | null {

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -23,6 +23,8 @@ import {
 } from 'react'
 import {
   MODEL_SWITCH_BLOCKED_TOAST,
+  ROLE_MODEL_CATALOG_ENDPOINT,
+  getModelAvailabilityBadge,
   getZeroForkModelInfoFlags,
   shouldBlockZeroForkModelSwitch,
 } from './chat-composer-model-switch'
@@ -257,11 +259,9 @@ async function fetchModels(): Promise<{
   providerLabels?: Record<string, string>
   providers?: Array<ClaudeProviderOption>
 }> {
-  // Use the curated /api/models endpoint which returns only models
-  // actually configured and available (OCPlatform gateway + local providers).
-  // Previously this hit /api/claude-proxy/api/available-models which returned
-  // every upstream provider model — flooding the picker with unusable options.
-  const response = await fetch('/api/models')
+  // Role selection is subscription-only unless the orchestration billing gate
+  // has been explicitly opened. Chat shares that same account-aware registry.
+  const response = await fetch(ROLE_MODEL_CATALOG_ENDPOINT)
   if (!response.ok) {
     throw new Error(`Models request failed (${response.status})`)
   }
@@ -349,10 +349,23 @@ async function fetchModelsForProvider(
 
 const LOCAL_PROVIDERS_SET = new Set(['ollama', 'atomic-chat'])
 
+function confirmLimitedModelSelection(entry: {
+  name: string
+  availability?: string
+  warning?: string
+  resetAt?: string | null
+}): boolean {
+  if (entry.availability !== 'quota_limited') return true
+  const reset = entry.resetAt ? `\nKnown reset: ${entry.resetAt}` : ''
+  return window.confirm(
+    `${entry.name} is currently quota-limited.${reset}\n\n${entry.warning || 'The subscription provider reported an exhausted usage window.'}\n\nChoose Cancel to select another subscription model, or OK to try this route anyway.`,
+  )
+}
+
 async function switchModel(
   model: string,
   provider?: string,
-  _sessionKey?: string,
+  sessionKey?: string,
 ): Promise<ModelSwitchResponse> {
   const modelId = model.trim()
   const modelProvider =
@@ -377,14 +390,25 @@ async function switchModel(
   // Switching to a cloud model — clear any local override
   setLocalModelOverride('')
 
-  // Write the model change to ~/.hermes/config.yaml via the webapi
-  const patch: Record<string, string> = { model: modelId }
-  if (modelProvider) patch.provider = modelProvider
-
-  const response = await fetch('/api/claude-proxy/api/config', {
+  // A picker change is scoped to this conversation. Global defaults are
+  // managed explicitly in Settings → Orchestration and never rewritten by a
+  // session-level model choice.
+  const modelRef =
+    modelId.startsWith('claude-') ||
+    (modelProvider && modelId.startsWith(`${modelProvider}/`))
+      ? modelId
+      : modelProvider
+        ? `${modelProvider}/${modelId}`
+        : modelId
+  const normalizedSessionKey = sessionKey?.trim() || ''
+  const response = await fetch('/api/orchestration-policy', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(patch),
+    body: JSON.stringify({
+      scope: normalizedSessionKey ? 'session' : 'global',
+      ...(normalizedSessionKey ? { sessionKey: normalizedSessionKey } : {}),
+      patch: { orchestratorModelRef: modelRef },
+    }),
   })
 
   if (!response.ok) {
@@ -395,7 +419,7 @@ async function switchModel(
     ok: true,
     resolved: {
       modelProvider: modelProvider || 'hermes-agent',
-      model: modelId,
+      model: modelRef,
     },
   }
 }
@@ -2586,6 +2610,18 @@ function ChatComposerComponent({
                               name: mName,
                               provider: mProvider,
                               isLocal,
+                              availability:
+                                typeof m === 'string'
+                                  ? ''
+                                  : String((m as Record<string, unknown>).availability || ''),
+                              warning:
+                                typeof m === 'string'
+                                  ? ''
+                                  : String((m as Record<string, unknown>).warning || ''),
+                              resetAt:
+                                typeof m === 'string'
+                                  ? null
+                                  : ((m as Record<string, unknown>).resetAt as string | null) ?? null,
                             }
                           })
                           // Split pinned vs unpinned, group unpinned by provider
@@ -2617,6 +2653,7 @@ function ChatComposerComponent({
                                 <button
                                   type="button"
                                   onClick={() => {
+                                    if (!confirmLimitedModelSelection(entry)) return
                                     handleModelSelect(
                                       entry.id,
                                       entry.provider || undefined,
@@ -2635,6 +2672,21 @@ function ChatComposerComponent({
                                   {entry.isLocal && (
                                     <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-800">
                                       local
+                                    </span>
+                                  )}
+                                  {getModelAvailabilityBadge(
+                                    entry.availability,
+                                  ) && (
+                                    <span
+                                      className="mr-6 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                                      title={
+                                        entry.warning ||
+                                        'Subscription quota is currently limited'
+                                      }
+                                    >
+                                      {getModelAvailabilityBadge(
+                                        entry.availability,
+                                      )}
                                     </span>
                                   )}
                                   {isActive && (
@@ -2975,8 +3027,21 @@ function ChatComposerComponent({
                                         const mId = String(typeof m === 'string' ? m : m.id || m.model || m.name || 'unknown')
                                         const mName = String(typeof m === 'string' ? m : m.name || m.displayName || m.label || m.id || m.model || m)
                                         const mProvider = typeof m === 'string' ? defaultProvider : ((m as Record<string, unknown>).provider as string) || defaultProvider
-                                        const isLocal = typeof m !== 'string' && (m as Record<string, unknown>).description === 'local'
-                                        return { id: mId, name: mName, provider: mProvider, isLocal }
+                                        const record = typeof m === 'string' ? null : m as Record<string, unknown>
+                                        const isLocal = record?.description === 'local'
+                                        return {
+                                          id: mId,
+                                          name: mName,
+                                          provider: mProvider,
+                                          isLocal,
+                                          availability: String(
+                                            record?.availability || record?.status || '',
+                                          ),
+                                          warning: String(
+                                            record?.warning || record?.statusMessage || '',
+                                          ),
+                                          resetAt: (record?.resetAt as string | null) ?? null,
+                                        }
                                       })
                                       const pinnedEntries = parsed.filter((e) => isPinned(e.id))
                                       const unpinnedGroups = new Map<string, typeof parsed>()
@@ -2997,6 +3062,7 @@ function ChatComposerComponent({
                                             <button
                                               type="button"
                                               onClick={() => {
+                                                if (!confirmLimitedModelSelection(entry)) return
                                                 handleModelSelect(entry.id, entry.provider || undefined)
                                                 setIsModelMenuOpen(false)
                                               }}
@@ -3008,6 +3074,14 @@ function ChatComposerComponent({
                                             >
                                               <span className="flex-1 truncate">{entry.name}</span>
                                               {entry.isLocal ? <span className="text-[10px] text-neutral-400 px-1.5 py-0.5 rounded-full bg-neutral-100 dark:bg-neutral-700">local</span> : null}
+                                              {getModelAvailabilityBadge(entry.availability) ? (
+                                                <span
+                                                  className="text-[10px] text-amber-600"
+                                                  title={entry.warning || 'Subscription quota is currently limited'}
+                                                >
+                                                  {getModelAvailabilityBadge(entry.availability)}
+                                                </span>
+                                              ) : null}
                                               {isActive ? <span className="h-1.5 w-1.5 rounded-full bg-accent-500" /> : null}
                                             </button>
                                             <button

--- a/src/screens/chat/components/chat-sidebar.tsx
+++ b/src/screens/chat/components/chat-sidebar.tsx
@@ -586,6 +586,7 @@ function ChatSidebarComponent({
   const isTasksActive = pathname === '/tasks'
   const isConductorActive = pathname === '/conductor'
   const isOperationsActive = pathname === '/operations'
+  const isRunsActive = pathname === '/runs'
   const isSwarmActive = pathname === '/swarm' || pathname === '/swarm2'
   const echoStudioEnabled = useSettingsStore(
     (state) => state.settings.experimentalEchoStudio,
@@ -840,6 +841,13 @@ function ChatSidebarComponent({
       icon: UserMultipleIcon,
       label: 'Operations',
       active: isOperationsActive,
+    },
+    {
+      kind: 'link',
+      to: '/runs',
+      icon: Clock01Icon,
+      label: 'Runs',
+      active: isRunsActive,
     },
     {
       kind: 'link',

--- a/src/screens/runs/components/run-detail-drawer.tsx
+++ b/src/screens/runs/components/run-detail-drawer.tsx
@@ -1,0 +1,335 @@
+import {   useCallback, useEffect, useRef, useState } from 'react'
+import { EM_DASH, formatAge, formatTimestamp, ownershipLabel, providerLabel, stateLabel } from '../runs-format'
+import { CapabilityPill, KanbanPill, OwnershipPill, ProviderPill, StatePill } from './run-pills'
+import type {KeyboardEvent, ReactNode} from 'react';
+
+import type { RuntimeRun, RuntimeRunCapability } from '@/server/runtime-run-projection'
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+
+const TITLE_ID = 'run-detail-title'
+const NO_ROUTE = 'No assignable subscription route is recorded for this run, so the control plane cannot address a provider for it.'
+const NEEDS_LEASE = 'Only an abandoned writer lease can be recovered.'
+
+/**
+ * Operations offered as buttons. Everything else in the capability matrix is
+ * reported but not invokable from here — the control plane has no
+ * metadata-only channel for it.
+ */
+const ACTIONS = [
+  { operation: 'resume', label: 'Resume', destructive: false },
+  { operation: 'fork', label: 'Fork', destructive: false },
+  { operation: 'steer', label: 'Steer', destructive: false },
+  { operation: 'interrupt', label: 'Interrupt', destructive: true },
+  { operation: 'archive', label: 'Archive', destructive: true },
+] as const
+
+const CONFIRMS: Partial<Record<string, string>> = {
+  interrupt: 'Interrupt the active turn on this runtime?',
+  archive: 'Archive this runtime? The provider may drop its resumable identity.',
+}
+
+type Props = {
+  run: RuntimeRun
+  availableRoutes: Array<{ id: string; account: string; model: string; status: string }>
+  onClose: () => void
+  onAction: (payload: Record<string, unknown>) => Promise<{ ok: boolean; error: string | null }>
+}
+
+function Field({ label, children, mono }: { label: string; children: ReactNode; mono?: boolean }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[11px] font-medium uppercase tracking-wide text-primary-500">{label}</dt>
+      <dd className={cn('mt-0.5 break-words text-sm text-primary-900', mono && 'font-mono text-xs')}>{children}</dd>
+    </div>
+  )
+}
+
+function Group({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="border-t border-primary-200 px-4 py-3 first:border-t-0">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-primary-500">{title}</h3>
+      {children}
+    </section>
+  )
+}
+
+/** Why an action is unavailable, phrased from what the projection actually knows. */
+function blockedReason(run: RuntimeRun, capability: RuntimeRunCapability | undefined, routeRef: string, operation: string, followUp: string): string | null {
+  if (!capability || !capability.invokable) return capability?.explanation ?? 'Not exposed by this runtime adapter.'
+  if (!routeRef) return NO_ROUTE
+  if (run.provider === 'claude' && (operation === 'resume' || operation === 'fork') && !followUp.trim()) return 'Claude resume requires bounded follow-up text.'
+  return null
+}
+
+export function RunDetailDrawer({ run, availableRoutes, onClose, onAction }: Props) {
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const closeRef = useRef<HTMLButtonElement | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionNotice, setActionNotice] = useState<string | null>(null)
+  const [routeRef, setRouteRef] = useState(run.route ?? '')
+  const [followUp, setFollowUp] = useState('')
+  const [kanbanTaskId, setKanbanTaskId] = useState(run.kanbanTaskId ?? '')
+
+  useEffect(() => {
+    setRouteRef(run.route ?? '')
+    setFollowUp('')
+    setKanbanTaskId(run.kanbanTaskId ?? '')
+  }, [run.id, run.route, run.kanbanTaskId])
+
+  // Focus moves into the drawer on open and returns to whatever opened it.
+  useEffect(() => {
+    const restoreTo = document.activeElement as HTMLElement | null
+    closeRef.current?.focus()
+    return () => { restoreTo?.focus() }
+  }, [])
+
+  // Keyboard focus is not enough for screen-reader browse mode: isolate every
+  // background sibling branch up to <body> while keeping the dialog and its
+  // clickable, aria-hidden backdrop active. Restore pre-existing states exactly.
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const states: Array<{ element: HTMLElement; inert: boolean; inertAttribute: string | null; ariaHidden: string | null }> = []
+    let branch: HTMLElement = dialog
+    while (branch.parentElement) {
+      const parent = branch.parentElement
+      for (const sibling of Array.from(parent.children)) {
+        if (!(sibling instanceof HTMLElement) || sibling === branch || sibling.hasAttribute('data-runs-dialog-backdrop')) continue
+        states.push({
+          element: sibling,
+          inert: sibling.inert,
+          inertAttribute: sibling.getAttribute('inert'),
+          ariaHidden: sibling.getAttribute('aria-hidden'),
+        })
+        sibling.inert = true
+        sibling.setAttribute('inert', '')
+        sibling.setAttribute('aria-hidden', 'true')
+      }
+      if (parent === document.body) break
+      branch = parent
+    }
+    return () => {
+      for (const state of states.reverse()) {
+        state.element.inert = state.inert
+        if (state.inertAttribute === null) state.element.removeAttribute('inert')
+        else state.element.setAttribute('inert', state.inertAttribute)
+        if (state.ariaHidden === null) state.element.removeAttribute('aria-hidden')
+        else state.element.setAttribute('aria-hidden', state.ariaHidden)
+      }
+    }
+  }, [])
+
+  const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+      onClose()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>('button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') ?? [],
+    )
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    } else if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    }
+  }, [onClose])
+
+  const dispatch = useCallback(async (operation: string, payload: Record<string, unknown>) => {
+    const confirmation = CONFIRMS[operation]
+    if (confirmation && typeof window !== 'undefined' && !window.confirm(confirmation)) return
+    setBusy(operation)
+    setActionError(null)
+    setActionNotice(null)
+    const result = await onAction(payload)
+    setBusy(null)
+    if (result.ok) setActionNotice(`${operation} accepted by the control plane.`)
+    else setActionError(result.error ?? 'Runtime action was rejected.')
+  }, [onAction])
+
+  const leaseRecoverable = run.ownership.state === 'recoverable'
+  const routeOptions = availableRoutes.filter((route) => (
+    route.status === 'available' && route.account === run.accountKey && (!run.route || route.id === run.route)
+  ))
+  const eligibleRouteRef = routeOptions.some((route) => route.id === routeRef) ? routeRef : ''
+
+  return (
+    <>
+      <div data-runs-dialog-backdrop className="fixed inset-0 z-40 bg-primary-950/30" onClick={onClose} aria-hidden="true" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
+        tabIndex={-1}
+        onKeyDown={onKeyDown}
+        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-[560px] flex-col overflow-y-auto border-l border-primary-200 bg-primary-50 shadow-[0_24px_80px_rgba(0,0,0,0.18)]"
+      >
+        <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-primary-200 bg-primary-50 px-4 py-3">
+          <div className="min-w-0">
+            <h2 id={TITLE_ID} className="truncate text-base font-semibold text-primary-900">{run.title}</h2>
+            <p className="mt-1 flex flex-wrap items-center gap-1.5">
+              <ProviderPill provider={run.provider} />
+              <StatePill state={run.state} />
+              <OwnershipPill ownership={run.ownership} />
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'shrink-0')}
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </header>
+
+        {actionError ? (
+          <p role="alert" className="mx-4 mt-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{actionError}</p>
+        ) : null}
+        {actionNotice ? (
+          <p role="status" className="mx-4 mt-3 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{actionNotice}</p>
+        ) : null}
+
+        <Group title="Identity">
+          <dl className="mt-2 grid grid-cols-2 gap-3">
+            <Field label="Runtime ID" mono>{run.id}</Field>
+            <Field label="Provider native ID" mono>{run.nativeId || EM_DASH}</Field>
+            <Field label="Short ID" mono>{run.shortId || EM_DASH}</Field>
+            <Field label="Runtime kind">{run.runtimeKind}</Field>
+            <Field label="Provider">{providerLabel(run.provider)}</Field>
+            <Field label="Host">{run.hostKind}</Field>
+            <Field label="State">{stateLabel(run.state)}</Field>
+            <Field label="Source">{run.source}</Field>
+            {run.parentRuntimeId ? <Field label="Forked from" mono>{run.parentRuntimeId}</Field> : null}
+          </dl>
+        </Group>
+
+        <Group title="Model and route">
+          <dl className="mt-2 grid grid-cols-2 gap-3">
+            <Field label="Account">{run.account || EM_DASH}</Field>
+            <Field label="Model">{run.model || EM_DASH}</Field>
+            <Field label="Recorded route" mono>{run.route || EM_DASH}</Field>
+          </dl>
+          <label className="mt-3 block text-[11px] font-medium uppercase tracking-wide text-primary-500" htmlFor="run-route-ref">Subscription route</label>
+          <select id="run-route-ref" className="mt-1 h-9 w-full rounded-lg border border-primary-200 bg-primary-50 px-2.5 text-sm" value={eligibleRouteRef} onChange={(event) => setRouteRef(event.target.value)}>
+            <option value="">Select a subscription-included route</option>
+            {routeOptions.map((route) => <option key={route.id} value={route.id}>{route.id}</option>)}
+          </select>
+          {!eligibleRouteRef ? <p className="mt-2 text-xs text-primary-500">{NO_ROUTE}</p> : null}
+        </Group>
+
+        <Group title="Workspace">
+          <dl className="mt-2 grid gap-3">
+            <Field label="Project">{run.project || EM_DASH}</Field>
+            <Field label="Worktree" mono>{run.worktree || EM_DASH}</Field>
+            <Field label="Working directory" mono>{run.cwd || EM_DASH}</Field>
+          </dl>
+        </Group>
+
+        <Group title="Kanban">
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <KanbanPill linked={run.linked} taskId={run.kanbanTaskId} />
+            <p className="text-xs text-primary-600">Kanban task state stays authoritative; runtime linkage is metadata only.</p>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <input aria-label="Kanban task ID" className="h-9 min-w-0 flex-1 rounded-lg border border-primary-200 bg-primary-50 px-2.5 text-sm" maxLength={64} value={kanbanTaskId} onChange={(event) => setKanbanTaskId(event.target.value)} placeholder="Task ID" />
+            <button type="button" className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }))} disabled={!kanbanTaskId.trim() || busy !== null} onClick={() => void dispatch('link_kanban', { action: 'link_kanban', runtimeId: run.id, kanbanTaskId: kanbanTaskId.trim() })}>Link Kanban</button>
+            {run.linked ? <button type="button" className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))} disabled={busy !== null} onClick={() => void dispatch('link_kanban', { action: 'link_kanban', runtimeId: run.id, kanbanTaskId: null })}>Unlink</button> : null}
+          </div>
+        </Group>
+
+        <Group title="Ownership">
+          <dl className="mt-2 grid grid-cols-2 gap-3">
+            <Field label="Writer lease">{ownershipLabel(run.ownership.state)}</Field>
+            <Field label="Owner">{run.ownership.owner || EM_DASH}</Field>
+            <Field label="Lease expires">{formatTimestamp(run.ownership.expiresAt)}</Field>
+            <Field label="Abandoned">{run.ownership.abandoned ? 'Yes' : 'No'}</Field>
+            <Field label="Created">{formatTimestamp(run.createdAt)}</Field>
+            <Field label="Updated">{`${formatAge(run.stalenessMs)} · ${formatTimestamp(run.updatedAt)}`}</Field>
+          </dl>
+          <div className="mt-3">
+            <button
+              type="button"
+              className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }))}
+              disabled={!leaseRecoverable || busy !== null}
+              aria-describedby={leaseRecoverable ? undefined : 'run-action-help-recover-lease'}
+              onClick={() => void dispatch('recover-lease', { action: 'recover-lease', runtimeId: run.id })}
+            >
+              Recover lease
+            </button>
+            {!leaseRecoverable ? (
+              <p id="run-action-help-recover-lease" className="mt-1 text-xs text-primary-500">{NEEDS_LEASE}</p>
+            ) : null}
+          </div>
+        </Group>
+
+        <Group title="Actions">
+          <p className="mt-1 text-xs text-primary-500">
+            Actions use this run&apos;s recorded identity. Follow-up text is sent only in the action POST body; it is never stored or written to the URL.
+          </p>
+          {run.provider === 'claude' ? (
+            <label className="mt-3 block text-xs font-medium text-primary-700">
+              Follow-up text
+              <textarea aria-label="Follow-up text" className="mt-1 min-h-20 w-full rounded-lg border border-primary-200 bg-primary-50 px-2.5 py-2 text-sm" maxLength={32_000} value={followUp} onChange={(event) => setFollowUp(event.target.value)} placeholder="Required for Claude resume" />
+            </label>
+          ) : null}
+          <ul className="mt-3 space-y-3">
+            {ACTIONS.map((action) => {
+              const capability = run.capabilities[action.operation]
+              const reason = blockedReason(run, capability, eligibleRouteRef, action.operation, followUp)
+              const helpId = `run-action-help-${action.operation}`
+              return (
+                <li key={action.operation} className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className={cn(buttonVariants({ variant: action.destructive ? 'outline' : 'secondary', size: 'sm' }), 'min-w-[104px]')}
+                      disabled={reason !== null || busy !== null}
+                      aria-describedby={reason ? helpId : undefined}
+                      onClick={() => void dispatch(action.operation, {
+                        action: action.operation,
+                        runtimeId: run.id,
+                        accountAlias: run.accountKey,
+                        routeRef: eligibleRouteRef,
+                        cwd: run.cwd,
+                        worktree: run.worktree,
+                        ...(followUp.trim() ? { prompt: followUp.trim() } : {}),
+                      })}
+                    >{action.label}</button>
+                    <CapabilityPill state={capability.state} />
+                    {capability.deferred ? <span className="text-xs text-primary-500">deferred</span> : null}
+                  </div>
+                  {reason ? <p id={helpId} className="text-xs text-primary-500">{reason}</p> : null}
+                </li>
+              )
+            })}
+          </ul>
+        </Group>
+
+        <Group title="Capability matrix">
+          <dl className="mt-2 space-y-2">
+            {Object.entries(run.capabilities).map(([operation, capability]) => (
+              <div key={operation} className="flex flex-wrap items-baseline gap-2">
+                <dt className="text-sm font-medium text-primary-900">{operation}</dt>
+                <dd className="flex flex-wrap items-center gap-2">
+                  <CapabilityPill state={capability.state} />
+                  <span className="text-xs text-primary-600">{capability.explanation}</span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </Group>
+      </div>
+    </>
+  )
+}

--- a/src/screens/runs/components/run-pills.tsx
+++ b/src/screens/runs/components/run-pills.tsx
@@ -1,0 +1,71 @@
+import { ownershipLabel, providerLabel, stateLabel } from '../runs-format'
+import type { ReactNode } from 'react'
+
+import type { RuntimeRunCapability, RuntimeRunOwnership, RuntimeRunState } from '@/server/runtime-run-projection'
+import { cn } from '@/lib/utils'
+
+
+const PILL = 'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap'
+
+export function Pill({ className, children, title }: { className?: string; children: ReactNode; title?: string }) {
+  return <span className={cn(PILL, className)} title={title}>{children}</span>
+}
+
+const STATE_STYLES: Record<RuntimeRunState, string> = {
+  active: 'border-emerald-300 bg-emerald-50 text-emerald-800',
+  idle: 'border-primary-300 bg-primary-100 text-primary-700',
+  stopped: 'border-primary-300 bg-primary-50 text-primary-600',
+  attention: 'border-amber-300 bg-amber-50 text-amber-800',
+}
+
+const STATE_HINTS: Record<RuntimeRunState, string> = {
+  active: 'The provider host reports this runtime as running.',
+  idle: 'Discovered and resumable; no host process is running.',
+  stopped: 'The host process has exited.',
+  attention: 'Host or writer-lease state could not be verified.',
+}
+
+export function StatePill({ state }: { state: RuntimeRunState }) {
+  return (
+    <Pill className={STATE_STYLES[state]} title={STATE_HINTS[state]}>
+      <span aria-hidden="true" className={cn('h-1.5 w-1.5 rounded-full', state === 'active' ? 'bg-emerald-500' : state === 'attention' ? 'bg-amber-500' : 'bg-primary-400')} />
+      {stateLabel(state)}
+    </Pill>
+  )
+}
+
+export function ProviderPill({ provider }: { provider: string }) {
+  return <Pill className="border-primary-200 bg-primary-50 text-primary-700">{providerLabel(provider)}</Pill>
+}
+
+export function OwnershipPill({ ownership }: { ownership: RuntimeRunOwnership }) {
+  const tone = ownership.state === 'owned'
+    ? 'border-sky-300 bg-sky-50 text-sky-800'
+    : ownership.state === 'recoverable'
+      ? 'border-amber-300 bg-amber-50 text-amber-800'
+      : ownership.state === 'unknown'
+        ? 'border-primary-300 bg-primary-100 text-primary-700'
+        : 'border-primary-200 bg-primary-50 text-primary-600'
+  return (
+    <Pill className={tone} title={ownership.owner ? `Writer lease held by ${ownership.owner}` : 'No writer lease is held for this runtime'}>
+      {ownershipLabel(ownership.state)}
+    </Pill>
+  )
+}
+
+const CAPABILITY_STYLES: Record<string, string> = {
+  supported: 'border-emerald-300 bg-emerald-50 text-emerald-800',
+  degraded: 'border-amber-300 bg-amber-50 text-amber-800',
+  experimental: 'border-sky-300 bg-sky-50 text-sky-800',
+  unsupported: 'border-primary-300 bg-primary-100 text-primary-600',
+}
+
+export function CapabilityPill({ state }: { state: RuntimeRunCapability['state'] }) {
+  return <Pill className={CAPABILITY_STYLES[state] ?? CAPABILITY_STYLES.unsupported}>{state}</Pill>
+}
+
+export function KanbanPill({ linked, taskId }: { linked: boolean; taskId: string | null }) {
+  return linked && taskId
+    ? <Pill className="border-primary-300 bg-primary-100 text-primary-800" title="Kanban remains authoritative; runtime linkage is metadata only.">{taskId}</Pill>
+    : <Pill className="border-dashed border-primary-300 bg-transparent text-primary-500">Unlinked</Pill>
+}

--- a/src/screens/runs/components/runs-cards.tsx
+++ b/src/screens/runs/components/runs-cards.tsx
@@ -1,0 +1,72 @@
+
+import { EM_DASH, formatAge, routeLabel, shortPath } from '../runs-format'
+import { KanbanPill, OwnershipPill, ProviderPill, StatePill } from './run-pills'
+import type { RuntimeRun } from '@/server/runtime-run-projection'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  runs: ReadonlyArray<RuntimeRun>
+  caption: string
+  selectedId: string | null
+  onSelect: (run: RuntimeRun) => void
+}
+
+/** Narrow-viewport rendering of the same rows the desktop table shows. */
+export function RunsCards({ runs, caption, selectedId, onSelect }: Props) {
+  return (
+    <section aria-label="Runs" className="md:hidden">
+      <p className="px-1 pb-2 text-xs text-primary-600">{caption}</p>
+      <ul className="space-y-2">
+        {runs.map((run) => (
+          <li key={run.id}>
+            <button
+              type="button"
+              aria-current={run.id === selectedId ? 'true' : undefined}
+              onClick={() => onSelect(run)}
+              className={cn(
+                'w-full rounded-xl border border-primary-200 bg-primary-50/80 p-3 text-left shadow-2xs focus-visible:ring-2 focus-visible:ring-primary-950',
+                run.id === selectedId ? 'border-primary-400 bg-primary-100/70' : 'active:bg-primary-50',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-primary-900">{run.title}</span>
+                  <span className="block truncate font-mono text-[11px] text-primary-500">{run.shortId || run.id}</span>
+                </span>
+                <StatePill state={run.state} />
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <ProviderPill provider={run.provider} />
+                <KanbanPill linked={run.linked} taskId={run.kanbanTaskId} />
+                {run.ownership.state !== 'free' ? <OwnershipPill ownership={run.ownership} /> : null}
+              </div>
+              <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-primary-600">
+                <div className="min-w-0">
+                  <dt className="text-primary-500">Account</dt>
+                  <dd className="truncate">{run.account || EM_DASH}</dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-primary-500">Model / route</dt>
+                  <dd className="truncate">{routeLabel(run)}</dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-primary-500">Project</dt>
+                  <dd className="truncate">{run.project ?? shortPath(run.worktree)}</dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-primary-500">Updated</dt>
+                  <dd className="truncate">{formatAge(run.stalenessMs)}</dd>
+                </div>
+              </dl>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {runs.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-primary-300 px-4 py-6 text-sm text-primary-600">
+          No runs match these filters.
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/src/screens/runs/components/runs-filters.tsx
+++ b/src/screens/runs/components/runs-filters.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useId, useState } from 'react'
+
+import {
+  CLEARED_FILTERS,
+  RUNS_OWNERSHIPS,
+  RUNS_PROVIDERS,
+  RUNS_STATES,
+  RUNS_WINDOWS,
+  hasActiveFilters,
+  normalizeKanban,
+  normalizeView,
+  normalizeWindow
+} from '../runs-search'
+import { ownershipLabel, providerLabel, stateLabel } from '../runs-format'
+import type {RunsSearch} from '../runs-search';
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+
+const FIELD = 'h-9 w-full rounded-lg border border-primary-200 bg-primary-50 px-2.5 text-sm text-primary-900 shadow-2xs outline-none focus-visible:ring-2 focus-visible:ring-primary-950 disabled:cursor-not-allowed disabled:opacity-60'
+const LABEL = 'text-[11px] font-medium uppercase tracking-wide text-primary-500'
+
+type Props = {
+  search: RunsSearch
+  accounts: ReadonlyArray<string>
+  projects: ReadonlyArray<string>
+  onChange: (patch: RunsSearch) => void
+}
+
+/**
+ * Filter controls. Every control writes to the URL, so a filtered inventory is
+ * shareable — and nothing but filters is ever written there.
+ */
+export function RunsFilters({ search, accounts, projects, onChange }: Props) {
+  const view = normalizeView(search.view)
+  const stateFromView = view === 'active' || view === 'attention'
+  const ids = useId()
+  const accountListId = `${ids}-accounts`
+  const projectListId = `${ids}-projects`
+  const stateHelpId = `${ids}-state-help`
+
+  // Local echo of the query so typing stays responsive; the URL is the source
+  // of truth and wins whenever it changes underneath us.
+  const [query, setQuery] = useState(search.q ?? '')
+  useEffect(() => { setQuery(search.q ?? '') }, [search.q])
+
+  return (
+    <section aria-labelledby="runs-filters-heading" className="rounded-xl border border-primary-200 bg-primary-50/70 p-3 md:p-4">
+      <h2 id="runs-filters-heading" className="sr-only">Filter runs</h2>
+      <form
+        className="grid gap-3 md:grid-cols-2 lg:grid-cols-4"
+        onSubmit={(event) => {
+          event.preventDefault()
+          onChange({ q: query.trim() || undefined, page: 1 })
+        }}
+      >
+        <div className="lg:col-span-2">
+          <label className={LABEL} htmlFor={`${ids}-q`}>Search</label>
+          <div className="mt-1 flex gap-2">
+            <input
+              id={`${ids}-q`}
+              type="search"
+              className={FIELD}
+              maxLength={200}
+              placeholder="Title, task, account, model, worktree, run ID"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onBlur={() => { if ((search.q ?? '') !== query.trim()) onChange({ q: query.trim() || undefined, page: 1 }) }}
+            />
+            <button type="submit" className={cn(buttonVariants({ variant: 'secondary', size: 'default' }), 'shrink-0')}>
+              Search
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-provider`}>Provider</label>
+          <select
+            id={`${ids}-provider`}
+            className={cn(FIELD, 'mt-1')}
+            value={search.provider ?? ''}
+            onChange={(event) => onChange({ provider: event.target.value || undefined, page: 1 })}
+          >
+            <option value="">Any provider</option>
+            {RUNS_PROVIDERS.map((provider) => <option key={provider} value={provider}>{providerLabel(provider)}</option>)}
+          </select>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-state`}>State</label>
+          <select
+            id={`${ids}-state`}
+            className={cn(FIELD, 'mt-1')}
+            disabled={stateFromView}
+            aria-describedby={stateFromView ? stateHelpId : undefined}
+            value={stateFromView ? view : (search.state ?? '')}
+            onChange={(event) => onChange({ state: event.target.value || undefined, page: 1 })}
+          >
+            <option value="">Any state</option>
+            {RUNS_STATES.map((state) => <option key={state} value={state}>{stateLabel(state)}</option>)}
+          </select>
+          {stateFromView ? (
+            <p id={stateHelpId} className="mt-1 text-xs text-primary-500">
+              The {view === 'active' ? 'Active' : 'Attention'} view already pins the state filter. Switch to Recent to choose a state.
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-account`}>Account</label>
+          <input
+            id={`${ids}-account`}
+            className={cn(FIELD, 'mt-1')}
+            list={accountListId}
+            maxLength={200}
+            placeholder="Any account"
+            defaultValue={search.account ?? ''}
+            key={`account:${search.account ?? ''}`}
+            onBlur={(event) => {
+              const value = event.target.value.trim()
+              if (value !== (search.account ?? '')) onChange({ account: value || undefined, page: 1 })
+            }}
+          />
+          <datalist id={accountListId}>
+            {accounts.map((account) => <option key={account} value={account} />)}
+          </datalist>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-project`}>Project</label>
+          <input
+            id={`${ids}-project`}
+            className={cn(FIELD, 'mt-1')}
+            list={projectListId}
+            maxLength={200}
+            placeholder="Any project"
+            defaultValue={search.project ?? ''}
+            key={`project:${search.project ?? ''}`}
+            onBlur={(event) => {
+              const value = event.target.value.trim()
+              if (value !== (search.project ?? '')) onChange({ project: value || undefined, page: 1 })
+            }}
+          />
+          <datalist id={projectListId}>
+            {projects.map((project) => <option key={project} value={project} />)}
+          </datalist>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-kanban`}>Kanban</label>
+          <select
+            id={`${ids}-kanban`}
+            className={cn(FIELD, 'mt-1')}
+            value={normalizeKanban(search.kanban)}
+            onChange={(event) => onChange({ kanban: event.target.value as RunsSearch['kanban'], page: 1 })}
+          >
+            <option value="all">Linked and unlinked</option>
+            <option value="linked">Linked to a task</option>
+            <option value="unlinked">Not linked</option>
+          </select>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-ownership`}>Writer lease</label>
+          <select
+            id={`${ids}-ownership`}
+            className={cn(FIELD, 'mt-1')}
+            value={search.ownership ?? ''}
+            onChange={(event) => onChange({ ownership: event.target.value || undefined, page: 1 })}
+          >
+            <option value="">Any lease state</option>
+            {RUNS_OWNERSHIPS.map((state) => <option key={state} value={state}>{ownershipLabel(state)}</option>)}
+          </select>
+        </div>
+
+        <div>
+          <label className={LABEL} htmlFor={`${ids}-window`}>Last updated</label>
+          <select
+            id={`${ids}-window`}
+            className={cn(FIELD, 'mt-1')}
+            value={normalizeWindow(search.window)}
+            onChange={(event) => onChange({ window: event.target.value as RunsSearch['window'], from: undefined, to: undefined, page: 1 })}
+          >
+            {RUNS_WINDOWS.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+          </select>
+        </div>
+
+        <div className="flex items-end justify-between gap-2 md:col-span-2 lg:col-span-4">
+          <p className="text-xs text-primary-500">
+            Filters live in the URL, so any view here can be shared or bookmarked. Prompts and action payloads never are.
+          </p>
+          <button
+            type="button"
+            className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'shrink-0')}
+            disabled={!hasActiveFilters(search)}
+            onClick={() => onChange(CLEARED_FILTERS)}
+          >
+            Clear filters
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/src/screens/runs/components/runs-header.tsx
+++ b/src/screens/runs/components/runs-header.tsx
@@ -1,0 +1,88 @@
+import { Link } from '@tanstack/react-router'
+
+import { RUNS_VIEWS  } from '../runs-search'
+import { formatTimestamp } from '../runs-format'
+import type {RunsView} from '../runs-search';
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/ui/button'
+
+
+type Props = {
+  view: RunsView
+  discovering: boolean
+  generatedAt: number | null
+  statusText: string
+  discoveryError: string | null
+  truncated: boolean
+  onView: (view: RunsView) => void
+  onRefresh: () => void
+}
+
+/**
+ * Provider discovery is a deliberate, visible act: it is only ever started by
+ * this button, never by rendering the screen.
+ */
+export function RunsHeader({ view, discovering, generatedAt, statusText, discoveryError, truncated, onView, onRefresh }: Props) {
+  const active = RUNS_VIEWS.find((entry) => entry.id === view)
+  return (
+    <header className="rounded-xl border border-primary-200 bg-primary-50/80 px-4 py-4 shadow-sm">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-base font-semibold text-primary-900">Runs</h1>
+          <p className="mt-1 text-sm text-primary-600">
+            Every provider runtime Workspace has discovered — Hermes, Claude, and Codex — as read-only metadata.
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-col items-start gap-1 md:items-end">
+          <div className="flex flex-wrap items-center gap-2">
+            <Link to="/conductor" className={cn(buttonVariants({ variant: 'default', size: 'default' }))}>New run</Link>
+            <button
+              type="button"
+              className={cn(buttonVariants({ variant: 'secondary', size: 'default' }))}
+              disabled={discovering}
+              onClick={onRefresh}
+            >
+              {discovering ? 'Refreshing…' : 'Refresh from providers'}
+            </button>
+          </div>
+          <p className="text-xs text-primary-500">
+            {generatedAt ? `Inventory read ${formatTimestamp(generatedAt)}` : 'Inventory not read yet'}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-1 rounded-xl border border-primary-200 bg-primary-50/70 p-1">
+        {RUNS_VIEWS.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            aria-pressed={entry.id === view}
+            aria-describedby={entry.id === view ? 'runs-view-hint' : undefined}
+            title={entry.hint}
+            onClick={() => onView(entry.id)}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+              entry.id === view ? 'bg-primary-950 text-primary-50' : 'text-primary-600 hover:bg-primary-100',
+            )}
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+      <p id="runs-view-hint" className="mt-2 text-xs text-primary-500">{active?.hint}</p>
+
+      <p aria-live="polite" className="mt-2 text-sm text-primary-700">{statusText}</p>
+
+      {truncated ? (
+        <p className="mt-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          The registry exceeds the bounded 5,000-run projection. Additional history needs an indexed registry cursor before it can be shown safely.
+        </p>
+      ) : null}
+      {discoveryError ? (
+        <p role="alert" className="mt-2 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {discoveryError} — the metadata below is the last successful read.
+        </p>
+      ) : null}
+    </header>
+  )
+}

--- a/src/screens/runs/components/runs-pagination.tsx
+++ b/src/screens/runs/components/runs-pagination.tsx
@@ -1,0 +1,54 @@
+
+import { RUNS_PAGE_SIZES  } from '../runs-search'
+import { formatCount } from '../runs-format'
+import type {RunsPageSize} from '../runs-search';
+import type { RunsPageInfo } from '../use-runs-inventory'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  page: RunsPageInfo
+  size: RunsPageSize
+  busy: boolean
+  onPage: (page: number) => void
+  onSize: (size: RunsPageSize) => void
+}
+
+export function RunsPagination({ page, size, busy, onPage, onSize }: Props) {
+  return (
+    <nav aria-label="Run pages" className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary-200 bg-primary-50/70 px-3 py-2">
+      <p className="text-xs text-primary-600">
+        Page {formatCount(page.number)} of {formatCount(page.pages)} · {formatCount(page.total)} matched
+      </p>
+      <div className="flex items-center gap-2">
+        <label className="flex items-center gap-1.5 text-xs text-primary-600" htmlFor="runs-page-size">
+          Per page
+          <select
+            id="runs-page-size"
+            className="h-8 rounded-lg border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900"
+            value={size}
+            onChange={(event) => onSize(Number(event.target.value) as RunsPageSize)}
+          >
+            {RUNS_PAGE_SIZES.map((option) => <option key={option} value={option}>{option}</option>)}
+          </select>
+        </label>
+        <button
+          type="button"
+          className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }))}
+          disabled={busy || !page.hasPrevious}
+          onClick={() => onPage(page.number - 1)}
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }))}
+          disabled={busy || !page.hasNext}
+          onClick={() => onPage(page.number + 1)}
+        >
+          Next
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/src/screens/runs/components/runs-summary-strip.tsx
+++ b/src/screens/runs/components/runs-summary-strip.tsx
@@ -1,0 +1,47 @@
+import { formatCount, providerLabel } from '../runs-format'
+import type { RuntimeRunSummary } from '@/server/runtime-run-projection'
+
+
+type Tile = { label: string; value: number; hint: string }
+
+function tilesFor(summary: RuntimeRunSummary): Array<Tile> {
+  return [
+    { label: 'Matched', value: summary.total, hint: 'Runs matching the current filters.' },
+    { label: 'Active', value: summary.active, hint: 'Provider hosts reported as running.' },
+    { label: 'Idle', value: summary.idle, hint: 'Discovered but not running.' },
+    { label: 'Stopped', value: summary.stopped, hint: 'Host process has exited.' },
+    { label: 'Attention', value: summary.attention, hint: 'Host or writer-lease state is unverified.' },
+    { label: 'Resumable', value: summary.idleResumable, hint: 'Idle or stopped runs a provider may be able to resume.' },
+    { label: 'Kanban linked', value: summary.linkedKanban, hint: 'Kanban stays authoritative; linkage is metadata only.' },
+    { label: 'Leased', value: summary.owned, hint: 'A writer lease is currently held.' },
+    { label: 'Recoverable', value: summary.recoverable, hint: 'Abandoned writer lease that can be recovered.' },
+    { label: 'Stale', value: summary.stale, hint: 'No metadata update for more than 15 minutes.' },
+  ]
+}
+
+export function RunsSummaryStrip({ summary }: { summary: RuntimeRunSummary | null }) {
+  if (!summary) return null
+  const providers = Object.entries(summary.byProvider).filter(([, count]) => count > 0)
+  return (
+    <section aria-labelledby="runs-summary-heading" className="rounded-xl border border-primary-200 bg-primary-50/70 px-3 py-3 md:px-4">
+      <h2 id="runs-summary-heading" className="sr-only">Run inventory summary</h2>
+      <dl className="flex snap-x gap-2 overflow-x-auto pb-1 md:grid md:grid-cols-5 md:gap-3 md:overflow-visible lg:grid-cols-10">
+        {tilesFor(summary).map((tile) => (
+          <div
+            key={tile.label}
+            title={tile.hint}
+            className="min-w-[104px] shrink-0 snap-start rounded-lg border border-primary-200 bg-primary-50/70 px-3 py-2 md:min-w-0"
+          >
+            <dt className="text-[11px] font-medium uppercase tracking-wide text-primary-500">{tile.label}</dt>
+            <dd className="mt-0.5 text-lg font-semibold tabular-nums text-primary-900">{formatCount(tile.value)}</dd>
+          </div>
+        ))}
+      </dl>
+      {providers.length > 0 ? (
+        <p className="mt-2 text-xs text-primary-600">
+          By provider: {providers.map(([provider, count]) => `${providerLabel(provider)} ${formatCount(count)}`).join(' · ')}
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/src/screens/runs/components/runs-table.tsx
+++ b/src/screens/runs/components/runs-table.tsx
@@ -1,0 +1,119 @@
+
+import { EM_DASH, formatAge, routeLabel, shortPath } from '../runs-format'
+import { KanbanPill, OwnershipPill, ProviderPill, StatePill } from './run-pills'
+import type { RuntimeRun, RuntimeRunSortDirection, RuntimeRunSortKey } from '@/server/runtime-run-projection'
+import { cn } from '@/lib/utils'
+
+type Column = {
+  key: string
+  label: string
+  sort?: RuntimeRunSortKey
+  className?: string
+}
+
+const COLUMNS: ReadonlyArray<Column> = [
+  { key: 'run', label: 'Run', sort: 'title' },
+  { key: 'provider', label: 'Provider', sort: 'provider' },
+  { key: 'state', label: 'State', sort: 'state' },
+  { key: 'account', label: 'Account' },
+  { key: 'model', label: 'Model / route' },
+  { key: 'project', label: 'Project', sort: 'project' },
+  { key: 'kanban', label: 'Kanban' },
+  { key: 'updated', label: 'Updated', sort: 'updated', className: 'text-right' },
+]
+
+type Props = {
+  runs: ReadonlyArray<RuntimeRun>
+  caption: string
+  captionDetail: string
+  sort: RuntimeRunSortKey
+  direction: RuntimeRunSortDirection
+  selectedId: string | null
+  onSort: (key: RuntimeRunSortKey) => void
+  onSelect: (run: RuntimeRun) => void
+}
+
+/**
+ * Compact desktop grid. One row per run, no nested interactive controls beyond
+ * the single row trigger, so keyboard traversal stays predictable.
+ */
+export function RunsTable({ runs, caption, captionDetail, sort, direction, selectedId, onSort, onSelect }: Props) {
+  return (
+    <div className="hidden overflow-x-auto rounded-xl border border-primary-200 bg-primary-50/70 md:block">
+      <table className="w-full border-collapse text-sm">
+        <caption className="border-b border-primary-200 px-4 py-2 text-left text-xs text-primary-600">
+          {caption}
+          <span className="ml-2 text-primary-500">{captionDetail}</span>
+        </caption>
+        <thead>
+          <tr className="border-b border-primary-200 bg-primary-50/80">
+            {COLUMNS.map((column) => {
+              const sorted = column.sort === sort
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  aria-sort={column.sort ? (sorted ? (direction === 'asc' ? 'ascending' : 'descending') : 'none') : undefined}
+                  className={cn('px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-primary-500', column.className)}
+                >
+                  {column.sort ? (
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded hover:text-primary-900 focus-visible:ring-2 focus-visible:ring-primary-950"
+                      onClick={() => onSort(column.sort as RuntimeRunSortKey)}
+                    >
+                      {column.label}
+                      <span aria-hidden="true" className={cn('text-[10px]', sorted ? 'opacity-100' : 'opacity-0')}>
+                        {direction === 'asc' ? '▲' : '▼'}
+                      </span>
+                    </button>
+                  ) : column.label}
+                </th>
+              )
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr
+              key={run.id}
+              aria-current={run.id === selectedId ? 'true' : undefined}
+              className={cn(
+                'border-b border-primary-100 align-middle last:border-b-0',
+                run.id === selectedId ? 'bg-primary-100/70' : 'hover:bg-primary-50',
+              )}
+            >
+              <th scope="row" className="max-w-[320px] px-3 py-2 text-left font-normal">
+                <button
+                  type="button"
+                  className="block w-full truncate text-left font-medium text-primary-900 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-primary-950"
+                  onClick={() => onSelect(run)}
+                >
+                  {run.title}
+                </button>
+                <span className="block truncate font-mono text-[11px] text-primary-500">{run.shortId || run.id}</span>
+              </th>
+              <td className="px-3 py-2"><ProviderPill provider={run.provider} /></td>
+              <td className="px-3 py-2">
+                <div className="flex flex-col items-start gap-1">
+                  <StatePill state={run.state} />
+                  {run.ownership.state !== 'free' ? <OwnershipPill ownership={run.ownership} /> : null}
+                </div>
+              </td>
+              <td className="max-w-[160px] truncate px-3 py-2 text-primary-700">{run.account || EM_DASH}</td>
+              <td className="max-w-[200px] truncate px-3 py-2 text-primary-700" title={run.route ?? undefined}>{routeLabel(run)}</td>
+              <td className="max-w-[200px] truncate px-3 py-2 text-primary-700" title={run.worktree ?? undefined}>
+                {run.project ?? shortPath(run.worktree)}
+              </td>
+              <td className="px-3 py-2"><KanbanPill linked={run.linked} taskId={run.kanbanTaskId} /></td>
+              <td className="whitespace-nowrap px-3 py-2 text-right text-primary-600">{formatAge(run.stalenessMs)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {runs.length === 0 ? (
+        <p className="px-4 py-6 text-sm text-primary-600">No runs match these filters.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/screens/runs/runs-format.ts
+++ b/src/screens/runs/runs-format.ts
@@ -1,0 +1,77 @@
+// Display helpers for the Runs screen. Durations are formatted from the
+// server-supplied staleness so the age shown never depends on client clock
+// skew against the machine that projected the inventory.
+
+import type { RuntimeRun, RuntimeRunState } from '@/server/runtime-run-projection'
+
+export const EM_DASH = '—'
+
+export function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return EM_DASH
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 45) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${Math.max(1, minutes)}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return `${Math.floor(days / 30)}mo ago`
+}
+
+export function formatTimestamp(ms: number | null): string {
+  if (!ms || !Number.isFinite(ms) || ms <= 0) return EM_DASH
+  return new Date(ms).toLocaleString()
+}
+
+export function formatCount(value: number): string {
+  return Number.isFinite(value) ? new Intl.NumberFormat().format(value) : EM_DASH
+}
+
+export function pluralRuns(count: number): string {
+  return `${formatCount(count)} ${count === 1 ? 'run' : 'runs'}`
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  hermes: 'Hermes',
+  claude: 'Claude',
+  codex: 'Codex',
+  unknown: 'Unknown',
+}
+
+export function providerLabel(provider: string): string {
+  return PROVIDER_LABELS[provider] ?? provider
+}
+
+const STATE_LABELS: Record<RuntimeRunState, string> = {
+  active: 'Active',
+  idle: 'Idle',
+  stopped: 'Stopped',
+  attention: 'Attention',
+}
+
+export function stateLabel(state: RuntimeRunState): string {
+  return STATE_LABELS[state]
+}
+
+const OWNERSHIP_LABELS: Record<string, string> = {
+  free: 'No writer lease',
+  owned: 'Leased',
+  recoverable: 'Lease recoverable',
+  unknown: 'Lease unverified',
+}
+
+export function ownershipLabel(state: string): string {
+  return OWNERSHIP_LABELS[state] ?? state
+}
+
+/** Last two path segments — enough to tell worktrees apart without the full path. */
+export function shortPath(value: string | null): string {
+  if (!value) return EM_DASH
+  const segments = value.split(/[\\/]+/).filter(Boolean)
+  return segments.length <= 2 ? value : `…/${segments.slice(-2).join('/')}`
+}
+
+export function routeLabel(run: RuntimeRun): string {
+  return run.model || run.route || EM_DASH
+}

--- a/src/screens/runs/runs-screen.test.tsx
+++ b/src/screens/runs/runs-screen.test.tsx
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RunsScreen } from './runs-screen'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const router = vi.hoisted(() => ({
+  search: {} as Record<string, unknown>,
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => router.navigate,
+  useSearch: () => router.search,
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) =>
+    React.createElement('a', { href: to, ...props }, children),
+}))
+
+const run = {
+  id: 'codex:thread-1234567890abcdef',
+  source: 'provider-runtime',
+  provider: 'codex',
+  runtimeKind: 'codex_thread',
+  nativeId: 'thread-1234567890abcdef',
+  shortId: 'thread-12345',
+  account: 'OpenAI Codex',
+  accountKey: 'openai-codex',
+  route: 'openai-codex/gpt-5.6-sol',
+  model: 'gpt-5.6-sol',
+  project: 'Workspace',
+  worktree: 'C:/work/Workspace',
+  cwd: 'C:/work/Workspace',
+  title: 'Workspace · Codex thread',
+  state: 'idle',
+  hostKind: 'stdio',
+  linked: false,
+  kanbanTaskId: null,
+  parentRuntimeId: null,
+  ownership: { state: 'free', owner: null, expiresAt: null, abandoned: false },
+  capabilities: {
+    fork: { state: 'unsupported', invokable: false, explanation: 'Disabled until provider fork identity has crash-safe durable recovery or idempotency.' },
+    resume: { state: 'experimental', invokable: true, explanation: 'Bounded local resume.' },
+    steer: { state: 'unsupported', invokable: false, explanation: 'No persistent connection.' },
+    interrupt: { state: 'unsupported', invokable: false, explanation: 'No persistent connection.' },
+    archive: { state: 'experimental', invokable: true, explanation: 'Bounded local archive.' },
+    status: { state: 'supported', invokable: true, explanation: 'Metadata status.' },
+  },
+  createdAt: 100,
+  updatedAt: 200,
+  stalenessMs: 800,
+}
+
+function inventory(runs = [run]) {
+  return {
+    ok: true,
+    runs,
+    summary: {
+      total: runs.length, active: 0, idle: runs.length, stopped: 0, attention: 0,
+      idleResumable: runs.length, linkedKanban: 0, unlinkedKanban: runs.length,
+      owned: 0, recoverable: 0, unknownOwnership: 0, stale: 0,
+      byProvider: { codex: runs.length }, byState: { active: 0, idle: runs.length, stopped: 0, attention: 0 },
+    },
+    page: { number: 1, size: 25, total: runs.length, pages: 1, hasNext: false, hasPrevious: false },
+    inventory: { projected: runs.length, matched: runs.length, truncated: false },
+    availableRoutes: [
+      { id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available' },
+      { id: 'claude-cwm4tx/opus-5', account: 'cwm4tx', model: 'opus-5', status: 'available' },
+    ],
+    generatedAt: 1_000,
+  }
+}
+
+async function settle() {
+  await React.act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)) })
+}
+
+function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
+  setter?.call(element, value)
+  element.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+async function renderScreen() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await React.act(async () => { root.render(<RunsScreen />) })
+  await settle()
+  return {
+    container,
+    unmount: async () => {
+      await React.act(async () => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  router.search = { view: 'recent', kanban: 'all', page: 1, size: 25, sort: 'updated', direction: 'desc' }
+  router.navigate.mockReset()
+  fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === 'POST') return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    return new Response(JSON.stringify(inventory()), { status: 200 })
+  })
+  global.fetch = fetchMock as typeof fetch
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('RunsScreen', () => {
+  it('loads metadata without refreshing providers and renders a compact semantic table', async () => {
+    const { container, unmount } = await renderScreen()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/runtime-runs')
+    expect(init?.method).not.toBe('POST')
+    expect(container.querySelector('table')).not.toBeNull()
+    expect(container.querySelector('caption')?.textContent).toContain('1 of 1')
+    expect(container.textContent).toContain('Workspace · Codex thread')
+    expect(container.textContent).toContain('OpenAI Codex')
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toContain('1 run')
+    expect(container.querySelector('a[href="/conductor"]')?.textContent).toContain('New run')
+    await unmount()
+  })
+
+  it('opens a deep-linked accessible detail drawer with truthful disabled-action help', async () => {
+    router.search = { ...router.search, run: run.id }
+    const { container, unmount } = await renderScreen()
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    if (!dialog) throw new Error('Expected run detail dialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    const tableBranch = container.querySelector('table')?.parentElement
+    expect(tableBranch?.hasAttribute('inert')).toBe(true)
+    expect(tableBranch?.getAttribute('aria-hidden')).toBe('true')
+    expect(dialog.textContent).toContain(run.nativeId)
+    expect(dialog.textContent).toContain(run.worktree)
+    const fork = Array.from(dialog.querySelectorAll('button')).find((button) => button.textContent === 'Fork')
+    expect(fork?.hasAttribute('disabled')).toBe(true)
+    const helpId = fork?.getAttribute('aria-describedby')
+    expect(helpId).toBeTruthy()
+    expect(container.querySelector(`#${helpId}`)?.textContent.toLowerCase()).toContain('recovery')
+    const close = Array.from(dialog.querySelectorAll('button')).find((button) => button.textContent === 'Close')
+    await React.act(async () => { close?.click() })
+    expect(router.navigate).toHaveBeenCalledWith(expect.objectContaining({
+      to: '/runs',
+      replace: true,
+      search: expect.any(Function),
+    }))
+    await unmount()
+  })
+
+  it('opens a deep-linked run returned outside the current page', async () => {
+    const selectedRun = { ...run, id: 'codex:off-page', nativeId: 'off-page', shortId: 'off-page' }
+    router.search = { ...router.search, run: selectedRun.id }
+    fetchMock.mockImplementation(async () => new Response(JSON.stringify({
+      ...inventory([]),
+      selectedRun,
+    }), { status: 200 }))
+
+    const { container, unmount } = await renderScreen()
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog?.textContent).toContain('off-page')
+    expect(container.textContent).not.toContain('not in the current filters or page')
+    await unmount()
+  })
+
+  it('keeps actions disabled when a recorded route is no longer eligible', async () => {
+    const staleRouteRun = { ...run, id: 'codex:stale-route', route: 'openai-codex/retired' }
+    router.search = { ...router.search, run: staleRouteRun.id }
+    fetchMock.mockImplementation(async () => new Response(JSON.stringify(inventory([staleRouteRun])), { status: 200 }))
+    const { container, unmount } = await renderScreen()
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    const archive = Array.from(dialog?.querySelectorAll('button') ?? []).find((button) => button.textContent === 'Archive')
+    expect(archive?.hasAttribute('disabled')).toBe(true)
+    const routeSelect = dialog?.querySelector('select#run-route-ref')
+    expect(Array.from(routeSelect?.querySelectorAll('option') ?? []).map((option) => option.getAttribute('value')))
+      .not.toContain('openai-codex/gpt-5.6-sol')
+    expect(dialog?.textContent).not.toContain('openai-codex/retired (recorded)')
+    await unmount()
+  })
+
+  it('rejects an available route owned by a different account key', async () => {
+    const otherAccountRun = { ...run, id: 'codex:other-account', account: 'Other Codex', accountKey: 'other-codex' }
+    router.search = { ...router.search, run: otherAccountRun.id }
+    fetchMock.mockImplementation(async () => new Response(JSON.stringify(inventory([otherAccountRun])), { status: 200 }))
+    const { container, unmount } = await renderScreen()
+    const dialog = container.querySelector('[role="dialog"]')
+    const archive = Array.from(dialog?.querySelectorAll('button') ?? []).find((button) => button.textContent === 'Archive')
+    expect(archive?.hasAttribute('disabled')).toBe(true)
+    await unmount()
+  })
+
+  it('keeps provider discovery explicit and preserves current URL filters after refresh', async () => {
+    router.search = { ...router.search, provider: 'codex', q: 'workspace' }
+    const { container, unmount } = await renderScreen()
+    const refresh = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Refresh'))
+    expect(refresh).toBeTruthy()
+    await React.act(async () => { refresh?.click() })
+    await settle()
+    const posts = fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')
+    expect(posts).toHaveLength(1)
+    expect(JSON.parse(String(posts[0][1]?.body))).toEqual({ action: 'refresh' })
+    const gets = fetchMock.mock.calls.filter(([, init]) => init?.method !== 'POST')
+    expect(gets.length).toBeGreaterThanOrEqual(2)
+    expect(String(gets.at(-1)?.[0])).toContain('provider=codex')
+    expect(String(gets.at(-1)?.[0])).toContain('q=workspace')
+    expect(router.navigate).not.toHaveBeenCalledWith(expect.objectContaining({ search: expect.objectContaining({ text: expect.anything() }) }))
+    await unmount()
+  })
+
+  it('keeps Claude follow-up and Kanban text local while dispatching route-authorized actions', async () => {
+    const claude = {
+      ...run,
+      id: 'claude:cwm4tx:session-1', provider: 'claude', runtimeKind: 'claude_session', nativeId: 'session-1', shortId: 'session-1',
+      account: 'cwm4tx', accountKey: 'cwm4tx', route: 'claude-cwm4tx/opus-5', model: 'opus-5', title: 'Workspace · Claude session',
+      capabilities: {
+        ...run.capabilities,
+        resume: { state: 'experimental', invokable: true, explanation: 'Isolated Claude resume.' },
+        archive: { state: 'degraded', invokable: true, explanation: 'Metadata archive.' },
+      },
+    }
+    router.search = { ...router.search, run: claude.id }
+    fetchMock.mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') return new Response(JSON.stringify({ ok: true }), { status: 200 })
+      return new Response(JSON.stringify(inventory([claude])), { status: 200 })
+    })
+    const { container, unmount } = await renderScreen()
+    const followUp = container.querySelector('textarea[aria-label="Follow-up text"]')
+    expect(followUp).not.toBeNull()
+    if (!(followUp instanceof HTMLTextAreaElement)) throw new Error('Expected follow-up textarea')
+    await React.act(async () => { setNativeValue(followUp, 'continue safely') })
+    const resume = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Resume')
+    await React.act(async () => { resume?.click() })
+    await settle()
+    const kanban = container.querySelector('input[aria-label="Kanban task ID"]')
+    expect(kanban).not.toBeNull()
+    if (!(kanban instanceof HTMLInputElement)) throw new Error('Expected Kanban input')
+    await React.act(async () => { setNativeValue(kanban, 'AUTH-14') })
+    const link = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Link Kanban')
+    await React.act(async () => { link?.click() })
+    await settle()
+    const payloads = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'POST')
+      .map(([, init]) => JSON.parse(String(init?.body)))
+    expect(payloads).toContainEqual(expect.objectContaining({
+      action: 'resume', runtimeId: claude.id, routeRef: 'claude-cwm4tx/opus-5', prompt: 'continue safely',
+    }))
+    expect(payloads).toContainEqual({ action: 'link_kanban', runtimeId: claude.id, kanbanTaskId: 'AUTH-14' })
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('link_kanban accepted')
+    expect(router.navigate).not.toHaveBeenCalledWith(expect.objectContaining({ search: expect.objectContaining({ prompt: expect.anything() }) }))
+    await unmount()
+  })
+})

--- a/src/screens/runs/runs-screen.tsx
+++ b/src/screens/runs/runs-screen.tsx
@@ -1,0 +1,175 @@
+// Runs — a provider-neutral control-center for every runtime Workspace has
+// discovered.
+//
+// Contract this screen keeps:
+//   • Loading it reads metadata only (GET /api/runtime-runs). It never starts a
+//     provider process, never launches a CLI, never takes a writer lease.
+//   • Provider discovery is one explicit button that posts {action:'refresh'}
+//     and then re-reads metadata with the filters the user still has applied.
+//   • The URL holds filters and one selected run ID. Prompts, instructions, and
+//     action payloads are never written to the URL or to storage.
+//   • Actions are enabled only when the projection says the operation is
+//     invokable today; anything else is disabled with the real reason attached.
+
+import { useCallback, useMemo } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+
+
+import { RunDetailDrawer } from './components/run-detail-drawer'
+import { RunsCards } from './components/runs-cards'
+import { RunsFilters } from './components/runs-filters'
+import { RunsHeader } from './components/runs-header'
+import { RunsPagination } from './components/runs-pagination'
+import { RunsSummaryStrip } from './components/runs-summary-strip'
+import { RunsTable } from './components/runs-table'
+import { pluralRuns } from './runs-format'
+import {
+  normalizeDirection,
+  normalizeSize,
+  normalizeSort,
+  normalizeView,
+  viewHasInventory
+} from './runs-search'
+import { useRunsInventory } from './use-runs-inventory'
+import type {RunsPageSize, RunsSearch, RunsView} from './runs-search';
+import type { RuntimeRun, RuntimeRunSortKey } from '@/server/runtime-run-projection'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const ARCHIVED_EXPLANATION =
+  'Archived runs need durable archive metadata — a recorded archive time and the identity that archived it. The provider runtime registry does not persist that yet, so an "archived" list here could only be a guess. Archive from a run\'s detail panel is reported per runtime.'
+
+function uniqueSorted(values: ReadonlyArray<string | null>): Array<string> {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value)))).sort((a, b) => a.localeCompare(b))
+}
+
+export function RunsScreen() {
+  const search = useSearch({ from: '/runs' })
+  const navigate = useNavigate()
+
+  const view = normalizeView(search.view)
+  const sort = normalizeSort(search.sort)
+  const direction = normalizeDirection(search.direction)
+  const size = normalizeSize(search.size)
+  const hasInventory = viewHasInventory(view)
+
+  const { status, data, error, discoveryError, discovering, reload, discover, dispatch } = useRunsInventory(search, hasInventory)
+
+  const update = useCallback((patch: RunsSearch, replace = false) => {
+    void navigate({
+      to: '/runs',
+      search: (previous: RunsSearch) => ({ ...previous, ...patch }),
+      ...(replace ? { replace: true } : {}),
+    })
+  }, [navigate])
+
+  const runs = data?.runs ?? []
+  const page = data?.page ?? null
+  const selectedId = typeof search.run === 'string' && search.run ? search.run : null
+  const selected = selectedId
+    ? runs.find((run) => run.id === selectedId) ?? (data?.selectedRun?.id === selectedId ? data.selectedRun : null)
+    : null
+
+  const accounts = useMemo(() => uniqueSorted(runs.map((run) => run.account)), [runs])
+  const projects = useMemo(() => uniqueSorted(runs.map((run) => run.project)), [runs])
+
+  const first = page && page.total > 0 ? (page.number - 1) * page.size + 1 : 0
+  const caption = page && page.total > 0
+    ? `Runs ${first}–${first + runs.length - 1} of ${page.total}`
+    : 'No runs match these filters'
+  const captionDetail = page
+    ? `Page ${page.number} of ${page.pages} · sorted by ${sort}, ${direction === 'asc' ? 'ascending' : 'descending'}`
+    : ''
+
+  const statusText = !hasInventory
+    ? 'Archived runs are unavailable — no durable archive metadata exists.'
+    : status === 'error'
+      ? `Runs unavailable — ${error ?? 'the inventory could not be read'}`
+      : !data
+        ? 'Loading runs…'
+        : `${pluralRuns(page?.total ?? 0)} matched · showing ${runs.length} on this page`
+
+  const onSort = useCallback((key: RuntimeRunSortKey) => {
+    update(key === sort
+      ? { direction: direction === 'asc' ? 'desc' : 'asc', page: 1 }
+      : { sort: key, direction: 'desc', page: 1 })
+  }, [direction, sort, update])
+
+  const onSelect = useCallback((run: RuntimeRun) => update({ run: run.id }), [update])
+  const onCloseDrawer = useCallback(() => update({ run: undefined }, true), [update])
+  const onView = useCallback((next: RunsView) => update({ view: next, page: 1, run: undefined }), [update])
+
+  return (
+    <main className="min-h-full bg-surface px-3 pb-24 pt-5 text-primary-900 md:px-5 md:pt-8">
+      <div className="mx-auto w-full max-w-[1320px] space-y-4">
+        <RunsHeader
+          view={view}
+          discovering={discovering}
+          generatedAt={data?.generatedAt ?? null}
+          statusText={statusText}
+          discoveryError={discoveryError}
+          truncated={Boolean(data?.inventory.truncated)}
+          onView={onView}
+          onRefresh={() => void discover()}
+        />
+
+        <RunsSummaryStrip summary={data?.summary ?? null} />
+
+        <RunsFilters search={search} accounts={accounts} projects={projects} onChange={update} />
+
+        {!hasInventory ? (
+          <section className="rounded-xl border border-dashed border-primary-300 bg-primary-50/60 px-4 py-8 text-center">
+            <h2 className="text-sm font-semibold text-primary-900">Archived runs are unavailable</h2>
+            <p className="mx-auto mt-2 max-w-2xl text-sm text-primary-600">{ARCHIVED_EXPLANATION}</p>
+            <button type="button" className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }), 'mt-4')} onClick={() => onView('recent')}>
+              Back to recent runs
+            </button>
+          </section>
+        ) : status === 'error' && !data ? (
+          <section role="alert" className="rounded-xl border border-red-300 bg-red-50 px-4 py-8 text-center">
+            <h2 className="text-sm font-semibold text-red-800">Runs could not be loaded</h2>
+            <p className="mx-auto mt-2 max-w-2xl text-sm text-red-700">{error}</p>
+            <button type="button" className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }), 'mt-4')} onClick={() => void reload()}>
+              Try again
+            </button>
+          </section>
+        ) : !data ? (
+          <section className="rounded-xl border border-primary-200 bg-primary-50/70 px-4 py-10 text-center text-sm text-primary-600">
+            Reading runtime metadata…
+          </section>
+        ) : (
+          <>
+            {selectedId && !selected ? (
+              <p className="rounded-xl border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                The linked run is not in the current filters or page.{' '}
+                <button type="button" className="underline underline-offset-2" onClick={onCloseDrawer}>Clear the selection</button>
+              </p>
+            ) : null}
+            <RunsTable
+              runs={runs}
+              caption={caption}
+              captionDetail={captionDetail}
+              sort={sort}
+              direction={direction}
+              selectedId={selectedId}
+              onSort={onSort}
+              onSelect={onSelect}
+            />
+            <RunsCards runs={runs} caption={`${caption} · ${captionDetail}`} selectedId={selectedId} onSelect={onSelect} />
+            {page ? (
+              <RunsPagination
+                page={page}
+                size={size}
+                busy={status === 'reloading'}
+                onPage={(next) => update({ page: next })}
+                onSize={(next: RunsPageSize) => update({ size: next, page: 1 })}
+              />
+            ) : null}
+          </>
+        )}
+
+        {selected ? <RunDetailDrawer run={selected} availableRoutes={data?.availableRoutes ?? []} onClose={onCloseDrawer} onAction={dispatch} /> : null}
+      </div>
+    </main>
+  )
+}

--- a/src/screens/runs/runs-search.test.ts
+++ b/src/screens/runs/runs-search.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { runsQueryString, runsRequestKey } from './runs-search'
+
+describe('Runs request identity', () => {
+  it('includes only a bounded run ID and changes when the deep-link selection changes', () => {
+    const first = { run: 'codex:first', page: 1, size: 25 } as const
+    const second = { ...first, run: 'codex:second' }
+
+    expect(new URLSearchParams(runsQueryString(first, 1_000)).get('run')).toBe('codex:first')
+    expect(runsRequestKey(first)).not.toBe(runsRequestKey(second))
+    expect(new URLSearchParams(runsQueryString({ ...first, run: 'x'.repeat(301) }, 1_000)).has('run')).toBe(false)
+  })
+})

--- a/src/screens/runs/runs-search.ts
+++ b/src/screens/runs/runs-search.ts
@@ -1,0 +1,218 @@
+// URL state for the Runs screen.
+//
+// The URL carries filters and one selected run ID — never prompt text, never
+// action payloads, never provider credentials. Everything here is pure so the
+// request key can be derived during render without touching the clock.
+
+import type {
+  RuntimeRunSortDirection,
+  RuntimeRunSortKey,
+} from '@/server/runtime-run-projection'
+
+export type RunsView = 'active' | 'recent' | 'attention' | 'archived'
+export type RunsKanbanFilter = 'all' | 'linked' | 'unlinked'
+export type RunsWindow = '1h' | '24h' | '7d' | '30d' | 'all'
+export type RunsPageSize = 25 | 50 | 100
+
+/** Mirrors the validated search schema of the `/runs` route. */
+export type RunsSearch = {
+  q?: string
+  view?: RunsView
+  provider?: string
+  account?: string
+  state?: string
+  ownership?: string
+  project?: string
+  kanban?: RunsKanbanFilter
+  task?: string
+  window?: RunsWindow
+  from?: string
+  to?: string
+  sort?: RuntimeRunSortKey
+  direction?: RuntimeRunSortDirection
+  page?: number
+  size?: RunsPageSize
+  run?: string
+}
+
+export const RUNS_VIEWS: ReadonlyArray<{ id: RunsView; label: string; hint: string }> = [
+  { id: 'active', label: 'Active', hint: 'Runs a provider reports as running right now.' },
+  { id: 'recent', label: 'Recent', hint: 'Every discovered run, newest activity first.' },
+  { id: 'attention', label: 'Attention', hint: 'Runs whose host or ownership state cannot be trusted.' },
+  { id: 'archived', label: 'Archived', hint: 'Needs durable archive metadata the registry does not record yet.' },
+]
+
+/** Views that are presets over the state filter rather than separate inventories. */
+const VIEW_STATE: Partial<Record<RunsView, string>> = { active: 'active', attention: 'attention' }
+
+export const RUNS_STATES = ['active', 'idle', 'stopped', 'attention'] as const
+export const RUNS_PROVIDERS = ['hermes', 'claude', 'codex', 'unknown'] as const
+export const RUNS_OWNERSHIPS = ['free', 'owned', 'recoverable', 'unknown'] as const
+export const RUNS_PAGE_SIZES: ReadonlyArray<RunsPageSize> = [25, 50, 100]
+
+export const RUNS_WINDOWS: ReadonlyArray<{ id: RunsWindow; label: string }> = [
+  { id: 'all', label: 'Any time' },
+  { id: '1h', label: 'Last hour' },
+  { id: '24h', label: 'Last 24 hours' },
+  { id: '7d', label: 'Last 7 days' },
+  { id: '30d', label: 'Last 30 days' },
+]
+
+const WINDOW_MS: Record<Exclude<RunsWindow, 'all'>, number> = {
+  '1h': 3_600_000,
+  '24h': 86_400_000,
+  '7d': 7 * 86_400_000,
+  '30d': 30 * 86_400_000,
+}
+
+const SORT_KEYS: ReadonlyArray<RuntimeRunSortKey> = ['updated', 'created', 'staleness', 'title', 'project', 'provider', 'state']
+
+const MAX_TEXT = 200
+const MAX_PAGE = 10_000
+
+function bounded(value: unknown, max = MAX_TEXT): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim().slice(0, max)
+  return trimmed || undefined
+}
+
+function boundedIdentity(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed && trimmed.length <= max ? trimmed : undefined
+}
+
+function oneOf<T extends string>(value: unknown, allowed: ReadonlyArray<T>, fallback: T): T {
+  return typeof value === 'string' && (allowed as ReadonlyArray<string>).includes(value) ? (value as T) : fallback
+}
+
+export function normalizeView(value: unknown): RunsView {
+  return oneOf(value, ['active', 'recent', 'attention', 'archived'] as const, 'recent')
+}
+
+export function normalizeKanban(value: unknown): RunsKanbanFilter {
+  return oneOf(value, ['all', 'linked', 'unlinked'] as const, 'all')
+}
+
+export function normalizeWindow(value: unknown): RunsWindow {
+  return oneOf(value, ['1h', '24h', '7d', '30d', 'all'] as const, 'all')
+}
+
+export function normalizeSort(value: unknown): RuntimeRunSortKey {
+  return oneOf(value, SORT_KEYS, 'updated')
+}
+
+export function normalizeDirection(value: unknown): RuntimeRunSortDirection {
+  return oneOf(value, ['asc', 'desc'] as const, 'desc')
+}
+
+export function normalizePage(value: unknown): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return 1
+  return Math.min(MAX_PAGE, Math.max(1, Math.trunc(numeric)))
+}
+
+export function normalizeSize(value: unknown): RunsPageSize {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  return RUNS_PAGE_SIZES.includes(numeric as RunsPageSize) ? (numeric as RunsPageSize) : 25
+}
+
+/** The state the grid is actually filtered by: the view wins over the raw param. */
+export function effectiveState(search: RunsSearch): string | undefined {
+  const view = normalizeView(search.view)
+  return VIEW_STATE[view] ?? bounded(search.state, 120)
+}
+
+/** True when the view is backed by real inventory rather than a deferred feature. */
+export function viewHasInventory(view: RunsView): boolean {
+  return view !== 'archived'
+}
+
+/**
+ * Builds the `/api/runtime-runs` query. `now` is passed in rather than read so
+ * the caller controls when the relative date window resolves — a value read
+ * during render would change on every pass and re-trigger the load effect.
+ */
+export function runsQueryString(search: RunsSearch, now: number): string {
+  const params = new URLSearchParams()
+  const set = (name: string, value: string | undefined) => {
+    if (value) params.set(name, value)
+  }
+  set('q', bounded(search.q))
+  set('provider', bounded(search.provider, 120))
+  set('account', bounded(search.account))
+  set('state', effectiveState(search))
+  set('ownership', bounded(search.ownership, 120))
+  set('project', bounded(search.project))
+  set('task', bounded(search.task))
+  const kanban = normalizeKanban(search.kanban)
+  if (kanban !== 'all') params.set('kanban', kanban)
+  const window = normalizeWindow(search.window)
+  if (window === 'all') {
+    set('from', bounded(search.from, 40))
+    set('to', bounded(search.to, 40))
+  } else {
+    params.set('from', String(Math.max(0, now - WINDOW_MS[window])))
+  }
+  set('run', boundedIdentity(search.run, 300))
+  params.set('sort', normalizeSort(search.sort))
+  params.set('direction', normalizeDirection(search.direction))
+  params.set('page', String(normalizePage(search.page)))
+  params.set('size', String(normalizeSize(search.size)))
+  return params.toString()
+}
+
+/** Stable identity of the complete metadata request, including a bounded deep-link ID. */
+export function runsRequestKey(search: RunsSearch): string {
+  return JSON.stringify([
+    boundedIdentity(search.run, 300) ?? '',
+    bounded(search.q) ?? '',
+    bounded(search.provider, 120) ?? '',
+    bounded(search.account) ?? '',
+    effectiveState(search) ?? '',
+    bounded(search.ownership, 120) ?? '',
+    bounded(search.project) ?? '',
+    bounded(search.task) ?? '',
+    normalizeKanban(search.kanban),
+    normalizeWindow(search.window),
+    bounded(search.from, 40) ?? '',
+    bounded(search.to, 40) ?? '',
+    normalizeSort(search.sort),
+    normalizeDirection(search.direction),
+    normalizePage(search.page),
+    normalizeSize(search.size),
+  ])
+}
+
+/** True when anything narrows the inventory beyond the current view preset. */
+export function hasActiveFilters(search: RunsSearch): boolean {
+  return Boolean(
+    bounded(search.q) ||
+    bounded(search.provider, 120) ||
+    bounded(search.account) ||
+    bounded(search.state, 120) ||
+    bounded(search.ownership, 120) ||
+    bounded(search.project) ||
+    bounded(search.task) ||
+    normalizeKanban(search.kanban) !== 'all' ||
+    normalizeWindow(search.window) !== 'all' ||
+    bounded(search.from, 40) ||
+    bounded(search.to, 40),
+  )
+}
+
+/** Every filter cleared; the view, sort, and page size are presentation, not filters. */
+export const CLEARED_FILTERS: RunsSearch = {
+  q: undefined,
+  provider: undefined,
+  account: undefined,
+  state: undefined,
+  ownership: undefined,
+  project: undefined,
+  task: undefined,
+  kanban: 'all',
+  window: 'all',
+  from: undefined,
+  to: undefined,
+  page: 1,
+}

--- a/src/screens/runs/use-runs-inventory.ts
+++ b/src/screens/runs/use-runs-inventory.ts
@@ -1,0 +1,161 @@
+// Data access for the Runs screen.
+//
+// Two endpoints, two very different contracts:
+//   • GET  /api/runtime-runs      — read-only projection, safe on every load.
+//   • POST /api/provider-runtimes — talks to provider processes; only ever
+//     reached from an explicit user gesture (Refresh, or a run action).
+// A page load must never fan out into provider CLIs, so the POST is never
+// wired into an effect.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {  runsQueryString, runsRequestKey } from './runs-search'
+import type {RunsSearch} from './runs-search';
+import type { RuntimeRun, RuntimeRunSummary } from '@/server/runtime-run-projection'
+
+
+export type RunsPageInfo = {
+  number: number
+  size: number
+  total: number
+  pages: number
+  hasNext: boolean
+  hasPrevious: boolean
+}
+
+export type RunsInventory = {
+  ok: boolean
+  runs: Array<RuntimeRun>
+  selectedRun: RuntimeRun | null
+  summary: RuntimeRunSummary
+  page: RunsPageInfo
+  inventory: { projected: number; matched: number; truncated: boolean }
+  availableRoutes: Array<{ id: string; account: string; model: string; status: string }>
+  generatedAt: number
+}
+
+export type RunsStatus = 'loading' | 'reloading' | 'ready' | 'error' | 'unavailable'
+
+const INVENTORY_ERROR = 'Run inventory is unavailable'
+const REFRESH_ERROR = 'Provider discovery failed'
+
+function messageOf(reason: unknown, fallback: string): string {
+  return reason instanceof Error && reason.message ? reason.message : fallback
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    return (await response.json()) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function errorOf(body: Record<string, unknown> | null, fallback: string): string {
+  return typeof body?.error === 'string' && body.error ? body.error : fallback
+}
+
+export type UseRunsInventory = {
+  status: RunsStatus
+  data: RunsInventory | null
+  error: string | null
+  /** Failure of the last explicit provider discovery, kept apart from load errors. */
+  discoveryError: string | null
+  discovering: boolean
+  /** Re-reads metadata with the current filters. No provider contact. */
+  reload: () => Promise<void>
+  /** Explicit provider discovery, then a metadata re-read with the same filters. */
+  discover: () => Promise<void>
+  /** Posts one lifecycle action to the control plane, then re-reads metadata. */
+  dispatch: (payload: Record<string, unknown>) => Promise<{ ok: boolean; error: string | null }>
+}
+
+export function useRunsInventory(search: RunsSearch, enabled: boolean): UseRunsInventory {
+  const [data, setData] = useState<RunsInventory | null>(null)
+  const [status, setStatus] = useState<RunsStatus>(enabled ? 'loading' : 'unavailable')
+  const [error, setError] = useState<string | null>(null)
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+  const [discovering, setDiscovering] = useState(false)
+
+  // Latest values without widening effect dependencies: the load effect must
+  // fire on filter identity only, never on unrelated re-renders.
+  const searchRef = useRef(search)
+  searchRef.current = search
+  const enabledRef = useRef(enabled)
+  enabledRef.current = enabled
+  const requestRef = useRef(0)
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
+
+  const reload = useCallback(async () => {
+    if (!enabledRef.current) return
+    const id = ++requestRef.current
+    setStatus((previous) => (previous === 'ready' ? 'reloading' : 'loading'))
+    setError(null)
+    try {
+      const query = runsQueryString(searchRef.current, Date.now())
+      const response = await fetch(`/api/runtime-runs?${query}`, { headers: { accept: 'application/json' } })
+      const body = await readJson(response)
+      if (!response.ok || body?.ok !== true) throw new Error(errorOf(body, INVENTORY_ERROR))
+      if (id !== requestRef.current || !mountedRef.current) return
+      setData(body as unknown as RunsInventory)
+      setStatus('ready')
+    } catch (reason) {
+      if (id !== requestRef.current || !mountedRef.current) return
+      setError(messageOf(reason, INVENTORY_ERROR))
+      setStatus('error')
+    }
+  }, [])
+
+  const key = runsRequestKey(search)
+  useEffect(() => {
+    if (!enabled) {
+      requestRef.current += 1
+      setStatus('unavailable')
+      setData(null)
+      setError(null)
+      return
+    }
+    void reload()
+  }, [key, enabled, reload])
+
+  const post = useCallback(async (payload: Record<string, unknown>) => {
+    const response = await fetch('/api/provider-runtimes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const body = await readJson(response)
+    if (!response.ok || body?.ok === false) {
+      const nested = (body?.result as { error?: unknown } | undefined)?.error
+      throw new Error(typeof nested === 'string' && nested ? nested : errorOf(body, REFRESH_ERROR))
+    }
+  }, [])
+
+  const discover = useCallback(async () => {
+    setDiscovering(true)
+    setDiscoveryError(null)
+    try {
+      await post({ action: 'refresh' })
+    } catch (reason) {
+      if (mountedRef.current) setDiscoveryError(messageOf(reason, REFRESH_ERROR))
+    } finally {
+      // Metadata is re-read either way: a partial discovery still moves rows.
+      await reload()
+      if (mountedRef.current) setDiscovering(false)
+    }
+  }, [post, reload])
+
+  const dispatch = useCallback(async (payload: Record<string, unknown>) => {
+    try {
+      await post(payload)
+      await reload()
+      return { ok: true, error: null }
+    } catch (reason) {
+      await reload()
+      return { ok: false, error: messageOf(reason, 'Runtime action was rejected') }
+    }
+  }, [post, reload])
+
+  return { status, data, error, discoveryError, discovering, reload, discover, dispatch }
+}

--- a/src/screens/swarm2/operational-worker-card-model.test.ts
+++ b/src/screens/swarm2/operational-worker-card-model.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('OperationalWorkerCard model assignment', () => {
+  it('does not expose a cosmetic localStorage-only model selector', () => {
+    const source = readFileSync(
+      new URL('./operational-worker-card.tsx', import.meta.url),
+      'utf8',
+    )
+    expect(source).not.toContain('const MODEL_OPTIONS')
+    expect(source).not.toContain('modelLabel: draftModel')
+    expect(source).toContain('Settings → Orchestration')
+  })
+})

--- a/src/screens/swarm2/operational-worker-card.tsx
+++ b/src/screens/swarm2/operational-worker-card.tsx
@@ -178,7 +178,6 @@ function formatAssignedModel(model?: string | null, provider?: string | null): s
 type WorkerCardSettings = {
   displayName?: string
   role?: string
-  modelLabel?: string
   avatarGlyph?: string
 }
 
@@ -196,18 +195,7 @@ const ROLE_OPTIONS = [
   'Hackathon',
   'Worker',
 ]
-const MODEL_OPTIONS = [
-  'GPT-5.5',
-  'GPT-5.4',
-  'GPT-5.3',
-  'Opus 4.7',
-  'Opus 4.6',
-  'Opus 4.5',
-  'MiniMax',
-  'Qwen3 8B',
-  'Qwen3 14B',
-  'Worker',
-]
+
 const AVATAR_OPTIONS = ['','🤖','🧠','🛠️','📊','🧪','📝','⚙️','🔬','🚀']
 
 export type OperationalWorkerCardProps = {
@@ -251,7 +239,7 @@ export function OperationalWorkerCard({
   const [settings, setSettings] = useState<WorkerCardSettings>({})
   const [draftName, setDraftName] = useState('')
   const [draftRole, setDraftRole] = useState('')
-  const [draftModel, setDraftModel] = useState('')
+
   const [draftAvatar, setDraftAvatar] = useState('')
   const [taskComposerOpen, setTaskComposerOpen] = useState(false)
   const state = deriveWorkerState(member, currentTask, checkpointStatus, runtimeState)
@@ -278,7 +266,7 @@ export function OperationalWorkerCard({
   const progressValue =
     state === 'idle' || state === 'offline' ? 8 : state === 'waiting' ? 38 : 68
   const baseModelLabel = formatAssignedModel(member.model, member.provider)
-  const modelLabel = settings.modelLabel || baseModelLabel
+  const modelLabel = baseModelLabel
   const avatarGlyph = settings.avatarGlyph || ''
   const outputFreshness = relativeOutputTime(recentOutputAt)
   const focusPanels = useMemo(() => {
@@ -343,9 +331,8 @@ export function OperationalWorkerCard({
     if (!settingsOpen) return
     setDraftName(settings.displayName || member.displayName || '')
     setDraftRole(settings.role || member.role || roleFromId(member.id))
-    setDraftModel(settings.modelLabel || baseModelLabel)
     setDraftAvatar(settings.avatarGlyph || '')
-  }, [settingsOpen, settings, member.displayName, member.role, member.id, baseModelLabel])
+  }, [settingsOpen, settings, member.displayName, member.role, member.id])
 
   useEffect(() => {
     if (!selected) return
@@ -662,20 +649,15 @@ export function OperationalWorkerCard({
                   ))}
                 </select>
               </label>
-              <label className="block">
-                <span className="mb-1 block text-[var(--theme-muted)]">Model label</span>
-                <select
-                  value={draftModel}
-                  onChange={(event) => setDraftModel(event.target.value)}
-                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
-                >
-                  {Array.from(new Set([draftModel || baseModelLabel, ...MODEL_OPTIONS].filter(Boolean))).map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2">
+                <span className="block text-[var(--theme-muted)]">Runtime model</span>
+                <code className="mt-1 block break-all text-[11px] text-[var(--theme-text)]">
+                  {baseModelLabel}
+                </code>
+                <span className="mt-1 block text-[10px] text-[var(--theme-muted)]">
+                  Change this canonical OAuth route in Settings → Orchestration.
+                </span>
+              </div>
             </div>
             <div className="mt-4 flex items-center justify-between gap-2">
               <button
@@ -710,7 +692,7 @@ export function OperationalWorkerCard({
                       displayName: draftName.trim() || undefined,
                       avatarGlyph: draftAvatar.trim() || undefined,
                       role: draftRole.trim() || undefined,
-                      modelLabel: draftModel.trim() || undefined,
+
                     }
                     setSettings(next)
                     try {

--- a/src/screens/swarm2/swarm2-screen.test.ts
+++ b/src/screens/swarm2/swarm2-screen.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  __runtimeTabInternals,
   SWARM2_CARD_DENSITY_CONTRACT,
   SWARM2_INFORMATION_HIERARCHY,
   SWARM2_OPERATIONS_REUSE,
@@ -19,8 +20,12 @@ describe('Swarm2 surface contract', () => {
     expect(SWARM2_INFORMATION_HIERARCHY[5]).toContain(
       'Central bottom router chat',
     )
-    expect(SWARM2_INFORMATION_HIERARCHY).toContainEqual(expect.stringContaining('Kanban view'))
-    expect(SWARM2_INFORMATION_HIERARCHY).toContainEqual(expect.stringContaining('Runtime view'))
+    expect(SWARM2_INFORMATION_HIERARCHY).toContainEqual(
+      expect.stringContaining('Kanban view'),
+    )
+    expect(SWARM2_INFORMATION_HIERARCHY).toContainEqual(
+      expect.stringContaining('Runtime view'),
+    )
   })
 
   it('documents the operational surfaces without replacing /swarm', () => {
@@ -48,6 +53,7 @@ describe('Swarm2 surface contract', () => {
       '/api/swarm-runtime',
       '/api/swarm-missions',
       '/api/swarm-roster',
+      '/api/orchestration-catalog',
       '/api/integrations',
       '/api/swarm-health',
       '/api/swarm-decompose',
@@ -60,6 +66,10 @@ describe('Swarm2 surface contract', () => {
       '/api/terminal-resize',
       '/api/terminal-close',
     ])
+  })
+
+  it('uses the canonical subscription route registry for role model assignment', () => {
+    expect(SWARM2_REAL_API_ENDPOINTS).toContain('/api/orchestration-catalog')
   })
 
   it('documents Operations card primitives reused for Swarm2 worker nodes', () => {
@@ -75,13 +85,15 @@ describe('Swarm2 surface contract', () => {
   it('keeps the default control plane denser than a terminal wall on laptop screens', () => {
     expect(SWARM2_CARD_DENSITY_CONTRACT.defaultView).toBe('cards')
     expect(SWARM2_CARD_DENSITY_CONTRACT.runtimeView).toBe('separate-mode')
-    expect(SWARM2_CARD_DENSITY_CONTRACT.workerCardMinHeightRem).toBeLessThanOrEqual(30)
-    expect(SWARM2_CARD_DENSITY_CONTRACT.laptopGridColumns).toBeGreaterThanOrEqual(2)
+    expect(
+      SWARM2_CARD_DENSITY_CONTRACT.workerCardMinHeightRem,
+    ).toBeLessThanOrEqual(30)
+    expect(
+      SWARM2_CARD_DENSITY_CONTRACT.laptopGridColumns,
+    ).toBeGreaterThanOrEqual(2)
     expect(SWARM2_CARD_DENSITY_CONTRACT.duplicateEmptyStates).toBe(false)
   })
 })
-
-import { __runtimeTabInternals } from './swarm2-screen'
 
 describe('Swarm2 runtime tab command resolution', () => {
   const { commandForRuntime } = __runtimeTabInternals
@@ -139,7 +151,13 @@ describe('Swarm2 runtime tab command resolution', () => {
       terminalKind: 'log-tail',
     })
     expect(result.kind).toBe('log-tail')
-    expect(result.command).toEqual(['tail', '-n', '200', '-F', '/tmp/agent.log'])
+    expect(result.command).toEqual([
+      'tail',
+      '-n',
+      '200',
+      '-F',
+      '/tmp/agent.log',
+    ])
   })
 
   it('falls back to a workspace shell when no tmux and no log file exist', () => {
@@ -209,4 +227,3 @@ describe('Swarm2 runtime tab command resolution', () => {
     expect(result.command[0]).toBe('zsh')
   })
 })
-

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -25,7 +25,11 @@ import { Swarm2OrchestratorCard } from './swarm2-orchestrator-card'
 import { Swarm2Wires } from './swarm2-wires'
 import { Swarm2ActivityFeed } from './swarm2-activity-feed'
 import { Swarm2KanbanBoard } from './swarm2-kanban-board'
-import { Swarm2ReportsView, buildSwarm2InboxLanes, type Swarm2InboxItem } from './swarm2-reports-view'
+import {
+  Swarm2ReportsView,
+  buildSwarm2InboxLanes,
+  type Swarm2InboxItem,
+} from './swarm2-reports-view'
 import { RouterChat } from '@/components/swarm/router-chat'
 import { SwarmTerminal } from '@/components/swarm/swarm-terminal'
 import { WorkflowHelpModal } from '@/components/workflow-help-modal'
@@ -44,15 +48,22 @@ const SWARM2_OPERATION_THEME: CSSProperties = {
   ['--theme-muted-2' as string]: 'var(--color-primary-600)',
   ['--theme-accent' as string]: 'var(--color-accent-500)',
   ['--theme-accent-strong' as string]: 'var(--color-accent-600)',
-  ['--theme-accent-soft' as string]: 'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
-  ['--theme-accent-soft-strong' as string]: 'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
-  ['--theme-shadow' as string]: 'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
+  ['--theme-accent-soft' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 12%, transparent)',
+  ['--theme-accent-soft-strong' as string]:
+    'color-mix(in srgb, var(--color-accent-500) 18%, transparent)',
+  ['--theme-shadow' as string]:
+    'color-mix(in srgb, var(--color-primary-950) 14%, transparent)',
   ['--theme-danger' as string]: 'var(--color-red-600, #dc2626)',
-  ['--theme-danger-soft' as string]: 'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
-  ['--theme-danger-border' as string]: 'color-mix(in srgb, var(--theme-danger) 35%, white)',
+  ['--theme-danger-soft' as string]:
+    'color-mix(in srgb, var(--theme-danger) 12%, transparent)',
+  ['--theme-danger-border' as string]:
+    'color-mix(in srgb, var(--theme-danger) 35%, white)',
   ['--theme-warning' as string]: 'var(--color-amber-600, #d97706)',
-  ['--theme-warning-soft' as string]: 'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
-  ['--theme-warning-border' as string]: 'color-mix(in srgb, var(--theme-warning) 35%, white)',
+  ['--theme-warning-soft' as string]:
+    'color-mix(in srgb, var(--theme-warning) 12%, transparent)',
+  ['--theme-warning-border' as string]:
+    'color-mix(in srgb, var(--theme-warning) 35%, white)',
 }
 
 export const SWARM2_INFORMATION_HIERARCHY = [
@@ -76,7 +87,8 @@ export const SWARM2_SURFACE_CONTRACT = {
   routerPlacement: 'bottom-center',
   cardInlineChat: true,
   routerDefaultOpen: false,
-  heartbeatOrchestration: 'main-session loop processes checkpoints and prompts review/continue decisions',
+  heartbeatOrchestration:
+    'main-session loop processes checkpoints and prompts review/continue decisions',
 } as const
 
 export const SWARM2_OPERATIONS_REUSE = [
@@ -101,6 +113,7 @@ export const SWARM2_REAL_API_ENDPOINTS = [
   '/api/swarm-runtime',
   '/api/swarm-missions',
   '/api/swarm-roster',
+  '/api/orchestration-catalog',
   '/api/integrations',
   '/api/swarm-health',
   '/api/swarm-decompose',
@@ -176,7 +189,6 @@ type HealthData = {
   }
 }
 
-
 type SwarmRosterWorker = {
   id: string
   name: string
@@ -244,64 +256,97 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
   {
     role: 'Orchestrator',
     specialty: 'control-plane state, dispatch, drift detection, escalation',
-    mission: 'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
-    systemPrompt: 'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
-    skills: ['swarm-orchestrator', 'swarm-worker-core', 'swarm-review-learning-loop', 'self-improvement'],
+    mission:
+      'Run the swarm. Read /swarm-specs/ at start. Dispatch workers per their standing missions. Detect drift, re-prompt, escalate to main agent when stuck.',
+    systemPrompt:
+      'You are the Hermes Agent orchestrator for the swarm. Read /swarm-specs/SWARM_SPEC.md and /swarm-specs/projects/swarmN.md for every worker before dispatching. Apply the swarm-orchestrator skill: assign work, request proof-bearing checkpoints, detect drift, re-prompt with stronger framing, escalate when blocked. Never make irreversible external actions without main-agent ack.',
+    skills: [
+      'swarm-orchestrator',
+      'swarm-worker-core',
+      'swarm-review-learning-loop',
+      'self-improvement',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Builder',
     specialty: 'full-stack implementation, fast ship cycles',
-    mission: 'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
-    systemPrompt: 'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
+    mission:
+      'Implement features per dispatched briefs. Smallest landed artifact first. Tests + build + smoke before checkpoint.',
+    systemPrompt:
+      'You are a senior builder. Ship working code. Always read the brief, plan smallest landed artifact, implement, run tests + build + smoke, commit (not push), checkpoint with proof.',
     skills: ['swarm-worker-core', 'byte-verified-code-review'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Reviewer',
     specialty: 'byte-verified code review, naming + tests + build gate',
-    mission: 'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
-    systemPrompt: 'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
+    mission:
+      'No PR ships without you. Verify diff, byte-check naming, run tests/build/smoke, verdict APPROVED/CHANGES_REQUESTED/BLOCKED.',
+    systemPrompt:
+      'You are the merge gate. For every PR: pull branch, read diff, xxd byte-check naming-sensitive areas, run tests, run build, smoke test. Verdict APPROVED routes to main agent for merge ack. Never merge yourself.',
+    skills: [
+      'swarm-worker-core',
+      'byte-verified-code-review',
+      'swarm-review-learning-loop',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Triage',
     specialty: 'autonomous PR/issues processor',
-    mission: 'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
-    systemPrompt: 'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
-    skills: ['swarm-worker-core', 'byte-verified-code-review', 'swarm-review-learning-loop'],
+    mission:
+      'Score open issues every 4h, repro top-1, fix branch + tests + PR, request review. Never merge or close.',
+    systemPrompt:
+      'You are the issues/PRs autopilot. Every 4h: gh issue list per repo, score by Impact x Tractability x (1 + locally-tested), pick top-1 unassigned, repro, fix branch, push, gh pr create, request reviewer. Never merge, never close, always escalate to main agent for greenlight.',
+    skills: [
+      'swarm-worker-core',
+      'byte-verified-code-review',
+      'swarm-review-learning-loop',
+    ],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Lab',
     specialty: 'local-model R&D, spec-dec, benchmarking',
-    mission: 'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
-    systemPrompt: 'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
-    skills: ['swarm-worker-core', 'pc1-ollama-gguf-bench', 'swarm-bench-worker'],
+    mission:
+      'Run autonomous lab loop. Test new model pulls. Wire spec-dec/DFlash/TurboQuant. Push tk/s + quality. Document every experiment.',
+    systemPrompt:
+      'You are the local-model lab. Read /swarm-specs/projects/lane-c-lab.md. Iterate experiments from open hypothesis space. Log to lab-loop-runs.jsonl. Escalate breakthroughs (>=10% tk/s) and install requests to main agent.',
+    skills: [
+      'swarm-worker-core',
+      'pc1-ollama-gguf-bench',
+      'swarm-bench-worker',
+    ],
     defaultModel: 'GPT-5.4',
   },
   {
     role: 'Sage',
     specialty: 'research + scripts + X content + creative briefs',
-    mission: 'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
-    systemPrompt: 'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
+    mission:
+      'Research what matters. Draft scripts, X content, briefs. Cite sources. Never post externally without ack.',
+    systemPrompt:
+      'You are the research/content scout. Find angles, write scripts and drafts, always cite sources. Never post X/Discord/blog without main-agent ack — always draft + escalate.',
     skills: ['swarm-worker-core', 'last30days', 'pdf-and-paper-deep-reading'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Scribe',
     specialty: 'docs, skills hygiene, memory curation',
-    mission: 'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
-    systemPrompt: 'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
+    mission:
+      'Keep docs current. Hygiene the skills folder. Curate memory. Write submission/release copy.',
+    systemPrompt:
+      'You are the source-of-truth keeper. Audit /skills/ every 12h, flag stale/unused/poorly-documented. Maintain SWARM_SPEC and worker specs as system evolves. Draft READMEs and changelogs.',
     skills: ['swarm-worker-core', 'last30days', 'creative-writing'],
     defaultModel: 'GPT-5.5',
   },
   {
     role: 'Foundation',
     specialty: 'infra, repair playbook, autopilot wiring',
-    mission: 'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
-    systemPrompt: 'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
+    mission:
+      'Keep the swarm running. Apply repair playbook. Wire autopilot. Maintain loop infra.',
+    systemPrompt:
+      'You are infrastructure. Maintain /swarm-specs/playbooks/auto-repair.yaml. Health-check tmux sessions, autopilot tick, dev server. Apply known fixes; escalate novel failures.',
     skills: ['swarm-worker-core'],
     defaultModel: 'GPT-5.4',
   },
@@ -309,7 +354,8 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
     role: 'QA',
     specialty: 'regression QA, render verification',
     mission: 'Run regression suite on every commit + render. Block bad ships.',
-    systemPrompt: 'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
+    systemPrompt:
+      'You are QA. On commit: full test suite. On render: ffprobe + tone consistency + pacing. Verdict PASS/FAIL/FLAKY with evidence.',
     skills: ['swarm-worker-core', 'byte-verified-code-review'],
     defaultModel: 'GPT-5.4',
   },
@@ -317,7 +363,8 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
     role: 'Mirror Integrations',
     specialty: 'asset packs, upstream sync',
     mission: 'Generate assets. Watch upstream. Pack integrations.',
-    systemPrompt: 'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
+    systemPrompt:
+      'You produce assets and watch upstream. Generate art/audio per Lane A. Every 12h diff upstream Hermes Agent main, surface portable items. Never cross-org PR without ack.',
     skills: ['swarm-worker-core', 'claude-promo', 'songwriting-and-ai-music'],
     defaultModel: 'GPT-5.4',
   },
@@ -332,13 +379,30 @@ const ROLE_PRESETS: ReadonlyArray<RolePreset> = [
 
 const ROLE_NAMES = ROLE_PRESETS.map((p) => p.role)
 
-async function fetchAvailableModels(): Promise<Array<{ id: string; name: string; provider: string }>> {
+async function fetchAvailableModels(): Promise<
+  Array<{
+    id: string
+    name: string
+    provider: string
+    status: string
+    selectable: boolean
+  }>
+> {
   try {
-    const res = await fetch('/api/models')
+    const res = await fetch('/api/orchestration-catalog')
     if (!res.ok) return []
     const data = await res.json()
-    if (!data?.ok || !Array.isArray(data?.data)) return []
-    return data.data
+    if (!data?.ok || !Array.isArray(data?.models)) return []
+    return data.models
+      .filter((model: { selectable?: unknown }) => model.selectable === true)
+      .map((model: { id?: unknown; provider?: unknown; status?: unknown }) => ({
+        id: typeof model.id === 'string' ? model.id : '',
+        name: typeof model.id === 'string' ? model.id : '',
+        provider: typeof model.provider === 'string' ? model.provider : '',
+        status: typeof model.status === 'string' ? model.status : 'unknown',
+        selectable: true,
+      }))
+      .filter((model: { id: string }) => Boolean(model.id))
   } catch {
     return []
   }
@@ -509,7 +573,8 @@ function withInstantScroll<T>(anchor: HTMLElement | null, fn: () => T): T {
   if (typeof window === 'undefined') return fn()
 
   const targets: HTMLElement[] = []
-  if (document.documentElement instanceof HTMLElement) targets.push(document.documentElement)
+  if (document.documentElement instanceof HTMLElement)
+    targets.push(document.documentElement)
   if (document.body instanceof HTMLElement) targets.push(document.body)
 
   let current: HTMLElement | null = anchor
@@ -518,13 +583,22 @@ function withInstantScroll<T>(anchor: HTMLElement | null, fn: () => T): T {
     current = current.parentElement
   }
 
-  for (const selector of ['main', '[data-slot="content"]', '[data-slot="main"]', '[data-scroll-container]']) {
+  for (const selector of [
+    'main',
+    '[data-slot="content"]',
+    '[data-slot="main"]',
+    '[data-scroll-container]',
+  ]) {
     const node = document.querySelector(selector)
     if (node instanceof HTMLElement) targets.push(node)
   }
 
-  const deduped = [...new Set(targets)].filter((node) => !node.closest('.xterm'))
-  const previous = deduped.map((node) => [node, node.style.scrollBehavior] as const)
+  const deduped = [...new Set(targets)].filter(
+    (node) => !node.closest('.xterm'),
+  )
+  const previous = deduped.map(
+    (node) => [node, node.style.scrollBehavior] as const,
+  )
   for (const [node] of previous) node.style.scrollBehavior = 'auto'
   try {
     return fn()
@@ -555,7 +629,8 @@ function scrollContextToTop(anchor: HTMLElement | null) {
     ]
 
     for (const node of candidates) {
-      if (node instanceof HTMLElement && !node.closest('.xterm')) scrollNodeToTop(node)
+      if (node instanceof HTMLElement && !node.closest('.xterm'))
+        scrollNodeToTop(node)
     }
 
     if (anchor) {
@@ -578,7 +653,9 @@ function scheduleScrollContextToTop(anchor: HTMLElement | null) {
 
   run()
   frames.push(window.requestAnimationFrame(run))
-  frames.push(window.requestAnimationFrame(() => window.requestAnimationFrame(run)))
+  frames.push(
+    window.requestAnimationFrame(() => window.requestAnimationFrame(run)),
+  )
   timers.push(window.setTimeout(run, 0))
   timers.push(window.setTimeout(run, 50))
   timers.push(window.setTimeout(run, 150))
@@ -602,25 +679,56 @@ function relativeTime(ts: number | null | undefined): string {
 
 function progressForRuntime(runtime: RuntimeEntry | undefined): number {
   if (!runtime) return 0
-  if (runtime.checkpointStatus === 'done' || runtime.checkpointStatus === 'handoff') return 100
-  if (runtime.checkpointStatus === 'blocked' || runtime.checkpointStatus === 'needs_input') return 100
+  if (
+    runtime.checkpointStatus === 'done' ||
+    runtime.checkpointStatus === 'handoff'
+  )
+    return 100
+  if (
+    runtime.checkpointStatus === 'blocked' ||
+    runtime.checkpointStatus === 'needs_input'
+  )
+    return 100
   if (!runtime.currentTask?.trim()) return 0
-  const text = `${runtime.phase ?? ''} ${runtime.currentTask ?? ''}`.toLowerCase()
+  const text =
+    `${runtime.phase ?? ''} ${runtime.currentTask ?? ''}`.toLowerCase()
   if (text.includes('review')) return 72
   if (text.includes('test') || text.includes('qa')) return 78
-  if (text.includes('implement') || text.includes('build') || text.includes('patch')) return 64
-  if (text.includes('plan') || text.includes('research') || text.includes('design')) return 48
+  if (
+    text.includes('implement') ||
+    text.includes('build') ||
+    text.includes('patch')
+  )
+    return 64
+  if (
+    text.includes('plan') ||
+    text.includes('research') ||
+    text.includes('design')
+  )
+    return 48
   return 58
 }
 
-function cleanSwarmLabel(rawValue: string, fallback = 'Ready for task', maxLength = 64): string {
+function cleanSwarmLabel(
+  rawValue: string,
+  fallback = 'Ready for task',
+  maxLength = 64,
+): string {
   const raw = rawValue.trim()
   if (!raw) return fallback
-  const lines = raw.split('\n').map((line) => line.trim()).filter(Boolean)
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
   const goalLine = lines.find((line) => /^goal\s*:/i.test(line))
   const selected = goalLine
     ? goalLine.replace(/^goal\s*:\s*/i, '')
-    : lines.find((line) => !/^you are\b/i.test(line) && !/^context\b/i.test(line) && !/^constraints\b/i.test(line)) || lines[0]
+    : lines.find(
+        (line) =>
+          !/^you are\b/i.test(line) &&
+          !/^context\b/i.test(line) &&
+          !/^constraints\b/i.test(line),
+      ) || lines[0]
   const cleaned = selected
     .replace(/^[A-Z][A-Z0-9_ -]{2,}TASK\s*:\s*/i, '')
     .replace(/^DESIGN_ADDENDUM\s*:\s*/i, '')
@@ -634,22 +742,41 @@ function cleanSwarmLabel(rawValue: string, fallback = 'Ready for task', maxLengt
   return compactText(cleaned || raw, maxLength)
 }
 
-function displayTaskTitle(runtime: RuntimeEntry | undefined, fallback: string): string {
+function displayTaskTitle(
+  runtime: RuntimeEntry | undefined,
+  fallback: string,
+): string {
   const realSummary = runtime?.lastRealSummary ?? null
   const realResult = runtime?.lastRealResult ?? null
-  return cleanSwarmLabel(runtime?.blockedReason || runtime?.currentTask || realSummary || runtime?.lastSummary || realResult || runtime?.lastResult || fallback || '', 'Ready for task', 64)
+  return cleanSwarmLabel(
+    runtime?.blockedReason ||
+      runtime?.currentTask ||
+      realSummary ||
+      runtime?.lastSummary ||
+      realResult ||
+      runtime?.lastResult ||
+      fallback ||
+      '',
+    'Ready for task',
+    64,
+  )
 }
 
-
-function formatAssignedModel(model?: string | null, provider?: string | null): string {
+function formatAssignedModel(
+  model?: string | null,
+  provider?: string | null,
+): string {
   const value = `${model || ''} ${provider || ''}`.toLowerCase()
-  if (value.includes('claude-opus-4-7') || value.includes('opus-4-7')) return 'Opus 4.7'
-  if (value.includes('claude-opus-4-6') || value.includes('opus-4-6')) return 'Opus 4.6'
+  if (value.includes('claude-opus-4-7') || value.includes('opus-4-7'))
+    return 'Opus 4.7'
+  if (value.includes('claude-opus-4-6') || value.includes('opus-4-6'))
+    return 'Opus 4.6'
   if (value.includes('gpt-5.5')) return 'GPT-5.5'
   if (value.includes('gpt-5.4')) return 'GPT-5.4'
   if (value.includes('gpt-5.3')) return 'GPT-5.3'
   if (model && model !== 'unknown') return model
-  if (provider && provider !== 'unknown') return provider.replace(/^custom:/, '').replace(/[-_]/g, ' ')
+  if (provider && provider !== 'unknown')
+    return provider.replace(/^custom:/, '').replace(/[-_]/g, ' ')
   return 'Worker'
 }
 
@@ -662,13 +789,37 @@ type ControlPlaneStageProps = {
   selectedLabel: string
   workspaceModel: string | null
   lanes: Array<{ role: string; count: number; active: number }>
-  activeAgents: Array<{ workerId: string; workerName: string; role: string; task: string; progress: number; state: 'working' | 'reviewing' | 'blocked' | 'ready'; age: string }>
-  recentUpdates: Array<{ workerId: string; workerName: string; text: string; age: string; tone: 'idle' | 'active' | 'warning' }>
-  latestMission: { id: string; title: string; state: string; assignmentCount: number; checkpointedCount: number } | null
+  activeAgents: Array<{
+    workerId: string
+    workerName: string
+    role: string
+    task: string
+    progress: number
+    state: 'working' | 'reviewing' | 'blocked' | 'ready'
+    age: string
+  }>
+  recentUpdates: Array<{
+    workerId: string
+    workerName: string
+    text: string
+    age: string
+    tone: 'idle' | 'active' | 'warning'
+  }>
+  latestMission: {
+    id: string
+    title: string
+    state: string
+    assignmentCount: number
+    checkpointedCount: number
+  } | null
   missions: Array<SwarmMissionSummary>
   runtimeEntries: Array<RuntimeEntry>
   inboxCounts: { needsReview: number; blocked: number; ready: number }
-  routerSeed: { key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null
+  routerSeed: {
+    key: number
+    prompt: string
+    mode: 'auto' | 'manual' | 'broadcast'
+  } | null
   onOpenInboxItem: (item: Swarm2InboxItem) => void
   onRouteToReviewer: (item: Swarm2InboxItem) => void
   viewMode: ViewMode
@@ -687,7 +838,11 @@ type ControlPlaneStageProps = {
   onToggleFocusedRuntimeWorker: (workerId: string) => void
   onClearFocusedRuntimeWorker: () => void
   onStartAgentSession: (workerId: string) => void
-  onScrollTmuxSession: (workerId: string, direction: 'up' | 'down', session?: string | null) => void
+  onScrollTmuxSession: (
+    workerId: string,
+    direction: 'up' | 'down',
+    session?: string | null,
+  ) => void
 }
 
 function ControlPlaneStage({
@@ -729,19 +884,22 @@ function ControlPlaneStage({
   const stageRef = useRef<HTMLDivElement | null>(null)
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const workerRefsMap = useRef<Map<string, HTMLElement>>(new Map())
-  const cardSetters = useRef<
-    Map<string, (node: HTMLElement | null) => void>
-  >(new Map())
+  const cardSetters = useRef<Map<string, (node: HTMLElement | null) => void>>(
+    new Map(),
+  )
   const [refsVersion, setRefsVersion] = useState(0)
   const bumpRefsVersion = useCallback(() => {
     setRefsVersion((value) => value + 1)
   }, [])
 
-  const setAnchor = useCallback((node: HTMLDivElement | null) => {
-    if (anchorRef.current === node) return
-    anchorRef.current = node
-    bumpRefsVersion()
-  }, [bumpRefsVersion])
+  const setAnchor = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (anchorRef.current === node) return
+      anchorRef.current = node
+      bumpRefsVersion()
+    },
+    [bumpRefsVersion],
+  )
 
   const setWorkerRef = useCallback(
     (workerId: string) => {
@@ -825,7 +983,12 @@ function ControlPlaneStage({
           className="w-full max-w-5xl"
         />
         <div className="relative w-full pt-3">
-          <div className={cn('relative z-10', viewMode === 'cards' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'cards' ? 'block' : 'hidden',
+            )}
+          >
             <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 min-[1680px]:grid-cols-3">
               {members.length === 0 ? (
                 <div className="col-span-full rounded-[1.5rem] border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-sm text-[var(--theme-muted)]">
@@ -843,8 +1006,19 @@ function ControlPlaneStage({
                       checkpointStatus={runtime?.checkpointStatus ?? null}
                       runtimeState={runtime?.state ?? null}
                       recentLines={recentLines(runtime)}
-                      recentOutputAt={runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? null}
-                      recentSummary={runtime?.lastRealSummary ?? runtime?.lastRealResult ?? runtime?.lastSummary ?? runtime?.lastResult ?? runtime?.blockedReason ?? null}
+                      recentOutputAt={
+                        runtime?.lastOutputAt ??
+                        runtime?.lastSessionStartedAt ??
+                        null
+                      }
+                      recentSummary={
+                        runtime?.lastRealSummary ??
+                        runtime?.lastRealResult ??
+                        runtime?.lastSummary ??
+                        runtime?.lastResult ??
+                        runtime?.blockedReason ??
+                        null
+                      }
                       artifacts={runtime?.artifacts ?? []}
                       previews={runtime?.previews ?? []}
                       inRoom={roomIds.includes(member.id)}
@@ -860,14 +1034,34 @@ function ControlPlaneStage({
             </div>
           </div>
 
-          <div className={cn('relative z-10 flex flex-col gap-3', viewMode === 'runtime' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10 flex flex-col gap-3',
+              viewMode === 'runtime' ? 'block' : 'hidden',
+            )}
+          >
             {!tmuxAvailable ? (
               <div className="rounded-xl border border-amber-300/40 bg-amber-300/10 px-4 py-2.5 text-xs text-amber-100">
-                <div className="font-semibold text-amber-50">tmux not installed on this host</div>
-                <div className="mt-1 text-amber-100/80">Spawning a Hermes swarm worker requires tmux. Without it, the worker can start but cannot dispatch tasks (you'll see &lsquo;can't find pane: swarm-&lt;id&gt;&rsquo; errors). Install tmux:</div>
-                <code className="mt-1 inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">brew install tmux</code>{' '}
-                <span className="text-amber-100/60">(macOS) or</span>{' '}
-                <code className="inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">apt install tmux</code>{' '}
+                <div className="font-semibold text-amber-50">
+                  tmux not installed on this host
+                </div>
+                <div className="mt-1 text-amber-100/80">
+                  Spawning a Hermes swarm worker requires tmux. Without it, the
+                  worker can start but cannot dispatch tasks (you'll see
+                  &lsquo;can't find pane: swarm-&lt;id&gt;&rsquo; errors).
+                  Install tmux:
+                </div>
+                <code className="mt-1 inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">
+                  winget install --id arndawg.tmux-windows
+                </code>{' '}
+                <span className="text-amber-100/60">(Windows),</span>{' '}
+                <code className="inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">
+                  brew install tmux
+                </code>{' '}
+                <span className="text-amber-100/60">(macOS), or</span>{' '}
+                <code className="inline-block rounded bg-black/30 px-2 py-0.5 text-[10px] text-amber-100">
+                  apt install tmux
+                </code>{' '}
                 <span className="text-amber-100/60">(Ubuntu/Debian).</span>
               </div>
             ) : null}
@@ -876,7 +1070,9 @@ function ControlPlaneStage({
                 <span>
                   Focus mode on{' '}
                   <span className="font-semibold text-[var(--theme-text)]">
-                    {members.find((member) => member.id === focusedRuntimeWorkerId)?.displayName || focusedRuntimeWorkerId}
+                    {members.find(
+                      (member) => member.id === focusedRuntimeWorkerId,
+                    )?.displayName || focusedRuntimeWorkerId}
                   </span>
                 </span>
                 <button
@@ -888,10 +1084,16 @@ function ControlPlaneStage({
                 </button>
               </div>
             ) : null}
-            <div className={cn('grid grid-cols-1 gap-3', focusedRuntimeWorkerId ? '' : '2xl:grid-cols-2')}>
+            <div
+              className={cn(
+                'grid grid-cols-1 gap-3',
+                focusedRuntimeWorkerId ? '' : '2xl:grid-cols-2',
+              )}
+            >
               {terminalTargets.length === 0 ? (
                 <div className="rounded-[1.5rem] border border-dashed border-[var(--theme-border)] bg-[var(--theme-card)] p-8 text-sm text-[var(--theme-muted)]">
-                  No active workers detected. Select a worker or wire it into the room to mount its terminal.
+                  No active workers detected. Select a worker or wire it into
+                  the room to mount its terminal.
                 </div>
               ) : (
                 terminalTargets.map((member) => {
@@ -904,35 +1106,118 @@ function ControlPlaneStage({
                         ? 'border-[var(--theme-warning-border)] bg-[var(--theme-warning-soft)] text-[var(--theme-warning)]'
                         : 'border-[var(--theme-border)] bg-[var(--theme-card2)] text-[var(--theme-muted)]'
                   const titleLabel = member.displayName || member.id
-                  const modelLabel = formatAssignedModel(member.model, member.provider)
+                  const modelLabel = formatAssignedModel(
+                    member.model,
+                    member.provider,
+                  )
                   return (
-                    <div key={member.id} className="overflow-hidden rounded-[1.5rem] border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_20px_60px_color-mix(in_srgb,var(--theme-shadow)_14%,transparent)]">
+                    <div
+                      key={member.id}
+                      className="overflow-hidden rounded-[1.5rem] border border-[var(--theme-border)] bg-[var(--theme-card)] shadow-[0_20px_60px_color-mix(in_srgb,var(--theme-shadow)_14%,transparent)]"
+                    >
                       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--theme-border)] px-3 py-2 text-[11px] text-[var(--theme-muted)]">
                         <span className="inline-flex items-center gap-2 font-semibold text-[var(--theme-text)]">
                           <HugeiconsIcon icon={CpuIcon} size={13} />
                           <span>{titleLabel}</span>
-                          <span className="text-[10px] font-medium text-[var(--theme-muted)]">· {modelLabel}</span>
+                          <span className="text-[10px] font-medium text-[var(--theme-muted)]">
+                            · {modelLabel}
+                          </span>
                         </span>
                         <div className="ml-auto flex items-center gap-1">
                           {runtime?.tmuxAttachable ? (
                             <>
-                              <button type="button" onClick={() => onScrollTmuxSession(member.id, 'up', runtime.tmuxSession)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={`Scroll up in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}>↑</button>
-                              <button type="button" onClick={() => onScrollTmuxSession(member.id, 'down', runtime.tmuxSession)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={`Scroll down in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}>↓</button>
-                              <button type="button" onClick={() => onToggleFocusedRuntimeWorker(member.id)} className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]" title={focusedRuntimeWorkerId === member.id ? `Exit focus for swarm-${member.id}` : `Focus swarm-${member.id}`}>
-                                {focusedRuntimeWorkerId === member.id ? '⛶' : '⤢'}
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onScrollTmuxSession(
+                                    member.id,
+                                    'up',
+                                    runtime.tmuxSession,
+                                  )
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={`Scroll up in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}
+                              >
+                                ↑
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onScrollTmuxSession(
+                                    member.id,
+                                    'down',
+                                    runtime.tmuxSession,
+                                  )
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={`Scroll down in ${runtime.tmuxSession ?? `swarm-${member.id}`}`}
+                              >
+                                ↓
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  onToggleFocusedRuntimeWorker(member.id)
+                                }
+                                className="rounded-full border border-transparent px-1.5 py-0.5 text-[12px] text-[var(--theme-muted)] transition-colors hover:border-[var(--theme-border)] hover:bg-[var(--theme-card2)] hover:text-[var(--theme-text)]"
+                                title={
+                                  focusedRuntimeWorkerId === member.id
+                                    ? `Exit focus for swarm-${member.id}`
+                                    : `Focus swarm-${member.id}`
+                                }
+                              >
+                                {focusedRuntimeWorkerId === member.id
+                                  ? '⛶'
+                                  : '⤢'}
                               </button>
                             </>
                           ) : (
-                            <button type="button" disabled={pendingTmux.has(member.id) || !tmuxAvailable} onClick={() => onStartAgentSession(member.id)} className={cn('rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] transition-colors', 'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:opacity-90', (pendingTmux.has(member.id) || !tmuxAvailable) && 'cursor-not-allowed opacity-50')} title={tmuxAvailable ? `Start a live agent session in tmux (swarm-${member.id})` : 'tmux is not installed on this host'}>
-                              {pendingTmux.has(member.id) ? 'Starting…' : 'Start agent'}
+                            <button
+                              type="button"
+                              disabled={
+                                pendingTmux.has(member.id) || !tmuxAvailable
+                              }
+                              onClick={() => onStartAgentSession(member.id)}
+                              className={cn(
+                                'rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] transition-colors',
+                                'border-[var(--theme-accent)] bg-[var(--theme-accent-soft)] text-[var(--theme-accent-strong)] hover:opacity-90',
+                                (pendingTmux.has(member.id) ||
+                                  !tmuxAvailable) &&
+                                  'cursor-not-allowed opacity-50',
+                              )}
+                              title={
+                                tmuxAvailable
+                                  ? `Start a live agent session in tmux (swarm-${member.id})`
+                                  : 'tmux is not installed on this host'
+                              }
+                            >
+                              {pendingTmux.has(member.id)
+                                ? 'Starting…'
+                                : 'Start agent'}
                             </button>
                           )}
                         </div>
-                        <span className={cn('inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]', kindBadgeClass)} title={cmd.command.join(' ')}>
-                          {cmd.kind === 'tmux' ? 'tmux' : cmd.kind === 'log-tail' ? 'logs' : 'shell'}
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]',
+                            kindBadgeClass,
+                          )}
+                          title={cmd.command.join(' ')}
+                        >
+                          {cmd.kind === 'tmux'
+                            ? 'tmux'
+                            : cmd.kind === 'log-tail'
+                              ? 'logs'
+                              : 'shell'}
                         </span>
                       </div>
-                      <SwarmTerminal workerId={member.id} command={cmd.command} cwd={runtime?.cwd ?? undefined} height={420} active={viewMode === 'runtime'} />
+                      <SwarmTerminal
+                        workerId={member.id}
+                        command={cmd.command}
+                        cwd={runtime?.cwd ?? undefined}
+                        height={420}
+                        active={viewMode === 'runtime'}
+                      />
                     </div>
                   )
                 })
@@ -940,7 +1225,12 @@ function ControlPlaneStage({
             </div>
           </div>
 
-          <div className={cn('relative z-10', viewMode === 'kanban' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'kanban' ? 'block' : 'hidden',
+            )}
+          >
             <Swarm2KanbanBoard
               workers={members}
               latestMission={latestMission}
@@ -950,7 +1240,12 @@ function ControlPlaneStage({
             />
           </div>
 
-          <div className={cn('relative z-10', viewMode === 'reports' ? 'block' : 'hidden')}>
+          <div
+            className={cn(
+              'relative z-10',
+              viewMode === 'reports' ? 'block' : 'hidden',
+            )}
+          >
             <Swarm2ReportsView
               missions={missions}
               runtimes={runtimeEntries}
@@ -967,8 +1262,6 @@ function ControlPlaneStage({
     </section>
   )
 }
-
-
 
 export const __runtimeTabInternals = {
   commandForRuntime,
@@ -994,7 +1287,11 @@ export function Swarm2Screen() {
   })
   const [viewMode, setViewMode] = useState<ViewMode>('cards')
   const [routerOpen, setRouterOpen] = useState(false)
-  const [routerSeed, setRouterSeed] = useState<{ key: number; prompt: string; mode: 'auto' | 'manual' | 'broadcast' } | null>(null)
+  const [routerSeed, setRouterSeed] = useState<{
+    key: number
+    prompt: string
+    mode: 'auto' | 'manual' | 'broadcast'
+  } | null>(null)
   const [notificationsOpen, setNotificationsOpen] = useState(false)
   const [addSwarmOpen, setAddSwarmOpen] = useState(false)
   const [addSwarmSaving, setAddSwarmSaving] = useState(false)
@@ -1014,7 +1311,9 @@ export function Swarm2Screen() {
   const [newWorkerMission, setNewWorkerMission] = useState('')
   // Worker IDs whose tmux session is currently being started/stopped via API.
   const [pendingTmux, setPendingTmux] = useState<Set<string>>(new Set())
-  const [focusedRuntimeWorkerId, setFocusedRuntimeWorkerId] = useState<string | null>(null)
+  const [focusedRuntimeWorkerId, setFocusedRuntimeWorkerId] = useState<
+    string | null
+  >(null)
   const topRef = useRef<HTMLDivElement | null>(null)
 
   const runtimeQuery = useQuery({
@@ -1050,13 +1349,14 @@ export function Swarm2Screen() {
         if (!res.ok) {
           const text = await res.text().catch(() => '')
           let parsed: { error?: string } = {}
-          try { parsed = JSON.parse(text) } catch {}
+          try {
+            parsed = JSON.parse(text)
+          } catch {}
           const msg = parsed.error || text || `HTTP ${res.status}`
           if (msg.includes('tmux not installed')) {
             toast({
               title: 'tmux not installed',
-              description:
-                `Swarm worker ${workerId} couldn't start because tmux is not installed on this host. Install tmux (‘brew install tmux’ or ‘apt install tmux’) and try again. See #244.`,
+              description: `Swarm worker ${workerId} couldn't start because tmux is not installed on this host. Install tmux (Windows: ‘winget install --id arndawg.tmux-windows’; macOS: ‘brew install tmux’; Debian/Ubuntu: ‘apt install tmux’) and try again. See #244.`,
               variant: 'destructive',
             })
           } else {
@@ -1114,7 +1414,11 @@ export function Swarm2Screen() {
   )
 
   const scrollTmuxSession = useCallback(
-    async (workerId: string, direction: 'up' | 'down', session?: string | null) => {
+    async (
+      workerId: string,
+      direction: 'up' | 'down',
+      session?: string | null,
+    ) => {
       try {
         const res = await fetch('/api/swarm-tmux-scroll', {
           method: 'POST',
@@ -1135,7 +1439,9 @@ export function Swarm2Screen() {
   )
 
   const toggleFocusedRuntimeWorker = useCallback((workerId: string) => {
-    setFocusedRuntimeWorkerId((current) => (current === workerId ? null : workerId))
+    setFocusedRuntimeWorkerId((current) =>
+      current === workerId ? null : workerId,
+    )
   }, [])
 
   const runtimeByWorker = useMemo(() => {
@@ -1222,7 +1528,6 @@ export function Swarm2Screen() {
     return scheduleScrollContextToTop(topRef.current)
   }, [])
 
-
   const activeRuntimeCount = members.filter((member) =>
     isRuntimeActive(runtimeByWorker.get(member.id)),
   ).length
@@ -1254,7 +1559,10 @@ export function Swarm2Screen() {
     ? autoMountTargets.filter((member) => member.id === focusedRuntimeWorkerId)
     : autoMountTargets
   const rosterLanes = useMemo(() => {
-    const map = new Map<string, { role: string; count: number; active: number }>()
+    const map = new Map<
+      string,
+      { role: string; count: number; active: number }
+    >()
     for (const member of members) {
       const role = member.role || 'Worker'
       const existing = map.get(role) ?? { role, count: 0, active: 0 }
@@ -1262,20 +1570,34 @@ export function Swarm2Screen() {
       if (isRuntimeActive(runtimeByWorker.get(member.id))) existing.active += 1
       map.set(role, existing)
     }
-    return [...map.values()].sort((a, b) => b.active - a.active || b.count - a.count || a.role.localeCompare(b.role))
+    return [...map.values()].sort(
+      (a, b) =>
+        b.active - a.active ||
+        b.count - a.count ||
+        a.role.localeCompare(b.role),
+    )
   }, [members, runtimeByWorker])
   const latestMission = useMemo(() => {
     const mission = missionsQuery.data?.[0]
     if (!mission) return null
     const assignments = mission.assignments ?? []
-    const genericTitle = /^\d+\s+assigned tasks?$/i.test(mission.title.trim()) || /assigned tasks/i.test(mission.title)
-    const firstTask = assignments.find((assignment) => assignment.task?.trim())?.task ?? ''
+    const genericTitle =
+      /^\d+\s+assigned tasks?$/i.test(mission.title.trim()) ||
+      /assigned tasks/i.test(mission.title)
+    const firstTask =
+      assignments.find((assignment) => assignment.task?.trim())?.task ?? ''
     return {
       id: mission.id,
-      title: cleanSwarmLabel(genericTitle ? firstTask : mission.title, 'Swarm mission', 72),
+      title: cleanSwarmLabel(
+        genericTitle ? firstTask : mission.title,
+        'Swarm mission',
+        72,
+      ),
       state: mission.state,
       assignmentCount: assignments.length,
-      checkpointedCount: assignments.filter((assignment) => ['checkpointed', 'done'].includes(assignment.state)).length,
+      checkpointedCount: assignments.filter((assignment) =>
+        ['checkpointed', 'done'].includes(assignment.state),
+      ).length,
     }
   }, [missionsQuery.data])
 
@@ -1284,17 +1606,30 @@ export function Swarm2Screen() {
       .map((member) => {
         const runtime = runtimeByWorker.get(member.id)
         const currentTask = runtime?.currentTask?.trim()
-        const blocked = Boolean(runtime?.blockedReason || runtime?.needsHuman || runtime?.checkpointStatus === 'blocked' || runtime?.checkpointStatus === 'needs_input')
-        const done = runtime?.checkpointStatus === 'done' || runtime?.checkpointStatus === 'handoff'
+        const blocked = Boolean(
+          runtime?.blockedReason ||
+          runtime?.needsHuman ||
+          runtime?.checkpointStatus === 'blocked' ||
+          runtime?.checkpointStatus === 'needs_input',
+        )
+        const done =
+          runtime?.checkpointStatus === 'done' ||
+          runtime?.checkpointStatus === 'handoff'
         if (!currentTask && !blocked) return null
         const state: 'working' | 'reviewing' | 'blocked' | 'ready' = blocked
           ? 'blocked'
           : done
             ? 'ready'
-            : `${runtime?.phase ?? ''} ${currentTask ?? ''}`.toLowerCase().includes('review')
+            : `${runtime?.phase ?? ''} ${currentTask ?? ''}`
+                  .toLowerCase()
+                  .includes('review')
               ? 'reviewing'
               : 'working'
-        const ts = runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? member.lastSessionAt ?? null
+        const ts =
+          runtime?.lastOutputAt ??
+          runtime?.lastSessionStartedAt ??
+          member.lastSessionAt ??
+          null
         return {
           workerId: member.id,
           workerName: member.displayName || member.id,
@@ -1309,7 +1644,11 @@ export function Swarm2Screen() {
       .filter((item): item is NonNullable<typeof item> => Boolean(item))
       .sort((a, b) => {
         const priority = { blocked: 0, reviewing: 1, working: 2, ready: 3 }
-        return priority[a.state] - priority[b.state] || b.ts - a.ts || a.workerId.localeCompare(b.workerId)
+        return (
+          priority[a.state] - priority[b.state] ||
+          b.ts - a.ts ||
+          a.workerId.localeCompare(b.workerId)
+        )
       })
       .map((item) => ({
         workerId: item.workerId,
@@ -1323,7 +1662,11 @@ export function Swarm2Screen() {
   }, [members, runtimeByWorker])
 
   const inboxLanes = useMemo(
-    () => buildSwarm2InboxLanes({ missions: missionsQuery.data ?? [], runtimes: runtimeQuery.data?.entries ?? [] }),
+    () =>
+      buildSwarm2InboxLanes({
+        missions: missionsQuery.data ?? [],
+        runtimes: runtimeQuery.data?.entries ?? [],
+      }),
     [missionsQuery.data, runtimeQuery.data?.entries],
   )
 
@@ -1389,23 +1732,46 @@ export function Swarm2Screen() {
         title: `Mission ${latestMission.state}`,
         body: `${latestMission.checkpointedCount}/${latestMission.assignmentCount} checkpointed · ${latestMission.title}`,
         age: latestMission.id,
-        actionable: latestMission.checkpointedCount < latestMission.assignmentCount,
+        actionable:
+          latestMission.checkpointedCount < latestMission.assignmentCount,
       })
     }
     return laneItems.slice(0, 8)
   }, [inboxLanes, latestMission])
-  const actionableNotificationCount = swarmNotifications.filter((item) => item.actionable).length
+  const actionableNotificationCount = swarmNotifications.filter(
+    (item) => item.actionable,
+  ).length
 
   const recentUpdates = useMemo(() => {
     return members
       .map((member) => {
         const runtime = runtimeByWorker.get(member.id)
-        const ts = runtime?.lastOutputAt ?? runtime?.lastSessionStartedAt ?? member.lastSessionAt ?? null
-        const rawText = runtime?.lastRealSummary ?? runtime?.lastRealResult ?? runtime?.lastSummary ?? runtime?.lastResult ?? runtime?.blockedReason ?? runtime?.currentTask ?? member.lastSessionTitle ?? `Ready in ${member.role || 'worker'} lane`
-        const state = (runtime?.phase || runtime?.currentTask || '').toLowerCase()
+        const ts =
+          runtime?.lastOutputAt ??
+          runtime?.lastSessionStartedAt ??
+          member.lastSessionAt ??
+          null
+        const rawText =
+          runtime?.lastRealSummary ??
+          runtime?.lastRealResult ??
+          runtime?.lastSummary ??
+          runtime?.lastResult ??
+          runtime?.blockedReason ??
+          runtime?.currentTask ??
+          member.lastSessionTitle ??
+          `Ready in ${member.role || 'worker'} lane`
+        const state = (
+          runtime?.phase ||
+          runtime?.currentTask ||
+          ''
+        ).toLowerCase()
         const tone: 'idle' | 'active' | 'warning' = runtime?.blockedReason
           ? 'warning'
-          : (state.includes('review') || state.includes('write') || state.includes('build') || state.includes('implement') || state.includes('active'))
+          : state.includes('review') ||
+              state.includes('write') ||
+              state.includes('build') ||
+              state.includes('implement') ||
+              state.includes('active')
             ? 'active'
             : 'idle'
         return {
@@ -1419,7 +1785,13 @@ export function Swarm2Screen() {
       })
       .sort((a, b) => b.ts - a.ts || a.workerId.localeCompare(b.workerId))
       .slice(0, 3)
-      .map(({ workerId, workerName, text, age, tone }) => ({ workerId, workerName, text, age, tone }))
+      .map(({ workerId, workerName, text, age, tone }) => ({
+        workerId,
+        workerName,
+        text,
+        age,
+        tone,
+      }))
   }, [members, runtimeByWorker])
 
   function toggleRoom(id: string) {
@@ -1431,7 +1803,9 @@ export function Swarm2Screen() {
   }
 
   function openAddSwarm() {
-    const existingIds = new Set((rosterQuery.data ?? []).map((worker) => worker.id))
+    const existingIds = new Set(
+      (rosterQuery.data ?? []).map((worker) => worker.id),
+    )
     let next = 13
     while (existingIds.has(`swarm${next}`)) next += 1
     setNewWorkerId(`swarm${next}`)
@@ -1458,7 +1832,10 @@ export function Swarm2Screen() {
           role: newWorkerRole.trim(),
           specialty: newWorkerSpecialty.trim() || preset?.specialty || '',
           model: newWorkerModel.trim(),
-          mission: newWorkerMission.trim() || preset?.mission || 'Awaiting orchestrator dispatch.',
+          mission:
+            newWorkerMission.trim() ||
+            preset?.mission ||
+            'Awaiting orchestrator dispatch.',
           systemPrompt: preset?.systemPrompt ?? null,
           skills: preset?.skills ?? [],
         }),
@@ -1470,15 +1847,20 @@ export function Swarm2Screen() {
       await rosterQuery.refetch()
       setAddSwarmOpen(false)
     } catch (error) {
-      setAddSwarmError(error instanceof Error ? error.message : 'Failed to save swarm agent')
+      setAddSwarmError(
+        error instanceof Error ? error.message : 'Failed to save swarm agent',
+      )
     } finally {
       setAddSwarmSaving(false)
     }
   }
 
-
   return (
-    <div ref={topRef} className="min-h-full bg-surface text-primary-900" style={SWARM2_OPERATION_THEME}>
+    <div
+      ref={topRef}
+      className="min-h-full bg-surface text-primary-900"
+      style={SWARM2_OPERATION_THEME}
+    >
       <div
         className={cn(
           'mx-auto flex min-h-full max-w-[1680px] flex-col gap-3 px-3 pt-3 sm:px-4 lg:px-5',
@@ -1539,7 +1921,11 @@ export function Swarm2Screen() {
                 aria-label="Swarm notifications"
                 title="Swarm notifications"
               >
-                <HugeiconsIcon icon={AlarmClockIcon} size={17} strokeWidth={1.8} />
+                <HugeiconsIcon
+                  icon={AlarmClockIcon}
+                  size={17}
+                  strokeWidth={1.8}
+                />
                 {actionableNotificationCount > 0 ? (
                   <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
                     {actionableNotificationCount}
@@ -1550,34 +1936,55 @@ export function Swarm2Screen() {
                 <div className="absolute right-0 top-12 z-40 w-[min(28rem,calc(100vw-2rem))] rounded-2xl border border-[var(--theme-border)] bg-[var(--theme-card)] p-3 text-left shadow-[0_24px_80px_var(--theme-shadow)]">
                   <div className="mb-2 flex items-center justify-between gap-3">
                     <div>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">Swarm updates</div>
-                      <div className="text-xs text-[var(--theme-muted-2)]">Actionable state from canonical mission checkpoints and durable report lanes.</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--theme-muted)]">
+                        Swarm updates
+                      </div>
+                      <div className="text-xs text-[var(--theme-muted-2)]">
+                        Actionable state from canonical mission checkpoints and
+                        durable report lanes.
+                      </div>
                     </div>
-                    <button type="button" onClick={() => setNotificationsOpen(false)} className="rounded-lg px-2 py-1 text-xs hover:bg-[var(--theme-card2)]">Close</button>
+                    <button
+                      type="button"
+                      onClick={() => setNotificationsOpen(false)}
+                      className="rounded-lg px-2 py-1 text-xs hover:bg-[var(--theme-card2)]"
+                    >
+                      Close
+                    </button>
                   </div>
                   <div className="max-h-80 space-y-2 overflow-y-auto">
-                    {swarmNotifications.length ? swarmNotifications.map((item) => (
-                      <button
-                        key={item.id}
-                        type="button"
-                        onClick={() => {
-                          if (item.workerId) {
-                            setViewMode('reports')
-                            setSelectedId(item.workerId)
-                            setFocusedRuntimeWorkerId(item.workerId)
-                          }
-                          setNotificationsOpen(false)
-                        }}
-                        className="block w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-left hover:border-[var(--theme-accent)]"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="truncate text-sm font-medium text-[var(--theme-text)]">{item.title}</span>
-                          <span className="shrink-0 text-[10px] text-[var(--theme-muted)]">{item.age}</span>
-                        </div>
-                        <div className="mt-1 truncate text-xs text-[var(--theme-muted-2)]">{item.body}</div>
-                      </button>
-                    )) : (
-                      <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-xs text-[var(--theme-muted)]">No active swarm updates.</div>
+                    {swarmNotifications.length ? (
+                      swarmNotifications.map((item) => (
+                        <button
+                          key={item.id}
+                          type="button"
+                          onClick={() => {
+                            if (item.workerId) {
+                              setViewMode('reports')
+                              setSelectedId(item.workerId)
+                              setFocusedRuntimeWorkerId(item.workerId)
+                            }
+                            setNotificationsOpen(false)
+                          }}
+                          className="block w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-left hover:border-[var(--theme-accent)]"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="truncate text-sm font-medium text-[var(--theme-text)]">
+                              {item.title}
+                            </span>
+                            <span className="shrink-0 text-[10px] text-[var(--theme-muted)]">
+                              {item.age}
+                            </span>
+                          </div>
+                          <div className="mt-1 truncate text-xs text-[var(--theme-muted-2)]">
+                            {item.body}
+                          </div>
+                        </button>
+                      ))
+                    ) : (
+                      <div className="rounded-xl border border-dashed border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-3 text-xs text-[var(--theme-muted)]">
+                        No active swarm updates.
+                      </div>
                     )}
                   </div>
                 </div>
@@ -1641,8 +2048,12 @@ export function Swarm2Screen() {
             focusedRuntimeWorkerId={focusedRuntimeWorkerId}
             onToggleFocusedRuntimeWorker={toggleFocusedRuntimeWorker}
             onClearFocusedRuntimeWorker={() => setFocusedRuntimeWorkerId(null)}
-            onStartAgentSession={(workerId) => { void startAgentSession(workerId) }}
-            onScrollTmuxSession={(workerId, direction, session) => { void scrollTmuxSession(workerId, direction, session) }}
+            onStartAgentSession={(workerId) => {
+              void startAgentSession(workerId)
+            }}
+            onScrollTmuxSession={(workerId, direction, session) => {
+              void scrollTmuxSession(workerId, direction, session)
+            }}
           />
         </div>
 
@@ -1656,14 +2067,17 @@ export function Swarm2Screen() {
         ) : null}
       </div>
 
-
       {addSwarmOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4 py-6 backdrop-blur-sm">
           <div className="w-full max-w-2xl rounded-3xl border border-[var(--theme-border2)] bg-[var(--theme-card)] p-6 shadow-[0_30px_100px_var(--theme-shadow)]">
             <div className="mb-4 flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-xl font-semibold text-[var(--theme-text)]">Add Swarm Agent</h2>
-                <p className="mt-1 text-sm text-[var(--theme-muted-2)]">Create a new swarm roster entry and configure its identity.</p>
+                <h2 className="text-xl font-semibold text-[var(--theme-text)]">
+                  Add Swarm Agent
+                </h2>
+                <p className="mt-1 text-sm text-[var(--theme-muted-2)]">
+                  Create a new swarm roster entry and configure its identity.
+                </p>
               </div>
               <button
                 type="button"
@@ -1675,7 +2089,9 @@ export function Swarm2Screen() {
             </div>
             <div className="grid gap-3 md:grid-cols-2">
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Role preset</span>
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Role preset
+                </span>
                 <select
                   value={newWorkerRole}
                   onChange={(e) => {
@@ -1683,71 +2099,165 @@ export function Swarm2Screen() {
                     setNewWorkerRole(role)
                     const preset = ROLE_PRESETS.find((p) => p.role === role)
                     if (preset && role !== 'Custom') {
-                      if (!newWorkerSpecialty.trim()) setNewWorkerSpecialty(preset.specialty)
-                      if (!newWorkerMission.trim()) setNewWorkerMission(preset.mission)
-                      if (preset.defaultModel && !newWorkerModel.trim()) setNewWorkerModel(preset.defaultModel)
+                      if (!newWorkerSpecialty.trim())
+                        setNewWorkerSpecialty(preset.specialty)
+                      if (!newWorkerMission.trim())
+                        setNewWorkerMission(preset.mission)
+                      if (preset.defaultModel && !newWorkerModel.trim())
+                        setNewWorkerModel(preset.defaultModel)
                     }
                   }}
                   className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
                 >
                   {ROLE_NAMES.map((r) => (
-                    <option key={r} value={r}>{r}</option>
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
                   ))}
                 </select>
                 <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Presets auto-fill specialty, mission, system prompt, and skill stack. Pick “Custom” for a blank slate.
+                  Presets auto-fill specialty, mission, system prompt, and skill
+                  stack. Pick “Custom” for a blank slate.
                 </p>
               </label>
               <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Worker ID</span>
-                <input value={newWorkerId} onChange={(e) => setNewWorkerId(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="swarmN" />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Worker ID
+                </span>
+                <input
+                  value={newWorkerId}
+                  onChange={(e) => setNewWorkerId(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder="swarmN"
+                />
               </label>
               <label className="block text-sm">
-                <span className="mb-1 block text-[var(--theme-muted)]">Display name</span>
-                <input value={newWorkerName} onChange={(e) => setNewWorkerName(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder="e.g. Mirror, Builder" />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Display name
+                </span>
+                <input
+                  value={newWorkerName}
+                  onChange={(e) => setNewWorkerName(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder="e.g. Mirror, Builder"
+                />
               </label>
               <label className="block text-sm md:col-span-2">
                 <span className="mb-1 flex items-center justify-between text-[var(--theme-muted)]">
                   <span>Model</span>
-                  <span className="text-[10px] text-[var(--theme-muted-2)]">{availableModels.length > 0 ? `${availableModels.length} available` : modelsQuery.isLoading ? 'loading…' : '0 found'}</span>
+                  <span className="text-[10px] text-[var(--theme-muted-2)]">
+                    {availableModels.length > 0
+                      ? `${availableModels.length} available`
+                      : modelsQuery.isLoading
+                        ? 'loading…'
+                        : '0 found'}
+                  </span>
                 </span>
                 <input
                   value={newWorkerModel}
                   onChange={(e) => setNewWorkerModel(e.target.value)}
                   list="swarm-add-models"
-                  placeholder={availableModels.length ? 'Search or pick a detected model…' : modelsQuery.isLoading ? 'Loading detected models…' : 'No models detected'}
+                  placeholder={
+                    availableModels.length
+                      ? 'Search or pick a detected model…'
+                      : modelsQuery.isLoading
+                        ? 'Loading detected models…'
+                        : 'No models detected'
+                  }
                   className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
                 />
                 <datalist id="swarm-add-models">
                   {availableModels.map((m) => (
-                    <option key={m.id} value={m.name}>{m.provider}</option>
+                    <option key={m.id} value={m.id}>
+                      {m.provider}
+                      {m.status === 'quota_limited' ? ' · quota limited' : ''}
+                    </option>
                   ))}
                 </datalist>
                 <p className="mt-1 text-xs text-[var(--theme-muted-2)]">
-                  Searchable picker backed by /api/models, the same source as chat. {modelsQuery.isError ? 'Model discovery errored, so this is empty until refresh.' : 'Start typing to see every detected model from the user’s Hermes config and local providers.'}
+                  Searchable picker backed by the canonical OAuth subscription
+                  registry used by Orchestration.{' '}
+                  {modelsQuery.isError
+                    ? 'Model discovery errored, so this is empty until refresh.'
+                    : 'Start typing to select any validated subscription route, including account-specific Claude and OpenAI Codex routes.'}
                 </p>
               </label>
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Specialty</span>
-                <input value={newWorkerSpecialty} onChange={(e) => setNewWorkerSpecialty(e.target.value)} className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.specialty || 'short focus area'} />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Specialty
+                </span>
+                <input
+                  value={newWorkerSpecialty}
+                  onChange={(e) => setNewWorkerSpecialty(e.target.value)}
+                  className="w-full rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder={
+                    ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                      ?.specialty || 'short focus area'
+                  }
+                />
               </label>
               <label className="block text-sm md:col-span-2">
-                <span className="mb-1 block text-[var(--theme-muted)]">Mission</span>
-                <textarea value={newWorkerMission} onChange={(e) => setNewWorkerMission(e.target.value)} rows={3} className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none" placeholder={ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.mission || 'standing mission for this worker'} />
+                <span className="mb-1 block text-[var(--theme-muted)]">
+                  Mission
+                </span>
+                <textarea
+                  value={newWorkerMission}
+                  onChange={(e) => setNewWorkerMission(e.target.value)}
+                  rows={3}
+                  className="w-full resize-none rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg)] px-3 py-2 text-[var(--theme-text)] outline-none"
+                  placeholder={
+                    ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                      ?.mission || 'standing mission for this worker'
+                  }
+                />
               </label>
-              {ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt ? (
+              {ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                ?.systemPrompt ? (
                 <div className="md:col-span-2 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-card2)] px-3 py-2 text-xs text-[var(--theme-muted-2)]">
-                  <div className="mb-1 font-semibold text-[var(--theme-muted)]">System prompt (embedded with role)</div>
-                  <div className="whitespace-pre-wrap leading-relaxed">{ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.systemPrompt}</div>
-                  <div className="mt-2 font-semibold text-[var(--theme-muted)]">Skills loaded</div>
-                  <div className="font-mono">{(ROLE_PRESETS.find((p) => p.role === newWorkerRole)?.skills ?? []).join(', ') || '—'}</div>
+                  <div className="mb-1 font-semibold text-[var(--theme-muted)]">
+                    System prompt (embedded with role)
+                  </div>
+                  <div className="whitespace-pre-wrap leading-relaxed">
+                    {
+                      ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                        ?.systemPrompt
+                    }
+                  </div>
+                  <div className="mt-2 font-semibold text-[var(--theme-muted)]">
+                    Skills loaded
+                  </div>
+                  <div className="font-mono">
+                    {(
+                      ROLE_PRESETS.find((p) => p.role === newWorkerRole)
+                        ?.skills ?? []
+                    ).join(', ') || '—'}
+                  </div>
                 </div>
               ) : null}
             </div>
-            {addSwarmError ? <div className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">{addSwarmError}</div> : null}
+            {addSwarmError ? (
+              <div className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+                {addSwarmError}
+              </div>
+            ) : null}
             <div className="mt-4 flex items-center justify-end gap-3">
-              <button type="button" onClick={() => setAddSwarmOpen(false)} className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]">Cancel</button>
-              <button type="button" disabled={addSwarmSaving || !newWorkerId.trim() || !newWorkerName.trim()} onClick={() => void saveAddSwarm()} className="rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 disabled:opacity-50">{addSwarmSaving ? 'Saving…' : 'Save swarm agent'}</button>
+              <button
+                type="button"
+                onClick={() => setAddSwarmOpen(false)}
+                className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-card)] px-4 py-2 text-sm text-[var(--theme-muted)] hover:text-[var(--theme-text)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={
+                  addSwarmSaving || !newWorkerId.trim() || !newWorkerName.trim()
+                }
+                onClick={() => void saveAddSwarm()}
+                className="rounded-lg bg-[var(--theme-accent)] px-4 py-2 text-sm font-medium text-primary-950 disabled:opacity-50"
+              >
+                {addSwarmSaving ? 'Saving…' : 'Save swarm agent'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -1,12 +1,14 @@
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { existsSync, readFileSync, writeFileSync, mkdirSync } = vi.hoisted(() => ({
-  existsSync: vi.fn().mockReturnValue(false),
-  readFileSync: vi.fn().mockReturnValue(''),
-  writeFileSync: vi.fn().mockImplementation(() => {}),
-  mkdirSync: vi.fn().mockImplementation(() => {}),
-}))
+const { existsSync, readFileSync, writeFileSync, mkdirSync } = vi.hoisted(
+  () => ({
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue(''),
+    writeFileSync: vi.fn().mockImplementation(() => {}),
+    mkdirSync: vi.fn().mockImplementation(() => {}),
+  }),
+)
 
 vi.mock('node:fs', () => ({
   default: { existsSync, readFileSync, writeFileSync, mkdirSync },
@@ -42,6 +44,9 @@ beforeEach(() => {
   delete process.env.HERMES_DASHBOARD_URL
   delete process.env.HERMES_DASHBOARD_TOKEN
   delete process.env.CLAUDE_DASHBOARD_TOKEN
+  delete process.env.HERMES_API_TOKEN
+  delete process.env.CLAUDE_API_TOKEN
+  delete process.env.API_SERVER_KEY
   delete process.env.HOST
 })
 
@@ -118,7 +123,9 @@ describe('gateway-capabilities', () => {
           },
           ['health', 'sessions'],
         ),
-      ).toBe(`[gateway] Missing Hermes APIs detected. ${mod.CLAUDE_UPGRADE_INSTRUCTIONS}`)
+      ).toBe(
+        `[gateway] Missing Hermes APIs detected. ${mod.CLAUDE_UPGRADE_INSTRUCTIONS}`,
+      )
     })
   })
 
@@ -172,12 +179,52 @@ describe('gateway-capabilities', () => {
     expect(resolved.source).toBe('default')
   })
 
+  it('uses the co-located Hermes API_SERVER_KEY for loopback gateway auth', async () => {
+    readFileSync.mockImplementation((file: unknown) =>
+      String(file).endsWith('.env')
+        ? 'API_SERVER_KEY="local-gateway-secret"\n'
+        : '',
+    )
+
+    const mod = await loadMod()
+
+    expect(mod.BEARER_TOKEN).toBe('local-gateway-secret')
+  })
+
+  it('prefers an explicitly configured gateway token over local disk discovery', async () => {
+    process.env.HERMES_API_TOKEN = 'explicit-local-token'
+    readFileSync.mockImplementation((file: unknown) =>
+      String(file).endsWith('.env')
+        ? 'API_SERVER_KEY="local-gateway-secret"\n'
+        : '',
+    )
+
+    const mod = await loadMod()
+
+    expect(mod.BEARER_TOKEN).toBe('explicit-local-token')
+  })
+
+  it('does not reuse a local gateway key for a remote deployment', async () => {
+    process.env.HOST = '0.0.0.0'
+    process.env.HERMES_API_TOKEN = 'explicit-remote-token'
+    readFileSync.mockImplementation((file: unknown) =>
+      String(file).endsWith('.env')
+        ? 'API_SERVER_KEY="local-gateway-secret"\n'
+        : '',
+    )
+
+    const mod = await loadMod()
+
+    expect(mod.BEARER_TOKEN).toBe('explicit-remote-token')
+  })
+
   describe('dashboard session token scraping', () => {
     it('scrapes the inline dashboard session token from root HTML', async () => {
       fetchMock.mockResolvedValue({
         ok: true,
         status: 200,
-        text: async () => '<html><head><script>window.__HERMES_SESSION_TOKEN__="fresh-token";</script></head></html>',
+        text: async () =>
+          '<html><head><script>window.__HERMES_SESSION_TOKEN__="fresh-token";</script></head></html>',
       })
 
       const mod = await loadMod()
@@ -193,12 +240,15 @@ describe('gateway-capabilities', () => {
       fetchMock.mockResolvedValue({
         ok: true,
         status: 200,
-        text: async () => '<html><head><script>window.__HERMES_SESSION_TOKEN__="live-token";</script></head></html>',
+        text: async () =>
+          '<html><head><script>window.__HERMES_SESSION_TOKEN__="live-token";</script></head></html>',
       })
 
       const mod = await loadMod()
       await expect(mod.fetchDashboardToken()).resolves.toBe('live-token')
-      expect(fetchMock.mock.calls.some(([url]) => url === 'http://127.0.0.1:9119/')).toBe(true)
+      expect(
+        fetchMock.mock.calls.some(([url]) => url === 'http://127.0.0.1:9119/'),
+      ).toBe(true)
     })
 
     it('returns an empty token instead of throwing when dashboard root fails', async () => {
@@ -222,51 +272,56 @@ describe('gateway-capabilities', () => {
   it('does not mark Conductor available when dashboard returns SPA HTML fallback', async () => {
     process.env.HERMES_API_URL = 'http://gateway.test'
     process.env.CLAUDE_DASHBOARD_URL = 'http://dashboard.test'
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input)
-      if (url === 'http://dashboard.test/api/status') {
-        return new Response(JSON.stringify({ version: '0.12.0' }), {
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-      if (url === 'http://dashboard.test/') {
-        return new Response("<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>", {
-          headers: { 'content-type': 'text/html' },
-        })
-      }
-      if (url === 'http://dashboard.test/api/conductor/missions') {
-        return new Response('<!doctype html><div id="root"></div>', {
-          status: 200,
-          headers: { 'content-type': 'text/html; charset=utf-8' },
-        })
-      }
-      if (url === 'http://dashboard.test/api/plugins/kanban/board') {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url === 'http://dashboard.test/api/status') {
+          return new Response(JSON.stringify({ version: '0.12.0' }), {
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://dashboard.test/') {
+          return new Response(
+            "<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>",
+            {
+              headers: { 'content-type': 'text/html' },
+            },
+          )
+        }
+        if (url === 'http://dashboard.test/api/conductor/missions') {
+          return new Response('<!doctype html><div id="root"></div>', {
+            status: 200,
+            headers: { 'content-type': 'text/html; charset=utf-8' },
+          })
+        }
+        if (url === 'http://dashboard.test/api/plugins/kanban/board') {
+          return new Response(JSON.stringify({ ok: true }), {
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://dashboard.test/api/mcp') {
+          return new Response('not found', { status: 404 })
+        }
+        if (url === 'http://dashboard.test/api/config') {
+          return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://gateway.test/v1/chat/completions') {
+          return new Response('', { status: 405 })
+        }
+        if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') {
+          return new Response('', { status: 404 })
+        }
+        if (url === 'http://gateway.test/api/mcp') {
+          return new Response('', { status: 404 })
+        }
         return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
           headers: { 'content-type': 'application/json' },
         })
-      }
-      if (url === 'http://dashboard.test/api/mcp') {
-        return new Response('not found', { status: 404 })
-      }
-      if (url === 'http://dashboard.test/api/config') {
-        return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-      if (url === 'http://gateway.test/v1/chat/completions') {
-        return new Response('', { status: 405 })
-      }
-      if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') {
-        return new Response('', { status: 404 })
-      }
-      if (url === 'http://gateway.test/api/mcp') {
-        return new Response('', { status: 404 })
-      }
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })
-    })
+      },
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     const mod = await loadMod()
@@ -283,36 +338,44 @@ describe('gateway-capabilities', () => {
   it('marks Conductor available when dashboard returns JSON from missions API', async () => {
     process.env.HERMES_API_URL = 'http://gateway.test'
     process.env.CLAUDE_DASHBOARD_URL = 'http://dashboard.test'
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url === 'http://dashboard.test/api/status') {
-        return new Response(JSON.stringify({ version: '0.12.0' }), {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url === 'http://dashboard.test/api/status') {
+          return new Response(JSON.stringify({ version: '0.12.0' }), {
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://dashboard.test/') {
+          return new Response(
+            "<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>",
+            {
+              headers: { 'content-type': 'text/html' },
+            },
+          )
+        }
+        if (url === 'http://dashboard.test/api/conductor/missions') {
+          return new Response(JSON.stringify({ missions: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://dashboard.test/api/config') {
+          return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url === 'http://gateway.test/v1/chat/completions')
+          return new Response('', { status: 405 })
+        if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream')
+          return new Response('', { status: 404 })
+        if (url.endsWith('/api/mcp')) return new Response('', { status: 404 })
+        return new Response(JSON.stringify({ ok: true }), {
           headers: { 'content-type': 'application/json' },
         })
-      }
-      if (url === 'http://dashboard.test/') {
-        return new Response("<script>window.__CLAUDE_SESSION_TOKEN__ = 'test-token'</script>", {
-          headers: { 'content-type': 'text/html' },
-        })
-      }
-      if (url === 'http://dashboard.test/api/conductor/missions') {
-        return new Response(JSON.stringify({ missions: [] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-      if (url === 'http://dashboard.test/api/config') {
-        return new Response(JSON.stringify({ config: { mcp_servers: {} } }), {
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-      if (url === 'http://gateway.test/v1/chat/completions') return new Response('', { status: 405 })
-      if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') return new Response('', { status: 404 })
-      if (url.endsWith('/api/mcp')) return new Response('', { status: 404 })
-      return new Response(JSON.stringify({ ok: true }), {
-        headers: { 'content-type': 'application/json' },
-      })
-    }))
+      }),
+    )
 
     const mod = await loadMod()
     const caps = await mod.probeGateway({ force: true })
@@ -328,6 +391,15 @@ describe('gateway-capabilities', () => {
     it('returns true for default loopback URLs with no HOST', async () => {
       const mod = await loadMod()
       expect(mod.isLocalhostDeployment()).toBe(true)
+    })
+
+    it('reports local Hermes config as reachable without dashboard config endpoints', async () => {
+      fetchMock.mockResolvedValue(new Response('', { status: 404 }))
+      const mod = await loadMod()
+
+      const caps = await mod.probeGateway({ force: true })
+
+      expect(caps.config).toBe(true)
     })
 
     it('returns false when HOST is bound to 0.0.0.0', async () => {

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -276,6 +276,15 @@ export function requireLocalOrAuth(request: Request): boolean {
   return isAuthenticated(request)
 }
 
+/** Strong boundary for provider-native mutations that can spawn tools or consume quota. */
+export function requireProviderRuntimeMutationAuth(request: Request): boolean {
+  if (isPasswordProtectionEnabled()) return isAuthenticated(request)
+  const configuredBind = (process.env.HERMES_HOST || process.env.HOST || '').trim().toLowerCase()
+  const requestHost = new URL(request.url).hostname.toLowerCase()
+  const loopbackNames = new Set(['127.0.0.1', '::1', '[::1]', 'localhost'])
+  return loopbackNames.has(configuredBind) && loopbackNames.has(requestHost)
+}
+
 /**
  * Whether session cookies should set the `Secure` attribute.
  *

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -258,8 +258,44 @@ let lastLoggedSummary = ''
 let dashboardTokenPromise: Promise<string> | null = null
 let dashboardTokenCache = ''
 
+function parseDotEnvValue(text: string, key: string): string {
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const separator = line.indexOf('=')
+    if (separator < 0 || line.slice(0, separator).trim() !== key) continue
+    const value = line.slice(separator + 1).trim()
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      return value.slice(1, -1)
+    }
+    return value
+  }
+  return ''
+}
+
+function readLocalGatewayKey(): string {
+  if (!isLocalhostDeployment()) return ''
+  try {
+    const hermesHome =
+      process.env.HERMES_HOME || path.join(os.homedir(), '.hermes')
+    const text = fs.readFileSync(path.join(hermesHome, '.env'), 'utf-8')
+    return parseDotEnvValue(text, 'API_SERVER_KEY')
+  } catch {
+    return ''
+  }
+}
+
 /** Optional bearer token for authenticated gateway endpoints. */
-export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
+export const BEARER_TOKEN =
+  process.env.HERMES_API_TOKEN ||
+  process.env.CLAUDE_API_TOKEN ||
+  process.env.API_SERVER_KEY ||
+  readLocalGatewayKey() ||
+  ''
 
 /**
  * Dashboard API auth uses the ephemeral session token injected into the
@@ -885,7 +921,10 @@ export async function probeGateway(options?: {
       // memory/*.md + memories/*.md directly from the local filesystem.
       // No remote gateway endpoint is required.
       memory: true,
-      config: dashboard.available || legacyConfig,
+      // The Workspace server can safely read/write its own Hermes config when
+      // it and the gateway are co-located on loopback. Do not require the
+      // optional port-9119 dashboard merely to unlock local settings.
+      config: dashboard.available || legacyConfig || isLocalhostDeployment(),
       jobs: dashboard.available || legacyJobs,
       mcp,
       mcpFallback,

--- a/src/server/hermes-config-route.ts
+++ b/src/server/hermes-config-route.ts
@@ -9,6 +9,7 @@ import { isAuthenticated } from './auth-middleware'
 import {
   ensureGatewayProbed,
   getCapabilities,
+  isLocalhostDeployment,
 } from './gateway-capabilities'
 import { normalizeHermesConfigState } from './hermes-config-migration'
 import {
@@ -23,6 +24,7 @@ import {
   getDiscoveredModels,
   getDiscoveryStatus,
 } from './local-provider-discovery'
+import { isOpenRouterModelRef } from './orchestration-policy'
 
 type AuthResult = Response | true
 
@@ -35,6 +37,8 @@ const ACTION_MESSAGES: Record<string, string> = {
 }
 
 const LEGACY_SAVE_MESSAGE = 'Saved.'
+const OPENROUTER_REJECTED = 'OpenRouter assignments are not permitted.'
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
 
 const PatchActionSchema = z.discriminatedUnion('action', [
   z.object({
@@ -90,6 +94,10 @@ function unavailablePayload(extra: Record<string, unknown> = {}): Response {
   })
 }
 
+function configIsReachable(): boolean {
+  return getCapabilities().config || isLocalhostDeployment()
+}
+
 export async function handleHermesConfigGet({
   request,
 }: {
@@ -99,7 +107,7 @@ export async function handleHermesConfigGet({
   if (auth !== true) return auth
 
   const paths = resolveHermesConfigPaths()
-  if (!getCapabilities().config) {
+  if (!configIsReachable()) {
     return unavailablePayload({ paths, claudeHome: paths.hermesHome })
   }
 
@@ -132,6 +140,7 @@ function deepMerge(
   source: Record<string, unknown>,
 ): void {
   for (const [key, value] of Object.entries(source)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue
     if (
       value &&
       typeof value === 'object' &&
@@ -191,6 +200,74 @@ function applyLegacyEnvBody(
   fs.writeFileSync(envPath, stringifyEnv(current), 'utf-8')
 }
 
+function isOpenRouterUrl(value: string): boolean {
+  try {
+    const trimmed = value.trim().replace(/\\/g, '/')
+    let parsed: URL
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      parsed = new URL(
+        trimmed.startsWith('//') ? `https:${trimmed}` : `https://${trimmed}`,
+      )
+    }
+    const hostname = parsed.hostname.toLowerCase().replace(/\.+$/, '')
+    return hostname === 'openrouter.ai' || hostname.endsWith('.openrouter.ai')
+  } catch {
+    return false
+  }
+}
+
+function containsUnsafeObjectKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsUnsafeObjectKey)
+  if (!value || typeof value !== 'object') return false
+  return Object.entries(value).some(
+    ([key, child]) =>
+      UNSAFE_OBJECT_KEYS.has(key) || containsUnsafeObjectKey(child),
+  )
+}
+
+const OPENROUTER_ASSIGNMENT_PATH =
+  /(?:provider|model|route|fallback|base_?url|api_?base)/i
+
+function containsOpenRouter(value: unknown, path: string[] = []): boolean {
+  if (typeof value === 'string') {
+    if (!path.some((segment) => OPENROUTER_ASSIGNMENT_PATH.test(segment))) {
+      return false
+    }
+    return isOpenRouterModelRef(value) || isOpenRouterUrl(value)
+  }
+  if (Array.isArray(value)) {
+    return value.some((child) => containsOpenRouter(child, path))
+  }
+  if (!value || typeof value !== 'object') return false
+  return Object.entries(value).some(([key, child]) => {
+    const parentIsProviderMap = path.some((segment) =>
+      /^(?:providers|custom_providers)$/i.test(segment),
+    )
+    if (parentIsProviderMap && /^openrouter$/i.test(key)) return true
+    return containsOpenRouter(child, [...path, key])
+  })
+}
+
+function patchAssignsOpenRouter(
+  patch: z.infer<typeof PatchActionSchema>,
+): boolean {
+  if (patch.action === 'set-default-model') {
+    return (
+      /^openrouter$/i.test(patch.providerId.trim()) ||
+      isOpenRouterModelRef(patch.modelId)
+    )
+  }
+  if (patch.action === 'set-custom-provider') {
+    return (
+      /^openrouter$/i.test(patch.provider.name.trim()) ||
+      isOpenRouterUrl(patch.provider.baseUrl)
+    )
+  }
+  return false
+}
+
 export async function handleHermesConfigPatch({
   request,
 }: {
@@ -199,7 +276,7 @@ export async function handleHermesConfigPatch({
   const auth = await authorize(request)
   if (auth !== true) return auth
 
-  if (!getCapabilities().config) {
+  if (!configIsReachable()) {
     return new Response(
       JSON.stringify(
         createCapabilityUnavailablePayload('config', {
@@ -231,6 +308,12 @@ export async function handleHermesConfigPatch({
         { status: 400 },
       )
     }
+    if (patchAssignsOpenRouter(parsed.data)) {
+      return Response.json(
+        { ok: false, error: OPENROUTER_REJECTED },
+        { status: 400 },
+      )
+    }
     const result = applyHermesConfigPatch(paths, parsed.data)
     return Response.json({ ...result, message: ACTION_MESSAGES[parsed.data.action] })
   }
@@ -239,6 +322,20 @@ export async function handleHermesConfigPatch({
   if (!legacy.success) {
     return Response.json(
       { ok: false, error: 'Invalid request body', issues: legacy.error.issues },
+      { status: 400 },
+    )
+  }
+
+  if (legacy.data.config && containsUnsafeObjectKey(legacy.data.config)) {
+    return Response.json(
+      { ok: false, error: 'Unsafe configuration key' },
+      { status: 400 },
+    )
+  }
+
+  if (legacy.data.config && containsOpenRouter(legacy.data.config)) {
+    return Response.json(
+      { ok: false, error: OPENROUTER_REJECTED },
       { status: 400 },
     )
   }

--- a/src/server/hermes-config-store.test.ts
+++ b/src/server/hermes-config-store.test.ts
@@ -9,6 +9,7 @@ import {
   parseEnvFile,
   resolveHermesConfigPaths,
   stringifyEnv,
+  writeHermesConfigFile,
 } from './hermes-config-store'
 
 let tmpHome = ''
@@ -126,7 +127,10 @@ describe('applyHermesConfigPatch', () => {
       { name: 'gw', base_url: 'https://b.test/v1' },
     ])
 
-    applyHermesConfigPatch(paths, { action: 'remove-custom-provider', name: 'gw' })
+    applyHermesConfigPatch(paths, {
+      action: 'remove-custom-provider',
+      name: 'gw',
+    })
     parsed = YAML.parse(
       fs.readFileSync(path.join(tmpHome, 'config.yaml'), 'utf-8'),
     )
@@ -148,5 +152,29 @@ describe('env value round-tripping', () => {
 
   it('refuses to write values containing newlines', () => {
     expect(() => stringifyEnv({ BAD: 'one\ntwo' })).toThrow(/newlines/)
+  })
+})
+
+describe('atomic Hermes config writes', () => {
+  it('replaces config.yaml atomically, keeps the previous file as a backup, and removes temp files', () => {
+    const paths = resolveHermesConfigPaths()
+    writeHermesConfigFile(paths, {
+      model: { provider: 'openai-codex', default: 'gpt-5.4' },
+    })
+    writeHermesConfigFile(paths, {
+      model: { provider: 'openai-codex', default: 'gpt-5.6-sol' },
+    })
+
+    expect(YAML.parse(fs.readFileSync(paths.configPath, 'utf8'))).toEqual({
+      model: { provider: 'openai-codex', default: 'gpt-5.6-sol' },
+    })
+    expect(
+      YAML.parse(fs.readFileSync(`${paths.configPath}.bak`, 'utf8')),
+    ).toEqual({
+      model: { provider: 'openai-codex', default: 'gpt-5.4' },
+    })
+    expect(
+      fs.readdirSync(tmpHome).filter((name) => name.includes('.tmp')),
+    ).toEqual([])
   })
 })

--- a/src/server/hermes-config-store.ts
+++ b/src/server/hermes-config-store.ts
@@ -104,9 +104,11 @@ function quoteEnvValue(value: string): string {
 }
 
 export function stringifyEnv(env: Record<string, string>): string {
-  return Object.entries(env)
-    .map(([k, v]) => `${k}=${quoteEnvValue(v)}`)
-    .join('\n') + '\n'
+  return (
+    Object.entries(env)
+      .map(([k, v]) => `${k}=${quoteEnvValue(v)}`)
+      .join('\n') + '\n'
+  )
 }
 
 function readYamlConfig(configPath: string): Record<string, unknown> {
@@ -121,9 +123,41 @@ function readYamlConfig(configPath: string): Record<string, unknown> {
   }
 }
 
-function writeYamlConfig(configPath: string, config: Record<string, unknown>): void {
-  fs.mkdirSync(path.dirname(configPath), { recursive: true })
-  fs.writeFileSync(configPath, YAML.stringify(config), 'utf-8')
+export function writeFileAtomicWithBackup(
+  filePath: string,
+  contents: string,
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const nonce = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`
+  const tempPath = `${filePath}.${nonce}.tmp`
+  const backupPath = `${filePath}.bak`
+  const backupTempPath = `${backupPath}.${nonce}.tmp`
+
+  try {
+    const descriptor = fs.openSync(tempPath, 'wx')
+    try {
+      fs.writeFileSync(descriptor, contents, 'utf8')
+      fs.fsyncSync(descriptor)
+    } finally {
+      fs.closeSync(descriptor)
+    }
+
+    if (fs.existsSync(filePath)) {
+      fs.copyFileSync(filePath, backupTempPath)
+      fs.renameSync(backupTempPath, backupPath)
+    }
+    fs.renameSync(tempPath, filePath)
+  } finally {
+    fs.rmSync(tempPath, { force: true })
+    fs.rmSync(backupTempPath, { force: true })
+  }
+}
+
+function writeYamlConfig(
+  configPath: string,
+  config: Record<string, unknown>,
+): void {
+  writeFileAtomicWithBackup(configPath, YAML.stringify(config))
 }
 
 function readEnv(envPath: string): Record<string, string> {
@@ -151,7 +185,9 @@ function readAuthProfiles(authProfilesPath: string): Record<string, unknown> {
   }
 }
 
-export function readHermesConfigFiles(paths: HermesConfigPaths): HermesConfigFiles {
+export function readHermesConfigFiles(
+  paths: HermesConfigPaths,
+): HermesConfigFiles {
   return {
     config: readYamlConfig(paths.configPath),
     env: readEnv(paths.envPath),
@@ -159,11 +195,22 @@ export function readHermesConfigFiles(paths: HermesConfigPaths): HermesConfigFil
   }
 }
 
-function readCustomProvidersList(config: Record<string, unknown>): Array<Record<string, unknown>> {
+export function writeHermesConfigFile(
+  paths: HermesConfigPaths,
+  config: Record<string, unknown>,
+): void {
+  writeYamlConfig(paths.configPath, config)
+}
+
+function readCustomProvidersList(
+  config: Record<string, unknown>,
+): Array<Record<string, unknown>> {
   const entries = config.custom_providers
   return Array.isArray(entries)
     ? entries.filter((entry): entry is Record<string, unknown> => {
-        return Boolean(entry && typeof entry === 'object' && !Array.isArray(entry))
+        return Boolean(
+          entry && typeof entry === 'object' && !Array.isArray(entry),
+        )
       })
     : []
 }

--- a/src/server/managed-python.test.ts
+++ b/src/server/managed-python.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveManagedPythonBin } from './managed-python'
+
+describe('resolveManagedPythonBin', () => {
+  it('prefers the managed Hermes Windows interpreter over python3', () => {
+    expect(
+      resolveManagedPythonBin({
+        platform: 'win32',
+        env: {
+          HERMES_HOME: 'C:\\Users\\test\\AppData\\Local\\hermes',
+        },
+        home: 'C:\\Users\\test',
+        pathExists: (candidate) =>
+          candidate.endsWith('venv\\Scripts\\python.exe'),
+      }),
+    ).toBe(
+      'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe',
+    )
+  })
+
+  it('uses python3 on POSIX when no managed interpreter exists', () => {
+    expect(
+      resolveManagedPythonBin({
+        platform: 'linux',
+        env: {},
+        home: '/home/test',
+        pathExists: () => false,
+      }),
+    ).toBe('python3')
+  })
+})

--- a/src/server/managed-python.ts
+++ b/src/server/managed-python.ts
@@ -1,0 +1,39 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { posix, win32 } from 'node:path'
+
+export function resolveManagedPythonBin(
+  input: {
+    platform?: NodeJS.Platform
+    env?: NodeJS.ProcessEnv
+    home?: string
+    pathExists?: (path: string) => boolean
+  } = {},
+): string {
+  const platform = input.platform ?? process.platform
+  const env = input.env ?? process.env
+  const home = input.home ?? homedir()
+  const pathExists = input.pathExists ?? existsSync
+  const pathApi = platform === 'win32' ? win32 : posix
+
+  const override = env.HERMES_PYTHON_BIN
+  if (override) {
+    if (!override.includes('/') && !override.includes('\\')) return override
+    if (pathExists(override)) return override
+  }
+
+  const hermesHome =
+    env.HERMES_HOME || env.CLAUDE_HOME || pathApi.join(home, '.hermes')
+  const managed =
+    platform === 'win32'
+      ? pathApi.join(
+          hermesHome,
+          'hermes-agent',
+          'venv',
+          'Scripts',
+          'python.exe',
+        )
+      : pathApi.join(hermesHome, 'hermes-agent', 'venv', 'bin', 'python')
+  if (pathExists(managed)) return managed
+  return platform === 'win32' ? 'python' : 'python3'
+}

--- a/src/server/operations-agent-config.test.ts
+++ b/src/server/operations-agent-config.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSubscriptionCatalog } from './subscription-model-catalog'
+import { operationsModelSelectionPatch } from './operations-agent-config'
+
+const catalog = buildSubscriptionCatalog({
+  relayModels: [
+    { id: 'claude-cwm4tx/opus-5', account: 'cwm4tx', status: 'available' },
+  ],
+  oauthProviders: [
+    {
+      provider: 'openai-codex',
+      authenticated: true,
+      models: ['gpt-5.6-sol'],
+    },
+    {
+      provider: 'nous',
+      authenticated: true,
+      models: ['google/gemini-3.1-pro-preview'],
+    },
+  ],
+  transports: [],
+  allowApiBilledModels: false,
+  showNousModels: true,
+  capabilities: {
+    'claude-cwm4tx/opus-5': {
+      contextWindow: 1_000_000,
+      maxInputTokens: null,
+      maxOutputTokens: 128_000,
+      supportsReasoning: true,
+      supportsTools: true,
+      supportsVision: true,
+      metadataSource: 'models.dev',
+    },
+    'openai-codex/gpt-5.6-sol': {
+      contextWindow: 1_050_000,
+      maxInputTokens: 922_000,
+      maxOutputTokens: 128_000,
+      supportsReasoning: true,
+      supportsTools: true,
+      supportsVision: true,
+      metadataSource: 'models.dev',
+    },
+    'nous/google/gemini-3.1-pro-preview': {
+      contextWindow: 1_048_576,
+      maxInputTokens: null,
+      maxOutputTokens: 65_536,
+      supportsReasoning: true,
+      supportsTools: true,
+      supportsVision: true,
+      metadataSource: 'models.dev',
+    },
+  },
+})
+
+describe('Operations agent model selection', () => {
+  it('translates a canonical Codex route into executable Hermes profile config', () => {
+    expect(
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'openai-codex/gpt-5.6-sol',
+          reasoningEffort: 'high',
+        },
+        {},
+        catalog,
+      ),
+    ).toEqual({
+      model: {
+        provider: 'openai-codex',
+        default: 'gpt-5.6-sol',
+      },
+      agent: { reasoning_effort: 'high' },
+      workspace: { route_ref: 'openai-codex/gpt-5.6-sol' },
+    })
+  })
+
+  it('keeps Claude account identity and configured relay transport', () => {
+    expect(
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'claude-cwm4tx/opus-5',
+          reasoningEffort: 'max',
+        },
+        {
+          model: {
+            provider: 'custom',
+            base_url: 'http://127.0.0.1:8650/v1',
+            api_key: 'existing-secret-reference',
+            api_mode: 'chat_completions',
+          },
+        },
+        catalog,
+      ).model,
+    ).toEqual({
+      provider: 'custom',
+      default: 'claude-cwm4tx/opus-5',
+      base_url: 'http://127.0.0.1:8650/v1',
+      api_key: 'existing-secret-reference',
+      api_mode: 'chat_completions',
+    })
+  })
+
+  it('rejects unknown, unavailable, and unsupported settings', () => {
+    expect(() =>
+      operationsModelSelectionPatch(
+        { routeRef: 'openai-api/gpt-paid' },
+        {},
+        catalog,
+      ),
+    ).toThrow('not an assignable subscription route')
+    expect(() =>
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'openai-codex/gpt-5.6-sol',
+          reasoningEffort: 'extreme',
+        },
+        {},
+        catalog,
+      ),
+    ).toThrow('Unsupported reasoning effort')
+    expect(() =>
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'openai-codex/gpt-5.6-sol',
+          maxOutputTokens: 32_768,
+        },
+        {},
+        catalog,
+      ),
+    ).toThrow('does not consume a configurable output-token cap')
+    expect(() =>
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'claude-cwm4tx/opus-5',
+          maxOutputTokens: 32_768,
+        },
+        {},
+        catalog,
+      ),
+    ).toThrow('does not consume a configurable output-token cap')
+    expect(() =>
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'nous/google/gemini-3.1-pro-preview',
+          maxOutputTokens: 65_537,
+        },
+        {},
+        catalog,
+      ),
+    ).toThrow('exceeds the model maximum')
+  })
+
+  it('persists an output cap only for a transport that consumes it', () => {
+    expect(
+      operationsModelSelectionPatch(
+        {
+          routeRef: 'nous/google/gemini-3.1-pro-preview',
+          maxOutputTokens: 32_768,
+        },
+        {},
+        catalog,
+      ).model,
+    ).toMatchObject({ max_tokens: 32_768 })
+  })
+
+  it('allows an authenticated API route after the explicit unhide option is enabled', () => {
+    const apiCatalog = buildSubscriptionCatalog({
+      relayModels: [],
+      oauthProviders: [
+        {
+          provider: 'openai-api',
+          authenticated: true,
+          models: ['gpt-paid'],
+          billingClass: 'api_billed',
+        },
+      ],
+      transports: [],
+      allowApiBilledModels: true,
+    })
+    expect(
+      operationsModelSelectionPatch(
+        { routeRef: 'openai-api/gpt-paid' },
+        {},
+        apiCatalog,
+      ).model,
+    ).toEqual({ provider: 'openai-api', default: 'gpt-paid' })
+  })
+})

--- a/src/server/operations-agent-config.test.ts
+++ b/src/server/operations-agent-config.test.ts
@@ -68,10 +68,18 @@ describe('Operations agent model selection', () => {
       model: {
         provider: 'openai-codex',
         default: 'gpt-5.6-sol',
+        openai_runtime: 'hermes_default',
       },
       agent: { reasoning_effort: 'high' },
-      workspace: { route_ref: 'openai-codex/gpt-5.6-sol' },
+      workspace: { route_ref: 'openai-codex/gpt-5.6-sol', codex_runtime: 'hermes_default' },
     })
+  })
+
+  it('persists explicit Codex app-server ownership and preserves unknown legacy values safely', () => {
+    expect(operationsModelSelectionPatch({ routeRef: 'openai-codex/gpt-5.6-sol', codexRuntime: 'codex_app_server' }, {}, catalog).workspace)
+      .toEqual({ route_ref: 'openai-codex/gpt-5.6-sol', codex_runtime: 'codex_app_server' })
+    expect(operationsModelSelectionPatch({ routeRef: 'openai-codex/gpt-5.6-sol', codexRuntime: 'future_runtime' }, {}, catalog).workspace)
+      .toEqual({ route_ref: 'openai-codex/gpt-5.6-sol', codex_runtime: 'hermes_default', codex_runtime_configured: 'future_runtime' })
   })
 
   it('keeps Claude account identity and configured relay transport', () => {

--- a/src/server/operations-agent-config.ts
+++ b/src/server/operations-agent-config.ts
@@ -8,6 +8,7 @@ export interface OperationsModelSelection {
   routeRef: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime?: string
 }
 
 export function operationsModelSelectionPatch(
@@ -52,14 +53,27 @@ export function operationsModelSelectionPatch(
     }
   }
 
+  const configuredCodexRuntime = selection.codexRuntime?.trim() || 'hermes_default'
+  const knownCodexRuntime = configuredCodexRuntime === 'hermes_default' || configuredCodexRuntime === 'codex_app_server'
+  const workspace = {
+    route_ref: routeRef,
+    ...(routeRef.startsWith('openai-codex/')
+      ? {
+          codex_runtime: knownCodexRuntime ? configuredCodexRuntime : 'hermes_default',
+          ...(knownCodexRuntime ? {} : { codex_runtime_configured: configuredCodexRuntime }),
+        }
+      : {}),
+  }
+
   return {
     model: {
       ...topLevelModelForRef(routeRef, currentConfig),
+      ...(routeRef.startsWith('openai-codex/') ? { openai_runtime: knownCodexRuntime ? configuredCodexRuntime : 'hermes_default' } : {}),
       ...(maxOutputTokens === undefined ? {} : { max_tokens: maxOutputTokens }),
     },
     ...(effort === 'provider_default'
       ? {}
       : { agent: { reasoning_effort: effort } }),
-    workspace: { route_ref: routeRef },
+    workspace,
   }
 }

--- a/src/server/operations-agent-config.ts
+++ b/src/server/operations-agent-config.ts
@@ -1,0 +1,65 @@
+import { topLevelModelForRef } from './orchestration-hermes-sync'
+import type {
+  ReasoningEffort,
+  SubscriptionCatalog,
+} from './subscription-model-catalog'
+
+export interface OperationsModelSelection {
+  routeRef: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
+}
+
+export function operationsModelSelectionPatch(
+  selection: OperationsModelSelection,
+  currentConfig: Record<string, unknown>,
+  catalog: SubscriptionCatalog,
+): Record<string, unknown> {
+  const routeRef = selection.routeRef.trim()
+  const route = catalog.models.find((entry) => entry.id === routeRef)
+  if (!route || !route.selectable) {
+    throw new Error(
+      `${routeRef || 'Empty model'} is not an assignable subscription route`,
+    )
+  }
+
+  const effort = selection.reasoningEffort?.trim() || 'provider_default'
+  const supportedEfforts = route.capabilities?.reasoningEfforts ?? [
+    'provider_default',
+  ]
+  if (!supportedEfforts.includes(effort as ReasoningEffort)) {
+    throw new Error(`Unsupported reasoning effort for ${routeRef}: ${effort}`)
+  }
+
+  const maxOutputTokens = selection.maxOutputTokens
+  if (maxOutputTokens !== undefined) {
+    if (!route.capabilities?.supportsOutputTokenLimit) {
+      throw new Error(
+        `${routeRef} does not consume a configurable output-token cap`,
+      )
+    }
+    if (!Number.isInteger(maxOutputTokens) || maxOutputTokens <= 0) {
+      throw new Error('Maximum output tokens must be a positive integer')
+    }
+    const modelMaximum = route.capabilities.maxOutputTokens
+    if (modelMaximum === null) {
+      throw new Error(`Maximum output tokens are not published for ${routeRef}`)
+    }
+    if (maxOutputTokens > modelMaximum) {
+      throw new Error(
+        `Maximum output tokens ${maxOutputTokens} exceeds the model maximum ${modelMaximum}`,
+      )
+    }
+  }
+
+  return {
+    model: {
+      ...topLevelModelForRef(routeRef, currentConfig),
+      ...(maxOutputTokens === undefined ? {} : { max_tokens: maxOutputTokens }),
+    },
+    ...(effort === 'provider_default'
+      ? {}
+      : { agent: { reasoning_effort: effort } }),
+    workspace: { route_ref: routeRef },
+  }
+}

--- a/src/server/orchestration-hermes-sync.test.ts
+++ b/src/server/orchestration-hermes-sync.test.ts
@@ -1,0 +1,310 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import YAML from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyGlobalOrchestrationPolicyTransaction,
+  normalizeLoopbackRelayBaseUrl,
+  policyToHermesPatch,
+  serializeOrchestrationWrite,
+  syncGlobalOrchestrationPolicy,
+  topLevelModelForRef,
+} from './orchestration-hermes-sync'
+import {
+  DEFAULT_ORCHESTRATION_POLICY,
+  getOrchestrationPolicy,
+} from './orchestration-policy'
+import type { SubscriptionCatalog } from './subscription-model-catalog'
+
+function canonicalCatalog(...ids: Array<string>): SubscriptionCatalog {
+  return {
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    subscriptionOnly: true,
+    transports: [],
+    visibility: { showNousModels: false, showApiBilledModels: false },
+    models: ids.map((id) => {
+      const slash = id.indexOf('/')
+      return {
+        id,
+        provider: id.slice(0, slash),
+        account: id.slice(0, slash),
+        model: id.slice(slash + 1),
+        transport: 'test',
+        billingClass: 'subscription_included',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+      }
+    }),
+  }
+}
+
+describe('orchestration policy Hermes synchronization', () => {
+  it('rejects non-loopback relay URLs', () => {
+    expect(
+      normalizeLoopbackRelayBaseUrl(
+        'https://example.com/v1',
+        'http://127.0.0.1:8651',
+      ),
+    ).toBe('http://127.0.0.1:8651')
+    expect(
+      normalizeLoopbackRelayBaseUrl(
+        'http://localhost:8651/v1',
+        'http://127.0.0.1:8651',
+      ),
+    ).toBe('http://localhost:8651/v1')
+  })
+
+  it('maps subscription defaults, memory review, limits, context, and named workers', () => {
+    const patch = policyToHermesPatch(
+      {
+        ...DEFAULT_ORCHESTRATION_POLICY,
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+        defaultSubagentModelRef: 'openai-codex/gpt-5.6-sol',
+        quota: {
+          ...DEFAULT_ORCHESTRATION_POLICY.quota,
+          fallbackModelRefs: ['claude-cwm4tx/sonnet'],
+        },
+        namedWorkers: [
+          {
+            id: 'reviewer',
+            name: 'Reviewer',
+            description: 'Independent review',
+            modelRef: 'openai-codex/gpt-5.6-sol',
+            role: 'leaf',
+          },
+        ],
+      },
+      {
+        model: {
+          provider: 'custom',
+          base_url: 'http://127.0.0.1:8650/v1',
+          api_key: 'local-placeholder',
+          api_mode: 'chat_completions',
+        },
+      },
+    )
+
+    expect(patch.model).toEqual({
+      provider: 'custom',
+      default: 'claude-cwm4tx/sonnet',
+      base_url: 'http://127.0.0.1:8650/v1',
+      api_key: 'local-placeholder',
+      api_mode: 'chat_completions',
+    })
+    expect(patch.delegation).toMatchObject({
+      provider: 'openai-codex',
+      model: 'gpt-5.6-sol',
+      max_concurrent_children: 3,
+      max_concurrent_per_account: 1,
+      max_spawn_depth: 2,
+      max_total_agents: 8,
+      context_mode: 'full',
+      context_overflow: 'auto_compact_notify',
+      memory_access: 'shared_read_write',
+      child_memory_write_review: 'parent_queue',
+      allow_api_billed_models: false,
+    })
+    expect(patch.delegation.named_workers[0]).toEqual({
+      id: 'reviewer',
+      name: 'Reviewer',
+      description: 'Independent review',
+      model_ref: 'openai-codex/gpt-5.6-sol',
+      role: 'leaf',
+    })
+    expect(patch.fallback_providers).toEqual([
+      {
+        provider: 'custom',
+        model: 'claude-cwm4tx/sonnet',
+        base_url: 'http://127.0.0.1:8650/v1',
+        api_key: 'local-placeholder',
+        api_mode: 'chat_completions',
+      },
+    ])
+    expect(patch.auxiliary).toEqual({ free_only: true })
+  })
+
+  it('can switch the orchestrator back to the Claude relay after using another OAuth provider', () => {
+    const patch = policyToHermesPatch(
+      {
+        ...DEFAULT_ORCHESTRATION_POLICY,
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+      },
+      {
+        model: {
+          provider: 'openai-codex',
+          model: 'gpt-5.6-sol',
+        },
+      },
+    )
+
+    expect(patch.model).toMatchObject({
+      provider: 'custom',
+      default: 'claude-cwm4tx/sonnet',
+      base_url: 'http://127.0.0.1:8650/v1',
+      api_mode: 'chat_completions',
+    })
+  })
+
+  it('never emits OpenRouter as a fallback provider', () => {
+    expect(() =>
+      policyToHermesPatch(
+        {
+          ...DEFAULT_ORCHESTRATION_POLICY,
+          quota: {
+            ...DEFAULT_ORCHESTRATION_POLICY.quota,
+            fallbackModelRefs: [
+              'OpenRouter/anthropic/claude-opus-5',
+              'openai-codex/gpt-5.6-sol',
+            ],
+          },
+        },
+        {},
+      ),
+    ).toThrow(/OpenRouter.*not permitted/i)
+  })
+
+  it('routes Antigravity Gemini models through the authenticated local relay', () => {
+    expect(
+      topLevelModelForRef('google-antigravity/gemini-3.6-flash-high', {}),
+    ).toEqual({
+      provider: 'custom',
+      default: 'google-antigravity/gemini-3.6-flash-high',
+      base_url: 'http://127.0.0.1:8651/v1',
+      api_key: 'local-placeholder',
+      api_mode: 'chat_completions',
+    })
+  })
+
+  it('rejects a non-loopback ANTIGRAVITY_RELAY_BASE_URL instead of silently substituting it', () => {
+    const previous = process.env.ANTIGRAVITY_RELAY_BASE_URL
+    process.env.ANTIGRAVITY_RELAY_BASE_URL = 'http://10.0.0.7:8651'
+    try {
+      expect(() =>
+        topLevelModelForRef('google-antigravity/gemini-3.6-flash-high', {}),
+      ).toThrow(/loopback/i)
+    } finally {
+      if (previous === undefined) delete process.env.ANTIGRAVITY_RELAY_BASE_URL
+      else process.env.ANTIGRAVITY_RELAY_BASE_URL = previous
+    }
+  })
+
+  it('preserves GPT-5.6-sol as an OpenAI Codex OAuth route in generated Hermes config', () => {
+    expect(
+      policyToHermesPatch(
+        {
+          ...DEFAULT_ORCHESTRATION_POLICY,
+          orchestratorModelRef: 'openai-codex/gpt-5.6-sol',
+        },
+        {},
+      ).model,
+    ).toEqual({
+      provider: 'openai-codex',
+      default: 'gpt-5.6-sol',
+    })
+  })
+
+  it('removes legacy fallback_model content when generating the canonical fallback chain', () => {
+    const home = mkdtempSync(join(tmpdir(), 'orchestration-hermes-sync-'))
+    const previousHome = process.env.HERMES_HOME
+    process.env.HERMES_HOME = home
+    try {
+      writeFileSync(
+        join(home, 'config.yaml'),
+        [
+          'fallback_model:',
+          '  provider: openrouter',
+          '  model: anthropic/claude-opus-5',
+          'fallback_providers:',
+          '  - provider: openrouter',
+          '    model: auto',
+          '',
+        ].join('\n'),
+        'utf8',
+      )
+      syncGlobalOrchestrationPolicy({
+        ...DEFAULT_ORCHESTRATION_POLICY,
+        quota: {
+          ...DEFAULT_ORCHESTRATION_POLICY.quota,
+          fallbackModelRefs: ['openai-codex/gpt-5.6-sol'],
+        },
+      })
+
+      const raw = readFileSync(join(home, 'config.yaml'), 'utf8')
+      const config = YAML.parse(raw)
+      expect(config.fallback_model).toBeUndefined()
+      expect(config.fallback_providers).toEqual([
+        { provider: 'openai-codex', model: 'gpt-5.6-sol' },
+      ])
+      expect(raw).not.toMatch(/openrouter/i)
+    } finally {
+      if (previousHome === undefined) delete process.env.HERMES_HOME
+      else process.env.HERMES_HOME = previousHome
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes orchestration writes in request order', async () => {
+    const events: Array<string> = []
+    let releaseFirst = () => {}
+    let markFirstStarted = () => {}
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const first = serializeOrchestrationWrite(async () => {
+      events.push('first:start')
+      markFirstStarted()
+      await firstGate
+      events.push('first:end')
+    })
+    await firstStarted
+    const second = serializeOrchestrationWrite(() => {
+      events.push('second:start')
+      events.push('second:end')
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(['first:start'])
+    releaseFirst()
+    await Promise.all([first, second])
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ])
+  })
+
+  it('rolls policy back when the Hermes config commit fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orchestration-transaction-'))
+    const stateDir = join(root, 'state')
+    const invalidHermesHome = join(root, 'hermes-home-is-a-file')
+    writeFileSync(invalidHermesHome, 'not a directory', 'utf8')
+    const previousStateDir = process.env.HERMES_WORKSPACE_STATE_DIR
+    const previousHome = process.env.HERMES_HOME
+    process.env.HERMES_WORKSPACE_STATE_DIR = stateDir
+    process.env.HERMES_HOME = invalidHermesHome
+    try {
+      await expect(
+        applyGlobalOrchestrationPolicyTransaction(
+          { orchestratorModelRef: 'openai-codex/gpt-5.6-sol' },
+          { catalog: canonicalCatalog('openai-codex/gpt-5.6-sol') },
+        ),
+      ).rejects.toThrow(/synchronize/i)
+      expect(getOrchestrationPolicy()).toEqual(DEFAULT_ORCHESTRATION_POLICY)
+    } finally {
+      if (previousStateDir === undefined)
+        delete process.env.HERMES_WORKSPACE_STATE_DIR
+      else process.env.HERMES_WORKSPACE_STATE_DIR = previousStateDir
+      if (previousHome === undefined) delete process.env.HERMES_HOME
+      else process.env.HERMES_HOME = previousHome
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/server/orchestration-hermes-sync.ts
+++ b/src/server/orchestration-hermes-sync.ts
@@ -1,0 +1,232 @@
+import {
+  readHermesConfigFiles,
+  resolveHermesConfigPaths,
+  writeHermesConfigFile,
+} from './hermes-config-store'
+import {
+  assertNoOpenRouterAssignments,
+  getOrchestrationPolicy,
+  restoreOrchestrationPolicySnapshot,
+  saveOrchestrationPolicy,
+} from './orchestration-policy'
+import { resolveAntigravityRelayBaseUrl } from './subscription-model-catalog'
+import type {
+  OrchestrationPolicy,
+  OrchestrationPolicyPatch,
+  OrchestrationPolicySaveOptions,
+} from './orchestration-policy'
+
+interface HermesModelConfig {
+  provider?: unknown
+  base_url?: unknown
+  api_key?: unknown
+  api_mode?: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+export function normalizeLoopbackRelayBaseUrl(
+  value: unknown,
+  fallback: string,
+): string {
+  const candidate = String(value || '').replace(/\/$/, '')
+  try {
+    const url = new URL(candidate)
+    const host = url.hostname.toLowerCase()
+    if (
+      url.protocol === 'http:' &&
+      !url.username &&
+      !url.password &&
+      ['127.0.0.1', 'localhost', '[::1]', '::1'].includes(host)
+    ) {
+      return candidate
+    }
+  } catch {
+    // Fall back to the fixed loopback relay below.
+  }
+  return fallback.replace(/\/$/, '')
+}
+
+function routeForModelRef(
+  modelRef: string,
+  currentConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const ref = modelRef.trim()
+  if (!ref) return { provider: '', model: '' }
+
+  if (ref.startsWith('google-antigravity/')) {
+    const configuredRelay = resolveAntigravityRelayBaseUrl(
+      process.env.ANTIGRAVITY_RELAY_BASE_URL,
+    )
+    const relayBaseUrl = configuredRelay.endsWith('/v1')
+      ? configuredRelay
+      : `${configuredRelay}/v1`
+    return {
+      provider: 'custom',
+      model: ref,
+      base_url: relayBaseUrl,
+      api_key: process.env.ANTIGRAVITY_RELAY_API_KEY || 'local-placeholder',
+      api_mode: 'chat_completions',
+    }
+  }
+
+  if (ref.startsWith('claude-')) {
+    const modelConfig = asRecord(currentConfig.model) as HermesModelConfig
+    const configuredRelay = normalizeLoopbackRelayBaseUrl(
+      modelConfig.provider === 'custom' && modelConfig.base_url
+        ? modelConfig.base_url
+        : process.env.CLAUDE_RELAY_BASE_URL,
+      'http://127.0.0.1:8650',
+    )
+    const relayBaseUrl = configuredRelay.endsWith('/v1')
+      ? configuredRelay
+      : `${configuredRelay}/v1`
+    return {
+      provider: 'custom',
+      model: ref,
+      base_url: relayBaseUrl,
+      api_key:
+        modelConfig.provider === 'custom' && modelConfig.api_key
+          ? modelConfig.api_key
+          : process.env.CLAUDE_RELAY_API_KEY || 'local-placeholder',
+      api_mode: modelConfig.api_mode || 'chat_completions',
+    }
+  }
+
+  const slash = ref.indexOf('/')
+  if (slash < 1) return { model: ref }
+  return {
+    provider: ref.slice(0, slash),
+    model: ref.slice(slash + 1),
+  }
+}
+
+export function topLevelModelForRef(
+  modelRef: string,
+  currentConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const route = routeForModelRef(modelRef, currentConfig)
+  const { model, ...transport } = route
+  return { ...transport, default: model }
+}
+
+export function policyToHermesPatch(
+  policy: OrchestrationPolicy,
+  currentConfig: Record<string, unknown>,
+): {
+  model?: Record<string, unknown>
+  delegation: Record<string, any>
+  fallback_providers: Array<Record<string, unknown>>
+  auxiliary: Record<string, unknown>
+} {
+  assertNoOpenRouterAssignments(policy)
+  const defaultRoute = policy.defaultSubagentModelRef
+    ? routeForModelRef(policy.defaultSubagentModelRef, currentConfig)
+    : { provider: '', model: '' }
+  const orchestratorRoute = policy.orchestratorModelRef
+    ? topLevelModelForRef(policy.orchestratorModelRef, currentConfig)
+    : undefined
+
+  return {
+    ...(orchestratorRoute ? { model: orchestratorRoute } : {}),
+    delegation: {
+      ...defaultRoute,
+      max_concurrent_children: policy.limits.maxConcurrentChildren,
+      max_concurrent_per_account: policy.limits.maxConcurrentPerAccount,
+      max_spawn_depth: policy.limits.maxSpawnDepth,
+      max_total_agents: policy.limits.maxTotalAgents,
+      orchestrator_enabled: policy.limits.maxSpawnDepth > 1,
+      context_mode: policy.context.preferred,
+      context_overflow: policy.context.overflow,
+      context_recent_messages: policy.context.recentMessages,
+      context_max_chars: 200000,
+      memory_access: policy.memory.childAccess,
+      child_memory_write_review: policy.memory.childWriteReview,
+      named_workers: policy.namedWorkers.map((worker) => ({
+        id: worker.id,
+        name: worker.name,
+        model_ref: worker.modelRef,
+        role: worker.role,
+        ...(worker.description ? { description: worker.description } : {}),
+      })),
+      quota_interactive: policy.quota.interactive,
+      quota_unattended: policy.quota.unattended,
+      fallback_model_refs: policy.quota.fallbackModelRefs,
+      allow_api_billed_models: policy.billing.allowApiBilledModels,
+    },
+    fallback_providers: policy.quota.fallbackModelRefs
+      .filter(Boolean)
+      .map((ref) => routeForModelRef(ref, currentConfig)),
+    auxiliary: {
+      // Prevent auxiliary/title/compression lanes from silently engaging a
+      // metered OpenRouter route while the subscription-only gate is closed.
+      free_only: !policy.billing.allowApiBilledModels,
+    },
+  }
+}
+
+export function syncGlobalOrchestrationPolicy(
+  policy: OrchestrationPolicy,
+): void {
+  const paths = resolveHermesConfigPaths()
+  const files = readHermesConfigFiles(paths)
+  const patch = policyToHermesPatch(policy, files.config)
+  const next: Record<string, unknown> = {
+    ...files.config,
+    ...(patch.model ? { model: patch.model } : {}),
+    delegation: {
+      ...asRecord(files.config.delegation),
+      ...patch.delegation,
+    },
+    fallback_providers: patch.fallback_providers,
+    auxiliary: {
+      ...asRecord(files.config.auxiliary),
+      ...patch.auxiliary,
+    },
+  }
+  delete next.fallback_model
+  writeHermesConfigFile(paths, next)
+}
+
+let orchestrationWriteTail: Promise<void> = Promise.resolve()
+
+export function serializeOrchestrationWrite<T>(
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  const result = orchestrationWriteTail.then(operation)
+  orchestrationWriteTail = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return result
+}
+
+export function applyGlobalOrchestrationPolicyTransaction(
+  patch: OrchestrationPolicyPatch,
+  options: OrchestrationPolicySaveOptions,
+): Promise<OrchestrationPolicy> {
+  return serializeOrchestrationWrite(() => {
+    const previous = getOrchestrationPolicy()
+    const policy = saveOrchestrationPolicy(patch, options)
+    try {
+      syncGlobalOrchestrationPolicy(policy)
+      return policy
+    } catch (error) {
+      try {
+        restoreOrchestrationPolicySnapshot(previous)
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          'Failed to synchronize orchestration policy and rollback failed',
+        )
+      }
+      throw new Error('Failed to synchronize orchestration policy', {
+        cause: error,
+      })
+    }
+  })
+}

--- a/src/server/orchestration-policy.test.ts
+++ b/src/server/orchestration-policy.test.ts
@@ -1,0 +1,240 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_ORCHESTRATION_POLICY,
+  getOrchestrationPolicy,
+  getSessionOrchestrationPolicy,
+  saveOrchestrationPolicy,
+  saveSessionOrchestrationPolicy,
+} from './orchestration-policy'
+import type { SubscriptionCatalog } from './subscription-model-catalog'
+
+let stateDir = ''
+const previousStateDir = process.env.HERMES_WORKSPACE_STATE_DIR
+
+function catalogWith(...ids: Array<string>): SubscriptionCatalog {
+  return {
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    subscriptionOnly: true,
+    transports: [],
+    visibility: { showNousModels: false, showApiBilledModels: false },
+    models: ids.map((id) => {
+      const slash = id.indexOf('/')
+      return {
+        id,
+        provider: id.slice(0, slash),
+        account: id.slice(0, slash),
+        model: id.slice(slash + 1),
+        transport: 'test',
+        billingClass: 'subscription_included',
+        status: 'available',
+        selectable: true,
+        warning: '',
+        resetAt: null,
+      }
+    }),
+  }
+}
+
+const canonicalCatalog = catalogWith(
+  'openai-codex/gpt-5.6-sol',
+  'claude-cwm4tx/sonnet',
+)
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'workspace-orchestration-'))
+  process.env.HERMES_WORKSPACE_STATE_DIR = stateDir
+})
+
+afterEach(() => {
+  if (previousStateDir === undefined)
+    delete process.env.HERMES_WORKSPACE_STATE_DIR
+  else process.env.HERMES_WORKSPACE_STATE_DIR = previousStateDir
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+describe('orchestration policy', () => {
+  it('uses subscription-only, review-queued, full-context defaults', () => {
+    const policy = getOrchestrationPolicy()
+
+    expect(policy).toEqual(DEFAULT_ORCHESTRATION_POLICY)
+    expect(policy.billing.allowApiBilledModels).toBe(false)
+    expect(policy.billing.showNousModels).toBe(false)
+    expect(policy.memory.childAccess).toBe('shared_read_write')
+    expect(policy.memory.childWriteReview).toBe('parent_queue')
+    expect(policy.context.preferred).toBe('full')
+    expect(policy.context.overflow).toBe('auto_compact_notify')
+    expect(policy.quota.unattended).toBe('subscription_fallback')
+  })
+
+  it('persists validated global policy updates without dropping defaults', () => {
+    const saved = saveOrchestrationPolicy(
+      {
+        defaultSubagentModelRef: 'openai-codex/gpt-5.6-sol',
+        limits: { maxConcurrentChildren: 2 },
+      },
+      { catalog: canonicalCatalog },
+    )
+
+    expect(saved.defaultSubagentModelRef).toBe('openai-codex/gpt-5.6-sol')
+    expect(saved.limits.maxConcurrentChildren).toBe(2)
+    expect(saved.limits.maxSpawnDepth).toBe(
+      DEFAULT_ORCHESTRATION_POLICY.limits.maxSpawnDepth,
+    )
+    expect(
+      JSON.parse(
+        readFileSync(join(stateDir, 'orchestration-policy.json'), 'utf8'),
+      ),
+    ).toMatchObject({ defaultSubagentModelRef: 'openai-codex/gpt-5.6-sol' })
+  })
+
+  it('stores per-session overrides separately and merges them over global policy', () => {
+    saveOrchestrationPolicy(
+      {
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+        routingMode: 'explicit',
+      },
+      { catalog: canonicalCatalog },
+    )
+    saveSessionOrchestrationPolicy(
+      'session/one',
+      {
+        orchestratorModelRef: 'openai-codex/gpt-5.6-sol',
+        routingMode: 'automatic',
+        context: { overflow: 'ask' },
+      },
+      { catalog: canonicalCatalog },
+    )
+
+    const effective = getSessionOrchestrationPolicy('session/one')
+    expect(effective.orchestratorModelRef).toBe('openai-codex/gpt-5.6-sol')
+    expect(effective.routingMode).toBe('automatic')
+    expect(effective.context.preferred).toBe('full')
+    expect(effective.context.overflow).toBe('ask')
+  })
+
+  it('persists the Nous visibility option without enabling API billing', () => {
+    const saved = saveOrchestrationPolicy({
+      billing: { showNousModels: true },
+    })
+    expect(saved.billing).toEqual({
+      allowApiBilledModels: false,
+      showNousModels: true,
+    })
+  })
+
+  it('rejects unsafe API-billing enablement unless explicitly confirmed', () => {
+    expect(() =>
+      saveOrchestrationPolicy({
+        billing: { allowApiBilledModels: true },
+      }),
+    ).toThrow(/explicit confirmation/i)
+
+    expect(
+      saveOrchestrationPolicy(
+        { billing: { allowApiBilledModels: true } },
+        { confirmApiBilling: true },
+      ).billing.allowApiBilledModels,
+    ).toBe(true)
+  })
+
+  it('does not allow policy patches to mutate object prototypes', () => {
+    const pollutedPatch = JSON.parse(
+      '{"__proto__":{"confirmApiBilling":true}}',
+    )
+    try {
+      saveOrchestrationPolicy(pollutedPatch)
+      expect(
+        ({} as { confirmApiBilling?: boolean }).confirmApiBilling,
+      ).toBeUndefined()
+    } finally {
+      delete (Object.prototype as { confirmApiBilling?: boolean })
+        .confirmApiBilling
+    }
+  })
+
+  it('rejects unknown or unavailable model references in every saved assignment field', () => {
+    const unavailableCatalog: SubscriptionCatalog = {
+      ...canonicalCatalog,
+      models: canonicalCatalog.models.map((model) => ({
+        ...model,
+        selectable: model.id !== 'claude-cwm4tx/sonnet',
+        status:
+          model.id === 'claude-cwm4tx/sonnet'
+            ? ('unavailable' as const)
+            : model.status,
+      })),
+    }
+    const invalidPatches = [
+      { orchestratorModelRef: 'unknown/model' },
+      { defaultSubagentModelRef: 'unknown/model' },
+      { quota: { fallbackModelRefs: ['unknown/model'] } },
+      {
+        namedWorkers: [
+          {
+            id: 'reviewer',
+            name: 'Reviewer',
+            modelRef: 'unknown/model',
+            role: 'leaf' as const,
+            description: '',
+          },
+        ],
+      },
+      { orchestratorModelRef: 'claude-cwm4tx/sonnet' },
+    ]
+
+    for (const patch of invalidPatches) {
+      expect(() =>
+        saveOrchestrationPolicy(patch, { catalog: unavailableCatalog }),
+      ).toThrow(/assignable.*catalog/i)
+    }
+    expect(getOrchestrationPolicy()).toEqual(DEFAULT_ORCHESTRATION_POLICY)
+  })
+
+  it('hard-denies OpenRouter case-insensitively in every global and session assignment field', () => {
+    const permissiveCatalog = catalogWith(
+      'OpenRouter/anthropic/claude-opus-5',
+      'openrouter/anthropic/claude-opus-5',
+    )
+    const openRouterPatches = [
+      { orchestratorModelRef: 'OpenRouter/anthropic/claude-opus-5' },
+      { defaultSubagentModelRef: 'OPENROUTER/anthropic/claude-opus-5' },
+      { quota: { fallbackModelRefs: ['openRouter/anthropic/claude-opus-5'] } },
+      {
+        namedWorkers: [
+          {
+            id: 'reviewer',
+            name: 'Reviewer',
+            modelRef: 'OpenRouter/anthropic/claude-opus-5',
+            role: 'leaf' as const,
+            description: '',
+          },
+        ],
+      },
+    ]
+
+    for (const patch of openRouterPatches) {
+      expect(() =>
+        saveOrchestrationPolicy(patch, { catalog: permissiveCatalog }),
+      ).toThrow(/OpenRouter.*not permitted/i)
+    }
+    expect(() =>
+      saveSessionOrchestrationPolicy(
+        'session-one',
+        { orchestratorModelRef: 'OpenRouter/anthropic/claude-opus-5' },
+        { catalog: permissiveCatalog },
+      ),
+    ).toThrow(/OpenRouter.*not permitted/i)
+  })
+
+  it('requires a canonical catalog whenever a saved policy contains model references', () => {
+    expect(() =>
+      saveOrchestrationPolicy({
+        orchestratorModelRef: 'openai-codex/gpt-5.6-sol',
+      }),
+    ).toThrow(/canonical catalog/i)
+  })
+})

--- a/src/server/orchestration-policy.ts
+++ b/src/server/orchestration-policy.ts
@@ -1,0 +1,320 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { z } from 'zod'
+
+import { writeFileAtomicWithBackup } from './hermes-config-store'
+import { getStateDir } from './workspace-state-dir'
+import type { SubscriptionCatalog } from './subscription-model-catalog'
+
+const ModelRef = z.string().trim().max(300)
+const NamedWorkerSchema = z.object({
+  id: z.string().trim().min(1).max(80),
+  name: z.string().trim().min(1).max(120),
+  modelRef: ModelRef,
+  role: z.enum(['leaf', 'orchestrator']).default('leaf'),
+  description: z.string().trim().max(500).default(''),
+})
+
+const PolicySchema = z.object({
+  orchestratorModelRef: ModelRef.default(''),
+  defaultSubagentModelRef: ModelRef.default(''),
+  routingMode: z.enum(['explicit', 'automatic', 'hybrid']).default('explicit'),
+  limits: z.object({
+    preset: z
+      .enum(['conservative', 'balanced', 'high_parallelism', 'custom'])
+      .default('balanced'),
+    maxConcurrentChildren: z.number().int().min(1).max(64).default(3),
+    maxConcurrentPerAccount: z.number().int().min(1).max(16).default(1),
+    maxSpawnDepth: z.number().int().min(1).max(12).default(2),
+    maxTotalAgents: z.number().int().min(1).max(256).default(8),
+  }),
+  quota: z.object({
+    interactive: z
+      .enum([
+        'offer_alternative',
+        'subscription_fallback',
+        'stop_notify',
+        'wait_reset',
+      ])
+      .default('offer_alternative'),
+    unattended: z
+      .enum(['subscription_fallback', 'stop_notify', 'wait_reset'])
+      .default('subscription_fallback'),
+    fallbackModelRefs: z.array(ModelRef).max(32).default([]),
+  }),
+  billing: z.object({
+    allowApiBilledModels: z.boolean().default(false),
+    showNousModels: z.boolean().default(false),
+  }),
+  memory: z.object({
+    childAccess: z
+      .enum(['shared_read_write', 'shared_read_only', 'context_only'])
+      .default('shared_read_write'),
+    childWriteReview: z
+      .enum(['parent_queue', 'normal_policy', 'automatic'])
+      .default('parent_queue'),
+  }),
+  context: z.object({
+    preferred: z
+      .enum(['full', 'summary_recent', 'focused', 'explicit_only'])
+      .default('full'),
+    overflow: z
+      .enum([
+        'auto_compact_notify',
+        'ask',
+        'larger_model',
+        'recent_window',
+        'cancel',
+      ])
+      .default('auto_compact_notify'),
+    recentMessages: z.number().int().min(1).max(1000).default(24),
+    maxInputPercent: z.number().int().min(30).max(90).default(75),
+  }),
+  namedWorkers: z.array(NamedWorkerSchema).max(64).default([]),
+})
+
+export type OrchestrationPolicy = z.infer<typeof PolicySchema>
+export type OrchestrationPolicyPatch = Partial<{
+  [K in keyof OrchestrationPolicy]: OrchestrationPolicy[K] extends Array<unknown>
+    ? OrchestrationPolicy[K]
+    : OrchestrationPolicy[K] extends object
+      ? Partial<OrchestrationPolicy[K]>
+      : OrchestrationPolicy[K]
+}>
+
+export interface OrchestrationPolicySaveOptions {
+  confirmApiBilling?: boolean
+  catalog?: SubscriptionCatalog
+}
+
+export const DEFAULT_ORCHESTRATION_POLICY: OrchestrationPolicy =
+  PolicySchema.parse({
+    orchestratorModelRef: '',
+    defaultSubagentModelRef: '',
+    routingMode: 'explicit',
+    limits: {
+      preset: 'balanced',
+      maxConcurrentChildren: 3,
+      maxConcurrentPerAccount: 1,
+      maxSpawnDepth: 2,
+      maxTotalAgents: 8,
+    },
+    quota: {
+      interactive: 'offer_alternative',
+      unattended: 'subscription_fallback',
+      fallbackModelRefs: [],
+    },
+    billing: { allowApiBilledModels: false, showNousModels: false },
+    memory: {
+      childAccess: 'shared_read_write',
+      childWriteReview: 'parent_queue',
+    },
+    context: {
+      preferred: 'full',
+      overflow: 'auto_compact_notify',
+      recentMessages: 24,
+      maxInputPercent: 75,
+    },
+    namedWorkers: [],
+  })
+
+function modelAssignments(
+  policy: OrchestrationPolicy,
+): Array<{ path: string; ref: string }> {
+  return [
+    { path: 'orchestratorModelRef', ref: policy.orchestratorModelRef },
+    { path: 'defaultSubagentModelRef', ref: policy.defaultSubagentModelRef },
+    ...policy.quota.fallbackModelRefs.map((ref, index) => ({
+      path: `quota.fallbackModelRefs[${index}]`,
+      ref,
+    })),
+    ...policy.namedWorkers.map((worker, index) => ({
+      path: `namedWorkers[${index}].modelRef`,
+      ref: worker.modelRef,
+    })),
+  ].filter((assignment) => Boolean(assignment.ref))
+}
+
+export function isOpenRouterModelRef(modelRef: string): boolean {
+  return /^openrouter(?:\/|$)/i.test(modelRef.trim())
+}
+
+export function assertNoOpenRouterAssignments(
+  policy: OrchestrationPolicy,
+): void {
+  const denied = modelAssignments(policy).find((assignment) =>
+    isOpenRouterModelRef(assignment.ref),
+  )
+  if (denied) {
+    throw new Error(
+      `OpenRouter is not permitted in orchestration assignment ${denied.path}`,
+    )
+  }
+}
+
+export function validateOrchestrationPolicyModelRefs(
+  policy: OrchestrationPolicy,
+  catalog?: SubscriptionCatalog,
+): void {
+  const assignments = modelAssignments(policy)
+  if (assignments.length === 0) return
+  assertNoOpenRouterAssignments(policy)
+  if (!catalog) {
+    throw new Error(
+      'A canonical catalog is required to save orchestration model assignments',
+    )
+  }
+  const routes = new Map(catalog.models.map((model) => [model.id, model]))
+  for (const assignment of assignments) {
+    const route = routes.get(assignment.ref)
+    if (
+      !route?.selectable ||
+      (route.billingClass === 'api_billed' &&
+        !policy.billing.allowApiBilledModels)
+    ) {
+      throw new Error(
+        `${assignment.path} must reference an assignable model in the canonical catalog`,
+      )
+    }
+  }
+}
+
+function deepMerge<T extends Record<string, unknown>>(
+  base: T,
+  patch: Record<string, unknown>,
+): T {
+  const result = structuredClone(base) as Record<string, unknown>
+  for (const [key, value] of Object.entries(patch)) {
+    const current = result[key]
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      current !== null &&
+      typeof current === 'object' &&
+      !Array.isArray(current)
+    ) {
+      result[key] = deepMerge(
+        current as Record<string, unknown>,
+        value as Record<string, unknown>,
+      )
+    } else if (value !== undefined) {
+      result[key] = value
+    }
+  }
+  return result as T
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return undefined
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileAtomicWithBackup(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function policyPath(): string {
+  return join(getStateDir(), 'orchestration-policy.json')
+}
+
+function sessionsPath(): string {
+  return join(getStateDir(), 'orchestration-sessions.json')
+}
+
+export function getOrchestrationPolicy(): OrchestrationPolicy {
+  const saved = readJson(policyPath())
+  const merged =
+    saved && typeof saved === 'object' && !Array.isArray(saved)
+      ? deepMerge(
+          DEFAULT_ORCHESTRATION_POLICY,
+          saved as Record<string, unknown>,
+        )
+      : DEFAULT_ORCHESTRATION_POLICY
+  const parsed = PolicySchema.safeParse(merged)
+  return parsed.success
+    ? parsed.data
+    : structuredClone(DEFAULT_ORCHESTRATION_POLICY)
+}
+
+export function saveOrchestrationPolicy(
+  patch: OrchestrationPolicyPatch,
+  options: OrchestrationPolicySaveOptions = {},
+): OrchestrationPolicy {
+  if (
+    patch.billing?.allowApiBilledModels === true &&
+    !options.confirmApiBilling
+  ) {
+    throw new Error('API-billed models require explicit confirmation')
+  }
+  const next = PolicySchema.parse(
+    deepMerge(getOrchestrationPolicy(), patch as Record<string, unknown>),
+  )
+  validateOrchestrationPolicyModelRefs(next, options.catalog)
+  writeJson(policyPath(), next)
+  return next
+}
+
+export function restoreOrchestrationPolicySnapshot(
+  policy: OrchestrationPolicy,
+): void {
+  writeJson(policyPath(), PolicySchema.parse(policy))
+}
+
+type SessionOverrides = Record<string, OrchestrationPolicyPatch>
+
+function readSessionOverrides(): SessionOverrides {
+  const saved = readJson(sessionsPath())
+  return saved && typeof saved === 'object' && !Array.isArray(saved)
+    ? (saved as SessionOverrides)
+    : {}
+}
+
+export function saveSessionOrchestrationPolicy(
+  sessionKey: string,
+  patch: OrchestrationPolicyPatch,
+  options: Pick<OrchestrationPolicySaveOptions, 'catalog'> = {},
+): OrchestrationPolicy {
+  const key = sessionKey.trim()
+  if (!key) throw new Error('sessionKey is required')
+  if (patch.billing?.allowApiBilledModels === true) {
+    throw new Error(
+      'API billing can only be enabled globally with explicit confirmation',
+    )
+  }
+  const sessions = readSessionOverrides()
+  sessions[key] = deepMerge(
+    (sessions[key] ?? {}) as Record<string, unknown>,
+    patch as Record<string, unknown>,
+  ) as OrchestrationPolicyPatch
+  const effective = PolicySchema.parse(
+    deepMerge(
+      getOrchestrationPolicy(),
+      sessions[key] as Record<string, unknown>,
+    ),
+  )
+  validateOrchestrationPolicyModelRefs(effective, options.catalog)
+  writeJson(sessionsPath(), sessions)
+  return effective
+}
+
+export function getSessionOrchestrationPolicy(
+  sessionKey: string,
+): OrchestrationPolicy {
+  const sessions = readSessionOverrides()
+  if (!Object.hasOwn(sessions, sessionKey)) return getOrchestrationPolicy()
+  const patch = sessions[sessionKey]
+  const parsed = PolicySchema.safeParse(
+    deepMerge(getOrchestrationPolicy(), patch as Record<string, unknown>),
+  )
+  return parsed.success ? parsed.data : getOrchestrationPolicy()
+}
+
+export function clearSessionOrchestrationPolicy(sessionKey: string): void {
+  const sessions = readSessionOverrides()
+  delete sessions[sessionKey]
+  writeJson(sessionsPath(), sessions)
+}

--- a/src/server/profiles-browser-model.test.ts
+++ b/src/server/profiles-browser-model.test.ts
@@ -19,7 +19,9 @@ describe('profile model settings readback', () => {
       provider: 'custom',
       routeRef: 'claude-cwm4tx/opus-5',
       reasoningEffort: 'max',
-      maxOutputTokens: 32768,
+      maxOutputTokens: 32_768,
+      codexRuntime: 'hermes_default',
+      codexRuntimeConfigured: 'hermes_default',
     })
   })
 
@@ -32,5 +34,11 @@ describe('profile model settings readback', () => {
     expect(
       extractProfileModelSettings({ model: 'legacy-model' }).routeRef,
     ).toBe('legacy-model')
+  })
+
+  it('reads Codex runtime ownership with a safe effective fallback', () => {
+    expect(extractProfileModelSettings({ workspace: { codex_runtime: 'codex_app_server' } })).toMatchObject({ codexRuntime: 'codex_app_server', codexRuntimeConfigured: 'codex_app_server' })
+    expect(extractProfileModelSettings({ workspace: { codex_runtime: 'future_runtime' } })).toMatchObject({ codexRuntime: 'hermes_default', codexRuntimeConfigured: 'future_runtime' })
+    expect(extractProfileModelSettings({})).toMatchObject({ codexRuntime: 'hermes_default', codexRuntimeConfigured: 'hermes_default' })
   })
 })

--- a/src/server/profiles-browser-model.test.ts
+++ b/src/server/profiles-browser-model.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractProfileModelSettings } from './profiles-browser'
+
+describe('profile model settings readback', () => {
+  it('prefers the persisted canonical route and returns tuning values', () => {
+    expect(
+      extractProfileModelSettings({
+        model: {
+          provider: 'custom',
+          default: 'claude-cwm4tx/opus-5',
+          max_tokens: 32768,
+        },
+        agent: { reasoning_effort: 'max' },
+        workspace: { route_ref: 'claude-cwm4tx/opus-5' },
+      }),
+    ).toEqual({
+      model: 'claude-cwm4tx/opus-5',
+      provider: 'custom',
+      routeRef: 'claude-cwm4tx/opus-5',
+      reasoningEffort: 'max',
+      maxOutputTokens: 32768,
+    })
+  })
+
+  it('reconstructs canonical provider routes and preserves legacy strings', () => {
+    expect(
+      extractProfileModelSettings({
+        model: { provider: 'openai-codex', default: 'gpt-5.6-sol' },
+      }).routeRef,
+    ).toBe('openai-codex/gpt-5.6-sol')
+    expect(
+      extractProfileModelSettings({ model: 'legacy-model' }).routeRef,
+    ).toBe('legacy-model')
+  })
+})

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -13,6 +13,8 @@ export type ProfileSummary = {
   routeRef?: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime?: 'hermes_default' | 'codex_app_server'
+  codexRuntimeConfigured?: string
   description?: string
   systemPrompt?: string
   skillCount: number
@@ -57,6 +59,8 @@ export function extractProfileModelSettings(config: Record<string, unknown>): {
   routeRef?: string
   reasoningEffort?: string
   maxOutputTokens?: number
+  codexRuntime: 'hermes_default' | 'codex_app_server'
+  codexRuntimeConfigured: string
 } {
   let model: string | undefined
   let provider: string | undefined
@@ -107,7 +111,26 @@ export function extractProfileModelSettings(config: Record<string, unknown>): {
       ? agent.reasoning_effort.trim() || undefined
       : undefined
 
-  return { model, provider, routeRef, reasoningEffort, maxOutputTokens }
+  const configuredCodexRuntime =
+    typeof workspace.codex_runtime_configured === 'string'
+      ? workspace.codex_runtime_configured.trim()
+      : typeof workspace.codex_runtime === 'string'
+        ? workspace.codex_runtime.trim()
+        : 'hermes_default'
+  const codexRuntime =
+    configuredCodexRuntime === 'codex_app_server'
+      ? 'codex_app_server'
+      : 'hermes_default'
+
+  return {
+    model,
+    provider,
+    routeRef,
+    reasoningEffort,
+    maxOutputTokens,
+    codexRuntime,
+    codexRuntimeConfigured: configuredCodexRuntime || 'hermes_default',
+  }
 }
 
 function getHermesRoot(): string {

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -10,6 +10,9 @@ export type ProfileSummary = {
   exists: boolean
   model?: string
   provider?: string
+  routeRef?: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
   description?: string
   systemPrompt?: string
   skillCount: number
@@ -47,6 +50,65 @@ const TEXT_REWRITE_EXTENSIONS = new Set([
   '.ts',
   '.tsx',
 ])
+
+export function extractProfileModelSettings(config: Record<string, unknown>): {
+  model?: string
+  provider?: string
+  routeRef?: string
+  reasoningEffort?: string
+  maxOutputTokens?: number
+} {
+  let model: string | undefined
+  let provider: string | undefined
+  let maxOutputTokens: number | undefined
+  if (typeof config.model === 'string') {
+    model = config.model
+  } else if (
+    config.model &&
+    typeof config.model === 'object' &&
+    !Array.isArray(config.model)
+  ) {
+    const modelConfig = config.model as Record<string, unknown>
+    if (typeof modelConfig.default === 'string') model = modelConfig.default
+    if (typeof modelConfig.provider === 'string')
+      provider = modelConfig.provider
+    if (
+      typeof modelConfig.max_tokens === 'number' &&
+      Number.isInteger(modelConfig.max_tokens) &&
+      modelConfig.max_tokens > 0
+    ) {
+      maxOutputTokens = modelConfig.max_tokens
+    }
+  }
+  if (!provider && typeof config.provider === 'string')
+    provider = config.provider
+
+  const workspace =
+    config.workspace &&
+    typeof config.workspace === 'object' &&
+    !Array.isArray(config.workspace)
+      ? (config.workspace as Record<string, unknown>)
+      : {}
+  const agent =
+    config.agent &&
+    typeof config.agent === 'object' &&
+    !Array.isArray(config.agent)
+      ? (config.agent as Record<string, unknown>)
+      : {}
+  const persistedRoute =
+    typeof workspace.route_ref === 'string' ? workspace.route_ref.trim() : ''
+  const routeRef =
+    persistedRoute ||
+    (provider && provider !== 'custom' && model
+      ? `${provider}/${model}`
+      : model)
+  const reasoningEffort =
+    typeof agent.reasoning_effort === 'string'
+      ? agent.reasoning_effort.trim() || undefined
+      : undefined
+
+  return { model, provider, routeRef, reasoningEffort, maxOutputTokens }
+}
 
 function getHermesRoot(): string {
   return (
@@ -333,7 +395,8 @@ export async function readProfileWithFallback(
           }>
         }
         const match = data.profiles?.find(
-          (p) => p.name === normalized || (normalized === 'default' && p.is_default),
+          (p) =>
+            p.name === normalized || (normalized === 'default' && p.is_default),
         )
         if (match) {
           const active = getActiveProfileName()
@@ -409,30 +472,17 @@ export function listProfiles(): Array<ProfileSummary> {
       const sessionCount = countFilesRecursive(sessionsDir, (full) =>
         /\.(jsonl|json|sqlite|db)$/i.test(full),
       )
-      // Resolve model/provider from nested or flat config structure
-      let modelName: string | undefined
-      let providerName: string | undefined
-      if (typeof config.model === 'string') {
-        modelName = config.model
-      } else if (
-        config.model &&
-        typeof config.model === 'object' &&
-        !Array.isArray(config.model)
-      ) {
-        const m = config.model as Record<string, unknown>
-        if (typeof m.default === 'string') modelName = m.default
-        if (typeof m.provider === 'string') providerName = m.provider
-      }
-      if (!providerName && typeof config.provider === 'string') {
-        providerName = config.provider
-      }
+      const modelSettings = extractProfileModelSettings(config)
       results.push({
         name,
         path: profilePath,
         active: name === activeProfile,
         exists: true,
-        model: modelName,
-        provider: providerName,
+        model: modelSettings.model,
+        provider: modelSettings.provider,
+        routeRef: modelSettings.routeRef,
+        reasoningEffort: modelSettings.reasoningEffort,
+        maxOutputTokens: modelSettings.maxOutputTokens,
         description: extractDescription(config) || undefined,
         systemPrompt: extractSystemPrompt(config, profilePath) || undefined,
         skillCount,
@@ -451,30 +501,17 @@ export function listProfiles(): Array<ProfileSummary> {
 
   const root = getClaudeRoot()
   const config = readYamlConfig(path.join(root, 'config.yaml'))
-  // Resolve model/provider for default profile too
-  let defaultModel: string | undefined
-  let defaultProvider: string | undefined
-  if (typeof config.model === 'string') {
-    defaultModel = config.model
-  } else if (
-    config.model &&
-    typeof config.model === 'object' &&
-    !Array.isArray(config.model)
-  ) {
-    const m = config.model as Record<string, unknown>
-    if (typeof m.default === 'string') defaultModel = m.default
-    if (typeof m.provider === 'string') defaultProvider = m.provider
-  }
-  if (!defaultProvider && typeof config.provider === 'string') {
-    defaultProvider = config.provider
-  }
+  const defaultModelSettings = extractProfileModelSettings(config)
   results.unshift({
     name: 'default',
     path: root,
     active: activeProfile === 'default',
     exists: true,
-    model: defaultModel,
-    provider: defaultProvider,
+    model: defaultModelSettings.model,
+    provider: defaultModelSettings.provider,
+    routeRef: defaultModelSettings.routeRef,
+    reasoningEffort: defaultModelSettings.reasoningEffort,
+    maxOutputTokens: defaultModelSettings.maxOutputTokens,
     description: extractDescription(config) || undefined,
     systemPrompt: extractSystemPrompt(config, root) || undefined,
     skillCount: countFilesRecursive(

--- a/src/server/provider-runtime-auth.test.ts
+++ b/src/server/provider-runtime-auth.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { requireProviderRuntimeMutationAuth } from './auth-middleware'
+
+const original = {
+  HERMES_PASSWORD: process.env.HERMES_PASSWORD,
+  CLAUDE_PASSWORD: process.env.CLAUDE_PASSWORD,
+  HOST: process.env.HOST,
+  HERMES_HOST: process.env.HERMES_HOST,
+}
+
+beforeEach(() => {
+  delete process.env.HERMES_PASSWORD
+  delete process.env.CLAUDE_PASSWORD
+  delete process.env.HOST
+  delete process.env.HERMES_HOST
+})
+
+afterEach(() => {
+  for (const [key, value] of Object.entries({
+    HERMES_PASSWORD: original.HERMES_PASSWORD,
+    CLAUDE_PASSWORD: original.CLAUDE_PASSWORD,
+    HOST: original.HOST,
+    HERMES_HOST: original.HERMES_HOST,
+  })) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+describe('provider runtime mutation authentication', () => {
+  it('fails closed without dashboard authentication', () => {
+    expect(requireProviderRuntimeMutationAuth(new Request('http://localhost/api/provider-runtimes'))).toBe(false)
+  })
+
+  it('does not treat a loopback-looking request as sufficient authority', () => {
+    expect(requireProviderRuntimeMutationAuth(new Request('http://localhost/api/provider-runtimes'))).toBe(false)
+    const loopback = Object.assign(new Request('http://localhost/api/provider-runtimes'), { remoteAddress: '127.0.0.1' })
+    expect(requireProviderRuntimeMutationAuth(loopback)).toBe(false)
+  })
+
+  it('allows no-password operation only when the trusted server bind and request are both loopback', () => {
+    process.env.HOST = '127.0.0.1'
+    expect(requireProviderRuntimeMutationAuth(new Request('http://127.0.0.1/api/provider-runtimes'))).toBe(true)
+    expect(requireProviderRuntimeMutationAuth(new Request('http://192.168.1.22/api/provider-runtimes'))).toBe(false)
+    process.env.HOST = '0.0.0.0'
+    expect(requireProviderRuntimeMutationAuth(new Request('http://127.0.0.1/api/provider-runtimes'))).toBe(false)
+  })
+
+  it('requires a valid session when password protection is enabled', () => {
+    process.env.HERMES_PASSWORD = 'configured'
+    const loopback = Object.assign(new Request('http://localhost/api/provider-runtimes'), { remoteAddress: '127.0.0.1' })
+    expect(requireProviderRuntimeMutationAuth(loopback)).toBe(false)
+  })
+})

--- a/src/server/provider-runtime-control-plane.test.ts
+++ b/src/server/provider-runtime-control-plane.test.ts
@@ -12,11 +12,11 @@ import {
   importClaudeAgents,
   importCodexThreads,
   normalizeClaudeAgents,
-  normalizeCodexThreads,
   normalizeCodexRuntimeSelection,
+  normalizeCodexThreads,
   providerRuntimeRequest,
-  type ProviderRuntimeRecord,
 } from './provider-runtime-control-plane'
+import type { ClaudeRun, ProviderRuntimeRecord } from './provider-runtime-control-plane'
 
 let dir: string
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'provider-runtime-')) })
@@ -92,44 +92,47 @@ describe('durable one-writer leases', () => {
 describe('capabilities and explicit Codex runtime selection', () => {
   it('marks direct messaging deferred and preserves unknown legacy selection safely', () => {
     expect(capabilityMatrix('codex_thread', 'win32').crossSessionMessage).toMatchObject({ state: 'unsupported', deferred: true })
+    expect(capabilityMatrix('codex_thread', 'win32').fork).toMatchObject({ state: 'unsupported', deferred: true })
     expect(normalizeCodexRuntimeSelection(undefined)).toEqual({ configured: 'hermes_default', effective: 'hermes_default', known: true })
     expect(normalizeCodexRuntimeSelection('future_runtime')).toEqual({ configured: 'future_runtime', effective: 'hermes_default', known: false })
   })
 })
 
 describe('provider lifecycle adapters', () => {
-  it('enables bounded one-shot Codex thread lifecycle while keeping active-turn controls disabled', async () => {
+  it('enables bounded Codex resume/archive while rejecting fork and active-turn controls before invocation', async () => {
     const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => 10)
     const invoke = vi.fn(async () => ({ ok: true, result: { thread: { id: 'thread-fork' } } }))
     const adapter = new CodexRuntimeAdapter({ invoke, leases, ownerToken: 'server' })
     expect(await adapter.status('thread-1')).toMatchObject({ ok: true })
     expect(invoke).toHaveBeenLastCalledWith('thread/read', { threadId: 'thread-1', includeTurns: false })
     expect(await adapter.mutate('codex:thread-1', 'resume', { providerModel: 'gpt-5.6-sol' })).toMatchObject({ ok: true })
-    let forkRegisteredWhileLeased = false
-    expect(await adapter.mutate('codex:thread-1', 'fork', {
-      providerModel: 'gpt-5.6-sol',
-      onForkCreated: () => { forkRegisteredWhileLeased = leases.get('codex:thread-1') !== null },
-    })).toMatchObject({ ok: true })
-    expect(forkRegisteredWhileLeased).toBe(true)
+    const onForkCreated = vi.fn()
+    const forkResult = await adapter.mutate('codex:thread-1', 'fork', {
+      providerModel: 'gpt-5.6-sol', onForkCreated,
+    })
+    expect(forkResult).toMatchObject({ ok: false })
+    expect(String(forkResult.error).toLowerCase()).toContain('disabled')
+    expect(onForkCreated).not.toHaveBeenCalled()
     expect(await adapter.mutate('codex:thread-1', 'archive', {})).toMatchObject({ ok: true })
     expect(invoke).toHaveBeenNthCalledWith(2, 'thread/resume', { threadId: 'thread-1', model: 'gpt-5.6-sol' })
-    expect(invoke).toHaveBeenNthCalledWith(3, 'thread/fork', { threadId: 'thread-1', model: 'gpt-5.6-sol' })
-    expect(invoke).toHaveBeenNthCalledWith(4, 'thread/archive', { threadId: 'thread-1' })
+    expect(invoke).toHaveBeenNthCalledWith(3, 'thread/archive', { threadId: 'thread-1' })
     expect(await adapter.mutate('codex:thread-1', 'steer', { text: 'bounded', turnId: 'turn-7' })).toMatchObject({ ok: false })
     expect(await adapter.mutate('codex:thread-1', 'interrupt', { turnId: 'turn-7' })).toMatchObject({ ok: false })
-    expect(invoke).toHaveBeenCalledTimes(4)
+    expect(invoke).toHaveBeenCalledTimes(3)
     expect(leases.get('codex:thread-1')).toBeNull()
   })
 
-  it('retains an abandoned Codex lease when fork registration is ambiguous', async () => {
+  it('does not acquire a lease or invoke the provider for disabled Codex fork', async () => {
     const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => 10)
-    const adapter = new CodexRuntimeAdapter({ invoke: vi.fn(async () => ({ ok: true, result: {} })), leases, ownerToken: 'server' })
-    expect(await adapter.mutate('codex:thread-2', 'fork', { onForkCreated: () => { throw new Error('registry unavailable') } })).toMatchObject({ ok: false })
-    expect(leases.get('codex:thread-2')).toMatchObject({ abandoned: true })
+    const invoke = vi.fn(async () => ({ ok: true, result: {} }))
+    const adapter = new CodexRuntimeAdapter({ invoke, leases, ownerToken: 'server' })
+    expect(await adapter.mutate('codex:thread-2', 'fork', { onForkCreated: vi.fn() })).toMatchObject({ ok: false })
+    expect(invoke).not.toHaveBeenCalled()
+    expect(leases.get('codex:thread-2')).toBeNull()
   })
 
   it('passes Claude prompts via stdin with official UUID resume/fork flags and strips API credentials', async () => {
-    const run = vi.fn(async () => ({ ok: true, stdout: '{"session_id":"11111111-1111-4111-8111-111111111111"}', stderr: '' }))
+    const run = vi.fn<ClaudeRun>(async () => ({ ok: true, stdout: '{"session_id":"11111111-1111-4111-8111-111111111111"}', stderr: '' }))
     const claudeLeases = new DurableRuntimeLeases(join(dir, 'leases'))
     const adapter = new ClaudeRuntimeAdapter({
       run, leases: claudeLeases, ownerToken: 'server',
@@ -145,6 +148,7 @@ describe('provider lifecycle adapters', () => {
       onCreated: (_sessionId, runtimeId) => { registeredWhileLeased = claudeLeases.get(runtimeId) !== null },
     })).ok).toBe(true)
     expect(registeredWhileLeased).toBe(true)
+    expect(run).toHaveBeenCalledTimes(1)
     const created = run.mock.calls[0][0]
     expect(created.args).toEqual(['-p', '--session-id', '11111111-1111-4111-8111-111111111111', '--model', 'opus', '--output-format', 'json'])
     expect(created.args).not.toContain('secret')

--- a/src/server/provider-runtime-control-plane.test.ts
+++ b/src/server/provider-runtime-control-plane.test.ts
@@ -24,7 +24,7 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }))
 
 const record: ProviderRuntimeRecord = {
   runtimeId: 'claude:session-1', kind: 'claude_session', routeRef: 'claude-cwm4tx/opus-5',
-  accountAlias: 'Claude Max CWM', externalId: 'session-1', cwd: 'C:/repo', worktree: 'C:/repo',
+  accountAlias: 'Claude Max CWM', externalId: 'session-1', model: null, cwd: 'C:/repo', worktree: 'C:/repo',
   hostKind: 'native', hostStatus: 'running', capabilities: capabilityMatrix('claude_session', 'win32'),
   lease: null, parentRuntimeId: null, kanbanTaskId: 'task-1', createdAt: 1, updatedAt: 2,
 }
@@ -34,8 +34,17 @@ describe('provider runtime durable registry', () => {
     const registry = new ProviderRuntimeRegistry(join(dir, 'runtimes.json'))
     registry.replace([record])
     expect(registry.list()).toEqual([record])
+    registry.upsert({ ...record, hostStatus: 'idle', updatedAt: 3 })
+    expect(registry.get(record.runtimeId)).toMatchObject({ hostStatus: 'idle', updatedAt: 3 })
     const text = readFileSync(join(dir, 'runtimes.json'), 'utf8')
     for (const forbidden of ['prompt', 'transcript', 'argv', 'token', 'credential']) expect(text.toLowerCase()).not.toContain(`"${forbidden}`)
+  })
+
+  it('inserts a new runtime without overwriting an existing identity', () => {
+    const registry = new ProviderRuntimeRegistry(join(dir, 'runtimes.json'))
+    expect(registry.insertIfAbsent(record)).toBe(true)
+    expect(registry.insertIfAbsent({ ...record, accountAlias: 'collision', updatedAt: 99 })).toBe(false)
+    expect(registry.get(record.runtimeId)).toMatchObject({ accountAlias: record.accountAlias, updatedAt: 2 })
   })
 
   it('normalizes partial Claude and Codex discovery records with provenance', () => {
@@ -91,20 +100,32 @@ describe('capabilities and explicit Codex runtime selection', () => {
 describe('provider lifecycle adapters', () => {
   it('enables bounded one-shot Codex thread lifecycle while keeping active-turn controls disabled', async () => {
     const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => 10)
-    const invoke = vi.fn(async () => ({ ok: true, result: { id: 'thread-1' } }))
+    const invoke = vi.fn(async () => ({ ok: true, result: { thread: { id: 'thread-fork' } } }))
     const adapter = new CodexRuntimeAdapter({ invoke, leases, ownerToken: 'server' })
     expect(await adapter.status('thread-1')).toMatchObject({ ok: true })
     expect(invoke).toHaveBeenLastCalledWith('thread/read', { threadId: 'thread-1', includeTurns: false })
-    expect(await adapter.mutate('codex:thread-1', 'resume', {})).toMatchObject({ ok: true })
-    expect(await adapter.mutate('codex:thread-1', 'fork', {})).toMatchObject({ ok: true })
+    expect(await adapter.mutate('codex:thread-1', 'resume', { providerModel: 'gpt-5.6-sol' })).toMatchObject({ ok: true })
+    let forkRegisteredWhileLeased = false
+    expect(await adapter.mutate('codex:thread-1', 'fork', {
+      providerModel: 'gpt-5.6-sol',
+      onForkCreated: () => { forkRegisteredWhileLeased = leases.get('codex:thread-1') !== null },
+    })).toMatchObject({ ok: true })
+    expect(forkRegisteredWhileLeased).toBe(true)
     expect(await adapter.mutate('codex:thread-1', 'archive', {})).toMatchObject({ ok: true })
-    expect(invoke).toHaveBeenNthCalledWith(2, 'thread/resume', { threadId: 'thread-1' })
-    expect(invoke).toHaveBeenNthCalledWith(3, 'thread/fork', { threadId: 'thread-1' })
+    expect(invoke).toHaveBeenNthCalledWith(2, 'thread/resume', { threadId: 'thread-1', model: 'gpt-5.6-sol' })
+    expect(invoke).toHaveBeenNthCalledWith(3, 'thread/fork', { threadId: 'thread-1', model: 'gpt-5.6-sol' })
     expect(invoke).toHaveBeenNthCalledWith(4, 'thread/archive', { threadId: 'thread-1' })
     expect(await adapter.mutate('codex:thread-1', 'steer', { text: 'bounded', turnId: 'turn-7' })).toMatchObject({ ok: false })
     expect(await adapter.mutate('codex:thread-1', 'interrupt', { turnId: 'turn-7' })).toMatchObject({ ok: false })
     expect(invoke).toHaveBeenCalledTimes(4)
     expect(leases.get('codex:thread-1')).toBeNull()
+  })
+
+  it('retains an abandoned Codex lease when fork registration is ambiguous', async () => {
+    const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => 10)
+    const adapter = new CodexRuntimeAdapter({ invoke: vi.fn(async () => ({ ok: true, result: {} })), leases, ownerToken: 'server' })
+    expect(await adapter.mutate('codex:thread-2', 'fork', { onForkCreated: () => { throw new Error('registry unavailable') } })).toMatchObject({ ok: false })
+    expect(leases.get('codex:thread-2')).toMatchObject({ abandoned: true })
   })
 
   it('passes Claude prompts via stdin with official UUID resume/fork flags and strips API credentials', async () => {
@@ -115,16 +136,17 @@ describe('provider lifecycle adapters', () => {
       accountHomes: { cwm4tx: 'C:/claude-cwm' }, uuid: () => '11111111-1111-4111-8111-111111111111',
       baseEnv: { ANTHROPIC_API_KEY: 'x', ANTHROPIC_AUTH_TOKEN: 'y', CLAUDE_CODE_OAUTH_TOKEN: 'z', SAFE: '1' },
     })
-    expect((await adapter.create({ accountAlias: 'not-allowed', cwd: 'C:/repo', prompt: 'secret' })).ok).toBe(false)
+    expect((await adapter.create({ accountAlias: 'not-allowed', cwd: 'C:/repo', prompt: 'secret', model: 'opus' })).ok).toBe(false)
     expect(run).not.toHaveBeenCalled()
     let registeredWhileLeased = false
     expect((await adapter.create({
       accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'secret',
+      model: 'opus',
       onCreated: (_sessionId, runtimeId) => { registeredWhileLeased = claudeLeases.get(runtimeId) !== null },
     })).ok).toBe(true)
     expect(registeredWhileLeased).toBe(true)
     const created = run.mock.calls[0][0]
-    expect(created.args).toEqual(['-p', '--session-id', '11111111-1111-4111-8111-111111111111', '--output-format', 'json'])
+    expect(created.args).toEqual(['-p', '--session-id', '11111111-1111-4111-8111-111111111111', '--model', 'opus', '--output-format', 'json'])
     expect(created.args).not.toContain('secret')
     expect(created.stdin).toBe('secret')
     expect(created.env).toMatchObject({ HOME: 'C:/claude-cwm', USERPROFILE: 'C:/claude-cwm' })
@@ -133,12 +155,12 @@ describe('provider lifecycle adapters', () => {
     expect(created.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
     expect(created.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
 
-    await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'resume', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'continue' })
+    await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'resume', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'continue', model: 'opus' })
     expect(run.mock.calls[1][0]).toMatchObject({
-      args: ['-p', '--resume', '22222222-2222-4222-8222-222222222222', '--output-format', 'json'],
+      args: ['-p', '--resume', '22222222-2222-4222-8222-222222222222', '--model', 'opus', '--output-format', 'json'],
       stdin: 'continue',
     })
-    expect((await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'fork', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'branch' })).ok).toBe(false)
+    expect((await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'fork', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'branch', model: 'opus' })).ok).toBe(false)
     expect(run).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/server/provider-runtime-control-plane.test.ts
+++ b/src/server/provider-runtime-control-plane.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ClaudeRuntimeAdapter,
+  CodexRuntimeAdapter,
+  DurableRuntimeLeases,
+  ProviderRuntimeRegistry,
+  capabilityMatrix,
+  importClaudeAgents,
+  importCodexThreads,
+  normalizeClaudeAgents,
+  normalizeCodexThreads,
+  normalizeCodexRuntimeSelection,
+  providerRuntimeRequest,
+  type ProviderRuntimeRecord,
+} from './provider-runtime-control-plane'
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'provider-runtime-')) })
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+const record: ProviderRuntimeRecord = {
+  runtimeId: 'claude:session-1', kind: 'claude_session', routeRef: 'claude-cwm4tx/opus-5',
+  accountAlias: 'Claude Max CWM', externalId: 'session-1', cwd: 'C:/repo', worktree: 'C:/repo',
+  hostKind: 'native', hostStatus: 'running', capabilities: capabilityMatrix('claude_session', 'win32'),
+  lease: null, parentRuntimeId: null, kanbanTaskId: 'task-1', createdAt: 1, updatedAt: 2,
+}
+
+describe('provider runtime durable registry', () => {
+  it('persists only the safe metadata schema atomically', () => {
+    const registry = new ProviderRuntimeRegistry(join(dir, 'runtimes.json'))
+    registry.replace([record])
+    expect(registry.list()).toEqual([record])
+    const text = readFileSync(join(dir, 'runtimes.json'), 'utf8')
+    for (const forbidden of ['prompt', 'transcript', 'argv', 'token', 'credential']) expect(text.toLowerCase()).not.toContain(`"${forbidden}`)
+  })
+
+  it('normalizes partial Claude and Codex discovery records with provenance', () => {
+    const claude = normalizeClaudeAgents([{ id: 'abc', cwd: 'C:/repo', status: 'active' }], { accountAlias: 'Claude Max GP', routeRef: 'claude-gp/opus-5', platform: 'win32', now: 5 })
+    expect(claude[0]).toMatchObject({ runtimeId: 'claude:Claude Max GP:abc', externalId: 'abc', accountAlias: 'Claude Max GP', hostStatus: 'running' })
+    expect(claude[0].capabilities.crossSessionMessage.state).toBe('unsupported')
+    expect(claude[0].capabilities.discoverPeers.state).toBe('unsupported')
+    const codex = normalizeCodexThreads([{ id: 'thread-1', cwd: 'C:/work' }], { accountAlias: 'OpenAI Codex', routeRef: 'openai-codex/gpt-5.6-sol', now: 6 })
+    expect(codex[0]).toMatchObject({ runtimeId: 'codex:thread-1', externalId: 'thread-1', kind: 'codex_thread' })
+  })
+
+  it('imports discovery through injectable fixture-only seams', async () => {
+    const registry = new ProviderRuntimeRegistry(join(dir, 'runtimes.json'))
+    const claudeRun = vi.fn(async () => ({ ok: true, stdout: JSON.stringify([{ id: 'c1' }]), stderr: '' }))
+    await importClaudeAgents({ run: claudeRun, registry, accountAlias: 'Claude Max CWM', routeRef: 'claude-cwm4tx/opus-5', home: 'C:/home', platform: 'win32' })
+    expect(claudeRun.mock.calls[0][0]).toMatchObject({ args: ['agents', '--json', '--all'] })
+    const codexInvoke = vi.fn(async () => ({ ok: true, result: { data: [{ id: 't1' }] } }))
+    await importCodexThreads({ invoke: codexInvoke, registry, accountAlias: 'OpenAI Codex', routeRef: 'openai-codex/gpt-5.6-sol' })
+    expect(codexInvoke).toHaveBeenCalledWith('thread/list', { limit: 20 })
+    expect(registry.list().map((entry) => entry.runtimeId)).toEqual(['claude:Claude Max CWM:c1', 'codex:t1'])
+  })
+})
+
+describe('durable one-writer leases', () => {
+  it('acquires, renews, releases, rejects foreign tokens, and refuses uncertain stale takeover', () => {
+    let now = 100
+    const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => now)
+    expect(leases.acquire('codex:thread-1', 'owner-a', 10)).toMatchObject({ ok: true })
+    expect(leases.acquire('codex:thread-1', 'owner-b', 10)).toMatchObject({ ok: false })
+    expect(leases.renew('codex:thread-1', 'owner-b', 10)).toMatchObject({ ok: false })
+    expect(leases.release('codex:thread-1', 'owner-b')).toBe(false)
+    expect(leases.renew('codex:thread-1', 'owner-a', 20)).toMatchObject({ ok: true, lease: { expiresAt: 120 } })
+    now = 121
+    expect(leases.acquire('codex:thread-1', 'owner-b', 10)).toMatchObject({ ok: false })
+    expect(leases.recoverExpired('codex:thread-1')).toMatchObject({ ok: false, error: expect.stringContaining('live Workspace owner') })
+    expect(leases.abandon('codex:thread-1', 'owner-a', 10)).toBe(true)
+    now = 132
+    expect(leases.recoverExpired('codex:thread-1')).toMatchObject({ ok: true })
+    expect(leases.get('codex:thread-1')).toBeNull()
+    expect(leases.acquire('codex:thread-1', 'owner-a', 10)).toMatchObject({ ok: true })
+    expect(leases.release('codex:thread-1', 'owner-a')).toBe(true)
+  })
+})
+
+describe('capabilities and explicit Codex runtime selection', () => {
+  it('marks direct messaging deferred and preserves unknown legacy selection safely', () => {
+    expect(capabilityMatrix('codex_thread', 'win32').crossSessionMessage).toMatchObject({ state: 'unsupported', deferred: true })
+    expect(normalizeCodexRuntimeSelection(undefined)).toEqual({ configured: 'hermes_default', effective: 'hermes_default', known: true })
+    expect(normalizeCodexRuntimeSelection('future_runtime')).toEqual({ configured: 'future_runtime', effective: 'hermes_default', known: false })
+  })
+})
+
+describe('provider lifecycle adapters', () => {
+  it('enables bounded one-shot Codex thread lifecycle while keeping active-turn controls disabled', async () => {
+    const leases = new DurableRuntimeLeases(join(dir, 'leases'), () => 10)
+    const invoke = vi.fn(async () => ({ ok: true, result: { id: 'thread-1' } }))
+    const adapter = new CodexRuntimeAdapter({ invoke, leases, ownerToken: 'server' })
+    expect(await adapter.status('thread-1')).toMatchObject({ ok: true })
+    expect(invoke).toHaveBeenLastCalledWith('thread/read', { threadId: 'thread-1', includeTurns: false })
+    expect(await adapter.mutate('codex:thread-1', 'resume', {})).toMatchObject({ ok: true })
+    expect(await adapter.mutate('codex:thread-1', 'fork', {})).toMatchObject({ ok: true })
+    expect(await adapter.mutate('codex:thread-1', 'archive', {})).toMatchObject({ ok: true })
+    expect(invoke).toHaveBeenNthCalledWith(2, 'thread/resume', { threadId: 'thread-1' })
+    expect(invoke).toHaveBeenNthCalledWith(3, 'thread/fork', { threadId: 'thread-1' })
+    expect(invoke).toHaveBeenNthCalledWith(4, 'thread/archive', { threadId: 'thread-1' })
+    expect(await adapter.mutate('codex:thread-1', 'steer', { text: 'bounded', turnId: 'turn-7' })).toMatchObject({ ok: false })
+    expect(await adapter.mutate('codex:thread-1', 'interrupt', { turnId: 'turn-7' })).toMatchObject({ ok: false })
+    expect(invoke).toHaveBeenCalledTimes(4)
+    expect(leases.get('codex:thread-1')).toBeNull()
+  })
+
+  it('passes Claude prompts via stdin with official UUID resume/fork flags and strips API credentials', async () => {
+    const run = vi.fn(async () => ({ ok: true, stdout: '{"session_id":"11111111-1111-4111-8111-111111111111"}', stderr: '' }))
+    const claudeLeases = new DurableRuntimeLeases(join(dir, 'leases'))
+    const adapter = new ClaudeRuntimeAdapter({
+      run, leases: claudeLeases, ownerToken: 'server',
+      accountHomes: { cwm4tx: 'C:/claude-cwm' }, uuid: () => '11111111-1111-4111-8111-111111111111',
+      baseEnv: { ANTHROPIC_API_KEY: 'x', ANTHROPIC_AUTH_TOKEN: 'y', CLAUDE_CODE_OAUTH_TOKEN: 'z', SAFE: '1' },
+    })
+    expect((await adapter.create({ accountAlias: 'not-allowed', cwd: 'C:/repo', prompt: 'secret' })).ok).toBe(false)
+    expect(run).not.toHaveBeenCalled()
+    let registeredWhileLeased = false
+    expect((await adapter.create({
+      accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'secret',
+      onCreated: (_sessionId, runtimeId) => { registeredWhileLeased = claudeLeases.get(runtimeId) !== null },
+    })).ok).toBe(true)
+    expect(registeredWhileLeased).toBe(true)
+    const created = run.mock.calls[0][0]
+    expect(created.args).toEqual(['-p', '--session-id', '11111111-1111-4111-8111-111111111111', '--output-format', 'json'])
+    expect(created.args).not.toContain('secret')
+    expect(created.stdin).toBe('secret')
+    expect(created.env).toMatchObject({ HOME: 'C:/claude-cwm', USERPROFILE: 'C:/claude-cwm' })
+    expect(created.env.SAFE).toBeUndefined()
+    expect(created.env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(created.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(created.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
+
+    await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'resume', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'continue' })
+    expect(run.mock.calls[1][0]).toMatchObject({
+      args: ['-p', '--resume', '22222222-2222-4222-8222-222222222222', '--output-format', 'json'],
+      stdin: 'continue',
+    })
+    expect((await adapter.mutate('claude:cwm4tx:22222222-2222-4222-8222-222222222222', 'fork', { accountAlias: 'cwm4tx', cwd: 'C:/repo', prompt: 'branch' })).ok).toBe(false)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('guarded provider runtime API seam', () => {
+  it('denies every mutation before JSON parsing or side effects', async () => {
+    const parse = vi.fn(async () => ({ action: 'steer' }))
+    const mutate = vi.fn()
+    const response = await providerRuntimeRequest({ method: 'POST', authorized: false, parseJson: parse, list: () => [], mutate })
+    expect(response.status).toBe(401)
+    expect(parse).not.toHaveBeenCalled()
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it('bounds mutating input before invoking an adapter', async () => {
+    const mutate = vi.fn(async () => ({ ok: true }))
+    const response = await providerRuntimeRequest({
+      method: 'POST', authorized: true, list: () => [], mutate,
+      parseJson: async () => ({ runtimeId: 'codex:thread-1', action: 'steer', text: 'x'.repeat(40_000) }),
+    })
+    expect(response.status).toBe(400)
+    expect(mutate).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/provider-runtime-control-plane.ts
+++ b/src/server/provider-runtime-control-plane.ts
@@ -1,0 +1,369 @@
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { dirname, join } from 'node:path'
+
+export type RuntimeKind = 'hermes_profile' | 'claude_session' | 'codex_thread'
+export type CapabilityState = 'supported' | 'degraded' | 'experimental' | 'unsupported'
+export type RuntimeOperation = 'create' | 'resume' | 'fork' | 'send' | 'steer' | 'interrupt' | 'status' | 'list' | 'archive' | 'attach' | 'discoverPeers' | 'crossSessionMessage'
+export type RuntimeCapability = { state: CapabilityState; explanation: string; deferred?: boolean }
+export type RuntimeCapabilities = Record<RuntimeOperation, RuntimeCapability>
+export type RuntimeLeaseMetadata = { owner: string; expiresAt: number; acquiredAt: number; processId?: number }
+
+export type ProviderRuntimeRecord = {
+  runtimeId: string
+  kind: RuntimeKind
+  routeRef: string | null
+  accountAlias: string
+  externalId: string
+  cwd: string | null
+  worktree: string | null
+  hostKind: 'native' | 'tmux' | 'stdio' | 'external' | 'unknown'
+  hostStatus: 'running' | 'stopped' | 'idle' | 'unknown'
+  capabilities: RuntimeCapabilities
+  lease: RuntimeLeaseMetadata | null
+  parentRuntimeId: string | null
+  kanbanTaskId: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+const operations: Array<RuntimeOperation> = ['create', 'resume', 'fork', 'send', 'steer', 'interrupt', 'status', 'list', 'archive', 'attach', 'discoverPeers', 'crossSessionMessage']
+const unsupportedMessaging: RuntimeCapability = { state: 'unsupported', explanation: 'Deferred until provider-native stability is proven.', deferred: true }
+const PROVIDER_CHILD_ENV_KEYS = new Set(['PATH', 'PATHEXT', 'SystemRoot', 'WINDIR', 'COMSPEC', 'TEMP', 'TMP', 'APPDATA', 'LOCALAPPDATA', 'LANG', 'LC_ALL', 'NO_COLOR'])
+
+export function capabilityMatrix(kind: RuntimeKind, platform: NodeJS.Platform = process.platform): RuntimeCapabilities {
+  const result = Object.fromEntries(operations.map((operation) => [operation, { state: 'unsupported', explanation: 'Not exposed by this runtime adapter.' }])) as RuntimeCapabilities
+  result.status = { state: 'supported', explanation: 'Read-only metadata status is available.' }
+  result.list = { state: 'supported', explanation: 'Read-only inventory is available.' }
+  result.crossSessionMessage = unsupportedMessaging
+  if (kind === 'hermes_profile') {
+    for (const operation of ['create', 'resume', 'send', 'interrupt', 'attach'] as const) result[operation] = { state: 'supported', explanation: 'Owned by the Hermes worker process host.' }
+    result.fork = { state: 'degraded', explanation: 'Forking uses a new Hermes profile rather than provider-native state.' }
+  } else if (kind === 'codex_thread') {
+    for (const operation of ['resume', 'fork', 'archive'] as const) result[operation] = { state: 'experimental', explanation: 'Schema-verified through a bounded local app-server request; prompts and remote transport are not used.' }
+    for (const operation of ['steer', 'interrupt'] as const) result[operation] = { state: 'unsupported', explanation: 'Disabled until Workspace owns one persistent app-server connection for the active turn.' }
+    result.create = { state: 'unsupported', explanation: 'Select model.openai_runtime=codex_app_server for the next Hermes profile restart.' }
+    result.attach = { state: 'degraded', explanation: 'Attach exposes metadata; Hermes does not take over the provider tool loop.' }
+  } else {
+    for (const operation of ['create', 'resume', 'attach'] as const) result[operation] = { state: 'experimental', explanation: 'Available through an isolated Claude CLI process.' }
+    result.fork = { state: 'unsupported', explanation: 'Disabled until the new fork UUID can be captured and registered distinctly.' }
+    result.interrupt = { state: 'unsupported', explanation: 'No verified graceful interrupt channel is owned by Workspace.' }
+    result.send = { state: 'degraded', explanation: 'Input is available only while Workspace owns the child stdin.' }
+    result.archive = { state: 'degraded', explanation: 'Archive is represented as stopped metadata.' }
+    result.discoverPeers = platform === 'win32'
+      ? { state: 'unsupported', explanation: 'Claude ListAgents is not claimed on Windows.' }
+      : { state: 'experimental', explanation: 'Discovery is read-only and fixture-tested.' }
+  }
+  return result
+}
+
+function atomicWrite(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const temp = `${path}.${process.pid}.${randomUUID()}.tmp`
+  writeFileSync(temp, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+  renameSync(temp, path)
+}
+
+function safeRecord(value: ProviderRuntimeRecord): ProviderRuntimeRecord {
+  return {
+    runtimeId: value.runtimeId, kind: value.kind, routeRef: value.routeRef, accountAlias: value.accountAlias,
+    externalId: value.externalId, cwd: value.cwd, worktree: value.worktree, hostKind: value.hostKind,
+    hostStatus: value.hostStatus, capabilities: value.capabilities, lease: value.lease,
+    parentRuntimeId: value.parentRuntimeId, kanbanTaskId: value.kanbanTaskId,
+    createdAt: value.createdAt, updatedAt: value.updatedAt,
+  }
+}
+
+export class ProviderRuntimeRegistry {
+  constructor(private readonly file: string) {}
+  list(): Array<ProviderRuntimeRecord> {
+    if (!existsSync(this.file)) return []
+    const parsed = JSON.parse(readFileSync(this.file, 'utf8')) as { version?: unknown; runtimes?: unknown }
+    if (parsed.version !== 1 || !Array.isArray(parsed.runtimes)) throw new Error('Provider runtime registry is corrupt or unsupported')
+    return (parsed.runtimes as Array<ProviderRuntimeRecord>).map(safeRecord).sort((a, b) => a.runtimeId.localeCompare(b.runtimeId))
+  }
+  get(runtimeId: string): ProviderRuntimeRecord | null { return this.list().find((entry) => entry.runtimeId === runtimeId) ?? null }
+  private locked<T>(operation: () => T): T {
+    mkdirSync(dirname(this.file), { recursive: true })
+    const lock = `${this.file}.lock`
+    let fd: number
+    try { fd = openSync(lock, 'wx') } catch { throw new Error('Provider runtime registry is busy; refusing an unlocked write') }
+    try { return operation() } finally { closeSync(fd); try { unlinkSync(lock) } catch { /* leftover lock fails closed */ } }
+  }
+  replace(records: Array<ProviderRuntimeRecord>): void {
+    this.locked(() => atomicWrite(this.file, { version: 1, runtimes: records.map(safeRecord) }))
+  }
+  merge(records: Array<ProviderRuntimeRecord>): void {
+    this.locked(() => {
+      const byId = new Map(this.list().map((entry) => [entry.runtimeId, entry]))
+      for (const record of records) byId.set(record.runtimeId, safeRecord(record))
+      atomicWrite(this.file, { version: 1, runtimes: [...byId.values()].map(safeRecord) })
+    })
+  }
+}
+
+function leaseFile(root: string, identity: string): string {
+  const encoded = Buffer.from(identity, 'utf8').toString('base64url')
+  if (!identity || encoded.length > 180) throw new Error('Invalid runtime identity')
+  return join(root, `${encoded}.lease.json`)
+}
+
+export class DurableRuntimeLeases {
+  constructor(private readonly root: string, private readonly now: () => number = () => Date.now()) {}
+  get(identity: string): RuntimeLeaseMetadata | null {
+    try { return JSON.parse(readFileSync(leaseFile(this.root, identity), 'utf8')) as RuntimeLeaseMetadata } catch { return null }
+  }
+  acquire(identity: string, owner: string, ttlMs: number): { ok: boolean; lease?: RuntimeLeaseMetadata; staleTakeover?: boolean; error?: string } {
+    if (!owner || !Number.isFinite(ttlMs) || ttlMs <= 0) return { ok: false, error: 'Invalid lease request' }
+    mkdirSync(this.root, { recursive: true })
+    const file = leaseFile(this.root, identity)
+    const current = this.get(identity)
+    if (current) {
+      if (current.expiresAt > this.now()) return { ok: false, lease: current, error: 'Runtime already has a writer' }
+      return { ok: false, lease: current, error: 'Expired lease requires explicit operator recovery; automatic takeover is disabled' }
+    }
+    const lease = { owner, acquiredAt: this.now(), expiresAt: this.now() + ttlMs, processId: process.pid }
+    try {
+      const fd = openSync(file, 'wx')
+      try { writeFileSync(fd, `${JSON.stringify(lease)}\n`, 'utf8') } finally { closeSync(fd) }
+      return { ok: true, lease, staleTakeover: false }
+    } catch { return { ok: false, error: 'Runtime already has a writer' } }
+  }
+  renew(identity: string, owner: string, ttlMs: number): { ok: boolean; lease?: RuntimeLeaseMetadata; error?: string } {
+    const releaseLock = this.lockIdentity(identity)
+    try {
+      const current = this.get(identity)
+      if (!current || current.owner !== owner) return { ok: false, error: 'Foreign lease' }
+      const lease = { ...current, expiresAt: this.now() + ttlMs }
+      atomicWrite(leaseFile(this.root, identity), lease)
+      return { ok: true, lease }
+    } finally { releaseLock() }
+  }
+  release(identity: string, owner: string): boolean {
+    const releaseLock = this.lockIdentity(identity)
+    try {
+      const current = this.get(identity)
+      if (!current || current.owner !== owner) return false
+      try { unlinkSync(leaseFile(this.root, identity)); return true } catch { return false }
+    } finally { releaseLock() }
+  }
+  recoverExpired(identity: string): { ok: boolean; error?: string } {
+    const releaseLock = this.lockIdentity(identity)
+    try {
+      const current = this.get(identity)
+      if (!current) return { ok: true }
+      if (current.expiresAt > this.now()) return { ok: false, error: 'Active lease cannot be recovered' }
+      if (current.processId && isProcessAlive(current.processId)) return { ok: false, error: 'Expired timestamp belongs to a live Workspace owner; recovery refused' }
+      try { unlinkSync(leaseFile(this.root, identity)); return { ok: true } } catch { return { ok: false, error: 'Expired lease recovery failed' } }
+    } finally { releaseLock() }
+  }
+  abandon(identity: string, owner: string, ttlMs = 30_000): boolean {
+    const releaseLock = this.lockIdentity(identity)
+    try {
+      const current = this.get(identity)
+      if (!current || current.owner !== owner) return false
+      atomicWrite(leaseFile(this.root, identity), { ...current, processId: undefined, expiresAt: this.now() + ttlMs })
+      return true
+    } finally { releaseLock() }
+  }
+  private lockIdentity(identity: string): () => void {
+    mkdirSync(this.root, { recursive: true })
+    const path = `${leaseFile(this.root, identity)}.lock`
+    let fd: number
+    try { fd = openSync(path, 'wx') } catch { throw new Error('Runtime lease is busy') }
+    return () => { closeSync(fd); try { unlinkSync(path) } catch { /* fail closed on the next mutation */ } }
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true } catch { return false }
+}
+
+type NormalizeOptions = { accountAlias: string; routeRef: string | null; now?: number; platform?: NodeJS.Platform }
+function text(value: unknown): string | null { return typeof value === 'string' && value.trim() ? value.trim() : null }
+function status(value: unknown): ProviderRuntimeRecord['hostStatus'] { return value === 'active' || value === 'running' ? 'running' : value === 'stopped' ? 'stopped' : value === 'idle' ? 'idle' : 'unknown' }
+
+export function normalizeClaudeAgents(input: unknown, options: NormalizeOptions): Array<ProviderRuntimeRecord> {
+  if (!Array.isArray(input)) return []
+  const now = options.now ?? Date.now()
+  return input.flatMap((item) => {
+    if (!item || typeof item !== 'object') return []
+    const raw = item as Record<string, unknown>; const id = text(raw.id) ?? text(raw.session_id) ?? text(raw.sessionId)
+    if (!id) return []
+    return [{ runtimeId: `claude:${options.accountAlias}:${id}`, kind: 'claude_session' as const, routeRef: options.routeRef, accountAlias: options.accountAlias,
+      externalId: id, cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'external' as const,
+      hostStatus: status(raw.status), capabilities: capabilityMatrix('claude_session', options.platform), lease: null,
+      parentRuntimeId: text(raw.parentRuntimeId), kanbanTaskId: text(raw.kanbanTaskId), createdAt: Number(raw.createdAt) || now, updatedAt: now }]
+  })
+}
+
+export function normalizeCodexThreads(input: unknown, options: NormalizeOptions): Array<ProviderRuntimeRecord> {
+  const rows = Array.isArray(input) ? input : (input && typeof input === 'object' && Array.isArray((input as { data?: unknown }).data) ? (input as { data: Array<unknown> }).data : [])
+  const now = options.now ?? Date.now()
+  return rows.flatMap((item) => {
+    if (!item || typeof item !== 'object') return []
+    const raw = item as Record<string, unknown>; const id = text(raw.id) ?? text(raw.threadId)
+    if (!id) return []
+    return [{ runtimeId: `codex:${id}`, kind: 'codex_thread' as const, routeRef: options.routeRef, accountAlias: options.accountAlias,
+      externalId: id, cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'stdio' as const,
+      hostStatus: status(raw.status), capabilities: capabilityMatrix('codex_thread'), lease: null,
+      parentRuntimeId: text(raw.parentRuntimeId), kanbanTaskId: text(raw.kanbanTaskId), createdAt: Number(raw.createdAt) || now, updatedAt: now }]
+  })
+}
+
+export type CodexRuntimeSelection = 'hermes_default' | 'codex_app_server'
+export function normalizeCodexRuntimeSelection(value: unknown): { configured: string; effective: CodexRuntimeSelection; known: boolean } {
+  if (value === undefined || value === null || value === '') return { configured: 'hermes_default', effective: 'hermes_default', known: true }
+  if (value === 'hermes_default' || value === 'codex_app_server') return { configured: value, effective: value, known: true }
+  return { configured: String(value), effective: 'hermes_default', known: false }
+}
+
+export type CodexInvoke = (method: string, params: Record<string, unknown>) => Promise<{ ok: boolean; result?: unknown; error?: string }>
+
+export async function importClaudeAgents(input: {
+  run: ClaudeRun
+  registry: ProviderRuntimeRegistry
+  accountAlias: string
+  routeRef: string | null
+  home: string
+  platform?: NodeJS.Platform
+}): Promise<{ ok: boolean; count: number; error?: string }> {
+  const env = { ...process.env, HOME: input.home, USERPROFILE: input.home }
+  delete env.ANTHROPIC_API_KEY
+  delete env.ANTHROPIC_AUTH_TOKEN
+  delete env.CLAUDE_CODE_OAUTH_TOKEN
+  const result = await input.run({ command: 'claude', args: ['agents', '--json', '--all'], cwd: input.home, env })
+  if (!result.ok) return { ok: false, count: 0, error: result.stderr.slice(0, 2_000) }
+  try {
+    const records = normalizeClaudeAgents(JSON.parse(result.stdout), input)
+    input.registry.merge(records)
+    return { ok: true, count: records.length }
+  } catch { return { ok: false, count: 0, error: 'Claude discovery returned invalid JSON' } }
+}
+
+export async function importCodexThreads(input: {
+  invoke: CodexInvoke
+  registry: ProviderRuntimeRegistry
+  accountAlias: string
+  routeRef: string | null
+}): Promise<{ ok: boolean; count: number; error?: string }> {
+  const result = await input.invoke('thread/list', { limit: 20 })
+  if (!result.ok) return { ok: false, count: 0, error: result.error?.slice(0, 2_000) }
+  const records = normalizeCodexThreads(result.result, input)
+  input.registry.merge(records)
+  return { ok: true, count: records.length }
+}
+
+export class CodexRuntimeAdapter {
+  constructor(private readonly deps: { invoke: CodexInvoke; leases: DurableRuntimeLeases; ownerToken: string; ttlMs?: number }) {}
+  list() { return this.deps.invoke('thread/list', {}) }
+  status(threadId: string) { return this.deps.invoke('thread/read', { threadId, includeTurns: false }) }
+  async mutate(runtimeId: string, action: 'resume' | 'fork' | 'steer' | 'interrupt' | 'archive', input: Record<string, unknown>) {
+    if (capabilityMatrix('codex_thread')[action].state === 'unsupported') return { ok: false, error: capabilityMatrix('codex_thread')[action].explanation }
+    const threadId = runtimeId.startsWith('codex:') ? runtimeId.slice(6) : ''
+    if (!threadId || threadId.length > 256) return { ok: false, error: 'Invalid Codex runtime ID' }
+    let method: string
+    let params: Record<string, unknown>
+    if (action === 'steer') {
+      const turnId = text(input.turnId)
+      const message = text(input.text)
+      if (!turnId || !message || message.length > 32_000) return { ok: false, error: 'Codex steer requires a bounded active turn and text' }
+      method = 'turn/steer'
+      params = { threadId, expectedTurnId: turnId, input: [{ type: 'text', text: message, text_elements: [] }] }
+    } else if (action === 'interrupt') {
+      const turnId = text(input.turnId)
+      if (!turnId) return { ok: false, error: 'Codex interrupt requires an active turn ID' }
+      method = 'turn/interrupt'
+      params = { threadId, turnId }
+    } else {
+      method = { resume: 'thread/resume', fork: 'thread/fork', archive: 'thread/archive' }[action]
+      params = { threadId }
+    }
+    const acquired = this.deps.leases.acquire(runtimeId, this.deps.ownerToken, this.deps.ttlMs ?? 30_000)
+    if (!acquired.ok) return acquired
+    try { return await this.deps.invoke(method, params) }
+    finally { this.deps.leases.release(runtimeId, this.deps.ownerToken) }
+  }
+}
+
+export type ClaudeRun = (input: { command: string; args: Array<string>; cwd: string; env: Record<string, string | undefined>; stdin?: string }) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+export class ClaudeRuntimeAdapter {
+  constructor(private readonly deps: { run: ClaudeRun; leases: DurableRuntimeLeases; ownerToken: string; accountHomes: Record<string, string>; baseEnv?: Record<string, string | undefined>; claudeBin?: string; uuid?: () => string }) {}
+  private env(alias: string) {
+    const home = this.deps.accountHomes[alias]
+    if (!home) return null
+    const source = this.deps.baseEnv ?? process.env
+    const env: Record<string, string | undefined> = { HOME: home, USERPROFILE: home }
+    for (const [key, value] of Object.entries(source)) if (PROVIDER_CHILD_ENV_KEYS.has(key)) env[key] = value
+    return env
+  }
+  async list(accountAlias: string) {
+    const env = this.env(accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
+    return this.deps.run({ command: this.deps.claudeBin ?? 'claude', args: ['agents', '--json', '--all'], cwd: env.HOME ?? '.', env })
+  }
+  async create(input: { accountAlias: string; cwd: string; prompt: string; background?: boolean; sessionId?: string; onCreated?: (sessionId: string, runtimeId: string) => void }) {
+    if (input.background) return { ok: false, error: 'Background launch requires durable process ownership and is not enabled' }
+    const env = this.env(input.accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
+    if (!input.cwd || input.cwd.length > 1024 || !input.prompt || input.prompt.length > 32_000) return { ok: false, error: 'Invalid Claude request' }
+    const sessionId = input.sessionId ?? (this.deps.uuid ?? randomUUID)()
+    const identity = `claude:${input.accountAlias}:${sessionId}`
+    const acquired = this.deps.leases.acquire(identity, this.deps.ownerToken, 30_000); if (!acquired.ok) return acquired
+    let releaseLease = true
+    const heartbeat = setInterval(() => { try { this.deps.leases.renew(identity, this.deps.ownerToken, 30_000) } catch { /* live owner PID keeps stale recovery fail-closed */ } }, 10_000)
+    heartbeat.unref?.()
+    try {
+      const args = ['-p', '--session-id', sessionId, '--output-format', 'json']
+      const result = await this.deps.run({ command: this.deps.claudeBin ?? 'claude', args, cwd: input.cwd, env, stdin: input.prompt })
+      if (!result.ok) return { ok: false, error: result.stderr.slice(0, 2_000) }
+      try { input.onCreated?.(sessionId, identity) } catch {
+        releaseLease = false
+        this.deps.leases.abandon(identity, this.deps.ownerToken)
+        return { ok: false, error: 'Claude session was created but durable registration failed; lease retained for explicit recovery' }
+      }
+      return { ok: true, runtimeId: identity, sessionId, result: result.stdout }
+    } finally {
+      clearInterval(heartbeat)
+      if (releaseLease) this.deps.leases.release(identity, this.deps.ownerToken)
+    }
+  }
+  async mutate(runtimeId: string, action: 'resume' | 'fork' | 'attach', input: { accountAlias: string; cwd: string; prompt?: string }) {
+    if (capabilityMatrix('claude_session')[action].state === 'unsupported') return { ok: false, error: capabilityMatrix('claude_session')[action].explanation }
+    const env = this.env(input.accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
+    const externalId = runtimeId.split(':').at(-1) ?? ''
+    if (!externalId || externalId.length > 256 || (input.prompt?.length ?? 0) > 32_000) return { ok: false, error: 'Invalid Claude runtime request' }
+    const acquired = this.deps.leases.acquire(runtimeId, this.deps.ownerToken, 30_000); if (!acquired.ok) return acquired
+    if (action === 'attach') {
+      this.deps.leases.release(runtimeId, this.deps.ownerToken)
+      return { ok: true, attach: { command: this.deps.claudeBin ?? 'claude', args: ['--resume', externalId], cwd: input.cwd } }
+    }
+    const args = ['-p', '--resume', externalId]
+    if (action === 'fork') args.push('--fork-session')
+    args.push('--output-format', 'json')
+    const heartbeat = setInterval(() => { try { this.deps.leases.renew(runtimeId, this.deps.ownerToken, 30_000) } catch { /* live owner PID keeps stale recovery fail-closed */ } }, 10_000)
+    heartbeat.unref?.()
+    try {
+      const result = await this.deps.run({ command: this.deps.claudeBin ?? 'claude', args, cwd: input.cwd, env, stdin: input.prompt })
+      return result.ok ? { ok: true, result: result.stdout } : { ok: false, error: result.stderr.slice(0, 2_000) }
+    } finally { clearInterval(heartbeat); this.deps.leases.release(runtimeId, this.deps.ownerToken) }
+  }
+}
+
+type ApiResult = { status: number; body: Record<string, unknown> }
+export async function providerRuntimeRequest(input: {
+  method: string; authorized: boolean; parseJson?: () => Promise<unknown>; list: () => Array<ProviderRuntimeRecord>;
+  mutate: (body: Record<string, unknown>) => Promise<unknown>
+}): Promise<ApiResult> {
+  if (!input.authorized) return { status: 401, body: { ok: false, error: 'Unauthorized' } }
+  if (input.method === 'GET') return { status: 200, body: { ok: true, runtimes: input.list(), directProviderMessaging: { enabled: false, state: 'deferred', explanation: unsupportedMessaging.explanation }, codexRuntimeChoices: [
+    { value: 'hermes_default', label: 'Hermes default', explanation: 'Hermes owns tools and the worker lifecycle.' },
+    { value: 'codex_app_server', label: 'Codex app server', explanation: 'Codex owns its provider-native thread and tool loop through local stdio.' },
+  ] } }
+  let body: unknown
+  try { body = await input.parseJson?.() } catch { return { status: 400, body: { ok: false, error: 'Invalid JSON body' } } }
+  if (!body || typeof body !== 'object') return { status: 400, body: { ok: false, error: 'Invalid request' } }
+  const raw = body as Record<string, unknown>
+  const createsClaudeRuntime = raw.action === 'create' || raw.action === 'background'
+  if ((typeof raw.runtimeId !== 'string' && !createsClaudeRuntime) || (typeof raw.runtimeId === 'string' && raw.runtimeId.length > 300) || typeof raw.action !== 'string' || raw.action.length > 32 || (typeof raw.text === 'string' && raw.text.length > 32_000)) return { status: 400, body: { ok: false, error: 'Invalid or oversized request' } }
+  const result = await input.mutate(raw)
+  return { status: 200, body: { ok: true, result } }
+}

--- a/src/server/provider-runtime-control-plane.ts
+++ b/src/server/provider-runtime-control-plane.ts
@@ -7,7 +7,13 @@ export type CapabilityState = 'supported' | 'degraded' | 'experimental' | 'unsup
 export type RuntimeOperation = 'create' | 'resume' | 'fork' | 'send' | 'steer' | 'interrupt' | 'status' | 'list' | 'archive' | 'attach' | 'discoverPeers' | 'crossSessionMessage'
 export type RuntimeCapability = { state: CapabilityState; explanation: string; deferred?: boolean }
 export type RuntimeCapabilities = Record<RuntimeOperation, RuntimeCapability>
-export type RuntimeLeaseMetadata = { owner: string; expiresAt: number; acquiredAt: number; processId?: number }
+export type RuntimeLeaseMetadata = {
+  owner: string
+  expiresAt: number
+  acquiredAt: number
+  processId?: number
+  abandoned?: boolean
+}
 
 export type ProviderRuntimeRecord = {
   runtimeId: string
@@ -15,6 +21,7 @@ export type ProviderRuntimeRecord = {
   routeRef: string | null
   accountAlias: string
   externalId: string
+  model?: string | null
   cwd: string | null
   worktree: string | null
   hostKind: 'native' | 'tmux' | 'stdio' | 'external' | 'unknown'
@@ -67,7 +74,7 @@ function atomicWrite(path: string, value: unknown): void {
 function safeRecord(value: ProviderRuntimeRecord): ProviderRuntimeRecord {
   return {
     runtimeId: value.runtimeId, kind: value.kind, routeRef: value.routeRef, accountAlias: value.accountAlias,
-    externalId: value.externalId, cwd: value.cwd, worktree: value.worktree, hostKind: value.hostKind,
+    externalId: value.externalId, model: value.model ?? null, cwd: value.cwd, worktree: value.worktree, hostKind: value.hostKind,
     hostStatus: value.hostStatus, capabilities: value.capabilities, lease: value.lease,
     parentRuntimeId: value.parentRuntimeId, kanbanTaskId: value.kanbanTaskId,
     createdAt: value.createdAt, updatedAt: value.updatedAt,
@@ -92,6 +99,15 @@ export class ProviderRuntimeRegistry {
   }
   replace(records: Array<ProviderRuntimeRecord>): void {
     this.locked(() => atomicWrite(this.file, { version: 1, runtimes: records.map(safeRecord) }))
+  }
+  upsert(record: ProviderRuntimeRecord): void { this.merge([record]) }
+  insertIfAbsent(record: ProviderRuntimeRecord): boolean {
+    return this.locked(() => {
+      const current = this.list()
+      if (current.some((entry) => entry.runtimeId === record.runtimeId)) return false
+      atomicWrite(this.file, { version: 1, runtimes: [...current, safeRecord(record)] })
+      return true
+    })
   }
   merge(records: Array<ProviderRuntimeRecord>): void {
     this.locked(() => {
@@ -162,7 +178,7 @@ export class DurableRuntimeLeases {
     try {
       const current = this.get(identity)
       if (!current || current.owner !== owner) return false
-      atomicWrite(leaseFile(this.root, identity), { ...current, processId: undefined, expiresAt: this.now() + ttlMs })
+      atomicWrite(leaseFile(this.root, identity), { ...current, abandoned: true, processId: undefined, expiresAt: this.now() + ttlMs })
       return true
     } finally { releaseLock() }
   }
@@ -191,7 +207,7 @@ export function normalizeClaudeAgents(input: unknown, options: NormalizeOptions)
     const raw = item as Record<string, unknown>; const id = text(raw.id) ?? text(raw.session_id) ?? text(raw.sessionId)
     if (!id) return []
     return [{ runtimeId: `claude:${options.accountAlias}:${id}`, kind: 'claude_session' as const, routeRef: options.routeRef, accountAlias: options.accountAlias,
-      externalId: id, cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'external' as const,
+      externalId: id, model: text(raw.model), cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'external' as const,
       hostStatus: status(raw.status), capabilities: capabilityMatrix('claude_session', options.platform), lease: null,
       parentRuntimeId: text(raw.parentRuntimeId), kanbanTaskId: text(raw.kanbanTaskId), createdAt: Number(raw.createdAt) || now, updatedAt: now }]
   })
@@ -205,7 +221,7 @@ export function normalizeCodexThreads(input: unknown, options: NormalizeOptions)
     const raw = item as Record<string, unknown>; const id = text(raw.id) ?? text(raw.threadId)
     if (!id) return []
     return [{ runtimeId: `codex:${id}`, kind: 'codex_thread' as const, routeRef: options.routeRef, accountAlias: options.accountAlias,
-      externalId: id, cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'stdio' as const,
+      externalId: id, model: text(raw.model), cwd: text(raw.cwd), worktree: text(raw.worktree) ?? text(raw.cwd), hostKind: 'stdio' as const,
       hostStatus: status(raw.status), capabilities: capabilityMatrix('codex_thread'), lease: null,
       parentRuntimeId: text(raw.parentRuntimeId), kanbanTaskId: text(raw.kanbanTaskId), createdAt: Number(raw.createdAt) || now, updatedAt: now }]
   })
@@ -228,7 +244,7 @@ export async function importClaudeAgents(input: {
   home: string
   platform?: NodeJS.Platform
 }): Promise<{ ok: boolean; count: number; error?: string }> {
-  const env = { ...process.env, HOME: input.home, USERPROFILE: input.home }
+  const env: Record<string, string | undefined> = { ...process.env, HOME: input.home, USERPROFILE: input.home }
   delete env.ANTHROPIC_API_KEY
   delete env.ANTHROPIC_AUTH_TOKEN
   delete env.CLAUDE_CODE_OAUTH_TOKEN
@@ -277,12 +293,25 @@ export class CodexRuntimeAdapter {
       params = { threadId, turnId }
     } else {
       method = { resume: 'thread/resume', fork: 'thread/fork', archive: 'thread/archive' }[action]
-      params = { threadId }
+      const model = text(input.providerModel)
+      params = action === 'archive' || !model ? { threadId } : { threadId, model }
     }
     const acquired = this.deps.leases.acquire(runtimeId, this.deps.ownerToken, this.deps.ttlMs ?? 30_000)
     if (!acquired.ok) return acquired
-    try { return await this.deps.invoke(method, params) }
-    finally { this.deps.leases.release(runtimeId, this.deps.ownerToken) }
+    let releaseLease = true
+    try {
+      const result = await this.deps.invoke(method, params)
+      if (result.ok && action === 'fork' && typeof input.onForkCreated === 'function') {
+        try { await (input.onForkCreated as (result: unknown) => unknown)(result.result) } catch {
+          releaseLease = false
+          this.deps.leases.abandon(runtimeId, this.deps.ownerToken)
+          return { ok: false, error: 'Codex fork succeeded but durable registration failed; lease retained for explicit recovery' }
+        }
+      }
+      return result
+    } finally {
+      if (releaseLease) this.deps.leases.release(runtimeId, this.deps.ownerToken)
+    }
   }
 }
 
@@ -301,10 +330,10 @@ export class ClaudeRuntimeAdapter {
     const env = this.env(accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
     return this.deps.run({ command: this.deps.claudeBin ?? 'claude', args: ['agents', '--json', '--all'], cwd: env.HOME ?? '.', env })
   }
-  async create(input: { accountAlias: string; cwd: string; prompt: string; background?: boolean; sessionId?: string; onCreated?: (sessionId: string, runtimeId: string) => void }) {
+  async create(input: { accountAlias: string; cwd: string; prompt: string; model: string; background?: boolean; sessionId?: string; onCreated?: (sessionId: string, runtimeId: string) => void }) {
     if (input.background) return { ok: false, error: 'Background launch requires durable process ownership and is not enabled' }
     const env = this.env(input.accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
-    if (!input.cwd || input.cwd.length > 1024 || !input.prompt || input.prompt.length > 32_000) return { ok: false, error: 'Invalid Claude request' }
+    if (!input.cwd || input.cwd.length > 1024 || !input.prompt || input.prompt.length > 32_000 || !input.model || input.model.length > 200) return { ok: false, error: 'Invalid Claude request' }
     const sessionId = input.sessionId ?? (this.deps.uuid ?? randomUUID)()
     const identity = `claude:${input.accountAlias}:${sessionId}`
     const acquired = this.deps.leases.acquire(identity, this.deps.ownerToken, 30_000); if (!acquired.ok) return acquired
@@ -312,7 +341,7 @@ export class ClaudeRuntimeAdapter {
     const heartbeat = setInterval(() => { try { this.deps.leases.renew(identity, this.deps.ownerToken, 30_000) } catch { /* live owner PID keeps stale recovery fail-closed */ } }, 10_000)
     heartbeat.unref?.()
     try {
-      const args = ['-p', '--session-id', sessionId, '--output-format', 'json']
+      const args = ['-p', '--session-id', sessionId, '--model', input.model, '--output-format', 'json']
       const result = await this.deps.run({ command: this.deps.claudeBin ?? 'claude', args, cwd: input.cwd, env, stdin: input.prompt })
       if (!result.ok) return { ok: false, error: result.stderr.slice(0, 2_000) }
       try { input.onCreated?.(sessionId, identity) } catch {
@@ -326,17 +355,17 @@ export class ClaudeRuntimeAdapter {
       if (releaseLease) this.deps.leases.release(identity, this.deps.ownerToken)
     }
   }
-  async mutate(runtimeId: string, action: 'resume' | 'fork' | 'attach', input: { accountAlias: string; cwd: string; prompt?: string }) {
+  async mutate(runtimeId: string, action: 'resume' | 'fork' | 'attach', input: { accountAlias: string; cwd: string; prompt?: string; model: string }) {
     if (capabilityMatrix('claude_session')[action].state === 'unsupported') return { ok: false, error: capabilityMatrix('claude_session')[action].explanation }
     const env = this.env(input.accountAlias); if (!env) return { ok: false, error: 'Account alias is not allowlisted' }
     const externalId = runtimeId.split(':').at(-1) ?? ''
-    if (!externalId || externalId.length > 256 || (input.prompt?.length ?? 0) > 32_000) return { ok: false, error: 'Invalid Claude runtime request' }
+    if (!externalId || externalId.length > 256 || (input.prompt?.length ?? 0) > 32_000 || !input.model || input.model.length > 200) return { ok: false, error: 'Invalid Claude runtime request' }
     const acquired = this.deps.leases.acquire(runtimeId, this.deps.ownerToken, 30_000); if (!acquired.ok) return acquired
     if (action === 'attach') {
       this.deps.leases.release(runtimeId, this.deps.ownerToken)
-      return { ok: true, attach: { command: this.deps.claudeBin ?? 'claude', args: ['--resume', externalId], cwd: input.cwd } }
+      return { ok: true, attach: { command: this.deps.claudeBin ?? 'claude', args: ['--resume', externalId, '--model', input.model], cwd: input.cwd } }
     }
-    const args = ['-p', '--resume', externalId]
+    const args = ['-p', '--resume', externalId, '--model', input.model]
     if (action === 'fork') args.push('--fork-session')
     args.push('--output-format', 'json')
     const heartbeat = setInterval(() => { try { this.deps.leases.renew(runtimeId, this.deps.ownerToken, 30_000) } catch { /* live owner PID keeps stale recovery fail-closed */ } }, 10_000)

--- a/src/server/provider-runtime-control-plane.ts
+++ b/src/server/provider-runtime-control-plane.ts
@@ -47,7 +47,8 @@ export function capabilityMatrix(kind: RuntimeKind, platform: NodeJS.Platform = 
     for (const operation of ['create', 'resume', 'send', 'interrupt', 'attach'] as const) result[operation] = { state: 'supported', explanation: 'Owned by the Hermes worker process host.' }
     result.fork = { state: 'degraded', explanation: 'Forking uses a new Hermes profile rather than provider-native state.' }
   } else if (kind === 'codex_thread') {
-    for (const operation of ['resume', 'fork', 'archive'] as const) result[operation] = { state: 'experimental', explanation: 'Schema-verified through a bounded local app-server request; prompts and remote transport are not used.' }
+    for (const operation of ['resume', 'archive'] as const) result[operation] = { state: 'experimental', explanation: 'Schema-verified through a bounded local app-server request; prompts and remote transport are not used.' }
+    result.fork = { state: 'unsupported', explanation: 'Disabled until provider fork identity has crash-safe durable recovery or idempotency.', deferred: true }
     for (const operation of ['steer', 'interrupt'] as const) result[operation] = { state: 'unsupported', explanation: 'Disabled until Workspace owns one persistent app-server connection for the active turn.' }
     result.create = { state: 'unsupported', explanation: 'Select model.openai_runtime=codex_app_server for the next Hermes profile restart.' }
     result.attach = { state: 'degraded', explanation: 'Attach exposes metadata; Hermes does not take over the provider tool loop.' }
@@ -56,7 +57,7 @@ export function capabilityMatrix(kind: RuntimeKind, platform: NodeJS.Platform = 
     result.fork = { state: 'unsupported', explanation: 'Disabled until the new fork UUID can be captured and registered distinctly.' }
     result.interrupt = { state: 'unsupported', explanation: 'No verified graceful interrupt channel is owned by Workspace.' }
     result.send = { state: 'degraded', explanation: 'Input is available only while Workspace owns the child stdin.' }
-    result.archive = { state: 'degraded', explanation: 'Archive is represented as stopped metadata.' }
+    result.archive = { state: 'unsupported', explanation: 'Archive is not implemented by the isolated Claude runtime adapter.' }
     result.discoverPeers = platform === 'win32'
       ? { state: 'unsupported', explanation: 'Claude ListAgents is not claimed on Windows.' }
       : { state: 'experimental', explanation: 'Discovery is read-only and fixture-tested.' }

--- a/src/server/provider-runtime-service.test.ts
+++ b/src/server/provider-runtime-service.test.ts
@@ -4,10 +4,43 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   codexThreadIdFromResult,
   createCodexStdioInvoker,
+  hydrateRuntimeLeases,
   resolveCliLaunch,
   resolveConfiguredAccountHomes,
+  runtimeKindMatchesId,
   validateCodexForkThreadId,
 } from './provider-runtime-service'
+import type { ProviderRuntimeRecord } from './provider-runtime-control-plane'
+
+describe('runtime dispatch identity', () => {
+  it('accepts only exact persisted-kind and runtime-ID-prefix pairs', () => {
+    expect(runtimeKindMatchesId({ kind: 'hermes_profile', runtimeId: 'hermes:worker-a' })).toBe(true)
+    expect(runtimeKindMatchesId({ kind: 'claude_session', runtimeId: 'claude:cwm4tx:session-1' })).toBe(true)
+    expect(runtimeKindMatchesId({ kind: 'codex_thread', runtimeId: 'codex:thread-1' })).toBe(true)
+    expect(runtimeKindMatchesId({ kind: 'stale_kind', runtimeId: 'codex:thread-1' } as never)).toBe(false)
+    expect(runtimeKindMatchesId({ kind: 'claude_session', runtimeId: 'codex:thread-1' })).toBe(false)
+    expect(runtimeKindMatchesId({ kind: 'codex_thread', runtimeId: 'unknown:thread-1' })).toBe(false)
+  })
+})
+
+describe('authoritative runtime lease projection', () => {
+  it('overlays durable leases without mutating registry records', () => {
+    const record = {
+      runtimeId: 'codex:thread-1', kind: 'codex_thread', routeRef: null, accountAlias: 'openai-codex',
+      externalId: 'thread-1', model: null, cwd: null, worktree: null, hostKind: 'stdio', hostStatus: 'idle',
+      capabilities: {}, lease: null, parentRuntimeId: null, kanbanTaskId: null, createdAt: 1, updatedAt: 2,
+    } as ProviderRuntimeRecord
+    const lease = { owner: 'workspace-1', acquiredAt: 3, expiresAt: 4, abandoned: true }
+    const getLease = vi.fn(() => lease)
+
+    const hydrated = hydrateRuntimeLeases([record], getLease)
+
+    expect(hydrated[0]).toEqual({ ...record, lease })
+    expect(hydrated[0]).not.toBe(record)
+    expect(record.lease).toBeNull()
+    expect(getLease).toHaveBeenCalledWith('codex:thread-1')
+  })
+})
 
 describe('Codex lifecycle result normalization', () => {
   it('extracts only a non-empty forked thread identity', () => {

--- a/src/server/provider-runtime-service.test.ts
+++ b/src/server/provider-runtime-service.test.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createCodexStdioInvoker,
+  resolveCliLaunch,
+  resolveConfiguredAccountHomes,
+} from './provider-runtime-service'
+
+describe('Codex stdio app-server transport', () => {
+  it('initializes the 0.147 protocol before sending the requested method and closes the child', async () => {
+    const stdout = new EventEmitter()
+    const stderr = new EventEmitter()
+    const writes: Array<Record<string, unknown>> = []
+    const child = {
+      stdout,
+      stderr,
+      stdin: {
+        write: vi.fn((line: string) => {
+          const message = JSON.parse(line) as Record<string, unknown>
+          writes.push(message)
+          if (message.id === 1) queueMicrotask(() => stdout.emit('data', '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"codex"}}}\n'))
+          if (message.id === 2) queueMicrotask(() => stdout.emit('data', '{"jsonrpc":"2.0","id":2,"result":{"data":[]}}\n'))
+          return true
+        }),
+        end: vi.fn(),
+      },
+      on: vi.fn(),
+      kill: vi.fn(),
+    }
+    const spawnProcess = vi.fn(() => child)
+    const invoke = createCodexStdioInvoker({
+      spawnProcess: spawnProcess as never,
+      timeoutMs: 1_000,
+      codexBin: 'C:/tools/codex.exe',
+      codexHome: 'C:/oauth/codex',
+      baseEnv: { PATH: 'safe', OPENAI_API_KEY: 'paid', ANTHROPIC_API_KEY: 'paid', CODEX_HOME: 'C:/ambient/wrong' },
+    })
+
+    await expect(invoke('thread/list', {})).resolves.toEqual({ ok: true, result: { data: [] } })
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'C:/tools/codex.exe',
+      ['app-server'],
+      expect.objectContaining({ shell: false, stdio: ['pipe', 'pipe', 'pipe'] }),
+    )
+    const childEnv = spawnProcess.mock.calls[0]?.[2]?.env as Record<string, string | undefined>
+    expect(childEnv).toMatchObject({ PATH: 'safe', CODEX_HOME: 'C:/oauth/codex' })
+    expect(childEnv.OPENAI_API_KEY).toBeUndefined()
+    expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(writes).toEqual([
+      {
+        id: 1, method: 'initialize',
+        params: { clientInfo: { name: 'hermes-workspace', version: '2.3.0' }, capabilities: { experimentalApi: true } },
+      },
+      { method: 'initialized' },
+      { id: 2, method: 'thread/list', params: {} },
+    ])
+    expect(child.stdin.end).toHaveBeenCalled()
+    expect(child.kill).toHaveBeenCalled()
+  })
+})
+
+describe('Claude account-home allowlist resolution', () => {
+  it('resolves npm CLI shims to executable launches without enabling a shell on Windows', () => {
+    const root = 'C:\\Users\\u\\AppData\\Roaming\\npm'
+    const exists = (path: string) => path.endsWith('claude.exe') || path.endsWith('codex.js')
+    expect(resolveCliLaunch('claude', [], 'win32', { APPDATA: 'C:\\Users\\u\\AppData\\Roaming' }, exists, 'C:\\node.exe'))
+      .toEqual({ command: `${root}\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe`, args: [] })
+    expect(resolveCliLaunch('codex', ['app-server'], 'win32', { APPDATA: 'C:\\Users\\u\\AppData\\Roaming' }, exists, 'C:\\node.exe'))
+      .toEqual({ command: 'C:\\node.exe', args: [`${root}\\node_modules\\@openai\\codex\\bin\\codex.js`, 'app-server'] })
+    expect(resolveCliLaunch('D:\\tools\\codex.exe', ['x'], 'win32', {}, () => false, 'C:\\node.exe'))
+      .toEqual({ command: 'D:\\tools\\codex.exe', args: ['x'] })
+  })
+
+  it('accepts only configured existing homes and conventional Windows homes', () => {
+    const exists = vi.fn((path: string) => ['D:\\ClaudeHomes\\cwm4tx', 'E:\\ClaudeGP'].includes(path))
+    expect(resolveConfiguredAccountHomes({
+      CLAUDE_CWM4TX_HOME: 'D:\\ClaudeHomes\\cwm4tx',
+      CLAUDE_GP_HOME: 'E:\\ClaudeGP',
+      HERMES_CLAUDE_ACCOUNT_HOMES_JSON: '{"ignored":"Z:\\\\missing","bad":5}',
+    }, 'win32', exists)).toEqual({ cwm4tx: 'D:\\ClaudeHomes\\cwm4tx', gp: 'E:\\ClaudeGP' })
+  })
+})

--- a/src/server/provider-runtime-service.test.ts
+++ b/src/server/provider-runtime-service.test.ts
@@ -2,10 +2,29 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  codexThreadIdFromResult,
   createCodexStdioInvoker,
   resolveCliLaunch,
   resolveConfiguredAccountHomes,
+  validateCodexForkThreadId,
 } from './provider-runtime-service'
+
+describe('Codex lifecycle result normalization', () => {
+  it('extracts only a non-empty forked thread identity', () => {
+    expect(codexThreadIdFromResult({ thread: { id: 'fork-123' } })).toBe('fork-123')
+    expect(codexThreadIdFromResult({ thread: {} })).toBeNull()
+    expect(codexThreadIdFromResult(null)).toBeNull()
+  })
+
+  it('rejects oversized, self-referential, and colliding fork identities', () => {
+    const exists = (runtimeId: string) => runtimeId === 'codex:already-owned'
+    expect(() => validateCodexForkThreadId('source', 'source', exists)).toThrow(/source/i)
+    expect(() => validateCodexForkThreadId('source', 'x'.repeat(257), exists)).toThrow(/invalid/i)
+    expect(() => validateCodexForkThreadId('source', 'bad/thread', exists)).toThrow(/invalid/i)
+    expect(() => validateCodexForkThreadId('source', 'already-owned', exists)).toThrow(/already registered/i)
+    expect(validateCodexForkThreadId('source', 'new-thread', exists)).toBe('new-thread')
+  })
+})
 
 describe('Codex stdio app-server transport', () => {
   it('initializes the 0.147 protocol before sending the requested method and closes the child', async () => {
@@ -78,6 +97,24 @@ describe('Claude account-home allowlist resolution', () => {
       CLAUDE_CWM4TX_HOME: 'D:\\ClaudeHomes\\cwm4tx',
       CLAUDE_GP_HOME: 'E:\\ClaudeGP',
       HERMES_CLAUDE_ACCOUNT_HOMES_JSON: '{"ignored":"Z:\\\\missing","bad":5}',
-    }, 'win32', exists)).toEqual({ cwm4tx: 'D:\\ClaudeHomes\\cwm4tx', gp: 'E:\\ClaudeGP' })
+    }, 'win32', exists, {
+      canonicalize: (path) => path,
+      isDirectory: () => true,
+      isLink: () => false,
+    })).toEqual({ cwm4tx: 'D:\\ClaudeHomes\\cwm4tx', gp: 'E:\\ClaudeGP' })
+  })
+
+  it('rejects linked and duplicate canonical account homes', () => {
+    const env = { CLAUDE_CWM4TX_HOME: 'D:\\ClaudeHomes\\cwm4tx', CLAUDE_GP_HOME: 'D:\\ClaudeHomes\\gp' }
+    const base = { isDirectory: () => true, isLink: () => false }
+    expect(() => resolveConfiguredAccountHomes(env, 'win32', () => true, {
+      ...base,
+      canonicalize: () => 'D:\\ClaudeHomes\\shared',
+    })).toThrow(/distinct canonical/)
+    expect(resolveConfiguredAccountHomes(env, 'win32', () => true, {
+      ...base,
+      canonicalize: (path) => path,
+      isLink: (path) => path.toLowerCase().endsWith('\\gp'),
+    })).toEqual({ cwm4tx: 'D:\\ClaudeHomes\\cwm4tx' })
   })
 })

--- a/src/server/provider-runtime-service.ts
+++ b/src/server/provider-runtime-service.ts
@@ -1,8 +1,8 @@
 import { execFileSync, spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { existsSync, realpathSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, win32 } from 'node:path'
+import { join, posix, win32 } from 'node:path'
 
 import { getStateDir } from './workspace-state-dir'
 import { buildSafeChildEnv, getWorkerProcessHost } from './worker-process-host'
@@ -20,8 +20,29 @@ import {
 } from './provider-runtime-control-plane'
 
 const MAX_DIAGNOSTIC = 2_000
-const MAX_STDIO = 2_000_000
+const MAX_STDIO = 2 * 1024 * 1024
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function codexThreadIdFromResult(result: unknown): string | null {
+  if (!result || typeof result !== 'object') return null
+  const thread = (result as { thread?: unknown }).thread
+  if (!thread || typeof thread !== 'object') return null
+  const id = (thread as { id?: unknown }).id
+  return typeof id === 'string' && id.trim() ? id.trim() : null
+}
+
+export function validateCodexForkThreadId(
+  sourceThreadId: string,
+  candidateThreadId: string,
+  runtimeExists: (runtimeId: string) => boolean,
+): string {
+  if (!candidateThreadId || candidateThreadId.length > 256 || !/^[A-Za-z0-9._:-]+$/.test(candidateThreadId)) {
+    throw new Error('Invalid Codex fork thread identity')
+  }
+  if (candidateThreadId === sourceThreadId) throw new Error('Codex fork returned the source thread identity')
+  if (runtimeExists(`codex:${candidateThreadId}`)) throw new Error('Codex fork thread is already registered')
+  return candidateThreadId
+}
 
 function verifiedWorktree(path: string): string | null {
   try {
@@ -65,6 +86,11 @@ export function resolveConfiguredAccountHomes(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
   pathExists: (path: string) => boolean = existsSync,
+  validation: {
+    canonicalize?: (path: string) => string
+    isDirectory?: (path: string) => boolean
+    isLink?: (path: string) => boolean
+  } = {},
 ): Record<string, string> {
   const candidates: Record<string, string> = {}
   try {
@@ -82,9 +108,30 @@ export function resolveConfiguredAccountHomes(
     candidates.cwm4tx ||= 'D:\\ClaudeHomes\\cwm4tx'
     candidates.gp ||= 'D:\\ClaudeHomes\\gp'
   }
-  return Object.fromEntries(
-    Object.entries(candidates).filter(([, home]) => home.length > 0 && home.length <= 1024 && pathExists(home)),
-  )
+  const pathApi = platform === 'win32' ? win32 : posix
+  const canonicalize = validation.canonicalize ?? ((path: string) => realpathSync.native(path))
+  const isDirectory = validation.isDirectory ?? ((path: string) => statSync(path).isDirectory())
+  const isLink = validation.isLink ?? ((path: string) => lstatSync(path).isSymbolicLink())
+  const resolved: Record<string, string> = {}
+  const identities = new Set<string>()
+  for (const [alias, home] of Object.entries(candidates)) {
+    if (!home || home.length > 1024 || !pathApi.isAbsolute(home) || !pathExists(home) || !isDirectory(home)) continue
+    const absolute = pathApi.resolve(home)
+    const root = pathApi.parse(absolute).root
+    let current = root
+    let linked = false
+    for (const segment of absolute.slice(root.length).split(pathApi.sep).filter(Boolean)) {
+      current = pathApi.join(current, segment)
+      if (isLink(current)) { linked = true; break }
+    }
+    if (linked) continue
+    const canonical = canonicalize(absolute)
+    const identity = platform === 'win32' ? canonical.toLowerCase() : canonical
+    if (identities.has(identity)) throw new Error('Claude account homes must resolve to distinct canonical directories')
+    identities.add(identity)
+    resolved[alias] = canonical
+  }
+  return resolved
 }
 
 function claudeRunner(): ClaudeRun {
@@ -183,15 +230,15 @@ export function getProviderRuntimeService(): RuntimeService {
     recoverLease: (runtimeId) => leases.recoverExpired(runtimeId),
     async refresh() {
       const workerRecords = await getWorkerProcessHost().list()
-      for (const worker of workerRecords) registry.upsert({
+      for (const worker of workerRecords) registry.merge([{
         runtimeId: `hermes:${worker.workerId}`,
         kind: 'hermes_profile', routeRef: null, accountAlias: 'hermes', externalId: worker.workerId,
         cwd: worker.cwd, worktree: worker.cwd, hostKind: worker.hostKind,
-        hostStatus: worker.status === 'starting' ? 'unknown' : worker.status,
+        hostStatus: worker.status,
         capabilities: capabilityMatrix('hermes_profile'), lease: null,
         parentRuntimeId: null, kanbanTaskId: null,
         createdAt: worker.startedAt ?? worker.updatedAt, updatedAt: worker.updatedAt,
-      })
+      }])
       const claudeImports = Object.entries(accountHomes).map(async ([accountAlias, home]) => ({
         source: `claude:${accountAlias}`,
         ...(await importClaudeAgents({ run: runClaude, registry, accountAlias, routeRef: null, home })),
@@ -210,6 +257,7 @@ export function getProviderRuntimeService(): RuntimeService {
       if (action === 'background') return { ok: false, error: 'Background Claude launch is disabled until durable writer ownership can be tracked' }
       const routeRef = typeof body.routeRef === 'string' ? body.routeRef : ''
       const accountAlias = typeof body.accountAlias === 'string' ? body.accountAlias : ''
+      const providerModel = typeof body.providerModel === 'string' ? body.providerModel.trim() : ''
       const existing = runtimeId ? registry.get(runtimeId) : null
       if (runtimeId && !existing) return { ok: false, error: 'Runtime must be imported or created before lifecycle mutation' }
       if (action === 'link_kanban' && existing) {
@@ -220,6 +268,7 @@ export function getProviderRuntimeService(): RuntimeService {
       }
       if (existing?.routeRef && existing.routeRef !== routeRef) return { ok: false, error: 'Runtime routeRef does not match the requested route' }
       if (existing?.kind === 'claude_session' && existing.accountAlias !== accountAlias) return { ok: false, error: 'Runtime account identity does not match' }
+      if (!providerModel || providerModel.length > 200) return { ok: false, error: 'A validated provider model is required' }
 
       const requestedCwd = typeof body.cwd === 'string' ? body.cwd : ''
       const requestedWorktree = typeof body.worktree === 'string' ? body.worktree : ''
@@ -231,11 +280,40 @@ export function getProviderRuntimeService(): RuntimeService {
       }
 
       if (runtimeId.startsWith('codex:') && ['resume', 'fork', 'steer', 'interrupt', 'archive'].includes(action)) {
+        let forkRuntimeId: string | null = null
         const result = await codex.mutate(runtimeId, action as 'resume' | 'fork' | 'steer' | 'interrupt' | 'archive', {
+          providerModel,
           ...(typeof body.text === 'string' ? { text: body.text } : {}),
           ...(typeof body.turnId === 'string' ? { turnId: body.turnId } : {}),
+          ...(action === 'fork' && existing ? { onForkCreated: (providerResult: unknown) => {
+            const returnedForkId = codexThreadIdFromResult(providerResult)
+            if (!returnedForkId) throw new Error('Codex fork response did not include a thread identity')
+            const forkId = validateCodexForkThreadId(existing.externalId, returnedForkId, (id) => registry.get(id) !== null)
+            const now = Date.now()
+            forkRuntimeId = `codex:${forkId}`
+            const inserted = registry.insertIfAbsent({
+              ...existing, runtimeId: forkRuntimeId, externalId: forkId, routeRef, model: providerModel,
+              cwd: cwd || existing.cwd, worktree: worktree || existing.worktree, hostStatus: 'idle',
+              parentRuntimeId: existing.runtimeId, createdAt: now, updatedAt: now,
+            })
+            if (!inserted) throw new Error('Codex fork thread is already registered')
+          } } : {}),
         })
-        if (result.ok && existing) registry.merge([{ ...existing, routeRef, cwd: cwd || existing.cwd, worktree: worktree || existing.worktree, updatedAt: Date.now() }])
+        if (result.ok && existing) {
+          if (action === 'fork') {
+            if (!forkRuntimeId) return { ok: false, error: 'Codex fork registration was not confirmed' }
+            return { ...result, runtimeId: forkRuntimeId }
+          }
+          registry.merge([{
+            ...existing,
+            routeRef: action === 'archive' ? existing.routeRef : routeRef,
+            model: action === 'archive' ? existing.model : providerModel,
+            cwd: cwd || existing.cwd,
+            worktree: worktree || existing.worktree,
+            hostStatus: action === 'archive' ? 'stopped' : existing.hostStatus,
+            updatedAt: Date.now(),
+          }])
+        }
         return result
       }
       const prompt = typeof body.prompt === 'string' ? body.prompt : (typeof body.text === 'string' ? body.text : '')
@@ -249,6 +327,7 @@ export function getProviderRuntimeService(): RuntimeService {
           accountAlias,
           cwd,
           prompt,
+          model: providerModel,
           background: action === 'background',
           sessionId: requestId,
           onCreated: (sessionId, createdRuntimeId) => {
@@ -259,6 +338,7 @@ export function getProviderRuntimeService(): RuntimeService {
               routeRef,
               accountAlias,
               externalId: sessionId,
+              model: providerModel,
               cwd,
               worktree,
               hostKind: 'external',
@@ -275,8 +355,8 @@ export function getProviderRuntimeService(): RuntimeService {
         return result
       }
       if (runtimeId.startsWith('claude:') && ['resume', 'fork', 'attach'].includes(action)) {
-        const result = await claude.mutate(runtimeId, action as 'resume' | 'fork' | 'attach', { accountAlias, cwd, prompt })
-        if (result.ok && existing) registry.merge([{ ...existing, routeRef, cwd, worktree, updatedAt: Date.now() }])
+        const result = await claude.mutate(runtimeId, action as 'resume' | 'fork' | 'attach', { accountAlias, cwd, prompt, model: providerModel })
+        if (result.ok && existing) registry.merge([{ ...existing, routeRef, model: providerModel, cwd, worktree, updatedAt: Date.now() }])
         return result
       }
       return { ok: false, error: 'Unsupported runtime lifecycle action' }

--- a/src/server/provider-runtime-service.ts
+++ b/src/server/provider-runtime-service.ts
@@ -11,13 +11,11 @@ import {
   CodexRuntimeAdapter,
   DurableRuntimeLeases,
   ProviderRuntimeRegistry,
+  capabilityMatrix,
   importClaudeAgents,
   importCodexThreads,
-  capabilityMatrix,
-  type ClaudeRun,
-  type CodexInvoke,
-  type ProviderRuntimeRecord,
 } from './provider-runtime-control-plane'
+import type { ClaudeRun, CodexInvoke, ProviderRuntimeRecord } from './provider-runtime-control-plane'
 
 const MAX_DIAGNOSTIC = 2_000
 const MAX_STDIO = 2 * 1024 * 1024
@@ -53,10 +51,10 @@ function verifiedWorktree(path: string): string | null {
 }
 
 type RuntimeService = {
-  list(): Array<ProviderRuntimeRecord>
-  refresh(): Promise<Array<{ source: string; ok: boolean; count: number; error?: string }>>
-  mutate(body: Record<string, unknown>): Promise<unknown>
-  recoverLease(runtimeId: string): { ok: boolean; error?: string }
+  list: () => Array<ProviderRuntimeRecord>
+  refresh: () => Promise<Array<{ source: string; ok: boolean; count: number; error?: string }>>
+  mutate: (body: Record<string, unknown>) => Promise<unknown>
+  recoverLease: (runtimeId: string) => { ok: boolean; error?: string }
 }
 
 export function resolveCliLaunch(
@@ -212,6 +210,27 @@ export function createCodexStdioInvoker(input: {
   })
 }
 
+export function hydrateRuntimeLeases(
+  records: Array<ProviderRuntimeRecord>,
+  getLease: (runtimeId: string) => ProviderRuntimeRecord['lease'],
+): Array<ProviderRuntimeRecord> {
+  return records.map((record) => ({ ...record, lease: getLease(record.runtimeId) }))
+}
+
+export function runtimeKindMatchesId(record: Pick<ProviderRuntimeRecord, 'kind' | 'runtimeId'>): boolean {
+  const prefixes: Record<string, string> = {
+    hermes_profile: 'hermes',
+    claude_session: 'claude',
+    codex_thread: 'codex',
+  }
+  const prefix = prefixes[String(record.kind)]
+  return typeof prefix === 'string' && record.runtimeId.startsWith(`${prefix}:`)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
 let singleton: RuntimeService | null = null
 
 export function getProviderRuntimeService(): RuntimeService {
@@ -226,7 +245,7 @@ export function getProviderRuntimeService(): RuntimeService {
   const codex = new CodexRuntimeAdapter({ invoke: invokeCodex, leases, ownerToken })
   const claude = new ClaudeRuntimeAdapter({ run: runClaude, leases, ownerToken, accountHomes })
   singleton = {
-    list: () => registry.list(),
+    list: () => hydrateRuntimeLeases(registry.list(), (runtimeId) => leases.get(runtimeId)),
     recoverLease: (runtimeId) => leases.recoverExpired(runtimeId),
     async refresh() {
       const workerRecords = await getWorkerProcessHost().list()
@@ -237,7 +256,7 @@ export function getProviderRuntimeService(): RuntimeService {
         hostStatus: worker.status,
         capabilities: capabilityMatrix('hermes_profile'), lease: null,
         parentRuntimeId: null, kanbanTaskId: null,
-        createdAt: worker.startedAt ?? worker.updatedAt, updatedAt: worker.updatedAt,
+        createdAt: worker.startedAt, updatedAt: worker.updatedAt,
       }])
       const claudeImports = Object.entries(accountHomes).map(async ([accountAlias, home]) => ({
         source: `claude:${accountAlias}`,
@@ -266,6 +285,7 @@ export function getProviderRuntimeService(): RuntimeService {
         registry.merge([{ ...existing, kanbanTaskId: taskId || null, updatedAt: Date.now() }])
         return { ok: true, runtimeId, kanbanTaskId: taskId || null }
       }
+      if (existing && !runtimeKindMatchesId(existing)) return { ok: false, error: 'Runtime kind and identity do not match' }
       if (existing?.routeRef && existing.routeRef !== routeRef) return { ok: false, error: 'Runtime routeRef does not match the requested route' }
       if (existing?.kind === 'claude_session' && existing.accountAlias !== accountAlias) return { ok: false, error: 'Runtime account identity does not match' }
       if (!providerModel || providerModel.length > 200) return { ok: false, error: 'A validated provider model is required' }
@@ -301,7 +321,7 @@ export function getProviderRuntimeService(): RuntimeService {
         })
         if (result.ok && existing) {
           if (action === 'fork') {
-            if (!forkRuntimeId) return { ok: false, error: 'Codex fork registration was not confirmed' }
+            if (!isNonEmptyString(forkRuntimeId)) return { ok: false, error: 'Codex fork registration was not confirmed' }
             return { ...result, runtimeId: forkRuntimeId }
           }
           registry.merge([{

--- a/src/server/provider-runtime-service.ts
+++ b/src/server/provider-runtime-service.ts
@@ -1,0 +1,288 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { existsSync, realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, win32 } from 'node:path'
+
+import { getStateDir } from './workspace-state-dir'
+import { buildSafeChildEnv, getWorkerProcessHost } from './worker-process-host'
+import {
+  ClaudeRuntimeAdapter,
+  CodexRuntimeAdapter,
+  DurableRuntimeLeases,
+  ProviderRuntimeRegistry,
+  importClaudeAgents,
+  importCodexThreads,
+  capabilityMatrix,
+  type ClaudeRun,
+  type CodexInvoke,
+  type ProviderRuntimeRecord,
+} from './provider-runtime-control-plane'
+
+const MAX_DIAGNOSTIC = 2_000
+const MAX_STDIO = 2_000_000
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function verifiedWorktree(path: string): string | null {
+  try {
+    const canonical = realpathSync(path)
+    const top = String(execFileSync('git', ['-C', canonical, 'rev-parse', '--show-toplevel'], { encoding: 'utf8', windowsHide: true })).trim()
+    return realpathSync(top) === canonical ? canonical : null
+  } catch { return null }
+}
+
+type RuntimeService = {
+  list(): Array<ProviderRuntimeRecord>
+  refresh(): Promise<Array<{ source: string; ok: boolean; count: number; error?: string }>>
+  mutate(body: Record<string, unknown>): Promise<unknown>
+  recoverLease(runtimeId: string): { ok: boolean; error?: string }
+}
+
+export function resolveCliLaunch(
+  command: string,
+  args: Array<string>,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+  nodeBin: string = process.execPath,
+): { command: string; args: Array<string> } {
+  if (platform !== 'win32' || /[\\/]/.test(command) || /\.(?:exe)$/i.test(command)) return { command, args }
+  const appData = env.APPDATA?.trim()
+  if (!appData) return { command, args }
+  const npmRoot = win32.join(appData, 'npm', 'node_modules')
+  if (command === 'claude') {
+    const binary = win32.join(npmRoot, '@anthropic-ai', 'claude-code', 'bin', 'claude.exe')
+    if (pathExists(binary)) return { command: binary, args }
+  }
+  if (command === 'codex') {
+    const script = win32.join(npmRoot, '@openai', 'codex', 'bin', 'codex.js')
+    if (pathExists(script)) return { command: nodeBin, args: [script, ...args] }
+  }
+  return { command, args }
+}
+
+export function resolveConfiguredAccountHomes(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  pathExists: (path: string) => boolean = existsSync,
+): Record<string, string> {
+  const candidates: Record<string, string> = {}
+  try {
+    const parsed = JSON.parse(env.HERMES_CLAUDE_ACCOUNT_HOMES_JSON ?? '{}') as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const alias of ['cwm4tx', 'gp']) {
+        const value = (parsed as Record<string, unknown>)[alias]
+        if (typeof value === 'string') candidates[alias] = value.trim()
+      }
+    }
+  } catch { /* malformed optional JSON contributes no homes */ }
+  if (env.CLAUDE_CWM4TX_HOME?.trim()) candidates.cwm4tx = env.CLAUDE_CWM4TX_HOME.trim()
+  if (env.CLAUDE_GP_HOME?.trim()) candidates.gp = env.CLAUDE_GP_HOME.trim()
+  if (platform === 'win32') {
+    candidates.cwm4tx ||= 'D:\\ClaudeHomes\\cwm4tx'
+    candidates.gp ||= 'D:\\ClaudeHomes\\gp'
+  }
+  return Object.fromEntries(
+    Object.entries(candidates).filter(([, home]) => home.length > 0 && home.length <= 1024 && pathExists(home)),
+  )
+}
+
+function claudeRunner(): ClaudeRun {
+  return (input) => new Promise((resolve) => {
+    const launch = resolveCliLaunch(input.command, input.args)
+    const child = spawn(launch.command, launch.args, { cwd: input.cwd, env: buildSafeChildEnv(input.env), shell: false, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''; let stderr = ''; let done = false
+    const finish = (result: { ok: boolean; stdout: string; stderr: string }) => { if (!done) { done = true; resolve(result) } }
+    child.stdout.on('data', (chunk) => { if (stdout.length < MAX_STDIO) stdout += String(chunk).slice(0, MAX_STDIO - stdout.length) })
+    child.stderr.on('data', (chunk) => { if (stderr.length < MAX_DIAGNOSTIC) stderr += String(chunk).slice(0, MAX_DIAGNOSTIC - stderr.length) })
+    child.on('error', () => finish({ ok: false, stdout: '', stderr: 'Claude process failed to start' }))
+    child.on('exit', (code) => finish({ ok: code === 0, stdout, stderr }))
+    if (input.stdin !== undefined) child.stdin.end(input.stdin); else child.stdin.end()
+  })
+}
+
+type SpawnProcess = typeof spawn
+
+export function createCodexStdioInvoker(input: {
+  spawnProcess?: SpawnProcess
+  timeoutMs?: number
+  codexBin?: string
+  baseEnv?: Record<string, string | undefined>
+  codexHome?: string
+} = {}): CodexInvoke {
+  const spawnProcess = input.spawnProcess ?? spawn
+  return (method, params) => new Promise((resolve) => {
+    const launch = resolveCliLaunch(input.codexBin ?? process.env.CODEX_CLI_BIN ?? 'codex', ['app-server'])
+    const child = spawnProcess(launch.command, launch.args, {
+      shell: false,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: buildSafeChildEnv(input.baseEnv ?? process.env, {
+        HOME: homedir(), USERPROFILE: homedir(), CODEX_HOME: input.codexHome ?? join(homedir(), '.codex'),
+      }),
+    })
+    let buffer = ''
+    let stderr = ''
+    let done = false
+    let initialized = false
+    const finish = (result: { ok: boolean; result?: unknown; error?: string }) => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      child.stdin.end()
+      child.kill()
+      resolve(result)
+    }
+    const timer = setTimeout(() => finish({ ok: false, error: 'Codex app-server timed out' }), input.timeoutMs ?? 30_000)
+    child.stdout.on('data', (chunk) => {
+      if (buffer.length >= MAX_STDIO) return finish({ ok: false, error: 'Codex app-server response exceeded the limit' })
+      buffer += String(chunk).slice(0, MAX_STDIO - buffer.length)
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
+      for (const line of lines) {
+        if (!line.trim()) continue
+        let message: { id?: unknown; result?: unknown; error?: { message?: unknown } }
+        try { message = JSON.parse(line) as typeof message } catch { continue }
+        if (message.id === 1 && !initialized) {
+          if (message.error) return finish({ ok: false, error: 'Codex app-server initialization failed' })
+          initialized = true
+          child.stdin.write(`${JSON.stringify({ method: 'initialized' })}\n`)
+          child.stdin.write(`${JSON.stringify({ id: 2, method, params })}\n`)
+        } else if (message.id === 2) {
+          if (message.error) finish({ ok: false, error: typeof message.error.message === 'string' ? message.error.message.slice(0, MAX_DIAGNOSTIC) : 'Codex app-server error' })
+          else finish({ ok: true, result: message.result })
+        }
+      }
+    })
+    child.stderr.on('data', (chunk) => { if (stderr.length < MAX_DIAGNOSTIC) stderr += String(chunk).slice(0, MAX_DIAGNOSTIC - stderr.length) })
+    child.on('error', () => finish({ ok: false, error: 'Codex app-server failed to start' }))
+    child.on('exit', () => { if (!done) finish({ ok: false, error: stderr || 'Codex app-server closed before replying' }) })
+    child.stdin.write(`${JSON.stringify({
+      id: 1,
+      method: 'initialize',
+      params: { clientInfo: { name: 'hermes-workspace', version: '2.3.0' }, capabilities: { experimentalApi: true } },
+    })}\n`)
+  })
+}
+
+let singleton: RuntimeService | null = null
+
+export function getProviderRuntimeService(): RuntimeService {
+  if (singleton) return singleton
+  const state = getStateDir()
+  const registry = new ProviderRuntimeRegistry(join(state, 'provider-runtimes.json'))
+  const leases = new DurableRuntimeLeases(join(state, 'provider-runtime-leases'))
+  const ownerToken = `workspace-${process.pid}-${randomUUID()}`
+  const invokeCodex = createCodexStdioInvoker()
+  const runClaude = claudeRunner()
+  const accountHomes = resolveConfiguredAccountHomes()
+  const codex = new CodexRuntimeAdapter({ invoke: invokeCodex, leases, ownerToken })
+  const claude = new ClaudeRuntimeAdapter({ run: runClaude, leases, ownerToken, accountHomes })
+  singleton = {
+    list: () => registry.list(),
+    recoverLease: (runtimeId) => leases.recoverExpired(runtimeId),
+    async refresh() {
+      const workerRecords = await getWorkerProcessHost().list()
+      for (const worker of workerRecords) registry.upsert({
+        runtimeId: `hermes:${worker.workerId}`,
+        kind: 'hermes_profile', routeRef: null, accountAlias: 'hermes', externalId: worker.workerId,
+        cwd: worker.cwd, worktree: worker.cwd, hostKind: worker.hostKind,
+        hostStatus: worker.status === 'starting' ? 'unknown' : worker.status,
+        capabilities: capabilityMatrix('hermes_profile'), lease: null,
+        parentRuntimeId: null, kanbanTaskId: null,
+        createdAt: worker.startedAt ?? worker.updatedAt, updatedAt: worker.updatedAt,
+      })
+      const claudeImports = Object.entries(accountHomes).map(async ([accountAlias, home]) => ({
+        source: `claude:${accountAlias}`,
+        ...(await importClaudeAgents({ run: runClaude, registry, accountAlias, routeRef: null, home })),
+      }))
+      const codexImport = importCodexThreads({
+        invoke: invokeCodex,
+        registry,
+        accountAlias: 'openai-codex',
+        routeRef: null,
+      }).then((result) => ({ source: 'codex:openai-codex', ...result }))
+      return Promise.all([{ source: 'hermes:worker-host', ok: true, count: workerRecords.length }, ...claudeImports, codexImport])
+    },
+    async mutate(body) {
+      const runtimeId = typeof body.runtimeId === 'string' ? body.runtimeId : ''
+      const action = typeof body.action === 'string' ? body.action : ''
+      if (action === 'background') return { ok: false, error: 'Background Claude launch is disabled until durable writer ownership can be tracked' }
+      const routeRef = typeof body.routeRef === 'string' ? body.routeRef : ''
+      const accountAlias = typeof body.accountAlias === 'string' ? body.accountAlias : ''
+      const existing = runtimeId ? registry.get(runtimeId) : null
+      if (runtimeId && !existing) return { ok: false, error: 'Runtime must be imported or created before lifecycle mutation' }
+      if (action === 'link_kanban' && existing) {
+        const taskId = typeof body.kanbanTaskId === 'string' ? body.kanbanTaskId.trim() : ''
+        if (taskId.length > 200) return { ok: false, error: 'Invalid Kanban task ID' }
+        registry.merge([{ ...existing, kanbanTaskId: taskId || null, updatedAt: Date.now() }])
+        return { ok: true, runtimeId, kanbanTaskId: taskId || null }
+      }
+      if (existing?.routeRef && existing.routeRef !== routeRef) return { ok: false, error: 'Runtime routeRef does not match the requested route' }
+      if (existing?.kind === 'claude_session' && existing.accountAlias !== accountAlias) return { ok: false, error: 'Runtime account identity does not match' }
+
+      const requestedCwd = typeof body.cwd === 'string' ? body.cwd : ''
+      const requestedWorktree = typeof body.worktree === 'string' ? body.worktree : ''
+      const cwd = requestedCwd || existing?.cwd || ''
+      const worktree = requestedWorktree || existing?.worktree || ''
+      if (['create', 'background', 'resume', 'fork'].includes(action)) {
+        const verified = verifiedWorktree(worktree)
+        if (!verified || verifiedWorktree(cwd) !== verified) return { ok: false, error: 'Lifecycle mutation requires cwd and worktree to resolve to the same Git worktree root' }
+      }
+
+      if (runtimeId.startsWith('codex:') && ['resume', 'fork', 'steer', 'interrupt', 'archive'].includes(action)) {
+        const result = await codex.mutate(runtimeId, action as 'resume' | 'fork' | 'steer' | 'interrupt' | 'archive', {
+          ...(typeof body.text === 'string' ? { text: body.text } : {}),
+          ...(typeof body.turnId === 'string' ? { turnId: body.turnId } : {}),
+        })
+        if (result.ok && existing) registry.merge([{ ...existing, routeRef, cwd: cwd || existing.cwd, worktree: worktree || existing.worktree, updatedAt: Date.now() }])
+        return result
+      }
+      const prompt = typeof body.prompt === 'string' ? body.prompt : (typeof body.text === 'string' ? body.text : '')
+      if (action === 'create' || action === 'background') {
+        const requestId = typeof body.requestId === 'string' ? body.requestId : ''
+        if (!UUID.test(requestId)) return { ok: false, error: 'Create requires a UUID requestId for durable idempotency' }
+        const expectedRuntimeId = `claude:${accountAlias}:${requestId}`
+        const prior = registry.get(expectedRuntimeId)
+        if (prior) return { ok: true, runtimeId: prior.runtimeId, sessionId: prior.externalId, replayed: true }
+        const result = await claude.create({
+          accountAlias,
+          cwd,
+          prompt,
+          background: action === 'background',
+          sessionId: requestId,
+          onCreated: (sessionId, createdRuntimeId) => {
+            const now = Date.now()
+            registry.merge([{
+              runtimeId: createdRuntimeId,
+              kind: 'claude_session',
+              routeRef,
+              accountAlias,
+              externalId: sessionId,
+              cwd,
+              worktree,
+              hostKind: 'external',
+              hostStatus: 'idle',
+              capabilities: capabilityMatrix('claude_session'),
+              lease: null,
+              parentRuntimeId: null,
+              kanbanTaskId: typeof body.kanbanTaskId === 'string' ? body.kanbanTaskId : null,
+              createdAt: now,
+              updatedAt: now,
+            }])
+          },
+        })
+        return result
+      }
+      if (runtimeId.startsWith('claude:') && ['resume', 'fork', 'attach'].includes(action)) {
+        const result = await claude.mutate(runtimeId, action as 'resume' | 'fork' | 'attach', { accountAlias, cwd, prompt })
+        if (result.ok && existing) registry.merge([{ ...existing, routeRef, cwd, worktree, updatedAt: Date.now() }])
+        return result
+      }
+      return { ok: false, error: 'Unsupported runtime lifecycle action' }
+    },
+  }
+  return singleton
+}
+
+export function setProviderRuntimeServiceForTests(service: RuntimeService | null): void { singleton = service }

--- a/src/server/runtime-route-cache.test.ts
+++ b/src/server/runtime-route-cache.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { clearRuntimeRouteSnapshot, readRuntimeRouteSnapshot, writeRuntimeRouteSnapshot } from './runtime-route-cache'
+
+describe('runtime route snapshot', () => {
+  beforeEach(() => clearRuntimeRouteSnapshot())
+
+  it('keeps a bounded defensive snapshot of currently available subscription routes', () => {
+    const input = [
+      { id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available' },
+      { id: 'claude-cwm4tx/opus-5', account: 'cwm4tx', model: 'opus-5', status: 'quota_limited' },
+      { id: 'bad', account: '', model: 'bad', status: 'available' },
+      ...Array.from({ length: 600 }, (_, index) => ({
+        id: `route-${index}/model`, account: `account-${index}`, model: 'model', status: 'available',
+      })),
+    ]
+
+    writeRuntimeRouteSnapshot(input)
+    input[0].id = 'mutated'
+    const first = readRuntimeRouteSnapshot()
+    expect(first).toHaveLength(500)
+    expect(first[0]).toEqual({
+      id: 'openai-codex/gpt-5.6-sol', account: 'openai-codex', model: 'gpt-5.6-sol', status: 'available',
+    })
+    first[0].id = 'also-mutated'
+    expect(readRuntimeRouteSnapshot()[0].id).toBe('openai-codex/gpt-5.6-sol')
+  })
+})

--- a/src/server/runtime-route-cache.ts
+++ b/src/server/runtime-route-cache.ts
@@ -1,0 +1,38 @@
+export type RuntimeRouteSnapshotEntry = {
+  id: string
+  account: string
+  model: string
+  status: 'available'
+}
+
+const MAX_ROUTES = 500
+const MAX_FIELD_LENGTH = 200
+let snapshot: Array<RuntimeRouteSnapshotEntry> = []
+
+function bounded(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  return normalized && normalized.length <= MAX_FIELD_LENGTH ? normalized : null
+}
+
+export function writeRuntimeRouteSnapshot(input: Array<unknown>): void {
+  const seen = new Set<string>()
+  snapshot = input.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return []
+    const raw = entry as Record<string, unknown>
+    const id = bounded(raw.id)
+    const account = bounded(raw.account)
+    const model = bounded(raw.model)
+    if (!id || !account || !model || raw.status !== 'available' || seen.has(id)) return []
+    seen.add(id)
+    return [{ id, account, model, status: 'available' as const }]
+  }).slice(0, MAX_ROUTES)
+}
+
+export function readRuntimeRouteSnapshot(): Array<RuntimeRouteSnapshotEntry> {
+  return snapshot.map((entry) => ({ ...entry }))
+}
+
+export function clearRuntimeRouteSnapshot(): void {
+  snapshot = []
+}

--- a/src/server/runtime-run-projection.test.ts
+++ b/src/server/runtime-run-projection.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+
+import { capabilityMatrix } from './provider-runtime-control-plane'
+import {
+  filterRuntimeRuns,
+  paginateRuntimeRuns,
+  projectRuntimeRun,
+  projectRuntimeRuns,
+  sortRuntimeRuns,
+  summarizeRuntimeRuns,
+} from './runtime-run-projection'
+import type { ProviderRuntimeRecord } from './provider-runtime-control-plane'
+
+function runtime(overrides: Partial<ProviderRuntimeRecord> = {}): ProviderRuntimeRecord {
+  return {
+    runtimeId: 'codex:thread-1234567890abcdef',
+    kind: 'codex_thread',
+    routeRef: 'openai-codex/gpt-5.6-sol',
+    accountAlias: 'openai-codex',
+    externalId: 'thread-1234567890abcdef',
+    model: 'gpt-5.6-sol',
+    cwd: 'C:/work/Workspace',
+    worktree: 'C:/work/Workspace',
+    hostKind: 'stdio',
+    hostStatus: 'idle',
+    capabilities: capabilityMatrix('codex_thread', 'win32'),
+    lease: null,
+    parentRuntimeId: null,
+    kanbanTaskId: null,
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides,
+  }
+}
+
+describe('provider-neutral runtime run projection', () => {
+  it('projects all providers, safe titles, paths, ownership, and current capability policy', () => {
+    const codex = projectRuntimeRun(runtime(), 1_000)
+    expect(codex).toMatchObject({
+      id: 'codex:thread-1234567890abcdef',
+      source: 'provider-runtime',
+      provider: 'codex',
+      runtimeKind: 'codex_thread',
+      nativeId: 'thread-1234567890abcdef',
+      shortId: 'thread-12345',
+      account: 'openai-codex',
+      accountKey: 'openai-codex',
+      project: 'Workspace',
+      worktree: 'C:/work/Workspace',
+      cwd: 'C:/work/Workspace',
+      state: 'idle',
+      linked: false,
+      stalenessMs: 800,
+      ownership: { state: 'free', owner: null, expiresAt: null, abandoned: false },
+    })
+    expect(codex.title).toBe('Workspace · Codex thread')
+    expect(codex.capabilities.fork).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(codex.capabilities.fork.explanation.toLowerCase()).toContain('recovery')
+    expect(codex.capabilities.steer.invokable).toBe(false)
+    expect(codex.capabilities.attach).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(codex.capabilities.resume.invokable).toBe(true)
+    expect(codex.capabilities.archive.invokable).toBe(true)
+
+    const claude = projectRuntimeRun(runtime({
+      runtimeId: 'claude:cwm4tx:session-1', kind: 'claude_session', accountAlias: 'cwm4tx',
+      externalId: 'session-1', routeRef: 'claude-cwm4tx/opus-5', hostKind: 'external', hostStatus: 'running',
+      worktree: 'D:\\Design\\Auth', cwd: 'D:\\Design\\Auth', kanbanTaskId: 'AUTH-14',
+      capabilities: capabilityMatrix('claude_session', 'linux'),
+      lease: { owner: 'workspace-1', acquiredAt: 10, expiresAt: 2_000 },
+    }), 1_000)
+    expect(claude).toMatchObject({ provider: 'claude', project: 'Auth', state: 'active', linked: true })
+    expect(claude.title).toBe('AUTH-14 · Auth')
+    expect(claude.ownership).toMatchObject({ state: 'owned', owner: 'workspace-1' })
+    expect(claude.capabilities.archive).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(claude.capabilities.send).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(claude.capabilities.discoverPeers).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(claude.capabilities.attach.invokable).toBe(true)
+
+    const hermes = projectRuntimeRun(runtime({
+      runtimeId: 'hermes:orchestrator', kind: 'hermes_profile', accountAlias: 'orchestrator', externalId: 'orchestrator',
+      routeRef: null, model: null, cwd: '/srv/workspace', worktree: '/srv/workspace', hostKind: 'native', hostStatus: 'unknown',
+      capabilities: capabilityMatrix('hermes_profile', 'linux'),
+      lease: { owner: 'dead-owner', acquiredAt: 1, expiresAt: 10, abandoned: true },
+    }), 1_000)
+    expect(hermes).toMatchObject({ provider: 'hermes', project: 'workspace', state: 'attention' })
+    expect(hermes.ownership).toMatchObject({ state: 'recoverable', abandoned: true })
+    for (const operation of ['create', 'resume', 'fork', 'send', 'steer', 'interrupt', 'archive', 'attach', 'discoverPeers', 'crossSessionMessage'] as const) {
+      expect(hermes.capabilities[operation], operation).toMatchObject({ state: 'unsupported', invokable: false })
+    }
+    expect(hermes.capabilities.status.invokable).toBe(true)
+    expect(hermes.capabilities.list.invokable).toBe(true)
+
+    const staleHermesKind = projectRuntimeRun({
+      ...runtime({
+        runtimeId: 'hermes:worker-a', externalId: 'worker-a', capabilities: capabilityMatrix('hermes_profile', 'win32'),
+      }),
+      kind: 'stale_kind',
+    } as unknown as ProviderRuntimeRecord, 1_000)
+    expect(staleHermesKind.provider).toBe('hermes')
+    expect(staleHermesKind.capabilities.resume).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(staleHermesKind.capabilities.archive).toMatchObject({ state: 'unsupported', invokable: false })
+
+    const staleCodexKind = projectRuntimeRun({
+      ...runtime({
+        runtimeId: 'codex:thread-future', externalId: 'thread-future', capabilities: capabilityMatrix('codex_thread', 'win32'),
+      }),
+      kind: 'future_kind',
+    } as unknown as ProviderRuntimeRecord, 1_000)
+    expect(staleCodexKind.provider).toBe('codex')
+    expect(staleCodexKind.capabilities.resume).toMatchObject({ state: 'unsupported', invokable: false })
+    expect(staleCodexKind.capabilities.archive).toMatchObject({ state: 'unsupported', invokable: false })
+
+    const abandonedDuringGrace = projectRuntimeRun(runtime({
+      runtimeId: 'codex:abandoned-grace', externalId: 'abandoned-grace', hostStatus: 'idle',
+      lease: { owner: 'dead-owner', acquiredAt: 1, expiresAt: 2_000, abandoned: true },
+    }), 1_000)
+    expect(abandonedDuringGrace).toMatchObject({
+      state: 'attention',
+      ownership: { state: 'unknown', owner: 'dead-owner', expiresAt: 2_000, abandoned: true },
+    })
+
+    const expiredButUnverified = projectRuntimeRun(runtime({
+      runtimeId: 'codex:expired', externalId: 'expired', hostStatus: 'idle',
+      lease: { owner: 'possibly-live', acquiredAt: 1, expiresAt: 10, processId: 4242 },
+    }), 1_000)
+    expect(expiredButUnverified).toMatchObject({
+      state: 'attention',
+      ownership: { state: 'unknown', owner: 'possibly-live', expiresAt: 10, abandoned: false },
+    })
+  })
+
+  it('never projects prompt, transcript, argv, token, or credential fields', () => {
+    const unsafe = {
+      ...runtime(),
+      prompt: 'secret prompt', transcript: 'secret transcript', argv: ['secret'], token: 'secret', credential: 'secret',
+    } as ProviderRuntimeRecord
+    const projected = JSON.stringify(projectRuntimeRun(unsafe, 1_000)).toLowerCase()
+    for (const forbidden of ['secret prompt', 'secret transcript', 'argv', 'token', 'credential']) {
+      expect(projected).not.toContain(forbidden)
+    }
+  })
+
+  it('combines filters, stable sorting, pagination, and honest summaries', () => {
+    const runs = [
+      projectRuntimeRun(runtime({ runtimeId: 'codex:z', externalId: 'z', updatedAt: 400 }), 1_000),
+      projectRuntimeRun(runtime({ runtimeId: 'codex:a', externalId: 'a', updatedAt: 400, kanbanTaskId: 'TASK-1' }), 1_000),
+      projectRuntimeRun(runtime({ runtimeId: 'claude:gp:c', kind: 'claude_session', accountAlias: 'gp', externalId: 'c', routeRef: 'claude-gp/opus-5', hostStatus: 'running', capabilities: capabilityMatrix('claude_session', 'win32'), updatedAt: 900 }), 1_000),
+      projectRuntimeRun(runtime({ runtimeId: 'hermes:h', kind: 'hermes_profile', accountAlias: 'orchestrator', externalId: 'h', routeRef: null, hostStatus: 'unknown', capabilities: capabilityMatrix('hermes_profile', 'win32'), updatedAt: 100 }), 1_000),
+    ]
+    expect(filterRuntimeRuns(runs, { provider: ['codex'], linked: 'linked', query: 'task-1' }).map((run) => run.id)).toEqual(['codex:a'])
+    expect(filterRuntimeRuns(runs, {
+      account: ['openai-codex'], project: ['workspace'], kanbanTaskId: 'TASK-1',
+      updatedFrom: 300, updatedTo: 500,
+    }).map((run) => run.id)).toEqual(['codex:a'])
+    expect(sortRuntimeRuns(runs.slice(0, 2), 'updated', 'desc').map((run) => run.id)).toEqual(['codex:a', 'codex:z'])
+    expect(paginateRuntimeRuns(runs, 2, 2)).toMatchObject({ total: 4, page: 2, pageSize: 2, pages: 2, items: [{ id: 'claude:gp:c' }, { id: 'hermes:h' }] })
+    expect(summarizeRuntimeRuns(runs, 1_000)).toMatchObject({
+      total: 4, active: 1, idleResumable: 2, attention: 1, unlinkedKanban: 3,
+      unknownOwnership: 0,
+      byProvider: { codex: 2, claude: 1, hermes: 1 },
+    })
+  })
+
+  it('projects and paginates a bounded 5,000-record inventory without expanding row payloads', () => {
+    const records = Array.from({ length: 5_000 }, (_, index) => runtime({
+      runtimeId: `codex:thread-${String(index).padStart(4, '0')}`,
+      externalId: `thread-${String(index).padStart(4, '0')}`,
+      updatedAt: index,
+    }))
+    const runs = projectRuntimeRuns(records, 6_000, 5_000)
+    expect(runs).toHaveLength(5_000)
+    const page = paginateRuntimeRuns(sortRuntimeRuns(runs, 'updated', 'desc'), 50, 100)
+    expect(page).toMatchObject({ page: 50, pageSize: 100, total: 5_000, pages: 50, hasPrevious: true, hasNext: false })
+    expect(page.items).toHaveLength(100)
+    expect(Object.hasOwn(page.items[0], 'prompt')).toBe(false)
+  })
+})

--- a/src/server/runtime-run-projection.ts
+++ b/src/server/runtime-run-projection.ts
@@ -1,0 +1,444 @@
+// Provider-neutral, read-only projection of the provider runtime registry.
+//
+// Everything here is pure: no filesystem, no provider process, no service call.
+// The projection is an explicit allowlist — records are never spread — so a
+// registry row that grows a prompt, transcript, argv, token, or credential
+// field can never reach an API response through this module.
+
+import type {
+  CapabilityState,
+  ProviderRuntimeRecord,
+  RuntimeCapability,
+  RuntimeKind,
+  RuntimeOperation,
+} from './provider-runtime-control-plane'
+
+export type RuntimeRunProvider = 'hermes' | 'claude' | 'codex' | 'unknown'
+export type RuntimeRunState = 'active' | 'idle' | 'stopped' | 'attention'
+export type RuntimeRunOwnershipState = 'free' | 'owned' | 'recoverable' | 'unknown'
+
+export type RuntimeRunCapability = {
+  state: CapabilityState
+  invokable: boolean
+  explanation: string
+  deferred?: boolean
+}
+
+export type RuntimeRunOwnership = {
+  state: RuntimeRunOwnershipState
+  owner: string | null
+  expiresAt: number | null
+  abandoned: boolean
+}
+
+export type RuntimeRun = {
+  id: string
+  source: 'provider-runtime'
+  provider: RuntimeRunProvider
+  runtimeKind: string
+  nativeId: string
+  shortId: string
+  account: string
+  accountKey: string
+  route: string | null
+  model: string | null
+  project: string | null
+  worktree: string | null
+  cwd: string | null
+  title: string
+  state: RuntimeRunState
+  hostKind: string
+  linked: boolean
+  kanbanTaskId: string | null
+  parentRuntimeId: string | null
+  ownership: RuntimeRunOwnership
+  capabilities: Record<RuntimeOperation, RuntimeRunCapability>
+  createdAt: number
+  updatedAt: number
+  stalenessMs: number
+}
+
+export type RuntimeRunLinkFilter = 'all' | 'linked' | 'unlinked'
+export type RuntimeRunFilters = {
+  provider?: ReadonlyArray<string>
+  account?: ReadonlyArray<string>
+  state?: ReadonlyArray<string>
+  ownership?: ReadonlyArray<string>
+  project?: ReadonlyArray<string>
+  linked?: RuntimeRunLinkFilter
+  kanbanTaskId?: string
+  updatedFrom?: number
+  updatedTo?: number
+  query?: string
+}
+
+export type RuntimeRunSortKey = 'updated' | 'created' | 'staleness' | 'title' | 'project' | 'provider' | 'state'
+export type RuntimeRunSortDirection = 'asc' | 'desc'
+
+export type RuntimeRunPage = {
+  items: Array<RuntimeRun>
+  total: number
+  page: number
+  pageSize: number
+  pages: number
+  hasNext: boolean
+  hasPrevious: boolean
+}
+
+export type RuntimeRunSummary = {
+  total: number
+  active: number
+  idle: number
+  stopped: number
+  attention: number
+  idleResumable: number
+  linkedKanban: number
+  unlinkedKanban: number
+  owned: number
+  recoverable: number
+  unknownOwnership: number
+  stale: number
+  byProvider: Record<string, number>
+  byState: Record<RuntimeRunState, number>
+}
+
+export const RUNTIME_OPERATIONS: ReadonlyArray<RuntimeOperation> = [
+  'create', 'resume', 'fork', 'send', 'steer', 'interrupt',
+  'status', 'list', 'archive', 'attach', 'discoverPeers', 'crossSessionMessage',
+]
+
+export const RUNTIME_RUN_SORT_KEYS: ReadonlyArray<RuntimeRunSortKey> = ['updated', 'created', 'staleness', 'title', 'project', 'provider', 'state']
+
+export const DEFAULT_PAGE_SIZE = 25
+export const MAX_PAGE_SIZE = 100
+/** Hard ceiling on how many registry rows a single projection pass will read. */
+export const MAX_PROJECTED_RUNS = 5_000
+export const STALE_AFTER_MS = 15 * 60_000
+
+const MAX_QUERY = 200
+
+// Effective policy, not just the declared matrix: an operation is only invokable
+// when Workspace actually owns a verified channel for it today. Codex fork is
+// disabled until crash-safe recovery exists; steer and interrupt require a
+// persistent app-server connection that Workspace does not own.
+const HERMES_SERVICE_UNDISPATCHABLE = ['create', 'resume', 'fork', 'send', 'steer', 'interrupt', 'archive', 'attach', 'discoverPeers', 'crossSessionMessage'] as const
+const HERMES_SERVICE_EXPLANATION = 'Not invokable from Runs until the runtime service owns a verified Hermes worker-host dispatch path.'
+const NON_INVOKABLE: Partial<Record<RuntimeKind, ReadonlyArray<RuntimeOperation>>> = {
+  hermes_profile: HERMES_SERVICE_UNDISPATCHABLE,
+  claude_session: ['archive', 'send', 'discoverPeers'],
+  codex_thread: ['fork', 'steer', 'interrupt', 'attach'],
+}
+const NON_INVOKABLE_EXPLANATION: Partial<Record<RuntimeKind, Partial<Record<RuntimeOperation, string>>>> = {
+  hermes_profile: Object.fromEntries(
+    HERMES_SERVICE_UNDISPATCHABLE.map((operation) => [operation, HERMES_SERVICE_EXPLANATION]),
+  ),
+  claude_session: {
+    archive: 'Archive is not implemented by the isolated Claude runtime adapter.',
+    send: 'Send is not implemented by the isolated Claude runtime adapter.',
+    discoverPeers: 'Peer discovery is not implemented by the Runs runtime service path.',
+  },
+  codex_thread: {
+    fork: 'Disabled until provider fork identity has crash-safe durable recovery or idempotency.',
+    steer: 'Disabled until Workspace owns one persistent Codex app-server connection for the active turn.',
+    interrupt: 'Disabled until Workspace owns one persistent Codex app-server connection for the active turn.',
+    attach: 'Attach is not implemented by the isolated Codex runtime service path.',
+  },
+}
+
+const KIND_LABELS: Record<string, string> = {
+  hermes_profile: 'Hermes profile',
+  claude_session: 'Claude session',
+  codex_thread: 'Codex thread',
+}
+const KIND_PROVIDERS: Record<string, RuntimeRunProvider> = {
+  hermes_profile: 'hermes',
+  claude_session: 'claude',
+  codex_thread: 'codex',
+}
+const ID_PROVIDERS: Record<string, RuntimeRunProvider> = {
+  hermes: 'hermes',
+  claude: 'claude',
+  codex: 'codex',
+}
+const STATE_RANK: Record<RuntimeRunState, number> = { attention: 0, active: 1, idle: 2, stopped: 3 }
+
+function text(value: unknown, max: number): string | null {
+  if (typeof value !== 'string') return null
+  const cleaned = Array.from(value, (character) => {
+    const code = character.codePointAt(0) ?? 0
+    return code <= 31 || (code >= 127 && code <= 159) ? ' ' : character
+  }).join('').trim()
+  return cleaned ? cleaned.slice(0, max) : null
+}
+
+function finite(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return fallback
+  return Math.min(max, Math.max(min, Math.trunc(numeric)))
+}
+
+/**
+ * Last path segment for both Windows and POSIX shapes, without touching the
+ * filesystem: handles `C:/a/b`, `D:\a\b`, `\\server\share\b`, mixed separators,
+ * trailing separators, and bare drive roots (which yield no project name).
+ */
+export function pathProjectName(value: unknown): string | null {
+  const raw = text(value, 1_024)
+  if (!raw) return null
+  const segments = raw.split(/[\\/]+/).filter((segment) => segment && segment !== '.' && segment !== '..')
+  const last = segments.at(-1)
+  if (!last || /^[A-Za-z]:$/.test(last)) return null
+  return last.slice(0, 80)
+}
+
+function providerOf(kind: unknown, runtimeId: string): RuntimeRunProvider {
+  if (typeof kind === 'string' && Object.hasOwn(KIND_PROVIDERS, kind)) return KIND_PROVIDERS[kind]
+  const prefix = runtimeId.split(':', 1)[0] ?? ''
+  return ID_PROVIDERS[prefix] ?? 'unknown'
+}
+
+function policyKindOf(kind: unknown, runtimeId: string): RuntimeKind | null {
+  if (kind === 'hermes_profile' && runtimeId.startsWith('hermes:')) return kind
+  if (kind === 'claude_session' && runtimeId.startsWith('claude:')) return kind
+  if (kind === 'codex_thread' && runtimeId.startsWith('codex:')) return kind
+  return null
+}
+
+function stateOf(hostStatus: unknown): RuntimeRunState {
+  if (hostStatus === 'running') return 'active'
+  if (hostStatus === 'idle') return 'idle'
+  if (hostStatus === 'stopped') return 'stopped'
+  return 'attention'
+}
+
+function projectOwnership(lease: unknown, now: number): RuntimeRunOwnership {
+  if (!lease || typeof lease !== 'object') return { state: 'free', owner: null, expiresAt: null, abandoned: false }
+  const raw = lease as Record<string, unknown>
+  const owner = text(raw.owner, 120)
+  const expiresAt = typeof raw.expiresAt === 'number' && Number.isFinite(raw.expiresAt) ? raw.expiresAt : null
+  const abandoned = raw.abandoned === true
+  if (abandoned) {
+    if (expiresAt !== null && expiresAt <= now) return { state: 'recoverable', owner, expiresAt, abandoned }
+    return { state: 'unknown', owner, expiresAt, abandoned }
+  }
+  if (expiresAt === null || expiresAt <= now) return { state: 'unknown', owner, expiresAt, abandoned }
+  return { state: 'owned', owner, expiresAt, abandoned }
+}
+
+function projectCapabilities(source: unknown, kind: RuntimeKind | null): Record<RuntimeOperation, RuntimeRunCapability> {
+  const declared = (source && typeof source === 'object' ? source : {}) as Record<string, RuntimeCapability | undefined>
+  const blocked = new Set<RuntimeOperation>(kind === null
+    ? RUNTIME_OPERATIONS.filter((operation) => operation !== 'status' && operation !== 'list')
+    : NON_INVOKABLE[kind] ?? [])
+  const blockedExplanation = kind === null ? undefined : NON_INVOKABLE_EXPLANATION[kind]
+  const result = {} as Record<RuntimeOperation, RuntimeRunCapability>
+  for (const operation of RUNTIME_OPERATIONS) {
+    const entry = declared[operation]
+    const declaredState = entry?.state
+    const state: CapabilityState = declaredState === 'supported' || declaredState === 'degraded' || declaredState === 'experimental'
+      ? declaredState
+      : 'unsupported'
+    const explanation = text(entry?.explanation, 400) ?? 'Not exposed by this runtime adapter.'
+    result[operation] = blocked.has(operation)
+      ? { state: 'unsupported', invokable: false, explanation: kind === null
+        ? 'Not invokable because the persisted runtime kind cannot be verified.'
+        : blockedExplanation?.[operation] ?? explanation, deferred: true }
+      : { state, invokable: state !== 'unsupported', explanation, ...(entry?.deferred === true ? { deferred: true } : {}) }
+  }
+  return result
+}
+
+function projectTitle(kanbanTaskId: string | null, project: string | null, kindLabel: string, shortId: string): string {
+  const title = kanbanTaskId && project ? `${kanbanTaskId} · ${project}`
+    : kanbanTaskId ? kanbanTaskId
+    : project ? `${project} · ${kindLabel}`
+    : shortId ? `${kindLabel} · ${shortId}`
+    : kindLabel
+  return title.slice(0, 160)
+}
+
+/** Projects one registry record into a provider-neutral, privacy-safe run. */
+export function projectRuntimeRun(record: ProviderRuntimeRecord, now: number = Date.now()): RuntimeRun {
+  const raw = record as unknown as Record<string, unknown>
+  const id = text(raw.runtimeId, 300) ?? ''
+  const kind = text(raw.kind, 64) ?? 'unknown'
+  const nativeId = text(raw.externalId, 256) ?? ''
+  const project = pathProjectName(raw.worktree) ?? pathProjectName(raw.cwd)
+  const worktree = text(raw.worktree, 1_024)
+  const cwd = text(raw.cwd, 1_024)
+  const kanbanTaskId = text(raw.kanbanTaskId, 64)
+  const shortId = nativeId.slice(0, 12)
+  const updatedAt = finite(raw.updatedAt)
+  const accountKey = text(raw.accountAlias, 120) ?? ''
+  const provider = providerOf(raw.kind, id)
+  const ownership = projectOwnership(raw.lease, now)
+  const projectedState = ownership.state === 'unknown' ? 'attention' : stateOf(raw.hostStatus)
+  return {
+    id,
+    source: 'provider-runtime',
+    provider,
+    runtimeKind: kind,
+    nativeId,
+    shortId,
+    account: accountKey,
+    accountKey,
+    route: text(raw.routeRef, 200),
+    model: text(raw.model, 200),
+    project,
+    worktree,
+    cwd,
+    title: projectTitle(kanbanTaskId, project, KIND_LABELS[kind] ?? 'Provider runtime', shortId),
+    state: projectedState,
+    hostKind: text(raw.hostKind, 32) ?? 'unknown',
+    linked: Boolean(kanbanTaskId),
+    kanbanTaskId,
+    parentRuntimeId: text(raw.parentRuntimeId, 300),
+    ownership,
+    capabilities: projectCapabilities(raw.capabilities, policyKindOf(raw.kind, id)),
+    createdAt: finite(raw.createdAt),
+    updatedAt,
+    stalenessMs: Math.max(0, now - updatedAt),
+  }
+}
+
+/** Projects a bounded slice of the registry; never reads more than MAX_PROJECTED_RUNS rows. */
+export function projectRuntimeRuns(records: unknown, now: number = Date.now(), limit: number = MAX_PROJECTED_RUNS): Array<RuntimeRun> {
+  if (!Array.isArray(records)) return []
+  const bounded = clampInt(limit, 0, MAX_PROJECTED_RUNS, MAX_PROJECTED_RUNS)
+  return records.slice(0, bounded).map((record) => projectRuntimeRun(record as ProviderRuntimeRecord, now))
+}
+
+function normalizeSet(values: ReadonlyArray<string> | undefined): Set<string> | null {
+  if (!Array.isArray(values)) return null
+  const normalized = values
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+  return normalized.length ? new Set(normalized) : null
+}
+
+function haystack(run: RuntimeRun): string {
+  return [run.id, run.title, run.nativeId, run.account, run.project, run.kanbanTaskId, run.provider, run.model, run.route, run.runtimeKind]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+/** Applies every provided filter with AND semantics; absent or empty filters do not constrain. */
+export function filterRuntimeRuns(runs: ReadonlyArray<RuntimeRun>, filters: RuntimeRunFilters = {}): Array<RuntimeRun> {
+  const providers = normalizeSet(filters.provider)
+  const accounts = normalizeSet(filters.account)
+  const states = normalizeSet(filters.state)
+  const ownerships = normalizeSet(filters.ownership)
+  const projects = normalizeSet(filters.project)
+  const linked = filters.linked ?? 'all'
+  const kanbanTaskId = typeof filters.kanbanTaskId === 'string' ? filters.kanbanTaskId.trim().toLowerCase() : ''
+  const updatedFrom = typeof filters.updatedFrom === 'number' && Number.isFinite(filters.updatedFrom) ? filters.updatedFrom : null
+  const updatedTo = typeof filters.updatedTo === 'number' && Number.isFinite(filters.updatedTo) ? filters.updatedTo : null
+  const query = typeof filters.query === 'string' ? filters.query.trim().slice(0, MAX_QUERY).toLowerCase() : ''
+  return runs.filter((run) => {
+    if (providers && !providers.has(run.provider)) return false
+    if (accounts && !accounts.has(run.account.toLowerCase())) return false
+    if (states && !states.has(run.state)) return false
+    if (ownerships && !ownerships.has(run.ownership.state)) return false
+    if (projects && !projects.has((run.project ?? '').toLowerCase())) return false
+    if (linked === 'linked' && !run.linked) return false
+    if (linked === 'unlinked' && run.linked) return false
+    if (kanbanTaskId && (run.kanbanTaskId ?? '').toLowerCase() !== kanbanTaskId) return false
+    if (updatedFrom !== null && run.updatedAt < updatedFrom) return false
+    if (updatedTo !== null && run.updatedAt > updatedTo) return false
+    if (query && !haystack(run).includes(query)) return false
+    return true
+  })
+}
+
+function compare(a: RuntimeRun, b: RuntimeRun, key: RuntimeRunSortKey): number {
+  switch (key) {
+    case 'created': return a.createdAt - b.createdAt
+    case 'staleness': return a.stalenessMs - b.stalenessMs
+    case 'title': return a.title.localeCompare(b.title)
+    case 'project': return (a.project ?? '').localeCompare(b.project ?? '')
+    case 'provider': return a.provider.localeCompare(b.provider)
+    case 'state': return STATE_RANK[a.state] - STATE_RANK[b.state]
+    default: return a.updatedAt - b.updatedAt
+  }
+}
+
+/**
+ * Total order: the requested key and direction, then always the runtime ID
+ * ascending, so equal keys never reorder between requests.
+ */
+export function sortRuntimeRuns(
+  runs: ReadonlyArray<RuntimeRun>,
+  key: RuntimeRunSortKey = 'updated',
+  direction: RuntimeRunSortDirection = 'desc',
+): Array<RuntimeRun> {
+  const sortKey = RUNTIME_RUN_SORT_KEYS.includes(key) ? key : 'updated'
+  const factor = direction === 'asc' ? 1 : -1
+  return [...runs].sort((a, b) => {
+    const primary = compare(a, b, sortKey) * factor
+    return primary !== 0 ? primary : a.id.localeCompare(b.id)
+  })
+}
+
+/** Clamps the page window into range so an out-of-bounds request still returns a real page. */
+export function paginateRuntimeRuns(
+  runs: ReadonlyArray<RuntimeRun>,
+  page: unknown = 1,
+  pageSize: unknown = DEFAULT_PAGE_SIZE,
+): RuntimeRunPage {
+  const total = runs.length
+  const size = clampInt(pageSize, 1, MAX_PAGE_SIZE, DEFAULT_PAGE_SIZE)
+  const pages = Math.max(1, Math.ceil(total / size))
+  const number = clampInt(page, 1, pages, 1)
+  const start = (number - 1) * size
+  return {
+    items: runs.slice(start, start + size),
+    total,
+    page: number,
+    pageSize: size,
+    pages,
+    hasNext: number < pages,
+    hasPrevious: number > 1,
+  }
+}
+
+/** Counts only what is in `runs` — the summary never claims more than it was given. */
+export function summarizeRuntimeRuns(runs: ReadonlyArray<RuntimeRun>, now: number = Date.now()): RuntimeRunSummary {
+  const byState: Record<RuntimeRunState, number> = { active: 0, idle: 0, stopped: 0, attention: 0 }
+  const byProvider: Record<string, number> = {}
+  let linkedKanban = 0
+  let owned = 0
+  let recoverable = 0
+  let unknownOwnership = 0
+  let stale = 0
+  for (const run of runs) {
+    byState[run.state] += 1
+    byProvider[run.provider] = (byProvider[run.provider] ?? 0) + 1
+    if (run.linked) linkedKanban += 1
+    if (run.ownership.state === 'owned') owned += 1
+    if (run.ownership.state === 'recoverable') recoverable += 1
+    if (run.ownership.state === 'unknown') unknownOwnership += 1
+    if (now - run.updatedAt >= STALE_AFTER_MS) stale += 1
+  }
+  return {
+    total: runs.length,
+    active: byState.active,
+    idle: byState.idle,
+    stopped: byState.stopped,
+    attention: byState.attention,
+    idleResumable: byState.idle + byState.stopped,
+    linkedKanban,
+    unlinkedKanban: runs.length - linkedKanban,
+    owned,
+    recoverable,
+    unknownOwnership,
+    stale,
+    byProvider,
+    byState,
+  }
+}

--- a/src/server/subscription-model-catalog.test.ts
+++ b/src/server/subscription-model-catalog.test.ts
@@ -1,0 +1,622 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { inflateSync } from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRelayModelInputs,
+  buildSubscriptionCatalog,
+  configuredApiBilledProviderInputs,
+  createAuxiliaryTransportResolver,
+  createCachedCapabilityResolver,
+  createProviderModelResolver,
+  discoverModelCapabilities,
+  metadataIdentityForRoute,
+  openAiCodexModelInventory,
+  parseAntigravityModelRows,
+  parseAntigravityModels,
+  resolveAntigravityProviderInventory,
+  resolveAntigravityRelayBaseUrl,
+  resolveHermesPython,
+  sanitizeProviderWarning,
+} from './subscription-model-catalog'
+
+describe('subscription model catalog', () => {
+  it('includes authenticated OAuth models and keeps limited accounts visible but disabled', () => {
+    const catalog = buildSubscriptionCatalog({
+      relayModels: [
+        { id: 'claude-cwm4tx/sonnet', account: 'cwm4tx', status: 'available' },
+        {
+          id: 'claude-gp/sonnet',
+          account: 'gp',
+          status: 'quota_limited',
+          warning: 'Monthly allocation reached',
+        },
+      ],
+      oauthProviders: [
+        {
+          provider: 'openai-codex',
+          authenticated: true,
+          models: ['gpt-5.6-sol'],
+        },
+        {
+          provider: 'nous',
+          authenticated: true,
+          models: ['anthropic/claude-opus-4.8'],
+        },
+        {
+          provider: 'google-antigravity',
+          authenticated: true,
+          models: ['gemini-3.1-pro', 'gemini-3.1-flash'],
+        },
+      ],
+      transports: [],
+      allowApiBilledModels: false,
+      showNousModels: false,
+    })
+
+    expect(catalog.models.map((model) => model.id)).toEqual([
+      'claude-cwm4tx/sonnet',
+      'claude-gp/sonnet',
+      'openai-codex/gpt-5.6-sol',
+      'google-antigravity/gemini-3.1-pro',
+      'google-antigravity/gemini-3.1-flash',
+    ])
+    expect(
+      catalog.models.find((model) => model.id === 'claude-gp/sonnet'),
+    ).toMatchObject({ selectable: false, status: 'quota_limited' })
+    expect(
+      catalog.models.every((model) => model.billingClass !== 'api_billed'),
+    ).toBe(true)
+  })
+
+  it('keeps static OpenAI Codex OAuth routes visible but unavailable when discovery and auth fail', () => {
+    const models = openAiCodexModelInventory([])
+    expect(models).toEqual(
+      expect.arrayContaining([
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+        'gpt-5.5',
+        'gpt-5.4',
+      ]),
+    )
+
+    const catalog = buildSubscriptionCatalog({
+      relayModels: [],
+      oauthProviders: [
+        {
+          provider: 'openai-codex',
+          authenticated: false,
+          models,
+        },
+      ],
+      transports: [],
+      allowApiBilledModels: false,
+      showNousModels: false,
+    })
+    expect(catalog.models.map((model) => model.id)).toContain(
+      'openai-codex/gpt-5.6-sol',
+    )
+    expect(catalog.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'openai-codex/gpt-5.6-sol',
+          status: 'unavailable',
+          selectable: false,
+        }),
+      ]),
+    )
+  })
+
+  it('keeps Nous configured but hides it until the visibility option is enabled', () => {
+    const common = {
+      relayModels: [],
+      oauthProviders: [
+        {
+          provider: 'nous',
+          authenticated: true,
+          models: ['google/gemini-3.1-pro-preview'],
+        },
+      ],
+      transports: [],
+      allowApiBilledModels: false,
+    }
+    expect(
+      buildSubscriptionCatalog({ ...common, showNousModels: false }).models,
+    ).toHaveLength(0)
+    expect(
+      buildSubscriptionCatalog({ ...common, showNousModels: true }).models,
+    ).toHaveLength(1)
+  })
+
+  it('keeps visible Nous subscription-unknown routes non-selectable without verified entitlement', () => {
+    const common = {
+      relayModels: [],
+      transports: [],
+      allowApiBilledModels: false,
+      showNousModels: true,
+    }
+    const unverified = buildSubscriptionCatalog({
+      ...common,
+      oauthProviders: [
+        {
+          provider: 'nous',
+          authenticated: true,
+          models: ['google/gemini-3.1-pro-preview'],
+          billingClass: 'subscription_unknown' as const,
+        },
+      ],
+    })
+    const entitled = buildSubscriptionCatalog({
+      ...common,
+      oauthProviders: [
+        {
+          provider: 'nous',
+          authenticated: true,
+          subscriptionEntitled: true,
+          models: ['google/gemini-3.1-pro-preview'],
+          billingClass: 'subscription_unknown' as const,
+        },
+      ],
+    })
+
+    expect(unverified.models[0]).toMatchObject({
+      status: 'unknown',
+      selectable: false,
+    })
+    expect(entitled.models[0]).toMatchObject({
+      status: 'available',
+      selectable: true,
+    })
+  })
+
+  it('marks relay rows without matching account health unavailable', () => {
+    const relayModels = buildRelayModelInputs(
+      [{ id: 'claude-cwm4tx/sonnet' }],
+      {},
+    )
+    const catalog = buildSubscriptionCatalog({
+      relayModels,
+      oauthProviders: [],
+      transports: [],
+      allowApiBilledModels: false,
+    })
+
+    expect(catalog.models[0]).toMatchObject({
+      id: 'claude-cwm4tx/sonnet',
+      status: 'unavailable',
+      selectable: false,
+      warning: 'Account health could not be verified.',
+    })
+  })
+
+  it('discovers only concrete Gemini routes from Antigravity inventory', () => {
+    expect(
+      parseAntigravityModels(
+        [
+          'Fetching available models...',
+          'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+          'gemini-3.1-pro-low\tGemini 3.1 Pro (Low)',
+          'claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)',
+        ].join('\n'),
+      ),
+    ).toEqual(['gemini-3.6-flash-high', 'gemini-3.1-pro-low'])
+  })
+
+  it('rejects non-Gemini IDs returned by the Antigravity relay', () => {
+    expect(
+      parseAntigravityModelRows([
+        { id: 'google-antigravity/gemini-3.6-flash-high' },
+        { id: 'google-antigravity/claude-opus-4-6-thinking' },
+        { id: '../gemini-unsafe' },
+        { id: null },
+      ]),
+    ).toEqual(['gemini-3.6-flash-high'])
+  })
+
+  it('maps provider warnings to fixed human-safe messages', () => {
+    const warning = sanitizeProviderWarning(
+      'prefix {"api_error_status":429,"result":"You have hit your monthly spend limit · raise it at claude.ai/settings/usage?from=cc_cli_limit_message","uuid":"secret-run-id"}',
+    )
+    expect(warning).toBe('Provider quota is currently limited.')
+
+    const unsafe = sanitizeProviderWarning(
+      'relay C:\\Users\\alice\\.hermes token sk-secret-123 request req_abc',
+    )
+    expect(unsafe).toBe('Provider is temporarily unavailable.')
+    expect(unsafe).not.toMatch(/alice|hermes|sk-secret|req_abc/i)
+  })
+
+  it('persists concrete Antigravity inventory and reuses it as unavailable after discovery failure', () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'antigravity-inventory-'))
+    try {
+      const inventoryPath = join(stateDir, 'inventory.json')
+      const live = resolveAntigravityProviderInventory(
+        ['gemini-3.6-flash-high', '../gemini-unsafe', 'claude-opus'],
+        inventoryPath,
+      )
+      const cached = resolveAntigravityProviderInventory([], inventoryPath)
+
+      expect(live).toMatchObject({
+        authenticated: true,
+        models: ['gemini-3.6-flash-high'],
+      })
+      expect(cached).toMatchObject({
+        authenticated: false,
+        models: ['gemini-3.6-flash-high'],
+      })
+      const catalog = buildSubscriptionCatalog({
+        relayModels: [],
+        oauthProviders: [cached],
+        transports: [],
+        allowApiBilledModels: false,
+      })
+      expect(catalog.models[0]).toMatchObject({
+        id: 'google-antigravity/gemini-3.6-flash-high',
+        status: 'unavailable',
+        selectable: false,
+      })
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects non-loopback Antigravity relay base URLs', () => {
+    expect(() =>
+      resolveAntigravityRelayBaseUrl('http://192.168.1.12:8651'),
+    ).toThrow(/loopback/i)
+    expect(resolveAntigravityRelayBaseUrl('http://localhost:8651/')).toBe(
+      'http://localhost:8651',
+    )
+  })
+
+  it('builds secret-free API-billed rows only for configured non-OpenRouter providers', () => {
+    const providers = configuredApiBilledProviderInputs(
+      {
+        ANTHROPIC_API_KEY: 'sk-ant-secret',
+        OPENROUTER_API_KEY: 'sk-or-secret',
+      },
+      (provider) =>
+        provider === 'anthropic' ? ['claude-sonnet-4-6'] : ['paid-model'],
+    )
+
+    expect(providers).toEqual([
+      {
+        provider: 'anthropic',
+        authenticated: true,
+        models: ['claude-sonnet-4-6'],
+        billingClass: 'api_billed',
+      },
+    ])
+    expect(JSON.stringify(providers)).not.toMatch(/sk-ant|sk-or|secret/i)
+    expect(
+      buildSubscriptionCatalog({
+        relayModels: [],
+        oauthProviders: providers,
+        transports: [],
+        allowApiBilledModels: true,
+      }).models,
+    ).toEqual([
+      expect.objectContaining({
+        id: 'anthropic/claude-sonnet-4-6',
+        billingClass: 'api_billed',
+        selectable: true,
+      }),
+    ])
+  })
+
+  it('enriches routes with model limits and provider-specific reasoning options', () => {
+    const catalog = buildSubscriptionCatalog({
+      relayModels: [
+        { id: 'claude-cwm4tx/opus-5', account: 'cwm4tx', status: 'available' },
+      ],
+      oauthProviders: [
+        {
+          provider: 'openai-codex',
+          authenticated: true,
+          models: ['gpt-5.6-sol'],
+        },
+      ],
+      transports: [],
+      allowApiBilledModels: false,
+      capabilities: {
+        'claude-cwm4tx/opus-5': {
+          contextWindow: 1_000_000,
+          maxInputTokens: null,
+          maxOutputTokens: 128_000,
+          supportsReasoning: true,
+          supportsTools: true,
+          supportsVision: true,
+          metadataSource: 'models.dev',
+        },
+        'openai-codex/gpt-5.6-sol': {
+          contextWindow: 1_050_000,
+          maxInputTokens: 922_000,
+          maxOutputTokens: 128_000,
+          supportsReasoning: true,
+          supportsTools: true,
+          supportsVision: true,
+          metadataSource: 'models.dev',
+        },
+      },
+    })
+
+    expect(catalog.models[0]?.capabilities).toMatchObject({
+      contextWindow: 1_000_000,
+      maxOutputTokens: 128_000,
+      supportsOutputTokenLimit: false,
+      reasoningEfforts: [
+        'provider_default',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+      ],
+    })
+    expect(catalog.models[1]?.capabilities).toMatchObject({
+      maxInputTokens: 922_000,
+      supportsOutputTokenLimit: false,
+      reasoningEfforts: [
+        'provider_default',
+        'none',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+        'ultra',
+      ],
+    })
+  })
+
+  it('hides API-billed transports until the future-use config is enabled', () => {
+    const common = {
+      relayModels: [],
+      oauthProviders: [
+        {
+          provider: 'openai-api',
+          authenticated: true,
+          models: ['gpt-api'],
+          billingClass: 'api_billed' as const,
+        },
+      ],
+      transports: [],
+    }
+    expect(
+      buildSubscriptionCatalog({ ...common, allowApiBilledModels: false })
+        .models,
+    ).toHaveLength(0)
+    expect(
+      buildSubscriptionCatalog({ ...common, allowApiBilledModels: true })
+        .models,
+    ).toHaveLength(1)
+  })
+
+  it('reports authenticated transports that are not currently usable', () => {
+    const catalog = buildSubscriptionCatalog({
+      relayModels: [],
+      oauthProviders: [],
+      transports: [
+        {
+          id: 'gemini-cli',
+          label: 'Gemini CLI OAuth',
+          authenticated: true,
+          status: 'ineligible',
+          warning:
+            'Authenticated account is not eligible for this CLI transport.',
+        },
+      ],
+      allowApiBilledModels: false,
+    })
+    expect(catalog.transports[0]).toMatchObject({
+      authenticated: true,
+      status: 'ineligible',
+    })
+  })
+
+  it('keeps quota-limited OAuth routes visible but disables unavailable routes', () => {
+    const catalog = buildSubscriptionCatalog({
+      relayModels: [
+        { id: 'claude-cwm4tx/opus', account: 'cwm4tx', status: 'auth_expired' },
+        { id: 'claude-gp/opus', account: 'gp', status: 'quota_limited' },
+      ],
+      oauthProviders: [],
+      transports: [],
+      allowApiBilledModels: false,
+    })
+
+    expect(
+      catalog.models.find((model) => model.id === 'claude-cwm4tx/opus'),
+    ).toMatchObject({ selectable: false, status: 'auth_expired' })
+    expect(
+      catalog.models.find((model) => model.id === 'claude-gp/opus'),
+    ).toMatchObject({ selectable: false, status: 'quota_limited' })
+  })
+
+  it('uses the Hermes-managed interpreter for live OAuth model discovery', () => {
+    const expected =
+      'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+    expect(
+      resolveHermesPython(
+        { LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' },
+        (candidate) => candidate === expected,
+        'C:\\Users\\test',
+        'win32',
+      ),
+    ).toBe(expected)
+  })
+
+  it('normalizes transport-prefixed routes for capability metadata only', () => {
+    expect(
+      metadataIdentityForRoute({
+        id: 'nous/anthropic/claude-opus-4.8',
+        provider: 'nous',
+        model: 'anthropic/claude-opus-4.8',
+      }),
+    ).toEqual({ provider: 'anthropic', model: 'claude-opus-4-8' })
+    expect(
+      metadataIdentityForRoute({
+        id: 'openai-codex/gpt-5.6-sol',
+        provider: 'openai-codex',
+        model: 'gpt-5.6-sol',
+      }),
+    ).toEqual({ provider: 'openai', model: 'gpt-5.6-sol' })
+    expect(
+      metadataIdentityForRoute({
+        id: 'claude-cwm4tx/fable',
+        provider: 'claude-max-relay',
+        model: 'fable',
+      }),
+    ).toEqual({ provider: 'anthropic', model: 'claude-fable-5' })
+    expect(
+      metadataIdentityForRoute({
+        id: 'claude-cwm4tx/claude-opus-5',
+        provider: 'claude-max-relay',
+        model: 'claude-opus-5',
+      }),
+    ).toEqual({ provider: 'anthropic', model: 'claude-opus-5' })
+    expect(
+      metadataIdentityForRoute({
+        id: 'claude-cwm4tx/opus-5',
+        provider: 'claude-max-relay',
+        model: 'opus-5',
+      }),
+    ).toEqual({ provider: 'anthropic', model: 'claude-opus-5' })
+  })
+
+  it('discovers route capabilities without changing route identity', () => {
+    const capabilities = discoverModelCapabilities(
+      [
+        {
+          id: 'openai-codex/gpt-5.6-sol',
+          provider: 'openai-codex',
+          model: 'gpt-5.6-sol',
+        },
+      ],
+      (_command, args) => {
+        const queries = inflateSync(
+          Buffer.from(String(args.at(-1)), 'base64'),
+        ).toString('utf8')
+        expect(queries).toContain('openai-codex/gpt-5.6-sol')
+        return JSON.stringify({
+          'openai-codex/gpt-5.6-sol': {
+            context_window: 1_050_000,
+            max_input_tokens: 922_000,
+            max_output_tokens: 128_000,
+            supports_reasoning: true,
+            supports_tools: true,
+            supports_vision: true,
+          },
+        })
+      },
+    )
+
+    expect(capabilities['openai-codex/gpt-5.6-sol']).toEqual({
+      contextWindow: 1_050_000,
+      maxInputTokens: 922_000,
+      maxOutputTokens: 128_000,
+      supportsReasoning: true,
+      supportsTools: true,
+      supportsVision: true,
+      metadataSource: 'models.dev',
+    })
+  })
+
+  it('compresses capability discovery into one managed-Python process', () => {
+    let calls = 0
+    discoverModelCapabilities(
+      Array.from({ length: 51 }, (_, index) => ({
+        id: `openai-codex/model-${index}`,
+        provider: 'openai-codex',
+        model: `model-${index}`,
+      })),
+      () => {
+        calls += 1
+        return '{}'
+      },
+    )
+    expect(calls).toBe(1)
+  })
+
+  it('caches static capabilities while invalidating when route identity changes', () => {
+    let calls = 0
+    const resolve = createCachedCapabilityResolver((routes) => {
+      calls += 1
+      return Object.fromEntries(
+        routes.map((route) => [
+          route.id,
+          {
+            contextWindow: 1000,
+            maxInputTokens: null,
+            maxOutputTokens: 100,
+            supportsReasoning: true,
+            supportsTools: true,
+            supportsVision: false,
+            metadataSource: 'test',
+          },
+        ]),
+      )
+    })
+    const routes = [
+      {
+        id: 'claude-cwm4tx/fable',
+        provider: 'claude-max-relay',
+        model: 'fable',
+      },
+    ]
+
+    resolve(routes)
+    resolve([...routes])
+    expect(calls).toBe(1)
+    resolve([{ ...routes[0], model: 'claude-fable-5' }])
+    expect(calls).toBe(2)
+  })
+
+  it('does not probe the deprecated Gemini CLI', () => {
+    let now = 1000
+    let calls = 0
+    const resolve = createAuxiliaryTransportResolver(
+      (command) => {
+        calls += 1
+        if (command === 'codex') return 'Logged in using ChatGPT'
+        return 'Copilot CLI'
+      },
+      () => now,
+      60_000,
+    )
+
+    expect(resolve().map((transport) => transport.id)).toEqual([
+      'openai-codex',
+      'github-copilot-cli',
+    ])
+    expect(resolve()).toHaveLength(2)
+    expect(calls).toBe(2)
+    now += 60_001
+    resolve()
+    expect(calls).toBe(4)
+  })
+
+  it('briefly caches static provider model inventories per provider', () => {
+    let now = 1000
+    let calls = 0
+    const resolve = createProviderModelResolver(
+      () => {
+        calls += 1
+        return '["model-a"]'
+      },
+      () => now,
+      60_000,
+    )
+
+    expect(resolve('nous')).toEqual(['model-a'])
+    expect(resolve('nous')).toEqual(['model-a'])
+    expect(resolve('openai-codex')).toEqual(['model-a'])
+    expect(calls).toBe(2)
+    now += 60_001
+    resolve('nous')
+    expect(calls).toBe(3)
+  })
+})

--- a/src/server/subscription-model-catalog.ts
+++ b/src/server/subscription-model-catalog.ts
@@ -1,0 +1,894 @@
+import { execFileSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, posix, win32 } from 'node:path'
+import { deflateSync } from 'node:zlib'
+
+import {
+  readHermesConfigFiles,
+  resolveHermesConfigPaths,
+} from './hermes-config-store'
+import { getOrchestrationPolicy } from './orchestration-policy'
+import { getStateDir } from './workspace-state-dir'
+
+export type ModelAvailability =
+  | 'available'
+  | 'quota_limited'
+  | 'auth_expired'
+  | 'unavailable'
+  | 'unknown'
+
+export type BillingClass =
+  | 'subscription_included'
+  | 'subscription_unknown'
+  | 'api_billed'
+
+export interface RelayModelInput {
+  id: string
+  account: string
+  status: ModelAvailability
+  warning?: string
+  resetAt?: string | null
+}
+
+export interface OAuthProviderInput {
+  provider: string
+  authenticated: boolean
+  models: Array<string>
+  billingClass?: BillingClass
+  subscriptionEntitled?: boolean
+  warning?: string
+}
+
+export interface SubscriptionTransportStatus {
+  id: string
+  label: string
+  authenticated: boolean
+  status: string
+  warning?: string
+}
+
+export type ReasoningEffort =
+  | 'provider_default'
+  | 'none'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max'
+  | 'ultra'
+
+export interface SubscriptionModelCapabilities {
+  contextWindow: number | null
+  maxInputTokens: number | null
+  maxOutputTokens: number | null
+  supportsReasoning: boolean
+  supportsTools: boolean
+  supportsVision: boolean
+  supportsOutputTokenLimit: boolean
+  reasoningEfforts: Array<ReasoningEffort>
+  metadataSource: string
+}
+
+export type CapabilityInput = Omit<
+  SubscriptionModelCapabilities,
+  'reasoningEfforts' | 'supportsOutputTokenLimit'
+>
+
+export interface SubscriptionModelEntry {
+  id: string
+  provider: string
+  account: string
+  model: string
+  transport: string
+  billingClass: BillingClass
+  status: ModelAvailability
+  selectable: boolean
+  warning: string
+  resetAt: string | null
+  capabilities?: SubscriptionModelCapabilities
+}
+
+export interface SubscriptionCatalog {
+  generatedAt: string
+  subscriptionOnly: boolean
+  models: Array<SubscriptionModelEntry>
+  transports: Array<SubscriptionTransportStatus>
+  visibility: {
+    showNousModels: boolean
+    showApiBilledModels: boolean
+  }
+}
+
+export interface BuildCatalogInput {
+  relayModels: Array<RelayModelInput>
+  oauthProviders: Array<OAuthProviderInput>
+  transports: Array<SubscriptionTransportStatus>
+  allowApiBilledModels: boolean
+  showNousModels?: boolean
+  capabilities?: Record<string, CapabilityInput>
+}
+
+function reasoningEffortsForRoute(
+  id: string,
+  capability: CapabilityInput,
+): Array<ReasoningEffort> {
+  if (!capability.supportsReasoning) return ['provider_default']
+  if (id.startsWith('claude-') || /\/anthropic\//.test(id)) {
+    return ['provider_default', 'low', 'medium', 'high', 'xhigh', 'max']
+  }
+  if (id.startsWith('openai-codex/')) {
+    return [
+      'provider_default',
+      'none',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+    ]
+  }
+  if (/\/google\/gemini-|^google-antigravity\//.test(id)) {
+    return ['provider_default', 'low', 'high']
+  }
+  return ['provider_default', 'none', 'low', 'medium', 'high']
+}
+
+function capabilitiesForRoute(
+  id: string,
+  input: BuildCatalogInput,
+): SubscriptionModelCapabilities | undefined {
+  const capability = input.capabilities?.[id]
+  if (!capability) return undefined
+  return {
+    ...capability,
+    supportsOutputTokenLimit:
+      !id.startsWith('claude-') && !id.startsWith('openai-codex/'),
+    reasoningEfforts: reasoningEffortsForRoute(id, capability),
+  }
+}
+
+export function buildSubscriptionCatalog(
+  input: BuildCatalogInput,
+): SubscriptionCatalog {
+  const relayEntries = input.relayModels.map(
+    (entry): SubscriptionModelEntry => {
+      const slash = entry.id.indexOf('/')
+      return {
+        id: entry.id,
+        provider: 'claude-max-relay',
+        account: entry.account,
+        model: slash >= 0 ? entry.id.slice(slash + 1) : entry.id,
+        transport: 'claude-cli-oauth',
+        billingClass: 'subscription_included',
+        status: entry.status,
+        selectable: entry.status === 'available',
+        warning: entry.warning || '',
+        resetAt: entry.resetAt || null,
+        capabilities: capabilitiesForRoute(entry.id, input),
+      }
+    },
+  )
+
+  const oauthEntries = input.oauthProviders.flatMap((provider) => {
+    const billingClass = provider.billingClass || 'subscription_included'
+    if (provider.provider === 'nous' && !input.showNousModels) return []
+    if (billingClass === 'api_billed' && !input.allowApiBilledModels) return []
+    const entitlementVerified =
+      billingClass !== 'subscription_unknown' ||
+      provider.subscriptionEntitled === true
+    const selectable = provider.authenticated && entitlementVerified
+    return provider.models.map(
+      (model): SubscriptionModelEntry => ({
+        id: `${provider.provider}/${model}`,
+        provider: provider.provider,
+        account: provider.provider,
+        model,
+        transport: `${provider.provider}-oauth`,
+        billingClass,
+        status: selectable
+          ? 'available'
+          : provider.authenticated
+            ? 'unknown'
+            : 'unavailable',
+        selectable,
+        warning: provider.warning || '',
+        resetAt: null,
+        capabilities: capabilitiesForRoute(
+          `${provider.provider}/${model}`,
+          input,
+        ),
+      }),
+    )
+  })
+
+  const seen = new Set<string>()
+  const models = [...relayEntries, ...oauthEntries].filter((entry) => {
+    if (seen.has(entry.id)) return false
+    seen.add(entry.id)
+    return true
+  })
+
+  return {
+    generatedAt: new Date().toISOString(),
+    subscriptionOnly: !input.allowApiBilledModels,
+    models,
+    transports: input.transports,
+    visibility: {
+      showNousModels: input.showNousModels === true,
+      showApiBilledModels: input.allowApiBilledModels,
+    },
+  }
+}
+
+export function metadataIdentityForRoute(
+  route: Pick<SubscriptionModelEntry, 'id' | 'provider' | 'model'>,
+): { provider: string; model: string } | null {
+  if (route.provider === 'openai-codex') {
+    return { provider: 'openai', model: route.model }
+  }
+  if (route.provider === 'claude-max-relay') {
+    if (/^(?:fable|opus|sonnet)$/.test(route.model)) {
+      return { provider: 'anthropic', model: `claude-${route.model}-5` }
+    }
+    if (/^claude-(?:opus|sonnet|haiku|fable)(?:-|$)/.test(route.model)) {
+      return { provider: 'anthropic', model: route.model }
+    }
+    if (!/^(opus|sonnet|haiku|fable)(?:-|$)/.test(route.model)) return null
+    return { provider: 'anthropic', model: `claude-${route.model}` }
+  }
+  if (route.provider === 'nous') {
+    const slash = route.model.indexOf('/')
+    if (slash < 1) return null
+    const provider = route.model.slice(0, slash).replace(/^~/, '')
+    let model = route.model.slice(slash + 1)
+    if (provider === 'anthropic') {
+      model = model.replace(/(\d)\.(\d)/g, '$1-$2')
+    }
+    return { provider, model }
+  }
+  if (
+    route.provider === 'gemini' ||
+    route.provider === 'google' ||
+    route.provider === 'google-antigravity'
+  ) {
+    return { provider: 'google', model: route.model }
+  }
+  return { provider: route.provider, model: route.model }
+}
+
+function commandOutput(
+  command: string,
+  args: Array<string>,
+  timeout = 30_000,
+): string {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      timeout,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+  } catch (error) {
+    const stderr = (error as { stderr?: string | Buffer }).stderr
+    return typeof stderr === 'string'
+      ? stderr.trim()
+      : Buffer.isBuffer(stderr)
+        ? stderr.toString('utf8').trim()
+        : ''
+  }
+}
+
+type CommandRunner = (
+  command: string,
+  args: Array<string>,
+  timeout?: number,
+) => string
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : null
+}
+
+export function discoverModelCapabilities(
+  routes: Array<Pick<SubscriptionModelEntry, 'id' | 'provider' | 'model'>>,
+  runCommand: CommandRunner = commandOutput,
+): Record<string, CapabilityInput> {
+  const queries = routes.flatMap((route) => {
+    const identity = metadataIdentityForRoute(route)
+    return identity ? [{ route: route.id, ...identity }] : []
+  })
+  if (queries.length === 0) return {}
+
+  const script = [
+    'import base64, json, sys, zlib',
+    'from agent.models_dev import get_model_capabilities, get_model_info',
+    'queries = json.loads(zlib.decompress(base64.b64decode(sys.argv[1])))',
+    'result = {}',
+    'for q in queries:',
+    '    try:',
+    '        info = get_model_info(q["provider"], q["model"])',
+    '        caps = get_model_capabilities(q["provider"], q["model"])',
+    '        if info is None and caps is None: continue',
+    '        result[q["route"]] = {',
+    '            "context_window": getattr(info, "context_window", 0) or getattr(caps, "context_window", 0),',
+    '            "max_input_tokens": getattr(info, "max_input", None),',
+    '            "max_output_tokens": getattr(info, "max_output", 0) or getattr(caps, "max_output_tokens", 0),',
+    '            "supports_reasoning": bool(getattr(info, "reasoning", False) or getattr(caps, "supports_reasoning", False)),',
+    '            "supports_tools": bool(getattr(info, "tool_call", False) or getattr(caps, "supports_tools", False)),',
+    '            "supports_vision": bool((info and info.supports_vision()) or getattr(caps, "supports_vision", False)),',
+    '        }',
+    '    except Exception:',
+    '        continue',
+    'print(json.dumps(result))',
+  ].join('\n')
+  const encodedQueries = deflateSync(
+    Buffer.from(JSON.stringify(queries), 'utf8'),
+  ).toString('base64')
+  const raw = runCommand(
+    resolveHermesPython(),
+    ['-c', script, encodedQueries],
+    120_000,
+  )
+  const discovered: Record<string, CapabilityInput> = {}
+  try {
+    const parsed = JSON.parse(raw) as Record<string, Record<string, unknown>>
+    for (const [id, value] of Object.entries(parsed)) {
+      discovered[id] = {
+        contextWindow: positiveInteger(value.context_window),
+        maxInputTokens: positiveInteger(value.max_input_tokens),
+        maxOutputTokens: positiveInteger(value.max_output_tokens),
+        supportsReasoning: value.supports_reasoning === true,
+        supportsTools: value.supports_tools === true,
+        supportsVision: value.supports_vision === true,
+        metadataSource: 'models.dev',
+      }
+    }
+  } catch {
+    // Preserve route visibility when capability discovery is unavailable.
+  }
+  return discovered
+}
+
+function hermesAuthenticated(provider: string): boolean {
+  return /logged in/i.test(
+    commandOutput('hermes', ['auth', 'status', provider], 15_000),
+  )
+}
+
+export function createCachedCapabilityResolver(
+  discover: typeof discoverModelCapabilities = discoverModelCapabilities,
+): typeof discoverModelCapabilities {
+  let cachedKey = ''
+  let cachedCapabilities: ReturnType<typeof discoverModelCapabilities> = {}
+
+  return (routes, runCommand) => {
+    // Injected runners are tests/probes and must always execute. The live path
+    // caches only static route identity; allocation health is rebuilt outside
+    // this resolver on every catalog request.
+    if (runCommand) return discover(routes, runCommand)
+    const key = JSON.stringify(
+      routes
+        .map(({ id, provider, model }) => ({ id, provider, model }))
+        .sort((a, b) => a.id.localeCompare(b.id)),
+    )
+    if (key === cachedKey) return cachedCapabilities
+    cachedCapabilities = discover(routes)
+    cachedKey = key
+    return cachedCapabilities
+  }
+}
+
+const resolveCachedModelCapabilities = createCachedCapabilityResolver()
+
+export function resolveHermesPython(
+  env: Record<string, string | undefined> = process.env,
+  fileExists: (candidate: string) => boolean = existsSync,
+  home: string = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (env.HERMES_PYTHON) return env.HERMES_PYTHON
+  const pathApi = platform === 'win32' ? win32 : posix
+  const executable =
+    platform === 'win32'
+      ? pathApi.join('venv', 'Scripts', 'python.exe')
+      : pathApi.join('venv', 'bin', 'python')
+  const roots = [
+    env.HERMES_HOME,
+    env.LOCALAPPDATA ? pathApi.join(env.LOCALAPPDATA, 'hermes') : undefined,
+    platform === 'win32'
+      ? pathApi.join(home, 'AppData', 'Local', 'hermes')
+      : pathApi.join(home, '.hermes'),
+  ].filter((value): value is string => Boolean(value))
+  for (const root of [...new Set(roots)]) {
+    const candidate = pathApi.join(root, 'hermes-agent', executable)
+    if (fileExists(candidate)) return candidate
+  }
+  return platform === 'win32' ? 'python' : 'python3'
+}
+
+export function createProviderModelResolver(
+  runCommand: AuxiliaryCommandRunner = commandOutput,
+  now: () => number = Date.now,
+  ttlMs = 60_000,
+): (provider: string) => Array<string> {
+  const cache = new Map<string, { expiresAt: number; models: Array<string> }>()
+
+  return (provider) => {
+    const currentTime = now()
+    const cached = cache.get(provider)
+    if (cached && currentTime < cached.expiresAt) return cached.models
+
+    const script = [
+      'import json',
+      'from hermes_cli.models import provider_model_ids',
+      `print(json.dumps(provider_model_ids(${JSON.stringify(provider)})))`,
+    ].join('; ')
+    const raw = runCommand(resolveHermesPython(), ['-c', script], 90_000)
+    let models: Array<string> = []
+    try {
+      const parsed = JSON.parse(raw)
+      models = Array.isArray(parsed)
+        ? parsed.filter((value): value is string => typeof value === 'string')
+        : []
+    } catch {
+      models = []
+    }
+    cache.set(provider, { expiresAt: currentTime + ttlMs, models })
+    return models
+  }
+}
+
+const resolveProviderModels = createProviderModelResolver()
+
+const STATIC_OPENAI_CODEX_MODELS = [
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'gpt-5.5',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.3-codex-spark',
+  'gpt-5.6-sol-pro',
+  'gpt-5.6-terra-pro',
+  'gpt-5.6-luna-pro',
+] as const
+
+export function openAiCodexModelInventory(
+  discovered: Array<string>,
+): Array<string> {
+  const models = [...STATIC_OPENAI_CODEX_MODELS, ...discovered]
+    .map((model) => model.trim())
+    .filter((model) => /^[a-z0-9][a-z0-9._-]*$/i.test(model))
+  return [...new Set(models)]
+}
+
+const API_BILLED_PROVIDER_ENV_KEYS: Array<{
+  provider: string
+  envKeys: Array<string>
+}> = [
+  { provider: 'anthropic', envKeys: ['ANTHROPIC_API_KEY'] },
+  { provider: 'openai', envKeys: ['OPENAI_API_KEY'] },
+  { provider: 'google', envKeys: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'] },
+  { provider: 'zai', envKeys: ['GLM_API_KEY'] },
+  { provider: 'kimi-coding', envKeys: ['KIMI_API_KEY'] },
+  { provider: 'minimax', envKeys: ['MINIMAX_API_KEY'] },
+  { provider: 'minimax-cn', envKeys: ['MINIMAX_CN_API_KEY'] },
+  { provider: 'xiaomi', envKeys: ['XIAOMI_API_KEY'] },
+]
+
+export function configuredApiBilledProviderInputs(
+  env: Record<string, string | undefined>,
+  resolveModels: (provider: string) => Array<string> = resolveProviderModels,
+): Array<OAuthProviderInput> {
+  return API_BILLED_PROVIDER_ENV_KEYS.flatMap((definition) => {
+    if (!definition.envKeys.some((key) => Boolean(env[key]?.trim()))) return []
+    const models = resolveModels(definition.provider)
+    if (models.length === 0) return []
+    return [
+      {
+        provider: definition.provider,
+        authenticated: true,
+        models,
+        billingClass: 'api_billed' as const,
+      },
+    ]
+  })
+}
+
+function isConcreteAntigravityModel(model: string): boolean {
+  return /^gemini-\d+(?:\.\d+)+(?:-[a-z0-9]+)+$/.test(model)
+}
+
+export function parseAntigravityModels(raw: string): Array<string> {
+  return raw.split(/\r?\n/).flatMap((line) => {
+    const [id] = line.split('\t', 1)
+    const model = id.trim()
+    return isConcreteAntigravityModel(model) ? [model] : []
+  })
+}
+
+export function parseAntigravityModelRows(
+  rows: Array<{ id?: unknown }>,
+): Array<string> {
+  return rows.flatMap((row) => {
+    if (typeof row.id !== 'string') return []
+    const prefix = 'google-antigravity/'
+    if (!row.id.startsWith(prefix)) return []
+    const model = row.id.slice(prefix.length)
+    return isConcreteAntigravityModel(model) ? [model] : []
+  })
+}
+
+export function sanitizeProviderWarning(raw?: string): string | undefined {
+  const warning = raw?.trim()
+  if (!warning) return undefined
+
+  if (
+    /429|quota|rate.?limit|spend limit|monthly.{0,30}limit|usage limit/i.test(
+      warning,
+    )
+  ) {
+    return 'Provider quota is currently limited.'
+  }
+  if (/entitl|subscription|ineligible|not eligible/i.test(warning)) {
+    return 'Provider subscription entitlement is unverified.'
+  }
+  if (
+    /oauth|auth(?:entication)?|log.?in|credential|token.{0,30}expir|expir.{0,30}token/i.test(
+      warning,
+    )
+  ) {
+    return 'Provider authentication needs attention.'
+  }
+  if (
+    /timeout|timed out|unavailable|connect|network|relay|\b5\d\d\b/i.test(
+      warning,
+    )
+  ) {
+    return 'Provider is temporarily unavailable.'
+  }
+  return 'Provider reported a status that could not be safely displayed.'
+}
+
+function antigravityInventoryPath(): string {
+  return join(getStateDir(), 'antigravity-model-inventory.json')
+}
+
+function readAntigravityInventory(path: string): Array<string> {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as {
+      models?: unknown
+    }
+    return Array.isArray(parsed.models)
+      ? parsed.models.filter(
+          (model): model is string =>
+            typeof model === 'string' && isConcreteAntigravityModel(model),
+        )
+      : []
+  } catch {
+    return []
+  }
+}
+
+function writeAntigravityInventory(path: string, models: Array<string>): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const temp = `${path}.${process.pid}.${Date.now()}.tmp`
+  try {
+    writeFileSync(
+      temp,
+      `${JSON.stringify({ models, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+      'utf8',
+    )
+    renameSync(temp, path)
+  } finally {
+    rmSync(temp, { force: true })
+  }
+}
+
+export function resolveAntigravityProviderInventory(
+  discoveredModels: Array<string>,
+  inventoryPath = antigravityInventoryPath(),
+): OAuthProviderInput {
+  const discovered = [
+    ...new Set(
+      discoveredModels
+        .map((model) => model.trim())
+        .filter(isConcreteAntigravityModel),
+    ),
+  ]
+  if (discovered.length > 0) {
+    writeAntigravityInventory(inventoryPath, discovered)
+    return {
+      provider: 'google-antigravity',
+      authenticated: true,
+      models: discovered,
+      billingClass: 'subscription_included',
+      warning: '',
+    }
+  }
+
+  const cached = readAntigravityInventory(inventoryPath)
+  return {
+    provider: 'google-antigravity',
+    authenticated: false,
+    models: cached,
+    billingClass: 'subscription_included',
+    warning:
+      cached.length > 0
+        ? 'Antigravity inventory is temporarily unavailable; showing last-known models as unavailable.'
+        : 'Antigravity OAuth is unavailable.',
+  }
+}
+
+export function resolveAntigravityRelayBaseUrl(raw?: string): string {
+  const candidate = (raw || 'http://127.0.0.1:8651').trim().replace(/\/+$/, '')
+  try {
+    const url = new URL(candidate)
+    const host = url.hostname.toLowerCase()
+    if (
+      url.protocol === 'http:' &&
+      !url.username &&
+      !url.password &&
+      ['127.0.0.1', 'localhost', '[::1]', '::1'].includes(host)
+    ) {
+      return candidate
+    }
+  } catch {
+    // The fixed error below intentionally avoids echoing the rejected value.
+  }
+  throw new Error('ANTIGRAVITY_RELAY_BASE_URL must be an HTTP loopback URL')
+}
+
+async function fetchAntigravityProvider(): Promise<OAuthProviderInput> {
+  const base = resolveAntigravityRelayBaseUrl(
+    process.env.ANTIGRAVITY_RELAY_BASE_URL,
+  )
+  const modelsUrl = base.endsWith('/v1')
+    ? `${base}/models`
+    : `${base}/v1/models`
+  let models: Array<string> = []
+  try {
+    const response = await fetch(modelsUrl, {
+      signal: AbortSignal.timeout(4_000),
+    })
+    if (response.ok) {
+      const payload = (await response.json()) as {
+        data?: Array<{ id?: unknown }>
+      }
+      models = parseAntigravityModelRows(payload.data || [])
+    }
+  } catch {
+    // The CLI fallback keeps the catalog available while the supervisor is
+    // recovering the local relay.
+  }
+  if (models.length === 0) {
+    models = parseAntigravityModels(commandOutput('agy', ['models'], 30_000))
+  }
+  return resolveAntigravityProviderInventory(models)
+}
+
+type RelayAccountHealth = Partial<
+  Record<
+    string,
+    {
+      status?: ModelAvailability
+      warning?: string
+      reset_at?: string | null
+    }
+  >
+>
+
+export function buildRelayModelInputs(
+  rows: Array<{ id?: unknown }>,
+  accountStatus: RelayAccountHealth,
+): Array<RelayModelInput> {
+  return rows.flatMap((row) => {
+    if (typeof row.id !== 'string') return []
+    const accountPart = row.id.split('/')[0] || ''
+    const account = accountPart.replace(/^claude-/, '')
+    const health = accountStatus[account]
+    if (!health?.status) {
+      return [
+        {
+          id: row.id,
+          account,
+          status: 'unavailable' as const,
+          warning: 'Account health could not be verified.',
+          resetAt: null,
+        },
+      ]
+    }
+    return [
+      {
+        id: row.id,
+        account,
+        status: health.status,
+        warning: sanitizeProviderWarning(health.warning),
+        resetAt: health.reset_at,
+      },
+    ]
+  })
+}
+
+async function fetchRelayModels(): Promise<Array<RelayModelInput>> {
+  const base = process.env.CLAUDE_RELAY_BASE_URL || 'http://127.0.0.1:8650'
+  try {
+    const [modelsResponse, healthResponse] = await Promise.all([
+      fetch(`${base}/v1/models`, { signal: AbortSignal.timeout(4_000) }),
+      fetch(`${base}/health`, { signal: AbortSignal.timeout(4_000) }),
+    ])
+    if (!modelsResponse.ok) return []
+    const modelPayload = (await modelsResponse.json()) as {
+      data?: Array<{ id?: unknown }>
+    }
+    const health = healthResponse.ok
+      ? ((await healthResponse.json()) as {
+          account_status?: Record<
+            string,
+            {
+              status?: ModelAvailability
+              warning?: string
+              reset_at?: string | null
+            }
+          >
+        })
+      : {}
+    return buildRelayModelInputs(
+      modelPayload.data || [],
+      health.account_status || {},
+    )
+  } catch {
+    return []
+  }
+}
+
+type AuxiliaryCommandRunner = (
+  command: string,
+  args: Array<string>,
+  timeoutMs: number,
+) => string
+
+export function createAuxiliaryTransportResolver(
+  runCommand: AuxiliaryCommandRunner = commandOutput,
+  now: () => number = Date.now,
+  ttlMs = 60_000,
+): () => Array<SubscriptionTransportStatus> {
+  let cached: Array<SubscriptionTransportStatus> | null = null
+  let expiresAt = 0
+
+  return () => {
+    const currentTime = now()
+    if (cached && currentTime < expiresAt) return cached
+
+    const transports: Array<SubscriptionTransportStatus> = []
+    const codexStatus = runCommand('codex', ['login', 'status'], 15_000)
+    transports.push({
+      id: 'openai-codex',
+      label: 'OpenAI Codex OAuth',
+      authenticated: /logged in using chatgpt/i.test(codexStatus),
+      status: /logged in using chatgpt/i.test(codexStatus)
+        ? 'available'
+        : 'logged_out',
+    })
+
+    const copilotStatus = runCommand('gh', ['copilot', '--', '--help'], 15_000)
+    const copilotInstalled =
+      !/not installed/i.test(copilotStatus) &&
+      /copilot cli/i.test(copilotStatus)
+    transports.push({
+      id: 'github-copilot-cli',
+      label: 'GitHub Copilot CLI',
+      authenticated: copilotInstalled,
+      status: /not installed/i.test(copilotStatus)
+        ? 'not_installed'
+        : 'unknown',
+      warning: /not installed/i.test(copilotStatus)
+        ? 'GitHub is authenticated, but the Copilot CLI transport is not installed.'
+        : 'Copilot subscription eligibility has not been verified.',
+    })
+
+    cached = transports
+    expiresAt = currentTime + ttlMs
+    return transports
+  }
+}
+
+const resolveAuxiliaryTransports = createAuxiliaryTransportResolver()
+
+export async function loadSubscriptionCatalog(): Promise<SubscriptionCatalog> {
+  const policy = getOrchestrationPolicy()
+  const providerIds = ['openai-codex', 'nous']
+  const oauthProviders = providerIds.map((provider): OAuthProviderInput => {
+    const authenticated = hermesAuthenticated(provider)
+    return {
+      provider,
+      authenticated,
+      models:
+        provider === 'openai-codex'
+          ? openAiCodexModelInventory(resolveProviderModels(provider))
+          : authenticated
+            ? resolveProviderModels(provider)
+            : [],
+      billingClass:
+        provider === 'nous' ? 'subscription_unknown' : 'subscription_included',
+      warning:
+        provider === 'nous'
+          ? 'Nous OAuth model subscription entitlement is unverified.'
+          : '',
+    }
+  })
+  oauthProviders.splice(1, 0, await fetchAntigravityProvider())
+  const configFiles = readHermesConfigFiles(resolveHermesConfigPaths())
+  const configuredApiEnv: Record<string, string | undefined> = {
+    ...configFiles.env,
+  }
+  for (const definition of API_BILLED_PROVIDER_ENV_KEYS) {
+    for (const key of definition.envKeys) {
+      configuredApiEnv[key] ||= process.env[key]
+    }
+  }
+  oauthProviders.push(...configuredApiBilledProviderInputs(configuredApiEnv))
+
+  const relayModels = await fetchRelayModels()
+  const transportsById = new Map(
+    resolveAuxiliaryTransports().map((transport) => [transport.id, transport]),
+  )
+  for (const provider of oauthProviders) {
+    transportsById.set(provider.provider, {
+      id: provider.provider,
+      label:
+        provider.provider === 'openai-codex'
+          ? 'OpenAI Codex OAuth'
+          : provider.provider === 'google-antigravity'
+            ? 'Antigravity — Gemini OAuth'
+            : 'Nous Portal OAuth',
+      authenticated: provider.authenticated,
+      status: provider.authenticated
+        ? 'available'
+        : provider.models.length > 0
+          ? 'unavailable'
+          : 'logged_out',
+      ...(provider.warning ? { warning: provider.warning } : {}),
+    })
+  }
+  for (const model of relayModels) {
+    const id = `claude-${model.account}`
+    if (transportsById.has(id)) continue
+    transportsById.set(id, {
+      id,
+      label:
+        model.account === 'cwm4tx'
+          ? 'Claude Max — CWM'
+          : model.account === 'gp'
+            ? 'Claude Max — GP'
+            : `Claude Max — ${model.account}`,
+      authenticated:
+        model.status === 'available' || model.status === 'quota_limited',
+      status: model.status,
+      ...(model.warning ? { warning: model.warning } : {}),
+    })
+  }
+
+  const input: BuildCatalogInput = {
+    relayModels,
+    oauthProviders,
+    transports: Array.from(transportsById.values()),
+    allowApiBilledModels: policy.billing.allowApiBilledModels,
+    showNousModels: policy.billing.showNousModels,
+  }
+  const baseCatalog = buildSubscriptionCatalog(input)
+  return buildSubscriptionCatalog({
+    ...input,
+    capabilities: resolveCachedModelCapabilities(baseCatalog.models),
+  })
+}

--- a/src/server/swarm-chat-reader.test.ts
+++ b/src/server/swarm-chat-reader.test.ts
@@ -1,8 +1,10 @@
+import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { readWorkerMessages } from './swarm-chat-reader'
+import { resolveManagedPythonBin } from './managed-python'
 
 describe('readWorkerMessages', () => {
   it('treats a missing state.db as an unavailable session, not a UI error', () => {
@@ -18,6 +20,29 @@ describe('readWorkerMessages', () => {
         ok: false,
       })
       expect(result.error).toBeUndefined()
+    } finally {
+      rmSync(profilePath, { recursive: true, force: true })
+    }
+  })
+
+  it('reads a worker SQLite session with the managed Hermes interpreter', () => {
+    const profilePath = mkdtempSync(join(tmpdir(), 'swarm-chat-reader-db-'))
+    const dbPath = join(profilePath, 'state.db')
+    const createFixture = `import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, started_at INTEGER)")
+conn.execute("CREATE TABLE messages (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, created_at INTEGER)")
+conn.execute("INSERT INTO sessions VALUES ('s1', 'Validation', 1)")
+conn.execute("INSERT INTO messages VALUES ('m1', 's1', 'assistant', 'PYTHON_READER_OK', 2)")
+conn.commit()
+conn.close()`
+
+    try {
+      execFileSync(resolveManagedPythonBin(), ['-c', createFixture, dbPath])
+      const result = readWorkerMessages(profilePath, 30)
+      expect(result.ok).toBe(true)
+      expect(result.sessionId).toBe('s1')
+      expect(result.messages.at(-1)?.content).toBe('PYTHON_READER_OK')
     } finally {
       rmSync(profilePath, { recursive: true, force: true })
     }

--- a/src/server/swarm-chat-reader.ts
+++ b/src/server/swarm-chat-reader.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveManagedPythonBin } from './managed-python'
 
 export type SwarmChatMessage = {
   id: string
@@ -139,7 +140,10 @@ print(json.dumps({
 }))
 `
 
-export function readWorkerMessages(profilePath: string, limit: number): SwarmChatReadResult {
+export function readWorkerMessages(
+  profilePath: string,
+  limit: number,
+): SwarmChatReadResult {
   const dbPath = join(profilePath, 'state.db')
   if (!existsSync(dbPath)) {
     return {
@@ -151,7 +155,7 @@ export function readWorkerMessages(profilePath: string, limit: number): SwarmCha
   }
   try {
     const raw = execFileSync(
-      'python3',
+      resolveManagedPythonBin(),
       ['-c', PYTHON_SCRIPT, dbPath, String(limit)],
       { encoding: 'utf-8', timeout: 5_000 },
     )

--- a/src/server/swarm-decompose-model.test.ts
+++ b/src/server/swarm-decompose-model.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectSwarmOrchestratorRoute } from './swarm-decompose-model'
+
+describe('selectSwarmOrchestratorRoute', () => {
+  const routes = [
+    { id: 'claude-cwm4tx/sonnet', selectable: true },
+    { id: 'openai-codex/gpt-5.6-sol', selectable: true },
+    { id: 'api/paid-model', selectable: false },
+  ]
+
+  it('uses the orchestration policy route when the request has no override', () => {
+    expect(
+      selectSwarmOrchestratorRoute({
+        requestedModel: '',
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+        routes,
+      }),
+    ).toBe('claude-cwm4tx/sonnet')
+  })
+
+  it('falls back to the configured default child route when no orchestrator override exists', () => {
+    expect(
+      selectSwarmOrchestratorRoute({
+        requestedModel: '',
+        orchestratorModelRef: '',
+        fallbackModelRef: 'openai-codex/gpt-5.6-sol',
+        routes,
+      }),
+    ).toBe('openai-codex/gpt-5.6-sol')
+  })
+
+  it('accepts only selectable canonical routes as explicit overrides', () => {
+    expect(
+      selectSwarmOrchestratorRoute({
+        requestedModel: 'openai-codex/gpt-5.6-sol',
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+        routes,
+      }),
+    ).toBe('openai-codex/gpt-5.6-sol')
+
+    expect(() =>
+      selectSwarmOrchestratorRoute({
+        requestedModel: 'api/paid-model',
+        orchestratorModelRef: 'claude-cwm4tx/sonnet',
+        routes,
+      }),
+    ).toThrow('not a selectable OAuth subscription route')
+  })
+})

--- a/src/server/swarm-decompose-model.ts
+++ b/src/server/swarm-decompose-model.ts
@@ -1,0 +1,24 @@
+export type SelectableRoute = {
+  id: string
+  selectable: boolean
+}
+
+export function selectSwarmOrchestratorRoute(input: {
+  requestedModel?: string | null
+  orchestratorModelRef?: string | null
+  fallbackModelRef?: string | null
+  routes: Array<SelectableRoute>
+}): string {
+  const requested = input.requestedModel?.trim() || ''
+  const configured = input.orchestratorModelRef?.trim() || ''
+  const fallback = input.fallbackModelRef?.trim() || ''
+  const selected = requested || configured || fallback
+  if (!selected) {
+    throw new Error('No orchestrator OAuth subscription route is configured')
+  }
+  const route = input.routes.find((entry) => entry.id === selected)
+  if (!route?.selectable) {
+    throw new Error(`${selected} is not a selectable OAuth subscription route`)
+  }
+  return route.id
+}

--- a/src/server/swarm-lifecycle-process-host.test.ts
+++ b/src/server/swarm-lifecycle-process-host.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const host = vi.hoisted(() => ({
+  send: vi.fn(async () => ({ ok: true })),
+  start: vi.fn(async () => ({ ok: true })),
+  stop: vi.fn(async () => ({ ok: true })),
+}))
+
+vi.mock('./worker-process-host', () => ({
+  getWorkerProcessHost: () => host,
+}))
+
+import { sendToWorker } from './swarm-lifecycle'
+
+describe('swarm lifecycle process host integration', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('delegates worker input to the durable WorkerProcessHost authority', async () => {
+    expect(await sendToWorker('builder', 'continue')).toEqual({ ok: true })
+    expect(host.send).toHaveBeenCalledWith('builder', 'continue')
+  })
+})

--- a/src/server/swarm-lifecycle.ts
+++ b/src/server/swarm-lifecycle.ts
@@ -3,6 +3,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync } from 'n
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { getProfilesDir } from './claude-paths'
+import { resolveManagedPythonBin } from './managed-python'
 import { SWARM_MEMORY_ROOT } from './swarm-environment'
 import { appendSwarmMemoryEvent } from './swarm-memory'
 import type {ChildProcess} from 'node:child_process';
@@ -102,7 +103,7 @@ export function getSwarmLifecycleStatus(workerId: string, policy = DEFAULT_POLIC
   const profilePath = join(getProfilesDir(), workerId)
   let parsed: Record<string, unknown> = {}
   try {
-    const raw = execFileSync('python3', ['-c', PYTHON_STATUS, profilePath], { encoding: 'utf8', timeout: 5_000 })
+    const raw = execFileSync(resolveManagedPythonBin(), ['-c', PYTHON_STATUS, profilePath], { encoding: 'utf8', timeout: 5_000 })
     parsed = JSON.parse(raw) as Record<string, unknown>
   } catch {
     parsed = { ok: false }

--- a/src/server/swarm-lifecycle.ts
+++ b/src/server/swarm-lifecycle.ts
@@ -153,6 +153,8 @@ export async function startWorkerProcess(workerId: string): Promise<{ ok: boolea
   const profilePath = join(getProfilesDir(), workerId)
   if (!existsSync(profilePath)) return { ok: false, error: `Profile not found: ${profilePath}` }
   const hermesBin = process.env.HERMES_CLI_PATH || resolveSwarmHermesBin()
+  // Hermes consumes model.openai_runtime from this profile's config.yaml on
+  // process start; dashboard runtime changes intentionally apply after restart.
   const result = await getWorkerProcessHost().start({
     workerId,
     command: hermesBin,

--- a/src/server/swarm-lifecycle.ts
+++ b/src/server/swarm-lifecycle.ts
@@ -1,12 +1,12 @@
-import {  execFile, execFileSync, spawn } from 'node:child_process'
-import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync } from 'node:fs'
-import { homedir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { getProfilesDir } from './claude-paths'
 import { resolveManagedPythonBin } from './managed-python'
 import { SWARM_MEMORY_ROOT } from './swarm-environment'
 import { appendSwarmMemoryEvent } from './swarm-memory'
-import type {ChildProcess} from 'node:child_process';
+import { getWorkerProcessHost } from './worker-process-host'
+import { resolveSwarmHermesBin } from './swarm-tmux-launch'
 
 export type SwarmContextState = 'healthy' | 'watch' | 'handoff_required' | 'renew_required'
 
@@ -143,185 +143,29 @@ export function getSwarmLifecycleStatus(workerId: string, policy = DEFAULT_POLIC
   }
 }
 
-// ═══════════════════════════════════════════════════════════════
-// Cross-platform worker process management
-// Replaces tmux with native child_process.spawn so workers run on Windows.
-// On Linux/macOS with tmux available, falls back to the tmux path.
-// ═══════════════════════════════════════════════════════════════
-
-// Active worker processes keyed by workerId
-const workerProcesses = new Map<string, ChildProcess>()
-
-function isWindows(): boolean {
-  return process.platform === 'win32'
+/** Send a prompt through the durable process-host authority. */
+export async function sendToWorker(workerId: string, prompt: string): Promise<{ ok: boolean; error?: string }> {
+  const result = await getWorkerProcessHost().send(workerId, prompt)
+  return { ok: result.ok, error: result.error }
 }
 
-function workerLogPath(workerId: string): string {
-  const dir = join(getProfilesDir(), workerId, 'logs')
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  return join(dir, 'worker.log')
-}
-
-function appendWorkerLog(workerId: string, text: string): void {
-  try {
-    appendFileSync(workerLogPath(workerId), text + '\n', 'utf8')
-  } catch {
-    // best-effort logging
-  }
-}
-
-function tmuxBin(): string | null {
-  if (isWindows()) return null
-  const local = join(homedir(), '.local', 'bin', 'tmux')
-  return existsSync(local) ? local : 'tmux'
-}
-
-function hasTmux(): boolean {
-  if (isWindows()) return false
-  try {
-    execFileSync(tmuxBin()!, ['list-sessions'], { stdio: 'ignore' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-// Use native process spawn on Windows, tmux on Linux/macOS when available
-function useNativeProcess(): boolean {
-  return isWindows() || !hasTmux()
-}
-
-/** Send a prompt to a worker's stdin (native) or tmux pane (Unix fallback) */
-export function sendToWorker(workerId: string, prompt: string): Promise<{ ok: boolean; error?: string }> {
-  if (useNativeProcess()) {
-    return sendToWorkerProcess(workerId, prompt)
-  }
-  return sendTmux(workerId, prompt)
-}
-
-function sendToWorkerProcess(workerId: string, prompt: string): Promise<{ ok: boolean; error?: string }> {
-  return new Promise((resolve) => {
-    const proc = workerProcesses.get(workerId)
-    if (!proc || !proc.stdin?.writable) {
-      resolve({ ok: false, error: `Worker ${workerId} process not running or stdin not writable` })
-      return
-    }
-    appendWorkerLog(workerId, `[dispatch] ${prompt}`)
-    proc.stdin.write(prompt + '\n', (err) => {
-      if (err) resolve({ ok: false, error: err.message })
-      else resolve({ ok: true })
-    })
-  })
-}
-
-function sendTmux(workerId: string, prompt: string): Promise<{ ok: boolean; error?: string }> {
-  const session = `swarm-${workerId}`
-  return new Promise((resolve) => {
-    const tmux = tmuxBin()
-    if (!tmux) return resolve({ ok: false, error: 'tmux not available on this platform' })
-    const child = execFile(tmux, ['load-buffer', '-b', `swarm-lifecycle-${workerId}`, '-'], (loadErr, _stdout, stderr) => {
-      if (loadErr) return resolve({ ok: false, error: stderr?.toString() || loadErr.message })
-      execFile(tmux, ['send-keys', '-t', session, 'C-u'], () => {
-        execFile(tmux, ['paste-buffer', '-d', '-b', `swarm-lifecycle-${workerId}`, '-t', session], (pasteErr, _out2, err2) => {
-          if (pasteErr) return resolve({ ok: false, error: err2?.toString() || pasteErr.message })
-          setTimeout(() => execFile(tmux, ['send-keys', '-t', session, 'Enter'], (enterErr, _out3, err3) => {
-            if (enterErr) return resolve({ ok: false, error: err3?.toString() || enterErr.message })
-            resolve({ ok: true })
-          }), 150)
-        })
-      })
-    })
-    child.stdin?.end(prompt)
-  })
-}
-
-async function killWorkerProcess(workerId: string): Promise<{ ok: boolean; error?: string }> {
-  const proc = workerProcesses.get(workerId)
-  if (!proc) return { ok: false, error: 'No active process' }
-  return new Promise((resolve) => {
-    proc.kill('SIGTERM')
-    const timeout = setTimeout(() => {
-      try { proc.kill('SIGKILL') } catch { /* */ }
-      workerProcesses.delete(workerId)
-      resolve({ ok: true })
-    }, 2000)
-    proc.on('exit', () => {
-      clearTimeout(timeout)
-      workerProcesses.delete(workerId)
-      resolve({ ok: true })
-    })
-  })
-}
-
-async function startWorkerProcess(workerId: string): Promise<{ ok: boolean; error?: string }> {
-  if (useNativeProcess()) {
-    return startWorkerProcessNative(workerId)
-  }
-  return tmuxStart(workerId)
-}
-
-async function stopWorkerProcess(workerId: string): Promise<{ ok: boolean; error?: string }> {
-  if (useNativeProcess()) {
-    return killWorkerProcess(workerId)
-  }
-  return tmuxKill(workerId)
-}
-
-function startWorkerProcessNative(workerId: string): { ok: boolean; error?: string } {
-  if (workerProcesses.has(workerId)) {
-    return { ok: false, error: `Worker ${workerId} already has an active process` }
-  }
-  
-  const profilesDir = getProfilesDir()
-  const profilePath = join(profilesDir, workerId)
-  if (!existsSync(profilePath)) {
-    return { ok: false, error: `Profile not found: ${profilePath}` }
-  }
-
-  // Build wrapper command: use hermes-agent CLI with the worker profile
-  const hermesCmd = process.env.HERMES_CLI_PATH || 'hermes'
-  const args = ['--tui', '--profile', workerId]
-  
-  const logPath = workerLogPath(workerId)
-  const logDir = join(profilePath, 'logs')
-  if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true })
-
-  const proc = spawn(hermesCmd, args, {
+export async function startWorkerProcess(workerId: string): Promise<{ ok: boolean; error?: string }> {
+  const profilePath = join(getProfilesDir(), workerId)
+  if (!existsSync(profilePath)) return { ok: false, error: `Profile not found: ${profilePath}` }
+  const hermesBin = process.env.HERMES_CLI_PATH || resolveSwarmHermesBin()
+  const result = await getWorkerProcessHost().start({
+    workerId,
+    command: hermesBin,
+    args: ['chat', '--tui'],
     cwd: profilePath,
-    env: {
-      ...process.env,
-      HERMES_PROFILE: workerId,
-    },
-    detached: isWindows(), // Windows needs detached for independent process tree
-    stdio: ['pipe', 'pipe', 'pipe'],
-    windowsHide: isWindows(), // Don't show terminal window on Windows
+    env: { HERMES_HOME: profilePath, HERMES_CLI_BIN: hermesBin, HERMES_PROFILE: workerId },
   })
+  return { ok: result.ok, error: result.error }
+}
 
-  if (!proc.pid) {
-    return { ok: false, error: 'Failed to spawn worker process' }
-  }
-
-  workerProcesses.set(workerId, proc)
-
-  // Log stdout/stderr
-  proc.stdout?.on('data', (data: Buffer) => {
-    appendWorkerLog(workerId, `[stdout] ${data.toString().trimEnd()}`)
-  })
-  proc.stderr?.on('data', (data: Buffer) => {
-    appendWorkerLog(workerId, `[stderr] ${data.toString().trimEnd()}`)
-  })
-
-  proc.on('exit', (code, signal) => {
-    appendWorkerLog(workerId, `[exit] code=${code} signal=${signal}`)
-    workerProcesses.delete(workerId)
-  })
-
-  proc.on('error', (err) => {
-    appendWorkerLog(workerId, `[error] ${err.message}`)
-    workerProcesses.delete(workerId)
-  })
-
-  return { ok: true }
+export async function stopWorkerProcess(workerId: string): Promise<{ ok: boolean; error?: string }> {
+  const result = await getWorkerProcessHost().stop(workerId)
+  return { ok: result.ok, error: result.error }
 }
 
 function readRuntimeMissionContext(workerId: string): { missionId: string | null; assignmentId: string | null } {
@@ -376,28 +220,6 @@ export function lifecycleHandoffPath(workerId: string): string {
   return handoffPath(workerId)
 }
 
-function tmuxKill(workerId: string): Promise<{ ok: boolean; error?: string }> {
-  const session = `swarm-${workerId}`
-  return new Promise((resolve) => {
-    execFile(tmuxBin(), ['kill-session', '-t', session], (err, _out, stderr) => {
-      if (err) return resolve({ ok: false, error: stderr?.toString() || err.message })
-      resolve({ ok: true })
-    })
-  })
-}
-
-function tmuxStart(workerId: string): Promise<{ ok: boolean; error?: string }> {
-  const session = `swarm-${workerId}`
-  const wrapper = join(homedir(), '.local', 'bin', workerId)
-  if (!existsSync(wrapper)) return Promise.resolve({ ok: false, error: `Wrapper not found: ${wrapper}` })
-  return new Promise((resolve) => {
-    execFile(tmuxBin(), ['new-session', '-d', '-s', session, wrapper], (err, _out, stderr) => {
-      if (err) return resolve({ ok: false, error: stderr?.toString() || err.message })
-      resolve({ ok: true })
-    })
-  })
-}
-
 export async function renewWorker(workerId: string): Promise<{ ok: boolean; restarted: boolean; resumeSent: boolean; error?: string; handoffPath: string }> {
   const hp = handoffPath(workerId)
   if (!existsSync(hp)) {
@@ -405,7 +227,7 @@ export async function renewWorker(workerId: string): Promise<{ ok: boolean; rest
   }
   const killed = await stopWorkerProcess(workerId)
   if (!killed.ok) {
-    // Process may already be gone; continue.
+    return { ok: false, restarted: false, resumeSent: false, error: killed.error ?? 'Worker stop could not be verified', handoffPath: hp }
   }
   await new Promise((resolve) => setTimeout(resolve, 600))
   const started = await startWorkerProcess(workerId)

--- a/src/server/swarm-model-resolver.test.ts
+++ b/src/server/swarm-model-resolver.test.ts
@@ -76,6 +76,17 @@ describe('resolveSwarmModelLabel', () => {
     })
   })
 
+  it('routes account-specific Claude Max OAuth refs through the configured relay', () => {
+    expect(resolveSwarmModelLabel('claude-cwm4tx/sonnet')).toEqual({
+      provider: 'custom',
+      default: 'claude-cwm4tx/sonnet',
+    })
+    expect(resolveSwarmModelLabel('claude-gp/opus')).toEqual({
+      provider: 'custom',
+      default: 'claude-gp/opus',
+    })
+  })
+
   it('returns null for unknown labels (so the worker is left alone)', () => {
     expect(resolveSwarmModelLabel('Unknown 9000')).toBeNull()
     expect(resolveSwarmModelLabel('typo opus')).toBeNull()

--- a/src/server/swarm-model-resolver.ts
+++ b/src/server/swarm-model-resolver.ts
@@ -101,6 +101,13 @@ export function resolveSwarmModelLabel(
     return { provider: 'ollama-pc1', default: 'qwen3-30b-a3b-fixed:latest' }
   }
 
+  // Account-specific Claude Max routes are served through the configured
+  // OpenAI-compatible relay. Keep the full route id as the model so account
+  // identity remains deterministic inside independently configured workers.
+  if (/^claude-[\w.-]+\/.+/.test(label.trim())) {
+    return { provider: 'custom', default: label.trim() }
+  }
+
   // Provider-prefixed full id (already in canonical form). Pass through.
   const slashMatch = label.trim().match(/^([\w.-]+)\/(.+)$/)
   if (slashMatch) {

--- a/src/server/swarm-profile-config.test.ts
+++ b/src/server/swarm-profile-config.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
 import * as yaml from 'yaml'
-import { syncSwarmProfileIdentity, syncSwarmProfileModel } from './swarm-profile-config'
+import {
+  ensureSwarmProfileConfig,
+  syncSwarmProfileIdentity,
+  syncSwarmProfileModel,
+} from './swarm-profile-config'
 
 function makeProfile(initial: Record<string, unknown>): string {
   const dir = mkdtempSync(join(tmpdir(), 'swarm-profile-cfg-'))
@@ -147,6 +157,29 @@ describe('syncSwarmProfileModel', () => {
   })
 })
 
+describe('ensureSwarmProfileConfig', () => {
+  it('bootstraps from the active Hermes home rather than assuming ~/.hermes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'swarm-profile-home-'))
+    const profilePath = join(root, 'profiles', 'builder')
+    writeFileSync(
+      join(root, 'config.yaml'),
+      'model:\n  provider: custom\n',
+      'utf8',
+    )
+    mkdirSync(join(root, 'mcp-tokens'), { recursive: true })
+
+    try {
+      const result = ensureSwarmProfileConfig(profilePath, root)
+      expect(result.ok).toBe(true)
+      expect(result.configCreated).toBe(true)
+      expect(readFileSync(join(profilePath, 'config.yaml'), 'utf8')).toContain(
+        'provider: custom',
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
 
 describe('syncSwarmProfileIdentity', () => {
   it('writes profile-local identity with name, role, mission, capabilities, and stable machine ID', () => {
@@ -156,7 +189,8 @@ describe('syncSwarmProfileIdentity', () => {
         id: 'swarm5',
         name: 'Builder',
         role: 'Primary Builder',
-        specialty: 'full-stack implementation across Hermes Workspace and Swarm2',
+        specialty:
+          'full-stack implementation across Hermes Workspace and Swarm2',
         model: 'GPT-5.5',
         mission: 'Ship focused product slices with tests and clean diffs.',
         skills: ['swarm-ui-worker', 'swarm-worker-core'],
@@ -169,9 +203,15 @@ describe('syncSwarmProfileIdentity', () => {
       expect(identity).toContain('- Name: Builder')
       expect(identity).toContain('- Worker ID: swarm5')
       expect(identity).toContain('- Role: Primary Builder')
-      expect(identity).toContain('- Mission: Ship focused product slices with tests and clean diffs.')
-      expect(identity).toContain('- Capabilities: code-editing, ui-implementation')
-      expect(identity).toContain('The worker ID is a stable machine identifier only')
+      expect(identity).toContain(
+        '- Mission: Ship focused product slices with tests and clean diffs.',
+      )
+      expect(identity).toContain(
+        '- Capabilities: code-editing, ui-implementation',
+      )
+      expect(identity).toContain(
+        'The worker ID is a stable machine identifier only',
+      )
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/src/server/swarm-profile-config.ts
+++ b/src/server/swarm-profile-config.ts
@@ -14,13 +14,28 @@
  * matches, so re-running on a healthy profile is free.
  */
 
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import * as yaml from 'yaml'
 
 export type ConfigSyncResult =
-  | { ok: true; changed: boolean; previous?: { provider: string; default: string } }
+  | {
+      ok: true
+      changed: boolean
+      previous?: { provider: string; default: string }
+    }
   | { ok: false; error: string }
 
 export type ProfileBootstrapResult = {
@@ -70,20 +85,31 @@ function linkSharedFile(source: string, target: string): boolean {
  * the operator's non-secret config.yaml and linking the private .env locally.
  * The config is copied (not symlinked) because per-worker model sync edits it.
  */
-export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapResult {
-  const result: ProfileBootstrapResult = { ok: true, configCreated: false, envLinked: false, authLinked: false, mcpTokensLinked: 0 }
+export function ensureSwarmProfileConfig(
+  profilePath: string,
+  sourceHome = process.env.HERMES_HOME ||
+    process.env.CLAUDE_HOME ||
+    join(homedir(), '.hermes'),
+): ProfileBootstrapResult {
+  const result: ProfileBootstrapResult = {
+    ok: true,
+    configCreated: false,
+    envLinked: false,
+    authLinked: false,
+    mcpTokensLinked: 0,
+  }
   try {
     mkdirSync(profilePath, { recursive: true })
 
     const configPath = join(profilePath, 'config.yaml')
-    const sourceConfig = join(homedir(), '.hermes', 'config.yaml')
+    const sourceConfig = join(sourceHome, 'config.yaml')
     if (!existsSync(configPath) && existsSync(sourceConfig)) {
       copyFileSync(sourceConfig, configPath)
       result.configCreated = true
     }
 
     const envPath = join(profilePath, '.env')
-    const sourceEnv = join(homedir(), '.hermes', '.env')
+    const sourceEnv = join(sourceHome, '.env')
     if (existsSync(sourceEnv)) {
       let shouldLink = !existsSync(envPath)
       if (!shouldLink) {
@@ -102,7 +128,7 @@ export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapR
     }
 
     const authPath = join(profilePath, 'auth.json')
-    const sourceAuth = join(homedir(), '.hermes', 'auth.json')
+    const sourceAuth = join(sourceHome, 'auth.json')
     if (existsSync(sourceAuth)) {
       let shouldLink = !existsSync(authPath)
       if (!shouldLink) {
@@ -121,23 +147,36 @@ export function ensureSwarmProfileConfig(profilePath: string): ProfileBootstrapR
     }
 
     const mcpTokensDir = join(profilePath, 'mcp-tokens')
-    const sourceMcpTokensDir = join(homedir(), '.hermes', 'mcp-tokens')
+    const sourceMcpTokensDir = join(sourceHome, 'mcp-tokens')
     if (existsSync(sourceMcpTokensDir)) {
       mkdirSync(mcpTokensDir, { recursive: true })
       for (const name of readdirSync(sourceMcpTokensDir)) {
         if (!name.endsWith('.json')) continue
-        if (linkSharedFile(join(sourceMcpTokensDir, name), join(mcpTokensDir, name))) {
+        if (
+          linkSharedFile(
+            join(sourceMcpTokensDir, name),
+            join(mcpTokensDir, name),
+          )
+        ) {
           result.mcpTokensLinked += 1
         }
       }
     }
 
     if (!existsSync(configPath)) {
-      return { ...result, ok: false, error: `config.yaml missing at ${configPath}` }
+      return {
+        ...result,
+        ok: false,
+        error: `config.yaml missing at ${configPath}`,
+      }
     }
     return result
   } catch (err) {
-    return { ...result, ok: false, error: err instanceof Error ? err.message : String(err) }
+    return {
+      ...result,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
   }
 }
 
@@ -146,9 +185,17 @@ export function renderSwarmWorkerIdentity(worker: SwarmWorkerIdentity): string {
   const role = worker.role?.trim() || 'Worker'
   const specialty = worker.specialty?.trim() || 'General execution'
   const model = worker.model?.trim() || 'Unspecified'
-  const mission = worker.mission?.trim() || 'Execute assigned swarm work and checkpoint progress.'
-  const skills = worker.skills && worker.skills.length > 0 ? worker.skills.join(', ') : 'swarm-worker-core'
-  const capabilities = worker.capabilities && worker.capabilities.length > 0 ? worker.capabilities.join(', ') : 'not declared'
+  const mission =
+    worker.mission?.trim() ||
+    'Execute assigned swarm work and checkpoint progress.'
+  const skills =
+    worker.skills && worker.skills.length > 0
+      ? worker.skills.join(', ')
+      : 'swarm-worker-core'
+  const capabilities =
+    worker.capabilities && worker.capabilities.length > 0
+      ? worker.capabilities.join(', ')
+      : 'not declared'
 
   return [
     `# IDENTITY.md — ${name}`,
@@ -170,7 +217,10 @@ export function renderSwarmWorkerIdentity(worker: SwarmWorkerIdentity): string {
   ].join('\n')
 }
 
-export function syncSwarmProfileIdentity(profilePath: string, worker: SwarmWorkerIdentity): ConfigSyncResult {
+export function syncSwarmProfileIdentity(
+  profilePath: string,
+  worker: SwarmWorkerIdentity,
+): ConfigSyncResult {
   if (!existsSync(profilePath)) {
     return { ok: false, error: `profile path missing: ${profilePath}` }
   }
@@ -179,14 +229,19 @@ export function syncSwarmProfileIdentity(profilePath: string, worker: SwarmWorke
   const next = renderSwarmWorkerIdentity(worker)
   try {
     mkdirSync(identityDir, { recursive: true })
-    const current = existsSync(identityPath) ? readFileSync(identityPath, 'utf8') : ''
+    const current = existsSync(identityPath)
+      ? readFileSync(identityPath, 'utf8')
+      : ''
     if (current === next) return { ok: true, changed: false }
     const tmpPath = `${identityPath}.tmp-${process.pid}-${Date.now()}`
     writeFileSync(tmpPath, next, 'utf8')
     renameSync(tmpPath, identityPath)
     return { ok: true, changed: true }
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
   }
 }
 
@@ -239,10 +294,7 @@ export function syncSwarmProfileModel(
       ? existingModel.default
       : ''
 
-  if (
-    existingProvider === next.provider &&
-    existingDefault === next.default
-  ) {
+  if (existingProvider === next.provider && existingDefault === next.default) {
     return {
       ok: true,
       changed: false,
@@ -250,9 +302,10 @@ export function syncSwarmProfileModel(
     }
   }
 
-  const previous = existingProvider || existingDefault
-    ? { provider: existingProvider, default: existingDefault }
-    : undefined
+  const previous =
+    existingProvider || existingDefault
+      ? { provider: existingProvider, default: existingDefault }
+      : undefined
 
   // Update in place to preserve any sibling fields (e.g. `model.alternates`).
   const merged = existingModel ? { ...existingModel } : {}

--- a/src/server/swarm-roster.test.ts
+++ b/src/server/swarm-roster.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { SwarmRosterSchema, SwarmRosterUpsertSchema, isSwarmWorkerId } from './swarm-roster'
+import {
+  SwarmRosterSchema,
+  SwarmRosterUpsertSchema,
+  applySwarmWorkerModel,
+  isSwarmWorkerId,
+} from './swarm-roster'
 
 describe('swarm roster semantic workers', () => {
   it('accepts both legacy swarm ids and semantic profile ids for upsert', () => {
@@ -15,11 +20,25 @@ describe('swarm roster semantic workers', () => {
       maxConcurrentTasks: 1,
     }
 
-    expect(SwarmRosterUpsertSchema.parse({ ...baseWorker, id: ' builder ' }).id).toBe('builder')
-    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'swarm13' }).success).toBe(true)
-    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'builder' }).success).toBe(true)
-    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'km-agent' }).success).toBe(true)
-    expect(SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'ops-watch' }).success).toBe(true)
+    expect(
+      SwarmRosterUpsertSchema.parse({ ...baseWorker, id: ' builder ' }).id,
+    ).toBe('builder')
+    expect(
+      SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'swarm13' })
+        .success,
+    ).toBe(true)
+    expect(
+      SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'builder' })
+        .success,
+    ).toBe(true)
+    expect(
+      SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'km-agent' })
+        .success,
+    ).toBe(true)
+    expect(
+      SwarmRosterUpsertSchema.safeParse({ ...baseWorker, id: 'ops-watch' })
+        .success,
+    ).toBe(true)
     expect(isSwarmWorkerId('builder')).toBe(true)
     expect(isSwarmWorkerId('km-agent')).toBe(true)
     expect(isSwarmWorkerId('../bad')).toBe(false)
@@ -64,5 +83,52 @@ describe('swarm roster semantic workers', () => {
       wrapper: 'km:health',
       greenlightRequiredFor: ['delete', 'purge', 'publish'],
     })
+  })
+
+  it('rejects wrapper names that can escape the managed wrapper directory', () => {
+    const worker = {
+      id: 'builder',
+      name: 'Builder',
+      wrapper: 'km:health',
+    }
+    expect(SwarmRosterUpsertSchema.safeParse(worker).success).toBe(true)
+    for (const wrapper of ['../escape', '..\\escape', '/absolute', 'a/b']) {
+      expect(
+        SwarmRosterUpsertSchema.safeParse({ ...worker, wrapper }).success,
+      ).toBe(false)
+    }
+  })
+
+  it('changes only the selected role model to a canonical OAuth route', () => {
+    const roster = SwarmRosterSchema.parse({
+      version: 1,
+      workers: [
+        {
+          id: 'builder',
+          name: 'Builder',
+          model: 'GPT-5.5',
+          skills: ['builder-core'],
+        },
+        {
+          id: 'reviewer',
+          name: 'Reviewer',
+          model: 'GPT-5.5',
+          skills: ['reviewer-core'],
+        },
+      ],
+    })
+
+    const next = applySwarmWorkerModel(
+      roster,
+      'builder',
+      'claude-cwm4tx/sonnet',
+    )
+
+    expect(
+      next.workers.find((worker) => worker.id === 'builder'),
+    ).toMatchObject({ model: 'claude-cwm4tx/sonnet', skills: ['builder-core'] })
+    expect(
+      next.workers.find((worker) => worker.id === 'reviewer'),
+    ).toMatchObject({ model: 'GPT-5.5', skills: ['reviewer-core'] })
   })
 })

--- a/src/server/swarm-roster.ts
+++ b/src/server/swarm-roster.ts
@@ -15,7 +15,20 @@ export function isSwarmWorkerId(value: unknown): value is string {
 const WorkerIdSchema = z
   .string()
   .trim()
-  .regex(WORKER_ID_PATTERN, 'worker id must look like swarm13 or a semantic profile id')
+  .regex(
+    WORKER_ID_PATTERN,
+    'worker id must look like swarm13 or a semantic profile id',
+  )
+
+const WrapperNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .regex(
+    /^[a-z0-9][a-z0-9_.:-]*$/i,
+    'wrapper must be a managed wrapper name without path separators',
+  )
 
 export const SwarmRosterWorkerSchema = z.object({
   id: WorkerIdSchema,
@@ -31,7 +44,7 @@ export const SwarmRosterWorkerSchema = z.object({
   plugins: z.array(z.string()).default([]),
   pluginToolsets: z.array(z.string()).default([]),
   mcpServers: z.array(z.string()).default([]),
-  wrapper: z.string().optional(),
+  wrapper: WrapperNameSchema.optional(),
   capabilities: z.array(z.string()).default([]),
   defaultCwd: z.string().optional(),
   preferredTaskTypes: z.array(z.string()).default([]),
@@ -54,6 +67,25 @@ export const SwarmRosterUpsertSchema = SwarmRosterWorkerSchema.extend({
 })
 
 export type SwarmRosterUpsert = z.infer<typeof SwarmRosterUpsertSchema>
+
+export function applySwarmWorkerModel(
+  roster: SwarmRoster,
+  workerId: string,
+  modelRef: string,
+): SwarmRoster {
+  const id = WorkerIdSchema.parse(workerId)
+  const model = z.string().trim().min(1).max(300).parse(modelRef)
+  const parsed = SwarmRosterSchema.parse(roster)
+  if (!parsed.workers.some((worker) => worker.id === id)) {
+    throw new Error(`Unknown swarm worker: ${id}`)
+  }
+  return {
+    ...parsed,
+    workers: parsed.workers.map((worker) =>
+      worker.id === id ? { ...worker, model } : worker,
+    ),
+  }
+}
 
 function titleCase(value: string): string {
   return value
@@ -134,7 +166,10 @@ export function writeSwarmRoster(roster: SwarmRoster): void {
   writeFileSync(SWARM_ROSTER_PATH, doc)
 }
 
-export function upsertSwarmRosterWorker(input: SwarmRosterUpsert, ids: Array<string> = []): SwarmRoster {
+export function upsertSwarmRosterWorker(
+  input: SwarmRosterUpsert,
+  ids: Array<string> = [],
+): SwarmRoster {
   const nextWorker = SwarmRosterUpsertSchema.parse(input)
   const current = readSwarmRoster(ids)
   const byId = new Map(current.workers.map((worker) => [worker.id, worker]))
@@ -151,12 +186,31 @@ export function upsertSwarmRosterWorker(input: SwarmRosterUpsert, ids: Array<str
   return next
 }
 
-export function rosterByWorkerId(ids: Array<string> = []): Map<string, SwarmRosterWorker> {
-  return new Map(readSwarmRoster(ids).workers.map((worker) => [worker.id, worker]))
+export function updateSwarmRosterWorkerModel(
+  workerId: string,
+  modelRef: string,
+  ids: Array<string> = [],
+): SwarmRoster {
+  const next = applySwarmWorkerModel(readSwarmRoster(ids), workerId, modelRef)
+  writeSwarmRoster(next)
+  return next
 }
 
-export function resolveSwarmWorkerDisplayName(workerId: string, worker?: Pick<SwarmRosterWorker, 'name'> | null): string {
-  return worker ? worker.name.trim() || titleCase(workerId) : titleCase(workerId)
+export function rosterByWorkerId(
+  ids: Array<string> = [],
+): Map<string, SwarmRosterWorker> {
+  return new Map(
+    readSwarmRoster(ids).workers.map((worker) => [worker.id, worker]),
+  )
+}
+
+export function resolveSwarmWorkerDisplayName(
+  workerId: string,
+  worker?: Pick<SwarmRosterWorker, 'name'> | null,
+): string {
+  return worker
+    ? worker.name.trim() || titleCase(workerId)
+    : titleCase(workerId)
 }
 
 export function formatSwarmWorkerLabel(
@@ -164,6 +218,8 @@ export function formatSwarmWorkerLabel(
   worker?: Pick<SwarmRosterWorker, 'name' | 'role'> | null,
 ): string {
   const displayName = resolveSwarmWorkerDisplayName(workerId, worker)
-  const role = worker ? worker.role.trim() || defaultRoleFromId(workerId) : defaultRoleFromId(workerId)
+  const role = worker
+    ? worker.role.trim() || defaultRoleFromId(workerId)
+    : defaultRoleFromId(workerId)
   return `${displayName} — ${role}`
 }

--- a/src/server/swarm-tmux-launch.test.ts
+++ b/src/server/swarm-tmux-launch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSwarmTmuxLaunchCommand,
+  buildTmuxBufferLoad,
+  buildTmuxNewSessionArgs,
+  buildTmuxSendKeysArgs,
+  resolveSwarmHermesBin,
+  resolveSwarmTmuxBin,
+} from './swarm-tmux-launch'
+
+describe('Windows Swarm tmux launch planning', () => {
+  it('uses the managed Windows Scripts launcher instead of venv/bin/hermes', () => {
+    expect(
+      resolveSwarmHermesBin({
+        platform: 'win32',
+        env: {
+          HERMES_HOME: 'C:\\Users\\test\\AppData\\Local\\hermes',
+        },
+        pathExists: (candidate) => candidate.endsWith('Scripts\\hermes.exe'),
+        home: 'C:\\Users\\test',
+      }),
+    ).toBe(
+      'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\hermes.exe',
+    )
+  })
+
+  it('selects PATH tmux on Windows instead of a Homebrew path', () => {
+    expect(
+      resolveSwarmTmuxBin({
+        platform: 'win32',
+        env: {},
+        pathExists: () => false,
+        home: 'C:\\Users\\test',
+      }),
+    ).toBe('tmux')
+  })
+
+  it('omits unsupported new-session -c on native Windows tmux', () => {
+    expect(
+      buildTmuxNewSessionArgs({
+        sessionName: 'swarm-builder',
+        cwd: 'C:\\dev\\project',
+        platform: 'win32',
+      }),
+    ).toEqual(['new-session', '-d', '-s', 'swarm-builder'])
+  })
+
+  it('keeps new-session -c on POSIX tmux', () => {
+    expect(
+      buildTmuxNewSessionArgs({
+        sessionName: 'swarm-builder',
+        cwd: '/srv/project',
+        platform: 'linux',
+      }),
+    ).toEqual([
+      'new-session',
+      '-d',
+      '-s',
+      'swarm-builder',
+      '-c',
+      '/srv/project',
+    ])
+  })
+
+  it('changes directory inside the Git Bash pane before launching Hermes on Windows', () => {
+    const command = buildSwarmTmuxLaunchCommand({
+      profilePath: 'C:\\Users\\test\\.hermes\\profiles\\builder',
+      cwd: 'C:\\dev\\project',
+      hermesBin: 'hermes',
+      platform: 'win32',
+      keepShellAlive: true,
+    })
+
+    expect(command).toContain("cd 'C:/dev/project' &&")
+    expect(command).toContain(
+      "HERMES_HOME='C:/Users/test/.hermes/profiles/builder'",
+    )
+    expect(command).toContain("'hermes' chat --tui")
+    expect(command).toContain('[Hermes worker exited with status %s]')
+  })
+
+  it('delivers the launch command through the interactive pane', () => {
+    expect(buildTmuxSendKeysArgs('swarm-builder', 'hermes chat --tui')).toEqual(
+      ['send-keys', '-t', 'swarm-builder', 'hermes chat --tui', 'C-m'],
+    )
+  })
+
+  it('uses set-buffer arguments on Windows instead of unsupported stdin loading', () => {
+    expect(
+      buildTmuxBufferLoad({
+        bufferName: 'swarm-dispatch-builder',
+        content: 'line one\nline two',
+        platform: 'win32',
+      }),
+    ).toEqual({
+      args: [
+        'set-buffer',
+        '-b',
+        'swarm-dispatch-builder',
+        '--',
+        'line one\nline two',
+      ],
+    })
+  })
+})

--- a/src/server/swarm-tmux-launch.ts
+++ b/src/server/swarm-tmux-launch.ts
@@ -1,0 +1,136 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, posix, win32 } from 'node:path'
+
+export function resolveSwarmHermesBin(
+  input: {
+    platform?: NodeJS.Platform
+    env?: NodeJS.ProcessEnv
+    pathExists?: (path: string) => boolean
+    home?: string
+  } = {},
+): string {
+  const platform = input.platform ?? process.platform
+  const env = input.env ?? process.env
+  const pathExists = input.pathExists ?? existsSync
+  const home = input.home ?? homedir()
+  const pathApi = platform === 'win32' ? win32 : posix
+  const override = env.HERMES_CLI_BIN
+  if (override) {
+    if (!override.includes('/') && !override.includes('\\')) return override
+    if (pathExists(override)) return override
+  }
+
+  const hermesHome =
+    env.HERMES_HOME || env.CLAUDE_HOME || pathApi.join(home, '.hermes')
+  const candidates =
+    platform === 'win32'
+      ? [
+          pathApi.join(
+            hermesHome,
+            'hermes-agent',
+            'venv',
+            'Scripts',
+            'hermes.exe',
+          ),
+          pathApi.join(hermesHome, 'hermes-agent', 'venv', 'Scripts', 'hermes'),
+        ]
+      : [
+          pathApi.join(hermesHome, 'hermes-agent', 'venv', 'bin', 'hermes'),
+          pathApi.join(home, '.local', 'bin', 'hermes'),
+        ]
+  return candidates.find(pathExists) ?? 'hermes'
+}
+
+export function resolveSwarmTmuxBin(
+  input: {
+    platform?: NodeJS.Platform
+    env?: NodeJS.ProcessEnv
+    pathExists?: (path: string) => boolean
+    home?: string
+  } = {},
+): string {
+  const platform = input.platform ?? process.platform
+  const env = input.env ?? process.env
+  const pathExists = input.pathExists ?? existsSync
+  const home = input.home ?? homedir()
+  const override = env.HERMES_TMUX_BIN || env.CLAUDE_TMUX_BIN || env.TMUX_BIN
+  if (override) {
+    if (!override.includes('/') && !override.includes('\\')) return override
+    if (pathExists(override)) return override
+  }
+
+  if (platform === 'darwin') {
+    for (const candidate of ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux']) {
+      if (pathExists(candidate)) return candidate
+    }
+  }
+  const local = join(home, '.local', 'bin', 'tmux')
+  return pathExists(local) ? local : 'tmux'
+}
+
+function shellEscapeSingle(value: string): string {
+  return value.replace(/'/g, `'\\''`)
+}
+
+function shellPath(value: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? value.replace(/\\/g, '/') : value
+}
+
+export function buildTmuxNewSessionArgs(input: {
+  sessionName: string
+  cwd: string
+  platform?: NodeJS.Platform
+}): Array<string> {
+  const platform = input.platform ?? process.platform
+  const args = ['new-session', '-d', '-s', input.sessionName]
+  if (platform !== 'win32') args.push('-c', input.cwd)
+  return args
+}
+
+export function buildTmuxSendKeysArgs(
+  sessionName: string,
+  launchCommand: string,
+): Array<string> {
+  return ['send-keys', '-t', sessionName, launchCommand, 'C-m']
+}
+
+export function buildTmuxBufferLoad(input: {
+  bufferName: string
+  content: string
+  platform?: NodeJS.Platform
+}): { args: Array<string>; stdin?: string } {
+  const platform = input.platform ?? process.platform
+  if (platform === 'win32') {
+    return {
+      args: ['set-buffer', '-b', input.bufferName, '--', input.content],
+    }
+  }
+  return {
+    args: ['load-buffer', '-b', input.bufferName, '-'],
+    stdin: input.content,
+  }
+}
+
+export function buildSwarmTmuxLaunchCommand(input: {
+  profilePath: string
+  cwd: string
+  hermesBin: string
+  platform?: NodeJS.Platform
+  keepShellAlive?: boolean
+}): string {
+  const platform = input.platform ?? process.platform
+  const profilePath = shellPath(input.profilePath, platform)
+  const cwd = shellPath(input.cwd, platform)
+  const hermesBin = shellPath(input.hermesBin, platform)
+  const launchPrefix = [
+    platform === 'win32' ? `cd '${shellEscapeSingle(cwd)}' &&` : '',
+    `HERMES_HOME='${shellEscapeSingle(profilePath)}'`,
+    `HERMES_CLI_BIN='${shellEscapeSingle(hermesBin)}'`,
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const invocation = `'${shellEscapeSingle(hermesBin)}' chat --tui`
+  if (input.keepShellAlive === false) return `${launchPrefix} ${invocation}`
+  return `${launchPrefix} ${invocation}; status=$?; printf '\n[Hermes worker exited with status %s]\n' "$status"`
+}

--- a/src/server/worker-process-host.test.ts
+++ b/src/server/worker-process-host.test.ts
@@ -126,9 +126,9 @@ describe('WorkerProcessHost durable registry', () => {
     const host = createWorkerProcessHost({
       platform: 'win32', registryFile: registryFile(), spawn: spawnMock() as never, isPidAlive: () => true,
     })
-    await host.start({ ...startSpec(), args: ['--secret-token'], env: { ANTHROPIC_AUTH_TOKEN: 'do-not-store' } })
+    await host.start({ ...startSpec(), args: ['--prompt', 'do-not-store'], env: { ANTHROPIC_AUTH_TOKEN: 'fake' } })
     const persisted = readFileSync(registryFile(), 'utf8')
-    expect(persisted).not.toContain('secret-token')
+    expect(persisted).not.toContain('--prompt')
     expect(persisted).not.toContain('do-not-store')
   })
 

--- a/src/server/worker-process-host.test.ts
+++ b/src/server/worker-process-host.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { buildSafeChildEnv, createWorkerProcessHost } from './worker-process-host'
+import { buildSafeChildEnv, createWorkerProcessHost, withStartupRecovery } from './worker-process-host'
 
 let stateDir: string
 
@@ -115,6 +116,110 @@ describe('WorkerProcessHost durable registry', () => {
     expect(calls[2]?.join(' ')).toContain("'/bin/hermes' chat --tui")
   })
 
+  it('handles synchronous spawn exceptions without leaving an unknown reservation', async () => {
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(),
+      spawn: () => { throw new Error('invalid cwd') },
+    })
+    expect(await host.start(startSpec('sync-spawn-error'))).toMatchObject({ ok: false })
+    expect(await host.status('sync-spawn-error')).toMatchObject({ status: 'stopped', pid: null })
+  })
+
+  it('handles asynchronous native spawn errors and marks an owned PID stopped', async () => {
+    const child = Object.assign(new EventEmitter(), { pid: 4301, stdin: { writable: true, write: () => true } })
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), spawn: () => child as never,
+    })
+    expect((await host.start(startSpec('spawn-error'))).ok).toBe(true)
+    expect(() => child.emit('error', new Error('missing executable'))).not.toThrow()
+    expect(await host.status('spawn-error')).toMatchObject({ status: 'stopped', pid: null })
+  })
+
+  it('retains recoverable PID ownership when registration cleanup cannot verify exit', async () => {
+    const taskkill = vi.fn(async () => ({ ok: false, stdout: '', stderr: 'access denied' }))
+    let writes = 0
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), isPidAlive: () => true, runCommand: taskkill,
+      cleanupPollMs: 0, cleanupTimeoutMs: 0,
+      spawn: () => ({ pid: 4302, on: () => {} }),
+      writeRegistry: (file, registry) => {
+        writes += 1
+        if (writes >= 2) throw new Error('simulated persistent registry failure')
+        writeFileSync(file, JSON.stringify(registry), 'utf8')
+      },
+    })
+    const result = await host.start(startSpec('registration-cleanup'))
+    expect(result).toMatchObject({
+      ok: false,
+      record: { pid: 4302, status: 'unknown', lastError: expect.stringMatching(/cleanup.*not verified/i) },
+    })
+    expect(taskkill).toHaveBeenCalledWith('taskkill.exe', ['/PID', '4302', '/T', '/F'])
+    const fresh = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), isPidAlive: () => true, runCommand: taskkill,
+    })
+    expect(await fresh.status('registration-cleanup')).toMatchObject({ pid: 4302, status: 'unknown' })
+    expect(await fresh.stop('registration-cleanup')).toMatchObject({ ok: false, record: { pid: 4302, status: 'unknown' } })
+    const reconciler = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), isPidAlive: () => false,
+      runCommand: async () => ({ ok: true, stdout: '', stderr: '' }),
+    })
+    expect(await reconciler.stop('registration-cleanup')).toMatchObject({ ok: true, record: { pid: null, status: 'stopped' } })
+    expect(await reconciler.status('registration-cleanup')).toMatchObject({ pid: null, status: 'stopped' })
+  })
+
+  it('retains a durable start lock containing PID ownership when emergency persistence fails', async () => {
+    let writes = 0
+    const file = registryFile()
+    const workerId = 'emergency-write-failure'
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: file,
+      spawn: () => ({ pid: 4303, on: () => {} }),
+      isPidAlive: () => true,
+      runCommand: async () => ({ ok: false, stdout: '', stderr: 'access denied' }),
+      writeRegistry: (path, registry) => {
+        writes += 1
+        if (writes >= 2) throw new Error('primary registry unavailable')
+        writeFileSync(path, JSON.stringify(registry), 'utf8')
+      },
+      writeEmergencyOwnership: () => { throw new Error('emergency registry unavailable') },
+    })
+    const result = await host.start(startSpec(workerId))
+    expect(result).toMatchObject({ ok: false, retainStartLock: true, record: { pid: 4303 } })
+    const lockFile = `${file}.${Buffer.from(workerId).toString('base64url')}.start.lock`
+    expect(existsSync(lockFile)).toBe(true)
+    expect(JSON.parse(readFileSync(lockFile, 'utf8'))).toMatchObject({ workerId, pid: 4303, status: 'unknown' })
+    const fresh = createWorkerProcessHost({ platform: 'win32', registryFile: file })
+    expect(await fresh.status(workerId)).toMatchObject({ workerId, pid: 4303, status: 'unknown' })
+    expect(await fresh.list()).toContainEqual(expect.objectContaining({ workerId, pid: 4303, status: 'unknown' }))
+    expect((await fresh.start(startSpec(workerId))).ok).toBe(false)
+    const reconciler = createWorkerProcessHost({
+      platform: 'win32', registryFile: file, isPidAlive: () => false,
+      runCommand: async () => ({ ok: true, stdout: '', stderr: '' }),
+    })
+    expect(await reconciler.stop(workerId)).toMatchObject({ ok: true, record: { pid: null, status: 'stopped' } })
+    expect(await reconciler.status(workerId)).toMatchObject({ pid: null, status: 'stopped' })
+    expect(await reconciler.list()).toContainEqual(expect.objectContaining({ workerId, pid: null, status: 'stopped' }))
+  })
+
+  it('recovers durable worker state exactly once before serving singleton operations', async () => {
+    let recoveries = 0
+    let starts = 0
+    const base = {
+      hostKind: 'native' as const,
+      recover: async () => { recoveries += 1; return [] },
+      start: async () => { starts += 1; return { ok: true } },
+      stop: async () => ({ ok: true }),
+      send: async () => ({ ok: true }),
+      capture: async () => ({ ok: true }),
+      status: async () => ({ workerId: 'x' }),
+      list: async () => [],
+    }
+    const host = withStartupRecovery(base as never)
+    await host.start(startSpec('first'))
+    await host.list()
+    expect({ recoveries, starts }).toEqual({ recoveries: 1, starts: 1 })
+  })
+
   it('constructs a minimal child environment and strips paid-provider credentials', () => {
     expect(buildSafeChildEnv(
       { PATH: 'safe', ANTHROPIC_API_KEY: 'paid', OPENAI_API_KEY: 'paid', RANDOM_SECRET: 'drop' },
@@ -130,6 +235,31 @@ describe('WorkerProcessHost durable registry', () => {
     const persisted = readFileSync(registryFile(), 'utf8')
     expect(persisted).not.toContain('--prompt')
     expect(persisted).not.toContain('do-not-store')
+  })
+
+  it('recovers emergency ownership through the production startup wrapper when the primary registry is corrupt', async () => {
+    const file = registryFile()
+    const workerId = 'wrapped-corrupt-primary'
+    writeFileSync(file, '{broken', 'utf8')
+    writeFileSync(`${file}.${Buffer.from(workerId).toString('base64url')}.emergency.json`, JSON.stringify({
+      workerId, hostKind: 'native', status: 'unknown', pid: 4304, sessionName: null,
+      cwd: 'C:\\repo', profile: null, runtime: null, startedAt: 1,
+      updatedAt: 2, lastError: 'manual reconciliation required',
+    }), 'utf8')
+
+    const wrapped = withStartupRecovery(createWorkerProcessHost({
+      platform: 'win32', registryFile: file, isPidAlive: () => true,
+    }))
+    await expect(wrapped.status(workerId)).resolves.toMatchObject({ pid: 4304, status: 'unknown' })
+    await expect(wrapped.list()).resolves.toContainEqual(expect.objectContaining({ workerId, pid: 4304, status: 'unknown' }))
+    await expect(wrapped.stop(workerId)).resolves.toMatchObject({ ok: false, record: { pid: 4304, status: 'unknown' } })
+  })
+
+  it('ignores malformed emergency ownership records', async () => {
+    const file = registryFile()
+    const workerId = 'malformed-emergency'
+    writeFileSync(`${file}.${Buffer.from(workerId).toString('base64url')}.emergency.json`, JSON.stringify({ workerId, pid: 'not-a-pid', status: 'unknown' }), 'utf8')
+    expect(await createWorkerProcessHost({ platform: 'win32', registryFile: file }).status(workerId)).toMatchObject({ workerId, pid: null, status: 'unknown' })
   })
 
   it('fails closed when the durable registry is corrupt', async () => {

--- a/src/server/worker-process-host.test.ts
+++ b/src/server/worker-process-host.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildSafeChildEnv, createWorkerProcessHost } from './worker-process-host'
+
+let stateDir: string
+
+function registryFile(): string {
+  return join(stateDir, 'worker-process-hosts.json')
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'hermes-process-host-'))
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+function startSpec(workerId = 'builder') {
+  return { workerId, command: 'hermes', args: ['chat', '--tui'], cwd: stateDir }
+}
+
+function spawnMock(pid = 4242) {
+  return () => ({ pid, stdin: { writable: true, write: () => true }, on: () => {} })
+}
+
+describe('WorkerProcessHost durable registry', () => {
+  it('persists a started worker so a fresh host instance still owns it', async () => {
+    const spawned: Array<{ command: string; args: Array<string> }> = []
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), hasTmux: () => false,
+      spawn: (command, args) => {
+        spawned.push({ command, args })
+        return { pid: 4242, stdin: { writable: true, write: () => true }, on: () => {} }
+      },
+    })
+    expect((await host.start(startSpec())).ok).toBe(true)
+    expect(spawned).toHaveLength(1)
+
+    const fresh = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), hasTmux: () => false,
+      spawn: () => { throw new Error('fresh instance must not spawn to read state') },
+    })
+    expect(await fresh.status('builder')).toMatchObject({ status: 'running', pid: 4242, hostKind: 'native' })
+  })
+
+  it('recovers stale native and tmux records after a server restart', async () => {
+    writeFileSync(registryFile(), JSON.stringify({ version: 1, workers: {
+      native: { workerId: 'native', hostKind: 'native', pid: 111, sessionName: null, cwd: stateDir, status: 'running', startedAt: 1, updatedAt: 1, lastError: null },
+      tmux: { workerId: 'tmux', hostKind: 'tmux', pid: null, sessionName: 'swarm-tmux', cwd: stateDir, status: 'running', startedAt: 1, updatedAt: 1, lastError: null },
+    }}))
+    const host = createWorkerProcessHost({
+      registryFile: registryFile(), hasTmux: () => true, isPidAlive: () => false,
+      runCommand: async (_command, args) => ({ ok: args[0] === 'has-session', stdout: '', stderr: '' }),
+      now: () => 9,
+    })
+    const recovered = await host.recover()
+    expect(recovered.find((record) => record.workerId === 'native')).toMatchObject({ status: 'stopped', pid: null, updatedAt: 9 })
+    expect(recovered.find((record) => record.workerId === 'tmux')).toMatchObject({ status: 'running' })
+  })
+
+  it('prevents duplicate starts from fresh host instances', async () => {
+    let spawns = 0
+    const deps = {
+      platform: 'win32' as const, registryFile: registryFile(), hasTmux: () => false,
+      spawn: () => { spawns += 1; return { pid: 4200 + spawns, on: () => {} } },
+    }
+    expect((await createWorkerProcessHost(deps).start(startSpec())).ok).toBe(true)
+    const duplicate = await createWorkerProcessHost(deps).start(startSpec())
+    expect(duplicate.ok).toBe(false)
+    expect(duplicate.error).toContain('already')
+    expect(spawns).toBe(1)
+  })
+
+  it('sends to a native child and captures bounded tmux output', async () => {
+    const writes: Array<string> = []
+    const native = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), hasTmux: () => false,
+      spawn: () => ({ pid: 77, stdin: { writable: true, write: (text, callback) => { writes.push(text); callback?.(); return true } }, on: () => {} }),
+    })
+    await native.start(startSpec('native'))
+    expect((await native.send('native', 'hello')).ok).toBe(true)
+    expect(writes).toEqual(['hello\n'])
+
+    writeFileSync(registryFile(), JSON.stringify({ version: 1, workers: {
+      tmux: { workerId: 'tmux', hostKind: 'tmux', pid: null, sessionName: 'swarm-tmux', cwd: stateDir, status: 'running', startedAt: 1, updatedAt: 1, lastError: null },
+    }}))
+    const calls: Array<Array<string>> = []
+    const tmux = createWorkerProcessHost({
+      registryFile: registryFile(), hasTmux: () => true,
+      runCommand: async (_command, args) => { calls.push(args); return { ok: true, stdout: 'pane output', stderr: '' } },
+    })
+    expect(await tmux.capture('tmux', { lines: 99_999 })).toMatchObject({ ok: true, output: 'pane output' })
+    expect(calls.at(-1)).toContain('-5000')
+  })
+
+  it('uses native hosting on Windows even when a tmux executable is present', () => {
+    const host = createWorkerProcessHost({ platform: 'win32', registryFile: registryFile(), hasTmux: () => true })
+    expect(host.hostKind).toBe('native')
+  })
+
+  it('launches tmux with the existing profile-aware command path', async () => {
+    const calls: Array<Array<string>> = []
+    const host = createWorkerProcessHost({
+      platform: 'linux', registryFile: registryFile(), hasTmux: () => true, tmuxBin: 'tmux',
+      runCommand: async (_command, args) => { calls.push(args); return { ok: args[0] !== 'has-session', stdout: '', stderr: '' } },
+    })
+    const result = await host.start({ ...startSpec(), env: { HERMES_HOME: '/profiles/builder', HERMES_CLI_BIN: '/bin/hermes' } })
+    expect(result.ok).toBe(true)
+    expect(calls[1]).toEqual(['new-session', '-d', '-s', 'swarm-builder', '-c', stateDir])
+    expect(calls[2]?.join(' ')).toContain("HERMES_HOME='/profiles/builder'")
+    expect(calls[2]?.join(' ')).toContain("'/bin/hermes' chat --tui")
+  })
+
+  it('constructs a minimal child environment and strips paid-provider credentials', () => {
+    expect(buildSafeChildEnv(
+      { PATH: 'safe', ANTHROPIC_API_KEY: 'paid', OPENAI_API_KEY: 'paid', RANDOM_SECRET: 'drop' },
+      { HERMES_HOME: 'profile', CLAUDE_CODE_OAUTH_TOKEN: 'drop' },
+    )).toEqual({ PATH: 'safe', HERMES_HOME: 'profile' })
+  })
+
+  it('never persists command arguments or environment secrets', async () => {
+    const host = createWorkerProcessHost({
+      platform: 'win32', registryFile: registryFile(), spawn: spawnMock() as never, isPidAlive: () => true,
+    })
+    await host.start({ ...startSpec(), args: ['--secret-token'], env: { ANTHROPIC_AUTH_TOKEN: 'do-not-store' } })
+    const persisted = readFileSync(registryFile(), 'utf8')
+    expect(persisted).not.toContain('secret-token')
+    expect(persisted).not.toContain('do-not-store')
+  })
+
+  it('fails closed when the durable registry is corrupt', async () => {
+    writeFileSync(registryFile(), '{not-json', 'utf8')
+    const host = createWorkerProcessHost({ platform: 'win32', registryFile: registryFile(), spawn: spawnMock() as never })
+    await expect(host.list()).rejects.toThrow()
+    await expect(host.start(startSpec())).rejects.toThrow()
+  })
+
+  it('serializes registry writes across host instances without losing workers', async () => {
+    const first = createWorkerProcessHost({ platform: 'win32', registryFile: registryFile(), spawn: spawnMock(4101) as never, isPidAlive: () => true })
+    const second = createWorkerProcessHost({ platform: 'win32', registryFile: registryFile(), spawn: spawnMock(4102) as never, isPidAlive: () => true })
+    const [one, two] = await Promise.all([
+      first.start({ ...startSpec(), workerId: 'builder-a' }),
+      second.start({ ...startSpec(), workerId: 'builder-b' }),
+    ])
+    expect(one.ok).toBe(true)
+    expect(two.ok).toBe(true)
+    expect((await first.list()).map((record) => record.workerId).sort()).toEqual(['builder-a', 'builder-b'])
+  })
+})

--- a/src/server/worker-process-host.ts
+++ b/src/server/worker-process-host.ts
@@ -1,7 +1,7 @@
 import { execFile, execFileSync, spawn as nodeSpawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 
 import {
   buildSwarmTmuxLaunchCommand,
@@ -43,6 +43,7 @@ export type WorkerProcessResult = {
   ok: boolean
   error?: string
   record?: WorkerProcessRecord
+  retainStartLock?: boolean
 }
 
 export type WorkerStartSpec = {
@@ -83,6 +84,10 @@ export type WorkerProcessHostDeps = {
   tmuxBin?: string
   isPidAlive?: (pid: number) => boolean
   now?: () => number
+  cleanupPollMs?: number
+  cleanupTimeoutMs?: number
+  writeRegistry?: (file: string, registry: { version: number; workers: Record<string, WorkerProcessRecord> }) => void
+  writeEmergencyOwnership?: (record: WorkerProcessRecord) => void
 }
 
 type RegistryFile = {
@@ -233,6 +238,9 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
   const now = deps.now ?? (() => Date.now())
   const runCommand = deps.runCommand ?? defaultRunCommand()
   const isPidAlive = deps.isPidAlive ?? defaultIsPidAlive
+  const cleanupPollMs = deps.cleanupPollMs ?? 25
+  const cleanupTimeoutMs = deps.cleanupTimeoutMs ?? 1_000
+  const writeAll = deps.writeRegistry ?? writeRegistry
   const spawnProcess: SpawnLike =
     deps.spawn ?? ((command, args, options) => nodeSpawn(command, args, options as never) as SpawnedChild)
 
@@ -261,6 +269,59 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
     return `${registryFile}::${workerId}`
   }
 
+  function emergencyOwnershipFile(workerId: string): string {
+    return `${registryFile}.${Buffer.from(workerId).toString('base64url')}.emergency.json`
+  }
+
+  function startLockFile(workerId: string): string {
+    return `${registryFile}.${Buffer.from(workerId).toString('base64url')}.start.lock`
+  }
+
+  function persistEmergencyOwnership(record: WorkerProcessRecord): void {
+    const file = emergencyOwnershipFile(record.workerId)
+    const temp = `${file}.${process.pid}.${randomUUID()}.tmp`
+    writeFileSync(temp, `${JSON.stringify(record)}\n`, 'utf8')
+    renameSync(temp, file)
+  }
+  const writeEmergencyOwnership = deps.writeEmergencyOwnership ?? persistEmergencyOwnership
+
+  function readEmergencyOwnership(workerId: string): WorkerProcessRecord | null {
+    try { return normalizeRecord(workerId, JSON.parse(readFileSync(emergencyOwnershipFile(workerId), 'utf8'))) } catch { return null }
+  }
+
+  function clearEmergencyOwnership(workerId: string): void {
+    try { unlinkSync(emergencyOwnershipFile(workerId)) } catch { /* absent or already reconciled */ }
+    try { unlinkSync(startLockFile(workerId)) } catch { /* absent or already reconciled */ }
+  }
+
+  function readRetainedStartOwnership(workerId: string): WorkerProcessRecord | null {
+    try { return normalizeRecord(workerId, JSON.parse(readFileSync(startLockFile(workerId), 'utf8'))) } catch { return null }
+  }
+
+  function listIndependentOwnership(): WorkerProcessRecord[] {
+    const records = new Map<string, { priority: number; record: WorkerProcessRecord }>()
+    const directory = dirname(registryFile)
+    const prefix = `${basename(registryFile)}.`
+    let names: string[]
+    try { names = readdirSync(directory) } catch { return [] }
+    for (const name of names) {
+      const emergency = name.startsWith(prefix) && name.endsWith('.emergency.json')
+      const retained = name.startsWith(prefix) && name.endsWith('.start.lock')
+      if (!emergency && !retained) continue
+      try {
+        const raw = JSON.parse(readFileSync(join(directory, name), 'utf8')) as Record<string, unknown>
+        if (typeof raw.workerId !== 'string') continue
+        const expected = emergency ? emergencyOwnershipFile(raw.workerId) : startLockFile(raw.workerId)
+        if (join(directory, name) !== expected) continue
+        const record = normalizeRecord(raw.workerId, raw)
+        if (!record) continue
+        const priority = emergency ? 2 : 1
+        if ((records.get(record.workerId)?.priority ?? 0) < priority) records.set(record.workerId, { priority, record })
+      } catch { /* malformed independent records are ignored */ }
+    }
+    return [...records.values()].map(({ record }) => record)
+  }
+
   function readAll(): RegistryFile {
     return readRegistry(registryFile)
   }
@@ -268,7 +329,7 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
   function persist(record: WorkerProcessRecord): WorkerProcessRecord {
     const registry = readAll()
     registry.workers[record.workerId] = record
-    writeRegistry(registryFile, registry)
+    writeAll(registryFile, registry)
     return record
   }
 
@@ -287,14 +348,40 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
   }
 
   async function startNative(spec: WorkerStartSpec): Promise<WorkerProcessResult> {
-    const child = spawnProcess(spec.command, spec.args, {
-      cwd: spec.cwd,
-      env: buildSafeChildEnv(process.env, spec.env),
-      detached: platform === 'win32',
-      windowsHide: platform === 'win32',
-      stdio: ['pipe', 'ignore', 'ignore'],
+    const reservedAt = now()
+    const reservation = persist({
+      workerId: spec.workerId, hostKind: 'native', pid: null, sessionName: null,
+      cwd: spec.cwd, status: 'unknown', startedAt: reservedAt, updatedAt: reservedAt,
+      lastError: 'Native process start reserved',
+    })
+    let child: SpawnedChild
+    try {
+      child = spawnProcess(spec.command, spec.args, {
+        cwd: spec.cwd,
+        env: buildSafeChildEnv(process.env, spec.env),
+        detached: platform === 'win32',
+        windowsHide: platform === 'win32',
+        stdio: ['pipe', 'ignore', 'ignore'],
+      })
+    } catch (error) {
+      const stopped = persist({
+        ...reservation,
+        status: 'stopped',
+        updatedAt: now(),
+        lastError: error instanceof Error ? error.message : 'native spawn failed',
+      })
+      return { ok: false, error: stopped.lastError ?? 'native spawn failed', record: stopped }
+    }
+    // Node emits spawn failures asynchronously even when `pid` is absent. Attach
+    // before inspecting the PID so a missing executable cannot crash Workspace.
+    child.on?.('error', (error) => {
+      if (child.pid) markExited(spec.workerId, child.pid)
+      else {
+        try { persist({ ...reservation, status: 'stopped', updatedAt: now(), lastError: error instanceof Error ? error.message : 'native spawn failed' }) } catch { /* reservation remains fail-closed */ }
+      }
     })
     if (!child.pid) {
+      persist({ ...reservation, status: 'stopped', updatedAt: now(), lastError: `Failed to spawn worker process for ${spec.workerId}` })
       return { ok: false, error: `Failed to spawn worker process for ${spec.workerId}` }
     }
     liveChildren.set(childKey(spec.workerId), child)
@@ -303,18 +390,57 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
       markExited(spec.workerId, child.pid!)
     })
     const timestamp = now()
-    const record = persist({
-      workerId: spec.workerId,
-      hostKind: 'native',
-      pid: child.pid,
-      sessionName: null,
-      cwd: spec.cwd,
-      status: 'running',
-      startedAt: timestamp,
-      updatedAt: timestamp,
-      lastError: null,
-    })
-    return { ok: true, record }
+    try {
+      const record = persist({
+        workerId: spec.workerId,
+        hostKind: 'native',
+        pid: child.pid,
+        sessionName: null,
+        cwd: spec.cwd,
+        status: 'running',
+        startedAt: timestamp,
+        updatedAt: timestamp,
+        lastError: null,
+      })
+      return { ok: true, record }
+    } catch (error) {
+      const recoverable = {
+        ...reservation,
+        pid: child.pid,
+        updatedAt: now(),
+        lastError: 'Native registration failed and process-tree cleanup was not verified',
+      }
+      // Independent durable ownership survives corruption/unavailability of the
+      // primary registry and is written before attempting destructive cleanup.
+      try { writeEmergencyOwnership(recoverable) } catch {
+        return {
+          ok: false,
+          error: 'Worker ownership registration and emergency persistence failed; start lock retained for manual recovery',
+          record: recoverable,
+          retainStartLock: true,
+        }
+      }
+      const terminationAccepted = platform === 'win32'
+        ? (await runCommand('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'])).ok
+        : child.kill?.('SIGTERM') !== false
+      const deadline = Date.now() + cleanupTimeoutMs
+      while (isPidAlive(child.pid) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, cleanupPollMs))
+      }
+      const cleanupVerified = terminationAccepted && !isPidAlive(child.pid)
+      if (cleanupVerified) {
+        liveChildren.delete(childKey(spec.workerId))
+        try { unlinkSync(emergencyOwnershipFile(spec.workerId)) } catch { /* already absent */ }
+      }
+      if (!cleanupVerified) {
+        try { persist(recoverable) } catch { /* retain the live handle and PID in the result */ }
+      }
+      return {
+        ok: false,
+        error: `Worker ownership registration failed: ${error instanceof Error ? error.message : 'unknown error'}${cleanupVerified ? '' : '; process-tree cleanup was not verified'}`,
+        record: cleanupVerified ? reservation : recoverable,
+      }
+    }
   }
 
   function markExited(workerId: string, expectedPid: number): void {
@@ -323,7 +449,7 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
       const existing = registry.workers[workerId]
       if (!existing || existing.pid !== expectedPid) return
       registry.workers[workerId] = { ...existing, status: 'stopped', pid: null, updatedAt: now() }
-      writeRegistry(registryFile, registry)
+      writeAll(registryFile, registry)
     } catch {
       // Registry writes are best-effort on process teardown.
     }
@@ -376,36 +502,43 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
     hostKind,
 
     async start(spec) {
-      const lockFile = `${registryFile}.${Buffer.from(spec.workerId).toString('base64url')}.start.lock`
+      const lockFile = startLockFile(spec.workerId)
       let lockFd: number
       try { lockFd = openSync(lockFile, 'wx') } catch {
-        return { ok: false, error: `Worker ${spec.workerId} start is already owned by another Workspace process` }
+        return { ok: false, error: `Worker ${spec.workerId} start is already owned by another Workspace process`, record: readRetainedStartOwnership(spec.workerId) ?? undefined }
       }
+      let retainStartLock = false
       try {
-        const current = readAll().workers[spec.workerId]
+        const current = readEmergencyOwnership(spec.workerId) ?? readAll().workers[spec.workerId]
         if (current?.status === 'running' || current?.status === 'unknown') {
           return { ok: false, error: `Worker ${spec.workerId} already has an active process`, record: current }
         }
-        return hostKind === 'tmux' ? await startTmux(spec) : await startNative(spec)
+        const result = hostKind === 'tmux' ? await startTmux(spec) : await startNative(spec)
+        retainStartLock = result.retainStartLock === true
+        if (retainStartLock && result.record) writeFileSync(lockFd, `${JSON.stringify(result.record)}\n`, 'utf8')
+        return result
       } finally {
         closeSync(lockFd)
-        try { unlinkSync(lockFile) } catch { /* a leftover lock fails closed */ }
+        if (!retainStartLock) try { unlinkSync(lockFile) } catch { /* a leftover lock fails closed */ }
       }
     },
 
     async stop(workerId) {
-      const record = readAll().workers[workerId]
+      const record = readEmergencyOwnership(workerId) ?? readRetainedStartOwnership(workerId) ?? readAll().workers[workerId]
       if (!record) return { ok: false, error: `Worker ${workerId} is not registered` }
       if (record.hostKind === 'tmux') {
         const killed = await runCommand(tmuxBin(), ['kill-session', '-t', record.sessionName ?? tmuxSessionNameForWorker(workerId)])
         if (!killed.ok) return { ok: false, error: killed.stderr.trim() || 'tmux kill-session failed', record }
         const stopped = persist({ ...record, status: 'stopped', pid: null, updatedAt: now() })
+        clearEmergencyOwnership(workerId)
         return { ok: true, record: stopped }
       }
       const child = liveChildren.get(childKey(workerId))
       if (!child) {
         if (record.pid && isPidAlive(record.pid)) return { ok: false, error: 'Recovered native PID ownership cannot be verified; refusing possible PID reuse', record }
-        return { ok: true, record: persist({ ...record, status: 'stopped', pid: null, updatedAt: now() }) }
+        const stopped = persist({ ...record, status: 'stopped', pid: null, updatedAt: now() })
+        clearEmergencyOwnership(workerId)
+        return { ok: true, record: stopped }
       }
       if (platform === 'win32' && record.pid) {
         const tree = await runCommand('taskkill.exe', ['/PID', String(record.pid), '/T', '/F'])
@@ -417,7 +550,9 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
       for (let attempt = 0; attempt < 40 && record.pid && isPidAlive(record.pid); attempt += 1) await new Promise((resolve) => setTimeout(resolve, 50))
       if (record.pid && isPidAlive(record.pid)) return { ok: false, error: 'Worker process tree did not exit; restart refused', record }
       liveChildren.delete(childKey(workerId))
-      return { ok: true, record: persist({ ...record, status: 'stopped', pid: null, updatedAt: now(), lastError: null }) }
+      const stopped = persist({ ...record, status: 'stopped', pid: null, updatedAt: now(), lastError: null })
+      clearEmergencyOwnership(workerId)
+      return { ok: true, record: stopped }
     },
 
     async send(workerId, text) {
@@ -473,11 +608,24 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
     },
 
     async status(workerId) {
-      return readAll().workers[workerId] ?? unknownRecord(workerId)
+      try { return readEmergencyOwnership(workerId) ?? readRetainedStartOwnership(workerId) ?? readAll().workers[workerId] ?? unknownRecord(workerId) }
+      catch (error) {
+        const emergency = readEmergencyOwnership(workerId)
+        if (emergency) return emergency
+        throw error
+      }
     },
 
     async list() {
-      return Object.values(readAll().workers).sort((a, b) => a.workerId.localeCompare(b.workerId))
+      const independent = listIndependentOwnership()
+      let primary: WorkerProcessRecord[]
+      try { primary = Object.values(readAll().workers) } catch (error) {
+        if (independent.length === 0) throw error
+        return independent.sort((a, b) => a.workerId.localeCompare(b.workerId))
+      }
+      const merged = new Map(primary.map((record) => [record.workerId, record]))
+      for (const record of independent) merged.set(record.workerId, record)
+      return [...merged.values()].sort((a, b) => a.workerId.localeCompare(b.workerId))
     },
 
     async recover() {
@@ -505,7 +653,7 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
         registry.workers[record.workerId] = next
         reconciled.push(next)
       }
-      writeRegistry(registryFile, registry)
+      writeAll(registryFile, registry)
       return reconciled.sort((a, b) => a.workerId.localeCompare(b.workerId))
     },
   }
@@ -513,9 +661,33 @@ export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): Worke
 
 let singletonHost: WorkerProcessHost | null = null
 
+export function withStartupRecovery(base: WorkerProcessHost): WorkerProcessHost {
+  let recovery: Promise<unknown> | null = null
+  const ready = () => { recovery ??= base.recover(); return recovery }
+  return {
+    get hostKind() { return base.hostKind },
+    async start(spec) { await ready(); return base.start(spec) },
+    async stop(workerId) {
+      try { await ready() } catch { return base.stop(workerId) }
+      return base.stop(workerId)
+    },
+    async send(workerId, prompt) { await ready(); return base.send(workerId, prompt) },
+    async capture(workerId, options) { await ready(); return base.capture(workerId, options) },
+    async status(workerId) {
+      try { await ready() } catch { return base.status(workerId) }
+      return base.status(workerId)
+    },
+    async list() {
+      try { await ready() } catch { return base.list() }
+      return base.list()
+    },
+    async recover() { await ready(); return base.list() },
+  }
+}
+
 /** Process-wide host. Routes and lifecycle helpers must share this authority. */
 export function getWorkerProcessHost(): WorkerProcessHost {
-  singletonHost ??= createWorkerProcessHost()
+  singletonHost ??= withStartupRecovery(createWorkerProcessHost())
   return singletonHost
 }
 

--- a/src/server/worker-process-host.ts
+++ b/src/server/worker-process-host.ts
@@ -1,0 +1,525 @@
+import { execFile, execFileSync, spawn as nodeSpawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+import {
+  buildSwarmTmuxLaunchCommand,
+  buildTmuxBufferLoad,
+  buildTmuxNewSessionArgs,
+  buildTmuxSendKeysArgs,
+  resolveSwarmTmuxBin,
+} from './swarm-tmux-launch'
+import { getStateDir } from './workspace-state-dir'
+
+/**
+ * Single server-side owner of Workspace worker processes.
+ *
+ * Before this module, three overlapping owners existed: the in-memory child
+ * map in `swarm-lifecycle`, the tmux session started by `/api/swarm-tmux-start`,
+ * and per-route ad hoc spawns. The in-memory map could not survive a server
+ * restart, so a worker started before a reload became invisible and
+ * unstoppable. The durable JSON registry below is the authority; live child
+ * handles are only a best-effort cache used to write stdin.
+ */
+
+export type ProcessHostKind = 'native' | 'tmux'
+
+export type WorkerProcessStatus = 'running' | 'stopped' | 'unknown'
+
+export type WorkerProcessRecord = {
+  workerId: string
+  hostKind: ProcessHostKind
+  pid: number | null
+  sessionName: string | null
+  cwd: string
+  status: WorkerProcessStatus
+  startedAt: number
+  updatedAt: number
+  lastError: string | null
+}
+
+export type WorkerProcessResult = {
+  ok: boolean
+  error?: string
+  record?: WorkerProcessRecord
+}
+
+export type WorkerStartSpec = {
+  workerId: string
+  /** Executable path or name. Never a shell string. */
+  command: string
+  /** Argument vector. Never interpolated into a shell. */
+  args: Array<string>
+  cwd: string
+  env?: Record<string, string>
+}
+
+type SpawnedChild = {
+  pid?: number
+  stdin?: { writable?: boolean; write: (chunk: string, cb?: (err?: Error | null) => void) => unknown } | null
+  on?: (event: string, listener: (...values: Array<unknown>) => void) => unknown
+  kill?: (signal?: string) => unknown
+}
+
+export type SpawnLike = (
+  command: string,
+  args: Array<string>,
+  options: { cwd: string; env: Record<string, string | undefined>; detached: boolean; windowsHide: boolean; stdio: Array<string> },
+) => SpawnedChild
+
+export type CommandRunner = (
+  command: string,
+  args: Array<string>,
+  options?: { stdin?: string; timeoutMs?: number },
+) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+
+export type WorkerProcessHostDeps = {
+  platform?: NodeJS.Platform
+  registryFile?: string
+  spawn?: SpawnLike
+  runCommand?: CommandRunner
+  hasTmux?: () => boolean
+  tmuxBin?: string
+  isPidAlive?: (pid: number) => boolean
+  now?: () => number
+}
+
+type RegistryFile = {
+  version: number
+  workers: Record<string, WorkerProcessRecord>
+}
+
+const REGISTRY_VERSION = 1
+const SAFE_ENV_KEYS = new Set(['PATH', 'PATHEXT', 'SystemRoot', 'WINDIR', 'COMSPEC', 'TEMP', 'TMP', 'APPDATA', 'LOCALAPPDATA', 'USERPROFILE', 'HOME', 'TERM', 'COLORTERM', 'LANG', 'LC_ALL', 'NO_COLOR'])
+
+export function buildSafeChildEnv(base: NodeJS.ProcessEnv, overrides: Record<string, string> = {}): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {}
+  for (const [key, value] of Object.entries(base)) if (SAFE_ENV_KEYS.has(key)) env[key] = value
+  for (const [key, value] of Object.entries(overrides)) {
+    if (/(?:API_KEY|AUTH_TOKEN|OAUTH_TOKEN|OPENROUTER)/i.test(key)) continue
+    env[key] = value
+  }
+  return env
+}
+
+export function defaultProcessRegistryFile(): string {
+  return join(getStateDir(), 'worker-process-hosts.json')
+}
+
+function emptyRegistry(): RegistryFile {
+  return { version: REGISTRY_VERSION, workers: {} }
+}
+
+function readRegistry(file: string): RegistryFile {
+  if (!existsSync(file)) return emptyRegistry()
+  const parsed = JSON.parse(readFileSync(file, 'utf8')) as Partial<RegistryFile>
+  if (!parsed || typeof parsed !== 'object' || parsed.version !== REGISTRY_VERSION || typeof parsed.workers !== 'object' || parsed.workers === null || Array.isArray(parsed.workers)) {
+    throw new Error('Worker process registry is corrupt or has an unsupported version')
+  }
+  const workers: Record<string, WorkerProcessRecord> = {}
+  for (const [workerId, value] of Object.entries(parsed.workers)) {
+    const record = normalizeRecord(workerId, value)
+    if (!record) throw new Error(`Worker process registry contains an invalid record: ${workerId}`)
+    workers[workerId] = record
+  }
+  return { version: REGISTRY_VERSION, workers }
+}
+
+function normalizeRecord(workerId: string, value: unknown): WorkerProcessRecord | null {
+  if (!value || typeof value !== 'object') return null
+  const raw = value as Record<string, unknown>
+  if (raw.workerId !== workerId || (raw.hostKind !== 'native' && raw.hostKind !== 'tmux') || (raw.status !== 'running' && raw.status !== 'stopped' && raw.status !== 'unknown')) return null
+  if (raw.pid !== null && (typeof raw.pid !== 'number' || !Number.isInteger(raw.pid) || raw.pid <= 0)) return null
+  if (raw.sessionName !== null && typeof raw.sessionName !== 'string') return null
+  if (typeof raw.cwd !== 'string' || typeof raw.startedAt !== 'number' || !Number.isFinite(raw.startedAt) || typeof raw.updatedAt !== 'number' || !Number.isFinite(raw.updatedAt)) return null
+  if (raw.lastError !== null && typeof raw.lastError !== 'string') return null
+  return {
+    workerId,
+    hostKind: raw.hostKind,
+    pid: raw.pid,
+    sessionName: raw.sessionName,
+    cwd: raw.cwd,
+    status: raw.status,
+    startedAt: raw.startedAt,
+    updatedAt: raw.updatedAt,
+    lastError: raw.lastError,
+  }
+}
+
+function writeRegistry(file: string, registry: RegistryFile): void {
+  const dir = dirname(file)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  const lock = `${file}.lock`
+  const deadline = Date.now() + 5_000
+  let lockFd: number | null = null
+  while (lockFd === null) {
+    try { lockFd = openSync(lock, 'wx') } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || Date.now() >= deadline) throw new Error('Worker process registry is locked by another Workspace process')
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20)
+    }
+  }
+  try {
+    const current = readRegistry(file)
+    const workers = { ...current.workers }
+    for (const [workerId, incoming] of Object.entries(registry.workers)) {
+      const prior = workers[workerId]
+      if (!prior || incoming.updatedAt >= prior.updatedAt) workers[workerId] = incoming
+    }
+    const temp = `${file}.${process.pid}.${randomUUID()}.tmp`
+    writeFileSync(temp, `${JSON.stringify({ version: REGISTRY_VERSION, workers }, null, 2)}\n`, 'utf8')
+    renameSync(temp, file)
+  } finally {
+    closeSync(lockFd)
+    try { unlinkSync(lock) } catch { /* best effort */ }
+  }
+}
+
+function defaultRunCommand(): CommandRunner {
+  return (command, args, options) =>
+    new Promise((resolve) => {
+      const child = execFile(
+        command,
+        args,
+        { timeout: options?.timeoutMs ?? 8_000 },
+        (error, stdout, stderr) => {
+          resolve({
+            ok: !error,
+            stdout: stdout?.toString() ?? '',
+            stderr: stderr?.toString() ?? (error ? error.message : ''),
+          })
+        },
+      )
+      child.on('error', (error) => {
+        resolve({ ok: false, stdout: '', stderr: error.message })
+      })
+      if (options?.stdin !== undefined) child.stdin?.end(options.stdin)
+    })
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM means the process exists but is owned by another user.
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+export function tmuxSessionNameForWorker(workerId: string): string {
+  return `swarm-${workerId}`
+}
+
+export interface WorkerProcessHost {
+  readonly hostKind: ProcessHostKind
+  start(spec: WorkerStartSpec): Promise<WorkerProcessResult>
+  stop(workerId: string): Promise<WorkerProcessResult>
+  send(workerId: string, text: string): Promise<WorkerProcessResult>
+  capture(workerId: string, options?: { lines?: number }): Promise<{ ok: boolean; output: string; error?: string }>
+  status(workerId: string): Promise<WorkerProcessRecord>
+  list(): Promise<Array<WorkerProcessRecord>>
+  recover(): Promise<Array<WorkerProcessRecord>>
+}
+
+// Live child handles for the current server process only. Keyed by
+// `${registryFile}::${workerId}` so parallel tests with distinct registries do
+// not collide.
+const liveChildren = new Map<string, SpawnedChild>()
+
+export function createWorkerProcessHost(deps: WorkerProcessHostDeps = {}): WorkerProcessHost {
+  const platform = deps.platform ?? process.platform
+  const registryFile = deps.registryFile ?? defaultProcessRegistryFile()
+  const now = deps.now ?? (() => Date.now())
+  const runCommand = deps.runCommand ?? defaultRunCommand()
+  const isPidAlive = deps.isPidAlive ?? defaultIsPidAlive
+  const spawnProcess: SpawnLike =
+    deps.spawn ?? ((command, args, options) => nodeSpawn(command, args, options as never) as SpawnedChild)
+
+  const hasTmux =
+    deps.hasTmux ??
+    (() => {
+      try {
+        execFileSync(tmuxBin(), ['-V'], { stdio: 'ignore' })
+        return true
+      } catch {
+        // `list-sessions` exits non-zero when tmux is installed but idle; treat
+        // "command missing" (ENOENT) as the only real negative.
+        return false
+      }
+    })
+
+  function tmuxBin(): string {
+    return deps.tmuxBin ?? resolveSwarmTmuxBin({ platform })
+  }
+
+  // Preserve the existing lifecycle policy: native child processes are the
+  // only supported Windows host. On Unix, prefer tmux when available.
+  const hostKind: ProcessHostKind = platform !== 'win32' && hasTmux() ? 'tmux' : 'native'
+
+  function childKey(workerId: string): string {
+    return `${registryFile}::${workerId}`
+  }
+
+  function readAll(): RegistryFile {
+    return readRegistry(registryFile)
+  }
+
+  function persist(record: WorkerProcessRecord): WorkerProcessRecord {
+    const registry = readAll()
+    registry.workers[record.workerId] = record
+    writeRegistry(registryFile, registry)
+    return record
+  }
+
+  function unknownRecord(workerId: string): WorkerProcessRecord {
+    return {
+      workerId,
+      hostKind,
+      pid: null,
+      sessionName: null,
+      cwd: '',
+      status: 'unknown',
+      startedAt: 0,
+      updatedAt: 0,
+      lastError: null,
+    }
+  }
+
+  async function startNative(spec: WorkerStartSpec): Promise<WorkerProcessResult> {
+    const child = spawnProcess(spec.command, spec.args, {
+      cwd: spec.cwd,
+      env: buildSafeChildEnv(process.env, spec.env),
+      detached: platform === 'win32',
+      windowsHide: platform === 'win32',
+      stdio: ['pipe', 'ignore', 'ignore'],
+    })
+    if (!child.pid) {
+      return { ok: false, error: `Failed to spawn worker process for ${spec.workerId}` }
+    }
+    liveChildren.set(childKey(spec.workerId), child)
+    child.on?.('exit', () => {
+      if (liveChildren.get(childKey(spec.workerId)) === child) liveChildren.delete(childKey(spec.workerId))
+      markExited(spec.workerId, child.pid!)
+    })
+    const timestamp = now()
+    const record = persist({
+      workerId: spec.workerId,
+      hostKind: 'native',
+      pid: child.pid,
+      sessionName: null,
+      cwd: spec.cwd,
+      status: 'running',
+      startedAt: timestamp,
+      updatedAt: timestamp,
+      lastError: null,
+    })
+    return { ok: true, record }
+  }
+
+  function markExited(workerId: string, expectedPid: number): void {
+    try {
+      const registry = readAll()
+      const existing = registry.workers[workerId]
+      if (!existing || existing.pid !== expectedPid) return
+      registry.workers[workerId] = { ...existing, status: 'stopped', pid: null, updatedAt: now() }
+      writeRegistry(registryFile, registry)
+    } catch {
+      // Registry writes are best-effort on process teardown.
+    }
+  }
+
+  async function startTmux(spec: WorkerStartSpec): Promise<WorkerProcessResult> {
+    const sessionName = tmuxSessionNameForWorker(spec.workerId)
+    const bin = tmuxBin()
+    const existing = await runCommand(bin, ['has-session', '-t', sessionName])
+    if (!existing.ok) {
+      const created = await runCommand(
+        bin,
+        buildTmuxNewSessionArgs({ sessionName, cwd: spec.cwd, platform }),
+      )
+      if (!created.ok) {
+        return { ok: false, error: created.stderr.trim() || 'tmux new-session failed' }
+      }
+      const launchCommand = buildSwarmTmuxLaunchCommand({
+        profilePath: spec.env?.HERMES_HOME ?? spec.cwd,
+        cwd: spec.cwd,
+        hermesBin: spec.env?.HERMES_CLI_BIN ?? spec.command,
+        platform,
+        keepShellAlive: true,
+      })
+      const launched = await runCommand(
+        bin,
+        buildTmuxSendKeysArgs(sessionName, launchCommand),
+      )
+      if (!launched.ok) {
+        await runCommand(bin, ['kill-session', '-t', sessionName])
+        return { ok: false, error: launched.stderr.trim() || 'tmux worker launch failed' }
+      }
+    }
+    const timestamp = now()
+    const record = persist({
+      workerId: spec.workerId,
+      hostKind: 'tmux',
+      pid: null,
+      sessionName,
+      cwd: spec.cwd,
+      status: 'running',
+      startedAt: timestamp,
+      updatedAt: timestamp,
+      lastError: null,
+    })
+    return { ok: true, record }
+  }
+
+  return {
+    hostKind,
+
+    async start(spec) {
+      const lockFile = `${registryFile}.${Buffer.from(spec.workerId).toString('base64url')}.start.lock`
+      let lockFd: number
+      try { lockFd = openSync(lockFile, 'wx') } catch {
+        return { ok: false, error: `Worker ${spec.workerId} start is already owned by another Workspace process` }
+      }
+      try {
+        const current = readAll().workers[spec.workerId]
+        if (current?.status === 'running' || current?.status === 'unknown') {
+          return { ok: false, error: `Worker ${spec.workerId} already has an active process`, record: current }
+        }
+        return hostKind === 'tmux' ? await startTmux(spec) : await startNative(spec)
+      } finally {
+        closeSync(lockFd)
+        try { unlinkSync(lockFile) } catch { /* a leftover lock fails closed */ }
+      }
+    },
+
+    async stop(workerId) {
+      const record = readAll().workers[workerId]
+      if (!record) return { ok: false, error: `Worker ${workerId} is not registered` }
+      if (record.hostKind === 'tmux') {
+        const killed = await runCommand(tmuxBin(), ['kill-session', '-t', record.sessionName ?? tmuxSessionNameForWorker(workerId)])
+        if (!killed.ok) return { ok: false, error: killed.stderr.trim() || 'tmux kill-session failed', record }
+        const stopped = persist({ ...record, status: 'stopped', pid: null, updatedAt: now() })
+        return { ok: true, record: stopped }
+      }
+      const child = liveChildren.get(childKey(workerId))
+      if (!child) {
+        if (record.pid && isPidAlive(record.pid)) return { ok: false, error: 'Recovered native PID ownership cannot be verified; refusing possible PID reuse', record }
+        return { ok: true, record: persist({ ...record, status: 'stopped', pid: null, updatedAt: now() }) }
+      }
+      if (platform === 'win32' && record.pid) {
+        const tree = await runCommand('taskkill.exe', ['/PID', String(record.pid), '/T', '/F'])
+        if (!tree.ok) return { ok: false, error: 'Windows worker process tree termination failed', record }
+      } else {
+        const signalled = child.kill?.('SIGTERM')
+        if (signalled === false) return { ok: false, error: 'Native worker rejected termination', record }
+      }
+      for (let attempt = 0; attempt < 40 && record.pid && isPidAlive(record.pid); attempt += 1) await new Promise((resolve) => setTimeout(resolve, 50))
+      if (record.pid && isPidAlive(record.pid)) return { ok: false, error: 'Worker process tree did not exit; restart refused', record }
+      liveChildren.delete(childKey(workerId))
+      return { ok: true, record: persist({ ...record, status: 'stopped', pid: null, updatedAt: now(), lastError: null }) }
+    },
+
+    async send(workerId, text) {
+      const record = readAll().workers[workerId]
+      if (!record || record.status !== 'running') {
+        return { ok: false, error: `Worker ${workerId} is not running` }
+      }
+      if (record.hostKind === 'tmux') {
+        const bin = tmuxBin()
+        const sessionName = record.sessionName ?? tmuxSessionNameForWorker(workerId)
+        const bufferName = `worker-host-${workerId}`
+        const buffer = buildTmuxBufferLoad({ bufferName, content: text, platform })
+        const loaded = await runCommand(bin, buffer.args, { stdin: buffer.stdin })
+        if (!loaded.ok) return { ok: false, error: loaded.stderr.trim() || 'tmux buffer load failed' }
+        const pasted = await runCommand(bin, ['paste-buffer', '-d', '-b', bufferName, '-t', sessionName])
+        if (!pasted.ok) return { ok: false, error: pasted.stderr.trim() || 'tmux paste-buffer failed' }
+        const entered = await runCommand(bin, ['send-keys', '-t', sessionName, 'Enter'])
+        if (!entered.ok) return { ok: false, error: entered.stderr.trim() || 'tmux send-keys failed' }
+        return { ok: true, record }
+      }
+      const child = liveChildren.get(childKey(workerId))
+      if (!child?.stdin?.writable) {
+        return {
+          ok: false,
+          error: `Worker ${workerId} has no writable stdin in this server process; restart the worker to reattach`,
+        }
+      }
+      return new Promise<WorkerProcessResult>((resolve) => {
+        child.stdin?.write(`${text}\n`, (error) => {
+          if (error) resolve({ ok: false, error: error.message })
+          else resolve({ ok: true, record })
+        })
+      })
+    },
+
+    async capture(workerId, options) {
+      const record = readAll().workers[workerId]
+      if (!record) return { ok: false, output: '', error: `Worker ${workerId} is not registered` }
+      if (record.hostKind !== 'tmux') {
+        return { ok: false, output: '', error: 'capture requires a tmux-hosted worker' }
+      }
+      const lines = Math.min(Math.max(options?.lines ?? 200, 1), 5_000)
+      const result = await runCommand(tmuxBin(), [
+        'capture-pane',
+        '-p',
+        '-t',
+        record.sessionName ?? tmuxSessionNameForWorker(workerId),
+        '-S',
+        `-${lines}`,
+      ])
+      if (!result.ok) return { ok: false, output: '', error: result.stderr.trim() || 'tmux capture-pane failed' }
+      return { ok: true, output: result.stdout }
+    },
+
+    async status(workerId) {
+      return readAll().workers[workerId] ?? unknownRecord(workerId)
+    },
+
+    async list() {
+      return Object.values(readAll().workers).sort((a, b) => a.workerId.localeCompare(b.workerId))
+    },
+
+    async recover() {
+      const registry = readAll()
+      const reconciled: Array<WorkerProcessRecord> = []
+      for (const record of Object.values(registry.workers)) {
+        if (record.status !== 'running') {
+          reconciled.push(record)
+          continue
+        }
+        let alive: boolean
+        if (record.hostKind === 'tmux') {
+          const probe = await runCommand(tmuxBin(), [
+            'has-session',
+            '-t',
+            record.sessionName ?? tmuxSessionNameForWorker(record.workerId),
+          ])
+          alive = probe.ok
+        } else {
+          alive = record.pid !== null && isPidAlive(record.pid)
+        }
+        const next: WorkerProcessRecord = alive
+          ? (record.hostKind === 'native' ? { ...record, status: 'unknown', updatedAt: now(), lastError: 'Recovered PID ownership is unverified; manual reconciliation required' } : record)
+          : { ...record, status: 'stopped', pid: null, updatedAt: now(), lastError: 'process not found during recovery' }
+        registry.workers[record.workerId] = next
+        reconciled.push(next)
+      }
+      writeRegistry(registryFile, registry)
+      return reconciled.sort((a, b) => a.workerId.localeCompare(b.workerId))
+    },
+  }
+}
+
+let singletonHost: WorkerProcessHost | null = null
+
+/** Process-wide host. Routes and lifecycle helpers must share this authority. */
+export function getWorkerProcessHost(): WorkerProcessHost {
+  singletonHost ??= createWorkerProcessHost()
+  return singletonHost
+}
+
+/** Test-only seam for integration tests; production callers should not replace it. */
+export function setWorkerProcessHostForTests(host: WorkerProcessHost | null): void {
+  singletonHost = host
+}

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -50,6 +50,7 @@ workers:
   - credential-change
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -102,6 +103,7 @@ workers:
   - source-of-record-change
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -152,6 +154,7 @@ workers:
   - external-write
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -245,6 +248,7 @@ workers:
   - external-write
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -299,6 +303,7 @@ workers:
   - long-running-loop
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -347,6 +352,7 @@ workers:
   - credential-change
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -397,6 +403,7 @@ workers:
   - fork-reset
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -443,6 +450,7 @@ workers:
   - irreversible-decision
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:
@@ -491,6 +499,7 @@ workers:
   - external-send
   maxConcurrentTasks: 1
   acceptsBroadcast: true
+  reviewRequired: false
   plugins: []
   pluginToolsets: []
   mcpServers:


### PR DESCRIPTION
## Summary
- add subscription-only model orchestration policy and account-aware controls
- unify Workspace worker process hosting and add isolated Claude/Codex runtime control-plane support
- add provider-neutral top-level Runs control center with metadata-only inventory
- keep inventory GET paths side-effect free and provider discovery explicit
- enforce authenticated, available subscription-route authority and exact account/kind provenance
- preserve authoritative durable lease ownership and fail-closed lifecycle capability projection
- add Windows deployment assets for the managed subscription stack

## Safety and isolation
- no prompts, transcripts, argv, credentials, tokens, API keys, or OAuth state are projected
- Codex fork remains unsupported and fails before provider, callback, or lease effects
- Claude Archive and other undispatchable operations are non-invokable
- stale/cross-account routes and kind-prefix mismatches fail closed

## Verification
- production build passed in a clean main integration worktree
- focused Runs/provider suite: 14 files, 69 tests passed
- changed-area ESLint: zero errors
- TypeScript: zero new normalized diagnostics versus base
- full Vitest remains baseline-red with zero new normalized failure signatures

Tip: 2376469a21e683b6e72d7951fb7b39b6861af4c9