### PR TITLE
fix: authenticate remote harness fetches with the workspace API token

### DIFF
--- a/src/server/remote-harnesses.ts
+++ b/src/server/remote-harnesses.ts
@@ -91,6 +91,8 @@ async function fetchJson(
   const headers = new Headers(init?.headers)
   headers.set('accept', 'application/json')
   if (init?.body) headers.set('content-type', 'application/json')
+  const apiToken = process.env.HERMES_API_TOKEN
+  if (apiToken) headers.set('authorization', `Bearer ${apiToken}`)
   const response = await fetch(url, {
     ...init,
     headers,


### PR DESCRIPTION
In split deployments the workspace container runs remotely from the paired Hermes gateway, so harness endpoints (health, sessions, chat) 401 unless the fetch carries the same bearer token the primary gateway already accepts. This attaches the workspace token when `HERMES_API_TOKEN` is set, which fixes paired harnesses (type `hermes`) in remote deployments.

Verified live: with this change, a workspace container reaching two remote Hermes gateways (Mac + Solvy) via internal reverse-tunnel bridges lists both as online and creates remote sessions.