### PR TITLE
fix: use the already-tested connection-error classifier in the chat banner

### DIFF
--- a/src/screens/chat/components/connection-status-message.tsx
+++ b/src/screens/chat/components/connection-status-message.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Alert02Icon, WifiDisconnected01Icon } from '@hugeicons/core-free-icons'
 import { cn } from '@/lib/utils'
+import { getConnectionErrorInfo } from '@/lib/connection-errors'
 
 type ConnectionStatusMessageProps = {
   state: 'checking' | 'error'
@@ -11,6 +12,14 @@ type ConnectionStatusMessageProps = {
   className?: string
 }
 
+// Classification previously duplicated an inline copy of this logic that
+// treated any message containing "auth" or "token" as a Hermes-Agent gateway
+// rejection — including a plain 401 from /api/ping, which only ever reflects
+// this Workspace's own password-session cookie, never the gateway token. That
+// misrouted users to "Settings -> Advanced -> Hermes Agent" for a problem
+// solved by just logging back in. `getConnectionErrorInfo` (src/lib/connection-errors.ts)
+// already disambiguates this correctly (and is unit-tested for it) but was
+// never wired into this component — use it instead of re-deriving locally.
 function classifyConnectionError(
   error?: string | null,
   status?: number | null,
@@ -19,10 +28,7 @@ function classifyConnectionError(
   description: string
   action: string
 } {
-  const normalizedError = error?.trim()
-  const lower = normalizedError?.toLowerCase() ?? ''
-
-  if (!normalizedError && !status) {
+  if (!error?.trim() && !status) {
     return {
       title: 'Not connected',
       description: "Hermes Workspace can't reach Hermes Agent.",
@@ -30,57 +36,11 @@ function classifyConnectionError(
     }
   }
 
-  if (
-    status === 401 ||
-    lower.includes('auth') ||
-    lower.includes('token') ||
-    lower.includes('unauthorized')
-  ) {
-    return {
-      title: 'Authentication required',
-      description: 'Hermes Agent rejected the connection token.',
-      action: 'Go to Settings -> Advanced -> Hermes Agent to update your token.',
-    }
-  }
-
-  if (
-    status === 403 ||
-    lower.includes('pair') ||
-    lower.includes('not paired')
-  ) {
-    return {
-      title: 'Pairing required',
-      description: "This device isn't paired with Hermes Agent yet.",
-      action: 'Check Hermes Agent connection.',
-    }
-  }
-
-  if (lower.includes('econnrefused') && lower.includes('8642')) {
-    return {
-      title: 'Hermes Agent gateway not running',
-      description: 'The Hermes Agent gateway is not running on port 8642.',
-      action: 'Run the official Hermes installer, then start the gateway with: hermes gateway run',
-    }
-  }
-
-  if (
-    lower.includes('econnrefused') ||
-    lower.includes('fetch') ||
-    lower.includes('failed to fetch') ||
-    lower.includes('timed out') ||
-    lower.includes('timeout')
-  ) {
-    return {
-      title: 'Hermes Agent unreachable',
-      description: "Can't connect to Hermes Agent at the configured URL.",
-      action: 'Make sure Hermes is running and the URL is correct.',
-    }
-  }
-
+  const info = getConnectionErrorInfo(error, status)
   return {
-    title: 'Connection error',
-    description: normalizedError || 'Something went wrong.',
-    action: 'Try refreshing or check Settings -> Advanced -> Hermes.',
+    title: info.title,
+    description: info.description,
+    action: info.action ?? 'Try again, or review the gateway settings.',
   }
 }
 


### PR DESCRIPTION
## Summary

`ConnectionStatusMessage` had its own inline `classifyConnectionError()` that treated any error message containing `"auth"` or `"token"` — including a plain `401` from `/api/ping` — as `"Hermes Agent rejected the connection token / Go to Settings -> Advanced -> Hermes Agent to update your token."`

That's misleading: `/api/ping` only ever checks this Workspace's own `requireLocalOrAuth` session-cookie gate, never the Agent gateway token (confirmed by reading the route — it never touches `HERMES_API_TOKEN`/`API_SERVER_KEY` at all). A `401` from `/api/ping` always means the browser's Workspace login session expired or was rejected, not that the Agent gateway did anything.

`src/lib/connection-errors.ts` already has a correct, disambiguated classifier — `clawsuite_auth_required` (plain session 401) vs `gateway_auth_rejected` (an actual gateway token failure), with its own passing test suite including a regression test guarding exactly this "token" substring false-positive (`does NOT misclassify benign uses of the word "token" as auth failures`). It just was never wired into this component — a bug that was already fixed elsewhere in the codebase, just not connected.

## Changes

Rewired `ConnectionStatusMessage` to call `getConnectionErrorInfo()` from `@/lib/connection-errors` instead of re-deriving the classification locally. No behavior change for any case already covered by that module's tests; the practical effect is that a plain Workspace-session 401 now correctly says "ClawSuite Login Required / Enter your password to continue" instead of blaming the Agent gateway.

## Test plan

- [x] `src/lib/connection-errors.test.ts` — 17/17 passing (unmodified, already covers the new code path)
- [x] Full suite regression check — no new failures introduced
- [x] Found and reproduced live on a real deployment while investigating a "Failed to load sessions" banner — the underlying Agent connection was fine, only the banner text was wrong