### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ The Docker setup runs both automatically — no action needed if using `docker c
 
 ## ⭐ Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=outsourc-e/hermes-workspace&type=date&logscale&legend=top-left)](https://www.star-history.com/#outsourc-e/hermes-workspace&type=date&logscale&legend=top-left)
+## [![Star History Chart](https://star-history.dera.page/svg?repos=outsourc-e/hermes-workspace&type=date&logscale&legend=top-left)](https://star-history.dera.page/#outsourc-e/hermes-workspace&type=date&logscale&legend=top-left)
 
 ## 💛 Support the Project
 


### PR DESCRIPTION
The star history chart in the README was broken and showed nothing, because the underlying service could not reliably reach the GitHub stargazer API anymore.

The chart now points to a token-free mirror of the service that works out of the box, so the stargazer graph renders correctly again for everyone who visits the repository.