### PR TITLE
docs: define workspace architecture

### DIFF
--- a/docs/workspace-architecture.md
+++ b/docs/workspace-architecture.md
@@ -1,0 +1,36 @@
+# Hermes Workspace Architecture
+
+Hermes Workspace is the interface and control layer through which a user can work across multiple environments, tools, agents, and knowledge systems.
+
+The central principle is:
+
+> **Unify the interface, not the domains. Preserve the unknowns.**
+
+## Conceptual Architecture
+
+```text
+                              USER
+                                │
+                           ┌────▼────┐
+                           │ HERMES  │
+                           │  MAIN   │
+                           │INTERFACE│
+                           └────┬────┘
+                                │
+          ┌─────────────────────┼─────────────────────┐
+          │                     │                     │
+          ▼                     ▼                     ▼
+     ENVIRONMENTS         SHARED INFRASTRUCTURE      AION
+          │                     │                     │
+     ┌────┴────┐          ┌─────┼─────┐              ?
+     ▼         ▼          ▼     ▼     ▼            UNKNOWN
+ Research   Art/Creative  Gateway Ollama MCP        ORGANISM
+    │           │                  │
+    │           │          Obsidian / Zotero /
+    │           │              GitHub / etc.
+    │           │
+ Research     Making
+ PhD          Works
+ Sources      Experiments
+ Questions    Assets
+ Experiments  Archive


### PR DESCRIPTION
## Summary

- add a canonical workspace architecture document for Hermes Workspace
- define separated Research and Art environments
- document shared infrastructure and the intentionally unresolved AION boundary
- clarify Hermes as the unified interface without collapsing domain boundaries

## Scope

This PR contains one documentation file only and does not change runtime behavior, personal workspace paths, local configuration, or application state.

## Local context

The architecture described here reflects the workspace model established locally around Hermes: separate environments, shared infrastructure, and AION treated as an intentionally unclassified experimental entity.