### PR TITLE
fix: land local UX/model-switch fixes rebased onto current main

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "smoke:managed": "node scripts/managed-companion-smoke.mjs",
     "playground:ws": "node scripts/playground-ws.mjs",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "format": "prettier",
     "check": "prettier --write . && eslint --fix",
     "electron:dev": "electron .",

--- a/src/components/chat-panel.tsx
+++ b/src/components/chat-panel.tsx
@@ -39,6 +39,7 @@ export function ChatPanel() {
     friendlyId: string
     sessionKey: string
   } | null>(null)
+  const [panelFresh, setPanelFresh] = useState(0)
 
   const isNewChat = sessionKey === 'new'
   const activeFriendlyId = sessionKey || 'main'
@@ -110,6 +111,7 @@ export function ChatPanel() {
   const handleNewChat = useCallback(() => {
     setForcedSession(null)
     setChatPanelSessionKey('new')
+    setPanelFresh((n) => n + 1)
   }, [setChatPanelSessionKey])
 
   const handleSelectSession = useCallback(
@@ -255,7 +257,7 @@ export function ChatPanel() {
             {/* Chat content */}
             <div className="relative flex flex-1 min-h-0 flex-col overflow-hidden">
               <ChatScreen
-                key={activeFriendlyId}
+                key={isNewChat ? `new-${panelFresh}` : activeFriendlyId}
                 activeFriendlyId={activeFriendlyId}
                 isNewChat={isNewChat}
                 forcedSessionKey={forcedSessionKey}

--- a/src/components/error-toast.tsx
+++ b/src/components/error-toast.tsx
@@ -5,20 +5,30 @@ import { cn } from '@/lib/utils'
 
 const AUTO_DISMISS_MS = 8_000
 
+// 'critical' errors require the user to act (auth/config/rate-limit/context
+// desync) — they must NOT auto-dismiss, or the actionable detail vanishes
+// before it can be read. 'transient' errors (network/model blips) keep the
+// 8s auto-dismiss since they're informational and self-healing.
+type Severity = 'critical' | 'transient'
+
 type ErrorEntry = {
   id: string
   message: string
+  severity: Severity
   raw?: string
 }
 
-function classifyError(raw: string): string {
+function classifyError(raw: string): { message: string; severity: Severity } {
   const lower = raw.toLowerCase()
   if (
     lower.includes('429') ||
     lower.includes('rate limit') ||
     lower.includes('too many')
   ) {
-    return 'Rate limited — try again in a moment'
+    return {
+      message: 'Rate limited — wait a moment before retrying',
+      severity: 'critical',
+    }
   }
   if (
     lower.includes('401') ||
@@ -27,14 +37,27 @@ function classifyError(raw: string): string {
     lower.includes('invalid api key') ||
     lower.includes('api key')
   ) {
-    return 'Authentication error — check your API key in Settings'
+    return {
+      message: 'Authentication error — check your API key in Settings',
+      severity: 'critical',
+    }
+  }
+  if (lower.includes('tool_use') && lower.includes('tool_result')) {
+    return {
+      message:
+        'Tool call context error — conversation history got out of sync. Start a new session to continue.',
+      severity: 'critical',
+    }
   }
   if (
     lower.includes('500') ||
     lower.includes('server error') ||
     lower.includes('model error')
   ) {
-    return 'Model error — the provider is having issues'
+    return {
+      message: 'Model error — the provider is having issues',
+      severity: 'transient',
+    }
   }
   if (
     lower.includes('network') ||
@@ -42,20 +65,19 @@ function classifyError(raw: string): string {
     lower.includes('failed to fetch') ||
     lower.includes('connection')
   ) {
-    return 'Connection lost — retrying…'
+    return { message: 'Connection lost — retrying…', severity: 'transient' }
   }
-  if (lower.includes('tool_use') && lower.includes('tool_result')) {
-    return 'Tool call context error — conversation history got out of sync. Start a new session to continue.'
-  }
-  // Return original message if no pattern matched
-  return raw
+  // Unmatched: surface the raw text and keep it until dismissed (don't let an
+  // unrecognized — possibly important — error slip away after 8s).
+  return { message: raw, severity: 'critical' }
 }
 
-let externalPush: ((msg: string) => void) | null = null
+let externalPush: ((msg: string, severity: Severity) => void) | null = null
 
 /** Call this from anywhere to show an error toast */
 export function showErrorToast(message: string): void {
-  externalPush?.(classifyError(message))
+  const { message: msg, severity } = classifyError(message)
+  externalPush?.(msg, severity)
 }
 
 type ToastItemProps = {
@@ -67,11 +89,14 @@ function ToastItem({ entry, onDismiss }: ToastItemProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    // Critical errors stay until the user dismisses them; only transient ones
+    // auto-expire.
+    if (entry.severity !== 'transient') return
     timerRef.current = setTimeout(() => onDismiss(entry.id), AUTO_DISMISS_MS)
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [entry.id, onDismiss])
+  }, [entry.id, entry.severity, onDismiss])
 
   return (
     <div
@@ -106,9 +131,9 @@ export function ErrorToastContainer() {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }, [])
 
-  const push = useCallback((message: string) => {
+  const push = useCallback((message: string, severity: Severity) => {
     const id = `${Date.now()}-${Math.random()}`
-    setToasts((prev) => [...prev.slice(-4), { id, message }])
+    setToasts((prev) => [...prev.slice(-4), { id, message, severity }])
   }, [])
 
   useEffect(() => {

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
+import { Add01Icon, Chat01Icon, RefreshIcon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
 
@@ -11,6 +11,9 @@ type Props = {
   activeFriendlyId: string
   onSelectSession: (key: string) => void
   onNewChat: () => void
+  sessionsLoading?: boolean
+  sessionsError?: string | null
+  onRetrySessions?: () => void
 }
 
 function normalizeLabel(value: string | undefined): string {
@@ -56,6 +59,9 @@ export function MobileSessionsPanel({
   activeFriendlyId,
   onSelectSession,
   onNewChat,
+  sessionsLoading,
+  sessionsError,
+  onRetrySessions,
 }: Props) {
   useEffect(() => {
     if (!open) return
@@ -108,7 +114,28 @@ export function MobileSessionsPanel({
           </div>
 
           <div className="flex-1 overflow-y-auto p-2">
-            {sessions.length === 0 ? (
+            {sessionsError ? (
+              <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-primary-500">
+                <HugeiconsIcon icon={Chat01Icon} size={24} strokeWidth={1.6} />
+                <p className="text-sm text-red-500">Failed to load sessions.</p>
+                <p className="text-xs text-primary-400">{sessionsError}</p>
+                {onRetrySessions && (
+                  <button
+                    type="button"
+                    onClick={onRetrySessions}
+                    className="mt-1 inline-flex items-center gap-1 rounded-lg border border-primary-200 px-3 py-1.5 text-xs font-medium text-primary-700 hover:border-accent-300 hover:text-accent-600 transition-colors"
+                  >
+                    <HugeiconsIcon icon={RefreshIcon} size={13} strokeWidth={1.8} />
+                    Retry
+                  </button>
+                )}
+              </div>
+            ) : sessionsLoading && sessions.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center gap-2 text-primary-400">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                <p className="text-xs">Loading sessions…</p>
+              </div>
+            ) : sessions.length === 0 ? (
               <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-primary-500">
                 <HugeiconsIcon icon={Chat01Icon} size={24} strokeWidth={1.6} />
                 <p className="text-sm">No sessions yet.</p>

--- a/src/lib/model-info.ts
+++ b/src/lib/model-info.ts
@@ -9,6 +9,8 @@ export type GatewayModelInfoFallbackCapabilities = {
   enhancedChat?: boolean
   config?: boolean
   sessions?: boolean
+  /** Gateway honors per-request `model` in chat completions (#D1). */
+  runtimeModelSwitch?: boolean
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -39,8 +41,22 @@ export function deriveFallbackModelInfoFromGateway(
   gatewayMode: string | null | undefined,
   capabilities: GatewayModelInfoFallbackCapabilities | null | undefined,
 ): NormalizedModelInfo {
+  // Vanilla gateway that advertises per-request model switching (#D1):
+  // the agent stays vanilla, but the composer's model picker must not be
+  // blocked — the API server validates the requested model server-side.
+  if (capabilities?.runtimeModelSwitch) {
+    return {
+      supportsRuntimeSwitching: true,
+      vanillaAgent: true,
+      mode: 'vanilla',
+      raw: null,
+    }
+  }
+
   const hasEnhancedRuntime = Boolean(
-    capabilities?.enhancedChat || capabilities?.config || capabilities?.sessions,
+    capabilities?.enhancedChat ||
+    capabilities?.config ||
+    capabilities?.sessions,
   )
 
   if (hasEnhancedRuntime || gatewayMode === 'enhanced-fork') {
@@ -60,7 +76,9 @@ export function deriveFallbackModelInfoFromGateway(
   }
 }
 
-export function normalizeModelInfoResponse(value: unknown): NormalizedModelInfo {
+export function normalizeModelInfoResponse(
+  value: unknown,
+): NormalizedModelInfo {
   const record = asRecord(value)
   if (!record) {
     return {

--- a/src/routes/api/model/info.ts
+++ b/src/routes/api/model/info.ts
@@ -1,9 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import {
-  deriveFallbackModelInfoFromGateway,
-  normalizeModelInfoResponse,
-} from '@/lib/model-info'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import {
   dashboardFetch,
@@ -11,6 +7,10 @@ import {
   getCapabilities,
   getGatewayMode,
 } from '../../../server/gateway-capabilities'
+import {
+  deriveFallbackModelInfoFromGateway,
+  normalizeModelInfoResponse,
+} from '@/lib/model-info'
 
 export const Route = createFileRoute('/api/model/info')({
   server: {
@@ -33,12 +33,13 @@ export const Route = createFileRoute('/api/model/info')({
           rawPayload = null
         }
 
+        const capabilities = getCapabilities()
         const normalized = normalizeModelInfoResponse(rawPayload)
         const shouldUseFallback =
           normalized.supportsRuntimeSwitching === null &&
           normalized.vanillaAgent === null
         const resolved = shouldUseFallback
-          ? deriveFallbackModelInfoFromGateway(gatewayMode, getCapabilities())
+          ? deriveFallbackModelInfoFromGateway(gatewayMode, capabilities)
           : normalized
 
         if (shouldUseFallback) {
@@ -51,10 +52,18 @@ export const Route = createFileRoute('/api/model/info')({
           rawPayload && typeof rawPayload === 'object' && !Array.isArray(rawPayload)
             ? (rawPayload as Record<string, unknown>)
             : {}
+        // Per-request model switching (#D1): when the gateway itself
+        // advertises runtime_model_switch, it validates the requested model
+        // server-side — so the picker must be unblocked even if a (stale)
+        // dashboard payload reported switching as unsupported.
+        const supportsRuntimeSwitching = capabilities.runtimeModelSwitch
+          ? true
+          : resolved.supportsRuntimeSwitching
 
         return json({
           ...passthrough,
           ...resolved,
+          supportsRuntimeSwitching,
           gatewayMode,
         })
       },

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -13,13 +13,13 @@ import {
   toSessionSummary,
   updateSession,
 } from '../../server/claude-api'
-import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 import {
   deleteLocalSession,
   getLocalSession,
   listLocalSessions,
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -31,6 +31,27 @@ export const Route = createFileRoute('/api/sessions')({
         }
         const capabilities = await ensureGatewayProbed()
         if (!capabilities.sessions) {
+          // Gateway doesn't support session listing, but still surface local
+          // portable sessions so mobile/remote clients aren't stuck with an
+          // empty list when the gateway is vanilla hermes-agent (zero-fork).
+          const localOnly = listLocalSessions()
+          if (localOnly.length > 0) {
+            return json({
+              sessions: localOnly.map((ls) => ({
+                key: ls.id,
+                id: ls.id,
+                friendlyId: ls.id,
+                title: ls.title || 'Local Chat',
+                label: ls.title || 'Local Chat',
+                derivedTitle: ls.title || 'Local Chat',
+                startedAt: ls.createdAt,
+                updatedAt: ls.updatedAt,
+                message_count: ls.messageCount,
+                model: ls.model,
+                source: 'local' as const,
+              })),
+            })
+          }
           return json({
             ok: true,
             sessions: [],
@@ -45,7 +66,9 @@ export const Route = createFileRoute('/api/sessions')({
 
           // Merge local portable sessions (Ollama, Atomic Chat, etc.)
           const localSessions = listLocalSessions()
-          const gatewayIds = new Set(gatewaySessions.map((s: any) => s.key || s.id))
+          const gatewayIds = new Set(
+            gatewaySessions.map((s: any) => s.key || s.id),
+          )
           for (const ls of localSessions) {
             if (!gatewayIds.has(ls.id)) {
               gatewaySessions.push({

--- a/src/routes/chat/$sessionKey.tsx
+++ b/src/routes/chat/$sessionKey.tsx
@@ -10,7 +10,7 @@ import { ErrorBoundary } from '@/components/error-boundary'
 import { useChatStore } from '@/stores/chat-store'
 
 const searchSchema = z.object({
-  fresh: z.number().optional(),
+  fresh: z.coerce.number().optional(),
 })
 
 const ChatScreen = lazy(async () => {

--- a/src/routes/chat/$sessionKey.tsx
+++ b/src/routes/chat/$sessionKey.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 import {
@@ -7,6 +7,7 @@ import {
   reconcileSessionDraft,
 } from '../../screens/chat/chat-queries'
 import { ErrorBoundary } from '@/components/error-boundary'
+import { useChatStore } from '@/stores/chat-store'
 
 const searchSchema = z.object({
   fresh: z.number().optional(),
@@ -67,10 +68,16 @@ function ChatRoute() {
 
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const clearChatStoreSession = useChatStore(
+    (s) => s.clearSession,
+  )
   const [forcedSession, setForcedSession] = useState<{
     friendlyId: string
     sessionKey: string
   } | null>(null)
+  // Track the outgoing session key so we can evict its Zustand bucket on New Chat.
+  // useRef avoids adding forcedSession to the reset-effect deps (avoids infinite loops).
+  const forcedSessionRef = useRef<typeof forcedSession>(null)
   const params = Route.useParams()
   const { fresh } = Route.useSearch()
   const activeFriendlyId =
@@ -81,16 +88,32 @@ function ChatRoute() {
       ? forcedSession.sessionKey
       : undefined
 
-  // Clear history cache and forcedSession when navigating to new chat.
-  // `fresh` changes every time the user taps "New Chat", even when already on
-  // /chat/new — this avoids TanStack Router's same-route no-op and ensures
-  // the reset runs even when isNewChat was already true.
+  // Keep ref in sync so the new-chat reset effect can read it without a dependency.
+  forcedSessionRef.current = forcedSession
+
+  // Clear history cache, forcedSession, and Zustand realtime bucket when navigating
+  // to a new chat. `fresh` changes every time the user taps "New Chat", even when
+  // already on /chat/new — this avoids TanStack Router's same-route no-op and
+  // ensures the reset runs even when isNewChat was already true.
   useEffect(() => {
     if (isNewChat) {
+      // Evict the previous session's Zustand realtimeMessages bucket so it cannot
+      // bleed into the new chat via mergeHistoryMessages (chat-store.ts:1184).
+      const outgoingKey = forcedSessionRef.current?.sessionKey
+      if (outgoingKey && outgoingKey !== 'new') {
+        clearChatStoreSession(outgoingKey)
+      }
       setForcedSession(null)
       queryClient.removeQueries({ queryKey: ['chat', 'history', 'new', 'new'] })
+      // Reset the last-session pointer so a PWA cold-start via /chat index also
+      // lands on a new chat instead of the previous conversation (manifest
+      // start_url="/chat/new" is the primary fix; this is a belt-and-suspenders
+      // guard for browser-URL reloads that hit /chat directly).
+      try {
+        localStorage.setItem('claude-last-session', 'new')
+      } catch {}
     }
-  }, [isNewChat, fresh, queryClient])
+  }, [isNewChat, fresh, queryClient, clearChatStoreSession])
 
   const handleSessionResolved = useCallback(
     function handleSessionResolved(payload: {

--- a/src/routes/chat/$sessionKey.tsx
+++ b/src/routes/chat/$sessionKey.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { z } from 'zod'
 import {
   moveHistoryMessages,
   reconcileSessionDraft,
 } from '../../screens/chat/chat-queries'
 import { ErrorBoundary } from '@/components/error-boundary'
+
+const searchSchema = z.object({
+  fresh: z.number().optional(),
+})
 
 const ChatScreen = lazy(async () => {
   const module = await import('../../screens/chat/chat-screen')
@@ -16,6 +21,7 @@ export const Route = createFileRoute('/chat/$sessionKey')({
   component: ChatRoute,
   // Disable SSR to prevent hydration mismatches from async data
   ssr: false,
+  validateSearch: searchSchema,
   errorComponent: function ChatError({ error, reset }) {
     return (
       <div className="flex flex-col items-center justify-center h-full p-6 text-center bg-primary-50">
@@ -66,6 +72,7 @@ function ChatRoute() {
     sessionKey: string
   } | null>(null)
   const params = Route.useParams()
+  const { fresh } = Route.useSearch()
   const activeFriendlyId =
     typeof params.sessionKey === 'string' ? params.sessionKey : 'main'
   const isNewChat = activeFriendlyId === 'new'
@@ -74,12 +81,16 @@ function ChatRoute() {
       ? forcedSession.sessionKey
       : undefined
 
-  // Clear history cache when navigating to new chat
+  // Clear history cache and forcedSession when navigating to new chat.
+  // `fresh` changes every time the user taps "New Chat", even when already on
+  // /chat/new — this avoids TanStack Router's same-route no-op and ensures
+  // the reset runs even when isNewChat was already true.
   useEffect(() => {
     if (isNewChat) {
+      setForcedSession(null)
       queryClient.removeQueries({ queryKey: ['chat', 'history', 'new', 'new'] })
     }
-  }, [isNewChat, queryClient])
+  }, [isNewChat, fresh, queryClient])
 
   const handleSessionResolved = useCallback(
     function handleSessionResolved(payload: {
@@ -138,6 +149,7 @@ function ChatRoute() {
         }
       >
         <ChatScreen
+          key={isNewChat ? `new-${fresh ?? 0}` : activeFriendlyId}
           activeFriendlyId={activeFriendlyId}
           isNewChat={isNewChat}
           forcedSessionKey={forcedSessionKey}

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -2360,7 +2360,11 @@ export function ChatScreen({
         // The /chat index route redirects to the last-active session via
         // localStorage, so navigating to '/chat' would land in the previous
         // chat instead of opening a fresh one. See #300.
-        navigate({ to: '/chat/$sessionKey', params: { sessionKey: 'new' } })
+        navigate({
+          to: '/chat/$sessionKey',
+          params: { sessionKey: 'new' },
+          search: { fresh: Date.now() },
+        })
         return true
       }
 

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -1650,7 +1650,15 @@ export function ChatScreen({
     refetchOnReconnect: true,
     refetchOnMount: true,
     staleTime: 30_000,
-    refetchInterval: 60_000, // Re-check every 60s to clear stale errors
+    // Poll fast (8s) while the gateway looks unhealthy so a recovered backend
+    // clears the error banner quickly instead of leaving it stuck for up to a
+    // minute; back off to 60s once healthy to keep idle cost low.
+    refetchInterval: (query) => {
+      const data = query.state.data
+      const unhealthy =
+        query.state.status === 'error' || (data != null && !data.ok)
+      return unhealthy ? 8_000 : 60_000
+    },
   })
   // Don't show errors for new chats or when SSE is connected
   const statusError =
@@ -1980,12 +1988,17 @@ export function ChatScreen({
         clientId: optimisticClientId,
       }
 
-      // Failsafe: clear waitingForResponse after 120s no matter what
-      // Prevents infinite spinner if SSE/idle detection both fail
+      // Failsafe: clear waitingForResponse after 120s no matter what.
+      // Prevents an infinite spinner if SSE/idle detection both fail — but
+      // tell the user explicitly instead of silently dropping the spinner,
+      // so a stalled run reads as "timed out, resend" rather than "done".
       if (failsafeTimerRef.current) {
         window.clearTimeout(failsafeTimerRef.current)
       }
       failsafeTimerRef.current = window.setTimeout(() => {
+        showErrorToast(
+          '応答が返ってきませんでした。少し待ってからもう一度送信してください。',
+        )
         streamFinish()
       }, 120_000)
 

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -563,9 +563,9 @@ export function ChatScreen({
     activeSessionKey,
     activeTitle,
     sessionsError,
-    sessionsLoading: _sessionsLoading,
+    sessionsLoading,
     sessionsFetching: _sessionsFetching,
-    refetchSessions: _refetchSessions,
+    refetchSessions,
   } = useChatSessions({ activeFriendlyId, isNewChat, forcedSessionKey })
   const {
     historyQuery,
@@ -2946,6 +2946,9 @@ export function ChatScreen({
           onClose={() => setSessionsOpen(false)}
           sessions={sessions}
           activeFriendlyId={activeFriendlyId}
+          sessionsLoading={sessionsLoading}
+          sessionsError={sessionsError}
+          onRetrySessions={refetchSessions}
           onSelectSession={(friendlyId) => {
             setSessionsOpen(false)
             void navigate({

--- a/src/server/__tests__/gateway-capabilities.test.ts
+++ b/src/server/__tests__/gateway-capabilities.test.ts
@@ -79,6 +79,7 @@ describe('gateway-capabilities', () => {
             jobs: true,
             mcp: false,
             mcpFallback: false,
+            runtimeModelSwitch: false,
             conductor: false,
             kanban: false,
             dashboard: {
@@ -109,6 +110,7 @@ describe('gateway-capabilities', () => {
             jobs: false,
             mcp: false,
             mcpFallback: false,
+            runtimeModelSwitch: false,
             conductor: false,
             kanban: false,
             dashboard: {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -87,7 +87,9 @@ export function setGatewayUrl(input: string | null | undefined): string {
   } else {
     delete overrides.claudeApiUrl
     CLAUDE_API = normalizeUrl(
-      process.env.HERMES_API_URL || process.env.CLAUDE_API_URL || 'http://127.0.0.1:8642',
+      process.env.HERMES_API_URL ||
+        process.env.CLAUDE_API_URL ||
+        'http://127.0.0.1:8642',
     )
   }
   writeOverrides(overrides)
@@ -109,7 +111,9 @@ export function setDashboardUrl(input: string | null | undefined): string {
   } else {
     delete overrides.claudeDashboardUrl
     CLAUDE_DASHBOARD_URL = normalizeUrl(
-      process.env.HERMES_DASHBOARD_URL || process.env.CLAUDE_DASHBOARD_URL || 'http://127.0.0.1:9119',
+      process.env.HERMES_DASHBOARD_URL ||
+        process.env.CLAUDE_DASHBOARD_URL ||
+        'http://127.0.0.1:9119',
     )
   }
   writeOverrides(overrides)
@@ -127,7 +131,7 @@ export function getResolvedUrls(): {
   const overrides = readOverrides()
   const source = overrides.claudeApiUrl
     ? 'override'
-    : (process.env.HERMES_API_URL || process.env.CLAUDE_API_URL)
+    : process.env.HERMES_API_URL || process.env.CLAUDE_API_URL
       ? 'env'
       : 'default'
   return { gateway: CLAUDE_API, dashboard: CLAUDE_DASHBOARD_URL, source }
@@ -150,7 +154,10 @@ const PROBE_TIMEOUT_MS = 3_000
 const PROBE_TTL_MS = 120_000
 const PROBE_TTL_DISCONNECTED_MS = 15_000
 
-function effectiveProbeTtl(caps: { health: boolean; chatCompletions: boolean }): number {
+function effectiveProbeTtl(caps: {
+  health: boolean
+  chatCompletions: boolean
+}): number {
   if (caps.health || caps.chatCompletions) return PROBE_TTL_MS
   return PROBE_TTL_DISCONNECTED_MS
 }
@@ -199,6 +206,14 @@ export type EnhancedCapabilities = {
    * file-backed swarm-kanban store. See v2.3.0 plan.
    */
   kanban: boolean
+  /**
+   * True when the gateway's `/v1/capabilities` advertises
+   * `runtime.runtime_model_switch` — i.e. the API server honors a
+   * per-request `model` field in chat completions (validated against its
+   * advertised /v1/models list). Lifts the vanilla-agent model-switch
+   * block in the composer (#D1).
+   */
+  runtimeModelSwitch: boolean
 }
 
 export type DashboardCapabilities = {
@@ -209,8 +224,7 @@ export type DashboardCapabilities = {
 }
 
 /** Full capabilities — backward compat with existing code */
-export type GatewayCapabilities =
-  CoreCapabilities &
+export type GatewayCapabilities = CoreCapabilities &
   EnhancedCapabilities &
   DashboardCapabilities
 
@@ -245,6 +259,7 @@ let capabilities: GatewayCapabilities = {
   mcpFallback: false,
   conductor: false,
   kanban: false,
+  runtimeModelSwitch: false,
   dashboard: {
     available: false,
     url: CLAUDE_DASHBOARD_URL,
@@ -259,7 +274,8 @@ let dashboardTokenPromise: Promise<string> | null = null
 let dashboardTokenCache = ''
 
 /** Optional bearer token for authenticated gateway endpoints. */
-export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
+export const BEARER_TOKEN =
+  process.env.HERMES_API_TOKEN || process.env.CLAUDE_API_TOKEN || ''
 
 /**
  * Dashboard API auth uses the ephemeral session token injected into the
@@ -438,12 +454,15 @@ async function probe(path: string): Promise<boolean> {
  */
 async function probeEnhancedChatStream(): Promise<boolean> {
   try {
-    const res = await fetch(`${CLAUDE_API}/api/sessions/__probe__/chat/stream`, {
-      method: 'POST',
-      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-      body: '{}',
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    })
+    const res = await fetch(
+      `${CLAUDE_API}/api/sessions/__probe__/chat/stream`,
+      {
+        method: 'POST',
+        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+        body: '{}',
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      },
+    )
     // Vanilla hermes-agent has no such endpoint — dashboard layer 404s,
     // gateway 404s, anything in between 404s. Enhanced fork accepts POST
     // and returns either a 4xx structured error (validation) or starts a
@@ -489,6 +508,28 @@ async function probeChatCompletions(): Promise<boolean> {
       }
     }
     return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Probe the gateway's `/v1/capabilities` for per-request model switching
+ * (#D1). Returns true only when `runtime.runtime_model_switch === true` —
+ * older gateways without the endpoint (404) or without the flag default to
+ * false, preserving the legacy "config-fixed model" behaviour.
+ */
+async function probeRuntimeModelSwitch(): Promise<boolean> {
+  try {
+    const res = await fetch(`${CLAUDE_API}/v1/capabilities`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+    if (!res.ok) return false
+    const payload = (await res.json()) as {
+      runtime?: { runtime_model_switch?: unknown }
+    }
+    return payload.runtime?.runtime_model_switch === true
   } catch {
     return false
   }
@@ -553,7 +594,9 @@ export function isLocalhostDeployment(): boolean {
   const isLoopbackHost = (host: string): boolean => {
     const h = host.trim().toLowerCase()
     if (!h) return false
-    return h === '127.0.0.1' || h === '::1' || h === 'localhost' || h === '[::1]'
+    return (
+      h === '127.0.0.1' || h === '::1' || h === 'localhost' || h === '[::1]'
+    )
   }
   const isLoopbackUrl = (raw: string): boolean => {
     try {
@@ -658,7 +701,6 @@ async function probeKanban(dashboardAvailable: boolean): Promise<boolean> {
     return false
   }
 }
-
 
 // Vanilla hermes-agent 0.10.0 satisfies: health, chatCompletions, models, streaming,
 // sessions, skills, config, jobs. Dashboard-only endpoints (themes/plugins) and the
@@ -840,6 +882,7 @@ export async function probeGateway(options?: {
       legacyConfig,
       legacyJobs,
       dashboard,
+      runtimeModelSwitch,
     ] = await Promise.all([
       probe('/health'),
       probeChatCompletions(),
@@ -850,6 +893,7 @@ export async function probeGateway(options?: {
       probe('/api/config'),
       probe('/api/jobs'),
       probeDashboard(),
+      probeRuntimeModelSwitch(),
     ])
 
     // Strict MCP probe runs after dashboard probe so dashboard token
@@ -891,6 +935,7 @@ export async function probeGateway(options?: {
       mcpFallback,
       conductor,
       kanban,
+      runtimeModelSwitch,
       dashboard,
     }
     lastProbeAt = Date.now()
@@ -906,8 +951,7 @@ export async function probeGateway(options?: {
 }
 
 export async function ensureGatewayProbed(): Promise<GatewayCapabilities> {
-  const isStale =
-    Date.now() - lastProbeAt > effectiveProbeTtl(capabilities)
+  const isStale = Date.now() - lastProbeAt > effectiveProbeTtl(capabilities)
   if (!capabilities.probed || isStale) {
     return probeGateway({ force: isStale })
   }
@@ -951,6 +995,7 @@ export function getEnhancedCapabilities(): EnhancedCapabilities {
     mcpFallback: capabilities.mcpFallback,
     conductor: capabilities.conductor,
     kanban: capabilities.kanban,
+    runtimeModelSwitch: capabilities.runtimeModelSwitch,
   }
 }
 


### PR DESCRIPTION
## Summary
Lands 4 local commits (previously stranded on a diverged local main since June) rebased onto current `origin/main`, plus a test fixture fix:

- **fix(ui):** New Chat no-op + fetch usage data toast spam suppression
- **fix(new-chat):** clear Zustand bucket + PWA start_url to break last-session restore chain
- **fix(mobile):** session list empty + loading/error state for MobileSessionsPanel
- **feat(ux+models):** explicit send-timeout toast, persistent critical error toasts, fast unhealthy-status polling, per-request model switching via gateway `runtime_model_switch`
- **test:** add `runtimeModelSwitch` to gateway-capabilities test fixtures (type parity after rebase)

## Verification
- Rebased cleanly after resolving 11 conflict files (origin/main side preferred; union merge for model/info.ts + gateway-capabilities.ts to keep both passthrough and runtime-switch semantics)
- `tsc --noEmit` error set vs origin/main: no new errors beyond pre-existing baseline (workspace-shell `search?.embed` typing pre-dates this branch)
- vitest failure set identical to origin/main baseline (all pre-existing e2e/Playwright env issues)

## Notes
Local working tree also had ~470 files of stale formatter churn (snapshot of wip/hermesworld-viral-sprint); stashed separately as `wip-snapshot-2026-06-reformatted-hermesworld` — not included here.