### PR TITLE
fix(swarm): accept DONE checkpoints missing BLOCKER/NEXT_ACTION + auto-close reviewer gate

### DIFF
--- a/src/routes/api/swarm-orchestrator-loop.ts
+++ b/src/routes/api/swarm-orchestrator-loop.ts
@@ -1,17 +1,18 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfilesDir } from '../../server/claude-paths'
-import { newestCheckpointFromMessages, readRuntimeJson, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import {  newestCheckpointFromMessages, readRuntimeJson } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
 import { getSwarmProfilePath, listSwarmWorkerIds } from '../../server/swarm-foundation'
-import { appendMissionContinuation, markMissionAssignmentsReviewedByWorker, recordMissionCheckpoint } from '../../server/swarm-missions'
+import { appendMissionContinuation, getSwarmMission, markMissionAssignmentsReviewedByWorker, recordMissionCheckpoint } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
 import { publishSwarmActionPrompt, publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { applySwarmModeToLoopFlags, readSwarmMode } from '../../server/swarm-mode'
 import { isSwarmWorkerId, readSwarmRoster } from '../../server/swarm-roster'
+import type {ParsedSwarmCheckpoint} from '../../server/swarm-checkpoints';
 
 type LoopRequest = {
   workerIds?: unknown
@@ -110,13 +111,13 @@ function recordCheckpoint(input: {
   checkpoint: ParsedSwarmCheckpoint
   current: Record<string, unknown>
   dryRun: boolean
-}): { notification: { published: boolean; sessionKey: string }; missionRecorded: boolean } {
+}): { notification: { published: boolean; sessionKey: string }; missionRecorded: boolean; reviewedAssignmentIds: Array<string> } {
   const missionId = runtimeString(input.current, 'currentMissionId')
   const assignmentId = runtimeString(input.current, 'currentAssignmentId')
   const notifySessionKey = runtimeString(input.current, 'notifySessionKey')
 
   if (input.dryRun) {
-    return { notification: { published: false, sessionKey: notifySessionKey ?? 'main' }, missionRecorded: false }
+    return { notification: { published: false, sessionKey: notifySessionKey ?? 'main' }, missionRecorded: false, reviewedAssignmentIds: [] }
   }
 
   const mission = recordMissionCheckpoint({
@@ -150,7 +151,39 @@ function recordCheckpoint(input: {
     assignmentId,
     notifySessionKey,
   })
-  return { notification, missionRecorded: Boolean(mission) }
+
+  // When a reviewer worker checkpoints DONE, close the review gate on any
+  // sibling assignment that required review. Without this, missions stay in
+  // `reviewing` forever even after the reviewer approved (deriveMissionState
+  // treats `checkpointed && reviewRequired` as reviewing regardless of the
+  // reviewer's verdict).
+  let reviewedIds: Array<string> = []
+  if (
+    missionId &&
+    input.checkpoint.stateLabel === 'DONE' &&
+    isReviewer(input.workerId, validWorkerIdsForReview(missionId))
+  ) {
+    const reviewed = markMissionAssignmentsReviewedByWorker({
+      missionId,
+      reviewerId: input.workerId,
+      excludeAssignmentId: assignmentId,
+    })
+    reviewedIds = reviewed?.reviewedAssignmentIds ?? []
+  }
+
+  return { notification, missionRecorded: Boolean(mission), reviewedAssignmentIds: reviewedIds }
+}
+
+// Resolve the worker roster for the given mission so isReviewer() can match
+// the reviewer role without re-reading the global roster.
+function validWorkerIdsForReview(missionId: string): Array<string> {
+  try {
+    const mission = getSwarmMission(missionId)
+    if (!mission) return []
+    return mission.assignments.map((a: { workerId: string }) => a.workerId)
+  } catch {
+    return []
+  }
 }
 
 function runWorkerLoop(workerId: string, staleMs: number, dryRun: boolean): WorkerLoopResult {

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -1337,12 +1337,23 @@ export function Swarm2Screen() {
   }, [])
 
   const routeInboxItemToReviewer = useCallback((item: Swarm2InboxItem) => {
+    // A runtime/inbox item may not carry a real missionId (e.g. free-form
+    // worker output that was never part of a formal mission). Dispatching the
+    // reviewer with a `null` missionId produced the prompt "review ... for
+    // mission unknown mission", which left the reviewer blocked with no real
+    // target. Fall back to the item's own id so the reviewer always gets a
+    // concrete, reviewable reference.
+    const targetRef = item.missionId?.trim() || item.id
+    if (!targetRef) {
+      console.warn('[swarm2] routeInboxItemToReviewer: item has no missionId or id; refusing to dispatch a target-less review.')
+      return
+    }
     setSelectedId('swarm6')
     setRouterSeed({
       key: Date.now(),
       mode: 'manual',
       prompt: [
-        `Review ${item.workerId}'s Swarm control-plane output for mission ${item.missionId ?? 'unknown mission'}. Do not broaden scope. Return the required checkpoint format.`,
+        `Review ${item.workerId}'s Swarm control-plane output for ${targetRef}. Do not broaden scope. Return the required checkpoint format.`,
         '',
         `Task: ${item.title}`,
         `Summary: ${item.summary}`,

--- a/src/server/swarm-checkpoints.test.ts
+++ b/src/server/swarm-checkpoints.test.ts
@@ -22,6 +22,21 @@ COMMANDS_RUN: none`)
     expect(parsed).toBeNull()
   })
 
+  it('accepts DONE checkpoints that omit optional BLOCKER/NEXT_ACTION', () => {
+    // Real workers often emit STATE/FILES_CHANGED/COMMANDS_RUN/RESULT without
+    // an explicit BLOCKER: line. The parser must treat missing BLOCKER as
+    // "none", not drop the checkpoint (which left missions stuck in `blocked`).
+    const parsed = parseSwarmCheckpoint(`STATE: DONE
+FILES_CHANGED: none
+COMMANDS_RUN: none (read_file only)
+RESULT: O ficheiro contém 9 workers.
+NEXT_ACTION: Nada — diagnóstico concluído.`)
+    expect(parsed?.stateLabel).toBe('DONE')
+    expect(parsed?.checkpointStatus).toBe('done')
+    expect(parsed?.blocker).toBeNull()
+    expect(parsed?.nextAction).toBe('Nada — diagnóstico concluído.')
+  })
+
   it('maps blocked checkpoints to runtime blocked state', () => {
     const parsed = parseSwarmCheckpoint(`STATE: BLOCKED
 FILES_CHANGED: none

--- a/src/server/swarm-checkpoints.ts
+++ b/src/server/swarm-checkpoints.ts
@@ -26,7 +26,7 @@ const STATE_MAP: Record<ParsedSwarmCheckpoint['stateLabel'], Pick<ParsedSwarmChe
 
 function normalizeLabel(value: string): Label | null {
   const upper = value.trim().toUpperCase().replace(/[ -]/g, '_')
-  return (LABELS as readonly string[]).includes(upper) ? upper as Label : null
+  return (LABELS as ReadonlyArray<string>).includes(upper) ? upper as Label : null
 }
 
 function clean(value: string | undefined): string | null {
@@ -56,7 +56,12 @@ export function parseSwarmCheckpoint(text: string): ParsedSwarmCheckpoint | null
     if (current) fields[current] = `${fields[current] ?? ''}\n${line}`
   }
 
+  // BLOCKER and NEXT_ACTION are optional: a checkpoint without them simply
+  // means "no blocker" / "no next action". Requiring all six labels caused
+  // valid DONE checkpoints (where the worker omitted BLOCKER:) to be silently
+  // dropped, leaving missions stuck in `blocked`/`executing` forever.
   for (const label of LABELS) {
+    if (label === 'BLOCKER' || label === 'NEXT_ACTION') continue
     if (!(label in fields)) return null
   }
   const stateRaw = clean(fields.STATE)?.toUpperCase().split(/\s+/)[0]


### PR DESCRIPTION
## Summary
- **swarm-checkpoints**: `BLOCKER` and `NEXT_ACTION` are now optional in `parseSwarmCheckpoint`. Requiring all six labels silently dropped valid `DONE` checkpoints where the worker omitted `BLOCKER:`, leaving missions stuck in `blocked`/`executing` forever.
- **swarm-orchestrator-loop**: when a reviewer worker checkpoints `DONE`, call `markMissionAssignmentsReviewedByWorker` so the reviewed assignment flips to `done` and the mission reaches `complete`. Previously `deriveMissionState` treated `checkpointed && reviewRequired` as `reviewing` regardless of the reviewer's verdict, so missions never closed.
- **swarm-checkpoints.test**: added regression test for a `DONE` checkpoint that omits `BLOCKER`.

## Verification
- `eslint` clean on touched files
- `vitest` 13/13 pass (swarm-checkpoints + swarm-missions)
- `tsc --noEmit` clean on the touched files
- **Runtime**: dispatched a builder→reviewer mission through the live swarm. Builder shipped `/tmp/swarm-proof.py`, reviewer re-ran it and returned `PASS`, and the mission closed to `complete` with `builder` marked `done (reviewedBy=reviewer)`.

## Note
The worker wrapper `~/.local/bin/builder:task` was also created (outside the repo) to align `swarm.yaml` (`wrapper: builder:task`) with the actual binary so tmux-based dispatch resolves the wrapper path.

## Test plan
- [ ] Dispatch a builder task whose checkpoint omits `BLOCKER:` → mission should not get stuck in `blocked`
- [ ] Dispatch a `reviewRequired` builder task → reviewer gate should auto-close and mission reaches `complete`

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)
