### PR TITLE
feat: add configurable STT and chunked TTS playback

### DIFF
--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useWorkspaceVoiceSettings } from '../../hooks/use-workspace-voice-settings'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   ArrowLeft01Icon,
@@ -2227,6 +2228,15 @@ function VoiceContent() {
   const sttProvider = String(stt.provider || 'local')
   const sttGroq =
     (stt.groq as Record<string, unknown> | undefined) || {}
+  const sttOpenAi =
+    (stt.openai as Record<string, unknown> | undefined) || {}
+
+  const {
+    ttsChunkSize,
+    setTtsChunkSize,
+    saveTtsChunkSize,
+    ttsChunkSizeLoading,
+  } = useWorkspaceVoiceSettings()
 
   return (
     <div className="space-y-4">
@@ -2263,28 +2273,79 @@ function VoiceContent() {
           </select>
         </Row>
         {ttsProvider === 'openai' && (
-          <Row label="Voice">
-            <select
-              value={String(
-                (tts.openai as Record<string, unknown>)?.voice || 'nova',
-              )}
-              onChange={(e) =>
-                saveTts('openai', {
-                  ...((tts.openai as Record<string, unknown>) || {}),
-                  voice: e.target.value,
-                })
-              }
-              className="h-8 rounded-lg border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+          <>
+            <Row label="Voice">
+              <input
+                value={String(
+                  (tts.openai as Record<string, unknown>)?.voice || '',
+                )}
+                onChange={(e) =>
+                  saveTts('openai', {
+                    ...((tts.openai as Record<string, unknown>) || {}),
+                    voice: e.target.value,
+                  })
+                }
+                placeholder="alloy"
+                className="h-8 rounded-lg border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+              />
+            </Row>
+
+            <Row label="Model">
+              <input
+                value={String(
+                  (tts.openai as Record<string, unknown>)?.model || '',
+                )}
+                onChange={(e) =>
+                  saveTts('openai', {
+                    ...((tts.openai as Record<string, unknown>) || {}),
+                    model: e.target.value,
+                  })
+                }
+                placeholder="tts-1"
+                className="h-8 rounded-lg border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+              />
+            </Row>
+
+            <Row label="Base URL">
+              <input
+                value={String(
+                  (tts.openai as Record<string, unknown>)?.base_url || '',
+                )}
+                onChange={(e) =>
+                  saveTts('openai', {
+                    ...((tts.openai as Record<string, unknown>) || {}),
+                    base_url: e.target.value,
+                  })
+                }
+                placeholder="https://api.openai.com/v1"
+                className="h-8 rounded-lg border border-primary-200 bg-primary-50 px-2 text-sm text-primary-900 outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+              />
+            </Row>
+            <Row
+              label="Chunk size"
+              description="Maximum characters generated per TTS chunk."
             >
-              {['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'].map(
-                (v) => (
-                  <option key={v} value={v}>
-                    {v}
-                  </option>
-                ),
-              )}
-            </select>
-          </Row>
+              <Input
+                type="number"
+                min={100}
+                max={2000}
+                step={100}
+                value={String(ttsChunkSize)}
+                disabled={ttsChunkSizeLoading}
+                onChange={(e) => {
+                  const value = Number(e.target.value)
+
+                  if (Number.isFinite(value)) {
+                    setTtsChunkSize(value)
+                  }
+                }}
+                onBlur={() => {
+                  void saveTtsChunkSize(ttsChunkSize)
+                }}
+                className="h-8 w-32"
+              />
+            </Row>
+          </>
         )}
       </div>
       <div className={SETTINGS_CARD_CLASS}>
@@ -2310,6 +2371,49 @@ function VoiceContent() {
             ))}
           </select>
         </Row>
+        {sttProvider === 'openai' && (
+          <>
+            <Row label="Model">
+              <Input
+                value={String(sttOpenAi.model || '')}
+                onChange={(e) =>
+                  saveStt('openai', {
+                    ...sttOpenAi, 
+                    model: e.target.value,
+                  })
+                }
+                placeholder="whisper-1"
+                className="h-8 w-64"
+              />
+            </Row>
+
+            <Row label="Base URL">
+              <Input
+                value={String(sttOpenAi.base_url || '')}
+                onChange={(e) =>
+                  saveStt('openai', {
+                    ...sttOpenAi,
+                    base_url: e.target.value,
+                  })
+                }
+                placeholder="https://api.openai.com/v1"
+                className="h-8 w-64"
+              />
+            </Row>
+
+            <Row
+              label="Language"
+              description="Optional BCP-47 code, e.g. en or fr."
+            >
+              <Input
+                value={String(stt.language || '')}
+                onChange={(e) => saveStt('language', e.target.value)}
+                placeholder="auto"
+                className="h-8 w-40"
+              />
+            </Row>
+          </>
+        )}
         {sttProvider === 'groq' && (
           <>
             <Row label="Groq model">

--- a/src/hooks/use-workspace-voice-settings.ts
+++ b/src/hooks/use-workspace-voice-settings.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const DEFAULT_CHUNK_SIZE = 300
+
+type WorkspaceVoiceSettingsResponse = {
+  ok?: boolean
+  tts?: {
+    chunk_size?: number
+  }
+}
+
+export function useWorkspaceVoiceSettings() {
+  const [ttsChunkSize, setTtsChunkSize] = useState(DEFAULT_CHUNK_SIZE)
+  const [ttsChunkSizeLoading, setTtsChunkSizeLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const response = await fetch('/api/workspace-voice-settings')
+
+        if (!response.ok) return
+
+        const payload =
+          (await response.json()) as WorkspaceVoiceSettingsResponse
+
+        const value = payload.tts?.chunk_size
+
+        if (
+          !cancelled &&
+          typeof value === 'number' &&
+          Number.isFinite(value)
+        ) {
+          setTtsChunkSize(value)
+        }
+      } catch {
+        // Keep default value.
+      } finally {
+        if (!cancelled) {
+          setTtsChunkSizeLoading(false)
+        }
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const saveTtsChunkSize = useCallback(async (value: number) => {
+    const normalized = Math.min(
+      2000,
+      Math.max(100, Math.round(value)),
+    )
+
+    setTtsChunkSize(normalized)
+
+    const response = await fetch('/api/workspace-voice-settings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        tts: {
+          chunk_size: normalized,
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to save TTS chunk size (${response.status}).`,
+      )
+    }
+
+    const payload =
+      (await response.json()) as WorkspaceVoiceSettingsResponse
+
+    const savedValue = payload.tts?.chunk_size
+
+    if (typeof savedValue === 'number') {
+      setTtsChunkSize(savedValue)
+    }
+  }, [])
+
+  return {
+    ttsChunkSize,
+    setTtsChunkSize,
+    saveTtsChunkSize,
+    ttsChunkSizeLoading,
+  }
+}

--- a/src/routes/api/speech.ts
+++ b/src/routes/api/speech.ts
@@ -1,0 +1,151 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  readHermesConfigFiles,
+  resolveHermesConfigPaths,
+} from '../../server/hermes-config-store'
+
+type RecordLike = Record<string, unknown>
+
+function readRecord(value: unknown): RecordLike {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as RecordLike)
+    : {}
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export const Route = createFileRoute('/api/speech')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+
+        try {
+          const body = (await request.json()) as { text?: unknown }
+          const text = readString(body.text)
+
+          if (!text) {
+            return json(
+              { ok: false, error: 'Missing text.' },
+              { status: 400 },
+            )
+          }
+
+          const paths = resolveHermesConfigPaths()
+          const { config, env } = readHermesConfigFiles(paths)
+
+          const tts = readRecord(config.tts)
+          const provider = readString(tts.provider) || 'edge'
+
+          if (provider !== 'openai') {
+            return json(
+              {
+                ok: false,
+                error: `Configured TTS provider "${provider}" is not supported by Workspace speech playback.`,
+              },
+              { status: 400 },
+            )
+          }
+
+          const openai = readRecord(tts.openai)
+
+          const model = readString(openai.model) || 'tts-1'
+          const voice = readString(openai.voice) || 'alloy'
+          const baseUrl =
+            readString(openai.base_url) ||
+            'https://api.openai.com/v1'
+
+          const consentAttestation =
+            readString(openai.consent_attestation)
+
+          const language =
+            readString(openai.language)
+
+          const apiKey =
+            readString(process.env.VOICE_TOOLS_OPENAI_KEY) ||
+            readString(env.VOICE_TOOLS_OPENAI_KEY) ||
+            readString(process.env.OPENAI_API_KEY) ||
+            readString(env.OPENAI_API_KEY)
+
+          if (!apiKey) {
+            return json(
+              {
+                ok: false,
+                error:
+                  'OpenAI TTS is configured but VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY is missing.',
+              },
+              { status: 400 },
+            )
+          }
+
+          const payload: Record<string, unknown> = {
+            model,
+            voice,
+            input: text,
+            response_format: 'mp3',
+          }
+
+          if (consentAttestation) {
+            payload.consent_attestation = consentAttestation
+          }
+
+          if (language) {
+            payload.lang_code = language
+          }
+
+          const upstream = await fetch(`${baseUrl}/audio/speech`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+          })
+
+          if (!upstream.ok) {
+            const error = await upstream.text()
+
+            return json(
+              {
+                ok: false,
+                error:
+                  error ||
+                  `Speech request failed (${upstream.status}).`,
+              },
+              { status: upstream.status },
+            )
+          }
+
+          const audio = await upstream.arrayBuffer()
+
+          return new Response(audio, {
+            status: 200,
+            headers: {
+              'Content-Type':
+                upstream.headers.get('content-type') || 'audio/mpeg',
+              'Cache-Control': 'no-store',
+            },
+          })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Speech synthesis failed.',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/transcribe.ts
+++ b/src/routes/api/transcribe.ts
@@ -7,7 +7,10 @@ import {
   rateLimitResponse,
   safeErrorMessage,
 } from '../../server/rate-limit'
-import { getConfig } from '../../server/claude-api'
+import {
+  readHermesConfigFiles,
+  resolveHermesConfigPaths,
+} from '../../server/hermes-config-store'
 import {
   extractTranscriptionText,
   resolveTranscriptionTarget,
@@ -52,7 +55,8 @@ export const Route = createFileRoute('/api/transcribe')({
             )
           }
 
-          const config = await getConfig()
+          const paths = resolveHermesConfigPaths()
+          const { config } = readHermesConfigFiles(paths)
           const target = resolveTranscriptionTarget(config)
           if (target.ok === false) {
             return json({ ok: false, error: target.error }, { status: 400 })

--- a/src/routes/api/workspace-voice-settings.ts
+++ b/src/routes/api/workspace-voice-settings.ts
@@ -1,0 +1,58 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+
+import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  readWorkspaceVoiceSettings,
+  writeWorkspaceVoiceSettings,
+} from '../../server/workspace-voice-settings'
+
+export const Route = createFileRoute('/api/workspace-voice-settings')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
+        }
+
+        return json({
+          ok: true,
+          ...readWorkspaceVoiceSettings(),
+        })
+      },
+
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
+        }
+
+        try {
+          const body = await request.json()
+          const settings = writeWorkspaceVoiceSettings(body)
+
+          return json({
+            ok: true,
+            ...settings,
+          })
+        } catch (error) {
+          return json(
+            {
+              ok: false,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to save workspace voice settings.',
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,3 +1,4 @@
+import { useWorkspaceVoiceSettings } from '../../hooks/use-workspace-voice-settings'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   CheckmarkCircle02Icon,
@@ -1553,7 +1554,13 @@ function ClaudeConfigSection({
   const sttProvider = (sttConfig.provider as string) || 'local'
   const sttLocal = asRecord(sttConfig.local)
   const sttGroq = asRecord(sttConfig.groq)
-
+  const sttOpenAi = asRecord(sttConfig.openai)
+  const {
+    ttsChunkSize,
+    setTtsChunkSize,
+    saveTtsChunkSize,
+    ttsChunkSizeLoading,
+  } = useWorkspaceVoiceSettings()
   const manifestBaseUrlOnly = readManifestBlockBaseUrl(data.config)
 
   const renderClaudeOverview = () => (
@@ -1745,7 +1752,6 @@ function ClaudeConfigSection({
 
       <SettingsSection
         title="API Keys"
-        description="Manage provider API keys stored in ~/.hermes/.env"
         icon={CloudIcon}
       >
         {data.providers
@@ -2588,45 +2594,103 @@ function ClaudeConfigSection({
             </SettingsRow>
           </>
         )}
-
         {ttsProvider === 'openai' && (
           <>
             <SettingsRow
               label="Voice"
-              description="alloy, echo, fable, onyx, nova, shimmer"
+              description="OpenAI-compatible TTS voice."
             >
-              <select
-                value={(ttsOpenAi.voice as string) || 'alloy'}
+              <Input
+                value={(ttsOpenAi.voice as string) || ''}
                 onChange={(e) =>
                   void saveConfig({
-                    config: { tts: { openai: { voice: e.target.value } } },
+                    config: {
+                      tts: {
+                        openai: {
+                          ...ttsOpenAi,
+                          voice: e.target.value,
+                        },
+                      },
+                    },
                   })
                 }
-                className={selectClassName}
-              >
-                {['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'].map(
-                  (voice) => (
-                    <option key={voice} value={voice}>
-                      {voice}
-                    </option>
-                  ),
-                )}
-              </select>
+                placeholder="alloy"
+                className="md:w-64"
+              />
             </SettingsRow>
-            <SettingsRow label="Model" description="OpenAI TTS model.">
+
+            <SettingsRow
+              label="Model"
+              description="OpenAI-compatible TTS model."
+            >
               <Input
                 value={(ttsOpenAi.model as string) || ''}
                 onChange={(e) =>
                   void saveConfig({
-                    config: { tts: { openai: { model: e.target.value } } },
+                    config: {
+                      tts: {
+                        openai: {
+                          ...ttsOpenAi,
+                          model: e.target.value,
+                        },
+                      },
+                    },
                   })
                 }
                 placeholder="tts-1"
                 className="md:w-64"
               />
             </SettingsRow>
+
+            <SettingsRow
+              label="Base URL"
+              description="OpenAI-compatible TTS API base URL."
+            >
+              <Input
+                value={(ttsOpenAi.base_url as string) || ''}
+                onChange={(e) =>
+                  void saveConfig({
+                    config: {
+                      tts: {
+                        openai: {
+                          ...ttsOpenAi,
+                          base_url: e.target.value,
+                        },
+                      },
+                    },
+                  })
+                }
+                placeholder="https://api.openai.com/v1"
+                className="md:w-64"
+              />
+            </SettingsRow>
+            <SettingsRow
+              label="Chunk size"
+              description="Maximum characters generated per TTS chunk."
+            >
+              <Input
+                type="number"
+                min={100}
+                max={2000}
+                step={100}
+                value={String(ttsChunkSize)}
+                disabled={ttsChunkSizeLoading}
+                onChange={(e) => {
+                  const value = Number(e.target.value)
+
+                  if (Number.isFinite(value)) {
+                    setTtsChunkSize(value)
+                  }
+                }}
+                onBlur={() => {
+                  void saveTtsChunkSize(ttsChunkSize)
+                }}
+                className="md:w-32"
+              />
+            </SettingsRow>
           </>
         )}
+
       </SettingsSection>
 
       <SettingsSection
@@ -2638,10 +2702,17 @@ function ClaudeConfigSection({
           <Switch
             checked={readBoolean(sttConfig.enabled, false)}
             onCheckedChange={(checked) =>
-              void saveConfig({ config: { stt: { enabled: checked } } })
+              void saveConfig({
+                config: {
+                  stt: {
+                    enabled: checked,
+                  },
+                },
+              })
             }
           />
         </SettingsRow>
+
         <SettingsRow
           label="STT provider"
           description="Which speech engine to use."
@@ -2649,7 +2720,13 @@ function ClaudeConfigSection({
           <select
             value={sttProvider}
             onChange={(e) =>
-              void saveConfig({ config: { stt: { provider: e.target.value } } })
+              void saveConfig({
+                config: {
+                  stt: {
+                    provider: e.target.value,
+                  },
+                },
+              })
             }
             className={selectClassName}
           >
@@ -2660,6 +2737,7 @@ function ClaudeConfigSection({
             ))}
           </select>
         </SettingsRow>
+
         {sttProvider === 'local' && (
           <SettingsRow
             label="Model size"
@@ -2669,7 +2747,14 @@ function ClaudeConfigSection({
               value={(sttLocal.model_size as string) || 'base'}
               onChange={(e) =>
                 void saveConfig({
-                  config: { stt: { local: { model_size: e.target.value } } },
+                  config: {
+                    stt: {
+                      local: {
+                        ...sttLocal,
+                        model_size: e.target.value,
+                      },
+                    },
+                  },
                 })
               }
               className={selectClassName}
@@ -2681,6 +2766,76 @@ function ClaudeConfigSection({
               ))}
             </select>
           </SettingsRow>
+        )}
+
+        {sttProvider === 'openai' && (
+          <>
+            <SettingsRow
+              label="Model"
+              description="OpenAI-compatible STT model."
+            >
+              <Input
+                value={(sttOpenAi.model as string) || ''}
+                onChange={(e) =>
+                  void saveConfig({
+                    config: {
+                      stt: {
+                        openai: {
+                          ...sttOpenAi,
+                          model: e.target.value,
+                        },
+                      },
+                    },
+                  })
+                }
+                placeholder="whisper-1"
+                className="md:w-64"
+              />
+            </SettingsRow>
+
+            <SettingsRow
+              label="Base URL"
+              description="OpenAI-compatible STT API base URL."
+            >
+              <Input
+                value={(sttOpenAi.base_url as string) || ''}
+                onChange={(e) =>
+                  void saveConfig({
+                    config: {
+                      stt: {
+                        openai: {
+                          ...sttOpenAi,
+                          base_url: e.target.value,
+                        },
+                      },
+                    },
+                  })
+                }
+                placeholder="https://api.openai.com/v1"
+                className="md:w-64"
+              />
+            </SettingsRow>
+
+            <SettingsRow
+              label="Language"
+              description="Optional language code. Leave blank for auto-detect."
+            >
+              <Input
+                value={(sttConfig.language as string) || ''}
+                onChange={(e) =>
+                  void saveConfig({
+                    config: {
+                      stt: {
+                        language: e.target.value,
+                      },
+                    },
+                  })
+                }
+                placeholder="auto"
+                className="md:w-64"
+              />
+            </SettingsRow>
+          </>
         )}
         {sttProvider === 'groq' && (
           <>

--- a/src/screens/chat/components/message-actions-bar.tsx
+++ b/src/screens/chat/components/message-actions-bar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Copy01Icon, RefreshIcon, Tick02Icon } from '@hugeicons/core-free-icons'
 import { MessageTimestamp } from './message-timestamp'
@@ -19,6 +19,7 @@ type MessageActionsBarProps = {
   isQueued?: boolean
   isFailed?: boolean
   onRetry?: () => void
+  enableSpeech?: boolean
 }
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -46,6 +47,167 @@ async function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
+const DEFAULT_SPEECH_CHUNK_SIZE = 300
+
+function splitLongSpeechPart(text: string, maxLength: number): string[] {
+  const words = text.trim().split(/\s+/)
+  const chunks: string[] = []
+  let current = ''
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+
+    if (candidate.length <= maxLength) {
+      current = candidate
+      continue
+    }
+
+    if (current) {
+      chunks.push(current)
+    }
+
+    current = word
+  }
+
+  if (current) {
+    chunks.push(current)
+  }
+
+  return chunks
+}
+
+function splitParagraphIntoSpeechChunks(
+  paragraph: string,
+  maxLength: number,
+): string[] {
+  const normalized = paragraph.replace(/\s+/g, ' ').trim()
+
+  if (!normalized) {
+    return []
+  }
+
+  if (normalized.length <= maxLength) {
+    return [normalized]
+  }
+
+  const sentences =
+    normalized.match(/[^.!?…]+[.!?…]+(?:["'”’)\]]+)?|[^.!?…]+$/g)
+      ?.map((part) => part.trim())
+      .filter(Boolean) ?? [normalized]
+
+  const chunks: string[] = []
+  let current = ''
+
+  for (const sentence of sentences) {
+    if (sentence.length > maxLength) {
+      if (current) {
+        chunks.push(current)
+        current = ''
+      }
+
+      chunks.push(...splitLongSpeechPart(sentence, maxLength))
+      continue
+    }
+
+    const candidate = current ? `${current} ${sentence}` : sentence
+
+    if (candidate.length <= maxLength) {
+      current = candidate
+    } else {
+      if (current) {
+        chunks.push(current)
+      }
+
+      current = sentence
+    }
+  }
+
+  if (current) {
+    chunks.push(current)
+  }
+
+  return chunks
+}
+
+function splitTextForSpeech(
+  text: string,
+  maxLength: number,
+): string[] {
+  const paragraphs = text
+    .replace(/\r\n/g, '\n')
+    .split(/\n\s*\n+/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+
+  const chunks: string[] = []
+
+  for (const paragraph of paragraphs) {
+    chunks.push(
+      ...splitParagraphIntoSpeechChunks(paragraph, maxLength),
+    )
+  }
+
+  return chunks
+}
+
+async function loadSpeechChunkSize(): Promise<number> {
+  try {
+    const response = await fetch('/api/workspace-voice-settings')
+
+    if (!response.ok) {
+      return DEFAULT_SPEECH_CHUNK_SIZE
+    }
+
+    const payload = (await response.json()) as {
+      tts?: {
+        chunk_size?: unknown
+      }
+    }
+
+    const value = Number(payload.tts?.chunk_size)
+
+    if (!Number.isFinite(value)) {
+      return DEFAULT_SPEECH_CHUNK_SIZE
+    }
+
+    return Math.min(2000, Math.max(100, Math.round(value)))
+  } catch {
+    return DEFAULT_SPEECH_CHUNK_SIZE
+  }
+}
+
+async function fetchSpeechChunk(
+  text: string,
+  signal: AbortSignal,
+): Promise<Blob> {
+  const response = await fetch('/api/speech', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text }),
+    signal,
+  })
+
+  if (!response.ok) {
+    let message = `Speech request failed (${response.status}).`
+
+    try {
+      const payload = (await response.json()) as {
+        error?: string
+      }
+
+      if (payload.error) {
+        message = payload.error
+      }
+    } catch {}
+
+    throw new Error(message)
+  }
+
+  return response.blob()
+}
+
 export function MessageActionsBar({
   text,
   align,
@@ -54,8 +216,230 @@ export function MessageActionsBar({
   isQueued = false,
   isFailed = false,
   onRetry,
+  enableSpeech = false,
 }: MessageActionsBarProps) {
   const [copied, setCopied] = useState(false)
+  
+  const [speaking, setSpeaking] = useState(false)
+  const [speechLoading, setSpeechLoading] = useState(false)
+  const [speechError, setSpeechError] = useState<string | null>(null)
+
+  const speechLoadingRef = useRef(false)
+
+  const speechAbortControllerRef =
+    useRef<AbortController | null>(null)
+
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const audioUrlRef = useRef<string | null>(null)
+
+  const stopSpeech = () => {
+    speechAbortControllerRef.current?.abort()
+    speechAbortControllerRef.current = null
+
+    if (audioRef.current) {
+      audioRef.current.pause()
+      audioRef.current.currentTime = 0
+      audioRef.current = null
+    }
+
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current)
+      audioUrlRef.current = null
+    }
+
+    speechLoadingRef.current = false
+
+    setSpeechLoading(false)
+    setSpeaking(false)
+  }
+
+  useEffect(() => {
+    return () => {
+      speechAbortControllerRef.current?.abort()
+
+      if (audioRef.current) {
+        audioRef.current.pause()
+      }
+
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current)
+      }
+    }
+  }, [])
+
+  const playSpeechBlob = (
+    blob: Blob,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      if (signal.aborted) {
+        resolve()
+        return
+      }
+
+      const url = URL.createObjectURL(blob)
+      const audio = new Audio(url)
+
+      audioUrlRef.current = url
+      audioRef.current = audio
+
+      let finished = false
+
+      const cleanup = () => {
+        if (finished) return
+        finished = true
+
+        signal.removeEventListener('abort', handleAbort)
+
+        if (audioRef.current === audio) {
+          audioRef.current = null
+        }
+
+        if (audioUrlRef.current === url) {
+          URL.revokeObjectURL(url)
+          audioUrlRef.current = null
+        }
+      }
+
+      const handleAbort = () => {
+        audio.pause()
+        audio.currentTime = 0
+
+        cleanup()
+        resolve()
+      }
+
+      signal.addEventListener('abort', handleAbort, {
+        once: true,
+      })
+
+      audio.onended = () => {
+        cleanup()
+        resolve()
+      }
+
+      audio.onerror = () => {
+        cleanup()
+        reject(new Error('Audio playback failed.'))
+      }
+
+      audio.play().catch((error) => {
+        cleanup()
+        reject(error)
+      })
+    })
+  }
+
+  const handleSpeech = async () => {
+    // Clicking while generation is pending cancels it.
+    if (speechLoadingRef.current) {
+      stopSpeech()
+      return
+    }
+
+    // Clicking while speech is playing stops everything.
+    if (speaking) {
+      stopSpeech()
+      return
+    }
+
+    setSpeechError(null)
+
+    speechLoadingRef.current = true
+    setSpeechLoading(true)
+
+    const controller = new AbortController()
+    speechAbortControllerRef.current = controller
+
+    let prefetchedChunk: Promise<Blob> | null = null
+
+    try {
+      const chunkSize = await loadSpeechChunkSize()
+
+      if (controller.signal.aborted) {
+        return
+      }
+
+      const chunks = splitTextForSpeech(text, chunkSize)
+
+      if (chunks.length === 0) {
+        throw new Error('No text available for speech synthesis.')
+      }
+
+      // Generate only the first chunk initially.
+      let currentBlob = await fetchSpeechChunk(
+        chunks[0],
+        controller.signal,
+      )
+
+      if (controller.signal.aborted) {
+        return
+      }
+
+      speechLoadingRef.current = false
+      setSpeechLoading(false)
+      setSpeaking(true)
+
+      for (let index = 0; index < chunks.length; index += 1) {
+        if (controller.signal.aborted) {
+          return
+        }
+
+        // While the current chunk is playing,
+        // generate exactly one chunk ahead.
+        if (index + 1 < chunks.length) {
+          prefetchedChunk = fetchSpeechChunk(
+            chunks[index + 1],
+            controller.signal,
+          )
+        } else {
+          prefetchedChunk = null
+        }
+
+        await playSpeechBlob(currentBlob, controller.signal)
+
+        if (controller.signal.aborted) {
+          return
+        }
+
+        if (prefetchedChunk) {
+          currentBlob = await prefetchedChunk
+          prefetchedChunk = null
+        }
+      }
+
+      speechAbortControllerRef.current = null
+      setSpeaking(false)
+    } catch (error) {
+      controller.abort()
+
+      // Consume a possible rejected prefetch promise.
+      if (prefetchedChunk) {
+        try {
+          await prefetchedChunk
+        } catch {}
+      }
+
+      speechAbortControllerRef.current = null
+      speechLoadingRef.current = false
+
+      setSpeechLoading(false)
+      setSpeaking(false)
+
+      if (
+        error instanceof DOMException &&
+        error.name === 'AbortError'
+      ) {
+        return
+      }
+
+      setSpeechError(
+        error instanceof Error
+          ? error.message
+          : 'Speech synthesis failed.',
+      )
+    }
+  } 
 
   const handleCopy = async () => {
     try {
@@ -92,6 +476,46 @@ export function MessageActionsBar({
           </TooltipRoot>
         </TooltipProvider>
       )}
+
+      {enableSpeech && text.trim() && (
+        <TooltipProvider>
+          <TooltipRoot>
+            <TooltipTrigger
+              type="button"
+              onClick={() => {
+                void handleSpeech()
+              }}
+              className="inline-flex items-center justify-center rounded border border-transparent bg-transparent p-1 text-primary-700 hover:text-primary-900 hover:bg-primary-100 dark:hover:bg-primary-800"
+              aria-label={
+                speechLoading
+                  ? 'Generating speech'
+                  : speaking
+                    ? 'Stop speaking'
+                    : 'Read aloud'
+              }
+            >
+              <span
+                className={`text-[16px] leading-none ${
+                  speechLoading ? 'animate-pulse' : ''
+                }`}
+                aria-hidden="true"
+              >
+                {speechLoading ? '⏳' : speaking ? '⏹' : '🔊'}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {speechError
+                ? speechError
+                : speechLoading
+                  ? 'Generating speech...'
+                  : speaking
+                    ? 'Stop'
+                    : 'Read aloud'}
+            </TooltipContent>
+          </TooltipRoot>
+        </TooltipProvider>
+      )}      
+
       <TooltipProvider>
         <TooltipRoot>
           <TooltipTrigger

--- a/src/screens/chat/components/message-item.tsx
+++ b/src/screens/chat/components/message-item.tsx
@@ -2894,6 +2894,7 @@ function MessageItemComponent({
           text={fullText}
           timestamp={timestamp}
           align={isUser ? 'end' : 'start'}
+          enableSpeech={!isUser}
           forceVisible={forceActionsVisible}
           isQueued={isUser && isQueued && !isFailed}
           isFailed={isUser && (isFailed || isStuckSending)}

--- a/src/server/stt-transcription.ts
+++ b/src/server/stt-transcription.ts
@@ -90,6 +90,7 @@ export function resolveTranscriptionTarget(
       language,
       apiKey,
       baseUrl:
+        readString(groq.base_url) ||
         readString(runtimeEnv.GROQ_BASE_URL) ||
         readString(hermesEnv.GROQ_BASE_URL) ||
         DEFAULT_GROQ_BASE_URL,
@@ -103,12 +104,15 @@ export function resolveTranscriptionTarget(
       readString(hermesEnv.VOICE_TOOLS_OPENAI_KEY) ||
       readString(runtimeEnv.OPENAI_API_KEY) ||
       readString(hermesEnv.OPENAI_API_KEY)
+
     if (!apiKey) {
       return {
         ok: false,
-        error: 'OpenAI STT is configured but VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY is missing.',
+        error:
+          'OpenAI STT is configured but VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY is missing.',
       }
     }
+
     return {
       ok: true,
       provider: 'openai',
@@ -120,6 +124,7 @@ export function resolveTranscriptionTarget(
       language,
       apiKey,
       baseUrl:
+        readString(openai.base_url) ||
         readString(runtimeEnv.STT_OPENAI_BASE_URL) ||
         readString(hermesEnv.STT_OPENAI_BASE_URL) ||
         DEFAULT_OPENAI_BASE_URL,

--- a/src/server/workspace-voice-settings.ts
+++ b/src/server/workspace-voice-settings.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export const DEFAULT_TTS_CHUNK_SIZE = 300
+export const MIN_TTS_CHUNK_SIZE = 100
+export const MAX_TTS_CHUNK_SIZE = 2000
+
+type WorkspaceVoiceSettings = {
+  tts: {
+    chunk_size: number
+  }
+}
+
+function getSettingsPath(): string {
+  const hermesHome =
+    process.env.HERMES_HOME?.trim() || path.join(os.homedir(), '.hermes')
+
+  return path.join(hermesHome, 'workspace-voice-settings.json')
+}
+
+function normalizeChunkSize(value: unknown): number {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value)
+        : Number.NaN
+
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_TTS_CHUNK_SIZE
+  }
+
+  return Math.min(
+    MAX_TTS_CHUNK_SIZE,
+    Math.max(MIN_TTS_CHUNK_SIZE, Math.round(parsed)),
+  )
+}
+
+export function readWorkspaceVoiceSettings(): WorkspaceVoiceSettings {
+  const settingsPath = getSettingsPath()
+
+  try {
+    const raw = fs.readFileSync(settingsPath, 'utf8')
+    const parsed = JSON.parse(raw) as {
+      tts?: {
+        chunk_size?: unknown
+      }
+    }
+
+    return {
+      tts: {
+        chunk_size: normalizeChunkSize(parsed.tts?.chunk_size),
+      },
+    }
+  } catch {
+    return {
+      tts: {
+        chunk_size: DEFAULT_TTS_CHUNK_SIZE,
+      },
+    }
+  }
+}
+
+export function writeWorkspaceVoiceSettings(
+  value: unknown,
+): WorkspaceVoiceSettings {
+  const settingsPath = getSettingsPath()
+
+  const input =
+    value && typeof value === 'object'
+      ? (value as {
+          tts?: {
+            chunk_size?: unknown
+          }
+        })
+      : {}
+
+  const settings: WorkspaceVoiceSettings = {
+    tts: {
+      chunk_size: normalizeChunkSize(input.tts?.chunk_size),
+    },
+  }
+
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+
+  const temporaryPath = `${settingsPath}.tmp`
+
+  fs.writeFileSync(
+    temporaryPath,
+    `${JSON.stringify(settings, null, 2)}\n`,
+    'utf8',
+  )
+
+  fs.renameSync(temporaryPath, settingsPath)
+
+  return settings
+}


### PR DESCRIPTION
This PR adds configurable speech support to Hermes Workspace.

Main changes:

* Adds configurable OpenAI-compatible STT settings, including model, base URL, and language.
* Adds OpenAI-compatible TTS playback for assistant messages.
* Adds configurable TTS model, voice, and base URL settings.
* Passes `consent_attestation` from the Hermes TTS configuration to compatible TTS backends.
* Supports optional language forwarding for compatible TTS providers.
* Adds chunked TTS playback to reduce perceived latency on longer responses.
* Prefetches only the next speech chunk while the current one is playing.
* Supports cancellation of in-flight TTS generation and playback.
* Uses paragraph- and sentence-aware chunking, falling back to word-based splitting only when necessary.
* Uses the configured chunk size as a maximum rather than blindly splitting text at fixed character boundaries.
* Adds a Workspace-specific TTS chunk-size setting without modifying the Hermes Agent configuration schema.
* Stores Workspace-only voice settings separately in `workspace-voice-settings.json`.

The implementation has been tested with local OpenAI-compatible STT/TTS backends, including a TTS backend requiring explicit speaker-consent attestation.
