### PR TITLE
feat(swarm): ship tasks↔swarm sync, swarm runtime PID fix, and terminal/stream hardening

### DIFF
--- a/src/components/swarm/swarm-terminal.tsx
+++ b/src/components/swarm/swarm-terminal.tsx
@@ -189,7 +189,15 @@ export const SwarmTerminal = memo(function SwarmTerminal({
       terminal.writeln(`\x1b[2mcommand: ${command.join(' ')}\x1b[0m`)
       terminal.writeln('')
 
-      setState('connecting')
+      // Mark connected immediately — the terminal UI is mounted and we are
+      // about to open the stream. Waiting for the fetch/stream response left
+      // panels stuck on "connecting…" when the browser fetch hung (stale tab,
+      // HMR not applied, or a slow SSE). Output streams in as it arrives.
+      setState('connected')
+      setTimeout(() => focusTerminal(), 50)
+
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 15_000)
       const response = await fetch('/api/terminal-stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -199,7 +207,9 @@ export const SwarmTerminal = memo(function SwarmTerminal({
           cols: terminal.cols,
           rows: terminal.rows,
         }),
+        signal: controller.signal,
       }).catch(() => null)
+      clearTimeout(timeout)
 
       if (cancelled) return
       if (!response || !response.ok || !response.body) {
@@ -209,14 +219,6 @@ export const SwarmTerminal = memo(function SwarmTerminal({
         return
       }
 
-      // Mark connected as soon as the stream responds. Some tmux attaches
-      // (reviewer/km-agent/orchestrator panes) emit no initial byte, so
-      // waiting for the first data chunk left the panel stuck on
-      // "connecting...". The SSE session id arrives immediately; treat that
-      // as connected and let output stream in as it arrives.
-      setState('connected')
-      // Give xterm a beat to finish mounting, then re-focus so keystrokes land.
-      setTimeout(() => focusTerminal(), 50)
       const reader = response.body.getReader()
       readerRef.current = reader
       const decoder = new TextDecoder()

--- a/src/components/swarm/swarm-terminal.tsx
+++ b/src/components/swarm/swarm-terminal.tsx
@@ -196,8 +196,8 @@ export const SwarmTerminal = memo(function SwarmTerminal({
       setState('connected')
       setTimeout(() => focusTerminal(), 50)
 
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 15_000)
+      // TEMP DIAGNOSTIC: capture the real fetch error instead of swallowing it.
+      let fetchError: unknown = null
       const response = await fetch('/api/terminal-stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -207,9 +207,15 @@ export const SwarmTerminal = memo(function SwarmTerminal({
           cols: terminal.cols,
           rows: terminal.rows,
         }),
-        signal: controller.signal,
-      }).catch(() => null)
-      clearTimeout(timeout)
+      }).catch((err) => {
+        fetchError = err
+        return null
+      })
+
+      if (fetchError) {
+        // eslint-disable-next-line no-console
+        console.error('[swarm-terminal] fetch failed:', fetchError)
+      }
 
       if (cancelled) return
       if (!response || !response.ok || !response.body) {

--- a/src/components/swarm/swarm-terminal.tsx
+++ b/src/components/swarm/swarm-terminal.tsx
@@ -238,8 +238,19 @@ export const SwarmTerminal = memo(function SwarmTerminal({
         } catch {
           /* noop */
         }
+        // Keep the latest output in view when the terminal is resized.
+        try {
+          terminal.scrollToBottom()
+        } catch {
+          /* noop */
+        }
       }
       window.addEventListener('resize', handleResize)
+      // The runtime grid switches between 1 and 2 columns, which resizes the
+      // container without a window resize event. Observe the container so the
+      // terminal refits and stays scrolled to the newest output.
+      const resizeObserver = new ResizeObserver(() => handleResize())
+      resizeObserver.observe(containerRef.current)
 
       try {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -268,7 +279,15 @@ export const SwarmTerminal = memo(function SwarmTerminal({
                 if (sessionId) sessionIdRef.current = sessionId
               } else if (event === 'data') {
                 const data = typeof parsed.data === 'string' ? parsed.data : ''
-                if (data) terminal.write(data)
+                if (data) {
+                  terminal.write(data)
+                  // Keep the newest output visible as data streams in.
+                  try {
+                    terminal.scrollToBottom()
+                  } catch {
+                    /* noop */
+                  }
+                }
               } else if (event === 'exit' || event === 'close') {
                 terminal.writeln('\r\n\x1b[33m[swarm] session ended\x1b[0m')
                 sessionIdRef.current = null
@@ -292,6 +311,7 @@ export const SwarmTerminal = memo(function SwarmTerminal({
         dataDisposable.dispose()
         resizeDisposable.dispose()
         window.removeEventListener('resize', handleResize)
+        resizeObserver.disconnect()
         if (!cancelled) setState('closed')
       }
     }
@@ -435,7 +455,7 @@ export const SwarmTerminal = memo(function SwarmTerminal({
             ? 'border-[var(--theme-accent)] ring-1 ring-[var(--theme-accent-soft)]'
             : 'border-[var(--theme-border)]',
         )}
-        style={{ height }}
+        style={{ minHeight: height }}
       />
       {error ? (
         <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">{error}</div>

--- a/src/components/swarm/swarm-terminal.tsx
+++ b/src/components/swarm/swarm-terminal.tsx
@@ -209,6 +209,11 @@ export const SwarmTerminal = memo(function SwarmTerminal({
         return
       }
 
+      // Mark connected as soon as the stream responds. Some tmux attaches
+      // (reviewer/km-agent/orchestrator panes) emit no initial byte, so
+      // waiting for the first data chunk left the panel stuck on
+      // "connecting...". The SSE session id arrives immediately; treat that
+      // as connected and let output stream in as it arrives.
       setState('connected')
       // Give xterm a beat to finish mounting, then re-focus so keystrokes land.
       setTimeout(() => focusTerminal(), 50)

--- a/src/hooks/use-swarm-chat.ts
+++ b/src/hooks/use-swarm-chat.ts
@@ -32,7 +32,7 @@ type DirectChatResponse = SwarmChatResponse & {
   delivery?: 'tmux'
 }
 
-const POLL_INTERVAL_MS = 5_000
+const POLL_INTERVAL_MS = 15_000
 const DEFAULT_LIMIT = 30
 
 async function fetchSwarmChat(
@@ -88,8 +88,10 @@ export function useSwarmChat({
     queryFn: () => fetchSwarmChat(workerId, limit),
     enabled: Boolean(workerId) && enabled,
     refetchInterval: POLL_INTERVAL_MS,
-    refetchIntervalInBackground: true,
-    staleTime: 2_000,
+    // Only poll while the tab is visible — background tabs should not keep
+    // hammering the dev server (11 workers × polling = hundreds of requests).
+    refetchIntervalInBackground: false,
+    staleTime: 10_000,
   })
 
   const dispatch = useMutation({

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -314,3 +314,39 @@ export async function dispatchTaskToSwarm(task: ClaudeTask): Promise<DispatchRes
   const data = (await res.json()) as { missionId?: string }
   return { ok: true, missionId: data.missionId }
 }
+
+/**
+ * Auto-classify every Nexum task on the board: dispatch the KM agent to read
+ * nexum-tasks.json, decide owner/due_date/priority per task, and apply the
+ * result via PATCH. Returns the mission id so the caller can track progress.
+ */
+export async function autoClassifyTasks(tasks: Array<ClaudeTask>): Promise<DispatchResult> {
+  const nexum = tasks.filter((t) => (t.tags as Array<string> | undefined)?.includes('nexum') ?? false)
+  if (nexum.length === 0) {
+    return { ok: false, error: 'No Nexum tasks on the board to classify' }
+  }
+  const { base: tasksBase } = await resolveBackend()
+  const swarmUrl = tasksBase.replace(/\/api\/hermes-tasks$/, '') + '/api/swarm-dispatch'
+  const assignment = {
+    workerId: 'km-agent',
+    task:
+      'Read /tmp/nexum-tasks.json (Nexum project tasks). For EVERY task decide ' +
+      '(a) owner/assignee from {builder, km-agent, ops-watch, orchestrator, reviewer, workspace} ' +
+      'by task type; (b) priority (high F0/F1, medium F2-F4, low F5/F6); (c) due_date YYYY-MM-DD ' +
+      'from the Nexum timeline. Then PATCH each task at ' +
+      `${tasksBase}/{id} with {assignee, priority, due_date}. Report counts by owner.`,
+    rationale: 'Auto-classify Nexum tasks from the Tasks board',
+    reviewRequired: false,
+  }
+  const res = await fetch(swarmUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignments: [assignment], missionTitle: 'Auto-classify Nexum tasks' }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    return { ok: false, error: (body as { error?: string }).error || `HTTP ${res.status}` }
+  }
+  const data = (await res.json()) as { missionId?: string }
+  return { ok: true, missionId: data.missionId }
+}

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -261,3 +261,56 @@ export function isOverdue(task: ClaudeTask): boolean {
   today.setHours(0, 0, 0, 0)
   return due < today
 }
+
+// --- Swarm dispatch integration -------------------------------------------
+
+/** Map a task assignee id to a swarm workerId. Unknown owners fall back to null. */
+export const SWARM_WORKER_BY_ASSIGNEE: Record<string, string> = {
+  builder: 'builder',
+  'km-agent': 'km-agent',
+  'ops-watch': 'ops-watch',
+  orchestrator: 'orchestrator',
+  reviewer: 'reviewer',
+  workspace: 'workspace',
+}
+
+export function resolveSwarmWorker(assignee: string | null | undefined): string | null {
+  if (!assignee) return null
+  return SWARM_WORKER_BY_ASSIGNEE[assignee] ?? null
+}
+
+export type DispatchResult = { ok: boolean; missionId?: string; error?: string }
+
+/**
+ * Dispatch a task to the swarm. The task's assignee (if any) becomes the
+ * workerId; otherwise it is sent to the orchestrator for routing. Returns the
+ * new mission id so callers can link the task and move it to Running.
+ */
+export async function dispatchTaskToSwarm(task: ClaudeTask): Promise<DispatchResult> {
+  const { base: tasksBase } = await resolveBackend()
+  const workerId = resolveSwarmWorker(task.assignee)
+  const assignments = [
+    {
+      workerId: workerId ?? 'orchestrator',
+      task: `${task.title}${task.description ? `\n\n${task.description}` : ''}`,
+      rationale: `Dispatched from Tasks board (task ${task.id})`,
+      reviewRequired: task.column === 'review',
+    },
+  ]
+  // swarm-dispatch lives under the same origin as the tasks API.
+  const swarmUrl = tasksBase.replace(/\/api\/hermes-tasks$/, '') + '/api/swarm-dispatch'
+  const res = await fetch(swarmUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      assignments,
+      missionTitle: `Tasks board: ${task.title}`.slice(0, 120),
+    }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    return { ok: false, error: (body as { error?: string }).error || `HTTP ${res.status}` }
+  }
+  const data = (await res.json()) as { missionId?: string }
+  return { ok: true, missionId: data.missionId }
+}

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -44,29 +44,26 @@ async function probeBackend(base: string): Promise<number> {
 }
 
 async function resolveBackend(): Promise<BackendResolution> {
-  if (_resolved) return _resolved
-  if (_resolving) return _resolving
+  // NOTE: resolution is intentionally NOT cached across calls. Caching caused
+  // the board to "lose" tasks: after a transient 500/timeout on the hermes
+  // probe, the page stayed pinned to the claude backend (which holds 1 task)
+  // for the whole session. Re-probing each call lets a later successful hermes
+  // probe win. The double-probe cost is negligible for a kanban board.
+  const [hermesCount, claudeCount] = await Promise.all([
+    probeBackend(HERMES_BASE),
+    probeBackend(CLAUDE_BASE),
+  ])
 
-  _resolving = (async () => {
-    const [hermesCount, claudeCount] = await Promise.all([
-      probeBackend(HERMES_BASE),
-      probeBackend(CLAUDE_BASE),
-    ])
-
-    // Prefer hermes if it has real data (> 0); fall back to claude if hermes is
-    // missing (returns -1 for non-JSON / route-not-found) or empty.
-    // Default to claude when both are empty — it is the active backend after the
-    // hermes-tasks → claude-tasks route rename (commit efcb7d14).
-    const useHermes = hermesCount > 0 && hermesCount >= claudeCount
-    _resolved = {
-      base: useHermes ? HERMES_BASE : CLAUDE_BASE,
-      assigneesBase: useHermes ? '/api/hermes-tasks-assignees' : '/api/claude-tasks-assignees',
-      backend: useHermes ? 'hermes' : 'claude',
-    }
-    return _resolved
-  })()
-
-  return _resolving
+  // Prefer hermes whenever it holds real data. It is the canonical agent task
+  // store (~/.hermes/tasks.json) and holds the NEXUM tasks. Only fall back to
+  // claude when hermes is empty (0) or unreachable (-1 for non-JSON / 404).
+  const useHermes = hermesCount > 0
+  _resolved = {
+    base: useHermes ? HERMES_BASE : CLAUDE_BASE,
+    assigneesBase: useHermes ? '/api/hermes-tasks-assignees' : '/api/claude-tasks-assignees',
+    backend: (useHermes ? 'hermes' : 'claude') as TasksBackend,
+  }
+  return _resolved
 }
 
 /** Returns the currently resolved backend id, or null if not yet probed. */

--- a/src/lib/tasks-api.ts
+++ b/src/lib/tasks-api.ts
@@ -323,16 +323,22 @@ export async function autoClassifyTasks(tasks: Array<ClaudeTask>): Promise<Dispa
     return { ok: false, error: 'No Nexum tasks on the board to classify' }
   }
   const { base: tasksBase } = await resolveBackend()
-  const swarmUrl = tasksBase.replace(/\/api\/hermes-tasks$/, '') + '/api/swarm-dispatch'
+  const missionUrl = tasksBase.replace(/\/api\/hermes-tasks$/, '')
+  const swarmUrl = `${missionUrl}/api/swarm-dispatch`
   const assignment = {
     workerId: 'km-agent',
     task:
-      'Read /tmp/nexum-tasks.json (Nexum project tasks). For EVERY task decide ' +
-      '(a) owner/assignee from {builder, km-agent, ops-watch, orchestrator, reviewer, workspace} ' +
-      'by task type; (b) priority (high F0/F1, medium F2-F4, low F5/F6); (c) due_date YYYY-MM-DD ' +
-      'from the Nexum timeline. Then PATCH each task at ' +
-      `${tasksBase}/{id} with {assignee, priority, due_date}. Report counts by owner.`,
-    rationale: 'Auto-classify Nexum tasks from the Tasks board',
+      'CLASSIFICATION-ONLY task. Do NOT implement or research anything.\n' +
+      '1) Read /tmp/nexum-tasks.json (Nexum project tasks, each has id/title/phase/deadline/category/priority).\n' +
+      '2) For EVERY one of the 174 tasks decide:\n' +
+      '   (a) assignee from {builder, km-agent, ops-watch, orchestrator, reviewer, workspace} by task TYPE ' +
+      '(code/platform->builder; docs/knowledge/marketing->km-agent; infra/runtime/health->ops-watch; qa/security/validation->reviewer; integration/summary/board->workspace; planning/governance/gate->orchestrator);\n' +
+      '   (b) priority already in the file (high/medium/low) — keep it;\n' +
+      '   (c) due_date YYYY-MM-DD from the Nexum timeline (M0=2026-08-12, each M = +1 week).\n' +
+      '3) PATCH each task via: PATCH ' + `${tasksBase}/{id}` + ' with JSON body {"assignee":..., "priority":..., "due_date":...} ' +
+      '(do NOT send "tags" — the server preserves existing tags).\n' +
+      '4) Report counts per owner when done.',
+    rationale: 'Auto-classify Nexum tasks from the Tasks board (classification only)',
     reviewRequired: false,
   }
   const res = await fetch(swarmUrl, {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -45,6 +45,8 @@ import { Route as ApiTerminalStreamRouteImport } from './routes/api/terminal-str
 import { Route as ApiTerminalResizeRouteImport } from './routes/api/terminal-resize'
 import { Route as ApiTerminalInputRouteImport } from './routes/api/terminal-input'
 import { Route as ApiTerminalCloseRouteImport } from './routes/api/terminal-close'
+import { Route as ApiTasksSwarmSyncRouteImport } from './routes/api/tasks-swarm-sync'
+import { Route as ApiTasksSwarmRunRouteImport } from './routes/api/tasks-swarm-run'
 import { Route as ApiSystemMetricsRouteImport } from './routes/api/system-metrics'
 import { Route as ApiSwarmTmuxStopRouteImport } from './routes/api/swarm-tmux-stop'
 import { Route as ApiSwarmTmuxStartRouteImport } from './routes/api/swarm-tmux-start'
@@ -348,6 +350,16 @@ const ApiTerminalInputRoute = ApiTerminalInputRouteImport.update({
 const ApiTerminalCloseRoute = ApiTerminalCloseRouteImport.update({
   id: '/api/terminal-close',
   path: '/api/terminal-close',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiTasksSwarmSyncRoute = ApiTasksSwarmSyncRouteImport.update({
+  id: '/api/tasks-swarm-sync',
+  path: '/api/tasks-swarm-sync',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiTasksSwarmRunRoute = ApiTasksSwarmRunRouteImport.update({
+  id: '/api/tasks-swarm-run',
+  path: '/api/tasks-swarm-run',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSystemMetricsRoute = ApiSystemMetricsRouteImport.update({
@@ -1071,6 +1083,8 @@ export interface FileRoutesByFullPath {
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
   '/api/system-metrics': typeof ApiSystemMetricsRoute
+  '/api/tasks-swarm-run': typeof ApiTasksSwarmRunRoute
+  '/api/tasks-swarm-sync': typeof ApiTasksSwarmSyncRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -1232,6 +1246,8 @@ export interface FileRoutesByTo {
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
   '/api/system-metrics': typeof ApiSystemMetricsRoute
+  '/api/tasks-swarm-run': typeof ApiTasksSwarmRunRoute
+  '/api/tasks-swarm-sync': typeof ApiTasksSwarmSyncRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -1395,6 +1411,8 @@ export interface FileRoutesById {
   '/api/swarm-tmux-start': typeof ApiSwarmTmuxStartRoute
   '/api/swarm-tmux-stop': typeof ApiSwarmTmuxStopRoute
   '/api/system-metrics': typeof ApiSystemMetricsRoute
+  '/api/tasks-swarm-run': typeof ApiTasksSwarmRunRoute
+  '/api/tasks-swarm-sync': typeof ApiTasksSwarmSyncRoute
   '/api/terminal-close': typeof ApiTerminalCloseRoute
   '/api/terminal-input': typeof ApiTerminalInputRoute
   '/api/terminal-resize': typeof ApiTerminalResizeRoute
@@ -1559,6 +1577,8 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
     | '/api/system-metrics'
+    | '/api/tasks-swarm-run'
+    | '/api/tasks-swarm-sync'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1720,6 +1740,8 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
     | '/api/system-metrics'
+    | '/api/tasks-swarm-run'
+    | '/api/tasks-swarm-sync'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -1882,6 +1904,8 @@ export interface FileRouteTypes {
     | '/api/swarm-tmux-start'
     | '/api/swarm-tmux-stop'
     | '/api/system-metrics'
+    | '/api/tasks-swarm-run'
+    | '/api/tasks-swarm-sync'
     | '/api/terminal-close'
     | '/api/terminal-input'
     | '/api/terminal-resize'
@@ -2045,6 +2069,8 @@ export interface RootRouteChildren {
   ApiSwarmTmuxStartRoute: typeof ApiSwarmTmuxStartRoute
   ApiSwarmTmuxStopRoute: typeof ApiSwarmTmuxStopRoute
   ApiSystemMetricsRoute: typeof ApiSystemMetricsRoute
+  ApiTasksSwarmRunRoute: typeof ApiTasksSwarmRunRoute
+  ApiTasksSwarmSyncRoute: typeof ApiTasksSwarmSyncRoute
   ApiTerminalCloseRoute: typeof ApiTerminalCloseRoute
   ApiTerminalInputRoute: typeof ApiTerminalInputRoute
   ApiTerminalResizeRoute: typeof ApiTerminalResizeRoute
@@ -2337,6 +2363,20 @@ declare module '@tanstack/react-router' {
       path: '/api/terminal-close'
       fullPath: '/api/terminal-close'
       preLoaderRoute: typeof ApiTerminalCloseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/tasks-swarm-sync': {
+      id: '/api/tasks-swarm-sync'
+      path: '/api/tasks-swarm-sync'
+      fullPath: '/api/tasks-swarm-sync'
+      preLoaderRoute: typeof ApiTasksSwarmSyncRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/tasks-swarm-run': {
+      id: '/api/tasks-swarm-run'
+      path: '/api/tasks-swarm-run'
+      fullPath: '/api/tasks-swarm-run'
+      preLoaderRoute: typeof ApiTasksSwarmRunRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/system-metrics': {
@@ -3514,6 +3554,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSwarmTmuxStartRoute: ApiSwarmTmuxStartRoute,
   ApiSwarmTmuxStopRoute: ApiSwarmTmuxStopRoute,
   ApiSystemMetricsRoute: ApiSystemMetricsRoute,
+  ApiTasksSwarmRunRoute: ApiTasksSwarmRunRoute,
+  ApiTasksSwarmSyncRoute: ApiTasksSwarmSyncRoute,
   ApiTerminalCloseRoute: ApiTerminalCloseRoute,
   ApiTerminalInputRoute: ApiTerminalInputRoute,
   ApiTerminalResizeRoute: ApiTerminalResizeRoute,

--- a/src/routes/api/commands.ts
+++ b/src/routes/api/commands.ts
@@ -22,10 +22,11 @@ export const Route = createFileRoute('/api/commands')({
           const res = await gatewayFetch('/v1/commands')
 
           if (!res.ok) {
-            return json(
-              { error: `Gateway responded with status ${res.status}` },
-              { status: res.status },
-            )
+            // The gateway may not expose /v1/commands (e.g. local dev).
+            // Return an empty list so the composer falls back to
+            // DEFAULT_SLASH_COMMANDS instead of spamming the browser
+            // console with a 404 on every mount.
+            return Response.json({ commands: [] })
           }
 
           const body = await res.json()

--- a/src/routes/api/hermes-tasks.$taskId.ts
+++ b/src/routes/api/hermes-tasks.$taskId.ts
@@ -55,7 +55,13 @@ export const Route = createFileRoute('/api/hermes-tasks/$taskId')({
             column: isTaskColumn(body.column) ? body.column : undefined,
             priority: isTaskPriority(body.priority) ? body.priority : undefined,
             assignee: body.assignee === null || typeof body.assignee === 'string' ? body.assignee : undefined,
-            tags: Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === 'string') : undefined,
+            // Only touch tags when the caller explicitly sends them as an
+            // array. Omitting `tags` from the body now PRESERVES existing tags
+            // instead of wiping them to [] (regression that deleted the
+            // 'nexum' tag during auto-classify bulk PATCHes).
+            tags: Array.isArray(body.tags)
+              ? body.tags.filter((tag): tag is string => typeof tag === 'string')
+              : undefined,
             due_date: body.due_date === null || typeof body.due_date === 'string' ? body.due_date : undefined,
             position: typeof body.position === 'number' ? body.position : undefined,
             session_id: body.session_id === null || typeof body.session_id === 'string' ? body.session_id : undefined,

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -1,17 +1,20 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { execFile } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { json } from '@tanstack/react-start'
+import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { newestCheckpointFromMessages, parseSwarmCheckpoint, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import {  newestCheckpointFromMessages, parseSwarmCheckpoint } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
-import { createOrUpdateMission, getSwarmMission, markMissionAssignmentDispatched, recordMissionAssignmentBlocked, recordMissionCheckpoint } from '../../server/swarm-missions'
+import {  createOrUpdateMission, getSwarmMission, markMissionAssignmentDispatched, readStore, recordMissionAssignmentBlocked, recordMissionCheckpoint, writeStore } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent, buildSwarmStartupSnapshot } from '../../server/swarm-memory'
-import { rosterByWorkerId, type SwarmRosterWorker } from '../../server/swarm-roster'
+import {  rosterByWorkerId } from '../../server/swarm-roster'
 import { publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { ensureSwarmProfileConfig } from '../../server/swarm-profile-config'
+import type {SwarmRosterWorker} from '../../server/swarm-roster';
+import type {SwarmMissionAssignment} from '../../server/swarm-missions';
+import type {ParsedSwarmCheckpoint} from '../../server/swarm-checkpoints';
 
 const HERMES_BIN_CANDIDATES = [
   process.env.HERMES_CLI_BIN,
@@ -784,7 +787,7 @@ async function sendPromptToLiveSession(workerId: string, prompt: string): Promis
   }
 }
 
-export function buildHermesChatQueryArgs(prompt: string): string[] {
+export function buildHermesChatQueryArgs(prompt: string): Array<string> {
   // `hermes chat -q` requires the query as the *immediate* next argv item.
   // Keeping the prompt adjacent to -q prevents argparse from interpreting
   // following flags (for example -Q) as a missing query and failing with:
@@ -1122,9 +1125,36 @@ export async function dispatchSwarmAssignments(body: DispatchRequest) {
     assignmentId: assignmentIdByKey.get(`${assignment.workerId}\n${assignment.task}`),
   }))
 
+  const latestMissionPre = getSwarmMission(mission.id) ?? mission
+  // Respect dependsOn: only dispatch assignments whose dependencies are already
+  // done; leave the rest queued so the orchestrator-loop picks them up once
+  // their prerequisites checkpoint. Without this, every assignment runs in
+  // parallel and dependents race ahead of the workers they depend on.
+  const doneWorkerIds = new Set(
+    latestMissionPre.assignments
+      .filter((item: SwarmMissionAssignment) => ['checkpointed', 'done'].includes(item.state))
+      .map((item: SwarmMissionAssignment) => item.workerId),
+  )
+  const ready = assignments.filter((assignment) => {
+    const deps = assignment.dependsOn ?? []
+    return deps.every((dep) => doneWorkerIds.has(dep))
+  })
+  const deferred = assignments.filter((assignment) => !(assignment.dependsOn ?? []).every((dep) => doneWorkerIds.has(dep)))
+  if (deferred.length) {
+    const store = readStore()
+    const live = store.missions.find((item) => item.id === mission.id)
+    if (live) {
+      for (const d of deferred) {
+        const a = live.assignments.find((item) => item.id === d.assignmentId)
+        if (a && a.state === 'dispatched') a.state = 'queued'
+      }
+      writeStore(store)
+    }
+  }
+
   const dispatchedAt = Date.now()
   const roster = rosterByWorkerId(assignments.map((assignment) => assignment.workerId))
-  const results = await Promise.all(assignments.map((assignment) => runWorker(
+  const results = await Promise.all(ready.map((assignment) => runWorker(
     assignment,
     timeoutMs,
     roster.get(assignment.workerId),

--- a/src/routes/api/swarm-dispatch.ts
+++ b/src/routes/api/swarm-dispatch.ts
@@ -490,6 +490,11 @@ function markDispatchStarted(workerId: string, task: string, missionId?: string 
     lastControlMessage: controlMessage,
     nextAction: 'Worker should execute and return the required checkpoint format.',
     notifySessionKey: notifySessionKey ?? 'main',
+    // Clear stale per-mission state so a fresh dispatch is not mistaken for an
+    // already-processed assignment by the orchestrator loop (which compares
+    // orchestratorProcessedRaw against the live checkpoint raw).
+    orchestratorProcessedRaw: null,
+    checkpointRaw: null,
   })
 }
 

--- a/src/routes/api/swarm-orchestrator-loop.ts
+++ b/src/routes/api/swarm-orchestrator-loop.ts
@@ -1,17 +1,18 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfilesDir } from '../../server/claude-paths'
-import { newestCheckpointFromMessages, readRuntimeJson, type ParsedSwarmCheckpoint } from '../../server/swarm-checkpoints'
+import {  newestCheckpointFromMessages, readRuntimeJson } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
 import { getSwarmProfilePath, listSwarmWorkerIds } from '../../server/swarm-foundation'
-import { appendMissionContinuation, markMissionAssignmentsReviewedByWorker, recordMissionCheckpoint } from '../../server/swarm-missions'
+import { appendMissionContinuation, getSwarmMission, markMissionAssignmentsReviewedByWorker, recordMissionCheckpoint } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
 import { publishSwarmActionPrompt, publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { applySwarmModeToLoopFlags, readSwarmMode } from '../../server/swarm-mode'
 import { isSwarmWorkerId, readSwarmRoster } from '../../server/swarm-roster'
+import type {ParsedSwarmCheckpoint} from '../../server/swarm-checkpoints';
 
 type LoopRequest = {
   workerIds?: unknown
@@ -110,13 +111,13 @@ function recordCheckpoint(input: {
   checkpoint: ParsedSwarmCheckpoint
   current: Record<string, unknown>
   dryRun: boolean
-}): { notification: { published: boolean; sessionKey: string }; missionRecorded: boolean } {
+}): { notification: { published: boolean; sessionKey: string }; missionRecorded: boolean; reviewedAssignmentIds: Array<string> } {
   const missionId = runtimeString(input.current, 'currentMissionId')
   const assignmentId = runtimeString(input.current, 'currentAssignmentId')
   const notifySessionKey = runtimeString(input.current, 'notifySessionKey')
 
   if (input.dryRun) {
-    return { notification: { published: false, sessionKey: notifySessionKey ?? 'main' }, missionRecorded: false }
+    return { notification: { published: false, sessionKey: notifySessionKey ?? 'main' }, missionRecorded: false, reviewedAssignmentIds: [] }
   }
 
   const mission = recordMissionCheckpoint({
@@ -150,7 +151,39 @@ function recordCheckpoint(input: {
     assignmentId,
     notifySessionKey,
   })
-  return { notification, missionRecorded: Boolean(mission) }
+
+  // When a reviewer worker checkpoints DONE, close the review gate on any
+  // sibling assignment that required review. Without this, missions stay in
+  // `reviewing` forever even after the reviewer approved (deriveMissionState
+  // treats `checkpointed && reviewRequired` as reviewing regardless of the
+  // reviewer's verdict).
+  let reviewedIds: Array<string> = []
+  if (
+    missionId &&
+    input.checkpoint.stateLabel === 'DONE' &&
+    isReviewer(input.workerId, validWorkerIdsForReview(missionId))
+  ) {
+    const reviewed = markMissionAssignmentsReviewedByWorker({
+      missionId,
+      reviewerId: input.workerId,
+      excludeAssignmentId: assignmentId,
+    })
+    reviewedIds = reviewed?.reviewedAssignmentIds ?? []
+  }
+
+  return { notification, missionRecorded: Boolean(mission), reviewedAssignmentIds: reviewedIds }
+}
+
+// Resolve the worker roster for the given mission so isReviewer() can match
+// the reviewer role without re-reading the global roster.
+function validWorkerIdsForReview(missionId: string): Array<string> {
+  try {
+    const mission = getSwarmMission(missionId)
+    if (!mission) return []
+    return mission.assignments.map((a: { workerId: string }) => a.workerId)
+  } catch {
+    return []
+  }
 }
 
 function runWorkerLoop(workerId: string, staleMs: number, dryRun: boolean): WorkerLoopResult {

--- a/src/routes/api/swarm-orchestrator-loop.ts
+++ b/src/routes/api/swarm-orchestrator-loop.ts
@@ -7,7 +7,7 @@ import { getProfilesDir } from '../../server/claude-paths'
 import {  newestCheckpointFromMessages, readRuntimeJson } from '../../server/swarm-checkpoints'
 import { readWorkerMessages } from '../../server/swarm-chat-reader'
 import { getSwarmProfilePath, listSwarmWorkerIds } from '../../server/swarm-foundation'
-import { appendMissionContinuation, getSwarmMission, markMissionAssignmentsReviewedByWorker, recordMissionCheckpoint } from '../../server/swarm-missions'
+import { appendMissionContinuation, getSwarmMission, markMissionAssignmentsReviewedByWorker, readyQueuedAssignments, recordMissionCheckpoint } from '../../server/swarm-missions'
 import { appendSwarmMemoryEvent } from '../../server/swarm-memory'
 import { publishSwarmActionPrompt, publishSwarmCheckpointNotification } from '../../server/swarm-notifications'
 import { applySwarmModeToLoopFlags, readSwarmMode } from '../../server/swarm-mode'
@@ -455,6 +455,16 @@ export const Route = createFileRoute('/api/swarm-orchestrator-loop')({
           const hasReviewerDone = results.some((item) => item.status === 'checkpointed' && item.checkpoint?.stateLabel === 'DONE' && isReviewer(item.workerId, workerIds))
           const reviewAssignment = reviewerId && !hasReviewerDone ? buildReviewAssignment(results, reviewerId, workerIds) : null
           if (reviewAssignment && !assignments.some((item) => item.workerId === reviewAssignment.workerId && item.task === reviewAssignment.task)) assignments.push(reviewAssignment)
+          // Dispatch assignments that were deferred at dispatch time because their
+          // dependsOn was not yet satisfied. Now that some workers have checkpointed,
+          // any queued assignment whose dependencies are done becomes ready.
+          if (missionId) {
+            for (const queued of readyQueuedAssignments(missionId)) {
+              if (!assignments.some((item) => item.workerId === queued.workerId && item.task === queued.task)) {
+                assignments.push({ workerId: queued.workerId, task: queued.task, rationale: 'Dependency satisfied; executing deferred assignment.' })
+              }
+            }
+          }
           continuation = await dispatchAssignments(request, assignments, missionId)
         }
 

--- a/src/routes/api/tasks-swarm-run.ts
+++ b/src/routes/api/tasks-swarm-run.ts
@@ -1,0 +1,184 @@
+/**
+ * Tasks → Swarm automation runner.
+ *
+ * Scans the Tasks board for tasks that have a swarm assignee (builder, km-agent,
+ * ops-watch, orchestrator, reviewer, workspace) and dispatches them to the
+ * matching swarm worker, marking the board task as in_progress.
+ *
+ * Concurrency is bounded by each worker's `maxConcurrentTasks` (from the swarm
+ * roster, default 1). At most `capacity` tasks per worker may be in_progress at
+ * once; everything else waits in `todo` until a slot frees up. This keeps the
+ * board honest: "running" means a worker is actually on it, not that it was
+ * blindly fanned out to every eligible card.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { listTasks, updateTask, type TaskColumn } from '../../server/tasks-store'
+import { createOrUpdateMission, readStore } from '../../server/swarm-missions'
+import { SWARM_WORKER_BY_ASSIGNEE } from '../../lib/tasks-api'
+import { readSwarmRoster } from '../../server/swarm-roster'
+import type { SwarmMission } from '../../server/swarm-missions'
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function isSwarmAssignee(assignee: string | null | undefined): assignee is string {
+  return Boolean(assignee && SWARM_WORKER_BY_ASSIGNEE[assignee])
+}
+
+function missionIsDone(mission: SwarmMission | undefined): boolean {
+  if (!mission) return false
+  if (mission.state === 'complete') return true
+  return mission.assignments.every(
+    (a) => a.state === 'checkpointed' || a.state === 'done' || a.state === 'cancelled',
+  )
+}
+
+// Per-worker concurrency capacity from the swarm roster.
+function capacityByWorker(): Map<string, number> {
+  const roster = readSwarmRoster()
+  const cap = new Map<string, number>()
+  for (const w of roster.workers) {
+    cap.set(w.id, Math.max(1, w.maxConcurrentTasks ?? 1))
+  }
+  for (const assignee of Object.keys(SWARM_WORKER_BY_ASSIGNEE)) {
+    if (!cap.has(assignee)) cap.set(assignee, 1)
+  }
+  return cap
+}
+
+function findMission(store: { missions: SwarmMission[] }, id: string | null | undefined) {
+  if (!id) return undefined
+  return store.missions.find((mm) => mm.id === id)
+}
+
+/**
+ * Core dispatch routine. Rebalances over-capacity in_progress tasks back to the
+ * queue and dispatches eligible tasks up to each worker's concurrency limit.
+ * Exported so the dev server can drive it on a timer (auto-dispatch loop).
+ */
+export async function runSwarmDispatch(opts: { onlyReady?: boolean; dryRun?: boolean } = {}) {
+  const onlyReady = opts.onlyReady === true
+  const dryRun = opts.dryRun === true
+
+  const all = listTasks({ includeDone: true })
+  const store = readStore()
+  const cap = capacityByWorker()
+
+  // Count tasks already occupying a worker's in_progress slot. Skip any whose
+  // mission is already done (slot is effectively free).
+  const activeByWorker = new Map<string, number>()
+  for (const t of all) {
+    if (t.column === 'in_progress' && isSwarmAssignee(t.assignee)) {
+      const wid = SWARM_WORKER_BY_ASSIGNEE[t.assignee as string]
+      const m = findMission(store, t.session_id)
+      if (missionIsDone(m)) continue
+      activeByWorker.set(wid, (activeByWorker.get(wid) ?? 0) + 1)
+    }
+  }
+
+  // Rebalance: in_progress tasks beyond a worker's capacity go back to `todo`
+  // so the board reflects reality (only `capacity` per worker run).
+  const rebalanced: Array<{ taskId: string; workerId: string }> = []
+  const keptInProgress = new Map<string, number>()
+  for (const t of all) {
+    if (t.column !== 'in_progress' || !isSwarmAssignee(t.assignee)) continue
+    const wid = SWARM_WORKER_BY_ASSIGNEE[t.assignee as string]
+    const used = keptInProgress.get(wid) ?? 0
+    const limit = cap.get(wid) ?? 1
+    if (used >= limit) {
+      if (!dryRun) updateTask(t.id, { column: 'todo' as TaskColumn })
+      rebalanced.push({ taskId: t.id, workerId: wid })
+    } else {
+      keptInProgress.set(wid, used + 1)
+    }
+  }
+  for (const [wid, n] of keptInProgress) activeByWorker.set(wid, n)
+
+  const eligible = all.filter((t) => {
+    if (!isSwarmAssignee(t.assignee)) return false
+    if (t.column === 'done' || t.column === 'blocked') return false
+    if (onlyReady && t.column !== 'todo' && t.column !== 'backlog') return false
+    if (t.session_id) {
+      const m = findMission(store, t.session_id)
+      if (m && !missionIsDone(m)) return false
+    }
+    return true
+  })
+
+  const skipped = all.filter(
+    (t) => isSwarmAssignee(t.assignee) && !eligible.includes(t),
+  ).length
+  const dispatched: Array<{ taskId: string; missionId: string; workerId: string; title: string }> = []
+
+  const tryDispatch = (task: (typeof all)[number]) => {
+    const workerId = SWARM_WORKER_BY_ASSIGNEE[task.assignee as string]
+    const used = activeByWorker.get(workerId) ?? 0
+    const limit = cap.get(workerId) ?? 1
+    if (used >= limit) return false
+    if (!dryRun) {
+      const res = createOrUpdateMission({
+        title: `Board: ${task.title}`.slice(0, 140),
+        assignments: [
+          {
+            workerId,
+            task: `${task.title}${task.description ? `\n\n${task.description}` : ''}`,
+            rationale: `Auto-run from Tasks board (task ${task.id})`,
+            reviewRequired: task.column === 'review',
+          },
+        ],
+      })
+      updateTask(task.id, { column: 'in_progress', session_id: res.id })
+      activeByWorker.set(workerId, used + 1)
+      dispatched.push({ taskId: task.id, missionId: res.id, workerId, title: task.title })
+    } else {
+      dispatched.push({ taskId: task.id, missionId: '(dry)', workerId, title: task.title })
+    }
+    return true
+  }
+
+  for (const task of eligible) tryDispatch(task)
+
+  return {
+    ok: true,
+    scanned: all.length,
+    eligible: eligible.length,
+    dispatched: dispatched.length,
+    rebalancedToTodo: rebalanced.length,
+    skipped,
+    dryRun,
+  }
+}
+
+export const Route = createFileRoute('/api/tasks-swarm-run')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        const all = listTasks({ includeDone: true })
+        const store = readStore()
+        const linked = all.filter((t) => t.session_id)
+        const live = linked.filter((t) => {
+          const m = findMission(store, t.session_id)
+          return m && !missionIsDone(m)
+        })
+        return jsonResponse({ linked: linked.length, liveMissions: live.length, total: all.length })
+      },
+
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) return jsonResponse({ error: 'Unauthorized' }, 401)
+        try {
+          const body = (await request.json().catch(() => ({}))) as {
+            onlyReady?: boolean
+            dryRun?: boolean
+          }
+          const result = await runSwarmDispatch(body)
+          return jsonResponse(result)
+        } catch (err) {
+          return jsonResponse({ error: String(err) }, 500)
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/terminal-resize.ts
+++ b/src/routes/api/terminal-resize.ts
@@ -40,8 +40,11 @@ export const Route = createFileRoute('/api/terminal-resize')({
         }
         const session = getTerminalSession(sessionId)
         if (!session) {
-          return new Response(JSON.stringify({ ok: false }), {
-            status: 404,
+          // Session may not be initialized yet (resize fires before the
+          // terminal tab is fully mounted). Treat as a no-op rather than 404
+          // so the client console stays clean.
+          return new Response(JSON.stringify({ ok: true, skipped: true }), {
+            status: 200,
             headers: { 'Content-Type': 'application/json' },
           })
         }

--- a/src/routes/api/terminal-stream.ts
+++ b/src/routes/api/terminal-stream.ts
@@ -15,6 +15,9 @@ export const Route = createFileRoute('/api/terminal-stream')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        // TEMP DIAGNOSTIC
+        // eslint-disable-next-line no-console
+        console.error('[terminal-stream] POST received from', getClientIp(request), 'origin=', request.headers.get('origin'))
         if (!requireLocalOrAuth(request)) {
           return new Response(
             JSON.stringify({ ok: false, error: 'Unauthorized' }),

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -995,7 +995,19 @@ export function useConductorGateway() {
         })
     },
     enabled: phase !== 'idle',
-    refetchInterval: phase === 'decomposing' || phase === 'running' || (phase === 'complete' && Object.keys(workerOutputs).length === 0) ? 3_000 : false,
+    // Keep polling while the mission is live OR any worker is still running.
+    // Previously we stopped at phase==='complete', which froze the Office
+    // view even though swarm workers (e.g. workspace summarizing) were still
+    // active — the user saw "12 workers / 7 live" stuck and no live update.
+    // react-query calls this fn on every tick, by which point data is ready.
+    refetchInterval: (): number | false => {
+      if (phase === 'decomposing' || phase === 'running') return 3_000
+      if (phase === 'complete' && Object.keys(workerOutputs).length === 0) return 3_000
+      const liveWorkers = (sessionsQuery.data ?? []).filter(
+        (w: { status?: string }) => w.status === 'running' || w.status === 'idle',
+      )
+      return liveWorkers.length > 0 ? 3_000 : false
+    },
   })
 
   const recentSessionsQuery = useQuery({

--- a/src/screens/gateway/hooks/use-conductor-gateway.ts
+++ b/src/screens/gateway/hooks/use-conductor-gateway.ts
@@ -1052,6 +1052,23 @@ export function useConductorGateway() {
     retryDelay: (attemptIndex: number) => Math.min(2000 * 2 ** attemptIndex, 10_000),
   })
 
+  // Surface the *live local swarm* (tmux workers) in the Office/Conductor view.
+  // The Conductor historically only read gateway sessions, so the Office never
+  // reflected the agents actually running in the local swarm (builder, km-agent,
+  // workspace, ...). We now also poll /api/swarm-runtime and merge those workers
+  // into the roster below.
+  const swarmRuntimeQuery = useQuery({
+    queryKey: ['conductor', 'swarm-runtime'],
+    queryFn: async () => {
+      const res = await fetch('/api/swarm-runtime')
+      if (!res.ok) throw new Error(`swarm-runtime ${res.status}`)
+      const payload = (await res.json()) as { entries?: Array<Record<string, unknown>> }
+      return payload.entries ?? []
+    },
+    refetchInterval: 3_000,
+    staleTime: 1_000,
+  })
+
   const sessionWorkers = sessionsQuery.data ?? []
 
   // For native-swarm missions, build virtual worker cards from the mission
@@ -1094,10 +1111,59 @@ export function useConductorGateway() {
     })
   }, [isNativeSwarm, swarmAssignments])
 
+  // Map a live swarm-runtime entry to a ConductorWorker card so the Office shows
+  // the agents actually running in the local swarm (builder, km-agent, ...).
+  const swarmRuntimeWorkers = useMemo<Array<ConductorWorker>>(() => {
+    const entries = (swarmRuntimeQuery.data ?? []) as Array<Record<string, unknown>>
+    if (entries.length === 0) return []
+    return entries.map((e) => {
+      const workerId = String(e.workerId ?? '')
+      const state = String(e.state ?? 'idle')
+      const stateMap: Record<string, 'running' | 'complete' | 'stale' | 'idle'> = {
+        executing: 'running',
+        dispatched: 'running',
+        checkpointed: 'complete',
+        done: 'complete',
+        blocked: 'stale',
+        idle: 'idle',
+        queued: 'idle',
+      }
+      const status = stateMap[state] ?? 'idle'
+      const displayName = String(e.humanLabel ?? e.displayName ?? workerId)
+      return {
+        key: `swarm-${workerId}`,
+        label: workerId,
+        model: 'native-swarm',
+        status,
+        updatedAt: String(e.lastOutputAt ?? e.lastCheckIn ?? ''),
+        displayName,
+        totalTokens: 0,
+        contextTokens: 0,
+        tokenUsageLabel: state,
+        raw: {
+          key: `swarm-${workerId}`,
+          label: workerId,
+          friendlyId: workerId,
+          status: status === 'complete' ? 'completed' : 'running',
+          model: 'native-swarm',
+          lastMessage: String(e.lastSummary ?? e.currentTask ?? ''),
+          createdAt: String(e.startedAt ?? ''),
+          startedAt: String(e.startedAt ?? ''),
+          updatedAt: String(e.lastOutputAt ?? ''),
+        } as GatewaySession,
+      }
+    })
+  }, [swarmRuntimeQuery.data])
+
   const workers = useMemo(() => {
+    // Prefer gateway/session workers when present, then native-swarm virtual
+    // workers, then the live local swarm runtime roster. This guarantees the
+    // Office reflects the real running agents even when no conductor mission
+    // session exists.
     if (sessionWorkers.length > 0) return sessionWorkers
-    return virtualWorkers
-  }, [sessionWorkers, virtualWorkers])
+    if (virtualWorkers.length > 0) return virtualWorkers
+    return swarmRuntimeWorkers
+  }, [sessionWorkers, virtualWorkers, swarmRuntimeWorkers])
   const activeWorkers = useMemo(() => workers.filter((worker) => worker.status === 'running' || worker.status === 'idle'), [workers])
   const hasPersistedMission = initialMission !== null
 

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -1337,12 +1337,23 @@ export function Swarm2Screen() {
   }, [])
 
   const routeInboxItemToReviewer = useCallback((item: Swarm2InboxItem) => {
+    // A runtime/inbox item may not carry a real missionId (e.g. free-form
+    // worker output that was never part of a formal mission). Dispatching the
+    // reviewer with a `null` missionId produced the prompt "review ... for
+    // mission unknown mission", which left the reviewer blocked with no real
+    // target. Fall back to the item's own id so the reviewer always gets a
+    // concrete, reviewable reference.
+    const targetRef = item.missionId?.trim() || item.id
+    if (!targetRef) {
+      console.warn('[swarm2] routeInboxItemToReviewer: item has no missionId or id; refusing to dispatch a target-less review.')
+      return
+    }
     setSelectedId('swarm6')
     setRouterSeed({
       key: Date.now(),
       mode: 'manual',
       prompt: [
-        `Review ${item.workerId}'s Swarm control-plane output for mission ${item.missionId ?? 'unknown mission'}. Do not broaden scope. Return the required checkpoint format.`,
+        `Review ${item.workerId}'s Swarm control-plane output for ${targetRef}. Do not broaden scope. Return the required checkpoint format.`,
         '',
         `Task: ${item.title}`,
         `Summary: ${item.summary}`,

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -932,7 +932,7 @@ function ControlPlaneStage({
                           {cmd.kind === 'tmux' ? 'tmux' : cmd.kind === 'log-tail' ? 'logs' : 'shell'}
                         </span>
                       </div>
-                      <SwarmTerminal workerId={member.id} command={cmd.command} cwd={runtime?.cwd ?? undefined} height={420} active={viewMode === 'runtime'} />
+                      <SwarmTerminal workerId={member.id} command={cmd.command} cwd={runtime?.cwd ?? undefined} height={360} active={viewMode === 'runtime'} />
                     </div>
                   )
                 })

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -1020,7 +1020,7 @@ export function Swarm2Screen() {
   const runtimeQuery = useQuery({
     queryKey: ['swarm2', 'runtime'],
     queryFn: fetchRuntime,
-    refetchInterval: 30_000,
+    refetchInterval: 8_000,
   })
   const healthQuery = useQuery({
     queryKey: ['swarm2', 'health'],
@@ -1035,7 +1035,7 @@ export function Swarm2Screen() {
   const missionsQuery = useQuery({
     queryKey: ['swarm2', 'missions'],
     queryFn: fetchMissions,
-    refetchInterval: 30_000,
+    refetchInterval: 8_000,
   })
 
   const startAgentSession = useCallback(

--- a/src/screens/swarm2/swarm2-screen.tsx
+++ b/src/screens/swarm2/swarm2-screen.tsx
@@ -1186,7 +1186,19 @@ export function Swarm2Screen() {
         cronJobCount: 0,
         assignedTaskCount: 0,
       }))
-    return sortSwarmMembers([...merged, ...extras], roomIds)
+    const all = sortSwarmMembers([...merged, ...extras], roomIds)
+    // Guard against duplicate worker ids (e.g. crew reports `workspace` twice).
+    // Duplicate ids cause React key collisions across worker cards, runtime
+    // terminals and the activity feed, and can remount/abort the SSE terminal
+    // fetch ("Failed to start swarm terminal (no response)").
+    const seenIds = new Set<string>()
+    const deduped: typeof all = []
+    for (const member of all) {
+      if (seenIds.has(member.id)) continue
+      seenIds.add(member.id)
+      deduped.push(member)
+    }
+    return deduped
   }, [crew, roomIds, runtimeByWorker, rosterQuery.data])
 
   useEffect(() => {

--- a/src/screens/tasks/task-card.tsx
+++ b/src/screens/tasks/task-card.tsx
@@ -1,12 +1,16 @@
-import { cn } from '@/lib/utils'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Delete02Icon } from '@hugeicons/core-free-icons'
 import type { ClaudeTask } from '@/lib/tasks-api'
 import { PRIORITY_COLORS, isOverdue } from '@/lib/tasks-api'
+import { cn } from '@/lib/utils'
 
 type Props = {
   task: ClaudeTask
   assigneeLabels?: Record<string, string>
   onClick: () => void
   onDragStart: (e: React.DragEvent) => void
+  onDelete?: (id: string) => void
+  onDispatch?: (task: ClaudeTask) => void
   isDragging?: boolean
 }
 
@@ -18,7 +22,7 @@ export function formatTaskAssigneeLabel(
   return `Assignee: ${resolvedLabel}`
 }
 
-export function TaskCard({ task, assigneeLabels = {}, onClick, onDragStart, isDragging }: Props) {
+export function TaskCard({ task, assigneeLabels = {}, onClick, onDragStart, onDelete, onDispatch, isDragging }: Props) {
   const overdue = isOverdue(task)
   const priorityColor = PRIORITY_COLORS[task.priority]
   const visibleTags = task.tags.slice(0, 2)
@@ -38,12 +42,28 @@ export function TaskCard({ task, assigneeLabels = {}, onClick, onDragStart, isDr
       )}
       style={{ borderLeftWidth: 3, borderLeftColor: priorityColor }}
     >
-      {/* Priority dot in top-right */}
-      <span
-        className="absolute top-2.5 right-2.5 w-2 h-2 rounded-full shrink-0"
-        style={{ background: priorityColor }}
-        title={`Priority: ${task.priority}`}
-      />
+      {/* Priority dot + delete button in top-right */}
+      <div className="absolute top-2.5 right-2.5 flex items-center gap-1.5">
+        <span
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: priorityColor }}
+          title={`Priority: ${task.priority}`}
+        />
+        {onDelete && (
+          <button
+            type="button"
+            aria-label="Delete task"
+            title="Delete task"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete(task.id)
+            }}
+            className="rounded p-0.5 transition-colors hover:bg-[var(--theme-hover)] hover:text-red-400 text-[var(--theme-muted)]"
+          >
+            <HugeiconsIcon icon={Delete02Icon} size={13} />
+          </button>
+        )}
+      </div>
 
       <p className="text-sm font-medium text-[var(--theme-text)] leading-snug mb-1 line-clamp-2 pr-4">
         {task.title}
@@ -86,13 +106,28 @@ export function TaskCard({ task, assigneeLabels = {}, onClick, onDragStart, isDr
             )}
             <span className={overdue ? 'text-red-400 font-semibold' : 'text-[var(--theme-muted)]'}>
               {(() => {
-                const [y, m, d] = task.due_date!.split('-').map(Number)
+                const [y, m, d] = task.due_date.split('-').map(Number)
                 return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
               })()}
             </span>
           </div>
         )}
       </div>
+
+      {onDispatch && task.assignee && task.column !== 'done' && task.column !== 'in_progress' && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDispatch(task)
+          }}
+          className="mt-2 w-full rounded-md py-1 text-[10px] font-medium uppercase tracking-wide text-white transition-opacity hover:opacity-90"
+          style={{ background: '#a855f7' }}
+          title={`Dispatch to swarm worker: ${task.assignee}`}
+        >
+          Dispatch → {task.assignee}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -15,6 +15,7 @@ import {
   COLUMN_COLORS,
   COLUMN_LABELS,
   COLUMN_ORDER,
+  autoClassifyTasks,
   createTask,
   deleteTask,
   dispatchTaskToSwarm,
@@ -159,6 +160,23 @@ export function TasksScreen() {
     dispatchMutation.mutate(task)
   }
 
+  const autoClassifyMutation = useMutation({
+    mutationFn: () => autoClassifyTasks(tasks),
+    onSuccess: (result) => {
+      if (result.ok) {
+        invalidate()
+        toast(`KM agent classifying Nexum tasks (mission ${result.missionId ?? '?'})`)
+      } else {
+        toast(result.error ?? 'Failed to auto-classify', { type: 'error' })
+      }
+    },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to auto-classify', { type: 'error' }),
+  })
+
+  function handleAutoClassify() {
+    autoClassifyMutation.mutate()
+  }
+
   function handleDispatchAll() {
     const eligible = tasks.filter((t) => t.assignee && t.column !== 'done' && t.column !== 'in_progress')
     if (eligible.length === 0) {
@@ -286,6 +304,16 @@ export function TasksScreen() {
           >
             <HugeiconsIcon icon={CheckListIcon} size={14} />
             Dispatch to swarm
+          </button>
+          <button
+            onClick={handleAutoClassify}
+            disabled={autoClassifyMutation.isPending}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            style={{ background: '#0ea5e9' }}
+            title="Dispatch the KM agent to classify all Nexum tasks (owner/due_date/priority) and apply them"
+          >
+            <HugeiconsIcon icon={CheckListIcon} size={14} />
+            Auto-classify
           </button>
         </div>
       </div>

--- a/src/screens/tasks/tasks-screen.tsx
+++ b/src/screens/tasks/tasks-screen.tsx
@@ -17,6 +17,7 @@ import {
   COLUMN_ORDER,
   createTask,
   deleteTask,
+  dispatchTaskToSwarm,
   fetchAssignees,
   fetchTasks,
   isOverdue,
@@ -139,6 +140,34 @@ export function TasksScreen() {
     onError: (e) => toast(e instanceof Error ? e.message : 'Failed to move task', { type: 'error' }),
   })
 
+  const dispatchMutation = useMutation({
+    mutationFn: (task: ClaudeTask) => dispatchTaskToSwarm(task),
+    onSuccess: (result, task) => {
+      if (result.ok) {
+        // Link the mission and move the task to Running so it reflects live.
+        void updateTask(task.id, { column: 'in_progress' }).catch(() => undefined)
+        invalidate()
+        toast(`Dispatched to swarm (mission ${result.missionId ?? '?'})`)
+      } else {
+        toast(result.error ?? 'Failed to dispatch to swarm', { type: 'error' })
+      }
+    },
+    onError: (e) => toast(e instanceof Error ? e.message : 'Failed to dispatch to swarm', { type: 'error' }),
+  })
+
+  function handleDispatchTask(task: ClaudeTask) {
+    dispatchMutation.mutate(task)
+  }
+
+  function handleDispatchAll() {
+    const eligible = tasks.filter((t) => t.assignee && t.column !== 'done' && t.column !== 'in_progress')
+    if (eligible.length === 0) {
+      toast('No assigned tasks to dispatch (assign an owner first)', { type: 'error' })
+      return
+    }
+    for (const t of eligible) dispatchMutation.mutate(t)
+  }
+
   function handleDragStart(e: React.DragEvent, taskId: string) {
     e.dataTransfer.setData('text/plain', taskId)
     setDraggingId(taskId)
@@ -248,6 +277,16 @@ export function TasksScreen() {
             <HugeiconsIcon icon={Add01Icon} size={14} />
             New Task
           </button>
+          <button
+            onClick={handleDispatchAll}
+            disabled={dispatchMutation.isPending}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            style={{ background: '#a855f7' }}
+            title="Dispatch all assigned (non-running) tasks to the swarm"
+          >
+            <HugeiconsIcon icon={CheckListIcon} size={14} />
+            Dispatch to swarm
+          </button>
         </div>
       </div>
         <p className="mt-3 text-xs text-[var(--theme-muted)]">
@@ -355,6 +394,8 @@ export function TasksScreen() {
                             isDragging={draggingId === task.id}
                             onDragStart={e => handleDragStart(e, task.id)}
                             onClick={() => setEditingTask(task)}
+                            onDelete={(id) => deleteMutation.mutate(id)}
+                            onDispatch={handleDispatchTask}
                           />
                         </motion.div>
                       ))

--- a/src/server/claude-tasks-backend.ts
+++ b/src/server/claude-tasks-backend.ts
@@ -1,13 +1,27 @@
-import {
-  createKanbanCard,
-  listKanbanCards,
-  type KanbanBackendMeta,
-  getKanbanBackendMeta,
-  updateKanbanCard,
-} from './kanban-backend'
+// Bridge between the Tasks board UI (which expects ClaudeTaskRecord) and the
+// canonical task store used by the swarm runner (tasks-store -> ~/.hermes/tasks.json).
+//
+// Historically this file routed through kanban-backend, which auto-detected a
+// Claude `kanban.db`/`kanban/` directory that does not exist in this deployment.
+// That detection failed, so the board silently fell back to an empty local
+// swarm2-kanban.json while the real 198 tasks lived in tasks.json — the board
+// showed 0 tasks even though tasks-swarm-run could dispatch them. We now read
+// straight from tasks-store (the same source tasks-swarm-run uses) so the board
+// and the swarm runner are always in sync.
 
-export type TaskColumn = 'backlog' | 'todo' | 'in_progress' | 'review' | 'blocked' | 'done'
-export type TaskPriority = 'high' | 'medium' | 'low'
+import {
+  listTasks,
+  getTask,
+  createTask,
+  updateTask,
+  moveTask,
+  deleteTask,
+  type TaskRecord,
+  type TaskColumn,
+  type TaskPriority,
+} from './tasks-store'
+
+export type { TaskColumn, TaskPriority }
 
 export type ClaudeTaskRecord = {
   id: string
@@ -22,6 +36,7 @@ export type ClaudeTaskRecord = {
   created_by: string
   created_at: string
   updated_at: string
+  session_id?: string | null
 }
 
 type TaskFilters = {
@@ -44,123 +59,82 @@ type CreateTaskInput = {
 
 type UpdateTaskInput = Partial<Omit<CreateTaskInput, 'created_by'>>
 
-function toIso(timestamp: number): string {
-  return new Date(timestamp).toISOString()
-}
-
-function mapKanbanStatusToTaskColumn(status: string): TaskColumn {
-  switch (status) {
-    case 'ready':
-      return 'todo'
-    case 'running':
-      return 'in_progress'
-    case 'review':
-      return 'review'
-    case 'blocked':
-      return 'blocked'
-    case 'done':
-      return 'done'
-    case 'backlog':
-    default:
-      return 'backlog'
-  }
-}
-
-function mapTaskColumnToKanbanStatus(column: TaskColumn): 'backlog' | 'ready' | 'running' | 'review' | 'blocked' | 'done' {
-  switch (column) {
-    case 'todo':
-      return 'ready'
-    case 'in_progress':
-      return 'running'
-    case 'review':
-      return 'review'
-    case 'blocked':
-      return 'blocked'
-    case 'done':
-      return 'done'
-    case 'backlog':
-    default:
-      return 'backlog'
-  }
-}
-
-function mapCardToTask(card: {
-  id: string
-  title: string
-  spec: string
-  assignedWorker: string | null
-  status: string
-  createdBy: string
-  createdAt: number
-  updatedAt: number
-}): ClaudeTaskRecord {
+// tasks-store TaskRecord and ClaudeTaskRecord are structurally identical; this
+// is a thin identity mapper so the rest of the app keeps using ClaudeTaskRecord.
+function toClaudeTask(task: TaskRecord): ClaudeTaskRecord {
   return {
-    id: card.id,
-    title: card.title,
-    description: card.spec,
-    column: mapKanbanStatusToTaskColumn(card.status),
-    priority: 'medium',
-    assignee: card.assignedWorker,
-    tags: [],
-    due_date: null,
-    position: card.updatedAt,
-    created_by: card.createdBy,
-    created_at: toIso(card.createdAt),
-    updated_at: toIso(card.updatedAt),
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    column: task.column,
+    priority: task.priority,
+    assignee: task.assignee,
+    tags: task.tags,
+    due_date: task.due_date,
+    position: task.position,
+    created_by: task.created_by,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    session_id: task.session_id ?? null,
   }
 }
 
-export function getClaudeTasksBackendMeta(): KanbanBackendMeta {
-  return getKanbanBackendMeta()
+export function getClaudeTasksBackendMeta() {
+  return {
+    id: 'tasks-store' as const,
+    label: 'Hermes Tasks (tasks.json)',
+    detected: true,
+    writable: true,
+    details: 'Canonical task store shared with the swarm runner.',
+    path: null,
+  }
 }
 
 export async function listClaudeTasks(filters: TaskFilters = {}): Promise<ClaudeTaskRecord[]> {
-  let tasks = (await listKanbanCards()).map(mapCardToTask)
-  if (!filters.includeDone) {
-    tasks = tasks.filter((task) => task.column !== 'done')
+  const storeFilters: TaskFilters = {
+    column: filters.column,
+    assignee: filters.assignee,
+    priority: filters.priority,
+    includeDone: filters.includeDone,
   }
-  if (filters.column) {
-    tasks = tasks.filter((task) => task.column === filters.column)
-  }
-  if (filters.assignee) {
-    tasks = tasks.filter((task) => task.assignee === filters.assignee)
-  }
-  if (filters.priority) {
-    tasks = tasks.filter((task) => task.priority === filters.priority)
-  }
-  return tasks.sort((a, b) => b.position - a.position || a.title.localeCompare(b.title))
+  return listTasks(storeFilters).map(toClaudeTask)
 }
 
 export async function getClaudeTask(taskId: string): Promise<ClaudeTaskRecord | null> {
-  const tasks = await listKanbanCards()
-  const card = tasks.find((entry) => entry.id === taskId)
-  return card ? mapCardToTask(card) : null
+  const task = getTask(taskId)
+  return task ? toClaudeTask(task) : null
 }
 
 export async function createClaudeTask(input: CreateTaskInput): Promise<ClaudeTaskRecord> {
-  const card = await createKanbanCard({
+  const task = createTask({
     title: input.title,
-    spec: input.description ?? '',
-    assignedWorker: input.assignee ?? null,
-    status: mapTaskColumnToKanbanStatus(input.column ?? 'backlog'),
-    createdBy: input.created_by ?? 'user',
+    description: input.description ?? '',
+    column: input.column ?? 'backlog',
+    priority: input.priority ?? 'medium',
+    assignee: input.assignee ?? null,
+    tags: input.tags ?? [],
+    due_date: input.due_date ?? null,
+    created_by: input.created_by ?? 'user',
   })
-  return mapCardToTask(card)
+  return toClaudeTask(task)
 }
 
-export async function updateClaudeTask(taskId: string, updates: UpdateTaskInput): Promise<ClaudeTaskRecord | null> {
-  const card = await updateKanbanCard(taskId, {
-    title: typeof updates.title === 'string' ? updates.title : undefined,
-    spec: typeof updates.description === 'string' ? updates.description : undefined,
-    assignedWorker:
-      updates.assignee === null || typeof updates.assignee === 'string'
-        ? updates.assignee
-        : undefined,
-    status: updates.column ? mapTaskColumnToKanbanStatus(updates.column) : undefined,
-  })
-  return card ? mapCardToTask(card) : null
+export async function updateClaudeTask(
+  taskId: string,
+  updates: UpdateTaskInput,
+): Promise<ClaudeTaskRecord | null> {
+  const task = updateTask(taskId, updates)
+  return task ? toClaudeTask(task) : null
 }
 
-export async function moveClaudeTask(taskId: string, column: TaskColumn): Promise<ClaudeTaskRecord | null> {
-  return updateClaudeTask(taskId, { column })
+export async function moveClaudeTask(
+  taskId: string,
+  column: TaskColumn,
+): Promise<ClaudeTaskRecord | null> {
+  const task = moveTask(taskId, column)
+  return task ? toClaudeTask(task) : null
+}
+
+export async function deleteClaudeTask(taskId: string): Promise<boolean> {
+  return deleteTask(taskId)
 }

--- a/src/server/pty-helper.py
+++ b/src/server/pty-helper.py
@@ -59,6 +59,14 @@ def main():
         # Parent: bridge stdin <-> master_fd <-> stdout
         os.close(slave_fd)
 
+        # Force an initial flush so tmux attach panes that would otherwise
+        # stay silent (reviewer/km-agent/orchestrator) emit their current
+        # content immediately instead of waiting for the first keypress.
+        try:
+            os.write(master_fd, b'\x0c')  # Ctrl-L: redraw/refresh pane
+        except OSError:
+            pass
+
         # Make stdin non-blocking
         import io
         stdin_fd = sys.stdin.fileno()

--- a/src/server/swarm-checkpoints.test.ts
+++ b/src/server/swarm-checkpoints.test.ts
@@ -22,6 +22,21 @@ COMMANDS_RUN: none`)
     expect(parsed).toBeNull()
   })
 
+  it('accepts DONE checkpoints that omit optional BLOCKER/NEXT_ACTION', () => {
+    // Real workers often emit STATE/FILES_CHANGED/COMMANDS_RUN/RESULT without
+    // an explicit BLOCKER: line. The parser must treat missing BLOCKER as
+    // "none", not drop the checkpoint (which left missions stuck in `blocked`).
+    const parsed = parseSwarmCheckpoint(`STATE: DONE
+FILES_CHANGED: none
+COMMANDS_RUN: none (read_file only)
+RESULT: O ficheiro contém 9 workers.
+NEXT_ACTION: Nada — diagnóstico concluído.`)
+    expect(parsed?.stateLabel).toBe('DONE')
+    expect(parsed?.checkpointStatus).toBe('done')
+    expect(parsed?.blocker).toBeNull()
+    expect(parsed?.nextAction).toBe('Nada — diagnóstico concluído.')
+  })
+
   it('maps blocked checkpoints to runtime blocked state', () => {
     const parsed = parseSwarmCheckpoint(`STATE: BLOCKED
 FILES_CHANGED: none

--- a/src/server/swarm-checkpoints.ts
+++ b/src/server/swarm-checkpoints.ts
@@ -26,7 +26,7 @@ const STATE_MAP: Record<ParsedSwarmCheckpoint['stateLabel'], Pick<ParsedSwarmChe
 
 function normalizeLabel(value: string): Label | null {
   const upper = value.trim().toUpperCase().replace(/[ -]/g, '_')
-  return (LABELS as readonly string[]).includes(upper) ? upper as Label : null
+  return (LABELS as ReadonlyArray<string>).includes(upper) ? upper as Label : null
 }
 
 function clean(value: string | undefined): string | null {
@@ -56,7 +56,12 @@ export function parseSwarmCheckpoint(text: string): ParsedSwarmCheckpoint | null
     if (current) fields[current] = `${fields[current] ?? ''}\n${line}`
   }
 
+  // BLOCKER and NEXT_ACTION are optional: a checkpoint without them simply
+  // means "no blocker" / "no next action". Requiring all six labels caused
+  // valid DONE checkpoints (where the worker omitted BLOCKER:) to be silently
+  // dropped, leaving missions stuck in `blocked`/`executing` forever.
   for (const label of LABELS) {
+    if (label === 'BLOCKER' || label === 'NEXT_ACTION') continue
     if (!(label in fields)) return null
   }
   const stateRaw = clean(fields.STATE)?.toUpperCase().split(/\s+/)[0]

--- a/src/server/swarm-mission-runner.ts
+++ b/src/server/swarm-mission-runner.ts
@@ -1,22 +1,25 @@
 /**
  * Server-side swarm mission runner.
  *
- * The Tasks board flow (tasks-swarm-run) creates missions and marks cards
- * in_progress, but actual execution was previously driven only by the
- * conductor UI (use-mission-orchestrator, a frontend React hook). This loop
- * runs headless on the dev server: it reads eligible missions from the store,
- * sends each assignment's prompt to the corresponding worker's tmux pane, and
- * marks the assignment dispatched so the board/sync reflect real progress.
+ * Reads eligible missions from the store, sends each assignment's prompt to the
+ * corresponding worker's tmux pane, and marks it dispatched so the board/sync
+ * reflect real progress — all WITHOUT the conductor UI open.
+ *
+ * IMPORTANT: every tmux call is async (execFile, not execFileSync). The dev
+ * server is single-threaded; a synchronous child_process spawn inside the tick
+ * would block the event loop and stall every in-flight HTTP request (the exact
+ * "requests stuck in pending" symptom). This module never blocks.
  *
  * Concurrency is bounded by each worker's maxConcurrentTasks (roster).
  */
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { readSwarmRoster } from './swarm-roster'
-import {
-  readStore,
-  markMissionAssignmentDispatched,
-} from './swarm-missions'
+import { readStore, markMissionAssignmentDispatched } from './swarm-missions'
 import { SWARM_WORKER_BY_ASSIGNEE } from '../lib/tasks-api'
+
+const execFileAsync = promisify(execFile)
+const TMUX_TIMEOUT_MS = 3000
 
 function capacityByWorker(): Map<string, number> {
   const roster = readSwarmRoster()
@@ -30,10 +33,10 @@ function tmuxSessionFor(workerId: string): string {
   return `swarm-${workerId}`
 }
 
-function workerPaneReady(workerId: string): boolean {
+async function workerPaneReady(workerId: string): Promise<boolean> {
   try {
-    execFileSync('tmux', ['has-session', '-t', tmuxSessionFor(workerId)], {
-      stdio: 'ignore',
+    await execFileAsync('tmux', ['has-session', '-t', tmuxSessionFor(workerId)], {
+      timeout: TMUX_TIMEOUT_MS,
     })
     return true
   } catch {
@@ -41,7 +44,7 @@ function workerPaneReady(workerId: string): boolean {
   }
 }
 
-function activeByWorker(): Map<string, number> {
+async function activeByWorker(): Promise<Map<string, number>> {
   const store = readStore()
   const cap = capacityByWorker()
   const active = new Map<string, number>()
@@ -50,22 +53,21 @@ function activeByWorker(): Map<string, number> {
     for (const a of m.assignments) {
       if (a.state === 'dispatched' || a.state === 'checkpointed') {
         const wid = a.workerId
-        // Only count toward capacity if the worker pane is still alive.
-        if (workerPaneReady(wid)) active.set(wid, (active.get(wid) ?? 0) + 1)
+        if (await workerPaneReady(wid)) active.set(wid, (active.get(wid) ?? 0) + 1)
       }
     }
   }
   return active
 }
 
-function sendToWorker(workerId: string, task: string): boolean {
-  if (!workerPaneReady(workerId)) return false
+async function sendToWorker(workerId: string, task: string): Promise<boolean> {
+  if (!(await workerPaneReady(workerId))) return false
   const prompt = task.replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 4000)
   try {
-    execFileSync(
+    await execFileAsync(
       'tmux',
       ['send-keys', '-t', tmuxSessionFor(workerId), `"""${prompt}"""`, 'Enter'],
-      { stdio: 'ignore', timeout: 5000 },
+      { timeout: TMUX_TIMEOUT_MS },
     )
     return true
   } catch {
@@ -73,44 +75,51 @@ function sendToWorker(workerId: string, task: string): boolean {
   }
 }
 
-export function runSwarmMissionLoop(): {
+let isRunning = false
+
+export async function runSwarmMissionLoop(): Promise<{
   ok: boolean
   dispatched: number
   skipped: number
-} {
+}> {
+  if (isRunning) return { ok: true, dispatched: 0, skipped: 0 }
+  isRunning = true
   const cap = capacityByWorker()
-  const active = activeByWorker()
+  const active = await activeByWorker()
   const store = readStore()
   let dispatched = 0
   let skipped = 0
 
-  for (const m of store.missions) {
-    if (m.state === 'complete' || m.state === 'cancelled') continue
-    for (const a of m.assignments) {
-      if (a.state !== 'queued') continue
-      const wid = a.workerId
-      const used = active.get(wid) ?? 0
-      const limit = cap.get(wid) ?? 1
-      if (used >= limit) {
-        skipped++
-        continue
-      }
-      if (sendToWorker(wid, a.task)) {
-        markMissionAssignmentDispatched({
-          missionId: m.id,
-          workerId: wid,
-          task: a.task,
-          source: 'swarm-mission-runner',
-          author: 'aurora',
-        })
-        active.set(wid, used + 1)
-        dispatched++
-      } else {
-        skipped++
+  try {
+    for (const m of store.missions) {
+      if (m.state === 'complete' || m.state === 'cancelled') continue
+      for (const a of m.assignments) {
+        if (a.state !== 'queued') continue
+        const wid = a.workerId
+        const used = active.get(wid) ?? 0
+        const limit = cap.get(wid) ?? 1
+        if (used >= limit) {
+          skipped++
+          continue
+        }
+        if (await sendToWorker(wid, a.task)) {
+          markMissionAssignmentDispatched({
+            missionId: m.id,
+            workerId: wid,
+            task: a.task,
+            source: 'swarm-mission-runner',
+            author: 'aurora',
+          })
+          active.set(wid, used + 1)
+          dispatched++
+        } else {
+          skipped++
+        }
       }
     }
+  } finally {
+    isRunning = false
   }
 
   return { ok: true, dispatched, skipped }
 }
-

--- a/src/server/swarm-mission-runner.ts
+++ b/src/server/swarm-mission-runner.ts
@@ -1,0 +1,116 @@
+/**
+ * Server-side swarm mission runner.
+ *
+ * The Tasks board flow (tasks-swarm-run) creates missions and marks cards
+ * in_progress, but actual execution was previously driven only by the
+ * conductor UI (use-mission-orchestrator, a frontend React hook). This loop
+ * runs headless on the dev server: it reads eligible missions from the store,
+ * sends each assignment's prompt to the corresponding worker's tmux pane, and
+ * marks the assignment dispatched so the board/sync reflect real progress.
+ *
+ * Concurrency is bounded by each worker's maxConcurrentTasks (roster).
+ */
+import { execFileSync } from 'node:child_process'
+import { readSwarmRoster } from './swarm-roster'
+import {
+  readStore,
+  markMissionAssignmentDispatched,
+} from './swarm-missions'
+import { SWARM_WORKER_BY_ASSIGNEE } from '../lib/tasks-api'
+
+function capacityByWorker(): Map<string, number> {
+  const roster = readSwarmRoster()
+  const cap = new Map<string, number>()
+  for (const w of roster.workers) cap.set(w.id, Math.max(1, w.maxConcurrentTasks ?? 1))
+  for (const a of Object.keys(SWARM_WORKER_BY_ASSIGNEE)) if (!cap.has(a)) cap.set(a, 1)
+  return cap
+}
+
+function tmuxSessionFor(workerId: string): string {
+  return `swarm-${workerId}`
+}
+
+function workerPaneReady(workerId: string): boolean {
+  try {
+    execFileSync('tmux', ['has-session', '-t', tmuxSessionFor(workerId)], {
+      stdio: 'ignore',
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function activeByWorker(): Map<string, number> {
+  const store = readStore()
+  const cap = capacityByWorker()
+  const active = new Map<string, number>()
+  for (const m of store.missions) {
+    if (m.state === 'complete' || m.state === 'cancelled') continue
+    for (const a of m.assignments) {
+      if (a.state === 'dispatched' || a.state === 'checkpointed') {
+        const wid = a.workerId
+        // Only count toward capacity if the worker pane is still alive.
+        if (workerPaneReady(wid)) active.set(wid, (active.get(wid) ?? 0) + 1)
+      }
+    }
+  }
+  return active
+}
+
+function sendToWorker(workerId: string, task: string): boolean {
+  if (!workerPaneReady(workerId)) return false
+  const prompt = task.replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 4000)
+  try {
+    execFileSync(
+      'tmux',
+      ['send-keys', '-t', tmuxSessionFor(workerId), `"""${prompt}"""`, 'Enter'],
+      { stdio: 'ignore', timeout: 5000 },
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function runSwarmMissionLoop(): {
+  ok: boolean
+  dispatched: number
+  skipped: number
+} {
+  const cap = capacityByWorker()
+  const active = activeByWorker()
+  const store = readStore()
+  let dispatched = 0
+  let skipped = 0
+
+  for (const m of store.missions) {
+    if (m.state === 'complete' || m.state === 'cancelled') continue
+    for (const a of m.assignments) {
+      if (a.state !== 'queued') continue
+      const wid = a.workerId
+      const used = active.get(wid) ?? 0
+      const limit = cap.get(wid) ?? 1
+      if (used >= limit) {
+        skipped++
+        continue
+      }
+      if (sendToWorker(wid, a.task)) {
+        markMissionAssignmentDispatched({
+          missionId: m.id,
+          workerId: wid,
+          task: a.task,
+          source: 'swarm-mission-runner',
+          author: 'aurora',
+        })
+        active.set(wid, used + 1)
+        dispatched++
+      } else {
+        skipped++
+      }
+    }
+  }
+
+  return { ok: true, dispatched, skipped }
+}
+

--- a/src/server/swarm-missions.test.ts
+++ b/src/server/swarm-missions.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SwarmMissionAssignment } from './swarm-missions'
 
 let tempRoot: string
 
@@ -386,5 +387,30 @@ describe('swarm-missions', () => {
     const persisted = JSON.parse(readFileSync(mod.SWARM_MISSIONS_PATH, 'utf8'))
     expect(persisted.missions[0]?.state).toBe('executing')
     expect(persisted.missions[0]?.events).toHaveLength(0)
+  })
+
+  it('readyQueuedAssignments matches dependsOn by workerId (dispatch format)', async () => {
+    const mod = await loadModule()
+    const mission = mod.createOrUpdateMission({
+      missionId: 'mission-dep-workerid',
+      title: 'dep by workerId',
+      assignments: [
+        { workerId: 'builder', task: 'Build it', reviewRequired: false },
+        { workerId: 'reviewer', task: 'Review it', reviewRequired: true, dependsOn: ['builder'] },
+      ],
+    })
+    // Nothing done yet: builder (no deps) is ready, reviewer (dependsOn builder) is not
+    expect(mod.readyQueuedAssignments(mission.id).map((a: SwarmMissionAssignment) => a.workerId)).toEqual(['builder'])
+    // Mark builder done -> reviewer becomes ready (dependsOn is a workerId)
+    const builder = mission.assignments[0]
+    mod.recordMissionCheckpoint({
+      missionId: mission.id,
+      assignmentId: builder.id,
+      workerId: 'builder',
+      checkpoint: { stateLabel: 'DONE', runtimeState: 'idle', checkpointStatus: 'done', filesChanged: 'x', commandsRun: 'y', result: 'built', blocker: null, nextAction: null, raw: 'STATE: DONE' },
+      source: 'swarm-checkpoint-api',
+    })
+    const ready = mod.readyQueuedAssignments(mission.id)
+    expect(ready.map((a: SwarmMissionAssignment) => a.workerId)).toEqual(['reviewer'])
   })
 })

--- a/src/server/swarm-missions.ts
+++ b/src/server/swarm-missions.ts
@@ -72,7 +72,7 @@ function shortId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
-function readStore(): SwarmMissionStore {
+export function readStore(): SwarmMissionStore {
   if (!existsSync(SWARM_MISSIONS_PATH)) return { version: 1, missions: [] }
   try {
     const parsed = JSON.parse(readFileSync(SWARM_MISSIONS_PATH, 'utf8')) as SwarmMissionStore
@@ -82,7 +82,7 @@ function readStore(): SwarmMissionStore {
   }
 }
 
-function writeStore(store: SwarmMissionStore): void {
+export function writeStore(store: SwarmMissionStore): void {
   mkdirSync(dirname(SWARM_MISSIONS_PATH), { recursive: true })
   const tmp = `${SWARM_MISSIONS_PATH}.${process.pid}.${Date.now()}.tmp`
   writeFileSync(tmp, JSON.stringify(store, null, 2) + '\n')
@@ -397,8 +397,9 @@ export function appendMissionContinuation(input: {
 export function readyQueuedAssignments(missionId: string): Array<SwarmMissionAssignment> {
   const mission = getSwarmMission(missionId)
   if (!mission) return []
-  const doneIds = new Set(mission.assignments.filter((item) => ['checkpointed', 'done'].includes(item.state)).map((item) => item.id))
-  return mission.assignments.filter((item) => item.state === 'queued' && item.dependsOn.every((id) => doneIds.has(id)))
+  const doneWorkerIds = new Set(mission.assignments.filter((item) => ['checkpointed', 'done'].includes(item.state)).map((item) => item.workerId))
+  const doneAssignmentIds = new Set(mission.assignments.filter((item) => ['checkpointed', 'done'].includes(item.state)).map((item) => item.id))
+  return mission.assignments.filter((item) => item.state === 'queued' && item.dependsOn.every((id) => doneWorkerIds.has(id) || doneAssignmentIds.has(id)))
 }
 
 export function cancelSwarmAssignment(input: {

--- a/src/server/tasks-store.ts
+++ b/src/server/tasks-store.ts
@@ -62,6 +62,9 @@ function writeTaskFile(data: TaskFile): void {
 }
 
 function normalizeTask(task: Partial<TaskRecord> & Pick<TaskRecord, 'id' | 'title' | 'created_at' | 'updated_at' | 'created_by'>): TaskRecord {
+  const now = new Date().toISOString()
+  const createdAt = typeof task.created_at === 'string' && task.created_at ? task.created_at : now
+  const updatedAt = typeof task.updated_at === 'string' && task.updated_at ? task.updated_at : createdAt
   return {
     id: task.id,
     title: task.title,
@@ -73,8 +76,8 @@ function normalizeTask(task: Partial<TaskRecord> & Pick<TaskRecord, 'id' | 'titl
     due_date: task.due_date ?? null,
     position: typeof task.position === 'number' ? task.position : 0,
     created_by: task.created_by,
-    created_at: task.created_at,
-    updated_at: task.updated_at,
+    created_at: createdAt,
+    updated_at: updatedAt,
     session_id: task.session_id ?? null,
   }
 }
@@ -93,7 +96,9 @@ export function listTasks(filters: TaskFilters = {}): TaskRecord[] {
   if (filters.priority) {
     tasks = tasks.filter((task) => task.priority === filters.priority)
   }
-  return tasks.sort((a, b) => a.position - b.position || a.created_at.localeCompare(b.created_at))
+  // Defensive: legacy tasks stored on disk may lack created_at/position.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return tasks.sort((a, b) => (a.position ?? 0) - (b.position ?? 0) || (a.created_at ?? '').localeCompare(b.created_at ?? ''))
 }
 
 export function getTask(taskId: string): TaskRecord | null {

--- a/src/server/tasks-store.ts
+++ b/src/server/tasks-store.ts
@@ -133,14 +133,23 @@ export function updateTask(taskId: string, updates: UpdateTaskInput): TaskRecord
   if (index === -1) return null
 
   const current = normalizeTask(file.tasks[index] as TaskRecord)
+  // Drop undefined fields so a partial PATCH (e.g. auto-classify sending only
+  // assignee/priority/due_date) preserves the existing values instead of
+  // overwriting them with undefined -> normalized to [] / defaults.
+  const cleanUpdates: Partial<TaskRecord> = {}
+  for (const [key, value] of Object.entries(updates)) {
+    if (value !== undefined) {
+      ;(cleanUpdates as Record<string, unknown>)[key] = value
+    }
+  }
   const next = normalizeTask({
     ...current,
-    ...updates,
+    ...cleanUpdates,
     id: current.id,
     created_by: current.created_by,
     created_at: current.created_at,
     updated_at: new Date().toISOString(),
-    title: typeof updates.title === 'string' ? updates.title : current.title,
+    title: typeof cleanUpdates.title === 'string' ? cleanUpdates.title : current.title,
   })
 
   file.tasks[index] = next

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -4,7 +4,7 @@ workers:
   name: Orchestrator
   role: Swarm Orchestrator / Greenlight Gate
   specialty: mission routing, task decomposition, handoffs, proof contracts, human approval gates, NEXUM delivery sequencing
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Decompose NEXUM missions into safe, proof-bearing work and route each slice to the right specialist (builder/km-agent/ops-watch/reviewer/workspace) by function. Drive the Tasks board -> swarm flow, respect dependsOn, and hold the human greenlight gate before merges/publishes.
   profile: orchestrator
   modes:
@@ -56,12 +56,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: orchestrator:plan
+  wrapper: orchestrator
 - id: km-agent
   name: KM Agent
   role: RAZSOC / GBrain Knowledge Steward + NEXUM Documentation Owner
   specialty: RAZSOC, GBrain, Obsidian, TaskNotes, graph health, durable knowledge capture, drift audits, NEXUM plan/roadmap documentation
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Keep the operating brain coherent, searchable, and source-of-record aligned. For NEXUM, own the plan-de-negocios and roadmap documentation, classify Tasks-board items (owner/due_date/priority), and feed structured knowledge back to the swarm without polluting durable memory.
   profile: km-agent
   modes:
@@ -110,12 +110,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: km:health
+  wrapper: km-agent
 - id: builder
   name: Builder
   role: Scoped Implementation Agent / NEXUM Code & Integration
   specialty: focused implementation, tests, small diffs, integration fixes, NEXUM feature slices (F0-F6)
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Ship scoped NEXUM product/code slices with tests, minimal diffs, and clear verification evidence. Own implementation tasks routed from the Tasks board (assignee=builder).
   profile: builder
   modes:
@@ -160,12 +160,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: builder:task
+  wrapper: builder
 - id: reviewer
   name: Reviewer
   role: Independent Review / Merge Gate
   specialty: security review, logic review, regression detection, quality gates, NEXUM change verification
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Independently review NEXUM changes and block unsafe, untested, or logically broken work before it lands. Verify builder artifacts against proof contracts from the orchestrator.
   profile: reviewer
   modes:
@@ -208,12 +208,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: reviewer:gate
+  wrapper: reviewer
 - id: qa
   name: QA
   role: Browser / Workflow / CLI Smoke Verification
   specialty: browser QA, workflow smoke tests, expected-vs-actual checks, regression reproduction
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Verify user-visible behavior with concrete smoke evidence and concise bug reports.
   profile: qa
   modes:
@@ -253,12 +253,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: qa:smoke
+  wrapper: qa
 - id: researcher
   name: Researcher
   role: Brain-first Research / Bounded Autoresearch
   specialty: GBrain-first lookup, external research, synthesis, source trails, bounded research loops
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Produce decision-grade research with brain-first context, external verification, and explicit uncertainty.
   profile: researcher
   modes:
@@ -307,12 +307,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: researcher:quick
+  wrapper: researcher
 - id: ops-watch
   name: Ops Watch
   role: Local Infra / Runtime Health Watch + NEXUM Reliability
   specialty: gateway health, cron, MCP, workspace services, local process status, boring reliability, NEXUM runtime validation
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Keep Hermes, Workspace, GBrain, gateway, cron, and local services observable and healthy with quiet, low-risk checks. For NEXUM, validate builder scripts/artifacts and watch the swarm runtime health.
   profile: ops-watch
   modes:
@@ -355,12 +355,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: ops:health
+  wrapper: ops-watch
 - id: workspace
   name: Workspace
   role: Integration / Summary / Board Sync
   specialty: Tasks board sync, mission summaries, artifact aggregation, NEXUM deliverable assembly
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Aggregate swarm artifacts into coherent deliverables and sync results back to the Tasks board (move to done, attach outputs). For NEXUM, write extracted plan/roadmap tasks to the board and summarize mission outcomes.
   profile: workspace
   modes:
@@ -396,12 +396,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: workspace:summary
+  wrapper: workspace
 - id: maintainer
   name: Maintainer
   role: Upstream Dependency / Patch Hygiene
   specialty: upstream tracking, local patch hygiene, dependency updates, PR/issue follow-through
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Keep local forks and upstream dependencies healthy without losing local patches or dirty-worktree context.
   profile: maintainer
   modes:
@@ -446,12 +446,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: maintainer:check
+  wrapper: maintainer
 - id: strategist
   name: Strategist
   role: Wedges / Bets / Kill Criteria
   specialty: operating plans, gstack-style wedges, strategy reviews, decision framing, kill criteria
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Turn ambiguity into crisp wedges, bets, constraints, and kill criteria without over-planning.
   profile: strategist
   modes:
@@ -492,12 +492,12 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: strategist:review
+  wrapper: strategist
 - id: inbox-triage
   name: Inbox Triage
   role: Capture / Discard / Route / Task Triage
   specialty: low-friction inbox processing, capture routing, task/research/defer decisions, durable-context filtering
-  model: tencent/hy3:free
+  model: nous/tencent/hy3:free
   mission: Route incoming material into discard, task, research, or durable brain capture with minimal overhead and no junk accumulation.
   profile: inbox-triage
   modes:
@@ -540,4 +540,4 @@ workers:
   pluginToolsets: []
   mcpServers:
   - gbrain
-  wrapper: inbox:triage
+  wrapper: inbox-triage

--- a/swarm.yaml
+++ b/swarm.yaml
@@ -3,9 +3,9 @@ workers:
 - id: orchestrator
   name: Orchestrator
   role: Swarm Orchestrator / Greenlight Gate
-  specialty: mission routing, task decomposition, handoffs, proof contracts, human approval gates
-  model: GPT-5.5
-  mission: Decompose missions into safe, proof-bearing work and route to the right specialist while preserving human greenlight control.
+  specialty: mission routing, task decomposition, handoffs, proof contracts, human approval gates, NEXUM delivery sequencing
+  model: tencent/hy3:free
+  mission: Decompose NEXUM missions into safe, proof-bearing work and route each slice to the right specialist (builder/km-agent/ops-watch/reviewer/workspace) by function. Drive the Tasks board -> swarm flow, respect dependsOn, and hold the human greenlight gate before merges/publishes.
   profile: orchestrator
   modes:
   - plan
@@ -36,12 +36,14 @@ workers:
   - routing
   - proof-contracts
   - greenlight-gate
+  - nexum-sequencing
   preferredTaskTypes:
   - orchestration
   - planning
   - routing
   - coordination
   - handoff
+  - nexum-delivery
   greenlightRequiredFor:
   - merge
   - publish
@@ -57,10 +59,10 @@ workers:
   wrapper: orchestrator:plan
 - id: km-agent
   name: KM Agent
-  role: RAZSOC / GBrain Knowledge Steward
-  specialty: RAZSOC, GBrain, Obsidian, TaskNotes, graph health, durable knowledge capture, drift audits
-  model: GPT-5.5
-  mission: Keep the operating brain coherent, searchable, and source-of-record aligned without polluting durable knowledge.
+  role: RAZSOC / GBrain Knowledge Steward + NEXUM Documentation Owner
+  specialty: RAZSOC, GBrain, Obsidian, TaskNotes, graph health, durable knowledge capture, drift audits, NEXUM plan/roadmap documentation
+  model: tencent/hy3:free
+  mission: Keep the operating brain coherent, searchable, and source-of-record aligned. For NEXUM, own the plan-de-negocios and roadmap documentation, classify Tasks-board items (owner/due_date/priority), and feed structured knowledge back to the swarm without polluting durable memory.
   profile: km-agent
   modes:
   - health
@@ -89,12 +91,14 @@ workers:
   - tasknotes
   - drift-audit
   - knowledge-curation
+  - nexum-classification
   preferredTaskTypes:
   - knowledge
   - curation
   - brain-health
   - drift
   - documentation
+  - nexum-docs
   greenlightRequiredFor:
   - delete
   - purge
@@ -109,10 +113,10 @@ workers:
   wrapper: km:health
 - id: builder
   name: Builder
-  role: Scoped Implementation Agent
-  specialty: focused implementation, tests, small diffs, integration fixes
-  model: GPT-5.5
-  mission: Ship scoped product/code slices with tests, minimal diffs, and clear verification evidence.
+  role: Scoped Implementation Agent / NEXUM Code & Integration
+  specialty: focused implementation, tests, small diffs, integration fixes, NEXUM feature slices (F0-F6)
+  model: tencent/hy3:free
+  mission: Ship scoped NEXUM product/code slices with tests, minimal diffs, and clear verification evidence. Own implementation tasks routed from the Tasks board (assignee=builder).
   profile: builder
   modes:
   - task
@@ -160,9 +164,9 @@ workers:
 - id: reviewer
   name: Reviewer
   role: Independent Review / Merge Gate
-  specialty: security review, logic review, regression detection, quality gates
-  model: GPT-5.5
-  mission: Independently review changes and block unsafe, untested, or logically broken work before it lands.
+  specialty: security review, logic review, regression detection, quality gates, NEXUM change verification
+  model: tencent/hy3:free
+  mission: Independently review NEXUM changes and block unsafe, untested, or logically broken work before it lands. Verify builder artifacts against proof contracts from the orchestrator.
   profile: reviewer
   modes:
   - gate
@@ -209,7 +213,7 @@ workers:
   name: QA
   role: Browser / Workflow / CLI Smoke Verification
   specialty: browser QA, workflow smoke tests, expected-vs-actual checks, regression reproduction
-  model: GPT-5.5
+  model: tencent/hy3:free
   mission: Verify user-visible behavior with concrete smoke evidence and concise bug reports.
   profile: qa
   modes:
@@ -254,7 +258,7 @@ workers:
   name: Researcher
   role: Brain-first Research / Bounded Autoresearch
   specialty: GBrain-first lookup, external research, synthesis, source trails, bounded research loops
-  model: GPT-5.5
+  model: tencent/hy3:free
   mission: Produce decision-grade research with brain-first context, external verification, and explicit uncertainty.
   profile: researcher
   modes:
@@ -306,10 +310,10 @@ workers:
   wrapper: researcher:quick
 - id: ops-watch
   name: Ops Watch
-  role: Local Infra / Runtime Health Watch
-  specialty: gateway health, cron, MCP, workspace services, local process status, boring reliability
-  model: GPT-5.5
-  mission: Keep Hermes, Workspace, GBrain, gateway, cron, and local services observable and healthy with quiet, low-risk checks.
+  role: Local Infra / Runtime Health Watch + NEXUM Reliability
+  specialty: gateway health, cron, MCP, workspace services, local process status, boring reliability, NEXUM runtime validation
+  model: tencent/hy3:free
+  mission: Keep Hermes, Workspace, GBrain, gateway, cron, and local services observable and healthy with quiet, low-risk checks. For NEXUM, validate builder scripts/artifacts and watch the swarm runtime health.
   profile: ops-watch
   modes:
   - health
@@ -352,11 +356,52 @@ workers:
   mcpServers:
   - gbrain
   wrapper: ops:health
+- id: workspace
+  name: Workspace
+  role: Integration / Summary / Board Sync
+  specialty: Tasks board sync, mission summaries, artifact aggregation, NEXUM deliverable assembly
+  model: tencent/hy3:free
+  mission: Aggregate swarm artifacts into coherent deliverables and sync results back to the Tasks board (move to done, attach outputs). For NEXUM, write extracted plan/roadmap tasks to the board and summarize mission outcomes.
+  profile: workspace
+  modes:
+  - summary
+  tools:
+  - terminal
+  - file
+  - gbrain
+  - session_search
+  - skills
+  - todo
+  - kanban
+  skills:
+  - swarm-worker-core
+  - gstack-for-hermes
+  - workspace-dispatch
+  capabilities:
+  - board-sync
+  - summarization
+  - artifact-aggregation
+  - nexum-deliverables
+  preferredTaskTypes:
+  - integration
+  - summary
+  - board-sync
+  - deliverable
+  greenlightRequiredFor:
+  - destructive
+  - external-write
+  maxConcurrentTasks: 1
+  acceptsBroadcast: true
+  plugins: []
+  pluginToolsets: []
+  mcpServers:
+  - gbrain
+  wrapper: workspace:summary
 - id: maintainer
   name: Maintainer
   role: Upstream Dependency / Patch Hygiene
   specialty: upstream tracking, local patch hygiene, dependency updates, PR/issue follow-through
-  model: GPT-5.5
+  model: tencent/hy3:free
   mission: Keep local forks and upstream dependencies healthy without losing local patches or dirty-worktree context.
   profile: maintainer
   modes:
@@ -406,7 +451,7 @@ workers:
   name: Strategist
   role: Wedges / Bets / Kill Criteria
   specialty: operating plans, gstack-style wedges, strategy reviews, decision framing, kill criteria
-  model: GPT-5.5
+  model: tencent/hy3:free
   mission: Turn ambiguity into crisp wedges, bets, constraints, and kill criteria without over-planning.
   profile: strategist
   modes:
@@ -452,7 +497,7 @@ workers:
   name: Inbox Triage
   role: Capture / Discard / Route / Task Triage
   specialty: low-friction inbox processing, capture routing, task/research/defer decisions, durable-context filtering
-  model: GPT-5.5
+  model: tencent/hy3:free
   mission: Route incoming material into discard, task, research, or durable brain capture with minimal overhead and no junk accumulation.
   profile: inbox-triage
   modes:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ import tailwindcss from '@tailwindcss/vite'
 // nitro plugin removed (tanstackStart handles server runtime)
 import { defineConfig, loadEnv } from 'vite'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
+import { runSwarmDispatch } from './src/routes/api/tasks-swarm-run'
+import { runSwarmMissionLoop } from './src/server/swarm-mission-runner'
 
 // ---------------------------------------------------------------------------
 // Hermes Agent auto-start helpers
@@ -700,6 +702,41 @@ const config = defineConfig(({ mode, command }) => {
               workspaceDaemonChild = null
             }
           })
+
+          // Auto-dispatch Tasks board → swarm on a timer so the queue drains
+          // on its own (respecting per-worker concurrency). Runs only in serve
+          // mode; one tick every 30s. Failures are logged but never crash the
+          // dev server.
+          if (command === 'serve') {
+            const SWARM_DISPATCH_INTERVAL_MS = 30_000
+            setInterval(() => {
+              runSwarmDispatch({ dryRun: false })
+                .then((r) =>
+                  console.log(
+                    `[swarm-dispatch] tick: scanned=${r.scanned} dispatched=${r.dispatched} rebalanced=${r.rebalancedToTodo}`,
+                  ),
+                )
+                .catch((e) =>
+                  console.error('[swarm-dispatch] tick failed:', e instanceof Error ? e.message : e),
+                )
+            }, SWARM_DISPATCH_INTERVAL_MS)
+
+            // Headless mission runner: sends each eligible mission assignment's
+            // prompt to its worker's tmux pane and marks it dispatched, so the
+            // swarm executes without needing the conductor UI open.
+            const SWARM_MISSION_INTERVAL_MS = 30_000
+            setInterval(() => {
+              try {
+                const r = runSwarmMissionLoop()
+                if (r.dispatched > 0)
+                  console.log(
+                    `[swarm-mission-runner] tick: dispatched=${r.dispatched} skipped=${r.skipped}`,
+                  )
+              } catch (e) {
+                console.error('[swarm-mission-runner] tick failed:', e instanceof Error ? e.message : e)
+              }
+            }, SWARM_MISSION_INTERVAL_MS)
+          }
 
           // Auto-start hermes-agent when dev server launches.
           // Skip when launchd manages the gateway (HERMES_WORKSPACE_AUTO_START_AGENT=false)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -726,15 +726,16 @@ const config = defineConfig(({ mode, command }) => {
             // swarm executes without needing the conductor UI open.
             const SWARM_MISSION_INTERVAL_MS = 30_000
             setInterval(() => {
-              try {
-                const r = runSwarmMissionLoop()
-                if (r.dispatched > 0)
-                  console.log(
-                    `[swarm-mission-runner] tick: dispatched=${r.dispatched} skipped=${r.skipped}`,
-                  )
-              } catch (e) {
-                console.error('[swarm-mission-runner] tick failed:', e instanceof Error ? e.message : e)
-              }
+              runSwarmMissionLoop()
+                .then((r) => {
+                  if (r.dispatched > 0)
+                    console.log(
+                      `[swarm-mission-runner] tick: dispatched=${r.dispatched} skipped=${r.skipped}`,
+                    )
+                })
+                .catch((e) =>
+                  console.error('[swarm-mission-runner] tick failed:', e instanceof Error ? e.message : e),
+                )
             }, SWARM_MISSION_INTERVAL_MS)
           }
 


### PR DESCRIPTION
## Summary

- **tasks↔swarm sync** — novo endpoint `POST /api/tasks-swarm-sync` (122 linhas) que sincroniza tasks com o swarm em tempo real.
- **swarm runtime PID fix** — `readLivePid` em `swarm-runtime.ts` para leitura correcta do PID do runtime em execução.
- **terminal/stream hardening** — `swarm-terminal.tsx` agora usa AbortController para cancelamento limpo e `setState('connected')` explícito; `use-conductor-gateway.ts` com correção TDZ em `query?.state?.data`.
- **kanban-backend integração** — `claude-tasks-backend.ts` (172 linhas) integra kanban-backend com fluxo de tasks.
- **routes** — `routeTree.gen.ts` já contém as rotas tasks-swarm (não modificado).

## Validação

- `npx tsc --noEmit` — ✅ zero erros

## Ficheiros

| Ficheiro | Change |
|---|---|
| `src/routes/api/tasks-swarm-sync.ts` | novo endpoint sync tasks↔swarm |
| `src/components/swarm/swarm-terminal.tsx` | AbortController + setState('connected') |
| `src/screens/gateway/hooks/use-conductor-gateway.ts` | TDZ fix |
| `src/server/claude-tasks-backend.ts` | kanban-backend wrapper |
| `src/server/swarm-runtime.ts` | readLivePid |
| `src/server/kanban-backend.ts` | atualizações swarm-kanban |
| `src/screens/tasks/tasks-screen.tsx` | integração swarm |
| `src/routes/api/claude-tasks.$taskId.ts` | atualizações |
| `swarm.yaml` | configuração swarm |