### PR TITLE
fix: return 401 instead of crashing on unauthenticated /api/hermes-config

### DIFF
--- a/src/routes/api/-hermes-config.test.ts
+++ b/src/routes/api/-hermes-config.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../server/auth-middleware', () => ({
 
 vi.mock('../../server/gateway-capabilities', () => ({
   ensureGatewayProbed: vi.fn(),
-  getCapabilities: () => ({ config: true }),
+  getCapabilities: vi.fn(() => ({ config: true })),
 }))
 
 vi.mock('../../server/local-provider-discovery', () => ({
@@ -132,10 +132,15 @@ describe('canonical /api/hermes-config route', () => {
   })
 
   it('PATCH returns 503 when the gateway capability is unavailable', async () => {
-    vi.doMock('../../server/gateway-capabilities', () => ({
-      ensureGatewayProbed: vi.fn(),
-      getCapabilities: () => ({ config: false }),
-    }))
+    // Scoped to this test only: a fresh `getCapabilities` vi.fn() is created
+    // by the top-level mock factory every time `vi.resetModules()` runs in
+    // `beforeEach`, so `mockReturnValueOnce` here can't leak into later tests
+    // the way a `vi.doMock`/`vi.doUnmock` pair around a dynamic import did
+    // (that previously left `config: false` active for whichever test ran
+    // next in this file — see the "legacy /api/claude-config alias" test).
+    const { getCapabilities } = await import('../../server/gateway-capabilities')
+    vi.mocked(getCapabilities).mockReturnValueOnce({ config: false } as any)
+
     const handlers = await loadHandlers('./hermes-config')
     const res = await handlers.PATCH({
       request: new Request('http://localhost/api/hermes-config', {
@@ -144,7 +149,6 @@ describe('canonical /api/hermes-config route', () => {
       }),
     })
     expect(res.status).toBe(503)
-    vi.doUnmock('../../server/gateway-capabilities')
   })
 })
 
@@ -165,5 +169,38 @@ describe('legacy /api/claude-config alias', () => {
 
     expect(openrouter.maskedKeys).toEqual(openrouter.maskedCredentials)
     expect(openrouter.maskedKeys.OPENROUTER_API_KEY).toBeTruthy()
+  })
+})
+
+describe('unauthenticated requests', () => {
+  it('GET /api/hermes-config returns a 401 Response instead of crashing', async () => {
+    vi.doMock('../../server/auth-middleware', () => ({
+      isAuthenticated: () => false,
+    }))
+    const handlers = await loadHandlers('./hermes-config')
+    const res = await handlers.GET({
+      request: new Request('http://localhost/api/hermes-config'),
+    })
+    expect(res).toBeInstanceOf(Response)
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toEqual({ ok: false, error: 'Unauthorized' })
+    vi.doUnmock('../../server/auth-middleware')
+  })
+
+  it('PATCH /api/claude-config returns a 401 Response instead of crashing', async () => {
+    vi.doMock('../../server/auth-middleware', () => ({
+      isAuthenticated: () => false,
+    }))
+    const handlers = await loadHandlers('./claude-config')
+    const res = await handlers.PATCH({
+      request: new Request('http://localhost/api/claude-config', {
+        method: 'PATCH',
+        body: JSON.stringify({ action: 'set-default-model', providerId: 'x', modelId: 'y' }),
+      }),
+    })
+    expect(res).toBeInstanceOf(Response)
+    expect(res.status).toBe(401)
+    vi.doUnmock('../../server/auth-middleware')
   })
 })

--- a/src/server/hermes-config-route.ts
+++ b/src/server/hermes-config-route.ts
@@ -72,8 +72,9 @@ const LegacyPatchSchema = z.object({
 })
 
 async function authorize(request: Request): Promise<AuthResult> {
-  const result = isAuthenticated(request) as AuthResult
-  if (result !== true) return result
+  if (!isAuthenticated(request)) {
+    return Response.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
   await ensureGatewayProbed()
   return true
 }


### PR DESCRIPTION
## Summary

`authorize()` in `src/server/hermes-config-route.ts` force-cast `isAuthenticated()`'s plain `boolean` return to a `Response | true` union, then returned the raw `false` on auth failure instead of a real `Response`. Every sibling route (`sessions.ts`, `files.ts`, etc.) follows the `if (!isAuthenticated(request)) return json(..., {status:401})` pattern — this was the one handler that didn't, so an unauthenticated `GET`/`PATCH` here crashed with an unhandled `500` instead of a clean `401`. This also affects the legacy `/api/claude-config` alias, which shares this handler.

Found this live (unauthenticated `curl` to `/api/claude-config` returned `{"status":500,"unhandled":true,"message":"HTTPError"}`), traced it to this one file via a repo-wide grep for the `isAuthenticated` usage pattern.

## Changes

- Fixed `authorize()` to return a real `401 Response` on auth failure.
- Added two regression tests (`GET`/`PATCH`, mocking `isAuthenticated` to `false`) asserting a proper `401 Response` comes back instead of a crash — the existing test suite mocked auth as always-`true`, which is exactly why this slipped through.
- Small unrelated test-hygiene fix in the same file: the "PATCH returns 503" test used `vi.doMock`/`vi.doUnmock` around a dynamic import, which left `config: false` active for whichever test ran next in the file (confirmed — this made the "legacy alias" test flaky depending on run order, reproduces on unmodified `main` too). Swapped to `vi.fn()` + `mockReturnValueOnce`, which doesn't leak across tests.

## Test plan

- [x] `npx vitest run src/routes/api/-hermes-config.test.ts` — 8/8 passing
- [x] Full suite regression check: baseline (unmodified `main`) is 58 failed/742 total; with this change, 57 failed/744 total — one fewer failure (the flaky test above) and two more passing tests, zero new breakage.
- [x] Live-verified against a real deployment: unauthenticated `curl /api/claude-config` now returns `401 {"ok":false,"error":"Unauthorized"}` instead of `500`.