### PR TITLE
fix: declare root pnpm workspace package

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   electron: true
   electron-winstaller: true


### PR DESCRIPTION
## Summary
- add the required non-empty `packages` field to `pnpm-workspace.yaml`
- keep the repository as a root-only pnpm workspace
- restore the one-line installer's `pnpm install` step on pnpm 9

## Root cause
`pnpm-workspace.yaml` only defined `allowBuilds`. pnpm treats the file as a workspace manifest and rejects it when `packages` is missing or empty, so fresh installs stopped at `ERROR packages field missing or empty`.

## Verification
- `pnpm install --reporter=append-only` succeeds
- `bash ./install.sh` completes end-to-end
- `pnpm build` succeeds
- `pnpm test` currently reports 38 failures across 13 files that are unrelated to this YAML-only change (704 tests pass)

Linear: COD-859