### PR TITLE
fix: sqlite3 in runtime image, usable loopback cookies, complete start:all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,10 @@ RUN pnpm build
 FROM node:22-slim
 # python3 is required by scripts/pty-helper.py (terminal feature). Originally
 # added in PR #185 for issue #161; regressed by the 2026-05-01 rename commit
-# efcb7d14 and re-added here per issue #259.
+# efcb7d14 and re-added here per issue #259. sqlite3 is used by the Kanban/
+# Claude Tasks backend to read and update the persisted kanban.db.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl tini python3 \
+      ca-certificates curl tini python3 sqlite3 \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r workspace && useradd -r -g workspace -u 10010 -m workspace
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       HERMES_PASSWORD: ${HERMES_PASSWORD:-${CLAUDE_PASSWORD:-}}
       # Enable the Secure flag on session cookies when terminated behind
       # HTTPS (reverse proxy / Tailscale Funnel / Cloudflare Tunnel). See #123.
-      COOKIE_SECURE: ${COOKIE_SECURE:-}
+      COOKIE_SECURE: ${COOKIE_SECURE:-0}
       # Trust proxy-forwarded headers (x-forwarded-for / x-real-ip) for IP
       # classification. Leave unset unless you deploy behind a trusted proxy
       # that sanitizes these headers — otherwise a client can spoof its IP

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "start:all": "concurrently \"hermes gateway run\" \"pnpm dev\"",
+    "start:all": "concurrently \"hermes gateway run\" \"hermes dashboard --port 9119 --host 127.0.0.1 --no-open\" \"pnpm dev\"",
     "start": "node server-entry.js",
     "start:dev": "vite dev",
     "preview": "vite preview",


### PR DESCRIPTION
Three production fixes found while operating the Docker stack.

## 1. Kanban / Claude Tasks 500s — `sqlite3` missing from the runtime image

`src/server/kanban-backend.ts` spawnSyncs the `sqlite3` CLI to read and update `kanban.db`. The runtime stage of the Dockerfile never installs it, so every Kanban and Claude Tasks request logs `spawnSync sqlite3 ENOENT` and can return HTTP 500.

**Fix:** add `sqlite3` to the runtime apt packages (same line that re-added `python3` for #259).

## 2. Login can silently fail on the default loopback-HTTP deployment

The compose file publishes the workspace on `127.0.0.1:3000` (plain HTTP), but `COOKIE_SECURE` defaulted to empty. Depending on `NODE_ENV`, the session cookie could be issued with the `Secure` attribute — which the browser then refuses to send back over `http://localhost`. Login returns 200, no session sticks.

**Fix:** default `COOKIE_SECURE: ${COOKIE_SECURE:-0}` in compose, matching the transport compose itself sets up. HTTPS deployments (reverse proxy / Tailscale Funnel / Cloudflare Tunnel, see #123) still opt in with `COOKIE_SECURE=1`.

## 3. `start:all` starts only two of the three documented services

The script launched the gateway and the workspace but not the dashboard, so enhanced capabilities (sessions, skills, config, jobs) were missing in this mode.

**Fix:** `start:all` now also runs `hermes dashboard --port 9119 --host 127.0.0.1 --no-open`.

## Verification

Ran on a live stack (macOS, Docker Desktop): rebuilt workspace image with sqlite3 → `sqlite3 3.40.1` present, authenticated Tasks API 200, no ENOENT in logs; login sets a cookie without `Secure` over loopback HTTP and the session persists; `pnpm build` passes; targeted Vitest 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)