### PR TITLE
fix: tolerate missing local AionCore companion in external-conversations

### DIFF
--- a/src/server/aioncore-conversations.ts
+++ b/src/server/aioncore-conversations.ts
@@ -184,7 +184,12 @@ export async function listExternalConversations(): Promise<
       : []
   const remote =
     remoteResult.status === 'fulfilled' ? remoteResult.value : []
-  if (!local.length && !remote.length && localResult.status === 'rejected') {
+  if (
+    !local.length &&
+    !remote.length &&
+    localResult.status === 'rejected' &&
+    !(localResult.reason instanceof Error && /fetch failed/i.test(localResult.reason.message))
+  ) {
     throw localResult.reason
   }
   return [...remote, ...local].sort(


### PR DESCRIPTION
Hermes-only deployments (workspace paired with a Hermes gateway, no local AionCore companion) hit a network-level `fetch failed` from `requestAionCoreJson` (the companion listens on 127.0.0.1:25808, absent in these setups), which made the external-conversations list throw HTTP 502 even when remote harness conversations existed. This treats connection failures as an empty local list, matching the existing fallback for non-success payloads.

Verified live: after this change the conversations list returns `{ok:true}` and remote sessions created against harnessed gateways appear.