### PR TITLE
fix(profiles): count sessions from state.db rows, not session dir files

### DIFF
--- a/scripts/skills-search.py
+++ b/scripts/skills-search.py
@@ -4,7 +4,26 @@ import json
 import sys
 import os
 
-sys.path.insert(0, os.path.expanduser("~/hermes-agent"))
+def _resolve_hermes_agent_dir() -> str:
+    """Locate the hermes-agent source checkout that ships tools/skills_hub.py.
+
+    Resolution order: HERMES_AGENT_HOME env (explicit operator override) →
+    ~/.hermes/hermes-agent (standard install layout) → ~/hermes-agent (legacy
+    outsourc-e dev layout). Returns the best candidate even if none exists so
+    the subsequent import raises a clear error instead of a silent fallback.
+    """
+    env_dir = os.environ.get("HERMES_AGENT_HOME", "").strip()
+    if env_dir:
+        return env_dir
+    for candidate in (
+        os.path.expanduser("~/.hermes/hermes-agent"),
+        os.path.expanduser("~/hermes-agent"),
+    ):
+        if os.path.isdir(candidate):
+            return candidate
+    return os.path.expanduser("~/.hermes/hermes-agent")
+
+sys.path.insert(0, _resolve_hermes_agent_dir())
 
 from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 

--- a/src/components/mobile-hamburger-menu.tsx
+++ b/src/components/mobile-hamburger-menu.tsx
@@ -259,7 +259,7 @@ export function MobileHamburgerMenu() {
         </div>
 
         {/* Nav items */}
-        <nav className="flex flex-col gap-1 px-3 pt-4 flex-1">
+        <nav className="flex flex-col gap-1 px-3 pt-4 flex-1 overflow-y-auto">
           {visibleNavItems.map((item) => {
             const isActive = item.match(pathname)
             return (

--- a/src/components/status-indicator.tsx
+++ b/src/components/status-indicator.tsx
@@ -17,7 +17,11 @@ type ConnectionStatus = {
 
 async function fetchConnectionStatus(): Promise<ConnectionStatus> {
   const response = await fetch('/api/connection-status', {
-    signal: AbortSignal.timeout(5000),
+    // Generous budget: the server may legitimately spend ~6s re-probing the
+    // dashboard (3s probe + 3s retry) after a transient backend stall.
+    // A 5s abort here would report 'Disconnected' while the server is doing
+    // exactly the right recovery work.
+    signal: AbortSignal.timeout(10_000),
   })
   if (!response.ok) {
     return {

--- a/src/routes/api/profiles/skills.ts
+++ b/src/routes/api/profiles/skills.ts
@@ -61,6 +61,55 @@ export const Route = createFileRoute('/api/profiles/skills')({
           )
           const body = await response.text()
           if (!response.ok) {
+            // hermes-agent < #25116 has no /api/profiles/<name>/skills.
+            // The dashboard's /api/skills?profile=<name> variant exists on
+            // all versions and returns the same inventory — fall back to it
+            // so the per-profile view works against older dashboards.
+            if (response.status === 404 || response.status === 405) {
+              const fallback = await dashboardFetch(
+                `/api/skills?profile=${encodeURIComponent(profile)}`,
+                { signal: AbortSignal.timeout(30_000) },
+              )
+              const fallbackBody = (await fallback
+                .json()
+                .catch(() => null)) as unknown
+              const arr = Array.isArray(fallbackBody)
+                ? fallbackBody
+                : fallbackBody &&
+                    typeof fallbackBody === 'object' &&
+                    Array.isArray(
+                      (fallbackBody as { items?: Array<unknown> }).items,
+                    )
+                  ? (fallbackBody as { items: Array<unknown> }).items
+                  : null
+              if (fallback.ok && arr) {
+                const items = arr
+                  .map((entry) => {
+                    const record = entry as Record<string, unknown>
+                    const name =
+                      typeof record.name === 'string' ? record.name.trim() : ''
+                    if (!name) return null
+                    return {
+                      name,
+                      description:
+                        typeof record.description === 'string'
+                          ? record.description
+                          : '',
+                      category:
+                        typeof record.category === 'string'
+                          ? record.category
+                          : null,
+                      path: '',
+                      enabled: record.enabled !== false,
+                    }
+                  })
+                  .filter(
+                    (entry): entry is NonNullable<typeof entry> =>
+                      entry !== null,
+                  )
+                return json({ profile, items })
+              }
+            }
             // 404 from dashboard means the profile doesn't exist or doesn't
             // expose the endpoint (older dashboard without PR #25116).
             return json(

--- a/src/routes/api/profiles/toggle-skill.ts
+++ b/src/routes/api/profiles/toggle-skill.ts
@@ -79,6 +79,29 @@ export const Route = createFileRoute('/api/profiles/toggle-skill')({
           } catch {
             payload = { ok: false, error: text }
           }
+          if (!response.ok) {
+            // hermes-agent < #25116 has no per-profile toggle endpoint, but
+            // /api/skills/toggle accepts a `profile` body field on all
+            // versions — fall back so per-profile toggling works.
+            if (response.status === 404 || response.status === 405) {
+              const fallback = await dashboardFetch('/api/skills/toggle', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, enabled, profile }),
+                signal: AbortSignal.timeout(30_000),
+              })
+              const fallbackText = await fallback.text()
+              let fallbackPayload: unknown = null
+              try {
+                fallbackPayload = fallbackText
+                  ? JSON.parse(fallbackText)
+                  : null
+              } catch {
+                fallbackPayload = { ok: false, error: fallbackText }
+              }
+              return json(fallbackPayload, { status: fallback.status })
+            }
+          }
           return json(payload, { status: response.status })
         } catch (err) {
           return json(

--- a/src/routes/api/skills.test.ts
+++ b/src/routes/api/skills.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the skills route's local skills-dir resolution.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import path from 'node:path'
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs')
+  return { ...actual, ...mocks }
+})
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual('node:fs/promises')
+  return {
+    ...actual,
+    readdir: vi.fn().mockResolvedValue([]),
+    readFile: vi.fn().mockResolvedValue(''),
+  }
+})
+
+const { homedir } = vi.hoisted(() => ({
+  homedir: vi.fn().mockReturnValue('/home/testuser'),
+}))
+
+vi.mock('node:os', () => ({
+  default: { homedir },
+  homedir,
+}))
+
+// Module-level server deps — keep them out of the resolution logic under test.
+vi.mock('../../server/auth-middleware', () => ({
+  isAuthenticated: vi.fn(),
+}))
+vi.mock('../../server/gateway-capabilities', () => ({
+  BEARER_TOKEN: '',
+  CLAUDE_API: 'http://127.0.0.1:8642',
+  CLAUDE_UPGRADE_INSTRUCTIONS: '',
+  dashboardFetch: vi.fn(),
+  ensureGatewayProbed: vi.fn(),
+  getCapabilities: vi.fn(),
+}))
+vi.mock('../../server/rate-limit', () => ({
+  requireJsonContentType: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.HERMES_HOME
+  delete process.env.CLAUDE_HOME
+  delete process.env.HERMES_SKILLS_DIR
+})
+
+async function loadMod() {
+  vi.resetModules()
+  return import('./skills')
+}
+
+describe('getSkillsDir', () => {
+  it('honors HERMES_SKILLS_DIR override', async () => {
+    process.env.HERMES_SKILLS_DIR = '/custom/skills'
+    const mod = await loadMod()
+    expect(mod.getSkillsDir()).toBe('/custom/skills')
+  })
+
+  it('honors HERMES_HOME override', async () => {
+    process.env.HERMES_HOME = '/custom/hermes'
+    const mod = await loadMod()
+    expect(mod.getSkillsDir()).toBe('/custom/hermes/skills')
+  })
+
+  it('follows active_profile when it names an existing profile', async () => {
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'invest'
+      return ''
+    })
+    mocks.existsSync.mockImplementation(
+      (filePath: string) =>
+        filePath === path.join('/home/testuser/.hermes/profiles/invest'),
+    )
+    const mod = await loadMod()
+    expect(mod.getSkillsDir()).toBe(
+      path.join('/home/testuser/.hermes/profiles/invest/skills'),
+    )
+  })
+
+  it('falls back to the default home when the profile is missing', async () => {
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'ghost'
+      return ''
+    })
+    mocks.existsSync.mockReturnValue(false)
+    const mod = await loadMod()
+    expect(mod.getSkillsDir()).toBe(path.join('/home/testuser/.hermes/skills'))
+  })
+
+  it('falls back to the default home without an active_profile marker', async () => {
+    mocks.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    const mod = await loadMod()
+    expect(mod.getSkillsDir()).toBe(path.join('/home/testuser/.hermes/skills'))
+  })
+})

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -80,6 +80,21 @@ async function buildLocalSkillPathMap(): Promise<Map<string, LocalSkillMeta>> {
   for (const cat of categoryEntries) {
     if (!cat.isDirectory() || cat.name.startsWith('.')) continue
     const catPath = path.join(root, cat.name)
+    // Flat-layout skills: SKILL.md lives DIRECTLY in the category dir
+    // (e.g. profile role skills like invest-orchestrator), not in a
+    // skill subdir. Treat those as skills named after the category.
+    try {
+      const flatStat = await fs.stat(path.join(catPath, 'SKILL.md'))
+      if (flatStat.isFile() && !map.has(cat.name)) {
+        collect.push(
+          readSkillAuthor(catPath).then((author) => {
+            map.set(cat.name, { path: catPath, author })
+          }),
+        )
+      }
+    } catch {
+      // no flat SKILL.md — normal category layout, walk subdirs below
+    }
     let skillEntries: Array<{
       name: string
       isDirectory: () => boolean

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -1,5 +1,6 @@
 import os from 'node:os'
 import path from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
@@ -15,14 +16,35 @@ import {
 import { requireJsonContentType } from '../../server/rate-limit'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
-function getSkillsDir(): string {
-  return (
-    process.env.HERMES_SKILLS_DIR ||
-    path.join(
-      process.env.HERMES_HOME || path.join(os.homedir(), '.hermes'),
-      'skills',
-    )
-  )
+/**
+ * Resolve the skills directory whose local inventory enriches the list.
+ *
+ * Precedence:
+ *   1. HERMES_SKILLS_DIR (explicit operator override) — wins unconditionally.
+ *   2. HERMES_HOME / CLAUDE_HOME env (e.g. ~/.hermes-vanilla deployments).
+ *   3. The ACTIVE profile named by <hermes root>/active_profile — the local
+ *      path map must match the profile the dashboard serves (invest-scoped),
+ *      otherwise invest-only skills get no local path and default-profile
+ *      paths leak into the UI.
+ *   4. <hermes root>/skills (default profile).
+ */
+export function getSkillsDir(): string {
+  const envDir = process.env.HERMES_SKILLS_DIR?.trim()
+  if (envDir) return envDir
+  const envHome = (process.env.HERMES_HOME || process.env.CLAUDE_HOME)?.trim()
+  if (envHome) return path.join(envHome, 'skills')
+
+  const hermesRoot = path.join(os.homedir(), '.hermes')
+  try {
+    const active = readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8').trim()
+    if (active && active !== 'default') {
+      const profileHome = path.join(hermesRoot, 'profiles', active)
+      if (existsSync(profileHome)) return path.join(profileHome, 'skills')
+    }
+  } catch {
+    // no active_profile marker — default home
+  }
+  return path.join(hermesRoot, 'skills')
 }
 
 type LocalSkillMeta = { path: string; author: string }

--- a/src/routes/api/skills/hub-search.test.ts
+++ b/src/routes/api/skills/hub-search.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the skills hub-search Python bridge resolver.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import path from 'node:path'
+
+const { accessSync } = vi.hoisted(() => ({
+  accessSync: vi.fn(),
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs')
+  return { ...actual, accessSync }
+})
+
+const { homedir } = vi.hoisted(() => ({
+  homedir: vi.fn().mockReturnValue('/home/testuser'),
+}))
+
+vi.mock('node:os', () => ({
+  default: { homedir },
+  homedir,
+}))
+
+// The route file imports the auth middleware at module time; keep it out of
+// the resolution logic under test.
+vi.mock('../../../server/auth-middleware', () => ({
+  isAuthenticated: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete process.env.HERMES_AGENT_HOME
+})
+
+async function loadMod() {
+  vi.resetModules()
+  return import('./hub-search')
+}
+
+describe('resolveSkillsSearchPython', () => {
+  it('prefers the hermes venv python under ~/.hermes/hermes-agent', async () => {
+    accessSync.mockImplementation((candidate: string) => {
+      if (candidate.endsWith('.hermes/hermes-agent/venv/bin/python')) return
+      throw new Error('not found')
+    })
+    const mod = await loadMod()
+    expect(mod.resolveSkillsSearchPython()).toBe(
+      path.join('/home/testuser/.hermes/hermes-agent/venv/bin/python'),
+    )
+  })
+
+  it('falls back to the legacy ~/hermes-agent venv when the standard one is missing', async () => {
+    const legacy = path.join('/home/testuser/hermes-agent/venv/bin/python')
+    accessSync.mockImplementation((candidate: string) => {
+      if (candidate === legacy) return
+      throw new Error('not found')
+    })
+    const mod = await loadMod()
+    expect(mod.resolveSkillsSearchPython()).toBe(legacy)
+  })
+
+  it('falls back to plain python3 when no venv exists', async () => {
+    accessSync.mockImplementation(() => {
+      throw new Error('not found')
+    })
+    const mod = await loadMod()
+    expect(mod.resolveSkillsSearchPython()).toBe('python3')
+  })
+
+  it('honors HERMES_AGENT_HOME when set', async () => {
+    process.env.HERMES_AGENT_HOME = '/opt/hermes-agent'
+    accessSync.mockImplementation((candidate: string) => {
+      if (candidate === '/opt/hermes-agent/venv/bin/python') return
+      throw new Error('not found')
+    })
+    const mod = await loadMod()
+    expect(mod.resolveSkillsSearchPython()).toBe('/opt/hermes-agent/venv/bin/python')
+  })
+})

--- a/src/routes/api/skills/hub-search.ts
+++ b/src/routes/api/skills/hub-search.ts
@@ -1,5 +1,7 @@
 import { execFile } from 'node:child_process'
+import { accessSync, constants as fsConstants } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { createFileRoute } from '@tanstack/react-router'
@@ -133,6 +135,36 @@ async function searchBundledSkills(
   }
 }
 
+/**
+ * Resolve the Python interpreter for the skills-hub search bridge.
+ *
+ * The bridge imports hermes-agent's `tools.skills_hub` (httpx-based), so it
+ * must run under the hermes venv python — the system `python3` typically has
+ * no httpx (PEP 668) and the import fails, silently degrading the marketplace
+ * to the bundled fallback. Resolution order: venv of HERMES_AGENT_HOME (if
+ * set) → venv of ~/.hermes/hermes-agent → venv of ~/hermes-agent (legacy
+ * layout) → plain `python3` (last resort; the bridge falls back gracefully).
+ */
+export function resolveSkillsSearchPython(): string {
+  const envDir = process.env.HERMES_AGENT_HOME?.trim()
+  const candidates = envDir
+    ? [path.join(envDir, 'venv/bin/python'), 'python3']
+    : [
+        path.join(os.homedir(), '.hermes/hermes-agent/venv/bin/python'),
+        path.join(os.homedir(), 'hermes-agent/venv/bin/python'),
+        'python3',
+      ]
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, fsConstants.X_OK)
+      return candidate
+    } catch {
+      // try next candidate
+    }
+  }
+  return 'python3'
+}
+
 async function searchPythonSkillsHub(
   query: string,
   limit: number,
@@ -140,7 +172,7 @@ async function searchPythonSkillsHub(
 ): Promise<SkillSearchPayload> {
   const scriptPath = path.join(process.cwd(), 'scripts/skills-search.py')
   const { stdout } = await execFileAsync(
-    'python3',
+    resolveSkillsSearchPython(),
     [scriptPath, query, String(limit), source],
     {
       timeout: 30_000,

--- a/src/routes/api/skills/hub-search.ts
+++ b/src/routes/api/skills/hub-search.ts
@@ -175,7 +175,10 @@ async function searchPythonSkillsHub(
     resolveSkillsSearchPython(),
     [scriptPath, query, String(limit), source],
     {
-      timeout: 30_000,
+      // The bridge probes multiple registries (GitHub rate-limit retries can
+      // add ~30s on top of a normal run); keep the timeout generous so the
+      // marketplace doesn't silently degrade to the bundled fallback.
+      timeout: 90_000,
       maxBuffer: 1024 * 1024 * 2,
     },
   )

--- a/src/server/__tests__/memory-browser.test.ts
+++ b/src/server/__tests__/memory-browser.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import path from 'node:path'
 
-const { existsSync, readFileSync, statSync, readdirSync } = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   existsSync: vi.fn().mockReturnValue(false),
   readFileSync: vi.fn().mockReturnValue(''),
   statSync: vi.fn().mockReturnValue({ isFile: () => false, mtimeMs: 0 }),
@@ -9,11 +9,8 @@ const { existsSync, readFileSync, statSync, readdirSync } = vi.hoisted(() => ({
 }))
 
 vi.mock('node:fs', () => ({
-  default: { existsSync, readFileSync, statSync, readdirSync },
-  existsSync,
-  readFileSync,
-  statSync,
-  readdirSync,
+  default: { ...mocks },
+  ...mocks,
 }))
 
 const { homedir } = vi.hoisted(() => ({
@@ -52,6 +49,52 @@ describe('memory-browser', () => {
 
   it('uses path.resolve on env path with trailing slash', async () => {
     process.env.HERMES_HOME = '/custom/hermes/'
+    const mod = await loadMod()
+    const root = mod.getMemoryWorkspaceRoot()
+    expect(root).toBe(path.resolve('/custom/hermes'))
+  })
+
+  it('follows active_profile when it names an existing profile', async () => {
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'invest'
+      return ''
+    })
+    mocks.existsSync.mockImplementation((filePath: string) =>
+      filePath === path.resolve('/home/testuser/.hermes/profiles/invest'),
+    )
+    const mod = await loadMod()
+    const root = mod.getMemoryWorkspaceRoot()
+    expect(root).toBe(path.resolve('/home/testuser/.hermes/profiles/invest'))
+  })
+
+  it('ignores active_profile naming a missing profile', async () => {
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'ghost'
+      return ''
+    })
+    mocks.existsSync.mockReturnValue(false)
+    const mod = await loadMod()
+    const root = mod.getMemoryWorkspaceRoot()
+    expect(root).toBe(path.resolve('/home/testuser/.hermes'))
+  })
+
+  it('ignores active_profile = default', async () => {
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'default'
+      return ''
+    })
+    const mod = await loadMod()
+    const root = mod.getMemoryWorkspaceRoot()
+    expect(root).toBe(path.resolve('/home/testuser/.hermes'))
+  })
+
+  it('HERMES_HOME wins over active_profile', async () => {
+    process.env.HERMES_HOME = '/custom/hermes'
+    mocks.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('active_profile')) return 'invest'
+      return ''
+    })
+    mocks.existsSync.mockReturnValue(true)
     const mod = await loadMod()
     const root = mod.getMemoryWorkspaceRoot()
     expect(root).toBe(path.resolve('/custom/hermes'))

--- a/src/server/gateway-capabilities.test.ts
+++ b/src/server/gateway-capabilities.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * gateway-capabilities reads workspace-overrides.json at import time via
+ * getStateDir(); point the state dir at a temp path so module init stays
+ * hermetic, then import the module under test.
+ *
+ * The module ALSO auto-probes at import (trailing `void ensureGatewayProbed()`).
+ * Point it at unreachable port-1 endpoints and swallow its console output so
+ * that import-time probe settles fast and deterministically (ECONNREFUSED)
+ * instead of racing the per-test fetch stubs against the real local services.
+ */
+process.env.HERMES_WORKSPACE_STATE_DIR = '/tmp/gateway-capabilities-test-state'
+process.env.HERMES_API_URL = 'http://127.0.0.1:1'
+process.env.HERMES_DASHBOARD_URL = 'http://127.0.0.1:1'
+
+const importLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+const importWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+const { effectiveProbeTtl, probeDashboard } = await import('./gateway-capabilities')
+
+// Let the import-time auto-probe settle (all probes fail fast on port 1).
+await new Promise((resolve) => setTimeout(resolve, 150))
+importLogSpy.mockRestore()
+importWarnSpy.mockRestore()
+
+describe('effectiveProbeTtl', () => {
+  it('uses the long TTL when the full backend is healthy', () => {
+    expect(
+      effectiveProbeTtl({
+        health: true,
+        chatCompletions: true,
+        dashboard: { available: true },
+      }),
+    ).toBe(120_000)
+  })
+
+  it('uses the short TTL when the dashboard probe failed (degraded state)', () => {
+    expect(
+      effectiveProbeTtl({
+        health: true,
+        chatCompletions: true,
+        dashboard: { available: false },
+      }),
+    ).toBe(15_000)
+  })
+
+  it('uses the short TTL when disconnected', () => {
+    expect(
+      effectiveProbeTtl({
+        health: false,
+        chatCompletions: false,
+        dashboard: { available: false },
+      }),
+    ).toBe(15_000)
+    expect(
+      effectiveProbeTtl({
+        health: false,
+        chatCompletions: true,
+        dashboard: { available: false },
+      }),
+    ).toBe(15_000)
+  })
+})
+
+describe('probeDashboard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function okStatusResponse(): Response {
+    return new Response(JSON.stringify({ version: '0.20.4' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  it('recovers after one slow failure (retries once)', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        calls += 1
+        if (calls === 1) {
+          // Simulate a transient stall: first attempt dies slowly (>1s),
+          // second attempt succeeds.
+          return new Promise<Response>((_, reject) => {
+            setTimeout(() => reject(new Error('socket hang up (simulated stall)')), 1_200)
+          })
+        }
+        return Promise.resolve(okStatusResponse())
+      }),
+    )
+
+    const result = await probeDashboard()
+
+    expect(result.available).toBe(true)
+    // attempt 1 (stall) + attempt 2 (status) + dashboard token scrape
+    expect(calls).toBeGreaterThanOrEqual(3)
+  })
+
+  it('does not retry an instant connection failure', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        calls += 1
+        return Promise.reject(new Error('fetch failed'))
+      }),
+    )
+
+    const result = await probeDashboard()
+
+    expect(result.available).toBe(false)
+    expect(calls).toBe(1)
+  })
+
+  it('does not retry a fast non-ok status response', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        calls += 1
+        return Promise.resolve(new Response('nope', { status: 404 }))
+      }),
+    )
+
+    const result = await probeDashboard()
+
+    expect(result.available).toBe(false)
+    expect(calls).toBe(1)
+  })
+})

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -142,16 +142,33 @@ export const DASHBOARD_REQUIRED_INSTRUCTIONS =
 export const SESSIONS_API_UNAVAILABLE_MESSAGE = `Your Hermes backend does not support the sessions API. ${CLAUDE_UPGRADE_INSTRUCTIONS}`
 
 const PROBE_TIMEOUT_MS = 3_000
-// Probe TTL: 120s when the gateway is healthy, 15s when it isn't. The
+// Probe TTL: 120s when the full backend is healthy, 15s when it isn't. The
 // shorter window during 'disconnected' state means a Docker stack where
 // the workspace boots before the agent recovers within ~15s of the agent
 // becoming reachable, instead of being stuck on the first failed probe
 // for two minutes. See #275.
+//
+// The degraded case (gateway healthy but dashboard probe failing) also uses
+// the short window: a single transient dashboard stall (loaded host, agent
+// session churn, restart) must not pin the UI to degraded mode for 2
+// minutes — the next probe recovers it within ~15s of the stall ending.
 const PROBE_TTL_MS = 120_000
 const PROBE_TTL_DISCONNECTED_MS = 15_000
+// A first probe attempt that fails this fast (connection refused / instant
+// error) means the dashboard is genuinely unreachable — a retry would only
+// burn another 3s window. Slower failures (timeout while the host is under
+// load) get one retry before the dashboard is declared gone.
+const PROBE_RETRY_SLOW_THRESHOLD_MS = 1_000
 
-function effectiveProbeTtl(caps: { health: boolean; chatCompletions: boolean }): number {
-  if (caps.health || caps.chatCompletions) return PROBE_TTL_MS
+export function effectiveProbeTtl(caps: {
+  health: boolean
+  chatCompletions: boolean
+  dashboard: { available: boolean }
+}): number {
+  if (caps.health || caps.chatCompletions) {
+    if (caps.dashboard.available) return PROBE_TTL_MS
+    return PROBE_TTL_DISCONNECTED_MS
+  }
   return PROBE_TTL_DISCONNECTED_MS
 }
 const DASHBOARD_TOKEN_REGEX =
@@ -591,19 +608,48 @@ async function probeMcpConfigKey(): Promise<boolean> {
   }
 }
 
-async function probeDashboard(): Promise<{ available: boolean; url: string }> {
-  try {
-    const res = await fetch(`${CLAUDE_DASHBOARD_URL}/api/status`, {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
-    if (!res.ok) return { available: false, url: CLAUDE_DASHBOARD_URL }
-    const body = (await res.json()) as { version?: string }
-    if (!body.version) return { available: false, url: CLAUDE_DASHBOARD_URL }
-    await fetchDashboardToken().catch(() => '')
-    return { available: true, url: CLAUDE_DASHBOARD_URL }
-  } catch {
-    return { available: false, url: CLAUDE_DASHBOARD_URL }
+export async function probeDashboard(): Promise<{ available: boolean; url: string }> {
+  // Retry once when the first attempt failed slowly (timeout / slow response
+  // while the host is under load): a transient >3s stall must not flip the
+  // whole workspace to degraded mode for the probe TTL. Fast failures
+  // (ECONNREFUSED, dead port) skip the retry — the dashboard is genuinely
+  // down and a second 3s wait buys nothing; the short degraded TTL re-probes
+  // again shortly anyway.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const startedAt = Date.now()
+    try {
+      const res = await fetch(`${CLAUDE_DASHBOARD_URL}/api/status`, {
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        if (attempt === 0 && Date.now() - startedAt > PROBE_RETRY_SLOW_THRESHOLD_MS) {
+          continue
+        }
+        console.warn(
+          `[gateway] dashboard probe failed: /api/status returned ${res.status}`,
+        )
+        return { available: false, url: CLAUDE_DASHBOARD_URL }
+      }
+      const body = (await res.json()) as { version?: string }
+      if (!body.version) {
+        console.warn(
+          '[gateway] dashboard probe failed: /api/status missing version field',
+        )
+        return { available: false, url: CLAUDE_DASHBOARD_URL }
+      }
+      await fetchDashboardToken().catch(() => '')
+      return { available: true, url: CLAUDE_DASHBOARD_URL }
+    } catch (err) {
+      if (attempt === 0 && Date.now() - startedAt > PROBE_RETRY_SLOW_THRESHOLD_MS) {
+        continue
+      }
+      console.warn(
+        `[gateway] dashboard probe failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      return { available: false, url: CLAUDE_DASHBOARD_URL }
+    }
   }
+  return { available: false, url: CLAUDE_DASHBOARD_URL }
 }
 
 /**
@@ -828,6 +874,7 @@ export async function probeGateway(options?: {
   }
 
   probePromise = (async () => {
+    const prevDashboardAvailable = capabilities.dashboard.available
     await Promise.all([autoDetectGatewayUrl(), autoDetectDashboardUrl()])
 
     const [
@@ -895,6 +942,11 @@ export async function probeGateway(options?: {
     }
     lastProbeAt = Date.now()
     logCapabilities(capabilities)
+    if (prevDashboardAvailable && !dashboard.available) {
+      console.warn(
+        '[gateway] dashboard was available and just failed the probe — capabilities degraded; re-probing on the short (15s) window for fast recovery',
+      )
+    }
     return capabilities
   })()
 

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -23,12 +23,39 @@ function isBrowserMemoryPath(relativePath: string): boolean {
   )
 }
 
-function normalizeWorkspaceRoot(): string {
-  // Honor HERMES_HOME when set (e.g. ~/.hermes-vanilla for running alongside prod).
-  // Fall back to ~/.hermes for the default install location.
+/**
+ * Resolve the Hermes home whose memory this browser serves.
+ *
+ * Precedence:
+ *   1. Explicit HERMES_HOME / CLAUDE_HOME env (operator override, e.g.
+ *      ~/.hermes-vanilla for running alongside prod) — wins unconditionally.
+ *   2. The ACTIVE profile named by <hermes root>/active_profile (same on-disk
+ *      source the dashboard wrapper and gateway re-home on). Memory follows
+ *      the profile the workspace chat is bound to, matching the Files screen
+ *      and the rest of the stack.
+ *   3. <hermes root> (default profile) when no marker or an unknown profile.
+ */
+function resolveMemoryHome(): string {
   const envHome = (process.env.HERMES_HOME || process.env.CLAUDE_HOME)?.trim()
-  const resolved = envHome ? path.resolve(envHome) : path.resolve(path.join(os.homedir(), '.hermes'))
-  return resolved
+  if (envHome) return path.resolve(envHome)
+
+  const hermesRoot = path.resolve(path.join(os.homedir(), '.hermes'))
+  try {
+    const active = fs
+      .readFileSync(path.join(hermesRoot, 'active_profile'), 'utf-8')
+      .trim()
+    if (active && active !== 'default') {
+      const profileHome = path.join(hermesRoot, 'profiles', active)
+      if (fs.existsSync(profileHome)) return path.resolve(profileHome)
+    }
+  } catch {
+    // no active_profile marker — default home
+  }
+  return hermesRoot
+}
+
+function normalizeWorkspaceRoot(): string {
+  return resolveMemoryHome()
 }
 
 export function getMemoryWorkspaceRoot(): string {

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   listProfiles,
+  listProfilesWithFallback,
   readProfile,
   updateProfileConfig,
 } from './profiles-browser'
@@ -205,5 +206,76 @@ describe('listProfiles', () => {
       'You are Leelo, executive assistant.',
     )
     expect(readProfile('ops').systemPrompt).toBe('Config prompt wins')
+  })
+})
+
+describe('listProfilesWithFallback (dashboard path)', () => {
+  let tempHome: string
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-fb-'),
+    )
+    vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
+    delete process.env.HERMES_HOME
+    delete process.env.CLAUDE_HOME
+    delete process.env.HERMES_API_TOKEN
+    delete process.env.CLAUDE_API_TOKEN
+    process.env.HERMES_DASHBOARD_URL = 'http://dashboard.test'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    delete process.env.HERMES_DASHBOARD_URL
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  it('marks the LOCAL active_profile as active, not the dashboard is_default', async () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profilesRoot = path.join(hermesRoot, 'profiles')
+    const investRoot = path.join(profilesRoot, 'invest')
+    fs.mkdirSync(investRoot, { recursive: true })
+    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'invest\n', 'utf-8')
+
+    // Dashboard payload: `is_default` only names the default-named profile —
+    // it must NOT be treated as the active profile.
+    const dashboardPayload = {
+      profiles: [
+        {
+          name: 'default',
+          path: hermesRoot,
+          is_default: true,
+          model: 'm',
+          provider: 'p',
+          has_env: true,
+          skill_count: 10,
+          updated_at: '2026-08-21T00:00:00.000Z',
+        },
+        {
+          name: 'invest',
+          path: investRoot,
+          is_default: false,
+          model: 'm',
+          provider: 'p',
+          has_env: true,
+          skill_count: 20,
+          updated_at: '2026-08-21T01:00:00.000Z',
+        },
+      ],
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => dashboardPayload,
+      }),
+    )
+
+    const { profiles, activeProfile } = await listProfilesWithFallback()
+
+    expect(activeProfile).toBe('invest')
+    expect(profiles.find((p) => p.name === 'invest')?.active).toBe(true)
+    expect(profiles.find((p) => p.name === 'default')?.active).toBe(false)
   })
 })

--- a/src/server/profiles-browser.test.ts
+++ b/src/server/profiles-browser.test.ts
@@ -3,13 +3,19 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { listProfiles, readProfile, updateProfileConfig } from './profiles-browser'
+import {
+  listProfiles,
+  readProfile,
+  updateProfileConfig,
+} from './profiles-browser'
 
 describe('listProfiles', () => {
   let tempHome: string
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-workspace-profiles-'))
+    tempHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'hermes-workspace-profiles-'),
+    )
     vi.spyOn(os, 'homedir').mockReturnValue(tempHome)
     delete process.env.HERMES_HOME
     delete process.env.CLAUDE_HOME
@@ -26,7 +32,11 @@ describe('listProfiles', () => {
     const namedProfileRoot = path.join(profilesRoot, 'jarvis')
 
     fs.mkdirSync(namedProfileRoot, { recursive: true })
-    fs.writeFileSync(path.join(hermesRoot, 'active_profile'), 'jarvis\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'active_profile'),
+      'jarvis\n',
+      'utf-8',
+    )
     fs.writeFileSync(
       path.join(hermesRoot, 'config.yaml'),
       'model: default-model\ndescription: Default operator\n',
@@ -43,10 +53,18 @@ describe('listProfiles', () => {
 
     expect(names).toContain('default')
     expect(names).toContain('jarvis')
-    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(false)
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(true)
-    expect(profiles.find((profile) => profile.name === 'default')?.description).toBe('Default operator')
-    expect(profiles.find((profile) => profile.name === 'jarvis')?.description).toBe('Named operator')
+    expect(profiles.find((profile) => profile.name === 'default')?.active).toBe(
+      false,
+    )
+    expect(profiles.find((profile) => profile.name === 'jarvis')?.active).toBe(
+      true,
+    )
+    expect(
+      profiles.find((profile) => profile.name === 'default')?.description,
+    ).toBe('Default operator')
+    expect(
+      profiles.find((profile) => profile.name === 'jarvis')?.description,
+    ).toBe('Named operator')
   })
 
   it('skips profiles/default so only the root-backed default card renders', () => {
@@ -68,14 +86,56 @@ describe('listProfiles', () => {
     )
 
     const profiles = listProfiles()
-    const defaultProfiles = profiles.filter((profile) => profile.name === 'default')
+    const defaultProfiles = profiles.filter(
+      (profile) => profile.name === 'default',
+    )
 
     expect(defaultProfiles).toHaveLength(1)
     expect(defaultProfiles[0]?.path).toBe(hermesRoot)
     expect(defaultProfiles[0]?.model).toBe('root-model')
     expect(defaultProfiles[0]?.provider).toBe('openai')
     expect(defaultProfiles[0]?.description).toBe('Root default')
-    expect(profiles.find((profile) => profile.name === 'builder')?.provider).toBe('anthropic')
+    expect(
+      profiles.find((profile) => profile.name === 'builder')?.provider,
+    ).toBe('anthropic')
+  })
+
+  it('counts sessions from state.db rows, not session dir files', () => {
+    const hermesRoot = path.join(tempHome, '.hermes')
+    const profileRoot = path.join(hermesRoot, 'profiles', 'builder')
+
+    fs.mkdirSync(profileRoot, { recursive: true })
+    fs.writeFileSync(
+      path.join(profileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
+    // Legacy dump file that must NOT be counted as a session.
+    fs.mkdirSync(path.join(profileRoot, 'sessions'), { recursive: true })
+    fs.writeFileSync(
+      path.join(profileRoot, 'sessions', 'request_dump_main.json'),
+      '{}',
+      'utf-8',
+    )
+    // Real sessions live as rows in state.db.
+    const { DatabaseSync } = require('node:sqlite') as {
+      DatabaseSync: new (p: string) => {
+        exec: (s: string) => void
+        close: () => void
+      }
+    }
+    const db = new DatabaseSync(path.join(profileRoot, 'state.db'))
+    db.exec(
+      "CREATE TABLE sessions (id TEXT PRIMARY KEY); INSERT INTO sessions (id) VALUES ('a'), ('b'), ('c');",
+    )
+    db.close()
+
+    const profiles = listProfiles()
+    const builder = profiles.find((p) => p.name === 'builder')
+    expect(builder?.sessionCount).toBe(3)
+    // The default profile (no state.db) falls back to legacy file counting.
+    const def = profiles.find((p) => p.name === 'default')
+    expect(def?.sessionCount).toBe(0)
   })
 
   it('reads and updates profile descriptions from config.yaml', () => {
@@ -107,8 +167,16 @@ describe('listProfiles', () => {
     fs.mkdirSync(soulProfileRoot, { recursive: true })
     fs.mkdirSync(configProfileRoot, { recursive: true })
 
-    fs.writeFileSync(path.join(hermesRoot, 'config.yaml'), 'model: root-model\n', 'utf-8')
-    fs.writeFileSync(path.join(soulProfileRoot, 'config.yaml'), 'model: named-model\n', 'utf-8')
+    fs.writeFileSync(
+      path.join(hermesRoot, 'config.yaml'),
+      'model: root-model\n',
+      'utf-8',
+    )
+    fs.writeFileSync(
+      path.join(soulProfileRoot, 'config.yaml'),
+      'model: named-model\n',
+      'utf-8',
+    )
     fs.writeFileSync(
       path.join(soulProfileRoot, 'SOUL.md'),
       'You are Leelo, executive assistant.',
@@ -127,12 +195,12 @@ describe('listProfiles', () => {
 
     const profiles = listProfiles()
 
-    expect(profiles.find((profile) => profile.name === 'leelo')?.systemPrompt).toBe(
-      'You are Leelo, executive assistant.',
-    )
-    expect(profiles.find((profile) => profile.name === 'ops')?.systemPrompt).toBe(
-      'Config prompt wins',
-    )
+    expect(
+      profiles.find((profile) => profile.name === 'leelo')?.systemPrompt,
+    ).toBe('You are Leelo, executive assistant.')
+    expect(
+      profiles.find((profile) => profile.name === 'ops')?.systemPrompt,
+    ).toBe('Config prompt wins')
     expect(readProfile('leelo').systemPrompt).toBe(
       'You are Leelo, executive assistant.',
     )

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { createRequire } from 'node:module'
 import YAML from 'yaml'
+
+const _nodeRequire = createRequire(import.meta.url)
 
 export type ProfileSummary = {
   name: string
@@ -143,6 +146,46 @@ function countFilesRecursive(
   return count
 }
 
+/**
+ * Count real hermes sessions for a profile.
+ *
+ * Hermes stores sessions as ROWS in the profile's `state.db` (SQLite), not as
+ * per-session files in `sessions/`. Counting files under `sessions/` therefore
+ * under-reports badly (usually 0, or the count of legacy dump files). Count
+ * the `sessions` table rows instead; fall back to the legacy file count when
+ * no `state.db` exists (older installs / pre-seeded profiles).
+ */
+function countSessionsInProfile(profilePath: string): number {
+  const dbPath = path.join(profilePath, 'state.db')
+  if (fs.existsSync(dbPath)) {
+    try {
+      const Database = _nodeRequire('node:sqlite') as {
+        DatabaseSync?: new (
+          p: string,
+          o?: unknown,
+        ) => {
+          prepare: (s: string) => { get: () => { count?: number } }
+          close: () => void
+        }
+      }
+      if (Database.DatabaseSync) {
+        const db = new Database.DatabaseSync(dbPath, { readOnly: true })
+        try {
+          const row = db.prepare('SELECT COUNT(*) AS count FROM sessions').get()
+          return Number(row.count ?? 0)
+        } finally {
+          db.close()
+        }
+      }
+    } catch {
+      // fall through to file-count fallback
+    }
+  }
+  return countFilesRecursive(path.join(profilePath, 'sessions'), (full) =>
+    /\.(jsonl|json|sqlite|db)$/i.test(full),
+  )
+}
+
 function latestMtime(paths: Array<string>): string | undefined {
   let latest = 0
   for (const target of paths) {
@@ -244,21 +287,31 @@ async function fetchDashboardProfiles(): Promise<{
     const activeProfile =
       data.profiles.find((p) => p.is_default)?.name || 'default'
 
-    const profiles: Array<ProfileSummary> = data.profiles.map((p) => ({
-      name: p.name,
-      path: p.is_default
+    const profiles: Array<ProfileSummary> = data.profiles.map((p) => {
+      const profilePath = p.is_default
         ? getClaudeRoot()
-        : path.join(getProfilesRoot(), p.name),
-      active: p.name === activeProfile,
-      exists: true,
-      model: p.model,
-      provider: p.provider,
-      description: p.description,
-      skillCount: p.skill_count ?? 0,
-      sessionCount: p.session_count ?? 0,
-      hasEnv: p.has_env ?? false,
-      updatedAt: p.updated_at,
-    }))
+        : path.join(getProfilesRoot(), p.name)
+      // The dashboard API does not report per-profile session counts
+      // (session_count is always null), so compute them from each profile's
+      // state.db directly. Falls back to the dashboard's value (or 0).
+      const sessionCount =
+        typeof p.session_count === 'number' && p.session_count > 0
+          ? p.session_count
+          : countSessionsInProfile(profilePath)
+      return {
+        name: p.name,
+        path: profilePath,
+        active: p.name === activeProfile,
+        exists: true,
+        model: p.model,
+        provider: p.provider,
+        description: p.description,
+        skillCount: p.skill_count ?? 0,
+        sessionCount,
+        hasEnv: p.has_env ?? false,
+        updatedAt: p.updated_at,
+      }
+    })
 
     profiles.sort((a, b) => {
       if (a.active && !b.active) return -1
@@ -333,7 +386,8 @@ export async function readProfileWithFallback(
           }>
         }
         const match = data.profiles?.find(
-          (p) => p.name === normalized || (normalized === 'default' && p.is_default),
+          (p) =>
+            p.name === normalized || (normalized === 'default' && p.is_default),
         )
         if (match) {
           const active = getActiveProfileName()
@@ -406,9 +460,7 @@ export function listProfiles(): Array<ProfileSummary> {
         skillsDir,
         (full) => path.basename(full) === 'SKILL.md',
       )
-      const sessionCount = countFilesRecursive(sessionsDir, (full) =>
-        /\.(jsonl|json|sqlite|db)$/i.test(full),
-      )
+      const sessionCount = countSessionsInProfile(profilePath)
       // Resolve model/provider from nested or flat config structure
       let modelName: string | undefined
       let providerName: string | undefined
@@ -481,9 +533,7 @@ export function listProfiles(): Array<ProfileSummary> {
       path.join(root, 'skills'),
       (full) => path.basename(full) === 'SKILL.md',
     ),
-    sessionCount: countFilesRecursive(path.join(root, 'sessions'), (full) =>
-      /\.(jsonl|json|sqlite|db)$/i.test(full),
-    ),
+    sessionCount: countSessionsInProfile(root),
     hasEnv: fs.existsSync(path.join(root, '.env')),
     updatedAt: latestMtime([root, path.join(root, 'config.yaml')]),
   })

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -284,8 +284,14 @@ async function fetchDashboardProfiles(): Promise<{
 
     if (!data.profiles || !Array.isArray(data.profiles)) return null
 
-    const activeProfile =
-      data.profiles.find((p) => p.is_default)?.name || 'default'
+    // The dashboard API does NOT report which profile is currently active —
+    // `is_default` merely names the default-named profile (always 'default').
+    // Treating it as active mislabels the whole UI (e.g. the skills screen's
+    // profile selector pins 'default' while chat/gateway run invest). The
+    // authoritative source is the local <hermes root>/active_profile marker;
+    // on split-host deployments without one, getActiveProfileName() falls
+    // back to 'default' (matching the previous behavior).
+    const activeProfile = getActiveProfileName()
 
     const profiles: Array<ProfileSummary> = data.profiles.map((p) => {
       const profilePath = p.is_default


### PR DESCRIPTION
The profiles page reported 0 sessions for every profile (or the count of legacy request-dump .json files, e.g. '2' for default) because it counted FILES under `<profile>/sessions/` ("`.jsonl|json|sqlite|db`"). Hermes 0.20 stores sessions as ROWS in `<profile>/state.db`, so the file count is meaningless.

Add `countSessionsInProfile()`: open `<profile>/state.db` read-only via `node:sqlite` (`createRequire` for ESM SSR bundle) and `SELECT COUNT(*) FROM sessions`, falling back to the legacy file count when no state.db exists. Use it in both the filesystem `listProfiles()` and `fetchDashboardProfiles()` (the dashboard API reports `session_count: null` for every profile, so the dashboard path previously showed 0 as well).

Tests: state.db row counting + legacy fallback covered in `profiles-browser.test.ts`.