### PR TITLE
fix(chat): persist model selection for new sessions

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -106,7 +106,11 @@ import { ContextAlertModal } from '@/components/usage-meter/context-alert-modal'
 import { ErrorToastContainer, showErrorToast } from '@/components/error-toast'
 // ContextMeter removed — ContextBar (PR #32) replaces it
 import { persistRecoveryMessage, useChatStore } from '@/stores/chat-store'
-import { useSessionModelStore } from '@/stores/session-model-store'
+import {
+  NEW_CHAT_MODEL_KEY,
+  getSessionModelKey,
+  useSessionModelStore,
+} from '@/stores/session-model-store'
 import { useResearchCard } from '@/hooks/use-research-card'
 // MOBILE_TAB_BAR_OFFSET removed — tab bar always hidden in chat
 import { useTapDebug } from '@/hooks/use-tap-debug'
@@ -1057,8 +1061,20 @@ export function ChatScreen({
     return models.map((m: any) => m.id).filter((id: string) => id)
   }, [modelsQuery.data])
 
+  const modelSessionKey = getSessionModelKey(
+    isNewChat
+      ? undefined
+      : forcedSessionKey ||
+          resolvedSessionKey ||
+          activeCanonicalKey ||
+          activeSessionKey,
+  )
+  const persistedSessionModel = useSessionModelStore((state) =>
+    state.getModel(modelSessionKey),
+  )
   const gatewayModel = currentModelQuery.data || ''
-  const currentModel = _localModelOverride || gatewayModel
+  const currentModel =
+    _localModelOverride || persistedSessionModel || gatewayModel
 
   // Ref so sendMessage can always read latest thinkingLevel without being in deps
   const thinkingLevelRef = useRef<ThinkingLevel>(thinkingLevel)
@@ -1146,6 +1162,14 @@ export function ChatScreen({
             friendlyId,
           }
         }
+        if (isNewChat) {
+          const modelStore = useSessionModelStore.getState()
+          const newChatModel = modelStore.getModel(NEW_CHAT_MODEL_KEY)
+          if (newChatModel) {
+            modelStore.setModel(sessionKey, newChatModel)
+            modelStore.clearModel(NEW_CHAT_MODEL_KEY)
+          }
+        }
         if (
           sessionKey === activeFriendlyId &&
           friendlyId === activeFriendlyId
@@ -1154,7 +1178,7 @@ export function ChatScreen({
         }
         onSessionResolved?.({ sessionKey, friendlyId })
       },
-      [activeFriendlyId, onSessionResolved],
+      [activeFriendlyId, isNewChat, onSessionResolved],
     ),
     onStarted: useCallback(
       ({ runId }: { runId: string | null }) => {

--- a/src/screens/chat/components/chat-composer-model-key.test.ts
+++ b/src/screens/chat/components/chat-composer-model-key.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getResolvedModelKey, isCurrentModel } from './chat-composer'
+
+describe('chat composer model keys', () => {
+  it('uses Hermes provider-qualified request syntax', () => {
+    expect(getResolvedModelKey('deepseek/deepseek-v4-pro', 'openrouter')).toBe(
+      'openrouter::deepseek/deepseek-v4-pro',
+    )
+  })
+
+  it('leaves the virtual Hermes model unqualified', () => {
+    expect(getResolvedModelKey('Hermes Agent', 'hermes')).toBe('Hermes Agent')
+  })
+
+  it('recognizes provider-qualified and legacy selected models', () => {
+    expect(
+      isCurrentModel(
+        'openrouter::deepseek/deepseek-v4-pro',
+        'deepseek/deepseek-v4-pro',
+        'openrouter',
+      ),
+    ).toBe(true)
+    expect(
+      isCurrentModel(
+        'openrouter/deepseek/deepseek-v4-pro',
+        'deepseek/deepseek-v4-pro',
+        'openrouter',
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -48,7 +48,10 @@ import {
 import { useSettings } from '@/hooks/use-settings'
 import { MOBILE_TAB_BAR_OFFSET } from '@/components/mobile-tab-bar'
 import { useWorkspaceStore } from '@/stores/workspace-store'
-import { useSessionModelStore } from '@/stores/session-model-store'
+import {
+  getSessionModelKey,
+  useSessionModelStore,
+} from '@/stores/session-model-store'
 import { Button } from '@/components/ui/button'
 import { usePinnedModels } from '@/hooks/use-pinned-models'
 // import { ModeSelector } from '@/components/mode-selector'
@@ -555,32 +558,31 @@ function readText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function getResolvedModelKey(model: string, provider?: string): string {
+export function getResolvedModelKey(model: string, provider?: string): string {
   const normalizedModel = model.trim()
   const normalizedProvider = typeof provider === 'string' ? provider.trim() : ''
 
   if (!normalizedModel) return ''
-  if (!normalizedProvider) return normalizedModel
-  if (normalizedModel.startsWith(`${normalizedProvider}/`))
+  if (
+    !normalizedProvider ||
+    normalizedProvider === 'hermes' ||
+    normalizedProvider === 'hermes-agent'
+  )
     return normalizedModel
-  return `${normalizedProvider}/${normalizedModel}`
+  if (normalizedModel.startsWith(`${normalizedProvider}::`))
+    return normalizedModel
+  return `${normalizedProvider}::${normalizedModel}`
 }
 
 /**
  * Checks whether a model entry matches the current model string.
  *
  * The current model can arrive in several formats depending on the source:
- *   - "provider/model-id"  (from session-status API, persisted session model)
+ *   - "provider::model-id" (Hermes per-request provider selection)
+ *   - "provider/model-id"  (legacy Workspace persistence)
  *   - "model-id"           (bare ID from config or old data)
- *
- * The entry always has { id, provider } from the models catalog.
- *
- * We match if:
- *   1. The current model equals the entry ID exactly (bare match), or
- *   2. The current model ends with "/<entry.id>" (provider-prefixed match), or
- *   3. The resolved key from entry (provider/id) equals the current model.
  */
-function isCurrentModel(
+export function isCurrentModel(
   currentModel: string,
   entryId: string,
   entryProvider: string,
@@ -596,9 +598,12 @@ function isCurrentModel(
   // Current model is "something/<entryId>"
   if (cm.endsWith(`/${eid}`)) return true
 
-  // Resolved entry key matches current model exactly
-  const resolved = eprov ? `${eprov}/${eid}` : eid
-  if (resolved === cm) return true
+  // Hermes provider-qualified entry key matches current model exactly.
+  if (getResolvedModelKey(eid, eprov) === cm) return true
+
+  // Preserve recognition of browser-local values written by older Workspace builds.
+  const legacyResolved = eprov ? `${eprov}/${eid}` : eid
+  if (legacyResolved === cm) return true
 
   return false
 }
@@ -1107,8 +1112,9 @@ function ChatComposerComponent({
   // Drives both the composer label and the model passed to startStreaming.
   // Replaces an earlier flow that PATCHed ~/.hermes/config.yaml — that path
   // 404s and would clobber the global default for every channel anyway.
+  const modelSessionKey = getSessionModelKey(sessionKey)
   const persistedSessionModel = useSessionModelStore((s) =>
-    s.getModel(sessionKey),
+    s.getModel(modelSessionKey),
   )
   const setPersistedSessionModel = useSessionModelStore((s) => s.setModel)
 
@@ -1122,10 +1128,7 @@ function ChatComposerComponent({
     function handleModelSelect(nextModel: string, provider?: string) {
       const model = nextModel.trim()
       if (!model) return
-      const normalizedSessionKey =
-        typeof sessionKey === 'string' && sessionKey.trim().length > 0
-          ? sessionKey.trim()
-          : undefined
+      const normalizedSessionKey = getSessionModelKey(sessionKey)
       if (
         shouldBlockZeroForkModelSwitch(
           gatewayModeQuery.data,
@@ -1141,9 +1144,7 @@ function ChatComposerComponent({
       // Per-session, browser-local persistence. No global config write —
       // picking a model here only affects this chat. The actual model is
       // passed on each request via the chat-completion `model` field.
-      if (normalizedSessionKey) {
-        setPersistedSessionModel(normalizedSessionKey, resolved)
-      }
+      setPersistedSessionModel(normalizedSessionKey, resolved)
       setIsModelMenuOpen(false)
     },
     [

--- a/src/stores/session-model-store.test.ts
+++ b/src/stores/session-model-store.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  NEW_CHAT_MODEL_KEY,
+  getSessionModelKey,
+  useSessionModelStore,
+} from './session-model-store'
+
+describe('session model preferences', () => {
+  beforeEach(() => {
+    useSessionModelStore.setState({ models: {} })
+  })
+
+  it('provides a stable key for model selection before a session exists', () => {
+    const key = getSessionModelKey(undefined)
+
+    expect(key).toBe(NEW_CHAT_MODEL_KEY)
+    useSessionModelStore
+      .getState()
+      .setModel(key, 'openrouter::deepseek/deepseek-v4-pro')
+    expect(useSessionModelStore.getState().getModel(key)).toBe(
+      'openrouter::deepseek/deepseek-v4-pro',
+    )
+  })
+
+  it('uses the real session key after the session exists', () => {
+    expect(getSessionModelKey('  session-123  ')).toBe('session-123')
+  })
+})

--- a/src/stores/session-model-store.ts
+++ b/src/stores/session-model-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { persist, createJSONStorage } from 'zustand/middleware'
+import { createJSONStorage, persist } from 'zustand/middleware'
 
 /**
  * Per-session model preference.
@@ -14,6 +14,15 @@ import { persist, createJSONStorage } from 'zustand/middleware'
  *
  * Cleared automatically when the session is deleted.
  */
+export const NEW_CHAT_MODEL_KEY = '__new_chat__'
+
+export function getSessionModelKey(
+  sessionKey: string | null | undefined,
+): string {
+  const normalized = typeof sessionKey === 'string' ? sessionKey.trim() : ''
+  return normalized || NEW_CHAT_MODEL_KEY
+}
+
 type State = {
   models: Record<string, string>
 }


### PR DESCRIPTION
## Summary

- give `/chat/new` a stable browser-local model preference key so selecting a model before a session exists is not silently discarded
- make the chat send path consume that persisted selection and transfer it to the real session key once Hermes resolves the new session
- encode cross-provider per-request models with Hermes Agent's `provider::model` syntax while retaining recognition of legacy browser-local `provider/model` values
- add regression coverage for pre-session model storage and provider-qualified model keys

## Root cause

`ChatComposer` only persisted a selection when `sessionKey` was defined, but `/chat/new` intentionally passes `undefined`. The click therefore closed the picker without changing state. In addition, `ChatScreen` did not consume the per-session model store when constructing `/api/send-stream`, and provider-qualified values used `/` even though current Hermes Agent parses `provider::model` for per-request routing.

## Verification

- `pnpm exec vitest run src/stores/session-model-store.test.ts src/screens/chat/components/chat-composer-model-key.test.ts` — 5 tests passed
- `pnpm build` — passed
- live Playwright regression against `/chat/new`:
  - before fix: selecting `deepseek/deepseek-v4-pro` left the composer on `gpt-5.6-sol`
  - after fix: composer changed to `openrouter::deepseek/deepseek-v4-pro`
  - intercepted `/api/send-stream` payload contained `model: "openrouter::deepseek/deepseek-v4-pro"`
- `git diff --check` — passed

Repository-wide `tsc` and test runs currently report existing unrelated baseline failures; the focused tests and production build pass.

## Related work

- #651 proposed broader backend session persistence but is closed and still left `/chat/new` without a model key. This PR is narrower: it fixes pre-session selection and the current Hermes request qualifier.
- #569 and #718 concern catalog/config discovery rather than applying a selected model.