### PR TITLE
fix(sessions): prefer gateway session list API

### DIFF
--- a/src/server/__tests__/claude-api.test.ts
+++ b/src/server/__tests__/claude-api.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fetchMock, getCapabilitiesMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getCapabilitiesMock: vi.fn(),
+}))
+
+vi.mock('../gateway-capabilities', () => ({
+  BEARER_TOKEN: 'test-token',
+  CLAUDE_API: 'http://hermes-agent:8642',
+  SESSIONS_API_UNAVAILABLE_MESSAGE: 'sessions unavailable',
+  dashboardFetch: vi.fn(),
+  ensureGatewayProbed: vi.fn(),
+  getCapabilities: getCapabilitiesMock,
+  probeGateway: vi.fn(),
+}))
+
+vi.mock('../claude-dashboard-api', () => ({
+  createSession: vi.fn(),
+  deleteSession: vi.fn(),
+  forkSession: vi.fn(),
+  getSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  listSessions: vi.fn(),
+  searchSessions: vi.fn(),
+  updateSession: vi.fn(),
+}))
+
+describe('claude-api session routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  it('uses the gateway session API when it is available', async () => {
+    getCapabilitiesMock.mockReturnValue({
+      sessions: true,
+      dashboard: { available: true },
+    })
+
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          object: 'list',
+          data: [
+            {
+              id: 'session-1',
+              title: 'Gateway session',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    )
+
+    const { listSessions } = await import('../claude-api')
+
+    const sessions = await listSessions(2, 0)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.id).toBe('session-1')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://hermes-agent:8642/api/sessions?limit=2&offset=0',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-token' },
+      }),
+    )
+  })
+
+  it('falls back to the dashboard when the gateway session request fails', async () => {
+    const dashboardListSessions = (
+      await import('../claude-dashboard-api')
+    ).listSessions
+
+    getCapabilitiesMock.mockReturnValue({
+      sessions: true,
+      dashboard: { available: true },
+    })
+
+    fetchMock.mockRejectedValueOnce(new Error('gateway unavailable'))
+
+    vi.mocked(dashboardListSessions).mockResolvedValue({
+      sessions: [
+        {
+          id: 'dashboard-session',
+        },
+      ],
+      total: 1,
+      limit: 2,
+      offset: 0,
+    })
+
+    const { listSessions } = await import('../claude-api')
+
+    const sessions = await listSessions(2, 0)
+
+    expect(sessions[0]?.id).toBe('dashboard-session')
+    expect(dashboardListSessions).toHaveBeenCalledWith(2, 0)
+  })
+})

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -129,19 +129,30 @@ export async function listSessions(
   limit = 50,
   offset = 0,
 ): Promise<Array<ClaudeSession>> {
-  if (getCapabilities().dashboard.available) {
+  const capabilities = getCapabilities()
+
+  if (capabilities.sessions) {
+    try {
+      const resp = await claudeGet<{
+        items?: Array<ClaudeSession>
+        data?: Array<ClaudeSession>
+        total?: number
+      }>(`/api/sessions?limit=${limit}&offset=${offset}`)
+
+      return resp.items ?? resp.data ?? []
+    } catch (error) {
+      if (!capabilities.dashboard.available) {
+        throw error
+      }
+    }
+  }
+
+  if (capabilities.dashboard.available) {
     const resp = await listDashboardSessions(limit, offset)
     return resp.sessions as Array<ClaudeSession>
   }
-  const resp = await claudeGet<{
-    items?: Array<ClaudeSession>
-    data?: Array<ClaudeSession>
-    total?: number
-  }>(`/api/sessions?limit=${limit}&offset=${offset}`)
-  // The gateway (OpenAI-compat) returns { object: 'list', data: [...] }, while the
-  // dashboard / older gateway shape uses { items: [...] }. Accept either, and never
-  // return undefined (callers .map over this).
-  return resp.items ?? resp.data ?? []
+
+  throw new Error(SESSIONS_API_UNAVAILABLE_MESSAGE)
 }
 
 export async function getSession(sessionId: string): Promise<ClaudeSession> {

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -599,7 +599,6 @@ async function probeDashboard(): Promise<{ available: boolean; url: string }> {
     if (!res.ok) return { available: false, url: CLAUDE_DASHBOARD_URL }
     const body = (await res.json()) as { version?: string }
     if (!body.version) return { available: false, url: CLAUDE_DASHBOARD_URL }
-    await fetchDashboardToken().catch(() => '')
     return { available: true, url: CLAUDE_DASHBOARD_URL }
   } catch {
     return { available: false, url: CLAUDE_DASHBOARD_URL }


### PR DESCRIPTION
## Summary

Previously, `listSessions()` preferred the dashboard whenever the dashboard was available. In authenticated Docker deployments, the Workspace server-side request could therefore hit the dashboard on `:9119` without a dashboard
session cookie and receive `401 no_cookie`.

This change makes session listing prefer the authenticated Hermes Agent gateway `/api/sessions` endpoint, with the dashboard retained as a fallback.

Old:
dashboard available
→ use :9119
→ dashboard requires cookie
→ 401 no_cookie

New:
try authenticated :8642/api/sessions
→ success
→ use gateway sessions

fallback:
gateway request fails
→ dashboard :9119

## Validation

- `src/server/__tests__/gateway-capabilities.test.ts`: 16/16 tests passed
- `src/server/__tests__/claude-api.test.ts`: 2/2 tests passed
- Combined targeted tests: 18/18 passed
- Production Docker build completed successfully
- Integration test against the real Hermes Agent gateway passed
- Production `/api/sessions` returned HTTP 200 with real sessions