### PR TITLE
fix: suppress AionCore companion error when remote harnesses are active

### DIFF
--- a/src/routes/api/external-agents.ts
+++ b/src/routes/api/external-agents.ts
@@ -27,6 +27,12 @@ export const Route = createFileRoute('/api/external-agents')({
               snapshot.online ||
               remoteRuntimes.some((runtime) => runtime.status === 'online'),
             runtimes: [...remoteRuntimes, ...snapshot.runtimes],
+            // A missing AionCore companion should not surface an error when
+            // remote harnesses are active (Hermes-only deployments).
+            error:
+              remoteRuntimes.length === 0
+                ? (snapshot.error ?? undefined)
+                : undefined,
           },
         })
       },


### PR DESCRIPTION
In Hermes-only deployments (no local AionCore companion), the external-agents endpoint returned a companion with error="fetch failed" even when remote harnesses were online. The UI surfaces this as an error state for the whole external section. Only surface the companion error when there are no remote runtimes to fall back on. Fixes the Solvy harness not showing in the workspace agent list.