### PR TITLE
fix(composer): render the workspace selector added in #243

### DIFF
--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -1340,6 +1340,7 @@ function ChatComposerComponent({
     if (
       !isModelMenuOpen &&
       !isProfileMenuOpen &&
+      !isWorkspaceMenuOpen &&
       !isThinkingMenuOpen &&
       !isControlsMenuOpen
     )
@@ -1349,11 +1350,13 @@ function ChatComposerComponent({
       if (controlsMenuRef.current?.contains(target)) return
       if (modelSelectorRef.current?.contains(target)) return
       if (profileMenuRef.current?.contains(target)) return
+      if (workspaceMenuRef.current?.contains(target)) return
       if (thinkingMenuRef.current?.contains(target)) return
       setIsControlsMenuOpen(false)
       setIsModelMenuOpen(false)
       setIsProviderSwitcherExpanded(false)
       setIsProfileMenuOpen(false)
+      setIsWorkspaceMenuOpen(false)
       setIsThinkingMenuOpen(false)
     }
 
@@ -1364,6 +1367,7 @@ function ChatComposerComponent({
   }, [
     isModelMenuOpen,
     isProfileMenuOpen,
+    isWorkspaceMenuOpen,
     isThinkingMenuOpen,
     isControlsMenuOpen,
   ])
@@ -2794,6 +2798,7 @@ function ChatComposerComponent({
                       onClick={() => {
                         setIsControlsMenuOpen((open) => !open)
                         setIsProfileMenuOpen(false)
+                        setIsWorkspaceMenuOpen(false)
                         setIsThinkingMenuOpen(false)
                         setIsModelMenuOpen(false)
                       }}
@@ -2836,6 +2841,7 @@ function ChatComposerComponent({
                               type="button"
                               onClick={() => {
                                 setIsProfileMenuOpen((open) => !open)
+                                setIsWorkspaceMenuOpen(false)
                                 setIsThinkingMenuOpen(false)
                                 setIsModelMenuOpen(false)
                               }}
@@ -2894,6 +2900,67 @@ function ChatComposerComponent({
 
                           <div
                             className="relative flex min-w-0 items-center"
+                            ref={workspaceMenuRef}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setIsWorkspaceMenuOpen((open) => !open)
+                                setIsProfileMenuOpen(false)
+                                setIsThinkingMenuOpen(false)
+                                setIsModelMenuOpen(false)
+                              }}
+                              disabled={disabled || workspaceSelectMutation.isPending}
+                              className="inline-flex h-8 max-w-[8rem] items-center gap-1.5 rounded-full bg-primary-100/70 px-2.5 text-xs font-medium text-primary-600 transition-colors hover:bg-primary-200/80 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-primary-800/60"
+                              title={detectedWorkspacePath || workspaceButtonLabel}
+                            >
+                              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z" />
+                              </svg>
+                              <span className="truncate">{workspaceButtonLabel}</span>
+                              <HugeiconsIcon icon={ArrowDown01Icon} size={11} />
+                            </button>
+                            {isWorkspaceMenuOpen && (
+                              <div className="absolute bottom-full left-0 z-[200] mb-2 min-w-[16rem] overflow-hidden rounded-xl border border-neutral-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150 dark:border-neutral-700 dark:bg-neutral-900">
+                                <div className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-400">
+                                  Workspace
+                                </div>
+                                {workspaceEntries.map((workspace) => {
+                                  const selected = workspace.path === detectedWorkspacePath
+                                  return (
+                                    <button
+                                      key={workspace.path}
+                                      type="button"
+                                      onClick={() => {
+                                        if (selected) {
+                                          setIsWorkspaceMenuOpen(false)
+                                          return
+                                        }
+                                        workspaceSelectMutation.mutate(workspace)
+                                      }}
+                                      className={cn(
+                                        'flex w-full flex-col rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                                        selected
+                                          ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                          : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-300 dark:hover:bg-neutral-800/60',
+                                      )}
+                                    >
+                                      <span className="flex items-center gap-2">
+                                        <span className="truncate font-medium">{workspace.name}</span>
+                                        {selected ? <span className="text-[10px] text-accent-500">active</span> : null}
+                                      </span>
+                                      <span className="mt-0.5 max-w-[14rem] truncate text-[11px] text-neutral-500">{workspace.path}</span>
+                                    </button>
+                                  )
+                                })}
+                                {workspaceEntries.length === 0 ? <div className="px-3 py-2 text-xs text-neutral-400">No workspaces configured</div> : null}
+                                {workspaceContextQuery.isError ? <div className="px-3 py-2 text-xs text-red-500">Failed to load workspaces</div> : null}
+                              </div>
+                            )}
+                          </div>
+
+                          <div
+                            className="relative flex min-w-0 items-center"
                             ref={thinkingMenuRef}
                           >
                             <button
@@ -2901,6 +2968,7 @@ function ChatComposerComponent({
                               onClick={() => {
                                 setIsThinkingMenuOpen((open) => !open)
                                 setIsProfileMenuOpen(false)
+                                setIsWorkspaceMenuOpen(false)
                                 setIsModelMenuOpen(false)
                               }}
                               className={cn(


### PR DESCRIPTION
Fixes #774

## What was wrong

#243 wired everything a workspace switcher needs into `chat-composer.tsx` — state, the `workspaceContextQuery`, and a fully correct `workspaceSelectMutation` (`POST /api/workspace`, invalidates the right query, closes the menu on success) — but never added the button/dropdown that would actually use them. So on the current `main`:

- `workspaceButtonLabel` was computed and unused.
- `handleOpenWorkspaceManager` was defined and never called (and even if it were, it just toggles the file-explorer search modal, not a workspace picker).
- `workspaceMenuRef` was declared and never attached to any element.
- `isWorkspaceMenuOpen` was set to `false` in a couple of places but never flipped to `true`, and wasn't part of the outside-click-to-close effect that every sibling menu (`isProfileMenuOpen`, `isModelMenuOpen`, `isThinkingMenuOpen`) already participates in.

Net effect: the workspace catalog from #243 has been unreachable from the UI since it landed. This is the gap behind #264 and #340 — both were answered with "that would need a UI, open a separate request" but the actual composer wiring for exactly that was already sitting there, just not rendered.

## What this changes

- Adds a workspace button + dropdown right next to the existing profile selector, same visual pattern (pill button, dropdown listing entries with the active one marked, path shown as a subtitle).
- Wires `isWorkspaceMenuOpen` into the existing outside-click handler and into the sibling buttons' "close other menus" calls (profile, thinking, and the top-level chat-controls toggle), matching how the other three menus already behave.
- No changes to any state, query, or mutation logic — `workspaceSelectMutation` was already correct and is used as-is.

## Testing

Built with `pnpm build` (clean), restarted a live zero-fork deployment (`hermes gateway` + this workspace pointed at it via `HERMES_API_URL`), and verified end-to-end with 5 real workspace entries registered in `~/.hermes/webui_state/workspaces.json`:

- Chat controls → the new "Home" pill opens a dropdown listing all 5 workspaces with their absolute paths, active one marked.
- Selecting a different entry (e.g. a project under `~/Downloads`) closes the menu, updates the pill label, and calls the existing mutation.
- `/files` immediately reflects the new active workspace — full real directory tree (nested folders, `CLAUDE.md`, etc.), not the placeholder "workspace is empty" state.
- Switching back to the original entry restores the original Files view.

Diff is additive/UI-only (68 insertions, 0 deletions) — didn't touch anything outside this one file.