### PR TITLE
fix: MCP servers use the wrong Agent API path (/api/mcp instead of /api/mcp/servers)

### DIFF
--- a/src/routes/api/-mcp.test.ts
+++ b/src/routes/api/-mcp.test.ts
@@ -207,6 +207,106 @@ describe('Phase 1.5 fallback — capability gating shape', () => {
   })
 })
 
+describe('mcp capability mode — hits the real Agent endpoint (/api/mcp/servers)', () => {
+  // Regression: this code (and the gateway-capabilities.ts probe) called the
+  // bare /api/mcp path, which doesn't exist on Hermes-Agent — confirmed live,
+  // it 404s with "No such API endpoint: /api/mcp". The real, working
+  // endpoints are GET/POST /api/mcp/servers and DELETE /api/mcp/servers/{name}
+  // (also verified live with a real create+list+delete round trip). Calling
+  // the wrong path meant the capability probe always reported mcp:false, so
+  // the whole MCP page permanently showed "Not available on this backend"
+  // even when the Agent fully supported it.
+  it('GET calls dashboardFetch with /api/mcp/servers, not the bare /api/mcp', async () => {
+    const dashboardFetchMock = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({ servers: [] }), { status: 200 })),
+    )
+    const fakeCaps = {
+      mcp: true,
+      mcpFallback: false,
+      dashboard: { available: true, url: 'http://127.0.0.1:9119' },
+    }
+    vi.doMock('../../server/gateway-capabilities', () => ({
+      ensureGatewayProbed: () => Promise.resolve(fakeCaps),
+      getCapabilities: () => fakeCaps,
+      BEARER_TOKEN: '',
+      CLAUDE_API: 'http://127.0.0.1:8642',
+      CLAUDE_UPGRADE_INSTRUCTIONS: 'noop',
+      dashboardFetch: dashboardFetchMock,
+    }))
+    vi.doMock('../../server/auth-middleware', () => ({
+      isAuthenticated: () => true,
+    }))
+    vi.doMock('@tanstack/react-router', () => ({
+      createFileRoute: () => (cfg: unknown) => cfg,
+    }))
+
+    const mod = await import('./mcp')
+    const route = mod.Route as unknown as {
+      server: { handlers: { GET: (ctx: { request: Request }) => Promise<Response> } }
+    }
+    await route.server.handlers.GET({
+      request: new Request('http://localhost/api/mcp'),
+    })
+
+    expect(dashboardFetchMock).toHaveBeenCalledWith(
+      '/api/mcp/servers',
+      expect.anything(),
+    )
+    expect(dashboardFetchMock).not.toHaveBeenCalledWith('/api/mcp', expect.anything())
+  })
+
+  it('POST calls dashboardFetch with /api/mcp/servers, not the bare /api/mcp', async () => {
+    const dashboardFetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ name: 'fs', transportType: 'stdio', command: 'npx', args: [] }), {
+          status: 200,
+        }),
+      ),
+    )
+    const fakeCaps = {
+      mcp: true,
+      mcpFallback: false,
+      dashboard: { available: true, url: 'http://127.0.0.1:9119' },
+    }
+    vi.doMock('../../server/gateway-capabilities', () => ({
+      ensureGatewayProbed: () => Promise.resolve(fakeCaps),
+      getCapabilities: () => fakeCaps,
+      BEARER_TOKEN: '',
+      CLAUDE_API: 'http://127.0.0.1:8642',
+      CLAUDE_UPGRADE_INSTRUCTIONS: 'noop',
+      dashboardFetch: dashboardFetchMock,
+    }))
+    vi.doMock('../../server/auth-middleware', () => ({
+      isAuthenticated: () => true,
+    }))
+    vi.doMock('@tanstack/react-router', () => ({
+      createFileRoute: () => (cfg: unknown) => cfg,
+    }))
+
+    const mod = await import('./mcp')
+    const route = mod.Route as unknown as {
+      server: { handlers: { POST: (ctx: { request: Request }) => Promise<Response> } }
+    }
+    await route.server.handlers.POST({
+      request: new Request('http://localhost/api/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'linear',
+          transportType: 'http',
+          url: 'https://mcp.linear.app/sse',
+        }),
+      }),
+    })
+
+    expect(dashboardFetchMock).toHaveBeenCalledWith(
+      '/api/mcp/servers',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(dashboardFetchMock).not.toHaveBeenCalledWith('/api/mcp', expect.anything())
+  })
+})
+
 describe('secret echo guard (PR4 acceptance contract)', () => {
   it('round-trip server payload never echoes the submitted bearerToken', () => {
     // 1. User submits an input with a bearer token.

--- a/src/routes/api/mcp.ts
+++ b/src/routes/api/mcp.ts
@@ -123,7 +123,7 @@ export const Route = createFileRoute('/api/mcp')({
 
           let servers: ReturnType<typeof normalizeMcpList>
           if (capabilities.mcp) {
-            const response = await mcpFetch('/api/mcp', {
+            const response = await mcpFetch('/api/mcp/servers', {
               signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
             })
             if (!response.ok) {
@@ -209,7 +209,7 @@ export const Route = createFileRoute('/api/mcp')({
           }
           const input = parsed.value
           if (capabilities.mcp) {
-            const response = await mcpFetch('/api/mcp', {
+            const response = await mcpFetch('/api/mcp/servers', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(input),

--- a/src/routes/api/mcp/$name.ts
+++ b/src/routes/api/mcp/$name.ts
@@ -52,7 +52,7 @@ export const Route = createFileRoute('/api/mcp/$name')({
         }
         try {
           if (capabilities.mcp) {
-            const response = await mcpFetch(`/api/mcp/${encodeURIComponent(name)}`, {
+            const response = await mcpFetch(`/api/mcp/servers/${encodeURIComponent(name)}`, {
               method: 'DELETE',
               signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
             })

--- a/src/routes/api/mcp/-$name.test.ts
+++ b/src/routes/api/mcp/-$name.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('DELETE /api/mcp/$name — hits the real Agent endpoint (/api/mcp/servers/{name})', () => {
+  // Regression: this handler called `/api/mcp/${name}` (bare, no /servers
+  // prefix), which doesn't exist on Hermes-Agent. Confirmed live: DELETE on
+  // that bare path returns 405 "Method Not Allowed" (some other route
+  // pattern happens to match it), while the real endpoint
+  // `/api/mcp/servers/{name}` correctly returns 404 "Server 'x' not found"
+  // for a missing server — verified with a real create+delete round trip.
+  it('calls dashboardFetch with /api/mcp/servers/{name}, not /api/mcp/{name}', async () => {
+    const dashboardFetchMock = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    )
+    const fakeCaps = {
+      mcp: true,
+      mcpFallback: false,
+      dashboard: { available: true, url: 'http://127.0.0.1:9119' },
+    }
+    vi.doMock('../../../server/gateway-capabilities', () => ({
+      ensureGatewayProbed: () => Promise.resolve(fakeCaps),
+      getCapabilities: () => fakeCaps,
+      BEARER_TOKEN: '',
+      CLAUDE_API: 'http://127.0.0.1:8642',
+      CLAUDE_UPGRADE_INSTRUCTIONS: 'noop',
+      dashboardFetch: dashboardFetchMock,
+    }))
+    vi.doMock('../../../server/auth-middleware', () => ({
+      isAuthenticated: () => true,
+    }))
+    vi.doMock('@tanstack/react-router', () => ({
+      createFileRoute: () => (cfg: unknown) => cfg,
+    }))
+
+    const mod = await import('./$name')
+    const route = mod.Route as unknown as {
+      server: {
+        handlers: {
+          DELETE: (ctx: {
+            request: Request
+            params: { name: string }
+          }) => Promise<Response>
+        }
+      }
+    }
+    await route.server.handlers.DELETE({
+      request: new Request('http://localhost/api/mcp/linear', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      params: { name: 'linear' },
+    })
+
+    expect(dashboardFetchMock).toHaveBeenCalledWith(
+      '/api/mcp/servers/linear',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(dashboardFetchMock).not.toHaveBeenCalledWith(
+      '/api/mcp/linear',
+      expect.anything(),
+    )
+  })
+})

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -245,7 +245,7 @@ describe('gateway-capabilities', () => {
           headers: { 'content-type': 'application/json' },
         })
       }
-      if (url === 'http://dashboard.test/api/mcp') {
+      if (url === 'http://dashboard.test/api/mcp/servers') {
         return new Response('not found', { status: 404 })
       }
       if (url === 'http://dashboard.test/api/config') {
@@ -259,7 +259,7 @@ describe('gateway-capabilities', () => {
       if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') {
         return new Response('', { status: 404 })
       }
-      if (url === 'http://gateway.test/api/mcp') {
+      if (url === 'http://gateway.test/api/mcp/servers') {
         return new Response('', { status: 404 })
       }
       return new Response(JSON.stringify({ ok: true }), {
@@ -308,7 +308,7 @@ describe('gateway-capabilities', () => {
       }
       if (url === 'http://gateway.test/v1/chat/completions') return new Response('', { status: 405 })
       if (url === 'http://gateway.test/api/sessions/__probe__/chat/stream') return new Response('', { status: 404 })
-      if (url.endsWith('/api/mcp')) return new Response('', { status: 404 })
+      if (url.endsWith('/api/mcp/servers')) return new Response('', { status: 404 })
       return new Response(JSON.stringify({ ok: true }), {
         headers: { 'content-type': 'application/json' },
       })

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -518,9 +518,12 @@ async function probeMcp(): Promise<boolean> {
   }
   // Use dashboardFetch so the probe goes through the same authenticated path
   // workspace routes use at runtime — otherwise an auth-protected dashboard
-  // /api/mcp would falsely report capability=false (Codex MAJOR finding).
+  // /api/mcp/servers would falsely report capability=false (Codex MAJOR
+  // finding). Note: the real Agent endpoint is /api/mcp/servers, not the
+  // bare /api/mcp — confirmed live (bare path 404s with "No such API
+  // endpoint", /api/mcp/servers returns the actual {servers:[...]} list).
   try {
-    const res = await dashboardFetch('/api/mcp', {
+    const res = await dashboardFetch('/api/mcp/servers', {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     })
     if (await validate(res)) return true
@@ -528,7 +531,7 @@ async function probeMcp(): Promise<boolean> {
     // fall through to gateway path
   }
   try {
-    const res = await fetch(`${CLAUDE_API}/api/mcp`, {
+    const res = await fetch(`${CLAUDE_API}/api/mcp/servers`, {
       headers: authHeaders(),
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     })


### PR DESCRIPTION
## Summary

The capability probe (`gateway-capabilities.ts`'s `probeMcp()`) and the list/create/delete handlers (`routes/api/mcp.ts`, `routes/api/mcp/$name.ts`) all called the bare `/api/mcp` path. That path doesn't exist on Hermes Agent — confirmed live against a real instance: it 404s with `{"detail":"No such API endpoint: /api/mcp"}`. The real endpoints are:

```
GET/POST /api/mcp/servers        (list / create)
DELETE   /api/mcp/servers/{name} (delete)
```

Because the capability probe used the same wrong path, `capabilities.mcp` was always `false` regardless of what the Agent actually supports — so the whole MCP page permanently shows "Not available on this backend" even when the Agent fully supports MCP servers and its own native dashboard (which correctly calls `/api/mcp/servers`) shows a working UI with installed servers and a full catalog.

## Verification

Did a full live round trip against a real Agent instance before writing the fix, to make sure I had the exact right paths (not just "the 404 went away"):
- `POST /api/mcp/servers` with a throwaway disabled server → `200`, returned the created server object
- `GET /api/mcp/servers` → confirmed the throwaway server appears in the list
- `DELETE /api/mcp/servers/{name}` → `200 {"ok":true}`, cleanly removed it
- Cross-checked the old code's path was really wrong, not just differently-shaped: `DELETE /api/mcp/{name}` → `405 Method Not Allowed` (some unrelated route happens to match the URL shape), while `DELETE /api/mcp/servers/{name}` on a nonexistent name correctly returns `404 {"detail":"Server 'x' not found"}` — an app-level "not found", not a framework-level "no such route".

## Changes

- `gateway-capabilities.ts`: `probeMcp()` now checks `/api/mcp/servers` on both the dashboard and gateway fallback path.
- `routes/api/mcp.ts`: GET (list) and POST (create) now call `/api/mcp/servers`.
- `routes/api/mcp/$name.ts`: DELETE now calls `/api/mcp/servers/{name}`.
- Updated 3 pre-existing incidental `/api/mcp` mocks in `gateway-capabilities.test.ts` (Conductor-focused tests that happened to stub an MCP response too) to the correct path — they weren't asserting on it, just kept for accuracy.

## Test plan

- [x] 3 new regression tests asserting the correct path is called (GET + POST in `mcp.ts`, DELETE in `mcp/$name.ts`) — all passing
- [x] Full suite regression check: 58 failed/745 total vs baseline 58 failed/742 total on unmodified `main` — zero new failures, 3 new passing tests
- [x] `npx tsc --noEmit` clean on the changed files