### PR TITLE
fix: sync pinned sessions across clients

### DIFF
--- a/src/components/mobile-sessions-panel.test.tsx
+++ b/src/components/mobile-sessions-panel.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MobileSessionsPanel } from './mobile-sessions-panel'
+import type { SessionMeta } from '@/screens/chat/types'
+
+const sessions: Array<SessionMeta> = [
+  {
+    key: 'pinned-session',
+    friendlyId: 'pinned-session',
+    title: 'Pinned chat',
+    pinned: true,
+  },
+  {
+    key: 'regular-session',
+    friendlyId: 'regular-session',
+    title: 'Regular chat',
+    pinned: false,
+  },
+]
+
+describe('MobileSessionsPanel', () => {
+  it('renders a visible pinned section and pin controls', () => {
+    const html = renderToStaticMarkup(
+      <MobileSessionsPanel
+        open
+        onClose={vi.fn()}
+        sessions={sessions}
+        activeFriendlyId="regular-session"
+        onSelectSession={vi.fn()}
+        onNewChat={vi.fn()}
+        onTogglePin={vi.fn()}
+      />,
+    )
+
+    expect(html).toContain('>Pinned<')
+    expect(html).toContain('Pinned chat')
+    expect(html).toContain('Unpin session')
+    expect(html).toContain('Pin session')
+  })
+})

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -119,6 +119,7 @@ export function MobileSessionsPanel({
                 : 'text-primary-400 hover:bg-primary-200 hover:text-primary-700',
             )}
             aria-label={`${session.pinned ? 'Unpin' : 'Pin'} session ${title}`}
+            aria-pressed={session.pinned === true}
           >
             <HugeiconsIcon
               icon={PinIcon}

--- a/src/components/mobile-sessions-panel.tsx
+++ b/src/components/mobile-sessions-panel.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Add01Icon, Chat01Icon } from '@hugeicons/core-free-icons'
+import { Add01Icon, Chat01Icon, PinIcon } from '@hugeicons/core-free-icons'
 import type { SessionMeta } from '@/screens/chat/types'
 import { cn } from '@/lib/utils'
+import { splitPinnedSessions } from '@/hooks/use-pinned-sessions'
 
 type Props = {
   open: boolean
@@ -11,6 +12,7 @@ type Props = {
   activeFriendlyId: string
   onSelectSession: (key: string) => void
   onNewChat: () => void
+  onTogglePin: (session: SessionMeta) => void
 }
 
 function normalizeLabel(value: string | undefined): string {
@@ -56,6 +58,7 @@ export function MobileSessionsPanel({
   activeFriendlyId,
   onSelectSession,
   onNewChat,
+  onTogglePin,
 }: Props) {
   useEffect(() => {
     if (!open) return
@@ -77,6 +80,57 @@ export function MobileSessionsPanel({
   }, [open])
 
   if (!open) return null
+
+  const [pinnedSessions, unpinnedSessions] = splitPinnedSessions(sessions)
+
+  const renderSession = (session: SessionMeta) => {
+    const active = session.friendlyId === activeFriendlyId
+    const timestamp = formatUpdatedAt(session.updatedAt)
+    const title = getSessionTitle(session)
+    return (
+      <div
+        key={session.key}
+        className={cn(
+          'flex w-full items-center rounded-lg border transition-colors',
+          active
+            ? 'border-accent-300 bg-accent-50'
+            : 'border-transparent bg-primary-50 hover:border-primary-200',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => onSelectSession(session.friendlyId)}
+          className="min-w-0 flex-1 px-3 py-2 text-left"
+        >
+          <div className="truncate text-sm font-medium text-ink">{title}</div>
+          <div className="mt-0.5 flex items-center justify-between gap-2 text-[11px] text-primary-500">
+            <span className="truncate">{session.friendlyId}</span>
+            {timestamp ? <span>{timestamp}</span> : null}
+          </div>
+        </button>
+        {session.source !== 'local' ? (
+          <button
+            type="button"
+            onClick={() => onTogglePin(session)}
+            className={cn(
+              'mr-1 inline-flex size-11 shrink-0 items-center justify-center rounded-lg transition-colors',
+              session.pinned
+                ? 'text-accent-600 hover:bg-accent-100'
+                : 'text-primary-400 hover:bg-primary-200 hover:text-primary-700',
+            )}
+            aria-label={`${session.pinned ? 'Unpin' : 'Pin'} session ${title}`}
+          >
+            <HugeiconsIcon
+              icon={PinIcon}
+              size={18}
+              strokeWidth={1.7}
+              className={session.pinned ? 'fill-current' : undefined}
+            />
+          </button>
+        ) : null}
+      </div>
+    )
+  }
 
   return (
     <div className="fixed inset-0 z-[97] no-swipe md:hidden">
@@ -117,32 +171,27 @@ export function MobileSessionsPanel({
                 </p>
               </div>
             ) : (
-              <div className="space-y-1">
-                {sessions.map((session) => {
-                  const active = session.friendlyId === activeFriendlyId
-                  const timestamp = formatUpdatedAt(session.updatedAt)
-                  return (
-                    <button
-                      key={session.key}
-                      type="button"
-                      onClick={() => onSelectSession(session.friendlyId)}
-                      className={cn(
-                        'w-full rounded-lg border px-3 py-2 text-left transition-colors',
-                        active
-                          ? 'border-accent-300 bg-accent-50'
-                          : 'border-transparent bg-primary-50 hover:border-primary-200',
-                      )}
-                    >
-                      <div className="truncate text-sm font-medium text-ink">
-                        {getSessionTitle(session)}
-                      </div>
-                      <div className="mt-0.5 flex items-center justify-between gap-2 text-[11px] text-primary-500">
-                        <span className="truncate">{session.friendlyId}</span>
-                        {timestamp ? <span>{timestamp}</span> : null}
-                      </div>
-                    </button>
-                  )
-                })}
+              <div className="space-y-4">
+                {pinnedSessions.length > 0 ? (
+                  <section>
+                    <h3 className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-primary-500">
+                      Pinned
+                    </h3>
+                    <div className="space-y-1">
+                      {pinnedSessions.map(renderSession)}
+                    </div>
+                  </section>
+                ) : null}
+                {unpinnedSessions.length > 0 ? (
+                  <section>
+                    <h3 className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-primary-500">
+                      Recent
+                    </h3>
+                    <div className="space-y-1">
+                      {unpinnedSessions.map(renderSession)}
+                    </div>
+                  </section>
+                ) : null}
               </div>
             )}
           </div>

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils'
 import { ConnectionStartupScreen } from '@/components/connection-startup-screen'
 import { ChatSidebar } from '@/screens/chat/components/chat-sidebar'
 import { useChatSessions } from '@/screens/chat/hooks/use-chat-sessions'
+import { usePinnedSessionMigration } from '@/hooks/use-pinned-sessions'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { SIDEBAR_TOGGLE_EVENT } from '@/hooks/use-global-shortcuts'
 import { useSwipeNavigation } from '@/hooks/use-swipe-navigation'
@@ -210,6 +211,7 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     activeFriendlyId,
     isNewChat,
   })
+  usePinnedSessionMigration(sessions)
 
   const startNewChat = useCallback(() => {
     setCreatingSession(true)

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -211,7 +211,10 @@ export function WorkspaceShell({ children }: WorkspaceShellProps) {
     activeFriendlyId,
     isNewChat,
   })
-  usePinnedSessionMigration(sessions)
+  usePinnedSessionMigration(
+    sessions,
+    !sessionsLoading && !sessionsFetching,
+  )
 
   const startNewChat = useCallback(() => {
     setCreatingSession(true)

--- a/src/hooks/use-pinned-sessions.test.ts
+++ b/src/hooks/use-pinned-sessions.test.ts
@@ -38,6 +38,28 @@ describe('writeSessionPin', () => {
       }),
     })
   })
+
+  it('rejects a successful response that does not confirm persistence', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+
+    await expect(
+      writeSessionPin(
+        {
+          key: 'session-key',
+          friendlyId: 'friendly-id',
+        },
+        true,
+      ),
+    ).rejects.toThrow('did not confirm')
+  })
 })
 
 describe('planLegacyPinMigration', () => {

--- a/src/hooks/use-pinned-sessions.test.ts
+++ b/src/hooks/use-pinned-sessions.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  planLegacyPinMigration,
+  writeSessionPin,
+} from './use-pinned-sessions'
+import type { SessionMeta } from '@/screens/chat/types'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('writeSessionPin', () => {
+  it('PATCHes the shared sessions API with the durable pin value', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, pinned: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await writeSessionPin(
+      {
+        key: 'session-key',
+        friendlyId: 'friendly-id',
+      },
+      true,
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/sessions', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionKey: 'session-key',
+        friendlyId: 'friendly-id',
+        pinned: true,
+      }),
+    })
+  })
+})
+
+describe('planLegacyPinMigration', () => {
+  it('migrates resolvable backend pins while preserving missing and local keys', () => {
+    const sessions: Array<SessionMeta> = [
+      {
+        key: 'already-pinned',
+        friendlyId: 'already-pinned',
+        pinned: true,
+      },
+      {
+        key: 'candidate',
+        friendlyId: 'candidate',
+        pinned: false,
+      },
+      {
+        key: 'local-session',
+        friendlyId: 'local-session',
+        source: 'local',
+        pinned: false,
+      },
+    ]
+
+    const plan = planLegacyPinMigration(
+      ['already-pinned', 'candidate', 'local-session', 'not-loaded'],
+      sessions,
+    )
+
+    expect(plan.candidates.map(({ legacyKey }) => legacyKey)).toEqual([
+      'candidate',
+    ])
+    expect([...plan.unresolved]).toEqual([
+      'candidate',
+      'local-session',
+      'not-loaded',
+    ])
+  })
+})

--- a/src/hooks/use-pinned-sessions.test.ts
+++ b/src/hooks/use-pinned-sessions.test.ts
@@ -96,5 +96,6 @@ describe('planLegacyPinMigration', () => {
       'local-session',
       'not-loaded',
     ])
+    expect([...plan.unattempted]).toEqual(['not-loaded'])
   })
 })

--- a/src/hooks/use-pinned-sessions.ts
+++ b/src/hooks/use-pinned-sessions.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { SessionMeta } from '@/screens/chat/types'
 import { chatQueryKeys } from '@/screens/chat/chat-queries'
+import { toast } from '@/components/ui/toast'
 
 const LEGACY_STORAGE_KEY = 'pinned-sessions'
 const MIGRATION_MARKER = 'pinned-sessions-backend-migrated-v1'
@@ -40,11 +41,15 @@ export async function writeSessionPin(
       pinned,
     }),
   })
+  const payload = (await response.json().catch(() => ({}))) as {
+    error?: string
+    pinned?: boolean
+  }
   if (!response.ok) {
-    const payload = (await response.json().catch(() => ({}))) as {
-      error?: string
-    }
     throw new Error(payload.error || `Pin update failed (${response.status})`)
+  }
+  if (payload.pinned !== pinned) {
+    throw new Error('Hermes backend did not confirm the session pin update')
   }
 }
 
@@ -126,10 +131,14 @@ export function usePinnedSessions() {
       )
       return { previous }
     },
-    onError: (_error, _variables, context) => {
+    onError: (error, _variables, context) => {
       if (context?.previous) {
         queryClient.setQueryData(chatQueryKeys.sessions, context.previous)
       }
+      toast(
+        error instanceof Error ? error.message : 'Failed to update session pin',
+        { type: 'error' },
+      )
     },
     onSettled: async () => {
       await Promise.all([
@@ -174,9 +183,7 @@ export function usePinnedSessionMigration(sessions: Array<SessionMeta>) {
 
       const remaining = [...unresolved]
       writeLegacyPinnedKeys(remaining)
-      if (remaining.length === 0) {
-        setStorageItem(MIGRATION_MARKER, '1')
-      }
+      setStorageItem(MIGRATION_MARKER, '1')
       if (migrated > 0) {
         await queryClient.invalidateQueries({
           queryKey: chatQueryKeys.sessions,

--- a/src/hooks/use-pinned-sessions.ts
+++ b/src/hooks/use-pinned-sessions.ts
@@ -156,11 +156,14 @@ export function usePinnedSessions() {
   }
 }
 
-export function usePinnedSessionMigration(sessions: Array<SessionMeta>) {
+export function usePinnedSessionMigration(
+  sessions: Array<SessionMeta>,
+  ready: boolean,
+) {
   const queryClient = useQueryClient()
 
   useEffect(() => {
-    if (migrationStarted || sessions.length === 0) return
+    if (migrationStarted || !ready || sessions.length === 0) return
     if (getStorageItem(MIGRATION_MARKER) === '1') return
     migrationStarted = true
 
@@ -174,8 +177,12 @@ export function usePinnedSessionMigration(sessions: Array<SessionMeta>) {
       candidates.map(({ session }) => writeSessionPin(session, true)),
     ).then(async (results) => {
       let migrated = 0
+      let rejected = 0
       results.forEach((result, index) => {
-        if (result.status !== 'fulfilled') return
+        if (result.status !== 'fulfilled') {
+          rejected += 1
+          return
+        }
         const candidate = candidates[index]
         unresolved.delete(candidate.legacyKey)
         migrated += 1
@@ -183,12 +190,19 @@ export function usePinnedSessionMigration(sessions: Array<SessionMeta>) {
 
       const remaining = [...unresolved]
       writeLegacyPinnedKeys(remaining)
-      setStorageItem(MIGRATION_MARKER, '1')
+      if (rejected === 0) {
+        setStorageItem(MIGRATION_MARKER, '1')
+      } else {
+        toast(
+          `Couldn't migrate ${rejected} pinned session${rejected === 1 ? '' : 's'}; will retry next time`,
+          { type: 'error' },
+        )
+      }
       if (migrated > 0) {
         await queryClient.invalidateQueries({
           queryKey: chatQueryKeys.sessions,
         })
       }
     })
-  }, [queryClient, sessions])
+  }, [queryClient, ready, sessions])
 }

--- a/src/hooks/use-pinned-sessions.ts
+++ b/src/hooks/use-pinned-sessions.ts
@@ -95,19 +95,24 @@ export function planLegacyPinMigration(
   sessions: Array<SessionMeta>,
 ) {
   const unresolved = new Set(legacyKeys)
+  const unattempted = new Set<string>()
   const candidates: Array<{ legacyKey: string; session: SessionMeta }> = []
   for (const legacyKey of legacyKeys) {
     const session = sessions.find(
       (row) => row.key === legacyKey || row.friendlyId === legacyKey,
     )
-    if (!session || session.source === 'local') continue
+    if (!session) {
+      unattempted.add(legacyKey)
+      continue
+    }
+    if (session.source === 'local') continue
     if (session.pinned) {
       unresolved.delete(legacyKey)
       continue
     }
     candidates.push({ legacyKey, session })
   }
-  return { candidates, unresolved }
+  return { candidates, unresolved, unattempted }
 }
 
 export function usePinnedSessions() {
@@ -169,7 +174,7 @@ export function usePinnedSessionMigration(
 
     const legacyKeys = readLegacyPinnedKeys()
     if (legacyKeys === null) return
-    const { candidates, unresolved } = planLegacyPinMigration(
+    const { candidates, unresolved, unattempted } = planLegacyPinMigration(
       legacyKeys,
       sessions,
     )
@@ -190,11 +195,12 @@ export function usePinnedSessionMigration(
 
       const remaining = [...unresolved]
       writeLegacyPinnedKeys(remaining)
-      if (rejected === 0) {
+      if (rejected === 0 && unattempted.size === 0) {
         setStorageItem(MIGRATION_MARKER, '1')
       } else {
+        const deferred = rejected + unattempted.size
         toast(
-          `Couldn't migrate ${rejected} pinned session${rejected === 1 ? '' : 's'}; will retry next time`,
+          `Couldn't migrate ${deferred} pinned session${deferred === 1 ? '' : 's'}; will retry next time`,
           { type: 'error' },
         )
       }

--- a/src/hooks/use-pinned-sessions.ts
+++ b/src/hooks/use-pinned-sessions.ts
@@ -1,46 +1,187 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { useEffect } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { SessionMeta } from '@/screens/chat/types'
+import { chatQueryKeys } from '@/screens/chat/chat-queries'
 
-type PinnedSessionsState = {
-  pinnedSessionKeys: Array<string>
-  pinSession: (key: string) => void
-  unpinSession: (key: string) => void
-  togglePinnedSession: (key: string) => void
-  isSessionPinned: (key: string) => boolean
+const LEGACY_STORAGE_KEY = 'pinned-sessions'
+const MIGRATION_MARKER = 'pinned-sessions-backend-migrated-v1'
+let migrationStarted = false
+
+function getStorageItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
 }
 
-export const usePinnedSessionsStore = create<PinnedSessionsState>()(
-  persist(
-    (set, get) => ({
-      pinnedSessionKeys: [],
-      pinSession: (key) =>
-        set((state) => {
-          if (state.pinnedSessionKeys.includes(key)) return state
-          return { pinnedSessionKeys: [...state.pinnedSessionKeys, key] }
-        }),
-      unpinSession: (key) =>
-        set((state) => ({
-          pinnedSessionKeys: state.pinnedSessionKeys.filter(
-            (pinnedKey) => pinnedKey !== key,
-          ),
-        })),
-      togglePinnedSession: (key) => {
-        if (get().isSessionPinned(key)) {
-          get().unpinSession(key)
-          return
-        }
-        get().pinSession(key)
-      },
-      isSessionPinned: (key) => get().pinnedSessionKeys.includes(key),
+function setStorageItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value)
+  } catch {}
+}
+
+function removeStorageItem(key: string) {
+  try {
+    localStorage.removeItem(key)
+  } catch {}
+}
+
+export async function writeSessionPin(
+  session: SessionMeta,
+  pinned: boolean,
+) {
+  const response = await fetch('/api/sessions', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sessionKey: session.key,
+      friendlyId: session.friendlyId,
+      pinned,
     }),
-    { name: 'pinned-sessions' },
-  ),
-)
+  })
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => ({}))) as {
+      error?: string
+    }
+    throw new Error(payload.error || `Pin update failed (${response.status})`)
+  }
+}
+
+function readLegacyPinnedKeys(): Array<string> | null {
+  try {
+    const raw = getStorageItem(LEGACY_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as {
+      state?: { pinnedSessionKeys?: unknown }
+    }
+    if (!Array.isArray(parsed.state?.pinnedSessionKeys)) return null
+    return parsed.state.pinnedSessionKeys.filter(
+      (key): key is string => typeof key === 'string' && key.length > 0,
+    )
+  } catch {
+    return null
+  }
+}
+
+function writeLegacyPinnedKeys(keys: Array<string>) {
+  if (keys.length === 0) {
+    removeStorageItem(LEGACY_STORAGE_KEY)
+    return
+  }
+  setStorageItem(
+    LEGACY_STORAGE_KEY,
+    JSON.stringify({ state: { pinnedSessionKeys: keys }, version: 0 }),
+  )
+}
+
+export function splitPinnedSessions(sessions: Array<SessionMeta>) {
+  const pinned: Array<SessionMeta> = []
+  const unpinned: Array<SessionMeta> = []
+  for (const session of sessions) {
+    if (session.pinned) pinned.push(session)
+    else unpinned.push(session)
+  }
+  return [pinned, unpinned] as const
+}
+
+export function planLegacyPinMigration(
+  legacyKeys: Array<string>,
+  sessions: Array<SessionMeta>,
+) {
+  const unresolved = new Set(legacyKeys)
+  const candidates: Array<{ legacyKey: string; session: SessionMeta }> = []
+  for (const legacyKey of legacyKeys) {
+    const session = sessions.find(
+      (row) => row.key === legacyKey || row.friendlyId === legacyKey,
+    )
+    if (!session || session.source === 'local') continue
+    if (session.pinned) {
+      unresolved.delete(legacyKey)
+      continue
+    }
+    candidates.push({ legacyKey, session })
+  }
+  return { candidates, unresolved }
+}
 
 export function usePinnedSessions() {
-  const pinnedSessionKeys = usePinnedSessionsStore((s) => s.pinnedSessionKeys)
-  const togglePinnedSession = usePinnedSessionsStore(
-    (s) => s.togglePinnedSession,
-  )
-  return { pinnedSessionKeys, togglePinnedSession }
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: ({ session, pinned }: { session: SessionMeta; pinned: boolean }) =>
+      writeSessionPin(session, pinned),
+    onMutate: async ({ session, pinned }) => {
+      await queryClient.cancelQueries({ queryKey: chatQueryKeys.sessions })
+      const previous = queryClient.getQueryData<Array<SessionMeta>>(
+        chatQueryKeys.sessions,
+      )
+      queryClient.setQueryData<Array<SessionMeta>>(
+        chatQueryKeys.sessions,
+        (current = []) =>
+          current.map((row) =>
+            row.key === session.key || row.friendlyId === session.friendlyId
+              ? { ...row, pinned }
+              : row,
+          ),
+      )
+      return { previous }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(chatQueryKeys.sessions, context.previous)
+      }
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: chatQueryKeys.sessions }),
+        queryClient.invalidateQueries({ queryKey: ['command-center-sessions'] }),
+      ])
+    },
+  })
+
+  return {
+    togglePinnedSession: (session: SessionMeta) => {
+      if (session.source === 'local') return
+      mutation.mutate({ session, pinned: !session.pinned })
+    },
+  }
+}
+
+export function usePinnedSessionMigration(sessions: Array<SessionMeta>) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (migrationStarted || sessions.length === 0) return
+    if (getStorageItem(MIGRATION_MARKER) === '1') return
+    migrationStarted = true
+
+    const legacyKeys = readLegacyPinnedKeys()
+    if (legacyKeys === null) return
+    const { candidates, unresolved } = planLegacyPinMigration(
+      legacyKeys,
+      sessions,
+    )
+    void Promise.allSettled(
+      candidates.map(({ session }) => writeSessionPin(session, true)),
+    ).then(async (results) => {
+      let migrated = 0
+      results.forEach((result, index) => {
+        if (result.status !== 'fulfilled') return
+        const candidate = candidates[index]
+        unresolved.delete(candidate.legacyKey)
+        migrated += 1
+      })
+
+      const remaining = [...unresolved]
+      writeLegacyPinnedKeys(remaining)
+      if (remaining.length === 0) {
+        setStorageItem(MIGRATION_MARKER, '1')
+      }
+      if (migrated > 0) {
+        await queryClient.invalidateQueries({
+          queryKey: chatQueryKeys.sessions,
+        })
+      }
+    })
+  }, [queryClient, sessions])
 }

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -244,19 +244,20 @@ export const Route = createFileRoute('/api/sessions')({
             })
           }
 
+          let persistedPinned: boolean | undefined
           if (pinned !== undefined) {
-            await setSessionPinned(sessionKey, pinned)
+            persistedPinned = await setSessionPinned(sessionKey, pinned)
             if (label === undefined) {
               return json({
                 ok: true,
                 sessionKey,
                 friendlyId: rawFriendlyId || sessionKey,
-                pinned,
+                pinned: persistedPinned,
                 entry: {
                   key: sessionKey,
                   id: sessionKey,
                   friendlyId: rawFriendlyId || sessionKey,
-                  pinned,
+                  pinned: persistedPinned,
                 },
               })
             }
@@ -273,9 +274,13 @@ export const Route = createFileRoute('/api/sessions')({
                 label: label || sessionKey,
                 derivedTitle: label || sessionKey,
                 updatedAt: Date.now(),
-                ...(pinned === undefined ? {} : { pinned }),
+                ...(persistedPinned === undefined
+                  ? {}
+                  : { pinned: persistedPinned }),
               },
-              ...(pinned === undefined ? {} : { pinned }),
+              ...(persistedPinned === undefined
+                ? {}
+                : { pinned: persistedPinned }),
               updated: false,
             })
           }
@@ -284,12 +289,14 @@ export const Route = createFileRoute('/api/sessions')({
             title: label,
           })
           const entry = toSessionSummary(session)
-          if (pinned !== undefined) entry.pinned = pinned
+          if (persistedPinned !== undefined) entry.pinned = persistedPinned
 
           return json({
             ok: true,
             sessionKey,
-            ...(pinned === undefined ? {} : { pinned }),
+            ...(persistedPinned === undefined
+              ? {}
+              : { pinned: persistedPinned }),
             entry,
           })
         } catch (err) {

--- a/src/routes/api/sessions.ts
+++ b/src/routes/api/sessions.ts
@@ -10,16 +10,17 @@ import {
   ensureGatewayProbed,
   getGatewayCapabilities,
   listSessions,
+  setSessionPinned,
   toSessionSummary,
   updateSession,
 } from '../../server/claude-api'
-import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 import {
   deleteLocalSession,
   getLocalSession,
   listLocalSessions,
   updateLocalSessionTitle,
 } from '../../server/local-session-store'
+import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
 
 export const Route = createFileRoute('/api/sessions')({
   server: {
@@ -192,6 +193,8 @@ export const Route = createFileRoute('/api/sessions')({
             typeof body.friendlyId === 'string' ? body.friendlyId.trim() : ''
           const label =
             typeof body.label === 'string' ? body.label.trim() : undefined
+          const pinned =
+            typeof body.pinned === 'boolean' ? body.pinned : undefined
           const sessionKey = rawSessionKey || rawFriendlyId
 
           if (!sessionKey) {
@@ -201,8 +204,24 @@ export const Route = createFileRoute('/api/sessions')({
             )
           }
 
+          if (label === undefined && pinned === undefined) {
+            return json(
+              { ok: false, error: 'label or pinned required' },
+              { status: 400 },
+            )
+          }
+
           const localSession = getLocalSession(sessionKey)
           if (localSession) {
+            if (pinned !== undefined) {
+              return json(
+                {
+                  ok: false,
+                  error: 'Portable local sessions do not support shared pins',
+                },
+                { status: 400 },
+              )
+            }
             if (label) updateLocalSessionTitle(sessionKey, label)
             return json({
               ok: true,
@@ -225,6 +244,24 @@ export const Route = createFileRoute('/api/sessions')({
             })
           }
 
+          if (pinned !== undefined) {
+            await setSessionPinned(sessionKey, pinned)
+            if (label === undefined) {
+              return json({
+                ok: true,
+                sessionKey,
+                friendlyId: rawFriendlyId || sessionKey,
+                pinned,
+                entry: {
+                  key: sessionKey,
+                  id: sessionKey,
+                  friendlyId: rawFriendlyId || sessionKey,
+                  pinned,
+                },
+              })
+            }
+          }
+
           if (capabilities.dashboard.available && !capabilities.enhancedChat) {
             return json({
               ok: true,
@@ -236,7 +273,9 @@ export const Route = createFileRoute('/api/sessions')({
                 label: label || sessionKey,
                 derivedTitle: label || sessionKey,
                 updatedAt: Date.now(),
+                ...(pinned === undefined ? {} : { pinned }),
               },
+              ...(pinned === undefined ? {} : { pinned }),
               updated: false,
             })
           }
@@ -244,11 +283,14 @@ export const Route = createFileRoute('/api/sessions')({
           const session = await updateSession(sessionKey, {
             title: label,
           })
+          const entry = toSessionSummary(session)
+          if (pinned !== undefined) entry.pinned = pinned
 
           return json({
             ok: true,
             sessionKey,
-            entry: toSessionSummary(session),
+            ...(pinned === undefined ? {} : { pinned }),
+            entry,
           })
         } catch (err) {
           return json(

--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -81,6 +81,7 @@ import type {
 import type { ApprovalRequest } from '@/screens/gateway/lib/approvals-store'
 import type { ChatAttachment, ChatMessage, SessionMeta } from './types'
 import type {AgentActivity} from '@/stores/chat-activity-store';
+import { usePinnedSessions } from '@/hooks/use-pinned-sessions'
 import { useChatSettingsStore } from '@/hooks/use-chat-settings'
 import { playChatComplete } from '@/lib/sounds'
 import {
@@ -567,6 +568,7 @@ export function ChatScreen({
     sessionsFetching: _sessionsFetching,
     refetchSessions: _refetchSessions,
   } = useChatSessions({ activeFriendlyId, isNewChat, forcedSessionKey })
+  const { togglePinnedSession } = usePinnedSessions()
   const {
     historyQuery,
     historyMessages,
@@ -2956,6 +2958,7 @@ export function ChatScreen({
               params: { sessionKey: 'new' },
             })
           }}
+          onTogglePin={togglePinnedSession}
         />
       )}
 

--- a/src/screens/chat/components/sidebar/session-item.tsx
+++ b/src/screens/chat/components/sidebar/session-item.tsx
@@ -107,6 +107,7 @@ function SessionItemComponent({
 }: SessionItemProps) {
   const isGenerating = session.titleStatus === 'generating'
   const isError = session.titleStatus === 'error'
+  const canPin = session.source !== 'local'
   const baseTitle = getSessionDisplayTitle(session, isGenerating)
 
   const updatedAt = useMemo(() => {
@@ -186,17 +187,19 @@ function SessionItemComponent({
           />
         </MenuTrigger>
         <MenuContent side="bottom" align="end">
-          <MenuItem
-            onClick={(event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              onTogglePin(session)
-            }}
-            className="gap-2"
-          >
-            <HugeiconsIcon icon={PinIcon} size={20} strokeWidth={1.5} />{' '}
-            {isPinned ? 'Unpin session' : 'Pin session'}
-          </MenuItem>
+          {canPin ? (
+            <MenuItem
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                onTogglePin(session)
+              }}
+              className="gap-2"
+            >
+              <HugeiconsIcon icon={PinIcon} size={20} strokeWidth={1.5} />{' '}
+              {isPinned ? 'Unpin session' : 'Pin session'}
+            </MenuItem>
+          ) : null}
           <MenuItem
             onClick={(event) => {
               event.preventDefault()

--- a/src/screens/chat/components/sidebar/sidebar-sessions.tsx
+++ b/src/screens/chat/components/sidebar/sidebar-sessions.tsx
@@ -17,7 +17,10 @@ import {
   ScrollAreaViewport,
 } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
-import { usePinnedSessions } from '@/hooks/use-pinned-sessions'
+import {
+  splitPinnedSessions,
+  usePinnedSessions,
+} from '@/hooks/use-pinned-sessions'
 
 type SidebarSessionsProps = {
   sessions: Array<SessionMeta>
@@ -44,24 +47,14 @@ export const SidebarSessions = memo(function SidebarSessions({
   error,
   onRetry,
 }: SidebarSessionsProps) {
-  const { pinnedSessionKeys, togglePinnedSession } = usePinnedSessions()
+  const { togglePinnedSession } = usePinnedSessions()
 
   const [pinnedSessions, unpinnedSessions] = useMemo(() => {
-    const pinnedKeys = new Set(pinnedSessionKeys)
-    const pinned: Array<SessionMeta> = []
-    const unpinned: Array<SessionMeta> = []
-    for (const session of sessions) {
-      if (pinnedKeys.has(session.key)) {
-        pinned.push(session)
-      } else {
-        unpinned.push(session)
-      }
-    }
-    return [pinned, unpinned] as const
-  }, [pinnedSessionKeys, sessions])
+    return splitPinnedSessions(sessions)
+  }, [sessions])
 
   function handleTogglePin(session: SessionMeta) {
-    togglePinnedSession(session.key)
+    togglePinnedSession(session)
   }
 
   return (

--- a/src/screens/chat/types.ts
+++ b/src/screens/chat/types.ts
@@ -83,6 +83,7 @@ export type SessionTitleSource = 'auto' | 'manual'
 
 export type SessionSummary = {
   key?: string
+  source?: string
   label?: string
   title?: string
   derivedTitle?: string
@@ -93,6 +94,7 @@ export type SessionSummary = {
   titleSource?: SessionTitleSource
   titleError?: string | null
   preview?: string | null
+  pinned?: boolean
 }
 
 export type SessionListResponse = {
@@ -108,6 +110,7 @@ export type HistoryResponse = {
 export type SessionMeta = {
   key: string
   friendlyId: string
+  source?: string
   title?: string
   derivedTitle?: string
   label?: string
@@ -117,6 +120,7 @@ export type SessionMeta = {
   titleSource?: SessionTitleSource
   titleError?: string | null
   preview?: string | null
+  pinned?: boolean
 }
 
 export type PathsPayload = {

--- a/src/screens/chat/utils.test.ts
+++ b/src/screens/chat/utils.test.ts
@@ -39,3 +39,35 @@ describe('chat utils workspace directive cleanup', () => {
     expect(sessions[1]?.derivedTitle).toBe('Fix Docker publish')
   })
 })
+
+describe('chat session pin normalization', () => {
+  it('preserves the durable backend pinned flag', () => {
+    const sessions = normalizeSessions([
+      {
+        key: 'pinned-session',
+        friendlyId: 'pinned-session',
+        pinned: true,
+      },
+      {
+        key: 'regular-session',
+        friendlyId: 'regular-session',
+        pinned: false,
+      },
+    ] satisfies Array<SessionSummary>)
+
+    expect(sessions.map((session) => session.pinned)).toEqual([true, false])
+  })
+
+  it('preserves source and leaves missing pin state undefined', () => {
+    const [session] = normalizeSessions([
+      {
+        key: 'legacy-session',
+        friendlyId: 'legacy-session',
+        source: 'desktop',
+      },
+    ])
+
+    expect(session?.source).toBe('desktop')
+    expect(session?.pinned).toBeUndefined()
+  })
+})

--- a/src/screens/chat/utils.ts
+++ b/src/screens/chat/utils.ts
@@ -253,6 +253,7 @@ export function normalizeSessions(
     return {
       key,
       friendlyId: friendlyIdCandidate,
+      source: typeof session.source === 'string' ? session.source : undefined,
       title: explicitTitle,
       derivedTitle,
       label,
@@ -262,6 +263,8 @@ export function normalizeSessions(
       titleStatus,
       titleSource,
       titleError: session.titleError ?? null,
+      pinned:
+        typeof session.pinned === 'boolean' ? session.pinned : undefined,
       preview:
         typeof session.preview === 'string'
           ? cleanUserText(session.preview) || session.preview.trim() || null

--- a/src/server/claude-api-session-summary.test.ts
+++ b/src/server/claude-api-session-summary.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { toSessionSummary } from './claude-api'
+
+describe('toSessionSummary', () => {
+  it('preserves the durable backend pin flag', () => {
+    expect(
+      toSessionSummary({
+        id: 'session-1',
+        pinned: true,
+      } as any),
+    ).toMatchObject({
+      key: 'session-1',
+      friendlyId: 'session-1',
+      pinned: true,
+    })
+  })
+
+  it('omits pinned when an older or label-only response has no pin opinion', () => {
+    const summary = toSessionSummary({
+      id: 'session-2',
+      source: 'desktop',
+    })
+
+    expect(summary).toMatchObject({ source: 'desktop' })
+    expect(summary).not.toHaveProperty('pinned')
+  })
+})

--- a/src/server/claude-api-session-summary.test.ts
+++ b/src/server/claude-api-session-summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { toSessionSummary } from './claude-api'
+import { requireConfirmedPinned, toSessionSummary } from './claude-api'
 
 describe('toSessionSummary', () => {
   it('preserves the durable backend pin flag', () => {
@@ -24,5 +24,21 @@ describe('toSessionSummary', () => {
 
     expect(summary).toMatchObject({ source: 'desktop' })
     expect(summary).not.toHaveProperty('pinned')
+  })
+})
+
+describe('requireConfirmedPinned', () => {
+  it('accepts a matching persisted pin response', () => {
+    expect(requireConfirmedPinned({ pinned: true }, true)).toBe(true)
+    expect(
+      requireConfirmedPinned({ session: { pinned: false } }, false),
+    ).toBe(false)
+  })
+
+  it('rejects an unconfirmed or contradictory response', () => {
+    expect(() => requireConfirmedPinned({}, true)).toThrow('did not confirm')
+    expect(() => requireConfirmedPinned({ pinned: false }, true)).toThrow(
+      'did not confirm',
+    )
   })
 })

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -48,6 +48,7 @@ export type ClaudeSession = {
   parent_session_id?: string | null
   last_active?: number | null
   preview?: string | null
+  pinned?: boolean
 }
 
 export type ClaudeMessage = {
@@ -172,17 +173,35 @@ export async function createSession(opts?: {
 
 export async function updateSession(
   sessionId: string,
-  updates: { title?: string },
+  updates: { title?: string; pinned?: boolean },
 ): Promise<ClaudeSession> {
   if (getCapabilities().dashboard.available) {
     const resp = await updateDashboardSession(sessionId, updates)
-    return resp.session as ClaudeSession
+    if (resp.session) return resp.session as ClaudeSession
+    return {
+      id: sessionId,
+      title: resp.title,
+      pinned: resp.pinned,
+    }
   }
   const resp = await claudePatch<{ session: ClaudeSession }>(
     `/api/sessions/${sessionId}`,
     updates,
   )
   return resp.session
+}
+
+export async function setSessionPinned(
+  sessionId: string,
+  pinned: boolean,
+): Promise<void> {
+  if (getCapabilities().dashboard.available) {
+    await updateDashboardSession(sessionId, { pinned })
+    return
+  }
+  await claudePatch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+    pinned,
+  })
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {
@@ -329,10 +348,14 @@ export function toSessionSummary(
     kind: 'chat',
     status: session.ended_at ? 'ended' : 'idle',
     model: session.model || '',
+    source: session.source,
     label: session.title || undefined,
     title: session.title || undefined,
     derivedTitle: session.title || session.preview || undefined,
     preview: session.preview || undefined,
+    ...(typeof session.pinned === 'boolean'
+      ? { pinned: session.pinned }
+      : {}),
     tokenCount: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
     totalTokens: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
     message_count: session.message_count ?? 0,

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -194,14 +194,30 @@ export async function updateSession(
 export async function setSessionPinned(
   sessionId: string,
   pinned: boolean,
-): Promise<void> {
+): Promise<boolean> {
   if (getCapabilities().dashboard.available) {
-    await updateDashboardSession(sessionId, { pinned })
-    return
+    const response = await updateDashboardSession(sessionId, { pinned })
+    const observed =
+      typeof response.pinned === 'boolean'
+        ? response.pinned
+        : response.session?.pinned
+    if (observed !== pinned) {
+      throw new Error('Hermes backend did not confirm the session pin update')
+    }
+    return observed
   }
-  await claudePatch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
-    pinned,
-  })
+  const response = await claudePatch<{
+    pinned?: boolean
+    session?: ClaudeSession
+  }>(`/api/sessions/${encodeURIComponent(sessionId)}`, { pinned })
+  const observed =
+    typeof response.pinned === 'boolean'
+      ? response.pinned
+      : response.session?.pinned
+  if (observed !== pinned) {
+    throw new Error('Hermes backend did not confirm the session pin update')
+  }
+  return observed
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {

--- a/src/server/claude-api.ts
+++ b/src/server/claude-api.ts
@@ -197,19 +197,19 @@ export async function setSessionPinned(
 ): Promise<boolean> {
   if (getCapabilities().dashboard.available) {
     const response = await updateDashboardSession(sessionId, { pinned })
-    const observed =
-      typeof response.pinned === 'boolean'
-        ? response.pinned
-        : response.session?.pinned
-    if (observed !== pinned) {
-      throw new Error('Hermes backend did not confirm the session pin update')
-    }
-    return observed
+    return requireConfirmedPinned(response, pinned)
   }
   const response = await claudePatch<{
     pinned?: boolean
     session?: ClaudeSession
   }>(`/api/sessions/${encodeURIComponent(sessionId)}`, { pinned })
+  return requireConfirmedPinned(response, pinned)
+}
+
+export function requireConfirmedPinned(
+  response: { pinned?: boolean; session?: { pinned?: boolean } },
+  pinned: boolean,
+): boolean {
   const observed =
     typeof response.pinned === 'boolean'
       ? response.pinned

--- a/src/server/claude-dashboard-api.test.ts
+++ b/src/server/claude-dashboard-api.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dashboardFetchMock } = vi.hoisted(() => ({
+  dashboardFetchMock: vi.fn(),
+}))
+
+vi.mock('./gateway-capabilities', () => ({
+  CLAUDE_DASHBOARD_URL: 'http://127.0.0.1:9119',
+  dashboardFetch: dashboardFetchMock,
+}))
+
+import { updateSession } from './claude-dashboard-api'
+
+beforeEach(() => {
+  dashboardFetchMock.mockReset()
+})
+
+describe('dashboard session pin updates', () => {
+  it('PATCHes the durable pinned field to the Hermes dashboard API', async () => {
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, pinned: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(updateSession('session-1', { pinned: true })).resolves.toMatchObject({
+      ok: true,
+      pinned: true,
+    })
+    expect(dashboardFetchMock).toHaveBeenCalledWith('/api/sessions/session-1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinned: true }),
+    })
+  })
+})

--- a/src/server/claude-dashboard-api.ts
+++ b/src/server/claude-dashboard-api.ts
@@ -22,6 +22,7 @@ export type DashboardSession = {
   last_active?: number | null
   is_active?: boolean
   preview?: string | null
+  pinned?: boolean
 }
 
 export type DashboardMessage = {
@@ -161,7 +162,12 @@ export async function createSession(
 export async function updateSession(
   id: string,
   body: Record<string, unknown>,
-): Promise<{ session: DashboardSession }> {
+): Promise<{
+  session?: DashboardSession
+  ok?: boolean
+  title?: string
+  pinned?: boolean
+}> {
   return dashboardJson(`/api/sessions/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- use Hermes Agent's durable `sessions.pinned` field as Workspace's source of truth
- synchronize native session pins across Hermes Desktop, desktop Workspace, and mobile Workspace
- migrate legacy browser-local pins once without deleting unresolved or portable-local keys
- add mobile **Pinned**/**Recent** sections and accessible 44px pin controls
- hide unsupported pin actions for portable local sessions

Fixes #777

## Root cause

Workspace introduced pinned sessions before Hermes Agent exposed durable session pins. It continued to store pin keys in per-browser Zustand `localStorage`, and its session adapters discarded the backend `pinned` field. The mobile drawer had no pin controls.

## Implementation

- preserve optional `pinned` and `source` fields through dashboard, server-summary, and client-normalization layers
- PATCH pin changes through Workspace's authenticated `/api/sessions` route to the Hermes dashboard/gateway
- optimistically update the exact shared React Query session cache and roll back failed writes
- run legacy migration once from `WorkspaceShell`; use `Promise.allSettled`, preserve unresolved/local keys, and guard blocked storage
- render backend-backed pin controls in both desktop and mobile session surfaces

## Verification

- `pnpm build` — passed
- focused Vitest suite — **13/13 passed**
  - server summary pin propagation and optional-pin semantics
  - dashboard PATCH payload
  - Workspace PATCH payload and migration planning
  - client normalization
  - mobile pinned-section/control rendering
- reversible live API smoke test — pin persisted to Hermes's durable database, read back through `/api/sessions`, then restored; original five pins remained unchanged
- Playwright mobile check at 412×915 — five durable pins shown in **Pinned**, 45 recent sessions with pin controls, no clipping
- static added-line security scan — no hardcoded secrets, shell injection, eval/exec, or unsafe deserialization
- Claude Opus 5, high-effort pre-commit review — initial BLOCK findings fixed; final verdict **PASS**

## Existing repository quality debt

`pnpm exec tsc --noEmit` still exits 2 with 96 existing diagnostics. The only three diagnostics in a touched file are the pre-existing `workspace-shell.tsx` `embed`/`mode` search-param errors (the import added by this PR shifts their line from 194 to 195). The repository also has pre-existing ESLint/test-suite failures documented on current `main`; this PR adds no known pin-sync type error and the production build is green.

## Scope

Portable local sessions remain local-only and do not gain backend pin synchronization. Pin ordering synchronization and unrelated sidebar/chat refactors are intentionally excluded.
