### PR TITLE
JARVIS epistemic UI (slices 1–7a): additive design system, read-only data wiring

### DIFF
--- a/src/components/jarvis/approval-gate-card.test.tsx
+++ b/src/components/jarvis/approval-gate-card.test.tsx
@@ -37,6 +37,50 @@ describe('ApprovalGateCard', () => {
     expect(onAction).toHaveBeenCalledWith('REJECT')
   })
 
+  it('shortens the panel headings only when asked to', () => {
+    const { unmount } = render(
+      <ApprovalGateCard
+        {...BASE}
+        cellLabels={{ blastRadius: 'RADIUS', undoPath: 'UNDO' }}
+      />,
+    )
+    expect(screen.getByText('RADIUS')).toBeTruthy()
+    expect(screen.getByText('UNDO')).toBeTruthy()
+    expect(screen.queryByText('BLAST RADIUS')).toBeNull()
+    expect(screen.queryByText('UNDO PATH')).toBeNull()
+    // The values are untouched — only the headings change.
+    expect(screen.getByText(BASE.blastRadius)).toBeTruthy()
+    expect(screen.getByText(BASE.undoPath)).toBeTruthy()
+    unmount()
+
+    // One override leaves the other heading full.
+    render(<ApprovalGateCard {...BASE} cellLabels={{ undoPath: 'UNDO' }} />)
+    expect(screen.getByText('BLAST RADIUS')).toBeTruthy()
+    expect(screen.getByText('UNDO')).toBeTruthy()
+  })
+
+  it('prints the keyboard hint only when given one, and only while pending', () => {
+    const hint = '⌘⏎ approve · ⌘⌫ reject'
+
+    const { unmount } = render(<ApprovalGateCard {...BASE} />)
+    expect(screen.queryByText(hint)).toBeNull()
+    unmount()
+
+    const withHint = render(<ApprovalGateCard {...BASE} hint={hint} />)
+    expect(screen.getByText(hint)).toBeTruthy()
+    // It sits in the button row, after the buttons.
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+    withHint.unmount()
+
+    for (const state of ['approved', 'rejected'] as const) {
+      const resolved = render(
+        <ApprovalGateCard {...BASE} hint={hint} state={state} />,
+      )
+      expect(screen.queryByText(hint)).toBeNull()
+      resolved.unmount()
+    }
+  })
+
   it('drops the buttons and the waiting timer once resolved', () => {
     for (const state of ['approved', 'rejected'] as const) {
       const { unmount } = render(

--- a/src/components/jarvis/approval-gate-card.test.tsx
+++ b/src/components/jarvis/approval-gate-card.test.tsx
@@ -1,0 +1,52 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApprovalGateCard } from './approval-gate-card'
+
+const BASE = {
+  title: 'Publish changelog 0.9.3 to the public site',
+  command: 'gh workflow run publish.yml -f tag=v0.9.3',
+  blastRadius: '1 public page · RSS to 2,411 subscribers',
+  undoPath: 'Revert commit + CDN purge ≈90s.',
+  actions: ['APPROVE', 'REJECT', 'HOLD FOR QA'],
+}
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('ApprovalGateCard', () => {
+  it('states blast radius and undo path before the buttons', () => {
+    render(<ApprovalGateCard {...BASE} waiting="4m 12s" />)
+
+    expect(screen.getByText('APPROVAL REQUIRED')).toBeTruthy()
+    expect(screen.getByText('BLAST RADIUS')).toBeTruthy()
+    expect(screen.getByText('UNDO PATH')).toBeTruthy()
+    expect(screen.getByText('waiting 4m 12s')).toBeTruthy()
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  it('is inert without a handler and reports the action with one', () => {
+    const { unmount } = render(<ApprovalGateCard {...BASE} />)
+    expect(() => fireEvent.click(screen.getByText('APPROVE'))).not.toThrow()
+    unmount()
+
+    const onAction = vi.fn()
+    render(<ApprovalGateCard {...BASE} onAction={onAction} />)
+    fireEvent.click(screen.getByText('REJECT'))
+    expect(onAction).toHaveBeenCalledWith('REJECT')
+  })
+
+  it('drops the buttons and the waiting timer once resolved', () => {
+    for (const state of ['approved', 'rejected'] as const) {
+      const { unmount } = render(
+        <ApprovalGateCard {...BASE} waiting="4m 12s" state={state} />,
+      )
+      expect(screen.getByText(state.toUpperCase())).toBeTruthy()
+      expect(screen.queryByText('waiting 4m 12s')).toBeNull()
+      expect(screen.queryAllByRole('button')).toHaveLength(0)
+      expect(screen.getByText(`gate resolved · ${state}`)).toBeTruthy()
+      unmount()
+    }
+  })
+})

--- a/src/components/jarvis/approval-gate-card.tsx
+++ b/src/components/jarvis/approval-gate-card.tsx
@@ -8,7 +8,12 @@
  * component never invents them.
  *
  * The buttons are presentational: they call `onAction` if one is supplied and
- * do nothing otherwise. No approval is resolved here.
+ * do nothing otherwise. No approval is resolved here. `hint` prints a keyboard
+ * affordance after them while pending — text only, this card binds no keys.
+ *
+ * `cellLabels` shortens the two headings for narrow boards (RADIUS / UNDO).
+ * Both it and `hint` are optional and default to the desktop rendering, so a
+ * caller that passes neither draws exactly what it drew before they existed.
  *
  * Token discipline: no raw colour, size, or px value in this file.
  */
@@ -77,6 +82,10 @@ const GATES: Record<ApprovalGateState, GateTokens> = {
 const CELL_LABEL_CLASS =
   'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wider-2'
 
+/** Full headings. Narrow boards override them; nothing else does. */
+const DEFAULT_BLAST_RADIUS_LABEL = 'BLAST RADIUS'
+const DEFAULT_UNDO_PATH_LABEL = 'UNDO PATH'
+
 export function ApprovalGateCard({
   title,
   command,
@@ -84,8 +93,10 @@ export function ApprovalGateCard({
   waiting,
   blastRadius,
   undoPath,
+  cellLabels,
   caveat,
   actions,
+  hint,
   state = 'pending',
   onAction,
 }: ApprovalGateCardProps) {
@@ -139,11 +150,19 @@ export function ApprovalGateCard({
 
         <div className={clsx('mt-jv-13 flex gap-jv-1 border', tokens.gutter)}>
           {[
-            { label: 'BLAST RADIUS', value: blastRadius },
-            { label: 'UNDO PATH', value: undoPath },
+            {
+              key: 'blast-radius',
+              label: cellLabels?.blastRadius ?? DEFAULT_BLAST_RADIUS_LABEL,
+              value: blastRadius,
+            },
+            {
+              key: 'undo-path',
+              label: cellLabels?.undoPath ?? DEFAULT_UNDO_PATH_LABEL,
+              value: undoPath,
+            },
           ].map((cell) => (
             <div
-              key={cell.label}
+              key={cell.key}
               className={clsx('flex-1 px-jv-11 py-jv-9', tokens.cell)}
             >
               <div className={clsx(CELL_LABEL_CLASS, tokens.cellLabel)}>
@@ -181,6 +200,11 @@ export function ApprovalGateCard({
                 {action}
               </button>
             ))}
+            {hint ? (
+              <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-text-faint">
+                {hint}
+              </span>
+            ) : null}
           </div>
         ) : (
           <div

--- a/src/components/jarvis/approval-gate-card.tsx
+++ b/src/components/jarvis/approval-gate-card.tsx
@@ -1,0 +1,198 @@
+/**
+ * Approval gate card — the honest gate.
+ *
+ * What makes it honest is the two-cell panel: BLAST RADIUS (what this does to
+ * the world) and UNDO PATH (what you can actually take back), stated before the
+ * buttons rather than after. Neither has a source in today's backend — see
+ * `docs/design/jarvis-ui-mapping.md` §3.2 — so both arrive as props and this
+ * component never invents them.
+ *
+ * The buttons are presentational: they call `onAction` if one is supplied and
+ * do nothing otherwise. No approval is resolved here.
+ *
+ * Token discipline: no raw colour, size, or px value in this file.
+ */
+/*
+ * NOTE: these components use `clsx` directly rather than the repo's `cn()`
+ * helper. `cn()` runs tailwind-merge, which does not know the `jv-*` scale and
+ * classifies `text-jv-3xs` (a font size) into the same conflict group as
+ * `text-jv-verified` (a colour) — so the size gets silently dropped whenever a
+ * colour appears alongside it. No class set below relies on conflict
+ * resolution, so plain `clsx` is both correct and lossless here.
+ */
+import { clsx } from 'clsx'
+import type { ApprovalGateCardProps, ApprovalGateState } from './types'
+
+interface GateTokens {
+  /** 2px rule across the top — the card's loudest signal. */
+  rule: string
+  frame: string
+  label: string
+  labelColor: string
+  sublabel: string
+  /** Hairline between the label and the sublabel. */
+  divider: string
+  /** Gutter behind the blast/undo grid (shows through the 1px gap). */
+  gutter: string
+  cell: string
+  cellLabel: string
+}
+
+const GATES: Record<ApprovalGateState, GateTokens> = {
+  pending: {
+    rule: 'bg-jv-blocked',
+    frame: 'border-jv-blocked-line bg-jv-blocked-bg',
+    label: 'APPROVAL REQUIRED',
+    labelColor: 'text-jv-blocked',
+    sublabel: 'text-jv-blocked-dim',
+    divider: 'bg-jv-blocked-divider',
+    gutter: 'bg-jv-blocked-line-soft border-jv-blocked-line-soft',
+    cell: 'bg-jv-blocked-bg-2',
+    cellLabel: 'text-jv-blocked-dim',
+  },
+  approved: {
+    rule: 'bg-jv-verified',
+    frame: 'border-jv-verified-line bg-jv-verified-bg-2',
+    label: 'APPROVED',
+    labelColor: 'text-jv-verified',
+    sublabel: 'text-jv-label',
+    divider: 'bg-jv-border',
+    gutter: 'bg-jv-line border-jv-line',
+    cell: 'bg-jv-surface-2',
+    cellLabel: 'text-jv-label',
+  },
+  rejected: {
+    rule: 'bg-jv-failed',
+    frame: 'border-jv-failed-line bg-jv-failed-bg',
+    label: 'REJECTED',
+    labelColor: 'text-jv-failed',
+    sublabel: 'text-jv-label',
+    divider: 'bg-jv-border',
+    gutter: 'bg-jv-line border-jv-line',
+    cell: 'bg-jv-surface-2',
+    cellLabel: 'text-jv-label',
+  },
+}
+
+const CELL_LABEL_CLASS =
+  'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wider-2'
+
+export function ApprovalGateCard({
+  title,
+  command,
+  subtitle,
+  waiting,
+  blastRadius,
+  undoPath,
+  caveat,
+  actions,
+  state = 'pending',
+  onAction,
+}: ApprovalGateCardProps) {
+  const tokens = GATES[state]
+  const pending = state === 'pending'
+
+  return (
+    <div data-jv-gate-state={state} className={clsx('border', tokens.frame)}>
+      <div className={clsx('h-jv-2', tokens.rule)} />
+
+      <div className="px-jv-16 pt-jv-13 pb-jv-16">
+        <div className="flex items-center gap-jv-10">
+          <span
+            className={clsx(
+              'font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-widest',
+              tokens.labelColor,
+            )}
+          >
+            {tokens.label}
+          </span>
+          {subtitle ? (
+            <>
+              <span
+                aria-hidden="true"
+                className={clsx('w-jv-1 h-jv-11 flex-none', tokens.divider)}
+              />
+              <span
+                className={clsx(
+                  'font-jv-mono text-jv-sm leading-jv-none',
+                  tokens.sublabel,
+                )}
+              >
+                {subtitle}
+              </span>
+            </>
+          ) : null}
+          <div className="flex-1" />
+          {pending && waiting ? (
+            <span className="font-jv-mono text-jv-sm leading-jv-none font-medium text-jv-blocked">
+              waiting {waiting}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-jv-11 font-jv-sans text-jv-6xl leading-jv-normal-2 font-medium text-jv-text-bright">
+          {title}
+        </div>
+        <div className="mt-jv-4 font-jv-mono text-jv-md leading-jv-loose text-jv-text-faint">
+          {command}
+        </div>
+
+        <div className={clsx('mt-jv-13 flex gap-jv-1 border', tokens.gutter)}>
+          {[
+            { label: 'BLAST RADIUS', value: blastRadius },
+            { label: 'UNDO PATH', value: undoPath },
+          ].map((cell) => (
+            <div
+              key={cell.label}
+              className={clsx('flex-1 px-jv-11 py-jv-9', tokens.cell)}
+            >
+              <div className={clsx(CELL_LABEL_CLASS, tokens.cellLabel)}>
+                {cell.label}
+              </div>
+              <div className="mt-jv-7 font-jv-sans text-jv-lg leading-jv-loose-3 text-jv-text-body">
+                {cell.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {caveat ? (
+          <div className="mt-jv-11 font-jv-sans text-jv-lg leading-jv-loose text-jv-text-dim-2">
+            {caveat}
+          </div>
+        ) : null}
+
+        {pending ? (
+          <div className="mt-jv-13 flex items-center gap-jv-8">
+            {actions.map((action, index) => (
+              <button
+                key={action}
+                type="button"
+                onClick={() => onAction?.(action)}
+                className={clsx(
+                  'font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider',
+                  index === 0
+                    ? 'px-jv-20 py-jv-9 bg-jv-verified text-jv-surface-0'
+                    : index === 1
+                      ? 'px-jv-20 py-jv-9 border border-jv-border-btn-2 text-jv-text-body'
+                      : 'px-jv-14 py-jv-9 border border-jv-border-btn text-jv-text-faint',
+                )}
+              >
+                {action}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div
+            className={clsx(
+              'mt-jv-13 font-jv-mono text-jv-sm leading-jv-none tracking-jv-label',
+              tokens.labelColor,
+            )}
+          >
+            {`gate resolved · ${state}`}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/jarvis/epistemic-mark.test.tsx
+++ b/src/components/jarvis/epistemic-mark.test.tsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { EpistemicMark } from './epistemic-mark'
+import type { EpistemicMarkKind } from './types'
+
+const EXPECTED_TAGS: Record<EpistemicMarkKind, string> = {
+  known: 'KN',
+  recalled: 'RC',
+  assumed: 'AS',
+}
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('EpistemicMark', () => {
+  it('renders the right tag for each mark', () => {
+    for (const [mark, tag] of Object.entries(EXPECTED_TAGS)) {
+      const { unmount } = render(
+        <EpistemicMark mark={mark as EpistemicMarkKind}>a claim</EpistemicMark>,
+      )
+      expect(screen.getByText('a claim')).toBeTruthy()
+      expect(screen.getByText(tag)).toBeTruthy()
+      unmount()
+    }
+  })
+
+  it('binds each mark to its own underline style token, never a literal', () => {
+    for (const mark of Object.keys(EXPECTED_TAGS) as Array<EpistemicMarkKind>) {
+      const { container, unmount } = render(
+        <EpistemicMark mark={mark}>a claim</EpistemicMark>,
+      )
+      const claim = container.querySelector(`[data-jv-mark="${mark}"]`)
+      const border = (claim as HTMLElement).style.borderBottom
+
+      expect(border).toContain(`var(--jv-${mark}-rule-style)`)
+      expect(border).toContain(`var(--jv-${mark}-rule)`)
+      expect(border).not.toMatch(/#[0-9a-fA-F]{3,8}/)
+      unmount()
+    }
+  })
+})

--- a/src/components/jarvis/epistemic-mark.tsx
+++ b/src/components/jarvis/epistemic-mark.tsx
@@ -1,0 +1,62 @@
+/**
+ * Epistemic mark — the KN / RC / AS inline claim marker.
+ *
+ * The product's core idea: every claim carries how it is known. The underline
+ * STYLE is part of the semantics (solid = Known, dotted = Recalled, dashed =
+ * Assumed) and is itself a token (`--jv-<kind>-rule-style`), so the binding
+ * lives in `src/jarvis-theme.css` and cannot drift here.
+ *
+ * Token discipline: no raw colour, size, or px value in this file.
+ */
+import type { EpistemicMarkKind, EpistemicMarkProps } from './types'
+
+interface MarkTokens {
+  /** `border-bottom` shorthand: width, style token, colour token. */
+  rule: string
+  /** Superscript colour token. */
+  sup: string
+  /** Optional body-text colour token (the artboard dims Assumed claims). */
+  text?: string
+  tag: string
+}
+
+const MARKS: Record<EpistemicMarkKind, MarkTokens> = {
+  known: {
+    rule: 'var(--jv-space-1) var(--jv-known-rule-style) var(--jv-known-rule)',
+    sup: 'var(--jv-known-sup)',
+    tag: 'KN',
+  },
+  recalled: {
+    rule: 'var(--jv-space-1) var(--jv-recalled-rule-style) var(--jv-recalled-rule)',
+    sup: 'var(--jv-recalled-sup)',
+    tag: 'RC',
+  },
+  assumed: {
+    rule: 'var(--jv-space-1) var(--jv-assumed-rule-style) var(--jv-assumed-rule)',
+    sup: 'var(--jv-assumed-sup)',
+    text: 'var(--jv-text-dim)',
+    tag: 'AS',
+  },
+}
+
+export function EpistemicMark({ mark, children }: EpistemicMarkProps) {
+  const tokens = MARKS[mark]
+
+  return (
+    <>
+      <span
+        data-jv-mark={mark}
+        style={{ borderBottom: tokens.rule, color: tokens.text }}
+      >
+        {children}
+      </span>
+      <sup
+        aria-label={mark}
+        className="ml-jv-3 align-[var(--jv-space-3)] font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide"
+        style={{ color: tokens.sup }}
+      >
+        {tokens.tag}
+      </sup>
+    </>
+  )
+}

--- a/src/components/jarvis/fixtures.ts
+++ b/src/components/jarvis/fixtures.ts
@@ -159,3 +159,418 @@ export const approvalGateFixtures: Array<ApprovalGateFixture> = [
     },
   },
 ]
+
+/* ══════════════════════════════════════════════════════════════════════
+   SLICE 3 — Desktop Command board (artboard 01) fixtures.
+
+   Appended below the Slice 2 gallery fixtures; nothing above is changed.
+
+   EVERY VALUE BELOW IS INVENTED. The board is composed from these fixtures
+   alone — no store, no gateway, no `/api/`, no fetch. That is deliberate for
+   slices 3–5; real wiring is slice 6.
+
+   Items flagged `NO SOURCE` in `docs/design/jarvis-ui-mapping.md` §3.5 appear
+   here as fixture values purely to prove the layout. The board marks each one
+   with `data-jv-fixture="no-source"` and states the list in a banner above the
+   frame, so nothing here can read as live. Slice 6 can grep this block to see
+   exactly what still needs a real source.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── Top bar ─────────────────────────────────────────────────────────── */
+
+export interface CommandTopbarFixture {
+  session: string
+  /** DERIVE in slice 6 — from `GatewaySession.startedAt`. */
+  uptime: string
+  vault: string
+  /** REAL in slice 6 — count of pending `/api/gateway/approvals` entries. */
+  gateLabel: string
+  greenlight: string
+}
+
+export const commandTopbarFixture: CommandTopbarFixture = {
+  session: 's-4471',
+  uptime: '18d 04:22',
+  vault: '~/Vault',
+  gateLabel: '1 GATE WAITING',
+  greenlight: 'enforced',
+}
+
+/* ── Left rail ───────────────────────────────────────────────────────── */
+
+/**
+ * The worker roster. Every `WorkerStatus` the primitive supports appears
+ * exactly once so the rail exercises the full set — see the note on
+ * `commandWorkerCounts` for where this diverges from the artboard.
+ */
+export const commandWorkerFixtures: Array<WorkerStatusLineProps> = [
+  { name: 'orchestrator', status: 'running', detail: 'routing' },
+  { name: 'builder', status: 'running', detail: '04:18' },
+  { name: 'reviewer', status: 'queued', detail: 'queued' },
+  { name: 'qa', status: 'queued', detail: 'queued' },
+  { name: 'km-agent', status: 'blocked' },
+  { name: 'researcher', status: 'idle', detail: 'idle 2h' },
+  { name: 'ops-watch', status: 'failed', detail: 'exit 1 · certs' },
+  { name: 'maintainer', status: 'stale', detail: 'stale 23d' },
+  { name: 'strategist', status: 'idle', detail: 'idle 6d' },
+  { name: 'inbox-triage', status: 'complete', detail: 'ran 14m' },
+]
+
+/**
+ * The artboard's literal count line. It is kept verbatim and does NOT tally
+ * `commandWorkerFixtures` — the artboard's own roster does not tally it either
+ * (it buckets everything that is not running or blocked as "IDLE"). Slice 6
+ * derives this from the real session list instead of restating a fixture.
+ */
+export const commandWorkerCounts = '2 RUN · 1 BLK · 7 IDLE'
+
+export type ThreadTone = 'active' | 'idle' | 'attention'
+
+export interface ThreadFixture {
+  title: string
+  meta: string
+  tone: ThreadTone
+}
+
+export const commandThreadFixtures: Array<ThreadFixture> = [
+  {
+    title: 'vault frontmatter loss',
+    meta: 'active · 6 msg · gate open',
+    tone: 'active',
+  },
+  { title: 'Q3 roadmap trim', meta: 'idle 2d · 31 msg', tone: 'idle' },
+  {
+    title: 'certbot renewal',
+    meta: 'needs attention · 4 msg',
+    tone: 'attention',
+  },
+]
+
+/** NO SOURCE — §3.5 item 10 (ctx %). Fixture only. */
+export const commandRailFooterLines: Array<string> = [
+  'ctx 41% · 3 worktrees',
+  'claude-code · 2 sessions',
+]
+
+/* ── Conversation ────────────────────────────────────────────────────── */
+
+/**
+ * One piece of a turn's body. The board assembles these into JSX because this
+ * file is `.ts` — same approach the gallery takes for `GateCaveatFixture`.
+ *
+ * `mark` is NO SOURCE (§3.5 item 1): nothing in `ChatMessage` or the SSE stream
+ * carries known/recalled/assumed today.
+ */
+export type RichSpan =
+  | { kind: 'text'; text: string }
+  /** Inline mono — a path or identifier inside prose. */
+  | { kind: 'code'; text: string }
+  | { kind: 'mark'; mark: EpistemicMarkKind; spans: Array<RichSpan> }
+  /** The streaming caret that trails an in-flight turn. */
+  | { kind: 'caret' }
+
+const text = (value: string): RichSpan => ({ kind: 'text', text: value })
+const code = (value: string): RichSpan => ({ kind: 'code', text: value })
+const mark = (
+  kind: EpistemicMarkKind,
+  ...spans: Array<RichSpan>
+): RichSpan => ({ kind: 'mark', mark: kind, spans })
+
+/** `→ delegated builder · worktree ../wt/… · branch …` */
+export interface DelegationNoteFixture {
+  label: string
+  value: string
+}
+
+export interface ConversationTurnFixture {
+  id: string
+  speaker: 'YOU' | 'JVS'
+  time?: string
+  /** `disagree` gets the left rule + the I DISAGREE label. NO SOURCE (§3.5 item 4). */
+  variant?: 'default' | 'disagree'
+  /** The artboard dims the trailing in-flight turn. */
+  dim?: boolean
+  body: Array<RichSpan>
+  /** NO SOURCE on chat messages (§3.5 items 2–3). */
+  evidence?: Array<VerificationBadgeProps>
+  delegation?: Array<DelegationNoteFixture>
+}
+
+export const commandConversationFixtures: Array<ConversationTurnFixture> = [
+  {
+    id: 'you-0941',
+    speaker: 'YOU',
+    time: '09:41',
+    body: [
+      text(
+        'km-agent is eating YAML frontmatter when it rewrites daily notes. Find it, fix it, then publish the changelog entry for the 0.9.3 release.',
+      ),
+    ],
+  },
+  {
+    id: 'jvs-0941',
+    speaker: 'JVS',
+    time: '09:41',
+    body: [
+      text('Reproduced it. '),
+      mark(
+        'known',
+        text(
+          '41 daily notes lost frontmatter between Aug 14 and today; I diffed them against the git history of the vault',
+        ),
+      ),
+      text('. '),
+      mark(
+        'recalled',
+        text(
+          'You hit something similar in May and we traced it to the YAML round-trip in ',
+        ),
+        code('vault/writer.ts'),
+      ),
+      text('. '),
+      mark(
+        'assumed',
+        text(
+          'The dump probably drops keys it cannot serialise rather than raising',
+        ),
+      ),
+      text('. I have not read that function this session.'),
+    ],
+    evidence: [
+      {
+        state: 'verified',
+        time: '09:38',
+        title: 'Reproduction case written and failing as expected',
+        evidence: [
+          'pnpm vitest vault/writer',
+          'exit 1 · 1 failed / 84 passed · 6.2s',
+        ],
+      },
+      {
+        state: 'claimed',
+        title: 'km-agent reports the 41 notes are restorable from vault git',
+        evidence: ['no artifact checked · no exit code'],
+        actions: ['VERIFY NOW', 'SHOW PLAN'],
+      },
+    ],
+    delegation: [
+      { label: 'delegated', value: 'builder' },
+      { label: 'worktree', value: '../wt/vault-frontmatter' },
+      { label: 'branch', value: 'fix/yaml-roundtrip' },
+    ],
+  },
+  {
+    id: 'you-0944',
+    speaker: 'YOU',
+    time: '09:44',
+    body: [
+      text(
+        "Don't overthink it — wrap the dump in a try/catch, log the failure, ship it. I want the changelog out this morning.",
+      ),
+    ],
+  },
+  {
+    id: 'jvs-0944',
+    speaker: 'JVS',
+    time: '09:44',
+    variant: 'disagree',
+    body: [
+      text('A try/catch hides it again. '),
+      mark(
+        'known',
+        text(
+          'The dump already swallows the error — that is why you got silent data loss instead of a crash',
+        ),
+      ),
+      text(
+        '. Catching it moves the loss into a log line nobody reads. I want to fail the write and leave the note untouched, which is eleven lines and one test. ',
+      ),
+      mark('assumed', text('Roughly twenty minutes to reviewer')),
+      text(
+        '. Say the word and I will do it your way, but I am logging the objection either way.',
+      ),
+    ],
+  },
+]
+
+/** Rendered after the gate, still streaming. */
+export const commandTrailingTurnFixture: ConversationTurnFixture = {
+  id: 'jvs-live',
+  speaker: 'JVS',
+  dim: true,
+  body: [
+    text('Holding the publish. builder is still on the writer fix — '),
+    mark('known', text('two files changed, tests running')),
+    { kind: 'caret' },
+  ],
+}
+
+/** The label on a `disagree` turn. */
+export const disagreeLabel = 'I DISAGREE'
+
+/* ── Inline approval gate ────────────────────────────────────────────── */
+
+/**
+ * The gate as it sits inline in the conversation. `blastRadius`, `undoPath`
+ * and the caveat are all NO SOURCE (§3.2) — nothing in today's backend models
+ * them, so they exist here and nowhere else.
+ */
+export const commandGateFixture: Omit<ApprovalGateCardProps, 'caveat'> = {
+  title: 'Publish changelog 0.9.3 to the public site',
+  command:
+    'gh workflow run publish.yml -f tag=v0.9.3 · builds site/, purges CDN',
+  subtitle: 'irreversible · orchestrator halted the chain',
+  waiting: '4m 12s',
+  state: 'pending',
+  blastRadius:
+    '1 public page · RSS to 2,411 subscribers · Discord webhook fires once',
+  undoPath:
+    'Revert commit + CDN purge ≈90s. RSS and Discord cannot be recalled.',
+  actions: ['APPROVE', 'REJECT', 'HOLD FOR QA'],
+}
+
+export const commandGateCaveatFixture: GateCaveatFixture = {
+  lead: 'Note: ',
+  mark: 'known',
+  claim: 'qa has not run against the fix yet',
+  trail:
+    ' — approving now publishes notes for a fix that is claimed, not verified.',
+}
+
+/* ── Composer ────────────────────────────────────────────────────────── */
+
+export interface ComposerFixture {
+  target: string
+  chips: Array<string>
+  slashHint: string
+  placeholder: string
+  newlineHint: string
+  sendLabel: string
+}
+
+export const commandComposerFixture: ComposerFixture = {
+  target: '→ ORCHESTRATOR',
+  chips: ['greenlight: on', 'vault: write', 'worktree: isolated'],
+  slashHint: '/delegate /verify /gate /recall /schedule',
+  placeholder: 'Instruct, or type / for a command',
+  newlineHint: '⇧⏎ newline',
+  sendLabel: 'SEND',
+}
+
+/* ── Right rail — work trail ─────────────────────────────────────────── */
+
+export type ChainNodeState = 'done' | 'active' | 'queued'
+
+export interface ChainNodeFixture {
+  name: string
+  state: ChainNodeState
+  /** One or two mono detail lines under the name. */
+  detail: Array<string>
+  /** Elapsed, shown only on the active node. */
+  time?: string
+}
+
+/**
+ * NO SOURCE as a graph (§3.5 item 14): a fixed orchestrator→builder→reviewer→qa
+ * chain is a LAYOUT CONVENTION, not a captured parent→child edge set. The board
+ * labels it as such rather than implying the edges are real.
+ */
+export const commandChainFixtures: Array<ChainNodeFixture> = [
+  { name: 'orchestrator', state: 'done', detail: ['routed · 0.4s'] },
+  {
+    name: 'builder',
+    state: 'active',
+    time: '04:18',
+    detail: [
+      'writing test · vitest --watch',
+      'claude-code · wt/vault-frontmatter',
+    ],
+  },
+  { name: 'reviewer', state: 'queued', detail: ['queued · gates diff'] },
+  { name: 'qa', state: 'queued', detail: ['queued · verifies behaviour'] },
+]
+
+export type FileChange = 'M' | 'A' | 'D'
+
+export interface FileTouchedFixture {
+  change: FileChange
+  path: string
+  /** `+11 −4`. NO SOURCE (§3.5 item 8) — no per-mission diff stream exists. */
+  diff: string
+}
+
+export const commandFilesTouchedFixtures: Array<FileTouchedFixture> = [
+  { change: 'M', path: 'src/vault/writer.ts', diff: '+11 −4' },
+  { change: 'A', path: 'src/vault/writer.test.ts', diff: '+38' },
+  { change: 'M', path: 'src/vault/frontmatter.ts', diff: '+2 −2' },
+]
+
+export type ToolCallState = 'ok' | 'failed' | 'live'
+
+export interface ToolCallFixture {
+  time: string
+  label: string
+  /** Duration is NO SOURCE (§3.5 item 9); `exit 1` / `live` are the other two. */
+  result: string
+  state: ToolCallState
+}
+
+export const commandToolCallFixtures: Array<ToolCallFixture> = [
+  {
+    time: '09:43',
+    label: 'read writer.ts:88-140',
+    result: '0.2s',
+    state: 'ok',
+  },
+  {
+    time: '09:43',
+    label: 'git worktree add ../wt/…',
+    result: '1.1s',
+    state: 'ok',
+  },
+  {
+    time: '09:45',
+    label: 'pnpm vitest vault/writer',
+    result: 'exit 1',
+    state: 'failed',
+  },
+  {
+    time: '09:46',
+    label: 'edit writer.ts dumpFrontmatter',
+    result: '0.9s',
+    state: 'ok',
+  },
+  {
+    time: '09:47',
+    label: 'pnpm vitest --watch',
+    result: 'live',
+    state: 'live',
+  },
+]
+
+export interface WorkTrailChromeFixture {
+  elapsed: string
+  footerLines: Array<string>
+  holdLabel: string
+}
+
+export const commandWorkTrailChrome: WorkTrailChromeFixture = {
+  elapsed: '06:12 elapsed',
+  footerLines: [
+    'tokens 41.2k · $0.38 this run',
+    'no network calls outside allowlist',
+  ],
+  holdLabel: 'HOLD ⌥',
+}
+
+/* ── Honesty banner ──────────────────────────────────────────────────── */
+
+/**
+ * Stated above the frame. The board must never read as live, and the NO SOURCE
+ * rows must never read as captured data.
+ */
+export const commandFixtureNotice =
+  'Fixture board — nothing here is wired to a store, the gateway, or an API. Every value is invented.'
+
+export const commandNoSourceNotice =
+  'Rendered from fixtures because they have NO SOURCE today (mapping §3.5): epistemic marks · verified/claimed on chat · the disagreement stance · blast radius · undo path · gate caveat · files touched · per-tool-call duration · ctx % · the delegation chain as a graph.'

--- a/src/components/jarvis/fixtures.ts
+++ b/src/components/jarvis/fixtures.ts
@@ -1,0 +1,161 @@
+/**
+ * Fixture data for the dev-only JARVIS gallery (`/jarvis-gallery`).
+ *
+ * INVENTED, NOT REAL. Nothing here is read from a store, an API, or the
+ * gateway — several of the states these fixtures exercise have NO SOURCE in
+ * today's backend (`docs/design/jarvis-ui-mapping.md` §3.5). The gallery exists
+ * so every primitive state can be reviewed side by side; wiring to real state
+ * is a later slice, and the NO SOURCE rows stay inert until a source exists.
+ *
+ * This file is `.ts`, so the gate caveat is described structurally (lead /
+ * mark / claim / trail) and assembled into JSX by the gallery screen.
+ */
+import type {
+  ApprovalGateCardProps,
+  EpistemicMarkKind,
+  VerificationBadgeProps,
+  WorkerStatusLineProps,
+} from './types'
+
+/** A claim rendered inline: `{lead}<Mark>{claim}</Mark>{trail}`. */
+export interface EpistemicMarkFixture {
+  mark: EpistemicMarkKind
+  lead: string
+  claim: string
+  trail: string
+}
+
+export const epistemicMarkFixtures: Array<EpistemicMarkFixture> = [
+  {
+    mark: 'known',
+    lead: 'Reproduced it. ',
+    claim:
+      '41 daily notes lost frontmatter between Aug 14 and today; I diffed them against the git history of the vault',
+    trail: '. I read every one of those diffs this session.',
+  },
+  {
+    mark: 'recalled',
+    lead: 'For context: ',
+    claim:
+      'you hit something similar in May and we traced it to the YAML round-trip in vault/writer.ts',
+    trail: '. That is memory, not a fresh check.',
+  },
+  {
+    mark: 'assumed',
+    lead: 'My read: ',
+    claim:
+      'the dump probably drops keys it cannot serialise rather than raising',
+    trail: '. I have not opened that function this session.',
+  },
+]
+
+export interface VerificationBadgeFixture {
+  /** Gallery caption — what this variant is here to prove. */
+  label: string
+  props: VerificationBadgeProps
+}
+
+export const verificationBadgeFixtures: Array<VerificationBadgeFixture> = [
+  {
+    label: 'verified · evidence + exit code',
+    props: {
+      state: 'verified',
+      time: '09:38',
+      title: 'Reproduction case written and failing as expected',
+      evidence: [
+        'pnpm vitest vault/writer',
+        'exit 1 · 1 failed / 84 passed · 6.2s',
+      ],
+    },
+  },
+  {
+    label: 'claimed · no artifact, action chips',
+    props: {
+      state: 'claimed',
+      title: 'km-agent reports the 41 notes are restorable from vault git',
+      evidence: ['no artifact checked · no exit code'],
+      actions: ['VERIFY NOW', 'SHOW PLAN'],
+    },
+  },
+  {
+    label: 'verified · no evidence lines (edge)',
+    props: {
+      state: 'verified',
+      title: 'Checkpoint approved by a human reviewer',
+    },
+  },
+]
+
+export const workerStatusFixtures: Array<WorkerStatusLineProps> = [
+  { name: 'orchestrator', status: 'running', detail: 'routing' },
+  { name: 'km-agent', status: 'blocked' },
+  { name: 'researcher', status: 'idle', detail: 'idle 2h' },
+  { name: 'maintainer', status: 'stale', detail: 'stale 23d' },
+  { name: 'ops-watch', status: 'failed', detail: 'exit 1 · certs' },
+  { name: 'reviewer', status: 'queued', detail: 'queued' },
+  { name: 'inbox-triage', status: 'complete', detail: 'ran 14m' },
+]
+
+/** Shown in place of the rail when there is nothing to list. */
+export const emptyRailNote = 'No workers reporting. Nothing is running.'
+
+/** Caveat line for a gate, assembled into JSX around an <EpistemicMark>. */
+export interface GateCaveatFixture {
+  lead: string
+  mark: EpistemicMarkKind
+  claim: string
+  trail: string
+}
+
+export interface ApprovalGateFixture {
+  /** Gallery caption — what this variant is here to prove. */
+  label: string
+  props: Omit<ApprovalGateCardProps, 'caveat'>
+  caveat?: GateCaveatFixture
+}
+
+const gateBody = {
+  title: 'Publish changelog 0.9.3 to the public site',
+  command:
+    'gh workflow run publish.yml -f tag=v0.9.3 · builds site/, purges CDN',
+  blastRadius:
+    '1 public page · RSS to 2,411 subscribers · Discord webhook fires once',
+  undoPath:
+    'Revert commit + CDN purge ≈90s. RSS and Discord cannot be recalled.',
+  actions: ['APPROVE', 'REJECT', 'HOLD FOR QA'],
+}
+
+export const approvalGateFixtures: Array<ApprovalGateFixture> = [
+  {
+    label: 'pending · full blast radius, undo path and caveat',
+    props: {
+      ...gateBody,
+      subtitle: 'irreversible · orchestrator halted the chain',
+      waiting: '4m 12s',
+      state: 'pending',
+    },
+    caveat: {
+      lead: 'Note: ',
+      mark: 'known',
+      claim: 'qa has not run against the fix yet',
+      trail:
+        ' — approving now publishes notes for a fix that is claimed, not verified.',
+    },
+  },
+  {
+    label: 'approved · resolved',
+    props: {
+      ...gateBody,
+      subtitle: 'resolved by you · chain resumed',
+      state: 'approved',
+    },
+  },
+  {
+    label: 'rejected · resolved',
+    props: {
+      ...gateBody,
+      subtitle: 'resolved by you · chain halted',
+      state: 'rejected',
+    },
+  },
+]

--- a/src/components/jarvis/fixtures.ts
+++ b/src/components/jarvis/fixtures.ts
@@ -1014,3 +1014,330 @@ export const conductorFixtureNotice =
 
 export const conductorNoSourceNotice =
   'Rendered from fixtures because they have NO SOURCE today (mapping §3.5): the cron PARTIAL badge as a structured state · the launchd "not loaded" diagnostic · run-log history beyond the latest run · the delegation chain as a real parent→child edge graph.'
+
+/* ══════════════════════════════════════════════════════════════════════
+   SLICE 5 — Mobile Command (artboard 03) and Mobile Conductor (artboard 04).
+
+   Appended below the Slice 3 and Slice 4 fixtures; nothing above is changed.
+
+   Mobile is a RECOMPOSITION, not a scaled desktop board — so these fixtures
+   are a deliberate SUBSET of the same story, re-cut for a 390pt column. The
+   gate body, the worker roster, the failing certs job and the run history are
+   the ones already declared above and are re-used verbatim wherever the mobile
+   artboard shows the same value; the entries below exist only where mobile
+   shows something the desktop fixtures do not already carry (a phone status
+   bar, a four-stat glance strip, a condensed thread, an abbreviated run list).
+
+   EVERY VALUE BELOW IS INVENTED, on the same terms as the blocks above: no
+   store, no gateway, no `/api/`, no fetch. The NO SOURCE items
+   (`docs/design/jarvis-ui-mapping.md` §3.5) carry `noSource` here and are
+   marked `data-jv-fixture="no-source"` in the DOM by the mobile boards.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── Shared phone chrome ─────────────────────────────────────────────── */
+
+/**
+ * The phone status bar. `glyphs` are the artboard's SF Symbols for signal and
+ * battery, kept as literal text: they are drawn characters in the artboard,
+ * not iconography this slice is entitled to introduce.
+ */
+export interface MobileStatusBarFixture {
+  time: string
+  wordmark: string
+  glyphs: string
+}
+
+export const mobileStatusBarFixture: MobileStatusBarFixture = {
+  time: '9:47',
+  wordmark: 'JARVIS',
+  glyphs: '􀙇 􀛨',
+}
+
+/* ── Artboard 03 — Mobile Command ────────────────────────────────────── */
+
+/**
+ * The slim alert strip under the status bar. Amber gate count on the left,
+ * the fleet tally on the right — the two things that decide whether you keep
+ * reading or act.
+ */
+export interface MobileAlertStripFixture {
+  gateLabel: string
+  counts: string
+}
+
+export const mobileCommandAlertStrip: MobileAlertStripFixture = {
+  gateLabel: '1 GATE WAITING',
+  counts: '2 running · 1 blocked',
+}
+
+/**
+ * The hero gate. Same body as `commandGateFixture` — mobile leads with the
+ * gate rather than burying it in the thread, but it must not lead with a
+ * DIFFERENT gate. Only the desktop header sublabel is dropped: at 390pt the
+ * label / sublabel / waiting row cannot hold all three, and `waiting` is the
+ * one that decays.
+ */
+export const mobileCommandGateFixture: Omit<ApprovalGateCardProps, 'caveat'> = {
+  title: commandGateFixture.title,
+  command: commandGateFixture.command,
+  waiting: commandGateFixture.waiting,
+  state: commandGateFixture.state,
+  blastRadius: commandGateFixture.blastRadius,
+  undoPath: commandGateFixture.undoPath,
+  actions: commandGateFixture.actions,
+}
+
+/** NO SOURCE — §3.5 item 7. The mobile artboard states the caveat shorter. */
+export const mobileCommandGateCaveatFixture: GateCaveatFixture = {
+  lead: 'Note: ',
+  mark: 'known',
+  claim: 'qa has not verified the fix',
+  trail: ' — approving publishes notes for a claim, not a check.',
+}
+
+/** `YOU 09:44` / `JARVIS 09:44 · DISAGREES` — the condensed thread's turns. */
+export interface MobileThreadTurnFixture {
+  id: string
+  speaker: string
+  time: string
+  /** The DISAGREES stance. NO SOURCE — §3.5 item 4. */
+  stance?: string
+  body: Array<RichSpan>
+}
+
+export interface MobileThreadFixture {
+  label: string
+  turns: Array<MobileThreadTurnFixture>
+  /** `→ builder running 04:18` — the delegation the thread handed off to. */
+  delegation: string
+  /** The compact CLAIMED strip. NO SOURCE on a chat turn — §3.5 items 2–3. */
+  evidence: VerificationBadgeProps
+}
+
+export const mobileCommandThreadFixture: MobileThreadFixture = {
+  label: 'THREAD · VAULT FRONTMATTER',
+  turns: [
+    {
+      id: 'm-you-0944',
+      speaker: 'YOU',
+      time: '09:44',
+      body: [text('Wrap the dump in a try/catch and ship it.')],
+    },
+    {
+      id: 'm-jvs-0944',
+      speaker: 'JARVIS',
+      time: '09:44',
+      stance: 'DISAGREES',
+      body: [
+        text('A try/catch hides it again — the '),
+        mark('known', code('dump'), text(' already swallows the error')),
+        text(', which is why you got silent loss. '),
+        mark('recalled', text('Same shape as the May incident')),
+        text('. Failing the write is eleven lines and one test, '),
+        mark('assumed', text('~twenty minutes')),
+        text(' to reviewer.'),
+      ],
+    },
+  ],
+  delegation: '→ builder running 04:18',
+  evidence: {
+    state: 'claimed',
+    title: '41 notes restorable from vault git',
+    actions: ['VERIFY'],
+  },
+}
+
+/**
+ * The legend the desktop board has room to omit. Each row is the underline
+ * STYLE named, then the kind itself wearing that style via `EpistemicMark` —
+ * so the legend is drawn by the same component it documents and cannot drift.
+ */
+export interface MobileLegendFixture {
+  mark: EpistemicMarkKind
+  style: string
+  label: string
+}
+
+export const mobileCommandLegendFixtures: Array<MobileLegendFixture> = [
+  { mark: 'known', style: 'solid', label: 'known' },
+  { mark: 'recalled', style: 'dotted', label: 'recalled' },
+  { mark: 'assumed', style: 'dashed', label: 'assumed' },
+]
+
+/**
+ * The mobile composer. Distinct from `ComposerFixture`: the desktop chip row
+ * and the `⇧⏎ newline` hint are both dropped on a phone, and the target
+ * abbreviates to `→ ORCH`, so sharing the type would mean four optional
+ * fields that only ever mean "desktop".
+ */
+export interface MobileComposerFixture {
+  target: string
+  slashHint: string
+  placeholder: string
+  sendLabel: string
+}
+
+export const mobileCommandComposerFixture: MobileComposerFixture = {
+  target: '→ ORCH',
+  slashHint: '/verify /hold /status',
+  placeholder: 'Instruct JARVIS',
+  sendLabel: 'SEND',
+}
+
+/* ── Artboard 04 — Mobile Conductor ──────────────────────────────────── */
+
+/** The four glance stats. `tone` hue-codes the NUMBER, not the label. */
+export type MobileStatTone = 'live' | 'blocked' | 'failed' | 'idle'
+
+export interface MobileStatFixture {
+  label: string
+  value: string
+  tone: MobileStatTone
+}
+
+/**
+ * Kept verbatim from the artboard rather than tallied from
+ * `conductorWorkerCardFixtures` — the same reason `commandWorkerCounts` is.
+ * Slice 6 derives these from the live session list.
+ */
+export const mobileConductorStatFixtures: Array<MobileStatFixture> = [
+  { label: 'RUNNING', value: '2', tone: 'live' },
+  { label: 'BLOCKED', value: '1', tone: 'blocked' },
+  { label: 'FAILED', value: '1', tone: 'failed' },
+  { label: 'IDLE', value: '7', tone: 'idle' },
+]
+
+/**
+ * NEEDS YOU — the blocked `km-agent` card from the desktop worker board, re-cut
+ * as the one thing on this screen that cannot wait. Deliberately NOT the full
+ * `ApprovalGateCard`: on the Conductor this is a POINTER to a gate, and drawing
+ * the honest blast-radius panel here would imply you can decide from a glance
+ * surface. The gate itself lives on Command.
+ */
+export interface MobileGateSummaryFixture {
+  heading: string
+  label: string
+  title: string
+  actions: Array<string>
+}
+
+export const mobileConductorNeedsYouFixture: MobileGateSummaryFixture = {
+  heading: 'NEEDS YOU',
+  label: 'GATE · km-agent',
+  title: 'Write 41 restored notes to Vault/Published/',
+  actions: ['APPROVE', 'REVIEW'],
+}
+
+/** RUNNING NOW — the two live workers, as `WorkerStatusLine` rows. */
+export const mobileConductorRunningFixtures: Array<WorkerStatusLineProps> = [
+  { name: 'builder', status: 'running', detail: 'vitest --watch · 04:18' },
+  { name: 'orchestrator', status: 'running', detail: 'routing · live' },
+]
+
+export interface MobileRunningChainFixture {
+  heading: string
+  /** NO SOURCE — §3.5 item 14: the chain is a layout convention. */
+  chain: string
+  holdLabel: string
+}
+
+export const mobileConductorRunningChain: MobileRunningChainFixture = {
+  heading: 'RUNNING NOW',
+  chain: 'chain: orchestrator → builder → reviewer → qa · step 2 of 4',
+  holdLabel: 'HOLD ⌥',
+}
+
+/**
+ * SCHEDULE HEALTH. Only the two unhealthy jobs get a row; the healthy six
+ * collapse into one footer line, because the point of the section on a phone
+ * is what is broken, not the roster.
+ */
+export type MobileJobTone = 'failed' | 'silent'
+
+export interface MobileJobFixture {
+  name: string
+  tone: MobileJobTone
+  badge: string
+  detail: string
+  /** Marks the DETAIL as having no source at all. */
+  noSource?: boolean
+}
+
+export const mobileConductorJobFixtures: Array<MobileJobFixture> = [
+  {
+    name: 'ops-watch:certs',
+    tone: 'failed',
+    badge: 'FAIL',
+    detail: 'certbot exit 1 · DNS-01 timeout',
+  },
+  {
+    name: 'maintainer:dep-audit',
+    tone: 'silent',
+    badge: 'SILENT',
+    // NO SOURCE — §3.5 item 12: the client cannot introspect launchd.
+    detail: 'no run in 23d · launchd unloaded',
+    noSource: true,
+  },
+]
+
+export interface MobileScheduleHealthFixture {
+  heading: string
+  /** `4 other jobs healthy`. */
+  healthy: string
+  /**
+   * `researcher:feed-scan partial`. NO SOURCE — §3.5 item 11: PARTIAL only
+   * ever exists as free text inside `last_run_error`.
+   */
+  partial: string
+}
+
+export const mobileConductorScheduleHealth: MobileScheduleHealthFixture = {
+  heading: 'SCHEDULE HEALTH',
+  healthy: '4 other jobs healthy',
+  partial: 'researcher:feed-scan partial',
+}
+
+/**
+ * LAST NIGHT — the unattended window, abbreviated. Same runs as
+ * `conductorRunLogFixtures`, cut to the five the artboard lists and shortened
+ * to a job stem, because a 390pt column cannot hold `TIME / JOB / WORKER /
+ * RESULT / OUTCOME / DURATION`.
+ *
+ * NO SOURCE as a list — §3.5 item 13: `ClaudeJob` exposes only the LATEST run
+ * of each job, so no per-run history can be assembled from today's API at all.
+ */
+export interface MobileRunFixture {
+  time: string
+  job: string
+  outcome: ConductorRunOutcome
+}
+
+export interface MobileLastNightFixture {
+  heading: string
+  /** `00:00 – 09:00 · 9 runs`. */
+  window: string
+  runs: Array<MobileRunFixture>
+}
+
+export const mobileConductorLastNightFixture: MobileLastNightFixture = {
+  heading: 'LAST NIGHT',
+  window: '00:00 – 09:00 · 9 runs',
+  runs: [
+    { time: '07:00', job: 'feed-scan', outcome: 'partial' },
+    { time: '06:00', job: 'vault-index', outcome: 'success' },
+    { time: '05:00', job: 'certs', outcome: 'failed' },
+    { time: '02:14', job: 'typecheck', outcome: 'success' },
+    { time: '00:00', job: 'daily-note', outcome: 'partial' },
+  ],
+}
+
+/* ── Honesty banner ──────────────────────────────────────────────────── */
+
+/**
+ * Stated above the mobile frames. The NO SOURCE list is the SAME list the
+ * desktop boards state — mobile recomposes the layout, not the honesty — so
+ * `commandNoSourceNotice` and `conductorNoSourceNotice` are re-used as-is and
+ * only the "this is the mobile cut" lede is new.
+ */
+export const mobileFixtureNotice =
+  'Fixture board — nothing here is wired to a store, the gateway, or an API. Every value is invented. Mobile is a recomposition of the same fixtures, not the desktop board scaled down.'

--- a/src/components/jarvis/fixtures.ts
+++ b/src/components/jarvis/fixtures.ts
@@ -574,3 +574,443 @@ export const commandFixtureNotice =
 
 export const commandNoSourceNotice =
   'Rendered from fixtures because they have NO SOURCE today (mapping §3.5): epistemic marks · verified/claimed on chat · the disagreement stance · blast radius · undo path · gate caveat · files touched · per-tool-call duration · ctx % · the delegation chain as a graph.'
+
+/* ══════════════════════════════════════════════════════════════════════
+   SLICE 4 — Desktop Conductor board (artboard 02) fixtures.
+
+   Appended below the Slice 3 Command fixtures; nothing above is changed.
+
+   EVERY VALUE BELOW IS INVENTED. The Conductor board is composed from these
+   fixtures alone — no store, no gateway, no `/api/`, no fetch. Real wiring is
+   slice 6.
+
+   Honesty note specific to this board. Per `docs/design/jarvis-ui-mapping.md`
+   §3.3–§3.4 several Conductor states DO have real sources today — worker
+   running/idle/failed/stale (`SwarmSession.swarmStatus`, `ConductorWorker`),
+   and job name/cadence/last-run success/error/next-run (`ClaudeJob` via
+   `/api/claude-jobs`). This slice still does NOT read them: it renders
+   fixtures so slice 6 has one file to replace. The values that have NO source
+   at all — §3.5 items 11 (cron PARTIAL as a structured badge), 12 (the launchd
+   "not loaded" diagnostic), 13 (run-log history beyond the latest run) and 14
+   (the delegation chain as a real edge graph) — carry `noSource` here and are
+   marked `data-jv-fixture="no-source"` in the DOM as well as being named in
+   the banner above the frame.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── Top bar ─────────────────────────────────────────────────────────── */
+
+/**
+ * The status line is written as three parts because two of its counts are
+ * hue-coded in the artboard: `1 job failed` in `--jv-failed`, `1 job stale 23d`
+ * in `--jv-blocked`. Splitting it here keeps the colour decision out of the
+ * component and the copy out of the markup.
+ */
+export interface ConductorTopbarFixture {
+  /** COMMAND / CONDUCTOR. `href` is optional and purely navigational. */
+  tabs: Array<{ label: string; active: boolean; href?: string }>
+  /** DERIVE in slice 6 — counts over the live session list. */
+  statusLead: string
+  /** REAL in slice 6 — `ClaudeJob.last_run_success === false`. */
+  statusFailed: string
+  /** DERIVE in slice 6 — `last_run_at` age ≫ cadence. */
+  statusStale: string
+  date: string
+}
+
+export const conductorTopbarFixture: ConductorTopbarFixture = {
+  tabs: [
+    { label: 'COMMAND', active: false, href: '/jarvis-command' },
+    { label: 'CONDUCTOR', active: true },
+  ],
+  statusLead: '2 running · 1 blocked · ',
+  statusFailed: '1 job failed',
+  statusStale: '1 job stale 23d',
+  date: 'Sat 23 Aug · 09:47',
+}
+
+/* ── Worker board ────────────────────────────────────────────────────── */
+
+/**
+ * Card frame + dot + name treatment. Deliberately NOT `WorkerStatus` from
+ * `./types`: the artboard's grid cards separate the frame from the badge (an
+ * idle-looking `ops-watch` card still carries an `ERR` badge for its LAST RUN),
+ * so one enum cannot drive both without lying about one of them.
+ *
+ * `queued` and `idle` differ only in frame weight — the chain row is drawn a
+ * step brighter than the fleet below it, exactly as the artboard has it.
+ */
+export type ConductorCardTone =
+  | 'running'
+  | 'active'
+  | 'queued'
+  | 'blocked'
+  | 'idle'
+
+/** Step number (01–04) or a state word (BLK / ERR / STALE). */
+export type ConductorBadgeTone = 'live' | 'muted' | 'blocked' | 'failed'
+
+/** Second detail line — independent of the card tone, see `ConductorCardTone`. */
+export type ConductorSubTone = 'default' | 'blocked' | 'failed'
+
+/**
+ * `hold` and `outline` are both outlined chips but are NOT the same chip: the
+ * artboard draws the worker-board HOLD affordance a step quieter (dimmer text,
+ * softer border, tighter padding) than a job's FULL LOG. Kept distinct rather
+ * than averaged, since the whole point of HOLD is that it recedes until wanted.
+ */
+export type ConductorChipTone = 'hold' | 'outline' | 'blocked' | 'failed'
+
+export interface ConductorChipFixture {
+  label: string
+  tone: ConductorChipTone
+}
+
+/**
+ * `connector` draws the chain edge to the card on its right:
+ *   `flow` — static rule + the `jv-flow` travelling dot (an in-flight hand-off)
+ *   `line` — static rule only (the next node has not been reached yet)
+ * NO SOURCE either way (§3.5 item 14): the edge is a layout convention.
+ */
+export type ConductorConnector = 'flow' | 'line'
+
+export interface ConductorWorkerCardFixture {
+  name: string
+  tone: ConductorCardTone
+  badge?: { label: string; tone: ConductorBadgeTone }
+  detail: string
+  sub: string
+  subTone?: ConductorSubTone
+  action?: ConductorChipFixture
+  connector?: ConductorConnector
+  /** Marks the card's sub-line as having no source at all. */
+  noSource?: boolean
+}
+
+/**
+ * Row 1 (the first five) is the active chain; the rest is the fleet.
+ * Same roster as `commandWorkerFixtures`, re-expressed as cards — the rail
+ * carries one detail string per worker, a card carries two lines, a badge and
+ * an action, so the shapes cannot be shared without padding one of them out.
+ */
+export const conductorWorkerCardFixtures: Array<ConductorWorkerCardFixture> = [
+  {
+    name: 'orchestrator',
+    tone: 'running',
+    badge: { label: '01', tone: 'live' },
+    detail: 'routing · enforcing greenlight',
+    sub: '3 gates today · 1 open',
+    connector: 'flow',
+  },
+  {
+    name: 'builder',
+    tone: 'active',
+    badge: { label: '02', tone: 'live' },
+    detail: 'running 04:18 · vitest --watch',
+    sub: 'wt/vault-frontmatter · 3 files',
+    action: { label: 'HOLD ⌥ TO INTERVENE', tone: 'hold' },
+    connector: 'flow',
+  },
+  {
+    name: 'reviewer',
+    tone: 'queued',
+    badge: { label: '03', tone: 'muted' },
+    detail: 'queued · gates the diff',
+    sub: 'last verdict 08:12 · pass',
+    connector: 'line',
+  },
+  {
+    name: 'qa',
+    tone: 'queued',
+    badge: { label: '04', tone: 'muted' },
+    detail: 'queued · behaviour check',
+    sub: 'turns claimed → verified',
+  },
+  {
+    name: 'km-agent',
+    tone: 'blocked',
+    badge: { label: 'BLK', tone: 'blocked' },
+    detail: 'blocked 00:42 · needs approval',
+    sub: 'write to Vault/Published/',
+    action: { label: 'OPEN GATE', tone: 'blocked' },
+  },
+  {
+    name: 'researcher',
+    tone: 'idle',
+    detail: 'idle 2h 11m',
+    sub: 'last: pricing scan → vault',
+  },
+  {
+    name: 'ops-watch',
+    tone: 'idle',
+    badge: { label: 'ERR', tone: 'failed' },
+    detail: 'idle · next 05:00',
+    sub: 'last run failed · certbot',
+    subTone: 'failed',
+  },
+  {
+    name: 'maintainer',
+    tone: 'idle',
+    badge: { label: 'STALE', tone: 'blocked' },
+    detail: 'no run in 23d',
+    // NO SOURCE — §3.5 item 12: the client cannot introspect launchd.
+    sub: 'launchd job not loaded',
+    subTone: 'blocked',
+    noSource: true,
+  },
+  {
+    name: 'strategist',
+    tone: 'idle',
+    detail: 'idle 6d',
+    sub: 'next: monthly scan Sep 1',
+  },
+  {
+    name: 'inbox-triage',
+    tone: 'idle',
+    detail: 'ran 14m ago · 0.9s',
+    sub: '31 mail → 4 actionable',
+  },
+]
+
+export interface ConductorSectionHeadingFixture {
+  label: string
+  /** The dim caption beside the label. */
+  note: string
+  /** Highlighted tail of the caption, if the artboard brightens one. */
+  noteAccent?: string
+}
+
+export const conductorWorkerBoardHeading: ConductorSectionHeadingFixture = {
+  label: 'WORKER BOARD',
+  note: 'chain: orchestrator → builder → reviewer → qa · thread ',
+  noteAccent: 'vault frontmatter loss',
+}
+
+/* ── Scheduled jobs ──────────────────────────────────────────────────── */
+
+/**
+ * `failed` and `silent` are the loud cards: a red frame with a hazard-stripe
+ * edge, and an amber frame. `partial` shares the `ok` frame and differs only in
+ * badge hue — the artboard treats it as a note on an otherwise healthy job.
+ */
+export type ConductorJobTone = 'ok' | 'failed' | 'silent' | 'partial'
+
+/** Per-line override; `default` follows the card tone. */
+export type ConductorJobLineTone = 'default' | 'failed' | 'dim'
+
+export interface ConductorJobLineFixture {
+  text: string
+  tone?: ConductorJobLineTone
+  /** Nothing in `ClaudeJob` produces this line. */
+  noSource?: boolean
+}
+
+export interface ConductorJobFixture {
+  name: string
+  tone: ConductorJobTone
+  badge: string
+  /** `every 6h · km-agent` — cadence and owning worker. */
+  cadence: string
+  detail: Array<ConductorJobLineFixture>
+  actions?: Array<ConductorChipFixture>
+  /** Marks the BADGE itself as unsourced (the PARTIAL case, §3.5 item 11). */
+  badgeNoSource?: boolean
+}
+
+export const conductorJobFixtures: Array<ConductorJobFixture> = [
+  {
+    name: 'vault-index-rebuild',
+    tone: 'ok',
+    badge: 'OK',
+    cadence: 'every 6h · km-agent',
+    detail: [{ text: 'last 06:00 · 41s · 3,209 notes' }],
+  },
+  {
+    name: 'inbox-triage:sweep',
+    tone: 'ok',
+    badge: 'OK',
+    cadence: 'hourly · inbox-triage',
+    detail: [{ text: 'last 09:33 · 0.9s · 4 actionable' }],
+  },
+  {
+    name: 'ops-watch:certs',
+    tone: 'failed',
+    badge: 'FAILED',
+    cadence: 'daily 05:00 · ops-watch · 3 runs failed',
+    detail: [
+      {
+        text: 'certbot renew → exit 1: DNS-01 challenge timeout (_acme-challenge.hexley.dev)',
+        tone: 'failed',
+      },
+    ],
+    actions: [
+      { label: 'TRIAGE', tone: 'failed' },
+      { label: 'FULL LOG', tone: 'outline' },
+    ],
+  },
+  {
+    name: 'maintainer:dep-audit',
+    tone: 'silent',
+    badge: 'SILENT 23d',
+    cadence: 'weekly Mon 03:00 · maintainer',
+    detail: [
+      { text: 'expected 4 runs · got 0 · never errored' },
+      // NO SOURCE — §3.5 item 12.
+      {
+        text: 'launchd: com.jarvis.maintainer not loaded',
+        tone: 'dim',
+        noSource: true,
+      },
+    ],
+    actions: [{ label: 'RELOAD & RUN', tone: 'blocked' }],
+  },
+  {
+    name: 'weekly-review-digest',
+    tone: 'ok',
+    badge: 'OK',
+    cadence: 'Sun 18:00 · strategist',
+    detail: [{ text: 'last Aug 17 · 2m 04s · gate cleared' }],
+  },
+  {
+    name: 'researcher:feed-scan',
+    tone: 'partial',
+    badge: 'PARTIAL',
+    // NO SOURCE — §3.5 item 11: PARTIAL is free text inside `last_run_error`,
+    // never a structured job status.
+    badgeNoSource: true,
+    cadence: 'daily 07:00 · researcher',
+    detail: [{ text: 'last 07:00 · 58s · 2 of 14 feeds 403' }],
+  },
+]
+
+export const conductorJobsHeading: ConductorSectionHeadingFixture = {
+  label: 'SCHEDULED JOBS',
+  note: '6 registered · health is last-run, not next-run',
+}
+
+/* ── Run log ─────────────────────────────────────────────────────────── */
+
+export type ConductorRunOutcome = 'success' | 'partial' | 'failed'
+
+export interface ConductorRunFixture {
+  time: string
+  job: string
+  worker: string
+  /** Free-text result summary — what the run actually did. */
+  result: string
+  outcome: ConductorRunOutcome
+  duration: string
+}
+
+/**
+ * NO SOURCE as a list (§3.5 item 13): `ClaudeJob` exposes only the LATEST run,
+ * so a multi-row history cannot be assembled from today's API at all. The whole
+ * table is therefore fixture data and says so.
+ */
+export const conductorRunLogFixtures: Array<ConductorRunFixture> = [
+  {
+    time: '09:33',
+    job: 'inbox-triage:sweep',
+    worker: 'inbox-triage',
+    result: '31 mail · 4 actionable · 2 vault notes written',
+    outcome: 'success',
+    duration: '0.9s',
+  },
+  {
+    time: '08:33',
+    job: 'inbox-triage:sweep',
+    worker: 'inbox-triage',
+    result: '18 mail · 1 actionable',
+    outcome: 'success',
+    duration: '0.7s',
+  },
+  {
+    time: '07:00',
+    job: 'researcher:feed-scan',
+    worker: 'researcher',
+    result: '12/14 feeds · 2 × HTTP 403 (substack)',
+    outcome: 'partial',
+    duration: '58s',
+  },
+  {
+    time: '06:00',
+    job: 'vault-index-rebuild',
+    worker: 'km-agent',
+    result: '3,209 notes · 118 links repaired',
+    outcome: 'success',
+    duration: '41s',
+  },
+  {
+    time: '05:00',
+    job: 'ops-watch:certs',
+    worker: 'ops-watch',
+    result: 'certbot renew → exit 1 · DNS-01 timeout after 120s',
+    outcome: 'failed',
+    duration: '2m 01s',
+  },
+  {
+    time: '05:00',
+    job: 'ops-watch:disk',
+    worker: 'ops-watch',
+    result: 'SSD 71% · 3 worktrees pruned',
+    outcome: 'success',
+    duration: '4.4s',
+  },
+  {
+    time: '02:14',
+    job: 'builder:nightly-typecheck',
+    worker: 'builder',
+    result: 'tsc --noEmit clean · 0 errors',
+    outcome: 'success',
+    duration: '1m 12s',
+  },
+  {
+    time: '00:00',
+    job: 'km-agent:daily-note',
+    worker: 'km-agent',
+    result: 'note created · frontmatter dropped (see 09:41 thread)',
+    outcome: 'partial',
+    duration: '0.3s',
+  },
+]
+
+export interface ConductorRunLogChromeFixture {
+  label: string
+  note: string
+  /**
+   * The artboard's literal tally. It counts the full 12h window (14 runs),
+   * which is deliberately MORE than the eight rows the table has room for —
+   * kept verbatim rather than tallied from `conductorRunLogFixtures`, which
+   * would silently restate a fixture as if it were derived.
+   */
+  summary: string
+  columns: {
+    time: string
+    job: string
+    worker: string
+    result: string
+    outcome: string
+    duration: string
+  }
+}
+
+export const conductorRunLogChrome: ConductorRunLogChromeFixture = {
+  label: 'RUN LOG · UNATTENDED',
+  note: 'last 12h · one entry per run',
+  summary: '14 runs · 11 success · 2 partial · 1 failed',
+  columns: {
+    time: 'TIME',
+    job: 'JOB',
+    worker: 'WORKER',
+    result: 'RESULT',
+    outcome: 'OUTCOME',
+    duration: 'DURATION',
+  },
+}
+
+/* ── Honesty banner ──────────────────────────────────────────────────── */
+
+export const conductorFixtureNotice =
+  'Fixture board — nothing here is wired to a store, the gateway, or an API. Every value is invented. Worker status and job last-run health DO have real sources (mapping §3.3–§3.4); this slice deliberately does not read them, so slice 6 has one file to replace.'
+
+export const conductorNoSourceNotice =
+  'Rendered from fixtures because they have NO SOURCE today (mapping §3.5): the cron PARTIAL badge as a structured state · the launchd "not loaded" diagnostic · run-log history beyond the latest run · the delegation chain as a real parent→child edge graph.'

--- a/src/components/jarvis/types.ts
+++ b/src/components/jarvis/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared prop types for the JARVIS primitives (Slice 2).
+ *
+ * These four components are presentational only — they render state that is
+ * handed to them, and none of them reads a store, calls an API, or derives a
+ * verdict of its own. See `docs/design/jarvis-ui-mapping.md` §2.1 and §3.5:
+ * several of the states below have NO SOURCE in today's backend and must never
+ * be faked by the components themselves.
+ */
+import type { ReactNode } from 'react'
+
+/** Known / Recalled / Assumed — the artboard's epistemic legend. */
+export type EpistemicMarkKind = 'known' | 'recalled' | 'assumed'
+
+/** Evidence attached vs the agent's word only. */
+export type VerificationState = 'verified' | 'claimed'
+
+/** Worker rail row states. */
+export type WorkerStatus =
+  | 'running'
+  | 'blocked'
+  | 'idle'
+  | 'stale'
+  | 'failed'
+  | 'queued'
+  | 'complete'
+
+/** Approval gate lifecycle. */
+export type ApprovalGateState = 'pending' | 'approved' | 'rejected'
+
+export interface EpistemicMarkProps {
+  mark: EpistemicMarkKind
+  children: ReactNode
+}
+
+export interface VerificationBadgeProps {
+  state: VerificationState
+  title: string
+  /** Evidence lines (command, exit code, counts). Rendered mono + muted. */
+  evidence?: Array<string>
+  /** Timestamp shown next to the VERIFIED label. */
+  time?: string
+  /** Presentational chips (first one reads as primary). */
+  actions?: Array<string>
+}
+
+export interface WorkerStatusLineProps {
+  name: string
+  status: WorkerStatus
+  /** Right-hand detail ("04:18", "idle 2h", "stale 23d"). */
+  detail?: string
+}
+
+export interface ApprovalGateCardProps {
+  title: string
+  command: string
+  /** Header sublabel, e.g. "irreversible · orchestrator halted the chain". */
+  subtitle?: string
+  /** Elapsed wait, shown only while pending. */
+  waiting?: string
+  blastRadius: string
+  undoPath: string
+  /** May contain an <EpistemicMark>, so it is a node rather than a string. */
+  caveat?: ReactNode
+  actions: Array<string>
+  state?: ApprovalGateState
+  /** Presentational — buttons are inert unless a handler is supplied. */
+  onAction?: (action: string) => void
+}

--- a/src/components/jarvis/types.ts
+++ b/src/components/jarvis/types.ts
@@ -60,9 +60,23 @@ export interface ApprovalGateCardProps {
   waiting?: string
   blastRadius: string
   undoPath: string
+  /**
+   * Overrides for the two panel headings. Narrow boards pass RADIUS / UNDO;
+   * unset means the full BLAST RADIUS / UNDO PATH, which is what every desktop
+   * caller gets.
+   */
+  cellLabels?: {
+    blastRadius?: string
+    undoPath?: string
+  }
   /** May contain an <EpistemicMark>, so it is a node rather than a string. */
   caveat?: ReactNode
   actions: Array<string>
+  /**
+   * Keyboard affordance printed after the buttons, e.g. `⌘⏎ approve · ⌘⌫
+   * reject`. Shown only while pending; the card binds no keys itself.
+   */
+  hint?: string
   state?: ApprovalGateState
   /** Presentational — buttons are inert unless a handler is supplied. */
   onAction?: (action: string) => void

--- a/src/components/jarvis/verification-badge.test.tsx
+++ b/src/components/jarvis/verification-badge.test.tsx
@@ -1,0 +1,52 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { VerificationBadge } from './verification-badge'
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('VerificationBadge', () => {
+  it('labels the two states distinctly', () => {
+    const { unmount } = render(
+      <VerificationBadge
+        state="verified"
+        title="Repro case fails as expected"
+      />,
+    )
+    expect(screen.getByText('VERIFIED')).toBeTruthy()
+    unmount()
+
+    render(<VerificationBadge state="claimed" title="Agent says it works" />)
+    expect(screen.getByText('CLAIMED · UNVERIFIED')).toBeTruthy()
+  })
+
+  it('renders evidence lines, time and action chips when supplied', () => {
+    render(
+      <VerificationBadge
+        state="claimed"
+        time="09:38"
+        title="Restorable from vault git"
+        evidence={['no artifact checked · no exit code']}
+        actions={['VERIFY NOW', 'SHOW PLAN']}
+      />,
+    )
+
+    expect(screen.getByText('09:38')).toBeTruthy()
+    expect(screen.getByText('no artifact checked · no exit code')).toBeTruthy()
+    expect(screen.getByText('VERIFY NOW')).toBeTruthy()
+    expect(screen.getByText('SHOW PLAN')).toBeTruthy()
+  })
+
+  it('omits the evidence block entirely when there is none', () => {
+    const { container } = render(
+      <VerificationBadge state="verified" title="Approved by a human" />,
+    )
+
+    // header + title only — no empty evidence or action rows.
+    expect(
+      container.querySelector('[data-jv-verification]')?.children,
+    ).toHaveLength(2)
+  })
+})

--- a/src/components/jarvis/verification-badge.tsx
+++ b/src/components/jarvis/verification-badge.tsx
@@ -1,0 +1,103 @@
+/**
+ * Verification badge — VERIFIED vs CLAIMED · UNVERIFIED.
+ *
+ * The honest distinction the product is built on: evidence attached, or the
+ * agent's word only. This component renders whichever state it is handed and
+ * decides nothing — there is no verification logic here (see
+ * `docs/design/jarvis-ui-mapping.md` §3.5, item 2).
+ *
+ * Token discipline: no raw colour, size, or px value in this file. The claimed
+ * card's hatch fill derives its tint from `--jv-blocked` via `color-mix`, so
+ * the amber is still written down exactly once, in the token layer.
+ */
+/*
+ * NOTE: these components use `clsx` directly rather than the repo's `cn()`
+ * helper. `cn()` runs tailwind-merge, which does not know the `jv-*` scale and
+ * classifies `text-jv-3xs` (a font size) into the same conflict group as
+ * `text-jv-verified` (a colour) — so the size gets silently dropped whenever a
+ * colour appears alongside it. No class set below relies on conflict
+ * resolution, so plain `clsx` is both correct and lossless here.
+ */
+import { clsx } from 'clsx'
+import type { VerificationBadgeProps } from './types'
+
+/** 135° hatch over the claimed card — the artboard's "unverified" texture. */
+const CLAIMED_HATCH =
+  'repeating-linear-gradient(135deg, transparent 0 var(--jv-space-6), color-mix(in srgb, var(--jv-blocked) 5%, transparent) var(--jv-space-6) var(--jv-space-7))'
+
+const LABEL_CLASS =
+  'font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-wide-2'
+
+export function VerificationBadge({
+  state,
+  title,
+  evidence,
+  time,
+  actions,
+}: VerificationBadgeProps) {
+  const verified = state === 'verified'
+
+  return (
+    <div
+      data-jv-verification={state}
+      className={clsx(
+        'px-jv-10 py-jv-7 border',
+        verified
+          ? 'border-solid border-jv-verified-line bg-jv-verified-bg'
+          : 'border-dashed border-jv-claimed-line',
+      )}
+      style={verified ? undefined : { background: CLAIMED_HATCH }}
+    >
+      <div className="flex items-center gap-jv-7">
+        <span
+          className={clsx(
+            LABEL_CLASS,
+            verified ? 'text-jv-verified' : 'text-jv-claimed-text',
+          )}
+        >
+          {verified ? 'VERIFIED' : 'CLAIMED · UNVERIFIED'}
+        </span>
+        {time ? (
+          <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-faint">
+            {time}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className={clsx(
+          'mt-jv-6 font-jv-sans text-jv-xl leading-jv-relaxed',
+          verified ? 'text-jv-text-evidence' : 'text-jv-text-dim-2',
+        )}
+      >
+        {title}
+      </div>
+
+      {evidence && evidence.length > 0 ? (
+        <div className="mt-jv-6 font-jv-mono text-jv-base leading-jv-loose text-jv-text-detail">
+          {evidence.map((line) => (
+            <div key={line}>{line}</div>
+          ))}
+        </div>
+      ) : null}
+
+      {actions && actions.length > 0 ? (
+        <div className="mt-jv-7 flex gap-jv-6">
+          {actions.map((action, index) => (
+            <span
+              key={action}
+              className={clsx(
+                'px-jv-8 py-jv-4 font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-label-2',
+                index === 0
+                  ? 'bg-jv-claimed-text text-jv-surface-1'
+                  : 'border border-jv-border-btn text-jv-text-dim-2',
+              )}
+            >
+              {action}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/jarvis/worker-status-line.test.tsx
+++ b/src/components/jarvis/worker-status-line.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { WorkerStatusLine } from './worker-status-line'
+import type { WorkerStatus } from './types'
+
+const ALL_STATUSES: Array<WorkerStatus> = [
+  'running',
+  'blocked',
+  'idle',
+  'stale',
+  'failed',
+  'queued',
+  'complete',
+]
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('WorkerStatusLine', () => {
+  it('renders a row for every status', () => {
+    for (const status of ALL_STATUSES) {
+      const { container, unmount } = render(
+        <WorkerStatusLine name={status} status={status} detail="detail" />,
+      )
+      expect(
+        container.querySelector(`[data-jv-worker-status="${status}"]`),
+      ).toBeTruthy()
+      expect(screen.getByText(status)).toBeTruthy()
+      unmount()
+    }
+  })
+
+  it('falls back to BLOCKED as the detail only for blocked workers', () => {
+    const { unmount } = render(
+      <WorkerStatusLine name="km-agent" status="blocked" />,
+    )
+    expect(screen.getByText('BLOCKED')).toBeTruthy()
+    unmount()
+
+    const { container } = render(<WorkerStatusLine name="qa" status="idle" />)
+    expect(container.textContent).toBe('qa')
+  })
+
+  it('gives blocked a square dot and running a pulsing round one', () => {
+    const { container: blocked, unmount } = render(
+      <WorkerStatusLine name="km-agent" status="blocked" />,
+    )
+    const blockedDot = blocked.querySelector('[aria-hidden="true"]')
+    expect(blockedDot?.className).not.toContain('rounded-jv-full')
+    unmount()
+
+    const { container: running } = render(
+      <WorkerStatusLine name="orchestrator" status="running" />,
+    )
+    const runningDot = running.querySelector('[aria-hidden="true"]')
+    expect(runningDot?.className).toContain('rounded-jv-full')
+    expect(runningDot?.className).toContain('animate-jv-pulse')
+  })
+})

--- a/src/components/jarvis/worker-status-line.tsx
+++ b/src/components/jarvis/worker-status-line.tsx
@@ -1,0 +1,120 @@
+/**
+ * Worker status line — one row of the WORKERS rail.
+ *
+ * dot (state) + name (flex-1) + detail (right). The dot's SHAPE carries meaning
+ * as well as its colour: blocked is the only square dot, so "waiting on a human"
+ * is distinguishable without relying on hue alone.
+ *
+ * Token discipline: no raw colour, size, or px value in this file.
+ */
+/*
+ * NOTE: these components use `clsx` directly rather than the repo's `cn()`
+ * helper. `cn()` runs tailwind-merge, which does not know the `jv-*` scale and
+ * classifies `text-jv-3xs` (a font size) into the same conflict group as
+ * `text-jv-verified` (a colour) — so the size gets silently dropped whenever a
+ * colour appears alongside it. No class set below relies on conflict
+ * resolution, so plain `clsx` is both correct and lossless here.
+ */
+import { clsx } from 'clsx'
+import type { WorkerStatus, WorkerStatusLineProps } from './types'
+
+interface StatusTokens {
+  /** Dot fill + shape. Blocked is square; everything else is round. */
+  dot: string
+  /** Row tint — only the states that need your attention get one. */
+  row: string
+  name: string
+  detail: string
+  /** Detail text shown when the caller supplies none. */
+  fallbackDetail?: string
+}
+
+const STATUSES: Record<WorkerStatus, StatusTokens> = {
+  running: {
+    dot: 'rounded-jv-full bg-jv-live animate-jv-pulse',
+    row: 'bg-jv-surface-3',
+    name: 'text-jv-text',
+    detail: 'text-jv-live',
+  },
+  blocked: {
+    // Square, deliberately: shape + hue, not hue alone.
+    dot: 'bg-jv-blocked',
+    row: 'bg-jv-blocked-bg-row',
+    name: 'text-jv-text',
+    detail: 'text-jv-blocked font-semibold tracking-jv-label',
+    fallbackDetail: 'BLOCKED',
+  },
+  idle: {
+    dot: 'rounded-jv-full bg-jv-dot-idle',
+    row: '',
+    name: 'text-jv-text-dim-2',
+    detail: 'text-jv-label-faint',
+  },
+  queued: {
+    dot: 'rounded-jv-full bg-jv-dot-idle',
+    row: '',
+    name: 'text-jv-text-dim-2',
+    detail: 'text-jv-label-faint',
+  },
+  stale: {
+    // Muted dot, red detail: silent long enough that it is a problem.
+    dot: 'rounded-jv-full bg-jv-dot-idle',
+    row: '',
+    name: 'text-jv-text-dim-2',
+    detail: 'text-jv-failed-muted',
+  },
+  failed: {
+    dot: 'rounded-jv-full bg-jv-failed',
+    row: 'bg-jv-failed-bg-row',
+    name: 'text-jv-text',
+    detail: 'text-jv-failed-text',
+  },
+  complete: {
+    dot: 'rounded-jv-full bg-jv-verified',
+    row: '',
+    name: 'text-jv-text-dim-2',
+    detail: 'text-jv-verified',
+  },
+}
+
+export function WorkerStatusLine({
+  name,
+  status,
+  detail,
+}: WorkerStatusLineProps) {
+  const tokens = STATUSES[status]
+  const detailText = detail ?? tokens.fallbackDetail
+
+  return (
+    <div
+      data-jv-worker-status={status}
+      className={clsx(
+        'flex items-center gap-jv-8 px-jv-14 py-jv-6 border-t border-jv-line-soft',
+        tokens.row,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={clsx('w-jv-5 h-jv-5 flex-none', tokens.dot)}
+      />
+      <span
+        className={clsx(
+          'flex-1 font-jv-mono text-jv-md leading-jv-none font-medium',
+          tokens.name,
+        )}
+      >
+        {name}
+      </span>
+      {detailText ? (
+        <span
+          className={clsx(
+            'font-jv-mono text-jv-xs leading-jv-none',
+            tokens.detail,
+          )}
+        >
+          {detailText}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/src/jarvis-theme.css
+++ b/src/jarvis-theme.css
@@ -1,0 +1,463 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+/* ════════════════════════════════════════════════════════════════════
+  JARVIS Theme — token layer (Slice 1)
+
+  Source of truth: `docs/design/jarvis-ui-mapping.md` §1. Every value below
+  was extracted programmatically from the `JARVIS Interface.dc.html`
+  artboard (65 distinct hexes, 17 font sizes, 3 weights, 10 tracking steps,
+  12 line-heights, 3 radii, 4 keyframes) — not eyeballed.
+
+  Layout of this file:
+    1. `@theme`  — canonical values, exposed to Tailwind v4 utilities
+                   (`bg-jv-surface-1`, `text-jv-live`, `border-jv-line`, …)
+    2. `[data-theme='jarvis']` — the `--jv-*` namespace, aliased to (1) so
+                   there is exactly ONE place a value is written down.
+    3. keyframes — file scope, so `animate-jv-*` works anywhere.
+
+  Additive only: this file defines NOTHING in the shared `--theme-*` /
+  `--color-primary-*` namespaces and therefore cannot disturb the other
+  12 themes or the `--color-*` remaps in `scifi-theme.css`.
+
+  NOTE on the font @import above / where this file is imported from:
+  `styles.css` pulls this file in from its import prologue (line 2), NOT
+  from the bottom next to `@import './scifi-theme.css'`. That position is
+  load-bearing: CSS requires `@import` to precede all other rules, so when
+  this file was imported at the bottom of `styles.css` the bundler silently
+  DROPPED the IBM Plex `@import url(...)` and the fonts never loaded. From
+  the prologue the bundler merges it into the emitted font import instead.
+  Cascade-neutral either way — nothing else defines `--jv-*`/`--color-jv-*`.
+
+  TOKEN-DISCIPLINE RULE for later slices: no JARVIS component may contain a
+  raw hex, px font-size, or px spacing value. Everything resolves through
+  `--jv-*` / `*-jv-*` utilities.
+  ═══════════════════════════════════════════════════════════════════ */
+
+@theme {
+  /* ── Fonts ──────────────────────────────────────────────────────── */
+  --font-jv-sans: 'IBM Plex Sans', sans-serif;
+  --font-jv-mono: 'IBM Plex Mono', monospace;
+
+  /* ── Surfaces (near-black, layered) ─────────────────────────────── */
+  --color-jv-bg: #07090b; /* page background (body) */
+  --color-jv-surface-0: #0a0e12; /* rails, composer background */
+  --color-jv-surface-1: #0c1014; /* board body */
+  --color-jv-surface-2: #0e1317; /* top bar, cards */
+  --color-jv-surface-3: #0f161b; /* active row highlight */
+  --color-jv-surface-4: #101820; /* worker chain card */
+  --color-jv-surface-5: #181f26; /* active tab */
+
+  /* ── Hairlines / borders ────────────────────────────────────────── */
+  --color-jv-line: #1a2128;
+  --color-jv-line-soft: #141a20;
+  --color-jv-line-faint: #131a20;
+  --color-jv-line-rule: #171e24; /* table row rules */
+  --color-jv-border: #1c242b;
+  --color-jv-border-muted: #1f272e;
+  --color-jv-border-input: #232c34;
+  --color-jv-border-chip: #262f37;
+  --color-jv-border-btn: #2a333b;
+  --color-jv-border-btn-2: #3a444d;
+
+  /* ── Text ramp ──────────────────────────────────────────────────── */
+  --color-jv-text-bright: #f2f6f9;
+  --color-jv-text: #e9eef2;
+  --color-jv-text-body: #d6dee5;
+  --color-jv-text-evidence: #c3cdd5; /* evidence body under a verified card */
+  --color-jv-text-muted: #b7c2cb;
+  --color-jv-text-dim: #a9b5bf;
+  --color-jv-text-dim-2: #98a6b2;
+  --color-jv-text-faint: #8b98a3;
+  --color-jv-text-caption: #7e8c97; /* board lede / caption */
+  --color-jv-text-detail: #6d7a84; /* worker + run-log detail lines */
+  --color-jv-label: #64727d;
+  --color-jv-label-dim: #5a6771;
+  --color-jv-label-faint: #4e5a63;
+  --color-jv-label-ghost: #3f4a53;
+  --color-jv-dot-idle: #2e3a43;
+
+  /* ── RESERVED HUE: live · running · streaming ───────────────────── */
+  /* Semantic. Never reuse for decoration. */
+  --color-jv-live: #35d6e8; /* live · running · streaming (JARVIS identity) */
+  --color-jv-live-bright: #7fe9f5; /* hover */
+  --color-jv-live-line: #1d4a52; /* running border */
+  --color-jv-live-bg: #0a1a1d; /* running tint */
+  --color-jv-live-bg-2: #0c171b; /* running card fill */
+
+  /* ── RESERVED HUE: blocked · waiting on human ───────────────────── */
+  /* Semantic. Never reuse for decoration. */
+  --color-jv-blocked: #f0a340; /* blocked · waiting on human */
+  --color-jv-blocked-text: #c08c3e; /* claimed text / amber text */
+  --color-jv-blocked-soft: #c9a96b; /* stale / silent detail */
+  --color-jv-blocked-dim: #8b7a55; /* gate sublabels */
+  --color-jv-blocked-line-2: #6b5326; /* CLAIMED · UNVERIFIED dashed border */
+  --color-jv-blocked-line: #4a3a1c; /* amber border */
+  --color-jv-blocked-divider: #3a2e16; /* 1px amber separator */
+  --color-jv-blocked-line-soft: #2a2214; /* gate grid gutter */
+  --color-jv-blocked-bg-chip: #191308; /* amber chip fill */
+  --color-jv-blocked-bg-2: #171309; /* gate cell fill */
+  --color-jv-blocked-bg: #12100a; /* gate background */
+  --color-jv-blocked-bg-row: #131009; /* blocked row tint */
+
+  /* ── RESERVED HUE: failed ───────────────────────────────────────── */
+  /* Semantic. Never reuse for decoration. */
+  --color-jv-failed: #ff4d6d; /* failed · plus filled block */
+  --color-jv-failed-text: #ff8fa3; /* failed detail text */
+  --color-jv-failed-muted: #b5556c; /* stale-worker red */
+  --color-jv-failed-line: #5a2434; /* failed border */
+  --color-jv-failed-bg: #170b0f; /* failed background */
+  --color-jv-failed-bg-row: #140a0e; /* failed row tint */
+
+  /* ── RESULT STATE: verified ─────────────────────────────────────── */
+  --color-jv-verified: #7fd1a8; /* verified / success / greenlight text */
+  --color-jv-verified-line: #2c5745; /* verified border */
+  --color-jv-verified-bg: #12271e; /* verified fill */
+  --color-jv-verified-bg-2: #0e1b16; /* verified card fill */
+
+  /* ── RESULT STATE: claimed (aliases into the amber ramp) ────────── */
+  --color-jv-claimed-line: #6b5326; /* == --color-jv-blocked-line-2 */
+  --color-jv-claimed-text: #c08c3e; /* == --color-jv-blocked-text */
+
+  /* ── EPISTEMIC MARKS ────────────────────────────────────────────── */
+  /* Bindings are from the artboard's own legend — do not swap them:
+       Known    → SOLID  underline
+       Recalled → DOTTED underline
+       Assumed  → DASHED underline
+     Each underline is `1px <style> var(--jv-*-rule)` on border-bottom. */
+  --color-jv-known-rule: #55666f; /* Known: solid underline */
+  --color-jv-known-sup: #93a3af; /* Known: `KN` superscript */
+  --color-jv-recalled-rule: #9a7434; /* Recalled: dotted underline */
+  --color-jv-recalled-sup: #d89a4a; /* Recalled: `RC` superscript */
+  --color-jv-assumed-rule: #7a6e90; /* Assumed: dashed underline */
+  --color-jv-assumed-sup: #a294be; /* Assumed: `AS` superscript */
+
+  /* ── Type scale (all 17 sizes present in the artboard) ──────────── */
+  --text-jv-4xs: 8px;
+  --text-jv-3xs: 8.5px;
+  --text-jv-2xs: 9px;
+  --text-jv-xs: 9.5px;
+  --text-jv-sm: 10px;
+  --text-jv-base: 10.5px;
+  --text-jv-md: 11px;
+  --text-jv-lg: 11.5px;
+  --text-jv-xl: 12px;
+  --text-jv-2xl: 12.5px;
+  --text-jv-3xl: 13px;
+  --text-jv-4xl: 13.5px;
+  --text-jv-5xl: 14px;
+  --text-jv-6xl: 16px;
+  --text-jv-7xl: 17px;
+  --text-jv-8xl: 20px;
+  --text-jv-9xl: 26px;
+
+  /* ── Line heights (all 12 present in the artboard) ──────────────── */
+  --leading-jv-none: 1;
+  --leading-jv-tight: 1.15;
+  --leading-jv-snug: 1.2;
+  --leading-jv-snug-2: 1.25;
+  --leading-jv-normal: 1.3;
+  --leading-jv-normal-2: 1.35;
+  --leading-jv-relaxed: 1.4;
+  --leading-jv-relaxed-2: 1.45;
+  --leading-jv-loose: 1.5;
+  --leading-jv-loose-2: 1.55;
+  --leading-jv-loose-3: 1.6;
+  --leading-jv-max: 1.75;
+
+  /* ── Tracking (all 10 steps present in the artboard) ────────────── */
+  --tracking-jv-tight: -0.01em;
+  --tracking-jv-label: 0.06em;
+  --tracking-jv-label-2: 0.08em;
+  --tracking-jv-wide: 0.09em;
+  --tracking-jv-wide-2: 0.1em;
+  --tracking-jv-wider: 0.12em;
+  --tracking-jv-wider-2: 0.14em;
+  --tracking-jv-widest: 0.16em;
+  --tracking-jv-ultra: 0.2em;
+  --tracking-jv-ultra-2: 0.22em;
+
+  /* ── Radii ──────────────────────────────────────────────────────── */
+  --radius-jv-sm: 2px;
+  --radius-jv: 3px;
+  --radius-jv-full: 9999px;
+
+  /* ── Spacing — 4px grid, with the sub-grid steps the artboard uses  */
+  --spacing-jv-0: 0px;
+  --spacing-jv-1: 1px;
+  --spacing-jv-2: 2px;
+  --spacing-jv-3: 3px;
+  --spacing-jv-4: 4px;
+  --spacing-jv-5: 5px;
+  --spacing-jv-6: 6px;
+  --spacing-jv-7: 7px;
+  --spacing-jv-8: 8px;
+  --spacing-jv-9: 9px;
+  --spacing-jv-10: 10px;
+  --spacing-jv-11: 11px;
+  --spacing-jv-12: 12px;
+  --spacing-jv-13: 13px;
+  --spacing-jv-14: 14px;
+  --spacing-jv-16: 16px;
+  --spacing-jv-20: 20px;
+  --spacing-jv-24: 24px;
+  --spacing-jv-28: 28px;
+  --spacing-jv-32: 32px;
+  --spacing-jv-40: 40px;
+  --spacing-jv-48: 48px;
+
+  /* ── Motion (bodies defined in the keyframes at the end of file) ── */
+  --animate-jv-pulse: jv-pulse 1.8s ease-in-out infinite;
+  --animate-jv-pulse-fast: jv-pulse 1.6s ease-in-out infinite;
+  --animate-jv-ring: jv-ring 2s ease-out infinite;
+  --animate-jv-caret: jv-caret 1s step-end infinite;
+  --animate-jv-flow: jv-flow 2.4s linear infinite;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+  The `--jv-*` namespace.
+
+  Scoped to `[data-theme='jarvis']`, matching how every other theme in this
+  repo declares its variables. Values alias the `@theme` block above so a
+  colour is written down exactly once.
+
+  JARVIS is DARK-ONLY — there is no light artboard, and therefore no
+  `jarvis-light` theme id.
+  ═══════════════════════════════════════════════════════════════════ */
+
+[data-theme='jarvis'] {
+  color-scheme: dark;
+
+  /* Fonts */
+  --jv-font-sans: var(--font-jv-sans);
+  --jv-font-mono: var(--font-jv-mono);
+
+  /* Surfaces */
+  --jv-bg: var(--color-jv-bg);
+  --jv-surface-0: var(--color-jv-surface-0);
+  --jv-surface-1: var(--color-jv-surface-1);
+  --jv-surface-2: var(--color-jv-surface-2);
+  --jv-surface-3: var(--color-jv-surface-3);
+  --jv-surface-4: var(--color-jv-surface-4);
+  --jv-surface-5: var(--color-jv-surface-5);
+
+  /* Hairlines / borders */
+  --jv-line: var(--color-jv-line);
+  --jv-line-soft: var(--color-jv-line-soft);
+  --jv-line-faint: var(--color-jv-line-faint);
+  --jv-line-rule: var(--color-jv-line-rule);
+  --jv-border: var(--color-jv-border);
+  --jv-border-muted: var(--color-jv-border-muted);
+  --jv-border-input: var(--color-jv-border-input);
+  --jv-border-chip: var(--color-jv-border-chip);
+  --jv-border-btn: var(--color-jv-border-btn);
+  --jv-border-btn-2: var(--color-jv-border-btn-2);
+
+  /* Text ramp */
+  --jv-text-bright: var(--color-jv-text-bright);
+  --jv-text: var(--color-jv-text);
+  --jv-text-body: var(--color-jv-text-body);
+  --jv-text-evidence: var(--color-jv-text-evidence);
+  --jv-text-muted: var(--color-jv-text-muted);
+  --jv-text-dim: var(--color-jv-text-dim);
+  --jv-text-dim-2: var(--color-jv-text-dim-2);
+  --jv-text-faint: var(--color-jv-text-faint);
+  --jv-text-caption: var(--color-jv-text-caption);
+  --jv-text-detail: var(--color-jv-text-detail);
+  --jv-label: var(--color-jv-label);
+  --jv-label-dim: var(--color-jv-label-dim);
+  --jv-label-faint: var(--color-jv-label-faint);
+  --jv-label-ghost: var(--color-jv-label-ghost);
+  --jv-dot-idle: var(--color-jv-dot-idle);
+
+  /* Reserved hue — live · running · streaming */
+  --jv-live: var(--color-jv-live);
+  --jv-live-bright: var(--color-jv-live-bright);
+  --jv-live-line: var(--color-jv-live-line);
+  --jv-live-bg: var(--color-jv-live-bg);
+  --jv-live-bg-2: var(--color-jv-live-bg-2);
+
+  /* Reserved hue — blocked · waiting on human */
+  --jv-blocked: var(--color-jv-blocked);
+  --jv-blocked-text: var(--color-jv-blocked-text);
+  --jv-blocked-soft: var(--color-jv-blocked-soft);
+  --jv-blocked-dim: var(--color-jv-blocked-dim);
+  --jv-blocked-line-2: var(--color-jv-blocked-line-2);
+  --jv-blocked-line: var(--color-jv-blocked-line);
+  --jv-blocked-divider: var(--color-jv-blocked-divider);
+  --jv-blocked-line-soft: var(--color-jv-blocked-line-soft);
+  --jv-blocked-bg-chip: var(--color-jv-blocked-bg-chip);
+  --jv-blocked-bg-2: var(--color-jv-blocked-bg-2);
+  --jv-blocked-bg: var(--color-jv-blocked-bg);
+  --jv-blocked-bg-row: var(--color-jv-blocked-bg-row);
+
+  /* Reserved hue — failed */
+  --jv-failed: var(--color-jv-failed);
+  --jv-failed-text: var(--color-jv-failed-text);
+  --jv-failed-muted: var(--color-jv-failed-muted);
+  --jv-failed-line: var(--color-jv-failed-line);
+  --jv-failed-bg: var(--color-jv-failed-bg);
+  --jv-failed-bg-row: var(--color-jv-failed-bg-row);
+
+  /* Result state — verified */
+  --jv-verified: var(--color-jv-verified);
+  --jv-verified-line: var(--color-jv-verified-line);
+  --jv-verified-bg: var(--color-jv-verified-bg);
+  --jv-verified-bg-2: var(--color-jv-verified-bg-2);
+
+  /* Result state — claimed */
+  --jv-claimed-line: var(--color-jv-claimed-line);
+  --jv-claimed-text: var(--color-jv-claimed-text);
+
+  /* Epistemic marks — colour + the underline style each one is bound to */
+  --jv-known-rule: var(--color-jv-known-rule);
+  --jv-known-rule-style: solid;
+  --jv-known-sup: var(--color-jv-known-sup);
+  --jv-recalled-rule: var(--color-jv-recalled-rule);
+  --jv-recalled-rule-style: dotted;
+  --jv-recalled-sup: var(--color-jv-recalled-sup);
+  --jv-assumed-rule: var(--color-jv-assumed-rule);
+  --jv-assumed-rule-style: dashed;
+  --jv-assumed-sup: var(--color-jv-assumed-sup);
+
+  /* Type scale */
+  --jv-text-4xs: var(--text-jv-4xs);
+  --jv-text-3xs: var(--text-jv-3xs);
+  --jv-text-2xs: var(--text-jv-2xs);
+  --jv-text-xs: var(--text-jv-xs);
+  --jv-text-sm: var(--text-jv-sm);
+  --jv-text-base: var(--text-jv-base);
+  --jv-text-md: var(--text-jv-md);
+  --jv-text-lg: var(--text-jv-lg);
+  --jv-text-xl: var(--text-jv-xl);
+  --jv-text-2xl: var(--text-jv-2xl);
+  --jv-text-3xl: var(--text-jv-3xl);
+  --jv-text-4xl: var(--text-jv-4xl);
+  --jv-text-5xl: var(--text-jv-5xl);
+  --jv-text-6xl: var(--text-jv-6xl);
+  --jv-text-7xl: var(--text-jv-7xl);
+  --jv-text-8xl: var(--text-jv-8xl);
+  --jv-text-9xl: var(--text-jv-9xl);
+
+  /* Weights */
+  --jv-weight-normal: 400;
+  --jv-weight-medium: 500;
+  --jv-weight-semibold: 600;
+
+  /* Line heights */
+  --jv-leading-none: var(--leading-jv-none);
+  --jv-leading-tight: var(--leading-jv-tight);
+  --jv-leading-snug: var(--leading-jv-snug);
+  --jv-leading-snug-2: var(--leading-jv-snug-2);
+  --jv-leading-normal: var(--leading-jv-normal);
+  --jv-leading-normal-2: var(--leading-jv-normal-2);
+  --jv-leading-relaxed: var(--leading-jv-relaxed);
+  --jv-leading-relaxed-2: var(--leading-jv-relaxed-2);
+  --jv-leading-loose: var(--leading-jv-loose);
+  --jv-leading-loose-2: var(--leading-jv-loose-2);
+  --jv-leading-loose-3: var(--leading-jv-loose-3);
+  --jv-leading-max: var(--leading-jv-max);
+
+  /* Tracking */
+  --jv-tracking-tight: var(--tracking-jv-tight);
+  --jv-tracking-label: var(--tracking-jv-label);
+  --jv-tracking-label-2: var(--tracking-jv-label-2);
+  --jv-tracking-wide: var(--tracking-jv-wide);
+  --jv-tracking-wide-2: var(--tracking-jv-wide-2);
+  --jv-tracking-wider: var(--tracking-jv-wider);
+  --jv-tracking-wider-2: var(--tracking-jv-wider-2);
+  --jv-tracking-widest: var(--tracking-jv-widest);
+  --jv-tracking-ultra: var(--tracking-jv-ultra);
+  --jv-tracking-ultra-2: var(--tracking-jv-ultra-2);
+
+  /* Radii */
+  --jv-radius-sm: var(--radius-jv-sm);
+  --jv-radius: var(--radius-jv);
+  --jv-radius-full: var(--radius-jv-full);
+
+  /* Spacing — 4px grid plus the sub-grid steps the artboard uses */
+  --jv-space-0: var(--spacing-jv-0);
+  --jv-space-1: var(--spacing-jv-1);
+  --jv-space-2: var(--spacing-jv-2);
+  --jv-space-3: var(--spacing-jv-3);
+  --jv-space-4: var(--spacing-jv-4);
+  --jv-space-5: var(--spacing-jv-5);
+  --jv-space-6: var(--spacing-jv-6);
+  --jv-space-7: var(--spacing-jv-7);
+  --jv-space-8: var(--spacing-jv-8);
+  --jv-space-9: var(--spacing-jv-9);
+  --jv-space-10: var(--spacing-jv-10);
+  --jv-space-11: var(--spacing-jv-11);
+  --jv-space-12: var(--spacing-jv-12);
+  --jv-space-13: var(--spacing-jv-13);
+  --jv-space-14: var(--spacing-jv-14);
+  --jv-space-16: var(--spacing-jv-16);
+  --jv-space-20: var(--spacing-jv-20);
+  --jv-space-24: var(--spacing-jv-24);
+  --jv-space-28: var(--spacing-jv-28);
+  --jv-space-32: var(--spacing-jv-32);
+  --jv-space-40: var(--spacing-jv-40);
+  --jv-space-48: var(--spacing-jv-48);
+
+  /* Motion */
+  --jv-anim-pulse: var(--animate-jv-pulse);
+  --jv-anim-pulse-fast: var(--animate-jv-pulse-fast);
+  --jv-anim-ring: var(--animate-jv-ring);
+  --jv-anim-caret: var(--animate-jv-caret);
+  --jv-anim-flow: var(--animate-jv-flow);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+  Motion — the four artboard keyframes, reproduced verbatim.
+  File scope (not inside the data-theme block) so `animate-jv-*` resolves.
+  ═══════════════════════════════════════════════════════════════════ */
+
+/* running dot (also a 1.6s variant; .4s / .5s stagger delays) */
+@keyframes jv-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.28;
+  }
+}
+
+/* active chain-node halo */
+@keyframes jv-ring {
+  0% {
+    box-shadow: 0 0 0 0 rgba(53, 214, 232, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 5px rgba(53, 214, 232, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(53, 214, 232, 0);
+  }
+}
+
+/* streaming caret */
+@keyframes jv-caret {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* delegation-chain flow line (also a .8s delay variant) */
+@keyframes jv-flow {
+  0% {
+    left: -3px;
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    left: 100%;
+    opacity: 0;
+  }
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,6 +11,7 @@ export type ThemeId =
   | 'claude-slate-light'
   | 'scifi'
   | 'scifi-light'
+  | 'jarvis'
 
 export const THEMES: Array<{
   id: ThemeId
@@ -90,14 +91,25 @@ export const THEMES: Array<{
     description: 'Cold steel and teal — cyberpunk interface in daylight',
     icon: '🌌',
   },
+  {
+    id: 'jarvis',
+    label: 'JARVIS',
+    description:
+      'Persistent assistant console — near-black with cyan signal, amber gates, epistemic marks',
+    icon: '◆',
+  },
 ]
 
 const STORAGE_KEY = 'claude-theme'
 const DEFAULT_THEME: ThemeId = 'claude-nous'
 const THEME_SET = new Set<ThemeId>(THEMES.map((theme) => theme.id))
+// JARVIS is dark-only (no light artboard, so no `jarvis-light` id). It
+// self-maps on both sides: asking for the light variant of JARVIS keeps
+// JARVIS. `| 'jarvis'` widens the value type just enough to allow that
+// without restructuring the maps.
 const LIGHT_THEME_MAP: Record<
   Exclude<ThemeId, `${string}-light`>,
-  Extract<ThemeId, `${string}-light`>
+  Extract<ThemeId, `${string}-light`> | 'jarvis'
 > = {
   'claude-nous': 'claude-nous-light',
   matrix: 'matrix-light',
@@ -105,9 +117,14 @@ const LIGHT_THEME_MAP: Record<
   'claude-classic': 'claude-classic-light',
   'claude-slate': 'claude-slate-light',
   'scifi': 'scifi-light',
+  jarvis: 'jarvis',
 }
+// `| 'jarvis'` on the key side for the same reason as LIGHT_THEME_MAP.
+// Never actually read for JARVIS — isDarkTheme('jarvis') is true, so
+// getThemeVariant(…, 'dark') short-circuits — but kept so the pair stays
+// symmetric and `jarvis` is present in both maps.
 const DARK_THEME_MAP: Record<
-  Extract<ThemeId, `${string}-light`>,
+  Extract<ThemeId, `${string}-light`> | 'jarvis',
   Exclude<ThemeId, `${string}-light`>
 > = {
   'claude-nous-light': 'claude-nous',
@@ -116,6 +133,7 @@ const DARK_THEME_MAP: Record<
   'claude-classic-light': 'claude-classic',
   'claude-slate-light': 'claude-slate',
   'scifi-light': 'scifi',
+  jarvis: 'jarvis',
 }
 
 const LIGHT_THEMES = new Set<ThemeId>([

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as JarvisGalleryRouteImport } from './routes/jarvis-gallery'
+import { Route as JarvisCommandRouteImport } from './routes/jarvis-command'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as EarlyAccessRouteImport } from './routes/early-access'
@@ -238,6 +239,11 @@ const JobsRoute = JobsRouteImport.update({
 const JarvisGalleryRoute = JarvisGalleryRouteImport.update({
   id: '/jarvis-gallery',
   path: '/jarvis-gallery',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JarvisCommandRoute = JarvisCommandRouteImport.update({
+  id: '/jarvis-command',
+  path: '/jarvis-command',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HermesWorldRoute = HermesWorldRouteImport.update({
@@ -925,6 +931,7 @@ export interface FileRoutesByFullPath {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-command': typeof JarvisCommandRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1077,6 +1084,7 @@ export interface FileRoutesByTo {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-command': typeof JarvisCommandRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1229,6 +1237,7 @@ export interface FileRoutesById {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-command': typeof JarvisCommandRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1383,6 +1392,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-command'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1535,6 +1545,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-command'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1686,6 +1697,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-command'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1839,6 +1851,7 @@ export interface RootRouteChildren {
   EarlyAccessRoute: typeof EarlyAccessRoute
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
+  JarvisCommandRoute: typeof JarvisCommandRoute
   JarvisGalleryRoute: typeof JarvisGalleryRoute
   JobsRoute: typeof JobsRoute
   McpRoute: typeof McpRoute
@@ -2065,6 +2078,13 @@ declare module '@tanstack/react-router' {
       path: '/jarvis-gallery'
       fullPath: '/jarvis-gallery'
       preLoaderRoute: typeof JarvisGalleryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jarvis-command': {
+      id: '/jarvis-command'
+      path: '/jarvis-command'
+      fullPath: '/jarvis-command'
+      preLoaderRoute: typeof JarvisCommandRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/hermes-world': {
@@ -3227,6 +3247,7 @@ const rootRouteChildren: RootRouteChildren = {
   EarlyAccessRoute: EarlyAccessRoute,
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
+  JarvisCommandRoute: JarvisCommandRoute,
   JarvisGalleryRoute: JarvisGalleryRoute,
   JobsRoute: JobsRoute,
   McpRoute: McpRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
 import { Route as JarvisGalleryRouteImport } from './routes/jarvis-gallery'
+import { Route as JarvisConductorRouteImport } from './routes/jarvis-conductor'
 import { Route as JarvisCommandRouteImport } from './routes/jarvis-command'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
@@ -239,6 +240,11 @@ const JobsRoute = JobsRouteImport.update({
 const JarvisGalleryRoute = JarvisGalleryRouteImport.update({
   id: '/jarvis-gallery',
   path: '/jarvis-gallery',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JarvisConductorRoute = JarvisConductorRouteImport.update({
+  id: '/jarvis-conductor',
+  path: '/jarvis-conductor',
   getParentRoute: () => rootRouteImport,
 } as any)
 const JarvisCommandRoute = JarvisCommandRouteImport.update({
@@ -932,6 +938,7 @@ export interface FileRoutesByFullPath {
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jarvis-command': typeof JarvisCommandRoute
+  '/jarvis-conductor': typeof JarvisConductorRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1085,6 +1092,7 @@ export interface FileRoutesByTo {
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jarvis-command': typeof JarvisCommandRoute
+  '/jarvis-conductor': typeof JarvisConductorRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1238,6 +1246,7 @@ export interface FileRoutesById {
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
   '/jarvis-command': typeof JarvisCommandRoute
+  '/jarvis-conductor': typeof JarvisConductorRoute
   '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
@@ -1393,6 +1402,7 @@ export interface FileRouteTypes {
     | '/files'
     | '/hermes-world'
     | '/jarvis-command'
+    | '/jarvis-conductor'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1546,6 +1556,7 @@ export interface FileRouteTypes {
     | '/files'
     | '/hermes-world'
     | '/jarvis-command'
+    | '/jarvis-conductor'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1698,6 +1709,7 @@ export interface FileRouteTypes {
     | '/files'
     | '/hermes-world'
     | '/jarvis-command'
+    | '/jarvis-conductor'
     | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
@@ -1852,6 +1864,7 @@ export interface RootRouteChildren {
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
   JarvisCommandRoute: typeof JarvisCommandRoute
+  JarvisConductorRoute: typeof JarvisConductorRoute
   JarvisGalleryRoute: typeof JarvisGalleryRoute
   JobsRoute: typeof JobsRoute
   McpRoute: typeof McpRoute
@@ -2078,6 +2091,13 @@ declare module '@tanstack/react-router' {
       path: '/jarvis-gallery'
       fullPath: '/jarvis-gallery'
       preLoaderRoute: typeof JarvisGalleryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jarvis-conductor': {
+      id: '/jarvis-conductor'
+      path: '/jarvis-conductor'
+      fullPath: '/jarvis-conductor'
+      preLoaderRoute: typeof JarvisConductorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jarvis-command': {
@@ -3248,6 +3268,7 @@ const rootRouteChildren: RootRouteChildren = {
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
   JarvisCommandRoute: JarvisCommandRoute,
+  JarvisConductorRoute: JarvisConductorRoute,
   JarvisGalleryRoute: JarvisGalleryRoute,
   JobsRoute: JobsRoute,
   McpRoute: McpRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as MemoryRouteImport } from './routes/memory'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as JobsRouteImport } from './routes/jobs'
+import { Route as JarvisGalleryRouteImport } from './routes/jarvis-gallery'
 import { Route as HermesWorldRouteImport } from './routes/hermes-world'
 import { Route as FilesRouteImport } from './routes/files'
 import { Route as EarlyAccessRouteImport } from './routes/early-access'
@@ -232,6 +233,11 @@ const McpRoute = McpRouteImport.update({
 const JobsRoute = JobsRouteImport.update({
   id: '/jobs',
   path: '/jobs',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JarvisGalleryRoute = JarvisGalleryRouteImport.update({
+  id: '/jarvis-gallery',
+  path: '/jarvis-gallery',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HermesWorldRoute = HermesWorldRouteImport.update({
@@ -919,6 +925,7 @@ export interface FileRoutesByFullPath {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
@@ -1070,6 +1077,7 @@ export interface FileRoutesByTo {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
@@ -1221,6 +1229,7 @@ export interface FileRoutesById {
   '/early-access': typeof EarlyAccessRoute
   '/files': typeof FilesRoute
   '/hermes-world': typeof HermesWorldRoute
+  '/jarvis-gallery': typeof JarvisGalleryRoute
   '/jobs': typeof JobsRoute
   '/mcp': typeof McpRoute
   '/memory': typeof MemoryRoute
@@ -1374,6 +1383,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
     | '/memory'
@@ -1525,6 +1535,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
     | '/memory'
@@ -1675,6 +1686,7 @@ export interface FileRouteTypes {
     | '/early-access'
     | '/files'
     | '/hermes-world'
+    | '/jarvis-gallery'
     | '/jobs'
     | '/mcp'
     | '/memory'
@@ -1827,6 +1839,7 @@ export interface RootRouteChildren {
   EarlyAccessRoute: typeof EarlyAccessRoute
   FilesRoute: typeof FilesRoute
   HermesWorldRoute: typeof HermesWorldRoute
+  JarvisGalleryRoute: typeof JarvisGalleryRoute
   JobsRoute: typeof JobsRoute
   McpRoute: typeof McpRoute
   MemoryRoute: typeof MemoryRoute
@@ -2045,6 +2058,13 @@ declare module '@tanstack/react-router' {
       path: '/jobs'
       fullPath: '/jobs'
       preLoaderRoute: typeof JobsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jarvis-gallery': {
+      id: '/jarvis-gallery'
+      path: '/jarvis-gallery'
+      fullPath: '/jarvis-gallery'
+      preLoaderRoute: typeof JarvisGalleryRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/hermes-world': {
@@ -3207,6 +3227,7 @@ const rootRouteChildren: RootRouteChildren = {
   EarlyAccessRoute: EarlyAccessRoute,
   FilesRoute: FilesRoute,
   HermesWorldRoute: HermesWorldRoute,
+  JarvisGalleryRoute: JarvisGalleryRoute,
   JobsRoute: JobsRoute,
   McpRoute: McpRoute,
   MemoryRoute: MemoryRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -57,6 +57,7 @@ const VALID_THEMES = [
   'claude-classic-light',
   'claude-slate',
   'claude-slate-light',
+  'jarvis',
 ]
 
 const themeScript = `
@@ -98,6 +99,7 @@ const themeColorScript = `
       'claude-classic-light': '#F5F2ED',
       'claude-slate': '#0d1117',
       'claude-slate-light': '#F6F8FA',
+      'jarvis': '#07090B',
     }
     const nextColor = colors[theme] || colors['${DEFAULT_THEME}']
     const isDark = !['claude-nous-light', 'claude-official-light', 'claude-classic-light', 'claude-slate-light'].includes(String(theme))

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -353,6 +353,22 @@ function RootLayout() {
 
   const rootSurfaceState = getRootSurfaceState(onboardingComplete, authStatus)
 
+  // DEV-ONLY: the JARVIS design-review surfaces (/jarvis-*) are self-contained,
+  // fixtures-only pages that must be reachable without backend onboarding or the
+  // workspace shell. Hard-gated on import.meta.env.DEV so it can never ship in a
+  // production build, and scoped to the /jarvis path prefix so no other route is
+  // affected. Each /jarvis-* route sets its own data-theme and is a full-page
+  // surface, so it renders directly through the Outlet with no chrome.
+  const isJarvisDevSurface =
+    import.meta.env.DEV && pathname.startsWith('/jarvis')
+  if (isJarvisDevSurface) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Outlet />
+      </QueryClientProvider>
+    )
+  }
+
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster />

--- a/src/routes/jarvis-command.tsx
+++ b/src/routes/jarvis-command.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { DesktopCommandScreen } from '@/screens/jarvis/command/desktop-command'
+
+export const Route = createFileRoute('/jarvis-command')({
+  ssr: false,
+  component: JarvisCommandRoute,
+})
+
+function JarvisCommandRoute() {
+  usePageTitle('JARVIS Command')
+
+  // Dev-only surface: the board renders fixture data for design review and
+  // must never be reachable in a production build.
+  if (!import.meta.env.DEV) {
+    return <div>Not available</div>
+  }
+
+  return <DesktopCommandScreen />
+}

--- a/src/routes/jarvis-conductor.tsx
+++ b/src/routes/jarvis-conductor.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { DesktopConductorScreen } from '@/screens/jarvis/conductor/desktop-conductor'
+
+export const Route = createFileRoute('/jarvis-conductor')({
+  ssr: false,
+  component: JarvisConductorRoute,
+})
+
+function JarvisConductorRoute() {
+  usePageTitle('JARVIS Conductor')
+
+  // Dev-only surface: the board renders fixture data for design review and
+  // must never be reachable in a production build.
+  if (!import.meta.env.DEV) {
+    return <div>Not available</div>
+  }
+
+  return <DesktopConductorScreen />
+}

--- a/src/routes/jarvis-gallery.tsx
+++ b/src/routes/jarvis-gallery.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { usePageTitle } from '@/hooks/use-page-title'
+import { JarvisGalleryScreen } from '@/screens/jarvis/gallery/jarvis-gallery'
+
+export const Route = createFileRoute('/jarvis-gallery')({
+  ssr: false,
+  component: JarvisGalleryRoute,
+})
+
+function JarvisGalleryRoute() {
+  usePageTitle('JARVIS Gallery')
+
+  // Dev-only surface: the gallery renders fixture data for design review and
+  // must never be reachable in a production build.
+  if (!import.meta.env.DEV) {
+    return <div>Not available</div>
+  }
+
+  return <JarvisGalleryScreen />
+}

--- a/src/screens/jarvis/command/command-topbar.tsx
+++ b/src/screens/jarvis/command/command-topbar.tsx
@@ -1,0 +1,49 @@
+/**
+ * Desktop Command — top bar (artboard 01, 44px).
+ *
+ * Wordmark · session/uptime/vault · the pending-gate pill · greenlight state.
+ * Fixture-driven and inert: nothing here reads a session or an approval queue.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. The only non-token
+ * numbers are structural, and they come from `JV_BOARD` (4px grid multiples).
+ */
+import { JV_BOARD } from './geometry'
+import type { CommandTopbarFixture } from '@/components/jarvis/fixtures'
+
+const LABEL_CLASS =
+  'font-jv-mono text-jv-md leading-jv-none whitespace-nowrap text-jv-text-faint'
+
+export function CommandTopbar({ data }: { data: CommandTopbarFixture }) {
+  return (
+    <header
+      className="flex flex-none items-center border-b border-jv-line bg-jv-surface-2 px-jv-16"
+      style={{ height: JV_BOARD.topbarHeight, gap: JV_BOARD.gap18 }}
+    >
+      <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-ultra text-jv-live">
+        JARVIS
+      </span>
+
+      <span aria-hidden="true" className="h-jv-16 w-jv-1 bg-jv-border-muted" />
+
+      <div className={LABEL_CLASS}>
+        session <span className="text-jv-text">{data.session}</span> · uptime{' '}
+        <span className="text-jv-text">{data.uptime}</span> · vault{' '}
+        <span className="text-jv-text">{data.vault}</span>
+      </div>
+
+      <div className="flex-1" />
+
+      <div className="flex items-center gap-jv-7 rounded-jv-sm border border-jv-blocked-line bg-jv-blocked-bg-chip px-jv-9 py-jv-5 font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wider whitespace-nowrap text-jv-blocked">
+        <span
+          aria-hidden="true"
+          className="h-jv-5 w-jv-5 flex-none rounded-jv-full bg-jv-blocked"
+        />
+        {data.gateLabel}
+      </div>
+
+      <div className="font-jv-mono text-jv-md leading-jv-none whitespace-nowrap text-jv-label">
+        greenlight <span className="text-jv-verified">{data.greenlight}</span>
+      </div>
+    </header>
+  )
+}

--- a/src/screens/jarvis/command/composer.tsx
+++ b/src/screens/jarvis/command/composer.tsx
@@ -1,0 +1,51 @@
+/**
+ * Desktop Command — composer (artboard 01), pinned under the conversation.
+ *
+ * Presentational only. The input is a static styled div, not a form control:
+ * this slice wires nothing, so there is no submit handler to hang off a real
+ * field and an inert-but-focusable textarea would be a lie about what happens
+ * when you type in it.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import type { ComposerFixture } from '@/components/jarvis/fixtures'
+
+export function Composer({ data }: { data: ComposerFixture }) {
+  return (
+    <div className="flex-none border-t border-jv-line bg-jv-surface-0 px-jv-14 pt-jv-11 pb-jv-12">
+      <div className="flex items-center gap-jv-9 font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+        <span className="border border-jv-live-line bg-jv-live-bg px-jv-7 py-jv-3 font-semibold tracking-jv-label-2 text-jv-live">
+          {data.target}
+        </span>
+        {data.chips.map((chip) => (
+          <span
+            key={chip}
+            className="border border-jv-border-chip px-jv-7 py-jv-3"
+          >
+            {chip}
+          </span>
+        ))}
+        <div className="flex-1" />
+        <span>{data.slashHint}</span>
+      </div>
+
+      <div className="mt-jv-9 flex items-center gap-jv-11 border border-jv-border-input bg-jv-surface-2 px-jv-13 py-jv-11">
+        <span
+          aria-hidden="true"
+          className="font-jv-mono text-jv-xl leading-jv-none font-semibold text-jv-live"
+        >
+          ⌘
+        </span>
+        <span className="flex-1 font-jv-sans text-jv-5xl leading-jv-none text-jv-label-faint">
+          {data.placeholder}
+        </span>
+        <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-ghost">
+          {data.newlineHint}
+        </span>
+        <span className="bg-jv-live px-jv-11 py-jv-6 font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wide-2 text-jv-surface-0">
+          {data.sendLabel}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/jarvis/command/conversation.tsx
+++ b/src/screens/jarvis/command/conversation.tsx
@@ -1,0 +1,213 @@
+/**
+ * Desktop Command — centre column (artboard 01): the conversation.
+ *
+ * COMPOSES three Slice 2 primitives and re-styles none of them:
+ *   • `EpistemicMark`      — inline KN / RC / AS claims inside a turn's prose
+ *   • `VerificationBadge`  — the verified / claimed pair under a turn
+ *   • `ApprovalGateCard`   — the inline gate after the disagreement turn
+ *
+ * Everything is fixture data. The epistemic marks, the verified/claimed state
+ * on a chat turn, the I DISAGREE stance and the whole gate body are NO SOURCE
+ * (`docs/design/jarvis-ui-mapping.md` §3.5 items 1–7) — they are drawn here to
+ * prove the layout only, and each carries `data-jv-fixture="no-source"`.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import { clsx } from 'clsx'
+import { JV_BOARD } from './geometry'
+import type {
+  ConversationTurnFixture,
+  DelegationNoteFixture,
+  GateCaveatFixture,
+  RichSpan,
+} from '@/components/jarvis/fixtures'
+import type { ApprovalGateCardProps } from '@/components/jarvis/types'
+import { ApprovalGateCard } from '@/components/jarvis/approval-gate-card'
+import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
+import { VerificationBadge } from '@/components/jarvis/verification-badge'
+
+/** Renders a fixture body: prose, inline mono, epistemic marks, the caret. */
+function RichText({ spans }: { spans: Array<RichSpan> }) {
+  return (
+    <>
+      {spans.map((span, index) => {
+        // Fixture spans are a static, ordered list — index is a stable key.
+        const key = `${span.kind}-${index}`
+        switch (span.kind) {
+          case 'text':
+            return <span key={key}>{span.text}</span>
+          case 'code':
+            return (
+              <span
+                key={key}
+                className="font-jv-mono text-jv-2xl text-jv-text-muted"
+              >
+                {span.text}
+              </span>
+            )
+          case 'mark':
+            return (
+              <EpistemicMark key={key} mark={span.mark}>
+                <RichText spans={span.spans} />
+              </EpistemicMark>
+            )
+          case 'caret':
+            return (
+              <span
+                key={key}
+                aria-hidden="true"
+                className="ml-jv-4 inline-block h-jv-14 w-jv-7 bg-jv-live animate-jv-caret"
+                style={{ verticalAlign: JV_BOARD.caretBaselineOffset }}
+              />
+            )
+        }
+      })}
+    </>
+  )
+}
+
+function SpeakerGutter({
+  speaker,
+  time,
+}: {
+  speaker: 'YOU' | 'JVS'
+  time?: string
+}) {
+  return (
+    <div
+      className={clsx(
+        'flex-none pt-jv-2 font-jv-mono text-jv-2xs leading-jv-loose-3 font-semibold tracking-jv-wider',
+        speaker === 'JVS' ? 'text-jv-live' : 'text-jv-label-dim',
+      )}
+      style={{ width: JV_BOARD.speakerGutterWidth }}
+    >
+      {speaker}
+      {time ? (
+        <>
+          <br />
+          <span className="font-normal tracking-normal text-jv-label-ghost">
+            {time}
+          </span>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function DelegationNote({ notes }: { notes: Array<DelegationNoteFixture> }) {
+  return (
+    <div className="flex items-center gap-jv-9 pt-jv-2 font-jv-mono text-jv-base leading-jv-none text-jv-label-dim">
+      <span aria-hidden="true" className="text-jv-live">
+        →
+      </span>
+      <span>
+        {notes.map((note, index) => (
+          <span key={note.label}>
+            {index > 0 ? ' · ' : null}
+            {note.label} <span className="text-jv-text-dim">{note.value}</span>
+          </span>
+        ))}
+      </span>
+    </div>
+  )
+}
+
+function Turn({
+  turn,
+  disagreeLabel,
+}: {
+  turn: ConversationTurnFixture
+  disagreeLabel: string
+}) {
+  const disagrees = turn.variant === 'disagree'
+  const rich = <RichText spans={turn.body} />
+  const bodyClass = clsx(
+    'font-jv-sans text-jv-5xl',
+    turn.evidence || disagrees ? 'leading-jv-loose-3' : 'leading-jv-loose-2',
+    turn.dim ? 'text-jv-text-dim-2' : 'text-jv-text-body',
+  )
+
+  // A plain turn is prose against the measure; anything richer needs a column.
+  const simple = !turn.evidence && !turn.delegation && !disagrees
+
+  return (
+    <article className="flex gap-jv-14">
+      <SpeakerGutter speaker={turn.speaker} time={turn.time} />
+
+      {simple ? (
+        <div className={bodyClass} style={{ maxWidth: JV_BOARD.turnMeasure }}>
+          {rich}
+        </div>
+      ) : disagrees ? (
+        <div
+          data-jv-fixture="no-source"
+          className="border-l border-jv-border-btn pl-jv-14"
+          style={{ maxWidth: JV_BOARD.turnMeasureWide }}
+        >
+          <div className="mb-jv-7 font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-wider-2 text-jv-assumed-sup">
+            {disagreeLabel}
+          </div>
+          <div className={bodyClass}>{rich}</div>
+        </div>
+      ) : (
+        <div
+          className="flex flex-col gap-jv-10"
+          style={{ maxWidth: JV_BOARD.turnMeasureWide }}
+        >
+          <div className={bodyClass}>{rich}</div>
+
+          {turn.evidence ? (
+            <div data-jv-fixture="no-source" className="flex gap-jv-10">
+              {turn.evidence.map((badge) => (
+                <div key={badge.title} className="flex-1">
+                  <VerificationBadge {...badge} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {turn.delegation ? <DelegationNote notes={turn.delegation} /> : null}
+        </div>
+      )}
+    </article>
+  )
+}
+
+export function Conversation({
+  turns,
+  trailingTurn,
+  gate,
+  gateCaveat,
+  disagreeLabel,
+}: {
+  turns: Array<ConversationTurnFixture>
+  trailingTurn: ConversationTurnFixture
+  gate: Omit<ApprovalGateCardProps, 'caveat'>
+  gateCaveat: GateCaveatFixture
+  disagreeLabel: string
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-jv-11 overflow-y-auto px-jv-32 pt-jv-14">
+      {turns.map((turn) => (
+        <Turn key={turn.id} turn={turn} disagreeLabel={disagreeLabel} />
+      ))}
+
+      <div data-jv-fixture="no-source">
+        <ApprovalGateCard
+          {...gate}
+          caveat={
+            <>
+              {gateCaveat.lead}
+              <EpistemicMark mark={gateCaveat.mark}>
+                {gateCaveat.claim}
+              </EpistemicMark>
+              {gateCaveat.trail}
+            </>
+          }
+        />
+      </div>
+
+      <Turn turn={trailingTurn} disagreeLabel={disagreeLabel} />
+    </div>
+  )
+}

--- a/src/screens/jarvis/command/conversation.tsx
+++ b/src/screens/jarvis/command/conversation.tsx
@@ -6,10 +6,17 @@
  *   • `VerificationBadge`  — the verified / claimed pair under a turn
  *   • `ApprovalGateCard`   — the inline gate after the disagreement turn
  *
- * Everything is fixture data. The epistemic marks, the verified/claimed state
- * on a chat turn, the I DISAGREE stance and the whole gate body are NO SOURCE
- * (`docs/design/jarvis-ui-mapping.md` §3.5 items 1–7) — they are drawn here to
- * prove the layout only, and each carries `data-jv-fixture="no-source"`.
+ * ONE THING HERE CAN BE LIVE (slice 6c): the gate. It arrives as a single
+ * `GateDisplay` from the routed screen — a real pending approval when the
+ * gateway has one, the slice-3 fixture otherwise — and this file neither
+ * fetches it nor resolves it. What it does own is the caveat slot, which is
+ * where the resolve confirm step surfaces.
+ *
+ * Everything else is fixture data. The epistemic marks, the verified/claimed
+ * state on a chat turn, the I DISAGREE stance and — on EVERY gate, live or not
+ * — BLAST RADIUS, UNDO PATH and the caveat are NO SOURCE
+ * (`docs/design/jarvis-ui-mapping.md` §3.2 and §3.5 items 1–7): they are drawn
+ * to prove the layout only, and each carries `data-jv-fixture="no-source"`.
  *
  * Token discipline: no raw colour, size, spacing or radius.
  */
@@ -21,7 +28,7 @@ import type {
   GateCaveatFixture,
   RichSpan,
 } from '@/components/jarvis/fixtures'
-import type { ApprovalGateCardProps } from '@/components/jarvis/types'
+import type { GateDisplay } from '../conductor/map-approvals'
 import { ApprovalGateCard } from '@/components/jarvis/approval-gate-card'
 import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
 import { VerificationBadge } from '@/components/jarvis/verification-badge'
@@ -173,39 +180,85 @@ function Turn({
   )
 }
 
+/**
+ * The caveat slot under the BLAST RADIUS / UNDO PATH panel, which holds one of
+ * three things and never two:
+ *
+ *   • the resolve line, when a confirm is pending or was blocked. It is UI
+ *     state, not entity data — it says what the button is about to do, which is
+ *     the one thing on a live gate that is knowable.
+ *   • the FIXTURE caveat, on the fixture fallback only, marked no-source as it
+ *     has been since slice 3.
+ *   • nothing. A live gate has no caveat: §3.2 makes it NO SOURCE, and
+ *     "qa has not verified…" over a real approval would be an invented reason
+ *     to hesitate.
+ */
+function GateCaveat({
+  note,
+  caveat,
+}: {
+  note?: string | null
+  caveat?: GateCaveatFixture
+}) {
+  if (note) {
+    return <span data-jv-resolve="note">{note}</span>
+  }
+  if (!caveat) return null
+  return (
+    <>
+      {caveat.lead}
+      <EpistemicMark mark={caveat.mark}>{caveat.claim}</EpistemicMark>
+      {caveat.trail}
+    </>
+  )
+}
+
 export function Conversation({
   turns,
   trailingTurn,
   gate,
-  gateCaveat,
   disagreeLabel,
 }: {
   turns: Array<ConversationTurnFixture>
   trailingTurn: ConversationTurnFixture
-  gate: Omit<ApprovalGateCardProps, 'caveat'>
-  gateCaveat: GateCaveatFixture
+  gate: GateDisplay
   disagreeLabel: string
 }) {
+  // Undefined, not an element that renders nothing: the card tests the prop for
+  // truthiness, so an "empty" caveat would still open the gap above it.
+  const caveat =
+    gate.note || gate.caveat ? (
+      <GateCaveat note={gate.note} caveat={gate.caveat} />
+    ) : undefined
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-jv-11 overflow-y-auto px-jv-32 pt-jv-14">
       {turns.map((turn) => (
         <Turn key={turn.id} turn={turn} disagreeLabel={disagreeLabel} />
       ))}
 
-      <div data-jv-fixture="no-source">
-        <ApprovalGateCard
-          {...gate}
-          caveat={
-            <>
-              {gateCaveat.lead}
-              <EpistemicMark mark={gateCaveat.mark}>
-                {gateCaveat.claim}
-              </EpistemicMark>
-              {gateCaveat.trail}
-            </>
-          }
-        />
+      {/*
+        The mark stays on a LIVE gate too, and it is not a leftover: the two
+        panel cells and the caveat have no source either way (§3.2). What
+        changes is the reason, so the tooltip does.
+      */}
+      <div
+        data-jv-fixture="no-source"
+        data-jv-gate-source={gate.isLive ? 'live' : 'fixture'}
+        title={
+          gate.isLive
+            ? 'Live approval — blast radius, undo path and the caveat have no source (§3.2)'
+            : 'Fixture — no pending approval was readable, so the slice-3 gate is drawn'
+        }
+      >
+        <ApprovalGateCard {...gate.props} caveat={caveat} onAction={gate.onAction} />
       </div>
+
+      {gate.othersWaiting ? (
+        <div className="font-jv-mono text-jv-sm leading-jv-none text-jv-blocked-dim">
+          {gate.othersWaiting}
+        </div>
+      ) : null}
 
       <Turn turn={trailingTurn} disagreeLabel={disagreeLabel} />
     </div>

--- a/src/screens/jarvis/command/desktop-command.tsx
+++ b/src/screens/jarvis/command/desktop-command.tsx
@@ -17,13 +17,24 @@
  * (flex) · work trail (320). Composed entirely from the Slice 2 primitives and
  * the `--jv-*` token layer; this slice re-styles none of them.
  *
- * FIXTURES ONLY. This directory imports no store, no gateway client and no
- * HTTP endpoint, and opens no request or event stream of any kind —
- * every value comes from `src/components/jarvis/fixtures.ts` so slice 6 can see
- * in one file exactly what still needs a real source. The NO SOURCE rows from
+ * ONE SECTION IS LIVE (slice 6b). The WORKER RAIL — its rows and its
+ * RUN/BLK/IDLE count line — reads real swarm sessions through `useWorkers`,
+ * with BLOCKED joined from the gateway's pending approvals queue. Both calls
+ * are GETs; this board issues no write of any kind, and no live row carries a
+ * control that implies one.
+ *
+ * Everything else is still FIXTURES: the conversation, the gate, the work
+ * trail, the threads list, the composer and the rail's ctx footer all come from
+ * `src/components/jarvis/fixtures.ts`, so a later slice can still see in one
+ * file exactly what needs a real source. The NO SOURCE rows from
  * `docs/design/jarvis-ui-mapping.md` §3.5 are drawn here to prove the layout
  * and are labelled as fixtures both in the banner above the frame and via
- * `data-jv-fixture="no-source"` in the DOM. Nothing on this board is live.
+ * `data-jv-fixture="no-source"` in the DOM.
+ *
+ * Live worker rows carry only what the session list actually supplies — a state
+ * and an age. The rail's detail column never invents a task, a file or a
+ * command, and when the gateway holds no sessions the rail falls back to the
+ * slice-3 fixture roster and the banner says so.
  *
  * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
  * so the board sets that attribute on <html> for as long as it is mounted and
@@ -45,6 +56,7 @@
  * `--jv-space-4`).
  */
 import { useEffect } from 'react'
+import { useWorkers } from '../conductor/use-workers'
 import { CommandTopbar } from './command-topbar'
 import { Composer } from './composer'
 import { Conversation } from './conversation'
@@ -52,6 +64,7 @@ import { JV_BOARD, JV_MOBILE } from './geometry'
 import { MobileCommandBoard } from './mobile-command'
 import { WorkTrail } from './work-trail'
 import { WorkerRail } from './worker-rail'
+import type { WorkersData } from '../conductor/use-workers'
 import {
   commandChainFixtures,
   commandComposerFixture,
@@ -76,6 +89,20 @@ import {
 const THEME_ATTRIBUTE = 'data-theme'
 const JARVIS_THEME = 'jarvis'
 
+/** The slice-3 roster and its verbatim artboard count line, as one prop. */
+const FIXTURE_RAIL = {
+  workers: commandWorkerFixtures,
+  counts: commandWorkerCounts,
+}
+
+/**
+ * `commandFixtureNotice` says nothing on this board is live — true only while
+ * the rail is on its fallback. This is what is actually on screen once the
+ * gateway answers with sessions.
+ */
+const commandLiveWorkersNotice =
+  'The WORKER RAIL is LIVE — real swarm sessions (GET /api/gateway/sessions), with BLOCKED joined from the pending approvals queue (GET /api/gateway/approvals) and the RUN/BLK/IDLE line tallied from the whole roster. Session status is the swarm store’s heuristic, not an authoritative gateway signal, and a live row carries only a state and an age: no task, no file, no command. Read-only — this board issues no write of any kind. Every other section — conversation, gate, work trail, threads, composer, ctx footer — is still invented fixtures.'
+
 /** Applies `data-theme='jarvis'` for the lifetime of the board only. */
 function useJarvisThemeAttribute() {
   useEffect(() => {
@@ -92,8 +119,18 @@ function useJarvisThemeAttribute() {
   }, [])
 }
 
-/** The board frame on its own — 1440×900, exactly what the artboard shows. */
-export function DesktopCommandBoard() {
+/**
+ * The board frame on its own — 1440×900, exactly what the artboard shows.
+ *
+ * The rail arrives as a prop with the fixtures as its default, so the frame
+ * still renders standalone with no query client and no store poll mounted; the
+ * routed screen below passes the live workers in when the gateway has any.
+ */
+export function DesktopCommandBoard({
+  rail = FIXTURE_RAIL,
+}: {
+  rail?: WorkersData['rail']
+} = {}) {
   return (
     <div
       data-jv-board="desktop-command"
@@ -107,8 +144,8 @@ export function DesktopCommandBoard() {
 
       <div className="flex min-h-0 flex-1">
         <WorkerRail
-          workers={commandWorkerFixtures}
-          counts={commandWorkerCounts}
+          workers={rail.workers}
+          counts={rail.counts}
           threads={commandThreadFixtures}
           footerLines={commandRailFooterLines}
         />
@@ -138,12 +175,17 @@ export function DesktopCommandBoard() {
 /**
  * The dev route's page. One route, two compositions: the desktop board at `lg`
  * and above, the mobile board below it. Both are mounted and CSS picks one —
- * they are inert fixture boards, so nothing is paid for the hidden one beyond
- * its markup, and a CSS swap cannot mismatch on first paint the way a
+ * nothing is paid for the hidden one beyond its markup (the worker read happens
+ * once, here), and a CSS swap cannot mismatch on first paint the way a
  * `matchMedia` read can.
+ *
+ * The mobile frame is NOT wired: artboard 03 leads with the gate rather than a
+ * worker roster, and wiring a gate means resolving one, which is slice 6c. Its
+ * banner still says fixtures, because it still is.
  */
 export function DesktopCommandScreen() {
   useJarvisThemeAttribute()
+  const workers = useWorkers()
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
@@ -161,14 +203,14 @@ export function DesktopCommandScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
-            {commandFixtureNotice}
+            {workers.isLive ? commandLiveWorkersNotice : commandFixtureNotice}
           </p>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
             {commandNoSourceNotice}
           </p>
         </header>
 
-        <DesktopCommandBoard />
+        <DesktopCommandBoard rail={workers.rail} />
       </div>
 
       <div className="flex flex-col items-center gap-jv-12 p-jv-14 lg:hidden">

--- a/src/screens/jarvis/command/desktop-command.tsx
+++ b/src/screens/jarvis/command/desktop-command.tsx
@@ -1,0 +1,146 @@
+/**
+ * JARVIS Desktop Command board — artboard 01, fixed 1440×900.
+ *
+ * Top bar over a three-zone body: workers/threads rail (220) · conversation
+ * (flex) · work trail (320). Composed entirely from the Slice 2 primitives and
+ * the `--jv-*` token layer; this slice re-styles none of them.
+ *
+ * FIXTURES ONLY. This directory imports no store, no gateway client and no
+ * HTTP endpoint, and opens no request or event stream of any kind —
+ * every value comes from `src/components/jarvis/fixtures.ts` so slice 6 can see
+ * in one file exactly what still needs a real source. The NO SOURCE rows from
+ * `docs/design/jarvis-ui-mapping.md` §3.5 are drawn here to prove the layout
+ * and are labelled as fixtures both in the banner above the frame and via
+ * `data-jv-fixture="no-source"` in the DOM. Nothing on this board is live.
+ *
+ * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
+ * so the board sets that attribute on <html> for as long as it is mounted and
+ * restores the previous value on unmount — never writing localStorage, so the
+ * user's stored theme comes back untouched. This mirrors the gallery screen's
+ * hook rather than importing it: sharing it would mean editing an existing
+ * screen, which is out of scope for this slice.
+ *
+ * Token discipline: no raw colour, size, spacing or radius in this directory.
+ * Structural dimensions come from `JV_BOARD` (multiples of `--jv-space-4`).
+ */
+import { useEffect } from 'react'
+import { CommandTopbar } from './command-topbar'
+import { Composer } from './composer'
+import { Conversation } from './conversation'
+import { JV_BOARD } from './geometry'
+import { WorkTrail } from './work-trail'
+import { WorkerRail } from './worker-rail'
+import {
+  commandChainFixtures,
+  commandComposerFixture,
+  commandConversationFixtures,
+  commandFilesTouchedFixtures,
+  commandFixtureNotice,
+  commandGateCaveatFixture,
+  commandGateFixture,
+  commandNoSourceNotice,
+  commandRailFooterLines,
+  commandThreadFixtures,
+  commandToolCallFixtures,
+  commandTopbarFixture,
+  commandTrailingTurnFixture,
+  commandWorkTrailChrome,
+  commandWorkerCounts,
+  commandWorkerFixtures,
+  disagreeLabel,
+} from '@/components/jarvis/fixtures'
+
+const THEME_ATTRIBUTE = 'data-theme'
+const JARVIS_THEME = 'jarvis'
+
+/** Applies `data-theme='jarvis'` for the lifetime of the board only. */
+function useJarvisThemeAttribute() {
+  useEffect(() => {
+    const root = document.documentElement
+    const previous = root.getAttribute(THEME_ATTRIBUTE)
+    root.setAttribute(THEME_ATTRIBUTE, JARVIS_THEME)
+    return () => {
+      if (previous === null) {
+        root.removeAttribute(THEME_ATTRIBUTE)
+      } else {
+        root.setAttribute(THEME_ATTRIBUTE, previous)
+      }
+    }
+  }, [])
+}
+
+/** The board frame on its own — 1440×900, exactly what the artboard shows. */
+export function DesktopCommandBoard() {
+  return (
+    <div
+      data-jv-board="desktop-command"
+      className="flex flex-none flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans text-jv-text"
+      style={{
+        width: JV_BOARD.frameWidth,
+        height: JV_BOARD.frameHeight,
+      }}
+    >
+      <CommandTopbar data={commandTopbarFixture} />
+
+      <div className="flex min-h-0 flex-1">
+        <WorkerRail
+          workers={commandWorkerFixtures}
+          counts={commandWorkerCounts}
+          threads={commandThreadFixtures}
+          footerLines={commandRailFooterLines}
+        />
+
+        <main className="flex min-w-0 flex-1 flex-col bg-jv-surface-1">
+          <Conversation
+            turns={commandConversationFixtures}
+            trailingTurn={commandTrailingTurnFixture}
+            gate={commandGateFixture}
+            gateCaveat={commandGateCaveatFixture}
+            disagreeLabel={disagreeLabel}
+          />
+          <Composer data={commandComposerFixture} />
+        </main>
+
+        <WorkTrail
+          chain={commandChainFixtures}
+          files={commandFilesTouchedFixtures}
+          toolCalls={commandToolCallFixtures}
+          chrome={commandWorkTrailChrome}
+        />
+      </div>
+    </div>
+  )
+}
+
+/** The dev route's page: the honesty banner, then the frame. */
+export function DesktopCommandScreen() {
+  useJarvisThemeAttribute()
+
+  return (
+    <div className="min-h-screen bg-jv-bg font-jv-sans text-jv-text">
+      <div className="flex flex-col items-center gap-jv-16 p-jv-24">
+        <header
+          className="flex w-full flex-col gap-jv-6"
+          style={{ maxWidth: JV_BOARD.frameWidth }}
+        >
+          <div className="flex items-baseline gap-jv-12">
+            <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider-2 text-jv-live">
+              01 · DESKTOP COMMAND
+            </span>
+            <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+              1440 × 900
+            </span>
+          </div>
+          <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
+            {commandFixtureNotice}
+          </p>
+          <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
+            {commandNoSourceNotice}
+          </p>
+        </header>
+
+        <DesktopCommandBoard />
+      </div>
+    </div>
+  )
+}

--- a/src/screens/jarvis/command/desktop-command.tsx
+++ b/src/screens/jarvis/command/desktop-command.tsx
@@ -17,14 +17,25 @@
  * (flex) · work trail (320). Composed entirely from the Slice 2 primitives and
  * the `--jv-*` token layer; this slice re-styles none of them.
  *
- * ONE SECTION IS LIVE (slice 6b). The WORKER RAIL — its rows and its
- * RUN/BLK/IDLE count line — reads real swarm sessions through `useWorkers`,
- * with BLOCKED joined from the gateway's pending approvals queue. Both calls
- * are GETs; this board issues no write of any kind, and no live row carries a
- * control that implies one.
+ * TWO SECTIONS CAN BE LIVE. The WORKER RAIL — its rows and its RUN/BLK/IDLE
+ * count line — reads real swarm sessions through `useWorkers` (slice 6b), with
+ * BLOCKED joined from the gateway's pending approvals queue. The GATE reads
+ * that same approvals queue through `useApprovals` (slice 6c) and shows the
+ * OLDEST pending one, with the rest as a real "+N more waiting" count.
  *
- * Everything else is still FIXTURES: the conversation, the gate, the work
- * trail, the threads list, the composer and the rail's ctx footer all come from
+ * BOTH READS ARE GETs. The one WRITE this app has for approvals —
+ * `resolveGatewayApproval` — is reached only through `useResolveApproval`, and
+ * this screen passes `enableResolve={false}`, so the gate's APPROVE / REJECT
+ * chips walk through their confirm step and then stop: nothing is POSTed. See
+ * `../conductor/use-resolve-approval.ts` for the locks. Flipping that flag is a
+ * product decision and is deliberately not made here.
+ *
+ * The gate is LIVE only in the sense of DISPLAY. Its BLAST RADIUS, UNDO PATH
+ * and caveat have NO SOURCE (§3.2) — live, the two cells carry an inert
+ * sentinel and the caveat is dropped rather than invented.
+ *
+ * Everything else is still FIXTURES: the conversation, the work trail, the
+ * threads list, the composer and the rail's ctx footer all come from
  * `src/components/jarvis/fixtures.ts`, so a later slice can still see in one
  * file exactly what needs a real source. The NO SOURCE rows from
  * `docs/design/jarvis-ui-mapping.md` §3.5 are drawn here to prove the layout
@@ -56,6 +67,8 @@
  * `--jv-space-4`).
  */
 import { useEffect } from 'react'
+import { useApprovals } from '../conductor/use-approvals'
+import { useResolveApproval } from '../conductor/use-resolve-approval'
 import { useWorkers } from '../conductor/use-workers'
 import { CommandTopbar } from './command-topbar'
 import { Composer } from './composer'
@@ -64,6 +77,7 @@ import { JV_BOARD, JV_MOBILE } from './geometry'
 import { MobileCommandBoard } from './mobile-command'
 import { WorkTrail } from './work-trail'
 import { WorkerRail } from './worker-rail'
+import type { GateDisplay } from '../conductor/map-approvals'
 import type { WorkersData } from '../conductor/use-workers'
 import {
   commandChainFixtures,
@@ -83,6 +97,7 @@ import {
   commandWorkerCounts,
   commandWorkerFixtures,
   disagreeLabel,
+  mobileCommandGateCaveatFixture,
   mobileFixtureNotice,
 } from '@/components/jarvis/fixtures'
 
@@ -95,13 +110,58 @@ const FIXTURE_RAIL = {
   counts: commandWorkerCounts,
 }
 
+/** The slice-3 gate and its caveat, as one prop. Nothing here is live. */
+const FIXTURE_GATE: GateDisplay = {
+  props: commandGateFixture,
+  caveat: commandGateCaveatFixture,
+  isLive: false,
+}
+
 /**
  * `commandFixtureNotice` says nothing on this board is live — true only while
  * the rail is on its fallback. This is what is actually on screen once the
  * gateway answers with sessions.
  */
-const commandLiveWorkersNotice =
-  'The WORKER RAIL is LIVE — real swarm sessions (GET /api/gateway/sessions), with BLOCKED joined from the pending approvals queue (GET /api/gateway/approvals) and the RUN/BLK/IDLE line tallied from the whole roster. Session status is the swarm store’s heuristic, not an authoritative gateway signal, and a live row carries only a state and an age: no task, no file, no command. Read-only — this board issues no write of any kind. Every other section — conversation, gate, work trail, threads, composer, ctx footer — is still invented fixtures.'
+const LIVE_RAIL_CLAUSE =
+  'The WORKER RAIL is LIVE — real swarm sessions (GET /api/gateway/sessions), with BLOCKED joined from the pending approvals queue (GET /api/gateway/approvals) and the RUN/BLK/IDLE line tallied from the whole roster. Session status is the swarm store’s heuristic, not an authoritative gateway signal, and a live row carries only a state and an age: no task, no file, no command.'
+
+const LIVE_GATE_CLAUSE =
+  'The GATE is LIVE as DISPLAY — the oldest pending approval from the same GET /api/gateway/approvals queue: real agent, real action, real tool and input, wait derived from requestedAt. Its BLAST RADIUS and UNDO PATH have NO SOURCE and read as an inert sentinel rather than a plausible number, and the caveat is dropped entirely.'
+
+const RESOLVE_CLAUSE =
+  'Resolve is BUILT BUT DISABLED: APPROVE / REJECT enter a two-step confirm and stop there — enableResolve is false, so nothing is POSTed to the gateway and no approval is decided from this board.'
+
+/**
+ * `commandFixtureNotice` says nothing on this board is live — true only while
+ * both wires are on their fallback, so the banner is assembled per section.
+ */
+function buildCommandNotice(railLive: boolean, gateLive: boolean): string {
+  const clauses: Array<string> = []
+  const stillFixture: Array<string> = []
+
+  if (railLive) clauses.push(LIVE_RAIL_CLAUSE)
+  else stillFixture.push('the worker rail')
+  if (gateLive) clauses.push(LIVE_GATE_CLAUSE)
+  else stillFixture.push('the gate')
+  stillFixture.push(
+    'the conversation',
+    'the work trail',
+    'threads',
+    'the composer',
+    'the ctx footer',
+  )
+
+  if (clauses.length === 0) return `${commandFixtureNotice} ${RESOLVE_CLAUSE}`
+  return `${clauses.join(' ')} ${RESOLVE_CLAUSE} Still invented fixtures: ${stillFixture.join(' · ')}.`
+}
+
+const MOBILE_LIVE_GATE_CLAUSE =
+  'The HERO GATE is LIVE as DISPLAY — the same real pending approval as the desktop board, from GET /api/gateway/approvals. Blast radius, undo path and the caveat have NO SOURCE: the two cells read as an inert sentinel and the caveat is dropped.'
+
+function buildMobileCommandNotice(gateLive: boolean): string {
+  if (!gateLive) return `${mobileFixtureNotice} ${RESOLVE_CLAUSE}`
+  return `${MOBILE_LIVE_GATE_CLAUSE} ${RESOLVE_CLAUSE} Still invented fixtures: the alert strip · the thread · the legend · the composer.`
+}
 
 /** Applies `data-theme='jarvis'` for the lifetime of the board only. */
 function useJarvisThemeAttribute() {
@@ -128,8 +188,10 @@ function useJarvisThemeAttribute() {
  */
 export function DesktopCommandBoard({
   rail = FIXTURE_RAIL,
+  gate = FIXTURE_GATE,
 }: {
   rail?: WorkersData['rail']
+  gate?: GateDisplay
 } = {}) {
   return (
     <div
@@ -154,8 +216,7 @@ export function DesktopCommandBoard({
           <Conversation
             turns={commandConversationFixtures}
             trailingTurn={commandTrailingTurnFixture}
-            gate={commandGateFixture}
-            gateCaveat={commandGateCaveatFixture}
+            gate={gate}
             disagreeLabel={disagreeLabel}
           />
           <Composer data={commandComposerFixture} />
@@ -179,13 +240,49 @@ export function DesktopCommandBoard({
  * once, here), and a CSS swap cannot mismatch on first paint the way a
  * `matchMedia` read can.
  *
- * The mobile frame is NOT wired: artboard 03 leads with the gate rather than a
- * worker roster, and wiring a gate means resolving one, which is slice 6c. Its
- * banner still says fixtures, because it still is.
+ * The mobile frame now shows the SAME gate as the desktop one — one read, one
+ * hero, two frames — because artboard 03 leads with it. Its resolve control is
+ * the same one, and it is off.
  */
 export function DesktopCommandScreen() {
   useJarvisThemeAttribute()
   const workers = useWorkers()
+  const approvals = useApprovals()
+
+  /**
+   * LOCK 1, shut, at the only call site on this screen. `useResolveApproval`
+   * already defaults `enabled` to false; it is passed explicitly anyway so that
+   * turning resolve on is a visible one-word edit in a reviewed diff rather
+   * than an omission somewhere else. While it is false the chips still walk
+   * through their confirm step — that is the interaction being reviewed — and
+   * the POST is never issued.
+   */
+  const enableResolve = false
+  const resolve = useResolveApproval({
+    enabled: enableResolve,
+    approvalId: approvals.approvalId,
+    baseActions: approvals.gate.actions,
+  })
+
+  const gateChrome = {
+    note: resolve.note,
+    othersWaiting: approvals.othersWaiting,
+    isLive: approvals.isLive,
+    onAction: resolve.onAction,
+    // NO SOURCE (§3.2) — a live gate carries no caveat at all.
+    caveat: approvals.isLive ? undefined : commandGateCaveatFixture,
+  }
+
+  const gate: GateDisplay = {
+    ...gateChrome,
+    props: { ...approvals.gate, actions: resolve.actions },
+  }
+
+  const mobileGate: GateDisplay = {
+    ...gateChrome,
+    props: { ...approvals.mobileGate, actions: resolve.actions },
+    caveat: approvals.isLive ? undefined : mobileCommandGateCaveatFixture,
+  }
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
@@ -203,14 +300,14 @@ export function DesktopCommandScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
-            {workers.isLive ? commandLiveWorkersNotice : commandFixtureNotice}
+            {buildCommandNotice(workers.isLive, approvals.isLive)}
           </p>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
             {commandNoSourceNotice}
           </p>
         </header>
 
-        <DesktopCommandBoard rail={workers.rail} />
+        <DesktopCommandBoard rail={workers.rail} gate={gate} />
       </div>
 
       <div className="flex flex-col items-center gap-jv-12 p-jv-14 lg:hidden">
@@ -227,14 +324,14 @@ export function DesktopCommandScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
-            {mobileFixtureNotice}
+            {buildMobileCommandNotice(approvals.isLive)}
           </p>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
             {commandNoSourceNotice}
           </p>
         </header>
 
-        <MobileCommandBoard />
+        <MobileCommandBoard gate={mobileGate} />
       </div>
     </div>
   )

--- a/src/screens/jarvis/command/desktop-command.tsx
+++ b/src/screens/jarvis/command/desktop-command.tsx
@@ -1,5 +1,17 @@
 /**
- * JARVIS Desktop Command board — artboard 01, fixed 1440×900.
+ * JARVIS Command — the routed screen, plus the Desktop Command board itself
+ * (artboard 01, fixed 1440×900).
+ *
+ * Slice 5 makes the ROUTE responsive without touching the board. At `lg` and
+ * above the screen renders `DesktopCommandBoard` exactly as slice 3 drew it;
+ * below `lg` it renders `MobileCommandBoard` — artboard 03, a different
+ * composition that leads with the gate — rather than reflowing a 1440 board
+ * into 390. The swap is CSS (`hidden` / `flex`), not a media-query hook, so
+ * there is no viewport read to get wrong on first paint.
+ *
+ * `DesktopCommandScreen` keeps its slice-3 name because `src/routes/
+ * jarvis-command.tsx` imports it and routes are out of scope for this slice.
+ * It is the Command screen at every width, not the desktop one.
  *
  * Top bar over a three-zone body: workers/threads rail (220) · conversation
  * (flex) · work trail (320). Composed entirely from the Slice 2 primitives and
@@ -20,14 +32,24 @@
  * hook rather than importing it: sharing it would mean editing an existing
  * screen, which is out of scope for this slice.
  *
+ * One class needs explaining: the roots below carry `tracking-normal`. The app
+ * sets `letter-spacing: -0.15px` on `html, body` in `styles.css`, which every
+ * descendant inherits; the artboard's text is untracked. Without this the whole
+ * board renders a hair tight and the drift compounds across a long mono line.
+ * The Conductor board has had this reset since slice 4 — this board inherited
+ * the bleed until now, so the two were a hair apart. Resetting at the root is
+ * local and additive: the explicit `tracking-jv-*` on labels still wins.
+ *
  * Token discipline: no raw colour, size, spacing or radius in this directory.
- * Structural dimensions come from `JV_BOARD` (multiples of `--jv-space-4`).
+ * Structural dimensions come from `JV_BOARD` / `JV_MOBILE` (multiples of
+ * `--jv-space-4`).
  */
 import { useEffect } from 'react'
 import { CommandTopbar } from './command-topbar'
 import { Composer } from './composer'
 import { Conversation } from './conversation'
-import { JV_BOARD } from './geometry'
+import { JV_BOARD, JV_MOBILE } from './geometry'
+import { MobileCommandBoard } from './mobile-command'
 import { WorkTrail } from './work-trail'
 import { WorkerRail } from './worker-rail'
 import {
@@ -48,6 +70,7 @@ import {
   commandWorkerCounts,
   commandWorkerFixtures,
   disagreeLabel,
+  mobileFixtureNotice,
 } from '@/components/jarvis/fixtures'
 
 const THEME_ATTRIBUTE = 'data-theme'
@@ -74,7 +97,7 @@ export function DesktopCommandBoard() {
   return (
     <div
       data-jv-board="desktop-command"
-      className="flex flex-none flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans text-jv-text"
+      className="flex flex-none flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans tracking-normal text-jv-text"
       style={{
         width: JV_BOARD.frameWidth,
         height: JV_BOARD.frameHeight,
@@ -112,13 +135,19 @@ export function DesktopCommandBoard() {
   )
 }
 
-/** The dev route's page: the honesty banner, then the frame. */
+/**
+ * The dev route's page. One route, two compositions: the desktop board at `lg`
+ * and above, the mobile board below it. Both are mounted and CSS picks one —
+ * they are inert fixture boards, so nothing is paid for the hidden one beyond
+ * its markup, and a CSS swap cannot mismatch on first paint the way a
+ * `matchMedia` read can.
+ */
 export function DesktopCommandScreen() {
   useJarvisThemeAttribute()
 
   return (
-    <div className="min-h-screen bg-jv-bg font-jv-sans text-jv-text">
-      <div className="flex flex-col items-center gap-jv-16 p-jv-24">
+    <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
+      <div className="hidden flex-col items-center gap-jv-16 p-jv-24 lg:flex">
         <header
           className="flex w-full flex-col gap-jv-6"
           style={{ maxWidth: JV_BOARD.frameWidth }}
@@ -140,6 +169,30 @@ export function DesktopCommandScreen() {
         </header>
 
         <DesktopCommandBoard />
+      </div>
+
+      <div className="flex flex-col items-center gap-jv-12 p-jv-14 lg:hidden">
+        <header
+          className="flex w-full flex-col gap-jv-6"
+          style={{ maxWidth: JV_MOBILE.frameWidth }}
+        >
+          <div className="flex items-baseline gap-jv-9">
+            <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider-2 text-jv-live">
+              03 · MOBILE COMMAND
+            </span>
+            <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+              390 × 844
+            </span>
+          </div>
+          <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
+            {mobileFixtureNotice}
+          </p>
+          <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
+            {commandNoSourceNotice}
+          </p>
+        </header>
+
+        <MobileCommandBoard />
       </div>
     </div>
   )

--- a/src/screens/jarvis/command/desktop-command.tsx
+++ b/src/screens/jarvis/command/desktop-command.tsx
@@ -25,10 +25,14 @@
  *
  * BOTH READS ARE GETs. The one WRITE this app has for approvals —
  * `resolveGatewayApproval` — is reached only through `useResolveApproval`, and
- * this screen passes `enableResolve={false}`, so the gate's APPROVE / REJECT
- * chips walk through their confirm step and then stop: nothing is POSTed. See
- * `../conductor/use-resolve-approval.ts` for the locks. Flipping that flag is a
- * product decision and is deliberately not made here.
+ * whether its LOCK 1 is open is now a decision the user makes at runtime, in
+ * this session, on the LIVE RESOLVE switch above the board (slice 6d). It is
+ * OFF on every fresh session and OFF in committed code: while it is off the
+ * gate's APPROVE / REJECT chips walk through their confirm step and then stop,
+ * and nothing is POSTed. Arming it opens that one lock and NOTHING else — the
+ * two-step confirm and the need for a real approval id are untouched, and the
+ * switch itself makes no request. See `../conductor/use-resolve-approval.ts`
+ * for the locks and `../conductor/use-resolve-arm.ts` for the flag.
  *
  * The gate is LIVE only in the sense of DISPLAY. Its BLAST RADIUS, UNDO PATH
  * and caveat have NO SOURCE (§3.2) — live, the two cells carry an inert
@@ -67,8 +71,10 @@
  * `--jv-space-4`).
  */
 import { useEffect } from 'react'
+import { ResolveArmToggle } from '../conductor/resolve-arm-toggle'
 import { useApprovals } from '../conductor/use-approvals'
 import { useResolveApproval } from '../conductor/use-resolve-approval'
+import { useResolveArm } from '../conductor/use-resolve-arm'
 import { useWorkers } from '../conductor/use-workers'
 import { CommandTopbar } from './command-topbar'
 import { Composer } from './composer'
@@ -128,14 +134,25 @@ const LIVE_RAIL_CLAUSE =
 const LIVE_GATE_CLAUSE =
   'The GATE is LIVE as DISPLAY — the oldest pending approval from the same GET /api/gateway/approvals queue: real agent, real action, real tool and input, wait derived from requestedAt. Its BLAST RADIUS and UNDO PATH have NO SOURCE and read as an inert sentinel rather than a plausible number, and the caveat is dropped entirely.'
 
-const RESOLVE_CLAUSE =
-  'Resolve is BUILT BUT DISABLED: APPROVE / REJECT enter a two-step confirm and stop there — enableResolve is false, so nothing is POSTed to the gateway and no approval is decided from this board.'
+const RESOLVE_CLAUSE_OFF =
+  'Resolve is BUILT and DISARMED: LIVE RESOLVE is OFF for this session, so APPROVE / REJECT enter a two-step confirm and stop there — nothing is POSTed to the gateway and no approval is decided from this board. Arm it on the switch above the board if you mean to decide from here.'
+
+const RESOLVE_CLAUSE_ARMED =
+  'Resolve is ARMED for this session: LIVE RESOLVE is ON, so a two-step-CONFIRMED approve or reject POSTs the real decision to the gateway and there is no undo. Arming sent nothing by itself, the confirm step still stands between a click and the POST, and a fixture gate has no approval id to act on. The arm is per-session and is not in the committed default.'
+
+function resolveClause(armed: boolean): string {
+  return armed ? RESOLVE_CLAUSE_ARMED : RESOLVE_CLAUSE_OFF
+}
 
 /**
  * `commandFixtureNotice` says nothing on this board is live — true only while
  * both wires are on their fallback, so the banner is assembled per section.
  */
-function buildCommandNotice(railLive: boolean, gateLive: boolean): string {
+function buildCommandNotice(
+  railLive: boolean,
+  gateLive: boolean,
+  armed: boolean,
+): string {
   const clauses: Array<string> = []
   const stillFixture: Array<string> = []
 
@@ -151,16 +168,17 @@ function buildCommandNotice(railLive: boolean, gateLive: boolean): string {
     'the ctx footer',
   )
 
-  if (clauses.length === 0) return `${commandFixtureNotice} ${RESOLVE_CLAUSE}`
-  return `${clauses.join(' ')} ${RESOLVE_CLAUSE} Still invented fixtures: ${stillFixture.join(' · ')}.`
+  if (clauses.length === 0)
+    return `${commandFixtureNotice} ${resolveClause(armed)}`
+  return `${clauses.join(' ')} ${resolveClause(armed)} Still invented fixtures: ${stillFixture.join(' · ')}.`
 }
 
 const MOBILE_LIVE_GATE_CLAUSE =
   'The HERO GATE is LIVE as DISPLAY — the same real pending approval as the desktop board, from GET /api/gateway/approvals. Blast radius, undo path and the caveat have NO SOURCE: the two cells read as an inert sentinel and the caveat is dropped.'
 
-function buildMobileCommandNotice(gateLive: boolean): string {
-  if (!gateLive) return `${mobileFixtureNotice} ${RESOLVE_CLAUSE}`
-  return `${MOBILE_LIVE_GATE_CLAUSE} ${RESOLVE_CLAUSE} Still invented fixtures: the alert strip · the thread · the legend · the composer.`
+function buildMobileCommandNotice(gateLive: boolean, armed: boolean): string {
+  if (!gateLive) return `${mobileFixtureNotice} ${resolveClause(armed)}`
+  return `${MOBILE_LIVE_GATE_CLAUSE} ${resolveClause(armed)} Still invented fixtures: the alert strip · the thread · the legend · the composer.`
 }
 
 /** Applies `data-theme='jarvis'` for the lifetime of the board only. */
@@ -242,7 +260,9 @@ export function DesktopCommandBoard({
  *
  * The mobile frame now shows the SAME gate as the desktop one — one read, one
  * hero, two frames — because artboard 03 leads with it. Its resolve control is
- * the same one, and it is off.
+ * the same one, and so is its arm: one `useResolveArm` for the screen, so the
+ * two frames can never disagree about whether this session is armed. Both
+ * frames carry the switch, because both frames carry the gate.
  */
 export function DesktopCommandScreen() {
   useJarvisThemeAttribute()
@@ -250,16 +270,18 @@ export function DesktopCommandScreen() {
   const approvals = useApprovals()
 
   /**
-   * LOCK 1, shut, at the only call site on this screen. `useResolveApproval`
-   * already defaults `enabled` to false; it is passed explicitly anyway so that
-   * turning resolve on is a visible one-word edit in a reviewed diff rather
-   * than an omission somewhere else. While it is false the chips still walk
-   * through their confirm step — that is the interaction being reviewed — and
-   * the POST is never issued.
+   * LOCK 1, and who holds it. It is no longer a constant in this file: it is
+   * the session's arm flag, false on every fresh session and false in the
+   * committed default, flipped only by the user on the switch below. Passing it
+   * through is the whole of this slice's wiring — `useResolveApproval`'s other
+   * two locks (the two-step confirm, a real approval id) are not touched, so an
+   * armed session still cannot POST from a single click or from a fixture gate.
+   * While it is false the chips walk their confirm step and land in `blocked`,
+   * exactly as before.
    */
-  const enableResolve = false
+  const arm = useResolveArm()
   const resolve = useResolveApproval({
-    enabled: enableResolve,
+    enabled: arm.armed,
     approvalId: approvals.approvalId,
     baseActions: approvals.gate.actions,
   })
@@ -300,11 +322,12 @@ export function DesktopCommandScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
-            {buildCommandNotice(workers.isLive, approvals.isLive)}
+            {buildCommandNotice(workers.isLive, approvals.isLive, arm.armed)}
           </p>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
             {commandNoSourceNotice}
           </p>
+          <ResolveArmToggle armed={arm.armed} onChange={arm.setArmed} />
         </header>
 
         <DesktopCommandBoard rail={workers.rail} gate={gate} />
@@ -324,11 +347,12 @@ export function DesktopCommandScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
-            {buildMobileCommandNotice(approvals.isLive)}
+            {buildMobileCommandNotice(approvals.isLive, arm.armed)}
           </p>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
             {commandNoSourceNotice}
           </p>
+          <ResolveArmToggle armed={arm.armed} onChange={arm.setArmed} />
         </header>
 
         <MobileCommandBoard gate={mobileGate} />

--- a/src/screens/jarvis/command/geometry.test.ts
+++ b/src/screens/jarvis/command/geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { JV_BOARD, jvGrid } from './geometry'
+import { JV_BOARD, JV_MOBILE, jvGrid, jvRule } from './geometry'
 
 describe('jvGrid', () => {
   it('expresses a dimension as a multiple of the 4px --jv-space-4 grid', () => {
@@ -21,5 +21,38 @@ describe('jvGrid', () => {
     // 360 * 4 = 1440, 225 * 4 = 900
     expect(JV_BOARD.frameWidth).toBe(jvGrid(360))
     expect(JV_BOARD.frameHeight).toBe(jvGrid(225))
+  })
+})
+
+describe('jvRule', () => {
+  it('adds the hairline a bordered edge eats under border-box', () => {
+    expect(jvRule(11)).toBe('calc(var(--jv-space-4) * 11 + var(--jv-space-1))')
+  })
+
+  it('gives the top bar 44px of content UNDER its rule, not including it', () => {
+    // The bar carries `border-b`, and `box-sizing: border-box` subtracts that
+    // border from `height` instead of adding it — so `jvGrid(11)` left a 43px
+    // bar and sat both desktop boards a pixel high. Regression guard.
+    expect(JV_BOARD.topbarHeight).toBe(jvRule(11))
+    expect(JV_BOARD.topbarHeight).not.toBe(jvGrid(11))
+  })
+})
+
+describe('JV_MOBILE', () => {
+  it('maps the mobile artboard frame to 390 × 844 on the same grid', () => {
+    // 97.5 * 4 = 390, 211 * 4 = 844
+    expect(JV_MOBILE.frameWidth).toBe(jvGrid(97.5))
+    expect(JV_MOBILE.frameHeight).toBe(jvGrid(211))
+  })
+
+  it('measures its status bar exactly like the desktop top bar', () => {
+    expect(JV_MOBILE.statusBarHeight).toBe(JV_BOARD.topbarHeight)
+  })
+
+  it('never emits a raw px value', () => {
+    for (const value of Object.values(JV_MOBILE)) {
+      expect(value).not.toMatch(/\d+px/)
+      expect(value).toContain('var(--jv-space-')
+    }
   })
 })

--- a/src/screens/jarvis/command/geometry.test.ts
+++ b/src/screens/jarvis/command/geometry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { JV_BOARD, jvGrid } from './geometry'
+
+describe('jvGrid', () => {
+  it('expresses a dimension as a multiple of the 4px --jv-space-4 grid', () => {
+    expect(jvGrid(55)).toBe('calc(var(--jv-space-4) * 55)')
+  })
+
+  it('keeps half-steps exact rather than rounding them', () => {
+    expect(jvGrid(8.5)).toBe('calc(var(--jv-space-4) * 8.5)')
+  })
+
+  it('never emits a raw px value', () => {
+    for (const value of Object.values(JV_BOARD)) {
+      expect(value).not.toMatch(/\d+px/)
+      expect(value).toContain('var(--jv-space-')
+    }
+  })
+
+  it('maps the artboard frame to 1440 × 900 on the grid', () => {
+    // 360 * 4 = 1440, 225 * 4 = 900
+    expect(JV_BOARD.frameWidth).toBe(jvGrid(360))
+    expect(JV_BOARD.frameHeight).toBe(jvGrid(225))
+  })
+})

--- a/src/screens/jarvis/command/geometry.ts
+++ b/src/screens/jarvis/command/geometry.ts
@@ -13,6 +13,11 @@
  *
  * Fractional steps are allowed and exact: the artboard uses a few half-steps
  * (18px = 4.5, 34px = 8.5) and `calc()` handles them without rounding.
+ *
+ * Slice 5 adds two things here. `jvRule()` — the grid step PLUS the hairline a
+ * bordered edge eats under `box-sizing: border-box` — and `JV_MOBILE`, the
+ * 390 × 844 frame artboards 03 and 04 are drawn on. Both boards share this
+ * module the same way they already share `JV_BOARD`.
  */
 
 /** `jvGrid(55)` → `calc(var(--jv-space-4) * 55)` → 220px. */
@@ -20,13 +25,34 @@ export function jvGrid(steps: number): string {
   return `calc(var(--jv-space-4) * ${steps})`
 }
 
+/**
+ * `jvGrid(steps)` plus one hairline — for a box whose artboard height is
+ * measured to the OUTSIDE of a 1px border.
+ *
+ * Every board here is `box-sizing: border-box`, so a `border-b` is subtracted
+ * from `height` rather than added to it: `height: jvGrid(11)` on a bar with a
+ * bottom rule leaves 43px of content under a 44px measurement. `jvRule(11)`
+ * asks for 44px of content and a rule beneath it, which is what the artboard
+ * actually draws. The hairline is `--jv-space-1`, the same token the border
+ * itself resolves to, so it is still a value from the grid and not a fudge.
+ */
+export function jvRule(steps: number): string {
+  return `calc(var(--jv-space-4) * ${steps} + var(--jv-space-1))`
+}
+
 /** Every structural dimension the board uses, named after what it measures. */
 export const JV_BOARD = {
   /** 1440 × 900 fixed frame. */
   frameWidth: jvGrid(360),
   frameHeight: jvGrid(225),
-  /** 44px top bar. */
-  topbarHeight: jvGrid(11),
+  /**
+   * The top bar: 44px of content under its 1px bottom rule.
+   *
+   * Was `jvGrid(11)`, which under `border-box` spent one of those 44px on the
+   * rule and left the bar 43px tall — so every row beneath it on BOTH desktop
+   * boards sat a pixel high. `jvRule(11)` restores the artboard's measurement.
+   */
+  topbarHeight: jvRule(11),
   /** 18px — the top bar's item gap and the THREADS label's top padding. */
   gap18: jvGrid(4.5),
   /** 220px workers/threads rail. */
@@ -42,4 +68,23 @@ export const JV_BOARD = {
   toolCallTimeWidth: jvGrid(8.5),
   /** The streaming caret sits 2px below the baseline. */
   caretBaselineOffset: `calc(var(--jv-space-2) * -1)`,
+} as const
+
+/**
+ * The mobile frame (artboards 03 and 04, 390 × 844).
+ *
+ * Only the frame and its status bar are fixed. Mobile is a single fluid
+ * column, so every other dimension on those boards is flow or a `--jv-space-*`
+ * padding — there is nothing else worth pinning to the grid, and pinning more
+ * would fight the "fills the viewport width" requirement.
+ */
+export const JV_MOBILE = {
+  /** 390px — the artboard width, used as a MAX so a narrower phone still fills. */
+  frameWidth: jvGrid(97.5),
+  /** 844px — the artboard height, used as a MIN so the column can grow. */
+  frameHeight: jvGrid(211),
+  /** 44px status bar over its 1px rule — same measurement as the desktop bar. */
+  statusBarHeight: jvRule(11),
+  /** 36px timestamp column in the LAST NIGHT list. */
+  runTimeWidth: jvGrid(9),
 } as const

--- a/src/screens/jarvis/command/geometry.ts
+++ b/src/screens/jarvis/command/geometry.ts
@@ -1,0 +1,45 @@
+/**
+ * Artboard geometry for the Desktop Command board (artboard 01, 1440×900).
+ *
+ * The board has a handful of STRUCTURAL dimensions — frame size, rail widths,
+ * top-bar height, the time gutter, the prose measure — that are neither colour,
+ * type, padding nor radius, and so have no `--jv-*` utility of their own.
+ *
+ * The slice's token-discipline gate forbids raw px in these files, and writing
+ * `w-[220px]` would smuggle a magic number in anyway. Every such dimension is
+ * therefore expressed as a multiple of the 4px `--jv-space-4` grid the artboard
+ * itself is drawn on, so the value still resolves through the token layer and
+ * changing the grid step changes the whole board.
+ *
+ * Fractional steps are allowed and exact: the artboard uses a few half-steps
+ * (18px = 4.5, 34px = 8.5) and `calc()` handles them without rounding.
+ */
+
+/** `jvGrid(55)` → `calc(var(--jv-space-4) * 55)` → 220px. */
+export function jvGrid(steps: number): string {
+  return `calc(var(--jv-space-4) * ${steps})`
+}
+
+/** Every structural dimension the board uses, named after what it measures. */
+export const JV_BOARD = {
+  /** 1440 × 900 fixed frame. */
+  frameWidth: jvGrid(360),
+  frameHeight: jvGrid(225),
+  /** 44px top bar. */
+  topbarHeight: jvGrid(11),
+  /** 18px — the top bar's item gap and the THREADS label's top padding. */
+  gap18: jvGrid(4.5),
+  /** 220px workers/threads rail. */
+  leftRailWidth: jvGrid(55),
+  /** 320px work-trail rail. */
+  rightRailWidth: jvGrid(80),
+  /** 52px YOU/JVS time gutter. */
+  speakerGutterWidth: jvGrid(13),
+  /** 640px measure for a plain turn, 660px for one carrying evidence cards. */
+  turnMeasure: jvGrid(160),
+  turnMeasureWide: jvGrid(165),
+  /** 34px timestamp column in the TOOL CALLS list. */
+  toolCallTimeWidth: jvGrid(8.5),
+  /** The streaming caret sits 2px below the baseline. */
+  caretBaselineOffset: `calc(var(--jv-space-2) * -1)`,
+} as const

--- a/src/screens/jarvis/command/mobile-command.test.tsx
+++ b/src/screens/jarvis/command/mobile-command.test.tsx
@@ -33,8 +33,12 @@ describe('MobileCommandBoard', () => {
     // Composing a second gate card for mobile would let the honest panel
     // drift; this asserts the primitive itself is what the phone shows.
     expect(screen.getByText('APPROVAL REQUIRED')).toBeTruthy()
-    expect(screen.getByText('BLAST RADIUS')).toBeTruthy()
-    expect(screen.getByText('UNDO PATH')).toBeTruthy()
+    // Artboard 03 shortens the two headings for the 390pt column — the same
+    // primitive, the same cells, fewer words.
+    expect(screen.getByText('RADIUS')).toBeTruthy()
+    expect(screen.getByText('UNDO')).toBeTruthy()
+    expect(screen.queryByText('BLAST RADIUS')).toBeNull()
+    expect(screen.queryByText('UNDO PATH')).toBeNull()
     expect(screen.getByText(mobileCommandGateFixture.blastRadius)).toBeTruthy()
     expect(screen.getAllByRole('button')).toHaveLength(3)
   })

--- a/src/screens/jarvis/command/mobile-command.test.tsx
+++ b/src/screens/jarvis/command/mobile-command.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MobileCommandBoard } from './mobile-command'
+import {
+  mobileCommandGateFixture,
+  mobileCommandThreadFixture,
+} from '@/components/jarvis/fixtures'
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('MobileCommandBoard', () => {
+  it('leads with the gate — the hero is above the thread, not inside it', () => {
+    const { container } = render(<MobileCommandBoard />)
+
+    const gate = container.querySelector('[data-jv-gate-state="pending"]')
+    const thread = screen.getByRole('region', { name: 'Thread' })
+    expect(gate).toBeTruthy()
+
+    // The whole point of artboard 03: the gate is not buried in the
+    // conversation. DOCUMENT_POSITION_FOLLOWING === the thread comes after.
+    expect(
+      gate?.compareDocumentPosition(thread) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(thread.contains(gate as Node)).toBe(false)
+  })
+
+  it('renders the real ApprovalGateCard, blast radius and undo path intact', () => {
+    render(<MobileCommandBoard />)
+
+    // Composing a second gate card for mobile would let the honest panel
+    // drift; this asserts the primitive itself is what the phone shows.
+    expect(screen.getByText('APPROVAL REQUIRED')).toBeTruthy()
+    expect(screen.getByText('BLAST RADIUS')).toBeTruthy()
+    expect(screen.getByText('UNDO PATH')).toBeTruthy()
+    expect(screen.getByText(mobileCommandGateFixture.blastRadius)).toBeTruthy()
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  it('condenses the thread and keeps its claim marked CLAIMED, not verified', () => {
+    const { container } = render(<MobileCommandBoard />)
+
+    expect(screen.getByText(mobileCommandThreadFixture.label)).toBeTruthy()
+    expect(screen.getByText(/DISAGREES/)).toBeTruthy()
+    expect(screen.getByText(mobileCommandThreadFixture.delegation)).toBeTruthy()
+
+    const badge = container.querySelector('[data-jv-verification="claimed"]')
+    expect(badge).toBeTruthy()
+    expect(
+      within(badge as HTMLElement).getByText('CLAIMED · UNVERIFIED'),
+    ).toBeTruthy()
+  })
+
+  it('draws the legend with the same marks the thread uses', () => {
+    const { container } = render(<MobileCommandBoard />)
+
+    // The legend is rendered by EpistemicMark itself, so a legend row can
+    // never describe an underline the marks above it do not actually use.
+    for (const kind of ['known', 'recalled', 'assumed']) {
+      expect(container.querySelector(`[data-jv-mark="${kind}"]`)).toBeTruthy()
+    }
+    expect(screen.getByText(/solid/)).toBeTruthy()
+    expect(screen.getByText(/dotted/)).toBeTruthy()
+    expect(screen.getByText(/dashed/)).toBeTruthy()
+  })
+
+  it('labels every unsourced region as a fixture', () => {
+    const { container } = render(<MobileCommandBoard />)
+
+    expect(
+      container.querySelectorAll('[data-jv-fixture="no-source"]').length,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/src/screens/jarvis/command/mobile-command.tsx
+++ b/src/screens/jarvis/command/mobile-command.tsx
@@ -1,0 +1,137 @@
+/**
+ * JARVIS Mobile Command board — artboard 03, 390 × 844.
+ *
+ * A DIFFERENT COMPOSITION, not the desktop board reflowed. Board 01 is a
+ * three-zone workspace that answers "show me everything about this mission";
+ * board 03 is approval-led and answers one question — "what is blocked on me,
+ * and can I unblock it from here" — so the gate is the FIRST thing on the
+ * screen rather than the fourth thing in a conversation, and the two rails
+ * (workers, work trail) are gone entirely rather than stacked underneath. What
+ * survives from board 01 survives because the gate needs it: the thread that
+ * produced the disagreement, the claim the gate turns on, and the legend that
+ * makes the marks readable.
+ *
+ * COMPOSES the Slice 2 primitives and re-styles none of them. The hero gate is
+ * the real `ApprovalGateCard` — the primitive is already fluid (it declares no
+ * width of its own), so the mobile board hands it a 390pt column and it lays
+ * out correctly without a variant. Composing a second gate card here would
+ * have meant two components owning the honest BLAST RADIUS / UNDO PATH panel,
+ * which is the one thing on this board that must not be able to drift.
+ *
+ * FIXTURES ONLY. This file imports no store, no gateway client and no HTTP
+ * endpoint, and opens no request or event stream of any kind — every value
+ * comes from `src/components/jarvis/fixtures.ts`. The NO SOURCE rows from
+ * `docs/design/jarvis-ui-mapping.md` §3.5 are drawn to prove the layout and are
+ * labelled both in the banner above the frame and via `data-jv-fixture=
+ * "no-source"` in the DOM. Nothing on this board is live.
+ *
+ * Fluid, not a 390px box: the frame is `w-full` with 390 as a MAX and 844 as a
+ * MIN, so on a real phone it fills the viewport and on a wider narrow window it
+ * stops at the artboard measure instead of stretching the prose.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. Structural
+ * dimensions come from `JV_MOBILE` (multiples of `--jv-space-4`).
+ */
+import { JV_MOBILE } from './geometry'
+import { MobileComposer } from './mobile-composer'
+import { MobileStatusBar } from './mobile-status-bar'
+import { MobileThread } from './mobile-thread'
+import type {
+  MobileAlertStripFixture,
+  MobileLegendFixture,
+} from '@/components/jarvis/fixtures'
+import {
+  mobileCommandAlertStrip,
+  mobileCommandComposerFixture,
+  mobileCommandGateCaveatFixture,
+  mobileCommandGateFixture,
+  mobileCommandLegendFixtures,
+  mobileCommandThreadFixture,
+  mobileStatusBarFixture,
+} from '@/components/jarvis/fixtures'
+import { ApprovalGateCard } from '@/components/jarvis/approval-gate-card'
+import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
+
+/** `1 GATE WAITING · 2 running · 1 blocked` — the strip under the status bar. */
+function AlertStrip({ data }: { data: MobileAlertStripFixture }) {
+  return (
+    <div className="flex flex-none items-center gap-jv-8 border-b border-jv-blocked-line bg-jv-blocked-bg px-jv-14 py-jv-8">
+      <span
+        aria-hidden="true"
+        className="h-jv-5 w-jv-5 flex-none rounded-jv-full bg-jv-blocked"
+      />
+      <span className="font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wider text-jv-blocked">
+        {data.gateLabel}
+      </span>
+      <div className="flex-1" />
+      <span className="font-jv-mono text-jv-sm leading-jv-none whitespace-nowrap text-jv-label">
+        {data.counts}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * `solid known · dotted recalled · dashed assumed`.
+ *
+ * The kind word wears its own underline via `EpistemicMark`, so the legend is
+ * drawn by the very component it documents — it cannot describe a rule the
+ * marks above it do not actually use.
+ */
+function MarkLegend({ marks }: { marks: Array<MobileLegendFixture> }) {
+  return (
+    <div className="flex flex-none flex-wrap items-baseline gap-jv-9 border-t border-jv-line-soft bg-jv-surface-0 px-jv-14 py-jv-9 font-jv-sans text-jv-md leading-jv-loose text-jv-label">
+      {marks.map((entry, index) => (
+        <span key={entry.mark}>
+          {index > 0 ? (
+            <span aria-hidden="true" className="text-jv-label-ghost">
+              {'· '}
+            </span>
+          ) : null}
+          {`${entry.style} `}
+          <EpistemicMark mark={entry.mark}>{entry.label}</EpistemicMark>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** The mobile frame on its own — what artboard 03 shows, fluid to the viewport. */
+export function MobileCommandBoard() {
+  return (
+    <div
+      data-jv-board="mobile-command"
+      className="flex w-full flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans tracking-normal text-jv-text"
+      style={{
+        maxWidth: JV_MOBILE.frameWidth,
+        minHeight: JV_MOBILE.frameHeight,
+      }}
+    >
+      <MobileStatusBar data={mobileStatusBarFixture} />
+      <AlertStrip data={mobileCommandAlertStrip} />
+
+      <main className="flex min-h-0 flex-1 flex-col gap-jv-16 overflow-y-auto px-jv-14 pt-jv-14 pb-jv-16">
+        {/* The hero: the gate leads the screen, it is not buried in the thread. */}
+        <div data-jv-fixture="no-source">
+          <ApprovalGateCard
+            {...mobileCommandGateFixture}
+            caveat={
+              <>
+                {mobileCommandGateCaveatFixture.lead}
+                <EpistemicMark mark={mobileCommandGateCaveatFixture.mark}>
+                  {mobileCommandGateCaveatFixture.claim}
+                </EpistemicMark>
+                {mobileCommandGateCaveatFixture.trail}
+              </>
+            }
+          />
+        </div>
+
+        <MobileThread thread={mobileCommandThreadFixture} />
+      </main>
+
+      <MarkLegend marks={mobileCommandLegendFixtures} />
+      <MobileComposer data={mobileCommandComposerFixture} />
+    </div>
+  )
+}

--- a/src/screens/jarvis/command/mobile-command.tsx
+++ b/src/screens/jarvis/command/mobile-command.tsx
@@ -63,6 +63,13 @@ import {
 import { ApprovalGateCard } from '@/components/jarvis/approval-gate-card'
 import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
 
+/**
+ * Artboard 03 shortens the gate's two headings to fit a 390pt column. Only the
+ * words change — the same primitive draws the same panel, so the honest cells
+ * still cannot drift from the desktop's.
+ */
+const MOBILE_GATE_CELL_LABELS = { blastRadius: 'RADIUS', undoPath: 'UNDO' }
+
 /** `1 GATE WAITING · 2 running · 1 blocked` — the strip under the status bar. */
 function AlertStrip({ data }: { data: MobileAlertStripFixture }) {
   return (
@@ -187,6 +194,7 @@ export function MobileCommandBoard({
         >
           <ApprovalGateCard
             {...gate.props}
+            cellLabels={MOBILE_GATE_CELL_LABELS}
             caveat={caveat}
             onAction={gate.onAction}
           />

--- a/src/screens/jarvis/command/mobile-command.tsx
+++ b/src/screens/jarvis/command/mobile-command.tsx
@@ -18,12 +18,21 @@
  * have meant two components owning the honest BLAST RADIUS / UNDO PATH panel,
  * which is the one thing on this board that must not be able to drift.
  *
- * FIXTURES ONLY. This file imports no store, no gateway client and no HTTP
- * endpoint, and opens no request or event stream of any kind — every value
- * comes from `src/components/jarvis/fixtures.ts`. The NO SOURCE rows from
- * `docs/design/jarvis-ui-mapping.md` §3.5 are drawn to prove the layout and are
+ * THE HERO GATE CAN BE LIVE (slice 6c). It arrives as a single `GateDisplay`
+ * from the routed screen — a real pending approval when the gateway has one,
+ * `mobileCommandGateFixture` otherwise, which is also what a standalone render
+ * and the tests get. This file itself still opens no request, imports no
+ * gateway client and holds no store subscription; it is a frame, not a fetcher,
+ * and it resolves nothing.
+ *
+ * Live or not, the gate's BLAST RADIUS, UNDO PATH and caveat have NO SOURCE
+ * (`docs/design/jarvis-ui-mapping.md` §3.2): live, the two cells read as an
+ * inert sentinel and the fixture caveat is DROPPED rather than carried over —
+ * "qa has not verified the fix" is a claim about a specific fixture, not
+ * something the approvals endpoint knows. Everything else on this board is
+ * fixtures. The NO SOURCE rows from §3.5 are drawn to prove the layout and are
  * labelled both in the banner above the frame and via `data-jv-fixture=
- * "no-source"` in the DOM. Nothing on this board is live.
+ * "no-source"` in the DOM.
  *
  * Fluid, not a 390px box: the frame is `w-full` with 390 as a MAX and 844 as a
  * MIN, so on a real phone it fills the viewport and on a wider narrow window it
@@ -37,9 +46,11 @@ import { MobileComposer } from './mobile-composer'
 import { MobileStatusBar } from './mobile-status-bar'
 import { MobileThread } from './mobile-thread'
 import type {
+  GateCaveatFixture,
   MobileAlertStripFixture,
   MobileLegendFixture,
 } from '@/components/jarvis/fixtures'
+import type { GateDisplay } from '../conductor/map-approvals'
 import {
   mobileCommandAlertStrip,
   mobileCommandComposerFixture,
@@ -96,8 +107,57 @@ function MarkLegend({ marks }: { marks: Array<MobileLegendFixture> }) {
   )
 }
 
-/** The mobile frame on its own — what artboard 03 shows, fluid to the viewport. */
-export function MobileCommandBoard() {
+/**
+ * The caveat slot. Same three-way rule as the desktop board: the resolve line
+ * when a confirm is pending, the FIXTURE caveat on the fallback only, and
+ * nothing at all on a live gate (§3.2 — the caveat has no source).
+ */
+function GateCaveat({
+  note,
+  caveat,
+}: {
+  note?: string | null
+  caveat?: GateCaveatFixture
+}) {
+  if (note) {
+    return <span data-jv-resolve="note">{note}</span>
+  }
+  if (!caveat) return null
+  return (
+    <>
+      {caveat.lead}
+      <EpistemicMark mark={caveat.mark}>{caveat.claim}</EpistemicMark>
+      {caveat.trail}
+    </>
+  )
+}
+
+/** The slice-3 gate and its caveat, as one prop. Nothing here is live. */
+const FIXTURE_GATE: GateDisplay = {
+  props: mobileCommandGateFixture,
+  caveat: mobileCommandGateCaveatFixture,
+  isLive: false,
+}
+
+/**
+ * The mobile frame on its own — what artboard 03 shows, fluid to the viewport.
+ *
+ * The gate arrives as a prop with the fixture as its default, so the frame
+ * still renders standalone with no query client mounted and the slice-5 board
+ * is unchanged when nothing is passed.
+ */
+export function MobileCommandBoard({
+  gate = FIXTURE_GATE,
+}: {
+  gate?: GateDisplay
+} = {}) {
+  // Undefined, not an element that renders nothing: the card tests the prop for
+  // truthiness, so an "empty" caveat would still open the gap above it.
+  const caveat =
+    gate.note || gate.caveat ? (
+      <GateCaveat note={gate.note} caveat={gate.caveat} />
+    ) : undefined
+
   return (
     <div
       data-jv-board="mobile-command"
@@ -111,21 +171,32 @@ export function MobileCommandBoard() {
       <AlertStrip data={mobileCommandAlertStrip} />
 
       <main className="flex min-h-0 flex-1 flex-col gap-jv-16 overflow-y-auto px-jv-14 pt-jv-14 pb-jv-16">
-        {/* The hero: the gate leads the screen, it is not buried in the thread. */}
-        <div data-jv-fixture="no-source">
+        {/*
+          The hero: the gate leads the screen, it is not buried in the thread.
+          The no-source mark stays on a LIVE gate too — the panel cells and the
+          caveat have no source either way (§3.2). Only the reason changes.
+        */}
+        <div
+          data-jv-fixture="no-source"
+          data-jv-gate-source={gate.isLive ? 'live' : 'fixture'}
+          title={
+            gate.isLive
+              ? 'Live approval — blast radius, undo path and the caveat have no source (§3.2)'
+              : 'Fixture — no pending approval was readable, so the slice-3 gate is drawn'
+          }
+        >
           <ApprovalGateCard
-            {...mobileCommandGateFixture}
-            caveat={
-              <>
-                {mobileCommandGateCaveatFixture.lead}
-                <EpistemicMark mark={mobileCommandGateCaveatFixture.mark}>
-                  {mobileCommandGateCaveatFixture.claim}
-                </EpistemicMark>
-                {mobileCommandGateCaveatFixture.trail}
-              </>
-            }
+            {...gate.props}
+            caveat={caveat}
+            onAction={gate.onAction}
           />
         </div>
+
+        {gate.othersWaiting ? (
+          <div className="font-jv-mono text-jv-sm leading-jv-none text-jv-blocked-dim">
+            {gate.othersWaiting}
+          </div>
+        ) : null}
 
         <MobileThread thread={mobileCommandThreadFixture} />
       </main>

--- a/src/screens/jarvis/command/mobile-composer.tsx
+++ b/src/screens/jarvis/command/mobile-composer.tsx
@@ -1,0 +1,45 @@
+/**
+ * Mobile Command — composer (artboard 03), pinned under the legend.
+ *
+ * `→ ORCH · /verify /hold /status` over `⌘ Instruct JARVIS   SEND`. The desktop
+ * chip row (greenlight / vault / worktree) and the `⇧⏎ newline` hint are both
+ * dropped: they are keyboard affordances and a 390pt column has no keyboard.
+ *
+ * Presentational only, exactly like the desktop composer — the input is a
+ * styled div, not a form control, because this slice wires nothing and an
+ * inert-but-focusable field would lie about what happens when you type in it.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import type { MobileComposerFixture } from '@/components/jarvis/fixtures'
+
+export function MobileComposer({ data }: { data: MobileComposerFixture }) {
+  return (
+    <div className="flex-none border-t border-jv-line bg-jv-surface-0 px-jv-14 pt-jv-10 pb-jv-12">
+      <div className="flex items-center gap-jv-8 font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+        <span className="border border-jv-live-line bg-jv-live-bg px-jv-7 py-jv-3 font-semibold tracking-jv-label-2 text-jv-live">
+          {data.target}
+        </span>
+        <span aria-hidden="true" className="text-jv-label-ghost">
+          ·
+        </span>
+        <span>{data.slashHint}</span>
+      </div>
+
+      <div className="mt-jv-9 flex items-center gap-jv-10 border border-jv-border-input bg-jv-surface-2 px-jv-11 py-jv-10">
+        <span
+          aria-hidden="true"
+          className="font-jv-mono text-jv-xl leading-jv-none font-semibold text-jv-live"
+        >
+          ⌘
+        </span>
+        <span className="flex-1 font-jv-sans text-jv-5xl leading-jv-none text-jv-label-faint">
+          {data.placeholder}
+        </span>
+        <span className="bg-jv-live px-jv-11 py-jv-6 font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap text-jv-surface-0">
+          {data.sendLabel}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/jarvis/command/mobile-status-bar.tsx
+++ b/src/screens/jarvis/command/mobile-status-bar.tsx
@@ -1,0 +1,45 @@
+/**
+ * The phone status bar shared by the two mobile boards (artboards 03 and 04).
+ *
+ * `9:47 · JARVIS · 􀙇 􀛨` — the time, the wordmark, and the artboard's signal
+ * and battery glyphs. The glyphs are literal characters, not icons: the
+ * artboard draws them as text and this slice introduces no iconography.
+ *
+ * Lives in `command/` and is imported by `conductor/` for the same reason
+ * `geometry.ts` does — the two boards already share this directory for
+ * anything neither of them owns alone, and duplicating a 44px bar so it can
+ * sit in "its own" folder would just give the two boards two bars to drift.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. The bar height is
+ * structural and comes from `JV_MOBILE` (a 4px grid multiple plus its rule).
+ */
+import { JV_MOBILE } from './geometry'
+import type { MobileStatusBarFixture } from '@/components/jarvis/fixtures'
+
+export function MobileStatusBar({ data }: { data: MobileStatusBarFixture }) {
+  return (
+    <header
+      className="flex flex-none items-center gap-jv-12 border-b border-jv-line bg-jv-surface-2 px-jv-14"
+      style={{ height: JV_MOBILE.statusBarHeight }}
+    >
+      <span className="font-jv-mono text-jv-md leading-jv-none font-medium text-jv-text">
+        {data.time}
+      </span>
+
+      <div className="flex-1" />
+
+      <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-ultra text-jv-live">
+        {data.wordmark}
+      </span>
+
+      <div className="flex-1" />
+
+      <span
+        aria-hidden="true"
+        className="font-jv-mono text-jv-md leading-jv-none text-jv-text-faint"
+      >
+        {data.glyphs}
+      </span>
+    </header>
+  )
+}

--- a/src/screens/jarvis/command/mobile-thread.tsx
+++ b/src/screens/jarvis/command/mobile-thread.tsx
@@ -1,0 +1,124 @@
+/**
+ * Mobile Command — the condensed thread (artboard 03).
+ *
+ * The desktop board gives a turn a speaker gutter, a 640px measure, an
+ * evidence pair and a delegation note. At 390pt none of that survives, so this
+ * is a RECOMPOSITION rather than a narrower `conversation.tsx`: the speaker
+ * moves above the prose, the thread keeps only the two turns that carry the
+ * disagreement, and the evidence collapses to the single CLAIMED strip that
+ * the gate above actually depends on.
+ *
+ * It still COMPOSES the same primitives and re-styles neither:
+ *   • `EpistemicMark`     — the inline KN / RC / AS claims
+ *   • `VerificationBadge` — the compact CLAIMED strip
+ *
+ * Honesty notes (`docs/design/jarvis-ui-mapping.md` §3.5): the epistemic marks
+ * (item 1), verified/claimed on a chat turn (items 2–3) and the DISAGREES
+ * stance (item 4) all have NO SOURCE today and carry `data-jv-fixture=
+ * "no-source"`.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import type {
+  MobileThreadFixture,
+  MobileThreadTurnFixture,
+  RichSpan,
+} from '@/components/jarvis/fixtures'
+import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
+import { VerificationBadge } from '@/components/jarvis/verification-badge'
+
+const SECTION_LABEL_CLASS =
+  'font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest text-jv-label'
+
+/**
+ * Same span vocabulary as the desktop conversation, minus the streaming caret:
+ * the mobile artboard's thread is history, and nothing in it is in flight.
+ */
+function RichText({ spans }: { spans: Array<RichSpan> }) {
+  return (
+    <>
+      {spans.map((span, index) => {
+        // Fixture spans are a static, ordered list — index is a stable key.
+        const key = `${span.kind}-${index}`
+        switch (span.kind) {
+          case 'code':
+            return (
+              <span
+                key={key}
+                className="font-jv-mono text-jv-xl text-jv-text-muted"
+              >
+                {span.text}
+              </span>
+            )
+          case 'mark':
+            return (
+              <EpistemicMark key={key} mark={span.mark}>
+                <RichText spans={span.spans} />
+              </EpistemicMark>
+            )
+          case 'text':
+            return <span key={key}>{span.text}</span>
+          // The thread is history; nothing in it is still streaming.
+          case 'caret':
+            return null
+        }
+      })}
+    </>
+  )
+}
+
+function Turn({ turn }: { turn: MobileThreadTurnFixture }) {
+  const body = (
+    <div className="mt-jv-6 font-jv-sans text-jv-3xl leading-jv-loose-3 text-jv-text-body">
+      <RichText spans={turn.body} />
+    </div>
+  )
+
+  return (
+    <article>
+      <div className="flex items-baseline gap-jv-7 font-jv-mono text-jv-2xs leading-jv-none">
+        <span className="font-semibold tracking-jv-wider text-jv-live">
+          {turn.speaker}
+        </span>
+        <span className="text-jv-label-ghost">{turn.time}</span>
+        {turn.stance ? (
+          <span
+            data-jv-fixture="no-source"
+            className="font-semibold tracking-jv-wider-2 text-jv-assumed-sup"
+          >
+            {`· ${turn.stance}`}
+          </span>
+        ) : null}
+      </div>
+
+      {turn.stance ? (
+        <div className="border-l border-jv-border-btn pl-jv-11">{body}</div>
+      ) : (
+        body
+      )}
+    </article>
+  )
+}
+
+export function MobileThread({ thread }: { thread: MobileThreadFixture }) {
+  return (
+    <section aria-label="Thread" className="flex flex-col gap-jv-11">
+      <div className={SECTION_LABEL_CLASS}>{thread.label}</div>
+
+      {thread.turns.map((turn) => (
+        <Turn key={turn.id} turn={turn} />
+      ))}
+
+      <div
+        data-jv-fixture="no-source"
+        className="font-jv-mono text-jv-base leading-jv-none text-jv-live"
+      >
+        {thread.delegation}
+      </div>
+
+      <div data-jv-fixture="no-source">
+        <VerificationBadge {...thread.evidence} />
+      </div>
+    </section>
+  )
+}

--- a/src/screens/jarvis/command/work-trail.tsx
+++ b/src/screens/jarvis/command/work-trail.tsx
@@ -1,0 +1,252 @@
+/**
+ * Desktop Command — right rail (artboard 01, 320px): WORK TRAIL.
+ *
+ * Delegation chain → files touched → tool calls → tokens/cost footer.
+ *
+ * Honesty notes, all from `docs/design/jarvis-ui-mapping.md` §3.5:
+ *   • the chain is a LAYOUT CONVENTION (item 14) — no parent→child edge graph
+ *     is modelled anywhere today, so the fixed four-node chain is drawn, not
+ *     captured, and the section says so;
+ *   • files touched (item 8) and per-tool-call duration (item 9) have no
+ *     source at all.
+ * Each carries `data-jv-fixture="no-source"`.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import { clsx } from 'clsx'
+import { JV_BOARD } from './geometry'
+import type {
+  ChainNodeFixture,
+  ChainNodeState,
+  FileChange,
+  FileTouchedFixture,
+  ToolCallFixture,
+  ToolCallState,
+  WorkTrailChromeFixture,
+} from '@/components/jarvis/fixtures'
+
+const SECTION_LABEL_CLASS =
+  'font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest text-jv-label-ghost'
+
+/** `jv-ring` is the artboard's active-node halo; the queued/done nodes are outlines. */
+const CHAIN_STATES: Record<
+  ChainNodeState,
+  { marker: string; connector: string; name: string; detail: string }
+> = {
+  done: {
+    marker: 'border border-jv-known-rule bg-jv-surface-0',
+    connector: 'bg-jv-border-input',
+    name: 'text-jv-text-faint font-medium',
+    detail: 'text-jv-label-faint',
+  },
+  active: {
+    marker: 'bg-jv-live animate-jv-ring',
+    connector: 'bg-jv-live-line',
+    name: 'text-jv-live font-semibold',
+    detail: 'text-jv-text-detail',
+  },
+  queued: {
+    marker: 'border border-jv-dot-idle',
+    connector: 'bg-jv-border-input',
+    name: 'text-jv-label-dim font-medium',
+    detail: 'text-jv-label-ghost',
+  },
+}
+
+const FILE_CHANGES: Record<FileChange, string> = {
+  M: 'text-jv-verified',
+  A: 'text-jv-live',
+  D: 'text-jv-failed',
+}
+
+const TOOL_CALL_STATES: Record<
+  ToolCallState,
+  { row: string; time: string; label: string; result: string }
+> = {
+  ok: {
+    row: '',
+    time: 'text-jv-label-ghost',
+    label: 'text-jv-text-dim',
+    result: 'text-jv-label-faint',
+  },
+  failed: {
+    row: '',
+    time: 'text-jv-label-ghost',
+    label: 'text-jv-text-dim',
+    result: 'text-jv-failed-muted',
+  },
+  live: {
+    row: 'bg-jv-surface-3',
+    time: 'text-jv-live',
+    label: 'text-jv-text',
+    result: 'text-jv-live animate-jv-pulse-fast',
+  },
+}
+
+function ChainNode({ node, last }: { node: ChainNodeFixture; last: boolean }) {
+  const tokens = CHAIN_STATES[node.state]
+
+  return (
+    <div data-jv-chain-state={node.state} className="flex gap-jv-10">
+      <div className="flex w-jv-9 flex-none flex-col items-center">
+        <span
+          aria-hidden="true"
+          className={clsx('mt-jv-4 h-jv-7 w-jv-7 flex-none', tokens.marker)}
+        />
+        {last ? null : (
+          <span
+            aria-hidden="true"
+            className={clsx('w-jv-1 flex-1', tokens.connector)}
+          />
+        )}
+      </div>
+
+      <div className={clsx('flex-1', last ? '' : 'pb-jv-11')}>
+        <div className="flex items-baseline justify-between gap-jv-8">
+          <span
+            className={clsx(
+              'font-jv-mono text-jv-lg leading-jv-snug',
+              tokens.name,
+            )}
+          >
+            {node.name}
+          </span>
+          {node.time ? (
+            <span className="font-jv-mono text-jv-sm leading-jv-snug text-jv-live">
+              {node.time}
+            </span>
+          ) : null}
+        </div>
+        <div
+          className={clsx(
+            'mt-jv-3 font-jv-mono text-jv-sm leading-jv-normal-2',
+            tokens.detail,
+          )}
+        >
+          {node.detail.map((line) => (
+            <div key={line}>{line}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function WorkTrail({
+  chain,
+  files,
+  toolCalls,
+  chrome,
+}: {
+  chain: Array<ChainNodeFixture>
+  files: Array<FileTouchedFixture>
+  toolCalls: Array<ToolCallFixture>
+  chrome: WorkTrailChromeFixture
+}) {
+  return (
+    <aside
+      aria-label="Work trail"
+      className="flex flex-none flex-col border-l border-jv-line bg-jv-surface-0"
+      style={{ width: JV_BOARD.rightRailWidth }}
+    >
+      <div className="flex items-baseline justify-between border-b border-jv-line-soft px-jv-14 pt-jv-13 pb-jv-10">
+        <span className="font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest text-jv-label">
+          WORK TRAIL
+        </span>
+        <span className="font-jv-mono text-jv-sm leading-jv-none font-medium text-jv-live">
+          {chrome.elapsed}
+        </span>
+      </div>
+
+      <div
+        data-jv-fixture="no-source"
+        title="Layout convention — no parent→child delegation graph is captured today"
+        className={clsx(SECTION_LABEL_CLASS, 'px-jv-14 pt-jv-14 pb-jv-4')}
+      >
+        DELEGATION CHAIN
+      </div>
+      <div className="flex flex-col px-jv-14 pt-jv-8 pb-jv-14">
+        {chain.map((node, index) => (
+          <ChainNode
+            key={node.name}
+            node={node}
+            last={index === chain.length - 1}
+          />
+        ))}
+      </div>
+
+      <div
+        data-jv-fixture="no-source"
+        className={clsx(
+          SECTION_LABEL_CLASS,
+          'border-t border-jv-line-soft px-jv-14 pt-jv-10 pb-jv-4',
+        )}
+      >
+        {`FILES TOUCHED · ${files.length}`}
+      </div>
+      <div className="px-jv-14 pt-jv-6 pb-jv-12 font-jv-mono text-jv-base leading-jv-max text-jv-text-faint">
+        {files.map((file) => (
+          <div key={file.path}>
+            <span className={FILE_CHANGES[file.change]}>{file.change}</span>{' '}
+            {file.path} <span className="text-jv-label-faint">{file.diff}</span>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className={clsx(
+          SECTION_LABEL_CLASS,
+          'border-t border-jv-line-soft px-jv-14 pt-jv-10 pb-jv-4',
+        )}
+      >
+        TOOL CALLS
+      </div>
+      <div className="flex flex-col pt-jv-4">
+        {toolCalls.map((call) => {
+          const tokens = TOOL_CALL_STATES[call.state]
+          return (
+            <div
+              key={`${call.time}-${call.label}`}
+              data-jv-tool-call-state={call.state}
+              className={clsx(
+                'flex gap-jv-8 px-jv-14 py-jv-5 font-jv-mono text-jv-base leading-jv-normal',
+                tokens.row,
+              )}
+            >
+              <span
+                className={clsx('flex-none', tokens.time)}
+                style={{ width: JV_BOARD.toolCallTimeWidth }}
+              >
+                {call.time}
+              </span>
+              <span className={clsx('flex-1 truncate', tokens.label)}>
+                {call.label}
+              </span>
+              <span
+                data-jv-fixture={call.state === 'ok' ? 'no-source' : undefined}
+                className={tokens.result}
+              >
+                {call.result}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex-1" />
+
+      <div className="flex items-center gap-jv-8 border-t border-jv-line px-jv-14 py-jv-11">
+        <span className="flex-1 font-jv-mono text-jv-sm leading-jv-relaxed-2 text-jv-label-faint">
+          {chrome.footerLines.map((line) => (
+            <span key={line} className="block">
+              {line}
+            </span>
+          ))}
+        </span>
+        <span className="border border-jv-border-btn px-jv-9 py-jv-6 font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap text-jv-text-faint">
+          {chrome.holdLabel}
+        </span>
+      </div>
+    </aside>
+  )
+}

--- a/src/screens/jarvis/command/worker-rail.tsx
+++ b/src/screens/jarvis/command/worker-rail.tsx
@@ -1,0 +1,125 @@
+/**
+ * Desktop Command — left rail (artboard 01, 220px): WORKERS then THREADS,
+ * with the ctx/worktree footer pinned to the bottom.
+ *
+ * The worker list COMPOSES the Slice 2 `WorkerStatusLine` primitive — every row
+ * is one call, no row is re-styled here. The rail only supplies the frame, the
+ * section labels and the thread rows the primitive does not cover.
+ *
+ * Fixture-driven and inert. `ctx 41%` in the footer is NO SOURCE
+ * (`docs/design/jarvis-ui-mapping.md` §3.5 item 10) and is marked as fixture
+ * data in the DOM.
+ *
+ * Token discipline: no raw colour, size, spacing or radius.
+ */
+import { clsx } from 'clsx'
+import { JV_BOARD } from './geometry'
+import type { ThreadFixture, ThreadTone } from '@/components/jarvis/fixtures'
+import type { WorkerStatusLineProps } from '@/components/jarvis/types'
+import { WorkerStatusLine } from '@/components/jarvis/worker-status-line'
+
+const SECTION_LABEL_CLASS =
+  'font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest text-jv-label'
+
+/** Tone drives both the title and the meta line — see the artboard rail. */
+const THREAD_TONES: Record<
+  ThreadTone,
+  { row: string; title: string; meta: string }
+> = {
+  active: {
+    row: 'bg-jv-surface-3',
+    title: 'text-jv-text',
+    meta: 'text-jv-live',
+  },
+  idle: { row: '', title: 'text-jv-text-dim', meta: 'text-jv-label-faint' },
+  attention: {
+    row: '',
+    title: 'text-jv-text-dim',
+    meta: 'text-jv-failed-muted',
+  },
+}
+
+export function WorkerRail({
+  workers,
+  counts,
+  threads,
+  footerLines,
+}: {
+  workers: Array<WorkerStatusLineProps>
+  counts: string
+  threads: Array<ThreadFixture>
+  footerLines: Array<string>
+}) {
+  return (
+    <nav
+      aria-label="Workers and threads"
+      className="flex flex-none flex-col border-r border-jv-line bg-jv-surface-0"
+      style={{ width: JV_BOARD.leftRailWidth }}
+    >
+      <div className="flex items-baseline justify-between px-jv-14 pt-jv-13 pb-jv-9">
+        <span className={SECTION_LABEL_CLASS}>WORKERS</span>
+        <span className="font-jv-mono text-jv-2xs leading-jv-none text-jv-label-ghost">
+          {counts}
+        </span>
+      </div>
+
+      {/* The primitive draws only a top rule, so the list closes itself. */}
+      <div className="flex flex-col border-b border-jv-line-soft">
+        {workers.map((worker) => (
+          <WorkerStatusLine key={worker.name} {...worker} />
+        ))}
+      </div>
+
+      <div
+        className={clsx(SECTION_LABEL_CLASS, 'px-jv-14 pb-jv-9')}
+        style={{ paddingTop: JV_BOARD.gap18 }}
+      >
+        THREADS
+      </div>
+
+      <div className="flex flex-col border-b border-jv-line-soft">
+        {threads.map((thread) => {
+          const tone = THREAD_TONES[thread.tone]
+          return (
+            <div
+              key={thread.title}
+              data-jv-thread-tone={thread.tone}
+              className={clsx(
+                'border-t border-jv-line-soft px-jv-14 py-jv-8',
+                tone.row,
+              )}
+            >
+              <div
+                className={clsx(
+                  'font-jv-sans text-jv-lg leading-jv-normal font-medium',
+                  tone.title,
+                )}
+              >
+                {thread.title}
+              </div>
+              <div
+                className={clsx(
+                  'mt-jv-3 font-jv-mono text-jv-xs leading-jv-none',
+                  tone.meta,
+                )}
+              >
+                {thread.meta}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex-1" />
+
+      <div
+        data-jv-fixture="no-source"
+        className="border-t border-jv-line px-jv-14 py-jv-12 font-jv-mono text-jv-xs leading-jv-loose text-jv-label-ghost"
+      >
+        {footerLines.map((line) => (
+          <div key={line}>{line}</div>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/src/screens/jarvis/conductor/conductor-chrome.tsx
+++ b/src/screens/jarvis/conductor/conductor-chrome.tsx
@@ -1,0 +1,88 @@
+/**
+ * Desktop Conductor — the two bits of chrome all three sections share: the
+ * section heading (label + dim caption) and the action chip.
+ *
+ * Extracted because WORKER BOARD, SCHEDULED JOBS and RUN LOG draw the same
+ * heading, and because the chips on a worker card and on a job card are the
+ * same four variants. Keeping one copy means the amber "waiting on a human"
+ * chip cannot drift between the two places it appears.
+ *
+ * Chips are PRESENTATIONAL — spans, not buttons, with no handler. Nothing on
+ * this board acts; slice 6 decides what OPEN GATE or RELOAD & RUN actually do.
+ *
+ * Token discipline: no raw colour, size, spacing or radius in this file.
+ */
+import { clsx } from 'clsx'
+import type {
+  ConductorChipFixture,
+  ConductorChipTone,
+  ConductorSectionHeadingFixture,
+} from '@/components/jarvis/fixtures'
+
+const CHIP_BASE =
+  'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap'
+
+const CHIP_TONES: Record<ConductorChipTone, string> = {
+  // Recedes: this is the "don't touch unless you mean it" affordance.
+  hold: 'border border-jv-border-btn px-jv-7 py-jv-5 text-jv-text-faint',
+  outline: 'border border-jv-border-btn-2 px-jv-8 py-jv-5 text-jv-text-dim',
+  // Filled chips invert — board surface on the reserved hue.
+  blocked: 'bg-jv-blocked px-jv-8 py-jv-5 text-jv-surface-1',
+  failed: 'bg-jv-failed px-jv-8 py-jv-5 text-jv-surface-1',
+}
+
+export function ConductorChip({ chip }: { chip: ConductorChipFixture }) {
+  return (
+    <span
+      data-jv-chip-tone={chip.tone}
+      className={clsx(CHIP_BASE, CHIP_TONES[chip.tone])}
+    >
+      {chip.label}
+    </span>
+  )
+}
+
+/**
+ * `SECTION LABEL   dim caption`, optionally with something pushed to the right
+ * (the run log's tally) and a `no-source` mark on the caption.
+ */
+export function ConductorSectionHeading({
+  heading,
+  trailing,
+  noSource,
+  className,
+  title,
+}: {
+  heading: ConductorSectionHeadingFixture
+  trailing?: string
+  /** Marks the CAPTION as fixture-only — used for the chain description. */
+  noSource?: boolean
+  className?: string
+  title?: string
+}) {
+  return (
+    <div className={clsx('flex items-baseline gap-jv-12', className)}>
+      <span className="font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest whitespace-nowrap text-jv-label">
+        {heading.label}
+      </span>
+      <span
+        data-jv-fixture={noSource ? 'no-source' : undefined}
+        title={title}
+        className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-ghost"
+      >
+        {heading.note}
+        {heading.noteAccent ? (
+          <span className="text-jv-text-faint">{heading.noteAccent}</span>
+        ) : null}
+      </span>
+      {trailing ? (
+        <>
+          <span className="flex-1" />
+          <span className="font-jv-mono text-jv-sm leading-jv-none whitespace-nowrap text-jv-label-faint">
+            {trailing}
+          </span>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/screens/jarvis/conductor/conductor-topbar.tsx
+++ b/src/screens/jarvis/conductor/conductor-topbar.tsx
@@ -1,0 +1,73 @@
+/**
+ * Desktop Conductor — top bar (artboard 02, 44px).
+ *
+ * Wordmark · COMMAND/CONDUCTOR tab pair · fleet status line · date.
+ *
+ * The tabs are the only navigation on this board and they are presentational:
+ * the active tab is a plain span, and the inactive one is a `<Link>` purely so
+ * the two dev boards are reachable from each other. No tab state, no handler.
+ *
+ * The status line is hue-coded — `failed` in `--jv-failed`, `stale` in
+ * `--jv-blocked` — so it is supplied pre-split by the fixture rather than
+ * parsed out of one string here.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. The only non-token
+ * numbers are structural, and they come from `JV_BOARD` (4px grid multiples).
+ */
+import { Link } from '@tanstack/react-router'
+import { clsx } from 'clsx'
+import { JV_BOARD } from '../command/geometry'
+import type { ConductorTopbarFixture } from '@/components/jarvis/fixtures'
+
+const TAB_CLASS =
+  'px-jv-10 py-jv-6 font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wide-2'
+
+export function ConductorTopbar({ data }: { data: ConductorTopbarFixture }) {
+  return (
+    <header
+      className="flex flex-none items-center border-b border-jv-line bg-jv-surface-2 px-jv-16"
+      style={{ height: JV_BOARD.topbarHeight, gap: JV_BOARD.gap18 }}
+    >
+      <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-ultra text-jv-live">
+        JARVIS
+      </span>
+
+      <span aria-hidden="true" className="h-jv-16 w-jv-1 bg-jv-border-muted" />
+
+      <nav aria-label="Boards" className="flex gap-jv-2">
+        {data.tabs.map((tab) =>
+          tab.active || !tab.href ? (
+            <span
+              key={tab.label}
+              aria-current={tab.active ? 'page' : undefined}
+              className={clsx(TAB_CLASS, 'bg-jv-surface-5 text-jv-text')}
+            >
+              {tab.label}
+            </span>
+          ) : (
+            <Link
+              key={tab.label}
+              to={tab.href}
+              className={clsx(TAB_CLASS, 'text-jv-label-dim')}
+            >
+              {tab.label}
+            </Link>
+          ),
+        )}
+      </nav>
+
+      <div className="flex-1" />
+
+      <div className="font-jv-mono text-jv-md leading-jv-none whitespace-nowrap text-jv-text-faint">
+        {data.statusLead}
+        <span className="text-jv-failed">{data.statusFailed}</span>
+        {' · '}
+        <span className="text-jv-blocked">{data.statusStale}</span>
+      </div>
+
+      <div className="font-jv-mono text-jv-md leading-jv-none whitespace-nowrap text-jv-label">
+        {data.date}
+      </div>
+    </header>
+  )
+}

--- a/src/screens/jarvis/conductor/desktop-conductor.tsx
+++ b/src/screens/jarvis/conductor/desktop-conductor.tsx
@@ -1,5 +1,18 @@
 /**
- * JARVIS Desktop Conductor board — artboard 02, fixed 1440×900.
+ * JARVIS Conductor — the routed screen, plus the Desktop Conductor board itself
+ * (artboard 02, fixed 1440×900).
+ *
+ * Slice 5 makes the ROUTE responsive without touching the board. At `lg` and
+ * above the screen renders `DesktopConductorBoard` exactly as slice 4 drew it;
+ * below `lg` it renders `MobileConductorBoard` — artboard 04, a glance surface
+ * that collapses the survey into four numbers and the two things that are
+ * broken — rather than reflowing a 1440 board into 390. The swap is CSS
+ * (`hidden` / `flex`), not a media-query hook, so there is no viewport read to
+ * get wrong on first paint.
+ *
+ * `DesktopConductorScreen` keeps its slice-4 name because `src/routes/
+ * jarvis-conductor.tsx` imports it and routes are out of scope for this slice.
+ * It is the Conductor screen at every width, not the desktop one.
  *
  * Top bar (COMMAND/CONDUCTOR tabs) over three stacked sections: WORKER BOARD,
  * SCHEDULED JOBS, RUN LOG · UNATTENDED. Where the Command board answers "what
@@ -42,8 +55,9 @@
  * `--jv-space-4`).
  */
 import { useEffect } from 'react'
-import { JV_BOARD } from '../command/geometry'
+import { JV_BOARD, JV_MOBILE } from '../command/geometry'
 import { ConductorTopbar } from './conductor-topbar'
+import { MobileConductorBoard } from './mobile-conductor'
 import { RunLog } from './run-log'
 import { ScheduledJobs } from './scheduled-jobs'
 import { WorkerBoard } from './worker-board'
@@ -57,6 +71,7 @@ import {
   conductorTopbarFixture,
   conductorWorkerBoardHeading,
   conductorWorkerCardFixtures,
+  mobileFixtureNotice,
 } from '@/components/jarvis/fixtures'
 
 const THEME_ATTRIBUTE = 'data-theme'
@@ -106,13 +121,19 @@ export function DesktopConductorBoard() {
   )
 }
 
-/** The dev route's page: the honesty banner, then the frame. */
+/**
+ * The dev route's page. One route, two compositions: the desktop board at `lg`
+ * and above, the mobile board below it. Both are mounted and CSS picks one —
+ * they are inert fixture boards, so nothing is paid for the hidden one beyond
+ * its markup, and a CSS swap cannot mismatch on first paint the way a
+ * `matchMedia` read can.
+ */
 export function DesktopConductorScreen() {
   useJarvisThemeAttribute()
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
-      <div className="flex flex-col items-center gap-jv-16 p-jv-24">
+      <div className="hidden flex-col items-center gap-jv-16 p-jv-24 lg:flex">
         <header
           className="flex w-full flex-col gap-jv-6"
           style={{ maxWidth: JV_BOARD.frameWidth }}
@@ -137,6 +158,30 @@ export function DesktopConductorScreen() {
         </header>
 
         <DesktopConductorBoard />
+      </div>
+
+      <div className="flex flex-col items-center gap-jv-12 p-jv-14 lg:hidden">
+        <header
+          className="flex w-full flex-col gap-jv-6"
+          style={{ maxWidth: JV_MOBILE.frameWidth }}
+        >
+          <div className="flex items-baseline gap-jv-9">
+            <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider-2 text-jv-live">
+              04 · MOBILE CONDUCTOR
+            </span>
+            <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+              390 × 844
+            </span>
+          </div>
+          <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
+            {mobileFixtureNotice}
+          </p>
+          <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
+            {conductorNoSourceNotice}
+          </p>
+        </header>
+
+        <MobileConductorBoard />
       </div>
     </div>
   )

--- a/src/screens/jarvis/conductor/desktop-conductor.tsx
+++ b/src/screens/jarvis/conductor/desktop-conductor.tsx
@@ -21,25 +21,37 @@
  * job wears a hazard-striped red frame and the silent one an amber frame, both
  * carrying the diagnostic and the chip you would actually reach for.
  *
- * ONE SECTION IS LIVE (slice 6a). SCHEDULED JOBS reads real `ClaudeJob` records
- * through `useScheduledJobs` — the same `['claude','jobs']` query the product
- * jobs screen runs, GET only, no mutation anywhere on this board. Everything
- * else (worker board, run log, top bar) is still fixtures, and worker status
- * has a real source it does not yet read (§3.3) — that is slice 6b.
+ * TWO SECTIONS ARE LIVE. SCHEDULED JOBS reads real `ClaudeJob` records through
+ * `useScheduledJobs` (slice 6a) — the same `['claude','jobs']` query the product
+ * jobs screen runs. The WORKER BOARD reads real swarm sessions through
+ * `useWorkers` (slice 6b), with `blocked` joined from the pending approvals
+ * queue. Both are GET only; no mutation anywhere on this board. The RUN LOG and
+ * the top bar are still fixtures.
+ *
+ * The two wires are INDEPENDENT: jobs can be live while workers fall back, or
+ * the reverse, so the banner reports each separately rather than declaring the
+ * whole board live off one of them.
  *
  * When the gateway is unreachable — the normal case for an offline design
- * review — the hook returns the slice-4 fixtures and `isLive: false`, and the
+ * review — the hooks return the slice-4 fixtures and `isLive: false`, and the
  * board renders exactly as it did before. The banner above the frame says which
  * of the two you are looking at; it is never left claiming "every value is
  * invented" over live data, or the reverse.
  *
  * Live cards carry no `data-jv-fixture="no-source"` marks, because nothing
- * unsourced is drawn for a real job: no PARTIAL badge (§3.5 item 11), no
- * launchd diagnostic (item 12), no invented duration or payload count, and no
- * action chips at all — TRIAGE / FULL LOG / RELOAD & RUN each imply a write
- * this read-only slice cannot do. Those elements survive only on the fixture
- * fallback, where they stay labelled as fixtures both in the banner and via
- * `data-jv-fixture="no-source"` in the DOM.
+ * unsourced is drawn for a real job or a real worker: no PARTIAL badge (§3.5
+ * item 11), no launchd diagnostic (item 12), no invented duration, payload count
+ * or per-worker narrative, no chain connector between real workers (item 14),
+ * and no action chips at all — TRIAGE / FULL LOG / RELOAD & RUN, HOLD ⌥ and
+ * OPEN GATE each imply a write this read-only slice cannot do. Those elements
+ * survive only on the fixture fallback, where they stay labelled as fixtures
+ * both in the banner and via `data-jv-fixture="no-source"` in the DOM.
+ *
+ * One over-mark is deliberate. `worker-board.tsx` renders its caption inside a
+ * `data-jv-fixture="no-source"` span unconditionally, so the live caption — a
+ * real roster count — keeps that mark; changing it would mean editing that
+ * file's rendering, which is out of scope here. Over-marking under-claims, which
+ * is the safe direction to be wrong.
  *
  * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
  * so the board sets that attribute on <html> for as long as it is mounted and
@@ -66,8 +78,10 @@ import { MobileConductorBoard } from './mobile-conductor'
 import { RunLog } from './run-log'
 import { ScheduledJobs } from './scheduled-jobs'
 import { useScheduledJobs } from './use-scheduled-jobs'
+import { useWorkers } from './use-workers'
 import { WorkerBoard } from './worker-board'
 import type { ScheduledJobsData } from './use-scheduled-jobs'
+import type { WorkersData } from './use-workers'
 import {
   conductorFixtureNotice,
   conductorJobFixtures,
@@ -101,17 +115,68 @@ function useJarvisThemeAttribute() {
 }
 
 /**
- * The honesty banner has two readings now, and the board must not show the
- * wrong one. `conductorFixtureNotice` says every value is invented — true only
- * while the fallback is up. These say what is actually on screen when SCHEDULED
- * JOBS is live; the NO SOURCE notice below them is printed either way, because
- * that list is about the design, not about the connection.
+ * The honesty banner now has FOUR readings, because the two wires fail
+ * independently: jobs live, workers live, both, or neither.
+ * `conductorFixtureNotice` says every value is invented — true only when
+ * neither is up — so the banner is assembled per section instead of picked from
+ * a pair of constants. The NO SOURCE notice below it is printed either way,
+ * because that list is about the design, not about the connection.
  */
-const conductorLiveJobsNotice =
-  'SCHEDULED JOBS is LIVE — real ClaudeJob records read from the gateway (GET /api/claude-jobs, the same query the jobs screen runs). Read-only: this board issues no write of any kind, so live cards carry no action chips and nothing without a source is drawn on them. Every other section — worker board, run log, top bar — is still invented fixtures.'
+const LIVE_WORKERS_CLAUSE =
+  'The WORKER BOARD is LIVE — real swarm sessions (GET /api/gateway/sessions), with BLOCKED joined from the pending approvals queue (GET /api/gateway/approvals). Status is the swarm store’s heuristic, not an authoritative gateway signal, and a real card draws no per-worker narrative and no chain connector, because neither has a source.'
 
-const mobileLiveJobsNotice =
-  'SCHEDULE HEALTH is LIVE — the same real ClaudeJob records as the desktop board, collapsed to what is unhealthy. Read-only. Every other section on this frame is still invented fixtures.'
+const LIVE_JOBS_CLAUSE =
+  'SCHEDULED JOBS is LIVE — real ClaudeJob records read from the gateway (GET /api/claude-jobs, the same query the jobs screen runs).'
+
+const READ_ONLY_CLAUSE =
+  'Read-only: this board issues no write of any kind, so live cards carry no action chips and nothing without a source is drawn on them.'
+
+const MOBILE_LIVE_WORKERS_CLAUSE =
+  'The stat strip and RUNNING NOW are LIVE — counted from the same real swarm sessions as the desktop board, BLOCKED joined from pending approvals.'
+
+const MOBILE_LIVE_JOBS_CLAUSE =
+  'SCHEDULE HEALTH is LIVE — the same real ClaudeJob records as the desktop board, collapsed to what is unhealthy.'
+
+function buildNotice(
+  fallback: string,
+  clauses: Array<string>,
+  stillFixture: Array<string>,
+): string {
+  if (clauses.length === 0) return fallback
+  return `${clauses.join(' ')} ${READ_ONLY_CLAUSE} Still invented fixtures: ${stillFixture.join(' · ')}.`
+}
+
+function buildConductorNotice(
+  workersLive: boolean,
+  jobsLive: boolean,
+): string {
+  const clauses: Array<string> = []
+  const stillFixture: Array<string> = []
+
+  if (workersLive) clauses.push(LIVE_WORKERS_CLAUSE)
+  else stillFixture.push('the worker board')
+  if (jobsLive) clauses.push(LIVE_JOBS_CLAUSE)
+  else stillFixture.push('scheduled jobs')
+  stillFixture.push('the run log', 'the top bar')
+
+  return buildNotice(conductorFixtureNotice, clauses, stillFixture)
+}
+
+function buildMobileConductorNotice(
+  workersLive: boolean,
+  jobsLive: boolean,
+): string {
+  const clauses: Array<string> = []
+  const stillFixture: Array<string> = []
+
+  if (workersLive) clauses.push(MOBILE_LIVE_WORKERS_CLAUSE)
+  else stillFixture.push('the stat strip', 'RUNNING NOW')
+  if (jobsLive) clauses.push(MOBILE_LIVE_JOBS_CLAUSE)
+  else stillFixture.push('SCHEDULE HEALTH')
+  stillFixture.push('NEEDS YOU', 'LAST NIGHT')
+
+  return buildNotice(mobileFixtureNotice, clauses, stillFixture)
+}
 
 /**
  * The board frame on its own — 1440×900, exactly what the artboard shows.
@@ -123,9 +188,13 @@ const mobileLiveJobsNotice =
 export function DesktopConductorBoard({
   jobs = conductorJobFixtures,
   jobsHeading = conductorJobsHeading,
+  workers = conductorWorkerCardFixtures,
+  workerHeading = conductorWorkerBoardHeading,
 }: {
   jobs?: ScheduledJobsData['jobs']
   jobsHeading?: ScheduledJobsData['heading']
+  workers?: WorkersData['cards']
+  workerHeading?: WorkersData['heading']
 } = {}) {
   return (
     <div
@@ -138,10 +207,7 @@ export function DesktopConductorBoard({
     >
       <ConductorTopbar data={conductorTopbarFixture} />
 
-      <WorkerBoard
-        heading={conductorWorkerBoardHeading}
-        cards={conductorWorkerCardFixtures}
-      />
+      <WorkerBoard heading={workerHeading} cards={workers} />
 
       <ScheduledJobs heading={jobsHeading} jobs={jobs} />
 
@@ -155,14 +221,15 @@ export function DesktopConductorBoard({
  * and above, the mobile board below it. Both are mounted and CSS picks one —
  * a CSS swap cannot mismatch on first paint the way a `matchMedia` read can.
  *
- * The jobs query is read ONCE here and handed to both frames, so the hidden one
- * still costs only its markup: two `useScheduledJobs` calls would share the
- * cache anyway, but one read keeps the two frames provably showing the same
- * jobs at the same moment.
+ * Both wires are read ONCE here and handed to both frames, so the hidden one
+ * still costs only its markup: a second `useScheduledJobs` / `useWorkers` call
+ * would share the cache and the store anyway, but one read keeps the two frames
+ * provably showing the same jobs and the same workers at the same moment.
  */
 export function DesktopConductorScreen() {
   useJarvisThemeAttribute()
   const scheduled = useScheduledJobs()
+  const workers = useWorkers()
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
@@ -183,9 +250,7 @@ export function DesktopConductorScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
-            {scheduled.isLive
-              ? conductorLiveJobsNotice
-              : conductorFixtureNotice}
+            {buildConductorNotice(workers.isLive, scheduled.isLive)}
           </p>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
             {conductorNoSourceNotice}
@@ -195,6 +260,8 @@ export function DesktopConductorScreen() {
         <DesktopConductorBoard
           jobs={scheduled.jobs}
           jobsHeading={scheduled.heading}
+          workers={workers.cards}
+          workerHeading={workers.heading}
         />
       </div>
 
@@ -212,7 +279,7 @@ export function DesktopConductorScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
-            {scheduled.isLive ? mobileLiveJobsNotice : mobileFixtureNotice}
+            {buildMobileConductorNotice(workers.isLive, scheduled.isLive)}
           </p>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
             {conductorNoSourceNotice}
@@ -222,6 +289,8 @@ export function DesktopConductorScreen() {
         <MobileConductorBoard
           jobs={scheduled.mobileJobs}
           scheduleHealth={scheduled.mobileScheduleHealth}
+          stats={workers.mobileStats}
+          running={workers.mobileRunning}
         />
       </div>
     </div>

--- a/src/screens/jarvis/conductor/desktop-conductor.tsx
+++ b/src/screens/jarvis/conductor/desktop-conductor.tsx
@@ -1,0 +1,143 @@
+/**
+ * JARVIS Desktop Conductor board — artboard 02, fixed 1440×900.
+ *
+ * Top bar (COMMAND/CONDUCTOR tabs) over three stacked sections: WORKER BOARD,
+ * SCHEDULED JOBS, RUN LOG · UNATTENDED. Where the Command board answers "what
+ * is JARVIS doing with me", this one answers "what is it doing without me" —
+ * so FAILED and STALE are the point of the screen, not edge cases: the failed
+ * job wears a hazard-striped red frame and the silent one an amber frame, both
+ * carrying the diagnostic and the chip you would actually reach for.
+ *
+ * FIXTURES ONLY. This directory imports no store, no gateway client and no HTTP
+ * endpoint, and opens no request or event stream of any kind — every value comes
+ * from `src/components/jarvis/fixtures.ts`.
+ *
+ * That is worth stating precisely for this board, because unlike the Command
+ * board much of what it shows DOES have a real source today
+ * (`docs/design/jarvis-ui-mapping.md` §3.3–§3.4): worker running/idle/failed/
+ * stale, and job cadence/last-run success/error/next-run. This slice still does
+ * not read them — slice 6 does, and it gets one file to replace. The rows with
+ * NO source at all (§3.5 items 11–14: the PARTIAL badge as a structured state,
+ * the launchd diagnostic, run-log history beyond the latest run, and the chain
+ * as a real edge graph) are drawn to prove the layout and are labelled as
+ * fixtures both in the banner above the frame and via `data-jv-fixture=
+ * "no-source"` in the DOM. Nothing on this board is live.
+ *
+ * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
+ * so the board sets that attribute on <html> for as long as it is mounted and
+ * restores the previous value on unmount — never writing localStorage, so the
+ * user's stored theme comes back untouched. Same hook as the Command board,
+ * copied rather than shared: lifting it would mean editing that screen, which
+ * is out of scope for this slice.
+ *
+ * One class needs explaining: the board root carries `tracking-normal`. The app
+ * sets `letter-spacing: -0.15px` on `html, body` in `styles.css`, which every
+ * descendant inherits; the artboard's text is untracked. Without this the whole
+ * board renders a hair tight, and the drift compounds across a long mono line
+ * like a run-log result. Resetting it at the board root is local and additive —
+ * the explicit `tracking-jv-*` on labels and badges still wins over it.
+ *
+ * Token discipline: no raw colour, size, spacing or radius in this directory.
+ * Structural dimensions come from `JV_BOARD` / `JV_CONDUCTOR` (multiples of
+ * `--jv-space-4`).
+ */
+import { useEffect } from 'react'
+import { JV_BOARD } from '../command/geometry'
+import { ConductorTopbar } from './conductor-topbar'
+import { RunLog } from './run-log'
+import { ScheduledJobs } from './scheduled-jobs'
+import { WorkerBoard } from './worker-board'
+import {
+  conductorFixtureNotice,
+  conductorJobFixtures,
+  conductorJobsHeading,
+  conductorNoSourceNotice,
+  conductorRunLogChrome,
+  conductorRunLogFixtures,
+  conductorTopbarFixture,
+  conductorWorkerBoardHeading,
+  conductorWorkerCardFixtures,
+} from '@/components/jarvis/fixtures'
+
+const THEME_ATTRIBUTE = 'data-theme'
+const JARVIS_THEME = 'jarvis'
+
+/** Applies `data-theme='jarvis'` for the lifetime of the board only. */
+function useJarvisThemeAttribute() {
+  useEffect(() => {
+    const root = document.documentElement
+    const previous = root.getAttribute(THEME_ATTRIBUTE)
+    root.setAttribute(THEME_ATTRIBUTE, JARVIS_THEME)
+    return () => {
+      if (previous === null) {
+        root.removeAttribute(THEME_ATTRIBUTE)
+      } else {
+        root.setAttribute(THEME_ATTRIBUTE, previous)
+      }
+    }
+  }, [])
+}
+
+/** The board frame on its own — 1440×900, exactly what the artboard shows. */
+export function DesktopConductorBoard() {
+  return (
+    <div
+      data-jv-board="desktop-conductor"
+      className="flex flex-none flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans tracking-normal text-jv-text"
+      style={{
+        width: JV_BOARD.frameWidth,
+        height: JV_BOARD.frameHeight,
+      }}
+    >
+      <ConductorTopbar data={conductorTopbarFixture} />
+
+      <WorkerBoard
+        heading={conductorWorkerBoardHeading}
+        cards={conductorWorkerCardFixtures}
+      />
+
+      <ScheduledJobs
+        heading={conductorJobsHeading}
+        jobs={conductorJobFixtures}
+      />
+
+      <RunLog chrome={conductorRunLogChrome} runs={conductorRunLogFixtures} />
+    </div>
+  )
+}
+
+/** The dev route's page: the honesty banner, then the frame. */
+export function DesktopConductorScreen() {
+  useJarvisThemeAttribute()
+
+  return (
+    <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
+      <div className="flex flex-col items-center gap-jv-16 p-jv-24">
+        <header
+          className="flex w-full flex-col gap-jv-6"
+          style={{ maxWidth: JV_BOARD.frameWidth }}
+        >
+          <div className="flex items-baseline gap-jv-12">
+            <span className="font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider-2 text-jv-live">
+              02 · DESKTOP CONDUCTOR
+            </span>
+            <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-dim">
+              1440 × 900
+            </span>
+            <span className="font-jv-sans text-jv-md leading-jv-none text-jv-label">
+              everything running, everything scheduled
+            </span>
+          </div>
+          <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
+            {conductorFixtureNotice}
+          </p>
+          <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
+            {conductorNoSourceNotice}
+          </p>
+        </header>
+
+        <DesktopConductorBoard />
+      </div>
+    </div>
+  )
+}

--- a/src/screens/jarvis/conductor/desktop-conductor.tsx
+++ b/src/screens/jarvis/conductor/desktop-conductor.tsx
@@ -77,6 +77,7 @@ import { ConductorTopbar } from './conductor-topbar'
 import { MobileConductorBoard } from './mobile-conductor'
 import { RunLog } from './run-log'
 import { ScheduledJobs } from './scheduled-jobs'
+import { useApprovals } from './use-approvals'
 import { useScheduledJobs } from './use-scheduled-jobs'
 import { useWorkers } from './use-workers'
 import { WorkerBoard } from './worker-board'
@@ -137,6 +138,9 @@ const MOBILE_LIVE_WORKERS_CLAUSE =
 const MOBILE_LIVE_JOBS_CLAUSE =
   'SCHEDULE HEALTH is LIVE — the same real ClaudeJob records as the desktop board, collapsed to what is unhealthy.'
 
+const MOBILE_LIVE_GATE_CLAUSE =
+  'NEEDS YOU is LIVE — the oldest pending approval from GET /api/gateway/approvals, with the rest counted behind it. It offers REVIEW only: this glance surface draws no blast-radius panel, so it must not offer a decision.'
+
 function buildNotice(
   fallback: string,
   clauses: Array<string>,
@@ -165,6 +169,7 @@ function buildConductorNotice(
 function buildMobileConductorNotice(
   workersLive: boolean,
   jobsLive: boolean,
+  gateLive: boolean,
 ): string {
   const clauses: Array<string> = []
   const stillFixture: Array<string> = []
@@ -173,7 +178,9 @@ function buildMobileConductorNotice(
   else stillFixture.push('the stat strip', 'RUNNING NOW')
   if (jobsLive) clauses.push(MOBILE_LIVE_JOBS_CLAUSE)
   else stillFixture.push('SCHEDULE HEALTH')
-  stillFixture.push('NEEDS YOU', 'LAST NIGHT')
+  if (gateLive) clauses.push(MOBILE_LIVE_GATE_CLAUSE)
+  else stillFixture.push('NEEDS YOU')
+  stillFixture.push('LAST NIGHT')
 
   return buildNotice(mobileFixtureNotice, clauses, stillFixture)
 }
@@ -230,6 +237,10 @@ export function DesktopConductorScreen() {
   useJarvisThemeAttribute()
   const scheduled = useScheduledJobs()
   const workers = useWorkers()
+  // DISPLAY only, and read-only: `useApprovals` issues the same GET the worker
+  // board already shares. The resolve mutation is not imported on this screen at
+  // all — the Conductor pointer offers REVIEW, never APPROVE.
+  const approvals = useApprovals()
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
@@ -279,7 +290,11 @@ export function DesktopConductorScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
-            {buildMobileConductorNotice(workers.isLive, scheduled.isLive)}
+            {buildMobileConductorNotice(
+              workers.isLive,
+              scheduled.isLive,
+              approvals.isLive,
+            )}
           </p>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
             {conductorNoSourceNotice}
@@ -291,6 +306,8 @@ export function DesktopConductorScreen() {
           scheduleHealth={scheduled.mobileScheduleHealth}
           stats={workers.mobileStats}
           running={workers.mobileRunning}
+          needsYou={approvals.needsYou}
+          needsYouIsLive={approvals.isLive}
         />
       </div>
     </div>

--- a/src/screens/jarvis/conductor/desktop-conductor.tsx
+++ b/src/screens/jarvis/conductor/desktop-conductor.tsx
@@ -21,20 +21,25 @@
  * job wears a hazard-striped red frame and the silent one an amber frame, both
  * carrying the diagnostic and the chip you would actually reach for.
  *
- * FIXTURES ONLY. This directory imports no store, no gateway client and no HTTP
- * endpoint, and opens no request or event stream of any kind — every value comes
- * from `src/components/jarvis/fixtures.ts`.
+ * ONE SECTION IS LIVE (slice 6a). SCHEDULED JOBS reads real `ClaudeJob` records
+ * through `useScheduledJobs` — the same `['claude','jobs']` query the product
+ * jobs screen runs, GET only, no mutation anywhere on this board. Everything
+ * else (worker board, run log, top bar) is still fixtures, and worker status
+ * has a real source it does not yet read (§3.3) — that is slice 6b.
  *
- * That is worth stating precisely for this board, because unlike the Command
- * board much of what it shows DOES have a real source today
- * (`docs/design/jarvis-ui-mapping.md` §3.3–§3.4): worker running/idle/failed/
- * stale, and job cadence/last-run success/error/next-run. This slice still does
- * not read them — slice 6 does, and it gets one file to replace. The rows with
- * NO source at all (§3.5 items 11–14: the PARTIAL badge as a structured state,
- * the launchd diagnostic, run-log history beyond the latest run, and the chain
- * as a real edge graph) are drawn to prove the layout and are labelled as
- * fixtures both in the banner above the frame and via `data-jv-fixture=
- * "no-source"` in the DOM. Nothing on this board is live.
+ * When the gateway is unreachable — the normal case for an offline design
+ * review — the hook returns the slice-4 fixtures and `isLive: false`, and the
+ * board renders exactly as it did before. The banner above the frame says which
+ * of the two you are looking at; it is never left claiming "every value is
+ * invented" over live data, or the reverse.
+ *
+ * Live cards carry no `data-jv-fixture="no-source"` marks, because nothing
+ * unsourced is drawn for a real job: no PARTIAL badge (§3.5 item 11), no
+ * launchd diagnostic (item 12), no invented duration or payload count, and no
+ * action chips at all — TRIAGE / FULL LOG / RELOAD & RUN each imply a write
+ * this read-only slice cannot do. Those elements survive only on the fixture
+ * fallback, where they stay labelled as fixtures both in the banner and via
+ * `data-jv-fixture="no-source"` in the DOM.
  *
  * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
  * so the board sets that attribute on <html> for as long as it is mounted and
@@ -60,7 +65,9 @@ import { ConductorTopbar } from './conductor-topbar'
 import { MobileConductorBoard } from './mobile-conductor'
 import { RunLog } from './run-log'
 import { ScheduledJobs } from './scheduled-jobs'
+import { useScheduledJobs } from './use-scheduled-jobs'
 import { WorkerBoard } from './worker-board'
+import type { ScheduledJobsData } from './use-scheduled-jobs'
 import {
   conductorFixtureNotice,
   conductorJobFixtures,
@@ -93,8 +100,33 @@ function useJarvisThemeAttribute() {
   }, [])
 }
 
-/** The board frame on its own — 1440×900, exactly what the artboard shows. */
-export function DesktopConductorBoard() {
+/**
+ * The honesty banner has two readings now, and the board must not show the
+ * wrong one. `conductorFixtureNotice` says every value is invented — true only
+ * while the fallback is up. These say what is actually on screen when SCHEDULED
+ * JOBS is live; the NO SOURCE notice below them is printed either way, because
+ * that list is about the design, not about the connection.
+ */
+const conductorLiveJobsNotice =
+  'SCHEDULED JOBS is LIVE — real ClaudeJob records read from the gateway (GET /api/claude-jobs, the same query the jobs screen runs). Read-only: this board issues no write of any kind, so live cards carry no action chips and nothing without a source is drawn on them. Every other section — worker board, run log, top bar — is still invented fixtures.'
+
+const mobileLiveJobsNotice =
+  'SCHEDULE HEALTH is LIVE — the same real ClaudeJob records as the desktop board, collapsed to what is unhealthy. Read-only. Every other section on this frame is still invented fixtures.'
+
+/**
+ * The board frame on its own — 1440×900, exactly what the artboard shows.
+ *
+ * Job data arrives as props with the fixtures as defaults, so the frame still
+ * renders standalone with no query client mounted; the routed screen below
+ * passes the live jobs in when the gateway has any.
+ */
+export function DesktopConductorBoard({
+  jobs = conductorJobFixtures,
+  jobsHeading = conductorJobsHeading,
+}: {
+  jobs?: ScheduledJobsData['jobs']
+  jobsHeading?: ScheduledJobsData['heading']
+} = {}) {
   return (
     <div
       data-jv-board="desktop-conductor"
@@ -111,10 +143,7 @@ export function DesktopConductorBoard() {
         cards={conductorWorkerCardFixtures}
       />
 
-      <ScheduledJobs
-        heading={conductorJobsHeading}
-        jobs={conductorJobFixtures}
-      />
+      <ScheduledJobs heading={jobsHeading} jobs={jobs} />
 
       <RunLog chrome={conductorRunLogChrome} runs={conductorRunLogFixtures} />
     </div>
@@ -124,12 +153,16 @@ export function DesktopConductorBoard() {
 /**
  * The dev route's page. One route, two compositions: the desktop board at `lg`
  * and above, the mobile board below it. Both are mounted and CSS picks one —
- * they are inert fixture boards, so nothing is paid for the hidden one beyond
- * its markup, and a CSS swap cannot mismatch on first paint the way a
- * `matchMedia` read can.
+ * a CSS swap cannot mismatch on first paint the way a `matchMedia` read can.
+ *
+ * The jobs query is read ONCE here and handed to both frames, so the hidden one
+ * still costs only its markup: two `useScheduledJobs` calls would share the
+ * cache anyway, but one read keeps the two frames provably showing the same
+ * jobs at the same moment.
  */
 export function DesktopConductorScreen() {
   useJarvisThemeAttribute()
+  const scheduled = useScheduledJobs()
 
   return (
     <div className="min-h-screen bg-jv-bg font-jv-sans tracking-normal text-jv-text">
@@ -150,14 +183,19 @@ export function DesktopConductorScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
-            {conductorFixtureNotice}
+            {scheduled.isLive
+              ? conductorLiveJobsNotice
+              : conductorFixtureNotice}
           </p>
           <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-blocked-dim">
             {conductorNoSourceNotice}
           </p>
         </header>
 
-        <DesktopConductorBoard />
+        <DesktopConductorBoard
+          jobs={scheduled.jobs}
+          jobsHeading={scheduled.heading}
+        />
       </div>
 
       <div className="flex flex-col items-center gap-jv-12 p-jv-14 lg:hidden">
@@ -174,14 +212,17 @@ export function DesktopConductorScreen() {
             </span>
           </div>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-text-caption">
-            {mobileFixtureNotice}
+            {scheduled.isLive ? mobileLiveJobsNotice : mobileFixtureNotice}
           </p>
           <p className="font-jv-sans text-jv-md leading-jv-loose text-jv-blocked-dim">
             {conductorNoSourceNotice}
           </p>
         </header>
 
-        <MobileConductorBoard />
+        <MobileConductorBoard
+          jobs={scheduled.mobileJobs}
+          scheduleHealth={scheduled.mobileScheduleHealth}
+        />
       </div>
     </div>
   )

--- a/src/screens/jarvis/conductor/geometry.test.ts
+++ b/src/screens/jarvis/conductor/geometry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { jvGrid } from '../command/geometry'
+import { JV_CONDUCTOR } from './geometry'
+
+describe('JV_CONDUCTOR', () => {
+  it('hangs the chain connector off the card by exactly its own width', () => {
+    // The connector spans the grid gutter, so the offset must be the width
+    // inverted — otherwise the edge detaches from the next card.
+    expect(JV_CONDUCTOR.connectorWidth).toBe(jvGrid(4))
+    expect(JV_CONDUCTOR.connectorOffset).toBe(jvGrid(-4))
+  })
+
+  it('states every run-log column as a grid multiple, not a raw px value', () => {
+    const columns = [
+      JV_CONDUCTOR.runTimeWidth,
+      JV_CONDUCTOR.runJobWidth,
+      JV_CONDUCTOR.runWorkerWidth,
+      JV_CONDUCTOR.runOutcomeWidth,
+      JV_CONDUCTOR.runDurationWidth,
+    ]
+
+    for (const column of columns) {
+      expect(column).toMatch(/^calc\(var\(--jv-space-4\) \* -?[\d.]+\)$/)
+    }
+  })
+
+  it('keeps the fixed columns clear of the 1440 frame', () => {
+    // Sum of the fixed columns + the 20px page gutters must leave RESULT room.
+    const steps = 14 + 52.5 + 30 + 19.5 + 17.5
+    expect(steps * 4).toBeLessThan(1440)
+  })
+})

--- a/src/screens/jarvis/conductor/geometry.ts
+++ b/src/screens/jarvis/conductor/geometry.ts
@@ -1,0 +1,36 @@
+/**
+ * Artboard geometry for the Desktop Conductor board (artboard 02, 1440×900).
+ *
+ * Companion to `../command/geometry.ts`, which owns the shared frame and the
+ * `jvGrid()` helper this file re-uses. Everything here is Conductor-only — the
+ * run-log column widths and the chain connector — so it lives beside the board
+ * rather than widening the Command board's module.
+ *
+ * Same rule as there: a structural dimension is expressed as a multiple of the
+ * 4px `--jv-space-4` grid, never as a raw `w-[..px]`. Fractional steps are
+ * exact — the run log's 210px JOB column is 52.5 steps and `calc()` handles it.
+ */
+import { jvGrid } from '../command/geometry'
+
+/** Conductor-only structural dimensions, named after what they measure. */
+export const JV_CONDUCTOR = {
+  /**
+   * The chain edge between two worker cards: 16px, which is exactly the grid
+   * gap, so the connector spans the gutter and the negative offset that hangs
+   * it off the card's right edge is the same measure inverted.
+   */
+  connectorWidth: jvGrid(4),
+  connectorOffset: jvGrid(-4),
+
+  /* Run-log columns. RESULT is the flexible one and takes what is left. */
+  /** 56px TIME. */
+  runTimeWidth: jvGrid(14),
+  /** 210px JOB. */
+  runJobWidth: jvGrid(52.5),
+  /** 120px WORKER. */
+  runWorkerWidth: jvGrid(30),
+  /** 78px OUTCOME, right-aligned. */
+  runOutcomeWidth: jvGrid(19.5),
+  /** 70px DURATION, right-aligned. */
+  runDurationWidth: jvGrid(17.5),
+} as const

--- a/src/screens/jarvis/conductor/map-approvals.test.ts
+++ b/src/screens/jarvis/conductor/map-approvals.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GATE_ACTIONS,
+  NO_SOURCE_TEXT,
+  OMITTED_ACTION,
+  buildOthersWaitingLine,
+  clampText,
+  deriveCommand,
+  deriveTitle,
+  formatWaiting,
+  mapApprovalToGateProps,
+  mapApprovalToGateSummary,
+  mapApprovalToMobileGateProps,
+  normalizeApprovals,
+  readableInput,
+  selectPendingApprovals,
+  statusToGateState,
+} from './map-approvals'
+import type { GatewayApprovalEntry } from '@/lib/gateway-api'
+import { commandGateFixture } from '@/components/jarvis/fixtures'
+
+const SECOND_MS = 1_000
+const MINUTE_MS = 60 * SECOND_MS
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/** A fixed clock, so every wait below is arithmetic and not a race. */
+const NOW = new Date('2026-08-24T12:00:00Z').getTime()
+
+function approval(
+  overrides: Partial<GatewayApprovalEntry> = {},
+): GatewayApprovalEntry {
+  return {
+    id: 'appr-1',
+    sessionKey: 'agent:km-agent:subagent:06ec90ba',
+    agentName: 'km-agent',
+    action: 'Write 41 restored notes to Vault/Published/',
+    tool: 'Write',
+    input: 'Vault/Published/2026-08-24-restored.md',
+    requestedAt: NOW - (4 * MINUTE_MS + 12 * SECOND_MS),
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+describe('deriveTitle', () => {
+  it('uses the real action sentence when the gateway supplies one', () => {
+    expect(deriveTitle(approval())).toBe(
+      'Write 41 restored notes to Vault/Published/',
+    )
+  })
+
+  it('falls back to the tool, then to a neutral line — never to an invention', () => {
+    expect(deriveTitle(approval({ action: '   ' }))).toBe('Write')
+    expect(deriveTitle(approval({ action: '', tool: '' }))).toBe(
+      'Approval requested',
+    )
+  })
+
+  it('never reproduces the fixture headline from a real entry', () => {
+    const entry = approval({ action: '', tool: '', input: undefined })
+    expect(deriveTitle(entry)).not.toBe(commandGateFixture.title)
+  })
+
+  it('clamps a title that would push the panel below the mobile fold', () => {
+    const title = deriveTitle(approval({ action: 'word '.repeat(60) }))
+    expect(title.length).toBeLessThanOrEqual(97)
+    expect(title.endsWith('…')).toBe(true)
+  })
+})
+
+describe('readableInput', () => {
+  it('reads a short string and a string argv', () => {
+    expect(readableInput('git push origin main')).toBe('git push origin main')
+    expect(readableInput(['git', 'push', 'origin', 'main'])).toBe(
+      'git push origin main',
+    )
+  })
+
+  it('refuses anything opaque rather than dumping it on the hero card', () => {
+    expect(readableInput({ file_path: '/a', old_string: 'x' })).toBeNull()
+    expect(readableInput(['ok', { nested: true }])).toBeNull()
+    expect(readableInput(undefined)).toBeNull()
+    expect(readableInput('')).toBeNull()
+    expect(readableInput([])).toBeNull()
+  })
+
+  it('clamps an unbounded string input', () => {
+    const long = readableInput('x'.repeat(500))
+    expect(long).not.toBeNull()
+    expect((long as string).length).toBeLessThanOrEqual(121)
+    expect((long as string).endsWith('…')).toBe(true)
+  })
+})
+
+describe('deriveCommand', () => {
+  it('puts the tool in front of a legible input', () => {
+    expect(deriveCommand(approval())).toBe(
+      'Write Vault/Published/2026-08-24-restored.md',
+    )
+  })
+
+  it('shows the tool alone when the input is a payload', () => {
+    expect(deriveCommand(approval({ input: { patch: 'x'.repeat(400) } }))).toBe(
+      'Write',
+    )
+  })
+
+  it('falls back to the entry context, then to its id', () => {
+    expect(
+      deriveCommand(
+        approval({ tool: '', input: undefined, context: 'vault write queue' }),
+      ),
+    ).toBe('vault write queue')
+    expect(
+      deriveCommand(
+        approval({ tool: '', input: undefined, context: '', id: 'appr-9' }),
+      ),
+    ).toBe('approval appr-9')
+  })
+
+  it('clamps the whole line, not just the input', () => {
+    const command = deriveCommand(
+      approval({ tool: 'Bash', input: 'echo '.repeat(80) }),
+    )
+    expect(command.length).toBeLessThanOrEqual(121)
+  })
+})
+
+describe('formatWaiting', () => {
+  it('derives the wait from requestedAt', () => {
+    expect(formatWaiting(NOW - 42 * SECOND_MS, NOW)).toBe('42s')
+    expect(formatWaiting(NOW - (4 * MINUTE_MS + 12 * SECOND_MS), NOW)).toBe(
+      '4m 12s',
+    )
+    expect(formatWaiting(NOW - (2 * HOUR_MS + 5 * MINUTE_MS), NOW)).toBe('2h 5m')
+    expect(formatWaiting(NOW - 3 * DAY_MS, NOW)).toBe('3d')
+  })
+
+  it('says nothing rather than "0s" when there is no usable timestamp', () => {
+    expect(formatWaiting(undefined, NOW)).toBeUndefined()
+    expect(formatWaiting(Number.NaN, NOW)).toBeUndefined()
+  })
+
+  it('treats a future timestamp as clock skew, not a negative wait', () => {
+    expect(formatWaiting(NOW + 10 * MINUTE_MS, NOW)).toBe('0s')
+  })
+})
+
+describe('statusToGateState', () => {
+  it('maps the gateway statuses onto the card states', () => {
+    expect(statusToGateState('pending')).toBe('pending')
+    expect(statusToGateState('approved')).toBe('approved')
+    expect(statusToGateState('denied')).toBe('rejected')
+  })
+
+  it('treats a status-less entry as pending — it came off the pending list', () => {
+    expect(statusToGateState(undefined)).toBe('pending')
+  })
+})
+
+describe('mapApprovalToGateProps', () => {
+  it('maps every REAL field the gateway actually carries', () => {
+    const props = mapApprovalToGateProps(approval(), NOW)
+
+    expect(props.title).toBe('Write 41 restored notes to Vault/Published/')
+    expect(props.command).toBe('Write Vault/Published/2026-08-24-restored.md')
+    expect(props.subtitle).toBe('km-agent')
+    expect(props.waiting).toBe('4m 12s')
+    expect(props.state).toBe('pending')
+  })
+
+  it('omits the sublabel rather than guessing when no agent is named', () => {
+    expect(mapApprovalToGateProps(approval({ agentName: '' }), NOW).subtitle)
+      .toBeUndefined()
+  })
+
+  it('ALWAYS fills blast radius and undo path with the inert sentinel', () => {
+    // NO SOURCE (§3.2). Nothing about the entry may reach these two cells, so
+    // the assertion is over a deliberately rich set of entries rather than one.
+    const entries: Array<GatewayApprovalEntry> = [
+      approval(),
+      approval({ action: '', tool: '', input: undefined, context: '' }),
+      approval({ status: 'approved' }),
+      approval({ status: 'denied', agentName: 'builder' }),
+      approval({
+        context: 'publishes 1 public page and fires an RSS blast',
+        input: { blastRadius: '2,411 subscribers', undoPath: 'revert ≈90s' },
+      }),
+    ]
+
+    for (const entry of entries) {
+      const props = mapApprovalToGateProps(entry, NOW)
+      expect(props.blastRadius).toBe(NO_SOURCE_TEXT)
+      expect(props.undoPath).toBe(NO_SOURCE_TEXT)
+      // And never the plausible fixture prose.
+      expect(props.blastRadius).not.toBe(commandGateFixture.blastRadius)
+      expect(props.undoPath).not.toBe(commandGateFixture.undoPath)
+    }
+  })
+
+  it('never synthesises a caveat', () => {
+    const props = mapApprovalToGateProps(
+      approval({ context: 'qa has not run against the fix yet' }),
+      NOW,
+    )
+    expect('caveat' in props).toBe(false)
+  })
+
+  it('offers only the two actions that map onto a real endpoint', () => {
+    const props = mapApprovalToGateProps(approval(), NOW)
+    expect(props.actions).toEqual(GATE_ACTIONS)
+    expect(props.actions).not.toContain(OMITTED_ACTION)
+  })
+
+  it('drops the header sublabel on the mobile hero and nothing else', () => {
+    const desktop = mapApprovalToGateProps(approval(), NOW)
+    const mobile = mapApprovalToMobileGateProps(approval(), NOW)
+
+    expect(mobile.subtitle).toBeUndefined()
+    expect({ ...mobile, subtitle: desktop.subtitle }).toEqual(desktop)
+  })
+})
+
+describe('mapApprovalToGateSummary', () => {
+  it('names the real agent and counts the real queue behind it', () => {
+    const summary = mapApprovalToGateSummary(approval(), 2, 'NEEDS YOU')
+
+    expect(summary.heading).toBe('NEEDS YOU')
+    expect(summary.label).toBe('GATE · km-agent · +2 more waiting')
+    expect(summary.title).toBe('Write 41 restored notes to Vault/Published/')
+  })
+
+  it('offers REVIEW only — a glance surface draws no blast radius panel', () => {
+    expect(mapApprovalToGateSummary(approval(), 0, 'NEEDS YOU').actions).toEqual(
+      ['REVIEW'],
+    )
+  })
+
+  it('drops the tally when the hero is the whole queue', () => {
+    expect(mapApprovalToGateSummary(approval(), 0, 'NEEDS YOU').label).toBe(
+      'GATE · km-agent',
+    )
+  })
+})
+
+describe('buildOthersWaitingLine', () => {
+  it('is empty unless something is actually behind the hero', () => {
+    expect(buildOthersWaitingLine(0)).toBe('')
+    expect(buildOthersWaitingLine(-1)).toBe('')
+    expect(buildOthersWaitingLine(2)).toBe('+2 more waiting')
+  })
+})
+
+describe('normalizeApprovals', () => {
+  it('stamps the pending list, keeps given statuses, and dedupes by id', () => {
+    const entries = normalizeApprovals({
+      pending: [{ id: 'a' }],
+      approvals: [
+        { id: 'a', status: 'approved' },
+        { id: 'b', status: 'denied' },
+      ],
+    })
+
+    expect(entries).toHaveLength(2)
+    expect(entries.find((entry) => entry.id === 'a')?.status).toBe('pending')
+    expect(entries.find((entry) => entry.id === 'b')?.status).toBe('denied')
+  })
+
+  it('reads an absent or empty response as an empty queue', () => {
+    expect(normalizeApprovals(undefined)).toEqual([])
+    expect(normalizeApprovals({ ok: false, approvals: [] })).toEqual([])
+  })
+})
+
+describe('selectPendingApprovals', () => {
+  it('keeps only pending entries, oldest first', () => {
+    const pending = selectPendingApprovals([
+      approval({ id: 'new', requestedAt: NOW - MINUTE_MS }),
+      approval({ id: 'done', status: 'approved' }),
+      approval({ id: 'old', requestedAt: NOW - HOUR_MS }),
+      approval({ id: 'refused', status: 'denied' }),
+    ])
+
+    expect(pending.map((entry) => entry.id)).toEqual(['old', 'new'])
+  })
+
+  it('sorts an unknown wait last — it is not evidence of a long one', () => {
+    const pending = selectPendingApprovals([
+      approval({ id: 'unknown', requestedAt: undefined }),
+      approval({ id: 'known', requestedAt: NOW - MINUTE_MS }),
+    ])
+
+    expect(pending.map((entry) => entry.id)).toEqual(['known', 'unknown'])
+  })
+})
+
+describe('clampText', () => {
+  it('cuts on a word boundary when there is one worth cutting on', () => {
+    expect(clampText('alpha beta gamma delta', 16)).toBe('alpha beta…')
+    expect(clampText('short', 16)).toBe('short')
+  })
+})

--- a/src/screens/jarvis/conductor/map-approvals.ts
+++ b/src/screens/jarvis/conductor/map-approvals.ts
@@ -1,0 +1,340 @@
+/**
+ * `GatewayApprovalEntry[]` → the approval gate as the boards draw it.
+ * Pure functions only: no React, no fetch, no styling, and — the point of this
+ * slice — no write. `use-approvals.ts` owns the query; `use-resolve-approval.ts`
+ * owns the (dormant) mutation; this file owns the honesty.
+ *
+ * `docs/design/jarvis-ui-mapping.md` §3.2 splits the gate cleanly, and the split
+ * is unusually harsh: the card's two most load-bearing cells have no source.
+ *
+ *   • REAL and mapped — `agentName`, `action`, `tool`, `input`, `context` and
+ *     `status`. Every string this file puts on a live card comes from one of
+ *     them or from arithmetic on `requestedAt`.
+ *   • DERIVED and marked as such below — the waiting duration (`formatWaiting`)
+ *     and the "+N more waiting" tally, both from the entry list alone.
+ *   • NO SOURCE and therefore NEVER produced here — BLAST RADIUS, UNDO PATH and
+ *     the caveat. `ApprovalGateCardProps` makes the first two REQUIRED, so they
+ *     cannot simply be omitted; they are filled with `NO_SOURCE_TEXT`, a
+ *     constant that reads as inert on screen. It is not a plausible fake — a
+ *     card that said "1 public page · RSS to 2,411 subscribers" over a real
+ *     approval would be inventing the one number a person actually decides on.
+ *     `caveat` IS optional, so the mapper's return type omits it entirely and no
+ *     code path here can synthesise one.
+ *
+ * On the title. §3.2 allows folding `tool` into the title line; this mapper
+ * does not, because `command` already leads with the tool and the artboard puts
+ * the two lines directly on top of each other — "Write" above "Write
+ * Vault/Published/note.md" is noise, not context. `action` alone is the human
+ * line, and when the entry carries no action the tool becomes it.
+ */
+import type {
+  GatewayApprovalEntry,
+  GatewayApprovalsResponse,
+} from '@/lib/gateway-api'
+import type {
+  GateCaveatFixture,
+  MobileGateSummaryFixture,
+} from '@/components/jarvis/fixtures'
+import type {
+  ApprovalGateCardProps,
+  ApprovalGateState,
+} from '@/components/jarvis/types'
+
+/** The gate props a mapper is allowed to produce — `caveat` is NO SOURCE. */
+export type MappedGateProps = Omit<ApprovalGateCardProps, 'caveat'>
+
+/**
+ * Everything a board needs to draw one gate, as a single prop: the card body,
+ * whether it is real, the resolve line, and the queue behind it. One object
+ * rather than six props because the pieces are only ever correct together — a
+ * live gate with a fixture caveat under it would be a lie assembled out of two
+ * honest halves.
+ */
+export interface GateDisplay {
+  props: MappedGateProps
+  /**
+   * The fixture caveat, present ONLY on the fixture fallback. §3.2 makes the
+   * caveat NO SOURCE, so a live gate carries none and no mapper can produce
+   * one.
+   */
+  caveat?: GateCaveatFixture
+  /** The confirm / disabled line from `use-resolve-approval`, or null. */
+  note?: string | null
+  /** "+2 more waiting", or empty when this gate is the whole queue. */
+  othersWaiting?: string
+  /** True only when `props` came from a real pending approval. */
+  isLive: boolean
+  /** The card's button handler. Absent means the chips are inert. */
+  onAction?: (action: string) => void
+}
+
+/**
+ * NO SOURCE (§3.2) — BLAST RADIUS and UNDO PATH. An em-dashed lowercase phrase
+ * where the artboard shows a sentence: unmissably not an answer. Nothing about
+ * the entry can change it, and `mapApprovalToGateProps` is tested on exactly
+ * that.
+ */
+export const NO_SOURCE_TEXT = '— not modelled —'
+
+/** The two labels that map onto a real endpoint. See `use-resolve-approval`. */
+export const GATE_ACTIONS: Array<string> = ['APPROVE', 'REJECT']
+
+/**
+ * HOLD FOR QA is on the artboard and on the fixture, and it is dropped from a
+ * live gate on purpose: there is no third resolution in
+ * `/api/gateway/approvals/:id/:action` — only `approve` and `deny` — so the
+ * chip could never do anything but sit there next to two that work.
+ */
+export const OMITTED_ACTION = 'HOLD FOR QA'
+
+/** A `tool`/`input` line past this reflows the card's fixed measure. */
+const COMMAND_MAX = 120
+
+/** Title text past this pushes the panel below the fold on mobile. */
+const TITLE_MAX = 96
+
+const SECOND_MS = 1_000
+const MINUTE_MS = 60 * SECOND_MS
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/* ── Reading the entry ───────────────────────────────────────────────── */
+
+function readText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/** Word-boundary clamp with an ellipsis — same shape `map-scheduled-jobs` uses. */
+export function clampText(text: string, max: number): string {
+  const trimmed = text.trim()
+  if (trimmed.length <= max) return trimmed
+  const cut = trimmed.slice(0, max)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > max / 2 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
+/**
+ * `input` is `unknown` on the wire and genuinely is: a Bash tool sends a string,
+ * an Edit tool sends an object of file paths and patches, an MCP tool sends
+ * whatever it likes. Only two shapes are legible on one mono line — a short
+ * string and a short argv — and everything else returns null so the caller
+ * falls back to the tool name. Serialising an object here would put a JSON blob
+ * with a diff inside it on the hero card.
+ */
+export function readableInput(input: unknown): string | null {
+  if (typeof input === 'string') {
+    const text = input.trim()
+    return text ? clampText(text, COMMAND_MAX) : null
+  }
+
+  if (Array.isArray(input) && input.length > 0) {
+    // argv only — a list with anything non-primitive in it is a payload, not a
+    // command line.
+    if (!input.every((part) => typeof part === 'string')) return null
+    const joined = input.join(' ').trim()
+    return joined ? clampText(joined, COMMAND_MAX) : null
+  }
+
+  return null
+}
+
+/**
+ * The mono line under the title. Tool first, then the input when it is legible;
+ * with neither, the entry's own `context` (REAL, §3.2) rather than an invented
+ * command. An entry with none of the three gets its id, which at least names
+ * the record a person is being asked to decide on.
+ */
+export function deriveCommand(entry: GatewayApprovalEntry): string {
+  const tool = readText(entry.tool)
+  const input = readableInput(entry.input)
+
+  if (tool && input) return clampText(`${tool} ${input}`, COMMAND_MAX)
+  if (tool) return tool
+  if (input) return input
+
+  const context = readText(entry.context)
+  if (context) return clampText(context, COMMAND_MAX)
+
+  return `approval ${readText(entry.id) || 'unknown'}`
+}
+
+/**
+ * The headline. `action` is the human sentence when the gateway supplies one;
+ * `tool` is the honest second best; the neutral constant is what is left. This
+ * function never composes a specific action out of parts — "Publish changelog
+ * 0.9.3 to the public site" is a fixture and must stay one.
+ */
+export function deriveTitle(entry: GatewayApprovalEntry): string {
+  const action = readText(entry.action)
+  if (action) return clampText(action, TITLE_MAX)
+
+  const tool = readText(entry.tool)
+  if (tool) return clampText(tool, TITLE_MAX)
+
+  return 'Approval requested'
+}
+
+/**
+ * DERIVE (§3.2) — how long this has been sitting there, from `requestedAt`.
+ *
+ * Returns undefined rather than "0s" when there is no usable timestamp: the
+ * card hides the field when it is absent, and a zero would read as "just now",
+ * which is a claim about the queue that nothing supports. A `requestedAt` in
+ * the future is clock skew, not a negative wait, so it clamps to zero.
+ */
+export function formatWaiting(
+  requestedAt: number | undefined,
+  now: number,
+): string | undefined {
+  if (typeof requestedAt !== 'number' || !Number.isFinite(requestedAt)) {
+    return undefined
+  }
+
+  const elapsed = Math.max(0, now - requestedAt)
+
+  if (elapsed < MINUTE_MS) return `${Math.floor(elapsed / SECOND_MS)}s`
+  if (elapsed < HOUR_MS) {
+    const minutes = Math.floor(elapsed / MINUTE_MS)
+    const seconds = Math.floor((elapsed % MINUTE_MS) / SECOND_MS)
+    return `${minutes}m ${String(seconds).padStart(2, '0')}s`
+  }
+  if (elapsed < DAY_MS) {
+    const hours = Math.floor(elapsed / HOUR_MS)
+    const minutes = Math.floor((elapsed % HOUR_MS) / MINUTE_MS)
+    return `${hours}h ${minutes}m`
+  }
+  return `${Math.floor(elapsed / DAY_MS)}d`
+}
+
+/** `.status` → the card's three states. `denied` is drawn as `rejected`. */
+export function statusToGateState(
+  status: GatewayApprovalEntry['status'],
+): ApprovalGateState {
+  if (status === 'approved') return 'approved'
+  if (status === 'denied') return 'rejected'
+  // An entry with no status came off the `pending` list, where pending is what
+  // membership means.
+  return 'pending'
+}
+
+/* ── The mapping ─────────────────────────────────────────────────────── */
+
+/**
+ * One entry → one gate card. The two NO SOURCE cells are assigned from the
+ * constant unconditionally and are not reachable from `entry` at all.
+ */
+export function mapApprovalToGateProps(
+  entry: GatewayApprovalEntry,
+  now: number,
+): MappedGateProps {
+  const agent = readText(entry.agentName)
+
+  return {
+    title: deriveTitle(entry),
+    command: deriveCommand(entry),
+    // REAL — who is asking. Absent rather than guessed when unnamed.
+    subtitle: agent || undefined,
+    waiting: formatWaiting(entry.requestedAt, now),
+    // NO SOURCE — §3.2. Constant, never entry-derived.
+    blastRadius: NO_SOURCE_TEXT,
+    undoPath: NO_SOURCE_TEXT,
+    actions: GATE_ACTIONS,
+    state: statusToGateState(entry.status),
+  }
+}
+
+/**
+ * The mobile hero. Same gate, minus the header sublabel: at 390pt the label /
+ * sublabel / waiting row cannot hold all three, and `waiting` is the one that
+ * carries decision-relevant information. Same reasoning
+ * `mobileCommandGateFixture` already encodes for the fixture board.
+ */
+export function mapApprovalToMobileGateProps(
+  entry: GatewayApprovalEntry,
+  now: number,
+): MappedGateProps {
+  const { subtitle: _subtitle, ...rest } = mapApprovalToGateProps(entry, now)
+  return rest
+}
+
+/**
+ * Conductor NEEDS YOU — a POINTER to the gate, not the gate.
+ *
+ * The live pointer carries REVIEW and nothing else. The fixture offers APPROVE
+ * here, but this board deliberately draws no BLAST RADIUS / UNDO PATH panel
+ * (see `mobile-conductor.tsx`), and approving from a surface that shows neither
+ * is the exact move the panel exists to prevent. The chip is also a plain
+ * `<span>` on that board — it resolves nothing today and must not look like it
+ * could.
+ */
+export function mapApprovalToGateSummary(
+  entry: GatewayApprovalEntry,
+  othersWaiting: number,
+  heading: string,
+): MobileGateSummaryFixture {
+  const agent = readText(entry.agentName)
+  const more = othersWaiting > 0 ? ` · +${othersWaiting} more waiting` : ''
+
+  return {
+    heading,
+    label: `GATE${agent ? ` · ${agent}` : ''}${more}`,
+    title: deriveTitle(entry),
+    actions: ['REVIEW'],
+  }
+}
+
+/** DERIVE — the queue behind the hero. Empty string when the hero is the queue. */
+export function buildOthersWaitingLine(othersWaiting: number): string {
+  if (othersWaiting <= 0) return ''
+  return `+${othersWaiting} more waiting`
+}
+
+/* ── The queue ───────────────────────────────────────────────────────── */
+
+/**
+ * The endpoint answers in two shapes — an `approvals` list and a `pending` one.
+ * Entries from `pending` are pending by construction, so they are stamped as
+ * such; entries from `approvals` keep whatever status the gateway gave them.
+ * Deduped by id, because a gateway that sends both lists sends the same record
+ * twice.
+ *
+ * This repeats the private helper in `use-workers.ts` rather than importing it:
+ * that file is a slice-6b deliverable and out of scope to edit, and the two
+ * copies are pinned to the same behaviour by this file's tests.
+ */
+export function normalizeApprovals(
+  response: GatewayApprovalsResponse | undefined,
+): Array<GatewayApprovalEntry> {
+  if (!response) return []
+
+  const byId = new Map<string, GatewayApprovalEntry>()
+
+  for (const entry of response.pending ?? []) {
+    byId.set(entry.id, { ...entry, status: 'pending' })
+  }
+  for (const entry of response.approvals ?? []) {
+    if (!byId.has(entry.id)) byId.set(entry.id, entry)
+  }
+
+  return [...byId.values()]
+}
+
+/**
+ * The pending queue, oldest first — the hero is whatever has been waiting
+ * longest, which is the one ordering a person would defend. Entries with no
+ * `requestedAt` sort last rather than first: an unknown wait is not evidence of
+ * a long one.
+ */
+export function selectPendingApprovals(
+  entries: Array<GatewayApprovalEntry>,
+): Array<GatewayApprovalEntry> {
+  return entries
+    .filter((entry) => statusToGateState(entry.status) === 'pending')
+    .slice()
+    .sort((left, right) => {
+      const a = typeof left.requestedAt === 'number' ? left.requestedAt : Infinity
+      const b =
+        typeof right.requestedAt === 'number' ? right.requestedAt : Infinity
+      return a - b
+    })
+}

--- a/src/screens/jarvis/conductor/map-checkpoints.test.ts
+++ b/src/screens/jarvis/conductor/map-checkpoints.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EVIDENCE_LINES_MAX,
+  EVIDENCE_LINE_MAX,
+  buildCheckpointSourceLine,
+  clampEvidenceLine,
+  formatCheckedAt,
+  mapCheckpointToBadges,
+  mapCheckpointToInertChecks,
+  mapOutputToEvidence,
+  mapVerificationItemToBadge,
+} from './map-checkpoints'
+import type {
+  WorkspaceCheckpointDetail,
+  WorkspaceCheckpointVerificationItem,
+  WorkspaceCheckpointVerificationMap,
+} from '@/lib/workspace-checkpoints'
+
+/**
+ * A fixed clock. Both it and every timestamp below are built in LOCAL time and
+ * then serialised, so the assertions hold in any timezone the suite runs in.
+ */
+const NOW = new Date(2026, 2, 10, 12, 0, 0).getTime()
+const TODAY_0938 = new Date(2026, 2, 10, 9, 38, 0).toISOString()
+const LAST_MONTH = new Date(2026, 1, 17, 9, 38, 0).toISOString()
+
+function item(
+  overrides: Partial<WorkspaceCheckpointVerificationItem> = {},
+): WorkspaceCheckpointVerificationItem {
+  return {
+    status: 'passed',
+    label: 'tsc --noEmit',
+    output: null,
+    checked_at: TODAY_0938,
+    ...overrides,
+  }
+}
+
+function verification(
+  overrides: Partial<WorkspaceCheckpointVerificationMap> = {},
+): WorkspaceCheckpointVerificationMap {
+  return {
+    tsc: item({ status: 'missing', label: 'Not run yet', checked_at: null }),
+    tests: item({
+      status: 'not_configured',
+      label: 'Not configured',
+      checked_at: null,
+    }),
+    lint: item({
+      status: 'not_configured',
+      label: 'Not configured',
+      checked_at: null,
+    }),
+    e2e: item({
+      status: 'not_configured',
+      label: 'Not configured',
+      checked_at: null,
+    }),
+    ...overrides,
+  }
+}
+
+function detail(
+  verificationMap: WorkspaceCheckpointVerificationMap = verification(),
+  overrides: Partial<WorkspaceCheckpointDetail> = {},
+): WorkspaceCheckpointDetail {
+  return {
+    id: '06ec90ba-4703-4a1e-9d1c-2f1a0b8e5c11',
+    task_run_id: 'run-1',
+    summary: 'Wired the badge to checkpoint verification',
+    diff_stat: null,
+    verification_raw: null,
+    status: 'pending',
+    reviewer_notes: null,
+    commit_hash: null,
+    created_at: '2026-03-10 09:40:00',
+    task_name: 'slice7a checkpoint verify',
+    mission_name: null,
+    project_name: 'hermes',
+    agent_name: 'builder',
+    task_id: null,
+    project_id: null,
+    project_path: null,
+    agent_model: null,
+    agent_adapter_type: null,
+    task_run_status: null,
+    task_run_attempt: null,
+    task_run_workspace_path: null,
+    task_run_started_at: null,
+    task_run_completed_at: null,
+    task_run_error: null,
+    task_run_input_tokens: null,
+    task_run_output_tokens: null,
+    task_run_cost_cents: null,
+    run_events: [],
+    diff_files: [],
+    verification: verificationMap,
+    ...overrides,
+  }
+}
+
+describe('mapVerificationItemToBadge', () => {
+  it('maps a passed check to VERIFIED', () => {
+    const badge = mapVerificationItemToBadge(item({ status: 'passed' }), 'tsc', NOW)
+
+    expect(badge).not.toBeNull()
+    expect(badge?.state).toBe('verified')
+    expect(badge?.title).toBe('TSC · tsc --noEmit')
+    expect(badge?.time).toBe('09:38')
+  })
+
+  it('maps a failed check to CLAIMED, and says FAILED in the title', () => {
+    const badge = mapVerificationItemToBadge(
+      item({ status: 'failed', label: 'vitest run', output: 'exit 1' }),
+      'tests',
+      NOW,
+    )
+
+    // A failing check must never wear the affirmative state...
+    expect(badge?.state).toBe('claimed')
+    // ...and "CLAIMED · UNVERIFIED" alone would read as "we don't know", so the
+    // failure is stated in words too.
+    expect(badge?.title).toBe('TESTS FAILED · vitest run')
+    expect(badge?.evidence).toEqual(['exit 1'])
+  })
+
+  it('renders NO badge for missing or not_configured — honest non-states', () => {
+    expect(mapVerificationItemToBadge(item({ status: 'missing' }), 'lint', NOW)).toBeNull()
+    expect(
+      mapVerificationItemToBadge(item({ status: 'not_configured' }), 'e2e', NOW),
+    ).toBeNull()
+  })
+
+  it('never fabricates a verified state from anything but `passed`', () => {
+    for (const status of ['failed', 'missing', 'not_configured'] as const) {
+      const badge = mapVerificationItemToBadge(item({ status }), 'tsc', NOW)
+      expect(badge?.state).not.toBe('verified')
+    }
+  })
+
+  it('emits no action chips — the slice is read-only', () => {
+    const badge = mapVerificationItemToBadge(item({ status: 'passed' }), 'tsc', NOW)
+    expect(badge?.actions).toEqual([])
+  })
+
+  it('carries no evidence when the check reported no output', () => {
+    const badge = mapVerificationItemToBadge(
+      item({ status: 'passed', output: null }),
+      'tsc',
+      NOW,
+    )
+    expect(badge?.evidence).toBeUndefined()
+  })
+
+  it('falls back to plain text rather than an empty title', () => {
+    const badge = mapVerificationItemToBadge(
+      item({ status: 'passed', label: '   ' }),
+      'tsc',
+      NOW,
+    )
+    expect(badge?.title).toBe('TSC · no command reported')
+  })
+})
+
+describe('mapOutputToEvidence / clampEvidenceLine', () => {
+  it('splits real output into lines and drops the blank ones', () => {
+    expect(mapOutputToEvidence('tsc --noEmit\n\nFound 0 errors.\n')).toEqual([
+      'tsc --noEmit',
+      'Found 0 errors.',
+    ])
+  })
+
+  it('returns nothing for absent or blank output', () => {
+    expect(mapOutputToEvidence(null)).toBeUndefined()
+    expect(mapOutputToEvidence('')).toBeUndefined()
+    expect(mapOutputToEvidence('\n  \n')).toBeUndefined()
+  })
+
+  it('clamps a long line at a word boundary and marks the truncation', () => {
+    const long = 'error TS2345: '.repeat(30)
+    const clamped = clampEvidenceLine(long)
+
+    expect(long.length).toBeGreaterThan(EVIDENCE_LINE_MAX)
+    expect(clamped.length).toBeLessThanOrEqual(EVIDENCE_LINE_MAX + 1)
+    expect(clamped.endsWith('…')).toBe(true)
+    expect(clamped.slice(0, -1).endsWith(' ')).toBe(false)
+    expect(long.startsWith(clamped.slice(0, -1))).toBe(true)
+  })
+
+  it('leaves a short line untouched', () => {
+    expect(clampEvidenceLine('exit 1 · 1 failed / 84 passed')).toBe(
+      'exit 1 · 1 failed / 84 passed',
+    )
+  })
+
+  it('clamps the line COUNT and says how many it dropped', () => {
+    const output = Array.from({ length: 9 }, (_, index) => `line ${index}`).join('\n')
+    const evidence = mapOutputToEvidence(output)
+
+    expect(evidence).toHaveLength(EVIDENCE_LINES_MAX + 1)
+    expect(evidence?.slice(0, EVIDENCE_LINES_MAX)).toEqual([
+      'line 0',
+      'line 1',
+      'line 2',
+      'line 3',
+    ])
+    expect(evidence?.at(-1)).toBe('… +5 more output lines')
+  })
+
+  it('says "line" when exactly one is dropped', () => {
+    const output = Array.from({ length: 5 }, (_, index) => `line ${index}`).join('\n')
+    expect(mapOutputToEvidence(output)?.at(-1)).toBe('… +1 more output line')
+  })
+})
+
+describe('formatCheckedAt', () => {
+  it('shows the clock for a check run today', () => {
+    expect(formatCheckedAt(TODAY_0938, NOW)).toBe('09:38')
+  })
+
+  it('shows the date for an older check', () => {
+    expect(formatCheckedAt(LAST_MONTH, NOW)).toBe('Feb 17 09:38')
+  })
+
+  it('reads a zone-less SQLite timestamp as UTC, like the lib does', () => {
+    expect(formatCheckedAt('2026-03-10 21:40:00', NOW)).toBe(
+      formatCheckedAt('2026-03-10T21:40:00Z', NOW),
+    )
+  })
+
+  it('yields nothing rather than an Invalid Date', () => {
+    expect(formatCheckedAt(null, NOW)).toBeUndefined()
+    expect(formatCheckedAt('   ', NOW)).toBeUndefined()
+    expect(formatCheckedAt('not a timestamp', NOW)).toBeUndefined()
+  })
+})
+
+describe('mapCheckpointToBadges', () => {
+  it('maps only the checks that ran, in check order', () => {
+    const badges = mapCheckpointToBadges(
+      detail(
+        verification({
+          tsc: item({ status: 'passed', label: 'tsc --noEmit' }),
+          tests: item({ status: 'failed', label: 'vitest run' }),
+        }),
+      ),
+      NOW,
+    )
+
+    expect(badges.map((badge) => badge.title)).toEqual([
+      'TSC · tsc --noEmit',
+      'TESTS FAILED · vitest run',
+    ])
+    expect(badges.map((badge) => badge.state)).toEqual(['verified', 'claimed'])
+  })
+
+  it('returns NOTHING for a checkpoint whose checks never ran', () => {
+    // The default map is all missing/not_configured — the common real case.
+    expect(mapCheckpointToBadges(detail(), NOW)).toEqual([])
+  })
+
+  it('gives every badge a distinct title, so the list keys cannot collide', () => {
+    const badges = mapCheckpointToBadges(
+      detail(
+        verification({
+          tsc: item({ status: 'passed', label: 'pnpm verify' }),
+          tests: item({ status: 'passed', label: 'pnpm verify' }),
+          lint: item({ status: 'failed', label: 'pnpm verify' }),
+          e2e: item({ status: 'passed', label: 'pnpm verify' }),
+        }),
+      ),
+      NOW,
+    )
+
+    expect(new Set(badges.map((badge) => badge.title)).size).toBe(badges.length)
+  })
+})
+
+describe('mapCheckpointToInertChecks', () => {
+  it('reports the checks that produced no verdict, and only those', () => {
+    const inert = mapCheckpointToInertChecks(
+      detail(
+        verification({
+          tsc: item({ status: 'passed' }),
+          tests: item({ status: 'missing', label: 'Not run yet' }),
+        }),
+      ),
+    )
+
+    expect(inert.map((entry) => entry.key)).toEqual(['tests', 'lint', 'e2e'])
+    expect(inert[0].note).toBe('never ran · no verdict recorded')
+    expect(inert[1].note).toBe('not configured for this project · no verdict')
+  })
+
+  it('reports nothing when every check ran', () => {
+    const inert = mapCheckpointToInertChecks(
+      detail(
+        verification({
+          tsc: item({ status: 'passed' }),
+          tests: item({ status: 'passed' }),
+          lint: item({ status: 'failed' }),
+          e2e: item({ status: 'passed' }),
+        }),
+      ),
+    )
+
+    expect(inert).toEqual([])
+  })
+})
+
+describe('buildCheckpointSourceLine', () => {
+  it('names the checkpoint from real fields only', () => {
+    expect(buildCheckpointSourceLine(detail())).toBe(
+      'slice7a checkpoint verify · hermes · checkpoint 06ec90ba · pending',
+    )
+  })
+
+  it('omits what the checkpoint does not carry', () => {
+    expect(
+      buildCheckpointSourceLine(
+        detail(verification(), { task_name: null, project_name: null }),
+      ),
+    ).toBe('checkpoint 06ec90ba · pending')
+  })
+})

--- a/src/screens/jarvis/conductor/map-checkpoints.ts
+++ b/src/screens/jarvis/conductor/map-checkpoints.ts
@@ -1,0 +1,274 @@
+/**
+ * `WorkspaceCheckpointVerificationItem` → `VerificationBadge` props. Pure
+ * functions only: no React, no fetch, no styling.
+ * `use-checkpoint-verification.ts` owns the query; this file owns the honesty.
+ *
+ * WHICH verification this is. `docs/design/jarvis-ui-mapping.md` §3.6 is
+ * explicit that verified-vs-claimed on a CHAT MESSAGE is NO SOURCE (§3.5 items
+ * 2–3) and that the ONE real source in the codebase is out-of-band from chat:
+ * the code checks a workspace checkpoint records — `tsc | tests | lint | e2e`,
+ * each with a `status`, real `output` and a `checked_at`. So everything mapped
+ * here is a statement about CODE, never about a conversational claim, and the
+ * surface that renders it says so. Nothing in this file may be pointed at a
+ * message.
+ *
+ * The four statuses, and why two of them produce no badge:
+ *   • `passed`  → VERIFIED. A check ran and succeeded; `output` is the evidence.
+ *   • `failed`  → CLAIMED · UNVERIFIED. The badge has two states and `verified`
+ *     is the affirmative one, so a failing check cannot wear it — that would
+ *     read as "this passed". It is rendered as the un-affirmed state instead,
+ *     and because "CLAIMED · UNVERIFIED" alone could be misread as "we don't
+ *     know", the title says FAILED outright and the real `output` sits under it.
+ *   • `missing` / `not_configured` → NO BADGE. These are honest non-states: no
+ *     check ran, so there is nothing verified AND nothing claimed. They are
+ *     returned separately by `mapCheckpointToInertChecks` as inert lines, so
+ *     the surface can say "lint: not configured" without dressing it as either
+ *     verdict. Nothing here ever invents a `passed`.
+ *
+ * `actions` is always empty. TRIAGE / RE-RUN imply a write, and this slice is
+ * read-only — an inert chip on a real badge would be a lie about what the
+ * surface can do.
+ */
+import type {
+  WorkspaceCheckpointDetail,
+  WorkspaceCheckpointVerificationItem,
+  WorkspaceCheckpointVerificationKey,
+} from '@/lib/workspace-checkpoints'
+import type { VerificationBadgeProps } from '@/components/jarvis/types'
+import { parseUtcTimestamp } from '@/lib/workspace-checkpoints'
+
+/** Render order — the order the checks run in, not the order the API returns. */
+export const VERIFICATION_KEYS: Array<WorkspaceCheckpointVerificationKey> = [
+  'tsc',
+  'tests',
+  'lint',
+  'e2e',
+]
+
+/**
+ * The check's own name, uppercased into the board's label idiom.
+ *
+ * This prefix is real data — it is the key the API stores the item under — and
+ * it is load-bearing twice over. `label` is free text with an `'Unknown'`
+ * fallback in the normalizer, so a bare title can end up saying nothing about
+ * WHICH check it is; and two checks may ship the same label, which would
+ * collide as a React key on the rendered list. The scope fixes both without
+ * adding a word the backend did not supply.
+ */
+const KEY_SCOPE: Record<WorkspaceCheckpointVerificationKey, string> = {
+  tsc: 'TSC',
+  tests: 'TESTS',
+  lint: 'LINT',
+  e2e: 'E2E',
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+/**
+ * `09:38` for a check run today, `Aug 17 09:38` for an older one — the same
+ * shape the Conductor's run times use, so one board reads in one register.
+ *
+ * `checked_at` arrives either as an ISO string or as a SQLite `2026-03-10
+ * 21:40:00` with no zone, which `parseUtcTimestamp` (the lib's own reader, so
+ * this file does not fork the rule) resolves as UTC. An unparseable value
+ * yields nothing rather than "Invalid Date".
+ */
+export function formatCheckedAt(
+  checkedAt: string | null,
+  now: number = Date.now(),
+): string | undefined {
+  if (typeof checkedAt !== 'string' || !checkedAt.trim()) return undefined
+
+  const at = parseUtcTimestamp(checkedAt)
+  if (Number.isNaN(at.getTime())) return undefined
+
+  const today = new Date(now)
+  const clock = `${pad2(at.getHours())}:${pad2(at.getMinutes())}`
+  const sameDay =
+    at.getFullYear() === today.getFullYear() &&
+    at.getMonth() === today.getMonth() &&
+    at.getDate() === today.getDate()
+
+  return sameDay ? clock : `${MONTHS[at.getMonth()]} ${at.getDate()} ${clock}`
+}
+
+/**
+ * A real `output` is unbounded — a failing `tsc` prints every error it found,
+ * and a failing test run prints stack traces. Rendered whole, one badge grows
+ * past the surface it sits on and pushes everything after it off screen.
+ *
+ * So the output is clamped twice: to the first few lines, and each line to
+ * roughly the width the badge allots. Both clamps announce themselves (a
+ * trailing ellipsis, and a counted "more output lines" line) so a reader can
+ * never mistake a clipped pass for a clean one. Nothing is lost — the full
+ * output is on the checkpoint itself, which is where a triage belongs.
+ */
+export const EVIDENCE_LINE_MAX = 120
+export const EVIDENCE_LINES_MAX = 4
+
+export function clampEvidenceLine(text: string): string {
+  if (text.length <= EVIDENCE_LINE_MAX) return text
+  const cut = text.slice(0, EVIDENCE_LINE_MAX)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > EVIDENCE_LINE_MAX / 2 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
+/**
+ * `output` as evidence lines, or nothing at all.
+ *
+ * An absent or blank `output` returns `undefined` rather than a stand-in: the
+ * badge simply carries no evidence block, which is the true statement. Writing
+ * "exit 0" under a passed check with no output would be inventing the one thing
+ * this component exists to be trusted about.
+ */
+export function mapOutputToEvidence(
+  output: string | null,
+): Array<string> | undefined {
+  if (typeof output !== 'string') return undefined
+
+  const lines = output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+
+  if (lines.length === 0) return undefined
+
+  const shown = lines.slice(0, EVIDENCE_LINES_MAX).map(clampEvidenceLine)
+  const hidden = lines.length - shown.length
+  if (hidden > 0) {
+    shown.push(`… +${hidden} more output ${hidden === 1 ? 'line' : 'lines'}`)
+  }
+  return shown
+}
+
+function readLabel(item: WorkspaceCheckpointVerificationItem): string {
+  const label = item.label.trim()
+  return label ? label : 'no command reported'
+}
+
+/**
+ * One verification item as one badge, or `null` when the item is a non-state.
+ *
+ * `now` is injected so the same-day branch of the timestamp is testable and so
+ * a whole map reads against one clock.
+ */
+export function mapVerificationItemToBadge(
+  item: WorkspaceCheckpointVerificationItem,
+  key: WorkspaceCheckpointVerificationKey,
+  now: number = Date.now(),
+): VerificationBadgeProps | null {
+  if (item.status !== 'passed' && item.status !== 'failed') return null
+
+  const scope = KEY_SCOPE[key]
+  const passed = item.status === 'passed'
+
+  return {
+    state: passed ? 'verified' : 'claimed',
+    title: passed
+      ? `${scope} · ${readLabel(item)}`
+      : `${scope} FAILED · ${readLabel(item)}`,
+    evidence: mapOutputToEvidence(item.output),
+    time: formatCheckedAt(item.checked_at, now),
+    // Read-only slice: no chip here may imply a re-run or a triage.
+    actions: [],
+  }
+}
+
+/**
+ * Every check that actually ran, in check order. A checkpoint whose checks are
+ * all `missing`/`not_configured` maps to an empty list — which the surface
+ * renders as the inert lines below, never as a fixture standing in for a real
+ * verdict.
+ */
+export function mapCheckpointToBadges(
+  detail: WorkspaceCheckpointDetail,
+  now: number = Date.now(),
+): Array<VerificationBadgeProps> {
+  const badges: Array<VerificationBadgeProps> = []
+
+  for (const key of VERIFICATION_KEYS) {
+    const badge = mapVerificationItemToBadge(detail.verification[key], key, now)
+    if (badge) badges.push(badge)
+  }
+
+  return badges
+}
+
+/** A check that produced no verdict — rendered as plain text, never as a badge. */
+export interface CheckpointInertCheck {
+  key: WorkspaceCheckpointVerificationKey
+  /** `TSC`, `TESTS`, … — the same scope the badges use. */
+  scope: string
+  status: 'missing' | 'not_configured'
+  /** What the absence actually means, in the API's own terms. */
+  note: string
+}
+
+/**
+ * The other half of the truth: which checks did NOT run.
+ *
+ * Dropping these silently would leave a checkpoint with one green TSC badge
+ * looking fully verified. Stated, the same checkpoint reads "tsc passed, tests
+ * never ran, lint and e2e are not configured" — which is what the API said.
+ */
+export function mapCheckpointToInertChecks(
+  detail: WorkspaceCheckpointDetail,
+): Array<CheckpointInertCheck> {
+  const inert: Array<CheckpointInertCheck> = []
+
+  for (const key of VERIFICATION_KEYS) {
+    const item = detail.verification[key]
+    if (item.status !== 'missing' && item.status !== 'not_configured') continue
+
+    inert.push({
+      key,
+      scope: KEY_SCOPE[key],
+      status: item.status,
+      note:
+        item.status === 'not_configured'
+          ? 'not configured for this project · no verdict'
+          : 'never ran · no verdict recorded',
+    })
+  }
+
+  return inert
+}
+
+/**
+ * Which checkpoint the badges above belong to. Real fields only — the task
+ * name, the project, and the checkpoint's own review status — so a reader can
+ * tell whether they are looking at last week's run.
+ */
+export function buildCheckpointSourceLine(
+  detail: WorkspaceCheckpointDetail,
+): string {
+  const parts: Array<string> = []
+
+  const task = detail.task_name?.trim()
+  if (task) parts.push(task)
+
+  const project = detail.project_name?.trim()
+  if (project) parts.push(project)
+
+  parts.push(`checkpoint ${detail.id.slice(0, 8)}`)
+  parts.push(detail.status)
+
+  return parts.join(' · ')
+}

--- a/src/screens/jarvis/conductor/map-scheduled-jobs.test.ts
+++ b/src/screens/jarvis/conductor/map-scheduled-jobs.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildScheduledJobsHeading,
+  mapClaudeJobToConductorFixture,
+  mapClaudeJobsToConductorFixtures,
+  mapConductorFixturesToMobileJobs,
+} from './map-scheduled-jobs'
+import type { ClaudeJob } from '@/lib/jobs-api'
+
+const DAY_MS = 86_400_000
+/** A fixed clock, so the SILENT derivation is arithmetic and not a race. */
+const NOW = new Date('2026-08-24T12:00:00Z').getTime()
+
+const daysAgo = (days: number) => new Date(NOW - days * DAY_MS).toISOString()
+
+function job(overrides: Partial<ClaudeJob> = {}): ClaudeJob {
+  return {
+    id: 'job-1',
+    name: 'vault-index-rebuild',
+    prompt: 'rebuild the index',
+    schedule: { kind: 'interval' },
+    schedule_display: 'every 6h',
+    enabled: true,
+    state: 'completed',
+    last_run_at: daysAgo(0),
+    last_run_success: true,
+    run_count: 41,
+    ...overrides,
+  }
+}
+
+describe('mapClaudeJobToConductorFixture', () => {
+  it('maps a healthy job to ok/OK', () => {
+    const card = mapClaudeJobToConductorFixture(job(), NOW)
+
+    expect(card.tone).toBe('ok')
+    expect(card.badge).toBe('OK')
+    expect(card.name).toBe('vault-index-rebuild')
+    expect(card.detail[0].text).toMatch(/^last .+ · 41 runs$/)
+  })
+
+  it('maps a failed state to failed/FAILED with the real error text', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({
+        name: 'ops-watch:certs',
+        state: 'failed',
+        last_run_success: false,
+        last_run_error: 'certbot renew → exit 1: DNS-01 challenge timeout',
+      }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('failed')
+    expect(card.badge).toBe('FAILED')
+    expect(card.detail).toContainEqual({
+      text: 'certbot renew → exit 1: DNS-01 challenge timeout',
+      tone: 'failed',
+    })
+  })
+
+  it('treats last_run_success === false as FAILED even in a success state', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ state: 'completed', last_run_success: false }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('failed')
+    expect(card.badge).toBe('FAILED')
+    // No error text served: the card says so rather than inventing a cause.
+    expect(card.detail.at(-1)).toEqual({
+      text: 'no error text reported',
+      tone: 'failed',
+    })
+  })
+
+  it('derives SILENT <N>d for an enabled job long past its last run', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ name: 'maintainer:dep-audit', last_run_at: daysAgo(23) }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('silent')
+    expect(card.badge).toBe('SILENT 23d')
+  })
+
+  it('holds the SILENT derivation below the conservative threshold', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ last_run_at: daysAgo(13) }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('ok')
+    expect(card.badge).toBe('OK')
+  })
+
+  it('does not call a disabled job silent — it says it is disabled', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ enabled: false, last_run_at: daysAgo(60) }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('ok')
+    expect(card.detail).toContainEqual({
+      text: 'disabled · not scheduled',
+      tone: 'dim',
+    })
+  })
+
+  it('does not invent an age for a job that has never run', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ last_run_at: null, run_count: 0 }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('ok')
+    expect(card.badge).toBe('OK')
+    expect(card.detail[0]).toEqual({ text: 'no last run recorded' })
+  })
+
+  it('takes the owning worker from the name prefix, or omits it', () => {
+    expect(
+      mapClaudeJobToConductorFixture(
+        job({ name: 'ops-watch:certs', schedule_display: 'daily 05:00' }),
+        NOW,
+      ).cadence,
+    ).toBe('daily 05:00 · ops-watch')
+
+    expect(
+      mapClaudeJobToConductorFixture(
+        job({ name: 'weekly-review-digest', schedule_display: 'Sun 18:00' }),
+        NOW,
+      ).cadence,
+    ).toBe('Sun 18:00')
+  })
+
+  it('falls back to the raw schedule rather than a tidy guess', () => {
+    expect(
+      mapClaudeJobToConductorFixture(
+        job({ schedule_display: undefined, schedule: { cron: '0 5 * * *' } }),
+        NOW,
+      ).cadence,
+    ).toBe('0 5 * * *')
+
+    expect(
+      mapClaudeJobToConductorFixture(
+        job({ schedule_display: undefined, schedule: {} }),
+        NOW,
+      ).cadence,
+    ).toBe('schedule unavailable')
+  })
+
+  /**
+   * These two cases come straight off a real gateway: `profiles=all` returns
+   * the same job registered under `default`, `orchestrator` and `researcher`,
+   * and the broken ones report `last_run_success: null` beside a populated
+   * `last_run_error`.
+   */
+  it('qualifies the card with the owning profile, as the board idiom does', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({
+        id: 'orchestrator:06ec90ba4703',
+        profile: 'orchestrator',
+        profile_name: 'orchestrator',
+        name: 'The Nutrient — Weekly Newsletter',
+        schedule_display: '0 9 * * 1',
+      }),
+      NOW,
+    )
+
+    expect(card.name).toBe('orchestrator:The Nutrient — Weekly Newsletter')
+    expect(card.cadence).toBe('0 9 * * 1 · orchestrator')
+  })
+
+  it('reads the profile off the id when the field is absent', () => {
+    expect(
+      mapClaudeJobToConductorFixture(job({ id: 'researcher:13b7bc8d94be' }), NOW)
+        .name,
+    ).toBe('researcher:vault-index-rebuild')
+  })
+
+  it('fails a run that recorded an error and never reported success', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({
+        state: 'scheduled',
+        last_run_success: null,
+        last_run_error: '[blocked_config] provider credential missing',
+      }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('failed')
+    expect(card.badge).toBe('FAILED')
+    expect(card.detail).toContainEqual({
+      text: '[blocked_config] provider credential missing',
+      tone: 'failed',
+    })
+  })
+
+  it('lets a reported success outrank an error left beside it', () => {
+    const card = mapClaudeJobToConductorFixture(
+      job({ state: 'scheduled', last_run_success: true, error: 'stale' }),
+      NOW,
+    )
+
+    expect(card.tone).toBe('ok')
+    expect(card.badge).toBe('OK')
+  })
+
+  it('clamps an unbounded error so a live card cannot clip the board', () => {
+    const long =
+      '[blocked_config] provider credential missing: No inference provider configured. ' +
+      "Run 'hermes model' to choose a provider and model, or set an API key " +
+      '(OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) in ~/.hermes/.env.'
+    const card = mapClaudeJobToConductorFixture(
+      job({ last_run_success: false, last_run_error: long }),
+      NOW,
+    )
+    const line = card.detail.at(-1)!
+
+    expect(line.tone).toBe('failed')
+    expect(line.text.length).toBeLessThanOrEqual(121)
+    expect(line.text.endsWith('…')).toBe(true)
+    // The clamp is a cut, never a rewrite: what is shown is verbatim.
+    expect(long.startsWith(line.text.slice(0, -1))).toBe(true)
+  })
+
+  it('leaves a short error verbatim', () => {
+    expect(
+      mapClaudeJobToConductorFixture(
+        job({ last_run_success: false, last_run_error: 'certbot exit 1' }),
+        NOW,
+      ).detail.at(-1),
+    ).toEqual({ text: 'certbot exit 1', tone: 'failed' })
+  })
+
+  it('renders no action chips — this slice cannot run, reload or triage', () => {
+    expect(
+      mapClaudeJobToConductorFixture(job({ state: 'failed' }), NOW).actions,
+    ).toEqual([])
+  })
+})
+
+describe('NO SOURCE items are never produced from real data', () => {
+  const jobs: Array<ClaudeJob> = [
+    job(),
+    job({ id: 'j2', name: 'ops-watch:certs', state: 'failed' }),
+    job({ id: 'j3', name: 'maintainer:dep-audit', last_run_at: daysAgo(23) }),
+    job({ id: 'j4', enabled: false }),
+    job({ id: 'j5', last_run_at: null }),
+    // The PARTIAL case as it really arrives: free text inside last_run_error.
+    job({
+      id: 'j6',
+      name: 'researcher:feed-scan',
+      last_run_success: false,
+      last_run_error: '2 of 14 feeds 403',
+    }),
+  ]
+  const cards = mapClaudeJobsToConductorFixtures(jobs, NOW)
+
+  it('never emits a partial tone or a PARTIAL badge (§3.5 item 11)', () => {
+    for (const card of cards) {
+      expect(card.tone).not.toBe('partial')
+      expect(card.badge).not.toContain('PARTIAL')
+      expect(card.badgeNoSource).toBeUndefined()
+    }
+    // The "2 of 14 feeds 403" job is a FAILED job whose error happens to be
+    // partial-sounding prose — the badge reports the state, not the prose.
+    expect(cards[5].tone).toBe('failed')
+    expect(cards[5].badge).toBe('FAILED')
+  })
+
+  it('never emits the launchd diagnostic or any unsourced line (§3.5 item 12)', () => {
+    for (const card of cards) {
+      for (const line of card.detail) {
+        expect(line.noSource).toBeUndefined()
+        expect(line.text.toLowerCase()).not.toContain('launchd')
+      }
+    }
+  })
+
+  it('never invents a run tally, a duration or a payload count', () => {
+    const text = cards.flatMap((card) => card.detail.map((l) => l.text)).join(' ')
+
+    expect(text).not.toMatch(/runs failed/)
+    expect(text).not.toMatch(/expected \d+ runs/)
+    expect(text).not.toMatch(/\d+ notes/)
+    expect(text).not.toMatch(/\b\d+(\.\d+)?s\b/) // no fake durations like "41s"
+  })
+})
+
+describe('mapClaudeJobsToConductorFixtures', () => {
+  it('keeps card names unique so the grid cannot key two cards alike', () => {
+    const cards = mapClaudeJobsToConductorFixtures(
+      [
+        job({ id: 'default:aaa', name: 'Morning Daily Briefing' }),
+        job({ id: 'orchestrator:aaa', name: 'Morning Daily Briefing' }),
+        // Same profile AND same name: only the id can separate these.
+        job({ id: 'default:bbb', name: 'Morning Daily Briefing' }),
+      ],
+      NOW,
+    )
+
+    expect(cards.map((c) => c.name)).toEqual([
+      'default:Morning Daily Briefing',
+      'orchestrator:Morning Daily Briefing',
+      'default:Morning Daily Briefing (default:bbb)',
+    ])
+    expect(new Set(cards.map((c) => c.name)).size).toBe(3)
+  })
+})
+
+describe('buildScheduledJobsHeading', () => {
+  it('counts what is actually registered', () => {
+    expect(buildScheduledJobsHeading(9)).toEqual({
+      label: 'SCHEDULED JOBS',
+      note: '9 registered · health is last-run, not next-run',
+    })
+  })
+})
+
+describe('mapConductorFixturesToMobileJobs', () => {
+  const cards = mapClaudeJobsToConductorFixtures(
+    [
+      job({ id: 'a' }),
+      job({ id: 'b', name: 'x-two' }),
+      job({
+        id: 'c',
+        name: 'ops-watch:certs',
+        state: 'failed',
+        last_run_error: 'certbot exit 1',
+      }),
+      job({ id: 'd', name: 'maintainer:dep-audit', last_run_at: daysAgo(23) }),
+    ],
+    NOW,
+  )
+
+  it('keeps only the unhealthy jobs and tallies the rest', () => {
+    const mobile = mapConductorFixturesToMobileJobs(cards)
+
+    expect(mobile.jobs.map((j) => [j.name, j.tone, j.badge])).toEqual([
+      ['ops-watch:certs', 'failed', 'FAIL'],
+      ['maintainer:dep-audit', 'silent', 'SILENT 23d'],
+    ])
+    expect(mobile.jobs[0].detail).toBe('certbot exit 1')
+    expect(mobile.healthy).toBe('2 other jobs healthy')
+  })
+
+  it('marks no live mobile row as unsourced', () => {
+    for (const row of mapConductorFixturesToMobileJobs(cards).jobs) {
+      expect(row.noSource).toBeUndefined()
+      expect(row.detail.toLowerCase()).not.toContain('launchd')
+    }
+  })
+
+  it('singularises the healthy tally', () => {
+    const mobile = mapConductorFixturesToMobileJobs(cards.slice(1))
+    expect(mobile.healthy).toBe('1 other job healthy')
+  })
+})

--- a/src/screens/jarvis/conductor/map-scheduled-jobs.ts
+++ b/src/screens/jarvis/conductor/map-scheduled-jobs.ts
@@ -1,0 +1,363 @@
+/**
+ * `ClaudeJob` → Conductor SCHEDULED JOBS card. Pure functions only: no React,
+ * no fetch, no styling. `use-scheduled-jobs.ts` owns the query; this file owns
+ * the honesty.
+ *
+ * The rule this file enforces is the one from `docs/design/jarvis-ui-mapping.md`
+ * §3.4/§3.5: a card may only say what a `ClaudeJob` actually supplies.
+ *   • REAL and mapped — name, `schedule_display`, `enabled`, `state`,
+ *     `last_run_success`, `last_run_error`, `last_run_at`, `run_count`.
+ *   • DERIVED and marked as such below — SILENT/stale, which has no declared
+ *     field and is computed from `enabled` + `last_run_at` age.
+ *   • NO SOURCE and therefore NEVER produced here — the structured PARTIAL
+ *     badge (§3.5 item 11), the launchd "not loaded" diagnostic (item 12), any
+ *     run tally beyond `run_count`, and any payload count ("3,209 notes") or
+ *     duration ("41s"), none of which `ClaudeJob` carries. A real job simply
+ *     does not render those lines; it does not render a plausible guess.
+ *
+ * `actions` is always empty. TRIAGE / FULL LOG / RELOAD & RUN all imply a side
+ * effect, and this slice is read-only — an inert chip on a real card would be a
+ * lie about what the board can do.
+ */
+import type { ClaudeJob } from '@/lib/jobs-api'
+import type {
+  ConductorJobFixture,
+  ConductorJobLineFixture,
+  ConductorSectionHeadingFixture,
+  MobileJobFixture,
+  MobileJobTone,
+} from '@/components/jarvis/fixtures'
+import { getJobErrorText, isFailedJobState } from '@/lib/jobs-api'
+
+const DAY_MS = 86_400_000
+
+/**
+ * DERIVE — SILENT/stale. `ClaudeJob.schedule` is an opaque `Record<string,
+ * unknown>` and `schedule_display` is free text, so a per-job cadence cannot be
+ * parsed reliably; `next_run_at − last_run_at` is not a cadence either, because
+ * for an already-stale job that gap IS the staleness and using it as the
+ * threshold would hide exactly the case this section exists to surface.
+ *
+ * So: one conservative, cadence-independent threshold. Fourteen days is two
+ * missed cycles for the slowest schedule these jobs use (weekly) and many more
+ * for anything faster, which means a SILENT badge is never a false alarm — at
+ * the cost of taking up to 14 days to call a stale hourly job. Under-reporting
+ * is the right way to be wrong here.
+ */
+export const SILENT_THRESHOLD_MS = 14 * DAY_MS
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+function parseTimestamp(value: string | null | undefined): number | null {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const parsed = new Date(value).getTime()
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+/** `09:33` for a run today, `Aug 17 09:33` for an older one. */
+function formatRunTime(timestamp: number, now: number): string {
+  const at = new Date(timestamp)
+  const today = new Date(now)
+  const clock = `${pad2(at.getHours())}:${pad2(at.getMinutes())}`
+
+  const sameDay =
+    at.getFullYear() === today.getFullYear() &&
+    at.getMonth() === today.getMonth() &&
+    at.getDate() === today.getDate()
+
+  return sameDay
+    ? clock
+    : `${MONTHS[at.getMonth()]} ${at.getDate()} ${clock}`
+}
+
+/**
+ * `ops-watch:certs` → `ops-watch`. The owning worker is only ever implied by
+ * the name prefix; when a name carries no prefix the cadence line simply omits
+ * the worker rather than inventing one.
+ */
+export function deriveWorkerFromName(name: string): string | null {
+  const separator = name.indexOf(':')
+  if (separator <= 0) return null
+  const prefix = name.slice(0, separator).trim()
+  return prefix || null
+}
+
+/**
+ * The owning profile — `profile`, else `profile_name`, else the prefix of the
+ * `id` (`orchestrator:06ec90ba4703` → `orchestrator`), which is where the
+ * gateway actually encodes it.
+ */
+export function deriveProfile(job: ClaudeJob): string | null {
+  for (const candidate of [job.profile, job.profile_name]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim()
+  }
+  return deriveWorkerFromName(job.id)
+}
+
+/**
+ * The card's title, in the board's `owner:job` idiom.
+ *
+ * This is not cosmetic. Real gateways register the SAME job under several
+ * profiles, so `/api/claude-jobs?profiles=all` returns three rows all named
+ * "Morning Daily Briefing" — distinct jobs with distinct ids, health and
+ * schedules. A bare `job.name` would collapse them into one indistinguishable
+ * title (and collide as a React key). The profile is real data and it is what
+ * tells them apart, so it goes in front, exactly as `ops-watch:certs` does.
+ */
+export function deriveCardName(job: ClaudeJob): string {
+  const profile = deriveProfile(job)
+  return profile ? `${profile}:${job.name}` : job.name
+}
+
+/**
+ * `schedule_display` when the API sends it. Otherwise the rawest readable form
+ * of `schedule` — the first non-empty string in the record, else the record
+ * itself — because a wrong-but-tidy cadence is worse than an ugly true one.
+ */
+export function formatSchedule(job: ClaudeJob): string {
+  const display = job.schedule_display
+  if (typeof display === 'string' && display.trim()) return display.trim()
+
+  for (const value of Object.values(job.schedule)) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  if (Object.keys(job.schedule).length > 0) {
+    try {
+      return JSON.stringify(job.schedule)
+    } catch {
+      // Fall through to the unknown-schedule text below.
+    }
+  }
+
+  return 'schedule unavailable'
+}
+
+/** Whole days since the last run, or `null` when there has never been one. */
+export function daysSinceLastRun(
+  job: ClaudeJob,
+  now: number,
+): number | null {
+  const lastRun = parseTimestamp(job.last_run_at)
+  if (lastRun === null) return null
+  return Math.floor((now - lastRun) / DAY_MS)
+}
+
+/**
+ * FAILED — a failed terminal state, or a last run the API marked unsuccessful.
+ *
+ * The third clause is not free-standing invention: real records come back with
+ * `state: 'scheduled'`, `last_run_success: null` and a populated
+ * `last_run_error` ("[blocked_config] provider credential missing: …"). That
+ * run did not succeed and the API says why, so badging it OK would be the exact
+ * dishonesty this board exists to prevent. `last_run_success === true` still
+ * wins, so a stale error left beside a successful run does not turn the card
+ * red.
+ */
+export function isFailedJob(job: ClaudeJob): boolean {
+  if (isFailedJobState(job.state)) return true
+  if (job.last_run_success === false) return true
+  return job.last_run_success !== true && getJobErrorText(job) !== null
+}
+
+/**
+ * SILENT — enabled, has run before, and has not run since the threshold above.
+ *
+ * A job that has NEVER run is deliberately not silent: with no `last_run_at`
+ * there is no age to report, and the badge counts days. Its card says
+ * "no last run recorded" instead, which is the true statement.
+ */
+export function isSilentJob(job: ClaudeJob, now: number): boolean {
+  if (isFailedJob(job)) return false
+  if (!job.enabled) return false
+  const lastRun = parseTimestamp(job.last_run_at)
+  if (lastRun === null) return false
+  return now - lastRun > SILENT_THRESHOLD_MS
+}
+
+/**
+ * The artboard is a fixed 1440×900 frame with `overflow-hidden`, and a real
+ * `last_run_error` is unbounded — the gateway serves 300+ character provider
+ * diagnostics. Left whole, one failed card grows the section and clips the RUN
+ * LOG off the bottom of the board.
+ *
+ * So the line is clamped to roughly the two lines the artboard allots a failed
+ * card, cut at a word boundary and ended with an ellipsis so the truncation
+ * declares itself. Nothing is lost: the full text is on the jobs screen, which
+ * reads the same record.
+ */
+const ERROR_TEXT_MAX = 120
+
+export function clampErrorText(text: string): string {
+  if (text.length <= ERROR_TEXT_MAX) return text
+  const cut = text.slice(0, ERROR_TEXT_MAX)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > ERROR_TEXT_MAX / 2 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
+function formatRunCount(runCount: unknown): string | null {
+  if (typeof runCount !== 'number' || !Number.isFinite(runCount)) return null
+  const whole = Math.max(0, Math.floor(runCount))
+  return `${whole.toLocaleString('en-US')} ${whole === 1 ? 'run' : 'runs'}`
+}
+
+function buildDetail(job: ClaudeJob, now: number): Array<ConductorJobLineFixture> {
+  const detail: Array<ConductorJobLineFixture> = []
+
+  const lastRun = parseTimestamp(job.last_run_at)
+  const runs = formatRunCount(job.run_count)
+  if (lastRun === null) {
+    detail.push({ text: 'no last run recorded' })
+  } else {
+    const parts = [`last ${formatRunTime(lastRun, now)}`]
+    if (runs) parts.push(runs)
+    detail.push({ text: parts.join(' · ') })
+  }
+
+  // REAL — `enabled` is a served field, and a paused job reading as healthy
+  // would be the same lie the SILENT card exists to prevent.
+  if (!job.enabled) {
+    detail.push({ text: 'disabled · not scheduled', tone: 'dim' })
+  }
+
+  if (isFailedJob(job)) {
+    const error = getJobErrorText(job)
+    detail.push({
+      text: error ? clampErrorText(error) : 'no error text reported',
+      tone: 'failed',
+    })
+  }
+
+  return detail
+}
+
+/**
+ * One `ClaudeJob` as one card. `now` is injected so the SILENT derivation is
+ * testable and so a list maps against a single clock.
+ */
+export function mapClaudeJobToConductorFixture(
+  job: ClaudeJob,
+  now: number = Date.now(),
+): ConductorJobFixture {
+  const name = deriveCardName(job)
+  const worker = deriveWorkerFromName(name)
+  const cadence = worker
+    ? `${formatSchedule(job)} · ${worker}`
+    : formatSchedule(job)
+
+  let tone: ConductorJobFixture['tone'] = 'ok'
+  let badge = 'OK'
+
+  if (isFailedJob(job)) {
+    tone = 'failed'
+    badge = 'FAILED'
+  } else if (isSilentJob(job, now)) {
+    tone = 'silent'
+    badge = `SILENT ${daysSinceLastRun(job, now) ?? 0}d`
+  }
+
+  return {
+    name,
+    tone,
+    badge,
+    cadence,
+    detail: buildDetail(job, now),
+    // Read-only slice: no chip here may imply a run, a reload or a triage.
+    actions: [],
+  }
+}
+
+/**
+ * A list of cards, with names guaranteed unique.
+ *
+ * `ScheduledJobs` keys its grid by name, so two cards sharing one would make
+ * React reconcile the wrong card — and one of the two would be the FAILED one.
+ * `profile:name` separates every real collision seen so far; anything still
+ * doubled gets the job's own id appended, which is the only remaining thing
+ * that distinguishes them and is, again, real data rather than an index.
+ */
+export function mapClaudeJobsToConductorFixtures(
+  jobs: Array<ClaudeJob>,
+  now: number = Date.now(),
+): Array<ConductorJobFixture> {
+  const seen = new Set<string>()
+
+  return jobs.map((job) => {
+    const card = mapClaudeJobToConductorFixture(job, now)
+    if (!seen.has(card.name)) {
+      seen.add(card.name)
+      return card
+    }
+    const disambiguated = `${card.name} (${job.id})`
+    seen.add(disambiguated)
+    return { ...card, name: disambiguated }
+  })
+}
+
+/**
+ * The section note counts what is actually registered. "6 registered" is a
+ * fixture number; live it has to be the live one.
+ */
+export function buildScheduledJobsHeading(
+  count: number,
+): ConductorSectionHeadingFixture {
+  return {
+    label: 'SCHEDULED JOBS',
+    note: `${count} registered · health is last-run, not next-run`,
+  }
+}
+
+/* ── Mobile ──────────────────────────────────────────────────────────── */
+
+/**
+ * SCHEDULE HEALTH on a phone shows only what is broken plus a tally of the
+ * rest, so the same mapped cards collapse: failed/silent become rows, every
+ * other job becomes the footer count.
+ *
+ * There is no `partial` entry — PARTIAL is NO SOURCE (§3.5 item 11), so the
+ * live footer omits that half of the line entirely rather than carrying a
+ * fixture through a live render.
+ */
+export function mapConductorFixturesToMobileJobs(
+  fixtures: Array<ConductorJobFixture>,
+): { jobs: Array<MobileJobFixture>; healthy: string } {
+  const jobs: Array<MobileJobFixture> = []
+
+  for (const fixture of fixtures) {
+    if (fixture.tone !== 'failed' && fixture.tone !== 'silent') continue
+    const tone: MobileJobTone = fixture.tone
+    // `buildDetail` always writes a last-run line, so `detail[0]` exists.
+    const line =
+      fixture.detail.find((entry) => entry.tone === 'failed') ??
+      fixture.detail[0]
+
+    jobs.push({
+      name: fixture.name,
+      tone,
+      badge: tone === 'failed' ? 'FAIL' : fixture.badge,
+      detail: line.text,
+    })
+  }
+
+  const healthyCount = fixtures.length - jobs.length
+  return {
+    jobs,
+    healthy: `${healthyCount} other ${healthyCount === 1 ? 'job' : 'jobs'} healthy`,
+  }
+}

--- a/src/screens/jarvis/conductor/map-workers.test.ts
+++ b/src/screens/jarvis/conductor/map-workers.test.ts
@@ -1,0 +1,465 @@
+import { describe, expect, it } from 'vitest'
+import {
+  STALE_THRESHOLD_MS,
+  WORKER_BOARD_MAX,
+  buildWorkerBoardHeading,
+  countWorkers,
+  deriveAgentFromKey,
+  deriveWorkerName,
+  findPendingApproval,
+  formatAge,
+  mapSwarmToMobileRunning,
+  mapSwarmToMobileStats,
+  mapSwarmToRailRows,
+  mapSwarmToWorkerCards,
+  swarmStatusToTone,
+} from './map-workers'
+import type { GatewayApprovalEntry } from '@/lib/gateway-api'
+import type { SwarmSession } from '@/stores/agent-swarm-store'
+import { conductorWorkerCardFixtures } from '@/components/jarvis/fixtures'
+
+const MINUTE_MS = 60_000
+/** A fixed clock, so every age below is arithmetic and not a race. */
+const NOW = new Date('2026-08-24T12:00:00Z').getTime()
+
+function session(overrides: Partial<SwarmSession> = {}): SwarmSession {
+  return {
+    key: 'agent:builder:subagent:06ec90ba4703',
+    friendlyId: 'sess-06ec90ba4703',
+    kind: 'subagent',
+    model: 'claude-opus-5',
+    startedAt: NOW - 4 * MINUTE_MS,
+    updatedAt: NOW,
+    totalTokens: 4200,
+    swarmStatus: 'running',
+    staleness: 2_000,
+    ...overrides,
+  }
+}
+
+function approval(
+  overrides: Partial<GatewayApprovalEntry> = {},
+): GatewayApprovalEntry {
+  return {
+    id: 'appr-1',
+    agentName: 'builder',
+    action: 'write to Vault/Published/',
+    tool: 'Write',
+    status: 'pending',
+    requestedAt: NOW - 42 * 1000,
+    ...overrides,
+  }
+}
+
+describe('deriveAgentFromKey', () => {
+  it('reads the owning agent out of a subagent session key', () => {
+    expect(deriveAgentFromKey('agent:builder:subagent:06ec90ba')).toBe('builder')
+    expect(deriveAgentFromKey('agent:main:subagent:abc123')).toBe('main')
+  })
+
+  it('returns null rather than guessing when the key names no agent', () => {
+    expect(deriveAgentFromKey('subagent:abc123')).toBeNull()
+    expect(deriveAgentFromKey('agent:main:main')).toBeNull()
+    expect(deriveAgentFromKey('')).toBeNull()
+  })
+})
+
+describe('deriveWorkerName', () => {
+  it('prefers a real served name over the key', () => {
+    expect(deriveWorkerName(session({ label: 'km-agent' }))).toBe('km-agent')
+  })
+
+  it('falls back to the key agent, then to the session id tail', () => {
+    expect(deriveWorkerName(session())).toBe('builder')
+    expect(
+      deriveWorkerName(
+        session({ key: 'subagent:zz', friendlyId: 'sess-abcdef' }),
+      ),
+    ).toBe('worker abcdef')
+  })
+})
+
+describe('swarmStatusToTone', () => {
+  it('maps running and thinking to running', () => {
+    expect(swarmStatusToTone('running', false)).toBe('running')
+    expect(swarmStatusToTone('thinking', false)).toBe('running')
+  })
+
+  it('maps failed and error to failed, complete to complete, idle to idle', () => {
+    expect(swarmStatusToTone('failed', false)).toBe('failed')
+    expect(swarmStatusToTone('error', false)).toBe('failed')
+    expect(swarmStatusToTone('complete', false)).toBe('complete')
+    expect(swarmStatusToTone('idle', false)).toBe('idle')
+  })
+
+  it('lets blocked win over every session status', () => {
+    for (const status of [
+      'running',
+      'thinking',
+      'complete',
+      'failed',
+      'error',
+      'idle',
+    ] as const) {
+      expect(swarmStatusToTone(status, true)).toBe('blocked')
+    }
+  })
+})
+
+describe('formatAge', () => {
+  it('never renders an age more precisely than the source supports', () => {
+    expect(formatAge(9_000)).toBe('9s')
+    expect(formatAge(14 * MINUTE_MS)).toBe('14m')
+    expect(formatAge(2 * 3600_000 + 11 * MINUTE_MS)).toBe('2h 11m')
+    expect(formatAge(3 * 3600_000)).toBe('3h')
+    expect(formatAge(23 * 86_400_000)).toBe('23d')
+    expect(formatAge(-5)).toBe('0s')
+  })
+})
+
+describe('findPendingApproval — the blocked join', () => {
+  it('joins on agentName, case-insensitively', () => {
+    expect(
+      findPendingApproval(session(), [approval({ agentName: 'Builder' })]),
+    ).not.toBeNull()
+  })
+
+  it('joins on an exact sessionKey even when agentName is absent', () => {
+    const entry = approval({
+      agentName: undefined,
+      sessionKey: 'agent:builder:subagent:06ec90ba4703',
+    })
+    expect(findPendingApproval(session(), [entry])).toBe(entry)
+  })
+
+  it('does not join on a partial name match', () => {
+    const other = session({
+      key: 'agent:builder-qa:subagent:99',
+      label: 'builder-qa',
+    })
+    expect(
+      findPendingApproval(other, [
+        approval({ agentName: 'builder', sessionKey: undefined }),
+      ]),
+    ).toBeNull()
+  })
+
+  it('ignores approvals that are not pending', () => {
+    for (const status of ['approved', 'denied', undefined] as const) {
+      expect(findPendingApproval(session(), [approval({ status })])).toBeNull()
+    }
+  })
+})
+
+describe('mapSwarmToWorkerCards', () => {
+  it('maps a running session to a running card with a live badge', () => {
+    const [card] = mapSwarmToWorkerCards([session()], [], NOW)
+
+    expect(card.name).toBe('builder')
+    expect(card.tone).toBe('running')
+    expect(card.badge).toEqual({ label: 'RUN', tone: 'live' })
+    expect(card.detail).toBe('running 4m')
+  })
+
+  it('says "thinking" when the store says thinking', () => {
+    const [card] = mapSwarmToWorkerCards(
+      [session({ swarmStatus: 'thinking' })],
+      [],
+      NOW,
+    )
+    expect(card.tone).toBe('running')
+    expect(card.detail).toBe('thinking 4m')
+  })
+
+  it('maps a joined pending approval to blocked/BLK with the real ask', () => {
+    const [card] = mapSwarmToWorkerCards([session()], [approval()], NOW)
+
+    expect(card.tone).toBe('blocked')
+    expect(card.badge).toEqual({ label: 'BLK', tone: 'blocked' })
+    expect(card.detail).toBe('blocked 42s · needs approval')
+    // REAL — §3.2: the approval's own action text, not a narrative.
+    expect(card.sub).toBe('write to Vault/Published/')
+  })
+
+  it('is not blocked when no approval matches, whatever the session says', () => {
+    const [card] = mapSwarmToWorkerCards(
+      [session({ status: 'waiting_for_input' })],
+      [approval({ agentName: 'someone-else', sessionKey: undefined })],
+      NOW,
+    )
+    expect(card.tone).not.toBe('blocked')
+    expect(card.badge).toEqual({ label: 'RUN', tone: 'live' })
+  })
+
+  it('gives a live-but-silent session the stale treatment', () => {
+    const [card] = mapSwarmToWorkerCards(
+      [session({ staleness: STALE_THRESHOLD_MS + MINUTE_MS })],
+      [],
+      NOW,
+    )
+
+    expect(card.badge).toEqual({ label: 'STALE', tone: 'blocked' })
+    expect(card.detail).toBe('no update in 11m')
+  })
+
+  it('does not badge a finished or idle session STALE for being quiet', () => {
+    const quiet = { staleness: STALE_THRESHOLD_MS * 10 }
+    const [done] = mapSwarmToWorkerCards(
+      [session({ swarmStatus: 'complete', ...quiet })],
+      [],
+      NOW,
+    )
+    const [idle] = mapSwarmToWorkerCards(
+      [session({ swarmStatus: 'idle', ...quiet })],
+      [],
+      NOW,
+    )
+
+    expect(done.badge).toEqual({ label: 'DONE', tone: 'muted' })
+    expect(idle.badge).toBeUndefined()
+    expect(idle.detail).toBe('idle 1h 40m')
+  })
+
+  it('maps failed and error to an ERR badge carrying the real error text', () => {
+    for (const swarmStatus of ['failed', 'error'] as const) {
+      const [card] = mapSwarmToWorkerCards(
+        [
+          session({
+            swarmStatus,
+            errorMessage: 'certbot renew → exit 1: DNS-01 challenge timeout',
+          }),
+        ],
+        [],
+        NOW,
+      )
+
+      expect(card.badge).toEqual({ label: 'ERR', tone: 'failed' })
+      expect(card.detail).toBe('failed')
+      expect(card.sub).toBe('certbot renew → exit 1: DNS-01 challenge…')
+      expect(card.subTone).toBe('failed')
+    }
+  })
+
+  it('omits the sub-line entirely when the gateway sent nothing for it', () => {
+    const [card] = mapSwarmToWorkerCards(
+      [session({ model: undefined })],
+      [],
+      NOW,
+    )
+    expect(card.sub).toBe('')
+    expect(card.noSource).toBeUndefined()
+  })
+
+  it('hoists blocked workers to the front without claiming a chain', () => {
+    const cards = mapSwarmToWorkerCards(
+      [
+        session({ key: 'agent:orchestrator:subagent:a', friendlyId: 'a' }),
+        session({ key: 'agent:km-agent:subagent:b', friendlyId: 'b' }),
+      ],
+      [approval({ agentName: 'km-agent' })],
+      NOW,
+    )
+
+    expect(cards.map((card) => card.name)).toEqual([
+      'km-agent',
+      'orchestrator',
+    ])
+    expect(cards.every((card) => card.connector === undefined)).toBe(true)
+  })
+
+  it('keeps card names unique when two subagents share an agent', () => {
+    const cards = mapSwarmToWorkerCards(
+      [
+        session({ friendlyId: 'sess-1111' }),
+        session({ friendlyId: 'sess-2222' }),
+      ],
+      [],
+      NOW,
+    )
+    expect(new Set(cards.map((card) => card.name)).size).toBe(2)
+  })
+
+  it('caps the grid at two rows without silently dropping the count', () => {
+    const many = Array.from({ length: 14 }, (_, index) =>
+      session({ key: `agent:w${index}:subagent:x`, friendlyId: `s-${index}` }),
+    )
+
+    expect(mapSwarmToWorkerCards(many, [], NOW)).toHaveLength(WORKER_BOARD_MAX)
+    expect(buildWorkerBoardHeading(14, WORKER_BOARD_MAX).note).toContain(
+      '14 live workers · 10 shown',
+    )
+  })
+
+  it('never produces an action chip, a connector, a noSource mark, or fixture narrative', () => {
+    const many = [
+      session({ key: 'agent:orchestrator:subagent:a', friendlyId: 'a' }),
+      session({ key: 'agent:builder:subagent:b', friendlyId: 'b' }),
+      session({
+        key: 'agent:maintainer:subagent:c',
+        friendlyId: 'c',
+        swarmStatus: 'idle',
+        staleness: 23 * 86_400_000,
+      }),
+      session({
+        key: 'agent:km-agent:subagent:d',
+        friendlyId: 'd',
+        swarmStatus: 'error',
+      }),
+    ]
+    const cards = mapSwarmToWorkerCards(
+      many,
+      [approval({ agentName: 'km-agent', action: 'rm -rf ~/tmp/scratch' })],
+      NOW,
+    )
+
+    // Every fixture sub-line is narrative the swarm store does not carry, and
+    // the launchd diagnostic has no source at all (§3.5 item 12).
+    const fixtureNarrative = conductorWorkerCardFixtures.map((card) => card.sub)
+    expect(fixtureNarrative).toContain('launchd job not loaded')
+
+    for (const card of cards) {
+      expect(card.action).toBeUndefined()
+      expect(card.connector).toBeUndefined()
+      expect(card.noSource).toBeUndefined()
+      expect(fixtureNarrative).not.toContain(card.sub)
+    }
+  })
+})
+
+describe('mapSwarmToRailRows', () => {
+  it('counts the whole roster in RUN · BLK · IDLE', () => {
+    const sessions = [
+      session({ key: 'agent:a:subagent:1', friendlyId: '1' }),
+      session({ key: 'agent:b:subagent:2', friendlyId: '2' }),
+      session({ key: 'agent:c:subagent:3', friendlyId: '3' }),
+      session({
+        key: 'agent:d:subagent:4',
+        friendlyId: '4',
+        swarmStatus: 'idle',
+      }),
+      session({
+        key: 'agent:e:subagent:5',
+        friendlyId: '5',
+        swarmStatus: 'failed',
+      }),
+    ]
+    const rail = mapSwarmToRailRows(sessions, [approval({ agentName: 'c' })], NOW)
+
+    // 2 running, 1 blocked, and everything else — including the failed one —
+    // in IDLE, exactly as the artboard's own count line buckets it.
+    expect(rail.counts).toBe('2 RUN · 1 BLK · 2 IDLE')
+    expect(rail.workers[0]).toEqual({
+      name: 'c',
+      status: 'blocked',
+      detail: 'BLOCKED 42s',
+    })
+  })
+
+  it('tallies the full roster even when the row list is capped', () => {
+    const many = Array.from({ length: 14 }, (_, index) =>
+      session({ key: `agent:w${index}:subagent:x`, friendlyId: `s-${index}` }),
+    )
+    const rail = mapSwarmToRailRows(many, [], NOW)
+
+    expect(rail.workers).toHaveLength(WORKER_BOARD_MAX)
+    expect(rail.counts).toBe('14 RUN · 0 BLK · 0 IDLE')
+  })
+
+  it('leaves a blocked row detail undefined when there is no wait to report', () => {
+    const rail = mapSwarmToRailRows(
+      [session()],
+      [approval({ requestedAt: undefined })],
+      NOW,
+    )
+    expect(rail.workers[0].detail).toBeUndefined()
+  })
+
+  it('carries only ages, never a fixture detail string', () => {
+    const rail = mapSwarmToRailRows(
+      [
+        session({ swarmStatus: 'idle', staleness: 2 * 3600_000 }),
+        session({
+          key: 'agent:ops:subagent:x',
+          friendlyId: 'x',
+          swarmStatus: 'failed',
+        }),
+      ],
+      [],
+      NOW,
+    )
+
+    expect(rail.workers.map((worker) => worker.detail)).toEqual([
+      'idle 2h',
+      'failed',
+    ])
+  })
+})
+
+describe('countWorkers', () => {
+  it('buckets everything that is not running or blocked as idle', () => {
+    expect(
+      countWorkers(['running', 'blocked', 'failed', 'stale', 'complete']),
+    ).toEqual({ running: 1, blocked: 1, idle: 3 })
+  })
+})
+
+describe('mobile mappers', () => {
+  it('derives the four-number strip, folding stale into idle', () => {
+    const sessions = [
+      session({ key: 'agent:a:subagent:1', friendlyId: '1' }),
+      session({ key: 'agent:b:subagent:2', friendlyId: '2' }),
+      session({
+        key: 'agent:c:subagent:3',
+        friendlyId: '3',
+        swarmStatus: 'failed',
+      }),
+      session({
+        key: 'agent:d:subagent:4',
+        friendlyId: '4',
+        staleness: STALE_THRESHOLD_MS * 2,
+      }),
+    ]
+
+    expect(
+      mapSwarmToMobileStats(sessions, [approval({ agentName: 'a' })]),
+    ).toEqual([
+      { label: 'RUNNING', value: '1', tone: 'live' },
+      { label: 'BLOCKED', value: '1', tone: 'blocked' },
+      { label: 'FAILED', value: '1', tone: 'failed' },
+      { label: 'IDLE', value: '1', tone: 'idle' },
+    ])
+  })
+
+  it('shows only the live workers in RUNNING NOW, and none when none run', () => {
+    const running = mapSwarmToMobileRunning(
+      [
+        session({ key: 'agent:a:subagent:1', friendlyId: '1' }),
+        session({
+          key: 'agent:b:subagent:2',
+          friendlyId: '2',
+          swarmStatus: 'idle',
+        }),
+      ],
+      [],
+      NOW,
+    )
+
+    expect(running).toEqual([{ name: 'a', status: 'running', detail: '4m' }])
+    expect(
+      mapSwarmToMobileRunning([session({ swarmStatus: 'idle' })], [], NOW),
+    ).toEqual([])
+  })
+})
+
+describe('buildWorkerBoardHeading', () => {
+  it('reports the live roster and drops the fixture chain claim', () => {
+    const heading = buildWorkerBoardHeading(1, 1)
+
+    expect(heading.label).toBe('WORKER BOARD')
+    expect(heading.note).toBe(
+      '1 live worker · status is heuristic · blocked = pending approval',
+    )
+    expect(heading.note).not.toContain('chain')
+    expect(heading.noteAccent).toBeUndefined()
+  })
+})

--- a/src/screens/jarvis/conductor/map-workers.ts
+++ b/src/screens/jarvis/conductor/map-workers.ts
@@ -1,0 +1,664 @@
+/**
+ * `SwarmSession[]` + `GatewayApprovalEntry[]` → the Conductor WORKER BOARD
+ * cards, the Command WORKER RAIL rows, and the Mobile Conductor stat strip.
+ * Pure functions only: no React, no fetch, no styling. `use-workers.ts` owns
+ * the subscriptions; this file owns the honesty.
+ *
+ * This board is the hardest one to wire truthfully, because most of what the
+ * artboard draws on a worker card is NARRATIVE and the swarm store carries no
+ * narrative at all. `docs/design/jarvis-ui-mapping.md` §3.3/§3.5 splits it:
+ *
+ *   • REAL and mapped — `swarmStatus` (running / thinking / complete / failed /
+ *     error / idle) and `staleness`, both already derived by
+ *     `agent-swarm-store.ts` from the gateway session list. The mapping doc is
+ *     explicit that `swarmStatus` is a HEURISTIC, not an authoritative gateway
+ *     signal, so nothing here treats it as more than the store's best guess.
+ *   • DERIVED and marked as such below — `blocked`, which is a pending approval
+ *     joined onto a worker (see `findPendingApproval`); STALE, which is a
+ *     session claiming to run while silent (see `STALE_THRESHOLD_MS`); the
+ *     RUN/BLK/IDLE counts; and every age string, all of which come from
+ *     `staleness` / `startedAt` / `requestedAt`.
+ *   • NO SOURCE and therefore NEVER produced here — the per-worker sub-line
+ *     narrative ("3 gates today · 1 open", "wt/vault-frontmatter · 3 files",
+ *     "last verdict 08:12 · pass", "31 mail → 4 actionable"), the launchd
+ *     diagnostic (§3.5 item 12), and the delegation chain as a real parent→child
+ *     edge graph (§3.5 item 14). A live card carries NO `connector`, so the
+ *     board draws no chain edge between real workers at all: rendering one would
+ *     assert an edge nothing captures.
+ *
+ * `action` is always absent. HOLD ⌥ TO INTERVENE and OPEN GATE both mean "do
+ * something to this worker", and this slice is read-only — an inert chip on a
+ * real card would be a lie about what the board can do. The chips survive only
+ * on the fixture fallback, where the banner already says nothing is wired.
+ */
+import type {
+  GatewayApprovalEntry,
+  GatewaySession,
+} from '@/lib/gateway-api'
+import type { SwarmSession } from '@/stores/agent-swarm-store'
+import type {
+  ConductorBadgeTone,
+  ConductorCardTone,
+  ConductorSectionHeadingFixture,
+  ConductorSubTone,
+  ConductorWorkerCardFixture,
+  MobileStatFixture,
+} from '@/components/jarvis/fixtures'
+import type { WorkerStatus, WorkerStatusLineProps } from '@/components/jarvis/types'
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * DERIVE — STALE. A session the gateway still calls running (or thinking) that
+ * has not produced an update in this long is contradicting itself, and that
+ * contradiction is the whole reason the badge exists.
+ *
+ * `use-conductor-gateway.ts` calls a worker stale after 120s. This board uses a
+ * far stricter ten minutes on purpose: STALE here renders as an alarm badge on
+ * a survey screen, and a worker that is merely between long tool calls must not
+ * trip it. Ten minutes is longer than any single turn these agents take, so the
+ * badge is never a false alarm — at the cost of taking ten minutes to notice a
+ * genuinely wedged worker. Under-reporting is the right way to be wrong here,
+ * the same call `map-scheduled-jobs.ts` makes for SILENT.
+ *
+ * Worth knowing for the next slice: this branch is NARROWER than it looks,
+ * because `deriveSwarmStatus` has no explicit `running` case. A session the
+ * gateway reports as `status: 'running'` but has not touched for an hour is
+ * re-derived by the store as `complete` (it has tokens) or `idle` (it does
+ * not), so it never reaches here as running. What DOES reach here is an
+ * explicit `thinking` / `reasoning` session gone quiet — which is precisely the
+ * contradiction worth badging. Widening this would mean overruling the store's
+ * own derivation, which is a change to `agent-swarm-store.ts`, not to a mapper.
+ */
+export const STALE_THRESHOLD_MS = 10 * MINUTE_MS
+
+/**
+ * The artboard's worker grid is five columns inside a fixed 1440×900 frame with
+ * `overflow-hidden`, and a real gateway can list far more subagent sessions than
+ * that — the fixture roster is ten, exactly two full rows. Past that the grid
+ * grows and pushes SCHEDULED JOBS and the RUN LOG off the bottom of the board.
+ *
+ * So the card list is capped at two rows. The cap is NOT silent: the section
+ * heading reports the true total alongside how many are drawn, and the rail's
+ * count line tallies the whole roster regardless of how many rows it shows.
+ */
+export const WORKER_BOARD_MAX = 10
+
+/** One card's worth of text, past which the fixed frame starts to reflow. */
+const SUB_TEXT_MAX = 44
+
+/* ── Identity ────────────────────────────────────────────────────────── */
+
+function readText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = new Date(value).getTime()
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+/**
+ * `agent:builder:subagent:06ec90ba` → `builder`.
+ *
+ * The gateway encodes the owning agent in segment 1 of the session key — the
+ * same shape `src/lib/format-session-name.ts` parses — and the swarm store only
+ * ever admits keys containing `subagent:`. When the key does not carry a usable
+ * agent segment this returns null rather than guessing at one.
+ */
+export function deriveAgentFromKey(key: string): string | null {
+  const parts = key.split(':')
+  const marker = parts.indexOf('subagent')
+  if (marker <= 0) return null
+
+  // The segment immediately before `subagent` is the owning agent, except for
+  // the generic `agent:` prefix, which names nothing.
+  const owner = (parts[marker - 1] ?? '').trim()
+  if (owner && owner !== 'agent') return owner
+
+  const named = (parts[1] ?? '').trim()
+  return named && named !== 'subagent' ? named : null
+}
+
+/**
+ * The card's title. Every candidate below is a REAL field the gateway serves;
+ * none is invented, and a session with nothing usable falls back to the tail of
+ * its own id rather than to a role name it may not have.
+ */
+export function deriveWorkerName(session: SwarmSession): string {
+  const row = session as Record<string, unknown>
+  const explicit =
+    readText(row.agentName) ||
+    readText(session.label) ||
+    readText(session.derivedTitle) ||
+    readText(session.title)
+  if (explicit) return explicit
+
+  const fromKey = deriveAgentFromKey(readText(session.key))
+  if (fromKey) return fromKey
+
+  const id = readText(session.friendlyId) || readText(session.key)
+  return id ? `worker ${id.slice(-6)}` : 'worker'
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+/**
+ * Every name this worker could be known by on an approval record. The join
+ * below is exact-on-normalized rather than fuzzy: a substring match would let
+ * one pending approval for `builder` block `builder-qa` too.
+ */
+function workerIdentities(session: SwarmSession): Set<string> {
+  const row = session as Record<string, unknown>
+  const identities = new Set<string>()
+
+  for (const candidate of [
+    readText(row.agentName),
+    readText(session.label),
+    readText(session.derivedTitle),
+    readText(session.title),
+    deriveAgentFromKey(readText(session.key)) ?? '',
+  ]) {
+    if (candidate) identities.add(normalize(candidate))
+  }
+
+  return identities
+}
+
+/* ── The blocked join ────────────────────────────────────────────────── */
+
+/**
+ * Pending, and only pending. `fetchGatewayApprovals` returns both an
+ * `approvals` list and a `pending` list; `use-workers.ts` stamps the latter as
+ * pending before calling in, so an entry that reaches here with no status is an
+ * `approvals` row the gateway declined to classify — and badging a worker
+ * BLOCKED on the strength of a record that never said "pending" would invent
+ * exactly the state this join exists to make real.
+ */
+export function isPendingApproval(entry: GatewayApprovalEntry): boolean {
+  return entry.status === 'pending'
+}
+
+/**
+ * DERIVE (§3.3) — the one join that matters.
+ *
+ * A worker is blocked when a PENDING approval belongs to it. Two ways to
+ * belong, both authoritative:
+ *   1. `sessionKey` equals this session's key — the strongest link there is,
+ *      because it names the exact session the gateway is holding.
+ *   2. `agentName` matches one of the worker's real identities, exactly, after
+ *      normalising case and whitespace.
+ *
+ * The mapping doc's other candidate — `AgentSessionStatusEntry.status ===
+ * 'waiting_for_input'` — is deliberately NOT consulted. That value is inferred
+ * client-side from the shape of the agent's output text (ends with "?", short,
+ * or carries a marker), which is a guess; rendering a guess as the hard BLOCKED
+ * state is the failure mode this board exists to avoid. No matching approval
+ * means not blocked, whatever the text looks like.
+ */
+export function findPendingApproval(
+  session: SwarmSession,
+  approvals: Array<GatewayApprovalEntry>,
+): GatewayApprovalEntry | null {
+  const key = readText(session.key)
+  const identities = workerIdentities(session)
+
+  for (const entry of approvals) {
+    if (!isPendingApproval(entry)) continue
+    if (key && readText(entry.sessionKey) === key) return entry
+    const agentName = readText(entry.agentName)
+    if (agentName && identities.has(normalize(agentName))) return entry
+  }
+
+  return null
+}
+
+/* ── State ───────────────────────────────────────────────────────────── */
+
+/**
+ * `swarmStatus` (+ the blocked join) → the rail's `WorkerStatus`. Blocked wins
+ * over everything: a worker holding a gate is waiting on a human no matter what
+ * the session list last said about it.
+ *
+ * `thinking` collapses into `running` because the rail has no third live state;
+ * the card's detail line still says which of the two it is.
+ */
+export function swarmStatusToTone(
+  status: SwarmSession['swarmStatus'],
+  blocked: boolean,
+): WorkerStatus {
+  if (blocked) return 'blocked'
+  switch (status) {
+    case 'running':
+    case 'thinking':
+      return 'running'
+    case 'complete':
+      return 'complete'
+    case 'failed':
+    case 'error':
+      return 'failed'
+    case 'idle':
+      return 'idle'
+  }
+}
+
+/**
+ * The tone above, plus the STALE override.
+ *
+ * Stale is only ever applied to a worker that claims to be LIVE. A finished or
+ * failed session is silent because it is over, and an idle one reports its
+ * silence as an age already ("idle 2h 11m") — neither is a contradiction, and
+ * badging them STALE would turn a normal end-of-life into an alarm.
+ */
+export function deriveWorkerState(
+  session: SwarmSession,
+  blocked: boolean,
+): WorkerStatus {
+  const tone = swarmStatusToTone(session.swarmStatus, blocked)
+  if (tone !== 'running') return tone
+  return session.staleness > STALE_THRESHOLD_MS ? 'stale' : tone
+}
+
+const CARD_TONES: Record<WorkerStatus, ConductorCardTone> = {
+  blocked: 'blocked',
+  running: 'running',
+  // The board's card tones are running / active / queued / blocked / idle —
+  // there is no failed frame, which is why the fixture's own failed worker
+  // (`ops-watch`) is an idle card wearing an ERR badge. Real ones match it.
+  stale: 'idle',
+  idle: 'idle',
+  complete: 'idle',
+  failed: 'idle',
+  queued: 'queued',
+}
+
+const CARD_BADGES: Partial<
+  Record<WorkerStatus, { label: string; tone: ConductorBadgeTone }>
+> = {
+  blocked: { label: 'BLK', tone: 'blocked' },
+  running: { label: 'RUN', tone: 'live' },
+  stale: { label: 'STALE', tone: 'blocked' },
+  complete: { label: 'DONE', tone: 'muted' },
+  failed: { label: 'ERR', tone: 'failed' },
+}
+
+/* ── Real text, and only real text ───────────────────────────────────── */
+
+/**
+ * `2h 11m`, `14m`, `9s`, `3d`. Every age on a card runs through this so the
+ * board never mixes precisions, and so no age is rendered to a resolution the
+ * source cannot support.
+ */
+export function formatAge(ms: number): string {
+  const safe = Math.max(0, ms)
+  if (safe < MINUTE_MS) return `${Math.floor(safe / 1000)}s`
+  if (safe < HOUR_MS) return `${Math.floor(safe / MINUTE_MS)}m`
+  if (safe < DAY_MS) {
+    const hours = Math.floor(safe / HOUR_MS)
+    const minutes = Math.floor((safe % HOUR_MS) / MINUTE_MS)
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  }
+  return `${Math.floor(safe / DAY_MS)}d`
+}
+
+/** Uptime, from whichever real start field the gateway sent. */
+function sessionUptime(session: GatewaySession, now: number): string | null {
+  const started = readNumber(session.startedAt) ?? readNumber(session.createdAt)
+  if (started === null || started > now) return null
+  return formatAge(now - started)
+}
+
+/** REAL — the gateway's own failure text, under whichever key it used. */
+function sessionErrorText(session: SwarmSession): string | null {
+  const row = session as Record<string, unknown>
+  for (const key of ['errorMessage', 'error', 'failureReason', 'lastError']) {
+    const text = readText(row[key])
+    if (text) return text
+  }
+  return null
+}
+
+/**
+ * A real `last_run_error` runs to hundreds of characters and a card is two
+ * lines wide; the same clamp `map-scheduled-jobs.ts` applies, cut at a word
+ * boundary and ellipsed so the truncation declares itself.
+ */
+export function clampSubText(text: string): string {
+  if (text.length <= SUB_TEXT_MAX) return text
+  const cut = text.slice(0, SUB_TEXT_MAX)
+  const lastSpace = cut.lastIndexOf(' ')
+  return `${(lastSpace > SUB_TEXT_MAX / 2 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`
+}
+
+/** What a pending approval actually asks for — REAL (§3.2: action / tool). */
+function approvalSummary(entry: GatewayApprovalEntry): string {
+  return readText(entry.action) || readText(entry.tool) || ''
+}
+
+/** How long the gate has been open — DERIVE from `requestedAt` (§3.2). */
+function approvalWait(
+  entry: GatewayApprovalEntry,
+  now: number,
+): string | null {
+  const requested = readNumber(entry.requestedAt)
+  if (requested === null || requested > now) return null
+  return formatAge(now - requested)
+}
+
+/**
+ * The card's first line: a real status word plus, where one exists, a real age.
+ * Nothing else. The fixture's "running 04:18 · vitest --watch" names a command
+ * the session list does not carry, so a live card says "running 4m" and stops.
+ */
+function buildDetail(
+  session: SwarmSession,
+  state: WorkerStatus,
+  approval: GatewayApprovalEntry | null,
+  now: number,
+): string {
+  switch (state) {
+    case 'blocked': {
+      const wait = approval ? approvalWait(approval, now) : null
+      return wait
+        ? `blocked ${wait} · needs approval`
+        : 'blocked · needs approval'
+    }
+    case 'running': {
+      const verb = session.swarmStatus === 'thinking' ? 'thinking' : 'running'
+      const uptime = sessionUptime(session, now)
+      return uptime ? `${verb} ${uptime}` : verb
+    }
+    case 'stale':
+      return `no update in ${formatAge(session.staleness)}`
+    case 'idle':
+      return `idle ${formatAge(session.staleness)}`
+    case 'complete':
+      return `complete · ${formatAge(session.staleness)} ago`
+    case 'failed':
+      return 'failed'
+    case 'queued':
+      return 'queued'
+  }
+}
+
+/**
+ * The card's SECOND line, which on the artboard is pure narrative and here is
+ * pure fact or nothing at all:
+ *   • blocked → what the pending approval asks for (REAL: action / tool)
+ *   • failed  → the gateway's own error text (REAL)
+ *   • else    → the session's model (REAL), and when the gateway sent none, the
+ *               empty string — an omitted line, not an invented one.
+ *
+ * There is deliberately no branch that produces a `noSource` sub. A real card
+ * draws nothing it cannot source, so it never needs the inert treatment; the
+ * fixture fallback keeps its own marked lines untouched.
+ */
+function buildSub(
+  session: SwarmSession,
+  state: WorkerStatus,
+  approval: GatewayApprovalEntry | null,
+): { sub: string; subTone?: ConductorSubTone } {
+  if (state === 'blocked' && approval) {
+    const summary = approvalSummary(approval)
+    return summary ? { sub: clampSubText(summary) } : { sub: '' }
+  }
+
+  if (state === 'failed') {
+    const error = sessionErrorText(session)
+    return error
+      ? { sub: clampSubText(error), subTone: 'failed' }
+      : { sub: '' }
+  }
+
+  return { sub: clampSubText(readText(session.model)) }
+}
+
+/* ── Ordering ────────────────────────────────────────────────────────── */
+
+/**
+ * The store already sorts its sessions (thinking, running, idle, complete,
+ * failed, error, then by staleness) and that order is preserved — it is a real
+ * ordering over real data and re-deriving one here would only add a second
+ * opinion.
+ *
+ * The single change: blocked workers are hoisted to the front, because a worker
+ * waiting on a human is the one thing on this board with a deadline. This is a
+ * READING ORDER, not a chain: no card carries a `connector`, so nothing about
+ * the sequence claims that the first worker delegated to the second (§3.5 item
+ * 14).
+ */
+function orderWorkers<T extends { state: WorkerStatus }>(rows: Array<T>): Array<T> {
+  return [
+    ...rows.filter((row) => row.state === 'blocked'),
+    ...rows.filter((row) => row.state !== 'blocked'),
+  ]
+}
+
+interface WorkerRow {
+  name: string
+  state: WorkerStatus
+  session: SwarmSession
+  approval: GatewayApprovalEntry | null
+}
+
+/**
+ * One row per session, names guaranteed unique.
+ *
+ * Both boards key their lists by name and two subagents of the same agent share
+ * a derived name routinely, so a collision would make React reconcile the wrong
+ * card — and one of the two could be the blocked one. The discriminator is the
+ * tail of the session's own id, which is real data rather than an index.
+ */
+function buildRows(
+  sessions: Array<SwarmSession>,
+  approvals: Array<GatewayApprovalEntry>,
+): Array<WorkerRow> {
+  const seen = new Set<string>()
+
+  const rows = sessions.map((session) => {
+    const approval = findPendingApproval(session, approvals)
+    const state = deriveWorkerState(session, approval !== null)
+
+    let name = deriveWorkerName(session)
+    if (seen.has(name)) {
+      const id = readText(session.friendlyId) || readText(session.key)
+      name = id ? `${name} ${id.slice(-4)}` : `${name} ${seen.size}`
+    }
+    // A doubled discriminator is still possible in principle; the suffix loop
+    // keeps the key unique without ever inventing a second worker.
+    while (seen.has(name)) name = `${name}'`
+    seen.add(name)
+
+    return { name, state, session, approval }
+  })
+
+  return orderWorkers(rows)
+}
+
+/* ── Public mappers ──────────────────────────────────────────────────── */
+
+/**
+ * The WORKER BOARD, capped at two rows. `now` is injected so every age on the
+ * board is measured against one clock and so the derivations are testable.
+ */
+export function mapSwarmToWorkerCards(
+  sessions: Array<SwarmSession>,
+  approvals: Array<GatewayApprovalEntry>,
+  now: number = Date.now(),
+): Array<ConductorWorkerCardFixture> {
+  return buildRows(sessions, approvals)
+    .slice(0, WORKER_BOARD_MAX)
+    .map(({ name, state, session, approval }) => {
+      const { sub, subTone } = buildSub(session, state, approval)
+
+      return {
+        name,
+        tone: CARD_TONES[state],
+        badge: CARD_BADGES[state],
+        detail: buildDetail(session, state, approval, now),
+        sub,
+        subTone,
+        // No `action`: every chip on this card implies a write (slice 6c).
+        // No `connector`: the delegation graph is NO SOURCE (§3.5 item 14).
+      }
+    })
+}
+
+/** RUN / BLK / IDLE over the WHOLE roster, however many rows are drawn. */
+export function countWorkers(states: Array<WorkerStatus>): {
+  running: number
+  blocked: number
+  idle: number
+} {
+  const running = states.filter((state) => state === 'running').length
+  const blocked = states.filter((state) => state === 'blocked').length
+  return { running, blocked, idle: states.length - running - blocked }
+}
+
+/**
+ * The Command rail. The count line tallies every session the store holds —
+ * the artboard buckets everything that is not running or blocked as IDLE, and
+ * so does this — while the row list is capped to the same two-rows-worth the
+ * board draws, so a large swarm cannot push THREADS off the rail.
+ */
+export function mapSwarmToRailRows(
+  sessions: Array<SwarmSession>,
+  approvals: Array<GatewayApprovalEntry>,
+  now: number = Date.now(),
+): { workers: Array<WorkerStatusLineProps>; counts: string } {
+  const rows = buildRows(sessions, approvals)
+  const { running, blocked, idle } = countWorkers(rows.map((row) => row.state))
+
+  const workers = rows
+    .slice(0, WORKER_BOARD_MAX)
+    .map(({ name, state, session, approval }) => ({
+      name,
+      status: state,
+      detail: buildRailDetail(session, state, approval, now),
+    }))
+
+  return {
+    workers,
+    counts: `${running} RUN · ${blocked} BLK · ${idle} IDLE`,
+  }
+}
+
+/**
+ * The rail's right-hand column is a few characters wide, so it carries the age
+ * alone rather than the card's fuller sentence. Blocked returns undefined on
+ * purpose: the primitive then prints its own BLOCKED label, which is the
+ * accurate thing to say when the gateway sent no `requestedAt` to age.
+ */
+function buildRailDetail(
+  session: SwarmSession,
+  state: WorkerStatus,
+  approval: GatewayApprovalEntry | null,
+  now: number,
+): string | undefined {
+  switch (state) {
+    case 'blocked': {
+      const wait = approval ? approvalWait(approval, now) : null
+      return wait ? `BLOCKED ${wait}` : undefined
+    }
+    case 'running': {
+      const uptime = sessionUptime(session, now)
+      const verb = session.swarmStatus === 'thinking' ? 'thinking' : 'running'
+      return uptime ?? verb
+    }
+    case 'stale':
+      return `stale ${formatAge(session.staleness)}`
+    case 'idle':
+      return `idle ${formatAge(session.staleness)}`
+    case 'complete':
+      return `ran ${formatAge(session.staleness)} ago`
+    case 'failed':
+      return 'failed'
+    case 'queued':
+      return 'queued'
+  }
+}
+
+/**
+ * The section caption. It reports what is actually on screen — the live total,
+ * and how many of it the two-row grid could fit — and says where the two states
+ * come from. It does NOT restate the fixture's "chain: orchestrator → builder →
+ * reviewer → qa", because no such chain is captured (§3.5 item 14).
+ *
+ * The caption still renders inside a `data-jv-fixture="no-source"` span, since
+ * `worker-board.tsx` marks it unconditionally and that file's rendering is out
+ * of scope for this slice. Over-marking a real caption under-claims rather than
+ * over-claims, which is the safe direction to be wrong.
+ */
+export function buildWorkerBoardHeading(
+  total: number,
+  shown: number,
+): ConductorSectionHeadingFixture {
+  const roster = `${total} live worker${total === 1 ? '' : 's'}`
+  const truncation = shown < total ? ` · ${shown} shown` : ''
+  return {
+    label: 'WORKER BOARD',
+    note: `${roster}${truncation} · status is heuristic · blocked = pending approval`,
+  }
+}
+
+/* ── Mobile ──────────────────────────────────────────────────────────── */
+
+/**
+ * The four-number glance strip. FAILED gets its own column, and STALE folds
+ * into IDLE — matching the artboard's own roster, where the stale `maintainer`
+ * is counted among the seven idle rather than called out separately.
+ */
+export function mapSwarmToMobileStats(
+  sessions: Array<SwarmSession>,
+  approvals: Array<GatewayApprovalEntry>,
+): Array<MobileStatFixture> {
+  const states = buildRows(sessions, approvals).map((row) => row.state)
+  const tally = (match: WorkerStatus) =>
+    states.filter((state) => state === match).length
+
+  const running = tally('running')
+  const blocked = tally('blocked')
+  const failed = tally('failed')
+
+  return [
+    { label: 'RUNNING', value: String(running), tone: 'live' },
+    { label: 'BLOCKED', value: String(blocked), tone: 'blocked' },
+    { label: 'FAILED', value: String(failed), tone: 'failed' },
+    {
+      label: 'IDLE',
+      value: String(states.length - running - blocked - failed),
+      tone: 'idle',
+    },
+  ]
+}
+
+/**
+ * RUNNING NOW — the live workers only, as rail rows.
+ *
+ * When nothing is running this is empty, and the section renders empty. That is
+ * the true answer, and the strip above it already says RUNNING 0; padding the
+ * section out with idle workers to keep it looking full would be the same lie
+ * in a different place.
+ */
+export function mapSwarmToMobileRunning(
+  sessions: Array<SwarmSession>,
+  approvals: Array<GatewayApprovalEntry>,
+  now: number = Date.now(),
+): Array<WorkerStatusLineProps> {
+  return buildRows(sessions, approvals)
+    .filter((row) => row.state === 'running')
+    .slice(0, WORKER_BOARD_MAX)
+    .map(({ name, state, session, approval }) => ({
+      name,
+      status: state,
+      detail: buildRailDetail(session, state, approval, now),
+    }))
+}

--- a/src/screens/jarvis/conductor/mobile-conductor.test.tsx
+++ b/src/screens/jarvis/conductor/mobile-conductor.test.tsx
@@ -1,0 +1,109 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileConductorBoard } from './mobile-conductor'
+import type { ReactNode } from 'react'
+import {
+  mobileConductorLastNightFixture,
+  mobileConductorNeedsYouFixture,
+  mobileConductorRunningChain,
+} from '@/components/jarvis/fixtures'
+
+/**
+ * The board's inactive COMMAND tab is a real `<Link>`, which needs a mounted
+ * router. Standing one up would test TanStack, not this board — and the board
+ * has no other router dependency — so `Link` is stubbed as the anchor it
+ * renders to and everything else is exercised for real.
+ */
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string
+    children: ReactNode
+    className?: string
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// This repo does not enable vitest `globals`, so Testing Library's automatic
+// cleanup is never registered — unmount between cases explicitly.
+afterEach(cleanup)
+
+describe('MobileConductorBoard', () => {
+  it('answers the four glance counts without a scroll', () => {
+    const { container } = render(<MobileConductorBoard />)
+
+    const stats = container.querySelectorAll('[data-jv-stat-tone]')
+    expect(stats).toHaveLength(4)
+    expect(screen.getByText('RUNNING')).toBeTruthy()
+    expect(screen.getByText('BLOCKED')).toBeTruthy()
+    expect(screen.getByText('FAILED')).toBeTruthy()
+    expect(screen.getByText('IDLE')).toBeTruthy()
+  })
+
+  it('points at the gate rather than drawing it', () => {
+    const { container } = render(<MobileConductorBoard />)
+
+    const needsYou = screen.getByRole('region', {
+      name: mobileConductorNeedsYouFixture.heading,
+    })
+    expect(
+      within(needsYou).getByText(mobileConductorNeedsYouFixture.label),
+    ).toBeTruthy()
+    expect(
+      within(needsYou).getByText(mobileConductorNeedsYouFixture.title),
+    ).toBeTruthy()
+
+    // A glance surface must not imply you can decide from here: the honest
+    // blast-radius panel belongs to the Command board's gate, not to this one.
+    expect(container.querySelector('[data-jv-gate-state]')).toBeNull()
+    expect(screen.queryByText('BLAST RADIUS')).toBeNull()
+  })
+
+  it('lists only the running workers and marks the chain as a convention', () => {
+    const { container } = render(<MobileConductorBoard />)
+
+    const running = container.querySelectorAll(
+      '[data-jv-worker-status="running"]',
+    )
+    expect(running).toHaveLength(2)
+
+    const chain = screen.getByText(mobileConductorRunningChain.chain)
+    expect(chain.getAttribute('data-jv-fixture')).toBe('no-source')
+  })
+
+  it('shows only the unhealthy jobs, with the healthy rest as one line', () => {
+    const { container } = render(<MobileConductorBoard />)
+
+    const jobs = container.querySelectorAll('[data-jv-job-tone]')
+    expect(jobs).toHaveLength(2)
+    expect(screen.getByText('ops-watch:certs')).toBeTruthy()
+    expect(screen.getByText('maintainer:dep-audit')).toBeTruthy()
+    expect(screen.getByText('4 other jobs healthy')).toBeTruthy()
+
+    // The launchd diagnostic has no source at all (mapping §3.5 item 12).
+    expect(
+      screen
+        .getByText('no run in 23d · launchd unloaded')
+        .getAttribute('data-jv-fixture'),
+    ).toBe('no-source')
+  })
+
+  it('marks the whole run history as a fixture — no per-run source exists', () => {
+    const { container } = render(<MobileConductorBoard />)
+
+    const lastNight = screen.getByRole('region', {
+      name: mobileConductorLastNightFixture.heading,
+    })
+    expect(lastNight.getAttribute('data-jv-fixture')).toBe('no-source')
+    expect(container.querySelectorAll('[data-jv-run-outcome]')).toHaveLength(
+      mobileConductorLastNightFixture.runs.length,
+    )
+  })
+})

--- a/src/screens/jarvis/conductor/mobile-conductor.tsx
+++ b/src/screens/jarvis/conductor/mobile-conductor.tsx
@@ -16,12 +16,16 @@
  * panel on a glance surface would imply you can decide from here. The gate
  * itself lives on Command.
  *
- * THREE SECTIONS CAN BE LIVE. SCHEDULE HEALTH accepts real jobs (slice 6a), and
- * the STAT STRIP and RUNNING NOW accept real swarm workers (slice 6b) — all
- * mapped by the routed screen, which owns the only query and the only store
- * subscription — falling back to the fixtures when nothing is passed, which is
- * what a standalone render and the tests get. This file itself still opens no
- * request and imports no client; it is a frame, not a fetcher.
+ * FOUR SECTIONS CAN BE LIVE. SCHEDULE HEALTH accepts real jobs (slice 6a), the
+ * STAT STRIP and RUNNING NOW accept real swarm workers (slice 6b), and NEEDS
+ * YOU accepts the real pending approval (slice 6c) — all mapped by the routed
+ * screen, which owns the only queries and the only store subscription — falling
+ * back to the fixtures when nothing is passed, which is what a standalone
+ * render and the tests get. This file itself still opens no request and imports
+ * no client; it is a frame, not a fetcher, and it resolves nothing: the live
+ * NEEDS YOU pointer offers REVIEW and no APPROVE, because approving from a
+ * surface that draws no blast-radius panel is exactly what that panel exists to
+ * prevent.
  *
  * Live, the footer's PARTIAL half-line is DROPPED rather than carried over
  * (§3.5 item 11: PARTIAL is not a job status, only free text inside
@@ -31,9 +35,9 @@
  * already says RUNNING 0; padding it with idle workers to keep the section
  * looking full would be the same lie in a different place. Its chain caption
  * stays fixture and stays marked, because the delegation graph has no source
- * (§3.5 item 14). NEEDS YOU and LAST NIGHT are still fixtures, and the rows
- * with NO source at all keep their `data-jv-fixture="no-source"` mark and their
- * line in the banner above the frame.
+ * (§3.5 item 14). LAST NIGHT is still a fixture, and the rows with NO source
+ * at all keep their `data-jv-fixture="no-source"` mark and their line in the
+ * banner above the frame.
  *
  * Fluid, not a 390px box: `w-full` with 390 as a MAX and 844 as a MIN.
  *
@@ -182,9 +186,19 @@ function StatStrip({ stats }: { stats: Array<MobileStatFixture> }) {
  * NEEDS YOU. A pointer to the gate, not the gate: label, what it would do, and
  * the two ways out of this screen.
  */
-function NeedsYou({ data }: { data: MobileGateSummaryFixture }) {
+function NeedsYou({
+  data,
+  isLive,
+}: {
+  data: MobileGateSummaryFixture
+  isLive: boolean
+}) {
   return (
-    <section aria-label={data.heading} className="flex flex-col gap-jv-9">
+    <section
+      aria-label={data.heading}
+      data-jv-gate-source={isLive ? 'live' : 'fixture'}
+      className="flex flex-col gap-jv-9"
+    >
       <SectionLabel label={data.heading} />
 
       <div className="border border-jv-blocked-line bg-jv-blocked-bg px-jv-12 pt-jv-10 pb-jv-11">
@@ -372,11 +386,15 @@ export function MobileConductorBoard({
   scheduleHealth = mobileConductorScheduleHealth,
   stats = mobileConductorStatFixtures,
   running = mobileConductorRunningFixtures,
+  needsYou = mobileConductorNeedsYouFixture,
+  needsYouIsLive = false,
 }: {
   jobs?: Array<MobileJobFixture>
   scheduleHealth?: MobileScheduleHealthFixture
   stats?: Array<MobileStatFixture>
   running?: Array<WorkerStatusLineProps>
+  needsYou?: MobileGateSummaryFixture
+  needsYouIsLive?: boolean
 } = {}) {
   return (
     <div
@@ -392,7 +410,7 @@ export function MobileConductorBoard({
       <StatStrip stats={stats} />
 
       <main className="flex min-h-0 flex-1 flex-col gap-jv-16 overflow-y-auto px-jv-14 pt-jv-14 pb-jv-16">
-        <NeedsYou data={mobileConductorNeedsYouFixture} />
+        <NeedsYou data={needsYou} isLive={needsYouIsLive} />
         <RunningNow chrome={mobileConductorRunningChain} workers={running} />
         <ScheduleHealth chrome={scheduleHealth} jobs={jobs} />
         <LastNight data={mobileConductorLastNightFixture} />

--- a/src/screens/jarvis/conductor/mobile-conductor.tsx
+++ b/src/screens/jarvis/conductor/mobile-conductor.tsx
@@ -1,0 +1,373 @@
+/**
+ * JARVIS Mobile Conductor board — artboard 04, 390 × 844.
+ *
+ * A DIFFERENT COMPOSITION, not the desktop board reflowed. Board 02 is a
+ * survey — a ten-card worker grid, six job cards, an eight-row run table — and
+ * none of that is a phone screen. Board 04 is a GLANCE SURFACE with one rule:
+ * nothing critical requires a scroll. So the ten workers collapse to a
+ * four-number strip plus the two that are actually running, the six jobs
+ * collapse to the two that are unhealthy plus a one-line tally of the rest,
+ * and the run table collapses to time + stem + outcome. What is dropped is
+ * dropped because it is survey, not signal.
+ *
+ * COMPOSES the Slice 2 `WorkerStatusLine` primitive for RUNNING NOW and
+ * re-styles it none. NEEDS YOU is deliberately NOT an `ApprovalGateCard`: on
+ * the Conductor it is a POINTER to a gate, and drawing the honest blast-radius
+ * panel on a glance surface would imply you can decide from here. The gate
+ * itself lives on Command.
+ *
+ * FIXTURES ONLY. This file imports no store, no gateway client and no HTTP
+ * endpoint, and opens no request or event stream of any kind — every value
+ * comes from `src/components/jarvis/fixtures.ts`. As on the desktop board,
+ * much of what is shown DOES have a real source today
+ * (`docs/design/jarvis-ui-mapping.md` §3.3–§3.4) and this slice still does not
+ * read it; the rows with NO source at all (§3.5 items 11–14) carry
+ * `data-jv-fixture="no-source"` and are named in the banner above the frame.
+ *
+ * Fluid, not a 390px box: `w-full` with 390 as a MAX and 844 as a MIN.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. Structural
+ * dimensions come from `JV_MOBILE` (multiples of `--jv-space-4`).
+ */
+import { Link } from '@tanstack/react-router'
+import { clsx } from 'clsx'
+import { JV_MOBILE } from '../command/geometry'
+import { MobileStatusBar } from '../command/mobile-status-bar'
+import type {
+  ConductorRunOutcome,
+  MobileGateSummaryFixture,
+  MobileJobFixture,
+  MobileJobTone,
+  MobileLastNightFixture,
+  MobileRunningChainFixture,
+  MobileScheduleHealthFixture,
+  MobileStatFixture,
+  MobileStatTone,
+} from '@/components/jarvis/fixtures'
+import type { WorkerStatusLineProps } from '@/components/jarvis/types'
+import {
+  conductorTopbarFixture,
+  mobileConductorJobFixtures,
+  mobileConductorLastNightFixture,
+  mobileConductorNeedsYouFixture,
+  mobileConductorRunningChain,
+  mobileConductorRunningFixtures,
+  mobileConductorScheduleHealth,
+  mobileConductorStatFixtures,
+  mobileStatusBarFixture,
+} from '@/components/jarvis/fixtures'
+import { WorkerStatusLine } from '@/components/jarvis/worker-status-line'
+
+const SECTION_LABEL_CLASS =
+  'font-jv-mono text-jv-2xs leading-jv-none font-semibold tracking-jv-widest text-jv-label'
+
+const TAB_CLASS =
+  'flex-1 py-jv-8 text-center font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wide-2'
+
+/** Only the NUMBER is hue-coded; the label stays neutral in every state. */
+const STAT_TONES: Record<MobileStatTone, string> = {
+  live: 'text-jv-live',
+  blocked: 'text-jv-blocked',
+  failed: 'text-jv-failed',
+  idle: 'text-jv-label-faint',
+}
+
+const JOB_TONES: Record<MobileJobTone, { frame: string; badge: string }> = {
+  failed: {
+    frame: 'border-jv-failed-line bg-jv-failed-bg',
+    badge: 'bg-jv-failed px-jv-5 py-jv-3 text-jv-surface-1',
+  },
+  silent: {
+    frame: 'border-jv-blocked-line bg-jv-blocked-bg-row',
+    badge: 'text-jv-blocked',
+  },
+}
+
+const JOB_DETAIL_TONES: Record<MobileJobTone, string> = {
+  failed: 'text-jv-failed-text',
+  silent: 'text-jv-blocked-soft',
+}
+
+const RUN_OUTCOMES: Record<ConductorRunOutcome, string> = {
+  success: 'text-jv-verified',
+  partial: 'text-jv-claimed-text',
+  failed: 'font-semibold text-jv-failed',
+}
+
+function SectionLabel({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="flex items-baseline gap-jv-9">
+      <span className={SECTION_LABEL_CLASS}>{label}</span>
+      {note ? (
+        <span className="font-jv-mono text-jv-sm leading-jv-none text-jv-label-ghost">
+          {note}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+/** COMMAND / CONDUCTOR, full-width under the status bar. */
+function MobileTabs({ tabs }: { tabs: typeof conductorTopbarFixture.tabs }) {
+  return (
+    <nav
+      aria-label="Boards"
+      className="flex flex-none border-b border-jv-line bg-jv-surface-0"
+    >
+      {tabs.map((tab) =>
+        tab.active || !tab.href ? (
+          <span
+            key={tab.label}
+            aria-current={tab.active ? 'page' : undefined}
+            className={clsx(TAB_CLASS, 'bg-jv-surface-5 text-jv-text')}
+          >
+            {tab.label}
+          </span>
+        ) : (
+          <Link
+            key={tab.label}
+            to={tab.href}
+            className={clsx(TAB_CLASS, 'text-jv-label-dim')}
+          >
+            {tab.label}
+          </Link>
+        ),
+      )}
+    </nav>
+  )
+}
+
+/** RUNNING 2 · BLOCKED 1 · FAILED 1 · IDLE 7 — the no-scroll answer. */
+function StatStrip({ stats }: { stats: Array<MobileStatFixture> }) {
+  return (
+    <div className="flex flex-none border-b border-jv-line bg-jv-surface-2">
+      {stats.map((stat, index) => (
+        <div
+          key={stat.label}
+          data-jv-stat-tone={stat.tone}
+          className={clsx(
+            'flex-1 px-jv-8 py-jv-9 text-center',
+            index > 0 ? 'border-l border-jv-line-soft' : '',
+          )}
+        >
+          <div
+            className={clsx(
+              'font-jv-mono text-jv-8xl leading-jv-none font-semibold',
+              STAT_TONES[stat.tone],
+            )}
+          >
+            {stat.value}
+          </div>
+          <div className="mt-jv-6 font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2 text-jv-label">
+            {stat.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * NEEDS YOU. A pointer to the gate, not the gate: label, what it would do, and
+ * the two ways out of this screen.
+ */
+function NeedsYou({ data }: { data: MobileGateSummaryFixture }) {
+  return (
+    <section aria-label={data.heading} className="flex flex-col gap-jv-9">
+      <SectionLabel label={data.heading} />
+
+      <div className="border border-jv-blocked-line bg-jv-blocked-bg px-jv-12 pt-jv-10 pb-jv-11">
+        <div className="flex items-center gap-jv-7">
+          <span
+            aria-hidden="true"
+            className="h-jv-5 w-jv-5 flex-none bg-jv-blocked"
+          />
+          <span className="font-jv-mono text-jv-xs leading-jv-none font-semibold tracking-jv-wider text-jv-blocked">
+            {data.label}
+          </span>
+        </div>
+
+        <div className="mt-jv-9 font-jv-sans text-jv-4xl leading-jv-normal-2 font-medium text-jv-text-bright">
+          {data.title}
+        </div>
+
+        <div className="mt-jv-11 flex items-center gap-jv-8">
+          {data.actions.map((action, index) => (
+            <span
+              key={action}
+              className={clsx(
+                'font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider',
+                index === 0
+                  ? 'px-jv-16 py-jv-8 bg-jv-verified text-jv-surface-0'
+                  : 'px-jv-14 py-jv-8 border border-jv-border-btn-2 text-jv-text-body',
+              )}
+            >
+              {action}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function RunningNow({
+  chrome,
+  workers,
+}: {
+  chrome: MobileRunningChainFixture
+  workers: Array<WorkerStatusLineProps>
+}) {
+  return (
+    <section aria-label={chrome.heading} className="flex flex-col gap-jv-9">
+      <SectionLabel label={chrome.heading} />
+
+      {/* The primitive draws only a top rule, so the list closes itself. */}
+      <div className="flex flex-col border-b border-jv-line-soft">
+        {workers.map((worker) => (
+          <WorkerStatusLine key={worker.name} {...worker} />
+        ))}
+      </div>
+
+      <div className="flex items-center gap-jv-9">
+        <span
+          data-jv-fixture="no-source"
+          title="Layout convention — no parent→child delegation graph is captured today"
+          className="flex-1 font-jv-mono text-jv-sm leading-jv-relaxed text-jv-label-faint"
+        >
+          {chrome.chain}
+        </span>
+        <span className="border border-jv-border-btn px-jv-8 py-jv-5 font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap text-jv-text-faint">
+          {chrome.holdLabel}
+        </span>
+      </div>
+    </section>
+  )
+}
+
+function ScheduleHealth({
+  chrome,
+  jobs,
+}: {
+  chrome: MobileScheduleHealthFixture
+  jobs: Array<MobileJobFixture>
+}) {
+  return (
+    <section aria-label={chrome.heading} className="flex flex-col gap-jv-9">
+      <SectionLabel label={chrome.heading} />
+
+      {jobs.map((job) => {
+        const tokens = JOB_TONES[job.tone]
+        return (
+          <div
+            key={job.name}
+            data-jv-job-tone={job.tone}
+            className={clsx('border px-jv-11 pt-jv-9 pb-jv-10', tokens.frame)}
+          >
+            <div className="flex items-baseline gap-jv-8">
+              <span className="flex-1 font-jv-mono text-jv-lg leading-jv-none font-semibold text-jv-text-bright">
+                {job.name}
+              </span>
+              <span
+                className={clsx(
+                  'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap',
+                  tokens.badge,
+                )}
+              >
+                {job.badge}
+              </span>
+            </div>
+            <div
+              data-jv-fixture={job.noSource ? 'no-source' : undefined}
+              className={clsx(
+                'mt-jv-6 font-jv-mono text-jv-base leading-jv-loose',
+                JOB_DETAIL_TONES[job.tone],
+              )}
+            >
+              {job.detail}
+            </div>
+          </div>
+        )
+      })}
+
+      <div className="flex items-center gap-jv-7 font-jv-mono text-jv-sm leading-jv-none text-jv-label-faint">
+        <span aria-hidden="true" className="text-jv-verified">
+          ●
+        </span>
+        <span>{chrome.healthy}</span>
+        <span aria-hidden="true" className="text-jv-label-ghost">
+          ·
+        </span>
+        <span data-jv-fixture="no-source" className="text-jv-claimed-text">
+          {chrome.partial}
+        </span>
+      </div>
+    </section>
+  )
+}
+
+function LastNight({ data }: { data: MobileLastNightFixture }) {
+  return (
+    <section
+      aria-label={data.heading}
+      data-jv-fixture="no-source"
+      title="Fixture — ClaudeJob exposes only the latest run, so no per-run history exists today"
+      className="flex flex-col gap-jv-9"
+    >
+      <SectionLabel label={data.heading} note={data.window} />
+
+      <div className="flex flex-col">
+        {data.runs.map((run, index) => (
+          <div
+            key={`${run.time}-${run.job}`}
+            data-jv-run-outcome={run.outcome}
+            className={clsx(
+              'flex items-baseline gap-jv-10 py-jv-7 font-jv-mono text-jv-md leading-jv-none',
+              index > 0 ? 'border-t border-jv-line-faint' : '',
+            )}
+          >
+            <span
+              className="flex-none text-jv-label-faint"
+              style={{ width: JV_MOBILE.runTimeWidth }}
+            >
+              {run.time}
+            </span>
+            <span className="flex-1 truncate text-jv-text-body">{run.job}</span>
+            <span className={RUN_OUTCOMES[run.outcome]}>{run.outcome}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+/** The mobile frame on its own — what artboard 04 shows, fluid to the viewport. */
+export function MobileConductorBoard() {
+  return (
+    <div
+      data-jv-board="mobile-conductor"
+      className="flex w-full flex-col overflow-hidden border border-jv-border bg-jv-surface-1 font-jv-sans tracking-normal text-jv-text"
+      style={{
+        maxWidth: JV_MOBILE.frameWidth,
+        minHeight: JV_MOBILE.frameHeight,
+      }}
+    >
+      <MobileStatusBar data={mobileStatusBarFixture} />
+      <MobileTabs tabs={conductorTopbarFixture.tabs} />
+      <StatStrip stats={mobileConductorStatFixtures} />
+
+      <main className="flex min-h-0 flex-1 flex-col gap-jv-16 overflow-y-auto px-jv-14 pt-jv-14 pb-jv-16">
+        <NeedsYou data={mobileConductorNeedsYouFixture} />
+        <RunningNow
+          chrome={mobileConductorRunningChain}
+          workers={mobileConductorRunningFixtures}
+        />
+        <ScheduleHealth
+          chrome={mobileConductorScheduleHealth}
+          jobs={mobileConductorJobFixtures}
+        />
+        <LastNight data={mobileConductorLastNightFixture} />
+      </main>
+    </div>
+  )
+}

--- a/src/screens/jarvis/conductor/mobile-conductor.tsx
+++ b/src/screens/jarvis/conductor/mobile-conductor.tsx
@@ -16,19 +16,24 @@
  * panel on a glance surface would imply you can decide from here. The gate
  * itself lives on Command.
  *
- * ONE SECTION CAN BE LIVE (slice 6a). SCHEDULE HEALTH accepts real jobs as
- * props — mapped from `ClaudeJob` by the routed screen, which owns the only
- * query — and falls back to the fixtures when nothing is passed, which is what
- * a standalone render and the tests get. This file itself still opens no
+ * THREE SECTIONS CAN BE LIVE. SCHEDULE HEALTH accepts real jobs (slice 6a), and
+ * the STAT STRIP and RUNNING NOW accept real swarm workers (slice 6b) — all
+ * mapped by the routed screen, which owns the only query and the only store
+ * subscription — falling back to the fixtures when nothing is passed, which is
+ * what a standalone render and the tests get. This file itself still opens no
  * request and imports no client; it is a frame, not a fetcher.
  *
  * Live, the footer's PARTIAL half-line is DROPPED rather than carried over
  * (§3.5 item 11: PARTIAL is not a job status, only free text inside
  * `last_run_error`), and no live row is marked `no-source` because nothing
- * unsourced is drawn for a real job. Everything else on the frame — the stat
- * strip, NEEDS YOU, RUNNING NOW, LAST NIGHT — is still fixtures, and the rows
- * with NO source at all (§3.5 items 11–14) keep their `data-jv-fixture=
- * "no-source"` mark and their line in the banner above the frame.
+ * unsourced is drawn for a real job or a real worker. RUNNING NOW can be EMPTY
+ * live — when nothing is running that is the true answer, and the strip above
+ * already says RUNNING 0; padding it with idle workers to keep the section
+ * looking full would be the same lie in a different place. Its chain caption
+ * stays fixture and stays marked, because the delegation graph has no source
+ * (§3.5 item 14). NEEDS YOU and LAST NIGHT are still fixtures, and the rows
+ * with NO source at all keep their `data-jv-fixture="no-source"` mark and their
+ * line in the banner above the frame.
  *
  * Fluid, not a 390px box: `w-full` with 390 as a MAX and 844 as a MIN.
  *
@@ -358,16 +363,20 @@ function LastNight({ data }: { data: MobileLastNightFixture }) {
 /**
  * The mobile frame on its own — what artboard 04 shows, fluid to the viewport.
  *
- * Jobs come in as props defaulting to the fixtures, so the frame renders
- * standalone with no query client mounted and the slice-5 board is unchanged
- * when nothing is passed.
+ * Jobs and workers come in as props defaulting to the fixtures, so the frame
+ * renders standalone with no query client and no store poll mounted, and the
+ * slice-5 board is unchanged when nothing is passed.
  */
 export function MobileConductorBoard({
   jobs = mobileConductorJobFixtures,
   scheduleHealth = mobileConductorScheduleHealth,
+  stats = mobileConductorStatFixtures,
+  running = mobileConductorRunningFixtures,
 }: {
   jobs?: Array<MobileJobFixture>
   scheduleHealth?: MobileScheduleHealthFixture
+  stats?: Array<MobileStatFixture>
+  running?: Array<WorkerStatusLineProps>
 } = {}) {
   return (
     <div
@@ -380,14 +389,11 @@ export function MobileConductorBoard({
     >
       <MobileStatusBar data={mobileStatusBarFixture} />
       <MobileTabs tabs={conductorTopbarFixture.tabs} />
-      <StatStrip stats={mobileConductorStatFixtures} />
+      <StatStrip stats={stats} />
 
       <main className="flex min-h-0 flex-1 flex-col gap-jv-16 overflow-y-auto px-jv-14 pt-jv-14 pb-jv-16">
         <NeedsYou data={mobileConductorNeedsYouFixture} />
-        <RunningNow
-          chrome={mobileConductorRunningChain}
-          workers={mobileConductorRunningFixtures}
-        />
+        <RunningNow chrome={mobileConductorRunningChain} workers={running} />
         <ScheduleHealth chrome={scheduleHealth} jobs={jobs} />
         <LastNight data={mobileConductorLastNightFixture} />
       </main>

--- a/src/screens/jarvis/conductor/mobile-conductor.tsx
+++ b/src/screens/jarvis/conductor/mobile-conductor.tsx
@@ -16,13 +16,19 @@
  * panel on a glance surface would imply you can decide from here. The gate
  * itself lives on Command.
  *
- * FIXTURES ONLY. This file imports no store, no gateway client and no HTTP
- * endpoint, and opens no request or event stream of any kind — every value
- * comes from `src/components/jarvis/fixtures.ts`. As on the desktop board,
- * much of what is shown DOES have a real source today
- * (`docs/design/jarvis-ui-mapping.md` §3.3–§3.4) and this slice still does not
- * read it; the rows with NO source at all (§3.5 items 11–14) carry
- * `data-jv-fixture="no-source"` and are named in the banner above the frame.
+ * ONE SECTION CAN BE LIVE (slice 6a). SCHEDULE HEALTH accepts real jobs as
+ * props — mapped from `ClaudeJob` by the routed screen, which owns the only
+ * query — and falls back to the fixtures when nothing is passed, which is what
+ * a standalone render and the tests get. This file itself still opens no
+ * request and imports no client; it is a frame, not a fetcher.
+ *
+ * Live, the footer's PARTIAL half-line is DROPPED rather than carried over
+ * (§3.5 item 11: PARTIAL is not a job status, only free text inside
+ * `last_run_error`), and no live row is marked `no-source` because nothing
+ * unsourced is drawn for a real job. Everything else on the frame — the stat
+ * strip, NEEDS YOU, RUNNING NOW, LAST NIGHT — is still fixtures, and the rows
+ * with NO source at all (§3.5 items 11–14) keep their `data-jv-fixture=
+ * "no-source"` mark and their line in the banner above the frame.
  *
  * Fluid, not a 390px box: `w-full` with 390 as a MAX and 844 as a MIN.
  *
@@ -252,6 +258,10 @@ function ScheduleHealth({
   chrome: MobileScheduleHealthFixture
   jobs: Array<MobileJobFixture>
 }) {
+  // Empty means live: there is no PARTIAL to report because no such status
+  // exists. Rendering the separator over nothing would imply one does.
+  const hasPartial = Boolean(chrome.partial)
+
   return (
     <section aria-label={chrome.heading} className="flex flex-col gap-jv-9">
       <SectionLabel label={chrome.heading} />
@@ -295,12 +305,16 @@ function ScheduleHealth({
           ●
         </span>
         <span>{chrome.healthy}</span>
-        <span aria-hidden="true" className="text-jv-label-ghost">
-          ·
-        </span>
-        <span data-jv-fixture="no-source" className="text-jv-claimed-text">
-          {chrome.partial}
-        </span>
+        {hasPartial ? (
+          <>
+            <span aria-hidden="true" className="text-jv-label-ghost">
+              ·
+            </span>
+            <span data-jv-fixture="no-source" className="text-jv-claimed-text">
+              {chrome.partial}
+            </span>
+          </>
+        ) : null}
       </div>
     </section>
   )
@@ -341,8 +355,20 @@ function LastNight({ data }: { data: MobileLastNightFixture }) {
   )
 }
 
-/** The mobile frame on its own — what artboard 04 shows, fluid to the viewport. */
-export function MobileConductorBoard() {
+/**
+ * The mobile frame on its own — what artboard 04 shows, fluid to the viewport.
+ *
+ * Jobs come in as props defaulting to the fixtures, so the frame renders
+ * standalone with no query client mounted and the slice-5 board is unchanged
+ * when nothing is passed.
+ */
+export function MobileConductorBoard({
+  jobs = mobileConductorJobFixtures,
+  scheduleHealth = mobileConductorScheduleHealth,
+}: {
+  jobs?: Array<MobileJobFixture>
+  scheduleHealth?: MobileScheduleHealthFixture
+} = {}) {
   return (
     <div
       data-jv-board="mobile-conductor"
@@ -362,10 +388,7 @@ export function MobileConductorBoard() {
           chrome={mobileConductorRunningChain}
           workers={mobileConductorRunningFixtures}
         />
-        <ScheduleHealth
-          chrome={mobileConductorScheduleHealth}
-          jobs={mobileConductorJobFixtures}
-        />
+        <ScheduleHealth chrome={scheduleHealth} jobs={jobs} />
         <LastNight data={mobileConductorLastNightFixture} />
       </main>
     </div>

--- a/src/screens/jarvis/conductor/resolve-arm-toggle.tsx
+++ b/src/screens/jarvis/conductor/resolve-arm-toggle.tsx
@@ -1,0 +1,87 @@
+/**
+ * The arm switch for the gate's resolve — the visible half of `use-resolve-arm`.
+ *
+ * It is a switch and nothing more: pressing it changes one boolean in this
+ * session and sends nothing. The line under it says which of the two worlds you
+ * are in, in the gate's own terms, so that "armed" is never something you have
+ * to infer from a button lighting up.
+ *
+ * ARMED IS NOT RESOLVED. Even lit, APPROVE / REJECT still walk their two-step
+ * confirm, and the POST still needs a real approval id — see
+ * `use-resolve-approval.ts`, which this slice does not touch. Arming opens LOCK
+ * 1 only.
+ *
+ * The repo's `<Switch>` (`src/components/ui/switch.tsx`) is deliberately not
+ * used: it is styled in the app's `primary`/`emerald` scale with raw px, and
+ * none of that resolves under `[data-theme='jarvis']`. This is a plain button
+ * with `role="switch"`, which is what that primitive would have been anyway.
+ *
+ * Colour choice: OFF is the board's dim label grey — an inert control. ARMED is
+ * the BLOCKED amber the gate itself is drawn in, not the LIVE cyan: cyan on
+ * this board means "a real thing is streaming", and amber means "a human is in
+ * the loop here". Armed is the second one.
+ *
+ * Token discipline: no raw colour, size, spacing or radius in this file.
+ */
+/*
+ * NOTE: `clsx` rather than the repo's `cn()`, for the reason given at the top of
+ * `src/components/jarvis/approval-gate-card.tsx` — tailwind-merge does not know
+ * the `jv-*` scale and drops `text-jv-*` sizes when a `text-jv-*` colour sits
+ * beside them.
+ */
+import { clsx } from 'clsx'
+
+export const ARM_LABEL_OFF = 'LIVE RESOLVE: OFF'
+export const ARM_LABEL_ARMED = 'LIVE RESOLVE: ARMED'
+
+export const ARM_NOTE_OFF =
+  'The gate is display-only this session. APPROVE / REJECT still walk their confirm step and then stop — nothing is sent to the gateway.'
+export const ARM_NOTE_ARMED =
+  'Armed for this session only. A CONFIRMED approve or reject now POSTs the real decision to the gateway, and there is no undo. Arming alone sends nothing.'
+
+export function ResolveArmToggle({
+  armed,
+  onChange,
+}: {
+  armed: boolean
+  onChange: (next: boolean) => void
+}) {
+  return (
+    <div data-jv-resolve-armed={armed} className="flex flex-col gap-jv-5">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={armed}
+        onClick={() => onChange(!armed)}
+        className={clsx(
+          'flex w-fit items-center gap-jv-8 border px-jv-11 py-jv-7 font-jv-mono text-jv-sm leading-jv-none font-semibold tracking-jv-wider',
+          armed
+            ? 'border-jv-blocked-line bg-jv-blocked-bg-chip text-jv-blocked'
+            : 'border-jv-border-btn bg-jv-surface-2 text-jv-label',
+        )}
+      >
+        {/* The lamp. Filled when armed, hollow when not — legible before the
+            text is read, and never the only signal. */}
+        <span
+          aria-hidden="true"
+          className={clsx(
+            'h-jv-6 w-jv-6 flex-none border',
+            armed
+              ? 'border-jv-blocked bg-jv-blocked'
+              : 'border-jv-label-faint bg-jv-surface-0',
+          )}
+        />
+        {armed ? ARM_LABEL_ARMED : ARM_LABEL_OFF}
+      </button>
+
+      <p
+        className={clsx(
+          'font-jv-sans text-jv-md leading-jv-loose',
+          armed ? 'text-jv-blocked-soft' : 'text-jv-text-caption',
+        )}
+      >
+        {armed ? ARM_NOTE_ARMED : ARM_NOTE_OFF}
+      </p>
+    </div>
+  )
+}

--- a/src/screens/jarvis/conductor/run-log.tsx
+++ b/src/screens/jarvis/conductor/run-log.tsx
@@ -1,0 +1,169 @@
+/**
+ * Desktop Conductor — RUN LOG · UNATTENDED (artboard 02).
+ *
+ * One row per unattended run over the last 12h: TIME / JOB / WORKER / RESULT /
+ * OUTCOME / DURATION. The failed row is tinted and re-coloured end to end
+ * rather than only in its OUTCOME cell — you should be able to find it while
+ * scrolling past, not by reading the right-hand column.
+ *
+ * Honesty note — `docs/design/jarvis-ui-mapping.md` §3.5 item 13: this table
+ * has NO SOURCE. `ClaudeJob` exposes only the LATEST run of each job, so a
+ * multi-row per-run history cannot be assembled from today's API at all. The
+ * whole section is marked `data-jv-fixture="no-source"`.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. The column widths
+ * are structural and come from `JV_CONDUCTOR` (multiples of `--jv-space-4`).
+ */
+import { clsx } from 'clsx'
+import { ConductorSectionHeading } from './conductor-chrome'
+import { JV_CONDUCTOR } from './geometry'
+import type {
+  ConductorRunFixture,
+  ConductorRunLogChromeFixture,
+  ConductorRunOutcome,
+} from '@/components/jarvis/fixtures'
+
+const HISTORY_NOTE_TITLE =
+  'Fixture — ClaudeJob exposes only the latest run, so no per-run history exists today'
+
+const COLUMN_WIDTHS = {
+  time: JV_CONDUCTOR.runTimeWidth,
+  job: JV_CONDUCTOR.runJobWidth,
+  worker: JV_CONDUCTOR.runWorkerWidth,
+  outcome: JV_CONDUCTOR.runOutcomeWidth,
+  duration: JV_CONDUCTOR.runDurationWidth,
+} as const
+
+interface RowTokens {
+  row: string
+  time: string
+  job: string
+  worker: string
+  result: string
+  outcome: string
+  duration: string
+}
+
+/**
+ * A failed run repaints its whole row; success and partial differ only in the
+ * OUTCOME cell, which is exactly how much emphasis each deserves.
+ */
+const OUTCOMES: Record<ConductorRunOutcome, RowTokens> = {
+  success: {
+    row: '',
+    time: 'text-jv-label-faint',
+    job: 'text-jv-text-body',
+    worker: 'text-jv-text-faint',
+    result: 'text-jv-text-detail',
+    outcome: 'text-jv-verified',
+    duration: 'text-jv-label-dim',
+  },
+  partial: {
+    row: '',
+    time: 'text-jv-label-faint',
+    job: 'text-jv-text-body',
+    worker: 'text-jv-text-faint',
+    result: 'text-jv-text-detail',
+    outcome: 'text-jv-claimed-text',
+    duration: 'text-jv-label-dim',
+  },
+  failed: {
+    row: 'bg-jv-failed-bg-row',
+    time: 'text-jv-failed-muted',
+    job: 'text-jv-text-bright',
+    worker: 'text-jv-text-faint',
+    result: 'text-jv-failed-text',
+    outcome: 'font-semibold text-jv-failed',
+    duration: 'text-jv-label-dim',
+  },
+}
+
+export function RunLog({
+  chrome,
+  runs,
+}: {
+  chrome: ConductorRunLogChromeFixture
+  runs: Array<ConductorRunFixture>
+}) {
+  const { columns } = chrome
+
+  return (
+    <section
+      aria-label="Unattended run log"
+      data-jv-fixture="no-source"
+      title={HISTORY_NOTE_TITLE}
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <ConductorSectionHeading
+        heading={{ label: chrome.label, note: chrome.note }}
+        trailing={chrome.summary}
+        className="px-jv-20 pt-jv-14 pb-jv-9"
+      />
+
+      <div className="flex border-b border-jv-line px-jv-20 pb-jv-5 font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wider text-jv-label-ghost">
+        <span style={{ width: COLUMN_WIDTHS.time }}>{columns.time}</span>
+        <span style={{ width: COLUMN_WIDTHS.job }}>{columns.job}</span>
+        <span style={{ width: COLUMN_WIDTHS.worker }}>{columns.worker}</span>
+        <span className="flex-1">{columns.result}</span>
+        <span className="text-right" style={{ width: COLUMN_WIDTHS.outcome }}>
+          {columns.outcome}
+        </span>
+        <span className="text-right" style={{ width: COLUMN_WIDTHS.duration }}>
+          {columns.duration}
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        {runs.map((run, index) => {
+          const tokens = OUTCOMES[run.outcome]
+          return (
+            <div
+              key={`${run.time}-${run.job}`}
+              data-jv-run-outcome={run.outcome}
+              className={clsx(
+                'flex px-jv-20 py-jv-7 font-jv-mono text-jv-md leading-jv-normal',
+                // The last row closes the table; the artboard draws no rule
+                // under it, so the section ends on the surface, not a hairline.
+                index === runs.length - 1
+                  ? ''
+                  : 'border-b border-jv-line-faint',
+                tokens.row,
+              )}
+            >
+              <span
+                className={tokens.time}
+                style={{ width: COLUMN_WIDTHS.time }}
+              >
+                {run.time}
+              </span>
+              <span className={tokens.job} style={{ width: COLUMN_WIDTHS.job }}>
+                {run.job}
+              </span>
+              <span
+                className={tokens.worker}
+                style={{ width: COLUMN_WIDTHS.worker }}
+              >
+                {run.worker}
+              </span>
+              <span className={clsx('flex-1 truncate', tokens.result)}>
+                {run.result}
+              </span>
+              <span
+                className={clsx('text-right', tokens.outcome)}
+                style={{ width: COLUMN_WIDTHS.outcome }}
+              >
+                {run.outcome}
+              </span>
+              <span
+                className={clsx('text-right', tokens.duration)}
+                style={{ width: COLUMN_WIDTHS.duration }}
+              >
+                {run.duration}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/jarvis/conductor/scheduled-jobs.tsx
+++ b/src/screens/jarvis/conductor/scheduled-jobs.tsx
@@ -1,0 +1,184 @@
+/**
+ * Desktop Conductor — SCHEDULED JOBS (artboard 02).
+ *
+ * A 3-column grid of job cards. Health here is LAST-run, not next-run — a job
+ * with a perfectly valid schedule that has not fired in 23 days is the failure
+ * this section exists to surface, so `failed` and `silent` are the loudest
+ * cards on the board:
+ *   • FAILED — red frame, hazard-striped left edge, the actual error text,
+ *     and the two chips you would reach for (TRIAGE / FULL LOG).
+ *   • SILENT — amber frame, the arithmetic that proves the silence
+ *     ("expected 4 runs · got 0 · never errored") and the launchd diagnostic
+ *     that explains it.
+ * `PARTIAL` is deliberately quieter: same frame as OK, amber badge only.
+ *
+ * Honesty notes (`docs/design/jarvis-ui-mapping.md`):
+ *   • §3.4 — name, cadence, last-run success/error and next-run ARE real today
+ *     (the `ClaudeJob` records the jobs endpoint serves). Not read here.
+ *   • §3.5 item 11 — PARTIAL is not a job status; it only ever exists as free
+ *     text inside `last_run_error`. Its badge is marked `no-source`.
+ *   • §3.5 item 12 — the launchd "not loaded" line has no source at all.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. The hazard stripe
+ * is a `repeating-linear-gradient` over `--jv-failed` / `--jv-failed-bg` at
+ * `--jv-space-4` intervals, so even the stripe resolves through the tokens.
+ */
+import { clsx } from 'clsx'
+import { JV_BOARD } from '../command/geometry'
+import { ConductorChip, ConductorSectionHeading } from './conductor-chrome'
+import type {
+  ConductorJobFixture,
+  ConductorJobLineTone,
+  ConductorJobTone,
+  ConductorSectionHeadingFixture,
+} from '@/components/jarvis/fixtures'
+
+/**
+ * The 3px striped edge on a failed job — a second, non-colour signal that this
+ * card is the emergency, readable before any text is.
+ */
+const HAZARD_STRIPE =
+  'repeating-linear-gradient(0deg, var(--jv-failed) 0 var(--jv-space-4), var(--jv-failed-bg) var(--jv-space-4) var(--jv-space-8))'
+
+interface JobTokens {
+  frame: string
+  name: string
+  /** Filled for FAILED, plain coloured text for the rest. */
+  badge: string
+  detail: string
+  /** Failed cards inset their content to clear the hazard stripe. */
+  inset?: string
+  stripe?: boolean
+}
+
+const JOB_TONES: Record<ConductorJobTone, JobTokens> = {
+  ok: {
+    frame: 'border-jv-border-muted bg-jv-surface-2',
+    name: 'font-medium text-jv-text',
+    badge: 'text-jv-verified',
+    detail: 'text-jv-label-dim',
+  },
+  partial: {
+    // Same frame as OK on purpose: the run happened, it just wasn't whole.
+    frame: 'border-jv-border-muted bg-jv-surface-2',
+    name: 'font-medium text-jv-text',
+    badge: 'text-jv-claimed-text',
+    detail: 'text-jv-label-dim',
+  },
+  failed: {
+    frame: 'border-jv-failed-line bg-jv-failed-bg',
+    name: 'font-semibold text-jv-text-bright',
+    badge: 'bg-jv-failed px-jv-5 py-jv-3 text-jv-surface-1',
+    detail: 'text-jv-text-faint',
+    inset: 'pl-jv-6',
+    stripe: true,
+  },
+  silent: {
+    frame: 'border-jv-blocked-line bg-jv-blocked-bg-row',
+    name: 'font-semibold text-jv-text-bright',
+    badge: 'text-jv-blocked',
+    detail: 'text-jv-blocked-soft',
+  },
+}
+
+const LINE_TONES: Record<Exclude<ConductorJobLineTone, 'default'>, string> = {
+  failed: 'text-jv-failed-text',
+  dim: 'text-jv-blocked-dim',
+}
+
+function JobCard({ job }: { job: ConductorJobFixture }) {
+  const tokens = JOB_TONES[job.tone]
+
+  return (
+    <div
+      data-jv-job-tone={job.tone}
+      className={clsx(
+        'relative border px-jv-11 pt-jv-9 pb-jv-10',
+        tokens.frame,
+      )}
+    >
+      {tokens.stripe ? (
+        <span
+          aria-hidden="true"
+          className="absolute top-jv-0 bottom-jv-0 left-jv-0 w-jv-3"
+          style={{ backgroundImage: HAZARD_STRIPE }}
+        />
+      ) : null}
+
+      <div className={clsx('flex items-baseline gap-jv-8', tokens.inset)}>
+        <span
+          className={clsx(
+            'flex-1 font-jv-mono text-jv-lg leading-jv-none',
+            tokens.name,
+          )}
+        >
+          {job.name}
+        </span>
+        <span
+          data-jv-fixture={job.badgeNoSource ? 'no-source' : undefined}
+          className={clsx(
+            'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2 whitespace-nowrap',
+            tokens.badge,
+          )}
+        >
+          {job.badge}
+        </span>
+      </div>
+
+      <div
+        className={clsx(
+          'mt-jv-6 font-jv-mono text-jv-base leading-jv-loose',
+          tokens.detail,
+          tokens.inset,
+        )}
+      >
+        <div>{job.cadence}</div>
+        {job.detail.map((line) => (
+          <div
+            key={line.text}
+            data-jv-fixture={line.noSource ? 'no-source' : undefined}
+            className={
+              line.tone && line.tone !== 'default'
+                ? LINE_TONES[line.tone]
+                : undefined
+            }
+          >
+            {line.text}
+          </div>
+        ))}
+      </div>
+
+      {job.actions?.length ? (
+        <div className={clsx('mt-jv-8 flex gap-jv-6', tokens.inset)}>
+          {job.actions.map((chip) => (
+            <ConductorChip key={chip.label} chip={chip} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function ScheduledJobs({
+  heading,
+  jobs,
+}: {
+  heading: ConductorSectionHeadingFixture
+  jobs: Array<ConductorJobFixture>
+}) {
+  return (
+    <section
+      aria-label="Scheduled jobs"
+      className="flex-none border-b border-jv-line px-jv-20 pt-jv-16"
+      style={{ paddingBottom: JV_BOARD.gap18 }}
+    >
+      <ConductorSectionHeading heading={heading} className="mb-jv-10" />
+
+      <div className="grid grid-cols-3 gap-jv-12">
+        {jobs.map((job) => (
+          <JobCard key={job.name} job={job} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/jarvis/conductor/use-approvals.ts
+++ b/src/screens/jarvis/conductor/use-approvals.ts
@@ -1,0 +1,107 @@
+/**
+ * The third wire into the JARVIS boards: the APPROVAL GATE, read-only.
+ *
+ * Reads the SAME query slice 6b already opened for the worker board — key
+ * `['gateway','approvals']`, `fetchGatewayApprovals`, 15s — rather than a second
+ * one. Sharing the key means the BLOCKED badge on a worker card and the gate on
+ * the Command hero are computed from the same response at the same moment, and
+ * two boards mounted together cost one request.
+ *
+ * READ-ONLY. `fetchGatewayApprovals` is a GET, and this file imports nothing
+ * else from the gateway client — the POST lives in `use-resolve-approval.ts`,
+ * behind a flag that is off, and is not reachable from here. What this hook
+ * produces is DISPLAY: what is waiting, who asked, for how long.
+ *
+ * FALLBACK, not failure state. No gateway, no pending approvals, or a response
+ * that never arrives: the boards render `commandGateFixture` and friends with
+ * `isLive: false`, exactly as slices 3–5 drew them. An empty gate slot would be
+ * worse than a fixture on both counts — it would make the design unreviewable
+ * offline, and "nothing is waiting on you" is a claim this hook cannot make
+ * from a request that may not have completed.
+ *
+ * ONE gate, not a list. The artboard shows a single hero gate, and that is the
+ * right shape: a queue of decisions rendered as a stack invites triage by
+ * scrolling. The hero is the OLDEST pending entry; the rest are a real derived
+ * count ("+2 more waiting") and nothing more.
+ */
+import { useQuery } from '@tanstack/react-query'
+import {
+  buildOthersWaitingLine,
+  mapApprovalToGateProps,
+  mapApprovalToGateSummary,
+  mapApprovalToMobileGateProps,
+  normalizeApprovals,
+  selectPendingApprovals,
+} from './map-approvals'
+import type { MappedGateProps } from './map-approvals'
+import type { MobileGateSummaryFixture } from '@/components/jarvis/fixtures'
+import {
+  commandGateFixture,
+  mobileCommandGateFixture,
+  mobileConductorNeedsYouFixture,
+} from '@/components/jarvis/fixtures'
+import { fetchGatewayApprovals } from '@/lib/gateway-api'
+
+/** Same key as `use-workers.ts` — one cache, one poll, one queue. */
+const APPROVALS_QUERY_KEY = ['gateway', 'approvals'] as const
+const APPROVALS_REFETCH_INTERVAL_MS = 15_000
+
+export interface ApprovalsData {
+  /** Desktop Command hero gate. */
+  gate: MappedGateProps
+  /** Mobile Command hero gate — same gate, no header sublabel. */
+  mobileGate: MappedGateProps
+  /** Conductor NEEDS YOU — a pointer to the gate, not the gate. */
+  needsYou: MobileGateSummaryFixture
+  /** "+2 more waiting", or empty when the hero is the whole queue. */
+  othersWaiting: string
+  /**
+   * The id the resolve path would act on. NULL on the fallback, which is a lock
+   * in its own right: a fixture gate has nothing to resolve, so
+   * `use-resolve-approval` cannot POST even with its flag flipped.
+   */
+  approvalId: string | null
+  /** True only when the gateway answered with at least one PENDING approval. */
+  isLive: boolean
+}
+
+const FALLBACK: ApprovalsData = {
+  gate: commandGateFixture,
+  mobileGate: mobileCommandGateFixture,
+  needsYou: mobileConductorNeedsYouFixture,
+  othersWaiting: '',
+  approvalId: null,
+  isLive: false,
+}
+
+export function useApprovals(): ApprovalsData {
+  const approvalsQuery = useQuery({
+    queryKey: APPROVALS_QUERY_KEY,
+    queryFn: fetchGatewayApprovals,
+    refetchInterval: APPROVALS_REFETCH_INTERVAL_MS,
+  })
+
+  const pending = selectPendingApprovals(normalizeApprovals(approvalsQuery.data))
+
+  // Loading, error, a gateway that is down, or a gateway that is up with an
+  // empty queue all land here. Only the last of those means "nothing is waiting
+  // on you", and this hook cannot tell it from the other three.
+  if (pending.length === 0) return FALLBACK
+
+  const [hero] = pending
+  const now = Date.now()
+  const others = pending.length - 1
+
+  return {
+    gate: mapApprovalToGateProps(hero, now),
+    mobileGate: mapApprovalToMobileGateProps(hero, now),
+    needsYou: mapApprovalToGateSummary(
+      hero,
+      others,
+      mobileConductorNeedsYouFixture.heading,
+    ),
+    othersWaiting: buildOthersWaitingLine(others),
+    approvalId: hero.id,
+    isLive: true,
+  }
+}

--- a/src/screens/jarvis/conductor/use-checkpoint-verification.ts
+++ b/src/screens/jarvis/conductor/use-checkpoint-verification.ts
@@ -1,0 +1,110 @@
+/**
+ * The fourth wire, and the only one that touches the product's thesis:
+ * CODE CHECKPOINT verification, read-only.
+ *
+ * `docs/design/jarvis-ui-mapping.md` §3.5 items 2–3 say verified-vs-claimed on
+ * a CHAT MESSAGE is NO SOURCE, and §3.6 says there is exactly one real
+ * verification source in the codebase — the `tsc | tests | lint | e2e` checks a
+ * workspace checkpoint records. That source is OUT OF BAND from chat. So this
+ * hook exists to feed ONE surface, its own, and the conversation stays inert:
+ * pointing this data at a message would claim a human-language assertion had
+ * been verified by a typechecker, which is precisely the dishonesty the
+ * primitive was built to prevent.
+ *
+ * TWO GETs, no writes. `listWorkspaceCheckpoints` and
+ * `getWorkspaceCheckpointDetail` are both reads. The same module also exports
+ * a checkpoint-review client and two typecheck-runner clients, all of them
+ * writes; the import list below names every function this file uses, and none
+ * of those three is on it, so no code path from this hook can approve a
+ * checkpoint or fire a verification run. The mapper emits no action chips, so
+ * nothing on a live badge can imply otherwise either.
+ *
+ * The list has to be fetched to reach the detail: `WorkspaceCheckpoint` carries
+ * only `verification_raw` (free text), while the per-check map lives on
+ * `WorkspaceCheckpointDetail`. So: newest checkpoint from the list, then its
+ * detail. Two requests, both cheap, both cached under the `['workspace', …]`
+ * key family the rest of the app already uses.
+ *
+ * FALLBACK, not failure state. The workspace API is served by the workspace
+ * daemon and simply 404s when it is not running — the normal case for a dev
+ * design review. Then, and on loading, on error, and when there are no
+ * checkpoints at all, the surface renders `verificationBadgeFixtures` with
+ * `isLive: false` and says so. `retry: false` keeps a missing daemon from
+ * becoming four failed requests.
+ *
+ * One case deliberately stays LIVE with nothing to show: a real checkpoint
+ * whose checks are all `missing`/`not_configured` produces zero badges, and
+ * that is NOT the fallback — "no check has run on this checkpoint" is real
+ * information, and replacing it with three fixture badges would bury it. The
+ * surface prints the inert lines instead.
+ */
+import { useQuery } from '@tanstack/react-query'
+import {
+  buildCheckpointSourceLine,
+  mapCheckpointToBadges,
+  mapCheckpointToInertChecks,
+} from './map-checkpoints'
+import type { CheckpointInertCheck } from './map-checkpoints'
+import type { VerificationBadgeProps } from '@/components/jarvis/types'
+import { verificationBadgeFixtures } from '@/components/jarvis/fixtures'
+import {
+  getWorkspaceCheckpointDetail,
+  listWorkspaceCheckpoints,
+  sortCheckpointsNewestFirst,
+} from '@/lib/workspace-checkpoints'
+
+const CHECKPOINTS_QUERY_KEY = ['workspace', 'checkpoints'] as const
+const CHECKPOINTS_REFETCH_INTERVAL_MS = 30_000
+
+export interface CheckpointVerificationData {
+  /** One badge per check that actually ran (`passed`/`failed`). */
+  badges: Array<VerificationBadgeProps>
+  /** The checks that produced no verdict — rendered as text, never as a badge. */
+  inertChecks: Array<CheckpointInertCheck>
+  /** Which checkpoint this is, from real fields. NULL on the fixture fallback. */
+  source: string | null
+  /** True only when the workspace API answered with a real checkpoint detail. */
+  isLive: boolean
+}
+
+const FALLBACK: CheckpointVerificationData = {
+  badges: verificationBadgeFixtures.map((fixture) => fixture.props),
+  inertChecks: [],
+  source: null,
+  isLive: false,
+}
+
+export function useCheckpointVerification(): CheckpointVerificationData {
+  const checkpointsQuery = useQuery({
+    queryKey: CHECKPOINTS_QUERY_KEY,
+    queryFn: () => listWorkspaceCheckpoints(),
+    refetchInterval: CHECKPOINTS_REFETCH_INTERVAL_MS,
+    // No workspace daemon is the expected dev case, not an outage worth
+    // retrying three times.
+    retry: false,
+  })
+
+  const newest = sortCheckpointsNewestFirst(checkpointsQuery.data ?? [])
+  const newestId = newest.length > 0 ? newest[0].id : null
+
+  const detailQuery = useQuery({
+    queryKey: [...CHECKPOINTS_QUERY_KEY, newestId ?? 'none'],
+    queryFn: () => getWorkspaceCheckpointDetail(newestId ?? ''),
+    enabled: newestId !== null,
+    refetchInterval: CHECKPOINTS_REFETCH_INTERVAL_MS,
+    retry: false,
+  })
+
+  const detail = detailQuery.data
+  // Loading, a daemon that is not running, and a workspace with no checkpoints
+  // all land here. None of them is "nothing has been verified" — that is a
+  // claim this hook cannot make from a request that may not have completed.
+  if (!detail) return FALLBACK
+
+  return {
+    badges: mapCheckpointToBadges(detail),
+    inertChecks: mapCheckpointToInertChecks(detail),
+    source: buildCheckpointSourceLine(detail),
+    isLive: true,
+  }
+}

--- a/src/screens/jarvis/conductor/use-resolve-approval.test.ts
+++ b/src/screens/jarvis/conductor/use-resolve-approval.test.ts
@@ -1,0 +1,316 @@
+/**
+ * The safety test for the one WRITE in the JARVIS boards.
+ *
+ * NOTHING HERE TOUCHES THE NETWORK, and that is asserted rather than assumed:
+ * `fetch` is replaced by a tripwire that throws if anything calls it, and every
+ * case checks it was never called. The resolve function is a spy in every case
+ * — the real `resolveGatewayApproval` is never imported here, so a POST cannot
+ * escape this file even if a guard regressed.
+ *
+ * The machine is exercised directly rather than through the hook because this
+ * repo's vitest setup cannot render a hook-using component at all (React ends
+ * up with a null dispatcher — `renderHook`, and any `useState` component,
+ * crashes repo-wide). `resolveMachine` is where every guard lives, so testing
+ * it is testing the lock; `drive` below is a five-line stand-in for the hook,
+ * carrying out effects exactly the way `dispatch` does, so "confirm calls the
+ * mocked fn" is a real assertion and not a paraphrase.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  APPROVE_LABEL,
+  CANCEL_LABEL,
+  CONFIRM_APPROVE_LABEL,
+  CONFIRM_REJECT_LABEL,
+  DEFAULT_GATE_ACTIONS,
+  DISABLED_NOTE,
+  IDLE_STATE,
+  REJECT_LABEL,
+  actionsFor,
+  eventForLabel,
+  noteFor,
+  resolveMachine,
+} from './use-resolve-approval'
+import type {
+  ResolveEffect,
+  ResolveLocks,
+  ResolveState,
+} from './use-resolve-approval'
+
+const OPEN: ResolveLocks = { enabled: true, approvalId: 'appr-1' }
+const FLAG_OFF: ResolveLocks = { enabled: false, approvalId: 'appr-1' }
+const NO_ID: ResolveLocks = { enabled: true, approvalId: null }
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  // Not a stub of a real call — a tripwire. If anything below reaches the
+  // network at all, this records it and the case fails.
+  fetchSpy = vi.fn(() => {
+    throw new Error('the resolve tests must never hit the network')
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * What `useResolveApproval`'s `dispatch` does, minus React: run the machine,
+ * keep the new state, and perform the effect if — and only if — it returned
+ * one. `resolve` is a spy, so "the write happened" is observable.
+ */
+function drive(locks: ResolveLocks) {
+  const resolve = vi.fn((): Promise<{ ok: boolean }> =>
+    Promise.resolve({ ok: true }),
+  )
+  let state: ResolveState = IDLE_STATE
+
+  return {
+    resolve,
+    state: () => state,
+    actions: () => actionsFor(state, DEFAULT_GATE_ACTIONS),
+    note: (enabled = locks.enabled) => noteFor(state, enabled),
+    /** A button press, exactly as the card delivers one. */
+    click(label: string) {
+      const event = eventForLabel(label, state)
+      if (!event) return
+      const step = resolveMachine(state, event, locks)
+      state = step.state
+      if (step.effect) resolve(step.effect.approvalId, step.effect.action)
+    },
+  }
+}
+
+/** Every case ends by proving no request left the process. */
+function expectNoNetwork() {
+  expect(fetchSpy).not.toHaveBeenCalled()
+}
+
+describe('the confirm gate — two presses, never one', () => {
+  it('first press only enters the confirm state; nothing is sent', () => {
+    const gate = drive(OPEN)
+
+    gate.click(APPROVE_LABEL)
+
+    expect(gate.state()).toEqual({ phase: 'confirming', intent: 'approve' })
+    expect(gate.actions()).toEqual([CONFIRM_APPROVE_LABEL, CANCEL_LABEL])
+    expect(gate.actions()).not.toContain(APPROVE_LABEL)
+    expect(gate.note()).toContain('this authorises the real action')
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+
+  it('the second, explicit confirm is what calls resolve — once', () => {
+    const gate = drive(OPEN)
+
+    gate.click(APPROVE_LABEL)
+    gate.click(CONFIRM_APPROVE_LABEL)
+
+    expect(gate.resolve).toHaveBeenCalledTimes(1)
+    expect(gate.resolve).toHaveBeenCalledWith('appr-1', 'approve')
+    expect(gate.state().phase).toBe('resolving')
+    expectNoNetwork()
+  })
+
+  it('rejects through the same two presses, as deny', () => {
+    const gate = drive(OPEN)
+
+    gate.click(REJECT_LABEL)
+    expect(gate.actions()).toEqual([CONFIRM_REJECT_LABEL, CANCEL_LABEL])
+    expect(gate.resolve).not.toHaveBeenCalled()
+
+    gate.click(CONFIRM_REJECT_LABEL)
+
+    expect(gate.resolve).toHaveBeenCalledWith('appr-1', 'deny')
+    expectNoNetwork()
+  })
+
+  it('cancel returns to idle and never calls resolve', () => {
+    const gate = drive(OPEN)
+
+    gate.click(APPROVE_LABEL)
+    gate.click(CANCEL_LABEL)
+
+    expect(gate.state()).toEqual(IDLE_STATE)
+    expect(gate.actions()).toEqual(DEFAULT_GATE_ACTIONS)
+    expect(gate.note()).toBeNull()
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+
+  it('will not confirm the other way — the chip must match the pending intent', () => {
+    const gate = drive(OPEN)
+
+    gate.click(APPROVE_LABEL)
+    gate.click(CONFIRM_REJECT_LABEL)
+
+    expect(gate.state()).toEqual({ phase: 'confirming', intent: 'approve' })
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+
+  it('ignores a chip that maps onto no endpoint', () => {
+    const gate = drive(OPEN)
+
+    gate.click('HOLD FOR QA')
+
+    expect(gate.state()).toEqual(IDLE_STATE)
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+})
+
+describe('LOCK 1 — the enabled flag, off by default', () => {
+  it('shows the confirm step but sends nothing while disabled', () => {
+    const gate = drive(FLAG_OFF)
+
+    gate.click(APPROVE_LABEL)
+    expect(gate.state().phase).toBe('confirming')
+    expect(gate.note()).toContain(DISABLED_NOTE)
+
+    gate.click(CONFIRM_APPROVE_LABEL)
+
+    expect(gate.state().phase).toBe('blocked')
+    expect(gate.note()).toBe(DISABLED_NOTE)
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+
+  it('emits no effect on any confirm while the flag is off', () => {
+    // Straight at the machine: whatever state it is handed, a shut flag means
+    // no write. `blocked` is terminal, so the only way on is a cancel.
+    for (const state of [
+      { phase: 'confirming', intent: 'approve' },
+      { phase: 'confirming', intent: 'deny' },
+    ] satisfies Array<ResolveState>) {
+      const step = resolveMachine(state, { type: 'confirm' }, FLAG_OFF)
+      expect(step.effect).toBeNull()
+      expect(step.state.phase).toBe('blocked')
+    }
+    expectNoNetwork()
+  })
+})
+
+describe('LOCK 2 — the confirm step cannot be skipped', () => {
+  it('a bare confirm from idle does nothing, flag on or off', () => {
+    for (const locks of [OPEN, FLAG_OFF, NO_ID]) {
+      const step = resolveMachine(IDLE_STATE, { type: 'confirm' }, locks)
+      expect(step.effect).toBeNull()
+      expect(step.state).toEqual(IDLE_STATE)
+    }
+    expectNoNetwork()
+  })
+
+  it('a second request cannot restart a settled gate without a cancel', () => {
+    const settled: ResolveState = { phase: 'resolved', intent: 'approve' }
+    const step = resolveMachine(
+      settled,
+      { type: 'request', intent: 'approve' },
+      OPEN,
+    )
+    expect(step.state).toEqual(settled)
+    expect(step.effect).toBeNull()
+    expectNoNetwork()
+  })
+})
+
+describe('LOCK 3 — a fixture gate has nothing to resolve', () => {
+  it('blocks the confirm when there is no real approval id', () => {
+    const gate = drive(NO_ID)
+
+    gate.click(APPROVE_LABEL)
+    gate.click(CONFIRM_APPROVE_LABEL)
+
+    expect(gate.state().phase).toBe('blocked')
+    expect(gate.resolve).not.toHaveBeenCalled()
+    expectNoNetwork()
+  })
+})
+
+describe('the only path that authorises a write', () => {
+  it('is a guarded confirm — and nothing else in the machine emits an effect', () => {
+    const states: Array<ResolveState> = [
+      IDLE_STATE,
+      { phase: 'confirming', intent: 'approve' },
+      { phase: 'confirming', intent: 'deny' },
+      { phase: 'blocked', intent: 'approve' },
+      { phase: 'resolving', intent: 'approve' },
+      { phase: 'resolved', intent: 'approve' },
+      { phase: 'failed', intent: 'deny' },
+    ]
+    const events = [
+      { type: 'request', intent: 'approve' },
+      { type: 'request', intent: 'deny' },
+      { type: 'confirm' },
+      { type: 'cancel' },
+      { type: 'settled', ok: true },
+      { type: 'settled', ok: false },
+    ] as const
+
+    const effects: Array<{ state: ResolveState; effect: ResolveEffect }> = []
+    for (const locks of [OPEN, FLAG_OFF, NO_ID]) {
+      for (const state of states) {
+        for (const event of events) {
+          const step = resolveMachine(state, event, locks)
+          if (step.effect) effects.push({ state, effect: step.effect })
+        }
+      }
+    }
+
+    // Exactly two: confirm-from-confirming, each intent, locks fully open.
+    expect(effects).toHaveLength(2)
+    expect(effects.every(({ state }) => state.phase === 'confirming')).toBe(true)
+    expect(effects.map(({ effect }) => effect.action).sort()).toEqual([
+      'approve',
+      'deny',
+    ])
+    expect(
+      effects.every(({ effect }) => effect.approvalId === OPEN.approvalId),
+    ).toBe(true)
+    expectNoNetwork()
+  })
+})
+
+describe('what the gate says after the POST', () => {
+  it('reports the refusal instead of claiming the decision landed', () => {
+    const resolving: ResolveState = { phase: 'resolving', intent: 'approve' }
+
+    expect(
+      resolveMachine(resolving, { type: 'settled', ok: true }, OPEN).state.phase,
+    ).toBe('resolved')
+
+    const failed = resolveMachine(
+      resolving,
+      { type: 'settled', ok: false },
+      OPEN,
+    ).state
+    expect(failed.phase).toBe('failed')
+    expect(noteFor(failed, true)).toContain('Nothing changed')
+    expectNoNetwork()
+  })
+
+  it('ignores a late settle that does not belong to an in-flight write', () => {
+    const step = resolveMachine(IDLE_STATE, { type: 'settled', ok: true }, OPEN)
+    expect(step.state).toEqual(IDLE_STATE)
+  })
+})
+
+describe('eventForLabel', () => {
+  it('reads the resting chips as requests, never as confirms', () => {
+    expect(eventForLabel(APPROVE_LABEL, IDLE_STATE)).toEqual({
+      type: 'request',
+      intent: 'approve',
+    })
+    expect(eventForLabel(REJECT_LABEL, IDLE_STATE)).toEqual({
+      type: 'request',
+      intent: 'deny',
+    })
+    expect(eventForLabel(CONFIRM_APPROVE_LABEL, IDLE_STATE)).toBeNull()
+  })
+
+  it('accepts cancel from anywhere', () => {
+    expect(eventForLabel(CANCEL_LABEL, { phase: 'blocked', intent: 'approve' }))
+      .toEqual({ type: 'cancel' })
+  })
+})

--- a/src/screens/jarvis/conductor/use-resolve-approval.ts
+++ b/src/screens/jarvis/conductor/use-resolve-approval.ts
@@ -1,0 +1,313 @@
+/**
+ * The ONLY place `resolveGatewayApproval` is referenced anywhere in
+ * `src/screens/jarvis/`. Read this file before changing anything in it.
+ *
+ * WHAT THE WRITE ACTUALLY DOES. `resolveGatewayApproval(id, 'approve')` POSTs
+ * `/api/gateway/approvals/:id/approve` and a real agent then performs the real
+ * action it was blocked on — a write to a vault, a push, a publish. There is no
+ * dry run and no undo (§3.2: UNDO PATH is NO SOURCE precisely because nothing
+ * models one). Every other JARVIS wire so far — slices 6a and 6b — is a GET.
+ * This one is not, and everything below exists to make that difference
+ * impossible to cross by accident.
+ *
+ * TWO INDEPENDENT LOCKS, plus one that comes free. All must be open:
+ *
+ *   1. `enabled` — off by default, at this hook's signature and at every call
+ *      site (`enableResolve = false`). Flipping it is a product decision, not a
+ *      refactor.
+ *   2. The confirm step — `request` only moves a state machine; the POST is
+ *      issued on a SECOND explicit act, on a card that by then says which way
+ *      it is about to go.
+ *   3. A real `approvalId`. The fixture fallback has none, so a fixture gate
+ *      cannot resolve anything even with the flag on.
+ *
+ * The confirm step works whether or not `enabled` is set, on purpose: with the
+ * flag off the gate still demonstrates its real interaction, and confirming
+ * lands in `blocked` — a terminal, honest state that says nothing was sent.
+ * That is what a reviewer sees on the board today, and the network panel stays
+ * empty while they see it.
+ *
+ * WHY A PURE REDUCER. `resolveMachine` decides, in one place and with no React
+ * around it, whether a POST may happen; the hook below only carries out what it
+ * returns. That makes the guard readable in isolation and — the reason it is
+ * shaped this way — testable in isolation: this repo's vitest setup cannot
+ * render a hook-using component at all (React ends up with a null dispatcher,
+ * which breaks `renderHook` and any stateful component, not just this one), so
+ * a machine that only existed inside a hook could not be tested here. The
+ * effect is DATA, never a call: nothing in this file invokes `resolve` except
+ * `dispatch`, and `dispatch` only does so when the machine hands it an effect.
+ */
+import { useCallback, useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { resolveGatewayApproval } from '@/lib/gateway-api'
+
+/** The two resolutions the endpoint actually has. */
+export type ResolveIntent = 'approve' | 'deny'
+
+export type ResolvePhase =
+  /** Nothing clicked. The only state in which the gate shows APPROVE/REJECT. */
+  | 'idle'
+  /** One click in. Nothing has been sent; CANCEL returns to `idle`. */
+  | 'confirming'
+  /** Confirmed with a lock shut — terminal, and nothing was sent. */
+  | 'blocked'
+  /** Confirmed with every lock open — the POST is in flight. */
+  | 'resolving'
+  | 'resolved'
+  | 'failed'
+
+export const APPROVE_LABEL = 'APPROVE'
+export const REJECT_LABEL = 'REJECT'
+export const CONFIRM_APPROVE_LABEL = 'CONFIRM APPROVE'
+export const CONFIRM_REJECT_LABEL = 'CONFIRM REJECT'
+export const CANCEL_LABEL = 'CANCEL'
+
+export const DEFAULT_GATE_ACTIONS: Array<string> = [APPROVE_LABEL, REJECT_LABEL]
+
+/** The prose under the panel while a confirm is pending. Deliberately blunt. */
+export const CONFIRM_NOTE: Record<ResolveIntent, string> = {
+  approve:
+    'Confirm approve — this authorises the real action. There is no undo path.',
+  deny: 'Confirm reject — this denies the agent’s request and unblocks it as refused.',
+}
+
+export const DISABLED_NOTE =
+  'Resolve is DISABLED in this build — nothing was sent to the gateway. The gate is display-only until approving from here is explicitly turned on.'
+
+export const RESOLVING_NOTE = 'Sending…'
+export const RESOLVED_NOTE = 'Sent — the gateway has the decision.'
+export const FAILED_NOTE =
+  'The gateway did not accept the decision. Nothing changed.'
+
+/* ── The machine ─────────────────────────────────────────────────────── */
+
+export interface ResolveState {
+  phase: ResolvePhase
+  /** Which way a pending confirm goes. Null outside `confirming`. */
+  intent: ResolveIntent | null
+}
+
+export const IDLE_STATE: ResolveState = { phase: 'idle', intent: null }
+
+export type ResolveEvent =
+  /** Step 1 — a button was pressed. Never sends. */
+  | { type: 'request'; intent: ResolveIntent }
+  /** Step 2 — the confirm was pressed. The only event that can emit an effect. */
+  | { type: 'confirm' }
+  | { type: 'cancel' }
+  /** The POST came back. */
+  | { type: 'settled'; ok: boolean }
+
+/** The locks, read at the moment of the confirm rather than at mount. */
+export interface ResolveLocks {
+  enabled: boolean
+  approvalId: string | null
+}
+
+/**
+ * The one shape that means "a POST is authorised". It is returned, not
+ * performed: whoever holds the machine decides to carry it out, and only
+ * `dispatch` below ever does.
+ */
+export interface ResolveEffect {
+  approvalId: string
+  action: ResolveIntent
+}
+
+export interface ResolveStep {
+  state: ResolveState
+  effect: ResolveEffect | null
+}
+
+/**
+ * Pure. Given where the gate is, what was pressed, and whether the locks are
+ * open, returns where the gate goes and — only ever from a `confirm` that
+ * passed every guard — the write to perform.
+ */
+export function resolveMachine(
+  state: ResolveState,
+  event: ResolveEvent,
+  locks: ResolveLocks,
+): ResolveStep {
+  switch (event.type) {
+    case 'request':
+      // Refuse to restart from a terminal or in-flight state without a cancel
+      // first: a second decision on a resolved gate is not a decision.
+      if (state.phase !== 'idle') return { state, effect: null }
+      return { state: { phase: 'confirming', intent: event.intent }, effect: null }
+
+    case 'cancel':
+      return { state: IDLE_STATE, effect: null }
+
+    case 'confirm': {
+      // LOCK 2 — the confirm must follow a request. Nothing may skip step 1.
+      if (state.phase !== 'confirming' || state.intent === null) {
+        return { state, effect: null }
+      }
+      // LOCK 1 and LOCK 3 — the flag, and a real approval to act on.
+      if (!locks.enabled || !locks.approvalId) {
+        return { state: { phase: 'blocked', intent: state.intent }, effect: null }
+      }
+      return {
+        state: { phase: 'resolving', intent: state.intent },
+        effect: { approvalId: locks.approvalId, action: state.intent },
+      }
+    }
+
+    case 'settled':
+      if (state.phase !== 'resolving') return { state, effect: null }
+      return {
+        state: { phase: event.ok ? 'resolved' : 'failed', intent: state.intent },
+        effect: null,
+      }
+  }
+}
+
+/** Which event a chip label means, given where the gate currently is. */
+export function eventForLabel(
+  label: string,
+  state: ResolveState,
+): ResolveEvent | null {
+  if (label === CANCEL_LABEL) return { type: 'cancel' }
+
+  if (state.phase === 'confirming' && state.intent !== null) {
+    // The confirm chip must match the pending intent — a CONFIRM REJECT press
+    // must never resolve an approve.
+    const expected =
+      state.intent === 'approve' ? CONFIRM_APPROVE_LABEL : CONFIRM_REJECT_LABEL
+    return label === expected ? { type: 'confirm' } : null
+  }
+
+  if (label === APPROVE_LABEL) return { type: 'request', intent: 'approve' }
+  if (label === REJECT_LABEL) return { type: 'request', intent: 'deny' }
+
+  // Anything else — an inert chip, a fixture label — means nothing at all.
+  return null
+}
+
+/** The chips the card should show. Confirming replaces them, never adds to them. */
+export function actionsFor(
+  state: ResolveState,
+  baseActions: Array<string>,
+): Array<string> {
+  if (state.phase === 'confirming' && state.intent !== null) {
+    return [
+      state.intent === 'approve' ? CONFIRM_APPROVE_LABEL : CONFIRM_REJECT_LABEL,
+      CANCEL_LABEL,
+    ]
+  }
+  if (state.phase === 'blocked' || state.phase === 'failed') {
+    return [CANCEL_LABEL]
+  }
+  return baseActions
+}
+
+/** The line under the panel, or null when there is nothing to say. */
+export function noteFor(state: ResolveState, enabled: boolean): string | null {
+  switch (state.phase) {
+    case 'confirming':
+      return state.intent
+        ? `${CONFIRM_NOTE[state.intent]}${enabled ? '' : ` ${DISABLED_NOTE}`}`
+        : null
+    case 'blocked':
+      return DISABLED_NOTE
+    case 'resolving':
+      return RESOLVING_NOTE
+    case 'resolved':
+      return RESOLVED_NOTE
+    case 'failed':
+      return FAILED_NOTE
+    case 'idle':
+      return null
+  }
+}
+
+/* ── The hook ────────────────────────────────────────────────────────── */
+
+export interface UseResolveApprovalOptions {
+  /**
+   * LOCK 1. False by default and false at every call site in this repo. While
+   * false, no `confirm` can produce an effect — see `resolveMachine`.
+   */
+  enabled?: boolean
+  /** LOCK 3. The live approval's id; null on the fixture fallback. */
+  approvalId?: string | null
+  /** The chips the gate offers at rest. */
+  baseActions?: Array<string>
+  /** Injected for tests ONLY. Production always uses the real client. */
+  resolve?: (
+    approvalId: string,
+    action: ResolveIntent,
+  ) => Promise<{ ok: boolean }>
+}
+
+export interface ResolveControl {
+  /** Mirrors LOCK 1 so a board can label itself honestly. */
+  enabled: boolean
+  state: ResolveState
+  /** What the card should show right now. */
+  actions: Array<string>
+  /** The line under the panel, or null. */
+  note: string | null
+  /** The card's `onAction`. Routes a label through the machine. */
+  onAction: (label: string) => void
+}
+
+export function useResolveApproval({
+  enabled = false,
+  approvalId = null,
+  baseActions = DEFAULT_GATE_ACTIONS,
+  resolve = resolveGatewayApproval,
+}: UseResolveApprovalOptions = {}): ResolveControl {
+  const [state, setState] = useState<ResolveState>(IDLE_STATE)
+
+  const mutation = useMutation({
+    mutationFn: ({ approvalId: id, action }: ResolveEffect) =>
+      resolve(id, action),
+    onSuccess: (result) =>
+      setState((current) =>
+        resolveMachine(current, { type: 'settled', ok: result.ok }, {
+          enabled,
+          approvalId,
+        }).state,
+      ),
+    onError: () =>
+      setState(
+        (current) =>
+          resolveMachine(current, { type: 'settled', ok: false }, {
+            enabled,
+            approvalId,
+          }).state,
+      ),
+  })
+  const { mutate } = mutation
+
+  /**
+   * The single call site of the mutation in this repo. It runs only when the
+   * machine returns an effect, which only a guarded `confirm` can produce.
+   */
+  const dispatch = useCallback(
+    (event: ResolveEvent) => {
+      const step = resolveMachine(state, event, { enabled, approvalId })
+      setState(step.state)
+      if (step.effect) mutate(step.effect)
+    },
+    [approvalId, enabled, mutate, state],
+  )
+
+  const onAction = useCallback(
+    (label: string) => {
+      const event = eventForLabel(label, state)
+      if (event) dispatch(event)
+    },
+    [dispatch, state],
+  )
+
+  const actions = useMemo(
+    () => actionsFor(state, baseActions),
+    [baseActions, state],
+  )
+  const note = useMemo(() => noteFor(state, enabled), [enabled, state])
+
+  return { enabled, state, actions, note, onAction }
+}

--- a/src/screens/jarvis/conductor/use-resolve-approval.ts
+++ b/src/screens/jarvis/conductor/use-resolve-approval.ts
@@ -72,7 +72,7 @@ export const CONFIRM_NOTE: Record<ResolveIntent, string> = {
 }
 
 export const DISABLED_NOTE =
-  'Resolve is DISABLED in this build — nothing was sent to the gateway. The gate is display-only until approving from here is explicitly turned on.'
+  'LIVE RESOLVE is off for this session — nothing was sent to the gateway. Arm it to decide from here.'
 
 export const RESOLVING_NOTE = 'Sending…'
 export const RESOLVED_NOTE = 'Sent — the gateway has the decision.'

--- a/src/screens/jarvis/conductor/use-resolve-arm.test.ts
+++ b/src/screens/jarvis/conductor/use-resolve-arm.test.ts
@@ -1,0 +1,199 @@
+/**
+ * The safety test for the arm flag.
+ *
+ * The property under test is one-directional: OFF is the answer to every
+ * question this file cannot answer with certainty. So the cases are mostly
+ * about the ways a read can go wrong — no storage, a hostile storage, a stored
+ * value that is not the one string that means armed — and all of them must land
+ * on false. Only a literal `'true'` arms it.
+ *
+ * NOTHING HERE TOUCHES THE NETWORK — this file imports no gateway client, and
+ * `fetch` is a tripwire that fails the case if anything calls it. Arming is a
+ * state change, and this asserts it stays one.
+ *
+ * The pure functions are exercised directly rather than through `useResolveArm`
+ * because this repo's vitest setup cannot render a hook-using component at all
+ * (React ends up with a null dispatcher — `renderHook`, and any `useState`
+ * component, crashes repo-wide). Every decision lives in `readArmed` /
+ * `writeArmed`; the hook is a `useState` around them.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ARMED_VALUE,
+  DISARMED_VALUE,
+  RESOLVE_ARM_STORAGE_KEY,
+  readArmed,
+  sessionArmStorage,
+  writeArmed,
+} from './use-resolve-arm'
+import type { ArmStorage } from './use-resolve-arm'
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn(() => {
+    throw new Error('arming must never hit the network')
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** A real-enough sessionStorage: one map, the two methods this file uses. */
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial))
+  return {
+    map,
+    storage: {
+      getItem: (key: string) => map.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        map.set(key, value)
+      },
+    } satisfies ArmStorage,
+  }
+}
+
+/** Safari private mode, an embedded webview, a blocked third-party context. */
+const THROWING_STORAGE: ArmStorage = {
+  getItem: () => {
+    throw new Error('storage is not available')
+  },
+  setItem: () => {
+    throw new Error('storage is not available')
+  },
+}
+
+describe('readArmed — OFF unless the session says otherwise', () => {
+  it('is false when the key was never written', () => {
+    const { storage } = fakeStorage()
+
+    expect(storage.getItem(RESOLVE_ARM_STORAGE_KEY)).toBeNull()
+    expect(readArmed(storage)).toBe(false)
+  })
+
+  it('is false when there is no storage at all', () => {
+    expect(readArmed(null)).toBe(false)
+  })
+
+  it("is false for a stored 'false'", () => {
+    const { storage } = fakeStorage({
+      [RESOLVE_ARM_STORAGE_KEY]: DISARMED_VALUE,
+    })
+
+    expect(readArmed(storage)).toBe(false)
+  })
+
+  it.each(['TRUE', 'True', '1', 'yes', 'armed', '', ' true '])(
+    'is false for the garbage value %o',
+    (value) => {
+      const { storage } = fakeStorage({ [RESOLVE_ARM_STORAGE_KEY]: value })
+
+      expect(readArmed(storage)).toBe(false)
+    },
+  )
+
+  it('is false — and does not throw — when the storage throws on read', () => {
+    expect(() => readArmed(THROWING_STORAGE)).not.toThrow()
+    expect(readArmed(THROWING_STORAGE)).toBe(false)
+  })
+
+  it("is true for exactly one value: 'true'", () => {
+    const { storage } = fakeStorage({ [RESOLVE_ARM_STORAGE_KEY]: ARMED_VALUE })
+
+    expect(readArmed(storage)).toBe(true)
+  })
+
+  it('ignores every key but its own', () => {
+    const { storage } = fakeStorage({ 'jarvis:resolve': ARMED_VALUE })
+
+    expect(readArmed(storage)).toBe(false)
+  })
+})
+
+describe('writeArmed — the arm survives the page view it was made in', () => {
+  it('persists an arm, and reads back as armed', () => {
+    const { map, storage } = fakeStorage()
+
+    writeArmed(storage, true)
+
+    expect(map.get(RESOLVE_ARM_STORAGE_KEY)).toBe(ARMED_VALUE)
+    expect(readArmed(storage)).toBe(true)
+  })
+
+  it('disarming writes a value that reads back as OFF', () => {
+    const { map, storage } = fakeStorage({
+      [RESOLVE_ARM_STORAGE_KEY]: ARMED_VALUE,
+    })
+
+    writeArmed(storage, false)
+
+    expect(map.get(RESOLVE_ARM_STORAGE_KEY)).toBe(DISARMED_VALUE)
+    expect(readArmed(storage)).toBe(false)
+  })
+
+  it('does not throw when there is no storage, or when it refuses the write', () => {
+    expect(() => writeArmed(null, true)).not.toThrow()
+    expect(() => writeArmed(THROWING_STORAGE, true)).not.toThrow()
+    // The refusal did not arm anything a later read could pick up.
+    expect(readArmed(THROWING_STORAGE)).toBe(false)
+  })
+
+  it('writes one key and only one key', () => {
+    const { map, storage } = fakeStorage()
+
+    writeArmed(storage, true)
+
+    expect([...map.keys()]).toEqual([RESOLVE_ARM_STORAGE_KEY])
+  })
+})
+
+describe('sessionArmStorage — session only, and never fatal', () => {
+  it('is null when there is no window (SSR)', () => {
+    vi.stubGlobal('window', undefined)
+
+    expect(sessionArmStorage()).toBeNull()
+  })
+
+  it('is null — not a throw — when touching sessionStorage throws', () => {
+    vi.stubGlobal('window', {
+      get sessionStorage(): ArmStorage {
+        throw new Error('access denied')
+      },
+    })
+
+    expect(() => sessionArmStorage()).not.toThrow()
+    expect(sessionArmStorage()).toBeNull()
+  })
+
+  it('hands back the session storage, and a fresh session reads OFF', () => {
+    const { storage } = fakeStorage()
+    vi.stubGlobal('window', { sessionStorage: storage })
+
+    expect(sessionArmStorage()).toBe(storage)
+    expect(readArmed(sessionArmStorage())).toBe(false)
+  })
+
+  it('never reaches localStorage — an armed localStorage still reads OFF', () => {
+    const { storage: session } = fakeStorage()
+    const { storage: local } = fakeStorage({
+      [RESOLVE_ARM_STORAGE_KEY]: ARMED_VALUE,
+    })
+    vi.stubGlobal('window', { sessionStorage: session, localStorage: local })
+
+    expect(readArmed(sessionArmStorage())).toBe(false)
+  })
+})
+
+describe('arming is not an action', () => {
+  it('reading and writing the flag never calls fetch', () => {
+    const { storage } = fakeStorage()
+
+    writeArmed(storage, true)
+    readArmed(storage)
+    writeArmed(storage, false)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/screens/jarvis/conductor/use-resolve-arm.ts
+++ b/src/screens/jarvis/conductor/use-resolve-arm.ts
@@ -1,0 +1,120 @@
+/**
+ * LOCK 1's switch — the per-session arm flag for the approval gate's resolve.
+ *
+ * This file owns ONE boolean and nothing else: whether the user has, in this
+ * browser session, consciously said "I intend to act from this board". It is
+ * fed into `useResolveApproval`'s `enabled` — it does not bypass it, weaken it,
+ * or reach the gateway. Arming is a state change and issues NO network call:
+ * the POST still needs the two-step confirm and a real approval id, and both
+ * guards live in `use-resolve-approval.ts`, untouched by this slice.
+ *
+ * WHY PER-SESSION, AND WHY `sessionStorage`. A resolve that is on by default is
+ * on by accident; a resolve that is on forever is on by forgetting. The middle
+ * position — armed only for as long as this tab lives — is the one that matches
+ * the act: you arm it when you sit down to decide something. `localStorage` is
+ * never touched here, deliberately: an arm that survives a browser restart is
+ * indistinguishable from a build-time default, which is exactly what the gate's
+ * design refuses.
+ *
+ * DEFAULT FALSE, ON EVERY PATH. No storage, a storage that throws (Safari
+ * private mode, embedded webviews, SSR where there is no `window` at all), a
+ * missing key, `'false'`, or any other value all read as OFF. `true` is
+ * returned for exactly one stored string, `'true'`. There is no path through
+ * `readArmed` that turns an unknown into an arm.
+ *
+ * WHY PURE FUNCTIONS UNDER THE HOOK. Same constraint as the resolve machine:
+ * this repo's vitest setup cannot render a hook-using component at all (React
+ * ends up with a null dispatcher, which breaks `renderHook` repo-wide). The
+ * storage logic therefore lives in `readArmed` / `writeArmed`, which take the
+ * storage as an argument and are tested directly, and the hook below is a thin
+ * `useState` around them with nothing to get wrong.
+ */
+import { useCallback, useEffect, useState } from 'react'
+
+/** The session key. Namespaced so it cannot collide with app state. */
+export const RESOLVE_ARM_STORAGE_KEY = 'jarvis:resolve-armed'
+
+/** The ONLY stored string that means armed. Anything else is OFF. */
+export const ARMED_VALUE = 'true'
+export const DISARMED_VALUE = 'false'
+
+/**
+ * The slice of the Storage interface this file uses. Narrow on purpose: it
+ * documents that nothing here enumerates, clears, or reads any other key, and
+ * it lets a test pass a fake — including one that throws.
+ */
+export interface ArmStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+/**
+ * `window.sessionStorage`, or null when there is not one to have. The access
+ * itself is inside the try: in some privacy modes merely touching the property
+ * throws, before any get or set.
+ */
+export function sessionArmStorage(): ArmStorage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    // Typed non-optional by lib.dom, but an embedded webview can hand back
+    // undefined rather than throwing — so it is read as possibly absent.
+    const storage = window.sessionStorage as ArmStorage | undefined
+    return storage ?? null
+  } catch {
+    return null
+  }
+}
+
+/** The stored flag, defaulting to OFF for every value that is not `'true'`. */
+export function readArmed(storage: ArmStorage | null): boolean {
+  if (!storage) return false
+  try {
+    return storage.getItem(RESOLVE_ARM_STORAGE_KEY) === ARMED_VALUE
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Records the flag. A storage that refuses the write is not an error worth
+ * surfacing — the arm still holds in React state for this page view, and the
+ * next page view falls back to OFF, which is the safe direction.
+ */
+export function writeArmed(storage: ArmStorage | null, next: boolean): void {
+  if (!storage) return
+  try {
+    storage.setItem(
+      RESOLVE_ARM_STORAGE_KEY,
+      next ? ARMED_VALUE : DISARMED_VALUE,
+    )
+  } catch {
+    // Storage full, blocked, or read-only. Nothing to do and nothing to say.
+  }
+}
+
+export interface ResolveArmControl {
+  /** Feeds `useResolveApproval`'s `enabled`. False until the user says so. */
+  armed: boolean
+  setArmed: (next: boolean) => void
+}
+
+/**
+ * The hook. First render is ALWAYS false — on the server there is no storage,
+ * and starting from the stored value would make the server and client markup
+ * disagree. The effect below then adopts the stored value on the client. The
+ * transient state is OFF, so the window between paint and effect fails closed.
+ */
+export function useResolveArm(): ResolveArmControl {
+  const [armed, setArmedState] = useState(false)
+
+  useEffect(() => {
+    setArmedState(readArmed(sessionArmStorage()))
+  }, [])
+
+  const setArmed = useCallback((next: boolean) => {
+    writeArmed(sessionArmStorage(), next)
+    setArmedState(next)
+  }, [])
+
+  return { armed, setArmed }
+}

--- a/src/screens/jarvis/conductor/use-scheduled-jobs.ts
+++ b/src/screens/jarvis/conductor/use-scheduled-jobs.ts
@@ -1,0 +1,94 @@
+/**
+ * The one wire into the Conductor board: SCHEDULED JOBS, read-only.
+ *
+ * Slices 2–5 drew this board from fixtures with a stated promise that slice 6
+ * would get "one file to replace". This is that file for §3.4 — it reads the
+ * SAME query the real jobs screen reads (`src/screens/jobs/jobs-screen.tsx`):
+ * key `['claude','jobs']`, `fetchJobs`, 30s poll. Sharing the key rather than
+ * opening a second request means the design surface and the product screen show
+ * the same jobs at the same moment, and the board costs nothing extra when both
+ * are mounted.
+ *
+ * READ-ONLY. `fetchJobs` is a GET; nothing here mutates, and the mapper emits
+ * no action chips, so no control on a live card can imply a run or a reload.
+ *
+ * FALLBACK, not failure state. With no gateway — which is the normal case for a
+ * dev design review — the query errors and the board renders the slice-4
+ * fixtures exactly as before, `isLive: false`. The board never renders a
+ * spinner or an empty grid: those would make the design unreviewable offline.
+ */
+import { useQuery } from '@tanstack/react-query'
+import {
+  buildScheduledJobsHeading,
+  mapClaudeJobsToConductorFixtures,
+  mapConductorFixturesToMobileJobs,
+} from './map-scheduled-jobs'
+import type {
+  ConductorJobFixture,
+  ConductorSectionHeadingFixture,
+  MobileJobFixture,
+  MobileScheduleHealthFixture,
+} from '@/components/jarvis/fixtures'
+import {
+  conductorJobFixtures,
+  conductorJobsHeading,
+  mobileConductorJobFixtures,
+  mobileConductorScheduleHealth,
+} from '@/components/jarvis/fixtures'
+import { fetchJobs } from '@/lib/jobs-api'
+
+/** Same key as the jobs screen — one cache, one poll, one truth. */
+const JOBS_QUERY_KEY = ['claude', 'jobs'] as const
+const JOBS_REFETCH_INTERVAL_MS = 30_000
+
+export interface ScheduledJobsData {
+  /** Desktop cards. */
+  jobs: Array<ConductorJobFixture>
+  /** Section heading — the registered count is live when the jobs are. */
+  heading: ConductorSectionHeadingFixture
+  /** Mobile SCHEDULE HEALTH rows (the unhealthy jobs only). */
+  mobileJobs: Array<MobileJobFixture>
+  /** Mobile SCHEDULE HEALTH footer. */
+  mobileScheduleHealth: MobileScheduleHealthFixture
+  /** True only when the gateway answered with at least one job. */
+  isLive: boolean
+}
+
+const FALLBACK: ScheduledJobsData = {
+  jobs: conductorJobFixtures,
+  heading: conductorJobsHeading,
+  mobileJobs: mobileConductorJobFixtures,
+  mobileScheduleHealth: mobileConductorScheduleHealth,
+  isLive: false,
+}
+
+export function useScheduledJobs(): ScheduledJobsData {
+  const jobsQuery = useQuery({
+    queryKey: JOBS_QUERY_KEY,
+    queryFn: fetchJobs,
+    refetchInterval: JOBS_REFETCH_INTERVAL_MS,
+  })
+
+  const jobs = jobsQuery.data
+  // Loading, error, or a gateway with no jobs at all: the fixture board is the
+  // honest thing to show, because an empty grid reads as "nothing scheduled"
+  // when what actually happened is "nothing answered".
+  if (!jobs || jobs.length === 0) return FALLBACK
+
+  const mapped = mapClaudeJobsToConductorFixtures(jobs)
+  const mobile = mapConductorFixturesToMobileJobs(mapped)
+
+  return {
+    jobs: mapped,
+    heading: buildScheduledJobsHeading(mapped.length),
+    mobileJobs: mobile.jobs,
+    mobileScheduleHealth: {
+      ...mobileConductorScheduleHealth,
+      healthy: mobile.healthy,
+      // NO SOURCE (§3.5 item 11) — a live footer carries no PARTIAL tally.
+      // `mobile-conductor.tsx` drops the half-line when this is empty.
+      partial: '',
+    },
+    isLive: true,
+  }
+}

--- a/src/screens/jarvis/conductor/use-workers.ts
+++ b/src/screens/jarvis/conductor/use-workers.ts
@@ -1,0 +1,164 @@
+/**
+ * The second wire into the JARVIS boards: WORKER STATUS, read-only.
+ *
+ * Two real sources, joined (`docs/design/jarvis-ui-mapping.md` §3.3):
+ *   • `useSwarmStore` — the gateway's subagent session list, already filtered
+ *     and status-derived by `src/stores/agent-swarm-store.ts`. This is the
+ *     worker roster, and it is the store the rest of the app uses; nothing here
+ *     re-derives a status the store already owns.
+ *   • `fetchGatewayApprovals()` — a GET on `/api/gateway/approvals`, whose
+ *     PENDING entries are the only authoritative source of `blocked`.
+ *
+ * On polling. The swarm store ships its own poller (`startPolling` /
+ * `stopPolling`, 5s) but nothing in the app currently starts it — the one other
+ * consumer, `use-sounds.ts`, subscribes passively and would read an empty list
+ * forever. So this hook drives the store's OWN loop rather than opening a second
+ * one, refcounted across mounts so the Command and Conductor boards share a
+ * single interval and the last one to unmount is the one that stops it. No new
+ * request shape, no new endpoint, no store change.
+ *
+ * READ-ONLY. Both calls are GETs. The approve/deny endpoint under
+ * `/api/gateway/approvals/:id/` is a POST and belongs to slice 6c; its client
+ * is not imported here, and the mapper emits no action chips, so no control on
+ * a live card can imply approving, denying, or intervening.
+ *
+ * FALLBACK, not failure state. With no gateway — the normal case for a dev
+ * design review — the store holds no sessions, the approvals GET resolves to an
+ * empty list, and both boards render the slice-3/4 fixtures with
+ * `isLive: false`. Neither board ever shows a spinner or an empty roster: an
+ * empty worker grid reads as "no workers are running" when what actually
+ * happened is "nothing answered".
+ */
+import { useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  buildWorkerBoardHeading,
+  mapSwarmToMobileRunning,
+  mapSwarmToMobileStats,
+  mapSwarmToRailRows,
+  mapSwarmToWorkerCards,
+} from './map-workers'
+import type { GatewayApprovalEntry } from '@/lib/gateway-api'
+import type {
+  ConductorSectionHeadingFixture,
+  ConductorWorkerCardFixture,
+  MobileStatFixture,
+} from '@/components/jarvis/fixtures'
+import type { WorkerStatusLineProps } from '@/components/jarvis/types'
+import {
+  commandWorkerCounts,
+  commandWorkerFixtures,
+  conductorWorkerBoardHeading,
+  conductorWorkerCardFixtures,
+  mobileConductorRunningFixtures,
+  mobileConductorStatFixtures,
+} from '@/components/jarvis/fixtures'
+import { fetchGatewayApprovals } from '@/lib/gateway-api'
+import { useSwarmStore } from '@/stores/agent-swarm-store'
+
+const APPROVALS_QUERY_KEY = ['gateway', 'approvals'] as const
+const APPROVALS_REFETCH_INTERVAL_MS = 15_000
+
+/** The store's own default. Kept explicit so the cadence is visible here. */
+const SWARM_POLL_INTERVAL_MS = 5_000
+
+export interface WorkersData {
+  /** Conductor WORKER BOARD cards. */
+  cards: Array<ConductorWorkerCardFixture>
+  /** WORKER BOARD section caption — the roster count is live when the cards are. */
+  heading: ConductorSectionHeadingFixture
+  /** Command WORKER RAIL rows plus its RUN/BLK/IDLE count line. */
+  rail: { workers: Array<WorkerStatusLineProps>; counts: string }
+  /** Mobile Conductor four-number strip. */
+  mobileStats: Array<MobileStatFixture>
+  /** Mobile Conductor RUNNING NOW rows. */
+  mobileRunning: Array<WorkerStatusLineProps>
+  /** True only when the store actually holds gateway sessions. */
+  isLive: boolean
+}
+
+const FALLBACK: WorkersData = {
+  cards: conductorWorkerCardFixtures,
+  heading: conductorWorkerBoardHeading,
+  rail: { workers: commandWorkerFixtures, counts: commandWorkerCounts },
+  mobileStats: mobileConductorStatFixtures,
+  mobileRunning: mobileConductorRunningFixtures,
+  isLive: false,
+}
+
+/**
+ * How many mounted boards want the swarm poll. Module scope because the store's
+ * `stopPolling` is global: an unmounting Conductor must not kill the interval a
+ * still-mounted Command board is reading from.
+ */
+let swarmSubscribers = 0
+
+function useSwarmPolling() {
+  useEffect(() => {
+    swarmSubscribers += 1
+    if (swarmSubscribers === 1) {
+      useSwarmStore.getState().startPolling(SWARM_POLL_INTERVAL_MS)
+    }
+    return () => {
+      swarmSubscribers -= 1
+      if (swarmSubscribers === 0) useSwarmStore.getState().stopPolling()
+    }
+  }, [])
+}
+
+/**
+ * The endpoint answers in two shapes — an `approvals` list and a `pending` one.
+ * Entries from `pending` are pending by construction, so they are stamped as
+ * such; entries from `approvals` keep whatever status the gateway gave them and
+ * are filtered on it downstream. Deduped by id, because a gateway that sends
+ * both lists sends the same record twice.
+ */
+function normalizeApprovals(response: {
+  approvals?: Array<GatewayApprovalEntry>
+  pending?: Array<GatewayApprovalEntry>
+}): Array<GatewayApprovalEntry> {
+  const byId = new Map<string, GatewayApprovalEntry>()
+
+  for (const entry of response.pending ?? []) {
+    byId.set(entry.id, { ...entry, status: 'pending' })
+  }
+  for (const entry of response.approvals ?? []) {
+    if (!byId.has(entry.id)) byId.set(entry.id, entry)
+  }
+
+  return [...byId.values()]
+}
+
+export function useWorkers(): WorkersData {
+  useSwarmPolling()
+
+  const sessions = useSwarmStore((state) => state.sessions)
+
+  const approvalsQuery = useQuery({
+    queryKey: APPROVALS_QUERY_KEY,
+    queryFn: fetchGatewayApprovals,
+    refetchInterval: APPROVALS_REFETCH_INTERVAL_MS,
+  })
+
+  // No sessions means no roster, whether that is "the gateway is down" or "the
+  // gateway is up and idle". Both render the fixtures: an empty five-column
+  // grid under a live banner would claim the swarm is empty on the strength of
+  // a request that may never have completed.
+  if (sessions.length === 0) return FALLBACK
+
+  const approvals = approvalsQuery.data
+    ? normalizeApprovals(approvalsQuery.data)
+    : []
+
+  const now = Date.now()
+  const cards = mapSwarmToWorkerCards(sessions, approvals, now)
+
+  return {
+    cards,
+    heading: buildWorkerBoardHeading(sessions.length, cards.length),
+    rail: mapSwarmToRailRows(sessions, approvals, now),
+    mobileStats: mapSwarmToMobileStats(sessions, approvals),
+    mobileRunning: mapSwarmToMobileRunning(sessions, approvals, now),
+    isLive: true,
+  }
+}

--- a/src/screens/jarvis/conductor/worker-board.tsx
+++ b/src/screens/jarvis/conductor/worker-board.tsx
@@ -1,0 +1,237 @@
+/**
+ * Desktop Conductor — WORKER BOARD (artboard 02).
+ *
+ * A 5-column grid. Row 1 is the active chain — orchestrator → builder →
+ * reviewer → qa, plus the blocked km-agent — with the horizontal connector
+ * drawn across the grid gutter; the rest of the fleet fills the rows below.
+ *
+ * Why a card and not `WorkerStatusLine`: the rail primitive is one row of
+ * dot + name + detail. A board card carries a step badge, TWO detail lines
+ * whose hues move independently, and a per-state action chip. Reusing the rail
+ * would mean either widening the primitive (out of scope for this slice) or
+ * padding the card out to a shape it isn't. The card is composed here instead
+ * and, like the primitive, keeps the blocked dot SQUARE so "waiting on a human"
+ * reads without relying on hue alone.
+ *
+ * Honesty notes (`docs/design/jarvis-ui-mapping.md`):
+ *   • §3.3 — worker running/idle/failed/stale DO have real sources today, and
+ *     `blocked` is derivable from a pending approval. This slice reads none of
+ *     them: every card below comes from `fixtures.ts`.
+ *   • §3.5 item 14 — the CHAIN is a layout convention. No parent→child edge
+ *     graph is captured anywhere, so the connectors and the chain caption are
+ *     marked `data-jv-fixture="no-source"`.
+ *   • §3.5 item 12 — maintainer's "launchd job not loaded" line has no source.
+ *
+ * Token discipline: no raw colour, size, spacing or radius. Structural
+ * dimensions come from `JV_CONDUCTOR` (multiples of `--jv-space-4`).
+ */
+import { clsx } from 'clsx'
+import { ConductorChip, ConductorSectionHeading } from './conductor-chrome'
+import { JV_CONDUCTOR } from './geometry'
+import type {
+  ConductorBadgeTone,
+  ConductorCardTone,
+  ConductorSectionHeadingFixture,
+  ConductorSubTone,
+  ConductorWorkerCardFixture,
+} from '@/components/jarvis/fixtures'
+
+const CHAIN_NOTE_TITLE =
+  'Layout convention — no parent→child delegation graph is captured today'
+
+interface CardTokens {
+  frame: string
+  /** Dot fill + shape. Blocked and the active node are square. */
+  dot: string
+  name: string
+  detail: string
+  sub: string
+}
+
+const CARD_TONES: Record<ConductorCardTone, CardTokens> = {
+  running: {
+    frame: 'border-jv-border-muted bg-jv-surface-4',
+    dot: 'rounded-jv-full bg-jv-live animate-jv-pulse',
+    name: 'font-semibold text-jv-text',
+    detail: 'text-jv-text-faint',
+    sub: 'text-jv-label-faint',
+  },
+  active: {
+    // The node the chain is currently ON — the only card wearing `jv-ring`.
+    frame: 'border-jv-live-line bg-jv-live-bg-2',
+    dot: 'bg-jv-live animate-jv-ring',
+    name: 'font-semibold text-jv-text',
+    detail: 'text-jv-text-muted',
+    sub: 'text-jv-label-faint',
+  },
+  queued: {
+    // In the chain but not reached: a step brighter than the fleet frame.
+    frame: 'border-jv-border-muted bg-jv-surface-2',
+    dot: 'rounded-jv-full bg-jv-dot-idle',
+    name: 'font-medium text-jv-text-dim',
+    detail: 'text-jv-label-dim',
+    sub: 'text-jv-label-ghost',
+  },
+  blocked: {
+    frame: 'border-jv-blocked-line bg-jv-blocked-bg-row',
+    dot: 'bg-jv-blocked',
+    name: 'font-semibold text-jv-text',
+    detail: 'text-jv-blocked-soft',
+    sub: 'text-jv-blocked-dim',
+  },
+  idle: {
+    frame: 'border-jv-line bg-jv-surface-2',
+    dot: 'rounded-jv-full bg-jv-dot-idle',
+    name: 'font-medium text-jv-text-dim',
+    detail: 'text-jv-label-dim',
+    sub: 'text-jv-label-ghost',
+  },
+}
+
+const BADGE_TONES: Record<ConductorBadgeTone, string> = {
+  live: 'text-jv-live',
+  muted: 'text-jv-label-faint',
+  blocked: 'text-jv-blocked',
+  failed: 'text-jv-failed',
+}
+
+/**
+ * The second detail line reports the LAST RUN, which need not agree with the
+ * card's current state — an idle worker can carry a failed last run.
+ */
+const SUB_TONES: Record<Exclude<ConductorSubTone, 'default'>, string> = {
+  blocked: 'text-jv-blocked-soft',
+  failed: 'text-jv-failed-muted',
+}
+
+/**
+ * The chain edge hanging off a card's right side: a static rule across the
+ * gutter, and for an in-flight hand-off a `jv-flow` dot travelling along it.
+ */
+function ChainConnector({ card }: { card: ConductorWorkerCardFixture }) {
+  const live = card.connector === 'flow'
+
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        data-jv-fixture="no-source"
+        className={clsx(
+          'absolute top-1/2 h-jv-1',
+          live ? 'bg-jv-live-line' : 'bg-jv-border-input',
+        )}
+        style={{
+          right: JV_CONDUCTOR.connectorOffset,
+          width: JV_CONDUCTOR.connectorWidth,
+        }}
+      />
+      {live ? (
+        <span
+          aria-hidden="true"
+          className="absolute top-1/2 h-jv-1 overflow-hidden"
+          style={{
+            right: JV_CONDUCTOR.connectorOffset,
+            width: JV_CONDUCTOR.connectorWidth,
+          }}
+        >
+          <span className="absolute top-jv-0 h-jv-1 w-jv-4 bg-jv-live animate-jv-flow" />
+        </span>
+      ) : null}
+    </>
+  )
+}
+
+function WorkerCard({ card }: { card: ConductorWorkerCardFixture }) {
+  const tokens = CARD_TONES[card.tone]
+  const subTone =
+    card.subTone && card.subTone !== 'default'
+      ? SUB_TONES[card.subTone]
+      : tokens.sub
+
+  return (
+    <div
+      data-jv-worker-tone={card.tone}
+      className={clsx(
+        'relative border px-jv-11 pt-jv-10 pb-jv-11',
+        tokens.frame,
+      )}
+    >
+      <div className="flex items-center gap-jv-7">
+        <span
+          aria-hidden="true"
+          className={clsx('h-jv-5 w-jv-5 flex-none', tokens.dot)}
+        />
+        <span
+          className={clsx(
+            'flex-1 font-jv-mono text-jv-lg leading-jv-none',
+            tokens.name,
+          )}
+        >
+          {card.name}
+        </span>
+        {card.badge ? (
+          <span
+            className={clsx(
+              'font-jv-mono text-jv-3xs leading-jv-none font-semibold tracking-jv-wide-2',
+              BADGE_TONES[card.badge.tone],
+            )}
+          >
+            {card.badge.label}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className={clsx(
+          'mt-jv-8 font-jv-mono text-jv-base leading-jv-relaxed-2',
+          tokens.detail,
+        )}
+      >
+        {card.detail}
+        <br />
+        <span
+          data-jv-fixture={card.noSource ? 'no-source' : undefined}
+          className={subTone}
+        >
+          {card.sub}
+        </span>
+      </div>
+
+      {card.action ? (
+        <div className="mt-jv-9 flex items-center gap-jv-6">
+          <ConductorChip chip={card.action} />
+        </div>
+      ) : null}
+
+      {card.connector ? <ChainConnector card={card} /> : null}
+    </div>
+  )
+}
+
+export function WorkerBoard({
+  heading,
+  cards,
+}: {
+  heading: ConductorSectionHeadingFixture
+  cards: Array<ConductorWorkerCardFixture>
+}) {
+  return (
+    <section
+      aria-label="Worker board"
+      className="flex-none border-b border-jv-line px-jv-20 pt-jv-16 pb-jv-20"
+    >
+      <ConductorSectionHeading
+        heading={heading}
+        noSource
+        title={CHAIN_NOTE_TITLE}
+        className="mb-jv-12"
+      />
+
+      <div className="grid grid-cols-5 gap-jv-16">
+        {cards.map((card) => (
+          <WorkerCard key={card.name} card={card} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/jarvis/gallery/jarvis-gallery.tsx
+++ b/src/screens/jarvis/gallery/jarvis-gallery.tsx
@@ -1,0 +1,208 @@
+/**
+ * JARVIS primitive gallery — DEV ONLY (`/jarvis-gallery`).
+ *
+ * Every state of the four primitives, side by side, against fixtures. No store,
+ * no gateway, no real data; interactions are no-ops. This is the surface the
+ * slice is reviewed on.
+ *
+ * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
+ * so this screen sets that attribute directly on <html> for as long as it is
+ * mounted and restores the previous value on unmount. It deliberately does NOT
+ * go through the app's setTheme — the user's stored theme in localStorage must
+ * come back untouched when they navigate away.
+ */
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import type { GateCaveatFixture } from '@/components/jarvis/fixtures'
+import { ApprovalGateCard } from '@/components/jarvis/approval-gate-card'
+import { EpistemicMark } from '@/components/jarvis/epistemic-mark'
+import { VerificationBadge } from '@/components/jarvis/verification-badge'
+import { WorkerStatusLine } from '@/components/jarvis/worker-status-line'
+import {
+  approvalGateFixtures,
+  emptyRailNote,
+  epistemicMarkFixtures,
+  verificationBadgeFixtures,
+  workerStatusFixtures,
+} from '@/components/jarvis/fixtures'
+
+const THEME_ATTRIBUTE = 'data-theme'
+const JARVIS_THEME = 'jarvis'
+
+/** Applies `data-theme='jarvis'` for the lifetime of the gallery only. */
+function useJarvisThemeAttribute() {
+  useEffect(() => {
+    const root = document.documentElement
+    const previous = root.getAttribute(THEME_ATTRIBUTE)
+    root.setAttribute(THEME_ATTRIBUTE, JARVIS_THEME)
+    return () => {
+      if (previous === null) {
+        root.removeAttribute(THEME_ATTRIBUTE)
+      } else {
+        root.setAttribute(THEME_ATTRIBUTE, previous)
+      }
+    }
+  }, [])
+}
+
+function Section({
+  title,
+  note,
+  children,
+}: {
+  title: string
+  note: string
+  children: ReactNode
+}) {
+  return (
+    <section className="flex flex-col gap-jv-12">
+      <div className="flex flex-col gap-jv-4 border-b border-jv-line pb-jv-8">
+        <h2 className="font-jv-mono text-jv-md leading-jv-none font-semibold tracking-jv-widest text-jv-text-muted">
+          {title}
+        </h2>
+        <p className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption">
+          {note}
+        </p>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function Caption({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-jv-mono text-jv-2xs leading-jv-none tracking-jv-label-2 text-jv-label">
+      {children}
+    </div>
+  )
+}
+
+function GateCaveat({ caveat }: { caveat: GateCaveatFixture }) {
+  return (
+    <>
+      {caveat.lead}
+      <EpistemicMark mark={caveat.mark}>{caveat.claim}</EpistemicMark>
+      {caveat.trail}
+    </>
+  )
+}
+
+export function JarvisGalleryScreen() {
+  useJarvisThemeAttribute()
+
+  return (
+    <div className="min-h-screen bg-jv-bg font-jv-sans text-jv-text">
+      <div className="mx-auto flex max-w-5xl flex-col gap-jv-40 p-jv-32">
+        <header className="flex flex-col gap-jv-6">
+          <h1 className="font-jv-mono text-jv-3xl leading-jv-none font-semibold tracking-jv-ultra text-jv-live">
+            JARVIS PRIMITIVES
+          </h1>
+          <p className="font-jv-sans text-jv-xl leading-jv-loose text-jv-text-caption">
+            Dev-only gallery. Every state below is fixture data — nothing here
+            is wired to a store, the gateway, or a real session, and no
+            component decides anything for itself.
+          </p>
+        </header>
+
+        <Section
+          title="EPISTEMIC MARK"
+          note="How a claim is known: Known (solid), Recalled (dotted), Assumed (dashed). The underline style is part of the meaning, not decoration."
+        >
+          <div className="flex flex-col gap-jv-16">
+            {epistemicMarkFixtures.map((fixture) => (
+              <div key={fixture.mark} className="flex flex-col gap-jv-6">
+                <Caption>{fixture.mark}</Caption>
+                <p className="font-jv-sans text-jv-5xl leading-jv-loose-3 text-jv-text-body">
+                  {fixture.lead}
+                  <EpistemicMark mark={fixture.mark}>
+                    {fixture.claim}
+                  </EpistemicMark>
+                  {fixture.trail}
+                </p>
+              </div>
+            ))}
+            <p className="font-jv-sans text-jv-5xl leading-jv-loose-3 text-jv-text-body">
+              All three in one sentence:{' '}
+              <EpistemicMark mark="known">the build is green</EpistemicMark>,{' '}
+              <EpistemicMark mark="recalled">
+                this broke the same way last quarter
+              </EpistemicMark>
+              , and{' '}
+              <EpistemicMark mark="assumed">
+                the cause is the same one
+              </EpistemicMark>
+              .
+            </p>
+          </div>
+        </Section>
+
+        <Section
+          title="VERIFICATION BADGE"
+          note="Evidence attached, or the agent's word only. The card never verifies anything itself."
+        >
+          <div className="flex flex-col gap-jv-16">
+            {verificationBadgeFixtures.map((fixture) => (
+              <div key={fixture.label} className="flex flex-col gap-jv-6">
+                <Caption>{fixture.label}</Caption>
+                <VerificationBadge {...fixture.props} />
+              </div>
+            ))}
+            <div className="flex flex-col gap-jv-6">
+              <Caption>side by side, as they appear under a turn</Caption>
+              <div className="flex gap-jv-10">
+                {verificationBadgeFixtures.slice(0, 2).map((fixture) => (
+                  <div key={fixture.label} className="flex-1">
+                    <VerificationBadge {...fixture.props} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <Section
+          title="WORKER STATUS LINE"
+          note="One rail row per worker. Blocked is the only square dot — shape as well as hue, so 'waiting on a human' survives a colourblind reading."
+        >
+          <div className="flex flex-col gap-jv-16">
+            <div className="flex flex-col gap-jv-6">
+              <Caption>every status</Caption>
+              <div className="border-b border-jv-line-soft bg-jv-surface-0">
+                {workerStatusFixtures.map((fixture) => (
+                  <WorkerStatusLine key={fixture.name} {...fixture} />
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-col gap-jv-6">
+              <Caption>empty rail</Caption>
+              <div className="border-y border-jv-line-soft bg-jv-surface-0 px-jv-14 py-jv-12 font-jv-mono text-jv-xs leading-jv-loose text-jv-label-faint">
+                {emptyRailNote}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <Section
+          title="APPROVAL GATE CARD"
+          note="Blast radius and undo path stated before the buttons. Both are props — neither has a source in today's backend, so the card cannot invent them."
+        >
+          <div className="flex flex-col gap-jv-16">
+            {approvalGateFixtures.map((fixture) => (
+              <div key={fixture.label} className="flex flex-col gap-jv-6">
+                <Caption>{fixture.label}</Caption>
+                <ApprovalGateCard
+                  {...fixture.props}
+                  caveat={
+                    fixture.caveat ? (
+                      <GateCaveat caveat={fixture.caveat} />
+                    ) : undefined
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        </Section>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/jarvis/gallery/jarvis-gallery.tsx
+++ b/src/screens/jarvis/gallery/jarvis-gallery.tsx
@@ -2,8 +2,18 @@
  * JARVIS primitive gallery — DEV ONLY (`/jarvis-gallery`).
  *
  * Every state of the four primitives, side by side, against fixtures. No store,
- * no gateway, no real data; interactions are no-ops. This is the surface the
- * slice is reviewed on.
+ * no gateway, interactions are no-ops. This is the surface the slice is
+ * reviewed on.
+ *
+ * ONE SECTION IS LIVE. `CODE CHECKPOINTS` reads the real `tsc | tests | lint |
+ * e2e` results recorded on a workspace checkpoint — per
+ * `docs/design/jarvis-ui-mapping.md` §3.6 the only genuine verified-vs-claimed
+ * source in the codebase. It lives HERE, on a dev surface of its own, and
+ * nowhere near the conversation: verification on a chat message is NO SOURCE
+ * (§3.5 items 2–3), so wiring code checks into a turn would claim a typechecker
+ * had confirmed something a person said. The Command board's conversation is
+ * untouched by this and stays inert. When the workspace daemon is not running
+ * the section falls back to the same fixtures as the section above and says so.
  *
  * Theme handling: the `--jv-*` tokens only resolve under `[data-theme='jarvis']`,
  * so this screen sets that attribute directly on <html> for as long as it is
@@ -25,6 +35,7 @@ import {
   verificationBadgeFixtures,
   workerStatusFixtures,
 } from '@/components/jarvis/fixtures'
+import { useCheckpointVerification } from '@/screens/jarvis/conductor/use-checkpoint-verification'
 
 const THEME_ATTRIBUTE = 'data-theme'
 const JARVIS_THEME = 'jarvis'
@@ -77,6 +88,68 @@ function Caption({ children }: { children: ReactNode }) {
   )
 }
 
+const LIVE_CHECKPOINT_NOTICE =
+  'CODE CHECKPOINT verification is LIVE (tsc/tests/lint/e2e) from the workspace API — this is code-check state, NOT conversation verification. A passed check is VERIFIED with its real output as evidence; a failed one is drawn as CLAIMED · UNVERIFIED, because the affirmative state would read as “this passed”, and its title says FAILED outright. Checks that never ran draw no badge at all. Read-only: no re-run, no review, no action chips.'
+
+const FIXTURE_CHECKPOINT_NOTICE =
+  'No checkpoint came back from the workspace API — without the workspace daemon, GET /api/workspace/checkpoints either 404s or falls through to the SPA shell, and both read as an empty list. That is the normal case for a design review, so the badges below are the SAME invented fixtures as the section above. Nothing here is a real code check.'
+
+/**
+ * The live section: real checkpoint verification, or the fixtures with the
+ * fallback said out loud. Both readings render badges, so the notice above them
+ * is the only thing that tells a reviewer which one they are looking at — it is
+ * printed first, and unconditionally.
+ */
+function CodeCheckpointSection() {
+  const { badges, inertChecks, source, isLive } = useCheckpointVerification()
+
+  return (
+    <Section
+      title="CODE CHECKPOINTS"
+      note="The one real verified-vs-claimed source in the codebase (§3.6) — the tsc/tests/lint/e2e checks recorded on a workspace code checkpoint. Out-of-band from chat: a conversation claim still has no verification field and stays inert."
+    >
+      <div className="flex flex-col gap-jv-16">
+        <p
+          data-jv-fixture={isLive ? undefined : 'no-source'}
+          className="font-jv-sans text-jv-lg leading-jv-loose text-jv-text-caption"
+        >
+          {isLive ? LIVE_CHECKPOINT_NOTICE : FIXTURE_CHECKPOINT_NOTICE}
+        </p>
+
+        {source ? <Caption>{source}</Caption> : null}
+
+        {badges.length > 0 ? (
+          <div className="flex flex-col gap-jv-10">
+            {badges.map((props) => (
+              <VerificationBadge key={props.title} {...props} />
+            ))}
+          </div>
+        ) : (
+          // LIVE with nothing to show. A real checkpoint on which no check ran
+          // is not an empty state to paper over — it is the answer.
+          <div className="border border-dashed border-jv-line px-jv-10 py-jv-7 font-jv-mono text-jv-base leading-jv-loose text-jv-label-faint">
+            No check on this checkpoint produced a verdict — nothing here is
+            verified, and nothing is claimed.
+          </div>
+        )}
+
+        {inertChecks.length > 0 ? (
+          <div className="flex flex-col gap-jv-6">
+            <Caption>ran nothing · no verdict, not a verdict</Caption>
+            <div className="border-y border-jv-line-soft bg-jv-surface-0 px-jv-14 py-jv-12 font-jv-mono text-jv-xs leading-jv-loose text-jv-label-faint">
+              {inertChecks.map((check) => (
+                <div key={check.key}>
+                  {check.scope} — {check.note}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Section>
+  )
+}
+
 function GateCaveat({ caveat }: { caveat: GateCaveatFixture }) {
   return (
     <>
@@ -98,9 +171,11 @@ export function JarvisGalleryScreen() {
             JARVIS PRIMITIVES
           </h1>
           <p className="font-jv-sans text-jv-xl leading-jv-loose text-jv-text-caption">
-            Dev-only gallery. Every state below is fixture data — nothing here
-            is wired to a store, the gateway, or a real session, and no
-            component decides anything for itself.
+            Dev-only gallery. Every state below is fixture data — nothing is
+            wired to a store, the gateway, or a real session, and no component
+            decides anything for itself. The one exception is CODE CHECKPOINTS,
+            which reads real tsc/tests/lint/e2e results from the workspace API
+            and labels itself live or fallback on every render.
           </p>
         </header>
 
@@ -159,6 +234,8 @@ export function JarvisGalleryScreen() {
             </div>
           </div>
         </Section>
+
+        <CodeCheckpointSection />
 
         <Section
           title="WORKER STATUS LINE"

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=EB+Garamond:opsz,wght@8..120,400..800&family=JetBrains+Mono:wght@400;500&display=swap');
+@import './jarvis-theme.css';
 @import 'tailwindcss';
 
 /* Tailwind v4 — enable dark: variant on .dark class (set by __root.tsx) */


### PR DESCRIPTION
## Summary

Adds the **JARVIS epistemic UI** — a self-contained, additive design system built over slices 1–7a. It reproduces four artboards (Desktop Command/Conductor + responsive mobile) and wires the parts that have a **real data source today**, read-only. Everything that has no source is rendered **visibly inert**, never faked.

Dev routes (gated on `import.meta.env.DEV`): `/jarvis-gallery`, `/jarvis-command`, `/jarvis-conductor`.

## What's included

- **`--jv-*` token layer** registered as a 13th theme (`data-theme='jarvis'`, dark-only, self-maps the light slot — no invented light palette).
- **Four primitives**: epistemic mark (KN/RC/AS), verification badge (verified/claimed), worker status line, approval-gate card.
- **Desktop Command + Conductor boards** and **recomposed mobile boards** (not scaled — matched to the mobile artboards directly). Conductor's failed & stale states are first-class.
- **Real data, read-only** (slices 6a–6c, 7a):
  - Scheduled jobs ← `ClaudeJob` (verified live against a real gateway).
  - Worker board/rail ← swarm store, with `blocked` derived from a pending-approval join.
  - Approval gate **displays** real approvals; resolve is behind a per-session arm toggle (**default OFF**) + a two-step confirm — nothing writes without both.
  - Code-checkpoint verification ← `WorkspaceCheckpointVerificationItem` (tsc/tests/lint/e2e), on the dev gallery only.

## Honesty model (the point of this work)

Every value the backend can't produce is rendered inert with a `data-jv-fixture="no-source"` marker, never a plausible fake. The 7 "product-thesis" NO-SOURCE items (epistemic marks on chat, verified/claimed on chat, evidence-on-claim, "I DISAGREE", gate blast-radius/undo/caveat) stay inert pending a separate agent/gateway contract — **5 of the 7 cannot be delivered in this fork at all** (chat content is agent-sourced; approvals are gateway-served). Code-checkpoint verification is the one real fork-only win and is kept explicitly separate from chat.

## Footprint

59 files, +11,124 / −2 — additive and contained. Shared-infra touches are minimal and flagged: `theme.ts` (theme registration), `__root.tsx` (dev-only `/jarvis-*` onboarding bypass, tree-shaken from prod), `styles.css` (one font `@import`), `routeTree.gen.ts` (auto-generated). No existing route/component/screen behaviour changed; nothing deleted.

## Verification

Each slice was independently verified (not on the builder's word): `pnpm build` exit 0, `pnpm lint` **0 new findings** vs baseline (repo baseline is pre-existing red), `pnpm test` **+227 new tests, 0 regressions** (same 37 pre-existing failures throughout). Read-only proven by grep on every data slice. The resolve write-path is guarded by a two-step confirm + a default-off per-session flag with 16 dedicated safety tests.

## Known limitations (stated plainly)

- **Live-data verification is partial.** Scheduled jobs are confirmed live against the real gateway. The **swarm-sessions and approvals feeds are not served by this gateway build** (`mode=disconnected, missing=[…sessions…]`), so the worker board, approval gate, and checkpoint surfaces render their fixture fallback here — their real-data paths are unit-tested and were exercised via labelled browser stubs, but are **unverified against real data** until those feeds exist.
- The repo's vitest can't render hook-using components (pre-existing infra limitation); hook logic is covered via pure reducers/mappers tested directly.

## Test plan

- [ ] `pnpm build` (exit 0)
- [ ] `pnpm test` (37 pre-existing failures unchanged; jarvis tests pass)
- [ ] Review `/jarvis-gallery`, `/jarvis-command`, `/jarvis-conductor` in dev
- [ ] Confirm the NO-SOURCE items render inert, not faked
- [ ] Decide whether to enable live resolve against a real approvals feed (currently off by default)

🤖 Generated with JARVIS (delegated builders, independently verified). Base branch is `main`; opened as **draft** for review.
