### PR TITLE
feat: support Hermes Agent's dashboard login-form auth gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,18 @@
 # Workspace scrapes the dashboard's ephemeral session token from the root HTML
 # automatically. Do not copy this token into .env: it changes whenever the
 # dashboard restarts and stale values cause 401s on /api/sessions and related APIs.
+# This only works when the dashboard has no login gate (loopback / same-host).
+
+# Dashboard login credentials (required if the Hermes Agent dashboard has
+# HERMES_DASHBOARD_BASIC_AUTH_USERNAME/_PASSWORD set on its own side, e.g. any
+# non-loopback deployment, where the auth gate is mandatory)
+#
+# Same variable names as the Agent side, so you can copy the pair straight
+# across. Without these, /api/sessions and other dashboard-backed APIs
+# (skills, MCP, cron jobs, model info) 401 the moment the dashboard requires
+# a login instead of serving its root page unauthenticated.
+# HERMES_DASHBOARD_BASIC_AUTH_USERNAME=
+# HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=
 
 # Bypass fail-closed startup guard (NOT recommended)
 #

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -42,6 +42,8 @@ beforeEach(() => {
   delete process.env.HERMES_DASHBOARD_URL
   delete process.env.HERMES_DASHBOARD_TOKEN
   delete process.env.CLAUDE_DASHBOARD_TOKEN
+  delete process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+  delete process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
   delete process.env.HOST
 })
 
@@ -216,6 +218,140 @@ describe('gateway-capabilities', () => {
         '[gateway] Dashboard index returned 500 — token unavailable',
       )
       warnSpy.mockRestore()
+    })
+  })
+
+  describe('dashboard login-form auth (basic-auth gated dashboards)', () => {
+    // The Agent's "basic auth" dashboard gate is actually a cookie-session
+    // login form (POST /auth/password-login), not RFC 7617 HTTP Basic — see
+    // hermes-claude-integration-summary.md in the vault for the live repro
+    // that found this. These tests cover the login-and-cache path added to
+    // dashboardFetch/dashboardAuthHeaders for that case.
+
+    function loginResponse(cookies: Array<string>) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { getSetCookie: () => cookies },
+        json: async () => ({ ok: true, next: '/' }),
+      }
+    }
+
+    it('logs in and reuses the session cookie for dashboard requests', async () => {
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME = 'admin'
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = 'secret'
+
+      fetchMock.mockImplementation(async (url: string) => {
+        if (url === 'http://127.0.0.1:9119/auth/password-login') {
+          return loginResponse(['hermes_session_at=abc; HttpOnly; Path=/', 'hermes_session_provider=basic; HttpOnly; Path=/'])
+        }
+        return { ok: true, status: 200, json: async () => ({ sessions: [] }) }
+      })
+
+      const mod = await loadMod()
+      // The module's own background auto-probe (`void ensureGatewayProbed()`
+      // at the bottom of gateway-capabilities.ts, fired on import) runs
+      // independently of the calls under test and, once credentials are
+      // configured, legitimately exercises this same login path itself.
+      // Let it settle and clear the call log before asserting, so these
+      // assertions only see the two dashboardFetch calls being tested.
+      await mod.ensureGatewayProbed()
+      fetchMock.mockClear()
+
+      const r1 = await mod.dashboardFetch('/api/sessions')
+      const r2 = await mod.dashboardFetch('/api/sessions')
+
+      expect(r1.status).toBe(200)
+      expect(r2.status).toBe(200)
+      // The probe above already logged in and cached a session cookie —
+      // neither call here should need to log in again.
+      expect(
+        fetchMock.mock.calls.some(([u]) => u === 'http://127.0.0.1:9119/auth/password-login'),
+      ).toBe(false)
+
+      const sessionCalls = fetchMock.mock.calls.filter(([u]) => u === 'http://127.0.0.1:9119/api/sessions')
+      expect(sessionCalls).toHaveLength(2)
+      for (const [, init] of sessionCalls) {
+        const headers = init.headers as Headers
+        expect(headers.get('Cookie')).toBe('hermes_session_at=abc; hermes_session_provider=basic')
+      }
+    })
+
+    it('sends the configured credentials in the login POST body', async () => {
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME = 'admin'
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = 'secret'
+
+      fetchMock.mockImplementation(async (url: string) => {
+        if (url === 'http://127.0.0.1:9119/auth/password-login') {
+          return loginResponse(['hermes_session_at=abc; Path=/'])
+        }
+        return { ok: true, status: 200, json: async () => ({}) }
+      })
+
+      const mod = await loadMod()
+      await mod.ensureGatewayProbed()
+
+      const loginCalls = fetchMock.mock.calls.filter(
+        ([u]) => u === 'http://127.0.0.1:9119/auth/password-login',
+      )
+      expect(loginCalls.length).toBeGreaterThan(0)
+      const body = JSON.parse(loginCalls[0][1].body)
+      expect(body).toEqual({ provider: 'basic', username: 'admin', password: 'secret', next: '' })
+    })
+
+    it('re-logs in after a 401 (expired/rotated session)', async () => {
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME = 'admin'
+      process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = 'secret'
+
+      let loginCount = 0
+      let sessionCallCount = 0
+      fetchMock.mockImplementation(async (url: string) => {
+        if (url === 'http://127.0.0.1:9119/auth/password-login') {
+          loginCount++
+          return loginResponse([`hermes_session_at=token-${loginCount}; Path=/`])
+        }
+        if (url === 'http://127.0.0.1:9119/api/sessions') {
+          sessionCallCount++
+          // First attempt: stale/expired cookie rejected. Second: fresh login succeeds.
+          return sessionCallCount === 1
+            ? { ok: false, status: 401, json: async () => ({ ok: false }) }
+            : { ok: true, status: 200, json: async () => ({ sessions: [] }) }
+        }
+        return { ok: true, status: 200, json: async () => ({}) }
+      })
+
+      const mod = await loadMod()
+      // Settle the background auto-probe first (see comment above) so the
+      // cache starts warm, simulating "this cookie is already stale" —
+      // which is exactly the scenario this test exercises.
+      await mod.ensureGatewayProbed()
+      fetchMock.mockClear()
+      sessionCallCount = 0
+
+      const res = await mod.dashboardFetch('/api/sessions')
+
+      expect(res.status).toBe(200)
+      expect(sessionCallCount).toBe(2)
+      const loginCallsAfterRetry = fetchMock.mock.calls.filter(
+        ([u]) => u === 'http://127.0.0.1:9119/auth/password-login',
+      )
+      expect(loginCallsAfterRetry).toHaveLength(1)
+    })
+
+    it('does not attempt a login POST when credentials are not configured', async () => {
+      fetchMock.mockImplementation(async (url: string) => {
+        if (url === 'http://127.0.0.1:9119/') {
+          return { ok: true, status: 200, text: async () => '<html></html>' }
+        }
+        return { ok: true, status: 200, json: async () => ({ sessions: [] }) }
+      })
+
+      const mod = await loadMod()
+      await mod.dashboardFetch('/api/sessions')
+
+      expect(
+        fetchMock.mock.calls.some(([u]) => u === 'http://127.0.0.1:9119/auth/password-login'),
+      ).toBe(false)
     })
   })
 

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -262,6 +262,83 @@ let dashboardTokenCache = ''
 export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
 
 /**
+ * Credentials for a dashboard behind Hermes Agent's login-form auth gate
+ * (`HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD` on the Agent side —
+ * same var names here so operators can copy the pair straight across).
+ * Optional: unset by default, which preserves the original ephemeral-token
+ * scrape below for dashboards with no auth gate (the common loopback case).
+ */
+function getDashboardLoginCredentials(): { username: string; password: string } | null {
+  const username = (process.env.HERMES_DASHBOARD_BASIC_AUTH_USERNAME || '').trim()
+  const password = process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD || ''
+  if (!username || !password) return null
+  return { username, password }
+}
+
+let dashboardSessionCookiePromise: Promise<string> | null = null
+let dashboardSessionCookieCache = ''
+
+/**
+ * Despite the "basic auth" naming on the Agent side, the dashboard's gate is
+ * a cookie-session login form (`POST /auth/password-login`), not RFC 7617
+ * HTTP Basic — a raw `Authorization: Basic ...` header is silently ignored
+ * and the request still gets redirected to /login. Log in once, cache the
+ * `Set-Cookie` values, and replay them as a `Cookie` header on every
+ * dashboard request until one comes back 401 (session expired / dashboard
+ * restarted), same invalidate-and-retry-once shape as the token cache above.
+ */
+async function loginToDashboard(options?: { force?: boolean }): Promise<string> {
+  const creds = getDashboardLoginCredentials()
+  if (!creds) return ''
+
+  const force = options?.force === true
+  if (!force && dashboardSessionCookieCache) return dashboardSessionCookieCache
+  if (!force && dashboardSessionCookiePromise) return dashboardSessionCookiePromise
+
+  dashboardSessionCookiePromise = (async () => {
+    try {
+      const res = await fetch(`${CLAUDE_DASHBOARD_URL}/auth/password-login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'basic',
+          username: creds.username,
+          password: creds.password,
+          next: '',
+        }),
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        console.warn(`[gateway] Dashboard login rejected (${res.status}) — check HERMES_DASHBOARD_BASIC_AUTH_USERNAME/_PASSWORD`)
+        return ''
+      }
+      const setCookie =
+        typeof res.headers.getSetCookie === 'function'
+          ? res.headers.getSetCookie()
+          : (res.headers.get('set-cookie') ? [res.headers.get('set-cookie') as string] : [])
+      const cookie = setCookie.map((c) => c.split(';')[0]).filter(Boolean).join('; ')
+      if (!cookie) {
+        console.warn('[gateway] Dashboard login succeeded but returned no session cookie')
+        return ''
+      }
+      dashboardSessionCookieCache = cookie
+      return cookie
+    } catch (err) {
+      console.warn(
+        `[gateway] Failed to log in to dashboard: ${err instanceof Error ? err.message : err}`,
+      )
+      return ''
+    }
+  })()
+
+  try {
+    return await dashboardSessionCookiePromise
+  } finally {
+    dashboardSessionCookiePromise = null
+  }
+}
+
+/**
  * Dashboard API auth uses the ephemeral session token injected into the
  * dashboard root HTML at startup. Do not reuse gateway bearer tokens here and
  * do not trust a manually copied dashboard token env var — it goes stale every
@@ -334,6 +411,14 @@ export async function getDashboardToken(options?: {
 export async function dashboardAuthHeaders(options?: {
   force?: boolean
 }): Promise<Record<string, string>> {
+  if (getDashboardLoginCredentials()) {
+    const cookie = await loginToDashboard(options)
+    if (cookie) return { Cookie: cookie }
+    // Login itself failed (bad creds, dashboard unreachable) — fall through
+    // to the token-scrape path below rather than sending an unauthenticated
+    // request outright; it will also fail, but with the original error
+    // shape callers already handle.
+  }
   const token = await getDashboardToken(options)
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
@@ -361,7 +446,7 @@ export async function dashboardFetch(
       !requestPath.endsWith('/api/dashboard/plugins') &&
       !requestPath.endsWith('/api/dashboard/plugins/rescan')
 
-    if (isProtected && !headers.has('Authorization')) {
+    if (isProtected && !headers.has('Authorization') && !headers.has('Cookie')) {
       const auth = await dashboardAuthHeaders({ force: forceToken })
       for (const [key, value] of Object.entries(auth)) {
         headers.set(key, value)
@@ -378,6 +463,7 @@ export async function dashboardFetch(
   let res = await doFetch(false)
   if (res.status === 401) {
     dashboardTokenCache = ''
+    dashboardSessionCookieCache = ''
     res = await doFetch(true)
   }
   return res


### PR DESCRIPTION
## Summary

Hermes Agent's dashboard, once it has `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD` configured (as recommended for any non-loopback bind — see the security note in the Docker docs about the June 2026 unauthenticated-dashboard exploit), is **not** gated by RFC 7617 HTTP Basic Auth despite the "basic auth" naming. It's a cookie-session login form: `GET /` redirects to `/login`, and a real `Authorization: Basic ...` header is silently ignored (confirmed live). Auth actually happens via `POST /auth/password-login` with a `{provider,username,password,next}` JSON body, returning session cookies (`hermes_session_at` etc.) that must be replayed on subsequent requests.

`hermes-workspace`'s only mechanism for reaching the dashboard (`fetchDashboardToken()` in `gateway-capabilities.ts`) scrapes an ephemeral token from the dashboard's *unauthenticated* root-page HTML — which only works when the dashboard has no login gate. Once one is configured, that scrape gets a login redirect instead of a token, and there was no code path anywhere in this app for supplying credentials. The practical effect: every dashboard-backed feature (sessions list, skills, MCP, kanban, cron jobs, model info, config) is **permanently broken — not intermittently** — the moment an operator follows the Agent's own documented security recommendation for a non-loopback dashboard.

## Fix

Adds an opt-in login-and-cookie-cache path:
- New env vars `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD` — same names as the Agent side, so operators can copy the pair straight across.
- `loginToDashboard()`: POSTs to `/auth/password-login`, caches the resulting session cookie in memory (same in-flight-promise dedup pattern as the existing token cache), replays it as a `Cookie` header.
- `dashboardAuthHeaders()` tries the login-cookie path first when credentials are configured, falling back to the original token-scrape path otherwise — so deployments without a dashboard login gate are completely unaffected (byte-for-byte identical behavior).
- `dashboardFetch()`'s existing 401-retry-once logic now also clears the cookie cache, so a rotated/expired session re-logs in automatically.

## Test plan

- [x] 4 new tests in `gateway-capabilities.test.ts` (login + cache reuse, credentials sent correctly, re-login after 401, no-op when credentials aren't configured) — 20/20 passing in the file, stable across 5 repeated runs
- [x] Full suite regression check — no new failures introduced
- [x] `npx tsc --noEmit` — no new type errors (pre-existing unrelated errors elsewhere in the repo, none in the changed file)
- [x] Live-verified against a real deployment with the dashboard's login gate enabled: authenticated `GET /api/sessions` now returns `200` with the real session list instead of `401`

One implementation note for reviewers: this module has a fire-and-forget `void ensureGatewayProbed()` at the bottom that runs a capability probe on every import. In tests that reset modules per-test, that background probe races with whatever the test does next and independently exercises this same login path — cost some debugging time (initially looked like a caching bug) before landing on `await mod.ensureGatewayProbed()` + `fetchMock.mockClear()` before asserting, to isolate what's actually under test.
