### PR TITLE
fix(workspace): pass active profile to dashboard API calls

### DIFF
--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { getStateDir } from './workspace-state-dir'
+import { getActiveProfileName } from './profiles-browser'
 
 type WorkspaceOverrides = {
   claudeApiUrl?: string
@@ -343,11 +344,30 @@ function withDashboardBase(path: string): string {
   return `${CLAUDE_DASHBOARD_URL}${path.startsWith('/') ? path : `/${path}`}`
 }
 
+/**
+ * Append the active Hermes profile as a query parameter so the dashboard
+ * reads the correct profile's config (model, provider, etc.) instead of
+ * defaulting to the 'default' profile which often has no model set.
+ */
+function withProfileParam(url: string): string {
+  // Don't double-inject if the caller already passed ?profile=
+  if (/[?&]profile=/.test(url)) return url
+  try {
+    const profile = getActiveProfileName()
+    if (!profile || profile === 'default') return url
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}profile=${encodeURIComponent(profile)}`
+  } catch {
+    return url
+  }
+}
+
 export async function dashboardFetch(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
-  const requestPath = withDashboardBase(path)
+  const rawUrl = withDashboardBase(path)
+  const requestPath = withProfileParam(rawUrl)
   const method = (init.method || 'GET').toUpperCase()
   const doFetch = async (forceToken = false) => {
     const headers = new Headers(init.headers)


### PR DESCRIPTION
## Summary

`dashboardFetch` was calling the dashboard API without the `?profile=` query parameter. The dashboard server always returned empty model/provider info because it defaulted to the `default` profile (which has no model configured).

## Root Cause

The workspace reads `~/.hermes/active_profile` to know which profile is active (e.g. `cto`), but `dashboardFetch()` in `gateway-capabilities.ts` built URLs via `withDashboardBase()` which only prepends the dashboard base URL — no profile parameter.

The dashboard's `/api/model/info` endpoint **does** accept `?profile=<name>` and returns correct data when provided:
- Without: `{model: '', provider: ''}`
- With `?profile=cto`: `{model: 'xiaomi/mimo-v2.5', provider: 'openrouter'}`

## Fix

Added `withProfileParam()` in `gateway-capabilities.ts` that:
1. Reads the active profile name via `getActiveProfileName()`
2. Appends `?profile=<name>` to all dashboard API URLs (when profile is not `default`)
3. Skips injection if `?profile=` is already present in the URL

## Impact

- Model info, cost tracking, and config reads now work correctly in the workspace UI when running under a named profile
- No effect when running under the `default` profile (skips injection)
- All dashboard API calls benefit (sessions, skills, config, cron, etc.)

## Test Plan

- [x] `curl http://127.0.0.1:9119/api/model/info` → empty (without profile)
- [x] `curl http://127.0.0.1:9119/api/model/info?profile=cto` → correct model
- [x] TypeScript compiles cleanly (no new errors)
- [ ] Restart workspace service and verify UI shows correct model